### PR TITLE
[Completions] Fix duplicated methods from implicit conversions

### DIFF
--- a/compiler/test/dotty/tools/dotc/interactive/CustomCompletion.scala
+++ b/compiler/test/dotty/tools/dotc/interactive/CustomCompletion.scala
@@ -37,7 +37,7 @@ object CustomCompletion {
     var extra = List.empty[Completion]
 
     val completions = path match {
-      case Select(qual, _) :: _                              => completer.selectionCompletions(qual)
+      case (sel : Select) :: _                                 => completer.selectionCompletions(sel)
       case Import(Ident(name), _) :: _ if name.decode.toString == "$ivy" && dependencyCompleteOpt.nonEmpty =>
         val complete = dependencyCompleteOpt.get
         val (pos, completions) = complete(prefix)

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -976,4 +976,14 @@ class CompletionTest {
               ("main", Module, "main")
             )
           )
+
+  @Test def singleConversionInstancePerMethod : Unit =
+    code"""val a = Array(1,2).fil${m1}"""
+          .withSource
+          .completion(m1,
+            Set(
+              ("filterNot", Method, "(p: Int => Boolean): Array[Int]"),
+              ("filter", Method, "(p: Int => Boolean): Array[Int]")
+            )
+          )
 }


### PR DESCRIPTION
Fixes the following case:
```scala
Array(1,2,3).fil@@
```

Before this fix there were several `filter` and `filterNot` methods in
completions they were taken from all eligible implicit candidates.

Now there is a kind of ranking per denotation.