### PR TITLE
Improve message for misplaced using

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -287,7 +287,7 @@ extends NotFoundMsg(MissingIdentID) {
         |imported from elsewhere.
         |
         |Possible reasons why no matching declaration was found:
-        | - The declaration or the use is mis-spelt.
+        | - The declaration or the use is misspelled.
         | - An import is missing."""
   }
 }
@@ -1220,6 +1220,17 @@ extends SyntaxMsg(ExpectedTokenButFoundID) {
     else
       ""
 }
+
+class ExpectedTokenButFoundSoftKeyword(expected: Token, found: Token, soft: Name, advice: String = "")(using Context)
+extends SyntaxMsg(ExpectedTokenButFoundID):
+  def addendum = if !advice.isEmpty then s"\n$advice" else advice
+  def msg(using Context) =
+    val expectedText = if Tokens.isIdentifier(expected) then "an identifier" else Tokens.showToken(expected)
+    val what = if Tokens.isIdentifier(found) || expected == Tokens.COLONop then "an identifier" else "the soft keyword"
+    s"""$expectedText expected, but ${Tokens.showToken(found)} found.
+       |The soft keyword `$soft` was taken as $what in this context.$addendum""".stripMargin
+  def explain(using Context) = s"The soft keyword `$soft` has special meaning only in certain contexts.$addendum"
+end ExpectedTokenButFoundSoftKeyword
 
 class MixedLeftAndRightAssociativeOps(op1: Name, op2: Name, op2LeftAssoc: Boolean)(using Context)
 extends SyntaxMsg(MixedLeftAndRightAssociativeOpsID) {

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -935,7 +935,12 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
       Option {
         if actualErrors == 0 then s"\nNo errors found when compiling neg test $testSource"
-        else if expectedErrors == 0 then s"\nNo errors expected/defined in $testSource -- use // error or // nopos-error"
+        else if expectedErrors == 0 then
+          s"""|No expected errors marked in $testSource -- use // error or // nopos-error
+              |actual error count: $actualErrors
+              |${unexpected.mkString("Unexpected errors:\n", "\n", "")}
+              |$showErrors
+              |""".stripMargin.trim.linesIterator.mkString("\n", "\n", "")
         else if expectedErrors != actualErrors then
           s"""|Wrong number of errors encountered when compiling $testSource
               |expected: $expectedErrors, actual: $actualErrors

--- a/tests/neg/i15614.check
+++ b/tests/neg/i15614.check
@@ -1,0 +1,208 @@
+-- [E040] Syntax Error: tests/neg/i15614.scala:3:20 --------------------------------------------------------------------
+3 |def f(i: Int, using j: Int) = i + j   // error
+  |                    ^
+  |                    ':' expected, but identifier found.
+  |                    The soft keyword `using` was taken as an identifier in this context.
+  |                    It is a keyword only at the beginning of a parameter clause.
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | The soft keyword `using` has special meaning only in certain contexts.
+  | It is a keyword only at the beginning of a parameter clause.
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:5:20 --------------------------------------------------------------------
+5 |def g(i: Int, using Int) = i + summon[Int]  // error  // error
+  |                    ^^^
+  |                    ':' expected, but identifier found.
+  |                    The soft keyword `using` was taken as an identifier in this context.
+  |                    It is a keyword only at the beginning of a parameter clause.
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | The soft keyword `using` has special meaning only in certain contexts.
+  | It is a keyword only at the beginning of a parameter clause.
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:7:19 --------------------------------------------------------------------
+7 |def z(i: Int, using) = i // error
+  |                   ^
+  |                   ':' expected, but ')' found.
+  |                   The soft keyword `using` was taken as an identifier in this context.
+  |                   It is a keyword only at the beginning of a parameter clause.
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | The soft keyword `using` has special meaning only in certain contexts.
+  | It is a keyword only at the beginning of a parameter clause.
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:9:26 --------------------------------------------------------------------
+9 |def erased(i: Int, erased j: Int) = i + j // error // error
+  |                          ^
+  |                          ':' expected, but identifier found
+-- [E040] Syntax Error: tests/neg/i15614.scala:11:33 -------------------------------------------------------------------
+11 |def usingAndErased(i: Int, using erased j: Int) = i + j // error // error
+   |                                 ^^^^^^
+   |                                 ':' expected, but identifier found.
+   |                                 The soft keyword `using` was taken as an identifier in this context.
+   |                                 It is a keyword only at the beginning of a parameter clause.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | The soft keyword `using` has special meaning only in certain contexts.
+   | It is a keyword only at the beginning of a parameter clause.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:13:37 -------------------------------------------------------------------
+13 |def usingAndErasedType(i: Int, using erased Int) = i + j // error // error
+   |                                     ^^^^^^
+   |                                     ':' expected, but identifier found.
+   |                                     The soft keyword `using` was taken as an identifier in this context.
+   |                                     It is a keyword only at the beginning of a parameter clause.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | The soft keyword `using` has special meaning only in certain contexts.
+   | It is a keyword only at the beginning of a parameter clause.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:15:40 -------------------------------------------------------------------
+15 |inline def usingAndInline(i: Int, using inline j: Int) = i + j // error
+   |                                        ^^^^^^
+   |                                        ':' expected, but identifier found.
+   |                                        The soft keyword `using` was taken as an identifier in this context.
+   |                                        It is a keyword only at the beginning of a parameter clause.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | The soft keyword `using` has special meaning only in certain contexts.
+   | It is a keyword only at the beginning of a parameter clause.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:17:53 -------------------------------------------------------------------
+17 |inline def usingAndInlineWithTypeError(i: Int, using inline j: Int): String = i + j // error
+   |                                                     ^^^^^^
+   |                                            ':' expected, but identifier found.
+   |                                            The soft keyword `using` was taken as an identifier in this context.
+   |                                            It is a keyword only at the beginning of a parameter clause.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | The soft keyword `using` has special meaning only in certain contexts.
+   | It is a keyword only at the beginning of a parameter clause.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:19:55 -------------------------------------------------------------------
+19 |inline def usingAndInlineReversed(i: Int, inline using j: Int) = i + j // error
+   |                                                       ^
+   |                                            ':' expected, but identifier found.
+   |                                            The soft keyword `using` was taken as an identifier in this context.
+   |                                            It is a keyword only at the beginning of a parameter clause.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | The soft keyword `using` has special meaning only in certain contexts.
+   | It is a keyword only at the beginning of a parameter clause.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:21:17 -------------------------------------------------------------------
+21 |def untoken(using: Int) = using // error // error
+   |                 ^
+   |                 an identifier expected, but ':' found.
+   |                 The soft keyword `using` was taken as the soft keyword in this context.
+   |                 It is a keyword only at the beginning of a parameter clause.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | The soft keyword `using` has special meaning only in certain contexts.
+   | It is a keyword only at the beginning of a parameter clause.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E040] Syntax Error: tests/neg/i15614.scala:23:22 -------------------------------------------------------------------
+23 |class C(i: Int, using j: Int): // error
+   |                      ^
+   |                      ':' expected, but identifier found.
+   |                      The soft keyword `using` was taken as an identifier in this context.
+   |                      It is a keyword only at the beginning of a parameter clause.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | The soft keyword `using` has special meaning only in certain contexts.
+   | It is a keyword only at the beginning of a parameter clause.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E172] Type Error: tests/neg/i15614.scala:24:25 ---------------------------------------------------------------------
+24 |  def c = i + summon[Int] // error
+   |                         ^
+   |                       No given instance of type Int was found for parameter x of method summon in object Predef
+-- [E172] Type Error: tests/neg/i15614.scala:5:42 ----------------------------------------------------------------------
+5 |def g(i: Int, using Int) = i + summon[Int]  // error  // error
+  |                                          ^
+  |                         No given instance of type Int was found for parameter x of method summon in object Predef
+-- [E006] Not Found Error: tests/neg/i15614.scala:9:40 -----------------------------------------------------------------
+9 |def erased(i: Int, erased j: Int) = i + j // error // error
+  |                                        ^
+  |                                        Not found: j
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Each identifier in Scala needs a matching declaration. There are two kinds of
+  | identifiers: type identifiers and value identifiers. Value identifiers are introduced
+  | by `val`, `def`, or `object` declarations. Type identifiers are introduced by `type`,
+  | `class`, `enum`, or `trait` declarations.
+  |
+  | Identifiers refer to matching declarations in their environment, or they can be
+  | imported from elsewhere.
+  |
+  | Possible reasons why no matching declaration was found:
+  |  - The declaration or the use is misspelled.
+  |  - An import is missing.
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E006] Not Found Error: tests/neg/i15614.scala:11:54 ----------------------------------------------------------------
+11 |def usingAndErased(i: Int, using erased j: Int) = i + j // error // error
+   |                                                      ^
+   |                                                      Not found: j
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Each identifier in Scala needs a matching declaration. There are two kinds of
+   | identifiers: type identifiers and value identifiers. Value identifiers are introduced
+   | by `val`, `def`, or `object` declarations. Type identifiers are introduced by `type`,
+   | `class`, `enum`, or `trait` declarations.
+   |
+   | Identifiers refer to matching declarations in their environment, or they can be
+   | imported from elsewhere.
+   |
+   | Possible reasons why no matching declaration was found:
+   |  - The declaration or the use is misspelled.
+   |  - An import is missing.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E006] Not Found Error: tests/neg/i15614.scala:13:55 ----------------------------------------------------------------
+13 |def usingAndErasedType(i: Int, using erased Int) = i + j // error // error
+   |                                                       ^
+   |                                                       Not found: j
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Each identifier in Scala needs a matching declaration. There are two kinds of
+   | identifiers: type identifiers and value identifiers. Value identifiers are introduced
+   | by `val`, `def`, or `object` declarations. Type identifiers are introduced by `type`,
+   | `class`, `enum`, or `trait` declarations.
+   |
+   | Identifiers refer to matching declarations in their environment, or they can be
+   | imported from elsewhere.
+   |
+   | Possible reasons why no matching declaration was found:
+   |  - The declaration or the use is misspelled.
+   |  - An import is missing.
+    --------------------------------------------------------------------------------------------------------------------
+-- [E006] Not Found Error: tests/neg/i15614.scala:21:26 ----------------------------------------------------------------
+21 |def untoken(using: Int) = using // error // error
+   |                          ^^^^^
+   |                          Not found: using
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Each identifier in Scala needs a matching declaration. There are two kinds of
+   | identifiers: type identifiers and value identifiers. Value identifiers are introduced
+   | by `val`, `def`, or `object` declarations. Type identifiers are introduced by `type`,
+   | `class`, `enum`, or `trait` declarations.
+   |
+   | Identifiers refer to matching declarations in their environment, or they can be
+   | imported from elsewhere.
+   |
+   | Possible reasons why no matching declaration was found:
+   |  - The declaration or the use is misspelled.
+   |  - An import is missing.
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i15614.scala
+++ b/tests/neg/i15614.scala
@@ -1,0 +1,30 @@
+//> using options -explain
+
+def f(i: Int, using j: Int) = i + j   // error
+
+def g(i: Int, using Int) = i + summon[Int]  // error  // error
+
+def z(i: Int, using) = i // error
+
+def erased(i: Int, erased j: Int) = i + j // error // error
+
+def usingAndErased(i: Int, using erased j: Int) = i + j // error // error
+
+def usingAndErasedType(i: Int, using erased Int) = i + j // error // error
+
+inline def usingAndInline(i: Int, using inline j: Int) = i + j // error
+
+inline def usingAndInlineWithTypeError(i: Int, using inline j: Int): String = i + j // error
+
+inline def usingAndInlineReversed(i: Int, inline using j: Int) = i + j // error
+
+def untoken(using: Int) = using // error // error
+
+class C(i: Int, using j: Int): // error
+  def c = i + summon[Int] // error
+
+/*
+was unhelpful:
+at 2: Not found: j
+at 2: ':' expected, but identifier found
+*/


### PR DESCRIPTION
Offer extra feedback when soft keyword `using` is found in identifier position, because it is a common beginner mistake.

```
def f(i: Int, using j: Int) = i + j
```

Skipping to the intended `j` may also reduce subsequent "not found" errors.

In Vulpix, show actual errors when no errors are marked. It is unlikely that this is "TMI" for the developer. Automatic `-rewrite` is left for another day.

Fixes #15614 