### PR TITLE
Fix span of xml literal

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
@@ -77,8 +77,9 @@ object MarkupParsers {
 
     import parser.{ symbXMLBuilder => handle }
 
-    def curOffset : Int = input.charOffset - 1
-    var tmppos : Span = NoSpan
+    def curOffset: Int = input.lastCharOffset
+
+    var tmppos: Span = NoSpan
     def ch: Char = input.ch
     /** this method assign the next character to ch and advances in input */
     def nextch(): Unit = { input.nextChar() }
@@ -169,10 +170,8 @@ object MarkupParsers {
       xTakeUntil(handle.charData, () => Span(start, curOffset, mid), "]]>")
     }
 
-    def xUnparsed: Tree = {
-      val start = curOffset
+    def xUnparsed(start: Int): Tree =
       xTakeUntil(handle.unparsed, () => Span(start, curOffset, start), "</xml:unparsed>")
-    }
 
     /** Comment ::= '<!--' ((Char - '-') | ('-' (Char - '-')))* '-->'
      *
@@ -276,7 +275,7 @@ object MarkupParsers {
      *                | xmlTag1 '/' '>'
      */
     def element: Tree = {
-      val start = curOffset // FIXME should be `curOffset - 1` (scalatest and tests/neg/i19100.scala must be updated)
+      val start = curOffset - 1 // include <
       val (qname, attrMap) = xTag(())
       if (ch == '/') { // empty element
         xToken("/>")
@@ -285,7 +284,7 @@ object MarkupParsers {
       else { // handle content
         xToken('>')
         if (qname == "xml:unparsed")
-          return xUnparsed
+          return xUnparsed(start)
 
         debugLastStartElement = (start, qname) :: debugLastStartElement
         val ts = content
@@ -363,7 +362,7 @@ object MarkupParsers {
         handle.isPattern = false
 
         val ts = new ArrayBuffer[Tree]
-        val start = curOffset
+        val start = curOffset - 1 // include <, start == parser.in.offset
         tmppos = Span(curOffset)    // Iuli: added this line, as it seems content_LT uses tmppos when creating trees
         content_LT(ts)
 
@@ -434,7 +433,7 @@ object MarkupParsers {
      *                  | Name [S] '/' '>'
      */
     def xPattern: Tree = {
-      var start = curOffset // FIXME should be `curOffset - 1` (scalatest and tests/neg/i19100.scala must be updated)
+      val start = curOffset - 1 // include <
       val qname = xName
       debugLastStartElement = (start, qname) :: debugLastStartElement
       xSpaceOpt()

--- a/compiler/test/dotty/tools/dotc/parsing/ParserEdgeTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/ParserEdgeTest.scala
@@ -4,10 +4,52 @@ package parsing
 
 import ast.untpd.*
 import core.Constants.*
+import core.Decorators.*
 
 import org.junit.Test
+import org.junit.Assert.assertTrue
 
 class ParserEdgeTest extends ParserTest {
+  def verifyXML(text: String)(p: Tree => Boolean): Unit =
+    val t = parseText(text)
+    t.checkPos(nonOverlapping = true)
+    assertTrue("predicate failed", p(t))
+
+  @Test def `i6547 xml blocks should be correctly positioned`: Unit =
+    val code =
+      i"""
+        |class Foo {
+        |  <foo a="hello &name; aaa"/>
+        |}
+      """
+    verifyXML(code)(_ => true)
+
+  @Test def `i15574 span of xml literal with windows line separators`: Unit =
+    val code =
+      i"""
+        |object Test {
+        |  Nil.map { _ =>
+        |    <X />
+        |    <Y />
+        |  }
+        |}
+      """
+    extension (text: String) def convertToLineSeparator(sep: String): String = text.linesIterator.map(_ + sep).mkString
+    val crlfCode = code.convertToLineSeparator("\r\n")
+    val lfCode = code.convertToLineSeparator("\n")
+    def verifyTreeHasSpans(text: String): Unit =
+      val x0 = text.indexOf('<')
+      val x1 = text.indexOf('>', x0+1) + 1
+      val y0 = text.indexOf('<', x1+1)
+      val y1 = text.indexOf('>', y0+1) + 1
+      def treeHasSpan(tree: Tree, start: Int, end: Int): Boolean =
+        tree.existsSubTree(t => t.span.exists && t.span.start == start && t.span.end == end)
+      verifyXML(text)(tree => treeHasSpan(tree, x0, x1) && treeHasSpan(tree, y0, y1))
+
+    assert(crlfCode != lfCode) // check construction
+    verifyTreeHasSpans(crlfCode)
+    verifyTreeHasSpans(lfCode)
+
   //
   // CR after right brace of interpolated expression was stripped.
   //
@@ -19,15 +61,15 @@ class ParserEdgeTest extends ParserTest {
     val text = s"""class C { def g = "X" ; def f = s${triple}123${CR}${NL}$${g}${CR}${NL}456${triple} }"""
     def isStripped(s: String) = s.contains(NL) && !s.contains(CR)
 
-    // sanity check
+    // check construction
     assert(text.linesIterator.size == 3, s"line count ${text.linesIterator.size}")
     assert(text.linesIterator.forall(!isStripped(_)))
 
     val t = parseText(text)
     //println(t.show)
-    assert(!t.existsSubTree {
+    assertTrue(!t.existsSubTree {
       case Literal(const @ Constant(_)) if const.tag == StringTag => isStripped(const.stringValue)
-      case st => false
+      case _ => false
     })
   }
   /* was:

--- a/tests/neg/i19100.check
+++ b/tests/neg/i19100.check
@@ -1,15 +1,15 @@
--- Error: tests/neg/i19100.scala:4:3 -----------------------------------------------------------------------------------
+-- Error: tests/neg/i19100.scala:4:2 -----------------------------------------------------------------------------------
 4 |  <foo/> match // error
-  |   ^^^^^
-  |   XML literals are no longer supported.
-  |   See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
--- Error: tests/neg/i19100.scala:5:10 ----------------------------------------------------------------------------------
+  |  ^^^^^^
+  |  XML literals are no longer supported.
+  |  See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
+-- Error: tests/neg/i19100.scala:5:9 -----------------------------------------------------------------------------------
 5 |    case <foo/> => 1 // error
-  |          ^^^^^
-  |          XML literals are no longer supported.
-  |          See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
--- Error: tests/neg/i19100.scala:6:3 -----------------------------------------------------------------------------------
+  |         ^^^^^^
+  |         XML literals are no longer supported.
+  |         See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
+-- Error: tests/neg/i19100.scala:6:2 -----------------------------------------------------------------------------------
 6 |  <bar></bar> // error
-  |   ^^^^^^^^^^
-  |   XML literals are no longer supported.
-  |   See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
+  |  ^^^^^^^^^^^
+  |  XML literals are no longer supported.
+  |  See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html


### PR DESCRIPTION
Forward port https://github.com/scala/scala/commit/f428cc6d94bbfee6ba3f7a956d0eee7126d785af
Forward port https://github.com/scala/scala/commit/85136e3f2591f0bf22d3845ecc83081a0b6c4aa4

The dotty reader has `lastCharOffset` to track where the last char began. There is no need to back up to it.

