### PR TITLE
Fix Closure span assignment in makeClosure

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1523,7 +1523,7 @@ object desugar {
       DefDef(nme.ANON_FUN, paramss, if (tpt == null) TypeTree() else tpt, body)
         .withSpan(span)
         .withMods(synthetic | Artifact),
-      Closure(Nil, Ident(nme.ANON_FUN), EmptyTree))
+      Closure(Nil, Ident(nme.ANON_FUN), EmptyTree).withSpan(span))
 
   /** If `nparams` == 1, expand partial function
    *

--- a/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
+++ b/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
@@ -4,7 +4,7 @@ package ast
 import core.Contexts.*
 import core.Decorators.*
 import util.Spans.*
-import Trees.{MemberDef, DefTree, WithLazyFields}
+import Trees.{Closure, MemberDef, DefTree, WithLazyFields}
 import dotty.tools.dotc.core.Types.AnnotatedType
 import dotty.tools.dotc.core.Types.ImportType
 import dotty.tools.dotc.core.Types.Type
@@ -76,7 +76,7 @@ object NavigateAST {
       var bestFit: List[Positioned] = path
       while (it.hasNext) {
         val path1 = it.next() match {
-          case p: Positioned => singlePath(p, path)
+          case p: Positioned if !p.isInstanceOf[Closure[?]] => singlePath(p, path)
           case m: untpd.Modifiers => childPath(m.productIterator, path)
           case xs: List[?] => childPath(xs.iterator, path)
           case _ => path

--- a/tests/neg/i15741.scala
+++ b/tests/neg/i15741.scala
@@ -1,15 +1,15 @@
   def get(using Int): String = summon[Int].toString
 
-  def pf2: PartialFunction[String, Int ?=> String] = {
+  def pf2: PartialFunction[String, Int ?=> String] = { // error
     case "hoge" => get
     case "huga" => get
-  } // error
+  }
 
   type IS = Int ?=> String
 
-  def pf3: PartialFunction[String, IS] = {
+  def pf3: PartialFunction[String, IS] = { // error
     case "hoge" => get
     case "huga" => get
-  } // error
+  }
 
 

--- a/tests/neg/i19351a.check
+++ b/tests/neg/i19351a.check
@@ -1,12 +1,4 @@
 -- Error: tests/neg/i19351a/Test.scala:8:34 ----------------------------------------------------------------------------
-8 |inline def not(b: Bool): Bool = ${notMacro('b)} // error // error
+8 |inline def not(b: Bool): Bool = ${notMacro('b)} // error
   |                                  ^
   |Cyclic macro dependency; macro refers to a toplevel symbol in tests/neg/i19351a/Test.scala from which the macro is called
--- [E046] Cyclic Error: tests/neg/i19351a/Test.scala:8:46 --------------------------------------------------------------
-8 |inline def not(b: Bool): Bool = ${notMacro('b)} // error // error
-  |                                              ^
-  |                                              Cyclic reference involving method $anonfun
-  |
-  |                                               Run with -explain-cyclic for more details.
-  |
-  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i19351a/Test.scala
+++ b/tests/neg/i19351a/Test.scala
@@ -5,7 +5,7 @@ type Bool = [R] => (R, R) => R
 val True: Bool = [R] => (t: R, _: R) => t
 val False: Bool = [R] => (_: R, f: R) => f
 
-inline def not(b: Bool): Bool = ${notMacro('b)} // error // error
+inline def not(b: Bool): Bool = ${notMacro('b)} // error
 inline def show(b: Bool): String = ${showMacro('b)}
 //inline def not(b: Bool): Bool = ${foldMacro('b, 'False, 'True)}
 //inline def show(b: Bool): String = ${foldMacro('b, '{"TRUE"}, '{"FALSE"})}

--- a/tests/neg/i9299.scala
+++ b/tests/neg/i9299.scala
@@ -1,4 +1,4 @@
 type F <: F = 1 match { // error
-  case _ => foo.foo // error // error
+  case _ => foo.foo // error
 }
 def foo(a: Int): Unit = ???


### PR DESCRIPTION
Fixes #15098

Wrong line numbers were coming from `Closure`. Previously it's span was inherited from block end position, now it's assigned explicitly.

This fix changes behaviour of test `tests/neg/i9299.scala`:
```scala
type F <: F = 1 match { // error
  case _ => foo.foo // error // error
}
def foo(a: Int): Unit = ???
```

Previously there were 3 errors generated:
<details>
<summary>Compiler output before fix (3 errors)</summary>

```
-- Error: tests/neg/i9299.scala:1:10 -------------------------------------------
1 |type F <: F = 1 match { // error
  |          ^
  |Recursion limit exceeded.
  |Maybe there is an illegal cyclic reference?
  |If that's not the case, you could also try to increase the stacksize using the -Xss JVM option.
  |A recurring operation is (inner to outer):
  |
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  ...
  |
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
-- Error: tests/neg/i9299.scala:2:12 -------------------------------------------
2 |  case _ => foo.foo // error // error
  |            ^
  |Recursion limit exceeded.
  |Maybe there is an illegal cyclic reference?
  |If that's not the case, you could also try to increase the stacksize using the -Xss JVM option.
  |A recurring operation is (inner to outer):
  |
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  ...
  |
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of  <: F
-- [E046] Cyclic Error: tests/neg/i9299.scala:2:15 -----------------------------
2 |  case _ => foo.foo // error // error
  |               ^
  |               Cyclic reference involving method $anonfun
  |-----------------------------------------------------------------------------
  | Explanation (enabled by `-explain`)
  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  | method $anonfun is declared as part of a cycle which makes it impossible for the
  | compiler to decide upon $anonfun's type.
  | To avoid this error, try giving $anonfun an explicit type.
   -----------------------------------------------------------------------------
3 errors found
```
</details>


Now there are 2 errors:
<details>
<summary>Compiler output after fix (2 errors)</summary>

```
-- Error: tests/neg/i9299.scala:1:10 -------------------------------------------
1 |type F <: F = 1 match { // error
  |          ^
  |Recursion limit exceeded.
  |Maybe there is an illegal cyclic reference?
  |If that's not the case, you could also try to increase the stacksize using the -Xss JVM option.
  |A recurring operation is (inner to outer):
  |
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  ...
  |
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
  |  type parameters of  <: F
  |  type parameters of F
-- Error: tests/neg/i9299.scala:2:12 -------------------------------------------
2 |  case _ => foo.foo // error // error
  |            ^
  |Recursion limit exceeded.
  |Maybe there is an illegal cyclic reference?
  |If that's not the case, you could also try to increase the stacksize using the -Xss JVM option.
  |A recurring operation is (inner to outer):
  |
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  ...
  |
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of F
  |  base classes of  <: F
2 errors found
```
</details>

This is because now in function `UniqueMessagePositions.isHidden`:
```scala
trait UniqueMessagePositions extends Reporter {
  // ...
  /** Logs a position and returns true if it was already logged.
   *  @note  Two positions are considered identical for logging if they have the same point.
   */
  override def isHidden(dia: Diagnostic)(using Context): Boolean =
    super.isHidden(dia)
    ||
      dia.pos.exists
      && !ctx.settings.YshowSuppressedErrors.value
      && (dia.pos.start to dia.pos.end).exists(pos =>
            positions.get((ctx.source, pos)).exists(_.hides(dia)))
  // ...
}
```
this fragment:
```scala
(dia.pos.start to dia.pos.end).exists(pos =>
    positions.get((ctx.source, pos)).exists(_.hides(dia)))
```
evaluates to `true` with third error. New position is considered as overlapping with position of previous error and it's not printed.

I think this may be desired behaviour, but I am not entirely sure.