### PR TITLE
Fix initializing parents of AnonClasses

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -182,4 +182,5 @@ class ExpandSAMs extends MiniPhase:
     case tpe =>
       tpe
   }
+
 end ExpandSAMs

--- a/tests/neg/i15855.scala
+++ b/tests/neg/i15855.scala
@@ -1,0 +1,7 @@
+class MyFunction(arg: String)
+
+trait MyFun[+R] extends MyFunction {
+  def apply(i: Int): R
+}
+
+val myFun: MyFun[Int] = (i: Int) => 1 // error

--- a/tests/run/i15855.check
+++ b/tests/run/i15855.check
@@ -1,0 +1,11 @@
+default
+List()
+other
+asdf
+420
+21.37
+1
+2
+3
+4
+5

--- a/tests/run/i15855.scala
+++ b/tests/run/i15855.scala
@@ -1,0 +1,82 @@
+class MyFunction1()
+
+trait MyFun1[+R] extends MyFunction1 {
+  def apply(i: Int): R
+}
+
+val myFun1: MyFun1[Int] = (i: Int) => 1
+
+//
+
+class MyFunction2(arg: String = "default") {
+  println(arg)
+}
+
+trait MyFun2[+R] extends MyFunction2 {
+  def apply(i: Int): R
+}
+
+val myFun2: MyFun2[Int] = (i: Int) => 2
+
+//
+
+class MyFunction3(arg: String*) {
+  println(arg)
+}
+
+trait MyFun3[+R] extends MyFunction3 {
+  def apply(i: Int): R
+}
+
+val myFun3: MyFun3[Int] = (i: Int) => 3
+
+//
+
+class MyFunction4(arg: String) {
+  println(arg)
+  def this() = {
+    this("other")
+  }
+}
+
+trait MyFun4[+R] extends MyFunction4 {
+  def apply(i: Int): R
+}
+
+val myFun4: MyFun4[Int] = (i: Int) => 4
+
+//
+
+class MyFunction5(arg: String = "asdf")(arg1: Int = 420, arg2: Double = 21.37) {
+  println(arg)
+  println(arg1)
+  println(arg2)
+}
+
+trait MyFun5[+R] extends MyFunction5 {
+  def apply(i: Int): R
+}
+
+val myFun5: MyFun5[Int] = (i: Int) => 5
+
+//
+
+trait Equiv[T] extends Any with Serializable {
+  def equiv(x: T, y: T): Boolean
+}
+
+def reference[T <: AnyRef]: Equiv[T] = { _ eq _ }
+def universal[T]: Equiv[T] = { _ == _ }
+def fromFunction[T](cmp: (T, T) => Boolean): Equiv[T] = {
+  (x, y) => cmp(x, y)
+}
+
+//
+
+object Test extends App {
+  println(myFun1(1))
+  println(myFun2(1))
+  println(myFun3(1))
+  println(myFun4(1))
+  println(myFun5(1))
+}


### PR DESCRIPTION
Previously creating ClassDefs of AnonClasses was only possible if the
parent class had a constructor with an empty parameter list. Otherwise,
the compiler would crash because of calling `asTerm` on a `NoSymbol`.
This PR adds logic that handles calling parent constructors with default
or repeated parameters. And also fails more gracefully if no instance can
be created.

fixes lampepfl#15855 (attempt 2)