### PR TITLE
Generalize named type arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -435,7 +435,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     ref(NamedType(sym.owner.thisType, sym.name, sym.denot))
 
   def placeholderTypeParam(using Context): Tree =
-    untpd.Ident(tpnme.USCOREkw).withType(NoType)
+    untpd.Ident(tpnme.USCOREkw).withType(defn.NothingType)
 
   private def followOuterLinks(t: Tree)(using Context) = t match {
     case t: This if ctx.erasedTypes && !(t.symbol == ctx.owner.enclosingClass || t.symbol.isStaticOwner) =>

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -434,6 +434,9 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def ref(sym: Symbol)(using Context): Tree =
     ref(NamedType(sym.owner.thisType, sym.name, sym.denot))
 
+  def placeholderTypeParam(using Context): Tree =
+    untpd.Ident(tpnme.USCOREkw).withType(NoType)
+
   private def followOuterLinks(t: Tree)(using Context) = t match {
     case t: This if ctx.erasedTypes && !(t.symbol == ctx.owner.enclosingClass || t.symbol.isStaticOwner) =>
       // after erasure outer paths should be respected

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -19,7 +19,7 @@ object Feature:
   private def deprecated(str: PreName): TermName =
     QualifiedName(nme.deprecated, str.toTermName)
 
-  private val namedTypeArguments = experimental("namedTypeArguments")
+  val namedTypeArguments = experimental("namedTypeArguments")
   private val genericNumberLiterals = experimental("genericNumberLiterals")
   val scala2macros = experimental("macros")
 
@@ -68,8 +68,6 @@ object Feature:
   def dynamicsEnabled(using Context): Boolean = enabled(nme.dynamics)
 
   def dependentEnabled(using Context) = enabled(dependent)
-
-  def namedTypeArgsEnabled(using Context) = enabled(namedTypeArguments)
 
   def genericNumberLiteralsEnabled(using Context) = enabled(genericNumberLiterals)
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -127,7 +127,7 @@ class TastyPrinter(bytes: Array[Byte]) {
           tag match {
             case RENAMED =>
               printName(); printName()
-            case VALDEF | DEFDEF | TYPEDEF | TYPEPARAM | PARAM | NAMEDARG | BIND =>
+            case VALDEF | DEFDEF | TYPEDEF | TYPEPARAM | PARAM | BIND =>
               printName(); printTrees()
             case REFINEDtype | TERMREFin | TYPEREFin | SELECTin =>
               printName(); printTree(); printTrees()
@@ -149,7 +149,7 @@ class TastyPrinter(bytes: Array[Byte]) {
         }
         else if (tag >= firstNatASTTreeTag) {
           tag match {
-            case IDENT | IDENTtpt | SELECT | SELECTtpt | TERMREF | TYPEREF | SELFDEF => printName()
+            case IDENT | IDENTtpt | SELECT | SELECTtpt | TERMREF | TYPEREF | SELFDEF | NAMEDARG => printName()
             case _ => printNat()
           }
           printTree()

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1868,7 +1868,7 @@ object Parsers {
           )
         }
 
-      if (namedOK && in.token == IDENTIFIER)
+      if (namedOK && in.featureEnabled(Feature.namedTypeArguments) && in.token == IDENTIFIER)
         in.currentRegion.withCommasExpected {
           val start = in.offset
           argType() match {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1727,14 +1727,18 @@ object Parsers {
       if isSimpleLiteral then
         SingletonTypeTree(simpleLiteral())
       else if in.token == USCORE then
-        if ctx.settings.YkindProjector.value == "underscores" then
-          val start = in.skipToken()
+        val start = in.skipToken()
+        /*if location == Location.InPatternArgs then
+          typeBounds().withSpan(Span(start, in.lastOffset, start))
+        else */
+        if in.featureEnabled(Feature.namedTypeArguments)
+           || ctx.settings.YkindProjector.value == "underscores"
+        then
           Ident(tpnme.USCOREkw).withSpan(Span(start, in.lastOffset, start))
         else
           if sourceVersion.isAtLeast(future) then
             deprecationWarning(em"`_` is deprecated for wildcard arguments of types: use `?` instead")
             patch(source, Span(in.offset, in.offset + 1), "?")
-          val start = in.skipToken()
           typeBounds().withSpan(Span(start, in.lastOffset, start))
       // Allow symbols -_ and +_ through for compatibility with code written using kind-projector in Scala 3 underscore mode.
       // While these signify variant type parameters in Scala 2 + kind-projector, we ignore their variance markers since variance is inferred.

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1734,19 +1734,17 @@ object Parsers {
       if isSimpleLiteral then
         SingletonTypeTree(simpleLiteral())
       else if in.token == USCORE then
-        val start = in.skipToken()
-        /*if location == Location.InPatternArgs then
-          typeBounds().withSpan(Span(start, in.lastOffset, start))
-        else */
         if (in.featureEnabled(Feature.namedTypeArguments)
            || ctx.settings.YkindProjector.value == "underscores"
            ) && !inTypePattern
         then
+          val start = in.skipToken()
           Ident(tpnme.USCOREkw).withSpan(Span(start, in.lastOffset, start))
         else
-          if sourceVersion.isAtLeast(future) then
+          if !inTypePattern && sourceVersion.isAtLeast(future) then
             deprecationWarning(em"`_` is deprecated for wildcard arguments of types: use `?` instead")
             patch(source, Span(in.offset, in.offset + 1), "?")
+          val start = in.skipToken()
           typeBounds().withSpan(Span(start, in.lastOffset, start))
       // Allow symbols -_ and +_ through for compatibility with code written using kind-projector in Scala 3 underscore mode.
       // While these signify variant type parameters in Scala 2 + kind-projector, we ignore their variance markers since variance is inferred.

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -97,7 +97,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case AnonymousFunctionMissingParamTypeID // errorNumber: 81
   case SuperCallsNotAllowedInlineableID // errorNumber: 82
   case NotAPathID // errorNumber: 83
-  case WildcardOnTypeArgumentNotAllowedOnNewID // errorNumber: 84
+  case WildcardTypeArgumentNotAllowedID // errorNumber: 84
   case FunctionTypeNeedsNonEmptyParameterListID // errorNumber: 85
   case WrongNumberOfParametersID // errorNumber: 86
   case DuplicatePrivateProtectedQualifierID // errorNumber: 87

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -185,6 +185,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case TargetNameOnTopLevelClassID // errorNumber: 169
   case NotClassTypeID // errorNumber 170
   case MissingArgumentID // errorNumer 171
+  case MissingTypeArgumentID // errorNumer 172
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1443,6 +1443,11 @@ import cc.CaptureSet.IdentityCaptRefMap
       else s"missing argument for parameter $pname of $methString"
     def explain = ""
 
+  class MissingTypeArgument(pname: Name, tpe: Type)(using Context)
+    extends TypeMsg(MissingTypeArgumentID):
+    def msg = em"missing type argument for parameter $pname of type $tpe"
+    def explain = ""
+
   class DoesNotConformToBound(tpe: Type, which: String, bound: Type)(using Context)
     extends TypeMismatchMsg(
       if which == "lower" then bound else tpe,

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -173,8 +173,8 @@ import cc.CaptureSet.IdentityCaptRefMap
     def explain = ""
   }
 
-  class WildcardOnTypeArgumentNotAllowedOnNew()(using Context)
-  extends SyntaxMsg(WildcardOnTypeArgumentNotAllowedOnNewID) {
+  class WildcardTypeArgumentNotAllowed()(using Context)
+  extends SyntaxMsg(WildcardTypeArgumentNotAllowedID) {
     def msg = "Type argument must be fully defined"
     def explain =
       val code1: String =

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1111,7 +1111,7 @@ trait Applications extends Compatibility {
         val arg1 = typedType(arg0)
         cpy.NamedArg(arg)(id, arg1).withType(arg1.tpe)
       case arg if isPlaceHolderTypeParam(arg) =>
-        arg.withType(NoType)
+        arg.withType(defn.NothingType)
       case arg =>
         typedType(arg)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1110,6 +1110,8 @@ trait Applications extends Compatibility {
       case arg @ NamedArg(id, arg0) =>
         val arg1 = typedType(arg0)
         cpy.NamedArg(arg)(id, arg1).withType(arg1.tpe)
+      case arg if isPlaceHolderTypeParam(arg) =>
+        arg.withType(NoType)
       case arg =>
         typedType(arg)
     }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -153,8 +153,8 @@ object Checking {
         traverseChildren(tp)
     checker.traverse(tpt.tpe)
 
-  def checkNoWildcard(tree: Tree)(using Context): Tree = tree.tpe match {
-    case tpe: TypeBounds => errorTree(tree, "no wildcard type allowed here")
+  def checkNoWildcard(tree: Tree)(using Context): Tree = tree.typeOpt match {
+    case tpe: TypeBounds => errorTree(tree, WildcardTypeArgumentNotAllowed())
     case _ => tree
   }
 
@@ -169,9 +169,10 @@ object Checking {
    *  A NoType paramBounds is used as a sign that checking should be suppressed.
    */
   def preCheckKind(arg: Tree, paramBounds: Type)(using Context): Tree =
-    if (arg.tpe.widen.isRef(defn.NothingClass) ||
-        !paramBounds.exists ||
-        arg.tpe.hasSameKindAs(paramBounds.bounds.hi)) arg
+    if arg.tpe.widen.isRef(defn.NothingClass)
+      || !paramBounds.exists
+      || arg.tpe.hasSameKindAs(paramBounds.bounds.hi)
+    then arg
     else errorTree(arg, em"Type argument ${arg.tpe} does not have the same kind as its bound $paramBounds")
 
   def preCheckKinds(args: List[Tree], paramBoundss: List[Type])(using Context): List[Tree] = {

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -636,7 +636,12 @@ object ProtoTypes {
     override def resultType(using Context): Type = resType
 
     def canInstantiate(tp: Type)(using Context) = tp.widen match
-      case tp: PolyType => tp.paramNames.length == targs.length
+      case tp: PolyType =>
+        if isNamedArg(targs.head) then
+          targs.forall {
+            case NamedArg(name, _) => tp.paramNames.contains(name)
+          }
+        else tp.paramNames.length == targs.length
       case _ => false
 
     override def isMatchedBy(tp: Type, keepConstraint: Boolean)(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2015,8 +2015,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     else {
       var args = tree.args
       if isNamedArgs(args) then
-        args = untpd.reorderArgs(tparams.map(_.paramName), tree.args,
-            untpd.TypedSplice(placeholderTypeParam))
+        args = untpd.reorderArgs(tparams.map(_.paramName), tree.args, placeholderTypeParam)
       val args1 = {
         if (args.length != tparams.length) {
           wrongNumberOfTypeArgs(tpt1.tpe, tparams, args, tree.srcPos)
@@ -2076,7 +2075,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 // wildcard identifiers `_` instead.
                 TypeTree(tparamBounds).withSpan(arg.span)
               case _ =>
-                typedType(desugaredArg, argPt, mapPatternBounds = true)
+                if isPlaceHolderTypeParam(arg) then arg.withType(NoType)
+                else typedType(desugaredArg, argPt, mapPatternBounds = true)
             }
           else desugaredArg.withType(UnspecifiedErrorType)
         }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2075,7 +2075,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 // wildcard identifiers `_` instead.
                 TypeTree(tparamBounds).withSpan(arg.span)
               case _ =>
-                if isPlaceHolderTypeParam(arg) then arg.withType(NoType)
+                if isPlaceHolderTypeParam(arg) then arg.withType(defn.NothingType)
                 else typedType(desugaredArg, argPt, mapPatternBounds = true)
             }
           else desugaredArg.withType(UnspecifiedErrorType)

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -656,7 +656,8 @@ object TastyFormat {
        | ANNOTATEDtpt
        | BYNAMEtpt
        | MATCHtpt
-       | BIND => true
+       | BIND
+       | NAMEDARG => true
     case _ => false
   }
 

--- a/tests/neg/i7751.scala
+++ b/tests/neg/i7751.scala
@@ -1,3 +1,3 @@
 import language.experimental.fewerBraces
-val a = Some(a=a,)=> // error // error
+val a = Some(a=a,)=> // error // error // error
 val a = Some(x=y,)=>

--- a/tests/neg/named-typeargs-2.check
+++ b/tests/neg/named-typeargs-2.check
@@ -1,0 +1,16 @@
+-- [E172] Type Error: tests/neg/named-typeargs-2.scala:7:36 ------------------------------------------------------------
+7 |class Bar1 extends Foo[Map[Key = Int]] // error
+  |                                    ^
+  |                                    missing type argument for parameter Value of type Map
+-- [E172] Type Error: tests/neg/named-typeargs-2.scala:8:38 ------------------------------------------------------------
+8 |class Bar2 extends Foo[Map[Value = Int]] // error
+  |                                      ^
+  |                                      missing type argument for parameter Key of type Map
+-- [E172] Type Error: tests/neg/named-typeargs-2.scala:9:48 ------------------------------------------------------------
+9 |class Bar5 extends Foo[Tuple3[T1 = Int, T3 = Int]] // error
+  |                                                ^
+  |                                                missing type argument for parameter T2 of type Tuple3
+-- [E172] Type Error: tests/neg/named-typeargs-2.scala:10:48 -----------------------------------------------------------
+10 |class Bar8 extends Foo[Baz[F = Int => _, B = Int]] // error
+   |                                                ^
+   |                                                missing type argument for parameter A of type Baz

--- a/tests/neg/named-typeargs-2.scala
+++ b/tests/neg/named-typeargs-2.scala
@@ -1,0 +1,10 @@
+import language.experimental.namedTypeArguments
+
+class Map[Key, Value](elems: (Key, Value)*)
+trait Foo[F[_]]
+trait Baz[F[_], A, B]
+
+class Bar1 extends Foo[Map[Key = Int]] // error
+class Bar2 extends Foo[Map[Value = Int]] // error
+class Bar5 extends Foo[Tuple3[T1 = Int, T3 = Int]] // error
+class Bar8 extends Foo[Baz[F = Int => _, B = Int]] // error

--- a/tests/neg/named-typeargs.check
+++ b/tests/neg/named-typeargs.check
@@ -6,6 +6,10 @@
 13 |  val xs4 = construct[List, Elem = Int]() // error // error
    |                                 ^
    |                                 ']' expected, but '=' found
+-- [E040] Syntax Error: tests/neg/named-typeargs.scala:28:17 -----------------------------------------------------------
+28 |type T = Foo[(T1 = Int)] // error // error
+   |                 ^
+   |                 ')' expected, but '=' found
 -- [E101] Syntax Error: tests/neg/named-typeargs.scala:7:35 ------------------------------------------------------------
 7 |  val xs1 = construct[Coll = List, Coll = Seq](1, 2, 3) // error
   |                                   ^^^^^^^^^^
@@ -58,5 +62,11 @@
    |                                            ^^^^^^^^
    |                                            Found:    (String, Int)
    |                                            Required: (Int, Int)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/named-typeargs.scala:28:14 --------------------------------------------------------
+28 |type T = Foo[(T1 = Int)] // error // error
+   |              ^^
+   |              Not found: type T1
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg/named-typeargs.check
+++ b/tests/neg/named-typeargs.check
@@ -6,8 +6,8 @@
 13 |  val xs4 = construct[List, Elem = Int]() // error // error
    |                                 ^
    |                                 ']' expected, but '=' found
--- [E040] Syntax Error: tests/neg/named-typeargs.scala:28:17 -----------------------------------------------------------
-28 |type T = Foo[(T1 = Int)] // error // error
+-- [E040] Syntax Error: tests/neg/named-typeargs.scala:29:17 -----------------------------------------------------------
+29 |type T = Foo[(T1 = Int)] // error // error
    |                 ^
    |                 ')' expected, but '=' found
 -- [E101] Syntax Error: tests/neg/named-typeargs.scala:7:35 ------------------------------------------------------------
@@ -64,8 +64,8 @@
    |                                            Required: (Int, Int)
    |
    | longer explanation available when compiling with `-explain`
--- [E006] Not Found Error: tests/neg/named-typeargs.scala:28:14 --------------------------------------------------------
-28 |type T = Foo[(T1 = Int)] // error // error
+-- [E006] Not Found Error: tests/neg/named-typeargs.scala:29:14 --------------------------------------------------------
+29 |type T = Foo[(T1 = Int)] // error // error
    |              ^^
    |              Not found: type T1
    |

--- a/tests/neg/named-typeargs.check
+++ b/tests/neg/named-typeargs.check
@@ -1,0 +1,62 @@
+-- Error: tests/neg/named-typeargs.scala:11:38 -------------------------------------------------------------------------
+11 |  val xs3 = construct[Coll = List, Int](1, 2, 3) // error
+   |                                      ^
+   |                                      `=` expected
+-- [E040] Syntax Error: tests/neg/named-typeargs.scala:13:33 -----------------------------------------------------------
+13 |  val xs4 = construct[List, Elem = Int]() // error // error
+   |                                 ^
+   |                                 ']' expected, but '=' found
+-- [E101] Syntax Error: tests/neg/named-typeargs.scala:7:35 ------------------------------------------------------------
+7 |  val xs1 = construct[Coll = List, Coll = Seq](1, 2, 3) // error
+  |                                   ^^^^^^^^^^
+  |                                   Type parameter Coll was defined multiple times.
+-- [E102] Syntax Error: tests/neg/named-typeargs.scala:9:22 ------------------------------------------------------------
+9 |  val xs2 = construct[C = List](1, 2, 3) // error
+  |                      ^^^^^^^^
+  |                      Type parameter C is undefined. Expected one of Elem, Coll.
+-- [E006] Not Found Error: tests/neg/named-typeargs.scala:13:28 --------------------------------------------------------
+13 |  val xs4 = construct[List, Elem = Int]() // error // error
+   |                            ^^^^
+   |                            Not found: type Elem
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E056] Syntax Error: tests/neg/named-typeargs.scala:17:8 ------------------------------------------------------------
+17 |val m1: Map[Key = Int] = ???   // error
+   |        ^^^^^^^^^^^^^^
+   |        Missing type parameter for [Value] =>> Map[Int, Value]
+-- [E056] Syntax Error: tests/neg/named-typeargs.scala:18:8 ------------------------------------------------------------
+18 |val m2: Map[Value = String] = ??? // error
+   |        ^^^^^^^^^^^^^^^^^^^
+   |        Missing type parameter for [Key] =>> Map[Key, String]
+-- [E101] Syntax Error: tests/neg/named-typeargs.scala:19:23 -----------------------------------------------------------
+19 |val m3: Map[Key = Int, Key = String] = ??? // error
+   |                       ^^^^^^^^^^^^
+   |                       Type parameter Key was defined multiple times.
+-- [E102] Syntax Error: tests/neg/named-typeargs.scala:20:12 -----------------------------------------------------------
+20 |val m4: Map[K = Int, Key = String, Value = Int] = ??? // error
+   |            ^^^^^^^
+   |            Type parameter K is undefined. Expected one of Key, Value.
+-- [E102] Syntax Error: tests/neg/named-typeargs.scala:23:20 -----------------------------------------------------------
+23 |def test2 = new Map[C = String, Value = Int]("a" -> 1) // error
+   |                    ^^^^^^^^^^
+   |                    Type parameter C is undefined. Expected one of Key, Value.
+-- [E084] Syntax Error: tests/neg/named-typeargs.scala:24:26 -----------------------------------------------------------
+24 |def test3 = new Map[Key = _, Value = Int]("a" -> 1) // error // error
+   |                          ^
+   |                          Type argument must be fully defined
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/named-typeargs.scala:24:42 ----------------------------------------------------
+24 |def test3 = new Map[Key = _, Value = Int]("a" -> 1) // error // error
+   |                                          ^^^^^^^^
+   |                                          Found:    (String, Int)
+   |                                          Required: (Nothing, Int)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/named-typeargs.scala:25:44 ----------------------------------------------------
+25 |def test4 = new Map[Value = Int, Key = Int]("a" -> 1) // error
+   |                                            ^^^^^^^^
+   |                                            Found:    (String, Int)
+   |                                            Required: (Int, Int)
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/named-typeargs.check
+++ b/tests/neg/named-typeargs.check
@@ -41,13 +41,13 @@
    |                    ^^^^^^^^^^
    |                    Type parameter C is undefined. Expected one of Key, Value.
 -- [E084] Syntax Error: tests/neg/named-typeargs.scala:24:26 -----------------------------------------------------------
-24 |def test3 = new Map[Key = _, Value = Int]("a" -> 1) // error // error
+24 |def test3 = new Map[Key = ?, Value = Int]("a" -> 1) // error // error
    |                          ^
    |                          Type argument must be fully defined
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg/named-typeargs.scala:24:42 ----------------------------------------------------
-24 |def test3 = new Map[Key = _, Value = Int]("a" -> 1) // error // error
+24 |def test3 = new Map[Key = ?, Value = Int]("a" -> 1) // error // error
    |                                          ^^^^^^^^
    |                                          Found:    (String, Int)
    |                                          Required: (Nothing, Int)

--- a/tests/neg/named-typeargs.scala
+++ b/tests/neg/named-typeargs.scala
@@ -25,4 +25,5 @@ def test3 = new Map[Key = ?, Value = Int]("a" -> 1) // error // error
 def test4 = new Map[Value = Int, Key = Int]("a" -> 1) // error
 
 trait Foo[F[_]]
+
 type T = Foo[(T1 = Int)] // error // error

--- a/tests/neg/named-typeargs.scala
+++ b/tests/neg/named-typeargs.scala
@@ -1,0 +1,26 @@
+import language.experimental.namedTypeArguments
+
+object t1:
+
+  def construct[Elem, Coll[_]](xs: Elem*): Coll[Elem] = ???
+
+  val xs1 = construct[Coll = List, Coll = Seq](1, 2, 3) // error
+
+  val xs2 = construct[C = List](1, 2, 3) // error
+
+  val xs3 = construct[Coll = List, Int](1, 2, 3) // error
+
+  val xs4 = construct[List, Elem = Int]() // error // error
+
+class Map[Key, Value](elems: (Key, Value)*)
+
+val m1: Map[Key = Int] = ???   // error
+val m2: Map[Value = String] = ??? // error
+val m3: Map[Key = Int, Key = String] = ??? // error
+val m4: Map[K = Int, Key = String, Value = Int] = ??? // error
+
+def test = new Map("a" -> 1)
+def test2 = new Map[C = String, Value = Int]("a" -> 1) // error
+def test3 = new Map[Key = _, Value = Int]("a" -> 1) // error // error
+def test4 = new Map[Value = Int, Key = Int]("a" -> 1) // error
+

--- a/tests/neg/named-typeargs.scala
+++ b/tests/neg/named-typeargs.scala
@@ -24,3 +24,5 @@ def test2 = new Map[C = String, Value = Int]("a" -> 1) // error
 def test3 = new Map[Key = ?, Value = Int]("a" -> 1) // error // error
 def test4 = new Map[Value = Int, Key = Int]("a" -> 1) // error
 
+trait Foo[F[_]]
+type T = Foo[(T1 = Int)] // error // error

--- a/tests/neg/named-typeargs.scala
+++ b/tests/neg/named-typeargs.scala
@@ -21,6 +21,6 @@ val m4: Map[K = Int, Key = String, Value = Int] = ??? // error
 
 def test = new Map("a" -> 1)
 def test2 = new Map[C = String, Value = Int]("a" -> 1) // error
-def test3 = new Map[Key = _, Value = Int]("a" -> 1) // error // error
+def test3 = new Map[Key = ?, Value = Int]("a" -> 1) // error // error
 def test4 = new Map[Value = Int, Key = Int]("a" -> 1) // error
 

--- a/tests/neg/namedTypeParams.scala
+++ b/tests/neg/namedTypeParams.scala
@@ -8,15 +8,9 @@ object Test0:
 object Test {
   import language.experimental.namedTypeArguments
 
-  val x: C[T = Int] = // error:  ']' expected, but `=` found // error
-    new C[T = Int] // error:  ']' expected, but `=` found // error
-
-  class E extends C[T = Int] // error: ']' expected, but `=` found // error
-  class F extends C[T = Int]() // error: ']' expected, but `=` found // error
-
   def f[X, Y](x: X, y: Y): Int = ???
 
-  f[X = Int, String](1, "") // error // error
+  f[X = Int, String](1, "") // error
   f[X = Int][X = Int][Y = String](1, "") // error: illegal repeated type application
 
   f[X = Int][Y = String](1, "") // error: illegal repeated type application

--- a/tests/neg/placeholder-typeargs.check
+++ b/tests/neg/placeholder-typeargs.check
@@ -1,0 +1,16 @@
+-- [E056] Syntax Error: tests/neg/placeholder-typeargs.scala:5:8 -------------------------------------------------------
+5 |val m1: Map[Int, _] = ???   // error
+  |        ^^^^^^^^^^^
+  |        Missing type parameter for [Value] =>> Map[Int, Value]
+-- [E056] Syntax Error: tests/neg/placeholder-typeargs.scala:6:8 -------------------------------------------------------
+6 |val m2: Map[_, String] = ??? // error
+  |        ^^^^^^^^^^^^^^
+  |        Missing type parameter for [Key] =>> Map[Key, String]
+-- [E023] Syntax Error: tests/neg/placeholder-typeargs.scala:7:8 -------------------------------------------------------
+7 |val m4: Map[Int, _, String] = ??? // error
+  |        ^^^^^^^^^^^^^^^^^^^
+  |        Too many type arguments for Map[Key, Value]
+  |        expected: [Key, Value]
+  |        actual:   [Int, _, String]
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/placeholder-typeargs.check
+++ b/tests/neg/placeholder-typeargs.check
@@ -14,3 +14,15 @@
   |        actual:   [Int, _, String]
   |
   | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/placeholder-typeargs.scala:9:10 --------------------------------------------------------------------
+9 |type E1 = Either[Int, _] // error
+  |          ^^^^^^^^^^^^^^
+  |          type Either takes more type parameters
+-- Error: tests/neg/placeholder-typeargs.scala:10:10 -------------------------------------------------------------------
+10 |type E2 = Either[_, String] // error
+   |          ^^^^^^^^^^^^^^^^^
+   |          type Either takes more type parameters
+-- Error: tests/neg/placeholder-typeargs.scala:11:20 -------------------------------------------------------------------
+11 |type E3 = Either[_, List] // error
+   |                    ^^^^
+   |                    Type argument List does not have the same kind as its bound 

--- a/tests/neg/placeholder-typeargs.scala
+++ b/tests/neg/placeholder-typeargs.scala
@@ -1,0 +1,8 @@
+import language.experimental.namedTypeArguments
+
+class Map[Key, Value](elems: (Key, Value)*)
+
+val m1: Map[Int, _] = ???   // error
+val m2: Map[_, String] = ??? // error
+val m4: Map[Int, _, String] = ??? // error
+

--- a/tests/neg/placeholder-typeargs.scala
+++ b/tests/neg/placeholder-typeargs.scala
@@ -6,3 +6,6 @@ val m1: Map[Int, _] = ???   // error
 val m2: Map[_, String] = ??? // error
 val m4: Map[Int, _, String] = ??? // error
 
+type E1 = Either[Int, _] // error
+type E2 = Either[_, String] // error
+type E3 = Either[_, List] // error

--- a/tests/pos/gadt-GadtStlc.scala
+++ b/tests/pos/gadt-GadtStlc.scala
@@ -101,7 +101,7 @@ object GadtStlc {
   case class ISLAMBDAC[X, E]() extends ISLAMBDA[Abs[Var[X], E]]
 
   // evidence that E reduces
-  type REDUCES[E] = REDUDER[E, _]
+  type REDUCES[E] = REDUDER[E, ?]
 
   def followsIsLambda[G, V, TY1, TY2](
     isval: ISVAL[V],

--- a/tests/pos/named-typeargs.scala
+++ b/tests/pos/named-typeargs.scala
@@ -43,10 +43,9 @@ object constrs:
   class F extends C[B = Int, A = String]("A")
 
 trait Foo[F[_]]
-trait Qux[F[_, _]]
 trait Baz[F[_], A, B]
 
-class Bar1 extends Foo[Map[Key = Int]]
-class Bar2 extends Foo[Map[Value = Int]]
-class Bar5 extends Foo[Tuple3[T1 = Int, T3 = Int]]
-class Bar8 extends Foo[Baz[F = Int => _, B = Int]]
+class Bar1 extends Foo[F = Map[Int, _]]
+class Bar2 extends Foo[F = Map[_, Int]]
+class Bar5 extends Foo[F = Tuple3[Int, _, Int]]
+class Bar8 extends Foo[[X] =>> Baz[F = Int => _, A = X, B = Int]]

--- a/tests/pos/named-typeargs.scala
+++ b/tests/pos/named-typeargs.scala
@@ -1,7 +1,6 @@
 import language.experimental.namedTypeArguments
-package namedTypeArgsR {
 
-object t1 {
+object t1:
 
   def construct[Elem, Coll[_]](xs: Elem*): Coll[Elem] = ???
 
@@ -9,6 +8,36 @@ object t1 {
 
   val xs2 = construct[Coll = List, Elem = Int](1, 2, 3)
 
-}
+class Map[Key, Value](elems: (Key, Value)*)
 
-}
+val m: Map[Value = String, Key = Int] = new Map(1 -> "")
+
+def test = new Map("a" -> 1)
+def test2 = new Map[String, Int]("a" -> 1)
+def test3 = new Map[Key = String]("a" -> 1)
+def test4 = new Map[Value = Int]("a" -> 1)
+
+class SubMap extends Map[Value = String](1 -> "")
+
+object overloaded:
+  def construct[Elem, Coll[_]](xs: Elem*): Coll[Elem] = ???
+  def construct[C[_], E](xs: E*): Int = ???
+  def construct[Coll[_], E](x: E, z: Boolean): Boolean = ???
+
+  val xs1 = construct[Coll = List](1, 2, 3)
+  val _ : List[Int] = xs1
+  val xs2 = construct[C = List](1, 2, 3)
+  val _ : Int = xs2
+  val xs3 = construct[Coll = List, Elem = Int](1, 2, 3)
+  val _ : List[Int] = xs3
+  val xs4 = construct[Coll = List](1, true)
+  val _ : Boolean = xs4
+
+
+object constrs:
+  class C[A, B](x: A)
+  val x: C[B = Int, A = Int] =
+    new C[B = Int](1)
+
+  class E extends C[B = Int]("A")
+  class F extends C[B = Int, A = String]("A")

--- a/tests/pos/named-typeargs.scala
+++ b/tests/pos/named-typeargs.scala
@@ -41,3 +41,12 @@ object constrs:
 
   class E extends C[B = Int]("A")
   class F extends C[B = Int, A = String]("A")
+
+trait Foo[F[_]]
+trait Qux[F[_, _]]
+trait Baz[F[_], A, B]
+
+class Bar1 extends Foo[Map[Key = Int]]
+class Bar2 extends Foo[Map[Value = Int]]
+class Bar5 extends Foo[Tuple3[T1 = Int, T3 = Int]]
+class Bar8 extends Foo[Baz[F = Int => _, B = Int]]

--- a/tests/pos/placeholder-typeargs.scala
+++ b/tests/pos/placeholder-typeargs.scala
@@ -1,0 +1,31 @@
+import language.experimental.namedTypeArguments
+
+object t1:
+
+  def construct[Elem, Coll[_]](xs: Elem*): Coll[Elem] = ???
+
+  val xs = construct[_, List](1, 2, 3)
+
+class Map[Key, Value](elems: (Key, Value)*)
+
+def test3 = new Map[String, _]("a" -> 1)
+def test4 = new Map[_, Int]("a" -> 1)
+
+class SubMap extends Map[_, String](1 -> "")
+
+object overloaded:
+  def construct[Elem, Coll[_]](xs: Elem*): Coll[Elem] = ???
+  def construct[Coll[_], E](x: E, z: Boolean): Boolean = ???
+
+  val xs1 = construct[_, List](1, 2, 3)
+  val _ : List[Int] = xs1
+  val xs4 = construct[List, _](1, true)
+  val _ : Boolean = xs4
+
+
+object constrs:
+  class C[A, B](x: A)
+  val x: C[Int, Int] =
+    new C[_, Int](1)
+
+  class E extends C[_, Int]("A")

--- a/tests/pos/placeholder-typeargs.scala
+++ b/tests/pos/placeholder-typeargs.scala
@@ -29,3 +29,15 @@ object constrs:
     new C[_, Int](1)
 
   class E extends C[_, Int]("A")
+
+trait Foo[F[_]]
+trait Qux[F[_, _]]
+trait Baz[F[_], A, B]
+
+class Bar1 extends Foo[Either[Int, _]]
+class Bar2 extends Foo[Either[_, Int]]
+class Bar3 extends Foo[_ => Int]
+class Bar4 extends Foo[Int => _]
+class Bar5 extends Foo[(Int, _, Int)]
+class Bar8 extends Foo[Baz[Int => _, _, Int]]
+


### PR DESCRIPTION
 - Also allow named type arguments in applied types and
   new expressions
 - Allow named type arguments in overloaded method calls
 - Introduce placeholder syntax `_` to express a missing
   argument without resorting to named type arguments
