### PR TITLE
Allow import language.experimental.captureChecking in the REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -31,8 +31,6 @@ object Feature:
   val pureFunctions = experimental("pureFunctions")
   val captureChecking = experimental("captureChecking")
 
-  val globalOnlyImports: Set[TermName] = Set(pureFunctions, captureChecking)
-
   /** Is `feature` enabled by by a command-line setting? The enabling setting is
    *
    *       -language:<prefix>feature

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -16,6 +16,8 @@ import ast.untpd
 import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, ReusableInstance}
 import typer.{Implicits, ImportInfo, SearchHistory, SearchRoot, TypeAssigner, Typer, Nullables}
 import inlines.Inliner
+import ast.{tpd, untpd}
+import config.Feature
 import Nullables._
 import Implicits.ContextualImplicits
 import config.Settings._
@@ -648,6 +650,14 @@ object Contexts {
         case Some(false) if ctx.settings.YexplicitNulls.value =>
           setMode(this.mode | Mode.SafeNulls)
         case _ =>
+
+      importInfo.qualifier match
+        case ref: untpd.RefTree =>
+          val prefix = ref.name.asTermName
+          for case untpd.ImportSelector(untpd.Ident(imported), untpd.EmptyTree, _) <- importInfo.selectors do
+            Feature.handleGlobalLanguageImport(prefix, imported)
+        case _ => ()
+
       updateStore(importInfoLoc, importInfo)
     def setTypeAssigner(typeAssigner: TypeAssigner): this.type = updateStore(typeAssignerLoc, typeAssigner)
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -30,7 +30,7 @@ import scala.annotation.tailrec
 import rewrites.Rewrites.{patch, overlapsPatch}
 import reporting._
 import config.Feature
-import config.Feature.{sourceVersion, migrateTo3, globalOnlyImports}
+import config.Feature.{sourceVersion, migrateTo3}
 import config.SourceVersion._
 import config.SourceVersion
 


### PR DESCRIPTION
Attempt to fix #16250 with @rjolly during the issue spree.

Two things currently seem to prevent `import language.experimental.captureChecking` to be used in the REPL.

### 1. `needsCaptureChecking` flag preservation across compilation units

The `needsCaptureChecking` is defined here:
https://github.com/scala/scala3/blob/b5941e4c55c45b8e3ba2f23ef9e82dfc76629a2f/compiler/src/dotty/tools/dotc/CompilationUnit.scala#L57

And is set from `handleGlobalLanguageImport`:

https://github.com/scala/scala3/blob/b5941e4c55c45b8e3ba2f23ef9e82dfc76629a2f/compiler/src/dotty/tools/dotc/config/Feature.scala#L153

To preserve it, we tried calling `handleGlobalLanguageImport` in `setImportInfo` (4702968c5ea1c29cc6b07b0f49c06e9e526cdae8).

### 2. outermost syntax errror

Currently, a syntax error is emitted if the import is not at the top level:

https://github.com/scala/scala3/blob/b5941e4c55c45b8e3ba2f23ef9e82dfc76629a2f/compiler/src/dotty/tools/dotc/parsing/Parsers.scala#L3312-L3313

Outermost is originally set here:

https://github.com/scala/scala3/blob/b5941e4c55c45b8e3ba2f23ef9e82dfc76629a2f/compiler/src/dotty/tools/dotc/parsing/Parsers.scala#L764

We are not sure yet if and how we should special-case this flag so that it works with wrapper objects generated by the REPL.