### PR TITLE
Match capability class as `CapturingType`

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -656,7 +656,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           expected
 
     /** Adapt `actual` type to `expected` type by inserting boxing and unboxing conversions
-     * 
+     *
      *  @param alwaysConst  always make capture set variables constant after adaptation
      */
     def adaptBoxed(actual: Type, expected: Type, pos: SrcPos, alwaysConst: Boolean = false)(using Context): Type =

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -12,6 +12,7 @@ import transform.Recheck.*
 import CaptureSet.IdentityCaptRefMap
 import Synthetics.isExcluded
 import util.Property
+import reporting.trace
 
 /** A tree traverser that prepares a compilation unit to be capture checked.
  *  It does the following:
@@ -408,8 +409,12 @@ extends tpd.TreeTraverser:
         traverse(tree.rhs)
       case tree @ TypeApply(fn, args) =>
         traverse(fn)
+        val isErasedValue = fn match
+          case Ident(tp) =>
+            fn.symbol eq defn.Compiletime_erasedValue
+          case _ => false
         for case arg: TypeTree <- args do
-          transformTT(arg, boxed = true, exact = false) // type arguments in type applications are boxed
+          transformTT(arg, boxed = !isErasedValue, exact = false) // type arguments in type applications are boxed
       case _ =>
         traverseChildren(tree)
     tree match

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1185,7 +1185,7 @@ class Definitions {
    */
   object ByNameFunction:
     def apply(tp: Type)(using Context): Type = tp match
-      case tp @ EventuallyCapturingType(tp1, refs) if tp.annot.symbol == RetainsByNameAnnot =>
+      case tp @ EventuallyCapturingType.Annotated(tp1, refs) if tp.annot.symbol == RetainsByNameAnnot =>
         CapturingType(apply(tp1), refs)
       case _ =>
         defn.ContextFunction0.typeRef.appliedTo(tp :: Nil)

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -377,6 +377,9 @@ object Flags {
   /** Symbol cannot be found as a member during typer */
   val (Invisible @ _, _, _) = newFlags(45, "<invisible>")
 
+  /** Symbol represents the pure base class of a capability class */
+  val (CapabilityBase @ _, _, _) = newFlags(46, "<capability-base>")
+
   // ------------ Flags following this one are not pickled ----------------------------------
 
   /** Symbol is not a member of its owner */

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2238,7 +2238,7 @@ object SymDenotations {
           case tp: TypeParamRef =>  // uncachable, since baseType depends on context bounds
             recur(TypeComparer.bounds(tp).hi)
 
-          case CapturingType(parent, refs) =>
+          case CapturingType.Annotated(parent, refs) =>
             tp.derivedCapturingType(recur(parent), refs)
 
           case tp: TypeProxy =>

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -296,7 +296,7 @@ object TypeOps:
       tp1 match {
         case tp1: RecType =>
           return tp1.rebind(approximateOr(tp1.parent, tp2))
-        case CapturingType(parent1, refs1) =>
+        case CapturingType.Annotated(parent1, refs1) =>
           return tp1.derivedCapturingType(approximateOr(parent1, tp2), refs1)
         case err: ErrorType =>
           return err
@@ -305,7 +305,7 @@ object TypeOps:
       tp2 match {
         case tp2: RecType =>
           return tp2.rebind(approximateOr(tp1, tp2.parent))
-        case CapturingType(parent2, refs2) =>
+        case CapturingType.Annotated(parent2, refs2) =>
           return tp2.derivedCapturingType(approximateOr(tp1, parent2), refs2)
         case err: ErrorType =>
           return err

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4974,7 +4974,7 @@ object Types {
           else if (clsd.is(Module)) givenSelf
           else if (ctx.erasedTypes) appliedRef
           else givenSelf match
-            case givenSelf @ EventuallyCapturingType(tp, _) =>
+            case givenSelf @ EventuallyCapturingType.Annotated(tp, _) =>
               givenSelf.derivedAnnotatedType(tp & appliedRef, givenSelf.annot)
             case _ =>
               AndType(givenSelf, appliedRef)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -242,7 +242,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
           ~ (Str(": ") provided !tp.resultType.isInstanceOf[MethodOrPoly])
           ~ toText(tp.resultType)
         }
-      case ExprType(ct @ EventuallyCapturingType(parent, refs))
+      case ExprType(ct @ EventuallyCapturingType.Annotated(parent, refs))
       if ct.annot.symbol == defn.RetainsByNameAnnot =>
         if refs.isUniversal then changePrec(GlobalPrec) { "=> " ~ toText(parent) }
         else toText(CapturingType(ExprType(parent), refs))

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -288,11 +288,14 @@ abstract class Recheck extends Phase, SymTransformer:
           assert(false, i"unexpected type of ${tree.fun}: $funtpe")
 
     def recheckTypeApply(tree: TypeApply, pt: Type)(using Context): Type =
-      recheck(tree.fun).widen match
+      val tp = recheck(tree.fun)
+      tp.widen match
         case fntpe: PolyType =>
           assert(fntpe.paramInfos.hasSameLengthAs(tree.args))
           val argTypes = tree.args.map(recheck(_))
           constFold(tree, fntpe.instantiate(argTypes))
+        case otherTp =>
+          assert(false, i"unexpected function type when checking $tree, $tp ~~> $otherTp")
 
     def recheckTyped(tree: Typed)(using Context): Type =
       val tptType = recheck(tree.tpt)

--- a/compiler/test/dotty/tools/dotc/Playground.scala
+++ b/compiler/test/dotty/tools/dotc/Playground.scala
@@ -4,10 +4,10 @@ import dotty.tools.vulpix._
 import org.junit.Test
 import org.junit.Ignore
 
-@Ignore class Playground:
+class Playground:
   import TestConfiguration._
   import CompilationTests._
 
   @Test def example: Unit =
     implicit val testGroup: TestGroup = TestGroup("playground")
-    compileFile("tests/playground/example.scala", defaultOptions).checkCompile()
+    compileFile("/Users/linyxus/Workspace/dotty/issues/real-try.scala", defaultOptions).checkCompile()

--- a/tests/neg-custom-args/captures/curried-simplified.check
+++ b/tests/neg-custom-args/captures/curried-simplified.check
@@ -15,28 +15,40 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:11:39 ---------------------------
 11 |  def y3: Cap -> Protect[Int -> Int] = x3 // error
    |                                       ^^
-   |                                       Found:    ? (x$0: Cap) -> {x$0} Int -> Int
-   |                                       Required: Cap -> Protect[Int -> Int]
+   |                                       Found:    ? (x$0: {*} Cap) -> {x$0} Int -> Int
+   |                                       Required: Cap² -> Protect[Int -> Int]
+   |
+   |                                       where:    Cap  is a class
+   |                                                 Cap² is a class
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:15:33 ---------------------------
 15 |  def y5: Cap -> {} Int -> Int = x5 // error
    |                                 ^^
-   |                                 Found:    ? Cap -> {x} Int -> Int
-   |                                 Required: Cap -> {} Int -> Int
+   |                                 Found:    ? ({*} Cap) -> {x} Int -> Int
+   |                                 Required: Cap² -> {} Int -> Int
+   |
+   |                                 where:    Cap  is a class
+   |                                           Cap² is a class
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:17:49 ---------------------------
 17 |  def y6: Cap -> {} Cap -> Protect[Int -> Int] = x6 // error
    |                                                 ^^
-   |                                             Found:    ? (x$0: Cap) -> {x$0} (x$0: Cap) -> {x$0, x$0} Int -> Int
-   |                                             Required: Cap -> {} Cap -> Protect[Int -> Int]
+   |                                     Found:    ? (x$0: {*} Cap) -> {x$0} (x$0: {*} Cap) -> {x$0, x$0} Int -> Int
+   |                                     Required: Cap² -> {} Cap² -> Protect[Int -> Int]
+   |
+   |                                     where:    Cap  is a class
+   |                                               Cap² is a class
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/curried-simplified.scala:19:49 ---------------------------
 19 |  def y7: Cap -> Protect[Cap -> {} Int -> Int] = x7 // error
    |                                                 ^^
-   |                                                 Found:    ? (x$0: Cap) -> {x$0} (x: Cap) -> {x$0, x} Int -> Int
-   |                                                 Required: Cap -> Protect[Cap -> {} Int -> Int]
+   |                                         Found:    ? (x$0: {*} Cap) -> {x$0} (x: {*} Cap) -> {x$0, x} Int -> Int
+   |                                         Required: Cap² -> Protect[Cap² -> {} Int -> Int]
+   |
+   |                                         where:    Cap  is a class
+   |                                                   Cap² is a class
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/pos-with-compiler-cc/dotc/config/WrappedProperties.scala
+++ b/tests/pos-with-compiler-cc/dotc/config/WrappedProperties.scala
@@ -30,7 +30,9 @@ trait WrappedProperties extends PropertiesTrait {
 object WrappedProperties {
   object AccessControl extends WrappedProperties {
     def wrap[T](body: => T): Option[T] =
-      try Some(body)
+      try
+        val result: T = body
+        Some(result)
       catch {
         // the actual exception we are concerned with is AccessControlException,
         // but that's deprecated on JDK 17, so catching its superclass is a convenient


### PR DESCRIPTION
This is an alternative to #16717.

It creates a symbol flagged as pure on-the-fly when pattern matching on capability classes.