### PR TITLE
Extend pattern type constraining to sealed hierarchies

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -563,6 +563,8 @@ object Flags {
   val JavaOrPrivateOrSynthetic: FlagSet      = Artifact | JavaDefined | Private | Synthetic
   val PrivateOrSynthetic: FlagSet            = Artifact | Private | Synthetic
   val EnumCase: FlagSet                      = Case | Enum
+  val CaseOrFinalOrSealed: FlagSet           = Case | Final | Sealed
+  val CaseOrSealed: FlagSet                  = Case | Sealed
   val CovariantLocal: FlagSet                = Covariant | Local                              // A covariant type parameter
   val ContravariantLocal: FlagSet            = Contravariant | Local                          // A contravariant type parameter
   val EffectivelyErased                      = ConstructorProxy | Erased

--- a/tests/neg/i18552.check
+++ b/tests/neg/i18552.check
@@ -8,6 +8,6 @@
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  | Refining a basetype of a case class is not allowed.
-  | This is a limitation that enables better GADT constraints in case class patterns
+  | Refining a basetype of a case class or a sealed trait (or a sealed class) is not allowed.
+  | This is a limitation that enables better GADT constraints in case class and sealed hierarchy patterns
    ---------------------------------------------------------------------------------------------------------------------

--- a/tests/pos/i4790.scala
+++ b/tests/pos/i4790.scala
@@ -1,0 +1,21 @@
+class Test:
+  def foo(as: Seq[Int]) =
+    val List(_, bs: _*) = as: @unchecked
+    val cs: Seq[Int] = bs
+
+class Test2:
+  def foo(as: SSeq[Int]) =
+    val LList(_, tail) = as: @unchecked
+    val cs: SSeq[Int] = tail
+
+trait SSeq[+A]
+sealed trait LList[+A] extends SSeq[A]
+final case class CCons[+A](head: A, tail: LList[A]) extends LList[A]
+case object NNil extends LList[Nothing]
+object LList:
+  def unapply[A](xs: LList[A]): Extractor[A] = Extractor[A](xs)
+  final class Extractor[A](private val xs: LList[A]) extends AnyVal:
+    def get: this.type   = this
+    def isEmpty: Boolean = xs.isInstanceOf[CCons[?]]
+    def _1: A            = xs.asInstanceOf[CCons[A]].head
+    def _2: SSeq[A]      = xs.asInstanceOf[CCons[A]].tail


### PR DESCRIPTION
Fixes #4790
Adds `sealed` to `case`, where #14820 looked to handle all classes.

Require sealed traits to be extended invariantly.