### PR TITLE
Warn if extension receiver already has member

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1355,7 +1355,7 @@ object SymDenotations {
      *  @param inClass   The class containing the result symbol's definition
      *  @param site      The base type from which member types are computed
      *
-     *  inClass <-- find denot.symbol      class C { <-- symbol is here
+     *  inClass <-- find denot.symbol      class C { <-- symbol is here }
      *
      *                   site: Subtype of both inClass and C
      */

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -207,6 +207,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case MatchTypeLegacyPatternID // errorNumber: 191
   case UnstableInlineAccessorID // errorNumber: 192
   case VolatileOnValID // errorNumber: 193
+  case ExtensionNullifiedByMemberID // errorNumber: 194
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2456,7 +2456,7 @@ class ExtensionNullifiedByMember(method: Symbol, target: Symbol)(using Context)
   def kind = MessageKind.PotentialIssue
   def msg(using Context) =
     i"""Extension method ${hl(method.name.toString)} will never be selected
-       |because ${hl(target.name.toString)} already has a member with the same name."""
+       |because ${hl(target.name.toString)} already has a member with the same name and compatible parameter types."""
   def explain(using Context) =
     i"""An extension method can be invoked as a regular method, but if that is intended,
        |it should not be defined as an extension.

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2451,6 +2451,17 @@ class SynchronizedCallOnBoxedClass(stat: tpd.Tree)(using Context)
         |you intended."""
 }
 
+class ExtensionNullifiedByMember(method: Symbol, target: Symbol)(using Context)
+  extends Message(ExtensionNullifiedByMemberID):
+  def kind = MessageKind.PotentialIssue
+  def msg(using Context) =
+    i"""Extension method ${hl(method.name.toString)} will never be selected
+       |because ${hl(target.name.toString)} already has a member with the same name."""
+  def explain(using Context) =
+    i"""An extension method can be invoked as a regular method, but if that is intended,
+       |it should not be defined as an extension.
+       |Although extensions can be overloaded, they do not overload existing member methods."""
+
 class TraitCompanionWithMutableStatic()(using Context)
   extends SyntaxMsg(TraitCompanionWithMutableStaticID) {
   def msg(using Context) = i"Companion of traits cannot define mutable @static fields"

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -346,6 +346,22 @@ object Applications {
     val flags2 = sym1.flags | NonMember // ensures Select typing doesn't let TermRef#withPrefix revert the type
     val sym2 = sym1.copy(info = methType, flags = flags2) // symbol not entered, to avoid overload resolution problems
     fun.withType(sym2.termRef)
+
+  /** Drop any leading implicit parameter sections */
+  def stripImplicit(tp: Type, wildcardOnly: Boolean = false)(using Context): Type = tp match {
+    case mt: MethodType if mt.isImplicitMethod =>
+      stripImplicit(resultTypeApprox(mt, wildcardOnly))
+    case pt: PolyType =>
+      pt.derivedLambdaType(pt.paramNames, pt.paramInfos,
+          stripImplicit(pt.resultType, wildcardOnly = true))
+            // can't use TypeParamRefs for parameter references in `resultTypeApprox`
+            // since their bounds can refer to type parameters in `pt` that are not
+            // bound by the constraint. This can lead to hygiene violations if subsequently
+            // `pt` itself is added to the constraint. Test case is run/enrich-gentraversable.scala.
+        .asInstanceOf[PolyType].flatten
+    case _ =>
+      tp
+  }
 }
 
 trait Applications extends Compatibility {
@@ -1585,22 +1601,6 @@ trait Applications extends Compatibility {
       stripInferrable(resultTypeApprox(mt))
     case pt: PolyType =>
       stripInferrable(pt.resType)
-    case _ =>
-      tp
-  }
-
-  /** Drop any leading implicit parameter sections */
-  def stripImplicit(tp: Type, wildcardOnly: Boolean = false)(using Context): Type = tp match {
-    case mt: MethodType if mt.isImplicitMethod =>
-      stripImplicit(resultTypeApprox(mt, wildcardOnly))
-    case pt: PolyType =>
-      pt.derivedLambdaType(pt.paramNames, pt.paramInfos,
-          stripImplicit(pt.resultType, wildcardOnly = true))
-            // can't use TypeParamRefs for parameter references in `resultTypeApprox`
-            // since their bounds can refer to type parameters in `pt` that are not
-            // bound by the constraint. This can lead to hygiene violations if subsequently
-            // `pt` itself is added to the constraint. Test case is run/enrich-gentraversable.scala.
-        .asInstanceOf[PolyType].flatten
     case _ =>
       tp
   }

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2564,17 +2564,17 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     vdef1.setDefTree
   }
 
-  def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(using Context): Tree = {
-    def canBeInvalidated(sym: Symbol): Boolean =
+  private def retractDefDef(sym: Symbol)(using Context): Tree =
+    // it's a discarded method (synthetic case class method or synthetic java record constructor or overridden member), drop it
+    val canBeInvalidated: Boolean =
       sym.is(Synthetic)
       && (desugar.isRetractableCaseClassMethodName(sym.name) ||
          (sym.owner.is(JavaDefined) && sym.owner.derivesFrom(defn.JavaRecordClass) && sym.is(Method)))
+    assert(canBeInvalidated)
+    sym.owner.info.decls.openForMutations.unlink(sym)
+    EmptyTree
 
-    if !sym.info.exists then
-      // it's a discarded method (synthetic case class method or synthetic java record constructor or overriden member), drop it
-      assert(canBeInvalidated(sym))
-      sym.owner.info.decls.openForMutations.unlink(sym)
-      return EmptyTree
+  def typedDefDef(ddef: untpd.DefDef, sym: Symbol)(using Context): Tree = if !sym.info.exists then retractDefDef(sym) else {
 
     // TODO: - Remove this when `scala.language.experimental.erasedDefinitions` is no longer experimental.
     //       - Modify signature to `erased def erasedValue[T]: T`

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -25,7 +25,7 @@ import java.io.File
 class PrintingTest {
 
   def options(phase: String, flags: List[String]) =
-    List(s"-Xprint:$phase", "-color:never", "-classpath", TestConfiguration.basicClasspath) ::: flags
+    List(s"-Xprint:$phase", "-color:never", "-nowarn", "-classpath", TestConfiguration.basicClasspath) ::: flags
 
   private def compileFile(path: JPath, phase: String): Boolean = {
     val baseFilePath  = path.toString.stripSuffix(".scala")

--- a/compiler/test/dotty/tools/scripting/ScriptTestEnv.scala
+++ b/compiler/test/dotty/tools/scripting/ScriptTestEnv.scala
@@ -217,8 +217,10 @@ object ScriptTestEnv {
 
     def toUrl: String = Paths.get(absPath).toUri.toURL.toString
 
+    // Used to be an extension on String
     // Treat norm paths with a leading '/' as absolute (Windows java.io.File#isAbsolute treats them as relative)
-    def isAbsolute = p.norm.startsWith("/") || (isWin && p.norm.secondChar == ":")
+    //@annotation.nowarn // hidden by Path#isAbsolute
+    //def isAbsolute = p.norm.startsWith("/") || (isWin && p.norm.secondChar == ":")
   }
 
   extension(f: File) {

--- a/scaladoc-testcases/src/tests/implicitConversions.scala
+++ b/scaladoc-testcases/src/tests/implicitConversions.scala
@@ -6,7 +6,9 @@ given Conversion[A, B] with {
   def apply(a: A): B = ???
 }
 
-extension (a: A) def extended_bar(): String = ???
+extension (a: A)
+  @annotation.nowarn
+  def extended_bar(): String = ???
 
 class A {
   implicit def conversion(c: C): D = ???
@@ -45,7 +47,7 @@ class B {
 class C {
   def extensionInCompanion: String = ???
 }
-
+@annotation.nowarn // extensionInCompanion
 object C {
   implicit def companionConversion(c: C): B = ???
 

--- a/scaladoc-testcases/src/tests/inheritedMembers1.scala
+++ b/scaladoc-testcases/src/tests/inheritedMembers1.scala
@@ -2,6 +2,7 @@ package tests
 package inheritedMembers1
 
 
+/*<-*/@annotation.nowarn/*->*/
 class A
 {
     def A: String

--- a/tests/warn/i16743.check
+++ b/tests/warn/i16743.check
@@ -1,0 +1,84 @@
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:30:6 --------------------------------------------------------
+30 |  def t = 27 // warn
+   |      ^
+   |      Extension method t will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:32:6 --------------------------------------------------------
+32 |  def g(x: String)(i: Int): String = x*i // warn
+   |      ^
+   |      Extension method g will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:33:6 --------------------------------------------------------
+33 |  def h(x: String): String = x // warn
+   |      ^
+   |      Extension method h will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:35:6 --------------------------------------------------------
+35 |  def j(x: Any, y: Int): String = (x.toString)*y // warn
+   |      ^
+   |      Extension method j will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:36:6 --------------------------------------------------------
+36 |  def k(x: String): String = x // warn
+   |      ^
+   |      Extension method k will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:38:6 --------------------------------------------------------
+38 |  def m(using String): String = "m" + summon[String] // warn
+   |      ^
+   |      Extension method m will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:39:6 --------------------------------------------------------
+39 |  def n(using String): String = "n" + summon[String] // warn
+   |      ^
+   |      Extension method n will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:40:6 --------------------------------------------------------
+40 |  def o: String = "42" // warn
+   |      ^
+   |      Extension method o will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:41:6 --------------------------------------------------------
+41 |  def u: Int = 27 // warn
+   |      ^
+   |      Extension method u will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:44:6 --------------------------------------------------------
+44 |  def at: Int = 42 // warn
+   |      ^
+   |      Extension method at will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:46:6 --------------------------------------------------------
+46 |  def x(using String)(n: Int): Int = summon[String].toInt + n // warn
+   |      ^
+   |      Extension method x will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i16743.scala:47:6 --------------------------------------------------------
+47 |  def y(using String)(s: String): String = s + summon[String] // warn
+   |      ^
+   |      Extension method y will never be selected
+   |      because T already has a member with the same name.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/warn/i16743.check
+++ b/tests/warn/i16743.check
@@ -2,83 +2,83 @@
 30 |  def t = 27 // warn
    |      ^
    |      Extension method t will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:32:6 --------------------------------------------------------
 32 |  def g(x: String)(i: Int): String = x*i // warn
    |      ^
    |      Extension method g will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:33:6 --------------------------------------------------------
 33 |  def h(x: String): String = x // warn
    |      ^
    |      Extension method h will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:35:6 --------------------------------------------------------
 35 |  def j(x: Any, y: Int): String = (x.toString)*y // warn
    |      ^
    |      Extension method j will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:36:6 --------------------------------------------------------
 36 |  def k(x: String): String = x // warn
    |      ^
    |      Extension method k will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:38:6 --------------------------------------------------------
 38 |  def m(using String): String = "m" + summon[String] // warn
    |      ^
    |      Extension method m will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:39:6 --------------------------------------------------------
 39 |  def n(using String): String = "n" + summon[String] // warn
    |      ^
    |      Extension method n will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:40:6 --------------------------------------------------------
 40 |  def o: String = "42" // warn
    |      ^
    |      Extension method o will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:41:6 --------------------------------------------------------
 41 |  def u: Int = 27 // warn
    |      ^
    |      Extension method u will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:44:6 --------------------------------------------------------
 44 |  def at: Int = 42 // warn
    |      ^
    |      Extension method at will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:46:6 --------------------------------------------------------
 46 |  def x(using String)(n: Int): Int = summon[String].toInt + n // warn
    |      ^
    |      Extension method x will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
 -- [E194] Potential Issue Warning: tests/warn/i16743.scala:47:6 --------------------------------------------------------
 47 |  def y(using String)(s: String): String = s + summon[String] // warn
    |      ^
    |      Extension method y will never be selected
-   |      because T already has a member with the same name.
+   |      because T already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/warn/i16743.scala
+++ b/tests/warn/i16743.scala
@@ -1,0 +1,119 @@
+
+trait G
+given G = new G { override def toString = "mygiven" }
+given String = "aGivenString"
+
+trait T:
+  def t = 42
+  def f(x: String): String = x*2
+  def g(x: String)(y: String): String = (x+y)*2
+  def h(x: Any): String = x.toString*2
+  def i(x: Any, y: String): String = (x.toString+y)*2
+  def j(x: Any, y: Any): String = (x.toString+y.toString)
+  def k(using G): String = summon[G].toString
+  def l(using G): String = summon[G].toString
+  def m: String = "mystring"
+  def n: Result = Result()
+  def o: Int = 42
+  def u: Int = 42
+  def u(n: Int): Int = u + n
+  def v(n: Int): Int = u + n
+  def v(s: String): String = s + u
+  def end: Int = 42
+  def at(n: Int) = n
+  def w(n: Int): Int = 42 + n
+  def x(n: Int): Int = 42 + n
+  def y(n: Int): Int = u + n
+  def y(s: String): String = s + u
+
+extension (_t: T)
+  def t = 27 // warn
+  def f(i: Int): String = String.valueOf(i)
+  def g(x: String)(i: Int): String = x*i // warn
+  def h(x: String): String = x // warn
+  def i(x: Any, y: Int): String = (x.toString)*y
+  def j(x: Any, y: Int): String = (x.toString)*y // warn
+  def k(x: String): String = x // warn
+  def l(using String): String = summon[String]
+  def m(using String): String = "m" + summon[String] // warn
+  def n(using String): String = "n" + summon[String] // warn
+  def o: String = "42" // warn
+  def u: Int = 27 // warn
+  def v(d: Double) = 3.14
+  def end(n: Int): Int = 42 + n
+  def at: Int = 42 // warn
+  def w(using String)(n: String): Int = (summon[String] + n).toInt
+  def x(using String)(n: Int): Int = summon[String].toInt + n // warn
+  def y(using String)(s: String): String = s + summon[String] // warn
+
+// deferred extension is defined in subclass
+trait Foo:
+  type X
+  extension (x: X) def t: Int
+
+trait Bar extends Foo:
+  type X = T
+  extension (x: X) def t = x.t // nowarn see Quote below
+
+// extension on opaque type matches member of underlying type
+object Dungeon:
+  opaque type IArray[+T] = Array[? <: T]
+  object IArray:
+    extension (arr: IArray[Byte]) def length: Int = arr.asInstanceOf[Array[Byte]].length
+trait DungeonDweller:
+  extension (arr: Dungeon.IArray[Byte]) def length: Int = 42 // nowarn
+  def f[A <: Byte](x: Dungeon.IArray[A]) = x.length
+trait SadDungeonDweller:
+  def f[A](x: Dungeon.IArray[A]) = 27 // x.length // just to confirm, length is not a member
+
+trait Quote:
+  type Tree <: AnyRef
+  given TreeMethods: TreeMethods
+  trait TreeMethods:
+    extension (self: Tree)
+      def length(): Int
+class QuotesImpl extends Quote:
+  type Tree = String
+  given TreeMethods: TreeMethods with
+    extension (self: Tree)
+      def length(): Int = self.length() // nowarn Tree already has a member with the same name.
+
+class Result:
+  def apply(using String): String = s"result ${summon[String]}"
+
+class Depends:
+  type Thing = String
+  def thing: Thing = ""
+object Depending:
+  extension (using depends: Depends)(x: depends.Thing)
+    def y = 42
+    def length() = 42 // nowarn see Quote above
+  def f(using d: Depends) = d.thing.y
+  def g(using d: Depends) = d.thing.length()
+
+@main def test() =
+  val x = new T {}
+  println(x.f(42)) // OK!
+  //println(x.g("x")(42)) // NOT OK!
+  println(x.h("hi")) // member!
+  println(x.i("hi", 5)) // OK!
+  println(x.j("hi", 5)) // member!
+  println(x.k)
+  //println(x.k("hi")) // no, implicit is either omitted (supplied implicitly) or explicitly (using foo)
+  println(x.l) // usual, invokes member
+  println("L"+x.l(using "x")) // explicit, member doesn't check, try extension
+  println(x.m(using "x")) // same idea as previous, except member takes no implicits or any params
+  println(x.m(2)) // member checks by adapting result
+  println(x.n) // Result
+  println(x.n.apply) // apply Result with given
+  println(x.n(using "x"))  // apply Result explicitly, not extension
+  println(x.end(2))
+  println(x.at(2))
+  println {
+    val p = x.at
+    p(2)
+  }
+  println {
+    given String = "42"
+    x.w("27")
+  }

--- a/tests/warn/i9241.scala
+++ b/tests/warn/i9241.scala
@@ -22,22 +22,31 @@ final class Baz private (val x: Int) extends AnyVal {
 }
 
 extension (x: Int)
+  @annotation.nowarn
   def unary_- : Int = ???
+  @annotation.nowarn
   def unary_+[T] : Int = ???
   def unary_!() : Int = ??? // warn
+  @annotation.nowarn
   def unary_~(using Int) : Int = ???
 end extension
 
 extension [T](x: Short)
+  @annotation.nowarn
   def unary_- : Int = ???
+  @annotation.nowarn
   def unary_+[U] : Int = ???
   def unary_!() : Int = ??? // warn
+  @annotation.nowarn
   def unary_~(using Int) : Int = ???
 end extension
 
 extension (using Int)(x: Byte)
+  @annotation.nowarn
   def unary_- : Int = ???
+  @annotation.nowarn
   def unary_+[U] : Int = ???
   def unary_!() : Int = ??? // warn
+  @annotation.nowarn
   def unary_~(using Int) : Int = ???
 end extension


### PR DESCRIPTION
Best effort to warn if defining extension method for a type which has a non-private member of the same name and a subsuming signature.

Excludes opaque types (for defining forwarders to a public API) and other alias types (where the type member may override an abstract type member).

Fixes #16743 