### PR TITLE
-Vphases takes names to mark, -Vprint is typer

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -348,7 +348,7 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
     val phasesSettings = List("-Vphases", "-Vprint")
     for phasesSetting <- ctx.settings.allSettings if phasesSettings.contains(phasesSetting.name) do
       for case vs: List[String] <- phasesSetting.userValue; p <- vs do
-        if !phases.exists(_.phaseName == p) then report.warning(s"'$p' specifies no phase")
+        if !phases.exists(List(p).containsPhase) then report.warning(s"'$p' specifies no phase")
 
     if ctx.settings.YnoDoubleBindings.value then
       ctx.base.checkNoDoubleBindings = true

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -367,7 +367,7 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
             profiler.onPhase(phase):
               try units = phase.runOn(units)
               catch case _: InterruptedException => cancelInterrupted()
-            if (ctx.settings.Vprint.value.containsPhase(phase))
+            for (printAt <- ctx.settings.Vprint.userValue if printAt.containsPhase(phase))
               for (unit <- units)
                 def printCtx(unit: CompilationUnit) = phase.printingContext(
                   ctx.fresh.setPhase(phase.next).setCompilationUnit(unit))

--- a/compiler/src/dotty/tools/dotc/config/CliCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CliCommand.scala
@@ -163,7 +163,7 @@ trait CliCommand:
       val maxCol = ctx.settings.pageWidth.value
       val field1 = maxField.min(texts.flatten.map(_._1.length).filter(_ < maxField).max) // widest field under maxField
       val field2 = if field1 + separation + maxField < maxCol then maxCol - field1 - separation else 0 // skinny window -> terminal wrap
-      val toMark = ctx.settings.XshowPhases.value.toSet
+      def toMark(name: String) = ctx.settings.Vphases.value.exists(s => name.toLowerCase.contains(s.toLowerCase))
       def separator(name: String) = if toMark(name) then "->" + " " * (separation - 2) else " " * separation
       val EOL = "\n"
       def formatField1(text: String): String = if text.length <= field1 then text.padLeft(field1) else text + EOL + "".padLeft(field1)

--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -18,10 +18,10 @@ abstract class CompilerCommand extends CliCommand:
         else if (settings.Xhelp.value) xusageMessage
         else if (settings.Yhelp.value) yusageMessage
         else if (settings.showPlugins.value) ctx.base.pluginDescriptions
-        else if (settings.XshowPhases.value) phasesMessage
+        else if settings.XshowPhases.isPresentIn(summon[SettingsState]) then phasesMessage
         else ""
 
   final def isHelpFlag(using settings: ConcreteSettings)(using SettingsState): Boolean =
     import settings.*
-    val flags = Set(help, Vhelp,  Whelp, Xhelp, Yhelp, showPlugins, XshowPhases)
-    flags.exists(_.value) || allSettings.exists(isHelping)
+    val flags = Set(help, Vhelp,  Whelp, Xhelp, Yhelp, showPlugins)
+    flags.exists(_.value) || XshowPhases.isPresentIn(summon[SettingsState]) || allSettings.exists(isHelping)

--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -18,10 +18,10 @@ abstract class CompilerCommand extends CliCommand:
         else if (settings.Xhelp.value) xusageMessage
         else if (settings.Yhelp.value) yusageMessage
         else if (settings.showPlugins.value) ctx.base.pluginDescriptions
-        else if settings.XshowPhases.isPresentIn(summon[SettingsState]) then phasesMessage
+        else if settings.Vphases.isPresent then phasesMessage
         else ""
 
-  final def isHelpFlag(using settings: ConcreteSettings)(using SettingsState): Boolean =
+  final def isHelpFlag(using settings: ConcreteSettings)(using ss: SettingsState): Boolean =
     import settings.*
     val flags = Set(help, Vhelp,  Whelp, Xhelp, Yhelp, showPlugins)
-    flags.exists(_.value) || XshowPhases.isPresentIn(summon[SettingsState]) || allSettings.exists(isHelping)
+    flags.exists(_.value) || Vphases.isPresentIn(ss) || allSettings.exists(isHelping)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -113,7 +113,7 @@ trait CommonScalaSettings:
   val explainTypes: Setting[Boolean] = BooleanSetting(RootSetting, "explain-types", "Explain type errors in more detail (deprecated, use -explain instead).", aliases = List("--explain-types", "-explaintypes"))
   val explainCyclic: Setting[Boolean] = BooleanSetting(RootSetting, "explain-cyclic", "Explain cyclic reference errors in more detail.", aliases = List("--explain-cyclic"))
   val unchecked: Setting[Boolean] = BooleanSetting(RootSetting, "unchecked", "Enable additional warnings where generated code depends on assumptions.", initialValue = true, aliases = List("--unchecked"))
-  val language: Setting[List[ChoiceWithHelp[String]]] = MultiChoiceHelpSetting(RootSetting, "language", "feature", "Enable one or more language features.", choices = ScalaSettingsProperties.supportedLanguageFeatures, legacyChoices = ScalaSettingsProperties.legacyLanguageFeatures, default = Nil, aliases = List("--language"))
+  val language: Setting[List[ChoiceWithHelp[String]]] = MultiChoiceHelpSetting(RootSetting, "language", "feature", "Enable one or more language features.", choices = ScalaSettingsProperties.supportedLanguageFeatures, legacyChoices = ScalaSettingsProperties.legacyLanguageFeatures, aliases = List("--language"))
   val experimental: Setting[Boolean] = BooleanSetting(RootSetting, "experimental", "Annotate all top-level definitions with @experimental. This enables the use of experimental features anywhere in the project.")
   val preview: Setting[Boolean] = BooleanSetting(RootSetting, "preview", "Enable the use of preview features anywhere in the project.")
 
@@ -190,7 +190,6 @@ private sealed trait WarningSettings:
       ),
       ChoiceWithHelp("unsafe-warn-patvars", "Deprecated alias for `patvars`"),
     ),
-    default = Nil
   )
   object WunusedHas:
     def isChoiceSet(s: String)(using Context) = Wunused.value.pipe(us => us.contains(s))
@@ -224,7 +223,6 @@ private sealed trait WarningSettings:
     WarningSetting,
     "Wconf",
     "patterns",
-    default = List(),
     descr =
     raw"""Configure compiler warnings.
          |Syntax: -Wconf:<filters>:<action>,<filters>:<action>,...
@@ -286,7 +284,6 @@ private sealed trait WarningSettings:
       ChoiceWithHelp("private-shadow", "Warn if a private field or class parameter shadows a superclass field"),
       ChoiceWithHelp("type-parameter-shadow", "Warn when a type parameter shadows a type already in the scope"),
     ),
-    default = Nil
   )
 
   object WshadowHas:

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -145,7 +145,7 @@ private sealed trait VerboseSettings:
   self: SettingGroup =>
   val Vhelp: Setting[Boolean] = BooleanSetting(VerboseSetting, "V", "Print a synopsis of verbose options.")
   val Vprint: Setting[List[String]] = PhasesSetting(VerboseSetting, "Vprint", "Print out program after", default = "typer", aliases = List("-Xprint"))
-  val XshowPhases: Setting[List[String]] = PhasesSetting(VerboseSetting, "Vphases", "List compiler phases.", default = "none", aliases = List("-Xshow-phases"))
+  val Vphases: Setting[List[String]] = PhasesSetting(VerboseSetting, "Vphases", "List compiler phases.", default = "none", aliases = List("-Xshow-phases"))
   val Vprofile: Setting[Boolean] = BooleanSetting(VerboseSetting, "Vprofile", "Show metrics about sources and internal representations to estimate compile-time complexity.")
   val VprofileSortedBy = ChoiceSetting(VerboseSetting, "Vprofile-sorted-by", "key", "Show metrics about sources and internal representations sorted by given column name", List("name", "path", "lines", "tokens", "tasty", "complexity"), "")
   val VprofileDetails = IntSetting(VerboseSetting, "Vprofile-details", "Show metrics about sources and internal representations of the most complex methods", 0)

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -144,9 +144,8 @@ private sealed trait PluginSettings:
 private sealed trait VerboseSettings:
   self: SettingGroup =>
   val Vhelp: Setting[Boolean] = BooleanSetting(VerboseSetting, "V", "Print a synopsis of verbose options.")
-  val Vprint: Setting[List[String]] = PhasesSetting(VerboseSetting, "Vprint", "Print out program after", aliases = List("-Xprint"))
-  val XshowPhases: Setting[Boolean] = BooleanSetting(VerboseSetting, "Vphases", "List compiler phases.", aliases = List("-Xshow-phases"))
-
+  val Vprint: Setting[List[String]] = PhasesSetting(VerboseSetting, "Vprint", "Print out program after", default = "typer", aliases = List("-Xprint"))
+  val XshowPhases: Setting[List[String]] = PhasesSetting(VerboseSetting, "Vphases", "List compiler phases.", default = "none", aliases = List("-Xshow-phases"))
   val Vprofile: Setting[Boolean] = BooleanSetting(VerboseSetting, "Vprofile", "Show metrics about sources and internal representations to estimate compile-time complexity.")
   val VprofileSortedBy = ChoiceSetting(VerboseSetting, "Vprofile-sorted-by", "key", "Show metrics about sources and internal representations sorted by given column name", List("name", "path", "lines", "tokens", "tasty", "complexity"), "")
   val VprofileDetails = IntSetting(VerboseSetting, "Vprofile-details", "Show metrics about sources and internal representations of the most complex methods", 0)

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -256,14 +256,17 @@ object Settings:
               doSetArg(arg = null, args) // update with default
 
       def doSetArg(arg: String | Null, argsLeft: List[String]) =
-        classTag[T] match
-          case ListTag if arg == null =>
-            update(default, argStringValue = "", argsLeft)
+        arg match
+        case null =>
+          classTag[T] match
           case ListTag =>
-            val strings = arg.split(",").toList
-            appendList(strings, arg, argsLeft)
-          case _ if arg == null =>
+            update(default, argStringValue = "", argsLeft)
+          case _ =>
             missingArg
+        case arg =>
+          classTag[T] match
+          case ListTag =>
+            appendList(arg.split(",").toList, arg, argsLeft)
           case StringTag =>
             setString(arg, argsLeft)
           case OutputTag =>

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -320,6 +320,7 @@ object Settings:
       def userValue(using Context): Option[T] = setting.userValueIn(ctx.settingsState)
       def update(x: T)(using Context): SettingsState = setting.updateIn(ctx.settingsState, x)
       def isDefault(using Context): Boolean = setting.isDefaultIn(ctx.settingsState)
+      def isPresent(using Context): Boolean = setting.isPresentIn(ctx.settingsState)
 
     /**
      * A choice with help description.

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -122,8 +122,6 @@ object Settings:
 
     def isMultivalue: Boolean = classTag[T] == ListTag
 
-    def acceptsNoArg: Boolean = classTag[T] == BooleanTag || classTag[T] == OptionTag || choices.exists(_.contains(""))
-
     def legalChoices: String =
       choices match
         case Some(xs) if xs.isEmpty => ""
@@ -246,10 +244,11 @@ object Settings:
             update(Some(propertyClass.get.getConstructor().newInstance()), "", args)
           case ct =>
             val argInArgRest = !argRest.isEmpty || legacyArgs
-            inline def argAfterParam = !argInArgRest && args.nonEmpty && (ct == IntTag || !args.head.startsWith("-"))
+            inline def argAfterParam = args.nonEmpty && (ct == IntTag || !args.head.startsWith("-"))
+            inline def isMultivalueWithDefault = isMultivalue && !isEmptyDefault
             if argInArgRest then
               doSetArg(argRest, args)
-            else if argAfterParam then
+            else if argAfterParam && !isMultivalueWithDefault then
               doSetArg(args.head, args.tail)
             else if isEmptyDefault then
               missingArg
@@ -418,7 +417,7 @@ object Settings:
     def MultiChoiceSetting(category: SettingCategory, name: String, helpArg: String, descr: String, choices: List[String], default: List[String] = Nil, legacyChoices: List[String] = Nil, aliases: List[String] = Nil, deprecation: Option[Deprecation] = None): Setting[List[String]] =
       publish(Setting(category, prependName(name), descr, default, helpArg, Some(choices), legacyChoices = Some(legacyChoices), aliases = aliases, deprecation = deprecation))
 
-    def MultiChoiceHelpSetting(category: SettingCategory, name: String, helpArg: String, descr: String, choices: List[ChoiceWithHelp[String]], default: List[ChoiceWithHelp[String]], legacyChoices: List[String] = Nil, aliases: List[String] = Nil, deprecation: Option[Deprecation] = None): Setting[List[ChoiceWithHelp[String]]] =
+    def MultiChoiceHelpSetting(category: SettingCategory, name: String, helpArg: String, descr: String, choices: List[ChoiceWithHelp[String]], default: List[ChoiceWithHelp[String]] = Nil, legacyChoices: List[String] = Nil, aliases: List[String] = Nil, deprecation: Option[Deprecation] = None): Setting[List[ChoiceWithHelp[String]]] =
       publish(Setting(category, prependName(name), descr, default, helpArg, Some(choices), legacyChoices = Some(legacyChoices), aliases = aliases, deprecation = deprecation))
 
     def IntSetting(category: SettingCategory, name: String, descr: String, default: Int, aliases: List[String] = Nil, deprecation: Option[Deprecation] = None): Setting[Int] =

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -251,13 +251,13 @@ object Decorators {
    *  a given phase. See [[config.CompilerCommand#explainAdvanced]] for the
    *  exact meaning of "contains" here.
    */
-   extension (names: List[String])
+  extension (names: List[String])
     def containsPhase(phase: Phase): Boolean =
       names.nonEmpty && {
         phase match {
-          case phase: MegaPhase => phase.miniPhases.exists(x => names.containsPhase(x))
+          case phase: MegaPhase => phase.miniPhases.exists(names.containsPhase)
           case _ =>
-            names exists { name =>
+            names.exists { name =>
               name == "all" || {
                 val strippedName = name.stripSuffix("+")
                 val logNextPhase = name != strippedName

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -253,20 +253,17 @@ object Decorators {
    */
   extension (names: List[String])
     def containsPhase(phase: Phase): Boolean =
-      names.nonEmpty && {
-        phase match {
-          case phase: MegaPhase => phase.miniPhases.exists(names.containsPhase)
-          case _ =>
-            names.exists { name =>
-              name == "all" || {
-                val strippedName = name.stripSuffix("+")
-                val logNextPhase = name != strippedName
-                phase.phaseName.startsWith(strippedName) ||
-                  (logNextPhase && phase.prev.phaseName.startsWith(strippedName))
-              }
-            }
-        }
-      }
+      names.nonEmpty &&
+        phase.match
+        case phase: MegaPhase => phase.miniPhases.exists(containsPhase)
+        case _ =>
+          names.exists:
+            case "all" => true
+            case name =>
+              val strippedName = name.stripSuffix("+")
+              val logNextPhase = name != strippedName
+                 phase.phaseName.startsWith(strippedName)
+              || logNextPhase && phase.prev.phaseName.startsWith(strippedName)
 
   extension [T](x: T)
     def showing[U](

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -49,7 +49,12 @@ import java.nio.file.Path
  */
 class ExtractSemanticDB private (phaseMode: ExtractSemanticDB.PhaseMode) extends Phase:
 
-  override val phaseName: String = ExtractSemanticDB.phaseNamePrefix + phaseMode.toString()
+  override val phaseName: String = s"""${ExtractSemanticDB.phaseNamePrefix}${
+    import ExtractSemanticDB.PhaseMode.*
+    phaseMode match
+      case ExtractSemanticInfo => "ExtractInfo"
+      case AppendDiagnostics   => "AppendDiag"
+  }"""
 
   override val description: String = ExtractSemanticDB.description
 
@@ -129,7 +134,7 @@ object ExtractSemanticDB:
   import java.nio.file.Files
   import java.nio.file.Paths
 
-  val phaseNamePrefix: String = "extractSemanticDB"
+  val phaseNamePrefix: String = "semanticDB"
   val description: String = "extract info into .semanticdb files"
 
   enum PhaseMode:

--- a/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CollectEntryPoints.scala
@@ -49,5 +49,5 @@ class CollectEntryPoints extends MiniPhase:
   }
 
 object CollectEntryPoints:
-  val name: String = "Collect entry points"
+  val name: String = "collectEntryPoints"
   val description: String = "collect all entry points and save them in the context"

--- a/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SetRootTree.scala
@@ -44,6 +44,6 @@ class SetRootTree extends Phase {
 }
 
 object SetRootTree {
-  val name: String = "SetRootTree"
+  val name: String = "setRootTree"
   val description: String = "set the rootTreeOrProvider on class symbols"
 }

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -280,7 +280,7 @@ class SettingsTests:
       val multiStringSetting = MultiStringSetting(RootSetting, "multiStringSetting", "multiStringSetting", "", List("a", "b"), List())
       val outputSetting = OutputSetting(RootSetting, "outputSetting", "outputSetting", "", new PlainDirectory(Directory(".")))
       val pathSetting = PathSetting(RootSetting, "pathSetting", "pathSetting", ".")
-      val phasesSetting = PhasesSetting(RootSetting, "phasesSetting", "phasesSetting", "all")
+      val phasesSetting = PhasesSetting(RootSetting, "phasesSetting", "phasesSetting")
       val versionSetting= VersionSetting(RootSetting, "versionSetting", "versionSetting")
 
     import Settings.*

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -306,4 +306,28 @@ class ScalaSettingsTests:
       assertEquals(0, result.warnings.length)
       assertEquals(1, result.errors.length)
 
+  @Test def `Vphases takes optional phase names`: Unit =
+    val settings = ScalaSettings
+    def process(args: List[String]) =
+      val summary = ArgsSummary(settings.defaultState, args, errors = Nil, warnings = Nil)
+      settings.processArguments(summary, processAll = true, skipped = Nil)
+    locally:
+      val summary = process("-Vphases:foo,bar,baz" :: Nil)
+      assertTrue(summary.errors.isEmpty && summary.warnings.isEmpty)
+      assertEquals(List("foo","bar","baz"), settings.Vphases.valueIn(summary.sstate))
+    locally:
+      val summary = process(List("-Vphases","foo","-Vphases","bar","-Vphases","baz"))
+      assertTrue(summary.errors.isEmpty && summary.warnings.isEmpty)
+      assertEquals(List("foo","bar","baz"), settings.Vphases.valueIn(summary.sstate))
+    locally:
+      val summary = process(List("-Vphases","--","foo"))
+      assertTrue(summary.errors.isEmpty && summary.warnings.isEmpty)
+      assertEquals(List("none"), settings.Vphases.valueIn(summary.sstate)) // nonempty default required
+      assertEquals(Some(List("none")), settings.Vphases.userValueIn(summary.sstate)) // nonempty default required
+    locally:
+      val summary = process(Nil)
+      assertTrue(summary.errors.isEmpty && summary.warnings.isEmpty)
+      assertEquals(List("none"), settings.Vphases.valueIn(summary.sstate)) // nonempty default required
+      assertEquals(None, settings.Vphases.userValueIn(summary.sstate))
+
 end ScalaSettingsTests

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -316,10 +316,6 @@ class ScalaSettingsTests:
       assertTrue(summary.errors.isEmpty && summary.warnings.isEmpty)
       assertEquals(List("foo","bar","baz"), settings.Vphases.valueIn(summary.sstate))
     locally:
-      val summary = process(List("-Vphases","foo","-Vphases","bar","-Vphases","baz"))
-      assertTrue(summary.errors.isEmpty && summary.warnings.isEmpty)
-      assertEquals(List("foo","bar","baz"), settings.Vphases.valueIn(summary.sstate))
-    locally:
       val summary = process(List("-Vphases","--","foo"))
       assertTrue(summary.errors.isEmpty && summary.warnings.isEmpty)
       assertEquals(List("none"), settings.Vphases.valueIn(summary.sstate)) // nonempty default required

--- a/sbt-bridge/test/xsbt/CompileProgressSpecification.scala
+++ b/sbt-bridge/test/xsbt/CompileProgressSpecification.scala
@@ -56,7 +56,7 @@ class CompileProgressSpecification {
         "sbt-deps",
         "posttyper",
         "sbt-api",
-        "SetRootTree",
+        "setRootTree",
         "pickler",
         "inlining",
         "postInlining",

--- a/tests/printing/transformed/lazy-vals-legacy.check
+++ b/tests/printing/transformed/lazy-vals-legacy.check
@@ -1,4 +1,4 @@
-[[syntax trees at end of MegaPhase{dropOuterAccessors, dropParentRefinements, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-legacy.scala
+[[syntax trees at end of MegaPhase{dropOuterAccessors, dropParentRefinements, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, collectEntryPoints, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-legacy.scala
 package <empty> {
   @SourceFile("tests/printing/transformed/lazy-vals-legacy.scala") final module
     class A extends Object {

--- a/tests/printing/transformed/lazy-vals-new.check
+++ b/tests/printing/transformed/lazy-vals-new.check
@@ -1,4 +1,4 @@
-[[syntax trees at end of MegaPhase{dropOuterAccessors, dropParentRefinements, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, Collect entry points, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new.scala
+[[syntax trees at end of MegaPhase{dropOuterAccessors, dropParentRefinements, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, collectEntryPoints, collectSuperCalls, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new.scala
 package <empty> {
   @SourceFile("tests/printing/transformed/lazy-vals-new.scala") final module
     class A extends Object {


### PR DESCRIPTION
`-Vphases` optionally takes a list of phase names to highlight in the output.

`-Vprint` optionally takes a list of phase names for printing, and defaults to `typer`.

Add plugins and `fuse` before listing `-Vphases`, to include plugins in the list. This also honors `-Ystop-after`, so the listing shows what will be constructed for a `Run`.

`setting.isPresent` if the user supplied the option; `setting.userValue` is the optional value supplied by the user.

If a setting has an empty default, an explicit argument must be supplied.

A couple of phase names are normalized to camelCase.

`-Vprint` loosely matches the phase name (`contains`), so do the same for `-Vphases`. (Would be nice to ignore upper/lower case.)

E.g., `-Vphases:checkUnused,elimByName` highlights both phases so that it's easy to find the miniphase of interest.

![image](https://github.com/scala/scala3/assets/369425/c9435c54-5e6e-4850-9fe6-8c5bc93b1b1d)

![image](https://github.com/scala/scala3/assets/369425/d569e3a5-b5ad-4552-80f2-5b2e8bc52323)

