### PR TITLE
throw error on ambiguous overload with methods and functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1944,12 +1944,18 @@ trait Applications extends Compatibility {
   end resolveOverloaded
 
   def isApplicableTerm(argTypes: List[Type], resultType: Type, argMatch: ArgMatch)(using Context): TermRef => Boolean =
-    onMethod(_, argTypes.nonEmpty):
-      isApplicableMethodRef(_, argTypes, resultType, argMatch)
+    term => term.widen match
+      case _: AppliedType =>
+        isApplicableType(term, argTypes, resultType)
+      case _ =>
+        isApplicableMethodRef(term, argTypes, resultType, argMatch)
 
   def isApplicableTerm(argTypes: List[Tree], resultType: Type, keepConstraint: Boolean, argMatch: ArgMatch)(using Context): TermRef => Boolean =
-    onMethod(_, argTypes.nonEmpty):
-      isApplicableMethodRef(_, argTypes, resultType, keepConstraint, argMatch)
+    term => term.widen match
+      case _: AppliedType =>
+        isApplicableType(term, argTypes, resultType, keepConstraint)
+      case _ =>
+        isApplicableMethodRef(term, argTypes, resultType, keepConstraint, argMatch)
 
 
   /** This private version of `resolveOverloaded` does the bulk of the work of

--- a/tests/neg/i18294.check
+++ b/tests/neg/i18294.check
@@ -1,0 +1,54 @@
+-- [E051] Reference Error: tests/neg/i18294.scala:18:30 ----------------------------------------------------------------
+18 |  val test01: Int => String = f1 // error
+   |                              ^^
+   |                              Ambiguous overload. The overloaded alternatives of method f1 with types
+   |                               => Int => String
+   |                               (s: Int): String
+   |                              both match expected type Int => String
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E051] Reference Error: tests/neg/i18294.scala:19:30 ----------------------------------------------------------------
+19 |  val test02: Int => String = f2 // error
+   |                              ^^
+   |                              Ambiguous overload. The overloaded alternatives of value f2 with types
+   |                               Int => String
+   |                               (s: Int): String
+   |                              both match expected type Int => String
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E051] Reference Error: tests/neg/i18294.scala:22:36 ----------------------------------------------------------------
+22 |  val test1: Int => String = DefDef.f4 // error
+   |                             ^^^^^^^^^
+   |                        Ambiguous overload. The overloaded alternatives of method f4 in object DefDef with types
+   |                         => Int => String
+   |                         (s: Int): String
+   |                        both match expected type Int => String
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E051] Reference Error: tests/neg/i18294.scala:23:37 ----------------------------------------------------------------
+23 |  def dtest1: Int => String = DefDef.f4 // error
+   |                              ^^^^^^^^^
+   |                        Ambiguous overload. The overloaded alternatives of method f4 in object DefDef with types
+   |                         => Int => String
+   |                         (s: Int): String
+   |                        both match expected type Int => String
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E051] Reference Error: tests/neg/i18294.scala:25:36 ----------------------------------------------------------------
+25 |  val test2: Int => String = DefVal.f5 // error
+   |                             ^^^^^^^^^
+   |                         Ambiguous overload. The overloaded alternatives of value f5 in object DefVal with types
+   |                          Int => String
+   |                          (s: Int): String
+   |                         both match expected type Int => String
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E051] Reference Error: tests/neg/i18294.scala:26:37 ----------------------------------------------------------------
+26 |  def dtest2: Int => String = DefVal.f5 // error
+   |                              ^^^^^^^^^
+   |                         Ambiguous overload. The overloaded alternatives of value f5 in object DefVal with types
+   |                          Int => String
+   |                          (s: Int): String
+   |                         both match expected type Int => String
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i18294.scala
+++ b/tests/neg/i18294.scala
@@ -1,0 +1,26 @@
+def f1(s: Int): String = "a"
+def f1: Int => String = _ => "b"
+
+def f2(s: Int): String = "a"
+val f2: Int => String = _ => "b"
+
+def f3(s: Int): String = "a"
+def f3(): Int => String = _ => "b"
+
+object DefDef:
+  def f4(s: Int): String = "a"
+  def f4: Int => String = _ => "b"
+object DefVal:
+  def f5(s: Int): String = "a"
+  val f5: Int => String = _ => "b"
+
+@main def Test =
+  val test01: Int => String = f1 // error
+  val test02: Int => String = f2 // error
+  val test03: Int => String = f3
+
+  val test1: Int => String = DefDef.f4 // error
+  def dtest1: Int => String = DefDef.f4 // error
+
+  val test2: Int => String = DefVal.f5 // error
+  def dtest2: Int => String = DefVal.f5 // error


### PR DESCRIPTION
Fixes #18294 

From what I saw, the compiler chose the method over the function in `Applications#narrowByTypes`. That's because in `Applications#isApplicationMethodRef()` only a `MethodType` could give a success, so the `Function1` was discarded and we could never reach the "ambiguous overloads" error