### PR TITLE
Splice hole with this capture

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -717,9 +717,12 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
             writeNat(idx)
             pickleType(tree.tpe, richTypes = true)
             args.foreach { arg =>
-              arg.tpe match
-                case _: TermRef if arg.isType => writeByte(EXPLICITtpt)
-                case _ =>
+              if arg.isType then
+                // Add EXPLICITtpt if the type can represent a type or a term.
+                // This is only needed if the tree of the type would be unpickled as a term tree.
+                arg.tpe match
+                  case _: TermRef | _: ThisType => writeByte(EXPLICITtpt)
+                  case _ =>
               pickleTree(arg)
             }
           }

--- a/tests/pos-macros/this-type-capture/Macro_1.scala
+++ b/tests/pos-macros/this-type-capture/Macro_1.scala
@@ -1,0 +1,37 @@
+import scala.quoted.*
+
+object Macro:
+  inline def generateCode: Unit = ${ testThisPaths }
+
+  def testThisPaths(using Quotes): Expr[Unit] =
+    '{
+      trait E extends G:
+        type V
+        val f: F
+        ${ val expr = '{ println(this) }; expr }
+        ${ val expr = '{ println(f) }; expr }
+        ${ val expr = '{ println(this.f) }; expr }
+        ${ val expr = '{ println(??? : this.type) }; expr }
+        ${ val expr = '{ println(??? : V) }; expr }
+        ${ val expr = '{ println(??? : this.V) }; expr }
+        ${ val expr = '{ println(??? : this.f.V) }; expr }
+        ${ val expr = '{ println(??? : this.f.type) }; expr }
+        ${
+          val expr = '{
+            println(this)
+            println(f)
+            println(this.f)
+            println(??? : this.type)
+            println(??? : V)
+            println(??? : this.V)
+            println(??? : this.f.V)
+            println(??? : this.f.type)
+          }
+          expr
+        }
+      trait F:
+        type V
+    }
+
+trait G:
+  val f: Any

--- a/tests/pos-macros/this-type-capture/Test_2.scala
+++ b/tests/pos-macros/this-type-capture/Test_2.scala
@@ -1,0 +1,1 @@
+@main def test = Macro.generateCode


### PR DESCRIPTION
This PR tackles two similar but distinct issues in two different phases of the staging process. 

* The mapping in `refBindingMap` for `this` was inconsistent. The mapping did not distinguish between a `this` type and `this` term because they have the same symbol. The solution is to split the mapping into types and terms.
* We cannot distinguish a pickling a `this` type from term. We use a `EXPLICITtpt` (as in #18357) to make sure a `ThisType` is unpickled as a type.

Revisit #17138