### PR TITLE
Fix macro dependency tracking for `this`

### DIFF
--- a/tests/pos-macros/i18434/Inline_2.scala
+++ b/tests/pos-macros/i18434/Inline_2.scala
@@ -1,0 +1,8 @@
+package user
+
+import defn.Macro
+
+object Inline extends Macro {
+  inline def callMacro(): Int =
+    ${ impl() }
+}

--- a/tests/pos-macros/i18434/Macro_1.scala
+++ b/tests/pos-macros/i18434/Macro_1.scala
@@ -1,0 +1,7 @@
+package defn
+
+import scala.quoted.*
+
+abstract class Macro {
+  def impl()(using Quotes): Expr[Int] = '{1}
+}

--- a/tests/pos-macros/i18434/Test_2.scala
+++ b/tests/pos-macros/i18434/Test_2.scala
@@ -1,0 +1,5 @@
+package user
+
+object Test {
+  Inline.callMacro()
+}


### PR DESCRIPTION
The symbols of trees do not have enough information to determine the full dependencies. For example, if we have an `Ident` we need to look at its type to figure out which is the `this` prefix on which it is defined.

Fix #18434