### PR TITLE
Fix #17603: position of for-comprehension implicit args pointing to yield/do

### DIFF
--- a/tests/neg/17603.check
+++ b/tests/neg/17603.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/17603.scala:7:20 -----------------------------------------------------------------------
+7 |    p <- Mappable(3) // error
+  |                    ^
+  |                    No given instance of type Int was found for parameter loc of method map in class Mappable

--- a/tests/neg/17603.scala
+++ b/tests/neg/17603.scala
@@ -1,0 +1,8 @@
+case class Mappable[A](value: A):
+  def map[B](f: A => B)(using loc: Int): Mappable[B] = Mappable(f(value))
+
+@main
+def main(): Unit =
+  val position = for {
+    p <- Mappable(3) // error
+  } yield p

--- a/tests/pos-macros/i17603/Macro_1.scala
+++ b/tests/pos-macros/i17603/Macro_1.scala
@@ -1,0 +1,17 @@
+import scala.quoted.{Quotes, Expr}
+
+case class Location(path: String, line: Int)
+
+object Macros:
+  inline given location: Location = ${locationImpl}
+
+  private def checkEquals[T](obtained: T, expected: T) =
+    assert(obtained == expected, s"obtained: ${obtained}, expected ${expected}")
+
+  private def locationImpl(using quotes: Quotes): Expr[Location] =
+    import quotes.reflect.Position
+    val file = Expr(Position.ofMacroExpansion.sourceFile.jpath.toString)
+    val line = Expr(Position.ofMacroExpansion.startLine + 1)
+    checkEquals(Position.ofMacroExpansion.startLine, 8)
+    checkEquals(Position.ofMacroExpansion.sourceFile.jpath.getFileName().toString, "Test_2.scala")
+    '{Location($file, $line)}

--- a/tests/pos-macros/i17603/Test_2.scala
+++ b/tests/pos-macros/i17603/Test_2.scala
@@ -1,0 +1,20 @@
+import Macros.given
+
+case class Mappable[A](value: A):
+  def map[B](f: Location => B)(using loc: Location): Mappable[B] = Mappable(f(loc))
+
+@main
+def main(): Unit =
+  val position = for {
+    p <- Mappable(3)
+
+
+
+
+
+
+
+
+
+
+  } yield p


### PR DESCRIPTION
Fixes #17603 
Fixed by first detecting if a tree was desugared from a for-comprehension, and if so, setting the position of the context parameter to the right method symbol in the for comprehension tree.

The detection mechanism was based off of a similar implementation made for semanticdb generation (`isForSynthetic` in SyntheticsExtractor), which seemed to be sound.