### PR TITLE
Do not Ycheck inlined positions for macro annotation classes

### DIFF
--- a/tests/pos-macros/i17007/Macro_1.scala
+++ b/tests/pos-macros/i17007/Macro_1.scala
@@ -1,0 +1,28 @@
+//> using option "-Ycheck:all"
+import scala.annotation.MacroAnnotation
+import scala.quoted.*
+
+class annotation extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition) =
+    import quotes.reflect.*
+
+    tree match
+      case tree: ClassDef =>
+        val List(DefDef(name, paramss, tpt, Some(body))) = tree.body: @unchecked
+        val rhs = body match
+          case Inlined(_, _, Block(List(Apply(_ /* `locally` */, List(rhs))), _)) => rhs
+        val method = DefDef.copy(tree.body.head)(name, paramss, tpt, Some(rhs.changeOwner(tree.body.head.symbol)))
+        List(ClassDef.copy(tree)(tree.name, tree.constructor, tree.parents, tree.self, List(method)))
+      case tree: DefDef =>
+        val DefDef(name, paramss, tpt, Some(body)) = tree: @unchecked
+        val rhs = body match
+          case Inlined(_, _, Block(List(Apply(_ /* `locally` */, List(rhs))), _)) => rhs
+        val defdef = DefDef.copy(tree)(name, paramss, tpt, Some(rhs.changeOwner(tree.symbol)))
+        List(defdef)
+      case tree: ValDef =>
+        val ValDef(name, tpt, Some(body)) = tree: @unchecked
+        val rhs = body match
+          case Inlined(_, _, Block(List(Apply(_ /* `locally` */, List(rhs))), _)) => rhs
+        val valdef = ValDef.copy(tree)(name, tpt, Some(rhs.changeOwner(tree.symbol)))
+        List(valdef)
+

--- a/tests/pos-macros/i17007/Test_2.scala
+++ b/tests/pos-macros/i17007/Test_2.scala
@@ -1,0 +1,12 @@
+//> using option "-Ycheck:all"
+transparent inline def inlineMethod(v: Int) =
+  locally(v)
+  0
+
+@annotation
+class Test1:
+  def method = inlineMethod(42)
+
+object Test2:
+  @annotation val valdef = inlineMethod(42)
+  @annotation def defdef = inlineMethod(42)


### PR DESCRIPTION
In macro annotation classes, as part of the macro expansion, users can mess with `Inlined` nodes, which can break YCheckPositions checks. Similarly to how it is done for macro methods, we now skip checking classes with a macro annotation.

Fixes #17007
In the issue specifically, the problem was that the "outer" `Inlined` node was removed, which YCheckPositions expected and aimed to retrieve the original source file from it, so when it reached the unaffected "inner" `Inlined` node the compiler would crash.