### PR TITLE
Add enum type param support in sourceSymbol

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Interactive.scala
@@ -144,6 +144,7 @@ object Interactive {
 
     (  sym == tree.symbol
     || sym.exists && sym == tree.symbol.sourceSymbol
+    || sym.exists && sym.sourceSymbol == tree.symbol
     || !include.isEmpty && sym.name == tree.symbol.name && sym.maybeOwner != tree.symbol.maybeOwner
        && (  include.isOverridden && overrides(sym, tree.symbol)
           || include.isOverriding && overrides(tree.symbol, sym)

--- a/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/DefinitionTest.scala
@@ -378,4 +378,38 @@ class DefinitionTest {
     .definition(m3 to m4, Nil)
     .definition(m5 to m6, Nil)
     .definition(m7 to m8, Nil)
+
+  @Test def typeParam: Unit = {
+    code"""|class Foo[${m1}T${m2}]:
+           |  def test: ${m3}T${m4}"""
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
+  @Test def enumTypeParam: Unit = {
+    code"""|enum Test[${m1}T${m2}]:
+           |  case EnumCase(value: ${m3}T${m4})"""
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
+  @Test def extMethodTypeParam: Unit = {
+    code"""extension [${m1}T${m2}](string: String) def xxxx(y: ${m3}T${m4}) = ???"""
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
+  @Test def typeParamCovariant: Unit = {
+    code"""|class Foo[+${m1}T${m2}]:
+           |  def test: ${m3}T${m4}"""
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
+  @Test def enumTypeParamCovariant: Unit = {
+    code"""|enum Test[+${m1}T${m2}]:
+           |  case EnumCase(value: ${m3}T${m4})"""
+      .definition(m3 to m4, List(m1 to m2))
+  }
+
+  @Test def extMethodTypeParamCovariant: Unit = {
+    code"""extension [+${m1}T${m2}](string: String) def xxxx(y: ${m3}T${m4}) = ???"""
+      .definition(m3 to m4, List(m1 to m2))
+  }
 }

--- a/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
@@ -478,6 +478,33 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
          |""".stripMargin
     )
 
+  @Test def `enum-class-type-param` =
+    check(
+      """|
+         |enum Options[<<AA>>]:
+         |  case Some(x: A@@A)
+         |  case None extends Options[Nothing]
+         |""".stripMargin
+    )
+
+  @Test def `enum-class-type-param-covariant` =
+    check(
+      """|
+         |enum Options[+<<AA>>]:
+         |  case Some(x: A@@A)
+         |  case None extends Options[Nothing]
+         |""".stripMargin
+    )
+
+  @Test def `enum-class-type-param-duplicate` =
+    check(
+      """|
+         |enum Testing[AA]:
+         |  case Some[<<AA>>](x: A@@A) extends Testing[AA]
+         |  case None extends Testing[Nothing]
+         |""".stripMargin
+    )
+
   @Test def `derives-def` =
     check(
       """|


### PR DESCRIPTION
Fixes https://github.com/lampepfl/dotty/issues/18541

`sourceSymbol` should point to the symbol present in source code including enum type params.
The need of such support is that enums are desugared in such a way that enum class type parameters are copied to enum case class. As this is desugar, the copied symbols are not present in source code, thus `sourceSymbol` should point to enum class type parameter.