### PR TITLE
Pre SIP: Improvements to Modularity

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -443,13 +443,13 @@ object desugar {
   private def toDefParam(tparam: TypeDef, keepAnnotations: Boolean): TypeDef = {
     var mods = tparam.rawMods
     if (!keepAnnotations) mods = mods.withAnnotations(Nil)
-    tparam.withMods(mods & (EmptyFlags | Sealed) | Param)
+    tparam.withMods(mods & EmptyFlags | Param)
   }
   private def toDefParam(vparam: ValDef, keepAnnotations: Boolean, keepDefault: Boolean): ValDef = {
     var mods = vparam.rawMods
     if (!keepAnnotations) mods = mods.withAnnotations(Nil)
     val hasDefault = if keepDefault then HasDefault else EmptyFlags
-    vparam.withMods(mods & (GivenOrImplicit | Erased | hasDefault) | Param)
+    vparam.withMods(mods & (GivenOrImplicit | Erased | hasDefault | Tracked) | Param)
   }
 
   def mkApply(fn: Tree, paramss: List[ParamClause])(using Context): Tree =
@@ -535,7 +535,7 @@ object desugar {
     // but not on the constructor parameters. The reverse is true for
     // annotations on class _value_ parameters.
     val constrTparams = impliedTparams.map(toDefParam(_, keepAnnotations = false))
-    val constrVparamss =
+    def defVparamss =
       if (originalVparamss.isEmpty) { // ensure parameter list is non-empty
         if (isCaseClass)
           report.error(CaseClassMissingParamList(cdef), namePos)
@@ -546,6 +546,10 @@ object desugar {
         ListOfNil
       }
       else originalVparamss.nestedMap(toDefParam(_, keepAnnotations = true, keepDefault = true))
+    val constrVparamss = defVparamss
+      // defVparamss also needed as separate tree nodes in implicitWrappers below.
+      // Need to be separate because they are `watch`ed in addParamRefinements.
+      // See parsercombinators-givens.scala for a test case.
     val derivedTparams =
       constrTparams.zipWithConserve(impliedTparams)((tparam, impliedParam) =>
         derivedTypeParam(tparam).withAnnotations(impliedParam.mods.annotations))
@@ -623,6 +627,11 @@ object desugar {
       case _ => false
     }
 
+    def isRepeated(tree: Tree): Boolean = stripByNameType(tree) match {
+      case PostfixOp(_, Ident(tpnme.raw.STAR)) => true
+      case _ => false
+    }
+
     def appliedRef(tycon: Tree, tparams: List[TypeDef] = constrTparams, widenHK: Boolean = false) = {
       val targs = for (tparam <- tparams) yield {
         val targ = refOfDef(tparam)
@@ -639,10 +648,13 @@ object desugar {
       appliedTypeTree(tycon, targs)
     }
 
-    def isRepeated(tree: Tree): Boolean = stripByNameType(tree) match {
-      case PostfixOp(_, Ident(tpnme.raw.STAR)) => true
-      case _ => false
-    }
+    def addParamRefinements(core: Tree, paramss: List[List[ValDef]]): Tree =
+      val refinements =
+        for params <- paramss; param <- params; if param.mods.is(Tracked) yield
+          ValDef(param.name, SingletonTypeTree(TermRefTree().watching(param)), EmptyTree)
+            .withSpan(param.span)
+      if refinements.isEmpty then core
+      else RefinedTypeTree(core, refinements).showing(i"refined result: $result", Printers.desugar)
 
     // a reference to the class type bound by `cdef`, with type parameters coming from the constructor
     val classTypeRef = appliedRef(classTycon)
@@ -864,18 +876,17 @@ object desugar {
         Nil
       }
       else {
-        val defParamss = constrVparamss match {
+        val defParamss = defVparamss match
           case Nil :: paramss =>
             paramss // drop leading () that got inserted by class
                     // TODO: drop this once we do not silently insert empty class parameters anymore
           case paramss => paramss
-        }
         val finalFlag = if ctx.settings.YcompileScala2Library.value then EmptyFlags else Final
         // implicit wrapper is typechecked in same scope as constructor, so
         // we can reuse the constructor parameters; no derived params are needed.
         DefDef(
           className.toTermName, joinParams(constrTparams, defParamss),
-          classTypeRef, creatorExpr)
+          addParamRefinements(classTypeRef, defParamss), creatorExpr)
           .withMods(companionMods | mods.flags.toTermFlags & (GivenOrImplicit | Inline) | finalFlag)
           .withSpan(cdef.span) :: Nil
       }
@@ -904,7 +915,9 @@ object desugar {
       }
       if mods.isAllOf(Given | Inline | Transparent) then
         report.error("inline given instances cannot be trasparent", cdef)
-      val classMods = if mods.is(Given) then mods &~ (Inline | Transparent) | Synthetic else mods
+      var classMods = if mods.is(Given) then mods &~ (Inline | Transparent) | Synthetic else mods
+      if vparamAccessors.exists(_.mods.is(Tracked)) then
+        classMods |= Dependent
       cpy.TypeDef(cdef: TypeDef)(
         name = className,
         rhs = cpy.Template(impl)(constr, parents1, clsDerived, self1,

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -231,6 +231,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
 
     case class Infix()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Infix)
 
+    case class Tracked()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Tracked)
+
     /** Used under pureFunctions to mark impure function types `A => B` in `FunctionWithMods` */
     case class Impure()(implicit @constructorOnly src: SourceFile) extends Mod(Flags.Impure)
   }

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -32,6 +32,7 @@ object Feature:
   val pureFunctions = experimental("pureFunctions")
   val captureChecking = experimental("captureChecking")
   val into = experimental("into")
+  val modularity = experimental("modularity")
 
   val globalOnlyImports: Set[TermName] = Set(pureFunctions, captureChecking)
 

--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -377,6 +377,9 @@ object Flags {
   /** Symbol cannot be found as a member during typer */
   val (Invisible @ _, _, _) = newFlags(45, "<invisible>")
 
+  /** Tracked modifier for class parameter / a class with some tracked parameters */
+  val (Tracked @ _, _, Dependent @ _) = newFlags(46, "tracked")
+
   // ------------ Flags following this one are not pickled ----------------------------------
 
   /** Symbol is not a member of its owner */
@@ -452,7 +455,7 @@ object Flags {
     CommonSourceModifierFlags.toTypeFlags | Abstract | Sealed | Opaque | Open
 
   val TermSourceModifierFlags: FlagSet =
-    CommonSourceModifierFlags.toTermFlags | Inline | AbsOverride | Lazy
+    CommonSourceModifierFlags.toTermFlags | Inline | AbsOverride | Lazy | Tracked
 
   /** Flags representing modifiers that can appear in trees */
   val ModifierFlags: FlagSet =
@@ -466,7 +469,7 @@ object Flags {
   val FromStartFlags: FlagSet = commonFlags(
     Module, Package, Deferred, Method, Case, Enum, Param, ParamAccessor,
     Scala2SpecialFlags, MutableOrOpen, Opaque, Touched, JavaStatic,
-    OuterOrCovariant, LabelOrContravariant, CaseAccessor,
+    OuterOrCovariant, LabelOrContravariant, CaseAccessor, Tracked,
     Extension, NonMember, Implicit, Given, Permanent, Synthetic, Exported,
     SuperParamAliasOrScala2x, Inline, Macro, ConstructorProxy, Invisible)
 
@@ -477,7 +480,7 @@ object Flags {
    */
   val AfterLoadFlags: FlagSet = commonFlags(
     FromStartFlags, AccessFlags, Final, AccessorOrSealed,
-    Abstract, LazyOrTrait, SelfName, JavaDefined, JavaAnnotation, Transparent)
+    Abstract, LazyOrTrait, SelfName, JavaDefined, JavaAnnotation, Transparent, Tracked)
 
   /** A value that's unstable unless complemented with a Stable flag */
   val UnstableValueFlags: FlagSet = Mutable | Method

--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -5,6 +5,7 @@ package core
 import Contexts.*, Symbols.*, Types.*, Flags.*, Scopes.*, Decorators.*, Names.*, NameOps.*
 import SymDenotations.{LazyType, SymDenotation}, StdNames.nme
 import TypeApplications.EtaExpansion
+import collection.mutable
 
 /** Operations that are shared between Namer and TreeUnpickler */
 object NamerOps:
@@ -17,6 +18,26 @@ object NamerOps:
     paramss match
       case TypeSymbols(tparams) :: _ => ctor.owner.typeRef.appliedTo(tparams.map(_.typeRef))
       case _ => ctor.owner.typeRef
+
+  /** Split dependent class refinements off parent type. Add them to `refinements`,
+   *  unless it is null.
+   */
+  extension (tp: Type)
+    def separateRefinements(cls: ClassSymbol, refinements: mutable.LinkedHashMap[Name, Type] | Null)(using Context): Type =
+      tp match
+        case RefinedType(tp1, rname, rinfo) =>
+          try tp1.separateRefinements(cls, refinements)
+          finally
+            if refinements != null then
+              refinements(rname) = refinements.get(rname) match
+                case Some(tp) => tp & rinfo
+                case None => rinfo
+        case tp @ AnnotatedType(tp1, ann) =>
+          tp.derivedAnnotatedType(tp1.separateRefinements(cls, refinements), ann)
+        case tp: RecType =>
+          tp.parent.substRecThis(tp, cls.thisType).separateRefinements(cls, refinements)
+        case tp =>
+          tp
 
   /** If isConstructor, make sure it has at least one non-implicit parameter list
    *  This is done by adding a () in front of a leading old style implicit parameter,

--- a/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
+++ b/compiler/src/dotty/tools/dotc/core/PatternTypeConstrainer.scala
@@ -88,11 +88,6 @@ trait PatternTypeConstrainer { self: TypeComparer =>
       }
     }
 
-    def stripRefinement(tp: Type): Type = tp match {
-      case tp: RefinedOrRecType => stripRefinement(tp.parent)
-      case tp => tp
-    }
-
     def tryConstrainSimplePatternType(pat: Type, scrut: Type) = {
       val patCls = pat.classSymbol
       val scrCls = scrut.classSymbol
@@ -181,14 +176,14 @@ trait PatternTypeConstrainer { self: TypeComparer =>
       case AndType(scrut1, scrut2) =>
         constrainPatternType(pat, scrut1) && constrainPatternType(pat, scrut2)
       case scrut: RefinedOrRecType =>
-        constrainPatternType(pat, stripRefinement(scrut))
+        constrainPatternType(pat, scrut.stripRefinement)
       case scrut => dealiasDropNonmoduleRefs(pat) match {
         case OrType(pat1, pat2) =>
           either(constrainPatternType(pat1, scrut), constrainPatternType(pat2, scrut))
         case AndType(pat1, pat2) =>
           constrainPatternType(pat1, scrut) && constrainPatternType(pat2, scrut)
         case pat: RefinedOrRecType =>
-          constrainPatternType(stripRefinement(pat), scrut)
+          constrainPatternType(pat.stripRefinement, scrut)
         case pat =>
           tryConstrainSimplePatternType(pat, scrut)
           || classesMayBeCompatible && constrainUpcasted(scrut)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -623,6 +623,7 @@ object StdNames {
     val toString_ : N           = "toString"
     val toTypeConstructor: N    = "toTypeConstructor"
     val tpe : N                 = "tpe"
+    val tracked: N              = "tracked"
     val transparent : N         = "transparent"
     val tree : N                = "tree"
     val true_ : N               = "true"

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1190,13 +1190,17 @@ object SymDenotations {
     final def isExtensibleClass(using Context): Boolean =
       isClass && !isOneOf(FinalOrModuleClass) && !isAnonymousClass
 
-    /** A symbol is effectively final if it cannot be overridden in a subclass */
+    /** A symbol is effectively final if it cannot be overridden */
     final def isEffectivelyFinal(using Context): Boolean =
       isOneOf(EffectivelyFinalFlags)
       || is(Inline, butNot = Deferred)
       || is(JavaDefinedVal, butNot = Method)
       || isConstructor
-      || !owner.isExtensibleClass
+      || !owner.isExtensibleClass && !is(Deferred)
+      	// Deferred symbols can arise through parent refinements.
+      	// For them, the overriding relationship reverses anyway, so
+      	// being in a final class does not mean the symbol cannot be
+      	// implemented concretely in a superclass.
 
     /** A class is effectively sealed if has the `final` or `sealed` modifier, or it
      *  is defined in Scala 3 and is neither abstract nor open.

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -6,11 +6,11 @@ import TypeErasure.ErasedValueType
 import Types.*, Contexts.*, Symbols.*, Flags.*, Decorators.*
 import Names.Name
 
-class TypeUtils {
+class TypeUtils:
   /** A decorator that provides methods on types
    *  that are needed in the transformer pipeline.
    */
-  extension (self: Type) {
+  extension (self: Type)
 
     def isErasedValueType(using Context): Boolean =
       self.isInstanceOf[ErasedValueType]
@@ -150,5 +150,11 @@ class TypeUtils {
       case _ =>
         val cls = self.underlyingClassRef(refinementOK = false).typeSymbol
         cls.isTransparentClass && (!traitOnly || cls.is(Trait))
-  }
-}
+
+    /** Strip all outer refinements off this type */
+    def stripRefinement: Type = self match
+      case self: RefinedOrRecType => self.parent.stripRefinement
+      case seld => self
+
+end TypeUtils
+

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -798,6 +798,7 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
     if (flags.is(Exported)) writeModTag(EXPORTED)
     if (flags.is(Given)) writeModTag(GIVEN)
     if (flags.is(Implicit)) writeModTag(IMPLICIT)
+    if (flags.is(Tracked)) writeModTag(TRACKED)
     if (isTerm) {
       if (flags.is(Lazy, butNot = Module)) writeModTag(LAZY)
       if (flags.is(AbsOverride)) { writeModTag(ABSTRACT); writeModTag(OVERRIDE) }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1054,7 +1054,7 @@ class TreeUnpickler(reader: TastyReader,
       }
       val parentReader = fork
       val parents = readParents(withArgs = false)(using parentCtx)
-      val parentTypes = parents.map(_.tpe.dealias)
+      val parentTypes = parents.map(_.tpe.dealiasKeepAnnots.separateRefinements(cls, null))
       if cls.is(JavaDefined) && parentTypes.exists(_.derivesFrom(defn.JavaAnnotationClass)) then
         cls.setFlag(JavaAnnotation)
       val self =

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -742,6 +742,7 @@ class TreeUnpickler(reader: TastyReader,
           case INVISIBLE => addFlag(Invisible)
           case TRANSPARENT => addFlag(Transparent)
           case INFIX => addFlag(Infix)
+          case TRACKED => addFlag(Tracked)
           case PRIVATEqualified =>
             readByte()
             privateWithin = readWithin

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -62,7 +62,7 @@ object Parsers {
     case ExtensionFollow // extension clause, following extension parameter
 
     def isClass = // owner is a class
-      this == Class || this == CaseClass
+      this == Class || this == CaseClass || this == Given
     def takesOnlyUsingClauses = // only using clauses allowed for this owner
       this == Given || this == ExtensionFollow
     def acceptsVariance =
@@ -3291,7 +3291,7 @@ object Parsers {
         val isAbstractOwner = paramOwner == ParamOwner.Type || paramOwner == ParamOwner.TypeParam
         val start = in.offset
         var mods = annotsAsMods() | Param
-        if paramOwner == ParamOwner.Class || paramOwner == ParamOwner.CaseClass then
+        if paramOwner.isClass then
           mods |= PrivateLocal
         if isIdent(nme.raw.PLUS) && checkVarianceOK() then
           mods |= Covariant
@@ -4011,6 +4011,14 @@ object Parsers {
       val nameStart = in.offset
       val name = if isIdent && followingIsGivenSig() then ident() else EmptyTermName
 
+      // TODO Change syntax description
+      def adjustDefParams(paramss: List[ParamClause]): List[ParamClause] =
+        paramss.nestedMap: param =>
+          if !param.mods.isAllOf(PrivateLocal) then
+            syntaxError(em"method parameter ${param.name} may not be `a val`", param.span)
+          param.withMods(param.mods &~ (AccessFlags | ParamAccessor | Mutable) | Param)
+        .asInstanceOf[List[ParamClause]]
+
       val gdef =
         val tparams = typeParamClauseOpt(ParamOwner.Given)
         newLineOpt()
@@ -4032,16 +4040,17 @@ object Parsers {
             mods1 |= Lazy
             ValDef(name, parents.head, subExpr())
           else
-            DefDef(name, joinParams(tparams, vparamss), parents.head, subExpr())
+            DefDef(name, adjustDefParams(joinParams(tparams, vparamss)), parents.head, subExpr())
         else if (isStatSep || isStatSeqEnd) && parentsIsType then
           if name.isEmpty then
             syntaxError(em"anonymous given cannot be abstract")
-          DefDef(name, joinParams(tparams, vparamss), parents.head, EmptyTree)
+          DefDef(name, adjustDefParams(joinParams(tparams, vparamss)), parents.head, EmptyTree)
         else
-          val tparams1 = tparams.map(tparam => tparam.withMods(tparam.mods | PrivateLocal))
-          val vparamss1 = vparamss.map(_.map(vparam =>
-            vparam.withMods(vparam.mods &~ Param | ParamAccessor | Protected)))
-          val constr = makeConstructor(tparams1, vparamss1)
+          val vparamss1 = vparamss.nestedMap: vparam =>
+            if vparam.mods.is(Private)
+            then vparam.withMods(vparam.mods &~ PrivateLocal | Protected)
+            else vparam
+          val constr = makeConstructor(tparams, vparamss1)
           val templ =
             if isStatSep || isStatSeqEnd then Template(constr, parents, Nil, EmptyValDef, Nil)
             else withTemplate(constr, parents)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3108,6 +3108,7 @@ object Parsers {
           case nme.open => Mod.Open()
           case nme.transparent => Mod.Transparent()
           case nme.infix => Mod.Infix()
+          case nme.tracked => Mod.Tracked()
         }
     }
 
@@ -3174,7 +3175,8 @@ object Parsers {
      *                  |  AccessModifier
      *                  |  override
      *                  |  opaque
-     *  LocalModifier  ::= abstract | final | sealed | open | implicit | lazy | erased | inline | transparent
+     *  LocalModifier  ::= abstract | final | sealed | open | implicit | lazy | erased |
+     *                     inline | transparent
      */
     def modifiers(allowed: BitSet = modifierTokens, start: Modifiers = Modifiers()): Modifiers = {
       @tailrec
@@ -3328,7 +3330,7 @@ object Parsers {
      *  UsingClsTermParamClause::= ‘(’ ‘using’ [‘erased’] (ClsParams | ContextTypes) ‘)’
      *  ClsParams         ::=  ClsParam {‘,’ ClsParam}
      *  ClsParam          ::=  {Annotation}
-     *
+     *                         [{Modifier | ‘tracked’} (‘val’ | ‘var’) | ‘inline’] Param
      *  TypelessClause    ::= DefTermParamClause
      *                      | UsingParamClause
      *
@@ -3364,6 +3366,8 @@ object Parsers {
         if isErasedKw then
           mods = addModifier(mods)
         if paramOwner.isClass then
+          if isIdent(nme.tracked) && in.featureEnabled(Feature.modularity) && !in.lookahead.isColon then
+            mods = addModifier(mods)
           mods = addFlag(modifiers(start = mods), ParamAccessor)
           mods =
             if in.token == VAL then
@@ -3435,7 +3439,8 @@ object Parsers {
                   val isParams =
                     !impliedMods.is(Given)
                     || startParamTokens.contains(in.token)
-                    || isIdent && (in.name == nme.inline || in.lookahead.isColon)
+                    || isIdent
+                        && (in.name == nme.inline || in.name == nme.tracked || in.lookahead.isColon)
                   (mods, isParams)
               (if isParams then commaSeparated(() => param())
               else contextTypes(paramOwner, numLeadParams, impliedMods)) match {
@@ -4015,8 +4020,8 @@ object Parsers {
       def adjustDefParams(paramss: List[ParamClause]): List[ParamClause] =
         paramss.nestedMap: param =>
           if !param.mods.isAllOf(PrivateLocal) then
-            syntaxError(em"method parameter ${param.name} may not be `a val`", param.span)
-          param.withMods(param.mods &~ (AccessFlags | ParamAccessor | Mutable) | Param)
+            syntaxError(em"method parameter ${param.name} may not be a `val`", param.span)
+          param.withMods(param.mods &~ (AccessFlags | ParamAccessor | Tracked | Mutable) | Param)
         .asInstanceOf[List[ParamClause]]
 
       val gdef =

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -111,7 +111,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def refinementNameString(tp: RefinedType): String = nameString(tp.refinedName)
 
   /** String representation of a refinement */
-  protected def toTextRefinement(rt: RefinedType): Text =
+  def toTextRefinement(rt: RefinedType): Text =
     val keyword = rt.refinedInfo match {
       case _: ExprType | _: MethodOrPoly => "def "
       case _: TypeBounds => "type "

--- a/compiler/src/dotty/tools/dotc/printing/Printer.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Printer.scala
@@ -4,7 +4,7 @@ package printing
 
 import core.*
 import Texts.*, ast.Trees.*
-import Types.{Type, SingletonType, LambdaParam, NamedType},
+import Types.{Type, SingletonType, LambdaParam, NamedType, RefinedType},
        Symbols.Symbol, Scopes.Scope, Constants.Constant,
        Names.Name, Denotations._, Annotations.Annotation, Contexts.Context
 import typer.Implicits.*
@@ -103,6 +103,9 @@ abstract class Printer {
 
   /** Textual representation of a prefix of some reference, ending in `.` or `#` */
   def toTextPrefixOf(tp: NamedType): Text
+
+  /** textual representation of a refinement, with no enclosing {...} */
+  def toTextRefinement(rt: RefinedType): Text
 
   /** Textual representation of a reference in a capture set */
   def toTextCaptureRef(tp: Type): Text

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -335,11 +335,15 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             case Select(nu: New, nme.CONSTRUCTOR) if isCheckable(nu) =>
               // need to check instantiability here, because the type of the New itself
               // might be a type constructor.
-              ctx.typer.checkClassType(tree.tpe, tree.srcPos, traitReq = false, stablePrefixReq = true)
+              def checkClassType(tpe: Type, stablePrefixReq: Boolean) =
+                ctx.typer.checkClassType(tpe, tree.srcPos,
+                    traitReq = false, stablePrefixReq = stablePrefixReq,
+                    refinementOK = Feature.enabled(Feature.modularity))
+              checkClassType(tree.tpe, true)
               if !nu.tpe.isLambdaSub then
                 // Check the constructor type as well; it could be an illegal singleton type
                 // which would not be reflected as `tree.tpe`
-                ctx.typer.checkClassType(nu.tpe, tree.srcPos, traitReq = false, stablePrefixReq = false)
+                checkClassType(nu.tpe, false)
               Checking.checkInstantiable(tree.tpe, nu.tpe, nu.srcPos)
               withNoCheckNews(nu :: Nil)(app1)
             case _ =>
@@ -415,8 +419,12 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
                   // Constructor parameters are in scope when typing a parent.
                   // While they can safely appear in a parent tree, to preserve
                   // soundness we need to ensure they don't appear in a parent
-                  // type (#16270).
-                  val illegalRefs = parent.tpe.namedPartsWith(p => p.symbol.is(ParamAccessor) && (p.symbol.owner eq sym))
+                  // type (#16270). We can strip any refinement of a parent type since
+                  // these refinements are split off from the parent type constructor
+                  // application `parent` in Namer and don't show up as parent types
+                  // of the class.
+                  val illegalRefs = parent.tpe.stripRefinement.namedPartsWith:
+                      p => p.symbol.is(ParamAccessor) && (p.symbol.owner eq sym)
                   if illegalRefs.nonEmpty then
                     report.error(
                       em"The type of a class parent cannot refer to constructor parameters, but ${parent.tpe} refers to ${illegalRefs.map(_.name.show).mkString(",")}", parent.srcPos)

--- a/compiler/src/dotty/tools/dotc/transform/init/Util.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Util.scala
@@ -20,6 +20,7 @@ object Util:
 
   def typeRefOf(tp: Type)(using Context): TypeRef = tp.dealias.typeConstructor match
     case tref: TypeRef => tref
+    case RefinedType(parent, _, _) => typeRefOf(parent)
     case hklambda: HKTypeLambda => typeRefOf(hklambda.resType)
 
 

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -33,8 +33,7 @@ import Applications.unapplyArgs
 import Inferencing.isFullyDefined
 import transform.patmat.SpaceEngine.{isIrrefutable, isIrrefutableQuotePattern}
 import transform.ValueClasses.underlyingOfValueClass
-import config.Feature
-import config.Feature.sourceVersion
+import config.Feature, Feature.{sourceVersion, modularity}
 import config.SourceVersion.*
 import config.MigrationVersion
 import printing.Formatting.hlAsKeyword
@@ -197,7 +196,7 @@ object Checking {
    *  and that the instance conforms to the self type of the created class.
    */
   def checkInstantiable(tp: Type, srcTp: Type, pos: SrcPos)(using Context): Unit =
-    tp.underlyingClassRef(refinementOK = false) match
+    tp.underlyingClassRef(refinementOK = Feature.enabled(modularity)) match
       case tref: TypeRef =>
         val cls = tref.symbol
         if (cls.isOneOf(AbstractOrTrait)) {
@@ -605,6 +604,7 @@ object Checking {
     // The issue with `erased inline` is that the erased semantics get lost
     // as the code is inlined and the reference is removed before the erased usage check.
     checkCombination(Erased, Inline)
+    checkNoConflict(Tracked, Mutable, em"mutable variables may not be `tracked`")
     checkNoConflict(Lazy, ParamAccessor, em"parameter may not be `lazy`")
   }
 
@@ -1059,8 +1059,8 @@ trait Checking {
   *   check that class prefix is stable.
    *  @return  `tp` itself if it is a class or trait ref, ObjectType if not.
    */
-  def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type =
-    tp.underlyingClassRef(refinementOK = false) match {
+  def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean, refinementOK: Boolean = false)(using Context): Type =
+    tp.underlyingClassRef(refinementOK) match
       case tref: TypeRef =>
         if (traitReq && !tref.symbol.is(Trait)) report.error(TraitIsExpected(tref.symbol), pos)
         if (stablePrefixReq && ctx.phase <= refchecksPhase) checkStable(tref.prefix, pos, "class prefix")
@@ -1068,7 +1068,6 @@ trait Checking {
       case _ =>
         report.error(NotClassType(tp), pos)
         defn.ObjectType
-    }
 
   /** If `sym` is an old-style implicit conversion, check that implicit conversions are enabled.
    *  @pre  sym.is(GivenOrImplicit)
@@ -1642,7 +1641,7 @@ trait NoChecking extends ReChecking {
   override def checkNonCyclic(sym: Symbol, info: TypeBounds, reportErrors: Boolean)(using Context): Type = info
   override def checkNonCyclicInherited(joint: Type, parents: List[Type], decls: Scope, pos: SrcPos)(using Context): Unit = ()
   override def checkStable(tp: Type, pos: SrcPos, kind: String)(using Context): Unit = ()
-  override def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean)(using Context): Type = tp
+  override def checkClassType(tp: Type, pos: SrcPos, traitReq: Boolean, stablePrefixReq: Boolean, refinementOK: Boolean)(using Context): Type = tp
   override def checkImplicitConversionDefOK(sym: Symbol)(using Context): Unit = ()
   override def checkImplicitConversionUseOK(tree: Tree, expected: Type)(using Context): Unit = ()
   override def checkFeasibleParent(tp: Type, pos: SrcPos, where: => String = "")(using Context): Type = tp

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -55,11 +55,12 @@ class Namer { typer: Typer =>
 
   import untpd.*
 
-  val TypedAhead      : Property.Key[tpd.Tree]            = new Property.Key
-  val ExpandedTree    : Property.Key[untpd.Tree]          = new Property.Key
-  val ExportForwarders: Property.Key[List[tpd.MemberDef]] = new Property.Key
-  val SymOfTree       : Property.Key[Symbol]              = new Property.Key
-  val AttachedDeriver : Property.Key[Deriver]             = new Property.Key
+  val TypedAhead       : Property.Key[tpd.Tree]            = new Property.Key
+  val ExpandedTree     : Property.Key[untpd.Tree]          = new Property.Key
+  val ExportForwarders : Property.Key[List[tpd.MemberDef]] = new Property.Key
+  val ParentRefinements: Property.Key[List[Symbol]]        = new Property.Key
+  val SymOfTree        : Property.Key[Symbol]              = new Property.Key
+  val AttachedDeriver  : Property.Key[Deriver]             = new Property.Key
     // was `val Deriver`, but that gave shadowing problems with constructor proxies
 
   /** A partial map from unexpanded member and pattern defs and to their expansions.
@@ -1499,6 +1500,7 @@ class Namer { typer: Typer =>
     /** The type signature of a ClassDef with given symbol */
     override def completeInCreationContext(denot: SymDenotation): Unit = {
       val parents = impl.parents
+      val parentRefinements = new mutable.LinkedHashMap[Name, Type]
 
       /* The type of a parent constructor. Types constructor arguments
        * only if parent type contains uninstantiated type parameters.
@@ -1550,8 +1552,13 @@ class Namer { typer: Typer =>
         val ptype = parentType(parent)(using completerCtx.superCallContext).dealiasKeepAnnots
         if (cls.isRefinementClass) ptype
         else {
-          val pt = checkClassType(ptype, parent.srcPos,
-              traitReq = parent ne parents.head, stablePrefixReq = true)
+          val pt = checkClassType(
+              if Feature.enabled(modularity)
+              then ptype.separateRefinements(cls, parentRefinements)
+              else ptype,
+              parent.srcPos,
+              traitReq = parent ne parents.head,
+              stablePrefixReq = true)
           if (pt.derivesFrom(cls)) {
             val addendum = parent match {
               case Select(qual: Super, _) if Feature.migrateTo3 =>
@@ -1577,6 +1584,21 @@ class Namer { typer: Typer =>
           }
         }
       }
+
+      /** Enter all parent refinements as public class members, unless a definition
+       *  with the same name already exists in the class.
+       */
+      def enterParentRefinementSyms(refinements: List[(Name, Type)]) =
+        val refinedSyms = mutable.ListBuffer[Symbol]()
+        for (name, tp) <- refinements do
+          if decls.lookupEntry(name) == null then
+            val flags = tp match
+              case tp: MethodOrPoly => Method | Synthetic | Deferred
+              case _ => Synthetic | Deferred
+            refinedSyms += newSymbol(cls, name, flags, tp, coord = original.rhs.span.startPos).entered
+        if refinedSyms.nonEmpty then
+          typr.println(i"parent refinement symbols: ${refinedSyms.toList}")
+          original.pushAttachment(ParentRefinements, refinedSyms.toList)
 
       /** If `parents` contains references to traits that have supertraits with implicit parameters
        *  add those supertraits in linearization order unless they are already covered by other
@@ -1646,6 +1668,7 @@ class Namer { typer: Typer =>
       cls.invalidateMemberCaches() // we might have checked for a member when parents were not known yet.
       cls.setNoInitsFlags(parentsKind(parents), untpd.bodyKind(rest))
       cls.setStableConstructor()
+      enterParentRefinementSyms(parentRefinements.toList)
       processExports(using localCtx)
       defn.patchStdLibClass(cls)
       addConstructorProxies(cls)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -26,7 +26,7 @@ import Nullables.*
 import transform.ValueClasses.*
 import TypeErasure.erasure
 import reporting.*
-import config.Feature.sourceVersion
+import config.Feature.{sourceVersion, modularity}
 import config.SourceVersion.*
 
 import scala.compiletime.uninitialized
@@ -1199,7 +1199,7 @@ class Namer { typer: Typer =>
                 target = target.etaExpand(target.typeParams)
               newSymbol(
                 cls, forwarderName,
-                Exported | Final,
+                Exported | (if Feature.enabled(modularity) then EmptyFlags else Final),
                 TypeAlias(target),
                 coord = span)
               // Note: This will always create unparameterzied aliases. So even if the original type is

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1514,8 +1514,9 @@ class Namer { typer: Typer =>
           core match
             case Select(New(tpt), nme.CONSTRUCTOR) =>
               val targs1 = targs map (typedAheadType(_))
-              val ptype = typedAheadType(tpt).tpe appliedTo targs1.tpes
-              if (ptype.typeParams.isEmpty) ptype
+              val ptype = typedAheadType(tpt).tpe.appliedTo(targs1.tpes)
+              if ptype.typeParams.isEmpty && !ptype.dealias.typeSymbol.is(Dependent) then
+                ptype
               else
                 if (denot.is(ModuleClass) && denot.sourceModule.isOneOf(GivenOrImplicit))
                   missingType(denot.symbol, "parent ")(using creationContext)
@@ -1593,7 +1594,8 @@ class Namer { typer: Typer =>
         for (name, tp) <- refinements do
           if decls.lookupEntry(name) == null then
             val flags = tp match
-              case tp: MethodOrPoly => Method | Synthetic | Deferred
+              case tp: MethodOrPoly => Method | Synthetic | Deferred | Tracked
+              case _ if name.isTermName => Synthetic | Deferred | Tracked
               case _ => Synthetic | Deferred
             refinedSyms += newSymbol(cls, name, flags, tp, coord = original.rhs.span.startPos).entered
         if refinedSyms.nonEmpty then

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -564,15 +564,22 @@ object RefChecks {
         overrideError("is not inline, cannot implement an inline method")
       else if (other.isScala2Macro && !member.isScala2Macro) // (1.11)
         overrideError("cannot be used here - only Scala-2 macros can override Scala-2 macros")
-      else if (!compatTypes(memberTp(self), otherTp(self)) &&
-                 !compatTypes(memberTp(upwardsSelf), otherTp(upwardsSelf)))
+      else if !compatTypes(memberTp(self), otherTp(self))
+           && !compatTypes(memberTp(upwardsSelf), otherTp(upwardsSelf))
+           && !member.is(Tracked)
+           	// Tracked members need to be excluded since they are abstract type members with
+           	// singleton types. Concrete overrides usually have a wider type.
+           	// TODO: Should we exclude all refinements inherited from parents?
+      then
         overrideError("has incompatible type", compareTypes = true)
       else if (member.targetName != other.targetName)
         if (other.targetName != other.name)
           overrideError(i"needs to be declared with @targetName(${"\""}${other.targetName}${"\""}) so that external names match")
         else
           overrideError("cannot have a @targetName annotation since external names would be different")
-      else if other.is(ParamAccessor) && !isInheritedAccessor(member, other) then // (1.12)
+      else if other.is(ParamAccessor) && !isInheritedAccessor(member, other)
+           && !member.is(Tracked)
+      then // (1.12)
         report.errorOrMigrationWarning(
             em"cannot override val parameter ${other.showLocated}",
             member.srcPos,
@@ -622,6 +629,10 @@ object RefChecks {
         mbr.isType
         || mbr.isSuperAccessor // not yet synthesized
         || mbr.is(JavaDefined) && hasJavaErasedOverriding(mbr)
+        || mbr.is(Tracked)
+          // Tracked members correspond to existing val parameters, so they don't
+          // count as deferred. The val parameter could not implement the tracked
+          // refinement since it usually has a wider type.
 
       def isImplemented(mbr: Symbol) =
         val mbrDenot = mbr.asSeenFrom(clazz.thisType)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -40,8 +40,7 @@ import annotation.tailrec
 import Implicits.*
 import util.Stats.record
 import config.Printers.{gadts, typr}
-import config.Feature
-import config.Feature.{sourceVersion, migrateTo3}
+import config.Feature, Feature.{sourceVersion, migrateTo3, modularity}
 import config.SourceVersion.*
 import rewrites.Rewrites, Rewrites.patch
 import staging.StagingLevel
@@ -909,10 +908,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         	tp.exists
         	&& !tp.typeSymbol.is(Final)
         	&& (!tp.isTopType || tp.isAnyRef) // Object is the only toplevel class that can be instantiated
-        if (templ1.parents.isEmpty &&
-            isFullyDefined(pt, ForceDegree.flipBottom) &&
-            isSkolemFree(pt) &&
-            isEligible(pt.underlyingClassRef(refinementOK = false)))
+        if templ1.parents.isEmpty
+            && isFullyDefined(pt, ForceDegree.flipBottom)
+            && isSkolemFree(pt)
+            && isEligible(pt.underlyingClassRef(refinementOK = Feature.enabled(modularity)))
+        then
           templ1 = cpy.Template(templ)(parents = untpd.TypeTree(pt) :: Nil)
         for case parent: RefTree <- templ1.parents do
           typedAhead(parent, tree => inferTypeParams(typedType(tree), pt))
@@ -2767,6 +2767,19 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       }
     }
 
+    /** Add all parent refinement symbols as declarations to this class */
+    def addParentRefinements(body: List[Tree])(using Context): List[Tree] =
+      cdef.getAttachment(ParentRefinements) match
+        case Some(refinedSyms) =>
+          val refinements = refinedSyms.map: sym =>
+            ( if sym.isType then TypeDef(sym.asType)
+              else if sym.is(Method) then DefDef(sym.asTerm)
+              else ValDef(sym.asTerm)
+            ).withSpan(impl.span.startPos)
+          body ++ refinements
+        case None =>
+          body
+
     ensureCorrectSuperClass()
     completeAnnotations(cdef, cls)
     val constr1 = typed(constr).asInstanceOf[DefDef]
@@ -2787,7 +2800,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       cdef.withType(UnspecifiedErrorType)
     else {
       val dummy = localDummy(cls, impl)
-      val body1 = addAccessorDefs(cls, typedStats(impl.body, dummy)(using ctx.inClassContext(self1.symbol))._1)
+      val body1 =
+        addParentRefinements(
+          addAccessorDefs(cls,
+            typedStats(impl.body, dummy)(using ctx.inClassContext(self1.symbol))._1))
 
       checkNoDoubleDeclaration(cls)
       val impl1 = cpy.Template(impl)(constr1, parents1, Nil, self1, body1)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4332,7 +4332,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           cpy.Ident(qual)(qual.symbol.name.sourceModuleName.toTypeName)
         case _ =>
           errorTree(tree, em"cannot convert from $tree to an instance creation expression")
-      val tycon = ctorResultType.underlyingClassRef(refinementOK = false)
+      val tycon = ctorResultType.underlyingClassRef(refinementOK = true)
       typed(
         untpd.Select(
           untpd.New(untpd.TypedSplice(tpt.withType(tycon))),

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -113,3 +113,6 @@ java-inherited-type1
 
 # recursion limit exceeded
 i7445b.scala
+
+# alias types at different levels of dereferencing
+parsercombinators-givens.scala

--- a/docs/_docs/internals/syntax.md
+++ b/docs/_docs/internals/syntax.md
@@ -353,7 +353,7 @@ ClsParamClause    ::=  [nl] ‘(’ ClsParams ‘)’
                     |  [nl] ‘(’ ‘using’ (ClsParams | FunArgTypes) ‘)’
 ClsParams         ::=  ClsParam {‘,’ ClsParam}
 ClsParam          ::=  {Annotation}                                             ValDef(mods, id, tpe, expr) -- point of mods on val/var
-                       [{Modifier} (‘val’ | ‘var’) | ‘inline’] Param
+                       [{Modifier | ‘tracked’} (‘val’ | ‘var’) | ‘inline’] Param
 
 DefParamClauses   ::=  DefParamClause { DefParamClause } -- and two DefTypeParamClause cannot be adjacent
 DefParamClause    ::=  DefTypeParamClause

--- a/docs/_docs/reference/experimental/modularity.md
+++ b/docs/_docs/reference/experimental/modularity.md
@@ -1,0 +1,191 @@
+---
+layout: doc-page
+title: "Modularity Improvements"
+nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/modularity.html
+---
+
+# Modularity Improvements
+
+Martin Odersky, 7.1.2024
+
+Scala is a language in the SML tradition, in the sense that it has
+abstract and alias types as members of classes. This leads to a simple dependently
+typed system, where dependencies in types are on paths instead of full terms.
+
+So far, some key ingredients were lacking which meant that module composition with functors is harder in Scala than in SML. In particular, one often needs to resort the infamous `Aux` pattern that lifts type members into type parameters so that they can be tracked across class instantiations. This makes modular, dependently typed programs
+much harder to write and read, and makes such programming only accessible to experts.
+
+In this note I propose some small changes to Scala's dependent typing that makes
+modular programming much more straightforward.
+
+The suggested improvements have been implemented and are available
+in source version `future` if the additional experimental language import `modularity` is present. For instance, using
+
+```
+  scala compile -source future -language experimental.modularity
+```
+
+## Tracked Parameters
+
+Scala is dependently typed for functions, but unfortunately not for classes.
+For instance, consider the following definitions:
+
+```scala
+  class C:
+    type T
+    ...
+
+  def f(x: C): x.T = ...
+
+  val y: C { type T = Int }
+```
+Then `f(y)` would have type `Int`, since the compiler will substitute the
+concrete parameter reference `y` for the formal parameter `x` in the result
+type of `f`.
+
+However, if we use a class `F` instead of a method `f`, things go wrong.
+
+```scala
+  class F(val x: C):
+    val result: x.T = ...
+```
+Now `F(y).result` would not have type `Int` but instead the rather less useful type `?1.T` where `?1` is a so-called skolem constant of type `C` (a skolem represents an unknown value).
+
+This shortcoming means that classes cannot really be used for advanced
+modularity constructs that rely on dependent typing.
+
+**Proposal:** Introduce a `tracked` modifier that can be added to
+a `val` parameter of a class or trait. For every tracked class parameter of a class `C`, add a refinement in the constructor type of `C` that the class member is the same as the parameter.
+
+**Example:** In the setting above, assume `F` is instead declared like this:
+```scala
+  class F(tracked val x: C):
+    val result: x.T = ...
+```
+Then the constructor `F` would get roughly the following type:
+```scala
+  F(x1: C): F { val x: x1.type }
+```
+_Aside:_ More precisely, both parameter and refinement would apply to the same name `x` but the refinement still refers to the parameter. We unfortunately can't express that in source, however, so we chose the new name `x1` for the parameter.
+
+With the new constructor type, the expression `F(y).result` would now have the type `Int`, as hoped for. The reasoning to get there is as follows:
+
+ - The result of the constructor `F(y)` has type `F { val x: y.type }` by
+   the standard typing for dependent functions.
+ - The type of `result` inside `F` is `x.T`.
+ - Hence, the type of `result` as a member of `F { val x: y.type }` is `y.T`, which is equal to `Int`.
+
+The addition of tracked parameters makes classes suitable as a fundamental modularity construct supporting dependent typing. Here is an example, taken from issue #3920:
+
+```scala
+trait Ordering:
+  type T
+  def compare(t1:T, t2: T): Int
+
+class SetFunctor(tracked val ord: Ordering):
+  type Set = List[ord.T]
+
+  def empty: Set = Nil
+
+  extension (s: Set)
+    def add(x: ord.T): Set = x :: remove(x)
+    def remove(x: ord.T): Set = s.filter(e => ord.compare(x, e) != 0)
+    def contains(x: ord.T): Boolean = s.exists(e => ord.compare(x, e) == 0)
+
+object intOrdering extends Ordering:
+  type T = Int
+  def compare(t1: T, t2: T): Int = t1 - t2
+
+val IntSet = new SetFunctor(intOrdering)
+
+@main def Test =
+  import IntSet.*
+  val set = IntSet.empty.add(6).add(8).add(23)
+  assert(!set.contains(7))
+  assert(set.contains(8))
+```
+This works as it should now. Without the addition of `tracked` to the
+parameter of `SetFunctor` typechecking would immediately lose track of
+the element type `T` after an `add`, and would therefore fail.
+
+**Syntax Change**
+
+```
+ClsParam  ::=  {Annotation} [{Modifier | ‘tracked’} (‘val’ | ‘var’) | ‘inline’] Param
+```
+
+The (soft) `tracked` modifier is only allowed for `val` parameters of classes.
+
+**Discussion**
+
+Since `tracked` is so useful, why not assume it by default? First, `tracked` makes sense only for `val` parameters. If a class parameter is not also a field declared using `val` then there's nothing to refine in the constructor.
+But making all `val` parameters tracked by default would also be a backwards
+incompatible change. For instance, the following code would break:
+
+```scala
+case class Foo(x: Int)
+var foo = Foo(1)
+if someCondition then foo = Foo(2)
+```
+if we assume `tracked` for parameter `x` (which is implicitly a `val`),
+then `foo` would get inferred type `Foo { val x: 1 }`, so it could not
+be reassigned to a value of type `Foo { val x: 2 }`.
+
+Another approach might be to assume `tracked` for a `val` parameter `x`
+only if the class refers to a type member of `x`. But it turns out that this
+scheme is unimplementable since it would quickly lead to cyclic references
+in recursive class graphs. So an explicit `tracked` looks like the best feasible option.
+
+## Allow Class Parents to be Refined Types
+
+Since `tracked` parameters create refinements in constructor types,
+it is now possible that a class has a parent that is a refined type.
+Previously such types were not permitted, since we were not quite sure how to handle them. But with tracked parameters it becomes pressing so
+admit such types.
+
+**Proposal** Allow refined types as parent types of classes. All refinements that are inherited in this way become synthetic members of the class.
+
+**Example**
+
+```scala
+class C:
+  type T
+  def m(): T
+
+type R = C:
+  type T = Int
+  def m(): 22
+
+class D extends R:
+  def next(): D
+```
+This code now compiles. The definition of `D` is expanded as follows:
+
+```scala
+class D extends C:
+  def next(): D
+  /*synthetic*/ type T = Int
+  /*synthetic*/ def m(): 22
+```
+Note how class refinements are moved from the parent constructor of `D` into the body of class `D` itself.
+
+This change does not entail a syntax change. Syntactically, parent types cannot be refined types themselves. So the following would be illegal:
+```scala
+class D extends C { type T = Int; def m(): 22 }: // error
+  def next(): D
+```
+If a refined type should be used directly as a parent type of a class, it needs to come in parentheses:
+```scala
+class D extends (C { type T = Int; def m(): 22 }) // ok
+  def next(): D
+```
+
+## A Small Relaxation To Export Rules
+
+The rules for export forwarders are changed as follows.
+
+Previously, all export forwarders were declared `final`. Now, only term members are declared `final`. Type aliases are left aside.
+
+This makes it possible to export the same type member into several traits and then mix these traits in the same class. `typeclass-aggregates.scala` shows why this is essential to be able to combine multiple givens with type members.
+
+The change does not lose safety since different type aliases would in any case lead to uninstantiatable classes.

--- a/docs/_docs/reference/other-new-features/export.md
+++ b/docs/_docs/reference/other-new-features/export.md
@@ -37,7 +37,12 @@ final def print(bits: BitMap): Unit = printUnit.print(bits)
 final type PrinterType              = printUnit.PrinterType
 ```
 
-They can be accessed inside `Copier` as well as from outside:
+With the experimental `modularity` language import, only exported methods and values are final, whereas the generated `PrinterType` would be a simple type alias
+```scala
+      type PrinterType              = printUnit.PrinterType
+```
+
+These aliases can be accessed inside `Copier` as well as from outside:
 
 ```scala
 val copier = new Copier
@@ -90,12 +95,17 @@ export O.*
 ```
 
 Export aliases copy the type and value parameters of the members they refer to.
-Export aliases are always `final`. Aliases of given instances are again defined as givens (and aliases of old-style implicits are `implicit`). Aliases of extensions are again defined as extensions. Aliases of inline methods or values are again defined `inline`. There are no other modifiers that can be given to an alias. This has the following consequences for overriding:
+Export aliases of term members are always `final`. Aliases of given instances are again defined as givens (and aliases of old-style implicits are `implicit`). Aliases of extensions are again defined as extensions. Aliases of inline methods or values are again defined `inline`. There are no other modifiers that can be given to an alias. This has the following consequences for overriding:
 
- - Export aliases cannot be overridden, since they are final.
+ - Export aliases of methods or fields cannot be overridden, since they are final.
  - Export aliases cannot override concrete members in base classes, since they are
    not marked `override`.
  - However, export aliases can implement deferred members of base classes.
+ - Export type aliases are normally also final, except when the experimental
+   language import `modularity` is present. The general
+   rules for type aliases ensure in any case that if there are several type aliases in a class,
+   they must agree on their right hand sides, or the class could not be instantiated.
+   So dropping the `final` for export type aliases is safe.
 
 Export aliases for public value definitions that are accessed without
 referring to private values in the qualifier path

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -154,6 +154,7 @@ subsection:
           - page: reference/experimental/cc.md
           - page: reference/experimental/purefuns.md
           - page: reference/experimental/tupled-function.md
+          - page: reference/experimental/modularity.md
       - page: reference/syntax.md
       - title: Language Versions
         index: reference/language-versions/language-versions.md

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -91,6 +91,17 @@ object language:
     @compileTimeOnly("`into` can only be used at compile time in import statements")
     object into
 
+    /** Experimental support for new features for better modularity, including
+     *   - better tracking of dependencies through classes
+     *   - better usability of context bounds
+     *   - better syntax and conventions for type classes
+     *   - ability to merge exported types in intersections
+     *
+     *  @see [[https://dotty.epfl.ch/docs/reference/experimental/modularity]]
+     */
+    @compileTimeOnly("`modularity` can only be used at compile time in import statements")
+    object modularity
+
     /** Was needed to add support for relaxed imports of extension methods.
       * The language import is no longer needed as this is now a standard feature since SIP was accepted.
       * @see [[http://dotty.epfl.ch/docs/reference/contextual/extension-methods]]

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -98,6 +98,7 @@ object language:
      *   - ability to merge exported types in intersections
      *
      *  @see [[https://dotty.epfl.ch/docs/reference/experimental/modularity]]
+     *  @see [[https://dotty.epfl.ch/docs/reference/experimental/typeclasses]]
      */
     @compileTimeOnly("`modularity` can only be used at compile time in import statements")
     object modularity

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -28,6 +28,8 @@ object MiMaFilters {
   val LibraryForward: Map[String, Seq[ProblemFilter]] = Map(
     // Additions that require a new minor version of the library
     Build.previousDottyVersion -> Seq(
+      ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.modularity"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$modularity$"),
     ),
 
     // Additions since last LTS
@@ -62,6 +64,7 @@ object MiMaFilters {
     ),
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem]("dotty.tools.tasty.TastyFormat.TRACKED"),
   )
   val Interfaces: Seq[ProblemFilter] = Seq(
   )

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -223,6 +223,7 @@ Standard-Section: "ASTs" TopLevelStat*
                   EXPORTED                                                         -- An export forwarder
                   OPEN                                                             -- an open class
                   INVISIBLE                                                        -- invisible during typechecking
+                  TRACKED                                                          -- a tracked class parameter / a dependent class
                   Annotation
 
   Variance      = STABLE                                                           -- invariant
@@ -504,6 +505,7 @@ object TastyFormat {
   final val INVISIBLE = 44
   final val EMPTYCLAUSE = 45
   final val SPLITCLAUSE = 46
+  final val TRACKED = 47
 
   // Tree Cat. 2:    tag Nat
   final val firstNatTreeTag = SHAREDterm
@@ -693,7 +695,8 @@ object TastyFormat {
        | INVISIBLE
        | ANNOTATION
        | PRIVATEqualified
-       | PROTECTEDqualified => true
+       | PROTECTEDqualified
+       | TRACKED => true
     case _ => false
   }
 

--- a/tests/neg/i0248-inherit-refined.check
+++ b/tests/neg/i0248-inherit-refined.check
@@ -1,0 +1,8 @@
+-- [E170] Type Error: tests/neg/i0248-inherit-refined.scala:8:18 -------------------------------------------------------
+8 |  class C extends Y                                   // error
+  |                  ^
+  |                  test.A & test.B is not a class type
+-- [E170] Type Error: tests/neg/i0248-inherit-refined.scala:10:18 ------------------------------------------------------
+10 |  class D extends Z                                   // error
+   |                  ^
+   |                  test.A | test.B is not a class type

--- a/tests/neg/i0248-inherit-refined.scala
+++ b/tests/neg/i0248-inherit-refined.scala
@@ -1,10 +1,12 @@
+//> using options -source future -language:experimental.modularity
+
 object test {
   class A { type T }
   type X = A { type T = Int }
-  class B extends X                                   // error
+  class B extends X                                   // was error, now OK
   type Y = A & B
   class C extends Y                                   // error
   type Z = A | B
   class D extends Z                                   // error
-  abstract class E extends ({ val x: Int })           // error
+  abstract class E extends ({ val x: Int })           // was error, now OK
 }

--- a/tests/neg/i3964.scala
+++ b/tests/neg/i3964.scala
@@ -1,0 +1,12 @@
+//> using options -source future -language:experimental.modularity
+trait Animal
+class Dog extends Animal
+class Cat extends Animal
+
+object Test1:
+
+  abstract class Bar { val x: Animal }
+  val bar: Bar { val x: Cat } = new Bar { val x = new Cat }  // error, but should work
+
+  trait Foo { val x: Animal }
+  val foo: Foo { val x: Cat } = new Foo { val x = new Cat }  // error, but should work

--- a/tests/neg/parent-refinement-access.check
+++ b/tests/neg/parent-refinement-access.check
@@ -1,0 +1,7 @@
+-- [E164] Declaration Error: tests/neg/parent-refinement-access.scala:6:6 ----------------------------------------------
+6 |trait Year2(private[Year2] val value: Int) extends (Gen { val x: Int }) // error
+  |      ^
+  |      error overriding value x in trait Year2 of type Int;
+  |        value x in trait Gen of type Any has weaker access privileges; it should be public
+  |      (Note that value x in trait Year2 of type Int is abstract,
+  |      and is therefore overridden by concrete value x in trait Gen of type Any)

--- a/tests/neg/parent-refinement-access.scala
+++ b/tests/neg/parent-refinement-access.scala
@@ -1,0 +1,6 @@
+//> using options -source future -language:experimental.modularity
+
+trait Gen:
+  private[Gen] val x: Any = ()
+
+trait Year2(private[Year2] val value: Int) extends (Gen { val x: Int }) // error

--- a/tests/neg/parent-refinement.check
+++ b/tests/neg/parent-refinement.check
@@ -1,4 +1,25 @@
--- Error: tests/neg/parent-refinement.scala:5:2 ------------------------------------------------------------------------
-5 |  with Ordered[Year] { // error
-  |  ^^^^
-  |  end of toplevel definition expected but 'with' found
+-- Error: tests/neg/parent-refinement.scala:11:6 -----------------------------------------------------------------------
+11 |class Bar extends IdOf[Int], (X { type Value = String }) // error
+   |      ^^^
+   |class Bar cannot be instantiated since it has a member Value with possibly conflicting bounds Int | String <: ... <: Int & String
+-- [E007] Type Mismatch Error: tests/neg/parent-refinement.scala:15:17 -------------------------------------------------
+15 |  val x: Value = 0 // error
+   |                 ^
+   |                 Found:    (0 : Int)
+   |                 Required: Baz.this.Value
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/parent-refinement.scala:21:6 --------------------------------------------------
+21 |  foo(2) // error
+   |      ^
+   |      Found:    (2 : Int)
+   |      Required: Boolean
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/parent-refinement.scala:17:22 -------------------------------------------------
+17 |val x: IdOf[Int] = Baz() // error
+   |                   ^^^^^
+   |                   Found:    Baz
+   |                   Required: IdOf[Int]
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/parent-refinement.scala
+++ b/tests/neg/parent-refinement.scala
@@ -1,7 +1,21 @@
+//> using options -source future -language:experimental.modularity
 
 trait Id { type Value }
-case class Year(value: Int) extends AnyVal
-  with Id { type Value = Int }
-  with Ordered[Year] { // error
+trait X { type Value }
+type IdOf[T] = Id { type Value = T }
 
-}
+case class Year(value: Int) extends AnyVal
+  with (Id { type Value = Int })
+  with Ordered[Year]
+
+class Bar extends IdOf[Int], (X { type Value = String }) // error
+
+class Baz extends IdOf[Int]:
+  type Value = String
+  val x: Value = 0 // error
+
+val x: IdOf[Int] = Baz() // error
+
+object Clash extends ({ def foo(x: Int): Int }):
+  def foo(x: Boolean): Int = 1
+  foo(2) // error

--- a/tests/neg/tracked.check
+++ b/tests/neg/tracked.check
@@ -1,0 +1,50 @@
+-- Error: tests/neg/tracked.scala:2:16 ---------------------------------------------------------------------------------
+2 |class C(tracked x: Int) // error
+  |                ^
+  |                `val` or `var` expected
+-- [E040] Syntax Error: tests/neg/tracked.scala:7:18 -------------------------------------------------------------------
+7 |  def foo(tracked a: Int) = // error
+  |                  ^
+  |                  ':' expected, but identifier found
+-- Error: tests/neg/tracked.scala:8:12 ---------------------------------------------------------------------------------
+8 |    tracked val b: Int = 2 // error
+  |            ^^^
+  |            end of statement expected but 'val' found
+-- Error: tests/neg/tracked.scala:11:10 --------------------------------------------------------------------------------
+11 |  tracked object Foo // error // error
+   |          ^^^^^^
+   |          end of statement expected but 'object' found
+-- Error: tests/neg/tracked.scala:14:10 --------------------------------------------------------------------------------
+14 |  tracked class D // error // error
+   |          ^^^^^
+   |          end of statement expected but 'class' found
+-- Error: tests/neg/tracked.scala:17:10 --------------------------------------------------------------------------------
+17 |  tracked type T = Int // error // error
+   |          ^^^^
+   |          end of statement expected but 'type' found
+-- Error: tests/neg/tracked.scala:20:29 --------------------------------------------------------------------------------
+20 |  given g2(using tracked val x: Int): C = C(x) // error
+   |                 ^^^^^^^^^^^^^^^^^^
+   |                 method parameter x may not be a `val`
+-- Error: tests/neg/tracked.scala:4:21 ---------------------------------------------------------------------------------
+4 |class C2(tracked var x: Int) // error
+  |                     ^
+  |                     mutable variables may not be `tracked`
+-- [E006] Not Found Error: tests/neg/tracked.scala:11:2 ----------------------------------------------------------------
+11 |  tracked object Foo // error // error
+   |  ^^^^^^^
+   |  Not found: tracked
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/tracked.scala:14:2 ----------------------------------------------------------------
+14 |  tracked class D // error // error
+   |  ^^^^^^^
+   |  Not found: tracked
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/tracked.scala:17:2 ----------------------------------------------------------------
+17 |  tracked type T = Int // error // error
+   |  ^^^^^^^
+   |  Not found: tracked
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/tracked.scala
+++ b/tests/neg/tracked.scala
@@ -1,0 +1,20 @@
+//> using options -source future -language:experimental.modularity
+class C(tracked x: Int) // error
+
+class C2(tracked var x: Int) // error
+
+object A:
+  def foo(tracked a: Int) = // error
+    tracked val b: Int = 2 // error
+
+object B:
+  tracked object Foo // error // error
+
+object C:
+  tracked class D // error // error
+
+object D:
+  tracked type T = Int // error // error
+
+object E:
+  given g2(using tracked val x: Int): C = C(x) // error

--- a/tests/neg/tracked2.scala
+++ b/tests/neg/tracked2.scala
@@ -1,0 +1,1 @@
+class C(tracked val x: Int) // error

--- a/tests/new/tracked-mixin-traits.scala
+++ b/tests/new/tracked-mixin-traits.scala
@@ -1,0 +1,16 @@
+trait A:
+  type T
+object a extends A:
+  type T = Int
+
+trait B(tracked val b: A):
+  type T = b.T
+
+trait C(tracked val c: A):
+  type T = c.T
+
+class D extends B(a), C(a):
+  val x: T = 2
+
+
+

--- a/tests/pos/depclass-1.scala
+++ b/tests/pos/depclass-1.scala
@@ -1,0 +1,19 @@
+//> using options -source future -language:experimental.modularity
+class A(tracked val source: String)
+
+class B(x: Int, tracked val source1: String) extends A(source1)
+
+class C(tracked val source2: String) extends B(1, source2)
+
+//class D(source1: String) extends C(source1)
+val x = C("hello")
+val _: A{ val source: "hello" } = x
+
+class Vec[Elem](tracked val size: Int)
+class Vec8 extends Vec[Float](8)
+
+val v = Vec[Float](10)
+val v2 = Vec8()
+val xx: 10 = v.size
+val x2: 8 = v2.size
+

--- a/tests/pos/i3920.scala
+++ b/tests/pos/i3920.scala
@@ -1,0 +1,32 @@
+//> using options -source future -language:experimental.modularity
+trait Ordering {
+  type T
+  def compare(t1:T, t2: T): Int
+}
+
+class SetFunctor(tracked val ord: Ordering) {
+  type Set = List[ord.T]
+  def empty: Set = Nil
+
+  implicit class helper(s: Set) {
+    def add(x: ord.T): Set = x :: remove(x)
+    def remove(x: ord.T): Set = s.filter(e => ord.compare(x, e) != 0)
+    def member(x: ord.T): Boolean = s.exists(e => ord.compare(x, e) == 0)
+  }
+}
+
+object Test {
+  val orderInt = new Ordering {
+    type T = Int
+    def compare(t1: T, t2: T): Int = t1 - t2
+  }
+
+  val IntSet = new SetFunctor(orderInt)
+  import IntSet.*
+
+  def main(args: Array[String]) = {
+    val set = IntSet.empty.add(6).add(8).add(23)
+    assert(!set.member(7))
+    assert(set.member(8))
+  }
+}

--- a/tests/pos/i3964.scala
+++ b/tests/pos/i3964.scala
@@ -1,0 +1,32 @@
+//> using options -source future -language:experimental.modularity
+trait Animal
+class Dog extends Animal
+class Cat extends Animal
+
+object Test2:
+  class Bar(tracked val x: Animal)
+  val b = new Bar(new Cat)
+  val bar: Bar { val x: Cat } = new Bar(new Cat)  // ok
+
+  trait Foo(tracked val x: Animal)
+  val foo: Foo { val x: Cat } = new Foo(new Cat) {} // ok
+
+object Test3:
+  trait Vec(tracked val size: Int)
+  class Vec8 extends Vec(8)
+
+  abstract class Lst(tracked val size: Int)
+  class Lst8 extends Lst(8)
+
+  val v8a: Vec { val size: 8 } = new Vec8
+  val v8b: Vec { val size: 8 } = new Vec(8) {}
+
+  val l8a: Lst { val size: 8 } = new Lst8
+  val l8b: Lst { val size: 8 } = new Lst(8) {}
+
+  class VecN(tracked val n: Int) extends Vec(n)
+  class Vec9 extends VecN(9)
+  val v9a = VecN(9)
+  val _: Vec { val size: 9 } = v9a
+  val v9b = Vec9()
+  val _: Vec { val size: 9 } = v9b

--- a/tests/pos/i3964a/Defs_1.scala
+++ b/tests/pos/i3964a/Defs_1.scala
@@ -1,0 +1,18 @@
+//> using options -source future -language:experimental.modularity
+trait Animal
+class Dog extends Animal
+class Cat extends Animal
+
+object Test2:
+  class Bar(tracked val x: Animal)
+  val b = new Bar(new Cat)
+  val bar: Bar { val x: Cat } = new Bar(new Cat)  // ok
+
+  trait Foo(tracked val x: Animal)
+  val foo: Foo { val x: Cat } = new Foo(new Cat) {} // ok
+
+package coll:
+  trait Vec(tracked val size: Int)
+  class Vec8 extends Vec(8)
+
+  abstract class Lst(tracked val size: Int)

--- a/tests/pos/i3964a/Uses_2.scala
+++ b/tests/pos/i3964a/Uses_2.scala
@@ -1,0 +1,16 @@
+//> using options -source future -language:experimental.modularity
+import coll.*
+class Lst8 extends Lst(8)
+
+val v8a: Vec { val size: 8 } = new Vec8
+val v8b: Vec { val size: 8 } = new Vec(8) {}
+
+val l8a: Lst { val size: 8 } = new Lst8
+val l8b: Lst { val size: 8 } = new Lst(8) {}
+
+class VecN(tracked val n: Int) extends Vec(n)
+class Vec9 extends VecN(9)
+val v9a = VecN(9)
+val _: Vec { val size: 9 } = v9a
+val v9b = Vec9()
+val _: Vec { val size: 9 } = v9b

--- a/tests/pos/parent-refinement.scala
+++ b/tests/pos/parent-refinement.scala
@@ -1,0 +1,48 @@
+//> using options -source future -language:experimental.modularity
+
+class A
+class B extends A
+class C extends B
+
+trait Id { type Value }
+type IdOf[T] = Id { type Value = T }
+trait X { type Value }
+
+case class Year(value: Int) extends IdOf[Int]:
+  val x: Value = 2
+
+type Between[Lo, Hi] = X { type Value >: Lo <: Hi }
+
+class Foo() extends IdOf[B], Between[C, A]:
+  val x: Value = B()
+
+trait Bar extends IdOf[Int], (X { type Value = String })
+
+class Baz extends IdOf[Int]:
+  type Value = String
+  val x: Value = ""
+
+trait Gen:
+  type T
+  val x: T
+
+type IntInst = Gen:
+  type T = Int
+  val x: 0
+
+trait IntInstTrait extends IntInst
+
+abstract class IntInstClass extends IntInstTrait, IntInst
+
+object obj1 extends IntInstTrait:
+  val x = 0
+
+object obj2 extends IntInstClass:
+  val x = 0
+
+def main =
+  val x: obj1.T = 2 - obj2.x
+  val y: obj2.T = 2 - obj1.x
+
+
+

--- a/tests/pos/parsercombinators-expanded.scala
+++ b/tests/pos/parsercombinators-expanded.scala
@@ -1,0 +1,64 @@
+//> using options -source future -language:experimental.modularity
+
+import collection.mutable
+
+/// A parser combinator.
+trait Combinator[T]:
+
+  /// The context from which elements are being parsed, typically a stream of tokens.
+  type Context
+  /// The element being parsed.
+  type Element
+
+  extension (self: T)
+    /// Parses and returns an element from `context`.
+    def parse(context: Context): Option[Element]
+end Combinator
+
+final case class Apply[C, E](action: C => Option[E])
+final case class Combine[A, B](first: A, second: B)
+
+object test:
+
+  class apply[C, E] extends Combinator[Apply[C, E]]:
+    type Context = C
+    type Element = E
+    extension(self: Apply[C, E])
+      def parse(context: C): Option[E] = self.action(context)
+
+  def apply[C, E]: apply[C, E] = new apply[C, E]
+
+  class combine[A, B](
+      tracked val f: Combinator[A],
+      tracked val s: Combinator[B] { type Context = f.Context}
+  ) extends Combinator[Combine[A, B]]:
+    type Context = f.Context
+    type Element = (f.Element, s.Element)
+    extension(self: Combine[A, B])
+      def parse(context: Context): Option[Element] = ???
+
+  def combine[A, B](
+      _f: Combinator[A],
+      _s: Combinator[B] { type Context = _f.Context}
+    ) = new combine[A, B](_f, _s)
+    // cast is needed since the type of new combine[A, B](_f, _s)
+    // drops the required refinement.
+
+  extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
+    if buf.isEmpty then None
+    else try Some(buf.head) finally buf.remove(0)
+
+  @main def hello: Unit = {
+    val source = (0 to 10).toList
+    val stream = source.to(mutable.ListBuffer)
+
+    val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
+    val m = Combine(n, n)
+
+    val c = combine(
+        apply[mutable.ListBuffer[Int], Int],
+        apply[mutable.ListBuffer[Int], Int]
+      )
+    val r = c.parse(m)(stream) // was type mismatch, now OK
+    val rc: Option[(Int, Int)] = r
+  }

--- a/tests/pos/parsercombinators-givens-2.scala
+++ b/tests/pos/parsercombinators-givens-2.scala
@@ -1,0 +1,52 @@
+//> using options -source future -language:experimental.modularity
+
+import collection.mutable
+
+/// A parser combinator.
+trait Combinator[T]:
+
+  /// The context from which elements are being parsed, typically a stream of tokens.
+  type Context
+  /// The element being parsed.
+  type Element
+
+  extension (self: T)
+    /// Parses and returns an element from `context`.
+    def parse(context: Context): Option[Element]
+end Combinator
+
+final case class Apply[C, E](action: C => Option[E])
+final case class Combine[A, B](first: A, second: B)
+
+given apply[C, E]: Combinator[Apply[C, E]] with {
+  type Context = C
+  type Element = E
+  extension(self: Apply[C, E]) {
+    def parse(context: C): Option[E] = self.action(context)
+  }
+}
+
+given combine[A, B, C](using
+    f: Combinator[A] { type Context = C },
+    s: Combinator[B] { type Context = C }
+): Combinator[Combine[A, B]] with {
+  type Context = f.Context
+  type Element = (f.Element, s.Element)
+  extension(self: Combine[A, B]) {
+    def parse(context: Context): Option[Element] = ???
+  }
+}
+
+extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
+  if buf.isEmpty then None
+  else try Some(buf.head) finally buf.remove(0)
+
+@main def hello: Unit = {
+  val source = (0 to 10).toList
+  val stream = source.to(mutable.ListBuffer)
+
+  val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
+  val m = Combine(n, n)
+
+  val r = m.parse(stream) // works, but Element type is not resolved correctly
+}

--- a/tests/pos/parsercombinators-givens.scala
+++ b/tests/pos/parsercombinators-givens.scala
@@ -1,0 +1,54 @@
+//> using options -source future -language:experimental.modularity
+
+import collection.mutable
+
+/// A parser combinator.
+trait Combinator[T]:
+
+  /// The context from which elements are being parsed, typically a stream of tokens.
+  type Context
+  /// The element being parsed.
+  type Element
+
+  extension (self: T)
+    /// Parses and returns an element from `context`.
+    def parse(context: Context): Option[Element]
+end Combinator
+
+final case class Apply[C, E](action: C => Option[E])
+final case class Combine[A, B](first: A, second: B)
+
+given apply[C, E]: Combinator[Apply[C, E]] with {
+  type Context = C
+  type Element = E
+  extension(self: Apply[C, E]) {
+    def parse(context: C): Option[E] = self.action(context)
+  }
+}
+
+given combine[A, B](using
+    tracked val f: Combinator[A],
+    tracked val s: Combinator[B] { type Context = f.Context }
+): Combinator[Combine[A, B]] with {
+  type Context = f.Context
+  type Element = (f.Element, s.Element)
+  extension(self: Combine[A, B]) {
+    def parse(context: Context): Option[Element] = ???
+  }
+}
+
+extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
+  if buf.isEmpty then None
+  else try Some(buf.head) finally buf.remove(0)
+
+@main def hello: Unit = {
+  val source = (0 to 10).toList
+  val stream = source.to(mutable.ListBuffer)
+
+  val n = Apply[mutable.ListBuffer[Int], Int](s => s.popFirst())
+  val m = Combine(n, n)
+
+  val r = m.parse(stream) // error: type mismatch, found `mutable.ListBuffer[Int]`, required `?1.Context`
+  val rc: Option[(Int, Int)] = r
+  // it would be great if this worked
+}

--- a/tests/pos/typeclass-aggregates.scala
+++ b/tests/pos/typeclass-aggregates.scala
@@ -1,0 +1,47 @@
+//> using options -source future -language:experimental.modularity
+trait Ord:
+  type This
+  extension (x: This)
+    def compareTo(y: This): Int
+    def < (y: This): Boolean = compareTo(y) < 0
+    def > (y: This): Boolean = compareTo(y) > 0
+
+  trait OrdProxy extends Ord:
+    export Ord.this.*
+
+trait SemiGroup:
+  type This
+  extension (x: This) def combine(y: This): This
+
+  trait SemiGroupProxy extends SemiGroup:
+    export SemiGroup.this.*
+
+trait Monoid extends SemiGroup:
+  def unit: This
+
+  trait MonoidProxy extends Monoid:
+    export Monoid.this.*
+
+def ordWithMonoid(ord: Ord, monoid: Monoid{ type This = ord.This }): Ord & Monoid =
+  new ord.OrdProxy with monoid.MonoidProxy {}
+
+trait OrdWithMonoid extends Ord, Monoid
+
+def ordWithMonoid2(ord: Ord, monoid: Monoid{ type This = ord.This }) = //: OrdWithMonoid { type This = ord.This} =
+  new OrdWithMonoid with ord.OrdProxy with monoid.MonoidProxy {}
+
+given intOrd: Ord { type This = Int } = ???
+given intMonoid: Monoid { type This = Int } = ???
+
+//given (using ord: Ord, monoid: Monoid{ type This = ord.This }): (Ord & Monoid { type This = ord.This}) =
+//  ordWithMonoid2(ord, monoid)
+
+val x = summon[Ord & Monoid { type This = Int}]
+val y: Int = ??? : x.This
+
+// given [A, B](using ord: A is Ord, monoid: A is Monoid) => A is Ord & Monoid =
+//   new ord.OrdProxy with monoid.MonoidProxy {}
+
+given [A](using ord: Ord { type This = A }, monoid: Monoid { type This = A}): (Ord & Monoid) { type This = A} =
+  new ord.OrdProxy with monoid.MonoidProxy {}
+

--- a/tests/run/i3920.scala
+++ b/tests/run/i3920.scala
@@ -1,0 +1,26 @@
+//> using options -source future -language:experimental.modularity
+trait Ordering:
+  type T
+  def compare(t1:T, t2: T): Int
+
+class SetFunctor(tracked val ord: Ordering):
+  type Set = List[ord.T]
+
+  def empty: Set = Nil
+
+  extension (s: Set)
+    def add(x: ord.T): Set = x :: remove(x)
+    def remove(x: ord.T): Set = s.filter(e => ord.compare(x, e) != 0)
+    def contains(x: ord.T): Boolean = s.exists(e => ord.compare(x, e) == 0)
+
+object intOrdering extends Ordering:
+  type T = Int
+  def compare(t1: T, t2: T): Int = t1 - t2
+
+val IntSet = new SetFunctor(intOrdering)
+
+@main def Test =
+  import IntSet.*
+  val set = IntSet.empty.add(6).add(8).add(23)
+  assert(!set.contains(7))
+  assert(set.contains(8))


### PR DESCRIPTION
For a tracked class parameter we add a refinement in the constructor type that
the class member is the same as the parameter. E.g.
```scala
class C { type T }
class D(tracked val x: C) { type T = x.T }
```
This will generate the constructor type:
```scala
(x1: C): D { val x: x1.type }
```
Without `tracked` the refinement would not be added. This can solve several problems with dependent class
types where previously we lost track of type dependencies.

In particular it addresses the parser combinator test cases that were prompted by this discussion in Scala Users: https://users.scala-lang.org/t/create-an-instance-of-a-type-class-with-methods-depending-on-type-members/9613/4.

This PR is essentially a feasibility study. It shows that we can get better tracking of types through constructors without breaking anything. 

But I am not sure yet a new modifier `tracked`  is the best way to achieve this. Ideally, we would detect when a class uses a class parameter as a path in a type, and refine those parameters only. The problem is that we don't know this in general when we compute the type of a constructor application, since types of class members are computed lazily on first access. 

Example:
```scala
    trait A:
       type T
       def m: T

    class D(x: A):
       def f = x.m
```
We need to typecheck the RHS of `f` in `D` to figure out that `f`'s result type `x.T` refers to the parameter `x`, so that `x` needs a refinement. So computing precise info of what needs to be refined is infeasible.

Some of the other options are:

 1. The current scheme: use a modifier such as `tracked` to indicate refinement. To make this more robust we could make it an error if a type in a public signature refers to an untracked class parameter. So in the example above, we could enforce that class `D` is declared as `class D(tracked x: A)`.
 2. Overapproximate wildly: Make all class parameters tracked (probably this would cause lots of problems).
 3. Overapproximate more conservatively: Maybe make all non-private class parameters tracked. This is appealing at first glance since private class parameters cannot appear in refinements anyway. On the other hand, it would still make all case class parameters tracked, which is probably overkill again. Variations: Make all parameters declared with explicit `val`s tracked, and/or make all parameters in `given ... with` clauses tracked. 
 4. Try to guess: Assume `tracked` for parameters that appear "obviously" in a path. E.g. there is a path with the name of the parameter in an explicitly given signature in the class. Provide a fallback such as a `tracked` modifier or an annotation for parameters that are not obviously in a path. The goal of this compared to (1) is to be less annoying. Why insist on explicit `tracked` if it is clear from the source that a parameter needs to be refined? But I don't like the fragility of this scheme.
