### PR TITLE
Simplify SymDenotations.isSelfSym using the SelfName flag.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -82,7 +82,7 @@ object ContextOps:
     /** A fresh local context with given tree and owner.
      *
      *  #19019 Self valdefs must always keep their enclosing ctx.owner. They
-     *  can be NoSymbol or having a symbol with the SelfName flag, depending on
+     *  can be NoSymbol or having a symbol that `isSelfSym`, depending on
      *  whether they have an explicit name or not. In either case, we avoid
      *  `setOwner`.
      *
@@ -92,7 +92,7 @@ object ContextOps:
      */
     def localContext(tree: untpd.Tree, owner: Symbol): FreshContext = inContext(ctx) {
       val freshCtx = ctx.fresh.setTree(tree)
-      if owner.exists && !owner.is(SelfName) then freshCtx.setOwner(owner) else freshCtx
+      if owner.exists && !owner.isSelfSym then freshCtx.setOwner(owner) else freshCtx
     }
 
     /** Context where `sym` is defined, assuming we are in a nested context. */

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -706,22 +706,8 @@ object SymDenotations {
     def isProvisional(using Context): Boolean =
       flagsUNSAFE.is(Provisional) // do not force the info to check the flag
 
-    /** Is this the denotation of a self symbol of some class?
-     *  This is the case if one of two conditions holds:
-     *  1. It is the symbol referred to in the selfInfo part of the ClassInfo
-     *     which is the type of this symbol's owner.
-     *  2. This symbol is owned by a class, it's selfInfo field refers to a type
-     *     (indicating the self definition does not introduce a name), and the
-     *     symbol's name is "_".
-     *  TODO: Find a more robust way to characterize self symbols, maybe by
-     *       spending a Flag on them?
-     */
-    final def isSelfSym(using Context): Boolean = owner.infoOrCompleter match {
-      case ClassInfo(_, _, _, _, selfInfo) =>
-        selfInfo == symbol ||
-          selfInfo.isInstanceOf[Type] && name == nme.WILDCARD
-      case _ => false
-    }
+    /** Is this the denotation of a self symbol of some class? */
+    final def isSelfSym(using Context): Boolean = this.is(SelfName)
 
     /** Is this definition contained in `boundary`?
      *  Same as `ownersIterator contains boundary` but more efficient.

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -366,7 +366,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
       /** Is `denot` the denotation of a self symbol? */
       def isSelfDenot(denot: Denotation)(using Context) = denot match {
-        case denot: SymDenotation => denot.is(SelfName)
+        case denot: SymDenotation => denot.isSelfSym
         case _ => false
       }
 


### PR DESCRIPTION
And make it more robust in the process.