### PR TITLE
Improvements to Tuples

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -271,22 +271,29 @@ object Tuple:
   def unapply(x: EmptyTuple): true = true
 
   /** Convert an array into a tuple of unknown arity and types */
-  def fromArray[T](xs: Array[T]): Tuple = {
+  def fromArray[T](xs: Array[T]): Tuple =
+    fromArray(xs, xs.length)
+
+  /** Convert the first `n` elements of an array into a tuple of unknown arity and types */
+  def fromArray[T](xs: Array[T], n: Int): Tuple = {
     val xs2 = xs match {
       case xs: Array[Object] => xs
       case xs => xs.map(_.asInstanceOf[Object])
     }
-    runtime.Tuples.fromArray(xs2)
+    runtime.Tuples.fromArray(xs2, n)
   }
 
   /** Convert an immutable array into a tuple of unknown arity and types */
-  def fromIArray[T](xs: IArray[T]): Tuple = {
+  def fromIArray[T](xs: IArray[T]): Tuple = fromIArray(xs, xs.length)
+
+  /** Convert the first `n` elements of an immutable array into a tuple of unknown arity and types */
+  def fromIArray[T](xs: IArray[T], n: Int): Tuple = {
     val xs2: IArray[Object] = xs match {
       case xs: IArray[Object] @unchecked => xs
       case _ =>
         xs.map(_.asInstanceOf[Object])
     }
-    runtime.Tuples.fromIArray(xs2)
+    runtime.Tuples.fromIArray(xs2, n)
   }
 
   /** Convert a Product into a tuple of unknown arity and types */

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -1,6 +1,6 @@
 package scala
 
-import annotation.{experimental, showAsInfix}
+import annotation.showAsInfix
 import compiletime.*
 import compiletime.ops.int.*
 
@@ -65,7 +65,6 @@ sealed trait Tuple extends Product {
   inline def take[This >: this.type <: Tuple](n: Int): Take[This, n.type] =
     runtime.Tuples.take(this, n).asInstanceOf[Take[This, n.type]]
 
-
   /** Given a tuple `(a1, ..., am)`, returns the tuple `(an+1, ..., am)` consisting
    *  all its elements except the first n ones.
    */
@@ -82,7 +81,6 @@ sealed trait Tuple extends Product {
   /** Given a tuple `(a1, ..., am)`, returns the reversed tuple `(am, ..., a1)`
    *  consisting all its elements.
    */
-  @experimental
   inline def reverse[This >: this.type <: Tuple]: Reverse[This] =
     runtime.Tuples.reverse(this).asInstanceOf[Reverse[This]]
 }
@@ -201,14 +199,11 @@ object Tuple {
   type IsMappedBy[F[_]] = [X <: Tuple] =>> X =:= Map[InverseMap[X, F], F]
 
   /** Type of the reversed tuple */
-  @experimental
   type Reverse[X <: Tuple] = Helpers.ReverseImpl[EmptyTuple, X]
 
-  @experimental
   object Helpers:
 
     /** Type of the reversed tuple */
-    @experimental
     type ReverseImpl[Acc <: Tuple, X <: Tuple] <: Tuple = X match
       case x *: xs => ReverseImpl[x *: Acc, xs]
       case EmptyTuple => Acc

--- a/library/src/scala/runtime/Tuples.scala
+++ b/library/src/scala/runtime/Tuples.scala
@@ -28,7 +28,7 @@ object Tuples {
     arr
   }
 
-  def fromArray(xs: Array[Object]): Tuple = xs.length match {
+  def fromArray(xs: Array[Object], n: Int): Tuple = n match {
     case 0  => EmptyTuple
     case 1  => Tuple1(xs(0))
     case 2  => Tuple2(xs(0), xs(1))
@@ -55,9 +55,14 @@ object Tuples {
     case _ => TupleXXL.fromIArray(xs.clone().asInstanceOf[IArray[Object]]).asInstanceOf[Tuple]
   }
 
-  def fromIArray(xs: IArray[Object]): Tuple =
-    if (xs.length <= 22) fromArray(xs.asInstanceOf[Array[Object]])
+  def fromArray(xs: Array[Object]): Tuple = fromArray(xs, xs.length)
+
+  def fromIArray(xs: IArray[Object], n: Int): Tuple =
+    if n <= 22 || n != xs.length
+    then fromArray(xs.asInstanceOf[Array[Object]], n)
     else TupleXXL.fromIArray(xs).asInstanceOf[Tuple]
+
+  def fromIArray(xs: IArray[Object]): Tuple = fromIArray(xs, xs.length)
 
   def fromProduct(xs: Product): Tuple = (xs.productArity match {
     case 0  => EmptyTuple

--- a/library/src/scala/runtime/Tuples.scala
+++ b/library/src/scala/runtime/Tuples.scala
@@ -505,7 +505,6 @@ object Tuples {
     }
   }
 
-  @experimental
   def reverse(self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlReverse(xxl)
     case _ => specialCaseReverse(self)

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -90,14 +90,6 @@ val experimentalDefinitionInLibrary = Set(
   "scala.quoted.Quotes.reflectModule.MethodTypeMethods.hasErasedParams",
   "scala.quoted.Quotes.reflectModule.TermParamClauseMethods.erasedArgs",
   "scala.quoted.Quotes.reflectModule.TermParamClauseMethods.hasErasedArgs",
-
-  // New feature: reverse method on Tuple
-  "scala.Tuple.reverse",
-  "scala.Tuple$.Helpers",
-  "scala.Tuple$.Helpers$",
-  "scala.Tuple$.Helpers$.ReverseImpl",
-  "scala.Tuple$.Reverse",
-  "scala.runtime.Tuples$.reverse"
 )
 
 


### PR DESCRIPTION
 - fromArray now takes optional length, useful when mapping a resizable buffer to a tuple.
 - New types: IndexOf, Contains, IndicesWhere, ReverseOnto
 - New methods: filter, indexOfType, containsType, reverseOnto
 - reverse methods stabilized
 - New boolean types useful for comparing labels: Conforms, Contains, Disjoint

Improve organization and doc comments

 - Bring some order and regularity into sequence of methods and types
 - Make doc comments more regular and informative

