### PR TITLE
Wunused: fix import false positive in constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -102,6 +102,7 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
     pushInBlockTemplatePackageDef(tree)
 
   override def prepareForTemplate(tree: tpd.Template)(using Context): Context =
+    traverser.traverse(tree.constr)
     pushInBlockTemplatePackageDef(tree)
 
   override def prepareForPackageDef(tree: tpd.PackageDef)(using Context): Context =

--- a/tests/pos/i19252.scala
+++ b/tests/pos/i19252.scala
@@ -1,0 +1,10 @@
+//> using options -Werror -Wunused:imports
+package foo {
+  trait D1
+}
+
+object Bug:
+  import foo.D1
+  class Cl(d1: D1):
+    import foo.D1
+end Bug


### PR DESCRIPTION
Fix #19252

In theory, it adds a new false negative instead, but the tree after typer contains the def of val from constructor, so the false pos would be present regardless:
```scala
package <empty> {
  package foo {
    trait D1() extends Object {}
  }
  final lazy module val Bug: Bug = new Bug()
  final module class Bug() extends Object() { this: Bug.type =>
    import foo.D1
    class Cl(d1: foo.D1) extends Object() {
      private[this] val d1: foo.D1
      import foo.*
    }
  }
}
```