### PR TITLE
Inline `unapply`s in the inlining phase

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1956,9 +1956,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             if (bounds != null) sym.info = bounds
           }
           b
-        case t: UnApply if t.symbol.is(Inline) =>
-          assert(!t.symbol.is(Transparent))
-          cpy.UnApply(t)(fun = Inlines.inlinedUnapplyFun(t.fun)) // TODO inline these in the inlining phase (see #19382)
         case t => t
       }
   }


### PR DESCRIPTION
These currently got inlined while typing. Therefore they used to generate code that should not be pickled. The non-transparent inline methods should be inlined in the inlining phase.

This was found while working on #19380.