### PR TITLE
Fix `TypeTreeTypeTest` to not match `TypeBoundsTree`s

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1105,7 +1105,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object TypeTreeTypeTest extends TypeTest[Tree, TypeTree]:
       def unapply(x: Tree): Option[TypeTree & x.type] = x match
-        case x: (tpd.TypeBoundsTree & x.type) => None
+        case TypeBoundsTreeTypeTest(_) => None
         case x: (tpd.Tree & x.type) if x.isType => Some(x)
         case _ => None
     end TypeTreeTypeTest

--- a/tests/pos-macros/i19480/Macro_1.scala
+++ b/tests/pos-macros/i19480/Macro_1.scala
@@ -1,0 +1,11 @@
+import scala.quoted.*
+
+inline def whatever: Int = ${whateverImpl}
+
+def whateverImpl(using Quotes): Expr[Int] = {
+  import quotes.reflect.*
+  val t = '{class K[T]}.asTerm
+  object mapper extends TreeMap
+  mapper.transformTree(t)(Symbol.spliceOwner)
+  '{42}
+}

--- a/tests/pos-macros/i19480/Test_2.scala
+++ b/tests/pos-macros/i19480/Test_2.scala
@@ -1,0 +1,1 @@
+def test = whatever

--- a/tests/pos-macros/i19480b/Macro_1.scala
+++ b/tests/pos-macros/i19480b/Macro_1.scala
@@ -1,0 +1,11 @@
+import scala.quoted.*
+
+inline def whatever: Int = ${whateverImpl}
+
+def whateverImpl(using Quotes): Expr[Int] = {
+  import quotes.reflect.*
+  val t = '{class K[T[_]]}.asTerm
+  object mapper extends TreeMap
+  mapper.transformTree(t)(Symbol.spliceOwner)
+  '{42}
+}

--- a/tests/pos-macros/i19480b/Test_2.scala
+++ b/tests/pos-macros/i19480b/Test_2.scala
@@ -1,0 +1,1 @@
+def test = whatever


### PR DESCRIPTION
Also see `TypeBoundsTreeTypeTest` in `QuotesImpl` and `Quotes` spec

```
   *           +- TypeTree ----+- Inferred
   *           |               +- ...
   *           |               ...
   *           +- TypeBoundsTree
```

Fixes  #19480