### PR TITLE
Publish `scala2-library-tasty-experimental`

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2121,7 +2121,7 @@ object Build {
     // FIXME: we do not aggregate `bin` because its tests delete jars, thus breaking other tests
     def asDottyRoot(implicit mode: Mode): Project = project.withCommonSettings.
       aggregate(`scala3-interfaces`, dottyLibrary, dottyCompiler, tastyCore, `scala3-sbt-bridge`, scala3PresentationCompiler).
-      bootstrappedAggregate(`scala3-language-server`, `scala3-staging`,
+      bootstrappedAggregate(`scala2-library-tasty`, `scala3-language-server`, `scala3-staging`,
         `scala3-tasty-inspector`, `scala3-library-bootstrappedJS`, scaladoc).
       dependsOn(tastyCore).
       dependsOn(dottyCompiler).


### PR DESCRIPTION
We will start publishing `org.scala-lang::scala2-library-tasty-experimental`. This is __not considered fully stable__. 

We publish it to allow users to depend on it for __stabilization purposes__. Once this version of the library is considered fully stable it will become a default dependency of any Scala build.

Example usage in SBT
```scala
libraryDependencies += "org.scala-lang" %% "scala2-library-tasty-experimental" % scalaVersion.value
```

### Behaviour changes
In general, nothing should when compiling against this version of the standard library. If something changes it should be flagged. But this version of the library has more information about the code, which can lead to new warnings (and maybe errors).
* Better pure expression detection, for example: pure trait initialization
* More information for the initialization checker. It might catch more errors that involve the initialization of library classes.
