### PR TITLE
Implement multiple assignments (SIP-59)

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2479,7 +2479,7 @@ object Parsers {
     def expr1Rest(t: Tree, location: Location): Tree =
       if in.token == EQUALS then
         t match
-          case Ident(_) | Select(_, _) | Apply(_, _) | PrefixOp(_, _) =>
+          case Ident(_) | Select(_, _) | Apply(_, _) | PrefixOp(_, _) | Tuple(_) =>
             atSpan(startOffset(t), in.skipToken()) {
               val loc = if location.inArgs then location else Location.ElseWhere
               Assign(t, subPart(() => expr(loc)))

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -215,7 +215,8 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case TailrecNestedCallID //errorNumber: 199
   case FinalLocalDefID // errorNumber: 200
   case InvalidMultipleAssignmentSourceID // errorNumber: 201
-  case MultipleAssignmentShapeMismatchID // errorNumber: 202
+  case InvalidMultipleAssignmentTargetID // errorNumber: 202
+  case MultipleAssignmentShapeMismatchID // errorNumber: 203
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -214,6 +214,8 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case UnusedSymbolID // errorNumber: 198
   case TailrecNestedCallID //errorNumber: 199
   case FinalLocalDefID // errorNumber: 200
+  case InvalidMultipleAssignmentSourceID // errorNumber: 201
+  case MultipleAssignmentShapeMismatchID // errorNumber: 202
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/UniqueMessagePositions.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/UniqueMessagePositions.scala
@@ -33,6 +33,6 @@ trait UniqueMessagePositions extends Reporter {
       for offset <- dia.pos.start to dia.pos.end do
         positions.get((ctx.source, offset)) match
           case Some(dia1) if dia1.hides(dia) =>
-          case _ => positions((ctx.source, offset)) = dia
+          case _ => positions((ctx.source, Integer.valueOf(offset).nn)) = dia
     super.markReported(dia)
 }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3297,6 +3297,14 @@ class InvalidMultipleAssignmentSource(found: Type)(using Context)
   def explain(using Context) = ""
 }
 
+class InvalidMultipleAssignmentTarget()(using Context)
+  extends TypeMsg(InvalidMultipleAssignmentTargetID) {
+  def msg(using Context) =
+    i"""invalid target of multiple assignment.
+        |Multiple assignments admit only one level of nesting."""
+  def explain(using Context) = ""
+}
+
 class MultipleAssignmentShapeMismatch(found: Int, required: Int)(using Context)
   extends TypeMsg(MultipleAssignmentShapeMismatchID) {
   def msg(using Context) =

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3288,3 +3288,20 @@ object UnusedSymbol {
     def privateMembers(using Context): UnusedSymbol = new UnusedSymbol(i"unused private member")
     def patVars(using Context): UnusedSymbol = new UnusedSymbol(i"unused pattern variable")
 }
+
+class InvalidMultipleAssignmentSource(found: Type)(using Context)
+  extends TypeMsg(InvalidMultipleAssignmentSourceID) {
+  def msg(using Context) =
+    i"""invalid source of multiple assignment.
+        |The right hand side must be a tuple but $found was found."""
+  def explain(using Context) = ""
+}
+
+class MultipleAssignmentShapeMismatch(found: Int, required: Int)(using Context)
+  extends TypeMsg(MultipleAssignmentShapeMismatchID) {
+  def msg(using Context) =
+    i"""Source and target of multiple assignment have different sizes.
+        |Source: $found
+        |Target: $required"""
+  def explain(using Context) = ""
+}

--- a/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
@@ -1,0 +1,123 @@
+package dotty.tools
+package dotc
+package typer
+
+import dotty.tools.dotc.ast.Trees.ApplyKind
+import dotty.tools.dotc.ast.tpd
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Names.Name
+import core.Symbols.defn
+
+/** A function computing the assignment of a lvalue.
+  *
+  * @param lhs The target of the assignment.
+  * @param perform: A closure that accepts `lhs` and an untyped tree `rhs`, and returns a tree
+  *   representing the assignment of `rhs` ro `lhs`.
+  */
+private[typer] final class PartialAssignment[+T <: LValue](val lhs: T)(
+    perform: (T, untpd.Tree) => untpd.Tree
+):
+
+  /** Returns a tree computing the assignment of `rhs` to `lhs`. */
+  def apply(rhs: untpd.Tree): untpd.Tree =
+    perform(lhs, rhs)
+
+end PartialAssignment
+
+/** The left-hand side of an assignment. */
+private[typer] sealed abstract class LValue:
+
+  /** Returns the local `val` definitions composing this lvalue. */
+  def locals: List[tpd.ValDef]
+
+  /** Returns this lvalue converted to a rvalue. */
+  def toRValue(using Context): untpd.Tree
+
+  /** Returns a tree computing the assignment of `rhs` to this lvalue. */
+  def formAssignment(rhs: untpd.Tree)(using Context): untpd.Tree
+
+  /** Returns the value of `t`, which may be an expression or a local `val` definition. */
+  protected final def read(t: tpd.Tree)(using Context): tpd.Tree =
+    t match
+      case d: tpd.ValDef => tpd.Ident(d.namedType)
+      case e => e
+
+end LValue
+
+/** A simple expression, typically valid on left-hand side of an `Assign` tree.
+  *
+  * Use this class to represent an assignment that translates to an `Assign` tree or to wrap an
+  * error whose diagnostic can be delayed until the right-hand side is known.
+  *
+  * @param expression The expression of the lvalue.
+  */
+private[typer] final case class SimpleLValue(expression: tpd.Tree) extends LValue:
+
+  def locals: List[tpd.ValDef] =
+    List()
+
+  def toRValue(using Context): untpd.Tree =
+    untpd.TypedSplice(expression)
+
+  def formAssignment(rhs: untpd.Tree)(using Context): untpd.Tree =
+    val s = untpd.Assign(untpd.TypedSplice(expression), rhs)
+    untpd.TypedSplice(s.withType(defn.UnitType))
+
+end SimpleLValue
+
+/** A lvalue represeted by the partial application a function.
+  *
+  * @param function The partially applied function.
+  * @param arguments The arguments of the partial application.
+  * @param kind The way in which the function is applied.
+  */
+private[typer] final case class ApplyLValue(
+    function: tpd.Tree,
+    arguments: List[tpd.Tree],
+    kind: ApplyKind = ApplyKind.Regular
+) extends LValue:
+
+  val locals: List[tpd.ValDef] =
+    (function +: arguments).collect { case d: tpd.ValDef => d }
+
+  def toRValue(using Context): untpd.Tree =
+    untpd.Apply(function, arguments)
+
+  def formAssignment(rhs: untpd.Tree)(using Context): untpd.Tree =
+    val s = untpd.TypedSplice(read(function))
+    val t = arguments.map((a) => untpd.TypedSplice(read(a))) :+ rhs
+    untpd.Apply(s, t)
+
+end ApplyLValue
+
+/** A lvalue represeted by the application of a partially applied method.
+  *
+  * @param receiver The receiver of the partially applied method.
+  * @param member The name of the partially applied method.
+  * @param arguments The arguments of the partial application.
+  */
+private[typer] final case class SelectLValue(
+    receiver: tpd.Tree,
+    member: Name,
+    arguments: List[tpd.Tree] = List()
+) extends LValue:
+
+  def expandReceiver()(using Context): tpd.Tree =
+    receiver match
+      case d: tpd.ValDef => d.rhs
+      case r => r
+
+  val locals: List[tpd.ValDef] =
+    (receiver +: arguments).collect { case d: tpd.ValDef => d }
+
+  def toRValue(using Context): untpd.Tree =
+    require(arguments.isEmpty)
+    untpd.Select(untpd.TypedSplice(expandReceiver()), member)
+
+  def formAssignment(rhs: untpd.Tree)(using Context): untpd.Tree =
+    val s = untpd.Select(untpd.TypedSplice(read(receiver)), member)
+    val t = arguments.map((a) => untpd.TypedSplice(read(a))) :+ rhs
+    untpd.Apply(s, t)
+
+end SelectLValue

--- a/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
@@ -50,9 +50,9 @@ private[typer] final class PossiblyHoistedValue private (representation: tpd.Tre
 
   /** Returns a tree representing the value of `self` along with its hoisted definition, if any. */
   def valueAndDefinition(using Context): (tpd.Tree, Option[tpd.ValDef]) =
-    definition
-      .map((d) => (tpd.Ident(d.namedType), Some(d)))
-      .getOrElse((representation, None))
+    definition match
+      case Some(d) => (tpd.Ident(d.namedType).withSpan(representation.span), Some(d))
+      case _ => (representation, None)
 
 object PossiblyHoistedValue:
 
@@ -61,7 +61,7 @@ object PossiblyHoistedValue:
     if isSingleAssignment || (tpd.exprPurity(e) >= TreeInfo.Pure) then
       new PossiblyHoistedValue(e)
     else
-      new PossiblyHoistedValue(tpd.SyntheticValDef(TempResultName.fresh(), e))
+      new PossiblyHoistedValue(tpd.SyntheticValDef(TempResultName.fresh(), e).withSpan(e.span))
 
 /** The left-hand side of an assignment. */
 private[typer] sealed abstract class LValue:

--- a/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
@@ -73,12 +73,10 @@ end SimpleLValue
   *
   * @param function The partially applied function.
   * @param arguments The arguments of the partial application.
-  * @param kind The way in which the function is applied.
   */
 private[typer] final case class ApplyLValue(
     function: tpd.Tree,
-    arguments: List[tpd.Tree],
-    kind: ApplyKind = ApplyKind.Regular
+    arguments: List[tpd.Tree]
 ) extends LValue:
 
   val locals: List[tpd.ValDef] =

--- a/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
@@ -13,7 +13,7 @@ import core.Symbols.defn
   *
   * @param lhs The target of the assignment.
   * @param perform: A closure that accepts `lhs` and an untyped tree `rhs`, and returns a tree
-  *   representing the assignment of `rhs` ro `lhs`.
+  *   representing the assignment of `rhs` to `lhs`.
   */
 private[typer] final class PartialAssignment[+T <: LValue](val lhs: T)(
     perform: (T, untpd.Tree) => untpd.Tree

--- a/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
@@ -115,6 +115,7 @@ object ApplyLValue:
   /** The callee of a lvalue represented by a partial application. */
   sealed abstract class Callee:
 
+    /** Returns the tree representing this callee. */
     def expanded(using Context): untpd.Tree
 
     /** Returns the local `val` definitions composing this lvalue. */

--- a/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
+++ b/compiler/src/dotty/tools/dotc/typer/PartialAssignment.scala
@@ -92,7 +92,7 @@ private[typer] final case class SimpleLValue(expression: tpd.Tree) extends LValu
 
 end SimpleLValue
 
-/** A lvalue represeted by the partial application a function.
+/** A lvalue represented by the partial application a function.
   *
   * @param function The partially applied function.
   * @param arguments The arguments of the partial application.

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1386,10 +1386,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 val u = ensureAccessible(t, isSuperSelection(core), lhs.srcPos)
                 val v = untpd.rename(core, setterName).withType(u)
                 PartialAssignment(SimpleLValue(v)) { (l, r) =>
-                  untpd.Apply(untpd.TypedSplice(l.expression), List(r))
                   // QUESTION: Why do we need the `typedUnadapted(s, WildcardType, locked)`?
-                  // val s = untpd.Apply(untpd.TypedSplice(lvalue.expression), List(rhs))
-                  // typedUnadapted(s, WildcardType, locked)
+                  val s = untpd.Apply(untpd.TypedSplice(l.expression), List(r))
+                  untpd.TypedSplice(typedUnadapted(s, WildcardType, locked))
                 }
               case _ =>
                 reassignmentToVal()

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1420,10 +1420,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       targets: List[untpd.Tree], rhs: Tree
   )(using Context): Tree =
     val s = mutable.ListBuffer[untpd.Tree]()
-    val u = formPairwiseAssignments(
+    formPairwiseAssignments(
       s, targets, untpd.TypedSplice(rhs), rhs.tpe,
       EmptyTermName)
-    typed(u)
+    typed(untpd.Block(s.toList, untpd.TypedSplice(unitLiteral)))
 
   /** Appends to `statements` the assignments of `targets` to corresponding values in `rhs`.
    *

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1440,7 +1440,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       rhs: untpd.Tree,
       rhsType: Type,
       prefix: TermName
-  )(using Context): untpd.Tree =
+  )(using Context): Unit =
     val source = UniqueName.fresh(prefix)
     val d = untpd.ValDef(source, untpd.TypeTree(rhsType), rhs)
       .withSpan(rhs.span)
@@ -1461,20 +1461,15 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             .withSpan(rhs.span)
 
         /** Forms the assignments of the targets in the range [`i`, `targets.length`). */
-        @tailrec def loop(i: Int): untpd.Block =
-          if (i == targets.length) then
-            untpd.Block(statements.toList, untpd.TypedSplice(unitLiteral))
-          else targets(i) match {
+        for i <- 0 until targets.length do {
+          targets(i) match {
             case untpd.Tuple(lhs) =>
               formPairwiseAssignments(statements, lhs, rhsElement(i + 1), sourceTypes(i), source)
-              loop(i + 1)
             case lhs =>
               val u = untpd.Assign(lhs, rhsElement(i + 1))
               statements.append(u)
-              loop(i + 1)
           }
-
-        loop(0)
+        }
     }
 
   def typedBlockStats(stats: List[untpd.Tree])(using Context): (List[tpd.Tree], Context) =

--- a/tests/init-global/warn/global-irrelevance2.check
+++ b/tests/init-global/warn/global-irrelevance2.check
@@ -1,4 +1,4 @@
--- Warning: tests/init-global/warn/global-irrelevance2.scala:5:6 -------------------------------------------------------
+-- Warning: tests/init-global/warn/global-irrelevance2.scala:5:2 -------------------------------------------------------
 5 |  A.x =  b * 2 // warn
   |  ^^^^^^^^^^^^
   |  Mutating object A during initialization of object B.

--- a/tests/neg/assignments.scala
+++ b/tests/neg/assignments.scala
@@ -13,7 +13,7 @@ object assignments {
     x = x + 1
     x *= 2
 
-    x_= = 2  // error should give missing arguments
+    x_= = 2  // error should give missing arguments // error
   }
 
   var c = new C

--- a/tests/neg/i11561.check
+++ b/tests/neg/i11561.check
@@ -1,5 +1,5 @@
 -- [E081] Type Error: tests/neg/i11561.scala:2:32 ----------------------------------------------------------------------
-2 |  val updateText1 = copy(text = _) // error
+2 |  val updateText1 = copy(text = _) // error // error
   |                                ^
   |                                Missing parameter type
   |
@@ -8,9 +8,15 @@
   |                                  _$1 => State.this.text = _$1
   |                                Expected type for the whole anonymous function:
   |                                  String
--- [E052] Type Error: tests/neg/i11561.scala:3:30 ----------------------------------------------------------------------
+-- [E052] Type Error: tests/neg/i11561.scala:2:25 ----------------------------------------------------------------------
+2 |  val updateText1 = copy(text = _) // error // error
+  |                         ^^^^
+  |                         Reassignment to val text
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i11561.scala:3:25 ----------------------------------------------------------------------
 3 |  val updateText2 = copy(text = (_: String)) // error
-  |                         ^^^^^^^^^^^^^^^^^^
+  |                         ^^^^
   |                         Reassignment to val text
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i11561.scala
+++ b/tests/neg/i11561.scala
@@ -1,3 +1,3 @@
 case class State(text: String):
-  val updateText1 = copy(text = _) // error
+  val updateText1 = copy(text = _) // error // error
   val updateText2 = copy(text = (_: String)) // error

--- a/tests/neg/i16655.check
+++ b/tests/neg/i16655.check
@@ -1,6 +1,13 @@
--- [E052] Type Error: tests/neg/i16655.scala:3:4 -----------------------------------------------------------------------
-3 |  x = 5 // error
-  |  ^^^^^
+-- [E052] Type Error: tests/neg/i16655.scala:3:2 -----------------------------------------------------------------------
+3 |  x = 5 // error // error
+  |  ^
   |  Reassignment to val x
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i16655.scala:3:6 --------------------------------------------------------------
+3 |  x = 5 // error // error
+  |      ^
+  |      Found:    (5 : Int)
+  |      Required: String
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i16655.scala
+++ b/tests/neg/i16655.scala
@@ -1,3 +1,3 @@
 object Test:
   val x = "MyString"
-  x = 5 // error
+  x = 5 // error // error

--- a/tests/neg/i20338a.scala
+++ b/tests/neg/i20338a.scala
@@ -1,10 +1,10 @@
 object types:
   opaque type Struct = Int
   val test: Struct = 25
-  extension (s: Struct) 
+  extension (s: Struct)
     def field: Int = s
     def field_=(other: Int) = ()
 
-@main def hello = 
+@main def hello =
   import types.*
   test.field = "hello" // error

--- a/tests/neg/i20338c.check
+++ b/tests/neg/i20338c.check
@@ -1,6 +1,6 @@
--- [E052] Type Error: tests/neg/i20338c.scala:9:6 ----------------------------------------------------------------------
+-- [E052] Type Error: tests/neg/i20338c.scala:9:4 ----------------------------------------------------------------------
 9 |  f.x = 42 // error
-  |  ^^^^^^^^
+  |  ^^^
   |  Reassignment to val x
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg/multiple-assignment.check
+++ b/tests/neg/multiple-assignment.check
@@ -1,0 +1,11 @@
+-- [E193] Type Error: tests/neg/multiple-assignment.scala:9:16 -----------------
+9 |  ((x, y), z) = 1
+  |                ^
+  |              invalid source of multiple assignment.
+  |              The right hand side must be a tuple but (1 : Int) was found.
+-- [E194] Type Error: tests/neg/multiple-assignment.scala:10:11 ----------------
+10 |  (x, y) = (1, 1, 1)
+   |           ^^^^^^^^^
+   |          Source and target of multiple assignment have different sizes.
+   |          Source: 3
+   |          Target: 2

--- a/tests/neg/multiple-assignment.check
+++ b/tests/neg/multiple-assignment.check
@@ -1,11 +1,23 @@
--- [E193] Type Error: tests/neg/multiple-assignment.scala:9:16 -----------------
-9 |  ((x, y), z) = 1
-  |                ^
-  |              invalid source of multiple assignment.
-  |              The right hand side must be a tuple but (1 : Int) was found.
--- [E194] Type Error: tests/neg/multiple-assignment.scala:10:11 ----------------
-10 |  (x, y) = (1, 1, 1)
+-- [E201] Type Error: tests/neg/multiple-assignment.scala:9:11 ---------------------------------------------------------
+9 |  (x, y) = 1 // error
+  |           ^
+  |           invalid source of multiple assignment.
+  |           The right hand side must be a tuple but (1 : Int) was found.
+-- [E203] Type Error: tests/neg/multiple-assignment.scala:10:11 --------------------------------------------------------
+10 |  (x, y) = (1, 1, 1) // error
    |           ^^^^^^^^^
-   |          Source and target of multiple assignment have different sizes.
-   |          Source: 3
-   |          Target: 2
+   |           Source and target of multiple assignment have different sizes.
+   |           Source: 3
+   |           Target: 2
+-- [E007] Type Mismatch Error: tests/neg/multiple-assignment.scala:11:11 -----------------------------------------------
+11 |  (x, y) = (1, 2) // error
+   |           ^^^^^^
+   |           Found:    (ev$1._2 : Int)
+   |           Required: Boolean
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E202] Type Error: tests/neg/multiple-assignment.scala:12:6 ---------------------------------------------------------
+12 |  (x, (y, z)) = (1, (true, "b")) // error
+   |      ^^^^^^
+   |      invalid target of multiple assignment.
+   |      Multiple assignments admit only one level of nesting.

--- a/tests/neg/multiple-assignment.scala
+++ b/tests/neg/multiple-assignment.scala
@@ -6,5 +6,7 @@ def tu(): (Int, Boolean) = (1, true)
   var y = false
   var z = "a"
 
-  ((x, y), z) = 1
-  (x, y) = (1, 1, 1)
+  (x, y) = 1 // error
+  (x, y) = (1, 1, 1) // error
+  (x, y) = (1, 2) // error
+  (x, (y, z)) = (1, (true, "b")) // error

--- a/tests/neg/multiple-assignment.scala
+++ b/tests/neg/multiple-assignment.scala
@@ -1,3 +1,4 @@
+
 def tu(): (Int, Boolean) = (1, true)
 
 @main def ma(): Unit =
@@ -5,5 +6,5 @@ def tu(): (Int, Boolean) = (1, true)
   var y = false
   var z = "a"
 
-  ((x, y), z) = (tu(), "b")
-
+  ((x, y), z) = 1
+  (x, y) = (1, 1, 1)

--- a/tests/neg/parser-stability-16.scala
+++ b/tests/neg/parser-stability-16.scala
@@ -2,4 +2,4 @@ class x0[x0] {
   val x1 : x0
 }
 trait x3 extends x0 { // error
-x1 = 0 object  // error // error
+x1 = 0 object  // error // error // error

--- a/tests/pos/fibonacci.scala
+++ b/tests/pos/fibonacci.scala
@@ -1,0 +1,15 @@
+class FibonacciIterator() extends Iterator[Int]:
+
+  private var a: Int = 0
+  private var b: Int = 1
+
+  def hasNext = true
+  def next() =
+    val r = a
+    (a, b) = (b, a + b)
+    r
+
+@main def fib() =
+  val i = FibonacciIterator()
+  for _ <- 0 until 10 do
+    println(i.next())

--- a/tests/pos/multiple-assignment.scala
+++ b/tests/pos/multiple-assignment.scala
@@ -5,5 +5,6 @@ def tu(): (Int, Boolean) = (1, true)
   var y = false
   var z = "a"
 
-  ((x, y), z) = (tu(), "b")
-
+  x = 99
+  (x, y) = tu()
+  (x, z) = (2, "b")

--- a/tests/pos/multiple-assignment.scala
+++ b/tests/pos/multiple-assignment.scala
@@ -1,0 +1,4 @@
+def ma(): Unit =
+  var x = 0
+  var y = false
+  (x, y) = (1, true)

--- a/tests/run/multiple-assignment.check
+++ b/tests/run/multiple-assignment.check
@@ -1,0 +1,12 @@
+after swap: (2, 4)
+after swap: (2, 4)
+after swap: (2, 4)
+load 1
+load 2
+load 2
+load 4 from 2
+load 1
+load 2 from 1
+store 4 to 1
+store 2 to 2
+after swap: (4, 2)

--- a/tests/run/multiple-assignment.scala
+++ b/tests/run/multiple-assignment.scala
@@ -1,0 +1,38 @@
+object Test:
+
+  class Container[T](val id: Int, var x: T):
+
+    def y: T =
+      println(s"load ${x} from ${id}")
+      x
+
+    def y_=(newValue: T): Unit =
+      println(s"store ${newValue} to ${id}")
+      this.x_=(newValue)
+
+  def main(args: Array[String]): Unit =
+    // simple swap
+    var x1 = 4
+    var x2 = 2
+    (x1, x2) = (x2, x1)
+    println(s"after swap: (${x1}, ${x2})")
+
+    // swap in a container
+    val a = Array(4, 2)
+    (a(0), a(1)) = (a(1), a(0))
+    println(s"after swap: (${a(0)}, ${a(1)})")
+
+    // swap fields with effectless left-hand sides
+    var c1 = Container(1, 4)
+    var c2 = Container(2, 2)
+    (c1.x, c2.x) = (c2.x, c1.x)
+    println(s"after swap: (${c1.x}, ${c2.x})")
+
+    // swap fields with side effectful left-hand sides
+    def f(n: Int): Container[Int] =
+      println(s"load ${n}")
+      n match
+        case 1 => c1
+        case 2 => c2
+    (f(1).y, f(2).y) = (f(2).y, f(1).y)
+    println(s"after swap: (${c1.x}, ${c2.x})")


### PR DESCRIPTION
This PR is a proof of concept for the implementation of multiple assignments (see [SIP-59](https://github.com/scala/improvement-proposals/pull/73)). ~It is still a work in progress. In particular, it doesn't satisfy Scala's left-to-right evaluation order.~

**Design overview**

The main challenge is to respect Scala's left-to-right evaluation order, which implies that all effectual operations on the left-hand side of the assignment be evaluated before the right-hand side.

An assignment generally desugars to one of two forms:

- If the left-hand side is a simple local variable, then `lhs = rhs` remains an `Assign` tree.
- If the left-hand side is anything more sophisticated, then `lhs = rhs` is rewritten as an `Apply` tree (e.g., `a(0) = 1` becomes `a.update(0, 1)`).

In the case of a single assignment, the current implementation can "simply" perform the translation in one go as it has access to the expressions of both the left-hand and the right-hand sides. In the case of a multiple-assignment, however, the right-hand side is not available during the desugaring of the left-hand side because it may be the result of an expression that we have not yet evaluated. For example:

```scala
def makePair(): (Int, Int) = ???
val a = Array(0, 0)
(a(0), a(1)) = makePair()
```

One solution to address this issue is to assign the result of all effectful sub-expressions to some temporary definitions an construct functions `untpd.Tree => tpd.Tree` that return the assignment of some left-hand side to the value represented by their arguments.  These functions will be called after the tree representing their corresponding right-hand side is evaluated. They are called "assignment builders" in this PR.

Consider this example to illustrate:

```scala
def f(x: Int): Int = ??? // possibly effectful expression
def makePair(): (Int, Int) = ???
val a = Array(0, 0)

// before
(a(f(0)), a(f(1))) = makePair()

// after
val x0 = f(0)
val x1 = f(1)
val x2 = makePair()
a.update(x0, x2._1)
a.update(x1, x2._2)
```

`x0` and `x1` represent the "hoisting" of the effectful operations performed in the left-hand side of the assignment. Then `x2` stores the result of the right-hand side. Finally the two updates perform the assignment. They are the result of calling instances of the aforementioned assignment builders.

*Note: the evaluation order is not "strictly" left-to-right in the sense that the assignments are notionally applications of functions that occur in sources before the right-hand side has been evaluated. These semantics are nonetheless inevitable and match the way an assignment "work" in Scala.*

An assignment composed of a so-called "lvalue" (borrowing from C/C++ terminology) together with a function that constructs a typed tree given an untyped right-hand side.

```scala
final class PartialAssignment[+T <: LValue](val lhs: T)(
    perform: (T, untpd.Tree) => untpd.Tree
)
```

A lvalue notionally represents the target of an assignment. It may be a simple value (e.g., a local variable) or the partial application of some update function or setter. It also contains the definitions of the sub-expressions whose values must be hoisted, which are called "locals" in the implementation:

```scala
sealed abstract class LValue:
  def locals: List[tpd.ValDef]
  def formAssignment(rhs: untpd.Tree)(using Context): untpd.Tree
end LValue
```

Partial assignments are constructed in the typer by the method `formPartialAssignmentTo`. This method is essentially a refactoring of `typedAssign` that constructs lvalues rather than desugaring left-hand sides directly while visiting the tree.

Once partial assignment has been constructed, the final result is built by creating a block containing, in this order:
- The definitions of all hoisted values preserving the order in which sub-expressions must be evaluated
- The evaluation of the right-hand side
- The assignments of all lvalues, from left to right

No value is hoisted in the case of a single assignment so that the result is equivalent to the current behavior.