### PR TITLE
Add supports for type cast and filtering type for field and method owner in global initialization checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -859,7 +859,7 @@ object Objects:
       report.warning("[Internal error] unexpected tree in assignment, fun = " + fun.code.show + Trace.show, Trace.position)
 
     case arr: OfArray =>
-      report.warning("[Internal error] unexpected tree in assignment, array = " + arr.show + s", owner = ${field.owner}\n" + Trace.show, Trace.position)
+      report.warning("[Internal error] unexpected tree in assignment, array = " + arr.show + Trace.show, Trace.position)
 
     case Cold =>
       report.warning("Assigning to cold aliases is forbidden. " + Trace.show, Trace.position)

--- a/compiler/src/dotty/tools/dotc/transform/init/Util.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Util.scala
@@ -78,6 +78,13 @@ object Util:
       case _ =>
         None
 
+  object TypeCast:
+    def unapply(tree: Tree)(using Context): Option[(Tree, Type)] =
+      tree match
+        case TypeApply(Select(qual, _), typeArg) if tree.symbol.isTypeCast =>
+          Some(qual, typeArg.head.tpe)
+        case _ => None
+
   def resolve(cls: ClassSymbol, sym: Symbol)(using Context): Symbol = log("resove " + cls + ", " + sym, printer, (_: Symbol).show):
     if sym.isEffectivelyFinal then sym
     else sym.matchingMember(cls.appliedRef)

--- a/compiler/src/dotty/tools/dotc/transform/init/Util.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Util.scala
@@ -81,8 +81,8 @@ object Util:
   object TypeCast:
     def unapply(tree: Tree)(using Context): Option[(Tree, Type)] =
       tree match
-        case TypeApply(Select(qual, _), typeArg) if tree.symbol.isTypeCast =>
-          Some(qual, typeArg.head.tpe)
+        case TypeApply(Select(qual, _), typeArgs) if tree.symbol.isTypeCast =>
+          Some(qual, typeArgs.head.tpe)
         case _ => None
 
   def resolve(cls: ClassSymbol, sym: Symbol)(using Context): Symbol = log("resove " + cls + ", " + sym, printer, (_: Symbol).show):

--- a/tests/init-global/neg/TypeCast.scala
+++ b/tests/init-global/neg/TypeCast.scala
@@ -1,0 +1,18 @@
+object A {
+  val f: Int = 10
+  def m() = f
+}
+object B {
+  val f: Int = g()
+  def g(): Int = f // error
+}
+object C {
+  val a: A.type | B.type = if ??? then A else B
+  def cast[T](a: Any): T = a.asInstanceOf[T]
+  val c: A.type = cast[A.type](a) // abstraction for c is {A, B}
+  val d = c.f // treat as c.asInstanceOf[owner of f].f
+  val e = c.m() // treat as c.asInstanceOf[owner of f].m()
+  val c2: B.type = cast[B.type](a)
+  val g = c2.f // no error here
+}
+

--- a/tests/init-global/pos/TypeCast1.scala
+++ b/tests/init-global/pos/TypeCast1.scala
@@ -1,0 +1,9 @@
+class A:
+  class B(val b: Int)
+
+object O:
+  val o: A | Array[Int] = new Array[Int](10)
+  o match
+    case a: A => new a.B(10)
+    case arr: Array[Int] => arr(5)
+

--- a/tests/init-global/pos/TypeCast2.scala
+++ b/tests/init-global/pos/TypeCast2.scala
@@ -1,0 +1,9 @@
+class A:
+  class B(val b: Int)
+
+object O:
+  val o: A | (Int => Int) = (x: Int) => x + 1
+  o match
+    case a: A => new a.B(10)
+    case f: (_ => _) => f.asInstanceOf[Int => Int](5)
+

--- a/tests/init-global/pos/TypeCast3.scala
+++ b/tests/init-global/pos/TypeCast3.scala
@@ -1,0 +1,8 @@
+class A:
+  var x: Int = 10
+
+object O:
+  val o: A | (Int => Int) = (x: Int) => x + 1
+  o match
+    case a: A => a.x = 20
+    case f: (_ => _) => f.asInstanceOf[Int => Int](5)

--- a/tests/init-global/pos/TypeCast4.scala
+++ b/tests/init-global/pos/TypeCast4.scala
@@ -1,0 +1,9 @@
+class A:
+  var x: Int = 10
+
+object O:
+  val o: A | Array[Int] = new Array[Int](10)
+  o match
+    case a: A => a.x = 20
+    case arr: Array[Int] => arr(5)
+

--- a/tests/init-global/pos/i18882.scala
+++ b/tests/init-global/pos/i18882.scala
@@ -1,0 +1,15 @@
+class A:
+  var a = 20
+
+class B:
+  var b = 20
+
+object O:
+  val o: A | B = new A
+  if o.isInstanceOf[A] then
+    o.asInstanceOf[A].a += 1
+  else
+    o.asInstanceOf[B].b += 1 // o.asInstanceOf[B] is treated as bottom
+  o match
+    case o: A => o.a += 1
+    case o: B => o.b += 1


### PR DESCRIPTION
This PR adds support for more precise analysis of type casting in global initialization checker, which filters impossible classes after reference casting and preserves only possible classes. It also automatically filter the set of possible classes during field selection or method invocation and only preserves owners of the field/method