### PR TITLE
Don't try default args when there are ambiguous implicits

### DIFF
--- a/tests/neg/19414-desugared.check
+++ b/tests/neg/19414-desugared.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/19414-desugared.scala:34:34 ------------------------------------------------------------
+34 |  summon[BodySerializer[JsObject]] // error: Ambiguous given instances
+   |                                  ^
+   |Ambiguous given instances: both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B] of parameter x of method summon in object Predef

--- a/tests/neg/19414-desugared.scala
+++ b/tests/neg/19414-desugared.scala
@@ -1,0 +1,34 @@
+/** This test checks that provided given instances take precedence over default
+  * given arguments, even when there are multiple default arguments.
+  *
+  * Before the fix for issue #19414, this code would fail with a "No given
+  * instance of type BodySerializer[JsObject]".
+  *
+  * See also:
+  *   - tests/neg/19414.scala
+  *   - tests/neg/given-ambiguous-default-1.scala
+  *   - tests/neg/given-ambiguous-default-2.scala
+  */
+
+trait JsValue
+trait JsObject extends JsValue
+
+trait Writer[T]
+trait BodySerializer[-B]
+
+class Printer
+
+given Writer[JsValue] = ???
+given Writer[JsObject] = ???
+
+// This is not an exact desugaring of the original code: currently the compiler
+// actually changes the modifier of the parameter list from `using` to
+// `implicit` when desugaring the context-bound `B: Writer` to `implicit writer:
+// Writer[B]`, but we can't write in user code as this is not valid syntax.
+given [B](using
+    writer: Writer[B],
+    printer: Printer = new Printer
+): BodySerializer[B] = ???
+
+def f: Unit =
+  summon[BodySerializer[JsObject]] // error: Ambiguous given instances

--- a/tests/neg/19414.check
+++ b/tests/neg/19414.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/19414.scala:27:34 ----------------------------------------------------------------------
+27 |  summon[BodySerializer[JsObject]] // error: Ambiguous given instances
+   |                                  ^
+   |Ambiguous given instances: both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B] of parameter x of method summon in object Predef

--- a/tests/neg/19414.scala
+++ b/tests/neg/19414.scala
@@ -1,0 +1,27 @@
+/** This test checks that provided given instances take precedence over default
+  * given arguments, even when there are multiple default arguments.
+  *
+  * Before the fix for issue #19414, this code would fail with a "No given
+  * instance of type BodySerializer[JsObject]".
+  *
+  * See also:
+  *   - tests/neg/19414-desugared.scala
+  *   - tests/neg/given-ambiguous-default-1.scala
+  *   - tests/neg/given-ambiguous-default-2.scala
+  */
+
+trait JsValue
+trait JsObject extends JsValue
+
+trait Writer[T]
+trait BodySerializer[-B]
+
+class Printer
+
+given Writer[JsValue] = ???
+given Writer[JsObject] = ???
+
+given [B: Writer](using printer: Printer = new Printer): BodySerializer[B] = ???
+
+def f: Unit =
+  summon[BodySerializer[JsObject]] // error: Ambiguous given instances

--- a/tests/neg/given-ambiguous-default-1.check
+++ b/tests/neg/given-ambiguous-default-1.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/given-ambiguous-default-1.scala:19:23 --------------------------------------------------
+19 |def f: Unit = summon[B] // error: Ambiguous given instances
+   |                       ^
+   |Ambiguous given instances: both given instance a1 and given instance a2 match type A of parameter x of method summon in object Predef

--- a/tests/neg/given-ambiguous-default-1.scala
+++ b/tests/neg/given-ambiguous-default-1.scala
@@ -1,0 +1,19 @@
+/** This test checks that provided given instances take precedence over default
+  * given arguments.
+  *
+  * In the following code, the compiler must report an "Ambiguous implicits"
+  * error for the parameter `a`, and must not use its default value.
+  *
+  * See also:
+  *   - tests/neg/19414.scala
+  *   - tests/neg/19414-desugared.scala
+  *   - tests/neg/given-ambiguous-default-2.scala
+  */
+
+class A
+class B
+given a1: A = ???
+given a2: A = ???
+given (using a: A = A()): B = ???
+
+def f: Unit = summon[B] // error: Ambiguous given instances

--- a/tests/neg/given-ambiguous-default-2.check
+++ b/tests/neg/given-ambiguous-default-2.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/given-ambiguous-default-2.scala:19:23 --------------------------------------------------
+19 |def f: Unit = summon[C] // error: Ambiguous given instances
+   |                       ^
+   |Ambiguous given instances: both given instance a1 and given instance a2 match type A of parameter x of method summon in object Predef

--- a/tests/neg/given-ambiguous-default-2.scala
+++ b/tests/neg/given-ambiguous-default-2.scala
@@ -1,0 +1,19 @@
+/** This test checks that provided given instances take precedence over default
+  * given arguments, even when there are multiple default arguments.
+  *
+  * Before the fix for issue #19414, this code would compile without errors.
+  *
+  * See also:
+  *   - tests/neg/given-ambiguous-default-1.scala
+  *   - tests/neg/19414.scala
+  *   - tests/neg/19414-desugared.scala
+  */
+
+class A
+class B
+class C
+given a1: A = ???
+given a2: A = ???
+given (using a: A = A(), b: B = B()): C = ???
+
+def f: Unit = summon[C] // error: Ambiguous given instances


### PR DESCRIPTION
Fixes #19414.