### PR TITLE
fix/scripts: Propagate runner JVM version and skip testing invalid compiler commits

### DIFF
--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -1,3 +1,4 @@
+//> using jvm 17 // Maximal JDK version which can be used with all Scala 3 versions, can be overriden via command line arguments '--jvm=21'
 /*
 This script will bisect a problem with the compiler based on success/failure of the validation script passed as an argument.
 It starts with a fast bisection on released nightly builds.

--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -124,6 +124,7 @@ object ValidationScript:
 
   def tmpScalaCliScript(command: String, args: Seq[String]): File = tmpScript(s"""
     |#!/usr/bin/env bash
+    |export JAVA_HOME=${sys.props("java.home")}
     |scala-cli ${command} -S "$$1" --server=false ${args.mkString(" ")}
     |""".stripMargin
   )
@@ -242,6 +243,7 @@ class CommitBisect(validationScript: File, shouldFail: Boolean, bootstrapped: Bo
     val bisectRunScript = raw"""
       |scalaVersion=$$(sbt "print ${scala3CompilerProject}/version" | tail -n1)
       |rm -rf out
+      |export JAVA_HOME=${sys.props("java.home")}
       |sbt "clean; set every doc := new File(\"unused\"); set scaladoc/Compile/resourceGenerators := (\`${scala3Project}\`/Compile/resourceGenerators).value; ${scala3Project}/publishLocal"
       |${validationCommandStatusModifier}${validationScript.getAbsolutePath} "$$scalaVersion"
     """.stripMargin

--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -244,8 +244,9 @@ class CommitBisect(validationScript: File, shouldFail: Boolean, bootstrapped: Bo
       |scalaVersion=$$(sbt "print ${scala3CompilerProject}/version" | tail -n1)
       |rm -rf out
       |export JAVA_HOME=${sys.props("java.home")}
-      |sbt "clean; set every doc := new File(\"unused\"); set scaladoc/Compile/resourceGenerators := (\`${scala3Project}\`/Compile/resourceGenerators).value; ${scala3Project}/publishLocal"
-      |${validationCommandStatusModifier}${validationScript.getAbsolutePath} "$$scalaVersion"
+      |(sbt "clean; set every doc := new File(\"unused\"); set scaladoc/Compile/resourceGenerators := (\`${scala3Project}\`/Compile/resourceGenerators).value; ${scala3Project}/publishLocal" \
+      |  || (echo "Failed to build compiler, skip $$scalaVersion"; git bisect skip) \
+      |) && ${validationCommandStatusModifier}${validationScript.getAbsolutePath} "$$scalaVersion"
     """.stripMargin
     "git bisect start".!
     s"git bisect bad $fistBadHash".!


### PR DESCRIPTION
Fixes #19650 

* Bisect script used JVM 17 by default, can be overriden using:
 `scala-cli run project/scripts/bisect.scala --jvm=21 -- <bisect args>`
* Bisect runner JVM version is propagated to scala-cli verification script and sbt when building compiler
* Skip testing commits for which compiler compilation fails