### PR TITLE
Include module owners of symbols in shortened printer

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
@@ -44,7 +44,7 @@ object SignatureHelpProvider:
         val path = Interactive.pathTo(unit.tpdTree, pos.span)(using driver.currentCtx)
 
         val localizedContext = Interactive.contextOfPath(path)(using driver.currentCtx)
-        val indexedContext = IndexedContext(driver.currentCtx)
+        val indexedContext = IndexedContext(localizedContext)
 
         given Context = localizedContext.fresh
           .setCompilationUnit(unit)

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseSyntheticDecorationsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseSyntheticDecorationsSuite.scala
@@ -53,8 +53,8 @@ class BaseSyntheticDecorationsSuite extends BasePCSuite {
       val obtained = TextEdits.applyEdits(withPkg, edits)
 
       assertNoDiff(
-        obtained,
         pkgWrap(expected),
+        obtained,
       )
 
 }

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideSuite.scala
@@ -118,7 +118,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite:
         |""".stripMargin
     )
 
-  @Test def `import` = // import position is flak
+  @Test def `import` =
     checkEdit(
       """
         |object Main {

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -108,7 +108,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => A): List[List[List[List[A]]] @uncheckedVariance]
          |tabulate[A](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => A): List[List[List[List[List[A]]]] @uncheckedVariance]
          |tabulate[A](n: Int)(f: Int => A): List[A]
-         |unapplySeq[A](x: List[A] @uncheckedVariance): UnapplySeqWrapper[A]
+         |unapplySeq[A](x: List[A] @uncheckedVariance): SeqFactory.UnapplySeqWrapper[A]
          |unfold[A, S](init: S)(f: S => Option[(A, S)]): List[A]
          |->[B](y: B): (List.type, B)
          |ensuring(cond: Boolean): List.type
@@ -517,8 +517,8 @@ class CompletionSuite extends BaseCompletionSuite:
       """.stripMargin,
       """|until(end: Int): Range
          |until(end: Int, step: Int): Range
-         |until(end: Long): Exclusive[Long]
-         |until(end: Long, step: Long): Exclusive[Long]
+         |until(end: Long): NumericRange.Exclusive[Long]
+         |until(end: Long, step: Long): NumericRange.Exclusive[Long]
          |""".stripMargin,
       postProcessObtained = _.replace("Float", "Double"),
       stableOrder = false

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
@@ -806,7 +806,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |
          |val j = MyTy@@
          |""".stripMargin,
-      """|MyType(m: Long): MyType
+      """|MyType(m: Long): other.MyType
          |MyType - demo.other""".stripMargin,
     )
 
@@ -822,7 +822,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |
          |val j = MyTy@@
          |""".stripMargin,
-      """|MyType(m: Long): MyType
+      """|MyType(m: Long): other.MyType
          |MyType - demo.other""".stripMargin,
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/decorations/SyntheticDecorationsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/decorations/SyntheticDecorationsSuite.scala
@@ -8,7 +8,7 @@ import org.junit.Test
 
 class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
 
-  @Test def `type-params` = 
+  @Test def `type-params` =
     check(
       """|object Main {
          |  def hello[T](t: T) = t
@@ -23,7 +23,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
       kind = Some(DecorationKind.TypeParameter)
     )
 
-  @Test def `type-params2` = 
+  @Test def `type-params2` =
     check(
       """|object Main {
          |  def hello[T](t: T) = t
@@ -38,7 +38,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
       kind = Some(DecorationKind.TypeParameter)
     )
 
-  @Test def `implicit-param` = 
+  @Test def `implicit-param` =
     check(
       """|case class User(name: String)
          |object Main {
@@ -57,7 +57,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
       kind = Some(DecorationKind.ImplicitParameter)
     )
 
-  @Test def `implicit-conversion` = 
+  @Test def `implicit-conversion` =
     check(
       """|case class User(name: String)
          |object Main {
@@ -74,7 +74,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
       kind = Some(DecorationKind.ImplicitConversion)
     )
 
-  @Test def `using-param` = 
+  @Test def `using-param` =
     check(
       """|case class User(name: String)
          |object Main {
@@ -93,7 +93,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
       kind = Some(DecorationKind.ImplicitParameter)
     )
 
-  @Test def `given-conversion` = 
+  @Test def `given-conversion` =
     check(
       """|case class User(name: String)
          |object Main {
@@ -110,7 +110,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
       kind = Some(DecorationKind.ImplicitConversion)
     )
 
-  @Test def `given-conversion2` = 
+  @Test def `given-conversion2` =
     check(
       """|trait Xg:
          |  def doX: Int
@@ -128,7 +128,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `basic` = 
+  @Test def `basic` =
     check(
       """|object Main {
          |  val foo = 123
@@ -140,7 +140,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `list` = 
+  @Test def `list` =
     check(
       """|object Main {
          |  val foo = List[Int](123)
@@ -152,7 +152,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `list2` = 
+  @Test def `list2` =
     check(
       """|object O {
          |  def m = 1 :: List(1)
@@ -164,7 +164,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `two-param` = 
+  @Test def `two-param` =
     check(
       """|object Main {
          |  val foo = Map((1, "abc"))
@@ -176,7 +176,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `tuple` = 
+  @Test def `tuple` =
     check(
       """|object Main {
          |  val foo = (123, 456)
@@ -188,7 +188,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `import-needed` = 
+  @Test def `import-needed` =
     check(
       """|object Main {
          |  val foo = List[String]("").toBuffer[String]
@@ -200,7 +200,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `lambda-type` = 
+  @Test def `lambda-type` =
     check(
     """|object Main {
        |  val foo = () => 123
@@ -212,7 +212,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
        |""".stripMargin
     )
 
-  @Test def `block` = 
+  @Test def `block` =
     check(
       """|object Main {
          |  val foo = { val z = 123; z + 2}
@@ -224,7 +224,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `refined-types` = 
+  @Test def `refined-types` =
     check(
       """|object O{
          |  trait Foo {
@@ -246,7 +246,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `refined-types1` = 
+  @Test def `refined-types1` =
     check(
       """|object O{
          |  trait Foo {
@@ -266,7 +266,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `refined-types4` = 
+  @Test def `refined-types4` =
     check(
       """|trait Foo extends Selectable {
          |  type T
@@ -292,7 +292,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `dealias` = 
+  @Test def `dealias` =
     check(
       """|class Foo() {
          |  type T = Int
@@ -314,7 +314,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `dealias2` = 
+  @Test def `dealias2` =
     check(
       """|object Foo {
          |  type T = Int
@@ -330,7 +330,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `dealias3` = 
+  @Test def `dealias3` =
     check(
       """|object Foo:
          |  opaque type T = Int
@@ -340,11 +340,11 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
       """|object Foo:
          |  opaque type T = Int
          |  def getT: T = 1
-         |val c: T = Foo.getT
+         |val c: Foo.T = Foo.getT
          |""".stripMargin
     )
 
-  @Test def `dealias4` = 
+  @Test def `dealias4` =
     check(
       """|object O:
          | type M = Int
@@ -362,7 +362,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `dealias5` = 
+  @Test def `dealias5` =
     check(
       """|object O:
          | opaque type M = Int
@@ -376,11 +376,11 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          | type W = M => Int
          | def get: W = ???
          |
-         |val m: M => Int = O.get
+         |val m: O.M => Int = O.get
          |""".stripMargin
     )
 
-  @Test def `explicit-tuple` = 
+  @Test def `explicit-tuple` =
     check(
       """|object Main {
          |  val x = Tuple2.apply(1, 2)
@@ -392,7 +392,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `explicit-tuple1` = 
+  @Test def `explicit-tuple1` =
     check(
       """|object Main {
          |  val x = Tuple2(1, 2)
@@ -404,7 +404,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `tuple-unapply` = 
+  @Test def `tuple-unapply` =
     check(
       """|object Main {
          |  val (fst, snd) = (1, 2)
@@ -416,7 +416,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `list-unapply` = 
+  @Test def `list-unapply` =
     check(
       """|object Main {
          |  val hd :: tail = List(1, 2)
@@ -428,7 +428,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `list-match` = 
+  @Test def `list-match` =
     check(
       """|object Main {
          |  val x = List(1, 2) match {
@@ -444,7 +444,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `case-class-unapply` = 
+  @Test def `case-class-unapply` =
     check(
       """|object Main {
          |case class Foo[A](x: A, y: A)
@@ -458,7 +458,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `valueOf` = 
+  @Test def `valueOf` =
     check(
       """|object O {
          |  def foo[Total <: Int](implicit total: ValueOf[Total]): Int = total.value
@@ -472,7 +472,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |""".stripMargin
     )
 
-  @Test def `case-class1` = 
+  @Test def `case-class1` =
     check(
       """|object O {
          |case class A(x: Int, g: Int)(implicit y: String)
@@ -483,8 +483,8 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
          |}
          |""".stripMargin
     )
-   
-  @Test def `ord` = 
+
+  @Test def `ord` =
     check(
       """
         |object Main {
@@ -498,7 +498,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
         |""".stripMargin
     )
 
-  @Test def `val-def-with-bind` = 
+  @Test def `val-def-with-bind` =
     check(
       """
         |object O {
@@ -512,7 +512,7 @@ class SyntheticDecorationsSuite extends BaseSyntheticDecorationsSuite:
         |""".stripMargin
     )
 
-  @Test def `val-def-with-bind-and-comment` = 
+  @Test def `val-def-with-bind-and-comment` =
     check(
       """
         |object O {

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/AutoImplementAbstractMembersSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/AutoImplementAbstractMembersSuite.scala
@@ -1166,13 +1166,12 @@ class AutoImplementAbstractMembersSuite extends BaseCodeActionSuite:
          |""".stripMargin,
       """|package a
          |import scala.deriving.Mirror
-         |import scala.deriving.Mirror.ProductOf
          |trait Foo:
          |  def foo[A](using mirror: Mirror.ProductOf[A])(ordering: Ordering[mirror.MirroredElemTypes]): Unit
          |
          |class Bar extends Foo {
          |
-         |  override def foo[A](using mirror: ProductOf[A])(ordering: Ordering[mirror.MirroredElemTypes]): Unit = ???
+         |  override def foo[A](using mirror: Mirror.ProductOf[A])(ordering: Ordering[mirror.MirroredElemTypes]): Unit = ???
          |
          |}
          |""".stripMargin

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
@@ -744,11 +744,10 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite:
          |  def getT: T = 1
          |val <<c>> = Foo.getT
          |""".stripMargin,
-      """|import Foo.T
-         |object Foo:
+      """|object Foo:
          |  opaque type T = Int
          |  def getT: T = 1
-         |val c: T = Foo.getT
+         |val c: Foo.T = Foo.getT
          |""".stripMargin
     )
 
@@ -779,13 +778,12 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite:
          |
          |val <<m>> = O.get
          |""".stripMargin,
-      """|import O.M
-         |object O:
+      """|object O:
          |  opaque type M = Int
          |  type W = M => Int
          |  def get: W = ???
          |
-         |val m: M => Int = O.get
+         |val m: O.M => Int = O.get
          |""".stripMargin
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
@@ -229,7 +229,7 @@ class HoverDefnSuite extends BaseHoverSuite:
          |```
          |**Symbol signature**:
          |```scala
-         |val x: Option[T]
+         |val x: Option[Derived.T]
          |```
          |""".stripMargin.hover
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -437,7 +437,7 @@ class HoverTermSuite extends BaseHoverSuite:
         |  val in: Logarithms.Logarithm = ???
         |  in.multi@@ply(in)
         |""".stripMargin,
-      "extension [K](vmap: Logarithm) def multiply(k: Logarithm): Logarithm".hover
+      "extension [K](vmap: Logarithms.Logarithm) def multiply(k: Logarithms.Logarithm): Logarithms.Logarithm".hover
     )
 
   @Test def `i5976` =

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpDocSuite.scala
@@ -151,8 +151,8 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite:
         |}
       """.stripMargin,
       """|Found documentation for scala/util/control/Exception.Catch#
-         |Catch[T](pf: Catcher[T], fin: Option[Finally], rethrow: Throwable => Boolean)
-         |         ^^^^^^^^^^^^^^
+         |Catch[T](pf: control.Exception.Catcher[T], fin: Option[control.Exception.Finally], rethrow: Throwable => Boolean)
+         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          |  @param pf Found documentation for param pf
          |  @param fin Found documentation for param fin
          |  @param rethrow Found documentation for param rethrow

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
@@ -323,9 +323,9 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
         |  } yield k
         |}
       """.stripMargin,
-      """|to(end: Int): Inclusive
+      """|to(end: Int): Range.Inclusive
          |   ^^^^^^^^
-         |to(end: Int, step: Int): Inclusive
+         |to(end: Int, step: Int): Range.Inclusive
          |""".stripMargin,
       stableOrder = false
     )
@@ -502,8 +502,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
         |  new scala.util.control.Exception.Catch(@@)
         |}
       """.stripMargin,
-      """|Catch[T](pf: Catcher[T], fin: Option[Finally], rethrow: Throwable => Boolean)
-         |         ^^^^^^^^^^^^^^
+      """|Catch[T](pf: control.Exception.Catcher[T], fin: Option[control.Exception.Finally], rethrow: Throwable => Boolean)
+         |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          |""".stripMargin
     )
 
@@ -1135,8 +1135,8 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
          |  def test(a: Foo.Test, b: Foo.Test): Int = ???
          |  test(Foo.Test(1), @@)
          |""".stripMargin,
-      """|test(a: Test, b: Test): Int
-         |              ^^^^^^^
+      """|test(a: Foo.Test, b: Foo.Test): Int
+         |                  ^^^^^^^^^^^
          |""".stripMargin
     )
 


### PR DESCRIPTION
I changed the logic of shortened printer to now include module owners of symbols.
The heuristic is described in code. It should add missing owners and help disambiguate symbols.

Feel free to give your opinions.

As this printer also handles auto imports for various features such as insert inferred type, it would be ideal to allow users to configure how they want to import symbols e.g: 

```scala
val x = java.nio.file.Paths.get("") // insert inferred type
```

Can be one of:
```scala
val x: java.nio.file.Path = java.nio.file.Paths.get("")
```

```scala
import java.nio
val x: nio.file.Path = java.nio.file.Paths.get("")
```

```scala
import java.nio
val x: file.Path = java.nio.file.Paths.get("")
```

```scala
import java.nio.file.Path
val x: Path = java.nio.file.Paths.get("")
```

Or we could return another prompt.
This is not the scope of this PR.