### PR TITLE
Fix patch of #19798

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,7 +153,7 @@ jobs:
         run: ./project/scripts/sbt ";set ThisBuild/Build.scala2Library := Build.Scala2LibraryTasty ;scala3-bootstrapped/testCompilation i5; scala3-bootstrapped/testCompilation tests/run/typelevel-peano.scala; scala3-bootstrapped/testOnly dotty.tools.backend.jvm.DottyBytecodeTests" # only test a subset of test to avoid doubling the CI execution time
 
       - name: Test with Scala 2 library with CC TASTy (fast)
-        run: ./project/scripts/sbt ";set ThisBuild/Build.scala2Library := Build.Scala2LibraryCCTasty; scala2-library-cc/compile; scala2-library-cc-tasty/compile; scala3-bootstrapped/testCompilation i3"
+        run: ./project/scripts/sbt ";set ThisBuild/Build.scala2Library := Build.Scala2LibraryCCTasty; scala2-library-cc/compile; scala2-library-cc-tasty/compile; scala3-bootstrapped/testCompilation i3; scala3-bootstrapped/testCompilation tests/run/i19819.scala"
 
   test_scala2_library_tasty:
     runs-on: [self-hosted, Linux]

--- a/scala2-library-cc/src/scala/collection/SeqView.scala
+++ b/scala2-library-cc/src/scala/collection/SeqView.scala
@@ -48,7 +48,7 @@ trait SeqView[+A] extends SeqViewOps[A, View, View[A]] with View[A] {
 
   // Copied from SeqOps. This is needed due to the change of class hierarchy in stdlib.
   // See #19660.
-  override def updated[B >: A](index: Int, elem: B): View[B]^{this} = {
+  inline override def updated[B >: A](index: Int, elem: B): View[B]^{this} = {
     if(index < 0) throw new IndexOutOfBoundsException(index.toString)
     val k = knownSize
     if(k >= 0 && index >= k) throw new IndexOutOfBoundsException(index.toString)

--- a/tests/run/i19819.scala
+++ b/tests/run/i19819.scala
@@ -1,0 +1,1 @@
+@main def Test = Vector(1, 2, 3).view.updated(1, 8)


### PR DESCRIPTION
This added a an override for the unapply method to fix the signature, but this method does not exist in the original library. We inline all calls to it to avoid any runtime calls to this new override.

Followup to #19798
Fixes #19819