### PR TITLE
fix(#19806): wrong tasty of scala module class reference

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -388,6 +388,7 @@ private sealed trait YSettings:
   val YshowPrintErrors: Setting[Boolean] = BooleanSetting("-Yshow-print-errors", "Don't suppress exceptions thrown during tree printing.")
   val YprintTasty: Setting[Boolean] = BooleanSetting("-Yprint-tasty", "Prints the generated TASTY to stdout.")
   val YtestPickler: Setting[Boolean] = BooleanSetting("-Ytest-pickler", "Self-test for pickling functionality; should be used with -Ystop-after:pickler.")
+  val YtestPicklerCheck: Setting[Boolean] = BooleanSetting("-Ytest-pickler-check", "Self-test for pickling -print-tasty output; should be used with -Ytest-pickler.")
   val YcheckReentrant: Setting[Boolean] = BooleanSetting("-Ycheck-reentrant", "Check that compiled program does not contain vars that can be accessed from a global root.")
   val YdropComments: Setting[Boolean] = BooleanSetting("-Ydrop-docs", "Drop documentation when scanning source files.", aliases = List("-Ydrop-comments"))
   val YcookComments: Setting[Boolean] = BooleanSetting("-Ycook-docs", "Cook the documentation (type check `@usecase`, etc.)", aliases = List("-Ycook-comments"))

--- a/compiler/src/dotty/tools/dotc/core/ContextOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/ContextOps.scala
@@ -64,10 +64,7 @@ object ContextOps:
         val directSearch =
           def asModule =
             if name.isTypeName && name.endsWith(StdNames.str.MODULE_SUFFIX) then
-              pre.findMember(name.stripModuleClassSuffix.moduleClassName, pre, required, excluded) match
-                case NoDenotation => NoDenotation
-                case symDenot: SymDenotation =>
-                  symDenot.companionModule.denot
+              pre.findMember(name.stripModuleClassSuffix.moduleClassName, pre, required, excluded)
             else NoDenotation
           pre.findMember(name, pre, required, excluded) match
             case NoDenotation => asModule

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyAnsiiPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyAnsiiPrinter.scala
@@ -2,7 +2,10 @@ package dotty.tools.dotc
 package core
 package tasty
 
-class TastyAnsiiPrinter(bytes: Array[Byte]) extends TastyPrinter(bytes) {
+class TastyAnsiiPrinter(bytes: Array[Byte], testPickler: Boolean) extends TastyPrinter(bytes, testPickler) {
+
+  def this(bytes: Array[Byte]) = this(bytes, testPickler = false)
+
   override protected def nameStr(str: String): String = Console.MAGENTA + str + Console.RESET
   override protected def treeStr(str: String): String = Console.YELLOW + str + Console.RESET
   override protected def lengthStr(str: String): String = Console.CYAN + str + Console.RESET

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -1010,7 +1010,10 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         var modsText = modText(constr.mods, constr.symbol, "", isType = false)
         if (!modsText.isEmpty) modsText = " " ~ modsText
         if (constr.mods.hasAnnotations && !constr.mods.hasFlags) modsText = modsText ~~ " this"
-        withEnclosingDef(constr) { addParamssText(tparamsTxt ~~ modsText, constr.trailingParamss) }
+        val ctorParamss =
+          // for fake `(x$1: Unit): Foo` constructor, don't print the param (span is not reconstructed correctly)
+          if constr.symbol.isAllOf(JavaParsers.fakeFlags) then Nil else constr.trailingParamss
+        withEnclosingDef(constr) { addParamssText(tparamsTxt ~~ modsText, ctorParamss) }
       }
     val parentsText = Text(impl.parents.map(constrText), if (ofNew) keywordStr(" with ") else ", ")
     val derivedText = Text(impl.derived.map(toText(_)), ", ")

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -307,9 +307,10 @@ class Pickler extends Phase {
   private def testSamePrinted(printed: String, checkContents: String, cls: ClassSymbol, check: AbstractFile)(using Context): Unit = {
     if hasDiff(printed, checkContents) then
       output("after-printing.txt", printed)
-      report.error(em"""TASTy printer difference for $cls in ${cls.source}, for details:
-                    |
-                    |  diff ${check.toString} after-printing.txt""")
+      report.error(em"""TASTy printer difference for $cls in ${cls.source}, did not match ${check},
+                    |  output dumped in after-printing.txt, check diff with `git diff --no-index -- after-printing.txt ${check}`
+                    |  actual output:
+                    |$printed""")
   }
 
   /** Reuse diff logic from compiler/test/dotty/tools/vulpix/FileDiff.scala */

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -688,7 +688,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       report.error(StableIdentPattern(tree, pt), tree.srcPos)
 
   def typedSelect(tree0: untpd.Select, pt: Type, qual: Tree)(using Context): Tree =
-    val selName = tree0.name
+    val selName =
+      if ctx.isJava && tree0.name.isTypeName && tree0.name.endsWith(StdNames.str.MODULE_SUFFIX) then
+        tree0.name.stripModuleClassSuffix.moduleClassName
+      else
+        tree0.name
     val tree = cpy.Select(tree0)(qual, selName)
     val superAccess = qual.isInstanceOf[Super]
     val rawType = selectionType(tree, qual)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -631,7 +631,13 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         case checkedType: NamedType if !prefixIsElidable(checkedType) =>
           ref(checkedType).withSpan(tree.span)
         case _ =>
-          tree.withType(checkedType)
+          def isScalaModuleRef = checkedType match
+            case moduleRef: TypeRef if moduleRef.symbol.is(ModuleClass, butNot = JavaDefined) => true
+            case _ => false
+          if ctx.isJava && isScalaModuleRef then
+            cpy.Ident(tree)(tree.name.unmangleClassName).withType(checkedType)
+          else
+            tree.withType(checkedType)
       val tree2 = toNotNullTermRef(tree1, pt)
       checkLegalValue(tree2, pt)
       tree2
@@ -688,11 +694,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       report.error(StableIdentPattern(tree, pt), tree.srcPos)
 
   def typedSelect(tree0: untpd.Select, pt: Type, qual: Tree)(using Context): Tree =
-    val selName =
-      if ctx.isJava && tree0.name.isTypeName && tree0.name.endsWith(StdNames.str.MODULE_SUFFIX) then
-        tree0.name.stripModuleClassSuffix.moduleClassName
-      else
-        tree0.name
+    val selName = tree0.name
     val tree = cpy.Select(tree0)(qual, selName)
     val superAccess = qual.isInstanceOf[Super]
     val rawType = selectionType(tree, qual)
@@ -769,26 +771,30 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
     def typeSelectOnTerm(using Context): Tree =
       val qual = typedExpr(tree.qualifier, shallowSelectionProto(tree.name, pt, this, tree.nameSpan))
-      typedSelect(tree, pt, qual).withSpan(tree.span).computeNullable()
-
-    def javaSelectOnType(qual: Tree)(using Context) =
-      // semantic name conversion for `O$` in java code
-      if !qual.symbol.is(JavaDefined) then
-        val tree2 = untpd.cpy.Select(tree)(qual, tree.name.unmangleClassName)
-        assignType(tree2, qual)
+      if ctx.isJava then
+        javaSelection(qual)
       else
-        assignType(cpy.Select(tree)(qual, tree.name), qual)
+        typedSelect(tree, pt, qual).withSpan(tree.span).computeNullable()
+
+    def javaSelection(qual: Tree)(using Context) =
+      val tree1 = assignType(cpy.Select(tree)(qual, tree.name), qual)
+      tree1.tpe match
+        case moduleRef: TypeRef if moduleRef.symbol.is(ModuleClass, butNot = JavaDefined) =>
+          // handle unmangling of module names (Foo$ -> Foo[ModuleClass])
+          cpy.Select(tree)(qual, tree.name.unmangleClassName).withType(moduleRef)
+        case _ =>
+          tree1
 
     def tryJavaSelectOnType(using Context): Tree = tree.qualifier match {
       case sel @ Select(qual, name) =>
         val qual1 = untpd.cpy.Select(sel)(qual, name.toTypeName)
         val qual2 = typedType(qual1, WildcardType)
-        javaSelectOnType(qual2)
+        javaSelection(qual2)
 
       case id @ Ident(name) =>
         val qual1 = untpd.cpy.Ident(id)(name.toTypeName)
         val qual2 = typedType(qual1, WildcardType)
-        javaSelectOnType(qual2)
+        javaSelection(qual2)
 
       case _ =>
         errorTree(tree, em"cannot convert to type selection") // will never be printed due to fallback

--- a/tests/pos/i19806/J.tastycheck
+++ b/tests/pos/i19806/J.tastycheck
@@ -3,7 +3,7 @@ Header:
   tooling: <elided>
      UUID: <elided>
 
-Names (217 bytes, starting from 80):
+Names (217 bytes, starting from <elided base index>):
      0: ASTs
      1: p
      2: J
@@ -31,8 +31,7 @@ Names (217 bytes, starting from 80):
     24: Comments
     25: Attributes
 
-
-Trees (145 bytes, starting from 300):
+Trees (145 bytes, starting from <elided base index>):
      0: PACKAGE(142)
      3:   TERMREFpkg 1 [p]
      5:   VALDEF(11) 2 [J]
@@ -113,7 +112,7 @@ Trees (145 bytes, starting from 300):
    143:           SHAREDtype 38
    145:
 
-Positions (145 bytes, starting from 448):
+Positions (145 bytes, starting from <elided base index>):
   lines: 23
   line sizes:
      10, 0, 19, 0, 15, 0, 35, 29, 3, 0, 36, 29, 3, 0, 52, 41, 3, 0, 53, 41
@@ -154,8 +153,7 @@ Positions (145 bytes, starting from 448):
   source paths:
      0: 23 [<elided source file name>]
 
-
-Attributes (4 bytes, starting from 597):
+Attributes (4 bytes, starting from <elided base index>):
   JAVAattr
   OUTLINEattr
   SOURCEFILEattr 23 [<elided source file name>]

--- a/tests/pos/i19806/J.tastycheck
+++ b/tests/pos/i19806/J.tastycheck
@@ -1,0 +1,161 @@
+Header:
+  version: <elided>
+  tooling: <elided>
+     UUID: <elided>
+
+Names (217 bytes, starting from 80):
+     0: ASTs
+     1: p
+     2: J
+     3: J[ModuleClass]
+     4: Object
+     5: java
+     6: lang
+     7: java[Qualified . lang]
+     8: _
+     9: <init>
+    10: Unit
+    11: scala
+    12: module2
+    13: Module
+    14: Module[ModuleClass]
+    15: module
+    16: innermodule2
+    17: InnerModule
+    18: InnerModule[ModuleClass]
+    19: innermodule
+    20: T
+    21: Nothing
+    22: Positions
+    23: tests/pos/i19806/J_SCALA_ONLY.java
+    24: Comments
+    25: Attributes
+
+
+Trees (145 bytes, starting from 300):
+     0: PACKAGE(142)
+     3:   TERMREFpkg 1 [p]
+     5:   VALDEF(11) 2 [J]
+     8:     IDENTtpt 3 [J[ModuleClass]]
+    10:       TYPEREFsymbol 18
+    12:         TERMREFpkg 1 [p]
+    14:     ELIDED
+    15:       SHAREDtype 10
+    17:     OBJECT
+    18:   TYPEDEF(86) 3 [J[ModuleClass]]
+    21:     TEMPLATE(82)
+    23:       TYPEREF 4 [Object]
+    25:         TERMREFpkg 7 [java[Qualified . lang]]
+    27:       SELFDEF 8 [_]
+    29:         SINGLETONtpt
+    30:           TERMREFsymbol 5
+    32:             SHAREDtype 12
+    34:       DEFDEF(7) 9 [<init>]
+    37:         EMPTYCLAUSE
+    38:         TYPEREF 10 [Unit]
+    40:           TERMREFpkg 11 [scala]
+    42:         STABLE
+    43:       DEFDEF(12) 12 [module2]
+    46:         EMPTYCLAUSE
+    47:         IDENTtpt 14 [Module[ModuleClass]]
+    49:           TYPEREF 14 [Module[ModuleClass]]
+    51:             SHAREDtype 12
+    53:         ELIDED
+    54:           SHAREDtype 49
+    56:         STATIC
+    57:       DEFDEF(12) 15 [module]
+    60:         EMPTYCLAUSE
+    61:         SELECTtpt 14 [Module[ModuleClass]]
+    63:           SHAREDtype 3
+    65:         ELIDED
+    66:           TYPEREF 14 [Module[ModuleClass]]
+    68:             SHAREDtype 3
+    70:         STATIC
+    71:       DEFDEF(14) 16 [innermodule2]
+    74:         EMPTYCLAUSE
+    75:         SELECTtpt 18 [InnerModule[ModuleClass]]
+    77:           TERMREF 13 [Module]
+    79:             SHAREDtype 12
+    81:         ELIDED
+    82:           TYPEREF 18 [InnerModule[ModuleClass]]
+    84:             SHAREDtype 77
+    86:         STATIC
+    87:       DEFDEF(16) 19 [innermodule]
+    90:         EMPTYCLAUSE
+    91:         SELECTtpt 18 [InnerModule[ModuleClass]]
+    93:           SELECT 13 [Module]
+    95:             SHAREDtype 3
+    97:         ELIDED
+    98:           TYPEREF 18 [InnerModule[ModuleClass]]
+   100:             TERMREF 13 [Module]
+   102:               SHAREDtype 3
+   104:         STATIC
+   105:     OBJECT
+   106:   TYPEDEF(37) 2 [J]
+   109:     TEMPLATE(34)
+   111:       TYPEPARAM(11) 20 [T]
+   114:         TYPEBOUNDS(6)
+   116:           TYPEREF 21 [Nothing]
+   118:             SHAREDtype 40
+   120:           SHAREDtype 23
+   122:         PRIVATE
+   123:         LOCAL
+   124:       SHAREDtype 120
+   126:       SPLITCLAUSE
+   127:       DEFDEF(16) 9 [<init>]
+   130:         TYPEPARAM(7) 20 [T]
+   133:           TYPEBOUNDStpt(4)
+   135:             SHAREDtype 116
+   137:             SHAREDtype 120
+   139:         EMPTYCLAUSE
+   140:         SHAREDtype 38
+   142:         ELIDED
+   143:           SHAREDtype 38
+   145:
+
+Positions (145 bytes, starting from 448):
+  lines: 23
+  line sizes:
+     10, 0, 19, 0, 15, 0, 35, 29, 3, 0, 36, 29, 3, 0, 52, 41, 3, 0, 53, 41
+     3, 1, 0
+  positions:
+     0: 0 .. 394
+     5: 12 .. 12
+     8: 12 .. 12
+    18: 12 .. 394
+    21: 52 .. 392
+    23: 25 .. 25
+    30: 52 .. 52
+    34: 52 .. 52
+    38: 52 .. 52
+    43: 52 .. 119
+    47: 66 .. 73
+    57: 123 .. 191
+    61: 137 .. 146
+    63: 137 .. 138
+    71: 195 .. 291
+    75: 209 .. 228
+    77: 209 .. 215
+    87: 295 .. 392
+    91: 309 .. 330
+    93: 309 .. 317
+    95: 309 .. 310
+   106: 12 .. 394
+   109: 27 .. 48
+   111: 27 .. 28
+   114: 27 .. 27
+   124: 28 .. 28
+   127: 35 .. 48
+   130: 27 .. 28
+   135: 27 .. 27
+   137: 27 .. 27
+   140: 46 .. 46
+
+  source paths:
+     0: 23 [tests/pos/i19806/J_SCALA_ONLY.java]
+
+
+Attributes (4 bytes, starting from 597):
+  JAVAattr
+  OUTLINEattr
+  SOURCEFILEattr 23 [tests/pos/i19806/J_SCALA_ONLY.java]

--- a/tests/pos/i19806/J.tastycheck
+++ b/tests/pos/i19806/J.tastycheck
@@ -27,7 +27,7 @@ Names (217 bytes, starting from 80):
     20: T
     21: Nothing
     22: Positions
-    23: tests/pos/i19806/J_SCALA_ONLY.java
+    23: <elided source file name>
     24: Comments
     25: Attributes
 
@@ -152,10 +152,10 @@ Positions (145 bytes, starting from 448):
    140: 46 .. 46
 
   source paths:
-     0: 23 [tests/pos/i19806/J_SCALA_ONLY.java]
+     0: 23 [<elided source file name>]
 
 
 Attributes (4 bytes, starting from 597):
   JAVAattr
   OUTLINEattr
-  SOURCEFILEattr 23 [tests/pos/i19806/J_SCALA_ONLY.java]
+  SOURCEFILEattr 23 [<elided source file name>]

--- a/tests/pos/i19806/J_SCALA_ONLY.java
+++ b/tests/pos/i19806/J_SCALA_ONLY.java
@@ -1,0 +1,22 @@
+package p;
+
+public class J<T> {
+
+  public J() {}
+
+  public static Module$ module2() {
+    return p.Module$.MODULE$;
+  }
+
+  public static p.Module$ module() {
+    return p.Module$.MODULE$;
+  }
+
+  public static Module.InnerModule$ innermodule2() {
+    return p.Module.InnerModule$.MODULE$;
+  }
+
+  public static p.Module.InnerModule$ innermodule() {
+    return p.Module.InnerModule$.MODULE$;
+  }
+}

--- a/tests/pos/i19806/Module.scala
+++ b/tests/pos/i19806/Module.scala
@@ -1,0 +1,9 @@
+//> using options -Yjava-tasty -Ytest-pickler-check
+
+package p
+
+object Module:
+  object InnerModule
+
+class Outer:
+  object InnerModule

--- a/tests/run/i17255/J.java
+++ b/tests/run/i17255/J.java
@@ -1,16 +1,29 @@
 package p;
 
 public class J {
-	public static J j = new J();
-	public static p.J f() {
-		return p.J.j;
-	}
-	public static Module$ module2() {
-		return p.Module$.MODULE$;
-	}
-	public static p.Module$ module() {
-		return p.Module$.MODULE$;
-	}
+  public static J j = new J();
 
-	public String toString() { return "J"; }
+  public static p.J f() {
+    return p.J.j;
+  }
+
+  public static Module$ module2() {
+    return p.Module$.MODULE$;
+  }
+
+  public static p.Module$ module() {
+    return p.Module$.MODULE$;
+  }
+
+  public static Module.InnerModule$ innermodule2() {
+    return p.Module.InnerModule$.MODULE$;
+  }
+
+  public static p.Module.InnerModule$ innermodule() {
+    return p.Module.InnerModule$.MODULE$;
+  }
+
+  public String toString() {
+    return "J";
+  }
 }

--- a/tests/run/i17255/Module.scala
+++ b/tests/run/i17255/Module.scala
@@ -1,3 +1,4 @@
+// scalajs: --skip
 package p {
   object Module {
     override def toString = "Module"

--- a/tests/run/i17255/Module.scala
+++ b/tests/run/i17255/Module.scala
@@ -1,8 +1,10 @@
-// scalajs: --skip
-
 package p {
   object Module {
     override def toString = "Module"
+
+    object InnerModule {
+      override def toString = "InnerModule"
+    }
   }
 }
 
@@ -10,4 +12,6 @@ object Test extends App {
   assert(p.J.f().toString == "J")
   assert(p.J.module().toString == "Module")
   assert(p.J.module2().toString == "Module")
+  assert(p.J.innermodule().toString == "InnerModule")
+  assert(p.J.innermodule2().toString == "InnerModule")
 }


### PR DESCRIPTION
This commit makes the following diff to TASTy for i17255 files. The TASTy before this commit relied on the compiler (aka all TASTy clients) intrinsically knowing how to resolve Module$ when the definition is actually Module[ModuleClass].

```sh
scalac tests/run/i17255/J.java tests/run/i17255/Module.scala -Yprint-tasty -Yjava-tasty
```

```diff
    90:         EMPTYCLAUSE
    91:         TERMREF 17 [Module]
    93:           SHAREDtype 12
    95:         ELIDED
    96:           SHAREDtype 91
    98:         STATIC
    99:       DEFDEF(12) 18 [module]
   102:         EMPTYCLAUSE
-  103:         SELECTtpt 19 [Module$]
+  103:         SELECTtpt 19 [Module[ModuleClass]]
   105:           SHAREDtype 3
   107:         ELIDED
   108:           TYPEREF 17 [Module]
   110:             SHAREDtype 3
   112:         STATIC
```

fixes #19806