### PR TITLE
Catch stackoverflow errors in the highlighter

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -145,7 +145,7 @@ object SyntaxHighlighting {
 
         highlighted.toString
       catch
-        case(e): StackOverflowError =>
+        case e: StackOverflowError =>
           in
     }
   }

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -126,22 +126,27 @@ object SyntaxHighlighting {
 
       val parser = new Parser(source)
       val trees = parser.blockStatSeq()
-      TreeHighlighter.highlight(trees)
+      try
+        TreeHighlighter.highlight(trees)
 
-      val highlighted = new StringBuilder()
 
-      for (idx <- colorAt.indices) {
-        val prev = if (idx == 0) NoColor else colorAt(idx - 1)
-        val curr = colorAt(idx)
-        if (curr != prev)
-          highlighted.append(curr)
-        highlighted.append(in(idx))
-      }
+        val highlighted = new StringBuilder()
 
-      if (colorAt.last != NoColor)
-        highlighted.append(NoColor)
+        for (idx <- colorAt.indices) {
+          val prev = if (idx == 0) NoColor else colorAt(idx - 1)
+          val curr = colorAt(idx)
+          if (curr != prev)
+            highlighted.append(curr)
+          highlighted.append(in(idx))
+        }
 
-      highlighted.toString
+        if (colorAt.last != NoColor)
+          highlighted.append(NoColor)
+
+        highlighted.toString
+      catch
+        case(e): StackOverflowError =>
+          in
     }
   }
 }

--- a/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/SyntaxHighlighting.scala
@@ -124,9 +124,9 @@ object SyntaxHighlighting {
         }
       }
 
-      val parser = new Parser(source)
-      val trees = parser.blockStatSeq()
       try
+        val parser = new Parser(source)
+        val trees = parser.blockStatSeq()
         TreeHighlighter.highlight(trees)
 
 
@@ -149,4 +149,5 @@ object SyntaxHighlighting {
           in
     }
   }
+
 }

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -463,3 +463,11 @@ class ReplHighlightTests extends ReplTest(ReplTest.defaultOptions.filterNot(_.st
   @Test def i18596: Unit = initially:
     run("""(1 to 500).foldRight("x") { case (_, n) => s"<x>$n</x>" }""")
 
+  @Test def i16904: Unit = initially:
+    run(""""works not fine"* 10000""")
+
+    run("""
+      case class Tree(left: Tree, right: Tree)
+      def deepTree(depth: Int): Tree
+      deepTree(300)""")
+

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -458,3 +458,8 @@ class ReplVerboseTests extends ReplTest(ReplTest.defaultOptions :+ "-verbose"):
   }
 
 end ReplVerboseTests
+
+class ReplHighlightTests extends ReplTest(ReplTest.defaultOptions.filterNot(_.startsWith("-color")) :+ "-color:always"):
+  @Test def i18596: Unit = initially:
+    run("""(1 to 500).foldRight("x") { case (_, n) => s"<x>$n</x>" }""")
+


### PR DESCRIPTION
# StackOverflow Exception on Highlight

Fixes #18596 and fixes #16904.

When there is too much instruction the Sytax Hyghlight can't make the tree and launch a StackOverflow Error

To fix the problem let's catch the Overflow and return the entry string with an error message

the lines that can triggers the error : 

```scala
val parser = new Parser(source)
val trees = parser.blockStatSeq()
TreeHighlighter.highlight(trees)
```

To fix it, let's put the try on everything starting from those lines and the catch in the end

```scala
case(e): StackOverflowError =>
          in
```

There is no obvious need of an error message, the command and result will simply not be highlighted so I choose to not put one there. 
