### PR TITLE
WIP - Simplify class instance initialization check

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -1048,7 +1048,7 @@ object PatternMatcher {
     end checkSwitch
 
     val optimizations: List[(String, Plan => Plan)] = List(
-      "mergeTests" -> mergeTests,
+      "mergeTests" -> mergeTests: @unchecked, // init check
       "inlineVars" -> inlineVars
     )
 

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -992,7 +992,7 @@ object Semantic:
                 eval(body, thisV, klass, cacheResult = true)
               }
               given Trace = Trace.empty.add(body)
-              res.promote("Only transitively initialized (Hot) values can be returned by functions. The function " + fun.show + " returns " + res.show + ".")
+              res.promote("Only transitively initialized (Hot) values can be returned by functions. The value is " + fun.show + " returns " + res.show + ".")
             }
             if errors.nonEmpty then
               reporter.report(UnsafePromotion(msg, errors.head)(trace))

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -982,7 +982,14 @@ object Semantic:
             reporter.report(PromoteError(msg + "\n" + fields)(trace))
 
         case warm: Warm =>
-          reporter.report(PromoteError(msg)(trace))
+          if !promoted.contains(warm) then
+            if warm.klass.isAnonymousClass then
+              promoted.add(warm)
+              val errors = warm.tryPromote(msg)
+              if errors.nonEmpty then promoted.remove(warm)
+              reporter.reportAll(errors)
+            else
+              reporter.report(PromoteError(msg)(trace))
 
         case fun @ Fun(body, thisV, klass) =>
           if !promoted.contains(fun) then
@@ -1002,6 +1009,85 @@ object Semantic:
         case RefSet(refs) =>
           refs.foreach(_.promote(msg))
     }
+  end extension
+
+  extension (warm: Warm)
+    /** Try early promotion of warm objects
+     *
+     *  Promotion is expensive and should only be performed for small classes.
+     *
+     *  1. for each concrete method `m` of the warm object:
+     *     call the method and promote the result
+     *
+     *  2. for each concrete field `f` of the warm object:
+     *     promote the field value
+     *
+     *  If the object contains nested classes as members, the checker simply
+     *  reports a warning to avoid expensive checks.
+     *
+     */
+    def tryPromote(msg: String): Contextual[List[Error]] = log("promote " + warm.show + ", promoted = " + promoted, printer) {
+      val obj = warm.objekt
+
+      def doPromote(klass: ClassSymbol, subClass: ClassSymbol, subClassSegmentHot: Boolean)(using Reporter): Unit =
+        val outer = obj.outer(klass)
+        val isHotSegment = outer.isHot && {
+          val ctor = klass.primaryConstructor
+          val ctorDef = ctor.defTree.asInstanceOf[DefDef]
+          val params = ctorDef.termParamss.flatten.map(_.symbol)
+          // We have cached all parameters on the object
+          params.forall(param => obj.field(param).isHot)
+        }
+
+        // Check invariant: subClassSegmentHot ==> isHotSegment
+        //
+        // This invariant holds because of the Scala/Java/JVM restriction that we cannot use `this` in super constructor calls.
+        if subClassSegmentHot && !isHotSegment then
+          report.warning("[Internal error] Expect current segment to be transitively initialized (Hot) in promotion, current klass = " + klass.show +
+              ", subclass = " + subClass.show + Trace.show, Trace.position)
+
+        // If the outer and parameters of a class are all hot, then accessing fields and methods of the current
+        // segment of the object should be OK. They may only create problems via virtual method calls on `this`, but
+        // those methods are checked as part of the check for the class where they are defined.
+        if !isHotSegment then
+          for member <- klass.info.decls do
+            if member.isClass then
+              val error = PromoteError("Promotion cancelled as the value contains inner " + member.show + ".")(Trace.empty)
+              reporter.report(error)
+            else if !member.isType && !member.isConstructor  && !member.is(Flags.Deferred) then
+              given Trace = Trace.empty
+              if member.is(Flags.Method, butNot = Flags.Accessor) then
+                val args = member.info.paramInfoss.flatten.map(_ => new ArgInfo(Hot: Value, Trace.empty))
+                val res = warm.call(member, args, receiver = warm.klass.typeRef, superType = NoType)
+                withTrace(trace.add(member.defTree)) {
+                  res.promote("Could not verify that the return value of " + member.show + " is transitively initialized (Hot). It was found to be " + res.show + ".")
+                }
+              else
+                val res = warm.select(member, receiver = warm.klass.typeRef)
+                withTrace(trace.add(member.defTree)) {
+                  res.promote("Could not verify that the field " + member.show + " is transitively initialized (Hot). It was found to be " + res.show + ".")
+                }
+          end for
+
+        // Promote parents
+        //
+        // Note that a parameterized trait may only get parameters from the class that extends the trait.
+        // A trait may not supply constructor arguments to another trait.
+        if !klass.is(Flags.Trait) then
+          val superCls = klass.superClass
+          if superCls.hasSource then doPromote(superCls.asClass, klass, isHotSegment)
+          val mixins = klass.baseClasses.tail.takeWhile(_ != superCls)
+          for mixin <- mixins if mixin.hasSource do doPromote(mixin.asClass, klass, isHotSegment)
+      end doPromote
+
+      val errors = Reporter.stopEarly {
+        doPromote(warm.klass, subClass = warm.klass, subClassSegmentHot = false)
+      }
+
+      if errors.isEmpty then Nil
+      else UnsafePromotion(msg, errors.head)(trace) :: Nil
+    }
+
   end extension
 
 // ----- Policies ------------------------------------------------------

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -299,106 +299,6 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         case t => mapOver(t)
     monoMap(mirroredType.resultType)
 
-  private[Synthesizer] enum MirrorSource:
-    case ClassSymbol(pre: Type, cls: Symbol)
-    case Singleton(src: Symbol, tref: TermRef)
-    case GenericTuple(tps: List[Type])
-
-    /** Tests that both sides are tuples of the same arity */
-    infix def sameTuple(that: MirrorSource)(using Context): Boolean =
-      def arity(msrc: MirrorSource): Int = msrc match
-        case GenericTuple(tps) => tps.size
-        case ClassSymbol(_, cls) if defn.isTupleClass(cls) => cls.typeParams.size // tested in tests/pos/i13859.scala
-        case _ => -1
-      def equivalent(n: Int, m: Int) =
-        n == m && n > 0
-      equivalent(arity(this), arity(that))
-
-    /** A comparison that chooses the most specific MirrorSource, this is guided by what is necessary for
-     * `Mirror.Product.fromProduct`. i.e. its result type should be compatible with the erasure of `mirroredType`.
-     */
-    def isSub(that: MirrorSource)(using Context): Boolean =
-      (this, that) match
-        case (Singleton(src, _), ClassSymbol(_, cls)) => src.info.classSymbol.isSubClass(cls)
-        case (ClassSymbol(_, cls1), ClassSymbol(_, cls2)) => cls1.isSubClass(cls2)
-        case (Singleton(src1, _), Singleton(src2, _)) => src1 eq src2
-        case (_: ClassSymbol, _: Singleton) => false
-        case _ => this sameTuple that
-
-    def show(using Context): String = this match
-      case ClassSymbol(_, cls) => i"$cls"
-      case Singleton(src, _) => i"$src"
-      case GenericTuple(tps) =>
-        val arity = tps.size
-        if arity <= Definitions.MaxTupleArity then s"class Tuple$arity"
-        else s"trait Tuple { def size: $arity }"
-
-  private[Synthesizer] object MirrorSource:
-
-    /** Reduces a mirroredType to either its most specific ClassSymbol,
-     *  or a TermRef to a singleton value. These are
-     *  the base elements required to generate a mirror.
-     */
-    def reduce(mirroredType: Type)(using Context): Either[String, MirrorSource] = mirroredType match
-      case tp: TypeRef =>
-        val sym = tp.symbol
-        if sym.isClass then // direct ref to a class, not an alias
-          if sym.isAllOf(Case | Module) then
-            // correct widened module ref. Tested in tests/run/i15234.scala
-            val singleton = sym.sourceModule
-            Right(MirrorSource.Singleton(singleton, TermRef(tp.prefix, singleton)))
-          else
-            Right(MirrorSource.ClassSymbol(tp.prefix, sym))
-        else
-          reduce(tp.superType)
-      case tp: TermRef =>
-        /** Dealias a path type to extract the underlying definition when it is either
-         *  a singleton enum case or a case object.
-         */
-        def reduceToEnumOrCaseObject(tp: Type)(using Context): Symbol = tp match
-          case tp: TermRef =>
-            val sym = tp.termSymbol
-            if sym.isEnumCase || (sym.isClass && sym.isAllOf(Case | Module)) then sym
-            else if sym.exists && !tp.isOverloaded then reduceToEnumOrCaseObject(tp.underlying.widenExpr)
-            else NoSymbol
-          case _ => NoSymbol
-
-        // capture enum singleton types. Tested in tests/run/i15234.scala
-        val singleton = reduceToEnumOrCaseObject(tp)
-        if singleton.exists then
-          Right(MirrorSource.Singleton(singleton, tp))
-        else
-          reduce(tp.underlying)
-      case tp: HKTypeLambda if tp.resultType.isInstanceOf[HKTypeLambda] =>
-        Left(i"its subpart `$tp` is not a supported kind (either `*` or `* -> *`)")
-      case tp: TypeProxy =>
-        tp match
-          case tp @ AppliedType(tref: TypeRef, _) if tref.symbol == defn.PairClass =>
-            tp.tupleElementTypes match
-              case Some(types) =>
-                // avoid type aliases for tuples
-                Right(MirrorSource.GenericTuple(types))
-              case _ => reduce(tp.underlying)
-          case tp: MatchType => reduce(tp.normalized)
-          case _ => reduce(tp.superType)
-      case tp @ AndType(l, r) =>
-        for
-          lsrc <- reduce(l)
-          rsrc <- reduce(r)
-          res <- locally {
-            if lsrc.isSub(rsrc) then Right(lsrc)
-            else if rsrc.isSub(lsrc) then Right(rsrc)
-            else Left(i"its subpart `$tp` is an intersection of unrelated definitions ${lsrc.show} and ${rsrc.show}.")
-          }
-        yield
-          res
-      case tp: OrType =>
-        Left(i"its subpart `$tp` is a top-level union type.")
-      case tp =>
-        Left(i"its subpart `$tp` is an unsupported type.")
-
-  end MirrorSource
-
   private def productMirror(mirroredType: Type, formal: Type, span: Span)(using Context): TreeWithErrors =
 
     /** `new scala.runtime.TupleMirror(arity)`
@@ -614,16 +514,6 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
     case JavaArrayType(elemTp) => defn.ArrayOf(escapeJavaArray(elemTp))
     case _                     => tp
 
-  private enum ManifestKind:
-    case Full, Opt, Clss
-
-    /** The kind that should be used for an array element, if we are `OptManifest` then this
-     *  prevents wildcards arguments of Arrays being converted to `NoManifest`
-     */
-    def arrayElem = if this == Full then this else Clss
-
-  end ManifestKind
-
   /** Manifest factory that does enough to satisfy the equality semantics for
    *  - `scala.reflect.OptManifest` (only runtime class is recorded)
    *  - `scala.reflect.Manifest` (runtime class of arguments are recorded, with wildcard upper bounds wrapped)
@@ -777,5 +667,115 @@ object Synthesizer:
   private def clearErrorsIfNotEmpty(treeWithErrors: TreeWithErrors) = treeWithErrors match
     case (tree, _) if tree eq genericEmptyTree => treeWithErrors
     case (tree, _)                             => withNoErrors(tree)
+
+  private enum ManifestKind:
+    case Full, Opt, Clss
+
+    /** The kind that should be used for an array element, if we are `OptManifest` then this
+     *  prevents wildcards arguments of Arrays being converted to `NoManifest`
+     */
+    def arrayElem = if this == Full then this else Clss
+
+  end ManifestKind
+
+  private[Synthesizer] enum MirrorSource:
+    case ClassSymbol(pre: Type, cls: Symbol)
+    case Singleton(src: Symbol, tref: TermRef)
+    case GenericTuple(tps: List[Type])
+
+    /** Tests that both sides are tuples of the same arity */
+    infix def sameTuple(that: MirrorSource)(using Context): Boolean =
+      def arity(msrc: MirrorSource): Int = msrc match
+        case GenericTuple(tps) => tps.size
+        case ClassSymbol(_, cls) if defn.isTupleClass(cls) => cls.typeParams.size // tested in tests/pos/i13859.scala
+        case _ => -1
+      def equivalent(n: Int, m: Int) =
+        n == m && n > 0
+      equivalent(arity(this), arity(that))
+
+    /** A comparison that chooses the most specific MirrorSource, this is guided by what is necessary for
+     * `Mirror.Product.fromProduct`. i.e. its result type should be compatible with the erasure of `mirroredType`.
+     */
+    def isSub(that: MirrorSource)(using Context): Boolean =
+      (this, that) match
+        case (Singleton(src, _), ClassSymbol(_, cls)) => src.info.classSymbol.isSubClass(cls)
+        case (ClassSymbol(_, cls1), ClassSymbol(_, cls2)) => cls1.isSubClass(cls2)
+        case (Singleton(src1, _), Singleton(src2, _)) => src1 eq src2
+        case (_: ClassSymbol, _: Singleton) => false
+        case _ => this sameTuple that
+
+    def show(using Context): String = this match
+      case ClassSymbol(_, cls) => i"$cls"
+      case Singleton(src, _) => i"$src"
+      case GenericTuple(tps) =>
+        val arity = tps.size
+        if arity <= Definitions.MaxTupleArity then s"class Tuple$arity"
+        else s"trait Tuple { def size: $arity }"
+
+  private object MirrorSource:
+
+    /** Reduces a mirroredType to either its most specific ClassSymbol,
+     *  or a TermRef to a singleton value. These are
+     *  the base elements required to generate a mirror.
+     */
+    def reduce(mirroredType: Type)(using Context): Either[String, MirrorSource] = mirroredType match
+      case tp: TypeRef =>
+        val sym = tp.symbol
+        if sym.isClass then // direct ref to a class, not an alias
+          if sym.isAllOf(Case | Module) then
+            // correct widened module ref. Tested in tests/run/i15234.scala
+            val singleton = sym.sourceModule
+            Right(MirrorSource.Singleton(singleton, TermRef(tp.prefix, singleton)))
+          else
+            Right(MirrorSource.ClassSymbol(tp.prefix, sym))
+        else
+          reduce(tp.superType)
+      case tp: TermRef =>
+        /** Dealias a path type to extract the underlying definition when it is either
+         *  a singleton enum case or a case object.
+         */
+        def reduceToEnumOrCaseObject(tp: Type)(using Context): Symbol = tp match
+          case tp: TermRef =>
+            val sym = tp.termSymbol
+            if sym.isEnumCase || (sym.isClass && sym.isAllOf(Case | Module)) then sym
+            else if sym.exists && !tp.isOverloaded then reduceToEnumOrCaseObject(tp.underlying.widenExpr)
+            else NoSymbol
+          case _ => NoSymbol
+
+        // capture enum singleton types. Tested in tests/run/i15234.scala
+        val singleton = reduceToEnumOrCaseObject(tp)
+        if singleton.exists then
+          Right(MirrorSource.Singleton(singleton, tp))
+        else
+          reduce(tp.underlying)
+      case tp: HKTypeLambda if tp.resultType.isInstanceOf[HKTypeLambda] =>
+        Left(i"its subpart `$tp` is not a supported kind (either `*` or `* -> *`)")
+      case tp: TypeProxy =>
+        tp match
+          case tp @ AppliedType(tref: TypeRef, _) if tref.symbol == defn.PairClass =>
+            tp.tupleElementTypes match
+              case Some(types) =>
+                // avoid type aliases for tuples
+                Right(MirrorSource.GenericTuple(types))
+              case _ => reduce(tp.underlying)
+          case tp: MatchType => reduce(tp.normalized)
+          case _ => reduce(tp.superType)
+      case tp @ AndType(l, r) =>
+        for
+          lsrc <- reduce(l)
+          rsrc <- reduce(r)
+          res <- locally {
+            if lsrc.isSub(rsrc) then Right(lsrc)
+            else if rsrc.isSub(lsrc) then Right(rsrc)
+            else Left(i"its subpart `$tp` is an intersection of unrelated definitions ${lsrc.show} and ${rsrc.show}.")
+          }
+        yield
+          res
+      case tp: OrType =>
+        Left(i"its subpart `$tp` is a top-level union type.")
+      case tp =>
+        Left(i"its subpart `$tp` is an unsupported type.")
+
+  end MirrorSource
 
 end Synthesizer

--- a/docs/_spec/TODOreference/other-new-features/safe-initialization.md
+++ b/docs/_spec/TODOreference/other-new-features/safe-initialization.md
@@ -226,10 +226,6 @@ A value `v` is _effectively hot_ if any of the following is true:
 
 - `v` is `Hot`.
 - `v` is `ThisRef` and all fields of the underlying object are assigned.
-- `v` is `Warm[C] { ... }` and
-  1. `C` does not contain inner classes; and
-  2. Calling any method on `v` encounters no initialization errors and the method return value is _effectively hot_; and
-  3. Each field of `v` is _effectively hot_.
 - `v` is `Fun(e, V, C)` and calling the function encounters no errors and the
   function return value is _effectively hot_.
 - The root object (refered by `ThisRef`) is _effectively hot_.

--- a/tests/init/warn/inner1.scala
+++ b/tests/init/warn/inner1.scala
@@ -4,7 +4,7 @@ class Foo {
   val list = List(1, 2, 3) // warn, as Inner access `this.list`
 
   val inner: Inner = new this.Inner // ok, `list` is instantiated
-  lib.escape(inner) // ok, can promote inner early
+  lib.escape(inner)                 // error: inner is warm
 
   val name = "good"
 

--- a/tests/init/warn/inner17.scala
+++ b/tests/init/warn/inner17.scala
@@ -5,7 +5,7 @@ class A {
     val a = f
   }
 
-  println(new B)              // OK, can promote B early
+  println(new B)              // error: warm value
 }
 
 class C extends A {

--- a/tests/init/warn/promotion-loop.scala
+++ b/tests/init/warn/promotion-loop.scala
@@ -4,7 +4,7 @@ class Test { test =>
   }
 
   val a = new A
-  println(a)
+  println(a)       // warn
 
 
   class B {


### PR DESCRIPTION
Previously we had a rule that checks whether a warm object can be promoted by checking
its member methods and the corresponding return values recursively. The rule is complex and produce
error messages that are difficult to understand.

Initially, the rule was motivated for the following use case:

``` Scala
    object C:
      case class Data(value: Int)
      val a = Data(3)
      val ref = foo(a) // safe to leak a
```

With the introduction of the global object checker, we do not check initialization of global objects
with the class instance checker anymore. Consequently, we can simplify the rules of class instance checker.


---

```Scala
[warn] -- Warning: /Users/liufengyun/Documents/dotty/compiler/src/dotty/tools/dotc/core/classfile/ReusableDataReader.scala:31:4
[warn] 31 |    new DataInputStream(stream)
[warn]    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |Problematic object instantiation: arg 1 is not transitively initialized (Hot). Calling trace:
[warn]    |├── final class ReusableDataReader() extends DataReader {	[ ReusableDataReader.scala:11 ]
[warn]    |│   ^
[warn]    |└── new DataInputStream(stream)	[ ReusableDataReader.scala:31 ]
[warn]    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |
[warn]    |It leads to the following error during object initialization:
[warn]    |Calling the external method constructor DataInputStream may cause initialization errors.
[warn] -- Warning: /Users/liufengyun/Documents/dotty/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala:75:31
[warn] 75 |      val zipCps = cps.collect { case cp: ZipArchiveFileLookup[?] => cp }
[warn]    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |Could not verify that the method argument is transitively initialized (Hot). It was found to be a non-transitively initialized (Warm) object of type (anonymous class
[warn]    |
[warn]    |    scala.runtime.AbstractPartialFunction[dotty.tools.io.ClassPath,
[warn]    |      dotty.tools.dotc.classpath.ZipArchiveFileLookup[?
[warn]    |         <: dotty.tools.io.ClassRepresentation]
[warn]    |    ]
[warn]    |   with
[warn]    |Serializable {...}) { outer = the original object of type (class InteractiveDriver) where initialization checking started }. Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
[warn]    |├── class InteractiveDriver(val settings: List[String]) extends Driver {	[ InteractiveDriver.scala:28 ]
[warn]    |│   ^
[warn]    |└── val zipCps = cps.collect { case cp: ZipArchiveFileLookup[?] => cp }	[ InteractiveDriver.scala:75 ]
[warn]    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn] -- Warning: /Users/liufengyun/Documents/dotty/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala:76:31
[warn] 76 |      val dirCps = cps.collect { case cp: JFileDirectoryLookup[?] => cp }
[warn]    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]    |Could not verify that the method argument is transitively initialized (Hot). It was found to be a non-transitively initialized (Warm) object of type (anonymous class
[warn]    |
[warn]    |    scala.runtime.AbstractPartialFunction[dotty.tools.io.ClassPath,
[warn]    |      dotty.tools.dotc.classpath.JFileDirectoryLookup[?
[warn]    |         <: dotty.tools.io.ClassRepresentation]
[warn]    |    ]
[warn]    |   with
[warn]    |Serializable {...}) { outer = the original object of type (class InteractiveDriver) where initialization checking started }. Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
[warn]    |├── class InteractiveDriver(val settings: List[String]) extends Driver {	[ InteractiveDriver.scala:28 ]
[warn]    |│   ^
[warn]    |└── val dirCps = cps.collect { case cp: JFileDirectoryLookup[?] => cp }	[ InteractiveDriver.scala:76 ]
[warn]    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn] -- Warning: /Users/liufengyun/Documents/dotty/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala:1051:22
[warn] 1051 |      "mergeTests" -> mergeTests,
[warn]      |                      ^^^^^^^^^^
[warn]      |Could not verify that the method argument is transitively initialized (Hot). It was found to be a function where "this" is (the original object of type (class Translator) where initialization checking started). Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
[warn]      |├── class Translator(resultType: Type, thisPhase: MiniPhase)(using Context) {	[ PatternMatcher.scala:98 ]
[warn]      |│   ^
[warn]      |└── "mergeTests" -> mergeTests,	[ PatternMatcher.scala:1051 ]
[warn]      |                    ^^^^^^^^^^
[warn]      |
[warn]      |Promoting the value to transitively initialized (Hot) failed due to the following problem:
[warn]      |The RHS of reassignment must be transitively initialized (Hot). It was found to be a non-transitively initialized (Warm) object of type (class SeqPlan) { outer = the original object of type (class Translator) where initialization checking started, args = (a transitively initialized (Hot) object, a transitively initialized (Hot) object) }.  Promotion trace:
[warn]      |├── "mergeTests" -> mergeTests,	[ PatternMatcher.scala:1051 ]
[warn]      |│                   ^^^^^^^^^^
[warn]      |├── def mergeTests(plan: Plan): Plan = {	[ PatternMatcher.scala:597 ]
[warn]      |│   ^
[warn]      |├── new MergeTests()(plan)	[ PatternMatcher.scala:662 ]
[warn]      |│   ^^^^^^^^^^^^^^^^^^^^^^
[warn]      |├── def apply(plan: Plan): Plan = plan match {	[ PatternMatcher.scala:504 ]
[warn]      |│   ^
[warn]      |├── case plan: SeqPlan => apply(plan)	[ PatternMatcher.scala:509 ]
[warn]      |│                         ^^^^^^^^^^^
[warn]      |├── override def apply(plan: SeqPlan): Plan = {	[ PatternMatcher.scala:608 ]
[warn]      |│   ^
[warn]      |├── tryMerge(plan.head, tailHead) match {	[ PatternMatcher.scala:650 ]
[warn]      |│   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[warn]      |├── def tryMerge(plan1: Plan, plan2: Plan): Option[Plan] = {	[ PatternMatcher.scala:609 ]
[warn]      |│   ^
[warn]      |└── testPlan1.onSuccess = SeqPlan(testPlan1.onSuccess,	[ PatternMatcher.scala:630 ]
[warn]      |    ^
[warn] -- Warning: /Users/liufengyun/Documents/dotty/compiler/src/dotty/tools/dotc/typer/Applications.scala:881:70
[warn] 881 |              val impureArgIndices = typedArgBuf.zipWithIndex.collect {
[warn]     |                                                                      ^
[warn]     |Could not verify that the method argument is transitively initialized (Hot). It was found to be a non-transitively initialized (Warm) object of type (anonymous class
[warn]     |
[warn]     |    scala.runtime.AbstractPartialFunction[
[warn]     |      (dotty.tools.dotc.ast.tpd.Tree @uncheckedVariance, Int), Int]
[warn]     |   with
[warn]     |Serializable {...}) { outer = the original object of type (class ApplyToUntyped) where initialization checking started }. Only transitively initialized arguments may be passed to methods (except constructors). Calling trace:
[warn]     |├── class ApplyToUntyped(	[ Applications.scala:909 ]
[warn]     |│   ^
[warn]     |├── abstract class TypedApply[T <: Untyped](	[ Applications.scala:786 ]
[warn]     |│   ^
[warn]     |└── val impureArgIndices = typedArgBuf.zipWithIndex.collect {	[ Applications.scala:881 ]
[warn]     |                                                            ^
[warn] 882 |                case (arg, idx) if !lifter.noLift(arg) => idx
[warn] -- Warning: /Users/liufengyun/Documents/dotty/out/bootstrap/scala3-compiler-bootstrapped/scala-3.4.0-RC1-bin-SNAPSHOT-nonbootstrapped/src_managed/main/scalajs-ir-src/org/scalajs/ir/Hashers.scala:128:6
[warn] 128 |      new DataOutputStream(new OutputStream {
[warn]     |      ^
[warn]     |Problematic object instantiation: arg 1 is not transitively initialized (Hot). Calling trace:
[warn]     |├── private final class TreeHasher {	[ Hashers.scala:124 ]
[warn]     |│   ^
[warn]     |└── new DataOutputStream(new OutputStream {	[ Hashers.scala:128 ]
[warn]     |    ^
[warn]     |
[warn]     |It leads to the following error during object initialization:
[warn]     |Calling the external method constructor DataOutputStream may cause initialization errors.
[warn] 129 |        def write(b: Int): Unit =
[warn] 130 |          digestBuilder.update(b.toByte)
[warn] 131 |        override def write(b: Array[Byte]): Unit =
[warn] 132 |          digestBuilder.update(b)
[warn] 133 |        override def write(b: Array[Byte], off: Int, len: Int): Unit =
[warn] 134 |          digestBuilder.update(b, off, len)
[warn] 135 |      })
```
