### PR TITLE
Cleanup unnecessary language flag

### DIFF
--- a/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
+++ b/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
@@ -60,7 +60,6 @@ class TastyBootstrapTests {
     val lib =
       compileList("lib", librarySources,
         defaultOptions.and("-Ycheck-reentrant",
-          "-language:experimental.erasedDefinitions", // support declaration of scala.compiletime.erasedValue
           //  "-source", "future",  // TODO: re-enable once library uses updated syntax for vararg splices, wildcard imports, and import renaming
           ))(libGroup)
 


### PR DESCRIPTION
At some point `scala.compiletime.erasedValue` was defined as erased and therefore we needed this flag. Now we special case `erasedValue` in the compiler to give it erased semantics without defining it as such.