### PR TITLE
Support snippet that refers to experimental definitions on stable releases

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
@@ -27,6 +27,8 @@ class SnippetCompiler(
   object SnippetDriver extends Driver:
     val currentCtx =
       val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions).addMode(Mode.Interactive)
+      rootCtx.setSetting(rootCtx.settings.YnoExperimental, true)
+      rootCtx.setSetting(rootCtx.settings.experimental, true)
       rootCtx.setSetting(rootCtx.settings.YretainTrees, true)
       rootCtx.setSetting(rootCtx.settings.YcookComments, true)
       rootCtx.setSetting(rootCtx.settings.YreadComments, true)


### PR DESCRIPTION
We add `-YnoExperimental` to simulate a releases version of the compile. Then fix the issue by allowing experimental code with `-experimental`.

<details>
<summary>Example failures with `-Yno-experimental` (or in stable version)</summary>

```scala
-- Error: library/src/scala/annotation/MacroAnnotation.scala:47:28 -------------
47 |   *  class memoize extends MacroAnnotation:
   |                            ^
   |       Experimental definition may only be used under experimental mode:
   |         1. in a definition marked as @experimental, or
   |         2. compiling with the -experimental compiler flag, or
   |         3. with a nightly or snapshot version of the compiler.
   |
   |       trait MacroAnnotation is marked @experimental
   |                 
-- Error: library/src/scala/annotation/MacroAnnotation.scala:54:41 -------------
54 |   *              val cacheName = Symbol.freshName(name + "Cache")
   |                                         ^
   |       Experimental definition may only be used under experimental mode:
   |         1. in a definition marked as @experimental, or
   |         2. compiling with the -experimental compiler flag, or
   |         3. with a nightly or snapshot version of the compiler.
   |
   |       method freshName is marked @experimental
   |                 
-- Error: library/src/scala/quoted/Quotes.scala:3772:42 ------------------------
3772 |       *  val moduleName: String = Symbol.freshName("MyModule")
     |                                          ^
     |   Experimental definition may only be used under experimental mode:
     |     1. in a definition marked as @experimental, or
     |     2. compiling with the -experimental compiler flag, or
     |     3. with a nightly or snapshot version of the compiler.
     |
     |   method freshName is marked @experimental
     |             
-- Error: library/src/scala/quoted/Quotes.scala:3777:27 ------------------------
3777 |       *  val mod = Symbol.newModule(Symbol.spliceOwner, moduleName, Flags.EmptyFlags, Flags.EmptyFlags, parents.map(_.tpe), decls, Symbol.noSymbol)
     |                           ^
     |   Experimental definition may only be used under experimental mode:
     |     1. in a definition marked as @experimental, or
     |     2. compiling with the -experimental compiler flag, or
     |     3. with a nightly or snapshot version of the compiler.
     |
     |   method newModule is marked @experimental
     |             
-- Error: library/src/scala/quoted/Quotes.scala:3782:32 ------------------------
3782 |       *  val modDef = ClassDef.module(mod, parents, body = List(runDef))
     |                                ^
     |   Experimental definition may only be used under experimental mode:
     |     1. in a definition marked as @experimental, or
     |     2. compiling with the -experimental compiler flag, or
     |     3. with a nightly or snapshot version of the compiler.
     |
     |   method module is marked @experimental
```
</details> 