### PR TITLE
Avoid crash after StopMacroExpansion

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -494,14 +494,14 @@ object Inlines:
 
       // Take care that only argument bindings go into `bindings`, since positions are
       // different for bindings from arguments and bindings from body.
-      val res = tpd.Inlined(call, bindings, expansion)
+      val inlined = tpd.Inlined(call, bindings, expansion)
 
-      if !hasOpaqueProxies then res
+      if !hasOpaqueProxies || !inlined.tpe.exists then inlined
       else
         val target =
-          if inlinedMethod.is(Transparent) then call.tpe & res.tpe
+          if inlinedMethod.is(Transparent) then call.tpe & inlined.tpe
           else call.tpe
-        res.ensureConforms(target)
+        inlined.ensureConforms(target)
           // Make sure that the sealing with the declared type
           // is type correct. Without it we might get problems since the
           // expression's type is the opaque alias but the call's type is

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -496,7 +496,7 @@ object Inlines:
       // different for bindings from arguments and bindings from body.
       val inlined = tpd.Inlined(call, bindings, expansion)
 
-      if !hasOpaqueProxies || !inlined.tpe.exists then inlined
+      if !hasOpaqueProxies then inlined
       else
         val target =
           if inlinedMethod.is(Transparent) then call.tpe & inlined.tpe

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -72,7 +72,7 @@ object Splicer {
           if !ctx.reporter.hasErrors then
             report.error("Macro expansion was aborted by the macro without any errors reported. Macros should issue errors to end-users when aborting a macro expansion with StopMacroExpansion.", splicePos)
           // errors have been emitted
-          EmptyTree
+          ref(defn.Predef_undefined).withType(ErrorType(em"macro expansion was stopped"))
         case ex: StopInterpretation =>
           report.error(ex.msg, ex.pos)
           ref(defn.Predef_undefined).withType(ErrorType(ex.msg))

--- a/tests/neg-macros/i19851/Macro_1.scala
+++ b/tests/neg-macros/i19851/Macro_1.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+opaque type Box[A] = Any
+object Box:
+  transparent inline def pack[A]: Nothing => Box[A] = ${ packImpl[A] }
+
+  private def packImpl[A](using Quotes, Type[A]): Expr[Nothing => Box[A]] =
+    import quotes.reflect.*
+    report.errorAndAbort("Not implemented")

--- a/tests/neg-macros/i19851/Test_2.scala
+++ b/tests/neg-macros/i19851/Test_2.scala
@@ -1,0 +1,3 @@
+class Test:
+  def t1: Unit =
+    Box.pack[Int] // error

--- a/tests/neg-macros/i9014b.check
+++ b/tests/neg-macros/i9014b.check
@@ -7,4 +7,4 @@
   |
   |                           given_Bar
   |
-  |                       But given instance given_Bar does not match type Bar.
+  |                       But macro expansion was stopped.


### PR DESCRIPTION
When a splice throws a StopMacroExpansion, it's replaced by an EmptyTree, which has NoType.  Which means you can't cast it, as you can't call .asInstanceOf on it.  So handle this before calling ensureConforms.

Fixes #19851
