### PR TITLE
simple scripts to run non-bootstrapped compiler after 'sbt buildQuick'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ testlogs/
 local/
 compiler/test/debug/Gen.jar
 
+/bin/.cp
+
 before-pickling.txt
 after-pickling.txt
 bench/compile.txt

--- a/bin/commonQ
+++ b/bin/commonQ
@@ -1,0 +1,6 @@
+cp=$(cat $ROOT/bin/.cp) 2> /dev/null
+
+if [[ "$cp" == "" ]]; then
+  echo "run 'sbt buildQuick' first"
+  exit 1
+fi

--- a/bin/scalaQ
+++ b/bin/scalaQ
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
+. $ROOT/bin/commonQ
+
+java -cp $cp dotty.tools.MainGenericRunner -usejavacp "$@"

--- a/bin/scalacQ
+++ b/bin/scalacQ
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/.."
+. $ROOT/bin/commonQ
+
+java -cp $cp dotty.tools.MainGenericCompiler -usejavacp "$@"

--- a/docs/_docs/contributing/getting-started.md
+++ b/docs/_docs/contributing/getting-started.md
@@ -81,6 +81,12 @@ $ scalac tests/pos/HelloWorld.scala
 $ scala HelloWorld
 ```
 
+Note that the `scalac` and `scala` scripts have slow roundtrip times when working on the compiler codebase: whenever
+any source file changes they invoke `sbt dist/pack` first.
+
+As an alternative, run the `buildQuick` task in sbt. It builds the compiler and writes its classpath to the `bin/.cp`
+file, which enables  the `scalacQ` and `scalaQ` scripts in the `bin/` folder.
+
 ## Starting a REPL
 
 ```bash

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -205,6 +205,8 @@ object Build {
 
   val repl = taskKey[Unit]("spawns a repl with the correct classpath")
 
+  val buildQuick = taskKey[Unit]("builds the compiler and writes the classpath to bin/.cp to enable the bin/scalacQ and bin/scalaQ scripts")
+
   // Compiles the documentation and static site
   val genDocs = inputKey[Unit]("run scaladoc to generate static documentation site")
 
@@ -2136,6 +2138,11 @@ object Build {
         // default.
         addCommandAlias("publishLocal", "scala3-bootstrapped/publishLocal"),
         repl := (`scala3-compiler-bootstrapped` / repl).value,
+        buildQuick := {
+          val _ = (`scala3-compiler` / Compile / compile).value
+          val cp = (`scala3-compiler` / Compile / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)
+          IO.write(baseDirectory.value / "bin" / ".cp", cp)
+        },
         (Compile / console) := (Compile / console).dependsOn(Def.task {
           import _root_.scala.io.AnsiColor._
           val msg = "`console` uses the reference Scala version. Use `repl` instead."


### PR DESCRIPTION
The current scripts in `bin` are not suitable for iterative development, as they invoke `sbt dist/pack` whenever any source file has a newer timestamp. Also they are full of magic which I don't think I need for compiler development.

I know there are `repl` / `scala` / `scalac` sbt tasks, but I highly prefer working in zsh versus sbt shell, for example because I can `cd` to a `sandbox` directory. Then I run `scq A.scala`, `cfr-decompiler A.class`, stuff like that.

This PR is a proposal, I'm curious if anyone else would find it useful.