### PR TITLE
Suppressing repetitive warnings in the global initialization checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -50,7 +50,8 @@ class Checker extends Phase:
         Semantic.checkClasses(classes)(using checkCtx)
 
       if ctx.settings.YcheckInitGlobal.value then
-        Objects.checkClasses(classes)(using checkCtx)
+        val obj = new Objects
+        obj.checkClasses(classes)(using checkCtx)
     }
 
     units0


### PR DESCRIPTION
This PR suppresses repetitive warnings in the global initialization checker to make the warnings more manageable to analyze.