### PR TITLE
Check deprecation of inline methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -100,7 +100,7 @@ object Inlines:
     if ctx.isAfterTyper then
       // During typer we wait with cross version checks until PostTyper, in order
       // not to provoke cyclic references. See i16116 for a test case.
-      CrossVersionChecks.checkExperimentalRef(tree.symbol, tree.srcPos)
+      CrossVersionChecks.checkRef(tree.symbol, tree.srcPos)
 
     if tree.symbol.isConstructor then return tree // error already reported for the inline constructor definition
 

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -369,7 +369,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           }
         case tree @ Inlined(call, bindings, expansion) if !tree.inlinedFromOuterScope =>
           val pos = call.sourcePos
-          CrossVersionChecks.checkExperimentalRef(call.symbol, pos)
+          CrossVersionChecks.checkRef(call.symbol, pos)
           withMode(Mode.NoInline)(transform(call))
           val callTrace = Inlines.inlineCallTrace(call.symbol, pos)(using ctx.withSource(pos.source))
           cpy.Inlined(tree)(callTrace, transformSub(bindings), transform(expansion)(using inlineContext(tree)))

--- a/scaladoc-testcases/src/tests/hugetype.scala
+++ b/scaladoc-testcases/src/tests/hugetype.scala
@@ -3,6 +3,7 @@ package tests.hugetype
 import compiletime._
 import compiletime.ops.int._
 import scala.annotation.experimental
+import scala.annotation.nowarn
 
 /**
  * a particular group of people or things that share similar characteristics and form a smaller division of a larger set:
@@ -39,7 +40,7 @@ trait XD extends E:
    */
   @experimental
   @deprecated
-  protected override final implicit transparent inline abstract infix def same[A](a: A): A = a
+  protected override final implicit transparent inline abstract infix def same[A](a: A): A = a: @nowarn
 
 trait Parent[X, A[_], B[_, _]]
 

--- a/tests/warn/i19913.check
+++ b/tests/warn/i19913.check
@@ -1,0 +1,8 @@
+-- Deprecation Warning: tests/warn/i19913.scala:13:25 ------------------------------------------------------------------
+13 |  Deprecated.inlineMethod() // warn
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |  method inlineMethod in object Deprecated is deprecated: test
+-- Deprecation Warning: tests/warn/i19913.scala:12:13 ------------------------------------------------------------------
+12 |  Deprecated.method() // warn
+   |  ^^^^^^^^^^^^^^^^^
+   |  method method in object Deprecated is deprecated: test

--- a/tests/warn/i19913.scala
+++ b/tests/warn/i19913.scala
@@ -1,0 +1,13 @@
+//> using options -deprecation
+
+object Deprecated:
+
+  @deprecated("test")
+  def method() = ???
+
+  @deprecated("test")
+  inline def inlineMethod() = ???
+
+object Test:
+  Deprecated.method() // warn
+  Deprecated.inlineMethod() // warn


### PR DESCRIPTION
We must check these constraint just before inlining as later on there on the call might completely disappear. We do the same as we did for experimental definition checks.

Fixes #19913


### Changes

- Define `CrossVersionChecks.checkRef` that checks both deprecation and experimental.
  - Used in `Inlines` and `PostTyper` to check the deprecation of inlined calls.
- Rename `checkDeprecated` to `checkDeprecatedRef`
- Move `checkDeprecatedRef` and `skipWarning` to `object CrossVersionChecks`