### PR TITLE
Use `concurrent.Map` in `MacroAnnotation` example

### DIFF
--- a/library/src/scala/annotation/MacroAnnotation.scala
+++ b/library/src/scala/annotation/MacroAnnotation.scala
@@ -42,7 +42,7 @@ trait MacroAnnotation extends StaticAnnotation:
    *  This example shows how to modify a `def` and add a `val` next to it using a macro annotation.
    *  ```scala
    *  import scala.quoted.*
-   *  import scala.collection.mutable
+   *  import scala.collection.concurrent
    *
    *  class memoize extends MacroAnnotation:
    *    def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
@@ -52,14 +52,14 @@ trait MacroAnnotation extends StaticAnnotation:
    *          (param.tpt.tpe.asType, tpt.tpe.asType) match
    *            case ('[t], '[u]) =>
    *              val cacheName = Symbol.freshName(name + "Cache")
-   *              val cacheSymbol = Symbol.newVal(Symbol.spliceOwner, cacheName, TypeRepr.of[mutable.Map[t, u]], Flags.Private, Symbol.noSymbol)
+   *              val cacheSymbol = Symbol.newVal(Symbol.spliceOwner, cacheName, TypeRepr.of[concurrent.Map[t, u]], Flags.Private, Symbol.noSymbol)
    *              val cacheRhs =
    *                given Quotes = cacheSymbol.asQuotes
-   *                '{ mutable.Map.empty[t, u] }.asTerm
+   *                '{ concurrent.TrieMap.empty[t, u] }.asTerm
    *              val cacheVal = ValDef(cacheSymbol, Some(cacheRhs))
    *              val newRhs =
    *                given Quotes = tree.symbol.asQuotes
-   *                val cacheRefExpr = Ref(cacheSymbol).asExprOf[mutable.Map[t, u]]
+   *                val cacheRefExpr = Ref(cacheSymbol).asExprOf[concurrent.Map[t, u]]
    *                val paramRefExpr = Ref(param.symbol).asExprOf[t]
    *                val rhsExpr = rhsTree.asExprOf[u]
    *                '{ $cacheRefExpr.getOrElseUpdate($paramRefExpr, $rhsExpr) }.asTerm
@@ -82,7 +82,7 @@ trait MacroAnnotation extends StaticAnnotation:
    *  and the macro will modify the definition to create
    *  ```scala
    *   val fibCache$macro$1 =
-   *     scala.collection.mutable.Map.empty[Int, Int]
+   *     scala.collection.concurrent.TrieMap.empty[Int, Int]
    *   def fib(n: Int): Int =
    *     fibCache$macro$1.getOrElseUpdate(
    *       n,


### PR DESCRIPTION
This is much safer if users copy-paste the example blindly into their code.

See https://contributors.scala-lang.org/t/scala-3-macro-annotations-sip-63-discussions/6593/2