### PR TITLE
Cover patterns using `reflect.TypeTest` in isMatchTypeShaped

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1814,7 +1814,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 // check `pat` here and throw away the result.
                 val gadtCtx: Context = ctx.fresh.setFreshGADTBounds
                 val pat1 = typedPattern(pat, selType)(using gadtCtx)
-                val Typed(_, tpt) = tpd.unbind(tpd.unsplice(pat1)): @unchecked
+                val tpt = tpd.unbind(tpd.unsplice(pat1)) match
+                  case Typed(_, tpt) => tpt
+                  case UnApply(fun, _, p1 :: _) if fun.symbol == defn.TypeTest_unapply => p1
                 instantiateMatchTypeProto(pat1, pt) match {
                   case defn.MatchCase(patternTp, _) => tpt.tpe frozen_=:= patternTp
                   case _ => false

--- a/tests/pos/i19692.scala
+++ b/tests/pos/i19692.scala
@@ -1,0 +1,8 @@
+
+trait UsingTypeTest[B](using reflect.TypeTest[Int, B]):
+
+  type M[U <: Int] = U match
+    case B => String
+
+  def m(t: Int): M[Int] = t match
+    case _: B => "hello"


### PR DESCRIPTION
Fixes #19692 