### PR TITLE
Publish `scala2-library-cc-tasty`

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2116,7 +2116,7 @@ object Build {
     // FIXME: we do not aggregate `bin` because its tests delete jars, thus breaking other tests
     def asDottyRoot(implicit mode: Mode): Project = project.withCommonSettings.
       aggregate(`scala3-interfaces`, dottyLibrary, dottyCompiler, tastyCore, `scala3-sbt-bridge`, scala3PresentationCompiler).
-      bootstrappedAggregate(`scala2-library-tasty`, `scala3-language-server`, `scala3-staging`,
+      bootstrappedAggregate(`scala2-library-tasty`, `scala2-library-cc-tasty`, `scala3-language-server`, `scala3-staging`,
         `scala3-tasty-inspector`, `scala3-library-bootstrappedJS`, scaladoc).
       dependsOn(tastyCore).
       dependsOn(dottyCompiler).


### PR DESCRIPTION
Similar to #19588.

We will start publishing `org.scala-lang::scala2-library-cc-tasty-experimental`. This is __not considered fully stable__. 

Example usage in SBT
```scala
libraryDependencies += "org.scala-lang" %% "scala2-library-cc-tasty-experimental" % scalaVersion.value
```
