### PR TITLE
Detect non `Exp[..]` splice patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
@@ -28,7 +28,9 @@ object QuotePatterns:
   /** Check for restricted patterns */
   def checkPattern(quotePattern: QuotePattern)(using Context): Unit = new tpd.TreeTraverser {
     def traverse(tree: Tree)(using Context): Unit = tree match {
-      case _: SplicePattern =>
+      case tree: SplicePattern =>
+        if !tree.body.typeOpt.derivesFrom(defn.QuotedExprClass) then
+          report.error(i"Spice pattern must match an Expr[...]", tree.body.srcPos)
       case tdef: TypeDef if tdef.symbol.isClass =>
         val kind = if tdef.symbol.is(Module) then "objects" else "classes"
         report.error(em"Implementation restriction: cannot match $kind", tree.srcPos)

--- a/tests/neg-macros/i19941.check
+++ b/tests/neg-macros/i19941.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg-macros/i19941.scala:7:14 ---------------------------------------------------------------------------
+7 |    case '{ ${hd *: tl} : *:[Int, EmptyTuple] } => '{ ??? } // error
+  |              ^^^^^^^^
+  |              Spice pattern must match an Expr[...]

--- a/tests/neg-macros/i19941.scala
+++ b/tests/neg-macros/i19941.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+inline def expandMacro(inline from: Tuple): Any = ${ expandMacroImpl }
+
+def expandMacroImpl(using Quotes): Expr[?] =
+  '{ 1 *: EmptyTuple } match
+    case '{ ${hd *: tl} : *:[Int, EmptyTuple] } => '{ ??? } // error

--- a/tests/neg-macros/quotedPatterns-4.scala
+++ b/tests/neg-macros/quotedPatterns-4.scala
@@ -3,7 +3,7 @@ object Test {
   def impl(receiver: Expr[StringContext])(using qctx: scala.quoted.Quotes) = {
     import quotes.reflect.Repeated
     receiver match {
-      case '{ StringContext(${Repeated(parts, tpt)}*) } => // now OK
+      case '{ StringContext(${Repeated(parts, tpt)}*) } => // error: Repeated is not an Expr pattern
     }
   }
 }


### PR DESCRIPTION
We compute the pattern using `Expr[pt]` of the prototype `pt` of the splice, but this is not enough to reject non-matching patterns. The quoted splices are encoded away before we get to the pattern matching phase where we could potentially detect that they will not match. Instead we check that all quote patterns are `Expr[..]` when typing the pattern.

Fixes #19941