### PR TITLE
Avoid spurious `val` binding in quote pattern

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3003,8 +3003,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
   /** Translate infix operation expression `l op r` to
    *
    *    l.op(r)   			        if `op` is left-associative
-   *    { val x = l; r.op(x) }  if `op` is right-associative call-by-value and `l` is impure
-   *    r.op(l)                 if `op` is right-associative call-by-name or `l` is pure
+   *    { val x = l; r.op(x) }  if `op` is right-associative call-by-value and `l` is impure, and not in a quote pattern
+   *    r.op(l)                 if `op` is right-associative call-by-name, or `l` is pure, or in a quote pattern
    *
    *  Translate infix type    `l op r` to `op[l, r]`
    *  Translate infix pattern `l op r` to `op(l, r)`
@@ -3021,7 +3021,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         typedUnApply(cpy.Apply(tree)(op, l :: r :: Nil), pt)
       else {
         val app = typedApply(desugar.binop(l, op, r), pt)
-        if op.name.isRightAssocOperatorName then
+        if op.name.isRightAssocOperatorName && !ctx.mode.is(Mode.QuotedExprPattern) then
           val defs = new mutable.ListBuffer[Tree]
           def lift(app: Tree): Tree = (app: @unchecked) match
             case Apply(fn, args) =>

--- a/tests/pos-macros/i19947/Macro_1.scala
+++ b/tests/pos-macros/i19947/Macro_1.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+inline def expandMacro(inline from: Tuple): Any =
+  ${ expandMacroImpl }
+
+def expandMacroImpl(using Quotes): Expr[?] =
+  '{ 1 *: EmptyTuple } match
+    case '{ ($hd: Int) *: ($tl: Tuple) } => '{ ??? }
+    case x => throw new MatchError(x.show)

--- a/tests/pos-macros/i19947/Test_2.scala
+++ b/tests/pos-macros/i19947/Test_2.scala
@@ -1,0 +1,1 @@
+def test: Any = expandMacro


### PR DESCRIPTION
In quoted patterns, we do not want to generate the val bindings. We care about the original structure if the pattern expression.

Fixes #19947