### PR TITLE
Stabilise returned completions by improving deduplication + extra completions for constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -125,7 +125,7 @@ object Completion:
   def completionPrefix(path: List[untpd.Tree], pos: SourcePosition)(using Context): String =
     def fallback: Int =
       var i = pos.point - 1
-      while i >= 0 && Chars.isIdentifierPart(pos.source.content()(i)) do i -= 1
+      while i >= 0 && Character.isUnicodeIdentifierPart(pos.source.content()(i)) do i -= 1
       i + 1
 
     path match
@@ -272,6 +272,32 @@ object Completion:
   def description(denot: SingleDenotation)(using Context): String =
     if denot.isType then denot.symbol.showFullName
     else denot.info.widenTermRefExpr.show
+
+  /** Include in completion sets only symbols that
+   *   1. is not absent (info is not NoType)
+   *   2. are not a primary constructor,
+   *   3. have an existing source symbol,
+   *   4. are the module class in case of packages,
+   *   5. are mutable accessors, to exclude setters for `var`,
+   *   6. symbol is not a package object
+   *   7. symbol is not an artifact of the compiler
+   *   8. symbol is not a constructor proxy module when in type completion mode
+   *   9. have same term/type kind as name prefix given so far
+   */
+  def isValidCompletionSymbol(sym: Symbol, completionMode: Mode)(using Context): Boolean =
+    sym.exists &&
+    !sym.isAbsent() &&
+    !sym.isPrimaryConstructor &&
+    sym.sourceSymbol.exists &&
+    (!sym.is(Package) || sym.is(ModuleClass)) &&
+    !sym.isAllOf(Mutable | Accessor) &&
+    !sym.isPackageObject &&
+    !sym.is(Artifact) &&
+    !(completionMode.is(Mode.Type) && sym.isAllOf(ConstructorProxyModule)) &&
+    (
+         (completionMode.is(Mode.Term) && (sym.isTerm || sym.is(ModuleClass))
+      || (completionMode.is(Mode.Type) && (sym.isType || sym.isStableMember)))
+    )
 
   given ScopeOrdering(using Context): Ordering[Seq[SingleDenotation]] with
     val order =
@@ -526,34 +552,13 @@ object Completion:
       extMethodsWithAppliedReceiver.groupByName
 
     /** Include in completion sets only symbols that
-     *   1. start with given name prefix, and
-     *   2. is not absent (info is not NoType)
-     *   3. are not a primary constructor,
-     *   4. have an existing source symbol,
-     *   5. are the module class in case of packages,
-     *   6. are mutable accessors, to exclude setters for `var`,
-     *   7. symbol is not a package object
-     *   8. symbol is not an artifact of the compiler
-     *   9. have same term/type kind as name prefix given so far
+     *   1. match the filter method,
+     *   2. satisfy [[Completion.isValidCompletionSymbol]]
      */
     private def include(denot: SingleDenotation, nameInScope: Name)(using Context): Boolean =
-      val sym = denot.symbol
-
-
       nameInScope.startsWith(prefix) &&
-      sym.exists &&
       completionsFilter(NoType, nameInScope) &&
-      !sym.isAbsent() &&
-      !sym.isPrimaryConstructor &&
-      sym.sourceSymbol.exists &&
-      (!sym.is(Package) || sym.is(ModuleClass)) &&
-      !sym.isAllOf(Mutable | Accessor) &&
-      !sym.isPackageObject &&
-      !sym.is(Artifact) &&
-      (
-           (mode.is(Mode.Term) && (sym.isTerm || sym.is(ModuleClass))
-        || (mode.is(Mode.Type) && (sym.isType || sym.isStableMember)))
-      )
+      isValidCompletionSymbol(denot.symbol, mode)
 
     private def extractRefinements(site: Type)(using Context): Seq[SingleDenotation] =
       site match

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -954,14 +954,8 @@ class CompletionTest {
       .noCompletions()
 
   @Test def i13624_annotType: Unit =
-    val expected1 = Set(
-        ("MyAnnotation", Class, "MyAnnotation"),
-        ("MyAnnotation", Module, "MyAnnotation"),
-      )
-    val expected2 = Set(
-        ("MyAnnotation", Class, "Foo.MyAnnotation"),
-        ("MyAnnotation", Module, "Foo.MyAnnotation"),
-      )
+    val expected1 = Set(("MyAnnotation", Class, "MyAnnotation"))
+    val expected2 = Set(("MyAnnotation", Class, "Foo.MyAnnotation"))
     code"""object Foo{
           |  class MyAnnotation extends annotation.StaticAnnotation
           |}
@@ -984,14 +978,8 @@ class CompletionTest {
   @Test def i13624_annotation : Unit =
     code"""@annotation.implicitNot${m1}
           |@annotation.implicitNotFound @mai${m2}"""
-      .completion(m1,
-          ("implicitNotFound", Class, "scala.annotation.implicitNotFound"),
-          ("implicitNotFound", Module, "scala.annotation.implicitNotFound"),
-      )
-      .completion(m2,
-          ("main", Class, "main"),
-          ("main", Module, "main"),
-      )
+      .completion(m1, ("implicitNotFound", Class, "scala.annotation.implicitNotFound"))
+      .completion(m2, ("main", Class, "main"))
 
   @Test def i13623_annotation : Unit =
     code"""import annot${m1}"""
@@ -1489,7 +1477,6 @@ class CompletionTest {
         ("xDef", Method, "=> Int"),
         ("xVal", Field, "Int"),
         ("xObject", Module, "Foo.xObject"),
-        ("xClass", Module, "Foo.xClass"),
         ("xClass", Class, "Foo.xClass")))
   }
 
@@ -1557,9 +1544,7 @@ class CompletionTest {
            |object T:
            |  extension (x: Test.TestSel$m1)
            |"""
-      .completion(m1, Set(
-        ("TestSelect", Module, "Test.TestSelect"), ("TestSelect", Class, "Test.TestSelect")
-      ))
+      .completion(m1, Set(("TestSelect", Class, "Test.TestSelect")))
 
   @Test def extensionDefinitionCompletionsSelectNested: Unit =
     code"""|object Test:
@@ -1568,9 +1553,7 @@ class CompletionTest {
            |object T:
            |  extension (x: Test.Test2.TestSel$m1)
            |"""
-      .completion(m1, Set(
-        ("TestSelect", Module, "Test.Test2.TestSelect"), ("TestSelect", Class, "Test.Test2.TestSelect")
-      ))
+      .completion(m1, Set(("TestSelect", Class, "Test.Test2.TestSelect")))
 
   @Test def extensionDefinitionCompletionsSelectInside: Unit =
     code"""|object Test:
@@ -1721,27 +1704,4 @@ class CompletionTest {
      .completion(m1, Set(
        ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
      ))
-
-  @Test def methodsWithInstantiatedTypeVars2: Unit =
-    code"""|object Test:
-           |  class TestSelect()
-           |object T:
-           |  extension (x: Test.TestSel$m1)
-           |"""
-     .completion(m1, Set(
-       ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
-     ))
-
-  @Test def methodsWithInstantiatedTypeVars3: Unit =
-    code"""|
-           |class TestSelect()
-           |class Test(x: TestSel$m1)
-           |"""
-     .completion(m1, Set(
-       ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
-     ))
-
-
-
-
 }

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1721,4 +1721,27 @@ class CompletionTest {
      .completion(m1, Set(
        ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
      ))
+
+  @Test def methodsWithInstantiatedTypeVars2: Unit =
+    code"""|object Test:
+           |  class TestSelect()
+           |object T:
+           |  extension (x: Test.TestSel$m1)
+           |"""
+     .completion(m1, Set(
+       ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
+     ))
+
+  @Test def methodsWithInstantiatedTypeVars3: Unit =
+    code"""|
+           |class TestSelect()
+           |class Test(x: TestSel$m1)
+           |"""
+     .completion(m1, Set(
+       ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
+     ))
+
+
+
+
 }

--- a/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
@@ -5,7 +5,7 @@ import scala.annotation.tailrec
 
 import dotc.*
 import ast.*, tpd.*
-import core.*, Contexts.*, Decorators.*, Flags.*, Names.*, Symbols.*, Types.*
+import core.*, Contexts.*, Flags.*, Names.*, Symbols.*, Types.*
 import interactive.*
 import util.*
 import util.SourcePosition

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -24,7 +24,6 @@ import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.Spans.Span
-import dotty.tools.pc.IndexedContext
 
 import org.eclipse.lsp4j.InlayHint
 import org.eclipse.lsp4j.InlayHintKind

--- a/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
@@ -6,20 +6,14 @@ import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
-import dotty.tools.dotc.parsing.Tokens.closingRegionTokens
-import dotty.tools.dotc.reporting.ErrorMessageID
-import dotty.tools.dotc.reporting.ExpectedTokenButFound
 import dotty.tools.dotc.util.Signatures
 import dotty.tools.dotc.util.SourceFile
-import dotty.tools.dotc.util.Spans
-import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.pc.printer.ShortenedTypePrinter
 import dotty.tools.pc.printer.ShortenedTypePrinter.IncludeDefaultParam
 import dotty.tools.pc.utils.MtagsEnrichments.*
 import org.eclipse.lsp4j as l
 
 import scala.jdk.CollectionConverters.*
-import scala.jdk.OptionConverters.*
 import scala.meta.internal.metals.ReportContext
 import scala.meta.pc.OffsetParams
 import scala.meta.pc.SymbolDocumentation

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
@@ -53,9 +53,9 @@ case class CompletionAffix(
       endPos   <- ranges.map(_.getEnd).maxOption
     yield Range(startPos, endPos)
 
-  private def loopPrefix(prefixes: List[PrefixKind]) =
+  private def loopPrefix(prefixes: List[PrefixKind]): String =
     prefixes match
-      case PrefixKind.New :: tail => "new "
+      case PrefixKind.New :: tail => "new " + loopPrefix(tail)
       case _ => ""
 
   /**

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
@@ -4,18 +4,19 @@ package dotty.tools.pc.completions
  * @param suffixes which we should insert
  * @param snippet which suffix should we insert the snippet $0
  */
-case class CompletionSuffix(
+case class CompletionAffix(
     suffixes: Set[SuffixKind],
+    prefix: PrefixKind,
     snippet: SuffixKind,
 ):
   def addLabelSnippet = suffixes.contains(SuffixKind.Bracket)
   def hasSnippet = snippet != SuffixKind.NoSuffix
-  def chain(copyFn: CompletionSuffix => CompletionSuffix) = copyFn(this)
-  def withNewSuffix(kind: SuffixKind) =
-    CompletionSuffix(suffixes + kind, snippet)
+  def chain(copyFn: CompletionAffix => CompletionAffix) = copyFn(this)
+  def withNewSuffix(kind: SuffixKind) = this.copy(suffixes = suffixes + kind)
+  def withNewPrefix(kind: PrefixKind) = this.copy(prefix = kind)
   def withNewSuffixSnippet(kind: SuffixKind) =
-    CompletionSuffix(suffixes + kind, kind)
-  def toEdit: String =
+    this.copy(suffixes = suffixes + kind, snippet = kind)
+  def toSuffix: String =
     def loop(suffixes: List[SuffixKind]): String =
       def cursor = if suffixes.head == snippet then "$0" else ""
       suffixes match
@@ -24,16 +25,25 @@ case class CompletionSuffix(
         case SuffixKind.Template :: tail => s" {$cursor}" + loop(tail)
         case _ => ""
     loop(suffixes.toList)
-  def toEditOpt: Option[String] =
-    val edit = toEdit
+  def toSuffixOpt: Option[String] =
+    val edit = toSuffix
     if edit.nonEmpty then Some(edit) else None
-end CompletionSuffix
 
-object CompletionSuffix:
-  val empty = CompletionSuffix(
+  def toPrefix: String = prefix match
+    case PrefixKind.New => "new "
+    case PrefixKind.NoPrefix => ""
+
+end CompletionAffix
+
+object CompletionAffix:
+  val empty = CompletionAffix(
     suffixes = Set.empty,
+    prefix = PrefixKind.NoPrefix,
     snippet = SuffixKind.NoSuffix,
   )
 
 enum SuffixKind:
   case Brace, Bracket, Template, NoSuffix
+
+enum PrefixKind:
+  case New, NoPrefix

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
@@ -1,52 +1,86 @@
 package dotty.tools.pc.completions
 
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.Position
+
 /**
  * @param suffixes which we should insert
+ * @param prefixes which we should insert
  * @param snippet which suffix should we insert the snippet $0
  */
 case class CompletionAffix(
-    suffixes: Set[SuffixKind],
-    prefixes: List[PrefixKind],
-    snippet: SuffixKind,
+    suffixes: Set[Suffix],
+    prefixes: Set[Prefix],
+    snippet: Suffix,
+    currentPrefix: Option[String],
 ):
-  def addLabelSnippet = suffixes.contains(SuffixKind.Bracket)
-  def hasSnippet = snippet != SuffixKind.NoSuffix
+  def addLabelSnippet = suffixes.exists(_.kind == SuffixKind.Bracket)
+  def hasSnippet = snippet.kind != SuffixKind.NoSuffix
   def chain(copyFn: CompletionAffix => CompletionAffix) = copyFn(this)
-  def withNewSuffix(kind: SuffixKind) = this.copy(suffixes = suffixes + kind)
-  def withNewPrefix(kind: PrefixKind) = this.copy(prefixes = prefixes :+ kind)
-  def withNewSuffixSnippet(kind: SuffixKind) =
-    this.copy(suffixes = suffixes + kind, snippet = kind)
+  def withNewSuffix(kind: Suffix) = this.copy(suffixes = suffixes + kind)
+  def withNewPrefix(kind: Prefix) = this.copy(prefixes = prefixes + kind)
+  def withCurrentPrefix(currentPrefix: String) = this.copy(currentPrefix = Some(currentPrefix))
+  def withNewSuffixSnippet(suffix: Suffix) =
+    this.copy(suffixes = suffixes + suffix, snippet = suffix)
 
   def nonEmpty: Boolean = suffixes.nonEmpty || prefixes.nonEmpty
 
   def toSuffix: String =
     def loop(suffixes: List[SuffixKind]): String =
-      def cursor = if suffixes.head == snippet then "$0" else ""
+      def cursor = if suffixes.head == snippet.kind then "$0" else ""
       suffixes match
         case SuffixKind.Brace :: tail => s"($cursor)" + loop(tail)
         case SuffixKind.Bracket :: tail => s"[$cursor]" + loop(tail)
         case SuffixKind.Template :: tail => s" {$cursor}" + loop(tail)
         case _ => ""
-    loop(suffixes.toList)
+    loop(suffixes.toList.map(_.kind))
 
   def toSuffixOpt: Option[String] =
     val edit = toSuffix
     if edit.nonEmpty then Some(edit) else None
 
+
+  given Ordering[Position] = Ordering.by(elem => (elem.getLine, elem.getCharacter))
+
+  def toInsertRange: Option[org.eclipse.lsp4j.Range] =
+    import scala.language.unsafeNulls
+
+    val ranges = prefixes.collect:
+      case Affix(_, Some(range)) => range
+    .toList
+    for
+      startPos <- ranges.map(_.getStart).minOption
+      endPos   <- ranges.map(_.getEnd).maxOption
+    yield org.eclipse.lsp4j.Range(startPos, endPos)
+
+  private def loopPrefix(prefixes: List[PrefixKind]) =
+    prefixes match
+      case PrefixKind.New :: tail => "new "
+      case _ => ""
+
+  /**
+   * We need to insert previous prefix, but we don't want to display it in the label i.e.
+   * ```scala
+   * scala.util.Tr@@
+   * ````
+   * should return `new Try[T]: Try[T]`
+   * but insert `new scala.util.Try`
+   *
+   */
+  def toInsertPrefix: String =
+    loopPrefix(prefixes.toList.map(_.kind)) + currentPrefix.getOrElse("")
+
   def toPrefix: String =
-    def loop(prefixes: List[PrefixKind]) =
-      prefixes match
-        case PrefixKind.New :: tail => "new "
-        case _ => ""
-    loop(prefixes)
+    loopPrefix(prefixes.toList.map(_.kind))
 
 end CompletionAffix
 
 object CompletionAffix:
   val empty = CompletionAffix(
     suffixes = Set.empty,
-    prefixes = Nil,
-    snippet = SuffixKind.NoSuffix,
+    prefixes = Set.empty,
+    snippet = Affix(SuffixKind.NoSuffix),
+    currentPrefix = None,
   )
 
 enum SuffixKind:
@@ -54,3 +88,8 @@ enum SuffixKind:
 
 enum PrefixKind:
   case New
+
+type Suffix = Affix[SuffixKind]
+type Prefix = Affix[PrefixKind]
+
+private case class Affix[+T](kind: T, insertRange: Option[org.eclipse.lsp4j.Range] = None)

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionAffix.scala
@@ -1,7 +1,7 @@
 package dotty.tools.pc.completions
 
-import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
 
 /**
  * @param suffixes which we should insert
@@ -42,7 +42,7 @@ case class CompletionAffix(
 
   given Ordering[Position] = Ordering.by(elem => (elem.getLine, elem.getCharacter))
 
-  def toInsertRange: Option[org.eclipse.lsp4j.Range] =
+  def toInsertRange: Option[Range] =
     import scala.language.unsafeNulls
 
     val ranges = prefixes.collect:
@@ -51,7 +51,7 @@ case class CompletionAffix(
     for
       startPos <- ranges.map(_.getStart).minOption
       endPos   <- ranges.map(_.getEnd).maxOption
-    yield org.eclipse.lsp4j.Range(startPos, endPos)
+    yield Range(startPos, endPos)
 
   private def loopPrefix(prefixes: List[PrefixKind]) =
     prefixes match
@@ -92,4 +92,4 @@ enum PrefixKind:
 type Suffix = Affix[SuffixKind]
 type Prefix = Affix[PrefixKind]
 
-private case class Affix[+T](kind: T, insertRange: Option[org.eclipse.lsp4j.Range] = None)
+private case class Affix[+T](kind: T, insertRange: Option[Range] = None)

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -196,8 +196,8 @@ class CompletionProvider(
       item
     end mkItem
 
-    val completionTextSuffix = completion.snippetSuffix.toSuffix
-    val completionTextPrefix = completion.snippetSuffix.toPrefix
+    val completionTextSuffix = completion.snippetAffix.toSuffix
+    val completionTextPrefix = completion.snippetAffix.toPrefix
 
     lazy val isInStringInterpolation =
       path match
@@ -280,7 +280,7 @@ class CompletionProvider(
       case _ =>
         val nameText = completion.insertText.getOrElse(ident.backticked(backtickSoftKeyword))
         val nameWithAffixes = completionTextPrefix + nameText + completionTextSuffix
-        val insertText = if completion.snippetSuffix.nonEmpty && isInStringInterpolation then
+        val insertText = if completion.snippetAffix.nonEmpty && isInStringInterpolation then
           "{" + nameWithAffixes + "}"
         else nameWithAffixes
         mkItem(insertText, range = completion.range)

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -196,7 +196,8 @@ class CompletionProvider(
       item
     end mkItem
 
-    val completionTextSuffix = completion.snippetSuffix.toEdit
+    val completionTextSuffix = completion.snippetSuffix.toSuffix
+    val completionTextPrefix = completion.snippetSuffix.toPrefix
 
     lazy val isInStringInterpolation =
       path match
@@ -232,7 +233,7 @@ class CompletionProvider(
                   mkItem(nameEdit.getNewText().nn, other.toList, range = Some(nameEdit.getRange().nn))
                 case _ =>
                   mkItem(
-                    v.insertText.getOrElse( ident.backticked(backtickSoftKeyword) + completionTextSuffix),
+                    v.insertText.getOrElse(completionTextPrefix + ident.backticked(backtickSoftKeyword) + completionTextSuffix),
                     edits.edits,
                     range = v.range
                   )
@@ -242,6 +243,7 @@ class CompletionProvider(
                 case IndexedContext.Result.InScope =>
                   mkItem(
                     v.insertText.getOrElse(
+                      completionTextPrefix +
                       ident.backticked(
                         backtickSoftKeyword
                       ) + completionTextSuffix
@@ -250,17 +252,17 @@ class CompletionProvider(
                   )
                 case _ if isInStringInterpolation =>
                   mkItem(
-                    "{" + sym.fullNameBackticked + completionTextSuffix + "}",
+                    "{" + completionTextPrefix + sym.fullNameBackticked + completionTextSuffix + "}",
                     range = v.range
                   )
                 case _ if v.isExtensionMethod =>
                   mkItem(
-                    ident.backticked(backtickSoftKeyword) + completionTextSuffix,
+                    completionTextPrefix + ident.backticked(backtickSoftKeyword) + completionTextSuffix,
                     range = v.range
                   )
                 case _ =>
                   mkItem(
-                    sym.fullNameBackticked(
+                    completionTextPrefix + sym.fullNameBackticked(
                       backtickSoftKeyword
                     ) + completionTextSuffix,
                     range = v.range
@@ -279,7 +281,7 @@ class CompletionProvider(
         val insert =
           completion.insertText.getOrElse(ident.backticked(backtickSoftKeyword))
         mkItem(
-          insert + completionTextSuffix,
+          completionTextPrefix + insert + completionTextSuffix,
           range = completion.range
         )
     end match

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -197,7 +197,7 @@ class CompletionProvider(
     end mkItem
 
     val completionTextSuffix = completion.snippetAffix.toSuffix
-    val completionTextPrefix = completion.snippetAffix.toPrefix
+    val completionTextPrefix = completion.snippetAffix.toInsertPrefix
 
     lazy val isInStringInterpolation =
       path match

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -278,12 +278,13 @@ class CompletionProvider(
       case v: CompletionValue.Interpolator if v.isWorkspace || v.isExtension =>
         mkItemWithImports(v)
       case _ =>
-        val insert =
-          completion.insertText.getOrElse(ident.backticked(backtickSoftKeyword))
-        mkItem(
-          completionTextPrefix + insert + completionTextSuffix,
-          range = completion.range
-        )
+        val nameText = completion.insertText.getOrElse(ident.backticked(backtickSoftKeyword))
+        val nameWithAffixes = completionTextPrefix + nameText + completionTextSuffix
+        val insertText = if completion.snippetSuffix.nonEmpty && isInStringInterpolation then
+          "{" + nameWithAffixes + "}"
+        else nameWithAffixes
+        mkItem(insertText, range = completion.range)
+
     end match
   end completionItems
 end CompletionProvider

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -32,7 +32,6 @@ import org.eclipse.lsp4j.InsertTextFormat
 import org.eclipse.lsp4j.InsertTextMode
 import org.eclipse.lsp4j.Range as LspRange
 import org.eclipse.lsp4j.TextEdit
-import dotty.tools.dotc.cc.CaptureSet.empty
 
 class CompletionProvider(
     search: SymbolSearch,

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -79,6 +79,9 @@ object CompletionValue:
       )
     def importSymbol: Symbol = symbol
 
+    override def range: Option[Range] =
+      snippetAffix.toInsertRange
+
     def completionItemKind(using Context): CompletionItemKind =
       val symbol = this.symbol
       if symbol.is(Package) || symbol.is(Module) then

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -130,6 +130,38 @@ object CompletionValue:
   ) extends Symbolic:
     override def completionItemDataKind: Integer = CompletionSource.CompilerKind.ordinal
 
+  /**
+    *  We need to access original completion in sorting phase.
+    *  This class is only a wrapper to hold both new completion and original completion.
+    *
+    *  All methods are proxied to @param extraMethod
+    *
+    *  FIXME Refactor this file to different architercture. At least to somethhing that is easier to modifiy and scale.
+    *  One solution may be a migration to flag based solution.
+    */
+  case class ExtraMethod(
+      owner: Denotation,
+      extraMethod: Symbolic,
+  ) extends Symbolic:
+    override def additionalEdits: List[TextEdit] = extraMethod.additionalEdits
+    override def command: Option[String] = extraMethod.command
+    override def completionData(buildTargetIdentifier: String)(using Context): CompletionItemData = extraMethod.completionData((buildTargetIdentifier))
+    override def completionItemKind(using Context): CompletionItemKind = extraMethod.completionItemKind
+    override def description(printer: ShortenedTypePrinter)(using Context): String = extraMethod.description(printer)
+    override def labelWithDescription(printer: ShortenedTypePrinter)(using Context): String = extraMethod.labelWithDescription(printer)
+    override def range: Option[Range] = extraMethod.range
+    override def denotation: Denotation = extraMethod.denotation
+    override def label: String = extraMethod.label
+    override def filterText: Option[String] = extraMethod.filterText
+    override def importSymbol: Symbol = extraMethod.importSymbol
+    override def lspTags(using Context): List[CompletionItemTag] = extraMethod.lspTags
+    override def insertText: Option[String] = extraMethod.insertText
+    override def isExtensionMethod: Boolean = extraMethod.isExtensionMethod
+    override def snippetAffix: CompletionAffix = extraMethod.snippetAffix
+    override def insertMode: Option[InsertTextMode] = extraMethod.insertMode
+    override val symbol: Symbol = extraMethod.symbol
+    override def completionItemDataKind: Integer = extraMethod.completionItemDataKind
+
   case class Scope(
       label: String,
       denotation: Denotation,

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -96,7 +96,7 @@ object CompletionValue:
     override def labelWithDescription(
         printer: ShortenedTypePrinter
     )(using Context): String =
-      if symbol.isConstructor then snippetSuffix.toPrefix + label
+      if symbol.isConstructor then s"${snippetSuffix.toPrefix}${label}${description(printer)}"
       else if symbol.is(Method) then s"${label}${description(printer)}"
       else if symbol.is(Mutable) then s"$label: ${description(printer)}"
       else if symbol.is(Package) || symbol.is(Module) || symbol.isClass then
@@ -143,7 +143,9 @@ object CompletionValue:
     override def completionItemDataKind: Integer = CompletionSource.WorkspaceKind.ordinal
 
     override def labelWithDescription(printer: ShortenedTypePrinter)(using Context): String =
-      if symbol.is(Method) && symbol.name != nme.apply && !symbol.isConstructor then
+      if symbol.isConstructor || symbol.name == nme.apply then
+        s"${snippetSuffix.toPrefix}${label}${description(printer)} - ${printer.fullNameString(importSymbol.effectiveOwner)}"
+      else if symbol.is(Method) then
         s"${labelWithSuffix(printer)} - ${printer.fullNameString(symbol.effectiveOwner)}"
       else if symbol.is(Package) || symbol.is(Module) || symbol.isClass then
         s"${labelWithSuffix(printer)} -${description(printer)}"

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -238,7 +238,9 @@ class Completions(
           .filter(_.symbol.isAccessibleFrom(denot.info))
         constructors -> true
 
-      else if shouldAddSnippet && completionMode.is(Mode.Term) && sym.name.isTermName && !sym.is(Flags.Method) && !sym.is(Flags.JavaDefined) then
+      else if shouldAddSnippet && completionMode.is(Mode.Term) && sym.name.isTermName &&
+          !sym.is(Flags.JavaDefined) && (sym.isClass || sym.is(Module) || (sym.isField && denot.info.isInstanceOf[TermRef])) then
+
         val constructors = if sym.isAllOf(ConstructorProxyModule) then
           sym.companionClass.info.member(nme.CONSTRUCTOR).allSymbols
         else

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -33,8 +33,7 @@ import dotty.tools.pc.completions.OverrideCompletions.OverrideExtractor
 import dotty.tools.pc.buildinfo.BuildInfo
 import dotty.tools.pc.utils.MtagsEnrichments.*
 import dotty.tools.dotc.core.Denotations.SingleDenotation
-import org.eclipse.lsp4j.TextEdit
-import org.eclipse.lsp4j.Position
+
 
 class Completions(
     text: String,

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
@@ -12,9 +12,7 @@ import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.Symbols.Symbol
-import dotty.tools.dotc.util.Spans
 import dotty.tools.dotc.core.Types.Type
-import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.pc.CompilerSearchVisitor
 import dotty.tools.pc.IndexedContext
 import dotty.tools.pc.utils.MtagsEnrichments.*

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
@@ -153,7 +153,7 @@ object InterpolatorCompletions:
               sym.name.toString()
             ) =>
           val label = sym.name.decoded
-          completions.completionsWithSuffix(
+          completions.completionsWithAffix(
             sym,
             label,
             (name, denot, suffix) =>
@@ -284,7 +284,7 @@ object InterpolatorCompletions:
             sym.name.decoded
           ) && !sym.isType =>
         val label = sym.name.decoded
-        completions.completionsWithSuffix(
+        completions.completionsWithAffix(
           sym,
           label,
           (name, denot, suffix) =>

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
@@ -110,18 +110,17 @@ object InterpolatorCompletions:
       buildTargetIdentifier: String
   )(using Context, ReportContext): List[CompletionValue] =
     def newText(
-        name: String,
-        suffix: Option[String],
+        label: String,
+        affix: CompletionAffix ,
         identOrSelect: Ident | Select
     ): String =
-      val snippetCursor = suffixEnding(suffix, areSnippetsSupported)
+      val snippetCursor = suffixEnding(affix.toSuffixOpt, areSnippetsSupported)
       new StringBuilder()
         .append('{')
-        .append(
-          text.substring(identOrSelect.span.start, identOrSelect.span.end)
-        )
+        .append(affix.toPrefix) // we use toPrefix here, because previous prefix is added in the next step
+        .append(text.substring(identOrSelect.span.start, identOrSelect.span.end))
         .append('.')
-        .append(name.backticked)
+        .append(label.backticked)
         .append(snippetCursor)
         .append('}')
         .toString
@@ -156,11 +155,11 @@ object InterpolatorCompletions:
           completions.completionsWithAffix(
             sym,
             label,
-            (name, denot, suffix) =>
+            (name, denot, affix) =>
               CompletionValue.Interpolator(
                 denot.symbol,
                 label,
-                Some(newText(name, suffix.toSuffixOpt, identOrSelect)),
+                Some(newText(name, affix, identOrSelect)),
                 Nil,
                 Some(completionPos.originalCursorPosition.withStart(identOrSelect.span.start).toLsp),
                 // Needed for VS Code which will not show the completion otherwise
@@ -250,16 +249,18 @@ object InterpolatorCompletions:
       interpolatorEdit ++ dollarEdits
     end additionalEdits
 
-    def newText(symbolName: String, suffix: Option[String]): String =
+    def newText(symbolName: String, affix: CompletionAffix): String =
       val out = new StringBuilder()
       val identifier = symbolName.backticked
       val symbolNeedsBraces =
         interpolator.needsBraces ||
           identifier.startsWith("`") ||
-          suffix.isDefined
+          affix.toSuffixOpt.isDefined ||
+          affix.toPrefix.nonEmpty
       if symbolNeedsBraces && !hasOpeningBrace then out.append('{')
+      out.append(affix.toInsertPrefix)
       out.append(identifier)
-      out.append(suffixEnding(suffix, areSnippetsSupported))
+      out.append(suffixEnding(affix.toSuffixOpt, areSnippetsSupported))
       if symbolNeedsBraces && !hasClosingBrace then out.append('}')
       out.toString
     end newText
@@ -287,11 +288,11 @@ object InterpolatorCompletions:
         completions.completionsWithAffix(
           sym,
           label,
-          (name, denot, suffix) =>
+          (name, denot, affix) =>
             CompletionValue.Interpolator(
               denot.symbol,
               label,
-              Some(newText(name, suffix.toSuffixOpt)),
+              Some(newText(name, affix)),
               additionalEdits(),
               Some(nameRange),
               None,

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
@@ -162,7 +162,7 @@ object InterpolatorCompletions:
               CompletionValue.Interpolator(
                 denot.symbol,
                 label,
-                Some(newText(name, suffix.toEditOpt, identOrSelect)),
+                Some(newText(name, suffix.toSuffixOpt, identOrSelect)),
                 Nil,
                 Some(completionPos.originalCursorPosition.withStart(identOrSelect.span.start).toLsp),
                 // Needed for VS Code which will not show the completion otherwise
@@ -293,7 +293,7 @@ object InterpolatorCompletions:
             CompletionValue.Interpolator(
               denot.symbol,
               label,
-              Some(newText(name, suffix.toEditOpt)),
+              Some(newText(name, suffix.toSuffixOpt)),
               additionalEdits(),
               Some(nameRange),
               None,

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/MatchCaseCompletions.scala
@@ -15,7 +15,6 @@ import dotty.tools.toOption
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.Definitions
 import dotty.tools.dotc.core.Denotations.Denotation
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Flags.*
@@ -24,7 +23,6 @@ import dotty.tools.dotc.core.Symbols.NoSymbol
 import dotty.tools.dotc.core.Symbols.Symbol
 import dotty.tools.dotc.core.Types.AndType
 import dotty.tools.dotc.core.Types.ClassInfo
-import dotty.tools.dotc.core.Types.NoType
 import dotty.tools.dotc.core.Types.OrType
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.core.Types.TypeRef

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
@@ -2,7 +2,6 @@ package dotty.tools.pc.completions
 
 import scala.util.Try
 
-import dotty.tools.dotc.ast.NavigateAST
 import dotty.tools.dotc.ast.Trees.ValDef
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.ast.untpd

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseCompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseCompletionSuite.scala
@@ -207,7 +207,8 @@ abstract class BaseCompletionSuite extends BasePCSuite:
       includeDetail: Boolean = true,
       filename: String = "A.scala",
       filter: String => Boolean = _ => true,
-      enablePackageWrap: Boolean = true
+      enablePackageWrap: Boolean = true,
+      includeCompletionKind: Boolean = false,
   ): Unit =
     val out = new StringBuilder()
     val withPkg =
@@ -221,13 +222,14 @@ abstract class BaseCompletionSuite extends BasePCSuite:
     filteredItems.foreach { item =>
       val label = TestCompletions.getFullyQualifiedLabel(item)
       val commitCharacter =
-        if (includeCommitCharacter)
+        if includeCommitCharacter then
           Option(item.getCommitCharacters)
             .getOrElse(Collections.emptyList())
             .asScala
             .mkString(" (commit: '", " ", "')")
         else ""
       val documentation = doc(item.getDocumentation)
+      val completionKind = Option.when(includeCompletionKind)(s" (${item.getKind.toString})").getOrElse("")
       if (includeDocs && documentation.nonEmpty) {
         out.append("> ").append(documentation).append("\n")
       }
@@ -244,6 +246,7 @@ abstract class BaseCompletionSuite extends BasePCSuite:
             ""
         })
         .append(commitCharacter)
+        .append(completionKind)
         .append("\n")
     }
     val completionSources = filteredItems

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
@@ -96,7 +96,7 @@ class CompletionArgSuite extends BaseCompletionSuite:
       """|age = : Int
          |followers = : Int
          |Main test
-         |User test
+         |User(name: String = ..., age: Int = ..., address: String = ..., followers: Int = ...): User
          |""".stripMargin,
       topLines = Option(4)
     )
@@ -130,7 +130,7 @@ class CompletionArgSuite extends BaseCompletionSuite:
       """|age = : Int
          |followers = : Int
          |Main test
-         |User test
+         |User(name: String = ..., age: Int = ..., address: String = ..., followers: Int = ...): User
          |""".stripMargin,
       topLines = Option(4)
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
@@ -305,7 +305,6 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |  }
         |}
       """.stripMargin,
-      """|myNumbers(i: Int): Int
-         |myNumbers: Vector[Int]
+      """|myNumbers: Vector[Int]
          |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
@@ -182,11 +182,10 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |}
       """.stripMargin,
       """
-        |> Found documentation for scala/util/Try.
-        |Try scala.util
         |> Found documentation for scala/util/Try.apply().
         |Try[T](r: => T): Try[T]
-        |new Try[T]: Try[T]
+        |> Found documentation for scala/util/Try.
+        |Try scala.util
         |""".stripMargin,
       includeDocs = true
     )
@@ -200,7 +199,7 @@ class CompletionDocSuite extends BaseCompletionSuite:
       """.stripMargin,
       """
         |> Found documentation for scala/collection/mutable/StringBuilder.
-        |StringBuilder scala.collection.mutable
+        |StringBuilder(): StringBuilder
         |""".stripMargin,
       includeDocs = true,
       topLines = Some(1)
@@ -214,9 +213,9 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |}
       """.stripMargin,
       """
+        |Vector[A](elems: A*): Vector[A]
         |> Found documentation for scala/package.Vector.
         |Vector scala.collection.immutable
-        |Vector[A](elems: A*): Vector[A]
         |""".stripMargin,
       includeDocs = true
     )
@@ -247,8 +246,8 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |  scala.util.Failure@@
         |}
       """.stripMargin,
-      """|Failure scala.util
-         |Failure[T](exception: Throwable): Failure[T]
+      """|Failure[T](exception: Throwable): Failure[T]
+         |Failure scala.util
          |""".stripMargin,
       includeDocs = true
     )
@@ -306,7 +305,7 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |  }
         |}
       """.stripMargin,
-      """|myNumbers: Vector[Int]
-         |myNumbers(i: Int): Int
+      """|myNumbers(i: Int): Int
+         |myNumbers: Vector[Int]
          |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
@@ -186,6 +186,7 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |Try scala.util
         |> Found documentation for scala/util/Try.apply().
         |Try[T](r: => T): Try[T]
+        |new Try[T]: Try[T]
         |""".stripMargin,
       includeDocs = true
     )
@@ -228,11 +229,8 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |}
       """.stripMargin,
       """
-        |> ### class Catch
-        |Found documentation for scala/util/control/Exception.Catch#
-        |### object Catch
-        |Found documentation for scala/util/control/Exception.Catch.
-        |Catch[T] - scala.util.control.Exception
+        |> Found documentation for scala/util/control/Exception.Catch#
+        |Catch[T](pf: Catcher[T], fin: Option[Finally] = ..., rethrow: Throwable => Boolean = ...): Catch[T] - scala.util.control.Exception
         |> ### class Catch
         |Found documentation for scala/util/control/Exception.Catch#
         |### object Catch
@@ -264,16 +262,8 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |}
       """.stripMargin,
       """
-        |> ### class DynamicVariable
-        |Found documentation for scala/util/DynamicVariable#
-        |### object DynamicVariable
-        |Found documentation for scala/util/DynamicVariable.
-        |DynamicVariable[T] scala.util
-        |> ### class DynamicVariable
-        |Found documentation for scala/util/DynamicVariable#
-        |### object DynamicVariable
-        |Found documentation for scala/util/DynamicVariable.
-        |DynamicVariable scala.util
+        |> Found documentation for scala/util/DynamicVariable#
+        |DynamicVariable[T](init: T): DynamicVariable[T]
         |""".stripMargin,
       includeDocs = true
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
@@ -8,6 +8,7 @@ import dotty.tools.pc.utils.MockEntries
 
 import org.junit.Test
 import org.junit.Ignore
+import scala.collection.immutable.ListMapBuilder
 
 class CompletionExtraConstructorSuite extends BaseCompletionSuite:
 
@@ -50,8 +51,8 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |  case class TestClass(x: Int)
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int): TestClass (Method)
+      """|TestClass(x: Int): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -62,8 +63,8 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |  case class TestClass()
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(): TestClass (Method)
+      """|TestClass(): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -74,56 +75,60 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |  case class TestClass[T](x: T)
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass[T](x: T): TestClass[T] (Method)
+      """|TestClass[T](x: T): TestClass[T] (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
-  @Ignore
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(x: Int): TestClass (Constructor)
   @Test def `extra-new-completions-abstract-class-1` =
     check(
       """|object Wrapper:
          |  abstract class TestClass(x: Int)
          |  TestCla@@
          |""".stripMargin,
-      """|new TestClass(x: Int): TestClass (Constructor)
+      """|
          |""".stripMargin,
       includeCompletionKind = true
     )
 
-  @Ignore
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(): TestClass (Constructor)
   @Test def `extra-new-completions-abstract-class-2` =
     check(
       """|object Wrapper:
          |  abstract class TestClass()
          |  TestCla@@
          |""".stripMargin,
-      """|new TestClass(): TestClass (Constructor)
+      """|
          |""".stripMargin,
       includeCompletionKind = true
     )
 
-  @Ignore
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass[T](x: T): TestClass[T] (Constructor)
   @Test def `extra-new-completions-abstract-class-3` =
     check(
       """|object Wrapper:
          |  abstract class TestClass[T](x: T)
          |  TestCla@@
          |""".stripMargin,
-      """|new TestClass[T](x: T): TestClass[T] (Constructor)
+      """|
          |""".stripMargin,
       includeCompletionKind = true
     )
 
-  @Ignore
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass (Constructor)
   @Test def `extra-new-completions-trait-1` =
     check(
       """|object Wrapper:
          |  trait TestClass
          |  TestCla@@
          |""".stripMargin,
-      """|new TestClass (Constructor)
+      """|
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -136,9 +141,9 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int, y: Int): TestClass = TestClass(x + y)
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int, y: Int): TestClass (Method)
+      """|TestClass(x: Int, y: Int): TestClass (Method)
          |new TestClass(x: Int): TestClass (Constructor)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -152,9 +157,9 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |  TestCla@@
          |}
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int): TestClass (Method)
+      """|TestClass(x: Int): TestClass (Method)
          |new TestClass(x: Int): TestClass (Constructor)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -167,13 +172,15 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(): TestClass = TestClass(1)
          |    TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(): TestClass (Method)
+      """|TestClass(): TestClass (Method)
          |new TestClass(): TestClass (Constructor)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(x: Int): TestClass (Constructor)
   @Test def `extra-new-completions-abstract-class-with-companion-1` =
     check(
       """|object Wrapper:
@@ -182,13 +189,14 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int, y: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int, y: Int): TestClass (Method)
-         |new TestClass(x: Int): TestClass (Constructor)
+      """|TestClass(x: Int, y: Int): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(x: Int): TestClass (Constructor)
   @Test def `extra-new-completions-abstract-class-with-companion-2` =
     check(
       """|object Wrapper:
@@ -197,13 +205,14 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int): TestClass (Method)
-         |new TestClass(x: Int): TestClass (Constructor)
+      """|TestClass(x: Int): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(): TestClass (Constructor)
   @Test def `extra-new-completions-abstract-class-with-companion-3` =
     check(
       """|object Wrapper:
@@ -212,13 +221,14 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(): TestClass (Method)
-         |new TestClass(): TestClass (Constructor)
+      """|TestClass(): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(x: Int): TestClass (Constructor)
   @Test def `extra-new-completions-trait-with-companion-1` =
     check(
       """|object Wrapper:
@@ -227,13 +237,14 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int, y: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int, y: Int): TestClass (Method)
-         |new TestClass(x: Int): TestClass (Constructor)
+      """|TestClass(x: Int, y: Int): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(x: Int): TestClass (Constructor)
   @Test def `extra-new-completions-trait-with-companion-2` =
     check(
       """|object Wrapper:
@@ -242,13 +253,14 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int): TestClass (Method)
-         |new TestClass(x: Int): TestClass (Constructor)
+      """|TestClass(x: Int): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(): TestClass (Constructor)
   @Test def `extra-new-completions-trait-with-companion-3` =
     check(
       """|object Wrapper:
@@ -257,14 +269,15 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(): TestClass (Method)
-         |new TestClass(): TestClass (Constructor)
+      """|TestClass(): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
   // This test should have new TestClass completion without parentheses. The actual issue is with printer, edit text is correct
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing new TestClass(): TestClass (Constructor)
   @Test def `extra-new-completions-trait-with-companion-4` =
     check(
       """|object Wrapper:
@@ -273,9 +286,8 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(): TestClass (Method)
-         |new TestClass(): TestClass (Constructor)
+      """|TestClass(): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -286,9 +298,8 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass
-         |TestClass()
-         |new TestClass
+      """|TestClass()
+         |TestClass
          |""".stripMargin,
     )
 
@@ -330,11 +341,11 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(z: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(z: Int): TestClass (Method)
+      """|TestClass(z: Int): TestClass (Method)
          |new TestClass(): TestClass (Constructor)
          |new TestClass(x: Int): TestClass (Constructor)
          |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -350,12 +361,12 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(z: Int, w: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(z: Int): TestClass (Method)
+      """|TestClass(z: Int): TestClass (Method)
          |TestClass(z: Int, w: Int): TestClass (Method)
          |new TestClass(): TestClass (Constructor)
          |new TestClass(x: Int): TestClass (Constructor)
          |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -370,11 +381,11 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int): TestClass (Method)
+      """|TestClass(x: Int): TestClass (Method)
          |new TestClass(): TestClass (Constructor)
          |new TestClass(x: Int): TestClass (Constructor)
          |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -389,11 +400,11 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
+      """|TestClass(): TestClass (Method)
          |TestClass(x: Int): TestClass (Method)
-         |TestClass(): TestClass (Method)
          |new TestClass(x: Int): TestClass (Constructor)
          |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -401,22 +412,23 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
   @Test def `multiple-extra-new-constructors-with-companion-same-signature-trait` =
     check(
       """|object Wrapper:
-         |  trait TestClass:
-         |    def this(x: Int) = this()
-         |    def this(x: Int, y: Int) = this()
+         |  trait TestClass
          |  object TestClass:
          |    def apply(x: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int): TestClass (Method)
-         |new TestClass(): TestClass (Constructor)
-         |new TestClass(x: Int): TestClass (Constructor)
-         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+      """|TestClass(x: Int): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
 
+
+  // TODO We first need to detect support when to add additional braces / colon
+  // missing:
+  // new TestClass(): TestClass (Constructor)
+  // new TestClass(x: Int): TestClass (Constructor)
+  // new TestClass(x: Int, y: Int): TestClass (Constructor)
   @Test def `multiple-extra-new-constructors-with-companion-same-signature-abstract` =
     check(
       """|object Wrapper:
@@ -427,11 +439,8 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |    def apply(x: Int): TestClass = ???
          |  TestCla@@
          |""".stripMargin,
-      """|TestClass test.Wrapper (Module)
-         |TestClass(x: Int): TestClass (Method)
-         |new TestClass(): TestClass (Constructor)
-         |new TestClass(x: Int): TestClass (Constructor)
-         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+      """|TestClass(x: Int): TestClass (Method)
+         |TestClass test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -502,12 +511,11 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |  TestCla@@
          |}
          |""".stripMargin,
-      """|
-         |TestClass - test.Wrapper (Module)
-         |TestClass(x: Int): TestClass - test.Wrapper (Method)
+      """|TestClass(x: Int): TestClass - test.Wrapper (Method)
          |new TestClass(): TestClass - test.Wrapper (Constructor)
          |new TestClass(x: Int): TestClass - test.Wrapper (Constructor)
          |new TestClass(x: Int, y: Int): TestClass - test.Wrapper (Constructor)
+         |TestClass - test.Wrapper (Module)
          |""".stripMargin,
       includeCompletionKind = true
     )
@@ -515,24 +523,32 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
   @Test def `prepend-new` =
     checkSnippet(
       """|object Wrapper:
-         |  Try@@
-         |
+         |  case class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |object Main {
+         |  TestClas@@
+         |}
          |""".stripMargin,
-      """|Try
-         |Try($0)
-         |new Try
-         |""".stripMargin,
+      """|TestClass($0)
+         |new TestClass
+         |TestClass
+         |""".stripMargin
     )
 
   @Test def `prepend-new-fully-qualified-path` =
     checkSnippet(
       """|object Wrapper:
-         |  scala.util.Try@@
-         |
+         |  case class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |object Main {
+         |  Wrapper.Test@@
+         |}
          |""".stripMargin,
-      """|Try
-         |Try($0)
-         |new scala.util.Try
-         |""".stripMargin,
+      """|TestClass($0)
+         |new Wrapper.TestClass
+         |TestClass
+         |""".stripMargin
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
@@ -512,3 +512,27 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
       includeCompletionKind = true
     )
 
+  @Test def `prepend-new` =
+    checkSnippet(
+      """|object Wrapper:
+         |  Try@@
+         |
+         |""".stripMargin,
+      """|Try
+         |Try($0)
+         |new Try
+         |""".stripMargin,
+    )
+
+  @Test def `prepend-new-fully-qualified-path` =
+    checkSnippet(
+      """|object Wrapper:
+         |  scala.util.Try@@
+         |
+         |""".stripMargin,
+      """|Try
+         |Try($0)
+         |new scala.util.Try
+         |""".stripMargin,
+    )
+

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
@@ -559,9 +559,7 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |object Main:
          |  TestObject@@
          |""".stripMargin,
-      """|TestClass($0)
-         |new Wrapper.TestClass
-         |TestClass
+      """|TestObject test
          |""".stripMargin
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
@@ -1,0 +1,514 @@
+package dotty.tools.pc.tests.completion
+
+import scala.meta.pc.SymbolDocumentation
+import scala.language.unsafeNulls
+
+import dotty.tools.pc.base.BaseCompletionSuite
+import dotty.tools.pc.utils.MockEntries
+
+import org.junit.Test
+import org.junit.Ignore
+
+class CompletionExtraConstructorSuite extends BaseCompletionSuite:
+
+  @Test def `no-extra-new-completions-class-1` =
+    check(
+      """|object Wrapper:
+         |  class TestClass(x: Int)
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-new-completions-class-2` =
+    check(
+      """|object Wrapper:
+         |  class TestClass()
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass(): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-new-completions-class-3` =
+    check(
+      """|object Wrapper:
+         |  class TestClass[T](x: T)
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass[T](x: T): TestClass[T] (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-new-completions-case-class-1` =
+    check(
+      """|object Wrapper:
+         |  case class TestClass(x: Int)
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-new-completions-case-class-2` =
+    check(
+      """|object Wrapper:
+         |  case class TestClass()
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(): TestClass (Method)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-new-completions-case-class-3` =
+    check(
+      """|object Wrapper:
+         |  case class TestClass[T](x: T)
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass[T](x: T): TestClass[T] (Method)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Ignore
+  @Test def `extra-new-completions-abstract-class-1` =
+    check(
+      """|object Wrapper:
+         |  abstract class TestClass(x: Int)
+         |  TestCla@@
+         |""".stripMargin,
+      """|new TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Ignore
+  @Test def `extra-new-completions-abstract-class-2` =
+    check(
+      """|object Wrapper:
+         |  abstract class TestClass()
+         |  TestCla@@
+         |""".stripMargin,
+      """|new TestClass(): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Ignore
+  @Test def `extra-new-completions-abstract-class-3` =
+    check(
+      """|object Wrapper:
+         |  abstract class TestClass[T](x: T)
+         |  TestCla@@
+         |""".stripMargin,
+      """|new TestClass[T](x: T): TestClass[T] (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Ignore
+  @Test def `extra-new-completions-trait-1` =
+    check(
+      """|object Wrapper:
+         |  trait TestClass
+         |  TestCla@@
+         |""".stripMargin,
+      """|new TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-class-1` =
+    check(
+      """|object Wrapper:
+         |  class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int, y: Int): TestClass = TestClass(x + y)
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int, y: Int): TestClass (Method)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-class-2` =
+    check(
+      """|object Wrapper:
+         |  class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = TestClass(x)
+         |  TestCla@@
+         |}
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-class-3` =
+    check(
+      """|object Wrapper:
+         |  class TestClass()
+         |  object TestClass:
+         |    def apply(): TestClass = TestClass(1)
+         |    TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-abstract-class-with-companion-1` =
+    check(
+      """|object Wrapper:
+         |  abstract class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int, y: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int, y: Int): TestClass (Method)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-abstract-class-with-companion-2` =
+    check(
+      """|object Wrapper:
+         |  abstract class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-abstract-class-with-companion-3` =
+    check(
+      """|object Wrapper:
+         |  abstract class TestClass()
+         |  object TestClass:
+         |    def apply(): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-trait-with-companion-1` =
+    check(
+      """|object Wrapper:
+         |  trait TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int, y: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int, y: Int): TestClass (Method)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-trait-with-companion-2` =
+    check(
+      """|object Wrapper:
+         |  trait TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `extra-new-completions-trait-with-companion-3` =
+    check(
+      """|object Wrapper:
+         |  trait TestClass()
+         |  object TestClass:
+         |    def apply(): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  // This test should have new TestClass completion without parentheses. The actual issue is with printer, edit text is correct
+  @Test def `extra-new-completions-trait-with-companion-4` =
+    check(
+      """|object Wrapper:
+         |  trait TestClass
+         |  object TestClass:
+         |    def apply(): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+    checkSnippet(
+      """|object Wrapper:
+         |  trait TestClass
+         |  object TestClass:
+         |    def apply(): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass
+         |TestClass()
+         |new TestClass
+         |""".stripMargin,
+    )
+
+  @Test def `multiple-extra-new-constructors-class-1` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass(): TestClass (Constructor)
+         |TestClass(x: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `multiple-extra-new-constructors-class-2` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass(): TestClass (Constructor)
+         |TestClass(x: Int): TestClass (Constructor)
+         |TestClass(x: Int, y: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `multiple-extra-new-constructors-with-companion-2` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(z: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(z: Int): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `multiple-extra-new-constructors-with-companion-3` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(z: Int): TestClass = ???
+         |    def apply(z: Int, w: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(z: Int): TestClass (Method)
+         |TestClass(z: Int, w: Int): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `multiple-extra-new-constructors-with-companion-same-signature-class` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `multiple-extra-new-constructors-with-companion-same-signature-case-class` =
+    check(
+      """|object Wrapper:
+         |  case class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |TestClass(): TestClass (Method)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `multiple-extra-new-constructors-with-companion-same-signature-trait` =
+    check(
+      """|object Wrapper:
+         |  trait TestClass:
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `multiple-extra-new-constructors-with-companion-same-signature-abstract` =
+    check(
+      """|object Wrapper:
+         |  abstract class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |  TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Module)
+         |TestClass(x: Int): TestClass (Method)
+         |new TestClass(): TestClass (Constructor)
+         |new TestClass(x: Int): TestClass (Constructor)
+         |new TestClass(x: Int, y: Int): TestClass (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-completions-in-type-mode-1` =
+    check(
+      """|object Wrapper:
+         |  class TestClass()
+         |  val x: TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Class)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-completions-in-type-mode-2` =
+    check(
+      """|object Wrapper:
+         |  class TestClass()
+         |  val x: TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Class)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `no-extra-completions-in-type-mode-3` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |  val x: TestCla@@
+         |""".stripMargin,
+      """|TestClass test.Wrapper (Class)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `workspace-no-extra-completions-in-type-mode-4` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |object M {
+         |  val x: TestCla@@
+         |}
+         |""".stripMargin,
+      """|TestClass - test.Wrapper (Class)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+
+  @Test def `workspace-multiple-extra-new-constructors` =
+    check(
+      """|object Wrapper:
+         |  class TestClass():
+         |    def this(x: Int) = this()
+         |    def this(x: Int, y: Int) = this()
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |object M {
+         |  TestCla@@
+         |}
+         |""".stripMargin,
+      """|
+         |TestClass - test.Wrapper (Module)
+         |TestClass(x: Int): TestClass - test.Wrapper (Method)
+         |new TestClass(): TestClass - test.Wrapper (Constructor)
+         |new TestClass(x: Int): TestClass - test.Wrapper (Constructor)
+         |new TestClass(x: Int, y: Int): TestClass - test.Wrapper (Constructor)
+         |""".stripMargin,
+      includeCompletionKind = true
+    )
+

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
@@ -552,3 +552,16 @@ class CompletionExtraConstructorSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
+  @Test def `dont-include-private-members` =
+    check(
+      """|object TestObject:
+         |  private def apply(i: Int) = i
+         |object Main:
+         |  TestObject@@
+         |""".stripMargin,
+      """|TestClass($0)
+         |new Wrapper.TestClass
+         |TestClass
+         |""".stripMargin
+    )
+

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
@@ -542,7 +542,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |}
          |""".stripMargin,
       """s"Hello $hello@@"""".stripMargin,
-      """s"Hello $helloMethod"""".stripMargin,
+      """s"Hello ${helloMethod($0)}"""".stripMargin,
       filter = _.contains("a: Int")
     )
 
@@ -626,10 +626,10 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |  s"this is an interesting ${java.nio.file.Paths}"
          |}
          |""".stripMargin,
+      itemIndex = 0,
       assertSingleItem = false,
-      // Scala 3 has an additional Paths() completion
-      itemIndex = 2
     )
+
 
   @Test def `auto-imports-prefix-with-interpolator` =
     checkEdit(
@@ -644,7 +644,6 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |  s"this is an interesting ${java.nio.file.Paths}"
          |}
          |""".stripMargin,
-      // Scala 3 has an additional Paths object completion
       itemIndex = 1,
       assertSingleItem = false
     )
@@ -745,7 +744,8 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |object Main {
          |  val a = s"${ListBuffer($0)}""
          |}""".stripMargin,
-      filter = _.contains("[A]")
+      assertSingleItem = false,
+      itemIndex = 1
     )
 
   @Test def `dont-show-when-writing-before-dollar` =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
@@ -4,6 +4,7 @@ import dotty.tools.pc.base.BaseCompletionSuite
 
 import org.junit.runners.MethodSorters
 import org.junit.{FixMethodOrder, Test}
+import org.junit.Ignore
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 class CompletionInterpolatorSuite extends BaseCompletionSuite:
@@ -627,6 +628,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |}
          |""".stripMargin,
       assertSingleItem = false,
+      filter = _.contains("java.nio.file")
     )
 
 
@@ -744,7 +746,6 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |  val a = s"${ListBuffer($0)}""
          |}""".stripMargin,
       assertSingleItem = false,
-      itemIndex = 1
     )
 
   @Test def `dont-show-when-writing-before-dollar` =
@@ -782,24 +783,59 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
 
   @Test def `prepend-new-missing-interpolator` =
     checkSnippet(
+      """|case class TestClass(x: Int)
+         |object TestClass:
+         |  def apply(x: Int): TestClass = ???
+         |object Main:
+         |  "$TestClas@@"
+         |""".stripMargin,
+      """|{TestClass($0)}
+         |{new TestClass$0}
+         |TestClass$0
+         |""".stripMargin
+    )
+
+  @Ignore("This case is not yet supported by metals")
+  @Test def `prepend-new-missing-interpolator-with-prefix` =
+    checkSnippet(
       """|object Wrapper:
-         |  "$Try@@"
-         |
+         |  case class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |object Main:
+         |  "$Wrapper.TestClas@@"
          |""".stripMargin,
-      """|Try$0
-         |{Try($0)}
-         |{new Try$0}
+      """|{Wrapper.TestClass($0)}
+         |{new Wrapper.TestClass$0}
+         |{Wrapper.TestClass$0}
+         |""".stripMargin
+    )
+
+  @Test def `prepend-new-with-prefix` =
+    checkSnippet(
+      """|object Wrapper:
+         |  case class TestClass(x: Int)
+         |  object TestClass:
+         |    def apply(x: Int): TestClass = ???
+         |object Main:
+         |  s"$Wrapper.TestClas@@"
          |""".stripMargin,
+      """|{Wrapper.TestClass($0)}
+         |{new Wrapper.TestClass$0}
+         |{Wrapper.TestClass$0}
+         |""".stripMargin
     )
 
   @Test def `prepend-new-interpolator` =
     checkSnippet(
-      """|object Wrapper:
-         |  s"$Try@@"
-         |
+      """|case class TestClass(x: Int)
+         |object TestClass:
+         |  def apply(x: Int): TestClass = ???
+         |object Main:
+         |  s"$TestClas@@"
          |""".stripMargin,
-      """|Try
-         |{Try($0)}
-         |{new Try}
-         |""".stripMargin,
+      """|{TestClass($0)}
+         |{new TestClass}
+         |TestClass
+         |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
@@ -779,3 +779,27 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |""".stripMargin,
       "host: String"
     )
+
+  @Test def `prepend-new-missing-interpolator` =
+    checkSnippet(
+      """|object Wrapper:
+         |  "$Try@@"
+         |
+         |""".stripMargin,
+      """|Try$0
+         |{Try($0)}
+         |{new Try$0}
+         |""".stripMargin,
+    )
+
+  @Test def `prepend-new-interpolator` =
+    checkSnippet(
+      """|object Wrapper:
+         |  s"$Try@@"
+         |
+         |""".stripMargin,
+      """|Try
+         |{Try($0)}
+         |{new Try}
+         |""".stripMargin,
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
@@ -626,7 +626,6 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |  s"this is an interesting ${java.nio.file.Paths}"
          |}
          |""".stripMargin,
-      itemIndex = 0,
       assertSingleItem = false,
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionKeywordSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionKeywordSuite.scala
@@ -151,8 +151,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite:
       """|value: Int
          |val
          |var
-         |varargs(): varargs
-         |varargs - scala.annotation
+         |varargs(): varargs - scala.annotation
          |""".stripMargin
     )
 
@@ -169,8 +168,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite:
         |""".stripMargin,
       """|val
          |var
-         |varargs(): varargs
-         |varargs - scala.annotation
+         |varargs(): varargs - scala.annotation
          |""".stripMargin
     )
 
@@ -203,8 +201,7 @@ class CompletionKeywordSuite extends BaseCompletionSuite:
         |}
         |""".stripMargin,
       """|value: Int
-         |varargs(): varargs
-         |varargs - scala.annotation""".stripMargin
+         |varargs(): varargs - scala.annotation""".stripMargin
     )
 
   @Test def `val-trailing-space` =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideSuite.scala
@@ -926,8 +926,8 @@ class CompletionOverrideSuite extends BaseCompletionSuite:
          |}
          |""".stripMargin,
       """|def hello1: Int
-         |override val hello2: Int
          |override def equals(x$0: Any): Boolean
+         |override def hashCode(): Int
          |""".stripMargin,
       includeDetail = false,
       topLines = Some(3)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
@@ -310,8 +310,19 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
           |""".stripMargin,
       """|Try
          |Try($0)
-         |new Try
+         |new scala.util.Try
          |""".stripMargin
+    )
+
+  @Test def `case-class2-edit` =
+    checkEditLine(
+      s"""|object Main {
+          |  ___
+          |}
+          |""".stripMargin,
+      "scala.util.Tr@@",
+      "new scala.util.Try",
+      filter = _.contains("new Try")
     )
 
   @Test def `case-class3` =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
@@ -172,7 +172,6 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
          |ArrayDequeOps[$0]
          |ArrayDeque
          |ArrayDeque
-         |ArrayDequeOps
          |""".stripMargin
     )
 
@@ -311,6 +310,7 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
           |""".stripMargin,
       """|Try
          |Try($0)
+         |new Try
          |""".stripMargin
     )
 
@@ -322,9 +322,11 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
           |""".stripMargin,
       // Note: the class and trait items in here are invalid. So
       // they are filtered out.
-      """|Try
-         |Try($0)
-         |""".stripMargin
+      """|Try -  scala.util
+         |Try($0) - [T](r: => T): Try[T]
+         |new Try - [T]: Try[T]
+         |""".stripMargin,
+      includeDetail = true
     )
 
   @Test def `symbol` =
@@ -365,18 +367,33 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
     checkSnippet(
       s"""|package example
           |
-          |object Widget{}
+          |object TestObject {}
           |object Main {
-          |  Wi@@
+          |  TestObjec@@
           |}
           |""".stripMargin,
-      """|Widget -  example
-         |Window -  java.awt
-         |WindowPeer -  java.awt.peer
-         |WithFilter -  scala.collection
+      """|TestObject -  example
          |""".stripMargin,
       includeDetail = true,
-      topLines = Some(4)
+    )
+
+  @Test def `dont-enter-empty-paramlist` =
+    checkSnippet(
+      s"""|package example
+          |
+          |object Main {
+          |  ListMa@@
+          |}
+          |""".stripMargin,
+      """|ListMap -  scala.collection.immutable
+         |ListMap -  scala.collection.mutable
+         |ListMap($0) - [K, V](elems: (K, V)*): ListMap[K, V]
+         |new ListMap - [K, V]: ListMap[K, V]
+         |ListMapBuilder - [K, V]: ListMapBuilder[K, V]
+         |new ListMap - [K, V]: ListMap[K, V]
+         |ConcurrentSkipListMap -  java.util.concurrent
+         |""".stripMargin,
+      includeDetail = true,
     )
 
   // https://github.com/scalameta/metals/issues/4004

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
@@ -304,25 +304,33 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
 
   @Test def `case-class2` =
     checkSnippet(
-      s"""|object Main {
-          |  scala.util.Tr@@
+      s"""|object wrapper:
+          |  case class Test2(x: Int)
+          |  object Test2:
+          |    def apply(x: Int): Test2 = ???
+          |object Main {
+          |  wrapper.Test@@
           |}
           |""".stripMargin,
-      """|Try
-         |Try($0)
-         |new scala.util.Try
+      """|Test2($0)
+         |new wrapper.Test2
+         |Test2
          |""".stripMargin
     )
 
   @Test def `case-class2-edit` =
     checkEditLine(
-      s"""|object Main {
+      s"""|object wrapper:
+          |  case class Test2(x: Int)
+          |  object Test2:
+          |    def apply(x: Int): Test2 = ???
+          |object Main {
           |  ___
           |}
           |""".stripMargin,
-      "scala.util.Tr@@",
-      "new scala.util.Try",
-      filter = _.contains("new Try")
+      "wrapper.Test@@",
+      "new wrapper.Test2",
+      filter = _.contains("new Test2")
     )
 
   @Test def `case-class3` =
@@ -333,9 +341,8 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
           |""".stripMargin,
       // Note: the class and trait items in here are invalid. So
       // they are filtered out.
-      """|Try -  scala.util
-         |Try($0) - [T](r: => T): Try[T]
-         |new Try - [T]: Try[T]
+      """|Try($0) - [T](r: => T): Try[T]
+         |Try -  scala.util
          |""".stripMargin,
       includeDetail = true
     )
@@ -365,10 +372,10 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
           |  Wi@@
           |}
           |""".stripMargin,
-      """|Widget -  example
-         |Widget($0) - (name: String): Widget
+      """|Widget($0) - (name: String): Widget
          |Widget($0) - (age: Int): Widget
          |Widget($0) - (name: String, age: Int): Widget
+         |Widget -  example
          |""".stripMargin,
       includeDetail = true,
       topLines = Some(4)
@@ -396,12 +403,13 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
           |  ListMa@@
           |}
           |""".stripMargin,
-      """|ListMap -  scala.collection.immutable
-         |ListMap -  scala.collection.mutable
+      """|ListMap($0) - [K, V](elems: (K, V)*): ListMap[K, V]
+         |new ListMap - [K, V]: ListMap[K, V]
+         |ListMap -  scala.collection.immutable
          |ListMap($0) - [K, V](elems: (K, V)*): ListMap[K, V]
          |new ListMap - [K, V]: ListMap[K, V]
+         |ListMap -  scala.collection.mutable
          |ListMapBuilder - [K, V]: ListMapBuilder[K, V]
-         |new ListMap - [K, V]: ListMap[K, V]
          |ConcurrentSkipListMap -  java.util.concurrent
          |""".stripMargin,
       includeDetail = true,

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1627,8 +1627,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |  val fooBar = List(123)
          |  foo@@
          |""".stripMargin,
-      """|fooBar(n: Int): Int
-         |fooBar: List[Int]
+      """|fooBar: List[Int]
          |""".stripMargin
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -26,8 +26,8 @@ class CompletionSuite extends BaseCompletionSuite:
         |  Lis@@
         |}""".stripMargin,
       """
-        |List scala.collection.immutable
         |List[A](elems: A*): List[A]
+        |List scala.collection.immutable
         |List - java.awt
         |List - java.util
         |""".stripMargin,
@@ -178,10 +178,10 @@ class CompletionSuite extends BaseCompletionSuite:
         |object A {
         |  TrieMap@@
         |}""".stripMargin,
-      """|TrieMap scala.collection.concurrent
-         |TrieMap[K, V](elems: (K, V)*): TrieMap[K, V]
+      """|TrieMap[K, V](elems: (K, V)*): TrieMap[K, V]
          |new TrieMap[K, V]: TrieMap[K, V]
          |new TrieMap[K, V](hashf: Hashing[K], ef: Equiv[K]): TrieMap[K, V]
+         |TrieMap scala.collection.concurrent
          |""".stripMargin
     )
 
@@ -629,8 +629,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Some(value) scala
-         |Some scala
          |Some[A](value: A): Some[A]
+         |Some scala
          |""".stripMargin
     )
 
@@ -641,8 +641,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |    case List(Som@@)
           |}
           |""".stripMargin,
-      """|Some scala
-         |Some[A](value: A): Some[A]
+      """|Some[A](value: A): Some[A]
+         |Some scala
          |""".stripMargin
     )
 
@@ -667,8 +667,8 @@ class CompletionSuite extends BaseCompletionSuite:
           |}
           |""".stripMargin,
       """|Some(value) scala
-         |Seq scala.collection.immutable
-         |Set scala.collection.immutable
+         |Set[A](elems: A*): Set[A]
+         |Seq[A](elems: A*): Seq[A]
          |""".stripMargin,
       topLines = Some(3)
     )
@@ -1627,8 +1627,8 @@ class CompletionSuite extends BaseCompletionSuite:
          |  val fooBar = List(123)
          |  foo@@
          |""".stripMargin,
-      """|fooBar: List[Int]
-         |fooBar(n: Int): Int
+      """|fooBar(n: Int): Int
+         |fooBar: List[Int]
          |""".stripMargin
     )
 
@@ -1638,9 +1638,11 @@ class CompletionSuite extends BaseCompletionSuite:
          |  List@@
          |""".stripMargin,
       """|List[A](elems: A*): List[A]
+         |ListSet[A](elems: A*): ListSet[A] - scala.collection.immutable
          |ListMap[K, V](elems: (K, V)*): ListMap[K, V] - scala.collection.immutable
          |new ListMap[K, V]: ListMap[K, V] - scala.collection.immutable
          |new ListSet[A]: ListSet[A] - scala.collection.immutable
+         |ListMap[K, V](elems: (K, V)*): ListMap[K, V] - scala.collection.mutable
          |new ListMap[K, V]: ListMap[K, V] - scala.collection.mutable
          |""".stripMargin,
       filter = _.contains("[")

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -30,9 +30,8 @@ class CompletionSuite extends BaseCompletionSuite:
         |List[A](elems: A*): List[A]
         |List - java.awt
         |List - java.util
-        |ListMap[K, V](elems: (K, V)*): ListMap[K, V]
         |""".stripMargin,
-      topLines = Some(5)
+      topLines = Some(4)
     )
 
   @Test def member =
@@ -181,6 +180,22 @@ class CompletionSuite extends BaseCompletionSuite:
         |}""".stripMargin,
       """|TrieMap scala.collection.concurrent
          |TrieMap[K, V](elems: (K, V)*): TrieMap[K, V]
+         |new TrieMap[K, V]: TrieMap[K, V]
+         |new TrieMap[K, V](hashf: Hashing[K], ef: Equiv[K]): TrieMap[K, V]
+         |""".stripMargin
+    )
+
+  @Test def `no-companion-apply-in-new`=
+    check(
+      """
+        |import scala.collection.concurrent._
+        |object A {
+        |  new TrieMap@@
+        |}""".stripMargin,
+      // TrieMap should be filtered if it doesn't contain any types that can be constructed in `new` keyword context.
+      """|TrieMap[K, V]: TrieMap[K, V]
+         |TrieMap[K, V](hashf: Hashing[K], ef: Equiv[K]): TrieMap[K, V]
+         |TrieMap scala.collection.concurrent
          |""".stripMargin
     )
 
@@ -216,16 +231,13 @@ class CompletionSuite extends BaseCompletionSuite:
       """
         |import JavaCon@@
         |""".stripMargin,
-      """|AsJavaConverters - scala.collection.convert
-         |JavaConverters - scala.collection
+      """|JavaConverters - scala.collection
          |JavaConversions - scala.concurrent
          |AsJavaConsumer - scala.jdk.FunctionWrappers
+         |AsJavaConverters - scala.collection.convert
          |FromJavaConsumer - scala.jdk.FunctionWrappers
          |AsJavaBiConsumer - scala.jdk.FunctionWrappers
          |AsJavaIntConsumer - scala.jdk.FunctionWrappers
-         |AsJavaLongConsumer - scala.jdk.FunctionWrappers
-         |FromJavaBiConsumer - scala.jdk.FunctionWrappers
-         |FromJavaIntConsumer - scala.jdk.FunctionWrappers
          |""".stripMargin
     )
 
@@ -473,8 +485,7 @@ class CompletionSuite extends BaseCompletionSuite:
         |
         |}
       """.stripMargin,
-      """|DelayedLazyVal scala.concurrent
-         |DelayedLazyVal[T](f: () => T, body: => Unit)(exec: ExecutionContext): DelayedLazyVal[T]""".stripMargin
+      "DelayedLazyVal[T](f: () => T, body: => Unit)(implicit exec: ExecutionContext): DelayedLazyVal[T]"
     )
 
   @Test def local2 =
@@ -1154,8 +1165,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |def main =
          |  Testin@@
          |""".stripMargin,
-      """|Testing a
-         |Testing(): Testing
+      """|Testing(): Testing
          |""".stripMargin
     )
 
@@ -1168,8 +1178,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |def main =
          |  Testin@@
          |""".stripMargin,
-      """|Testing a
-         |Testing(a: Int, b: String): Testing
+      """|Testing(a: Int, b: String): Testing
          |""".stripMargin
     )
 
@@ -1314,9 +1323,20 @@ class CompletionSuite extends BaseCompletionSuite:
           |""".stripMargin,
       """|AClass[A <: Int] test.O
          |AClass test.O
-         |AbstractTypeClassManifest - scala.reflect.ClassManifestFactory
          """.stripMargin
     )
+
+  val extensionResult =
+    """|Foo test
+       |Found - scala.collection.Searching
+       |Font - java.awt
+       |Form - java.text.Normalizer
+       |Format - java.text
+       |FontPeer - java.awt.peer
+       |FormView - javax.swing.text.html
+       |Formatter - java.util
+       |Formatter - java.util.logging
+       |FocusEvent - java.awt.event""".stripMargin
 
   @Test def `extension-definition-scope` =
     check(
@@ -1324,18 +1344,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension (x: Fo@@)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-symbol-search` =
@@ -1354,18 +1363,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension [A <: Fo@@]
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-type-parameter-symbol-search` =
@@ -1384,18 +1382,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension (using Fo@@)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
 
@@ -1405,18 +1392,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension (x: Int)(using Fo@@)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-mix-2` =
@@ -1425,18 +1401,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension (using Fo@@)(x: Int)(using Foo)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-mix-3` =
@@ -1445,18 +1410,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension (using Foo)(x: Int)(using Fo@@)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-mix-4` =
@@ -1465,18 +1419,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension [A](x: Fo@@)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-mix-5` =
@@ -1485,18 +1428,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension [A](using Fo@@)(x: Int)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-mix-6` =
@@ -1505,18 +1437,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension [A](using Foo)(x: Fo@@)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-mix-7` =
@@ -1525,18 +1446,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |object T:
          |  extension [A](using Foo)(x: Fo@@)(using Foo)
          |""".stripMargin,
-      """|Foo test
-         |Font - java.awt
-         |Form - java.text.Normalizer
-         |Format - java.text
-         |FontPeer - java.awt.peer
-         |FormView - javax.swing.text.html
-         |Formatter - java.util
-         |Formatter - java.util.logging
-         |FocusEvent - java.awt.event
-         |FontMetrics - java.awt
-         |Found - scala.collection.Searching
-         |""".stripMargin
+      extensionResult
     )
 
   @Test def `extension-definition-select` =
@@ -1569,7 +1479,6 @@ class CompletionSuite extends BaseCompletionSuite:
          |  extension [T](x: Test.TestSel@@)
          |""".stripMargin,
       """|TestSelect[T] test.Test
-         |TestSelect test.Test
          |""".stripMargin
     )
 
@@ -1665,11 +1574,11 @@ class CompletionSuite extends BaseCompletionSuite:
     check(
       """import scala.collection.{AbstractMap, @@}
         |""".stripMargin,
-      """GenIterable scala.collection
-        |GenMap scala.collection
-        |GenSeq scala.collection
-        |GenSet scala.collection
-        |GenTraversable scala.collection
+      """+: scala.collection
+        |:+ scala.collection
+        |AbstractIndexedSeqView scala.collection
+        |AbstractIterable scala.collection
+        |AbstractIterator scala.collection
         |""".stripMargin,
       topLines = Some(5)
     )
@@ -1729,7 +1638,10 @@ class CompletionSuite extends BaseCompletionSuite:
          |  List@@
          |""".stripMargin,
       """|List[A](elems: A*): List[A]
-         |ListMap[K, V](elems: (K, V)*): ListMap[K, V]
+         |ListMap[K, V](elems: (K, V)*): ListMap[K, V] - scala.collection.immutable
+         |new ListMap[K, V]: ListMap[K, V] - scala.collection.immutable
+         |new ListSet[A]: ListSet[A] - scala.collection.immutable
+         |new ListMap[K, V]: ListMap[K, V] - scala.collection.mutable
          |""".stripMargin,
       filter = _.contains("[")
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
@@ -810,8 +810,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |}
          |""".stripMargin,
       """|fooBar: String
-         |fooBar: List[Int]
          |fooBar(n: Int): Int - test.A
+         |fooBar: List[Int]
          |""".stripMargin,
     )
 
@@ -827,8 +827,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |
          |val j = MyTy@@
          |""".stripMargin,
-      """|MyType - demo.other
-         |MyType(m: Long): MyType - demo.other
+      """|MyType(m: Long): MyType - demo.other
+         |MyType - demo.other
          """.stripMargin,
     )
 
@@ -844,8 +844,8 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |
          |val j = MyTy@@
          |""".stripMargin,
-      """|MyType - demo.other
-         |MyType(m: Long): MyType - demo.other
+      """|MyType(m: Long): MyType - demo.other
+         |MyType - demo.other
       """.stripMargin,
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
@@ -810,7 +810,6 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |}
          |""".stripMargin,
       """|fooBar: String
-         |fooBar(n: Int): Int - test.A
          |fooBar: List[Int]
          |""".stripMargin,
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
@@ -700,7 +700,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |object Main {
          |  val a = ListBuffer($0)
          |}""".stripMargin,
-      filter = _.contains("[A]")
+      filter = _.startsWith("ListBuffer[A]")
     )
 
   @Test def `type-import` =
@@ -811,7 +811,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |""".stripMargin,
       """|fooBar: String
          |fooBar: List[Int]
-         |fooBar(n: Int): Int
+         |fooBar(n: Int): Int - test.A
          |""".stripMargin,
     )
 
@@ -827,8 +827,9 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |
          |val j = MyTy@@
          |""".stripMargin,
-      """|MyType(m: Long): MyType
-         |MyType - demo.other""".stripMargin,
+      """|MyType - demo.other
+         |MyType(m: Long): MyType - demo.other
+         """.stripMargin,
     )
 
   @Test def `type-apply2` =
@@ -843,8 +844,9 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |
          |val j = MyTy@@
          |""".stripMargin,
-      """|MyType(m: Long): MyType
-         |MyType - demo.other""".stripMargin,
+      """|MyType - demo.other
+         |MyType(m: Long): MyType - demo.other
+      """.stripMargin,
     )
 
   @Test def `method-name-conflict` =


### PR DESCRIPTION
This PR doesn't address all issues.
In the future we need to get rid of https://github.com/scala/scala3/compare/main...rochala:improved-deduplication-and-constructors-search?expand=1#diff-035851592480495dfdb20da6b615ec7dd77b3db70cda46aba56230d8cd690773R157-R167 as it is not working as intended. The future PR of shortened type printer refactor includes a proper way to split extension params.
`CompletionValue.Interpolator` should also be removed, and instead we should return workspace / completions as it is now hard to sort those completions.

Next refactor is reusing completion affix for other kinds of completions such as case completions, so prefix / suffix is handled in single place.

This PR will unblock fuzzy search in the compiler because of stabilizing returned completions.