### PR TITLE
Prevent HTML/XSS Injection in Scala Search

### DIFF
--- a/docs/_layouts/search.html
+++ b/docs/_layouts/search.html
@@ -47,11 +47,11 @@ title: Search
 
     // Set search term and title:
     var searchTerm = decodeURIComponent(parameters["searchTerm"]);
-    document.getElementById("searching-for").innerHTML = 'Search results for "' + searchTerm + '"';
+    document.getElementById("searching-for").innerText = 'Search results for "' + searchTerm + '"';
     document.title = searchTerm + ' - Search results';
 
     if (!window.Worker) {
-        document.getElementById("searching-for").innerHTML =
+        document.getElementById("searching-for").innerText =
             "Couldn't search for \"" + searchTerm + "\", " +
             "web workers not supported. Please update your browser.";
     }


### PR DESCRIPTION
This PR fixes the `_layouts/search.html` file to use `innerText` rather than `innerHTML`. This will prevent the ability to inject HTML/XSS into the code of the page.