### PR TITLE
Fix parsing of conditional expressions in parentheses

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2192,7 +2192,8 @@ object Parsers {
     def condExpr(altToken: Token): Tree =
       val t: Tree =
         if in.token == LPAREN then
-          var t: Tree = atSpan(in.offset) { Parens(inParens(exprInParens())) }
+          var t: Tree = atSpan(in.offset):
+            makeTupleOrParens(inParensWithCommas(commaSeparated(exprInParens)))
           if in.token != altToken then
             if toBeContinued(altToken) then
               t = inSepRegion(InCond) {

--- a/tests/pos/if-parse.scala
+++ b/tests/pos/if-parse.scala
@@ -1,0 +1,4 @@
+import scala.math.Ordering.Implicits.infixOrderingOps
+
+def test =
+  if (1, 2) < (3, 4) then 1 else 2


### PR DESCRIPTION
We overlooked that the first parenthesized expression might be a tuple.

See https://users.scala-lang.org/t/parsing-conditionals/9888