### PR TITLE
Add more methods in `SeqViewOps`

### DIFF
--- a/scala2-library-cc/src/scala/collection/Seq.scala
+++ b/scala2-library-cc/src/scala/collection/Seq.scala
@@ -118,7 +118,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any with SeqViewOps[A, CC, C] { self =>
     * Note that :-ending operators are right associative (see example).
     * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
     */
-  @`inline` final def +: [B >: A](elem: B): CC[B] = prepended(elem)
+  @`inline` override final def +: [B >: A](elem: B): CC[B] = prepended(elem)
 
   /** A copy of this $coll with an element appended.
     *
@@ -148,7 +148,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any with SeqViewOps[A, CC, C] { self =>
     * Note that :-ending operators are right associative (see example).
     * A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
     */
-  @`inline` final def :+ [B >: A](elem: B): CC[B] = appended(elem)
+  @`inline` override final def :+ [B >: A](elem: B): CC[B] = appended(elem)
 
   /** As with `:++`, returns a new collection containing the elements from the left operand followed by the
     *  elements from the right operand.

--- a/scala2-library-cc/src/scala/collection/SeqView.scala
+++ b/scala2-library-cc/src/scala/collection/SeqView.scala
@@ -65,6 +65,10 @@ trait SeqViewOps[+A, +CC[_], +C] extends Any with IterableOps[A, CC, C] {
   def distinctBy[B](f: A -> B): C^{this} =
     assert(false, "This is a placeholder implementation in the capture checked Scala 2 library.")
     ???
+
+  // The following methods are copied from [[SeqOps]].
+  @`inline` def +: [B >: A](elem: B): CC[B]^{this} = prepended(elem)
+  @`inline` def :+ [B >: A](elem: B): CC[B]^{this} = appended(elem)
   // -------------------
 
   def reverseIterator: Iterator[A]^{this} = reversed.iterator

--- a/tests/pos/i19988.scala
+++ b/tests/pos/i19988.scala
@@ -1,0 +1,7 @@
+import collection.IndexedSeqView
+object Hello extends App {
+  def foo(view: IndexedSeqView[Int]): Unit =
+    val x1 = 1 +: view
+    val x2 = view :+ 1
+}
+


### PR DESCRIPTION
fixes #19988

The issue is caused by the change of class hierarchy in Scala 2 library CC: `SeqView` no longer extends `SeqOps`. To fix this we have to copy methods from `SeqOps` to `SeqViewOps`. Similar to what is done in #19873.