### PR TITLE
First pass of combining multiple union types

### DIFF
--- a/compiler/test-resources/repl/10693
+++ b/compiler/test-resources/repl/10693
@@ -1,0 +1,23 @@
+scala> def test[A, B](a: A, b: B): A | B = a
+def test[A, B](a: A, b: B): A | B
+
+scala>   def d0 = test("string", 1)
+def d0: String | Int
+
+scala> def d1 = test(1, "string")
+def d1: Int | String
+
+scala> def d2 = test(d0, d1)
+def d2: Int | String
+
+scala> def d3 = test(d1, d0)
+def d3: String | Int
+
+scala> def d4 = test(d2, d3)
+def d4: String | Int
+
+scala> def d5 = test(d3, d2)
+def d5: Int | String
+
+scala> def d6 = test(d4, d5)
+def d6: Int | String

--- a/tests/pos/i10693.scala
+++ b/tests/pos/i10693.scala
@@ -1,0 +1,19 @@
+object Example {
+  def test[A, B](a: A, b: B): A | B = a
+
+  val v0 = test("string", 1)
+  val v1 = test(1, "string")
+  val v2 = test(v0, v1)
+  val v3 = test(v1, v0)
+  val v4 = test(v2, v3)
+  val v5 = test(v3, v2)
+  val v6 = test(v4, v5)
+
+  def d0 = test("string", 1)
+  def d1 = test(1, "string")
+  def d2 = test(d0, d1)
+  def d3 = test(d1, d0)
+  def d4 = test(d2, d3)
+  def d5 = test(d3, d2)
+  def d6 = test(d4, d5)
+}


### PR DESCRIPTION
I've worked with some much simpler compilers before, thought it was about time I made an attempt at something on a more serious scale.

I had an alternate attempt to address this via an extra case within TypeOps, but that seemed to have significantly more ripple effects than I was anticipating.

Avoided using a traditional set for comparisons such that I could maintain a guarantee of ordering based on the order at the inputs. The output order is deterministic for a given input type, but I have not aimed for consistency between conceptually similar types.

My understanding is that by limiting this to inferred types, it should only impact a type that is not user provided, so use cases where a user wants a non-impactful type can be maintained through compilation.

Would likely want to expand this to cover and types as well as or types in the same code.

I'm fully expecting to be ripped apart on performance, but the big win I had spotted was to make sure I was not using subset relations between OrTypes, as that appears to be expensive.

Expecting that there's still more to do here, but keen to get back into real code again, so any feedback would be very welcome