### PR TITLE
Do match type reduction atPhaseNoLater than ElimOpaque

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -220,6 +220,7 @@ object Phases {
     private var myPatmatPhase: Phase = uninitialized
     private var myElimRepeatedPhase: Phase = uninitialized
     private var myElimByNamePhase: Phase = uninitialized
+    private var myElimOpaquePhase: Phase = uninitialized
     private var myExtensionMethodsPhase: Phase = uninitialized
     private var myExplicitOuterPhase: Phase = uninitialized
     private var myGettersPhase: Phase = uninitialized
@@ -245,6 +246,7 @@ object Phases {
     final def patmatPhase: Phase = myPatmatPhase
     final def elimRepeatedPhase: Phase = myElimRepeatedPhase
     final def elimByNamePhase: Phase = myElimByNamePhase
+    final def elimOpaquePhase: Phase = myElimOpaquePhase
     final def extensionMethodsPhase: Phase = myExtensionMethodsPhase
     final def explicitOuterPhase: Phase = myExplicitOuterPhase
     final def gettersPhase: Phase = myGettersPhase
@@ -272,6 +274,7 @@ object Phases {
       myRefChecksPhase = phaseOfClass(classOf[RefChecks])
       myElimRepeatedPhase = phaseOfClass(classOf[ElimRepeated])
       myElimByNamePhase = phaseOfClass(classOf[ElimByName])
+      myElimOpaquePhase = phaseOfClass(classOf[ElimOpaque])
       myExtensionMethodsPhase = phaseOfClass(classOf[ExtensionMethods])
       myErasurePhase = phaseOfClass(classOf[Erasure])
       myElimErasedValueTypePhase = phaseOfClass(classOf[ElimErasedValueType])
@@ -511,6 +514,7 @@ object Phases {
   def refchecksPhase(using Context): Phase              = ctx.base.refchecksPhase
   def elimRepeatedPhase(using Context): Phase           = ctx.base.elimRepeatedPhase
   def elimByNamePhase(using Context): Phase             = ctx.base.elimByNamePhase
+  def elimOpaquePhase(using Context): Phase             = ctx.base.elimOpaquePhase
   def extensionMethodsPhase(using Context): Phase       = ctx.base.extensionMethodsPhase
   def explicitOuterPhase(using Context): Phase          = ctx.base.explicitOuterPhase
   def gettersPhase(using Context): Phase                = ctx.base.gettersPhase

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5026,7 +5026,7 @@ object Types extends TypeUtils {
 
     private def thisMatchType = this
 
-    def reduced(using Context): Type = {
+    def reduced(using Context): Type = atPhaseNoLater(elimOpaquePhase) {
 
       def contextInfo(tp: Type): Type = tp match {
         case tp: TypeParamRef =>

--- a/tests/pos/i19434.scala
+++ b/tests/pos/i19434.scala
@@ -1,0 +1,11 @@
+
+object Test:
+
+  object Named:
+    opaque type Named[name <: String & Singleton, A] >: A = A
+
+  type DropNames[T <: Tuple] = T match
+    case Named.Named[_, x] *: xs => x *: DropNames[xs]
+    case _ => T
+
+  def f[T <: Tuple]: DropNames[T] = ???


### PR DESCRIPTION
If a match type pattern is an opaque type, we use its bounds when checking the validity of the pattern. 
Following the `ElimOpaque` phase however, the pattern is beta-reduced (as normal applied type aliases), which may result in an illegal pattern, and hence an ErrorType.

We initially discussed doing the changes in the TypeComparer `reduceMatchWith`, but I think the `atPhaseNoLater(elimOpaquePhase)` should be in the reduced method of MatchType, for the footprint computation to happen in the same context.

Fixes #19434 
Also allows to keep `bad-footprint.scala` in #19954