### PR TITLE
Avoid duplications of properties in pom.xml

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1999,6 +1999,10 @@ object Build {
     publishTo := sonatypePublishToBundle.value,
     publishConfiguration ~= (_.withOverwrite(true)),
     publishLocalConfiguration ~= (_.withOverwrite(true)),
+    projectID ~= {id =>
+      val line = "scala.versionLine" -> versionLine
+      id.withExtraAttributes(id.extraAttributes + line)
+    },
     Test / publishArtifact := false,
     homepage := Some(url(dottyGithubUrl)),
     licenses += (("Apache-2.0",
@@ -2009,10 +2013,6 @@ object Build {
         "scm:git:git@github.com:scala/scala3.git"
       )
     ),
-    pomExtra :=
-      <properties>
-        <scala.versionLine>{versionLine}</scala.versionLine>
-      </properties>,
     developers := List(
       Developer(
         id = "odersky",


### PR DESCRIPTION
Inspired by how to add release notes URL : https://contributors.scala-lang.org/t/add-release-notes-urls-to-your-poms/6059

Closes #20016