### PR TITLE
Re-lub also hard union types in simplify

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -157,15 +157,8 @@ object TypeOps:
         tp.derivedAlias(simplify(tp.alias, theMap))
       case AndType(l, r) if !ctx.mode.is(Mode.Type) =>
         simplify(l, theMap) & simplify(r, theMap)
-      case tp @ OrType(l, r)
-      if !ctx.mode.is(Mode.Type)
-         && (tp.isSoft || l.isBottomType || r.isBottomType) =>
-        // Normalize A | Null and Null | A to A even if the union is hard (i.e.
-        // explicitly declared), but not if -Yexplicit-nulls is set. The reason is
-        // that in this case the normal asSeenFrom machinery is not prepared to deal
-        // with Nulls (which have no base classes). Under -Yexplicit-nulls, we take
-        // corrective steps, so no widening is wanted.
-        simplify(l, theMap) | simplify(r, theMap)
+      case tp @ OrType(l, r) if !ctx.mode.is(Mode.Type) =>
+        TypeComparer.lub(simplify(l, theMap), simplify(r, theMap), isSoft = tp.isSoft)
       case tp @ CapturingType(parent, refs) =>
         if !ctx.mode.is(Mode.Type)
             && refs.subCaptures(parent.captureSet, frozen = true).isOK

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3598,12 +3598,11 @@ object Types extends TypeUtils {
 
     override def widenUnionWithoutNull(using Context): Type =
       if myUnionPeriod != ctx.period then
-        myUnion =
-          if isSoft then
-            TypeComparer.lub(tp1.widenUnionWithoutNull, tp2.widenUnionWithoutNull, canConstrain = true, isSoft = isSoft) match
-              case union: OrType => union.join
-              case res => res
-          else derivedOrType(tp1.widenUnionWithoutNull, tp2.widenUnionWithoutNull, soft = isSoft)
+        val union = TypeComparer.lub(
+          tp1.widenUnionWithoutNull, tp2.widenUnionWithoutNull, canConstrain = isSoft, isSoft = isSoft)
+        myUnion = union match
+          case union: OrType if isSoft => union.join
+          case _ => union
         if !isProvisional then myUnionPeriod = ctx.period
       myUnion
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1961,7 +1961,8 @@ class Namer { typer: Typer =>
       else
         // don't strip @uncheckedVariance annot for default getters
         TypeOps.simplify(tp.widenTermRefExpr,
-            if defaultTp.exists then TypeOps.SimplifyKeepUnchecked() else null) match
+            if defaultTp.exists then TypeOps.SimplifyKeepUnchecked() else null)
+        match
           case ctp: ConstantType if sym.isInlineVal => ctp
           case tp => TypeComparer.widenInferred(tp, pt, widenUnions = true)
 

--- a/compiler/test-resources/repl/10693
+++ b/compiler/test-resources/repl/10693
@@ -1,0 +1,16 @@
+scala> def test[A, B](a: A, b: B): A | B = a
+def test[A, B](a: A, b: B): A | B
+scala>   def d0 = test("string", 1)
+def d0: String | Int
+scala> def d1 = test(1, "string")
+def d1: Int | String
+scala> def d2 = test(d0, d1)
+def d2: String | Int
+scala> def d3 = test(d1, d0)
+def d3: Int | String
+scala> def d4 = test(d2, d3)
+def d4: String | Int
+scala> def d5 = test(d3, d2)
+def d5: Int | String
+scala> def d6 = test(d4, d5)
+def d6: String | Int

--- a/tests/pos/i10693.scala
+++ b/tests/pos/i10693.scala
@@ -1,0 +1,8 @@
+def test[A, B](a: A, b: B): A | B = a
+val v0 = test("string", 1)
+val v1 = test(1, "string")
+val v2 = test(v0, v1)
+val v3 = test(v1, v0)
+val v4 = test(v2, v3)
+val v5 = test(v3, v2)
+val v6 = test(v4, v5)


### PR DESCRIPTION
Simplify had some elaborate condition that prevented hard union types to be recomputed with a lub. I am not sure why that was. In the concrete scenario of i10693.scala, we had an explicitly written union result type `B | A` where `A` and `B` are type parameters. So that is a hard union type. Then `A` was instantiated to `Int | String` and `B` was instantiated to `String | Int`. Re-forming the lub of that union would have eliminated one pair, but since the union type was hard that was not done. On the other hand I see no reason why hard unions should not be re-lubbed. Hard unions are about preventing the widening of or types with a join. I don't see a connection with avoiding re-lubbing.

Fixes #10693