### PR TITLE
Extra check to avoid converting block expressions on the rhs of an in…

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -75,6 +75,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i12340.scala", unindentOptions.and("-rewrite")),
       compileFile("tests/rewrites/i17187.scala", unindentOptions.and("-rewrite")),
       compileFile("tests/rewrites/i17399.scala", unindentOptions.and("-rewrite")),
+      compileFile("tests/rewrites/i20002.scala", defaultOptions.and("-indent", "-rewrite")),
     ).checkRewrites()
   }
 

--- a/tests/rewrites/i20002.check
+++ b/tests/rewrites/i20002.check
@@ -1,0 +1,51 @@
+object Reactions:
+  def main: Unit =
+    Reactions += {
+      case 0 =>
+      case 1 =>
+    }
+
+    Reactions run:
+      case 0 =>
+      case 1 =>
+
+    Reactions run_+ :
+      case 0 =>
+      case 1 =>
+
+    Reactions `+=`:
+      case 0 =>
+      case 1 =>
+
+    def bar: Int = ???
+
+    bar match
+      case 0 =>
+      case 1 =>
+
+    def partPartial(i: Int): PartialFunction[Int, Unit] =
+      case `i` =>
+
+    Reactions += {
+      val pp1 = partPartial(1)
+      val pp2 = partPartial(2)
+      def codeBlock =
+        ???
+        ???
+      pp1 orElse pp2
+    }
+
+    val partialFunction = partPartial(1) orElse partPartial(2)
+    Reactions += {
+      partialFunction
+    }
+
+  def +=(f: PartialFunction[Int, Unit]) =
+    ???
+
+  def run (f: PartialFunction[Int, Unit]) =
+    ???
+
+  def run_+ (f: PartialFunction[Int, Unit]) =
+    ???
+

--- a/tests/rewrites/i20002.scala
+++ b/tests/rewrites/i20002.scala
@@ -1,0 +1,62 @@
+object Reactions {
+  def main: Unit = {
+    Reactions += {
+      case 0 =>
+      case 1 =>
+    }
+
+    Reactions run {
+      case 0 =>
+      case 1 =>
+    }
+
+    Reactions run_+ {
+      case 0 =>
+      case 1 =>
+    }
+
+    Reactions `+=` {
+      case 0 =>
+      case 1 =>
+    }
+
+    def bar: Int = ???
+
+    bar match {
+      case 0 =>
+      case 1 =>
+    }
+
+    def partPartial(i: Int): PartialFunction[Int, Unit] = {
+      case `i` =>
+    }
+
+    Reactions += {
+      val pp1 = partPartial(1)
+      val pp2 = partPartial(2)
+      def codeBlock = {
+        ???
+        ???
+      }
+      pp1 orElse pp2
+    }
+
+    val partialFunction = partPartial(1) orElse partPartial(2)
+    Reactions += {
+      partialFunction
+    }
+  }
+
+  def +=(f: PartialFunction[Int, Unit]) = {
+    ???
+  }
+
+  def run (f: PartialFunction[Int, Unit]) = {
+    ???
+  }
+
+  def run_+ (f: PartialFunction[Int, Unit]) = {
+    ???
+  }
+
+}


### PR DESCRIPTION
…fix expression.

Tests added for:
* Original cast as per the ticket should not be changed
* Similar match statement that should update
* Code blocks in this position, as opposed to a partial function, cant update here
* Simple change that should apply but in a code position where the op stack is nonempty
* Equivalent code, but passing in the partial function as a single parameter, again, not updating

Fixes #20002 