### PR TITLE
Plug soundness hole for reach capabilities

### DIFF
--- a/tests/neg/unsound-reach-2.scala
+++ b/tests/neg/unsound-reach-2.scala
@@ -1,0 +1,25 @@
+import language.experimental.captureChecking
+trait Consumer[-T]:
+  def apply(x: T): Unit
+
+trait File:
+  def close(): Unit
+
+def withFile[R](path: String)(op: Consumer[File]): R = ???
+
+trait Foo[+X]:
+  def use(x: File^)(op: Consumer[X]): Unit
+class Bar extends Foo[File^]:
+  def use(x: File^)(op: Consumer[File^]): Unit = op.apply(x)
+
+def bad(): Unit =
+  val backdoor: Foo[File^] = new Bar
+  val boom: Foo[File^{backdoor*}] = backdoor
+
+  var escaped: File^{backdoor*} = null
+  withFile("hello.txt"): f =>
+    boom.use(f): // error
+      new Consumer[File^{backdoor*}]:
+        def apply(f1: File^{backdoor*}) =
+          escaped = f1
+

--- a/tests/neg/unsound-reach-3.scala
+++ b/tests/neg/unsound-reach-3.scala
@@ -1,0 +1,21 @@
+import language.experimental.captureChecking
+trait File:
+  def close(): Unit
+
+def withFile[R](path: String)(op: File^ => R): R = ???
+
+trait Foo[+X]:
+  def use(x: File^): X
+class Bar extends Foo[File^]:
+  def use(x: File^): File^ = x
+
+def bad(): Unit =
+  val backdoor: Foo[File^] = new Bar
+  val boom: Foo[File^{backdoor*}] = backdoor
+
+  var escaped: File^{backdoor*} = null
+  withFile("hello.txt"): f =>
+    escaped = boom.use(f) // error
+      // boom.use: (x: File^) -> File^{backdoor*}, it is a selection so reach capabilities are allowed
+      // f: File^, so there is no reach capabilities
+

--- a/tests/neg/unsound-reach.check
+++ b/tests/neg/unsound-reach.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg/unsound-reach.scala:18:9 ---------------------------------------------------------------------------
+18 |    boom.use(f): (f1: File^{backdoor*}) => // error
+   |    ^^^^^^^^
+   |    Reach capability backdoor* and universal capability cap cannot both
+   |    appear in the type (x: File^)(op: box File^{backdoor*} => Unit): Unit of this expression

--- a/tests/neg/unsound-reach.scala
+++ b/tests/neg/unsound-reach.scala
@@ -1,0 +1,20 @@
+import language.experimental.captureChecking
+trait File:
+  def close(): Unit
+
+def withFile[R](path: String)(op: File^ => R): R = ???
+
+trait Foo[+X]:
+  def use(x: File^)(op: X => Unit): Unit
+class Bar extends Foo[File^]:
+  def use(x: File^)(op: File^ => Unit): Unit = op(x)
+
+def bad(): Unit =
+  val backdoor: Foo[File^] = new Bar
+  val boom: Foo[File^{backdoor*}] = backdoor
+
+  var escaped: File^{backdoor*} = null
+  withFile("hello.txt"): f =>
+    boom.use(f): (f1: File^{backdoor*}) => // error
+      escaped = f1
+


### PR DESCRIPTION
~~To prevent that a reach capability is undermined by passing in a local capability from the outside, we disallow function arguments where reach capabilities appear in contravariant or invariant positions.~~

New scheme:

Enforce an analogous restriction to the one for creating reach capabilities
for all values. The type of a value cannot both have a reach capability with variance >= 0 and at the same time a universal capability with variance <= 0. 