### PR TITLE
Fix missing changesParents in PostTyper

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -293,10 +293,13 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
       if (ctx.settings.YtestPickler.value) List("pickler")
       else ctx.settings.YstopAfter.value
 
+    val runCtx = ctx.fresh
+    runCtx.setProfiler(Profiler())
+
     val pluginPlan = ctx.base.addPluginPhases(ctx.base.phasePlan)
     val phases = ctx.base.fusePhases(pluginPlan,
       ctx.settings.Yskip.value, ctx.settings.YstopBefore.value, stopAfter, ctx.settings.Ycheck.value)
-    ctx.base.usePhases(phases)
+    ctx.base.usePhases(phases, runCtx)
 
     if ctx.settings.YnoDoubleBindings.value then
       ctx.base.checkNoDoubleBindings = true
@@ -340,9 +343,6 @@ class Run(comp: Compiler, ictx: Context) extends ImplicitRunInfo with Constraint
       profiler.finished()
     }
 
-    val runCtx = ctx.fresh
-    runCtx.setProfiler(Profiler())
-    unfusedPhases.foreach(_.initContext(runCtx))
     val fusedPhases = runCtx.base.allPhases
     if ctx.settings.explainCyclic.value then
       runCtx.setProperty(CyclicReference.Trace, new CyclicReference.Trace())

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -892,7 +892,7 @@ object Contexts {
     val definitions: Definitions = new Definitions
 
     // Set up some phases to get started */
-    usePhases(List(SomePhase))
+    usePhases(List(SomePhase), FreshContext(this))
 
     /** Initializes the `ContextBase` with a starting context.
      *  This initializes the `platform` and the `definitions`.

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -583,7 +583,9 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
       if !sym.hasAnnotation(defn.ExperimentalAnnot) && ctx.settings.experimental.value && isTopLevelDefinitionInSource(sym) then
         sym.addAnnotation(ExperimentalAnnotation("Added by -experimental", sym.span))
 
-    private def scala2LibPatch(tree: TypeDef)(using Context) =
+    // It needs to run at the phase of the postTyper --- otherwise, the test of the symbols will use
+    // the transformed denotation with added `Serializable` and `AbstractFunction`.
+    private def scala2LibPatch(tree: TypeDef)(using Context) = atPhase(thisPhase):
       val sym = tree.symbol
       if compilingScala2StdLib && sym.is(ModuleClass) then
         // Add Serializable to companion objects of serializable classes,

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -76,6 +76,13 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
 
   override def changesMembers: Boolean = true // the phase adds super accessors and synthetic members
 
+  /**
+   * Serializable and AbstractFunction are added for scala2-library companion object of case class
+   *
+   * Ideally `compilingScala2StdLib` should be used, but it is initialized too late to be effective.
+   */
+  override def changesParents: Boolean = true
+
   override def transformPhase(using Context): Phase = thisPhase.next
 
   def newTransformer(using Context): Transformer =

--- a/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Checker.scala
@@ -36,12 +36,16 @@ class Checker extends Phase:
     traverser.traverse(unit.tpdTree)
 
   override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
-    val checkCtx = ctx.fresh.setPhase(this.start)
+    val checkCtx = ctx.fresh.setPhase(this)
     val traverser = new InitTreeTraverser()
-    val unitContexts = units.map(unit => checkCtx.fresh.setCompilationUnit(unit))
 
     val units0 =
-      for unitContext <- unitContexts if traverse(traverser)(using unitContext) yield unitContext.compilationUnit
+      for
+        unit <- units
+        unitContext = checkCtx.fresh.setCompilationUnit(unit)
+        if traverse(traverser)(using unitContext)
+      yield
+        unitContext.compilationUnit
 
     cancellable {
       val classes = traverser.getClasses()

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -11,6 +11,7 @@ import StdNames.*
 import Names.TermName
 import NameKinds.OuterSelectName
 import NameKinds.SuperAccessorName
+import Decorators.*
 
 import ast.tpd.*
 import util.{ SourcePosition, NoSourcePosition }
@@ -66,12 +67,11 @@ import dotty.tools.dotc.core.Flags.AbstractOrTrait
  *     whole-program analysis. However, the check is not modular in terms of project boundaries.
  *
  */
-import Decorators.*
 class Objects(using Context @constructorOnly):
   val immutableHashSetBuider: Symbol = requiredClass("scala.collection.immutable.HashSetBuilder")
   // TODO: this should really be an annotation on the rhs of the field initializer rather than the field itself.
   val HashSetBuilder_rootNode: Symbol = immutableHashSetBuider.requiredValue("rootNode")
-  
+
   val whiteList = Set(HashSetBuilder_rootNode)
 
   // ----------------------------- abstract domain -----------------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1053,6 +1053,7 @@ object Build {
     settings(commonBootstrappedSettings).
     settings(scala2LibraryBootstrappedSettings).
     settings(moduleName := "scala2-library")
+    // -Ycheck:all is set in project/scripts/scala2-library-tasty-mima.sh
 
   /** Scala 2 library compiled by dotty using the latest published sources of the library.
    *

--- a/tests/init-global/pos/scala2-library.scala
+++ b/tests/init-global/pos/scala2-library.scala
@@ -1,0 +1,2 @@
+//> using options -Ysafe-init-global -Ycompile-scala2-library
+case class UninitializedFieldError(msg: String) extends RuntimeException(msg)

--- a/tests/init-global/pos/scala2-library.scala
+++ b/tests/init-global/pos/scala2-library.scala
@@ -1,2 +1,2 @@
-//> using options -Ysafe-init-global -Ycompile-scala2-library
+//> using options -Ycompile-scala2-library
 case class UninitializedFieldError(msg: String) extends RuntimeException(msg)


### PR DESCRIPTION
The following two problems lead to crash of -Ysafe-init-global while compiling scala2-library-bootstrapped:

- Fix missing changesParents in PostTyper
- Fix mismatch of parents tree and parents in symbol info

[test_scala2_library_tasty]
