### PR TITLE
Refine overloading and implicit disambiguation

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1839,11 +1839,7 @@ trait Applications extends Compatibility {
       else -1
 
     def compareWithTypes(tp1: Type, tp2: Type) = {
-      val ownerScore =
-        val sym1 = alt1.symbol
-        val sym2 = alt2.symbol
-        if sym1 == sym2 then comparePrefixes(widenPrefix(alt1), widenPrefix(alt2))
-        else compareOwner(sym1.maybeOwner, sym2.maybeOwner)
+      val ownerScore = compareOwner(alt1.symbol.maybeOwner, alt2.symbol.maybeOwner)
 
       def winsType1 = isAsSpecific(alt1, tp1, alt2, tp2)
       def winsType2 = isAsSpecific(alt2, tp2, alt1, tp1)
@@ -1874,11 +1870,14 @@ trait Applications extends Compatibility {
       val strippedType2 = stripImplicit(fullType2)
 
       val result = compareWithTypes(strippedType1, strippedType2)
-      if (result != 0) result
-      else if (strippedType1 eq fullType1)
-        if (strippedType2 eq fullType2) 0         // no implicits either side: its' a draw
+      if result != 0 then result
+      else if strippedType1 eq fullType1 then
+        if strippedType2 eq fullType2 then
+          if alt1.symbol != alt2.symbol then 0    // no implicits either side: it's a draw ...
+          else comparePrefixes(                   // ... unless the symbol is the same, in which case
+            widenPrefix(alt1), widenPrefix(alt2)) // we compare prefixes
         else 1                                    // prefer 1st alternative with no implicits
-      else if (strippedType2 eq fullType2) -1     // prefer 2nd alternative with no implicits
+      else if strippedType2 eq fullType2 then -1  // prefer 2nd alternative with no implicits
       else compareWithTypes(fullType1, fullType2) // continue by comparing implicits parameters
   }
   end compare

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -495,8 +495,8 @@ object Signatures {
         case res => List(tpe)
 
     def isSyntheticEvidence(name: String) =
-      if !name.startsWith(NameKinds.ContextBoundParamName.separator) then false else
-        symbol.paramSymss.flatten.find(_.name.show == name).exists(_.flags.is(Flags.Implicit))
+      name.startsWith(NameKinds.ContextBoundParamName.separator)
+      && symbol.paramSymss.flatten.find(_.name.show == name).exists(_.flags.is(Flags.Implicit))
 
     def toTypeParam(tpe: PolyType): List[Param] =
       val evidenceParams = (tpe.paramNamess.flatten zip tpe.paramInfoss.flatten).flatMap:

--- a/tests/pos/implicit-prefix-disambiguation.scala
+++ b/tests/pos/implicit-prefix-disambiguation.scala
@@ -1,7 +1,10 @@
+
 class I[X]
+class J[X]
 
 trait A:
   given I[B] = ???
+  given (using I[B]): J[B] = ???
 object A extends A
 
 trait B extends A
@@ -9,6 +12,6 @@ object B extends B
 
 //import B.given, A.given
 
-def Test = summon[I[B]]
-
-
+def Test =
+  summon[I[B]]
+  summon[J[B]]

--- a/tests/pos/implicit-prefix-disambiguation.scala
+++ b/tests/pos/implicit-prefix-disambiguation.scala
@@ -1,0 +1,14 @@
+class I[X]
+
+trait A:
+  given I[B] = ???
+object A extends A
+
+trait B extends A
+object B extends B
+
+//import B.given, A.given
+
+def Test = summon[I[B]]
+
+


### PR DESCRIPTION
We sometimes have two alternatives a.m and b.m with the same symbol and type but different prefixes. Previously these would always be ambiguous. We now try to disambiguate this so that the alternative with the more specific prefix wins. To determine this, we widen prefixes also going from module classes to their parents and then compare the resulting types.

This might fix a problem in ScalaTest that popped up after #20054.