### PR TITLE
Set the inlining phase in the Context used for checking macro trees

### DIFF
--- a/tests/pos-macros/i17009/Macro_1.scala
+++ b/tests/pos-macros/i17009/Macro_1.scala
@@ -1,0 +1,6 @@
+import scala.quoted._
+
+object Macro {
+  transparent inline def transform[T](inline expr: T): T = ${ transformImpl[T]('expr) }
+  def transformImpl[T: Type](f: Expr[T])(using Quotes): Expr[T] = f
+}

--- a/tests/pos-macros/i17009/Main_2.scala
+++ b/tests/pos-macros/i17009/Main_2.scala
@@ -1,0 +1,6 @@
+def processLine(line: String): Unit = {
+  Macro.transform {
+    line.split(" ").nn
+    ???
+  }
+}


### PR DESCRIPTION
Fixes #17009 
The problem here was with the sub typing check for `line.split(" ").nn`, which needed to confirm that:

```scala
(?2 : Array[String]) & Array[String]  <:  (?1 : Array[String]) & Array[String]
```
`TypeComparer` would eventually try to compare two skolem types:
```scala
(?2 : Array[String]) <: (?1 : Array[String])
```
The behavior of `TypeComparer` differs here when executed during the typer phase, where it always returns false for two skolem types, without checking the sub typing further. This makes sense for Typer, but not so much for the macro checks, which for `transparent inline`s end up being executed during Typer. I think the best solution here is to artificially change the phase in the checkingContext, so the checks done for transparent and non-transparent macros are the same. 