### PR TITLE
Fix #19789: Merge same TypeParamRef in orDominator

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -249,7 +249,8 @@ object TypeOps:
           mergeRefinedOrApplied(tp1, tp21) & mergeRefinedOrApplied(tp1, tp22)
         case _ =>
           fail
-      tp1 match {
+      if tp1 eq tp2 then tp1
+      else tp1 match {
         case tp1 @ RefinedType(parent1, name1, rinfo1) =>
           tp2 match {
             case RefinedType(parent2, `name1`, rinfo2) =>
@@ -273,6 +274,7 @@ object TypeOps:
           }
         case AndType(tp11, tp12) =>
           mergeRefinedOrApplied(tp11, tp2) & mergeRefinedOrApplied(tp12, tp2)
+        case tp1: TypeParamRef if tp1 == tp2 => tp1
         case _ => fail
       }
     }

--- a/tests/pos/i19789.scala
+++ b/tests/pos/i19789.scala
@@ -1,0 +1,5 @@
+type Kinded[F[_]] = F[Any] | F[Nothing]
+
+def values[F[_]]: Vector[Kinded[F]] = ???
+
+def mapValues[F[_], T](f: Kinded[F] => T): Vector[T] = values[F].map { case x => f(x) }


### PR DESCRIPTION
Fix #19789

Merge refined or applied types if they share the same `TypeParamRef` as tycon in `orDominator`.

