### PR TITLE
Refactor constant folding of applications

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1190,8 +1190,7 @@ trait Applications extends Compatibility {
           case _                                             => tree.withType(TryDynamicCallType)
         }
         if (typedFn.tpe eq TryDynamicCallType) tryDynamicTypeApply()
-        else
-          ConstFold(assignType(cpy.TypeApply(tree)(typedFn, typedArgs), typedFn, typedArgs))
+        else assignType(cpy.TypeApply(tree)(typedFn, typedArgs), typedFn, typedArgs)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1124,12 +1124,13 @@ trait Applications extends Compatibility {
         }
         app
       }
-    app1 match {
+    val app2 = app1 match {
       case Apply(Block(stats, fn), args) =>
         tpd.cpy.Block(app1)(stats, tpd.cpy.Apply(app1)(fn, args))
       case _ =>
         app1
     }
+    ConstFold(app2)
   }
 
   /** Typecheck an Apply node with a typed function and possibly-typed arguments coming from `proto` */
@@ -1189,7 +1190,8 @@ trait Applications extends Compatibility {
           case _                                             => tree.withType(TryDynamicCallType)
         }
         if (typedFn.tpe eq TryDynamicCallType) tryDynamicTypeApply()
-        else assignType(cpy.TypeApply(tree)(typedFn, typedArgs), typedFn, typedArgs)
+        else
+          ConstFold(assignType(cpy.TypeApply(tree)(typedFn, typedArgs), typedFn, typedArgs))
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4200,7 +4200,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
     def adaptToSubType(wtp: Type): Tree =
       // try converting a constant to the target type
-      ConstFold(tree).tpe.widenTermRefExpr.normalized match
+      tree.tpe.widenTermRefExpr.normalized match
         case ConstantType(x) =>
           val converted = x.convertTo(pt)
           if converted != null && (converted ne x) then

--- a/tests/pos/constfold.scala
+++ b/tests/pos/constfold.scala
@@ -15,4 +15,12 @@ object Test extends App {
     Console.println(A.y);
     Console.println(A.z);
     Console.println(A.s);
+
+    def f(x: 12): Int = 1
+    def f(x: Int): Double = 2
+    val x = f(12)
+    val _: Int = x
+    val y = f(2 * 6)
+    val _: Int = x
+
 }


### PR DESCRIPTION
Move them in typedApply/typedTypeApply instead of leaving them until adapt. This aligns these folds with folds of unary operations, which are done already in typedSelect and avoids potentially several calls to ConstFold when arguments are passed to overloaded methods.