### PR TITLE
Fix TermRef prefixes not having their type healed

### DIFF
--- a/compiler/src/dotty/tools/dotc/staging/HealType.scala
+++ b/compiler/src/dotty/tools/dotc/staging/HealType.scala
@@ -35,7 +35,7 @@ class HealType(pos: SrcPos)(using Context) extends TypeMap {
       case tp: TermRef =>
         val inconsistentRoot = levelInconsistentRootOfPath(tp)
         if inconsistentRoot.exists then levelError(inconsistentRoot, tp, pos)
-        else tp
+        else mapOver(tp)
       case tp: AnnotatedType =>
         derivedAnnotatedType(tp, apply(tp.parent), tp.annot)
       case _ =>

--- a/tests/pos-macros/i19767.scala
+++ b/tests/pos-macros/i19767.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+class ICons[K <: Singleton](val key: K)
+
+def filterX(using Quotes): Unit =
+  (??? : Expr[Any]) match
+    case '{ $y : ICons[k1] } => '{ ICons($y.key) }


### PR DESCRIPTION
Fixes #19767

In the minimization from the issue, after the splicing phase we ended up with a quote with illegal `k1` types, which should have been healed during the splicing phase:
```scala
'<k1$given2>{
  new ICons[(ICons[k1]#key : k1)](
  //...
```
To fix that, we now map over and heal the prefix of the TermRef as well, so we end up with:
```scala
'<k1$given2>{
  new ICons[(ICons[k1$given2]#key : k1$given2)](
  //...
```