### PR TITLE
Rollback constraints if `isSameType` failed second direction

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2304,7 +2304,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         Stats.record("cache same type")
         sames = new util.EqHashMap()
       val res =
-        try isSubType(tp1, tp2) && isSubType(tp2, tp1)
+        try rollbackConstraintsUnless(isSubType(tp1, tp2) && isSubType(tp2, tp1))
         finally
           sameLevel -= 1
           sames = savedSames


### PR DESCRIPTION
It turns out the following assertion does not hold in the current definition of `isSameType`
```scala 3
val preConstraint = constraint
val isSame = isSubType(tp1, tp2) && isSubType(tp2, tp1)
isSame.ensuring(_ || constraint == preConstraint)
```

I didn't try to form a minimised snippet where this would cause a problem. But as an example, the code in https://github.com/scala/scala3/issues/19955#issuecomment-2037681171 produces invalid constraints which lead to suspicious looking `<notypes>`s in the subtyping trace.