### PR TITLE
Regression: Fix match type extraction of a MatchAlias

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3518,7 +3518,7 @@ class MatchReducer(initctx: Context) extends TypeComparer(initctx) {
             stableScrut.member(typeMemberName) match
               case denot: SingleDenotation if denot.exists =>
                 val info = denot.info match
-                  case TypeAlias(alias)                => alias              // Extract the alias
+                  case alias: AliasingBounds           => alias.alias        // Extract the alias
                   case ClassInfo(prefix, cls, _, _, _) => prefix.select(cls) // Re-select the class from the prefix
                   case info => info // Notably, RealTypeBounds, which will eventually give a MatchResult.NoInstances
                 val infoRefersToSkolem = stableScrut.isInstanceOf[SkolemType] && stableScrut.occursIn(info)

--- a/tests/pos/match-type-extract-matchalias.scala
+++ b/tests/pos/match-type-extract-matchalias.scala
@@ -1,0 +1,11 @@
+trait Base:
+  type Value
+trait Sub[T <: Tuple] extends Base:
+  type Value = Tuple.Head[T]
+object Base:
+  type BaseOf[V] = Base { type Value = V }
+  type ExtractValue[B <: Base] = B match
+    case BaseOf[v] => v
+
+class Test:
+  val test: Base.ExtractValue[Sub[Int *: EmptyTuple]] = 1


### PR DESCRIPTION
Previously this failed with:

```
14 |    val x: Base.ExtractValue[Sub[Int *: EmptyTuple]] = 1
   |                                                       ^
   |           Found:    (1 : Int)
   |           Required: Base.ExtractValue[Sub[Int *: EmptyTuple]]
   |
   |           Note: a match type could not be fully reduced:
   |
   |             trying to reduce  Base.ExtractValue[Sub[Int *: EmptyTuple]]
   |             failed since selector Sub[Int *: EmptyTuple]
   |             does not uniquely determine parameter v in
   |               case Base.BaseOf[v] => v
   |             The computed bounds for the parameter are:
   |               v = Tuple.Head[Int *: EmptyTuple]
```

Because the match type logic incorrectly believed that `v` was a non-alias TypeBounds.

This used to work in 3.3 and regressed in 3.4.0.