### PR TITLE
Backport "Regression: Fix match type extraction of a MatchAlias" to 3.4.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3508,7 +3508,7 @@ class MatchReducer(initctx: Context) extends TypeComparer(initctx) {
             stableScrut.member(typeMemberName) match
               case denot: SingleDenotation if denot.exists =>
                 val info = denot.info match
-                  case TypeAlias(alias)                => alias              // Extract the alias
+                  case alias: AliasingBounds           => alias.alias        // Extract the alias
                   case ClassInfo(prefix, cls, _, _, _) => prefix.select(cls) // Re-select the class from the prefix
                   case info => info // Notably, RealTypeBounds, which will eventually give a MatchResult.NoInstances
                 val infoRefersToSkolem = stableScrut.isInstanceOf[SkolemType] && stableScrut.occursIn(info)

--- a/tests/pos/match-type-extract-matchalias.scala
+++ b/tests/pos/match-type-extract-matchalias.scala
@@ -1,0 +1,11 @@
+trait Base:
+  type Value
+trait Sub[T <: NonEmptyTuple] extends Base:
+  type Value = Tuple.Head[T]
+object Base:
+  type BaseOf[V] = Base { type Value = V }
+  type ExtractValue[B <: Base] = B match
+    case BaseOf[v] => v
+
+class Test:
+  val test: Base.ExtractValue[Sub[Int *: EmptyTuple]] = 1


### PR DESCRIPTION
Backports #20111 which fixes a regression introduced in 3.4.0.