### PR TITLE
Don't dealias when deciding which arguments to defer

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1714,8 +1714,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
          *  comparison will instantiate or constrain type variables first.
          */
         def isIncomplete(arg1: Type, arg2: Type): Boolean =
-          val arg1d = arg1.strippedDealias
-          val arg2d = arg2.strippedDealias
+          val arg1d = arg1.stripped
+          val arg2d = arg2.stripped
           (v >= 0) && (arg1d.isInstanceOf[AndType] || arg2d.isInstanceOf[OrType])
           ||
           (v <= 0) && (arg1d.isInstanceOf[OrType] || arg2d.isInstanceOf[AndType])

--- a/tests/pos/i20078/AbstractShapeBuilder.java
+++ b/tests/pos/i20078/AbstractShapeBuilder.java
@@ -1,0 +1,3 @@
+public abstract class AbstractShapeBuilder<B extends AbstractShapeBuilder<B, S>, S extends Shape> {
+	abstract public B addTrait(Trait trait);
+}

--- a/tests/pos/i20078/Shape.java
+++ b/tests/pos/i20078/Shape.java
@@ -1,0 +1,1 @@
+public interface Shape {}

--- a/tests/pos/i20078/Test.scala
+++ b/tests/pos/i20078/Test.scala
@@ -1,0 +1,3 @@
+@main def Test =
+  val builder: AbstractShapeBuilder[? <: AbstractShapeBuilder[?, ?], ? <: Shape] = ???
+  List.empty[Trait].foreach(builder.addTrait(_))

--- a/tests/pos/i20078/Trait.java
+++ b/tests/pos/i20078/Trait.java
@@ -1,0 +1,1 @@
+public interface Trait {}


### PR DESCRIPTION
Don't dealias when deciding which arguments to defer for subtype checking

Fixes #20078