### PR TITLE
REPL security filter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ val `scala3-language-server` = Build.`scala3-language-server`
 val `scala3-bench` = Build.`scala3-bench`
 val `scala3-bench-bootstrapped` = Build.`scala3-bench-bootstrapped`
 val `scala3-bench-micro` = Build.`scala3-bench-micro`
+val `scala3-repl-filter` = Build.`scala3-repl-filter`
 val `scala2-library-bootstrapped` = Build.`scala2-library-bootstrapped`
 val `scala2-library-tasty` = Build.`scala2-library-tasty`
 val `scala2-library-cc` = Build.`scala2-library-cc`

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -126,6 +126,7 @@ trait CommonScalaSettings:
   val encoding: Setting[String] = StringSetting(RootSetting, "encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding, aliases = List("--encoding"))
   val usejavacp: Setting[Boolean] = BooleanSetting(RootSetting, "usejavacp", "Utilize the java.class.path in classpath resolution.", aliases = List("--use-java-class-path"))
   val scalajs: Setting[Boolean] = BooleanSetting(RootSetting, "scalajs", "Compile in Scala.js mode (requires scalajs-library.jar on the classpath).", aliases = List("--scalajs"))
+  val replfilter: Setting[String] = StringSetting(RootSetting, "replfilter", "Apply given filter class to commands entered in the REPL.", "Canonical name of class", "", List("--replfilter"))
 end CommonScalaSettings
 
 /** -P "plugin" settings. Various tools might support plugins. */

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -126,7 +126,7 @@ trait CommonScalaSettings:
   val encoding: Setting[String] = StringSetting(RootSetting, "encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding, aliases = List("--encoding"))
   val usejavacp: Setting[Boolean] = BooleanSetting(RootSetting, "usejavacp", "Utilize the java.class.path in classpath resolution.", aliases = List("--use-java-class-path"))
   val scalajs: Setting[Boolean] = BooleanSetting(RootSetting, "scalajs", "Compile in Scala.js mode (requires scalajs-library.jar on the classpath).", aliases = List("--scalajs"))
-  val replfilter: Setting[String] = StringSetting(RootSetting, "replfilter", "Apply given filter class to commands entered in the REPL.", "Canonical name of class", "", List("--replfilter"))
+  val replfilter: Setting[String] = StringSetting(RootSetting, "replfilter", "Canonical name of class", "Apply given filter class to commands entered in the REPL.", "", List("--replfilter"))
 end CommonScalaSettings
 
 /** -P "plugin" settings. Various tools might support plugins. */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3,11 +3,10 @@ package dotc
 package parsing
 
 import scala.language.unsafeNulls
-
 import scala.annotation.internal.sharable
 import scala.collection.mutable.ListBuffer
 import scala.collection.immutable.BitSet
-import util.{ SourceFile, SourcePosition, NoSourcePosition }
+import util.{NoSourcePosition, SourceFile, SourcePosition}
 import Tokens.*
 import Scanners.*
 import xml.MarkupParsers.MarkupParser
@@ -15,7 +14,7 @@ import core.*
 import Flags.*
 import Contexts.*
 import Names.*
-import NameKinds.{WildcardParamName, QualifiedName}
+import NameKinds.{QualifiedName, WildcardParamName}
 import NameOps.*
 import ast.{Positioned, Trees}
 import ast.Trees.*
@@ -26,14 +25,16 @@ import Symbols.NoSymbol
 import ScriptParsers.*
 import Decorators.*
 import util.Chars
+
 import scala.annotation.tailrec
-import rewrites.Rewrites.{patch, overlapsPatch}
+import rewrites.Rewrites.{overlapsPatch, patch}
 import reporting.*
 import config.Feature
-import config.Feature.{sourceVersion, migrateTo3}
+import config.Feature.{migrateTo3, sourceVersion}
 import config.SourceVersion.*
 import config.SourceVersion
 import dotty.tools.dotc.config.MigrationVersion
+import dotty.tools.repl.ReplFilter
 
 object Parsers {
 
@@ -4499,7 +4500,10 @@ object Parsers {
       topstats() match {
         case List(stat @ PackageDef(_, _)) => stat
         case Nil => EmptyTree  // without this case we'd get package defs without positions
-        case stats => PackageDef(Ident(nme.EMPTY_PACKAGE), stats)
+        case stats =>
+          val passing = ReplFilter.pass(stats)
+          if (passing.nonEmpty) PackageDef(Ident(nme.EMPTY_PACKAGE), passing)
+          else EmptyTree
       }
     }
   }

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -148,7 +148,7 @@ class ReplDriver(settings: Array[String],
       s"""Welcome to Scala $simpleVersionString ($javaVersion, Java $javaVmName).
          |Type in expressions for evaluation. Or try :help.""".stripMargin)
 
-    ReplFilter.init(rootCtx).swap.toOption.collect {
+    ReplFilter.init(rootCtx, out).swap.toOption.collect {
       case e: Throwable =>
         out.println(s"${Console.RED}Error loading REPL filter, all entries will be passing${Console.RESET}")
         out.println(s"${Console.RED}- ${e.getMessage}${Console.RESET}")

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -148,6 +148,12 @@ class ReplDriver(settings: Array[String],
       s"""Welcome to Scala $simpleVersionString ($javaVersion, Java $javaVmName).
          |Type in expressions for evaluation. Or try :help.""".stripMargin)
 
+    ReplFilter.init(rootCtx).swap.toOption.collect {
+      case e: Throwable =>
+        out.println(s"${Console.RED}Error loading REPL filter, all entries will be passing${Console.RESET}")
+        out.println(s"${Console.RED}- ${e.getMessage}${Console.RESET}")
+    }
+
     /** Blockingly read a line, getting back a parse result */
     def readLine()(using state: State): ParseResult = {
       given Context = state.context

--- a/compiler/src/dotty/tools/repl/ReplFilter.scala
+++ b/compiler/src/dotty/tools/repl/ReplFilter.scala
@@ -1,0 +1,38 @@
+package dotty.tools.repl
+
+import dotty.tools.dotc.core.Contexts.*
+
+import java.io.PrintStream
+import java.lang.reflect.Constructor
+import scala.util.{Failure, Success, Try}
+
+
+trait ReplFilter
+
+object ReplFilter:
+  private var replFilterOpt: Option[ReplFilter] = None
+  private var isInitialized_ : Boolean = false
+  def init(rootCtx: Context): Either[Throwable, ReplFilter] =
+    val returnValue =
+      rootCtx.settings.rootSettings.find(_.name == "-replfilter") match
+        case Some(replFilterSetting) =>
+          val replFilterClassName = inContext[String](rootCtx){replFilterSetting.value.asInstanceOf[String]}
+          Try(Class.forName(replFilterClassName)) match
+            case Success(clazz : Class[?]) =>
+              clazz.getDeclaredConstructor() match
+                case c: Constructor[?] => 
+                  c.newInstance() match
+                    case rf: ReplFilter => 
+                      replFilterOpt = Some(rf)
+                      Right(rf)
+                    case rf if rf != null => Left(RuntimeException(s"Provided REPL filter class has an inappropriate type"))
+                    case _ => Left(RuntimeException(s"Provided REPL filter class can't be instantiated"))
+                case _ => Left(RuntimeException(s"Provided REPL filter class does not have a valid constructor"))
+            case Success(_) => Left(RuntimeException(s"Class $replFilterClassName is not of type ReplFilter"))
+            case Failure(error: ClassNotFoundException) => Left(RuntimeException(s"REPL filter class can't be located on classpath"))
+            case Failure(error) => Left(error)
+        case None => Left(RuntimeException("The setting -replfilter does not exist"))
+    isInitialized_ = true
+    returnValue
+
+  def isInitialized: Boolean = isInitialized_

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1400,6 +1400,9 @@ object Build {
       BuildInfoPlugin.buildInfoDefaultSettings
     )
 
+  lazy val `scala3-repl-filter` = project.in(file("repl-filter")).
+    dependsOn(dottyCompiler(Bootstrapped)).withCommonSettings(Bootstrapped)
+
   /** A sandbox to play with the Scala.js back-end of dotty.
    *
    *  This sandbox is compiled with dotty with support for Scala.js. It can be

--- a/repl-filter/src/dotty/tools/replfilter/DemoFilter.scala
+++ b/repl-filter/src/dotty/tools/replfilter/DemoFilter.scala
@@ -1,0 +1,9 @@
+package dotty.tools.replfilter
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.repl.ReplFilter
+
+
+class DemoFilter extends ReplFilter("FORBIDDEN\nThis operation is not permitted, skipping.."):
+  def passImpl(stats: List[untpd.Tree]): Option[List[untpd.Tree]] =
+    None


### PR DESCRIPTION
This REPL security filter implementation lets users create filters to decide what statements can be evaluated in the REPL and what are forbidden.

I'm sharing this in this phase because I need a pre-review before going on with all the steps in the contributing guidelines.

I have issues creating a test because I have problems handling the classpath. Firstly, I'm about to compile a DemoFilter being added as a project to develop a test run, but I need help finding a best practice for handling the classpath. As you can see, I let the user choose a filter with a CLI setting, and for that reason, I needed to use `Class.forName`, which is bound to custom classloader implementations.

Can you give me guidance regarding how to go on with this PR?