### PR TITLE
Fix inline match on blocks with multiple statements

### DIFF
--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -812,7 +812,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
       )
 
       assert(instructions == expected,
-        "`i was not properly beta-reduced in `test`\n" + diffInstructions(instructions, expected))
+        "`i was not properly inlined in `test`\n" + diffInstructions(instructions, expected))
 
     }
   }

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -785,4 +785,36 @@ class InlineBytecodeTests extends DottyBytecodeTest {
     }
   }
 
+  @Test def inline_match_scrutinee_with_side_effect = {
+    val source = """class Test:
+                   |  inline def inlineTest(): Int =
+                   |    inline {
+                   |      println("scrutinee")
+                   |      (1, 2)
+                   |    } match
+                   |      case (e1, e2) => e1 + e2
+                   |
+                   |  def test: Int = inlineTest()
+                 """.stripMargin
+
+    checkBCode(source) { dir =>
+      val clsIn      = dir.lookupName("Test.class", directory = false).input
+      val clsNode    = loadClassNode(clsIn)
+
+      val fun = getMethod(clsNode, "test")
+      val instructions = instructionsFromMethod(fun)
+      val expected = List(
+        Field(GETSTATIC, "scala/Predef$", "MODULE$", "Lscala/Predef$;"),
+        Ldc(LDC, "scrutinee"),
+        Invoke(INVOKEVIRTUAL, "scala/Predef$", "println", "(Ljava/lang/Object;)V", false),
+        Op(ICONST_3),
+        Op(IRETURN),
+      )
+
+      assert(instructions == expected,
+        "`i was not properly beta-reduced in `test`\n" + diffInstructions(instructions, expected))
+
+    }
+  }
+
 }

--- a/tests/pos/i18151a.scala
+++ b/tests/pos/i18151a.scala
@@ -1,0 +1,10 @@
+case class El[A](attr: String, child: String)
+
+transparent inline def inlineTest(): String =
+  inline {
+    val el: El[Any] = El("1", "2")
+    El[Any](el.attr, el.child)
+  } match
+    case El(attr, child) => attr + child
+
+def test: Unit = inlineTest()

--- a/tests/pos/i18151b.scala
+++ b/tests/pos/i18151b.scala
@@ -1,0 +1,10 @@
+case class El[A](val attr: String, val child: String)
+
+transparent inline def tmplStr(inline t: El[Any]): String =
+  inline t match
+    case El(attr, child) => attr + child
+
+def test: Unit = tmplStr {
+  val el = El("1", "2")
+  El[Any](el.attr, null)
+}

--- a/tests/pos/i18151c.scala
+++ b/tests/pos/i18151c.scala
@@ -1,0 +1,39 @@
+import scala.compiletime.*
+import scala.compiletime.ops.any.ToString
+
+trait Attr
+case object EmptyAttr extends Attr
+transparent inline def attrStr(inline a: Attr): String = inline a match
+  case EmptyAttr => ""
+transparent inline def attrStrHelper(inline a: Attr): String = inline a match
+  case EmptyAttr => ""
+trait TmplNode
+case class El[T <: String & Singleton, A <: Attr, C <: Tmpl](val tag: T, val attr: A, val child: C)
+    extends TmplNode
+case class Sib[L <: Tmpl, R <: Tmpl](left: L, right: R) extends TmplNode
+type TmplSingleton = String | Char | Int | Long | Float | Double | Boolean
+type Tmpl = TmplNode | Unit | (TmplSingleton & Singleton)
+transparent inline def tmplStr(inline t: Tmpl): String = inline t match
+  case El(tag, attr, child) => inline attrStr(attr) match
+      case "" => "<" + tag + ">" + tmplStr(child)
+      case x  => "<" + tag + " " + x + ">" + tmplStr(child)
+  case Sib(left, right) => inline tmplStr(right) match
+      case ""    => tmplStr(left)
+      case right => tmplStrHelper(left) + right
+  case ()                     => ""
+  case s: (t & TmplSingleton) => constValue[ToString[t]]
+transparent inline def tmplStrHelper(inline t: Tmpl): String = inline t match
+  case El(tag, attr, child) => inline (tmplStr(child), attrStr(attr)) match
+      case ("", "")      => "<" + tag + "/>"
+      case (child, "")   => "<" + tag + ">" + child + "</" + tag + ">"
+      case ("", attr)    => "<" + tag + " " + attr + "/>"
+      case (child, attr) => "<" + tag + " " + attr + ">" + child + "</" + tag + ">"
+  case Sib(left, right)       => tmplStrHelper(left) + tmplStrHelper(right)
+  case ()                     => ""
+  case s: (t & TmplSingleton) => constValue[ToString[t]]
+transparent inline def el(tag: String & Singleton): El[tag.type, EmptyAttr.type, Unit] =
+  El(tag, EmptyAttr, ())
+extension [T <: String & Singleton, A <: Attr, C <: Tmpl](el: El[T, A, C])
+  transparent inline def >>[C2 <: Tmpl](child: C2) = El(el.tag, el.attr, el.child ++ child)
+
+extension [L <: Tmpl](left: L) transparent inline def ++[R <: Tmpl](right: R) = Sib(left, right)


### PR DESCRIPTION
Only the last expression of the block is considered as the inlined scrutinee. Otherwise we may not reduce as much as we should. We also need to make sure that side effects and bindings in the scrutinee are not duplicated.

Inlined are converted into blocks to be able to apply the previous semantics without breaking the tree source files.

Fixes #18151