### PR TITLE
Fix infinite loop in Mirror synthesis of unreducible match type

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -379,7 +379,9 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
                 // avoid type aliases for tuples
                 Right(MirrorSource.GenericTuple(types))
               case _ => reduce(tp.underlying)
-          case tp: MatchType => reduce(tp.tryNormalize.orElse(tp.superType))
+          case tp: MatchType =>
+            val n = tp.tryNormalize
+            if n.exists then reduce(n) else Left(i"its subpart `$tp` is an unreducible match type.")
           case _ => reduce(tp.superType)
       case tp @ AndType(l, r) =>
         for

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -379,7 +379,7 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
                 // avoid type aliases for tuples
                 Right(MirrorSource.GenericTuple(types))
               case _ => reduce(tp.underlying)
-          case tp: MatchType => reduce(tp.normalized)
+          case tp: MatchType => reduce(tp.tryNormalize.orElse(tp.superType))
           case _ => reduce(tp.superType)
       case tp @ AndType(l, r) =>
         for

--- a/tests/neg/i19198.scala
+++ b/tests/neg/i19198.scala
@@ -4,6 +4,10 @@ import compiletime.summonInline
 type DoesNotReduce[T] = T match
   case String => Any
 
+type DoesNotReduce2[T] <: T = T match
+  case String => T
+
 class Foo
 @main def Test: Unit =
   summonInline[Mirror.Of[DoesNotReduce[Option[Int]]]] // error
+  summonInline[Mirror.Of[DoesNotReduce2[Option[Int]]]] // error

--- a/tests/neg/i19198.scala
+++ b/tests/neg/i19198.scala
@@ -1,0 +1,9 @@
+import deriving.Mirror
+import compiletime.summonInline
+
+type DoesNotReduce[T] = T match
+  case String => Any
+
+class Foo
+@main def Test: Unit =
+  summonInline[Mirror.Of[DoesNotReduce[Option[Int]]]] // error


### PR DESCRIPTION
This regressed in f7e2e7ce752f9c472c06fe1685464879fa06f6f7 (present in 3.4.0).
The second commit fixes a soundness bug.