### PR TITLE
Improve reporting in staging about the possible use of an incorrect class loader

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -661,4 +661,6 @@ object Run {
         report.enrichErrorMessage(errorMessage)
       else
         errorMessage
+    def doNotEnrichErrorMessage: Unit =
+      if run != null then run.myEnrichedErrorMessage = true
 }

--- a/staging/src/scala/quoted/staging/QuoteCompiler.scala
+++ b/staging/src/scala/quoted/staging/QuoteCompiler.scala
@@ -48,7 +48,9 @@ private class QuoteCompiler extends Compiler:
 
   override def newRun(implicit ctx: Context): ExprRun =
     reset()
-    new ExprRun(this, ctx.addMode(Mode.ReadPositions))
+    val run = new ExprRun(this, ctx.addMode(Mode.ReadPositions))
+    run.doNotEnrichErrorMessage
+    run
 
   def outputClassName: TypeName = "Generated$Code$From$Quoted".toTypeName
 

--- a/tests/run-staging/i19170c.check
+++ b/tests/run-staging/i19170c.check
@@ -1,0 +1,1 @@
+exception thrown, no additional printlns

--- a/tests/run-staging/i19170c.scala
+++ b/tests/run-staging/i19170c.scala
@@ -1,0 +1,16 @@
+import scala.quoted.*
+
+given staging.Compiler =
+  staging.Compiler.make(getClass.getClassLoader.getParent) // different classloader that 19170b.scala
+class A(i: Int)
+
+def f(i: Expr[Int])(using Quotes): Expr[A] = { '{ new A($i) } }
+
+@main def Test = {
+  try
+    val g: Int => A = staging.run { '{ (i: Int) => ${ f('{i}) } } }
+    println(g(3))
+  catch case ex: Exception =>
+    assert(ex.getMessage().startsWith("An unhandled exception was thrown in the staging compiler."), ex.getMessage())
+    println("exception thrown, no additional printlns")
+}

--- a/tests/run-staging/i19176b.check
+++ b/tests/run-staging/i19176b.check
@@ -1,0 +1,1 @@
+exception thrown, no additional printlns

--- a/tests/run-staging/i19176b.scala
+++ b/tests/run-staging/i19176b.scala
@@ -1,0 +1,14 @@
+import scala.quoted.*
+
+given staging.Compiler =
+  staging.Compiler.make(getClass.getClassLoader.getParent) // we want to make sure the classloader is incorrect
+
+class A
+
+@main def Test =
+  try
+    val f: (A, Int) => Int = staging.run { '{ (q: A, x: Int) => x } }
+    f(new A, 3)
+  catch case ex: Exception =>
+    assert(ex.getMessage().startsWith("An unhandled exception was thrown in the staging compiler."), ex.getMessage())
+    println("exception thrown, no additional printlns")


### PR DESCRIPTION
(Hopefully) closes #19170 and #19176 and extends the changes from #19428

I do not really think it's possible to comprehensively check whether the class loader that is being passed into the staging.compiler is the correct one or not, so instead I tried improving the reporting here (like in the previous PR above) coming from the compiler, so that:
* We do not print to stdout information about the compiler crash like what happened in #19176 (I think it's more confusing than useful to get that on runtime, can get lost in logs etc)
* We enrich the errors coming from the compiler with additional hints about using the correct classloader

@nicolasstucki what do you think about this? I don't really know what else we can do for those 2 issues
