### PR TITLE
Normalize types in `implicitScope` too

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -724,7 +724,7 @@ trait ImplicitRunInfo:
               companions ++= iscopeRefs(t.underlying)
       end addCompanions
 
-      def addPath(pre: Type): Unit = pre.dealias match
+      def addPath(pre: Type): Unit = pre.dealias.normalized match
         case pre: ThisType if pre.cls.is(Module) && pre.cls.isStaticOwner =>
           addPath(pre.cls.sourceModule.termRef)
         case pre: TermRef if !isExcluded(pre.symbol) =>
@@ -817,7 +817,7 @@ trait ImplicitRunInfo:
                   else AndType.make(apply(lo), apply(hi))
                 case u => apply(u)
 
-          def apply(t: Type) = t.dealias match
+          def apply(t: Type) = t.dealias.normalized match
             case t: TypeRef =>
               if t.symbol.isClass || isAnchor(t.symbol) then t else applyToUnderlying(t)
             case t: TypeVar => apply(t.underlying)

--- a/tests/pos/i20136/A_1.scala
+++ b/tests/pos/i20136/A_1.scala
@@ -1,0 +1,8 @@
+package a
+
+trait Expr:
+  type Value
+object Expr:
+  type Of[V] = Expr { type Value = V }
+  type ExtractValue[E <: Expr] = E match
+    case Expr.Of[v] => v

--- a/tests/pos/i20136/B_2.scala
+++ b/tests/pos/i20136/B_2.scala
@@ -1,0 +1,8 @@
+package a
+
+trait TC[E <: Expr]:
+  type Elem = Expr.ExtractValue[E]
+class BIExpr extends Expr:
+  type Value = BigInt
+class Foo extends TC[BIExpr]:
+  val v: Elem = 0


### PR DESCRIPTION
This is needed for the same reason than the normalization in `computeIScope` added by 90c3fbde37a70fdd366ed25d2082e05ddf24ac3e.

IMO, it's already very hard to figure out where `.normalize` should be used, but the fact that it sometimes is only needed under separate compilation is really error-prone and leads to very hard to debug issues. Ideally we should deal with the same types under separate and join compilation.

While I'm at it, I added one defensively in `addPath` since I can't tell whether it is needed or not.

Fixes #20136.