### PR TITLE
Load docstrings lazily from TASTy

### DIFF
--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -79,7 +79,7 @@ class Driver {
     Positioned.init(using ictx)
 
     inContext(ictx) {
-      if !ctx.settings.YdropComments.value || ctx.settings.YreadComments.value then
+      if !ctx.settings.YdropComments.value then
         ictx.setProperty(ContextDoc, new ContextDocstrings)
       val fileNamesOrNone = command.checkUsage(summary, sourcesRequired)(using ctx.settings)(using ctx.settingsState)
       fileNamesOrNone.map { fileNames =>

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -394,7 +394,7 @@ private sealed trait YSettings:
   val YcheckReentrant: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycheck-reentrant", "Check that compiled program does not contain vars that can be accessed from a global root.")
   val YdropComments: Setting[Boolean] = BooleanSetting(ForkSetting, "Ydrop-docs", "Drop documentation when scanning source files.", aliases = List("-Ydrop-comments"))
   val YcookComments: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycook-docs", "Cook the documentation (type check `@usecase`, etc.)", aliases = List("-Ycook-comments"))
-  val YreadComments: Setting[Boolean] = BooleanSetting(ForkSetting, "Yread-docs", "Read documentation from tasty.")
+  val YreadDocsEagerly: Setting[Boolean] = BooleanSetting(ForkSetting, "Yread-docs", "Read documentation eagerly from TASTy")
   val YforceSbtPhases: Setting[Boolean] = BooleanSetting(ForkSetting, "Yforce-sbt-phases", "Run the phases used by sbt for incremental compilation (ExtractDependencies and ExtractAPI) even if the compiler is ran outside of sbt, for debugging.")
   val YdumpSbtInc: Setting[Boolean] = BooleanSetting(ForkSetting, "Ydump-sbt-inc", "For every compiled foo.scala, output the API representation and dependencies used for sbt incremental compilation in foo.inc, implies -Yforce-sbt-phases.")
   val YcheckAllPatmat: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycheck-all-patmat", "Check exhaustivity and redundancy of all pattern matching (used for testing the algorithm).")

--- a/compiler/src/dotty/tools/dotc/core/Comments.scala
+++ b/compiler/src/dotty/tools/dotc/core/Comments.scala
@@ -44,8 +44,8 @@ object Comments {
     def registerLoader(sym: Symbol, loader: () => Option[Comment]): Unit =
       docstrings.update(sym, CommentLoader(loader))
 
-    def addDocstring(sym: Symbol, doc: Option[Comment]): Unit =
-      doc.foreach(d => docstrings.update(sym, d))
+    def addDocstring(sym: Symbol, doc: Comment): Unit =
+      docstrings.update(sym, doc)
   }
 
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -2169,7 +2169,7 @@ class Definitions {
   @tu lazy val LazyValsControlState = requiredClass(s"$LazyValsModuleName.LazyValControlState")
 
   def addSyntheticSymbolsComments(using Context): Unit =
-    def add(sym: Symbol, doc: String) = ctx.docCtx.foreach(_.addDocstring(sym, Some(Comment(NoSpan, doc))))
+    def add(sym: Symbol, doc: String) = ctx.docCtx.foreach(_.addDocstring(sym, Comment(NoSpan, doc)))
 
     add(AnyClass,
     """/** Class `Any` is the root of the Scala class hierarchy.  Every class in a Scala

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -366,9 +366,10 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
     if sym.is(Method) && sym.owner.isClass then
       profile.recordMethodSize(sym, (currentAddr.index - addr.index) max 1, mdef.span)
     for docCtx <- ctx.docCtx do
-      val comment = docCtx.docstrings.lookup(sym)
-      if comment != null then
-        docStrings(mdef) = comment
+      docCtx.docstring(sym) match
+        case Some(comment) =>
+          docStrings(mdef) = comment
+        case _ =>
   }
 
   def pickleParam(tree: Tree)(using Context): Unit = {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -982,10 +982,7 @@ class TreeUnpickler(reader: TastyReader,
         sym.info = ta.avoidPrivateLeaks(sym)
 
       commentUnpicklerOpt.foreach { commentUnpickler =>
-        def loadComment() =
-          val comment = commentUnpickler.commentAt(start)
-          tree.setComment(comment) // TODO should this be set?
-          comment
+        def loadComment() = commentUnpickler.commentAt(start)
         if ctx.settings.YreadDocsEagerly.value then
           ctx.docCtx.get.addDocstring(tree.symbol, loadComment())
         else

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -981,13 +981,15 @@ class TreeUnpickler(reader: TastyReader,
       if !sym.isType && !sym.is(ParamAccessor) then
         sym.info = ta.avoidPrivateLeaks(sym)
 
-      if (ctx.settings.YreadComments.value) {
-        assert(ctx.docCtx.isDefined, "`-Yread-docs` enabled, but no `docCtx` is set.")
-        commentUnpicklerOpt.foreach { commentUnpickler =>
+      commentUnpicklerOpt.foreach { commentUnpickler =>
+        def loadComment() =
           val comment = commentUnpickler.commentAt(start)
-          ctx.docCtx.get.addDocstring(tree.symbol, comment)
-          tree.setComment(comment)
-        }
+          tree.setComment(comment) // TODO should this be set?
+          comment
+        if ctx.settings.YreadDocsEagerly.value then
+          ctx.docCtx.get.addDocstring(tree.symbol, loadComment())
+        else
+          ctx.docCtx.get.registerLoader(tree.symbol, loadComment)
       }
 
       tree.setDefTree

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -984,7 +984,7 @@ class TreeUnpickler(reader: TastyReader,
       commentUnpicklerOpt.foreach { commentUnpickler =>
         def loadComment() = commentUnpickler.commentAt(start)
         if ctx.settings.YreadDocsEagerly.value then
-          ctx.docCtx.get.addDocstring(tree.symbol, loadComment())
+          loadComment().foreach(doc => ctx.docCtx.get.addDocstring(tree.symbol, doc))
         else
           ctx.docCtx.get.registerLoader(tree.symbol, loadComment)
       }

--- a/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/IDEDecompilerDriver.scala
@@ -19,7 +19,6 @@ class IDEDecompilerDriver(val settings: List[String]) extends dotc.Driver {
 
   private val myInitCtx: Context = {
     val rootCtx = initCtx.fresh.addMode(Mode.Interactive | Mode.ReadPositions)
-    rootCtx.setSetting(rootCtx.settings.YreadComments, true)
     rootCtx.setSetting(rootCtx.settings.YretainTrees, true)
     rootCtx.setSetting(rootCtx.settings.fromTasty, true)
     val ctx = setup(settings.toArray :+ "dummy.scala", rootCtx).get._2

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -34,7 +34,6 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
     val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions).addMode(Mode.Interactive)
     rootCtx.setSetting(rootCtx.settings.YretainTrees, true)
     rootCtx.setSetting(rootCtx.settings.YcookComments, true)
-    rootCtx.setSetting(rootCtx.settings.YreadComments, true)
     val ctx = setup(settings.toArray, rootCtx) match
       case Some((_, ctx)) => ctx
       case None => rootCtx

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -203,7 +203,6 @@ class Pickler extends Phase {
         super.runOn(units)
     if ctx.settings.YtestPickler.value then
       val ctx2 = ctx.fresh
-        .setSetting(ctx.settings.YreadComments, true)
         .setSetting(ctx.settings.YshowPrintErrors, true)
       testUnpickler(
         using ctx2

--- a/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Docstrings.scala
@@ -43,7 +43,7 @@ object Docstrings {
           }
 
           val commentWithUsecases = expanded.copy(usecases = typedUsecases)
-          docCtx.addDocstring(sym, Some(commentWithUsecases))
+          docCtx.addDocstring(sym, commentWithUsecases)
           commentWithUsecases
         }
     }
@@ -52,7 +52,7 @@ object Docstrings {
     val tplExp = docCtx.templateExpander
     tplExp.defineVariables(sym)
     val newComment = comment.expand(tplExp.expandedDocComment(sym, owner, _))
-    docCtx.addDocstring(sym, Some(newComment))
+    docCtx.addDocstring(sym, newComment)
     newComment
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -501,7 +501,7 @@ class Namer { typer: Typer =>
 
   def setDocstring(sym: Symbol, tree: Tree)(using Context): Unit = tree match {
     case t: MemberDef if t.rawComment.isDefined =>
-      ctx.docCtx.foreach(_.addDocstring(sym, t.rawComment))
+      ctx.docCtx.foreach(_.addDocstring(sym, t.rawComment.get))
     case t: ExtMethods =>
       for meth <- t.methods.find(_.span.point == sym.span.point) do
         setDocstring(sym, meth)

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -83,7 +83,6 @@ class ReplDriver(settings: Array[String],
   private def initialCtx(settings: List[String]) = {
     val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions | Mode.Interactive)
     rootCtx.setSetting(rootCtx.settings.YcookComments, true)
-    rootCtx.setSetting(rootCtx.settings.YreadComments, true)
     setupRootCtx(this.settings ++ settings, rootCtx)
   }
 

--- a/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
@@ -108,10 +108,6 @@ class CommentPicklingTest {
   }
 
   private class UnpicklingDriver extends Driver {
-    override def initCtx =
-      val ctx = super.initCtx.fresh
-      ctx.setSetting(ctx.settings.YreadComments, true)
-      ctx
 
     def unpickle[T](args: Array[String], files: List[File])(fn: (List[tpd.Tree], Context) => T): T = {
       implicit val ctx: Context = setup(args, initCtx).map(_._2).getOrElse(initCtx)

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
@@ -31,7 +31,7 @@ class SnippetCompiler(
       rootCtx.setSetting(rootCtx.settings.experimental, true)
       rootCtx.setSetting(rootCtx.settings.YretainTrees, true)
       rootCtx.setSetting(rootCtx.settings.YcookComments, true)
-      rootCtx.setSetting(rootCtx.settings.YreadComments, true)
+      rootCtx.setSetting(rootCtx.settings.YreadDocsEagerly, true)
       rootCtx.setSetting(rootCtx.settings.color, "never")
       rootCtx.setSetting(rootCtx.settings.XimportSuggestionTimeout, 0)
 

--- a/scaladoc/src/scala/tasty/inspector/TastyInspector.scala
+++ b/scaladoc/src/scala/tasty/inspector/TastyInspector.scala
@@ -103,7 +103,7 @@ object TastyInspector:
         reset()
         val ctx2 = ctx.fresh
             .addMode(Mode.ReadPositions)
-            .setSetting(ctx.settings.YreadComments, true)
+            .setSetting(ctx.settings.YreadDocsEagerly, true)
         new TASTYRun(this, ctx2)
 
     new InspectorDriver

--- a/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
+++ b/tasty-inspector/src/scala/tasty/inspector/TastyInspector.scala
@@ -100,7 +100,6 @@ object TastyInspector:
         reset()
         val ctx2 = ctx.fresh
             .addMode(Mode.ReadPositions)
-            .setSetting(ctx.settings.YreadComments, true)
         new TASTYRun(this, ctx2)
 
     new InspectorDriver

--- a/tests/run-macros/i20106.check
+++ b/tests/run-macros/i20106.check
@@ -1,0 +1,16 @@
+docs from same compilation run:
+Some(/**
+ * my doc string for Main
+ *
+ * @param tracks track listing
+ * */)
+docs loaded from tasty:
+Some(/**
+ * my doc string for Main
+ *
+ * @param tracks track listing
+ * */)
+docs from same compilation run:
+Some(/**
+ * Doc of Test
+ * */)

--- a/tests/run-macros/i20106/Macro_1.scala
+++ b/tests/run-macros/i20106/Macro_1.scala
@@ -1,0 +1,12 @@
+import scala.quoted.*
+
+object Doc {
+  inline def of[A]: Option[String] = ${ ofImpl[A] }
+
+  def ofImpl[A: Type](using Quotes): Expr[Option[String]] = {
+    import quotes.reflect.*
+
+    val symbol = TypeRepr.of[A].typeSymbol
+    Expr(symbol.docstring)
+  }
+}

--- a/tests/run-macros/i20106/Main_1.scala
+++ b/tests/run-macros/i20106/Main_1.scala
@@ -1,0 +1,14 @@
+/**
+ * my doc string for Main
+ *
+ * @param tracks track listing
+ * */
+
+class Main(tracks: String)
+
+object Main {
+  def printdoc(): Unit = {
+    val docString = Doc.of[Main]
+    println(docString)
+  }
+}

--- a/tests/run-macros/i20106/Test_2.scala
+++ b/tests/run-macros/i20106/Test_2.scala
@@ -1,0 +1,19 @@
+/**
+ * Doc of Test
+ * */
+class Test
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    println("docs from same compilation run:")
+    Main.printdoc()
+
+    println("docs loaded from tasty:")
+    val docString = Doc.of[Main]
+    println(docString)
+
+    println("docs from same compilation run:")
+    val docStringTest = Doc.of[Test]
+    println(docStringTest)
+  }
+}


### PR DESCRIPTION
Now we are always able to load docstrings from TASTy, even if `-Yread-docs` is not set. The `-Yread-docs` flag loads the doc strings eagerly, as it did before.

Fixes #20106