### PR TITLE
write pipelined tasty in parallel.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/ClassfileWriters.scala
+++ b/compiler/src/dotty/tools/backend/jvm/ClassfileWriters.scala
@@ -20,7 +20,11 @@ import dotty.tools.io.JarArchive
 
 import scala.language.unsafeNulls
 
-
+/** !!! This file is now copied in `dotty.tools.io.FileWriters` in a more general way that does not rely upon
+ * `PostProcessorFrontendAccess`, this should probably be changed to wrap that class instead.
+ *
+ * Until then, any changes to this file should be copied to `dotty.tools.io.FileWriters` as well.
+ */
 class ClassfileWriters(frontendAccess: PostProcessorFrontendAccess) {
   type NullableFile =  AbstractFile | Null
   import frontendAccess.{compilerSettings, backendReporting}

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
 import scala.compiletime.uninitialized
 import java.util.concurrent.TimeoutException
 
-import scala.concurrent.duration.given
+import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 
 class GenBCode extends Phase { self =>
@@ -94,20 +94,15 @@ class GenBCode extends Phase { self =>
     try
       val result = super.runOn(units)
       generatedClassHandler.complete()
-      for holder <- ctx.asyncTastyPromise do
-        try
-          val asyncState = Await.result(holder.promise.future, 5.seconds)
-          for reporter <- asyncState.pending do
-            reporter.relayReports(frontendAccess.backendReporting)
-        catch
-          case _: TimeoutException =>
-            report.error(
-              """Timeout (5s) in backend while waiting for async writing of TASTy files to -Yearly-tasty-output,
-                |  this may be a bug in the compiler.
-                |
-                |Alternatively consider turning off pipelining for this project.""".stripMargin
-            )
-      end for
+      try
+        for
+          async <- ctx.run.nn.asyncTasty
+          bufferedReporter <- async.sync()
+        do
+          bufferedReporter.relayReports(frontendAccess.backendReporting)
+      catch
+        case ex: Exception =>
+          report.error(s"exception from future: $ex, (${Option(ex.getCause())})")
       result
     finally
       // frontendAccess and postProcessor are created lazilly, clean them up only if they were initialized

--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -98,11 +98,15 @@ class CompilationUnit protected (val source: SourceFile, val info: CompilationUn
     depRecorder.clear()
     if !suspended then
       suspended = true
-      ctx.run.nn.suspendedUnits += this
+      val currRun = ctx.run.nn
+      currRun.suspendedUnits += this
+      val isInliningPhase = ctx.phase == Phases.inliningPhase
       if ctx.settings.XprintSuspension.value then
-        ctx.run.nn.suspendedHints += (this -> hint)
-      if ctx.phase == Phases.inliningPhase then
+        currRun.suspendedHints += (this -> (hint, isInliningPhase))
+      if isInliningPhase then
         suspendedAtInliningPhase = true
+      else
+        currRun.suspendedAtTyperPhase = true
     throw CompilationUnit.SuspendException()
 
   private var myAssignmentSpans: Map[Int, List[Span]] | Null = null

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -66,6 +66,13 @@ class Driver {
 
   protected def command: CompilerCommand = ScalacCommand
 
+  private def setupAsyncTasty(ictx: FreshContext): Unit = inContext(ictx):
+    ictx.settings.YearlyTastyOutput.value match
+      case earlyOut if earlyOut.isDirectory && earlyOut.exists =>
+        ictx.setInitialAsyncTasty()
+      case _ =>
+        () // do nothing
+
   /** Setup context with initialized settings from CLI arguments, then check if there are any settings that
    *  would change the default behaviour of the compiler.
    *
@@ -82,6 +89,7 @@ class Driver {
     Positioned.init(using ictx)
 
     inContext(ictx) {
+      setupAsyncTasty(ictx)
       if !ctx.settings.YdropComments.value || ctx.settings.YreadComments.value then
         ictx.setProperty(ContextDoc, new ContextDocstrings)
       val fileNamesOrNone = command.checkUsage(summary, sourcesRequired)(using ctx.settings)(using ctx.settingsState)

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -31,11 +31,9 @@ import StdNames.nme
 import compiletime.uninitialized
 
 import scala.annotation.internal.sharable
-import scala.concurrent.Promise
 
 import DenotTransformers.DenotTransformer
 import dotty.tools.dotc.profile.Profiler
-import dotty.tools.dotc.transform.Pickler.AsyncTastyHolder
 import dotty.tools.dotc.sbt.interfaces.{IncrementalCallback, ProgressCallback}
 import util.Property.Key
 import util.Store
@@ -56,9 +54,8 @@ object Contexts {
   private val (importInfoLoc,        store9) = store8.newLocation[ImportInfo | Null]()
   private val (typeAssignerLoc,     store10) = store9.newLocation[TypeAssigner](TypeAssigner)
   private val (progressCallbackLoc, store11) = store10.newLocation[ProgressCallback | Null]()
-  private val (tastyPromiseLoc,     store12) = store11.newLocation[Option[AsyncTastyHolder]](None)
 
-  private val initialStore = store12
+  private val initialStore = store11
 
   /** The current context */
   inline def ctx(using ctx: Context): Context = ctx
@@ -199,8 +196,6 @@ object Contexts {
 
     /** The current settings values */
     def settingsState: SettingsState = store(settingsStateLoc)
-
-    def asyncTastyPromise: Option[AsyncTastyHolder] = store(tastyPromiseLoc)
 
     /** The current compilation unit */
     def compilationUnit: CompilationUnit = store(compilationUnitLoc)
@@ -690,9 +685,6 @@ object Contexts {
       updateStore(compilationUnitLoc, compilationUnit)
     }
 
-    def setInitialAsyncTasty(): this.type =
-      assert(store(tastyPromiseLoc) == None, "trying to set async tasty promise twice!")
-      updateStore(tastyPromiseLoc, Some(AsyncTastyHolder(settings.YearlyTastyOutput.value, Promise())))
 
     def setCompilerCallback(callback: CompilerCallback): this.type = updateStore(compilerCallbackLoc, callback)
     def setIncCallback(callback: IncrementalCallback): this.type = updateStore(incCallbackLoc, callback)

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -31,9 +31,11 @@ import StdNames.nme
 import compiletime.uninitialized
 
 import scala.annotation.internal.sharable
+import scala.concurrent.Promise
 
 import DenotTransformers.DenotTransformer
 import dotty.tools.dotc.profile.Profiler
+import dotty.tools.dotc.transform.Pickler.AsyncTastyHolder
 import dotty.tools.dotc.sbt.interfaces.{IncrementalCallback, ProgressCallback}
 import util.Property.Key
 import util.Store
@@ -54,8 +56,9 @@ object Contexts {
   private val (importInfoLoc,        store9) = store8.newLocation[ImportInfo | Null]()
   private val (typeAssignerLoc,     store10) = store9.newLocation[TypeAssigner](TypeAssigner)
   private val (progressCallbackLoc, store11) = store10.newLocation[ProgressCallback | Null]()
+  private val (tastyPromiseLoc,     store12) = store11.newLocation[Option[AsyncTastyHolder]](None)
 
-  private val initialStore = store11
+  private val initialStore = store12
 
   /** The current context */
   inline def ctx(using ctx: Context): Context = ctx
@@ -196,6 +199,8 @@ object Contexts {
 
     /** The current settings values */
     def settingsState: SettingsState = store(settingsStateLoc)
+
+    def asyncTastyPromise: Option[AsyncTastyHolder] = store(tastyPromiseLoc)
 
     /** The current compilation unit */
     def compilationUnit: CompilationUnit = store(compilationUnitLoc)
@@ -684,6 +689,10 @@ object Contexts {
       setSource(compilationUnit.source)
       updateStore(compilationUnitLoc, compilationUnit)
     }
+
+    def setInitialAsyncTasty(): this.type =
+      assert(store(tastyPromiseLoc) == None, "trying to set async tasty promise twice!")
+      updateStore(tastyPromiseLoc, Some(AsyncTastyHolder(settings.YearlyTastyOutput.value, Promise())))
 
     def setCompilerCallback(callback: CompilerCallback): this.type = updateStore(compilerCallbackLoc, callback)
     def setIncCallback(callback: IncrementalCallback): this.type = updateStore(incCallbackLoc, callback)

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -90,14 +90,7 @@ class ExtractAPI extends Phase {
       val sourceFile = cls.source
       if sourceFile.exists && cls.isDefinedInCurrentRun then
         recordNonLocalClass(cls, sourceFile, cb)
-    for holder <- ctx.asyncTastyPromise do
-      import scala.concurrent.ExecutionContext.Implicits.global
-      // do not expect to be completed with failure
-      holder.promise.future.foreach: state =>
-        if !state.hasErrors then
-          // We also await the promise at GenBCode to emit warnings/errors
-          cb.apiPhaseCompleted()
-          cb.dependencyPhaseCompleted()
+    ctx.run.nn.asyncTasty.foreach(_.signalAPIComplete())
 
   private def recordNonLocalClass(cls: Symbol, sourceFile: SourceFile, cb: interfaces.IncrementalCallback)(using Context): Unit =
     def registerProductNames(fullClassName: String, binaryClassName: String) =

--- a/compiler/src/dotty/tools/dotc/sbt/package.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/package.scala
@@ -17,7 +17,7 @@ inline val TermNameHash = 1987 // 300th prime
 inline val TypeNameHash = 1993 // 301st prime
 inline val InlineParamHash = 1997 // 302nd prime
 
-def asyncZincPhasesCompleted(cb: IncrementalCallback, pending: Option[BufferingReporter]): Option[BufferingReporter] =
+def asyncZincPhasesCompleted(cb: IncrementalCallback, pending: Option[BufferingReporter]): BufferingReporter =
   val zincReporter = pending match
     case Some(buffered) => buffered
     case None => BufferingReporter()
@@ -27,7 +27,7 @@ def asyncZincPhasesCompleted(cb: IncrementalCallback, pending: Option[BufferingR
   catch
     case NonFatal(t) =>
       zincReporter.exception(em"signaling API and Dependencies phases completion", t)
-  if zincReporter.hasErrors then Some(zincReporter) else None
+  zincReporter
 
 extension (sym: Symbol)
 

--- a/compiler/src/dotty/tools/dotc/sbt/package.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/package.scala
@@ -6,9 +6,28 @@ import dotty.tools.dotc.core.NameOps.stripModuleClassSuffix
 import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.Names.termName
 
+import interfaces.IncrementalCallback
+import dotty.tools.io.FileWriters.BufferingReporter
+import dotty.tools.dotc.core.Decorators.em
+
+import scala.util.chaining.given
+import scala.util.control.NonFatal
+
 inline val TermNameHash = 1987 // 300th prime
 inline val TypeNameHash = 1993 // 301st prime
 inline val InlineParamHash = 1997 // 302nd prime
+
+def asyncZincPhasesCompleted(cb: IncrementalCallback, pending: Option[BufferingReporter]): Option[BufferingReporter] =
+  val zincReporter = pending match
+    case Some(buffered) => buffered
+    case None => BufferingReporter()
+  try
+    cb.apiPhaseCompleted()
+    cb.dependencyPhaseCompleted()
+  catch
+    case NonFatal(t) =>
+      zincReporter.exception(em"signaling API and Dependencies phases completion", t)
+  if zincReporter.hasErrors then Some(zincReporter) else None
 
 extension (sym: Symbol)
 

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -1,8 +1,7 @@
 package dotty.tools.io
 
-import dotty.tools.dotc.core.Contexts.*
-import dotty.tools.dotc.core.Decorators.em
-import dotty.tools.dotc.report
+import scala.language.unsafeNulls
+
 import dotty.tools.io.AbstractFile
 import dotty.tools.io.JarArchive
 import dotty.tools.io.PlainFile
@@ -25,12 +24,106 @@ import java.util.zip.CRC32
 import java.util.zip.Deflater
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
-import scala.language.unsafeNulls
+import scala.collection.mutable
+
+import dotty.tools.dotc.core.Contexts, Contexts.Context
+import dotty.tools.dotc.core.Decorators.em
+
+import dotty.tools.dotc.util.{SourcePosition, NoSourcePosition}
+
+import dotty.tools.dotc.reporting.Message
+import dotty.tools.dotc.report
+
+import dotty.tools.backend.jvm.PostProcessorFrontendAccess.BackendReporting
+import scala.annotation.constructorOnly
 
 /** Copied from `dotty.tools.backend.jvm.ClassfileWriters` but no `PostProcessorFrontendAccess` needed */
 object FileWriters {
   type InternalName = String
   type NullableFile =  AbstractFile | Null
+
+  inline def ctx(using ReadOnlyContext): ReadOnlyContext = summon[ReadOnlyContext]
+
+  sealed trait DelayedReporting {
+    def hasErrors: Boolean
+    def error(message: Context ?=> Message, position: SourcePosition): Unit
+    def warning(message: Context ?=> Message, position: SourcePosition): Unit
+    def log(message: String): Unit
+
+    def error(message: Context ?=> Message): Unit = error(message, NoSourcePosition)
+    def warning(message: Context ?=> Message): Unit = warning(message, NoSourcePosition)
+  }
+
+  final class EagerDelayedReporting(using captured: Context) extends DelayedReporting:
+    private var _hasErrors = false
+
+    def hasErrors: Boolean = _hasErrors
+
+    def error(message: Context ?=> Message, position: SourcePosition): Unit =
+      report.error(message, position)
+      _hasErrors = true
+
+    def warning(message: Context ?=> Message, position: SourcePosition): Unit =
+      report.warning(message, position)
+
+    def log(message: String): Unit = report.echo(message)
+
+  final class BufferingDelayedReporting extends DelayedReporting {
+    // We optimise access to the buffered reports for the common case - that there are no warning/errors to report
+    // We could use a listBuffer etc - but that would be extra allocation in the common case
+    // Note - all access is externally synchronized, as this allow the reports to be generated in on thread and
+    // consumed in another
+    private var bufferedReports = List.empty[Report]
+    private var _hasErrors = false
+    enum Report(val relay: Context ?=> BackendReporting => Unit):
+      case Error(message: Context => Message, position: SourcePosition) extends Report(ctx ?=> _.error(message(ctx), position))
+      case Warning(message: Context => Message, position: SourcePosition) extends Report(ctx ?=> _.warning(message(ctx), position))
+      case Log(message: String) extends Report(_.log(message))
+
+    def hasErrors: Boolean = synchronized:
+      _hasErrors
+
+    def error(message: Context ?=> Message, position: SourcePosition): Unit = synchronized:
+      bufferedReports ::= Report.Error({case given Context => message}, position)
+      _hasErrors = true
+
+    def warning(message: Context ?=> Message, position: SourcePosition): Unit = synchronized:
+      bufferedReports ::= Report.Warning({case given Context => message}, position)
+
+    def log(message: String): Unit = synchronized:
+      bufferedReports ::= Report.Log(message)
+
+    /** Should only be called from main compiler thread. */
+    def relayReports(toReporting: BackendReporting)(using Context): Unit = synchronized:
+      if bufferedReports.nonEmpty then
+        bufferedReports.reverse.foreach(_.relay(toReporting))
+        bufferedReports = Nil
+  }
+
+  trait ReadSettings:
+    def jarCompressionLevel: Int
+    def debug: Boolean
+
+  trait ReadOnlyContext:
+
+    val settings: ReadSettings
+    val reporter: DelayedReporting
+
+  trait BufferedReadOnlyContext extends ReadOnlyContext:
+    val reporter: BufferingDelayedReporting
+
+  object ReadOnlyContext:
+    def readSettings(using ctx: Context): ReadSettings = new:
+      val jarCompressionLevel = ctx.settings.YjarCompressionLevel.value
+      val debug = ctx.settings.Ydebug.value
+
+    def buffered(using Context): BufferedReadOnlyContext = new:
+      val settings = readSettings
+      val reporter = BufferingDelayedReporting()
+
+    def eager(using Context): ReadOnlyContext = new:
+      val settings = readSettings
+      val reporter = EagerDelayedReporting()
 
   /**
    * The interface to writing classfiles. GeneratedClassHandler calls these methods to generate the
@@ -47,7 +140,7 @@ object FileWriters {
      *
      * @param name the internal name of the class, e.g. "scala.Option"
      */
-    def writeTasty(name: InternalName, bytes: Array[Byte])(using Context): NullableFile
+    def writeTasty(name: InternalName, bytes: Array[Byte])(using ReadOnlyContext): NullableFile
 
     /**
      * Close the writer. Behavior is undefined after a call to `close`.
@@ -60,7 +153,7 @@ object FileWriters {
 
   object TastyWriter {
 
-    def apply(output: AbstractFile)(using Context): TastyWriter = {
+    def apply(output: AbstractFile)(using ReadOnlyContext): TastyWriter = {
 
       // In Scala 2 depenening on cardinality of distinct output dirs MultiClassWriter could have been used
       // In Dotty we always use single output directory
@@ -73,7 +166,7 @@ object FileWriters {
 
     private final class SingleTastyWriter(underlying: FileWriter) extends TastyWriter {
 
-      override def writeTasty(className: InternalName, bytes: Array[Byte])(using Context): NullableFile = {
+      override def writeTasty(className: InternalName, bytes: Array[Byte])(using ReadOnlyContext): NullableFile = {
         underlying.writeFile(classToRelativePath(className), bytes)
       }
 
@@ -83,14 +176,14 @@ object FileWriters {
   }
 
   sealed trait FileWriter {
-    def writeFile(relativePath: String, bytes: Array[Byte])(using Context): NullableFile
+    def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext): NullableFile
     def close(): Unit
   }
 
   object FileWriter {
-    def apply(file: AbstractFile, jarManifestMainClass: Option[String])(using Context): FileWriter =
+    def apply(file: AbstractFile, jarManifestMainClass: Option[String])(using ReadOnlyContext): FileWriter =
       if (file.isInstanceOf[JarArchive]) {
-        val jarCompressionLevel = ctx.settings.YjarCompressionLevel.value
+        val jarCompressionLevel = ctx.settings.jarCompressionLevel
         // Writing to non-empty JAR might be an undefined behaviour, e.g. in case if other files where
         // created using `AbstractFile.bufferedOutputStream`instead of JarWritter
         val jarFile = file.underlyingSource.getOrElse{
@@ -127,7 +220,7 @@ object FileWriters {
 
     lazy val crc = new CRC32
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): NullableFile = this.synchronized {
+    override def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext): NullableFile = this.synchronized {
       val entry = new ZipEntry(relativePath)
       if (storeOnly) {
         // When using compression method `STORED`, the ZIP spec requires the CRC and compressed/
@@ -155,14 +248,14 @@ object FileWriters {
     val noAttributes = Array.empty[FileAttribute[?]]
     private val isWindows = scala.util.Properties.isWin
 
-    private def checkName(component: Path)(using Context): Unit = if (isWindows) {
+    private def checkName(component: Path)(using ReadOnlyContext): Unit = if (isWindows) {
       val specials = raw"(?i)CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]".r
       val name = component.toString
-      def warnSpecial(): Unit = report.warning(em"path component is special Windows device: ${name}")
+      def warnSpecial(): Unit = ctx.reporter.warning(em"path component is special Windows device: ${name}")
       specials.findPrefixOf(name).foreach(prefix => if (prefix.length == name.length || name(prefix.length) == '.') warnSpecial())
     }
 
-    def ensureDirForPath(baseDir: Path, filePath: Path)(using Context): Unit = {
+    def ensureDirForPath(baseDir: Path, filePath: Path)(using ReadOnlyContext): Unit = {
       import java.lang.Boolean.TRUE
       val parent = filePath.getParent
       if (!builtPaths.containsKey(parent)) {
@@ -192,7 +285,7 @@ object FileWriters {
     private val fastOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
     private val fallbackOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): NullableFile = {
+    override def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext): NullableFile = {
       val path = base.resolve(relativePath)
       try {
         ensureDirForPath(base, path)
@@ -213,10 +306,10 @@ object FileWriters {
         os.close()
       } catch {
         case e: FileConflictException =>
-          report.error(em"error writing ${path.toString}: ${e.getMessage}")
+          ctx.reporter.error(em"error writing ${path.toString}: ${e.getMessage}")
         case e: java.nio.file.FileSystemException =>
-          if (ctx.settings.Ydebug.value) e.printStackTrace()
-          report.error(em"error writing ${path.toString}: ${e.getClass.getName} ${e.getMessage}")
+          if (ctx.settings.debug) e.printStackTrace()
+          ctx.reporter.error(em"error writing ${path.toString}: ${e.getClass.getName} ${e.getMessage}")
       }
       AbstractFile.getFile(path)
     }
@@ -241,7 +334,7 @@ object FileWriters {
       finally out.close()
     }
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context):NullableFile = {
+    override def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext):NullableFile = {
       val outFile = getFile(base, relativePath)
       writeBytes(outFile, bytes)
       outFile

--- a/compiler/src/dotty/tools/io/JarArchive.scala
+++ b/compiler/src/dotty/tools/io/JarArchive.scala
@@ -11,7 +11,7 @@ import scala.jdk.CollectionConverters.*
  * that be can used as the compiler's output directory.
  */
 class JarArchive private (root: Directory) extends PlainDirectory(root) {
-  def close(): Unit = jpath.getFileSystem().close()
+  def close(): Unit = this.synchronized(jpath.getFileSystem().close())
   override def exists: Boolean = jpath.getFileSystem().isOpen() && super.exists
   def allFileNames(): Iterator[String] =
     java.nio.file.Files.walk(jpath).iterator().asScala.map(_.toString)

--- a/sbt-test/pipelining/pipelining-cancel/a/src/main/scala/a/A.scala
+++ b/sbt-test/pipelining/pipelining-cancel/a/src/main/scala/a/A.scala
@@ -1,0 +1,7 @@
+package a
+
+import scala.util.Success
+
+object A {
+  val foo: (1,2,3) = (1,2,3)
+}

--- a/sbt-test/pipelining/pipelining-cancel/a/src/test/scala/a/Hello.scala
+++ b/sbt-test/pipelining/pipelining-cancel/a/src/test/scala/a/Hello.scala
@@ -1,0 +1,10 @@
+package a
+
+import org.junit.Test
+
+class Hello {
+
+  @Test def test(): Unit = {
+    assert(A.foo == (1,2,3))
+  }
+}

--- a/sbt-test/pipelining/pipelining-cancel/b/src/main/scala/b/Hello.scala
+++ b/sbt-test/pipelining/pipelining-cancel/b/src/main/scala/b/Hello.scala
@@ -1,0 +1,9 @@
+package b
+
+import a.A
+
+object Hello {
+  @main def test(): Unit = {
+    assert(A.foo == (1,2,3))
+  }
+}

--- a/sbt-test/pipelining/pipelining-cancel/build.sbt
+++ b/sbt-test/pipelining/pipelining-cancel/build.sbt
@@ -1,0 +1,12 @@
+ThisBuild / usePipelining := true
+
+lazy val a = project.in(file("a"))
+  .settings(
+    scalacOptions += "-Ystop-after:pickler", // before ExtractAPI is reached, will cancel the pipeline output
+  )
+
+lazy val b = project.in(file("b"))
+  .dependsOn(a)
+  .settings(
+    scalacOptions += "-Ycheck:all",
+  )

--- a/sbt-test/pipelining/pipelining-cancel/project/DottyInjectedPlugin.scala
+++ b/sbt-test/pipelining/pipelining-cancel/project/DottyInjectedPlugin.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    scalacOptions += "-source:3.0-migration"
+  )
+}

--- a/sbt-test/pipelining/pipelining-cancel/test
+++ b/sbt-test/pipelining/pipelining-cancel/test
@@ -1,0 +1,6 @@
+# - Test depending on a project where upstream runs short of reaching backend,
+#   and cancels pipelined tasty writing.
+# - Because `a` finishes compile run before the sending the signal to Zinc
+#   that pipeline jar is written, sbt will continue to the downstream project anyway.
+# - Downstream project `b` will fail as it can't find a.A from upstream.
+-> b/compile

--- a/sbt-test/pipelining/pipelining-scala-macro/build.sbt
+++ b/sbt-test/pipelining/pipelining-scala-macro/build.sbt
@@ -6,14 +6,14 @@ ThisBuild / usePipelining := true
 // force a failure by always forcing early output.
 lazy val a = project.in(file("a"))
   .settings(
-    scalacOptions += "-Ycheck:all",
+    // scalacOptions += "-Ycheck:all",
     scalacOptions += "-Xprint-suspension",
     Compile / incOptions := {
       val old = (Compile / incOptions).value
       val hooks = old.externalHooks
       val newHooks = hooks.withExternalLookup(
         new sbt.internal.inc.NoopExternalLookup {
-          @volatile var knownSuspension = false
+          @volatile var earlyOutputChecks = 0
 
           def didFindMacros(analysis: xsbti.compile.CompileAnalysis) = {
             val foundMacros = analysis.asInstanceOf[sbt.internal.inc.Analysis].apis.internal.values.exists(_.hasMacro)
@@ -23,20 +23,26 @@ lazy val a = project.in(file("a"))
 
           // force early output, this is safe because the macro class from `macros` will be available.
           override def shouldDoEarlyOutput(analysis: xsbti.compile.CompileAnalysis): Boolean = {
+            earlyOutputChecks += 1
+            assert(earlyOutputChecks <= 2, "should only be called twice (apiPhaseCompleted, dependencyPhaseCompleted).")
             val internalClasses = analysis.asInstanceOf[sbt.internal.inc.Analysis].apis.internal
             val a_A = internalClasses.get("a.A")
             val a_ASuspendTyper = internalClasses.get("a.ASuspendTyper")
             val a_ASuspendInlining = internalClasses.get("a.ASuspendInlining")
+
+            // both `a.A` and `a.ASuspendInlining` should be found in the analysis.
+            // even though `a.ASuspendInlining` suspends, it happens at inlining, so we should still
+            // record API for it in the first run.
             assert(a_A.isDefined, s"`a.A` wasn't found.")
-
-            if (!knownSuspension) {
-              // this callback is called multiple times, so we only want to assert the first time,
-              // in subsequent runs the suspended definition will be "resumed", so a.ASuspendTyper be found.
-              knownSuspension = true
-              assert(a_ASuspendTyper.isEmpty, s"`a.ASuspendTyper` should have been suspended initially.")
-            }
-
             assert(a_ASuspendInlining.isDefined, s"`a.ASuspendInlining` wasn't found.")
+
+            // in run 1, `a.ASuspendTyper` would have suspended at typer, and not be present in Analysis.
+            // Therefore we wouldn't close the early output jar.
+            // Therefore, because it is present here, we waited to the second run to close the early output jar,
+            // at which point we recorded API for `a.ASuspendTyper`, and because we closed the early output jar,
+            // we send the signal to Zinc that the early output was written.
+            assert(a_ASuspendTyper.isDefined, s"`a.ASuspendTyper` wasn't found.")
+
 
             // do what sbt does typically,
             // it will not force early output because macros are found


### PR DESCRIPTION
sets up the executor in pickler to write the files as the final task, meaning we no longer read from `unit.pickled`, but directly send the tasty bytes to the `serialized` holder, which queues up the internal name string of the class, and its bytes. When writing TASTy asynchronously, collect any logs into a buffer.

When the task for writing is finished, complete a promise with info describing if the writing was successful, and any pending log messages.

when the promise completes, and no errors occur in writing tasty, then asynchronously call the Zinc callbacks which trigger downstream pipelined compilation.

await on the promise in GenBCode, at which point report any buffered errors

fixes #20101