### PR TITLE
Make parameter types of context functions inferred type trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3271,7 +3271,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val paramTypes = {
       val hasWildcard = formals.exists(_.existsPart(_.isInstanceOf[WildcardType], StopAt.Static))
       if hasWildcard then formals.map(_ => untpd.TypeTree())
-      else formals.map(formal => untpd.TypeTree(formal.loBound)) // about loBound, see tests/pos/i18649.scala
+      else formals.map(formal => untpd.InferredTypeTree(formal.loBound)) // about loBound, see tests/pos/i18649.scala
     }
 
     val erasedParams = pt match {

--- a/tests/pos/i20135.scala
+++ b/tests/pos/i20135.scala
@@ -1,0 +1,11 @@
+import language.experimental.captureChecking
+
+class Network
+
+class Page(using nw: Network^):
+  def render(client: Page^{nw} ?-> Unit) = client(using this)
+
+def main(net: Network^) =
+  var page = Page(using net)
+  page.render(())
+


### PR DESCRIPTION


A non-sensical capture reference appeared in the type of a synthesized context function literal. We do clean out @retains annotations that can contain such references, but only for inferred type trees. The problem was that context function parameters were treated like explicitly given types before.

Fixes #20135