### PR TITLE
Make error reporting resilient to exception thrown while reporting

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -155,6 +155,7 @@ abstract class Reporter extends interfaces.ReporterResult {
       addUnreported(key, 1)
     case _                                                  =>
       if !isHidden(dia) then // avoid isHidden test for summarized warnings so that message is not forced
+        withMode(Mode.Printing)(doReport(dia))
         dia match {
           case w: Warning =>
             warnings = w :: warnings
@@ -168,7 +169,6 @@ abstract class Reporter extends interfaces.ReporterResult {
           // match error if d is something else
         }
         markReported(dia)
-        withMode(Mode.Printing)(doReport(dia))
   end issueUnconfigured
 
   def issueIfNotSuppressed(dia: Diagnostic)(using Context): Unit =

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -71,8 +71,8 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
     }
 
     if dia.level >= WARNING then
-      _diagnosticBuf.append(dia)
       _consoleReporter.doReport(dia)
+      _diagnosticBuf.append(dia)
     printMessageAndPos(dia, extra)
   }
 }

--- a/tests/neg/mt-deskolemize.scala
+++ b/tests/neg/mt-deskolemize.scala
@@ -1,0 +1,16 @@
+trait Expr:
+  type Value
+object Expr:
+  type Of[V] = Expr { type Value = V }
+  type ExtractValue[F <: Expr] = F match
+    case Expr.Of[v] => v
+import Expr.ExtractValue
+
+class SimpleLoop1 extends Expr:
+  type Value = ExtractValue[SimpleLoop2]
+
+class SimpleLoop2 extends Expr:
+  type Value = ExtractValue[SimpleLoop1]
+
+object Test1:
+  val x: ExtractValue[SimpleLoop1] = 1 // error


### PR DESCRIPTION
Previously the added test failed with `1 error reported` but no actual error message printed, because a stack overflow is thrown while reporting the original error. This is then caught and handled to emit a RecursionOverflow error, but that second error is non-sensical and non-sensical errors are only printed if `hasErrors` returns false.

We fix this by deferring incrementing the error count (and therefore having `hasErrors` return true) until after having displayed the error. We also defer calling `markReported` otherwise the second error will also be suppressed. A similar change is necessary in our testing infrastructure to keep the error count is coherent.