### PR TITLE
Fix #20146: attach the original name if there is an import selection for an indent

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -96,7 +96,8 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
       ctx
 
   override def prepareForSelect(tree: tpd.Select)(using Context): Context =
-    unusedDataApply(_.registerUsed(tree.symbol, Some(tree.name)))
+    val name = tree.getAttachment(OriginalName).orElse(Some(tree.name))
+    unusedDataApply(_.registerUsed(tree.symbol, name))
 
   override def prepareForBlock(tree: tpd.Block)(using Context): Context =
     pushInBlockTemplatePackageDef(tree)
@@ -326,6 +327,8 @@ object CheckUnused:
    * from the compilation `Context`
    */
   private val _key = Property.StickyKey[UnusedData]
+
+  val OriginalName = Property.StickyKey[Name]
 
   class PostTyper extends CheckUnused(PhaseMode.Aggregate, "PostTyper", _key)
 

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -96,7 +96,7 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
       ctx
 
   override def prepareForSelect(tree: tpd.Select)(using Context): Context =
-    val name = tree.getAttachment(OriginalName).orElse(Some(tree.name))
+    val name = tree.removeAttachment(OriginalName).orElse(Some(tree.name))
     unusedDataApply(_.registerUsed(tree.symbol, name))
 
   override def prepareForBlock(tree: tpd.Block)(using Context): Context =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -51,6 +51,7 @@ import NullOpsDecorator.*
 import cc.{CheckCaptures, isRetainsLike}
 import config.Config
 import config.MigrationVersion
+import transform.CheckUnused.OriginalName
 
 import scala.annotation.constructorOnly
 
@@ -629,7 +630,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       val checkedType = checkNotShadowed(ownType)
       val tree1 = checkedType match
         case checkedType: NamedType if !prefixIsElidable(checkedType) =>
-          ref(checkedType).withSpan(tree.span)
+          ref(checkedType).withSpan(tree.span).withAttachment(OriginalName, name)
         case _ =>
           def isScalaModuleRef = checkedType match
             case moduleRef: TypeRef if moduleRef.symbol.is(ModuleClass, butNot = JavaDefined) => true

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -630,7 +630,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       val checkedType = checkNotShadowed(ownType)
       val tree1 = checkedType match
         case checkedType: NamedType if !prefixIsElidable(checkedType) =>
-          ref(checkedType).withSpan(tree.span).withAttachment(OriginalName, name)
+          ref(checkedType).withSpan(tree.span)
         case _ =>
           def isScalaModuleRef = checkedType match
             case moduleRef: TypeRef if moduleRef.symbol.is(ModuleClass, butNot = JavaDefined) => true
@@ -663,7 +663,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       val selection = untpd.cpy.Select(tree)(qualifier, name)
       typed(selection, pt)
     else if rawType.exists then
-      setType(ensureAccessible(rawType, superAccess = false, tree.srcPos))
+      val ref = setType(ensureAccessible(rawType, superAccess = false, tree.srcPos))
+      if ref.symbol.name != name then
+        ref.withAttachment(OriginalName, name)
+      else ref
     else if name == nme._scope then
       // gross hack to support current xml literals.
       // awaiting a better implicits based solution for library-supported xml

--- a/tests/warn/i20146.scala
+++ b/tests/warn/i20146.scala
@@ -1,0 +1,7 @@
+//> using options -Wunused:imports
+
+def test(list: List[Int]): Int =
+  import list.{head => first}
+  import list.{length => len} // warn
+  import list.{addString => add} // warn
+  first + list.length


### PR DESCRIPTION
Fix #20146

Attach the original name to the tree if there is an imported term selection for an indent.