### PR TITLE
Suppress "extension method will never be selected" for overrides

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1108,6 +1108,8 @@ object RefChecks {
    *  An extension method is hidden if it does not offer a parameter that is not subsumed
    *  by the corresponding parameter of the member with the same name (or of all alternatives of an overload).
    *
+   *  This check is suppressed if this method is an override.
+   *
    *  For example, it is not possible to define a type-safe extension `contains` for `Set`,
    *  since for any parameter type, the existing `contains` method will compile and would be used.
    *
@@ -1125,31 +1127,32 @@ object RefChecks {
    *  If the extension method is nullary, it is always hidden by a member of the same name.
    *  (Either the member is nullary, or the reference is taken as the eta-expansion of the member.)
    */
-  def checkExtensionMethods(sym: Symbol)(using Context): Unit = if sym.is(Extension) then
-    extension (tp: Type)
-      def strippedResultType = Applications.stripImplicit(tp.stripPoly, wildcardOnly = true).resultType
-      def firstExplicitParamTypes = Applications.stripImplicit(tp.stripPoly, wildcardOnly = true).firstParamTypes
-      def hasImplicitParams = tp.stripPoly match { case mt: MethodType => mt.isImplicitMethod case _ => false }
-    val target = sym.info.firstExplicitParamTypes.head // required for extension method, the putative receiver
-    val methTp = sym.info.strippedResultType // skip leading implicits and the "receiver" parameter
-    def hidden =
-      target.nonPrivateMember(sym.name)
-      .filterWithPredicate:
-        member =>
-        val memberIsImplicit = member.info.hasImplicitParams
-        val paramTps =
-          if memberIsImplicit then methTp.stripPoly.firstParamTypes
-          else methTp.firstExplicitParamTypes
+  def checkExtensionMethods(sym: Symbol)(using Context): Unit =
+    if sym.is(Extension) && !sym.nextOverriddenSymbol.exists then
+      extension (tp: Type)
+        def strippedResultType = Applications.stripImplicit(tp.stripPoly, wildcardOnly = true).resultType
+        def firstExplicitParamTypes = Applications.stripImplicit(tp.stripPoly, wildcardOnly = true).firstParamTypes
+        def hasImplicitParams = tp.stripPoly match { case mt: MethodType => mt.isImplicitMethod case _ => false }
+      val target = sym.info.firstExplicitParamTypes.head // required for extension method, the putative receiver
+      val methTp = sym.info.strippedResultType // skip leading implicits and the "receiver" parameter
+      def hidden =
+        target.nonPrivateMember(sym.name)
+        .filterWithPredicate:
+          member =>
+          val memberIsImplicit = member.info.hasImplicitParams
+          val paramTps =
+            if memberIsImplicit then methTp.stripPoly.firstParamTypes
+            else methTp.firstExplicitParamTypes
 
-        paramTps.isEmpty || memberIsImplicit && !methTp.hasImplicitParams || {
-          val memberParamTps = member.info.stripPoly.firstParamTypes
-          !memberParamTps.isEmpty
-          && memberParamTps.lengthCompare(paramTps) == 0
-          && memberParamTps.lazyZip(paramTps).forall((m, x) => x frozen_<:< m)
-        }
-      .exists
-    if !target.typeSymbol.denot.isAliasType && !target.typeSymbol.denot.isOpaqueAlias && hidden
-    then report.warning(ExtensionNullifiedByMember(sym, target.typeSymbol), sym.srcPos)
+          paramTps.isEmpty || memberIsImplicit && !methTp.hasImplicitParams || {
+            val memberParamTps = member.info.stripPoly.firstParamTypes
+            !memberParamTps.isEmpty
+            && memberParamTps.lengthCompare(paramTps) == 0
+            && memberParamTps.lazyZip(paramTps).forall((m, x) => x frozen_<:< m)
+          }
+        .exists
+      if !target.typeSymbol.denot.isAliasType && !target.typeSymbol.denot.isOpaqueAlias && hidden
+      then report.warning(ExtensionNullifiedByMember(sym, target.typeSymbol), sym.srcPos)
   end checkExtensionMethods
 
   /** Verify that references in the user-defined `@implicitNotFound` message are valid.

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -30,6 +30,7 @@ strict-pattern-bindings-3.0-migration.scala
 i17186b.scala
 i11982a.scala
 i17255
+i17735.scala
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/tests/pos/ext-override.scala
+++ b/tests/pos/ext-override.scala
@@ -1,0 +1,12 @@
+//> using options -Xfatal-warnings
+
+trait Foo[T]:
+  extension (x: T)
+    def hi: String
+
+class Bla:
+  def hi: String = "hi"
+object Bla:
+  given Foo[Bla] with
+    extension (x: Bla)
+      def hi: String = x.hi

--- a/tests/pos/i17735.scala
+++ b/tests/pos/i17735.scala
@@ -1,4 +1,4 @@
-//> using options -Wvalue-discard
+//> using options -Xfatal-warnings -Wvalue-discard
 
 import scala.collection.mutable
 import scala.annotation.nowarn

--- a/tests/pos/i17735a.scala
+++ b/tests/pos/i17735a.scala
@@ -1,4 +1,4 @@
-//> using options -Wvalue-discard -Wconf:msg=non-Unit:s
+//> using options -Xfatal-warnings -Wvalue-discard -Wconf:msg=non-Unit:s
 
 import scala.collection.mutable
 import scala.annotation.nowarn

--- a/tests/pos/i17741.scala
+++ b/tests/pos/i17741.scala
@@ -1,4 +1,4 @@
-//> using options -Wnonunit-statement
+//> using options -Xfatal-warnings -Wnonunit-statement
 
 class Node()
 class Elem(

--- a/tests/pos/nowarnannot.scala
+++ b/tests/pos/nowarnannot.scala
@@ -1,3 +1,5 @@
+//> using options -Xfatal-warnings -Wvalue-discard
+
 case class F(i: Int)
 
 object Main {


### PR DESCRIPTION
When we're overriding an existing extension method, we don't have the liberty
of renaming the method, so we shouldn't get warnings we can't do anything
about.
