### PR TITLE
Retain default parameters with `export`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -535,6 +535,9 @@ object Flags {
   /** Flags retained in term export forwarders */
   val RetainedExportTermFlags = Infix | Given | Implicit | Inline | Transparent | Erased | HasDefaultParams | NoDefaultParams | ExtensionMethod
 
+  /** Flags retained in parameters of term export forwarders */
+  val RetainedExportTermParamFlags = Given | Implicit | Erased | HasDefault | Inline
+
   val MandatoryExportTermFlags = Exported | Method | Final
 
   /** Flags retained in type export forwarders */

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1293,7 +1293,7 @@ class Namer { typer: Typer =>
                 getter => addForwarder(
                   getter.name.asTermName, getter.asSeenFrom(path.tpe), span))
 
-            // adding annotations at the parameter level
+            // adding annotations and flags at the parameter level
             // TODO: This probably needs to be filtered to avoid adding some annotation
             // such as MacroAnnotations
             if sym.is(Method) then
@@ -1301,6 +1301,8 @@ class Namer { typer: Typer =>
                   (origParameter, exportedParameter) <- orig.lazyZip(forwarded)
               do
                 exportedParameter.addAnnotations(origParameter.annotations)
+                if exportedParameter.isTerm then
+                  exportedParameter.setFlag(origParameter.flags & RetainedExportTermParamFlags)
       end addForwarder
 
       def addForwardersNamed(name: TermName, alias: TermName, span: Span): Unit =

--- a/tests/pos/export-param-flags/A_1.scala
+++ b/tests/pos/export-param-flags/A_1.scala
@@ -1,0 +1,5 @@
+object A:
+  def defaultParam(x: Int = 1) = x
+
+object Exported:
+  export A.*

--- a/tests/pos/export-param-flags/B_2.scala
+++ b/tests/pos/export-param-flags/B_2.scala
@@ -1,0 +1,2 @@
+object B:
+  val x = Exported.defaultParam()

--- a/tests/printing/export-param-flags.check
+++ b/tests/printing/export-param-flags.check
@@ -1,0 +1,13 @@
+[[syntax trees at end of                     typer]] // tests/printing/export-param-flags.scala
+package <empty> {
+  final lazy module val A: A = new A()
+  final module class A() extends Object() { this: A.type =>
+    inline def inlinedParam(inline x: Int): Int = x.+(x):Int
+  }
+  final lazy module val Exported: Exported = new Exported()
+  final module class Exported() extends Object() { this: Exported.type =>
+    export A.*
+    final inline def inlinedParam(inline x: Int): Int = A.inlinedParam(x)
+  }
+}
+

--- a/tests/printing/export-param-flags.scala
+++ b/tests/printing/export-param-flags.scala
@@ -1,0 +1,5 @@
+object A:
+  inline def inlinedParam(inline x: Int): Int = x + x
+
+object Exported:
+  export A.*


### PR DESCRIPTION
Default parameters need to have the `HasDefault` flag set to work properly, it seems that without this flag they were still selected but only under join compilation.

While we're at it, we define a full set of flags that might be exported. Note that Given/Implicit/Erased were already set by `tpd.DefDef` and Inlined doesn't seem to make a difference in practice since the body of the exported inline def is manually constructed and doesn't contain proxies either way.