### PR TITLE
Backport "Attempt implicit search for old style implicit parameters in Application matchArgs"

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -622,7 +622,7 @@ trait Applications extends Compatibility {
               defaultArg.tpe.widen match
                 case _: MethodOrPoly if testOnly => matchArgs(args1, formals1, n + 1)
                 case _ => matchArgs(args1, addTyped(treeToArg(defaultArg)), n + 1)
-            else if methodType.isContextualMethod && ctx.mode.is(Mode.ImplicitsEnabled) then
+            else if methodType.isImplicitMethod && ctx.mode.is(Mode.ImplicitsEnabled) then
               matchArgs(args1, addTyped(treeToArg(implicitArg)), n + 1)
             else
               missingArg(n)

--- a/tests/neg/i19594.check
+++ b/tests/neg/i19594.check
@@ -1,0 +1,8 @@
+-- [E172] Type Error: tests/neg/i19594.scala:12:14 ---------------------------------------------------------------------
+12 |  assertEquals(true, 1, "values are not the same") // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |  Can you see me?!
+-- [E172] Type Error: tests/neg/i19594.scala:13:14 ---------------------------------------------------------------------
+13 |  assertEquals(true, 1) // error
+   |  ^^^^^^^^^^^^^^^^^^^^^
+   |  Can you see me?!

--- a/tests/neg/i19594.scala
+++ b/tests/neg/i19594.scala
@@ -1,0 +1,13 @@
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Can you see me?!")
+trait Compare[A, B]
+
+object example extends App:
+
+  // The presence of the below default argument prevents the `implicitNotFound` message from appearing
+  def assertEquals[A, B](a: A, b: B, clue: => Any = "values are not the same")
+                        (implicit comp: Compare[A, B]): Unit = ()
+
+  assertEquals(true, 1, "values are not the same") // error
+  assertEquals(true, 1) // error


### PR DESCRIPTION
Backports #19737 to the LTS branch.

Fixes #19594

This prevents munit from updating to Scala 3.3.x: https://github.com/scalameta/munit/issues/565