### PR TITLE
Improve ConstraintHandling of SkolemTypes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -248,18 +248,7 @@ trait ConstraintHandling {
     override def apply(tp: Type): Type = tp match
       case tp: TypeVar if !tp.isInstantiated && !levelOK(tp.nestingLevel, maxLevel) =>
         legalVar(tp)
-        // TypeParamRef can occur in tl bounds
-      case tp: TypeVar if tp.isInstantiated =>
-        /* `TypeMap` always strips instantiated type variables in `mapOver`.
-         * We can keep the original type var if its instance is not transformed
-         * by the LevelAvoidMap. This allows for simpler bounds and for
-         * derived skolems (see ApproximatingTypeMap#derivedSkolemType) to
-         * remain the same by keeping their info unchanged. Loosing skolems
-         * in the legalBound computation prevented type vars from being
-         * instantiated with theses skolems, even if they were within the bounds.
-         */
-        val res = apply(tp.instanceOpt)
-        if res eq tp.instanceOpt then tp else res
+      // TypeParamRef can occur in tl bounds
       case tp: TypeParamRef =>
         constraint.typeVarOfParam(tp) match
           case tvar: TypeVar =>

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -248,7 +248,18 @@ trait ConstraintHandling {
     override def apply(tp: Type): Type = tp match
       case tp: TypeVar if !tp.isInstantiated && !levelOK(tp.nestingLevel, maxLevel) =>
         legalVar(tp)
-      // TypeParamRef can occur in tl bounds
+        // TypeParamRef can occur in tl bounds
+      case tp: TypeVar if tp.isInstantiated =>
+        /* `TypeMap` always strips instantiated type variables in `mapOver`.
+         * We can keep the original type var if its instance is not transformed
+         * by the LevelAvoidMap. This allows for simpler bounds and for
+         * derived skolems (see ApproximatingTypeMap#derivedSkolemType) to
+         * remain the same by keeping their info unchanged. Loosing skolems
+         * in the legalBound computation prevented type vars from being
+         * instantiated with theses skolems, even if they were within the bounds.
+         */
+        val res = apply(tp.instanceOpt)
+        if res eq tp.instanceOpt then tp else res
       case tp: TypeParamRef =>
         constraint.typeVarOfParam(tp) match
           case tvar: TypeVar =>

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -119,4 +119,7 @@ i7445b.scala
 
 # more aggresive reduce projection makes a difference
 i15525.scala
+i19955a.scala
+i19955b.scala
+i20053b.scala
 

--- a/tests/pos/i19955a.scala
+++ b/tests/pos/i19955a.scala
@@ -1,0 +1,27 @@
+
+trait Summon[R, T <: R]:
+  type Out
+object Summon:
+  given [R, T <: R]: Summon[R, T] with
+    type Out = R
+
+trait DFTypeAny
+trait DFBits[W <: Int] extends DFTypeAny
+class DFVal[+T <: DFTypeAny]
+type DFValAny = DFVal[DFTypeAny]
+type DFValOf[+T <: DFTypeAny] = DFVal[T]
+trait Candidate[R]:
+  type OutW <: Int
+object Candidate:
+  type Aux[R, O <: Int] = Candidate[R] { type OutW = O }
+  given [W <: Int, R <: DFValOf[DFBits[W]]]: Candidate[R] with
+    type OutW = W
+
+extension [L](lhs: L) def foo(using es: Summon[L, lhs.type]): Unit = ???
+extension [L <: DFValAny](lhs: L)(using icL: Candidate[L]) def baz: DFValOf[DFBits[icL.OutW]] = ???
+extension [L <: DFValAny, W <: Int](lhs: L)(using icL: Candidate.Aux[L, W])
+  def bazAux: DFValOf[DFBits[W]] = ???
+
+val x = new DFVal[DFBits[4]]
+val works = x.bazAux.foo
+val fails = x.baz.foo

--- a/tests/pos/i19955b.scala
+++ b/tests/pos/i19955b.scala
@@ -1,0 +1,17 @@
+
+trait Wrap[W]
+
+trait IsWrapOfInt[R]:
+  type Out <: Int
+given [W <: Int, R <: Wrap[W]]: IsWrapOfInt[R] with
+  type Out = Int
+
+trait IsInt[U <: Int]
+given [U <: Int]: IsInt[U] = ???
+
+extension [L](lhs: L) def get(using ev: IsWrapOfInt[L]): ev.Out = ???
+extension (lhs: Int) def isInt(using IsInt[lhs.type]): Unit = ???
+
+val x: Wrap[Int] = ???
+val works = (x.get: Int).isInt
+val fails = x.get.isInt

--- a/tests/pos/i20053b.scala
+++ b/tests/pos/i20053b.scala
@@ -1,0 +1,22 @@
+
+trait Sub[R, T >: R]
+given [R, T >: R]: Sub[R, T] with {}
+
+trait Candidate[-R]:
+  type OutP
+given [P]: Candidate[Option[P]] with
+  type OutP = P
+
+extension [L](lhs: L)
+  def ^^^[P](rhs: Option[P])
+            (using es: Sub[lhs.type, Any])
+            (using c: Candidate[L])
+            (using check: c.type <:< Any): Option[c.OutP] = ???
+
+val x: Option[Boolean] = ???
+
+val z1 = x ^^^ x // Ok
+val z2 = z1 ^^^ x // Ok
+val zz = ^^^[Option[Boolean]](x ^^^ x)(x) // Ok
+
+val zzz = x ^^^ x ^^^ x // Error before changes


### PR DESCRIPTION
By retaining instantiated type vars in LevelAvoidMap when possible.

Fixes #19955

Consider pos/i19955a as an example.
We try to adapt the given_IsInt_U for skolems of the form (?2 : Int) and (?7 : ?8.Out) where ?8 is an unknown value of type given_IsWrapOfInt_R[Int, Wrap[Int]], but only the former succeeds, even though ?8.Out is trivially within the bounds of U.

The typing trace from the two implicit search results includes:
```
[log typer] ==> typedImplicit(Cand(given_IsInt_U L4), IsInt[(?2 : Int)], <empty>, <399..399>)?
[log typer]   ==> isSubType(IsInt[U], IsInt[(?2 : Int)])?
[log typer]     ==> isSameType((?2 : Int), U)?
[log typer]       ==> isSubType((?2 : Int), U)?
[log typer]       <== isSubType((?2 : Int), U) = true
[log typer]       ==> isSubType(U, (?2 : Int))?
[log typer]       <== isSubType(U, (?2 : Int)) = true
[log typer]     <== isSameType((?2 : Int), U) = true
[log typer]   <== isSubType(IsInt[U], IsInt[(?2 : Int)]) = true
[log typer] <== typedImplicit(Cand(given_IsInt_U L4), IsInt[(?2 : Int)], <empty>, <399..399>) = SearchSuccess: (given_IsInt_U : [U <: Int]: IsInt[U]) via given_IsInt_U[(?2 : Int)]
[log typer] ==> typedImplicit(Cand(given_IsInt_U L4), IsInt[(?7 : ?8.Out)], <empty>, <423..423>)?
[log typer]   ==> isSubType(IsInt[U], IsInt[(?7 : ?8.Out)])?
[log typer]     ==> isSameType((?7 : ?8.Out), U)?
[log typer]       ==> isSubType((?7 : ?8.Out), U)?
[log typer]       <== isSubType((?7 : ?8.Out), U) = true
[log typer]       ==> isSubType(Int, (?7 : ?8.Out))?
[log typer]       <== isSubType(Int, (?7 : ?8.Out)) = false
[log typer]     <== isSameType((?7 : ?8.Out), U) = false
[log typer]   <== isSubType(IsInt[U], IsInt[(?7 : ?8.Out)]) = false
[log typer] <== typedImplicit(Cand(given_IsInt_U L4), IsInt[(?7 : ?8.Out)], <empty>, <423..423>) = Search Failure: given_IsInt_U[U]
```
The difference in the failing case from the passing case is that the type variable U has been instantiated to Int by the first direction of isSameType before attempting the second direction.

If we look closer at the ConstraintHandling:
```
[log typer]         ==> addConstraint(U, (?2 : Int), true)?
[log typer]           ==> legalBound(U, (?2 : Int), false)?
[log typer]             ==> ApproximatingTypeMap#derivedSkolemType((?2 : Int), Int)?
[log typer]             <== ApproximatingTypeMap#derivedSkolemType((?2 : Int), Int) = (?2 : Int)
[log typer]           <== legalBound(U, (?2 : Int), false) = (?2 : Int)
[log typer]           ==> isSubType((?2 : Int), Int)?
[log typer]           <== isSubType((?2 : Int), Int) = true
[log typer]         <== addConstraint(U, (?2 : Int), true) = true
[log typer]         ==> addConstraint(U, (?7 : ?8.Out), true)?
[log typer]           ==> legalBound(U, (?7 : ?8.Out), false)?
[log typer]             ==> ApproximatingTypeMap#derivedSkolemType((?8 : given_IsWrapOfInt_R[Int, Wrap[Int]]), given_IsWrapOfInt_R[Int, Wrap[Int]])?
[log typer]             <== ApproximatingTypeMap#derivedSkolemType((?8 : given_IsWrapOfInt_R[Int, Wrap[Int]]), given_IsWrapOfInt_R[Int, Wrap[Int]]) = given_IsWrapOfInt_R[Int, Wrap[Int]]
[log typer]             ==> ApproximatingTypeMap#derivedSkolemType((?7 : ?8.Out), Int)?
[log typer]             <== ApproximatingTypeMap#derivedSkolemType((?7 : ?8.Out), Int) = Int
[log typer]           <== legalBound(U, (?7 : ?8.Out), false) = Int
[log typer]         <== addConstraint(U, (?7 : ?8.Out), true) = true
```
we can see that the issue lies in the approximation in the LevelAvoidMap used to obtain the legalBound.

Modifying `ApproximatingTypeMap#derivedSkolemType` from `if info eq tp.info then tp` to `if info frozen_=:= tp.info then tp.derivedSkolem(info)`, allows each direction of the subtyping checks in `isSameType` to obtain the more precise skolem as legal bound. But it does not solve the issue, since they obtain distinct skolems even if they equivalently-shaped, the constraints are still unsatisfiable.

We can instead try to make `info eq tp.info` be true. It was not the case in the above example because `given_IsWrapOfInt_R[Int, Wrap[Int]]` contained a type variable `R := Wrap[Int]` which was substituted by the map.

We can modify TypeMap to keep type variables rather than replace them by their instance when possible, i.e. when the instance is itself not transformed by the map. This solves the issue but breaks other places which assumed the stripping of type vars in TypeMaps. That problem is avoided by doing the changes in LevelAvoidMap only.