### PR TITLE
Regression: fix compilation performance on Windows

### DIFF
--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -136,12 +136,6 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   /** Does this abstract file represent something which can contain classfiles? */
   def isClassContainer: Boolean = isDirectory || (jpath != null && ext.isJarOrZip)
 
-  /** Create a file on disk, if one does not exist already. */
-  def create(): Unit
-
-  /** Delete the underlying file or directory (recursively). */
-  def delete(): Unit
-
   /** Is this abstract file a directory? */
   def isDirectory: Boolean
 

--- a/compiler/src/dotty/tools/io/NoAbstractFile.scala
+++ b/compiler/src/dotty/tools/io/NoAbstractFile.scala
@@ -17,8 +17,6 @@ import java.io.InputStream
 object NoAbstractFile extends AbstractFile {
   def absolute: AbstractFile = this
   def container: AbstractFile = this
-  def create(): Unit = ???
-  def delete(): Unit = ???
   def jpath: JPath = null
   def input: InputStream = null
   def isDirectory: Boolean = false

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -15,7 +15,6 @@ import java.nio.file.{InvalidPathException, Paths}
 class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
   override val isDirectory: Boolean = true
   override def iterator(): Iterator[PlainFile] = givenPath.list.filter(_.exists).map(new PlainFile(_))
-  override def delete(): Unit = givenPath.deleteRecursively()
 }
 
 /** This class implements an abstract file backed by a File.
@@ -112,14 +111,6 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
     else
       null
   }
-
-  /** Does this abstract file denote an existing file? */
-  def create(): Unit = if (!exists) givenPath.createFile()
-
-  /** Delete the underlying file or directory (recursively). */
-  def delete(): Unit =
-    if (givenPath.isFile) givenPath.delete()
-    else if (givenPath.isDirectory) givenPath.toDirectory.deleteRecursively()
 
   /** Returns a plain file with the given name. It does not
    *  check that it exists.

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -77,7 +77,7 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
   }
 
   /** Is this abstract file a directory? */
-  val isDirectory: Boolean = givenPath.isDirectory
+  val isDirectory: Boolean = givenPath.isDirectory // cached for performance on Windows
 
   /** Returns the time that this abstract file was last modified. */
   def lastModified: Long = givenPath.lastModified.toMillis

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -13,7 +13,7 @@ import java.nio.file.{InvalidPathException, Paths}
 
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
-  override def isDirectory: Boolean = true
+  override val isDirectory: Boolean = true
   override def iterator(): Iterator[PlainFile] = givenPath.list.filter(_.exists).map(new PlainFile(_))
   override def delete(): Unit = givenPath.deleteRecursively()
 }
@@ -78,7 +78,7 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
   }
 
   /** Is this abstract file a directory? */
-  def isDirectory: Boolean = givenPath.isDirectory
+  val isDirectory: Boolean = givenPath.isDirectory
 
   /** Returns the time that this abstract file was last modified. */
   def lastModified: Long = givenPath.lastModified.toMillis

--- a/compiler/src/dotty/tools/io/VirtualDirectory.scala
+++ b/compiler/src/dotty/tools/io/VirtualDirectory.scala
@@ -34,12 +34,6 @@ extends AbstractFile {
   override def input: InputStream = sys.error("directories cannot be read")
   override def output: OutputStream = sys.error("directories cannot be written")
 
-  /** Does this abstract file denote an existing file? */
-  def create(): Unit = { unsupported() }
-
-  /** Delete the underlying file or directory (recursively). */
-  def delete(): Unit = { unsupported() }
-
   /** Returns an abstract file with the given name. It does not
    *  check that it exists.
    */

--- a/compiler/src/dotty/tools/io/VirtualFile.scala
+++ b/compiler/src/dotty/tools/io/VirtualFile.scala
@@ -82,12 +82,6 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
     Iterator.empty
   }
 
-  /** Does this abstract file denote an existing file? */
-  def create(): Unit = unsupported()
-
-  /** Delete the underlying file or directory (recursively). */
-  def delete(): Unit = unsupported()
-
   /**
    * Returns the abstract file in this abstract directory with the
    * specified name. If there is no such file, returns null. The

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -61,8 +61,6 @@ abstract class ZipArchive(override val jpath: JPath, release: Option[String]) ex
   def isDirectory: Boolean = true
   def lookupName(name: String, directory: Boolean): AbstractFile = unsupported()
   def lookupNameUnchecked(name: String, directory: Boolean): AbstractFile = unsupported()
-  def create(): Unit = unsupported()
-  def delete(): Unit = unsupported()
   def output: OutputStream    = unsupported()
   def container: AbstractFile = unsupported()
   def absolute: AbstractFile  = unsupported()


### PR DESCRIPTION
Caches isDirectory calls

Too many of them were added in https://github.com/scala/scala3/commit/607e4d59d93e4ceb0e46469923161516c4e04b60 and this degraded compilation performance by up to 100% on Windows

Fixes #19924
backport to release-3.4.2