### PR TITLE
Attempt to fix performance regression from #20120

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -815,6 +815,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     newConstraint(hardVars = this.hardVars + tv)
 
   def instType(tvar: TypeVar): Type = entry(tvar.origin) match
+    case TypeBounds(lo, hi) if lo eq hi => lo
     case _: TypeBounds => NoType
     case tp: TypeParamRef => typeVarOfParam(tp).orElse(tp)
     case tp => tp


### PR DESCRIPTION
Attempts to fix #20120.
I'll try to prepare an explanation later today/tomorrow, for now let's see if it will pass CI (it does fix the performance in the minimization)
Also, there may be better ways of achieving the same effect (like not producing redundant TypeBounds before committing the typerState, I'll look into this later).