### PR TITLE
Interactive: handle context bounds in extension construct workaround

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -186,7 +186,12 @@ object Completion:
   )(using Context): List[tpd.Tree] =
     untpdPath.collectFirst:
       case untpd.ExtMethods(paramss, _) =>
-        val enclosingParam = paramss.flatten.find(_.span.contains(pos.span))
+        val enclosingParam = paramss.flatten
+          .find(_.span.contains(pos.span))
+          .flatMap:
+            case untpd.TypeDef(_, bounds: untpd.ContextBounds) => bounds.cxBounds.find(_.span.contains(pos.span))
+            case other => Some(other)
+
         enclosingParam.map: param =>
           ctx.typer.index(paramss.flatten)
           val typedEnclosingParam = ctx.typer.typed(param)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1838,3 +1838,42 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin,
       topLines = Some(3)
     )
+
+  @Test def `context-bound-in-extension-construct` =
+    check(
+      """
+        |object x {
+        |  extension [T: Orde@@]
+        |}
+        |""".stripMargin,
+      """Ordered[T] scala.math
+        |Ordering[T] scala.math
+        |""".stripMargin,
+      topLines = Some(2)
+    )
+
+  @Test def `context-bounds-in-extension-construct` =
+    check(
+      """
+        |object x {
+        |  extension [T: Ordering: Orde@@]
+        |}
+        |""".stripMargin,
+      """Ordered[T] scala.math
+        |Ordering[T] scala.math
+        |""".stripMargin,
+      topLines = Some(2)
+    )
+
+  @Test def `type-bound-in-extension-construct` =
+    check(
+      """
+        |object x {
+        |  extension [T <: Orde@@]
+        |}
+        |""".stripMargin,
+      """Ordered[T] scala.math
+        |Ordering[T] scala.math
+        |""".stripMargin,
+      topLines = Some(2)
+    )


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/19971