### PR TITLE
Handle reach capabilities correctly in depedent functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4054,7 +4054,7 @@ object Types extends TypeUtils {
             tp match
               case CapturingType(parent, refs) =>
                 (compute(status, parent, theAcc) /: refs.elems) {
-                  (s, ref) => ref match
+                  (s, ref) => ref.stripReach match
                     case tp: TermParamRef if tp.binder eq thisLambdaType => combine(s, CaptureDeps)
                     case _ => s
                 }

--- a/tests/pos-custom-args/captures/dep-reach.scala
+++ b/tests/pos-custom-args/captures/dep-reach.scala
@@ -1,0 +1,21 @@
+object Test:
+  class C
+  type Proc = () => Unit
+
+  def f(c: C^, d: C^): () ->{c, d} Unit =
+    def foo(xs: Proc*): () ->{xs*} Unit =
+      xs.head
+    val a: () ->{c} Unit = () => ()
+    val b: () ->{d} Unit = () => ()
+    val xx = foo(a, b)
+    xx
+
+  def g(c: C^, d: C^): () ->{c, d} Unit =
+
+    def foo(xs: Seq[() => Unit]): () ->{xs*} Unit =
+      xs.head
+
+    val a: () ->{c} Unit = () => ()
+    val b: () ->{d} Unit = () => ()
+    val xx = foo(Seq(a, b))
+    xx


### PR DESCRIPTION
Handle reach capabilities correctly when computing whether a function is dependent.