### PR TITLE
Instantiate constraint entries when updated to equal bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -327,7 +327,7 @@ trait ConstraintHandling {
         (c1 eq constraint)
         || {
           constraint = c1
-          val TypeBounds(lo, hi) = constraint.entry(param): @unchecked
+          val TypeBounds(lo, hi) = constraint.nonParamBounds(param)
           isSub(lo, hi)
         }
   end addOneBound

--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -111,7 +111,7 @@ object OrderingConstraint {
         case TypeBounds(lo, hi) if lo eq hi =>
           val replaceParams = new TypeMap:
             def apply(tp: Type): Type = tp match
-              case tp: TypeParamRef => current.typeVarOfParam(tp)
+              case tp: TypeParamRef => current.typeVarOfParam(tp).orElse(tp)
               case _ => mapOver(tp)
           super.update(prev, current, poly, idx, replaceParams(hi))
         case _ =>


### PR DESCRIPTION
Checking `isSub` on the resulting bounds may have introduced new constraints, which might allow us to replace the type parameter entirely.

Adapted from #20200
@jchyb can you test if this also addresses the performance issue in #20120 ?