### PR TITLE
Fix overloaded default methods test in RefChecks

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -52,7 +52,7 @@ object RefChecks {
       }}
 
       for (name <- defaultMethodNames) {
-        val methods = clazz.info.member(name).alternatives.map(_.symbol)
+        val methods = clazz.thisType.member(name).alternatives.map(_.symbol)
         val haveDefaults = methods.filter(_.hasDefaultParams)
         if (haveDefaults.length > 1) {
           val owners = haveDefaults map (_.owner)

--- a/tests/pos/i18555.scala
+++ b/tests/pos/i18555.scala
@@ -1,0 +1,14 @@
+trait GenericCollectionWithCommands {
+  self: PackSupport =>
+
+  def bar(foo: Int = 1): Any = ???
+  def bar(writer: GenericCollectionWithCommands.this.pack.Writer[Any]): Any = ???
+}
+
+trait PackSupport {
+  val pack: SerializationPack
+}
+
+trait SerializationPack {
+  type Writer[A]
+}


### PR DESCRIPTION
It used `cls.info` instead of `cls.thisType`, which caused symbols accessible only through the self type of `cls` to be forgotten.

Fixes #18555