### PR TITLE
Fix the visibility check in `markFree`

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -407,8 +407,12 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
         case tree @ TypeApply(fn, args) =>
           traverse(fn)
-          for case arg: TypeTree <- args do
-            transformTT(arg, boxed = true, exact = false) // type arguments in type applications are boxed
+          fn match
+            case Select(qual, nme.asInstanceOf_) =>
+              // No need to box type arguments of an asInstanceOf call. See #20224.
+            case _ =>
+              for case arg: TypeTree <- args do
+                transformTT(arg, boxed = true, exact = false) // type arguments in type applications are boxed
 
         case tree: TypeDef if tree.symbol.isClass =>
           inContext(ctx.withOwner(tree.symbol)):

--- a/tests/neg-custom-args/captures/i16725.scala
+++ b/tests/neg-custom-args/captures/i16725.scala
@@ -1,0 +1,15 @@
+import language.experimental.captureChecking
+@annotation.capability
+class IO:
+  def brewCoffee(): Unit = ???
+def usingIO[T](op: IO => T): T = ???
+
+type Wrapper[T] = [R] -> (f: T => R) -> R
+def mk[T](x: T): Wrapper[T] = [R] => f => f(x)
+def useWrappedIO(wrapper: Wrapper[IO]): () -> Unit =
+  () =>
+    wrapper: io => // error
+      io.brewCoffee()
+def main(): Unit =
+  val escaped = usingIO(io => useWrappedIO(mk(io)))
+  escaped()  // boom

--- a/tests/neg-custom-args/captures/i20169.scala
+++ b/tests/neg-custom-args/captures/i20169.scala
@@ -1,0 +1,8 @@
+case class Box[T](x: T):
+  def foreach(f: T => Unit): Unit = f(x)
+
+def runOps(ops: Box[() => Unit]): () -> Unit =
+  val applyFn: (() => Unit) -> Unit = f => f()
+  val fn: () -> Unit = () =>
+    ops.foreach(applyFn)  // error
+  fn


### PR DESCRIPTION
Fixes #20169. Fixes #20224.

It turns out that the type argument in #20169 is properly boxed. It is just that when doing box adaptation, when charging `cap` into environments it gets discarded by the visibility check.

Right now, a symbol is considered visible in an environment only when the owner of the environment is contained in the symbol. This is not right: when there is not containment relation between the symbol and the environment owner the symbol is also visible from the environment, which is the case here for `cap`.