### PR TITLE
Add fromNullable to Predef for explicit nulls

### DIFF
--- a/library/src-bootstrapped/scala/annotation/experimental.scala
+++ b/library/src-bootstrapped/scala/annotation/experimental.scala
@@ -5,6 +5,5 @@ package scala.annotation
  *  @see [[https://dotty.epfl.ch/docs/reference/other-new-features/experimental-defs]]
  *  @syntax markdown
  */
-@deprecatedInheritance("Scheduled for being final in the future", "3.4.0")
-class experimental(message: String) extends StaticAnnotation:
+final class experimental(message: String) extends StaticAnnotation:
   def this() = this("")

--- a/library/src-non-bootstrapped/scala/annotation/experimental.scala
+++ b/library/src-non-bootstrapped/scala/annotation/experimental.scala
@@ -1,4 +1,3 @@
 package scala.annotation
 
-@deprecatedInheritance("Scheduled for being final in the future", "3.4.0")
-class experimental extends StaticAnnotation
+final class experimental extends StaticAnnotation

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -62,4 +62,8 @@ object Predef:
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. */
     inline def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
+
+  extension (inline opt: Option.type)
+    @experimental
+    inline def fromNullable[T](t: T | Null): Option[T] = Option(t).asInstanceOf
 end Predef

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -63,7 +63,7 @@ object Predef:
     inline def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
 
-  extension (inline opt: Option.type)
+  extension (opt: Option.type)
     @experimental
     inline def fromNullable[T](t: T | Null): Option[T] = Option(t).asInstanceOf[Option[T]]
 end Predef

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -65,5 +65,5 @@ object Predef:
 
   extension (inline opt: Option.type)
     @experimental
-    inline def fromNullable[T](t: T | Null): Option[T] = Option(t).asInstanceOf
+    inline def fromNullable[T](t: T | Null): Option[T] = Option(t).asInstanceOf[Option[T]]
 end Predef

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -9,6 +9,7 @@ object MiMaFilters {
       // Additions that require a new minor version of the library
       Build.mimaPreviousDottyVersion -> Seq(
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.annotation.experimental.this"),
+        ProblemFilters.exclude[FinalClassProblem]("scala.annotation.experimental"),
       ),
 
       // Additions since last LTS

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -56,6 +56,7 @@ object MiMaFilters {
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#MethodTypeModule.apply"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#MethodTypeMethods.methodTypeKind"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#MethodTypeMethods.isContextual"),
+          // Change `experimental` annotation to a final class
           ProblemFilters.exclude[FinalClassProblem]("scala.annotation.experimental"),
         ),
 

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -56,6 +56,7 @@ object MiMaFilters {
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#MethodTypeModule.apply"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#MethodTypeMethods.methodTypeKind"),
           ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.quoted.Quotes#reflectModule#MethodTypeMethods.isContextual"),
+          ProblemFilters.exclude[FinalClassProblem]("scala.annotation.experimental"),
         ),
 
       // Breaking changes since last LTS

--- a/tests/explicit-nulls/neg/from-nullable.scala
+++ b/tests/explicit-nulls/neg/from-nullable.scala
@@ -1,0 +1,6 @@
+import scala.annotation.experimental
+
+@experimental def testFromNullable =
+  val s: String | Null = "abc"
+  val sopt1: Option[String] = Option(s) // error
+  val sopt2: Option[String] = Option.fromNullable(s) // ok

--- a/tests/explicit-nulls/run/from-nullable.check
+++ b/tests/explicit-nulls/run/from-nullable.check
@@ -1,0 +1,2 @@
+hello
+None

--- a/tests/explicit-nulls/run/from-nullable.scala
+++ b/tests/explicit-nulls/run/from-nullable.scala
@@ -1,0 +1,17 @@
+object Test:
+  import scala.annotation.experimental
+
+  @experimental def main(args: Array[String]): Unit =
+    val s1: String | Null = "hello"
+    val s2: String | Null = null
+
+    val opts1: Option[String] = Option.fromNullable(s1)
+    val opts2: Option[String] = Option.fromNullable(s2)
+
+    opts1 match
+      case Some(s) => println(s)
+      case None => println("None")
+
+    opts2 match
+      case Some(s) => println(s)
+      case None => println("None")

--- a/tests/neg/experimentalExperimental.scala
+++ b/tests/neg/experimentalExperimental.scala
@@ -1,0 +1,1 @@
+class MyExperimentalAnnot extends scala.annotation.experimental // error

--- a/tests/pos/experimentalExperimental.scala
+++ b/tests/pos/experimentalExperimental.scala
@@ -1,1 +1,0 @@
-class MyExperimentalAnnot extends scala.annotation.experimental

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -76,6 +76,9 @@ val experimentalDefinitionInLibrary = Set(
   "scala.Tuple$.Reverse", // can be stabilized in 3.5
   "scala.Tuple$.ReverseOnto", // can be stabilized in 3.5
   "scala.runtime.Tuples$.reverse", // can be stabilized in 3.5
+
+  // New feature: fromNullable for explicit nulls
+  "scala.Predef$.fromNullable",
 )
 
 


### PR DESCRIPTION
The attempt to enable explicit nulls for community projects has shown the usefulness of `fromNullable`,
so we decide to include it in the std library.

It is a helper function which can turn a nullable value into an option.

```scala
extension (inline opt: Option.type)
  @experimental
  inline def fromNullable[T](t: T | Null): Option[T] = Option(t).asInstanceOf

val s: String | Null = "abc"
val sopt: Option[String] = Option.fromNullable(s)
```

<details>
  <summary>The experimental issue (wait for #20260)</summary>

This PR is currently blocked by the experimental annotation: using the annotation in `Predef` would cause cyclic references when compiling the library.

```
[error] -- [E046] Cyclic Error: /dotty/library/src-non-bootstrapped/scala/annotation/experimental.scala:3:1 
[error] 3 |@deprecatedInheritance("Scheduled for being final in the future", "3.4.0")
[error]   | ^
[error]   | Cyclic reference involving class experimental
[error]   |
[error]   |  Run with -explain-cyclic for more details.
[error]   |
[error]   | longer explanation available when compiling with `-explain`
[error] -- [E008] Not Found Error: /dotty/library/src/scala/quoted/Expr.scala:70:17 
[error] 70 |    scala.Predef.summon[ToExpr[T]].apply(x)
[error]    |    ^^^^^^^^^^^^^^^^^^^
[error]    |    value summon is not a member of object Predef
[error] -- [E008] Not Found Error: /dotty/library/src/scala/quoted/Expr.scala:85:17 
[error] 85 |    scala.Predef.summon[FromExpr[T]].unapply(x)
[error]    |    ^^^^^^^^^^^^^^^^^^^
[error]    |    value summon is not a member of object Predef
[error] -- [E006] Not Found Error: /dotty/library/src/scala/quoted/Quotes.scala:68:6 
[error] 68 |      summon[FromExpr[T]].unapply(self)
[error]    |      ^^^^^^
[error]    |      Not found: summon
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[error] -- [E006] Not Found Error: /dotty/library/src/scala/quoted/Quotes.scala:77:21 
[error] 77 |      val fromExpr = summon[FromExpr[T]]
[error]    |                     ^^^^^^
[error]    |                     Not found: summon
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[error] -- [E006] Not Found Error: /dotty/library/src/scala/quoted/ToExpr.scala:100:46 
[error] 100 |      '{ Array[T](${Expr(arr.toSeq)}*)(${Expr(summon[ClassTag[T]])}) }
[error]     |                                              ^^^^^^
[error]     |                                              Not found: summon
[error]     |
[error]     | longer explanation available when compiling with `-explain`
[error] -- [E006] Not Found Error: /dotty/library/src/scala/quoted/ToExpr.scala:168:24 
[error] 168 |      Expr.ofSeq(xs.map(summon[ToExpr[T]].apply))
[error]     |                        ^^^^^^
[error]     |                        Not found: summon
[error]     |
[error]     | longer explanation available when compiling with `-explain`
[error] -- [E006] Not Found Error: /dotty/library/src/scala/quoted/ToExpr.scala:174:25 
[error] 174 |      Expr.ofList(xs.map(summon[ToExpr[T]].apply))
[error]     |                         ^^^^^^
[error]     |                         Not found: summon
[error]     |
[error]     | longer explanation available when compiling with `-explain`
[error] -- [E008] Not Found Error: /dotty/library/src/scala/reflect/Selectable.scala:24:60 
[error] 24 |      val fld = rcls.getField(NameTransformer.encode(name)).nn
[error]    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |value nn is not a member of java.lang.reflect.Field | Null, but could be made available as an extension method.
[error]    |
[error]    |The following import might fix the problem:
[error]    |
[error]    |  import scala.runtime.stdLibPatches.Predef.nn
[error]    |
[error] -- [E008] Not Found Error: /dotty/library/src/scala/reflect/Selectable.scala:38:72 
[error] 38 |    val mth = rcls.getMethod(NameTransformer.encode(name), paramTypes*).nn
[error]    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |value nn is not a member of java.lang.reflect.Method | Null, but could be made available as an extension method.
[error]    |
[error]    |The following import might fix the problem:
[error]    |
[error]    |  import scala.runtime.stdLibPatches.Predef.nn
[error]    |
[error] -- [E008] Not Found Error: /dotty/library/src/scala/runtime/LazyVals.scala:18:79 
[error] 18 |      val unsafeField = classOf[sun.misc.Unsafe].getDeclaredField("theUnsafe").nn
[error]    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |value nn is not a member of java.lang.reflect.Field | Null, but could be made available as an extension method.
[error]    |
[error]    |The following import might fix the problem:
[error]    |
[error]    |  import scala.runtime.stdLibPatches.Predef.nn
[error]    |
[error] -- [E008] Not Found Error: /dotty/library/src/scala/runtime/LazyVals.scala:29:50 
[error] 29 |    val processors = java.lang.Runtime.getRuntime.nn.availableProcessors()
[error]    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |value nn is not a member of Runtime | Null, but could be made available as an extension method.
[error]    |
[error]    |The following import might fix the problem:
[error]    |
[error]    |  import scala.runtime.stdLibPatches.Predef.nn
[error]    |
[error] -- [E008] Not Found Error: /dotty/library/src/scala/runtime/coverage/Invoker.scala:54:66 
[error] 54 |    MeasurementsPrefix + runtimeUUID + "." + Thread.currentThread.nn.getId
[error]    |                                             ^^^^^^^^^^^^^^^^^^^^^^^
[error]    |value nn is not a member of Thread | Null, but could be made available as an extension method.
[error]    |
[error]    |The following import might fix the problem:
[error]    |
[error]    |  import scala.runtime.stdLibPatches.Predef.nn
[error]    |
[error] -- [E046] Cyclic Error: /dotty/library/src/scala/runtime/stdLibPatches/Predef.scala:68:15 
[error] 68 |    inline def fromNullable[T](t: T | Null): Option[T] = Option(t).asInstanceOf
[error]    |               ^
[error]    |               Cyclic reference involving method fromNullable
[error]    |
[error]    |                Run with -explain-cyclic for more details.
[error]    |
[error]    | longer explanation available when compiling with `-explain`
[warn] -- Warning: /dotty/library/src/scala/runtime/stdLibPatches/Predef.scala:64:10 
[warn] 64 |      !(x eq y)
[warn]    |          ^^
[warn]    |Alphanumeric method eq is not declared infix; it should not be used as infix operator.
[warn]    |Instead, use method syntax .eq(...) or backticked identifier `eq`.
[warn]    |The latter can be rewritten automatically under -rewrite -source 3.4-migration.
[error] -- [E008] Not Found Error: /dotty/library/src/scala/util/FromDigits.scala:138:56 
[error] 138 |    if (x == 0.0f && !zeroFloat.pattern.matcher(digits).nn.matches) throw NumberTooSmall()
[error]     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     |value nn is not a member of java.util.regex.Matcher | Null, but could be made available as an extension method.
[error]     |
[error]     |The following import might fix the problem:
[error]     |
[error]     |  import scala.runtime.stdLibPatches.Predef.nn
[error]     |
[error] -- [E008] Not Found Error: /dotty/library/src/scala/util/FromDigits.scala:156:56 
[error] 156 |    if (x == 0.0d && !zeroFloat.pattern.matcher(digits).nn.matches) throw NumberTooSmall()
[error]     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     |value nn is not a member of java.util.regex.Matcher | Null, but could be made available as an extension method.
[error]     |
[error]     |The following import might fix the problem:
[error]     |
[error]     |  import scala.runtime.stdLibPatches.Predef.nn
[error]     |
[error] No warnings can be incurred under -Werror (or -Xfatal-warnings)
[warn] one warning found
[error] 17 errors found
[error] (scala3-library / Compile / compileIncremental) Compilation failed
[error] Total time: 6 s, completed 18 Apr 2024, 14:59:41
```
</details>

cc @olhotak 