### PR TITLE
Allow @retains arguments to be context functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1056,6 +1056,7 @@ class Definitions {
   @tu lazy val RetainsAnnot: ClassSymbol = requiredClass("scala.annotation.retains")
   @tu lazy val RetainsCapAnnot: ClassSymbol = requiredClass("scala.annotation.retainsCap")
   @tu lazy val RetainsByNameAnnot: ClassSymbol = requiredClass("scala.annotation.retainsByName")
+  @tu lazy val RetainsArgAnnot: ClassSymbol = requiredClass("scala.annotation.retainsArg")
   @tu lazy val PublicInBinaryAnnot: ClassSymbol = requiredClass("scala.annotation.publicInBinary")
 
   @tu lazy val JavaRepeatableAnnot: ClassSymbol = requiredClass("java.lang.annotation.Repeatable")

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4047,10 +4047,15 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             true
           }
 
+      def isRetainsArg(pt: Type) = pt match
+        case AnnotatedType(arg, annot) => annot.symbol == defn.RetainsArgAnnot
+        case _ => false
+
       if (implicitFun || caseCompanion)
           && !isApplyProto(pt)
           && pt != SingletonTypeProto
           && pt != LhsProto
+          && !isRetainsArg(pt)
           && !ctx.mode.is(Mode.Pattern)
           && !tree.isInstanceOf[SplicePattern]
           && !ctx.isAfterTyper

--- a/library/src/scala/annotation/retains.scala
+++ b/library/src/scala/annotation/retains.scala
@@ -12,12 +12,20 @@ package scala.annotation
  *  non-standard capturing type syntax.
  */
 @experimental
-class retains(xs: Any*) extends annotation.StaticAnnotation
+class retains(xs: (Any@retainsArg)*) extends annotation.StaticAnnotation
 
-/** Equivalent in meaning to `@retains(cap)`, but consumes less bytecode. 
+/** Equivalent in meaning to `@retains(cap)`, but consumes less bytecode.
  */
 @experimental
 class retainsCap() extends annotation.StaticAnnotation
   // This special case is needed to be able to load standard library modules without
   // cyclic reference errors. Specifically, load sequences involving IterableOnce.
 
+/** Internal use, only for parameters of `retains` and `retainsByName`.
+ */
+@experimental
+class retainsArg extends annotation.StaticAnnotation
+  // This annotation prevents argument references to retains and retainsByName from being
+  // augmented with explicit arguments. That's unsound in general, but necessary
+  // since a captureRef could have an impure context function type, A ?=> B, but
+  // we still need to have the unapplied captureRef in the annotation.

--- a/library/src/scala/annotation/retainsByName.scala
+++ b/library/src/scala/annotation/retainsByName.scala
@@ -2,5 +2,5 @@ package scala.annotation
 
 /** An annotation that indicates capture of an enclosing by-name type
  */
-@experimental class retainsByName(xs: Any*) extends annotation.StaticAnnotation
+@experimental class retainsByName(xs: (Any@retainsArg)*) extends annotation.StaticAnnotation
 

--- a/tests/pos-custom-args/captures/i20231.scala
+++ b/tests/pos-custom-args/captures/i20231.scala
@@ -1,0 +1,4 @@
+class Async
+class C(val x: Async ?=> Unit)
+def foo(x: Async ?=> Unit): C^{x} = C(x)
+def foo(x: Async ?=> Unit)(using Async): C^{x} = C(x)

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -30,6 +30,7 @@ val experimentalDefinitionInLibrary = Set(
   "scala.annotation.retains",
   "scala.annotation.retainsByName",
   "scala.annotation.retainsCap",
+  "scala.annotation.retainsArg",
   "scala.Pure",
   "scala.caps",
   "scala.caps$",


### PR DESCRIPTION
Suppress the creation of apply method selections for these arguments

Fixes #20231