### PR TITLE
Add missing dependency to AsyncFile community build project

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -605,7 +605,7 @@ object projects:
     project           = "AsyncFile",
     sbtTestCommand    = "rootJVM/test",
     sbtPublishCommand = "rootJVM/publishLocal",
-    dependencies      = List(scissLog, scalatest),
+    dependencies      = List(scissLog, scissModel, scalatest),
   )
 
   lazy val scissSpan = SbtCommunityProject(


### PR DESCRIPTION
The AsyncFile project [depends on](https://github.com/dotty-staging/AsyncFile/blob/d72a5279e4b055ad13d1c19d75939b9bd9d014a0/build.sbt#L39) the Model project but does not declare this dependency.