### PR TITLE
Make inline proxy vals have inferred types

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -237,7 +237,7 @@ class Inliner(val call: tpd.Tree)(using Context):
       if bindingFlags.is(Inline) && argIsBottom then
         newArg = Typed(newArg, TypeTree(formal.widenExpr)) // type ascribe RHS to avoid type errors in expansion. See i8612.scala
       if isByName then DefDef(boundSym, newArg)
-      else ValDef(boundSym, newArg)
+      else ValDef(boundSym, newArg, inferred = true)
     }.withSpan(boundSym.span)
     inlining.println(i"parameter binding: $binding, $argIsBottom")
     buf += binding
@@ -319,7 +319,7 @@ class Inliner(val call: tpd.Tree)(using Context):
             else pre
 
       val binding = accountForOpaques(
-        ValDef(selfSym.asTerm, QuoteUtils.changeOwnerOfTree(rhs, selfSym)).withSpan(selfSym.span))
+        ValDef(selfSym.asTerm, QuoteUtils.changeOwnerOfTree(rhs, selfSym), inferred = true).withSpan(selfSym.span))
       bindingsBuf += binding
       inlining.println(i"proxy at $level: $selfSym = ${bindingsBuf.last}")
       lastSelf = selfSym
@@ -368,7 +368,7 @@ class Inliner(val call: tpd.Tree)(using Context):
               RefinedType(parent, refinement._1, TypeAlias(refinement._2))
             )
             val refiningSym = newSym(InlineBinderName.fresh(), Synthetic, refinedType).asTerm
-            val refiningDef = ValDef(refiningSym, tpd.ref(ref).cast(refinedType)).withSpan(span)
+            val refiningDef = ValDef(refiningSym, tpd.ref(ref).cast(refinedType), inferred = true).withSpan(span)
             inlining.println(i"add opaque alias proxy $refiningDef for $ref in $tp")
             bindingsBuf += refiningDef
             opaqueProxies += ((ref, refiningSym.termRef))

--- a/tests/pos/i20237.scala
+++ b/tests/pos/i20237.scala
@@ -1,0 +1,15 @@
+import language.experimental.captureChecking
+import scala.annotation.capability
+
+@capability class Cap:
+  def use[T](body: Cap ?=> T) = body(using this)
+
+class Box[T](body: Cap ?=> T):
+  inline def open(using cap: Cap) = cap.use(body)
+
+object Box:
+  def make[T](body: Cap ?=> T)(using Cap): Box[T]^{body} = Box(body)
+
+def main =
+  given Cap = new Cap
+  val box = Box.make(1).open


### PR DESCRIPTION
Fixes #20237 since it erases illegal capture sets containing skolem types.