### PR TITLE
Better error diagnostics under -explain-cyclic

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -168,16 +168,11 @@ object SymDenotations {
           }
         }
         else
-          val traceCycles = CyclicReference.isTraced
-          try
-            if traceCycles then
-              CyclicReference.pushTrace("compute the signature of ", symbol, "")
+          CyclicReference.trace("compute the signature of ", symbol):
             if myFlags.is(Touched) then
               throw CyclicReference(this)(using ctx.withOwner(symbol))
             myFlags |= Touched
             atPhase(validFor.firstPhaseId)(completer.complete(this))
-          finally
-            if traceCycles then CyclicReference.popTrace()
 
     protected[dotc] def info_=(tp: Type): Unit = {
       /* // DEBUG
@@ -2994,12 +2989,9 @@ object SymDenotations {
     def apply(clsd: ClassDenotation)(implicit onBehalf: BaseData, ctx: Context)
         : (List[ClassSymbol], BaseClassSet) = {
       assert(isValid)
-      val traceCycles = CyclicReference.isTraced
-      try
-        if traceCycles then
-          CyclicReference.pushTrace("compute the base classes of ", clsd.symbol, "")
-        if (cache != null) cache.uncheckedNN
-        else {
+      CyclicReference.trace("compute the base classes of ", clsd.symbol):
+        if cache != null then cache.uncheckedNN
+        else
           if (locked) throw CyclicReference(clsd)
           locked = true
           provisional = false
@@ -3009,10 +3001,6 @@ object SymDenotations {
           if (!provisional) cache = computed
           else onBehalf.signalProvisional()
           computed
-        }
-      finally
-        if traceCycles then CyclicReference.popTrace()
-        addDependent(onBehalf)
     }
 
     def sameGroup(p1: Phase, p2: Phase) = p1.sameParentsStartId == p2.sameParentsStartId

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -205,7 +205,7 @@ object CyclicReference:
   private def isTraced(using Context) =
     ctx.property(CyclicReference.Trace).isDefined
 
-  private def pushTrace(info: Context ?=> String)(using Context): Unit =
+  private def pushTrace(info: TraceElement)(using Context): Unit =
     for buf <- ctx.property(CyclicReference.Trace) do
       buf += info
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -158,20 +158,15 @@ class TreeUnpickler(reader: TastyReader,
         if f == null then "" else s" in $f"
       def fail(ex: Throwable) = throw UnpicklingError(denot, where, ex)
       treeAtAddr(currentAddr) =
-        val traceCycles = CyclicReference.isTraced
-        try
-          if traceCycles then
-            CyclicReference.pushTrace("read the definition of ", denot.symbol, where)
-          atPhaseBeforeTransforms {
-            new TreeReader(reader).readIndexedDef()(
-              using ctx.withOwner(owner).withModeBits(mode).withSource(source))
-          }
-        catch
-          case ex: CyclicReference => throw ex
-          case ex: AssertionError => fail(ex)
-          case ex: Exception => fail(ex)
-        finally
-          if traceCycles then CyclicReference.popTrace()
+        CyclicReference.trace(i"read the definition of ${denot.symbol}$where"):
+          try
+            atPhaseBeforeTransforms:
+              new TreeReader(reader).readIndexedDef()(
+                using ctx.withOwner(owner).withModeBits(mode).withSource(source))
+          catch
+            case ex: CyclicReference => throw ex
+            case ex: AssertionError => fail(ex)
+            case ex: Exception => fail(ex)
   }
 
   class TreeReader(val reader: TastyReader) {

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -95,7 +95,8 @@ abstract class CyclicMsg(errorId: ErrorMessageID)(using Context) extends Message
   protected def context: String = ex.optTrace match
     case Some(trace) =>
       s"\n\nThe error occurred while trying to ${
-        trace.map((prefix, sym, suffix) => i"$prefix$sym$suffix").mkString("\n  which required to ")
+        trace.map(identity) // map with identity will turn Context ?=> String elements to String elements
+          .mkString("\n  which required to ")
       }$debugInfo"
     case None =>
       "\n\n Run with -explain-cyclic for more details."

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -349,10 +349,7 @@ object Checking {
           }
 
           if isInteresting(pre) then
-            val traceCycles = CyclicReference.isTraced
-            try
-              if traceCycles then
-                CyclicReference.pushTrace("explore ", tp.symbol, " for cyclic references")
+            CyclicReference.trace(i"explore ${tp.symbol} for cyclic references"):
               val pre1 = this(pre, false, false)
               if locked.contains(tp)
                   || tp.symbol.infoOrCompleter.isInstanceOf[NoCompleter]
@@ -367,8 +364,6 @@ object Checking {
               finally
                 locked -= tp
               tp.withPrefix(pre1)
-            finally
-              if traceCycles then CyclicReference.popTrace()
           else tp
         }
         catch {

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1084,10 +1084,15 @@ trait Implicits:
             (searchCtx.scope eq ctx.scope) && (searchCtx.owner eq ctx.owner.owner)
           do ()
 
-        try ImplicitSearch(pt, argument, span)(using searchCtx).bestImplicit
-        catch case ce: CyclicReference =>
-          ce.inImplicitSearch = true
-          throw ce
+        def searchStr =
+          if argument.isEmpty then i"argument of type $pt"
+          else i"conversion from ${argument.tpe} to $pt"
+
+        CyclicReference.trace(i"searching for an implicit $searchStr"):
+          try ImplicitSearch(pt, argument, span)(using searchCtx).bestImplicit
+          catch case ce: CyclicReference =>
+            ce.inImplicitSearch = true
+            throw ce
       else NoMatchingImplicitsFailure
 
       val result =

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1442,7 +1442,8 @@ class Namer { typer: Typer =>
 
       def process(stats: List[Tree])(using Context): Unit = stats match
         case (stat: Export) :: stats1 =>
-          processExport(stat, NoSymbol)
+          CyclicReference.trace(i"elaborate the export clause $stat"):
+            processExport(stat, NoSymbol)
           process(stats1)
         case (stat: Import) :: stats1 =>
           process(stats1)(using ctx.importContext(stat, symbolOfTree(stat)))
@@ -1954,8 +1955,9 @@ class Namer { typer: Typer =>
     rhsCtx = prepareRhsCtx(rhsCtx, paramss)
 
     def typedAheadRhs(pt: Type) =
-      PrepareInlineable.dropInlineIfError(sym,
-        typedAheadExpr(mdef.rhs, pt)(using rhsCtx))
+      CyclicReference.trace(i"type the right hand side of $sym since no explicit type was given"):
+        PrepareInlineable.dropInlineIfError(sym,
+          typedAheadExpr(mdef.rhs, pt)(using rhsCtx))
 
     def rhsType =
       // For default getters, we use the corresponding parameter type as an

--- a/tests/neg-macros/i14772.check
+++ b/tests/neg-macros/i14772.check
@@ -5,6 +5,7 @@
   |
   |       The error occurred while trying to compute the signature of method $anonfun
   |         which required to compute the signature of method impl
+  |         which required to type the right hand side of method impl since no explicit type was given
   |
   |        Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
   |

--- a/tests/neg-macros/i16582.check
+++ b/tests/neg-macros/i16582.check
@@ -6,7 +6,9 @@
   |           dotty.tools.dotc.core.CyclicReference: Recursive value o2 needs type
   |
   |           The error occurred while trying to compute the signature of method test
+  |             which required to type the right hand side of method test since no explicit type was given
   |             which required to compute the signature of value o2
+  |             which required to type the right hand side of value o2 since no explicit type was given
   |             which required to compute the signature of value o2
   |
   |            Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.

--- a/tests/neg/cyclic.check
+++ b/tests/neg/cyclic.check
@@ -4,9 +4,13 @@
   |            Overloaded or recursive method f needs return type
   |
   |            The error occurred while trying to compute the signature of method f
+  |              which required to type the right hand side of method f since no explicit type was given
   |              which required to compute the signature of method g
+  |              which required to type the right hand side of method g since no explicit type was given
   |              which required to compute the signature of method h
+  |              which required to type the right hand side of method h since no explicit type was given
   |              which required to compute the signature of method i
+  |              which required to type the right hand side of method i since no explicit type was given
   |              which required to compute the signature of method f
   |
   |             Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.

--- a/tests/neg/i20245.check
+++ b/tests/neg/i20245.check
@@ -1,0 +1,17 @@
+
+-- [E046] Cyclic Error: tests/neg/i20245/Typer_2.scala:16:57 -----------------------------------------------------------
+16 |  private[typer] val unification = new Unification(using this) // error
+   |                                                         ^
+   |              Cyclic reference involving class Context
+   |
+   |              The error occurred while trying to compute the base classes of class Context
+   |                which required to compute the base classes of trait TyperOps
+   |                which required to compute the signature of trait TyperOps
+   |                which required to elaborate the export clause export unification.requireSubtype
+   |                which required to compute the signature of value unification
+   |                which required to type the right hand side of value unification since no explicit type was given
+   |                which required to compute the base classes of class Context
+   |
+   |               Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i20245/Context_1.scala
+++ b/tests/neg/i20245/Context_1.scala
@@ -1,0 +1,12 @@
+package effekt
+package context
+
+import effekt.typer.TyperOps
+
+
+abstract class Context extends TyperOps {
+
+  // bring the context itself in scope
+  implicit val context: Context = this
+
+}

--- a/tests/neg/i20245/Messages_1.scala
+++ b/tests/neg/i20245/Messages_1.scala
@@ -1,0 +1,8 @@
+package effekt
+package util
+
+object messages {
+  trait ErrorReporter {
+
+  }
+}

--- a/tests/neg/i20245/Tree_1.scala
+++ b/tests/neg/i20245/Tree_1.scala
@@ -1,0 +1,18 @@
+package effekt
+package source
+
+import effekt.context.Context
+
+object Resolvable {
+
+  // There need to be two resolve extension methods for the error to show up
+  // They also need to take an implicit Context
+  extension (n: Int) {
+    def resolve(using C: Context): Unit = ???
+  }
+
+  extension (b: Boolean) {
+    def resolve(using C: Context): Unit = ???
+  }
+}
+export Resolvable.resolve

--- a/tests/neg/i20245/Typer_1.scala
+++ b/tests/neg/i20245/Typer_1.scala
@@ -1,0 +1,28 @@
+package effekt
+package typer
+
+import effekt.util.messages.ErrorReporter
+
+import effekt.context.{ Context }
+
+// This import is also NECESSARY for the cyclic error
+import effekt.source.{ resolve }
+
+
+trait TyperOps extends ErrorReporter { self: Context =>
+
+  // passing `this` as ErrorReporter here is also NECESSARY for the cyclic error
+  private[typer] val unification = new Unification(using this)
+
+  // this export is NECESSARY for the cyclic error
+  export unification.{ requireSubtype }
+
+  println(1)
+
+  // vvvvvvvv insert a line here, save, and run `compile` again vvvvvvvvvv
+}
+
+
+
+
+

--- a/tests/neg/i20245/Typer_2.scala
+++ b/tests/neg/i20245/Typer_2.scala
@@ -1,0 +1,27 @@
+//> using options -explain-cyclic
+package effekt
+package typer
+
+import effekt.util.messages.ErrorReporter
+
+import effekt.context.{ Context }
+
+// This import is also NECESSARY for the cyclic error
+import effekt.source.{ resolve }
+
+
+trait TyperOps extends ErrorReporter { self: Context =>
+
+  // passing `this` as ErrorReporter here is also NECESSARY for the cyclic error
+  private[typer] val unification = new Unification(using this) // error
+
+  // this export is NECESSARY for the cyclic error
+  export unification.{ requireSubtype }
+
+  // vvvvvvvv insert a line here, save, and run `compile` again vvvvvvvvvv
+}
+
+
+
+
+

--- a/tests/neg/i20245/Unification_1.scala
+++ b/tests/neg/i20245/Unification_1.scala
@@ -1,0 +1,11 @@
+package effekt
+package typer
+
+import effekt.util.messages.ErrorReporter
+
+
+class Unification(using C: ErrorReporter) {
+
+  def requireSubtype(): Unit = ()
+
+}


### PR DESCRIPTION
Also report type-checked right hand sides and export expansions.

Streamline trace-handling code using inline functions.

Fixes #20245