### PR TITLE
Make logLevel invisible

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1085,7 +1085,7 @@ object Build {
       scalacOptions += "-Yscala2Unpickler:never",
       scalacOptions += "-Yno-experimental",
       scalacOptions -= "-Xfatal-warnings",
-      Compile / compile / logLevel := Level.Error,
+      Compile / compile / logLevel.withRank(KeyRanks.Invisible) := Level.Error,
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       libraryDependencies +=


### PR DESCRIPTION
To silence this warning when opening SBT:

```
[warn] there are 2 keys that are not used by any other settings/tasks:
[warn]  
[warn] * scala2-library-bootstrapped / Compile / compile / logLevel
[warn]   +- /Users/mbovel/dotty/project/Build.scala:1083
[warn] * scala2-library-cc / Compile / compile / logLevel
[warn]   +- /Users/mbovel/dotty/project/Build.scala:1083
[warn]  
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
```