### PR TITLE
Normalize for underlyingClassRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1584,7 +1584,8 @@ object Types extends TypeUtils {
         else if (tp.symbol.isAliasType) tp.underlying.underlyingClassRef(refinementOK)
         else NoType
       case tp: AppliedType =>
-        if (tp.tycon.isLambdaSub) NoType
+        if tp.isMatchAlias then tp.tryNormalize.underlyingClassRef(refinementOK)
+        else if (tp.tycon.isLambdaSub) NoType
         else tp.superType.underlyingClassRef(refinementOK)
       case tp: AnnotatedType =>
         tp.parent.underlyingClassRef(refinementOK)

--- a/tests/pos/i15827b/A_1.scala
+++ b/tests/pos/i15827b/A_1.scala
@@ -1,0 +1,8 @@
+
+case class Foo()
+
+type T = Tuple.Elem[(Foo, Any), 0]
+type U = Tuple.Elem[(Any, T), 1]
+
+val _ = new T() // ok
+val _ = new U() // ok

--- a/tests/pos/i15827b/B_2.scala
+++ b/tests/pos/i15827b/B_2.scala
@@ -1,0 +1,3 @@
+
+val _ = new T() // was error
+val _ = new U() // was error


### PR DESCRIPTION
Related to #20258

Here too, I would be fine with not normalizing,
but in that case pos/i15827 should become a neg test.