### PR TITLE
Fix conflict with `new ScalaSettings`

### DIFF
--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -104,7 +104,7 @@ class ScalaSettingsTests:
   private def wconfSrcFilterTest(argsStr: String,
                                  warning: reporting.Diagnostic.Warning): Either[List[String], reporting.Action] =
     import reporting.Diagnostic
-    val settings = new ScalaSettings
+    val settings = ScalaSettings
     val args = ArgsSummary(settings.defaultState, List(argsStr), errors = Nil, warnings = Nil)
     val proc = settings.processArguments(args, processAll = true, skipped = Nil)
     val wconfStr = settings.Wconf.valueIn(proc.sstate)


### PR DESCRIPTION
Conflict between #18783 and #19766.

See `val sets = ScalaSettings` in the test just above.