### PR TITLE
Streamline `tryNormalize` with `underlyingMatchType`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -491,7 +491,7 @@ object Types extends TypeUtils {
     /** Does this application expand to a match type? */
     def isMatchAlias(using Context): Boolean = underlyingNormalizable.isMatch
 
-    def underlyingNormalizable(using Context): Type = stripped match
+    def underlyingNormalizable(using Context): Type = stripped.stripLazyRef match
       case tp: MatchType => tp
       case tp: AppliedType => tp.underlyingNormalizable
       case _ => NoType
@@ -3256,8 +3256,6 @@ object Types extends TypeUtils {
   case class LazyRef(private var refFn: (Context => (Type | Null)) | Null) extends UncachedProxyType with ValueType {
     private var myRef: Type | Null = null
     private var computed = false
-
-    override def tryNormalize(using Context): Type = ref.tryNormalize
 
     def ref(using Context): Type =
       if computed then

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5158,11 +5158,7 @@ object Types extends TypeUtils {
     private var reductionContext: util.MutableMap[Type, Type] | Null = null
 
     override def tryNormalize(using Context): Type =
-      try
-        reduced.normalized
-      catch
-        case ex: Throwable =>
-          handleRecursive("normalizing", s"${scrutinee.show} match ..." , ex)
+      reduced.normalized
 
     private def thisMatchType = this
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4694,7 +4694,7 @@ object Types extends TypeUtils {
           case AliasingBounds(alias) if isMatchAlias =>
             trace(i"normalize $this", typr, show = true) {
               MatchTypeTrace.recurseWith(this) {
-                alias.applyIfParameterized(args.map(_.normalized)).tryNormalize
+                alias.applyIfParameterized(args).tryNormalize
                 /* `applyIfParameterized` may reduce several HKTypeLambda applications
                  * before the underlying MatchType is reached.
                  * Even if they do not involve any match type normalizations yet,

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5692,7 +5692,8 @@ object Types extends TypeUtils {
   /** Common supertype of `TypeAlias` and `MatchAlias` */
   abstract class AliasingBounds(val alias: Type) extends TypeBounds(alias, alias) {
 
-    def derivedAlias(alias: Type)(using Context): AliasingBounds
+    def derivedAlias(alias: Type)(using Context): AliasingBounds =
+      if alias eq this.alias then this else AliasingBounds(alias)
 
     override def computeHash(bs: Binders): Int = doHash(bs, alias)
     override def hashIsStable: Boolean = alias.hashIsStable
@@ -5714,10 +5715,7 @@ object Types extends TypeUtils {
 
   /**    = T
    */
-  class TypeAlias(alias: Type) extends AliasingBounds(alias) {
-    def derivedAlias(alias: Type)(using Context): AliasingBounds =
-      if (alias eq this.alias) this else TypeAlias(alias)
-  }
+  class TypeAlias(alias: Type) extends AliasingBounds(alias)
 
   /**    = T     where `T` is a `MatchType`
    *
@@ -5726,10 +5724,7 @@ object Types extends TypeUtils {
    *  If we assumed full substitutivity, we would have to reject all recursive match
    *  aliases (or else take the jump and allow full recursive types).
    */
-  class MatchAlias(alias: Type) extends AliasingBounds(alias) {
-    def derivedAlias(alias: Type)(using Context): AliasingBounds =
-      if (alias eq this.alias) this else MatchAlias(alias)
-  }
+  class MatchAlias(alias: Type) extends AliasingBounds(alias)
 
   object TypeBounds {
     def apply(lo: Type, hi: Type)(using Context): TypeBounds =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -489,11 +489,11 @@ object Types extends TypeUtils {
       case _ => false
 
     /** Does this application expand to a match type? */
-    def isMatchAlias(using Context): Boolean = underlyingMatchType.exists
+    def isMatchAlias(using Context): Boolean = underlyingNormalizable.isMatch
 
-    def underlyingMatchType(using Context): Type = stripped match
+    def underlyingNormalizable(using Context): Type = stripped match
       case tp: MatchType => tp
-      case tp: AppliedType => tp.underlyingMatchType
+      case tp: AppliedType => tp.underlyingNormalizable
       case _ => NoType
 
     /** Is this a higher-kinded type lambda with given parameter variances?
@@ -4612,8 +4612,8 @@ object Types extends TypeUtils {
     private var myEvalRunId: RunId = NoRunId
     private var myEvalued: Type = uninitialized
 
-    private var validUnderlyingMatch: Period = Nowhere
-    private var cachedUnderlyingMatch: Type = uninitialized
+    private var validUnderlyingNormalizable: Period = Nowhere
+    private var cachedUnderlyingNormalizable: Type = uninitialized
 
     def isGround(acc: TypeAccumulator[Boolean])(using Context): Boolean =
       if myGround == 0 then myGround = if acc.foldOver(true, this) then 1 else -1
@@ -4681,11 +4681,15 @@ object Types extends TypeUtils {
      *  Anything else should have already been reduced in `appliedTo` by the TypeAssigner.
      *  May reduce several HKTypeLambda applications before the underlying MatchType is reached.
      */
-    override def underlyingMatchType(using Context): Type =
-      if ctx.period != validUnderlyingMatch then
-        cachedUnderlyingMatch = superType.underlyingMatchType
-        validUnderlyingMatch = validSuper
-      cachedUnderlyingMatch
+    override def underlyingNormalizable(using Context): Type =
+      if ctx.period != validUnderlyingNormalizable then tycon match
+        case tycon: TypeRef if defn.isCompiletimeAppliedType(tycon.symbol) =>
+          cachedUnderlyingNormalizable = this
+          validUnderlyingNormalizable = ctx.period
+        case _ =>
+          cachedUnderlyingNormalizable = superType.underlyingNormalizable
+          validUnderlyingNormalizable = validSuper
+      cachedUnderlyingNormalizable
 
     override def tryNormalize(using Context): Type =
       def tryMatchAlias =
@@ -4693,7 +4697,7 @@ object Types extends TypeUtils {
           if MatchTypeTrace.isRecording then
             MatchTypeTrace.recurseWith(this)(superType.tryNormalize)
           else
-            underlyingMatchType.tryNormalize
+            underlyingNormalizable.tryNormalize
         else NoType
       tryCompiletimeConstantFold.orElse(tryMatchAlias)
 
@@ -5267,7 +5271,7 @@ object Types extends TypeUtils {
     def apply(bound: Type, scrutinee: Type, cases: List[Type])(using Context): MatchType =
       unique(new CachedMatchType(bound, scrutinee, cases))
 
-    def thatReducesUsingGadt(tp: Type)(using Context): Boolean = tp.underlyingMatchType match
+    def thatReducesUsingGadt(tp: Type)(using Context): Boolean = tp.underlyingNormalizable match
       case mt: MatchType => mt.reducesUsingGadt
       case _ => false
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1555,11 +1555,13 @@ object Types extends TypeUtils {
       if (normed.exists) normed else this
     }
 
-    /** If this type can be normalized at the top-level by rewriting match types
-     *  of S[n] types, the result after applying all toplevel normalizations,
-     *  otherwise NoType
+    /** If this type has an underlying match type or applied compiletime.ops,
+     *  then the result after applying all toplevel normalizations, otherwise NoType.
      */
-    def tryNormalize(using Context): Type = NoType
+    def tryNormalize(using Context): Type = underlyingNormalizable match
+      case mt: MatchType => mt.tryNormalize
+      case tp: AppliedType => tp.tryCompiletimeConstantFold
+      case _ => NoType
 
     private def widenDealias1(keep: AnnotatedType => Context ?=> Boolean)(using Context): Type = {
       val res = this.widen.dealias1(keep, keepOpaques = false)
@@ -4692,14 +4694,9 @@ object Types extends TypeUtils {
       cachedUnderlyingNormalizable
 
     override def tryNormalize(using Context): Type =
-      def tryMatchAlias =
-        if isMatchAlias then trace(i"normalize $this", typr, show = true):
-          if MatchTypeTrace.isRecording then
-            MatchTypeTrace.recurseWith(this)(superType.tryNormalize)
-          else
-            underlyingNormalizable.tryNormalize
-        else NoType
-      tryCompiletimeConstantFold.orElse(tryMatchAlias)
+      if isMatchAlias && MatchTypeTrace.isRecording then
+        MatchTypeTrace.recurseWith(this)(superType.tryNormalize)
+      else super.tryNormalize
 
     /** Is this an unreducible application to wildcard arguments?
      *  This is the case if tycon is higher-kinded. This means

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -491,11 +491,6 @@ object Types extends TypeUtils {
     /** Does this application expand to a match type? */
     def isMatchAlias(using Context): Boolean = underlyingNormalizable.isMatch
 
-    def underlyingNormalizable(using Context): Type = stripped.stripLazyRef match
-      case tp: MatchType => tp
-      case tp: AppliedType => tp.underlyingNormalizable
-      case _ => NoType
-
     /** Is this a higher-kinded type lambda with given parameter variances?
      *  These lambdas are used as the RHS of higher-kinded abstract types or
      *  type aliases. The variance info is strictly needed only for abstract types.
@@ -1547,20 +1542,23 @@ object Types extends TypeUtils {
       }
       deskolemizer(this)
 
-    /** The result of normalization using `tryNormalize`, or the type itself if
-     *  tryNormlize yields NoType
-     */
-    final def normalized(using Context): Type = {
-      val normed = tryNormalize
-      if (normed.exists) normed else this
-    }
+    /** The result of normalization, or the type itself if none apply. */
+    final def normalized(using Context): Type = tryNormalize.orElse(this)
 
     /** If this type has an underlying match type or applied compiletime.ops,
      *  then the result after applying all toplevel normalizations, otherwise NoType.
      */
     def tryNormalize(using Context): Type = underlyingNormalizable match
-      case mt: MatchType => mt.tryNormalize
+      case mt: MatchType => mt.reduced.normalized
       case tp: AppliedType => tp.tryCompiletimeConstantFold
+      case _ => NoType
+
+    /** Perform successive strippings, and beta-reductions of applied types until
+     *  a match type or applied compiletime.ops is reached, if any, otherwise NoType.
+     */
+    def underlyingNormalizable(using Context): Type = stripped.stripLazyRef match
+      case tp: MatchType => tp
+      case tp: AppliedType => tp.underlyingNormalizable
       case _ => NoType
 
     private def widenDealias1(keep: AnnotatedType => Context ?=> Boolean)(using Context): Type = {
@@ -4677,9 +4675,10 @@ object Types extends TypeUtils {
         case nil => x
       foldArgs(op(x, tycon), args)
 
-    /** Exists if the tycon is a TypeRef of an alias with an underlying match type.
-     *  Anything else should have already been reduced in `appliedTo` by the TypeAssigner.
-     *  May reduce several HKTypeLambda applications before the underlying MatchType is reached.
+    /** Exists if the tycon is a TypeRef of an alias with an underlying match type,
+     *  or a compiletime applied type. Anything else should have already been
+     *  reduced in `appliedTo` by the TypeAssigner. This may reduce several
+     *  HKTypeLambda applications before the underlying normalizable type is reached.
      */
     override def underlyingNormalizable(using Context): Type =
       if ctx.period != validUnderlyingNormalizable then tycon match
@@ -5156,9 +5155,6 @@ object Types extends TypeUtils {
 
     private var myReduced: Type | Null = null
     private var reductionContext: util.MutableMap[Type, Type] | Null = null
-
-    override def tryNormalize(using Context): Type =
-      reduced.normalized
 
     private def thisMatchType = this
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2044,7 +2044,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               case _ => false
             }
 
-        val result = pt.underlyingMatchType match {
+        val result = pt.underlyingNormalizable match {
           case mt: MatchType if isMatchTypeShaped(mt) =>
             typedDependentMatchFinish(tree, sel1, selType, tree.cases, mt)
           case _ =>

--- a/compiler/test/dotc/neg-best-effort-pickling.blacklist
+++ b/compiler/test/dotc/neg-best-effort-pickling.blacklist
@@ -15,6 +15,7 @@ illegal-match-types.scala
 i13780-1.scala
 i20317a.scala
 i11226.scala
+i974.scala
 
 # semantic db generation fails in the first compilation
 i1642.scala

--- a/tests/neg/i12049d.check
+++ b/tests/neg/i12049d.check
@@ -1,0 +1,14 @@
+-- [E007] Type Mismatch Error: tests/neg/i12049d.scala:14:52 -----------------------------------------------------------
+14 |val x: M[NotRelevant[Nothing], Relevant[Nothing]] = 2 // error
+   |                                                    ^
+   |                                                  Found:    (2 : Int)
+   |                                                  Required: M[NotRelevant[Nothing], Relevant[Nothing]]
+   |
+   |                                                  Note: a match type could not be fully reduced:
+   |
+   |                                                    trying to reduce  M[NotRelevant[Nothing], Relevant[Nothing]]
+   |                                                    trying to reduce  Relevant[Nothing]
+   |                                                    failed since selector Nothing
+   |                                                    is uninhabited (there are no values of that type).
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i12049d.scala
+++ b/tests/neg/i12049d.scala
@@ -1,0 +1,14 @@
+
+trait A
+trait B
+
+type M[X, Y] = Y match
+  case A => Int
+  case B => String
+
+type Relevant[Z] = Z match
+  case A => B
+type NotRelevant[Z] = Z match
+  case B => A
+
+val x: M[NotRelevant[Nothing], Relevant[Nothing]] = 2 // error

--- a/tests/pos/i20482.scala
+++ b/tests/pos/i20482.scala
@@ -1,0 +1,16 @@
+trait WrapperType[A]
+
+case class Foo[A]()
+
+case class Bar[A]()
+
+type FooToBar[D[_]] = [A] =>> D[Unit] match {
+  case Foo[Unit] => Bar[A]
+}
+
+case class Test()
+object Test {
+  implicit val wrapperType: WrapperType[Bar[Test]] = new WrapperType[Bar[Test]] {}
+}
+
+val test = summon[WrapperType[FooToBar[Foo][Test]]]

--- a/tests/pos/matchtype-unusedArg/A_1.scala
+++ b/tests/pos/matchtype-unusedArg/A_1.scala
@@ -1,0 +1,8 @@
+
+type Rec[X] = X match
+  case Int => Rec[X]
+
+type M[Unused, Y] = Y match
+  case String => Double
+
+def foo[X](d: M[Rec[X], "hi"]) = ???

--- a/tests/pos/matchtype-unusedArg/B_2.scala
+++ b/tests/pos/matchtype-unusedArg/B_2.scala
@@ -1,0 +1,2 @@
+
+def Test = foo[Int](3d) // crash before changes


### PR DESCRIPTION
Based on #20257

This PR has multiple small but significant changes to `tryNormalize`, I would recommend reviewing the commits individually.
The overall goal was to have a more uniform treatment of `tryNormalize` rather than the three overrides, making the logic easier to follow.

It also now reuses `underlyingMatchType` for it, which not only has a caching benefit but also ensures consistent results between them. In particular, making `tryNormalize.exists` imply `underlyingMatchType.exists`, which one might assume as true but did not hold in general previously. And yet, we use `isMatchAlias := underlyingMatchType.exists` in a bunch of places with the assumption that there is nothing to normalise if it returns false.

The next step will be to rework the MatchTypeTrace, which still overlooks some cases. But doing so should be simpler from the proposed setup.