### PR TITLE
Adjust the API name entry for nested classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -295,7 +295,7 @@ private class ExtractAPICollector(nonLocalClassSymbols: mutable.HashSet[Symbol])
 
     val selfType = apiType(sym.givenSelfType)
 
-    val name = sym.fullName.stripModuleClassSuffix.toString
+    val name = ExtractDependencies.classNameAsString(sym)
       // We strip module class suffix. Zinc relies on a class and its companion having the same name
 
     val tparams = sym.typeParams.map(apiTypeParameter).toArray


### PR DESCRIPTION
## Problem

https://github.com/scala/scala3/pull/20157 demonstrated that some build pipelining tests fail on the latest sbt 1.10.0-RC2:

```
Error:  (sbt-test / scripted) Failed tests:
Error:  	pipelining/Yjava-tasty-fromjavaobject
Error:  	pipelining/Yjava-tasty-paths
```

This is likely caused by inconsistent capturing of APIs from Java sources in ExtractAPI vs AnalyzingJavaCompiler in Zinc.

## Solution
This adjusts the API name entry for Java nested classes.