### PR TITLE
Special case for next field of colon colon in global init checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -812,7 +812,8 @@ class Objects(using Context @constructorOnly):
         else
           Bottom
       else if target.exists then
-        if target.isOneOf(Flags.Mutable) then
+        def isNextFieldOfColonColon: Boolean = ref.klass == defn.ConsClass && target.name.toString == "next"
+        if target.isOneOf(Flags.Mutable) && !isNextFieldOfColonColon then
           if ref.hasVar(target) then
             val addr = ref.varAddr(target)
             if addr.owner == State.currentObject then

--- a/tests/init-global/pos/list-colon-colon-next.scala
+++ b/tests/init-global/pos/list-colon-colon-next.scala
@@ -1,0 +1,5 @@
+object A:
+  val a: List[Int] = List(1, 2, 3)
+
+object B:
+  val b = A.a.size


### PR DESCRIPTION
This PR adds a special case to suppress a warning pertaining to the next field and colon colon operator. Added a test case that produces the warning when the hardcoded logic is not present.