### PR TITLE
Extend whitelist in global initialization checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -83,7 +83,7 @@ class Objects(using Context @constructorOnly):
   val immutableLazyList: Symbol = requiredModule("scala.collection.immutable.LazyList")
   val LazyList_empty: Symbol = immutableLazyList.requiredValue("_empty")
 
-  val whiteList: Set[Symbol] = Set()
+  val whiteList: Set[Symbol] = Set(SetNode_EmptySetNode, HashSet_EmptySet, Vector_EmptyIterator, MapNode_EmptyMapNode, HashMap_EmptyMap, LazyList_empty)
 
   // ----------------------------- abstract domain -----------------------------
 
@@ -173,7 +173,7 @@ class Objects(using Context @constructorOnly):
   extends Ref(valsMap = mutable.Map.empty, varsMap = mutable.Map.empty, outersMap = mutable.Map.empty):
     val owner = klass
 
-    def show(using Context) = "ObjectRef(" + klass.show + ")" + "valMap = " + vals + "varMap = " + vars
+    def show(using Context) = "ObjectRef(" + klass.show + ")"
 
   /**
    * Represents values that are instances of the specified class.
@@ -832,7 +832,6 @@ class Objects(using Context @constructorOnly):
               errorReadOtherStaticObject(State.currentObject, addr)
               Bottom
           else if ref.isObjectRef && ref.klass.hasSource then
-            println(s"Uninitialized field Position 2, ref = $ref, target = $target")
             report.warning("Access uninitialized field " + field.show + ". " + Trace.show, Trace.position)
             Bottom
           else
@@ -841,7 +840,6 @@ class Objects(using Context @constructorOnly):
         else if ref.hasVal(target) then
           ref.valValue(target)
         else if ref.isObjectRef && ref.klass.hasSource then
-          println(s"Uninitialized field Position 2, ref = $ref, target = $target")
           report.warning("Access uninitialized field " + field.show + ". " + Trace.show, Trace.position)
           Bottom
         else

--- a/tests/init-global/pos/EmptyMap.scala
+++ b/tests/init-global/pos/EmptyMap.scala
@@ -1,0 +1,6 @@
+import scala.collection.immutable.HashMap
+
+object O {
+  val emptyMap: HashMap[Int, Int] = HashMap.empty
+  val key = emptyMap.get(0)
+}

--- a/tests/init-global/pos/EmptyMap2.scala
+++ b/tests/init-global/pos/EmptyMap2.scala
@@ -1,0 +1,4 @@
+import scala.collection.immutable.HashMap
+
+object A:
+  val a = HashMap.empty[Int, Int].updated(1, 2)

--- a/tests/init-global/pos/EmptySet.scala
+++ b/tests/init-global/pos/EmptySet.scala
@@ -1,0 +1,6 @@
+import scala.collection.immutable.HashSet
+
+object O {
+  val emptySet = HashSet.empty
+  val emptySetSize = emptySet.size
+}

--- a/tests/init-global/pos/EmptySet2.scala
+++ b/tests/init-global/pos/EmptySet2.scala
@@ -1,0 +1,4 @@
+import scala.collection.immutable.HashSet
+
+object A:
+  val a = HashSet.empty[Int] + 1

--- a/tests/init-global/pos/EmptyVectorIterator.scala
+++ b/tests/init-global/pos/EmptyVectorIterator.scala
@@ -1,0 +1,7 @@
+import scala.collection.immutable.Vector
+
+object O {
+  val emptyVector = Vector.empty
+  val emptyVectorIterator = emptyVector.iterator
+  val hasNext = emptyVectorIterator.hasNext
+}

--- a/tests/init-global/pos/LazyList.scala
+++ b/tests/init-global/pos/LazyList.scala
@@ -1,0 +1,4 @@
+import scala.collection.immutable.LazyList
+
+object A:
+  val a = LazyList.empty[Int] :+ 1


### PR DESCRIPTION
This PR extends the whitelist in global object initialization checker in order to suppress initialization irrelevance errors in Scala2LibraryTasty.