### PR TITLE
Generalize warnings for top-level calls to Any or AnyRef methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1236,14 +1236,12 @@ object RefChecks {
 
   end checkImplicitNotFoundAnnotation
 
-  def checkAnyRefMethodCall(tree: Tree)(using Context) =
-    if tree.symbol.exists
-       && defn.topClasses.contains(tree.symbol.owner)
-       && (!ctx.owner.enclosingClass.exists
-           || ctx.owner.enclosingClass.isPackageObject
-           || ctx.owner.enclosingClass.isValueClass) then
-      report.warning(UnqualifiedCallToAnyRefMethod(tree, tree.symbol), tree)
-
+  def checkAnyRefMethodCall(tree: Tree)(using Context): Unit =
+    if tree.symbol.exists && defn.topClasses.contains(tree.symbol.owner) then
+      tree.tpe match
+        case tp: NamedType if tp.prefix.typeSymbol != ctx.owner.enclosingClass =>
+          report.warning(UnqualifiedCallToAnyRefMethod(tree, tree.symbol), tree)
+        case _ => ()
 }
 import RefChecks.*
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1239,7 +1239,9 @@ object RefChecks {
   def checkAnyRefMethodCall(tree: Tree)(using Context) =
     if tree.symbol.exists
        && defn.topClasses.contains(tree.symbol.owner)
-       && (!ctx.owner.enclosingClass.exists || ctx.owner.enclosingClass.isPackageObject) then
+       && (!ctx.owner.enclosingClass.exists
+           || ctx.owner.enclosingClass.isPackageObject
+           || ctx.owner.enclosingClass.isValueClass) then
       report.warning(UnqualifiedCallToAnyRefMethod(tree, tree.symbol), tree)
 
 }

--- a/tests/warn/i17266.check
+++ b/tests/warn/i17266.check
@@ -96,3 +96,14 @@
     | resolved to calls on Predef or on imported methods. This might not be what
     | you intended.
      -------------------------------------------------------------------------------------------------------------------
+-- [E181] Potential Issue Warning: tests/warn/i17266.scala:148:2 -------------------------------------------------------
+148 |  synchronized { // warn
+    |  ^^^^^^^^^^^^
+    |  Suspicious top-level unqualified call to synchronized
+    |-------------------------------------------------------------------------------------------------------------------
+    | Explanation (enabled by `-explain`)
+    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    | Top-level unqualified calls to AnyRef or Any methods such as synchronized are
+    | resolved to calls on Predef or on imported methods. This might not be what
+    | you intended.
+     -------------------------------------------------------------------------------------------------------------------

--- a/tests/warn/i17266.scala
+++ b/tests/warn/i17266.scala
@@ -43,13 +43,13 @@ object Test6:
 object Test7:
   import MyLib.*
   def test7 =
-    synchronized { // not an error
+    synchronized { // not an error; resolves to `Test7.synchronized`
       println("hello")
     }
 
 /*
 object Test7b:
-  def test8 =
+  def test7b =
     import MyLib.*
     synchronized { // already an error: Reference to synchronized is ambiguous.
       println("hello")
@@ -62,21 +62,21 @@ class Test8:
   }
 
 class Test9:
-  def test5 =
+  def test9 =
     synchronized { // not an error
       println("hello")
     }
 
 class Test10:
   import MyLib.*
-  synchronized { // not an error
+  synchronized { // not an error; resolves to `this.synchronized`
     println("hello")
   }
 
 class Test11:
   import MyLib.*
-  def test7 =
-    synchronized { // not an error
+  def test11 =
+    synchronized { // not an error; resolves to `this.synchronized`
       println("hello")
     }
 
@@ -86,14 +86,14 @@ trait Test12:
   }
 
 trait Test13:
-  def test5 =
+  def test13 =
     synchronized { // not an error
       println("hello")
     }
 
 trait Test14:
   import MyLib.*
-  synchronized { // not an error
+  synchronized { // not an error; resolves to `this.synchronized`
     println("hello")
   }
 
@@ -142,3 +142,9 @@ def test26 =
 
 def test27 =
   1.hashCode()// not an error (should be? probably not)
+
+def test28 =
+  import MyLib.*
+  synchronized { // warn
+    println("hello")
+  }

--- a/tests/warn/i17493.check
+++ b/tests/warn/i17493.check
@@ -1,0 +1,11 @@
+-- [E181] Potential Issue Warning: tests/warn/i17493.scala:3:11 --------------------------------------------------------
+3 |   def g = synchronized { println("hello, world") } // warn
+  |           ^^^^^^^^^^^^
+  |           Suspicious top-level unqualified call to synchronized
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Top-level unqualified calls to AnyRef or Any methods such as synchronized are
+  | resolved to calls on Predef or on imported methods. This might not be what
+  | you intended.
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/warn/i17493.check
+++ b/tests/warn/i17493.check
@@ -1,7 +1,7 @@
--- [E181] Potential Issue Warning: tests/warn/i17493.scala:3:11 --------------------------------------------------------
-3 |   def g = synchronized { println("hello, world") } // warn
-  |           ^^^^^^^^^^^^
-  |           Suspicious top-level unqualified call to synchronized
+-- [E181] Potential Issue Warning: tests/warn/i17493.scala:4:10 --------------------------------------------------------
+4 |  def g = synchronized { println("hello, world") } // warn
+  |          ^^^^^^^^^^^^
+  |          Suspicious top-level unqualified call to synchronized
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/warn/i17493.scala
+++ b/tests/warn/i17493.scala
@@ -1,0 +1,4 @@
+//> using options -explain
+ class A(val s: String) extends AnyVal {
+   def g = synchronized { println("hello, world") } // warn
+ }

--- a/tests/warn/i17493.scala
+++ b/tests/warn/i17493.scala
@@ -1,4 +1,5 @@
 //> using options -explain
  class A(val s: String) extends AnyVal {
-   def g = synchronized { println("hello, world") } // warn
+  // def f = eq("hello, world") // no warning for now because `eq` is inlined
+  def g = synchronized { println("hello, world") } // warn
  }

--- a/tests/warn/i17493.scala
+++ b/tests/warn/i17493.scala
@@ -1,5 +1,5 @@
 //> using options -explain
- class A(val s: String) extends AnyVal {
+class A(val s: String) extends AnyVal {
   // def f = eq("hello, world") // no warning for now because `eq` is inlined
   def g = synchronized { println("hello, world") } // warn
- }
+}


### PR DESCRIPTION
751cc2ffd0f2bac65ccc79565deb20f64b08cbd5 is a more direct way to fix #17493 than #20301.

7a9102a215b4f83547077f24ca92a5aba55a3744 further generalizes `checkAnyRefMethodCall`, as suggested by @odersky.