### PR TITLE
remove non-deterministic cancellation of async TASTy in sbt-test

### DIFF
--- a/sbt-test/pipelining/Yearly-tasty-output-inline/build.sbt
+++ b/sbt-test/pipelining/Yearly-tasty-output-inline/build.sbt
@@ -1,8 +1,10 @@
-// defines a inline method
+// NOTE: in this test, we are explictly fixing the classpath of project `b` to be `a-early.jar`
+// to manually test pipelining without sbt/zinc managing the classpath.
+
+// defines a inline method.
 lazy val a = project.in(file("a"))
   .settings(
     scalacOptions ++= Seq("-Yearly-tasty-output", ((ThisBuild / baseDirectory).value / "a-early.jar").toString),
-    scalacOptions += "-Ystop-after:firstTransform",
     scalacOptions += "-Ycheck:all",
   )
 

--- a/sbt-test/pipelining/Yearly-tasty-output/build.sbt
+++ b/sbt-test/pipelining/Yearly-tasty-output/build.sbt
@@ -1,8 +1,10 @@
+// NOTE: in this test, we are explictly fixing the classpath of project `c` to be `a-early.jar:b-early-out`
+// to manually test pipelining without sbt/zinc managing the classpath.
+
 // early out is a jar
 lazy val a = project.in(file("a"))
   .settings(
     scalacOptions ++= Seq("-Yearly-tasty-output", ((ThisBuild / baseDirectory).value / "a-early.jar").toString),
-    scalacOptions += "-Ystop-after:firstTransform",
     scalacOptions += "-Ycheck:all",
   )
 
@@ -10,7 +12,6 @@ lazy val a = project.in(file("a"))
 lazy val b = project.in(file("b"))
   .settings(
     scalacOptions ++= Seq("-Yearly-tasty-output", ((ThisBuild / baseDirectory).value / "b-early-out").toString),
-    scalacOptions += "-Ystop-after:firstTransform",
     scalacOptions += "-Ycheck:all",
   )
 


### PR DESCRIPTION
how-i-fixed-it:

Originally these tests were written before we implemented async TASTy writing. This meant that we blocked the main thread at the end of `ExtractAPI` until TASTy was written. This meant that `-Ystop-after:firstTransform` would prevent the compiler reaching the backend, but stop after we knew that TASTy was written to `a-early.jar`

Originally we did this to explicitly communicate that TASTy comes from `a-early.jar`, rather than `genBCode` output. In reality, it doesn't assert anything stronger than a comment would, because we manually fix the classpath to only be `a-early.jar`.

After we added async TASTy writing, this test became non-deterministic, because we cancel async TASTy writing at the end of a run without synchronizing. So it's possible TASTy isn't written by the time we cancel after `firstTransform`.

So instead, we remove `-Ystop-after`, guaranteeing that `a/compile` does not finish until we synchronize async TASTy in `genBCode`.

fixes #20306
fixes #20278