### PR TITLE
Make CheckUnused not slow.

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -827,23 +827,24 @@ object CheckUnused:
   end UnusedData
 
   private object UnusedData:
-      enum ScopeType:
-        case Local
-        case Template
-        case ReplWrapper
-        case Other
+    enum ScopeType:
+      case Local
+      case Template
+      case ReplWrapper
+      case Other
 
-      object ScopeType:
-        /** return the scope corresponding to the enclosing scope of the given tree */
-        def fromTree(tree: tpd.Tree)(using Context): ScopeType = tree match
-          case tree: tpd.Template => if tree.symbol.name.isReplWrapperName then ReplWrapper else Template
-          case _:tpd.Block => Local
-          case _ => Other
+    object ScopeType:
+      /** return the scope corresponding to the enclosing scope of the given tree */
+      def fromTree(tree: tpd.Tree)(using Context): ScopeType = tree match
+        case tree: tpd.Template => if tree.symbol.name.isReplWrapperName then ReplWrapper else Template
+        case _:tpd.Block => Local
+        case _ => Other
 
-      case class UnusedSymbol(pos: SrcPos, name: Name, warnType: WarnTypes)
-      /** A container for the results of the used elements analysis */
-      case class UnusedResult(warnings: Set[UnusedSymbol])
-      object UnusedResult:
-        val Empty = UnusedResult(Set.empty)
+    case class UnusedSymbol(pos: SrcPos, name: Name, warnType: WarnTypes)
+    /** A container for the results of the used elements analysis */
+    case class UnusedResult(warnings: Set[UnusedSymbol])
+    object UnusedResult:
+      val Empty = UnusedResult(Set.empty)
+  end UnusedData
 
 end CheckUnused

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -290,7 +290,7 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
 
   /** Do the actual reporting given the result of the anaylsis */
   private def reportUnused(res: UnusedData.UnusedResult)(using Context): Unit =
-    res.warnings.toList.sortBy(_.pos.line)(using Ordering[Int]).foreach { s =>
+    res.warnings.toList.sortBy(_.pos.span.point)(using Ordering[Int]).foreach { s =>
       s match
         case UnusedSymbol(t, _, WarnTypes.Imports) =>
           report.warning(s"unused import", t)
@@ -583,19 +583,14 @@ object CheckUnused:
         else
           Nil
       val warnings =
-        val unsorted =
-          sortedImp :::
-          sortedLocalDefs :::
-          sortedExplicitParams :::
-          sortedImplicitParams :::
-          sortedPrivateDefs :::
-          sortedPatVars :::
-          unsetLocalDefs :::
-          unsetPrivateDefs
-        unsorted.sortBy { s =>
-          val pos = s.pos.sourcePos
-          (pos.line, pos.column)
-        }
+        sortedImp :::
+        sortedLocalDefs :::
+        sortedExplicitParams :::
+        sortedImplicitParams :::
+        sortedPrivateDefs :::
+        sortedPatVars :::
+        unsetLocalDefs :::
+        unsetPrivateDefs
       UnusedResult(warnings.toSet)
     end getUnused
     //============================ HELPERS ====================================

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -40,8 +40,10 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
   import CheckUnused.*
   import UnusedData.*
 
-  private def unusedDataApply[U](f: UnusedData => U)(using Context): Context =
-    ctx.property(_key).foreach(f)
+  private inline def unusedDataApply[U](inline f: UnusedData => U)(using Context): Context =
+    ctx.property(_key) match
+      case Some(ud) => f(ud)
+      case None     => ()
     ctx
 
   override def phaseName: String = CheckUnused.phaseNamePrefix + suffix

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -125,8 +125,7 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
       traverseAnnotations(tree.symbol)
       if !tree.symbol.is(Module) then
         ud.registerDef(tree)
-      if tree.name.mangledString.startsWith(nme.derived.mangledString + "$")
-          && tree.typeOpt != NoType then
+      if tree.name.startsWith("derived$") && tree.typeOpt != NoType then
         ud.registerUsed(tree.typeOpt.typeSymbol, None, true)
       ud.addIgnoredUsage(tree.symbol)
     }

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -207,9 +207,6 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
     }
     ctx
 
-  private def newCtx(tree: tpd.Tree)(using Context) =
-    if tree.symbol.exists then ctx.withOwner(tree.symbol) else ctx
-
   /**
    * This traverse is the **main** component of this phase
    *

--- a/tests/warn/i15503i.scala
+++ b/tests/warn/i15503i.scala
@@ -270,7 +270,7 @@ package foo.test.i16679b:
     given x: myPackage.CaseClassName[secondPackage.CoolClass] = null
 
   object secondPackage:
-    import myPackage.CaseClassName // OK
+    import myPackage.CaseClassName // warn
     import Foo.x
     case class CoolClass(i: Int)
     println(summon[myPackage.CaseClassName[CoolClass]])


### PR DESCRIPTION
It doesn't mean that it's *fast* yet, but it is already a significant step in that direction. In particular, this goes in the direction of addressing #19671.

The most important commit is "Simplify the logic for checking unused imports.", whose commit message follows:

Instead of dealing with entire `tpd.Import`s at the end of the scope, we eagerly flatten them into individual `ImportSelector`s. We store them along with some data, including a mutable flag for whether a selector has been used.

This allows to dramatically simplify `isInImport`, as well as more aggressively cache the resolution of selectors. We also get rid of the `IdentityHashMap`.

The algorithm is still `O(n*m)` where n is the number of imports in a scope, and m the number of references found in that scope. It is not entirely clear to me whether the previous logic was already `O(n*m)` or worse (it may have included an additional `p` factor for the number of possible selections from a given qualifier).

Regardless, it is already quite a bit faster than before, thanks to smaller constant factors.