### PR TITLE
Harden GADT constraint handling to survive illegal F-bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/GadtConstraint.scala
@@ -193,7 +193,8 @@ sealed trait GadtState {
                 case i => pt.paramRefs(i)
             case tp => tp
         }
-
+        if !param.info.exists then
+          throw TypeError(em"illegal recursive reference involving $param")
         val tb = param.info.bounds
         tb.derivedTypeBounds(
           lo = substDependentSyms(tb.lo, isUpper = false),

--- a/compiler/test/dotc/neg-best-effort-pickling.blacklist
+++ b/compiler/test/dotc/neg-best-effort-pickling.blacklist
@@ -13,6 +13,7 @@ curried-dependent-ift.scala
 i17121.scala
 illegal-match-types.scala
 i13780-1.scala
+i20317a.scala
 
 # semantic db generation fails in the first compilation
 i1642.scala

--- a/tests/neg/i20317.scala
+++ b/tests/neg/i20317.scala
@@ -1,0 +1,3 @@
+type Foo[A] = A
+
+def foo[A <: Foo[A]]: Unit = () // error // error

--- a/tests/neg/i20317a.scala
+++ b/tests/neg/i20317a.scala
@@ -1,0 +1,5 @@
+type SemigroupStructural[A] =
+  A & { def combine(a: A): A }
+def combineAll[A <: SemigroupStructural[A]](
+  i: A, l: List[A]
+): A = l.foldLeft(i)(_.combine(_)) // error


### PR DESCRIPTION
This currently fails BestEffortCompilationTests

The problem is that i20317a.scala contains illegal cyclic references. The cycles cause many different algorithms in the compiler to loop. We normally reject the program, and that's that. But under best-effort, we crash with Stackoverflows in the loops later. What to do? It's not feasible to avoid the looping behavior at acceptable cost. Can we disable best effort under certain conditions? 
