### PR TITLE
ConsoleReporter sends INFO to stdout

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ConsoleReporter.scala
@@ -5,15 +5,18 @@ package reporting
 import core.Contexts.*
 import java.io.{ BufferedReader, PrintWriter }
 import Diagnostic.*
+import dotty.tools.dotc.interfaces.Diagnostic.INFO
 
 /**
   * This class implements a Reporter that displays messages on a text console
   */
 class ConsoleReporter(
   reader: BufferedReader = Console.in,
-  writer: PrintWriter = new PrintWriter(Console.err, true)
+  writer: PrintWriter = new PrintWriter(Console.err, true),
+  echoer: PrintWriter = new PrintWriter(Console.out, true)
 ) extends ConsoleReporter.AbstractConsoleReporter {
-  override def printMessage(msg: String): Unit = { writer.print(msg + "\n"); writer.flush() }
+  override def printMessage(msg: String): Unit = { writer.println(msg); writer.flush() }
+  override def echoMessage(msg: String): Unit = { echoer.println(msg); echoer.flush() }
   override def flush()(using Context): Unit    = writer.flush()
 
   override def doReport(dia: Diagnostic)(using Context): Unit = {
@@ -22,18 +25,21 @@ class ConsoleReporter(
       dia match
         case _: Error                                        => Reporter.displayPrompt(reader, writer)
         case _: Warning if ctx.settings.XfatalWarnings.value => Reporter.displayPrompt(reader, writer)
-        case _                                                 =>
+        case _                                               =>
   }
 }
 
 object ConsoleReporter {
   abstract class AbstractConsoleReporter extends AbstractReporter {
-    /** Prints the message. */
+    /** Print the diagnostic message. */
     def printMessage(msg: String): Unit
 
-    /** Prints the message with the given position indication. */
-    def doReport(dia: Diagnostic)(using Context): Unit = {
-      printMessage(messageAndPos(dia))
-    }
+    /** Print the informative message. */
+    def echoMessage(msg: String): Unit
+
+    /** Print the message with the given position indication. */
+    def doReport(dia: Diagnostic)(using Context): Unit =
+      if dia.level == INFO then echoMessage(messageAndPos(dia))
+      else printMessage(messageAndPos(dia))
   }
 }

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -14,7 +14,7 @@ import dotty.tools.dotc.util.NoSourcePosition
 import java.io.{BufferedReader, PrintWriter}
 import scala.annotation.internal.sharable
 import scala.collection.mutable
-import core.Decorators.em
+import core.Decorators.{em, toMessage}
 import core.handleRecursive
 
 object Reporter {
@@ -236,10 +236,9 @@ abstract class Reporter extends interfaces.ReporterResult {
       report(Warning(msg, NoSourcePosition))
 
   /** Print the summary of warnings and errors */
-  def printSummary()(using Context): Unit = {
+  def printSummary()(using Context): Unit =
     val s = summary
-    if (s != "") report(new Info(s, NoSourcePosition))
-  }
+    if (s != "") doReport(Warning(s.toMessage, NoSourcePosition))
 
   /** Returns a string meaning "n elements". */
   protected def countString(n: Int, elements: String): String = n match {

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -545,6 +545,7 @@ class ReplDriver(settings: Array[String],
   private object ReplConsoleReporter extends ConsoleReporter.AbstractConsoleReporter {
     override def posFileStr(pos: SourcePosition) = "" // omit file paths
     override def printMessage(msg: String): Unit = out.println(msg)
+    override def echoMessage(msg: String): Unit  = printMessage(msg)
     override def flush()(using Context): Unit    = out.flush()
   }
 

--- a/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/TestReporter.scala
@@ -75,6 +75,8 @@ extends Reporter with UniqueMessagePositions with HideNonSensicalMessages with M
       _diagnosticBuf.append(dia)
     printMessageAndPos(dia, extra)
   }
+
+  override def printSummary()(using Context): Unit = ()
 }
 
 object TestReporter {


### PR DESCRIPTION
Fixes #16701 

Tested only manually.

For example, with `tailrec` printer enabled,
```
scalac -Vprint:typer example.scala > x 2> y
```
puts tree output and tailrec trace in x, warnings & errors & summary count in y.

x is the output I asked for. This makes it easier to see trace and trees correctly interleaved, since `> out 2>&1` does not guarantee it.

Tests may depend on how output is captured. Scala 2 partest captures stderr to log, for example.