### PR TITLE
Improve documentation of implicit conversions

### DIFF
--- a/docs/_docs/reference/changed-features/implicit-conversions-spec.md
+++ b/docs/_docs/reference/changed-features/implicit-conversions-spec.md
@@ -43,8 +43,9 @@ Views are applied in three situations:
    `v` which is applicable to `e` and whose result contains a method
    `m` which is applicable to `args` is searched. The search proceeds
    as in the case of implicit parameters, where the implicit scope is
-   the one of `T`. If such a view is found, the application
-   `e.m(args)` is converted to `v(e).m(args)`.
+   the one of `T => pt`, with `pt` being the structural type
+   `{ def m(args: T_1 , ... , T_n): U }`. If such a view is found,
+   the application `e.m(args)` is converted to `v(e).m(args)`.
 
 # Differences with Scala 2 implicit conversions
 

--- a/docs/_spec/07-implicits.md
+++ b/docs/_spec/07-implicits.md
@@ -63,7 +63,7 @@ The _parts_ of a type ´T´ are:
 - if ´T´ is a type projection `´S´#´U´`, the parts of ´S´ as well as ´T´ itself;
 - if ´T´ is a type alias, the parts of its expansion;
 - if ´T´ is an abstract type, the parts of its upper bound;
-- if ´T´ denotes an implicit conversion to a type with a method with argument types ´T_1, ..., T_n´ and result type ´U´, the union of the parts of ´T_1, ..., T_n´ and ´U´;
+- if ´T´ is a structural type with a method with argument types ´T_1, ..., T_n´ and result type ´U´, the union of the parts of ´T_1, ..., T_n´ and ´U´;
 - in all other cases, just ´T´ itself.
 
 Note that packages are internally represented as classes with companion modules to hold the package members.
@@ -288,7 +288,7 @@ The search proceeds as in the case of implicit parameters, where the implicit sc
 If such a view is found, the selection ´e.m´ is converted to `´v´(´e´).´m´`.
 1.  In a selection ´e.m(\mathit{args})´ with ´e´ of type ´T´, if the selector ´m´ denotes some member(s) of ´T´, but none of these members is applicable to the arguments ´\mathit{args}´.
 In this case a view ´v´ is searched which is applicable to ´e´ and whose result contains a method ´m´ which is applicable to ´\mathit{args}´.
-The search proceeds as in the case of implicit parameters, where the implicit scope is the one of ´T´.  If such a view is found, the selection ´e.m´ is converted to `´v´(´e´).´m(\mathit{args})´`.
+The search proceeds as in the case of implicit parameters, where the implicit scope is the one of `´T´ => ´\mathit{pt}´`, with ´\mathit{pt}´ being the structural type ´{ def m(\mathit{args}: T_1 , ... , T_n): U }´.  If such a view is found, the selection ´e.m´ is converted to `´v´(´e´).´m(\mathit{args})´`.
 
 The implicit view, if it is found, can accept its argument ´e´ as a call-by-value or as a call-by-name parameter.
 However, call-by-value implicits take precedence over call-by-name implicits.


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala3/pull/20103 . This needs to be merged into language-reference-stable for the change to be visible on the website.