### PR TITLE
Relax font-weight reset

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/typography.css
+++ b/scaladoc/resources/dotty_res/styles/theme/typography.css
@@ -1,4 +1,4 @@
-* {
+h1, h2, h3, h4, h5, h6 {
   /*text-rendering: geometricPrecision;*/
   font-weight: initial;
 }


### PR DESCRIPTION
[skip ci]

Reseting the `font-weight` of _all_ elements might be a bit __bold__—even `<strong>` elements are displayed in normal weight!

Could we specialize this rule to headings only?