### PR TITLE
Fix for macro annotation that resolves macro-based implicit crashing the compiler

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1104,6 +1104,8 @@ class Inliner(val call: tpd.Tree)(using Context):
     new TreeAccumulator[List[Symbol]] {
       override def apply(syms: List[Symbol], tree: tpd.Tree)(using Context): List[Symbol] =
         tree match {
+          case Closure(env, meth, tpt) if meth.symbol.isAnonymousFunction =>
+            this(syms, tpt :: env)
           case tree: RefTree if tree.isTerm && level == -1 && tree.symbol.isDefinedInCurrentRun && !tree.symbol.isLocal =>
             foldOver(tree.symbol :: syms, tree)
           case _: This if level == -1 && tree.symbol.isDefinedInCurrentRun =>

--- a/tests/pos-macros/i20353/Macro_1.scala
+++ b/tests/pos-macros/i20353/Macro_1.scala
@@ -1,0 +1,22 @@
+//> using options -experimental -Yno-experimental
+
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted.*
+
+class ImplicitValue
+
+object ImplicitValue:
+  inline given ImplicitValue =
+    ${ makeImplicitValue }
+
+  def makeImplicitValue(using Quotes) =
+    import quotes.reflect.*
+    '{ ImplicitValue() }
+end ImplicitValue
+
+@experimental
+class Test extends MacroAnnotation:
+  def transform(using Quotes)(tree: quotes.reflect.Definition) =
+    import quotes.reflect.*
+    Implicits.search(TypeRepr.of[ImplicitValue])
+    List(tree)

--- a/tests/pos-macros/i20353/Macro_1.scala
+++ b/tests/pos-macros/i20353/Macro_1.scala
@@ -16,7 +16,7 @@ end ImplicitValue
 
 @experimental
 class Test extends MacroAnnotation:
-  def transform(using Quotes)(tree: quotes.reflect.Definition) =
+  def transform(using Quotes)(definition: quotes.reflect.Definition, companion: Option[quotes.reflect.Definition]) =
     import quotes.reflect.*
     Implicits.search(TypeRepr.of[ImplicitValue])
-    List(tree)
+    List(definition)

--- a/tests/pos-macros/i20353/Macro_1.scala
+++ b/tests/pos-macros/i20353/Macro_1.scala
@@ -1,4 +1,4 @@
-//> using options -experimental -Yno-experimental
+//> using options -experimental
 
 import scala.annotation.{experimental, MacroAnnotation}
 import scala.quoted.*

--- a/tests/pos-macros/i20353/Test_2.scala
+++ b/tests/pos-macros/i20353/Test_2.scala
@@ -1,0 +1,17 @@
+//> using options -experimental -Yno-experimental
+
+class OuterClass:
+  @Test
+  class InnerClass
+
+  @Test
+  object InnerObject
+end OuterClass
+
+object OuterObject:
+  @Test
+  class InnerClass
+
+  @Test
+  object InnerObject
+end OuterObject

--- a/tests/pos-macros/i20353/Test_2.scala
+++ b/tests/pos-macros/i20353/Test_2.scala
@@ -1,4 +1,4 @@
-//> using options -experimental -Yno-experimental
+//> using options -experimental
 
 class OuterClass:
   @Test


### PR DESCRIPTION
When (1) macro-annotating a class or object nested in another class or object and (2) the annotation macro tries to summon an implicit value using `Implicits.search` and (3) the implicit search needs to expand a `given` macro, the compiler crashes with:

```
Failed to evaluate macro.
  Caused by class dotty.tools.dotc.CompilationUnit$SuspendException
```

I found that the reason for the crash is [`macroDependencies`](https://github.com/scala/scala3/blob/3.4.1/compiler/src/dotty/tools/dotc/inlines/Inliner.scala#L1067) returning locally defined variables, which, I believe, it should not. In particular it returns a list containing `$anonfun` for trees of the following shape that appear when resolving implicit macros:

```
{
  def $anonfun(using contextual$1: scala.quoted.Quotes): scala.quoted.Expr[<type for implicit search>] =
    <given macro for implicit value>(contextual$1)
  closure($anonfun)
}
```

This PR skips over such `Closure` nodes, which should be the correct behavior. Not sure if there are other cases that `macroDependencies` handles incorrectly and that should be fixed ...