### PR TITLE
Fix main: revert "Regression: fix compilation performance on Windows"

### DIFF
--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -136,6 +136,12 @@ abstract class AbstractFile extends Iterable[AbstractFile] {
   /** Does this abstract file represent something which can contain classfiles? */
   def isClassContainer: Boolean = isDirectory || (jpath != null && ext.isJarOrZip)
 
+  /** Create a file on disk, if one does not exist already. */
+  def create(): Unit
+
+  /** Delete the underlying file or directory (recursively). */
+  def delete(): Unit
+
   /** Is this abstract file a directory? */
   def isDirectory: Boolean
 

--- a/compiler/src/dotty/tools/io/NoAbstractFile.scala
+++ b/compiler/src/dotty/tools/io/NoAbstractFile.scala
@@ -17,6 +17,8 @@ import java.io.InputStream
 object NoAbstractFile extends AbstractFile {
   def absolute: AbstractFile = this
   def container: AbstractFile = this
+  def create(): Unit = ???
+  def delete(): Unit = ???
   def jpath: JPath = null
   def input: InputStream = null
   def isDirectory: Boolean = false

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -13,8 +13,9 @@ import java.nio.file.{InvalidPathException, Paths}
 
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
 class PlainDirectory(givenPath: Directory) extends PlainFile(givenPath) {
-  override val isDirectory: Boolean = true
+  override def isDirectory: Boolean = true
   override def iterator(): Iterator[PlainFile] = givenPath.list.filter(_.exists).map(new PlainFile(_))
+  override def delete(): Unit = givenPath.deleteRecursively()
 }
 
 /** This class implements an abstract file backed by a File.
@@ -77,7 +78,7 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
   }
 
   /** Is this abstract file a directory? */
-  val isDirectory: Boolean = givenPath.isDirectory // cached for performance on Windows
+  def isDirectory: Boolean = givenPath.isDirectory
 
   /** Returns the time that this abstract file was last modified. */
   def lastModified: Long = givenPath.lastModified.toMillis
@@ -111,6 +112,14 @@ class PlainFile(val givenPath: Path) extends AbstractFile {
     else
       null
   }
+
+  /** Does this abstract file denote an existing file? */
+  def create(): Unit = if (!exists) givenPath.createFile()
+
+  /** Delete the underlying file or directory (recursively). */
+  def delete(): Unit =
+    if (givenPath.isFile) givenPath.delete()
+    else if (givenPath.isDirectory) givenPath.toDirectory.deleteRecursively()
 
   /** Returns a plain file with the given name. It does not
    *  check that it exists.

--- a/compiler/src/dotty/tools/io/VirtualDirectory.scala
+++ b/compiler/src/dotty/tools/io/VirtualDirectory.scala
@@ -34,6 +34,12 @@ extends AbstractFile {
   override def input: InputStream = sys.error("directories cannot be read")
   override def output: OutputStream = sys.error("directories cannot be written")
 
+  /** Does this abstract file denote an existing file? */
+  def create(): Unit = { unsupported() }
+
+  /** Delete the underlying file or directory (recursively). */
+  def delete(): Unit = { unsupported() }
+
   /** Returns an abstract file with the given name. It does not
    *  check that it exists.
    */

--- a/compiler/src/dotty/tools/io/VirtualFile.scala
+++ b/compiler/src/dotty/tools/io/VirtualFile.scala
@@ -82,6 +82,12 @@ class VirtualFile(val name: String, override val path: String) extends AbstractF
     Iterator.empty
   }
 
+  /** Does this abstract file denote an existing file? */
+  def create(): Unit = unsupported()
+
+  /** Delete the underlying file or directory (recursively). */
+  def delete(): Unit = unsupported()
+
   /**
    * Returns the abstract file in this abstract directory with the
    * specified name. If there is no such file, returns null. The

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -61,6 +61,8 @@ abstract class ZipArchive(override val jpath: JPath, release: Option[String]) ex
   def isDirectory: Boolean = true
   def lookupName(name: String, directory: Boolean): AbstractFile = unsupported()
   def lookupNameUnchecked(name: String, directory: Boolean): AbstractFile = unsupported()
+  def create(): Unit = unsupported()
+  def delete(): Unit = unsupported()
   def output: OutputStream    = unsupported()
   def container: AbstractFile = unsupported()
   def absolute: AbstractFile  = unsupported()


### PR DESCRIPTION
Reverts scala/scala3#20193
Cartoonishly failed right after I checked every other project for the existence of `create` and `delete` methods... except the compiler itself, where I personally added those a few weeks ago.
I will remove those for the next release, so we can re-merge this performance PR.