### PR TITLE
Add regression test for issue 20309

### DIFF
--- a/tests/pos-macros/i20309/Macro_1.scala
+++ b/tests/pos-macros/i20309/Macro_1.scala
@@ -1,0 +1,24 @@
+import scala.quoted.*
+import scala.compiletime.*
+
+trait Context
+object Scope:
+  def spawn[A](f: Context ?=> A): A = ???
+
+type Contextual[T] = Context ?=> T
+
+object Macros {
+  inline def transformContextLambda[T](inline expr: Context ?=> T): Context => T =
+    ${ transformContextLambdaImpl[T]('expr) }
+
+  def transformContextLambdaImpl[T: Type](
+      cexpr: Expr[Context ?=> T]
+  )(using Quotes): Expr[Context => T] = {
+    import quotes.reflect.*
+    val tree = asTerm(cexpr)
+    val traverse = new TreeMap() {}
+    println(tree.show)
+    traverse.transformTree(tree)(tree.symbol)
+    '{ _ => ??? }
+  }
+}

--- a/tests/pos-macros/i20309/Test_2.scala
+++ b/tests/pos-macros/i20309/Test_2.scala
@@ -1,0 +1,10 @@
+
+transparent inline def inScope[T](inline expr: Context ?=> T): T =
+  val fn = Macros.transformContextLambda[T](expr)
+  fn(new Context {})
+
+@main def Test = {
+  inScope {
+    Scope.spawn[Unit] { () }
+  }
+}


### PR DESCRIPTION
Closes #20309 
Looks like the issue was fixed somewhere between `3.5.0-RC1-bin-20240429-e2c456f-NIGHTLY` and `3.5.0-RC1-bin-20240501-e6bc130-NIGHTLY`. Since the cutoff for 3.5.0 was well after 01.05, there does not seem to be any need to backport anything here to 3.5.0-release.