### PR TITLE
Fix erasure crash for Inlined rhs of a context function closure

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -945,6 +945,8 @@ object Erasure {
                   vparams = vparams :+ param
               if crCount == 1 then meth.rhs.changeOwnerAfter(meth.symbol, sym, erasurePhase)
               else skipContextClosures(meth.rhs, crCount - 1)
+            case inlined: Inlined =>
+              skipContextClosures(Inlines.dropInlined(inlined), crCount)
 
         var rhs1 = skipContextClosures(ddef.rhs.asInstanceOf[Tree], contextResultCount(sym))
 

--- a/tests/pos-macros/i16963/Macro_1.scala
+++ b/tests/pos-macros/i16963/Macro_1.scala
@@ -1,0 +1,14 @@
+import scala.quoted.*
+
+inline def myMacro = ${ myMacroExpr }
+
+def myMacroExpr(using Quotes) =
+  import quotes.reflect.*
+
+  '{ def innerMethod = (_: String) ?=> ???; () }.asTerm match
+    case block @ Inlined(_, _, Block(List(defdef: DefDef), _)) =>
+      val rhs =
+        given Quotes = defdef.symbol.asQuotes
+        '{ (x: String) ?=> ??? }.asTerm
+
+      Block(List(DefDef(defdef.symbol, _ => Some(rhs))), '{}.asTerm).asExprOf[Unit]

--- a/tests/pos-macros/i16963/Test_2.scala
+++ b/tests/pos-macros/i16963/Test_2.scala
@@ -1,0 +1,1 @@
+def method: Unit = myMacro


### PR DESCRIPTION
Fixes #16963

The regression here was caused by https://github.com/scala/scala3/commit/229fdaaeaede5edd4489fd67c0c383bb8ffa3255, by the changes to TreeInfo. Since the aim of that PR was to reduce unnecessary `Inlined` removal, instead of reintroducing `Inlined` node removal in `closureDef` in `TreeInfo` (which is used in many places in the compiler), we just remove it directly in erasure, where it would have been removed later in the same manner either way (in `typedInlined`).