### PR TITLE
Retry `constraint.replace` after `constraint.updateEntry`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -306,14 +306,15 @@ trait ConstraintHandling {
 
       // If the narrowed bounds are equal and not recursive,
       // we can remove `param` from the constraint.
-      def tryReplace(lo: Type, hi: Type): Boolean =
+      def tryReplace: Boolean =
+        val TypeBounds(lo, hi) = constraint.nonParamBounds(param)
         val equalBounds = (if isUpper then lo else hi) eq bound
         val canReplace = equalBounds && !recBound
         if canReplace then constraint = constraint.replace(param, bound)
         canReplace
 
-      val oldBounds @ TypeBounds(lo, hi) = constraint.nonParamBounds(param)
-      tryReplace(lo, hi) || locally:
+      tryReplace || locally:
+        val oldBounds @ TypeBounds(lo, hi) = constraint.nonParamBounds(param)
         // Narrow one of the bounds of type parameter `param`
         // If `isUpper` is true, ensure that `param <: `bound`, otherwise ensure
         // that `param >: bound`.
@@ -333,7 +334,7 @@ trait ConstraintHandling {
           constraint = c1
           val TypeBounds(lo, hi) = constraint.entry(param): @unchecked
           val isSat = isSub(lo, hi)
-          if isSat then tryReplace(lo, hi) // isSub may have introduced new constraints
+          if isSat then tryReplace // isSub may have introduced new constraints
           isSat
         }
   end addOneBound

--- a/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
+++ b/compiler/src/dotty/tools/dotc/core/ConstraintHandling.scala
@@ -302,6 +302,9 @@ trait ConstraintHandling {
       false
     else
 
+      // Narrow one of the bounds of type parameter `param`
+      // If `isUpper` is true, ensure that `param <: `bound`,
+      // otherwise ensure that `param >: bound`.
       val narrowedBounds: TypeBounds =
         val bound = legalBound(param, rawBound, isUpper)
         val oldBounds @ TypeBounds(lo, hi) = constraint.nonParamBounds(param)
@@ -325,9 +328,6 @@ trait ConstraintHandling {
         canReplace
 
       tryReplace(narrowedBounds) || locally:
-        // Narrow one of the bounds of type parameter `param`
-        // If `isUpper` is true, ensure that `param <: `bound`, otherwise ensure
-        // that `param >: bound`.
         //println(i"narrow bounds for $param from $oldBounds to $narrowedBounds")
         val c1 = constraint.updateEntry(param, narrowedBounds)
         (c1 eq constraint)


### PR DESCRIPTION
Checking `isSub` on the resulting bounds can have introduced new constraints, which might allow us to replace the type parameter entirely.

Fix #20120
Close #20208 the original implementation