### PR TITLE
Fix #20372: Check pattern match exhaustivity in inlined code

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -56,6 +56,10 @@ class PatternMatcher extends MiniPhase {
       if !inInlinedCode then
         // check exhaustivity and unreachability
         SpaceEngine.checkMatch(tree)
+      else
+        // only check exhaustivity, as inlining may generate unreachable code 
+        // like in i19157.scala
+        SpaceEngine.checkMatchExhaustivityOnly(tree)
 
       translated.ensureConforms(matchType)
     }

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -901,6 +901,9 @@ object SpaceEngine {
   }
 
   def checkMatch(m: Match)(using Context): Unit =
-    if exhaustivityCheckable(m.selector) then checkExhaustivity(m)
+    checkMatchExhaustivityOnly(m)
     if reachabilityCheckable(m.selector) then checkReachability(m)
+  
+  def checkMatchExhaustivityOnly(m: Match)(using Context): Unit =
+    if exhaustivityCheckable(m.selector) then checkExhaustivity(m)
 }

--- a/tests/warn/i20372.check
+++ b/tests/warn/i20372.check
@@ -1,0 +1,8 @@
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/i20372.scala:8:5 ----------------------------------------------
+8 |  id(foo match { // warn
+  |     ^^^
+  |     match may not be exhaustive.
+  |
+  |     It would fail on pattern case: Baz
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/warn/i20372.scala
+++ b/tests/warn/i20372.scala
@@ -1,0 +1,10 @@
+sealed trait Foo
+case object Bar extends Foo
+case object Baz extends Foo
+
+inline def id[A](a: A): A = a
+
+def shouldThrowAWarning(foo: Foo) =
+  id(foo match { // warn
+    case Bar => "Bar"
+  })


### PR DESCRIPTION
Fixes #20372 
c0e93f1a57 previously disabled warnings for pattern matches in Inlined code, as things like:
```scala
inline def count(inline x: Boolean) = x match
    case true => 1
    case false => 0
count(true) // inlined to true match {case true => 1; case false => 0 }
```
would throw warnings about unreachable cases, which could have been confusing to the users. However, in those cases it should be enough to disallow checks for unreachable cases specifically, and leave exhaustivity checks intact.