### PR TITLE
Avoid forcing whole package when using `-experimental`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -806,10 +806,11 @@ object Checking {
   def checkAndAdaptExperimentalImports(trees: List[Tree])(using Context): Unit =
     def nonExperimentalTopLevelDefs(pack: Symbol): Iterator[Symbol] =
       def isNonExperimentalTopLevelDefinition(sym: Symbol) =
-        !sym.isExperimental
+        sym.isDefinedInCurrentRun
         && sym.source == ctx.compilationUnit.source
         && !sym.isConstructor // not constructor of package object
         && !sym.is(Package) && !sym.name.isPackageObjectName
+        && !sym.isExperimental
 
       pack.info.decls.toList.iterator.flatMap: sym =>
         if sym.isClass && (sym.is(Package) || sym.isPackageObject) then

--- a/sbt-test/java-compat/moduleInfo/A.scala
+++ b/sbt-test/java-compat/moduleInfo/A.scala
@@ -1,0 +1,2 @@
+// Previously, we crashed trying to parse module-info.class in the empty package.
+class A

--- a/sbt-test/java-compat/moduleInfo/build.sbt
+++ b/sbt-test/java-compat/moduleInfo/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+scalacOptions ++= Seq(
+  "-experimental"
+)

--- a/sbt-test/java-compat/moduleInfo/test
+++ b/sbt-test/java-compat/moduleInfo/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
In https://github.com/scala/scala3/pull/19807, the behavior of `-experimental` was changed to mark all top-level definitions as experimental. To do so, the implementation traverses the whole package and checks every symbol to see if it should be transformed or not. The problem was that the first check we do is `sym.isExperimental` which ends up forcing the symbol.

Besides being a performance issue, this could also lead to a crash if the current package is the empty package, because we could end up forcing the magic `module-info.class` that Java modules place there. For some reason, this appear to only happen when building with sbt, hence the additional scripted test.

This PR fixes this issue by reordering the checks (and adding a preliminary `isDefinedInCurrentRun` check for good measure). We should also investigate whether we can avoid creating a symbol for `module-info.class`, but this PR is intentionally minimal so we can backport it to 3.5.0-RC2 without risks.