### PR TITLE
Backport: Avoid forcing whole package when using `-experimental`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -806,10 +806,11 @@ object Checking {
   def checkAndAdaptExperimentalImports(trees: List[Tree])(using Context): Unit =
     def nonExperimentalTopLevelDefs(pack: Symbol): Iterator[Symbol] =
       def isNonExperimentalTopLevelDefinition(sym: Symbol) =
-        !sym.isExperimental
+        sym.isDefinedInCurrentRun
         && sym.source == ctx.compilationUnit.source
         && !sym.isConstructor // not constructor of package object
         && !sym.is(Package) && !sym.name.isPackageObjectName
+        && !sym.isExperimental
 
       pack.info.decls.toList.iterator.flatMap: sym =>
         if sym.isClass && (sym.is(Package) || sym.isPackageObject) then

--- a/sbt-test/java-compat/moduleInfo/A.scala
+++ b/sbt-test/java-compat/moduleInfo/A.scala
@@ -1,0 +1,2 @@
+// Previously, we crashed trying to parse module-info.class in the empty package.
+class A

--- a/sbt-test/java-compat/moduleInfo/build.sbt
+++ b/sbt-test/java-compat/moduleInfo/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+scalacOptions ++= Seq(
+  "-experimental"
+)

--- a/sbt-test/java-compat/moduleInfo/test
+++ b/sbt-test/java-compat/moduleInfo/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
This backports https://github.com/scala/scala3/pull/20409 which fixes a regression introduced in 3.5.0-RC1 causing compiler crashes when enabling `-experimental`.