### PR TITLE
Adapt toInstantiate in interpolateTypeVars to consider #20399

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -706,7 +706,9 @@ trait Inferencing { this: Typer =>
                   else
                     typr.println(i"no interpolation for nonvariant $tvar in $state")
                 )
-          buf.toList
+          // constrainIfDependentParamRef could also have instantiated tvars added to buf before the check
+          buf.filterNot(_._1.isInstantiated).toList
+        end toInstantiate
 
         def typeVarsIn(xs: ToInstantiate): TypeVars =
           xs.foldLeft(SimpleIdentitySet.empty: TypeVars)((tvs, tvi) => tvs + tvi._1)


### PR DESCRIPTION
constrainIfDependentParamRef can now not only instantiate the tvar being constrained, but also tvars having already been added to buf.

We simply re-filter buf at the end as this should be a rare occurrence.

[test_scala2_library_tasty]