### PR TITLE
Set default source version to 3.5

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1718,7 +1718,7 @@ trait Implicits:
           SearchSuccess(tpd.ref(ref).withSpan(span.startPos), ref, 0)(ctx.typerState, ctx.gadt)
         case _ =>
           searchImplicit(ctx.implicits,
-            if sourceVersion.isAtLeast(SourceVersion.future) then SearchMode.New
+            if sourceVersion.isAtLeast(SourceVersion.`3.6`) then SearchMode.New
             else if sourceVersion.isAtLeast(SourceVersion.`3.5`) then SearchMode.CompareErr
             else if sourceVersion.isAtLeast(SourceVersion.`3.4`) then SearchMode.CompareWarn
             else SearchMode.Old)

--- a/tests/neg/i20415.scala
+++ b/tests/neg/i20415.scala
@@ -1,0 +1,2 @@
+class Foo:
+  given ord: Ordering[Int] = summon[Ordering[Int]] // error

--- a/tests/neg/i6716-source-3.4.scala
+++ b/tests/neg/i6716-source-3.4.scala
@@ -1,0 +1,19 @@
+//> using options -Xfatal-warnings -source 3.4
+
+trait Monad[T]:
+  def id: String
+class Foo
+object Foo {
+  given Monad[Foo] with { def id = "Foo" }
+}
+
+opaque type Bar = Foo
+object Bar {
+  given Monad[Bar] = summon[Monad[Foo]] // warn
+}
+
+object Test extends App {
+  println(summon[Monad[Foo]].id)
+  println(summon[Monad[Bar]].id)
+}
+// nopos-error: No warnings can be incurred under -Werror (or -Xfatal-warnings)

--- a/tests/pos/given-loop-prevention.scala
+++ b/tests/pos/given-loop-prevention.scala
@@ -1,0 +1,14 @@
+//> using options -Xfatal-warnings -source 3.4
+
+class Foo
+
+object Bar {
+  given Foo with {}
+  given List[Foo] = List(summon[Foo]) // ok
+}
+
+object Baz {
+  @annotation.nowarn
+  given List[Foo] = List(summon[Foo]) // gives a warning, which is suppressed
+  given Foo with {}
+}


### PR DESCRIPTION
The main part of this branch was superseded by #20441, but there were a couple of tests to add, and also a change 
in the treatment of looping implicits in 3.6
