### PR TITLE
Treat 3.5-migration the same as 3.5 for a warning

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1311,14 +1311,14 @@ trait Implicits:
         else
           var cmp = comp(using searchContext())
           val sv = Feature.sourceVersion
-          if sv == SourceVersion.`3.5` || sv == SourceVersion.`3.6-migration` then
+          if sv.stable == SourceVersion.`3.5` || sv == SourceVersion.`3.6-migration` then
             val prev = comp(using searchContext().addMode(Mode.OldImplicitResolution))
             if cmp != prev then
               def choice(c: Int) = c match
                 case -1 => "the second alternative"
                 case  1 => "the first alternative"
                 case _  => "none - it's ambiguous"
-              if sv == SourceVersion.`3.5` then
+              if sv.stable == SourceVersion.`3.5` then
                 report.warning(
                   em"""Given search preference for $pt between alternatives ${alt1.ref} and ${alt2.ref} will change
                       |Current choice           : ${choice(prev)}

--- a/tests/warn/i20420.scala
+++ b/tests/warn/i20420.scala
@@ -1,0 +1,27 @@
+//> using options -source 3.5-migration
+
+final class StrictEqual[V]
+final class Less[V]
+type LessEqual[V] = Less[V] | StrictEqual[V]
+
+object TapirCodecIron:
+  trait ValidatorForPredicate[Value, Predicate]
+  trait PrimitiveValidatorForPredicate[Value, Predicate]
+      extends ValidatorForPredicate[Value, Predicate]
+
+  given validatorForLessEqual[N: Numeric, NM <: N](using
+      ValueOf[NM]
+  ): PrimitiveValidatorForPredicate[N, LessEqual[NM]] = ???
+  given validatorForDescribedOr[N, P](using
+      IsDescription[P]
+  ): ValidatorForPredicate[N, P] = ???
+
+  trait IsDescription[A]
+  object IsDescription:
+    given derived[A]: IsDescription[A] = ???
+
+@main def Test = {
+  import TapirCodecIron.{*, given}
+  type IntConstraint = LessEqual[3]
+  summon[ValidatorForPredicate[Int, IntConstraint]] // warn
+}


### PR DESCRIPTION
Treat 3.5-migration the same as 3.5 for a warning about implicit priority change

Fixes #20420