### PR TITLE
chore: Bump mtags to latest stable

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1339,10 +1339,8 @@ object Build {
       BuildInfoPlugin.buildInfoDefaultSettings
 
   def presentationCompilerSettings(implicit mode: Mode) = {
-    val mtagsVersion = "1.3.0+56-a06a024d-SNAPSHOT"
-
+    val mtagsVersion = "1.3.1"
     Seq(
-      resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",
         "io.get-coursier" % "interface" % "1.0.18",


### PR DESCRIPTION
We should avoid using non stable versions since this can cause issues like https://github.com/scalameta/metals/issues/6402

Closes https://github.com/scalameta/metals/issues/6402