### PR TITLE
Fix NamedTuple selection on an unstable prefix

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -826,7 +826,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if qual.tpe.derivesFrom(defn.SelectableClass) && !isDynamicExpansion(tree)
         && !pt.isInstanceOf[FunOrPolyProto] && pt != LhsProto
     then
-      val fieldsType = qual.tpe.select(tpnme.Fields).dealias.simplified
+      val pre = if !TypeOps.isLegalPrefix(qual.tpe) then SkolemType(qual.tpe) else qual.tpe
+      val fieldsType = pre.select(tpnme.Fields).dealias.simplified
       val fields = fieldsType.namedTupleElementTypes
       typr.println(i"try dyn select $qual, $selName, $fields")
       fields.find(_._1 == selName) match

--- a/tests/pos/named-tuple-unstable.scala
+++ b/tests/pos/named-tuple-unstable.scala
@@ -1,0 +1,15 @@
+import scala.language.experimental.namedTuples
+import NamedTuple.{AnyNamedTuple, NamedTuple}
+
+trait Foo extends Selectable:
+  val f: Any
+  type Fields = (myfield: f.type)
+  def selectDynamic(name: String): Any
+
+object Test:
+  val elem1: Foo { val f: Int } = ???
+  def elem2: Foo { val f: Int } = ???
+
+  def test: Unit =
+    val a: Int = elem1.myfield // OK
+    val b: Int = elem2.myfield // error: value myfield is not a member of Foo { val f: Int }


### PR DESCRIPTION
Without a stable prefix, asSeenFrom could end up widening `Fields` to `>: Nothing <: Any`.