### PR TITLE
Reduce some match type in inlining to avoid opaque type headaches

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -67,6 +67,7 @@ mt-redux-norm.perspective.scala
 i18211.scala
 10867.scala
 named-tuples1.scala
+inline-match-opaque.scala
 
 # Opaque type
 i5720.scala

--- a/tests/pos/inline-match-opaque-2.scala
+++ b/tests/pos/inline-match-opaque-2.scala
@@ -1,0 +1,6 @@
+import scala.language.experimental.namedTuples
+
+object Test:
+  type NT = NamedTuple.Concat[(hi: Int), (bla: String)]
+  def foo(x: NT) =
+    x.hi // error

--- a/tests/pos/inline-match-opaque.scala
+++ b/tests/pos/inline-match-opaque.scala
@@ -1,0 +1,19 @@
+object Foo:
+  opaque type Wrapper[T] = T
+  def part[T](w: Wrapper[T]): T = w
+  inline def part2[T](w: Wrapper[T]): T = part(w) //part(w.asInstanceOf[Wrapper[T]]) also fixes the issue
+  type Rewrap[W] = Wrapper[Extra.Unwrap[W]]
+
+object Extra:
+  type Unwrap[W] = W match
+    case Foo.Wrapper[t] => t
+  type Rewrap[W] = Foo.Wrapper[Unwrap[W]]
+
+object Test:
+  type X = Extra.Rewrap[Foo.Wrapper[Int]]
+  def foo1(x: Foo.Wrapper[Extra.Unwrap[Foo.Wrapper[Int]]]) =
+    Foo.part(x) // ok
+    Foo.part2(x) // ok
+  def foo2(x: X) =
+    Foo.part(x) // ok
+    Foo.part2(x) // error


### PR DESCRIPTION
The inliner tries to handle opaque types by replacing prefixes containing them by proxy objects with type aliases. When the type we're mapping is a match type application, this can end up breaking its reduction.

Reducing match type applications instead of performing this mapping seems to avoid the issue in practice, but I don't know if it completely solves the problem.

Fixes #20427.