### PR TITLE
Correct Java signature for value classes appearing in type arguments

### DIFF
--- a/tests/pos/i10347/C_2.java
+++ b/tests/pos/i10347/C_2.java
@@ -1,5 +1,5 @@
 public class C_2 {
   String hi = A.foo().head();
-  String hy = A.bar().head();
+  String hy = A.bar().head().s();
   String hj = A.baz("").head();
 }

--- a/tests/run/i10846.check
+++ b/tests/run/i10846.check
@@ -1,0 +1,3 @@
+i10846.V: scala.Option<i10846.V>
+i10846.U: scala.Option<i10846.U>
+i10846.W: scala.Option<i10846.W<scala.Function1<java.lang.Object, java.lang.String>>>

--- a/tests/run/i10846/i10846.scala
+++ b/tests/run/i10846/i10846.scala
@@ -1,0 +1,28 @@
+// scalajs: --skip
+
+package i10846 {
+  final class V(val x: Int) extends AnyVal
+  object V { def get: Option[V] = null }
+
+  final class U(val y: String) extends AnyVal
+  object U { def get: Option[U] = null }
+
+  final class W[T](val z: T) extends AnyVal
+  object W { def get: Option[W[Int => String]] = null }
+}
+
+
+object Test extends scala.App {
+  def check[T](implicit tt: reflect.ClassTag[T]): Unit = {
+    val companion = tt.runtimeClass.getClassLoader.loadClass(tt.runtimeClass.getName + '$')
+    val get = companion.getMethod("get")
+    assert(get.getReturnType == classOf[Option[_]])
+    println(s"${tt.runtimeClass.getName}: ${get.getGenericReturnType}")
+  }
+
+  import i10846._
+
+  check[V]
+  check[U]
+  check[W[_]]
+}


### PR DESCRIPTION
As suggested in #10846 the fix to this issue should be to port https://github.com/scala/scala/pull/8127 to scala3

I started by adding the same tests as in the scala2 PR and then tried to find the place where to do the fix by adding some log traces. Unfortunately I am still pretty lost because this is my first time looking at the compiler code. 

Any tips where this needs to be fixed are very welcome. Meanwhile a few questions:
* The scala2 fix was done in `src/compiler/scala/tools/nsc/transform/Erasure.scala`, should I do the fix for scala3 in `compiler/src/dotty/tools/dotc/transform/Erasure.scala` as well? 
* I think I need to do the fix around `ErasedValueType`, either when it is created (in `TypeErasure#eraseDerivedValueClass`) or when it is used (in `Erasure#unbox`). 

Please also send me any pointers besides https://dotty.epfl.ch/docs/contributing/index.html regarding compiler contributions