### PR TITLE
Fix #20458: do not expose ClassInfo in quotes reflect widenTermRefByName

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1811,7 +1811,10 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def =:=(that: TypeRepr): Boolean = self =:= that
         def <:<(that: TypeRepr): Boolean = self <:< that
         def widen: TypeRepr = self.widen
-        def widenTermRefByName: TypeRepr = self.widenTermRefExpr
+        def widenTermRefByName: TypeRepr =
+          self.widenTermRefExpr match
+            case dotc.core.Types.ClassInfo(prefix, sym, _, _, _) => prefix.select(sym)
+            case other => other
         def widenByName: TypeRepr = self.widenExpr
         def dealias: TypeRepr = self.dealias
         def dealiasKeepOpaques: TypeRepr = self.dealiasKeepOpaques

--- a/tests/pos-macros/i20458/Macro_1.scala
+++ b/tests/pos-macros/i20458/Macro_1.scala
@@ -1,0 +1,12 @@
+import scala.quoted._
+
+inline def matchCustom[F](): Unit = ${ matchCustomImpl[F] }
+
+private def matchCustomImpl[F: Type](using q: Quotes): Expr[Unit] = {
+  import q.reflect.*
+  val any = TypeRepr.of[Any].typeSymbol
+  assert(!any.termRef.widenTermRefByName.toString.contains("ClassInfo"))
+  any.termRef.widenTermRefByName.asType match
+    case '[t] => ()
+  '{ () }
+}

--- a/tests/pos-macros/i20458/Test_2.scala
+++ b/tests/pos-macros/i20458/Test_2.scala
@@ -1,0 +1,1 @@
+def main() = matchCustom()


### PR DESCRIPTION
Previously ClassInfo could easily be exposed with calls like `TypeRepr.of[T].termRef.widenTermRefByName`.

Fixes #20458