### PR TITLE
Fix isEffectivelySingleton

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -329,13 +329,12 @@ object Types extends TypeUtils {
     def isSingleton(using Context): Boolean = dealias.isInstanceOf[SingletonType]
 
     /** Is this type a (possibly aliased) singleton type or a type proxy
-     *  or Or/And type known to be a singleton type?
+     *  or an AndType where one operand is effectively a singleton?
      */
     def isEffectivelySingleton(using Context): Boolean = dealias match
       case tp: SingletonType => true
       case tp: TypeProxy => tp.superType.isEffectivelySingleton
       case AndType(tpL, tpR) => tpL.isEffectivelySingleton || tpR.isEffectivelySingleton
-      case OrType(tpL, tpR) => tpL.isEffectivelySingleton && tpR.isEffectivelySingleton
       case _ => false
 
     /** Is this upper-bounded by a (possibly aliased) singleton type?

--- a/tests/neg/i20474.scala
+++ b/tests/neg/i20474.scala
@@ -1,0 +1,13 @@
+class A
+class B extends A
+
+def f(a: A, c: A) =
+  val b1: a.type = a
+  val b2: a.type & B = a.asInstanceOf[a.type & B]
+  val b3: c.type & A = c
+  val b4: a.type | c.type = c
+
+  val d1: b1.type = a
+  val d2: b2.type = a // ok
+  val d3: b3.type = a // error
+  val d4: b4.type = a // error


### PR DESCRIPTION
As usual, OrTypes need to be excluded. a.type | b.type is not effectively a singleton. It seems to be an easy trap to fall into.

Follow-up to #20474
