### PR TITLE
Avoid stacked thisCall contexts

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -477,7 +477,7 @@ object Contexts {
 
     /** Is the flexible types option set? */
     def flexibleTypes: Boolean = base.settings.YexplicitNulls.value && !base.settings.YnoFlexibleTypes.value
-    
+
     /** Is the best-effort option set? */
     def isBestEffort: Boolean = base.settings.YbestEffort.value
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1067,7 +1067,7 @@ trait Implicits:
     trace(s"search implicit ${pt.show}, arg = ${argument.show}: ${argument.tpe.show}", implicits, show = true) {
       record("inferImplicit")
       assert(ctx.phase.allowsImplicitSearch,
-        if (argument.isEmpty) i"missing implicit parameter of type $pt after typer at phase ${ctx.phase.phaseName}"
+        if (argument.isEmpty) i"missing implicit parameter of type $pt after typer at phase ${ctx.phase}"
         else i"type error: ${argument.tpe} does not conform to $pt${err.whyNoMatchStr(argument.tpe, pt)}")
 
       val usableForInference = pt.exists && !pt.unusableForInference

--- a/tests/pos/i20483.scala
+++ b/tests/pos/i20483.scala
@@ -1,0 +1,13 @@
+
+class Foo
+  (x: Option[String])
+  (using Boolean)
+  (using Int)
+  (using Double):
+
+  def this
+    (x: String)
+    (using Boolean)
+    (using Int)
+    (using Double) =
+    this(Some(x))


### PR DESCRIPTION
AddImplicitArgs can recursively add several implicit parameter lists. We need to make sure we don't perform a thisCallContext search in another thisCall context in this case.

Fixes #20483

The original code would back out further and further in the context chain for every implicit parameter section on the secondary constructor. Eventually (in this case after 2 times) bad things happen.