### PR TITLE
Fix symbol reference retrivial for `scala.caps.Caps`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -991,7 +991,7 @@ class Definitions {
 
   @tu lazy val CapsModule: Symbol = requiredModule("scala.caps")
     @tu lazy val captureRoot: TermSymbol = CapsModule.requiredValue("cap")
-    @tu lazy val Caps_Capability: TypeSymbol = CapsModule.requiredType("Capability")
+    @tu lazy val Caps_Capability: ClassSymbol = requiredClass("scala.caps.Capability")
     @tu lazy val Caps_reachCapability: TermSymbol = CapsModule.requiredMethod("reachCapability")
     @tu lazy val CapsUnsafeModule: Symbol = requiredModule("scala.caps.unsafe")
     @tu lazy val Caps_unsafeAssumePure: Symbol = CapsUnsafeModule.requiredMethod("unsafeAssumePure")


### PR DESCRIPTION
Fixes #20556
The `scala.caps.Cap` was changed from opaque type to class in #18463 
It could have lead to compiler crash when trying to reference it, eg in `tminglei/slick-pg` - [see Open CB logs](https://github.com/VirtusLab/community-build3/actions/runs/9272311130/job/25514668617) probably by entering some unexpected paths