### PR TITLE
make NamedTuple.Empty an alias to NamedTuple

### DIFF
--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -201,10 +201,10 @@ object NamedTuple:
   type From[T] <: AnyNamedTuple
 
   /** The type of the empty named tuple */
-  type Empty = EmptyTuple.type
+  type Empty = NamedTuple[EmptyTuple, EmptyTuple]
 
   /** The empty named tuple */
-  val Empty: Empty = EmptyTuple.asInstanceOf[Empty]
+  val Empty: Empty = EmptyTuple
 
 end NamedTuple
 

--- a/tests/run/named-tuples.check
+++ b/tests/run/named-tuples.check
@@ -9,3 +9,5 @@ Bob is younger than Lucy
 Bill is younger than Lucy
 (((Lausanne,Pully),Preverenges),((1003,1009),1028))
 118
+()
+(name,age)

--- a/tests/run/named-tuples.scala
+++ b/tests/run/named-tuples.scala
@@ -110,6 +110,14 @@ val _: CombinedInfo = bob ++ addr
   val totalAge = persons.mapReduce(reducer)
   println(totalAge)
 
+  inline def namesOf[T <: AnyNamedTuple](t: T): Names[T] = compiletime.constValueTuple[Names[T]]
+  val namesEmpty = namesOf(NamedTuple.Empty)
+  val namesBob = namesOf(bob)
+  val namesEmpty2: EmptyTuple = namesEmpty
+  val namesBob2: ("name", "age") = namesBob
+  println(namesEmpty)
+  println(namesBob)
+
   // testing conversions
 object Conv:
 


### PR DESCRIPTION
It was suggested for a follow-up perhaps we should also rename Empty -> EmptyNamedTuple (most code will be doing `import NamedTuple.*`)

fixes #20428