### PR TITLE
Mark AppliedType cachedSuper valid Nowhere when using provisional args

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4677,8 +4677,8 @@ object Types extends TypeUtils {
      */
     override def underlyingMatchType(using Context): Type =
       if ctx.period != validUnderlyingMatch then
-        validUnderlyingMatch = if tycon.isProvisional then Nowhere else ctx.period
         cachedUnderlyingMatch = superType.underlyingMatchType
+        validUnderlyingMatch = validSuper
       cachedUnderlyingMatch
 
     override def tryNormalize(using Context): Type = tycon.stripTypeVar match {

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4643,7 +4643,9 @@ object Types extends TypeUtils {
         cachedSuper = tycon match
           case tycon: HKTypeLambda => defn.AnyType
           case tycon: TypeRef if tycon.symbol.isClass => tycon
-          case tycon: TypeProxy => tycon.superType.applyIfParameterized(args)
+          case tycon: TypeProxy =>
+            if validSuper != Nowhere && args.exists(_.isProvisional) then validSuper = Nowhere
+            tycon.superType.applyIfParameterized(args)
           case _ => defn.AnyType
       cachedSuper
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4644,7 +4644,11 @@ object Types extends TypeUtils {
           case tycon: HKTypeLambda => defn.AnyType
           case tycon: TypeRef if tycon.symbol.isClass => tycon
           case tycon: TypeProxy =>
-            if validSuper != Nowhere && args.exists(_.isProvisional) then validSuper = Nowhere
+            if validSuper != Nowhere && args.exists(_.isProvisional) then
+              // applyIfParameterized may perform eta-reduction leading to different
+              // variance annotations depending on the instantiation of type params
+              // see tests/pos/typeclass-encoding3b.scala:348 for an example
+              validSuper = Nowhere
             tycon.superType.applyIfParameterized(args)
           case _ => defn.AnyType
       cachedSuper

--- a/tests/pos/typeclass-encoding3b.scala
+++ b/tests/pos/typeclass-encoding3b.scala
@@ -347,10 +347,10 @@ object functors {
   MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5))) // ok, synthesizes (using ListMonad)
   MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5)))(using ListMonad) // was an error
   /*
-  When checking `ListMonad <:< functors.Monad.Impl[T]`
-  we eventually get to the comparison `[X] =>> T[X] <:< [+X] =>> List[X]`
+  Before the changes, when checking `ListMonad <:< functors.Monad.Impl[T]`
+  we eventually got to the comparison `[X] =>> T[X] <:< [+X] =>> List[X]`
   because the `This` type member of `ListMonad` has a covariance annotation.
-  This fails the variance conformance checks despite the fact that T has been instantiated to List,
-  since it has been substituted into the refinement (and cached) before its instantiation.
+  This failed the variance conformance checks despite the fact that T had been instantiated to List,
+  since it had been substituted into the refinement (and cached) before its instantiation.
   */
 }

--- a/tests/pos/typeclass-encoding3b.scala
+++ b/tests/pos/typeclass-encoding3b.scala
@@ -345,5 +345,12 @@ object functors {
   }
 
   MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5))) // ok, synthesizes (using ListMonad)
-  MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5)))(using ListMonad)
+  MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5)))(using ListMonad) // was an error
+  /*
+  When checking `ListMonad <:< functors.Monad.Impl[T]`
+  we eventually get to the comparison `[X] =>> T[X] <:< [+X] =>> List[X]`
+  because the `This` type member of `ListMonad` has a covariance annotation.
+  This fails the variance conformance checks despite the fact that T has been instantiated to List,
+  since it has been substituted into the refinement (and cached) before its instantiation.
+  */
 }

--- a/tests/pos/typeclass-encoding3b.scala
+++ b/tests/pos/typeclass-encoding3b.scala
@@ -345,5 +345,5 @@ object functors {
   }
 
   MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5))) // ok, synthesizes (using ListMonad)
-  MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5)))(using ListMonad) // error
+  MonadFlatten.flattened(List(List(1, 2, 3), List(4, 5)))(using ListMonad)
 }


### PR DESCRIPTION
I'm not sure why it wasn't the case previously. 

It solves some stale caching issues I encounter when introducing more caching for match types in #20268, as well as the problem in `neg/typeclass-encoding3` apparently.

There seems to be no significant performance impact from the reduced opportunities for caching.