### PR TITLE
Fix error related to reaches when using scala2-library-cc-tasty

### DIFF
--- a/tests/neg/i20503.scala
+++ b/tests/neg/i20503.scala
@@ -1,6 +1,16 @@
 import language.experimental.captureChecking
+
+class List[+A]:
+  def head: A = ???
+  def tail: List[A] = ???
+  def map[B](f: A => B): List[B] = ???
+  def foreach[U](f: A => U): Unit = ???
+  def nonEmpty: Boolean = ???
+
 def runOps(ops: List[() => Unit]): Unit =
-  ops.foreach(op => op())
+  // See i20156, due to limitation in expressiveness of current system,
+  // we cannot map over the list of impure elements.
+  ops.foreach(op => op()) // error
 
 def main(): Unit =
   val f: List[() => Unit] -> Unit = runOps  // error


### PR DESCRIPTION
Fix error introduced by a test of #20524

Due to limitation in expressiveness of current system, we are not able to map over lists of impure elements.

See discussion in #20156

[test_scala2_library_tasty]