### PR TITLE
Generalize isAlwaysEmpty and streamline isBoxedCaptured

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -158,7 +158,15 @@ extension (tp: Type)
     getBoxed(tp)
 
   /** Is the boxedCaptureSet of this type nonempty? */
-  def isBoxedCapturing(using Context) = !tp.boxedCaptureSet.isAlwaysEmpty
+  def isBoxedCapturing(using Context): Boolean =
+    tp match
+      case tp @ CapturingType(parent, refs) =>
+        tp.isBoxed && !refs.isAlwaysEmpty || parent.isBoxedCapturing
+      case tp: TypeRef if tp.symbol.isAbstractOrParamType => false
+      case tp: TypeProxy => tp.superType.isBoxedCapturing
+      case tp: AndType => tp.tp1.isBoxedCapturing && tp.tp2.isBoxedCapturing
+      case tp: OrType => tp.tp1.isBoxedCapturing || tp.tp2.isBoxedCapturing
+      case _ => false
 
   /** If this type is a capturing type, the version with boxed statues as given by `boxed`.
    *  If it is a TermRef of a capturing type, and the box status flips, widen to a capturing

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -455,7 +455,7 @@ object CaptureSet:
     var deps: Deps = emptySet
 
     def isConst = isSolved
-    def isAlwaysEmpty = false
+    def isAlwaysEmpty = isSolved && elems.isEmpty
 
     def isMaybeSet = false // overridden in BiMapped
 


### PR DESCRIPTION
 - isBoxedCaptured no longer requires the construction of intermediate capture sets.
 - isAlwaysEmpty is also true for solved variables that have no elements