### PR TITLE
completions: do not complete package

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -90,6 +90,8 @@ object Completion:
    * Otherwise, provide no completion suggestion.
    */
   def completionMode(path: List[untpd.Tree], pos: SourcePosition): Mode = path match
+    // Ignore `package foo@@` and `package foo.bar@@`
+    case ((_: tpd.Select) | (_: tpd.Ident)):: (_ : tpd.PackageDef) :: _  => Mode.None
     case GenericImportSelector(sel) =>
       if sel.imported.span.contains(pos.span) then Mode.ImportOrExport // import scala.@@
       else if sel.isGiven && sel.bound.span.contains(pos.span) then Mode.ImportOrExport

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2223,3 +2223,17 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin,
       topLines = Some(3)
     )
+
+  @Test def `packageIssueIdent` =
+    check(
+      """package one@@
+        |""".stripMargin,
+      ""
+    )
+
+  @Test def `packageIssueSelect` =
+    check(
+      """package one.two@@
+        |""".stripMargin,
+      ""
+    )


### PR DESCRIPTION
There is an issue with completions for package in Metals.

```scala
// code
package one@@
// compeltions
oneCURSOR
```

It seems there is no need in completions for Package at all.