### PR TITLE
Only consider methods with 0 parameters in valueOf

### DIFF
--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -115,7 +115,8 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
     val objectName = sym.owner.fullName.encode.toString.stripSuffix("$")
     val resObj: Class[?] = Class.forName(objectName, true, classLoader())
     val symValue = resObj
-      .getDeclaredMethods.find(_.getName == sym.name.encode.toString)
+      .getDeclaredMethods
+      .find(method => method.getName == sym.name.encode.toString && method.getParameterCount == 0)
       .flatMap(result => rewrapValueClass(sym.info.classSymbol, result.invoke(null)))
     symValue
       .filter(_ => sym.is(Flags.Method) || sym.info != defn.UnitType)

--- a/compiler/test-resources/repl/19184
+++ b/compiler/test-resources/repl/19184
@@ -1,0 +1,5 @@
+scala> def o(s: String) = "o"; def oo(s: String) = "oo"; val o = "o"; val oo = "oo"
+def o(s: String): String
+def oo(s: String): String
+val o: String = o
+val oo: String = oo


### PR DESCRIPTION
`valueOf` should only consider getters, which have 0 parameters.

test with:
scala3-compiler / testOnly dotty.tools.repl.ScriptedTests -- dotty.tools.repl.ScriptedTests.replTests

Fixes #19184