### PR TITLE
Add the `-Wall` option that enables all warnings

### DIFF
--- a/tests/warn/i18559a.check
+++ b/tests/warn/i18559a.check
@@ -1,0 +1,12 @@
+-- [E198] Unused Symbol Warning: tests/warn/i18559a.scala:4:28 ---------------------------------------------------------
+4 |  import collection.mutable.Set // warn
+  |                            ^^^
+  |                            unused import
+-- [E198] Unused Symbol Warning: tests/warn/i18559a.scala:8:8 ----------------------------------------------------------
+8 |    val x = 1  // warn
+  |        ^
+  |        unused local definition
+-- [E198] Unused Symbol Warning: tests/warn/i18559a.scala:11:26 --------------------------------------------------------
+11 |  import SomeGivenImports.given // warn
+   |                          ^^^^^
+   |                          unused import

--- a/tests/warn/i18559a.scala
+++ b/tests/warn/i18559a.scala
@@ -1,0 +1,15 @@
+//> using options -Wall
+// This test checks that -Wall turns on -Wunused:all if -Wunused is not set
+object FooImportUnused:
+  import collection.mutable.Set // warn
+
+object FooUnusedLocal:
+  def test(): Unit =
+    val x = 1  // warn
+
+object FooGivenUnused:
+  import SomeGivenImports.given // warn
+
+object SomeGivenImports:
+  given Int = 0
+  given String = "foo"

--- a/tests/warn/i18559b.check
+++ b/tests/warn/i18559b.check
@@ -1,0 +1,12 @@
+-- Warning: tests/warn/i18559b.scala:8:6 -------------------------------------------------------------------------------
+8 |  val localFile: String = s"${url.##}.tmp"  // warn
+  |      ^
+  |      Access non-initialized value localFile. Calling trace:
+  |      ├── class RemoteFile(url: String) extends AbstractFile:	[ i18559b.scala:7 ]
+  |      │   ^
+  |      ├── abstract class AbstractFile:	[ i18559b.scala:3 ]
+  |      │   ^
+  |      ├── val extension: String = name.substring(4)	[ i18559b.scala:5 ]
+  |      │                           ^^^^
+  |      └── def name: String = localFile	[ i18559b.scala:9 ]
+  |                             ^^^^^^^^^

--- a/tests/warn/i18559b.scala
+++ b/tests/warn/i18559b.scala
@@ -1,0 +1,9 @@
+//> using options -Wall
+// This test checks that -Wall turns on -Wsafe-init
+abstract class AbstractFile:
+  def name: String
+  val extension: String = name.substring(4)
+
+class RemoteFile(url: String) extends AbstractFile:
+  val localFile: String = s"${url.##}.tmp"  // warn
+  def name: String = localFile

--- a/tests/warn/i18559c.check
+++ b/tests/warn/i18559c.check
@@ -1,0 +1,4 @@
+-- [E198] Unused Symbol Warning: tests/warn/i18559c.scala:8:8 ----------------------------------------------------------
+8 |    val x = 1  // warn
+  |        ^
+  |        unused local definition

--- a/tests/warn/i18559c.scala
+++ b/tests/warn/i18559c.scala
@@ -1,0 +1,15 @@
+//> using options -Wall -Wunused:locals
+// This test checks that -Wall leaves -Wunused:... untouched if it is already set
+object FooImportUnused:
+  import collection.mutable.Set // not warn
+
+object FooUnusedLocal:
+  def test(): Unit =
+    val x = 1  // warn
+
+object FooGivenUnused:
+  import SomeGivenImports.given // not warn
+
+object SomeGivenImports:
+  given Int = 0
+  given String = "foo"


### PR DESCRIPTION
fixes #18559

This PR adds the `-Wall` option, which enables all warnings when it is set. Note that when `-Wunused` is not set (empty), setting `-Wall` is equivalent to passing `-Wunused:all`. But when `-Wunused` is set to some specific value (e.g. `-Wunused:imports,locals`), passing `-Wall` does not change it.