### PR TITLE
More principled filtering of abstract values in initialization check

### DIFF
--- a/tests/init/warn/type-filter.scala
+++ b/tests/init/warn/type-filter.scala
@@ -1,0 +1,15 @@
+class A(o: O):
+  var a = 20
+
+class B(o: O):
+  var b = 20
+
+class O:
+  val o: A | B = new A(this)
+  if o.isInstanceOf[A] then
+    o.asInstanceOf[A].a += 1
+  else
+    o.asInstanceOf[B].b += 1 // o.asInstanceOf[B] is treated as bottom
+
+  // prevent early promotion
+  val x = 10

--- a/tests/init/warn/type-filter2.scala
+++ b/tests/init/warn/type-filter2.scala
@@ -13,7 +13,7 @@ class C(x: Int):
 
   val c: A = a.asInstanceOf[A]         // abstraction for c is {A, B}
   val d = c.f                          // treat as c.asInstanceOf[owner of f].f
-  val e = c.m()                        // treat as c.asInstanceOf[owner of f].m()
+  val e = c.m()                        // treat as c.asInstanceOf[owner of m].m()
   val c2: B = a.asInstanceOf[B]
   val g = c2.f                         // no error here
 

--- a/tests/init/warn/type-filter2.scala
+++ b/tests/init/warn/type-filter2.scala
@@ -1,0 +1,19 @@
+class A(c: C):
+  val f: Int = 10
+  def m() = f
+
+class B(c: C):
+  val f: Int = g()       // warn
+  def g(): Int = f
+
+class C(x: Int):
+  val a: A | B = if x > 0 then new A(this) else new B(this)
+
+  def cast[T](a: Any): T = a.asInstanceOf[T]
+
+  val c: A = a.asInstanceOf[A]         // abstraction for c is {A, B}
+  val d = c.f                          // treat as c.asInstanceOf[owner of f].f
+  val e = c.m()                        // treat as c.asInstanceOf[owner of f].m()
+  val c2: B = a.asInstanceOf[B]
+  val g = c2.f                         // no error here
+


### PR DESCRIPTION
More principled filtering of abstract values in initialization check.

It ports the similar improvement to the global initialization checker https://github.com/scala/scala3/pull/19612.