### PR TITLE
Only set `AppliedType#validSuper` after `AppliedType#cachedSuper`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4646,18 +4646,18 @@ object Types extends TypeUtils {
 
     override def superType(using Context): Type =
       if ctx.period != validSuper then
-        validSuper = if (tycon.isProvisional) Nowhere else ctx.period
+        var superIsProvisional = tycon.isProvisional
         cachedSuper = tycon match
           case tycon: HKTypeLambda => defn.AnyType
           case tycon: TypeRef if tycon.symbol.isClass => tycon
           case tycon: TypeProxy =>
-            if validSuper != Nowhere && args.exists(_.isProvisional) then
+            superIsProvisional ||= args.exists(_.isProvisional)
               // applyIfParameterized may perform eta-reduction leading to different
               // variance annotations depending on the instantiation of type params
               // see tests/pos/typeclass-encoding3b.scala:348 for an example
-              validSuper = Nowhere
             tycon.superType.applyIfParameterized(args)
           case _ => defn.AnyType
+        validSuper = if superIsProvisional then Nowhere else ctx.period
       cachedSuper
 
     override def translucentSuperType(using Context): Type = tycon match {

--- a/tests/neg/i20546.scala
+++ b/tests/neg/i20546.scala
@@ -1,0 +1,22 @@
+import NamedTuple.{NamedTuple, AnyNamedTuple}
+
+type And[X <: Boolean, Y <: Boolean] <: Boolean = (X, Y) match
+  case (true, true) => true
+  case _ => false
+type AndLambda = [X <: Boolean, Y <: Boolean] =>> And[X, Y]
+
+trait Expr2[Result, Scalar <: Boolean]:
+  type StripScalar[E] = E match
+    case Expr2[_, s] => s
+
+  type AllScalar[A <: AnyNamedTuple] = Tuple.Fold[Tuple.Map[NamedTuple.DropNames[A], StripScalar], true, AndLambda] // error: cyclic
+
+
+object Minimization:
+  type And[X <: Boolean, Y <: Boolean] = (X, Y) match
+    case (true, true) => true
+    case _ => false
+
+  type AndLambda = [X <: Boolean, Y <: Boolean] =>> And[X, Y]
+
+  type All[A <: Tuple] = Tuple.Fold[A, true, AndLambda] // error: cyclic


### PR DESCRIPTION
since cycles are possible when computing `AppliedType#superType`, see tests/neg/i20546.scala for an example leading to an NPE.

We could use `ctx.period == validSuper && cachedSuper == null` as condition to detect cycles, but they are already handled in `TypeApplications#appliedTo`, with a better error message.

We can update `AppliedType#validSuper` only after the computation is done to fix #20546