### PR TITLE
Fix EnclosingMethod for lifted anonfun

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeAsmCommon.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeAsmCommon.scala
@@ -60,7 +60,7 @@ final class BCodeAsmCommon[I <: DottyBackendInterface](val interface: I) {
     assert(classSym.isClass, classSym)
     def enclosingMethod(sym: Symbol): Option[Symbol] = {
       if (sym.isClass || sym == NoSymbol) None
-      else if (sym.is(Method)) Some(sym)
+      else if (sym.is(Method, butNot=Synthetic)) Some(sym)
       else enclosingMethod(sym.originalOwner)
     }
     enclosingMethod(classSym.originalOwner)

--- a/tests/run/i18701.check
+++ b/tests/run/i18701.check
@@ -1,0 +1,1 @@
+public TB A$$anon$1.tb()

--- a/tests/run/i18701.fixed.check
+++ b/tests/run/i18701.fixed.check
@@ -1,0 +1,1 @@
+public TB A$$anon$2.apply()

--- a/tests/run/i18701.fixed.scala
+++ b/tests/run/i18701.fixed.scala
@@ -1,0 +1,15 @@
+abstract class TA { def tb(): TB }
+abstract class TB { def chk(): Unit }
+class A:
+  def a(): TA =
+    new TA {
+      def tb(): TB =
+        val fn: () => TB = new Function0[TB]:
+          def apply(): TB = new TB {
+            def chk() = println(getClass.getEnclosingMethod())
+          }
+        fn()
+    }
+
+object Test:
+  def main(args: Array[String]): Unit = new A().a().tb().chk()

--- a/tests/run/i18701.fixed.scala
+++ b/tests/run/i18701.fixed.scala
@@ -1,3 +1,5 @@
+// scalajs: --skip
+//    Use of Java reflection (getEnclosingMethod)
 abstract class TA { def tb(): TB }
 abstract class TB { def chk(): Unit }
 class A:

--- a/tests/run/i18701.scala
+++ b/tests/run/i18701.scala
@@ -1,3 +1,5 @@
+// scalajs: --skip
+//    Use of Java reflection (getEnclosingMethod)
 abstract class TA { def tb(): TB }
 abstract class TB { def chk(): Unit }
 class A:

--- a/tests/run/i18701.scala
+++ b/tests/run/i18701.scala
@@ -1,0 +1,14 @@
+abstract class TA { def tb(): TB }
+abstract class TB { def chk(): Unit }
+class A:
+  def a(): TA =
+    new TA {
+      def tb(): TB =
+        val fn: () => TB = () => new TB {
+          def chk() = println(getClass.getEnclosingMethod())
+        }
+        fn()
+    }
+
+object Test:
+  def main(args: Array[String]): Unit = new A().a().tb().chk()


### PR DESCRIPTION
The anonfun "() => new TB {.." code is lifted to a static method, in the
original class (A), but the GenBCode logic was still returning the TA
anon class.

Fixes #18701