### PR TITLE
Change the trigger to check the CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,15 +1,9 @@
-name: Scala CLA
+name: Check Scala CLA
 on:
   pull_request:
+    types: opened
     branches-ignore:
       - 'language-reference-stable'
-  push:
-    branches:
-      - 'language-reference-stable'
-  merge_group:
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   check:
@@ -17,6 +11,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: ./project/scripts/check-cla.sh
-      if: github.event_name == 'pull_request'
       env:
         AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
This PR changes the trigger to check the Scala CLA to the PR creation. It avoids wasting resources by checking the CLA on each push to an open PR. 

It also cleans the workflow by removing unnecessary triggers such as `push` and `merge_group` since it was previously filtered in the job. 

It also removes unnecessary permissions.