### PR TITLE
Revert "Change the trigger to check the CLA"

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,9 +1,15 @@
-name: Check Scala CLA
+name: Scala CLA
 on:
   pull_request:
-    types: opened
     branches-ignore:
       - 'language-reference-stable'
+  push:
+    branches:
+      - 'language-reference-stable'
+  merge_group:
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   check:
@@ -11,5 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: ./project/scripts/check-cla.sh
+      if: github.event_name == 'pull_request'
       env:
         AUTHOR: ${{ github.event.pull_request.user.login }}


### PR DESCRIPTION
Reverts scala/scala3#20567

It turns out to be a bad idea, PRs only keep the status of the jobs of the last commit. Therefore, we will always have a the CLA job that is not reported...

I've played around in a different repository to test which is best but this new trigger is very much useless in our use case.