### PR TITLE
When registering Ident use, consider the original span for synthetics

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -394,7 +394,12 @@ object ExtractSemanticDB:
         case tree: Ident =>
           if tree.name != nme.WILDCARD then
             val sym = tree.symbol.adjustIfCtorTyparam
-            registerUseGuarded(None, sym, tree.span, tree.source)
+            val span =
+              if tree.span.isSynthetic then
+                // use synthetic's definition span instead of the original span, if exists
+                localBodies.get(tree.symbol).map(_.span).filter(_.exists).getOrElse(tree.span)
+              else tree.span
+            registerUseGuarded(None, sym, span, tree.source)
         case tree: Select =>
           val qual = tree.qualifier
           val qualSpan = qual.span

--- a/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SyntheticsExtractor.scala
@@ -13,7 +13,8 @@ class SyntheticsExtractor:
 
   val visited = collection.mutable.HashSet[Tree]()
 
-  def tryFindSynthetic(tree: Tree)(using Context, SemanticSymbolBuilder, TypeOps): Option[s.Synthetic] =
+  /** Attempt to format the given tree as a Synthetic apply, if applicable. */
+  def tryFindSynthetic(tree: Apply | TypeApply)(using Context, SemanticSymbolBuilder, TypeOps): Option[s.Synthetic] =
     extension (synth: s.Synthetic)
       def toOpt: Some[s.Synthetic] = Some(synth)
 

--- a/tests/semanticdb/expect/NamedApplyBlock.expect.scala
+++ b/tests/semanticdb/expect/NamedApplyBlock.expect.scala
@@ -4,7 +4,7 @@ object NamedApplyBlockMethods/*<-example::NamedApplyBlockMethods.*/ {
   val local/*<-example::NamedApplyBlockMethods.local.*/ = 1
   def foo/*<-example::NamedApplyBlockMethods.foo().*/(a/*<-example::NamedApplyBlockMethods.foo().(a)*/: Int/*->scala::Int#*/ = 1, b/*<-example::NamedApplyBlockMethods.foo().(b)*/: Int/*->scala::Int#*/ = 2, c/*<-example::NamedApplyBlockMethods.foo().(c)*/: Int/*->scala::Int#*/ = 3): Int/*->scala::Int#*/ = a/*->example::NamedApplyBlockMethods.foo().(a)*/ +/*->scala::Int#`+`(+4).*/ b/*->example::NamedApplyBlockMethods.foo().(b)*/ +/*->scala::Int#`+`(+4).*/ c/*->example::NamedApplyBlockMethods.foo().(c)*/
   def baseCase/*<-example::NamedApplyBlockMethods.baseCase().*/ = foo/*->example::NamedApplyBlockMethods.foo().*/(local/*->example::NamedApplyBlockMethods.local.*/, c/*->example::NamedApplyBlockMethods.foo().(c)*/ = 3)
-  def recursive/*<-example::NamedApplyBlockMethods.recursive().*/ = foo/*->example::NamedApplyBlockMethods.foo().*/(local/*->example::NamedApplyBlockMethods.local.*/, c/*->example::NamedApplyBlockMethods.foo().(c)*/ = foo/*->example::NamedApplyBlockMethods.foo().*/(local/*->example::NamedApplyBlockMethods.local.*/, c/*->example::NamedApplyBlockMethods.foo().(c)*/ = 3))
+  def recursive/*<-example::NamedApplyBlockMethods.recursive().*/ = foo/*->example::NamedApplyBlockMethods.foo().*//*->local1*/(local/*->example::NamedApplyBlockMethods.local.*/, c/*->example::NamedApplyBlockMethods.foo().(c)*/ = foo/*->example::NamedApplyBlockMethods.foo().*/(local/*->example::NamedApplyBlockMethods.local.*/, c/*->example::NamedApplyBlockMethods.foo().(c)*/ = 3))
 }
 
 object NamedApplyBlockCaseClassConstruction/*<-example::NamedApplyBlockCaseClassConstruction.*/ {

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -2841,7 +2841,7 @@ Uri => NamedApplyBlock.scala
 Text => empty
 Language => Scala
 Symbols => 43 entries
-Occurrences => 41 entries
+Occurrences => 42 entries
 
 Symbols:
 example/NamedApplyBlockCaseClassConstruction. => final object NamedApplyBlockCaseClassConstruction extends Object { self: NamedApplyBlockCaseClassConstruction.type => +6 decls }
@@ -2911,6 +2911,7 @@ Occurrences:
 [5:28..5:29): c -> example/NamedApplyBlockMethods.foo().(c)
 [6:6..6:15): recursive <- example/NamedApplyBlockMethods.recursive().
 [6:18..6:21): foo -> example/NamedApplyBlockMethods.foo().
+[6:18..6:21): foo -> local1
 [6:22..6:27): local -> example/NamedApplyBlockMethods.local.
 [6:29..6:30): c -> example/NamedApplyBlockMethods.foo().(c)
 [6:33..6:36): foo -> example/NamedApplyBlockMethods.foo().


### PR DESCRIPTION


## Fix #19970

- Consider the original span for synthetics for registering Ident use
- Clarify that tryFindSynthetic is for `Apply | TypeApply` tree
- Update tests

<!--
  TODO first sign the CLA
  https://www.lightbend.com/contribute/cla/scala
-->

<!-- TODO description of the change -->


<!-- Ideally should have a called "Fix #XYZ: A SHORT FIX DESCRIPTION" -->
