### PR TITLE
Backport: Disable ClasspathTests.unglobClasspathVerifyTest" to 3.5.0

### DIFF
--- a/compiler/test/dotty/tools/scripting/ClasspathTests.scala
+++ b/compiler/test/dotty/tools/scripting/ClasspathTests.scala
@@ -77,6 +77,7 @@ class ClasspathTests:
   /*
    * verify classpath is unglobbed by MainGenericRunner.
    */
+  @Ignore
   @Test def unglobClasspathVerifyTest = {
     val testScriptName = "unglobClasspath.sc"
     val testScript = scripts("/scripting").find { _.name.matches(testScriptName) } match


### PR DESCRIPTION
Backports #20551 to 3.5.0-RC2