### PR TITLE
chore: Fix doc link in clauseInterleaving docstring

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -64,7 +64,7 @@ object language:
     /** Adds support for clause interleaving:
       * Methods can now have as many type clauses as they like, this allows to have type bounds depend on terms: `def f(x: Int)[A <: x.type]: A`
       *
-      * @see [[http://dotty.epfl.ch/docs/reference/other-new-features/explicit-nulls.html]]
+      * @see [[https://github.com/scala/improvement-proposals/blob/main/content/clause-interleaving.md]]
       */
     @compileTimeOnly("`clauseInterleaving` can only be used at compile time in import statements")
     object clauseInterleaving


### PR DESCRIPTION
The `See also` section in the `clauseInterleaving` [scaladoc](https://dotty.epfl.ch/api/scala/runtime/stdLibPatches/language$$experimental$$clauseInterleaving$.html) was pointing to the wrong link.