### PR TITLE
Fix deterministically adding additional interfaces

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypesFromSymbols.scala
@@ -113,11 +113,12 @@ class BTypesFromSymbols[I <: DottyBackendInterface](val int: I, val frontendAcce
       val directlyInheritedTraits = sym.directlyInheritedTraits
       val directlyInheritedTraitsSet = directlyInheritedTraits.toSet
       val allBaseClasses = directlyInheritedTraits.iterator.flatMap(_.asClass.baseClasses.drop(1)).toSet
-      val superCalls = superCallsMap.getOrElse(sym, Set.empty)
-      val additional = (superCalls -- directlyInheritedTraitsSet).filter(_.is(Trait))
+      val superCalls = superCallsMap.getOrElse(sym, List.empty)
+      val superCallsSet = superCalls.toSet
+      val additional = superCalls.filter(t => !directlyInheritedTraitsSet(t) && t.is(Trait))
 //      if (additional.nonEmpty)
 //        println(s"$fullName: adding supertraits $additional")
-      directlyInheritedTraits.filter(t => !allBaseClasses(t) || superCalls(t)) ++ additional
+      directlyInheritedTraits.filter(t => !allBaseClasses(t) || superCallsSet(t)) ++ additional
     }
 
     val interfaces = classSym.superInterfaces.map(classBTypeFromSymbol)

--- a/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
+++ b/compiler/src/dotty/tools/backend/jvm/DottyBackendInterface.scala
@@ -25,7 +25,7 @@ import StdNames.nme
 import NameKinds.{LazyBitMapName, LazyLocalName}
 import Names.Name
 
-class DottyBackendInterface(val superCallsMap: ReadOnlyMap[Symbol, Set[ClassSymbol]])(using val ctx: Context) {
+class DottyBackendInterface(val superCallsMap: ReadOnlyMap[Symbol, List[ClassSymbol]])(using val ctx: Context) {
 
   private val desugared = new java.util.IdentityHashMap[Type, tpd.Select]
 

--- a/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenBCode.scala
@@ -23,10 +23,11 @@ class GenBCode extends Phase { self =>
 
   override def isRunnable(using Context) = super.isRunnable && !ctx.usedBestEffortTasty
 
-  private val superCallsMap = new MutableSymbolMap[Set[ClassSymbol]]
+  private val superCallsMap = new MutableSymbolMap[List[ClassSymbol]]
   def registerSuperCall(sym: Symbol, calls: ClassSymbol): Unit = {
-    val old = superCallsMap.getOrElse(sym, Set.empty)
-    superCallsMap.update(sym, old + calls)
+    val old = superCallsMap.getOrElse(sym, List.empty)
+    if (!old.contains(calls))
+      superCallsMap.update(sym, old :+ calls)
   }
 
   private val entryPoints = new mutable.HashSet[String]()


### PR DESCRIPTION
When a class contains calls to 'super' for traits it does not directly implement, these are added to the list of interfaces of the generated class. Previously, because these interfaces were determined using set logic, the ordering of that list was not deterministic.

This PR makes the order deterministic assuming the order in which these calls are registered using `registerSuperCall` in the `CollectSuperCalls` phase is deterministic within each class. This seems likely to me but it'd be great if someone could confirm.

Fixes #20496