### PR TITLE
Backport "Fix link resolving in scaladoc and fix invalid links in docs" to LTS

### DIFF
--- a/docs/_docs/contributing/architecture/types.md
+++ b/docs/_docs/contributing/architecture/types.md
@@ -11,7 +11,7 @@ format corresponding to the backing data structure, e.g. `ExprType(...)`
 corresponds to `class ExprType`, defined in [Types.scala].
 
 > You can inspect the representation of any type using the [dotty.tools.printTypes][DottyTypeStealer]
-> script, its usage and integration into your debugging workflow is [described here](../issues/inspection.md).
+> script, its usage and integration into your debugging workflow is [described here](../debugging/inspection.md).
 
 ### Types of Definitions
 

--- a/docs/_docs/contributing/debugging/debugging.md
+++ b/docs/_docs/contributing/debugging/debugging.md
@@ -9,6 +9,6 @@ that you're having issues with. This can be just inspecting the trees of your
 code or stepping through the dotty codebase with a Debugger.
 
 The following sections will help you with this:
-- [Debugging with your IDE](./ide-debugging.md.md)
+- [Debugging with your IDE](./ide-debugging.md)
 - [How to Inspect Values](./inspection.md)
 - [Other Debugging Techniques](./other-debugging.md)

--- a/docs/_docs/contributing/issues/cause.md
+++ b/docs/_docs/contributing/issues/cause.md
@@ -69,7 +69,7 @@ This flag forces a stack trace to be printed each time an error happens, from th
 Analysing the trace will give you a clue about the objects involved in producing
 the error. For example, you can add some debug statements before the error is
 issued to discover the state of the compiler. [See some useful ways to debug
-values.](./debugging/inspection.md)
+values.](../debugging/inspection.md)
 
 ### Where was a particular object created?
 

--- a/docs/_docs/contributing/issues/reproduce.md
+++ b/docs/_docs/contributing/issues/reproduce.md
@@ -133,7 +133,7 @@ not be passed). This saves typing the same arguments each time you want to use t
 
 The following `launch.iss` file is an example of how you can use multiline
 commands as a template for solving issues that [run compiled
-code](../issues/testing.md#checking-program-output). It demonstrates configuring
+code](../testing.md#checking-program-output). It demonstrates configuring
 the `scala3/scalac` command using compiler flags, which are commented out. Put
 your favourite flags there for quick usage.
 


### PR DESCRIPTION
Backports #18465 to the LTS branch.

PR submitted by the release tooling.
[skip ci]