### PR TITLE
Backport "Exclude test file that fails on Scala.js + JVM 8" to LTS

### DIFF
--- a/tests/run/StringConcat.scala
+++ b/tests/run/StringConcat.scala
@@ -1,3 +1,9 @@
+// scalajs: --skip
+
+// Under JVM 8,
+// this sometimes blows a StackOverflowError
+// in PrepJSInterop
+
 @main def Test() = {
 
   // This should generally obey 15.18.1. of the JLS (String Concatenation Operator +)


### PR DESCRIPTION
Backports #18600 to the LTS branch.

PR submitted by the release tooling.
[skip ci]