### PR TITLE
Backport "use directives instead of scalac options in tests" to LTS

### DIFF
--- a/compiler/test-resources/repl/i13208.scala
+++ b/compiler/test-resources/repl/i13208.scala
@@ -1,4 +1,4 @@
-// scalac: -source:future -deprecation
+//> using options -source:future -deprecation
 scala> type M[X] = X match { case Int => String case _ => Int }
 scala> type N[X] = X match { case List[_] => Int }
 1 warning found

--- a/compiler/test-resources/repl/rewrite-messages
+++ b/compiler/test-resources/repl/rewrite-messages
@@ -1,4 +1,4 @@
-// scalac: -source:future-migration -deprecation -Werror
+//> using options -source:future-migration -deprecation -Werror
 scala> import scala.util._
 -- Error: ----------------------------------------------------------------------
 1 | import scala.util._

--- a/compiler/test/dotty/tools/repl/ReplTest.scala
+++ b/compiler/test/dotty/tools/repl/ReplTest.scala
@@ -69,7 +69,7 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
 
     val expectedOutput = lines.filter(nonBlank)
     val actualOutput = {
-      val opts = toolArgsFor(ToolName.Scalac)(lines.take(1))
+      val opts = toolArgsFor(ToolName.Scalac, scriptFile.map(_.toString))(lines.take(1))
       val (optsLine, inputLines) = if opts.isEmpty then ("", lines) else (lines.head, lines.drop(1))
       resetToInitial(opts)
 

--- a/tests/disabled/macro/pos/t8013/inpervolated_2.scala
+++ b/tests/disabled/macro/pos/t8013/inpervolated_2.scala
@@ -1,6 +1,4 @@
-/*
- * scalac: -Xfatal-warnings -Xlint
- */
+//> using options -Xfatal-warnings -Xlint
 package t8013
 
 // unsuspecting user of perverse macro


### PR DESCRIPTION
Backports #18560 to the LTS branch.

PR submitted by the release tooling.
[skip ci]