### PR TITLE
Backport "fix scala 2 macros in traits with type parameters" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1030,7 +1030,7 @@ object SymDenotations {
 
     /** Is this a Scala 2 macro defined */
     final def isScala2MacroInScala3(using Context): Boolean =
-      is(Macro, butNot = Inline) && is(Erased)
+      is(Macro, butNot = Inline) && flagsUNSAFE.is(Erased) // flag is set initially for macros - we check if it's a scala 2 macro before completing the type constructor so do not force the info to check the flag
       // Consider the macros of StringContext as plain Scala 2 macros when
       // compiling the standard library with Dotty.
       // This should be removed on Scala 3.x

--- a/tests/pos-macros/i16630.scala
+++ b/tests/pos-macros/i16630.scala
@@ -1,0 +1,14 @@
+import scala.language.experimental.macros
+import scala.quoted.{Quotes, Expr, Type}
+
+trait TraitWithTypeParam[A]:
+  inline def foo: Option[A] = ${ MacrosImpl.fooImpl[A] }
+  def foo: Option[A] = macro MacrosImpl.compatFooImpl[A]
+
+object MacrosImpl:
+  def fooImpl[A: Type](using quotes: Quotes): Expr[Option[A]] = ???
+  def compatFooImpl[A: c.WeakTypeTag](c: Context): c.Tree = ???
+
+trait Context:
+  type WeakTypeTag[A]
+  type Tree


### PR DESCRIPTION
Backports #18663 to the LTS branch.

PR submitted by the release tooling.
[skip ci]