### PR TITLE
Backport "`LambdaType.derivedLambdaType` return a `LambdaType.This`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -3640,7 +3640,7 @@ object Types {
   trait LambdaType extends BindingType with TermType { self =>
     type ThisName <: Name
     type PInfo <: Type
-    type This <: LambdaType{type PInfo = self.PInfo}
+    type This >: this.type <: LambdaType{type PInfo = self.PInfo}
     type ParamRefType <: ParamRef
 
     def paramNames: List[ThisName]
@@ -3698,7 +3698,7 @@ object Types {
 
     final def derivedLambdaType(paramNames: List[ThisName] = this.paramNames,
                           paramInfos: List[PInfo] = this.paramInfos,
-                          resType: Type = this.resType)(using Context): LambdaType =
+                          resType: Type = this.resType)(using Context): This =
       if ((paramNames eq this.paramNames) && (paramInfos eq this.paramInfos) && (resType eq this.resType)) this
       else newLikeThis(paramNames, paramInfos, resType)
 
@@ -3817,7 +3817,7 @@ object Types {
     import DepStatus._
     type ThisName = TermName
     type PInfo = Type
-    type This <: TermLambda
+    type This >: this.type <: TermLambda
     type ParamRefType = TermParamRef
 
     override def resultType(using Context): Type =
@@ -4114,7 +4114,7 @@ object Types {
   trait TypeLambda extends LambdaType {
     type ThisName = TypeName
     type PInfo = TypeBounds
-    type This <: TypeLambda
+    type This >: this.type <: TypeLambda
     type ParamRefType = TypeParamRef
 
     def isResultDependent(using Context): Boolean = true


### PR DESCRIPTION
Backports #18428 to the LTS branch.

PR submitted by the release tooling.
[skip ci]