### PR TITLE
Backport "fix: Don't collect map, flatMap, withFilter in for-comprehension" to LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/PcRenameSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/PcRenameSuite.scala
@@ -471,3 +471,16 @@ class PcRenameSuite extends BasePcRenameSuite:
          |} yield <<a@@bc>>
          |""".stripMargin
     )
+
+  @Test def `map-method` =
+    check(
+      """|case class Bar(x: List[Int]) {
+         |  def <<ma@@p>>(f: Int => Int): Bar = Bar(x.map(f))
+         |}
+         |
+         |val f = 
+         |  for {
+         |    b <- Bar(List(1,2,3))
+         |  } yield b
+         |""".stripMargin,
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
@@ -758,6 +758,90 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite:
         |  }
         |}""".stripMargin
     )
+  
+  @Test def `for-comp-map` = 
+    check(
+      """|object Main {
+         |  val x = List(1).<<m@@ap>>(_ + 1)
+         |  val y = for {
+         |    a <- List(1)
+         |  } yield a + 1
+         |}
+         |""".stripMargin,
+    )
+
+  @Test def `for-comp-map1` = 
+    check(
+      """|object Main {
+         |  val x = List(1).<<m@@ap>>(_ + 1)
+         |  val y = for {
+         |    a <- List(1)
+         |    if true
+         |  } yield a + 1
+         |}
+         |""".stripMargin,
+    )
+
+  @Test def `for-comp-foreach` = 
+    check(
+      """|object Main {
+         |  val x = List(1).<<for@@each>>(_ => ())
+         |  val y = for {
+         |    a <- List(1)
+         |  } {}
+         |}
+         |""".stripMargin,
+    )
+
+  @Test def `for-comp-withFilter` = 
+    check(
+      """|object Main {
+         |  val x = List(1).<<with@@Filter>>(_ => true)
+         |  val y = for {
+         |    a <- List(1)
+         |    if true
+         |  } {}
+         |}
+         |""".stripMargin,
+    )
+
+  @Test def `for-comp-withFilter1` = 
+    check(
+      """|object Main {
+         |  val x = List(1).withFilter(_ => true).<<m@@ap>>(_ + 1)
+         |  val y = for {
+         |    a <- List(1)
+         |    if true
+         |  } yield a + 1
+         |}
+         |""".stripMargin,
+    )
+
+  @Test def `for-comp-flatMap1` = 
+    check(
+      """|object Main {
+         |  val x = List(1).<<flat@@Map>>(_ => List(1))
+         |  val y = for {
+         |    a <- List(1)
+         |    b <- List(2)
+         |    if true
+         |  } yield a + 1
+         |}
+         |""".stripMargin,
+    )
+
+  @Test def `for-comp-flatMap2` = 
+    check(
+      """|object Main {
+         |  val x = List(1).withFilter(_ => true).<<flat@@Map>>(_ => List(1))
+         |  val y = for {
+         |    a <- List(1)
+         |    if true
+         |    b <- List(2)
+         |  } yield a + 1
+         |}
+         |""".stripMargin,
+    )
 
   @Test def `enum1` =
     check(


### PR DESCRIPTION
Backports #18430 to the LTS branch.

PR submitted by the release tooling.
[skip ci]