### PR TITLE
Backport "Improve `defn.PolyFunctionOf` extractor" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -732,7 +732,7 @@ class CheckCaptures extends Recheck, SymTransformer:
 
         try
           val eres = expected.dealias.stripCapturing match
-            case RefinedType(_, _, rinfo: PolyType) => rinfo.resType
+            case defn.PolyFunctionOf(rinfo: PolyType) => rinfo.resType
             case expected: PolyType => expected.resType
             case _ => WildcardType
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1151,11 +1151,12 @@ class Definitions {
      *
      *  Pattern: `PolyFunction { def apply: $pt }`
      */
-    def unapply(ft: Type)(using Context): Option[PolyType] = ft.dealias match
-      case RefinedType(parent, nme.apply, pt: PolyType)
-      if parent.derivesFrom(defn.PolyFunctionClass) =>
-        Some(pt)
-      case _ => None
+    def unapply(tpe: RefinedType)(using Context): Option[MethodOrPoly] =
+      tpe.refinedInfo match
+        case mt: MethodOrPoly
+        if tpe.refinedName == nme.apply && tpe.parent.derivesFrom(defn.PolyFunctionClass) =>
+          Some(mt)
+        case _ => None
   }
 
   object ErasedFunctionOf {


### PR DESCRIPTION
Backports #18442 to the LTS branch.

PR submitted by the release tooling.
[skip ci]