### PR TITLE
Backport "bugfix: Fix coursier completions tests for the presentation compiler" to LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
@@ -12,8 +12,7 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |package A
          |""".stripMargin,
       """|io.circe
-         |io.circul
-         |""".stripMargin
+         |io.circul""".stripMargin
     )
 
   @Test def `multiple-deps` =
@@ -131,8 +130,7 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |package A
          |""".stripMargin,
       """|io.circe
-         |io.circul
-         |""".stripMargin
+         |io.circul""".stripMargin
     )
 
   @Test def `multiple-deps2` =


### PR DESCRIPTION
Backports #18662 to the LTS branch.

PR submitted by the release tooling.
[skip ci]