### PR TITLE
Backport "Fix exhaustivity due to separate TypeVar lambdas" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -759,7 +759,7 @@ object Trees {
   /** A type tree that represents an existing or inferred type */
   case class TypeTree[+T <: Untyped]()(implicit @constructorOnly src: SourceFile)
     extends DenotingTree[T] with TypTree[T] {
-    type ThisTree[+T <: Untyped] = TypeTree[T]
+    type ThisTree[+T <: Untyped] <: TypeTree[T]
     override def isEmpty: Boolean = !hasType
     override def toString: String =
       s"TypeTree${if (hasType) s"[$typeOpt]" else ""}"
@@ -783,7 +783,8 @@ object Trees {
    *    - as a (result-)type of an inferred ValDef or DefDef.
    *  Every TypeVar is created as the type of one InferredTypeTree.
    */
-  class InferredTypeTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends TypeTree[T]
+  class InferredTypeTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends TypeTree[T]:
+    type ThisTree[+T <: Untyped] <: InferredTypeTree[T]
 
   /** ref.type */
   case class SingletonTypeTree[+T <: Untyped] private[ast] (ref: Tree[T])(implicit @constructorOnly src: SourceFile)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3125,7 +3125,7 @@ class TrackingTypeComparer(initctx: Context) extends TypeComparer(initctx) {
     def matchCase(cas: Type): MatchResult = trace(i"$scrut match ${MatchTypeTrace.caseText(cas)}", matchTypes, show = true) {
       val cas1 = cas match {
         case cas: HKTypeLambda =>
-          caseLambda = constrained(cas)
+          caseLambda = constrained(cas, ast.tpd.EmptyTree)._1
           caseLambda.resultType
         case _ =>
           cas

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4885,6 +4885,9 @@ object Types {
       if (inst.exists) inst else origin
     }
 
+    def wrapInTypeTree(owningTree: Tree)(using Context): InferredTypeTree =
+      new InferredTypeTree().withSpan(owningTree.span).withType(this)
+
     override def computeHash(bs: Binders): Int = identityHash(bs)
     override def equals(that: Any): Boolean = this.eq(that.asInstanceOf[AnyRef])
 

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -501,12 +501,9 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
             (rawRef, rawInfo)
       baseInfo match
         case tl: PolyType =>
-          val (tl1, tpts) = constrained(tl, untpd.EmptyTree, alwaysAddTypeVars = true)
-          val targs =
-            for (tpt <- tpts) yield
-              tpt.tpe match {
-                case tvar: TypeVar => tvar.instantiate(fromBelow = false)
-              }
+          val tvars = constrained(tl)
+          val targs = for tvar <- tvars yield
+            tvar.instantiate(fromBelow = false)
           (baseRef.appliedTo(targs), extractParams(tl.instantiate(targs)))
         case methTpe =>
           (baseRef, extractParams(methTpe))

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -82,7 +82,7 @@ object TypeTestsCasts {
         case tp: TypeProxy => underlyingLambda(tp.superType)
       }
       val typeLambda = underlyingLambda(tycon)
-      val tvars = constrained(typeLambda, untpd.EmptyTree, alwaysAddTypeVars = true)._2.map(_.tpe)
+      val tvars = constrained(typeLambda)
       val P1 = tycon.appliedTo(tvars)
 
       debug.println("before " + ctx.typerState.constraint.show)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -540,7 +540,7 @@ object SpaceEngine {
     val mt: MethodType = unapp.widen match {
       case mt: MethodType => mt
       case pt: PolyType   =>
-          val tvars = constrained(pt, EmptyTree)._2.tpes
+          val tvars = constrained(pt)
           val mt = pt.instantiate(tvars).asInstanceOf[MethodType]
           scrutineeTp <:< mt.paramInfos(0)
           // force type inference to infer a narrower type: could be singleton

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -485,8 +485,8 @@ object SpaceEngine {
         erase(parent, inArray, isValue, isTyped)
 
       case tref: TypeRef if tref.symbol.isPatternBound =>
-        if inArray then tref.underlying
-        else if isValue then tref.superType
+        if inArray then erase(tref.underlying, inArray, isValue, isTyped)
+        else if isValue then erase(tref.superType, inArray, isValue, isTyped)
         else WildcardType
 
       case _ => tp
@@ -540,7 +540,7 @@ object SpaceEngine {
     val mt: MethodType = unapp.widen match {
       case mt: MethodType => mt
       case pt: PolyType   =>
-          val tvars = pt.paramInfos.map(newTypeVar(_))
+          val tvars = constrained(pt, EmptyTree)._2.tpes
           val mt = pt.instantiate(tvars).asInstanceOf[MethodType]
           scrutineeTp <:< mt.paramInfos(0)
           // force type inference to infer a narrower type: could be singleton

--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -317,7 +317,7 @@ object Inferencing {
   def inferTypeParams(tree: Tree, pt: Type)(using Context): Tree = tree.tpe match
     case tl: TypeLambda =>
       val (tl1, tvars) = constrained(tl, tree)
-      var tree1 = AppliedTypeTree(tree.withType(tl1), tvars)
+      val tree1 = AppliedTypeTree(tree.withType(tl1), tvars.map(_.wrapInTypeTree(tree)))
       tree1.tpe <:< pt
       if isFullyDefined(tree1.tpe, force = ForceDegree.failBottom) then
         tree1

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -713,7 +713,7 @@ object ProtoTypes {
     tl: TypeLambda, owningTree: untpd.Tree,
     alwaysAddTypeVars: Boolean,
     nestingLevel: Int = ctx.nestingLevel
-  ): (TypeLambda, List[TypeTree]) = {
+  ): (TypeLambda, List[TypeVar]) = {
     val state = ctx.typerState
     val addTypeVars = alwaysAddTypeVars || !owningTree.isEmpty
     if (tl.isInstanceOf[PolyType])
@@ -721,33 +721,31 @@ object ProtoTypes {
         s"inconsistent: no typevars were added to committable constraint ${state.constraint}")
       // hk type lambdas can be added to constraints without typevars during match reduction
 
-    def newTypeVars(tl: TypeLambda): List[TypeTree] =
-      for (paramRef <- tl.paramRefs)
-      yield {
-        val tt = InferredTypeTree().withSpan(owningTree.span)
+    def newTypeVars(tl: TypeLambda): List[TypeVar] =
+      for paramRef <- tl.paramRefs
+      yield
         val tvar = TypeVar(paramRef, state, nestingLevel)
         state.ownedVars += tvar
-        tt.withType(tvar)
-      }
+        tvar
 
     val added = state.constraint.ensureFresh(tl)
-    val tvars = if (addTypeVars) newTypeVars(added) else Nil
-    TypeComparer.addToConstraint(added, tvars.tpes.asInstanceOf[List[TypeVar]])
+    val tvars = if addTypeVars then newTypeVars(added) else Nil
+    TypeComparer.addToConstraint(added, tvars)
     (added, tvars)
   }
 
-  def constrained(tl: TypeLambda, owningTree: untpd.Tree)(using Context): (TypeLambda, List[TypeTree]) =
+  def constrained(tl: TypeLambda, owningTree: untpd.Tree)(using Context): (TypeLambda, List[TypeVar]) =
     constrained(tl, owningTree,
       alwaysAddTypeVars = tl.isInstanceOf[PolyType] && ctx.typerState.isCommittable)
 
-  /**  Same as `constrained(tl, EmptyTree)`, but returns just the created type lambda */
-  def constrained(tl: TypeLambda)(using Context): TypeLambda =
-    constrained(tl, EmptyTree)._1
+  /**  Same as `constrained(tl, EmptyTree, alwaysAddTypeVars = true)`, but returns just the created type vars. */
+  def constrained(tl: TypeLambda)(using Context): List[TypeVar] =
+    constrained(tl, EmptyTree, alwaysAddTypeVars = true)._2
 
   /** Instantiate `tl` with fresh type variables added to the constraint. */
   def instantiateWithTypeVars(tl: TypeLambda)(using Context): Type =
-    val targs = constrained(tl, ast.tpd.EmptyTree, alwaysAddTypeVars = true)._2
-    tl.instantiate(targs.tpes)
+    val tvars = constrained(tl)
+    tl.instantiate(tvars)
 
   /** A fresh type variable added to the current constraint.
    *  @param  bounds        The initial bounds of the variable
@@ -766,7 +764,7 @@ object ProtoTypes {
         pt => bounds :: Nil,
         pt => represents.orElse(defn.AnyType))
     constrained(poly, untpd.EmptyTree, alwaysAddTypeVars = true, nestingLevel)
-      ._2.head.tpe.asInstanceOf[TypeVar]
+      ._2.head
 
   /** If `param` was created using `newTypeVar(..., represents = X)`, returns X.
    *  This is used in:

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4260,7 +4260,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             var typeArgs = tree match
               case Select(qual, nme.CONSTRUCTOR) => qual.tpe.widenDealias.argTypesLo.map(TypeTree(_))
               case _ => Nil
-            if typeArgs.isEmpty then typeArgs = constrained(poly, tree)._2
+            if typeArgs.isEmpty then typeArgs = constrained(poly, tree)._2.map(_.wrapInTypeTree(tree))
             convertNewGenericArray(readapt(tree.appliedToTypeTrees(typeArgs)))
         case wtp =>
           val isStructuralCall = wtp.isValueType && isStructuralTermSelectOrApply(tree)

--- a/compiler/test/dotty/tools/SignatureTest.scala
+++ b/compiler/test/dotty/tools/SignatureTest.scala
@@ -63,7 +63,7 @@ class SignatureTest:
         |  def tuple2(x: Foo *: (T | Tuple) & Foo): Unit = {}
         |""".stripMargin):
       val cls = requiredClass("A")
-      val tvar = constrained(cls.requiredMethod(nme.CONSTRUCTOR).info.asInstanceOf[TypeLambda], untpd.EmptyTree, alwaysAddTypeVars = true)._2.head.tpe
+      val tvar = constrained(cls.requiredMethod(nme.CONSTRUCTOR).info.asInstanceOf[TypeLambda]).head
       tvar <:< defn.TupleTypeRef
       val prefix = cls.typeRef.appliedTo(tvar)
 
@@ -89,7 +89,7 @@ class SignatureTest:
         |  def and(x: T & Foo): Unit = {}
         |""".stripMargin):
       val cls = requiredClass("A")
-      val tvar = constrained(cls.requiredMethod(nme.CONSTRUCTOR).info.asInstanceOf[TypeLambda], untpd.EmptyTree, alwaysAddTypeVars = true)._2.head.tpe
+      val tvar = constrained(cls.requiredMethod(nme.CONSTRUCTOR).info.asInstanceOf[TypeLambda]).head
       val prefix = cls.typeRef.appliedTo(tvar)
       val ref = prefix.select(cls.requiredMethod("and")).asInstanceOf[TermRef]
 

--- a/tests/pos/i14224.1.scala
+++ b/tests/pos/i14224.1.scala
@@ -1,0 +1,11 @@
+//> using options -Werror
+
+// Derived from the extensive test in the gist in i14224
+// Minimising to the false positive in SealedTrait1.either
+
+sealed trait Foo[A, A1 <: A]
+final case class Bar[A, A1 <: A](value: A1) extends Foo[A, A1]
+
+class Main:
+  def test[A, A1 <: A](foo: Foo[A, A1]): A1 = foo match
+    case Bar(v) => v


### PR DESCRIPTION
Backports #18616 to the LTS branch.

PR submitted by the release tooling.
[skip ci]