### PR TITLE
Use context.outers instead of owner chain to find class for suspicious top-level resolution

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2637,7 +2637,7 @@ class PureUnitExpression(stat: untpd.Tree, tpe: Type)(using Context)
 class UnqualifiedCallToAnyRefMethod(stat: untpd.Tree, method: Symbol)(using Context)
   extends Message(UnqualifiedCallToAnyRefMethodID) {
   def kind = MessageKind.PotentialIssue
-  def msg(using Context) = i"Suspicious top-level unqualified call to ${hl(method.name.toString)}"
+  def msg(using Context) = i"Universal method ${hl(method.name.toString)} does not resolve to the enclosing class"
   def explain(using Context) =
     val getClassExtraHint =
       if method.name == nme.getClass_ && ctx.settings.classpath.value.contains("scala3-staging") then

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1327,11 +1327,13 @@ object RefChecks {
   end checkImplicitNotFoundAnnotation
 
   def checkAnyRefMethodCall(tree: Tree)(using Context): Unit =
+    extension (c: Context) def enclosingClass: Symbol =
+      c.outersIterator.find(_.isClassDefContext).map(_.owner).getOrElse(NoSymbol)
     if tree.symbol.exists && defn.topClasses.contains(tree.symbol.owner) then
       tree.tpe match
-        case tp: NamedType if tp.prefix.typeSymbol != ctx.owner.enclosingClass =>
+        case tp: NamedType if tp.prefix.typeSymbol != ctx.enclosingClass =>
           report.warning(UnqualifiedCallToAnyRefMethod(tree, tree.symbol), tree)
-        case _ => ()
+        case _ =>
 }
 import RefChecks.*
 

--- a/docs/_docs/reference/error-codes/E181.md
+++ b/docs/_docs/reference/error-codes/E181.md
@@ -26,7 +26,7 @@ def example(): Unit =
 -- [E181] Potential Issue Warning: example.scala:2:2 ---------------------------
 2 |  synchronized {
   |  ^^^^^^^^^^^^
-  |  Suspicious top-level unqualified call to synchronized
+  |  Universal method synchronized does not resolve to the enclosing class
   |-----------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/warn/i17266.check
+++ b/tests/warn/i17266.check
@@ -1,7 +1,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:4:2 ---------------------------------------------------------
 4 |  synchronized { // warn
   |  ^^^^^^^^^^^^
-  |  Suspicious top-level unqualified call to synchronized
+  |  Universal method synchronized does not resolve to the enclosing class
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -12,7 +12,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:17:2 --------------------------------------------------------
 17 |  synchronized { // warn
    |  ^^^^^^^^^^^^
-   |  Suspicious top-level unqualified call to synchronized
+   |  Universal method synchronized does not resolve to the enclosing class
    |--------------------------------------------------------------------------------------------------------------------
    | Explanation (enabled by `-explain`)
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -33,7 +33,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:108:2 -------------------------------------------------------
 108 |  wait() // warn
     |  ^^^^
-    |  Suspicious top-level unqualified call to wait
+    |  Universal method wait does not resolve to the enclosing class
     |-------------------------------------------------------------------------------------------------------------------
     | Explanation (enabled by `-explain`)
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -44,7 +44,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:115:2 -------------------------------------------------------
 115 |  wait() // warn
     |  ^^^^
-    |  Suspicious top-level unqualified call to wait
+    |  Universal method wait does not resolve to the enclosing class
     |-------------------------------------------------------------------------------------------------------------------
     | Explanation (enabled by `-explain`)
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -55,7 +55,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:121:2 -------------------------------------------------------
 121 |  wait(10) // warn
     |  ^^^^
-    |  Suspicious top-level unqualified call to wait
+    |  Universal method wait does not resolve to the enclosing class
     |-------------------------------------------------------------------------------------------------------------------
     | Explanation (enabled by `-explain`)
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -66,7 +66,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:128:2 -------------------------------------------------------
 128 |  wait(10) // warn
     |  ^^^^
-    |  Suspicious top-level unqualified call to wait
+    |  Universal method wait does not resolve to the enclosing class
     |-------------------------------------------------------------------------------------------------------------------
     | Explanation (enabled by `-explain`)
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -77,7 +77,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:134:2 -------------------------------------------------------
 134 |  hashCode() // warn
     |  ^^^^^^^^
-    |  Suspicious top-level unqualified call to hashCode
+    |  Universal method hashCode does not resolve to the enclosing class
     |-------------------------------------------------------------------------------------------------------------------
     | Explanation (enabled by `-explain`)
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -88,7 +88,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:141:2 -------------------------------------------------------
 141 |  hashCode() // warn
     |  ^^^^^^^^
-    |  Suspicious top-level unqualified call to hashCode
+    |  Universal method hashCode does not resolve to the enclosing class
     |-------------------------------------------------------------------------------------------------------------------
     | Explanation (enabled by `-explain`)
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -99,7 +99,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17266.scala:148:2 -------------------------------------------------------
 148 |  synchronized { // warn
     |  ^^^^^^^^^^^^
-    |  Suspicious top-level unqualified call to synchronized
+    |  Universal method synchronized does not resolve to the enclosing class
     |-------------------------------------------------------------------------------------------------------------------
     | Explanation (enabled by `-explain`)
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/warn/i17493.check
+++ b/tests/warn/i17493.check
@@ -1,7 +1,7 @@
 -- [E181] Potential Issue Warning: tests/warn/i17493.scala:4:10 --------------------------------------------------------
 4 |  def g = synchronized { println("hello, world") } // warn
   |          ^^^^^^^^^^^^
-  |          Suspicious top-level unqualified call to synchronized
+  |          Universal method synchronized does not resolve to the enclosing class
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/warn/i20651.scala
+++ b/tests/warn/i20651.scala
@@ -1,0 +1,21 @@
+package example
+
+class B(val x: String)
+
+class C:
+  def wasBad = new B(getClass.getName){}.x // nowarn ever C.this.getClass
+  def neverBad = new B(getClass.getName).x // nowarn ever
+
+def alwaysBad = new B(getClass.getName).x // warn Predef.getClass not `package`.getClass
+def alwaysGood = new B(this.getClass.getName).x // nowarn
+
+object A:
+  def main(args: Array[String]): Unit =
+    println(new B(getClass.getName){}.x) // nowarn was warn bc A is not $anon
+    println(new B(getClass.getName).x) // nowarn A.getClass
+
+trait T(val x: String)
+
+object U:
+  def main(args: Array[String]): Unit =
+    println(new T(getClass.getName){}.x) // nowarn


### PR DESCRIPTION
Fixes #20651 

Also tweak the message text to express Odersky's formulation of the rule.

```
Universal method synchronized does not resolve to the enclosing class
```

Follow-up to https://github.com/scala/scala3/pull/20312
