### PR TITLE
Backport "Use constructor's default getters in case class synthetic `apply` methods" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1137,11 +1137,16 @@ class Namer { typer: Typer =>
 
       def foreachDefaultGetterOf(sym: TermSymbol, op: TermSymbol => Unit): Unit =
         var n = 0
+        val methodName =
+          if sym.name == nme.apply && sym.is(Synthetic) && sym.owner.companionClass.is(Case) then
+            // The synthesized `apply` methods of case classes use the constructor's default getters
+            nme.CONSTRUCTOR
+          else sym.name
         for params <- sym.paramSymss; param <- params do
           if param.isTerm then
             if param.is(HasDefault) then
-              val getterName = DefaultGetterName(sym.name, n)
-              val getter = pathType.member(DefaultGetterName(sym.name, n)).symbol
+              val getterName = DefaultGetterName(methodName, n)
+              val getter = pathType.member(getterName).symbol
               assert(getter.exists, i"$path does not have a default getter named $getterName")
               op(getter.asTerm)
             n += 1

--- a/tests/pos/i18715.scala
+++ b/tests/pos/i18715.scala
@@ -1,0 +1,5 @@
+case class Foo(x: Int = 0)
+
+extension (x: Any)
+  private def foo = Foo
+  export foo.apply


### PR DESCRIPTION
Backports #18716 to the LTS branch.

PR submitted by the release tooling.
[skip ci]