### PR TITLE
Backport "Properly dealias tuple types when specializing" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SpecializeTuples.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SpecializeTuples.scala
@@ -37,10 +37,10 @@ class SpecializeTuples extends MiniPhase:
   end transformApply
 
   override def transformSelect(tree: Select)(using Context): Tree = tree match
-    case Select(qual, nme._1) if isAppliedSpecializableTuple(qual.tpe.widen) =>
-      Select(qual, nme._1.specializedName(qual.tpe.widen.argInfos.slice(0, 1)))
-    case Select(qual, nme._2) if isAppliedSpecializableTuple(qual.tpe.widen) =>
-      Select(qual, nme._2.specializedName(qual.tpe.widen.argInfos.slice(1, 2)))
+    case Select(qual, nme._1) if isAppliedSpecializableTuple(qual.tpe.widenDealias) =>
+      Select(qual, nme._1.specializedName(qual.tpe.widenDealias.argInfos.slice(0, 1)))
+    case Select(qual, nme._2) if isAppliedSpecializableTuple(qual.tpe.widenDealias) =>
+      Select(qual, nme._2.specializedName(qual.tpe.widenDealias.argInfos.slice(1, 2)))
     case _ => tree
 
   private def isAppliedSpecializableTuple(tp: Type)(using Context) = tp match

--- a/tests/run/i18638.scala
+++ b/tests/run/i18638.scala
@@ -1,0 +1,18 @@
+type U[H, T] = (Unit, Unit)
+object O:
+  opaque type U[H, T] <: (Unit, Unit) = (Unit, Unit)
+  def u: U[Int, Int] = ((), ())
+
+
+def test1(u: (Unit, Unit)) = u._1
+def test2(u: U[Int, Int]) = u._1
+def test3(u: O.U[Int, Int]) = u._1
+def test4() =
+  (((), ()): U[Int, Int]) match
+    case ((), ()) => println("ok")
+
+@main def Test: Unit =
+  test1(((), ()))
+  test2(((), ()))
+  test3(O.u)
+  test4()


### PR DESCRIPTION
Backports #18724 to the LTS branch.

PR submitted by the release tooling.
[skip ci]