### PR TITLE
Backport "Retract SynthesizeExtMethodReceiver mode when when going deeper in overloading resolution" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2212,7 +2212,8 @@ trait Applications extends Compatibility {
     }
     val mapped = reverseMapping.map(_._1)
     overload.println(i"resolve mapped: ${mapped.map(_.widen)}%, % with $pt")
-    resolveOverloaded(mapped, pt).map(reverseMapping.toMap)
+    resolveOverloaded(mapped, pt)(using ctx.retractMode(Mode.SynthesizeExtMethodReceiver))
+      .map(reverseMapping.toMap)
 
   /** Try to typecheck any arguments in `pt` that are function values missing a
    *  parameter type. If the formal parameter types corresponding to a closure argument

--- a/tests/pos/i18744.scala
+++ b/tests/pos/i18744.scala
@@ -1,0 +1,13 @@
+package dotty.tools.dotc.typer
+
+object Color:
+  def apply(): Int = ???
+
+extension (u: Unit)
+  def foo(that: String, f: Int => Int): Int = ???
+  def foo(that: Long, f: Int => Int): Int = ???
+
+def test =
+  val c = Color()
+  ().foo("", (_: Int) => c)
+  ().foo("", (_: Int) => Color())

--- a/tests/pos/i18745.scala
+++ b/tests/pos/i18745.scala
@@ -1,0 +1,14 @@
+object Color:
+  def apply(i: Int): Int = i
+
+type Plane
+
+object Plane:
+  extension (plane: Plane)
+    def zipWith(that: String, f: Int => Int): Int = ???
+    def zipWith(that: Int, f: Int => Int): Int = ???
+
+import Plane.zipWith
+
+def test(p: Plane) =
+  p.zipWith("", (_: Int) => Color(25))


### PR DESCRIPTION
Backports #18759 to the LTS branch.

PR submitted by the release tooling.
[skip ci]