### PR TITLE
Backport "Avoid too eager transform of $outer for lhs & accessor rhs" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -15,6 +15,7 @@ import Symbols._
 import Decorators._
 import DenotTransformers._
 import collection.mutable
+import Types.*
 
 object Constructors {
   val name: String = "constructors"
@@ -197,6 +198,10 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
              ) &&
              fn.symbol.info.resultType.classSymbol == outerParam.info.classSymbol =>
           ref(outerParam)
+        case Assign(lhs, rhs) if lhs.symbol.name == nme.OUTER => // not transform LHS of assignment to $outer field
+            cpy.Assign(tree)(lhs, super.transform(rhs))
+        case dd: DefDef if dd.name.endsWith(nme.OUTER.asSimpleName) => // not transform RHS of outer accessor
+          dd
         case tree: RefTree if tree.symbol.is(ParamAccessor) && tree.symbol.name == nme.OUTER =>
           ref(outerParam)
         case _ =>

--- a/tests/pos/i18927.scala
+++ b/tests/pos/i18927.scala
@@ -1,0 +1,14 @@
+class A
+
+class B {
+  val a = new A
+
+  class C(i: Int) {
+    def this() = {
+      this(1)
+      class Inner() {
+        println(a)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Backports #18949 to the LTS branch.

PR submitted by the release tooling.
[skip ci]