### PR TITLE
Backport "Completions should prepend, not replace as it is for Scala 2" to LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionPos.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionPos.scala
@@ -29,10 +29,9 @@ case class CompletionPos(
 ):
 
   def sourcePos: SourcePosition = cursorPos.withSpan(Spans.Span(start, end))
+  def stripSuffixEditRange: l.Range = new l.Range(cursorPos.offsetToPos(start), cursorPos.offsetToPos(end))
+  def toEditRange: l.Range = cursorPos.withStart(start).withEnd(cursorPos.point).toLsp
 
-  def toEditRange: l.Range =
-    new l.Range(cursorPos.offsetToPos(start), cursorPos.offsetToPos(end))
-  end toEditRange
 end CompletionPos
 
 object CompletionPos:

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1500,3 +1500,47 @@ class CompletionSuite extends BaseCompletionSuite:
         |""".stripMargin,
    )
 
+  @Test def `prepend-instead-of-replace` =
+    checkEdit(
+      """|object O:
+         |  printl@@println()
+         |""".stripMargin,
+      """|object O:
+         |  printlnprintln()
+         |""".stripMargin,
+      assertSingleItem = false
+    )
+
+  @Test def `prepend-instead-of-replace-duplicate-word` =
+    checkEdit(
+      """|object O:
+         |  println@@println()
+         |""".stripMargin,
+      """|object O:
+         |  printlnprintln()
+         |""".stripMargin,
+      assertSingleItem = false
+    )
+
+  @Test def `replace-when-inside` =
+    checkEdit(
+      """|object O:
+         |  print@@ln()
+         |""".stripMargin,
+      """|object O:
+         |  println()
+         |""".stripMargin,
+      assertSingleItem = false
+    )
+
+  @Test def `replace-exact-same` =
+    checkEdit(
+      """|object O:
+         |  println@@()
+         |""".stripMargin,
+      """|object O:
+         |  println()
+         |""".stripMargin,
+      assertSingleItem = false
+    )
+


### PR DESCRIPTION
Backports #18803 to the LTS branch.

PR submitted by the release tooling.
[skip ci]