### PR TITLE
Backport "reference doc: fix incorrect syntax production" to LTS

### DIFF
--- a/docs/_docs/reference/contextual/givens.md
+++ b/docs/_docs/reference/contextual/givens.md
@@ -181,7 +181,7 @@ GivenDef            ::=  [GivenSig] StructuralInstance
                      |   [GivenSig] AnnotType ‘=’ Expr
                      |   [GivenSig] AnnotType
 GivenSig            ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’
-StructuralInstance  ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
+StructuralInstance  ::=  ConstrApp {‘with’ ConstrApp} [‘with’ TemplateBody]
 ```
 
 A given instance starts with the reserved word `given` and an optional _signature_. The signature


### PR DESCRIPTION
Backports #19017 to the LTS branch.

PR submitted by the release tooling.
[skip ci]