### PR TITLE
Backport "Remove linearization requirement for override ref checks from java classes" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -219,19 +219,23 @@ object RefChecks {
           false
       precedesIn(parent.asClass.baseClasses)
 
-    // We can exclude pairs safely from checking only under three additional conditions
-    //   - their signatures also match in the parent class.
-    //     See neg/i12828.scala for an example where this matters.
-    //   - They overriding/overridden appear in linearization order.
-    //     See neg/i5094.scala for an example where this matters.
-    //   - The overridden symbol is not `abstract override`. For such symbols
-    //     we need a more extensive test since the virtual super chain depends
-    //     on the precise linearization order, which might be different for the
-    //     subclass. See neg/i14415.scala.
+    /** We can exclude pairs safely from checking only under three additional conditions
+     *   - their signatures also match in the parent class.
+     *     See neg/i12828.scala for an example where this matters.
+     *   - They overriding/overridden appear in linearization order.
+     *     See neg/i5094.scala for an example where this matters.
+     *   - They overriding/overridden appear in linearization order,
+     *     or the parent is a Java class (because linearization does not apply to java classes).
+     *     See neg/i5094.scala and pos/i18654.scala for examples where this matters.
+     *   - The overridden symbol is not `abstract override`. For such symbols
+     *     we need a more extensive test since the virtual super chain depends
+     *     on the precise linearization order, which might be different for the
+     *     subclass. See neg/i14415.scala.
+     */
     override def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parent: Symbol): Boolean =
       isOverridingPair(sym1, sym2, parent.thisType)
         .showing(i"already handled ${sym1.showLocated}: ${sym1.asSeenFrom(parent.thisType).signature}, ${sym2.showLocated}: ${sym2.asSeenFrom(parent.thisType).signature} = $result", refcheck)
-      && inLinearizationOrder(sym1, sym2, parent)
+      && (inLinearizationOrder(sym1, sym2, parent) || parent.is(JavaDefined))
       && !sym2.is(AbsOverride)
 
     // Checks the subtype relationship tp1 <:< tp2.

--- a/sbt-test/java-compat/i18764/Test.scala
+++ b/sbt-test/java-compat/i18764/Test.scala
@@ -1,0 +1,4 @@
+
+import org.jooq.impl.TableRecordImpl
+
+class TRecord extends TableRecordImpl[TRecord](null) {}

--- a/sbt-test/java-compat/i18764/build.sbt
+++ b/sbt-test/java-compat/i18764/build.sbt
@@ -1,0 +1,9 @@
+
+scalaVersion := sys.props("plugin.scalaVersion")
+
+lazy val dependencies = Seq(
+  "org.jooq" % "jooq-codegen" % "3.18.7",
+)
+
+lazy val jooqtest = (project in file("."))
+    .settings(libraryDependencies ++= dependencies)

--- a/sbt-test/java-compat/i18764/test
+++ b/sbt-test/java-compat/i18764/test
@@ -1,0 +1,1 @@
+> compile

--- a/tests/pos/i18654/AbstractQueryPart.java
+++ b/tests/pos/i18654/AbstractQueryPart.java
@@ -1,0 +1,9 @@
+package org.jooq.impl;
+
+import org.jooq.Configuration;
+
+abstract class AbstractQueryPart {
+  Configuration configuration() {
+    return null;
+  }
+}

--- a/tests/pos/i18654/AbstractRoutine.java
+++ b/tests/pos/i18654/AbstractRoutine.java
@@ -1,0 +1,11 @@
+package org.jooq.impl;
+
+import org.jooq.Configuration;
+import org.jooq.Attachable;
+
+public abstract class AbstractRoutine<T> extends AbstractQueryPart implements Attachable {
+  @Override
+  public final Configuration configuration() {
+    return null;
+  }
+}

--- a/tests/pos/i18654/Attachable.java
+++ b/tests/pos/i18654/Attachable.java
@@ -1,0 +1,5 @@
+package org.jooq;
+
+public interface Attachable {
+  Configuration configuration();
+}

--- a/tests/pos/i18654/Configuration.java
+++ b/tests/pos/i18654/Configuration.java
@@ -1,0 +1,3 @@
+package org.jooq;
+
+public interface Configuration {}

--- a/tests/pos/i18654/MyRoutineScala.scala
+++ b/tests/pos/i18654/MyRoutineScala.scala
@@ -1,0 +1,6 @@
+package com.example
+
+import org.jooq.impl.AbstractRoutine
+
+// Works in Scala 2.12 and 2.13 but is broken in Scala 3
+class MyRoutineScala extends AbstractRoutine[String] {}

--- a/tests/pos/i19007/MyRunConfigurationScala.scala
+++ b/tests/pos/i19007/MyRunConfigurationScala.scala
@@ -1,0 +1,2 @@
+
+class MyRunConfigurationScala extends RunConfigurationBase

--- a/tests/pos/i19007/RunConfiguration.java
+++ b/tests/pos/i19007/RunConfiguration.java
@@ -1,0 +1,4 @@
+
+public interface RunConfiguration extends Cloneable {
+    RunConfiguration clone();
+}

--- a/tests/pos/i19007/RunConfigurationBase.java
+++ b/tests/pos/i19007/RunConfigurationBase.java
@@ -1,0 +1,6 @@
+public abstract class RunConfigurationBase<T> extends UserDataHolderBase implements RunConfiguration {
+  @Override
+  public RunConfiguration clone() {
+    return null;
+  }
+}

--- a/tests/pos/i19007/UserDataHolderBase.java
+++ b/tests/pos/i19007/UserDataHolderBase.java
@@ -1,0 +1,8 @@
+import java.util.concurrent.atomic.AtomicReference;
+
+public class UserDataHolderBase extends AtomicReference<String> {
+  @Override
+  protected Object clone() {
+    return null;
+  }
+}


### PR DESCRIPTION
Backports #18953 to the LTS branch.

PR submitted by the release tooling.
[skip ci]