### PR TITLE
chore: fix doc link in namedTuples docstring

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -93,7 +93,7 @@ object language:
 
     /** Experimental support for named tuples.
      *
-     *  @see [[https://github.com/scala/improvement-proposals/pull/72]]
+     *  @see [[https://dotty.epfl.ch/docs/reference/experimental/named-tuples]]
      */
     @compileTimeOnly("`namedTuples` can only be used at compile time in import statements")
     object namedTuples

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -93,7 +93,7 @@ object language:
 
     /** Experimental support for named tuples.
      *
-     *  @see [[https://dotty.epfl.ch/docs/reference/experimental/into-modifier]]
+     *  @see [[https://github.com/scala/improvement-proposals/pull/72]]
      */
     @compileTimeOnly("`namedTuples` can only be used at compile time in import statements")
     object namedTuples


### PR DESCRIPTION
The `See also` section in the `namedTuples` [scaladoc](https://dotty.epfl.ch/api/scala/runtime/stdLibPatches/language$$experimental$$namedTuples$.html) was pointing to the wrong link.