### PR TITLE
bugfix: Exclude newer LSP4j, which is built on JDK 11

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1356,8 +1356,10 @@ object Build {
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",
         "io.get-coursier" % "interface" % "1.0.18",
-        "org.scalameta" % "mtags-interfaces" % mtagsVersion,
-        "com.google.guava" % "guava" % "33.2.1-jre"
+        ("org.scalameta" % "mtags-interfaces" % mtagsVersion)
+          .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j")
+          .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j.jsonrpc"),
+        "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.20.1",
       ),
       libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.12" % mtagsVersion % SourceDeps),
       ivyConfigurations += SourceDeps.hide,


### PR DESCRIPTION
It seems the CI started failing because of out bump, but that was not picked up aside from windows tests weirdly.

Metals recently updated to newest LSP4j, though I think nothing new was added and no changes were done to the presentation compiler so we should be ok to downgrade locally: https://github.com/scalameta/metals/pull/6126/files

The update was mostly done so that we done fall behind in the LSP standard, but this might become a problem in the future here. Do we ever plan do drop supporting JDK 8?