### PR TITLE
Backport "Check @targetName when subtyping Refined Types" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1989,9 +1989,11 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
 
       def qualifies(m: SingleDenotation): Boolean =
         val info1 = m.info.widenExpr
-        isSubInfo(info1, tp2.refinedInfo.widenExpr, m.symbol.info.orElse(info1))
-        || matchAbstractTypeMember(m.info)
-        || (tp1.isStable && isSubType(TermRef(tp1, m.symbol), tp2.refinedInfo))
+        m.symbol.hasTargetName(m.symbol.name) && (
+          isSubInfo(info1, tp2.refinedInfo.widenExpr, m.symbol.info.orElse(info1))
+          || matchAbstractTypeMember(m.info)
+          || (tp1.isStable && isSubType(TermRef(tp1, m.symbol), tp2.refinedInfo))
+        )
 
       tp1.member(name) match // inlined hasAltWith for performance
         case mbr: SingleDenotation => qualifies(mbr)

--- a/tests/neg/i18922.check
+++ b/tests/neg/i18922.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/i18922.scala:11:27 ------------------------------------------------------------
+11 |def test = doClose(Resource()) // error
+   |                   ^^^^^^^^^^
+   |                   Found:    Resource
+   |                   Required: Object{def close(): Unit}
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i18922.scala
+++ b/tests/neg/i18922.scala
@@ -1,0 +1,11 @@
+import scala.annotation.targetName
+
+def doClose(closable: { def close(): Unit }): Unit =
+  import reflect.Selectable.reflectiveSelectable
+  closable.close()
+
+class Resource:
+  @targetName("foo")
+  def close(): Unit = ???
+
+def test = doClose(Resource()) // error

--- a/tests/neg/targetName-refine.check
+++ b/tests/neg/targetName-refine.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/targetName-refine.scala:7:27 --------------------------------------------------
+7 |val x: T { def f: Int } = C() // error
+  |                          ^^^
+  |                          Found:    C
+  |                          Required: T{def f: Int}
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/targetName-refine.scala
+++ b/tests/neg/targetName-refine.scala
@@ -4,5 +4,5 @@ trait T:
 class C extends T:
   @targetName("f2") def f: Int = 1
 
-val x: T { def f: Int } = C()
+val x: T { def f: Int } = C() // error
 


### PR DESCRIPTION
Backports #19081 to the LTS branch.

PR submitted by the release tooling.
[skip ci]