### PR TITLE
Backport "Make `List` documentation more consistent" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -2220,7 +2220,7 @@ class Definitions {
     """.stripMargin)
 
     add(Any_hashCode,
-    """/** Calculate a hash code value for the object.
+    """/** Calculates a hash code value for the object.
       | *
       | *  The default hashing algorithm is platform dependent.
       | *


### PR DESCRIPTION
Backports #19108 to the LTS branch.

PR submitted by the release tooling.
[skip ci]