### PR TITLE
Backport "Disable match anaylsis in inlined trees" to LTS

### DIFF
--- a/tests/pos/i19157.scala
+++ b/tests/pos/i19157.scala
@@ -1,0 +1,11 @@
+//> using options -Werror
+
+class Test:
+  inline def count(inline x: Boolean) = x match
+    case true => 1
+    case false => 0
+
+  assert(count(true) == 1)
+  assert(count(false) == 0)
+  var x = true
+  assert(count(x) == 1)


### PR DESCRIPTION
Backports #19190 to the LTS branch.

PR submitted by the release tooling.
[skip ci]