### PR TITLE
Backport "Improve `asExprOf` cast error formatting" to LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/ExprCastException.scala
+++ b/compiler/src/scala/quoted/runtime/impl/ExprCastException.scala
@@ -1,0 +1,20 @@
+package scala.quoted.runtime.impl
+
+import dotty.tools.dotc.ast.tpd.Tree
+import dotty.tools.dotc.core.Contexts.*
+
+class ExprCastException(msg: String) extends Exception(msg)
+
+
+object ExprCastException:
+  def apply(expectedType: String, actualType: String, exprCode: String): ExprCastException =
+    new ExprCastException(
+      s"""|
+          |  Expected type: ${formatLines(expectedType)}
+          |  Actual type: ${formatLines(actualType)}
+          |  Expression: ${formatLines(exprCode)}
+          |""".stripMargin)
+
+  private def formatLines(str: String): String =
+    if !str.contains("\n") then str
+    else str.linesIterator.mkString("\n    ", "\n    ", "\n")

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -22,6 +22,7 @@ import scala.quoted.runtime.{QuoteUnpickler, QuoteMatching}
 import scala.quoted.runtime.impl.printers.*
 
 import scala.reflect.TypeTest
+import dotty.tools.dotc.core.NameKinds.ExceptionBinderName
 
 object QuotesImpl {
 
@@ -68,11 +69,10 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       if self.isExprOf[X] then
         self.asInstanceOf[scala.quoted.Expr[X]]
       else
-        throw Exception(
-          s"""Expr cast exception: ${self.show}
-            |of type: ${reflect.Printer.TypeReprCode.show(reflect.asTerm(self).tpe)}
-            |did not conform to type: ${reflect.Printer.TypeReprCode.show(reflect.TypeRepr.of[X])}
-            |""".stripMargin
+        throw ExprCastException(
+          expectedType = reflect.Printer.TypeReprCode.show(reflect.TypeRepr.of[X]),
+          actualType = reflect.Printer.TypeReprCode.show(reflect.asTerm(self).tpe),
+          exprCode = self.show
         )
     }
   end extension


### PR DESCRIPTION
Backports #19195 to the LTS branch.

PR submitted by the release tooling.
[skip ci]