### PR TITLE
Backport "bugfix: Completions for extension methods with name conflict" to LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -248,6 +248,10 @@ class CompletionProvider(
                   mkItem(
                     "{" + sym.fullNameBackticked + completionTextSuffix + "}"
                   )
+                case _ if v.isExtensionMethod =>
+                  mkItem(
+                    ident.backticked(backtickSoftKeyword) + completionTextSuffix
+                  )
                 case _ =>
                   mkItem(
                     sym.fullNameBackticked(

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -64,6 +64,7 @@ object CompletionValue:
     def symbol: Symbol
     def isFromWorkspace: Boolean = false
     override def completionItemDataKind = CompletionItemData.None
+    def isExtensionMethod: Boolean = false
 
     override def completionData(
         buildTargetIdentifier: String
@@ -153,6 +154,7 @@ object CompletionValue:
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Method
     override def completionItemDataKind: Integer = CompletionSource.ExtensionKind.ordinal
+    override def isExtensionMethod: Boolean = true
     override def description(printer: ShortenedTypePrinter)(using Context): String =
       s"${printer.completionSymbol(symbol)} (extension)"
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
@@ -174,3 +174,35 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
          |increment2: Int (extension)
          |""".stripMargin
     )
+
+  @Test def `name-conflict` = 
+    checkEdit(
+      """
+        |package example
+        |
+        |import example.enrichments.*
+        |
+        |object enrichments:
+        |  extension (num: Int)
+        |    def plus(other: Int): Int = num + other
+        |
+        |def main = {
+        |  val plus = 100.plus(19)
+        |  val y = 19.pl@@
+        |}
+        |""".stripMargin,
+      """
+        |package example
+        |
+        |import example.enrichments.*
+        |
+        |object enrichments:
+        |  extension (num: Int)
+        |    def plus(other: Int): Int = num + other
+        |
+        |def main = {
+        |  val plus = 100.plus(19)
+        |  val y = 19.plus($0)
+        |}
+        |""".stripMargin
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
@@ -825,3 +825,27 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |MyType - demo.other""".stripMargin,
     )
 
+  @Test def `method-name-conflict` = 
+    checkEdit(
+      """|package demo
+         |
+         |object O {
+         |  def mmmm(x: Int) = x + 3
+         |  class Test {
+         |    val mmmm = "abc"
+         |    val foo = mmmm@@
+         |  }
+         |}
+         |""".stripMargin,
+      """|package demo
+         |
+         |object O {
+         |  def mmmm(x: Int) = x + 3
+         |  class Test {
+         |    val mmmm = "abc"
+         |    val foo = demo.O.mmmm($0)
+         |  }
+         |}
+         |""".stripMargin,
+      filter = _.contains("mmmm(x: Int)")
+    )


### PR DESCRIPTION
Backports #19225 to the LTS branch.

PR submitted by the release tooling.
[skip ci]