### PR TITLE
Backport "Make sure that the stacktrace is shown with `-Ydebug-unpickling`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -128,12 +128,7 @@ class TreeUnpickler(reader: TastyReader,
         def where =
           val f = denot.symbol.associatedFile
           if f == null then "" else s" in $f"
-        if ctx.settings.YdebugUnpickling.value then throw ex
-        else throw TypeError(
-          em"""Could not read definition of $denot$where
-              |An exception was encountered:
-              |  $ex
-              |Run with -Ydebug-unpickling to see full stack trace.""")
+        throw UnpicklingError(denot, where, ex)
       treeAtAddr(currentAddr) =
         try
           atPhaseBeforeTransforms {


### PR DESCRIPTION
Backports #19115 to the LTS branch.

PR submitted by the release tooling.
[skip ci]