### PR TITLE
Backport "Properly identify empty bounds in error message" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -125,7 +125,7 @@ object Message:
       }
 
       def addendum(cat: String, info: Type): String = info match {
-        case bounds @ TypeBounds(lo, hi) if bounds ne TypeBounds.empty =>
+        case bounds @ TypeBounds(lo, hi) if !(bounds =:= TypeBounds.empty) =>
           if (lo eq hi) i" which is an alias of $lo"
           else i" with $cat ${boundsStr(bounds)}"
         case _ =>


### PR DESCRIPTION
Backports #19310 to the LTS branch.

PR submitted by the release tooling.
[skip ci]