### PR TITLE
Fix #18238: Emit an explicit LineNumber for empty `else` branches.

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -250,6 +250,10 @@ trait BCodeBodyBuilder extends BCodeSkelBuilder {
         if hasElse then
           genLoadTo(elsep, expectedType, dest)
         else
+          /* #18238 Re-emit a line number attached to the If, so that the adaptation
+           * and jump are not associated to the last instruction of the then branch.
+           */
+          lineNumber(tree)
           genAdaptAndSendToDest(UNIT, expectedType, dest)
         expectedType
       end if


### PR DESCRIPTION
If we don't, the code generated for the `else` branch remains associated with the last instruction of the `then` branch, which yields to confusing debugging sessions.