### PR TITLE
Mark genSJSIR as *disabled* (rather than non-*runnable*) when no `-scalajs`.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/GenSJSIR.scala
+++ b/compiler/src/dotty/tools/backend/sjs/GenSJSIR.scala
@@ -11,8 +11,11 @@ class GenSJSIR extends Phase {
 
   override def description: String = GenSJSIR.description
 
+  override def isEnabled(using Context): Boolean =
+    ctx.settings.scalajs.value
+
   override def isRunnable(using Context): Boolean =
-    super.isRunnable && ctx.settings.scalajs.value && !ctx.usedBestEffortTasty
+    super.isRunnable && !ctx.usedBestEffortTasty
 
   def run(using Context): Unit =
     new JSCodeGen().run()

--- a/sbt-bridge/test/xsbt/CompileProgressSpecification.scala
+++ b/sbt-bridge/test/xsbt/CompileProgressSpecification.scala
@@ -66,7 +66,6 @@ class CompileProgressSpecification {
         "MegaPhase{pruneErasedDefs,...,arrayConstructors}",
         "erasure",
         "constructors",
-        "genSJSIR",
         "genBCode"
       )
     val missingExpectedPhases = someExpectedPhases -- allPhases.toSet

--- a/tests/pos/i20296.scala
+++ b/tests/pos/i20296.scala
@@ -1,0 +1,14 @@
+trait Foo
+
+object Foo {
+  inline def bar(): Foo =
+    class InlinedFoo extends Foo {}
+    new InlinedFoo
+
+  inline def foo(): Foo =
+    bar()
+    class InlinedFoo extends Foo {}
+    new InlinedFoo
+
+  def Test: Foo = Foo.foo()
+}


### PR DESCRIPTION
This works around the issue seen in #20296. However, the issue resurfaces if we actually run `-Ycheck:all` in a Scala.js-enabled build.