### PR TITLE
Backport "Don't explain erroneous bounds" to LTS

### DIFF
--- a/tests/neg/i19334.check
+++ b/tests/neg/i19334.check
@@ -1,0 +1,12 @@
+-- [E081] Type Error: tests/neg/i19334.scala:6:4 -----------------------------------------------------------------------
+6 |  f(_) // error was OOM formatting TypeVar(TypeParamRef(T)) when offering explanations
+  |    ^
+  |    Missing parameter type
+  |
+  |    I could not infer the type of the parameter _$1
+  |    in expanded function:
+  |      _$1 => f(_$1)
+  |    Expected type for the whole anonymous function:
+  |      T
+  |
+  |    where:    T is a type variable

--- a/tests/neg/i19334.scala
+++ b/tests/neg/i19334.scala
@@ -1,0 +1,6 @@
+
+def foo[T](f: T): T = ???
+
+@main def main = foo:
+  def f() = ()
+  f(_) // error was OOM formatting TypeVar(TypeParamRef(T)) when offering explanations


### PR DESCRIPTION
Backports #19338 to the LTS branch.
Fixes #20134

PR submitted by the release tooling.
[skip ci]