### PR TITLE
Backport "Make SBT `clean` clean `scala2-library-bootstrapped` and `scala2-library-cc`" to LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1905,7 +1905,7 @@ object Build {
       nonBootstrappedSettings(
         addCommandAlias("run", "scala3-compiler/run"),
         // Clean everything by default
-        addCommandAlias("clean", ";scala3/clean;scala3-bootstrapped/clean"),
+        addCommandAlias("clean", ";scala3/clean;scala3-bootstrapped/clean;stdlib-bootstrapped/clean"),
         // `publishLocal` on the non-bootstrapped compiler does not produce a
         // working distribution (it can't in general, since there's no guarantee
         // that the non-bootstrapped library is compatible with the


### PR DESCRIPTION
Backports #19447 to the LTS branch.

PR submitted by the release tooling.
[skip ci]