### PR TITLE
Backport "Don't leave underspecified SAM types in the code" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1664,8 +1664,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                     // Replace the underspecified expected type by one based on the closure method type
                     defn.PartialFunctionOf(mt.firstParamTypes.head, mt.resultType)
                   else
-                    report.error(em"result type of lambda is an underspecified SAM type $samParent", tree.srcPos)
-                    samParent
+                    errorType(em"result type of lambda is an underspecified SAM type $samParent", tree.srcPos)
                 TypeTree(targetTpe)
               case _ =>
                 if (mt.isParamDependent)

--- a/tests/neg/i15785.scala
+++ b/tests/neg/i15785.scala
@@ -1,0 +1,4 @@
+trait SAMFunction1[-T1, +R]:
+  def apply(x1: T1): R
+
+def fooSAM[T](foo: SAMFunction1[T, T] = (f: T) => f): Unit = ()  // error


### PR DESCRIPTION
Backports #19461 to the LTS branch.

PR submitted by the release tooling.
[skip ci]