### PR TITLE
Backport "Clean `scala2-library` on `scala3-bootstrapped/clean`" to LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1902,6 +1902,9 @@ object Build {
       dependsOn(tastyCore).
       dependsOn(dottyCompiler).
       dependsOn(dottyLibrary).
+      bootstrappedSettings(
+        addCommandAlias("clean", ";scala3-bootstrapped/clean;stdlib-bootstrapped/clean"),
+      ).
       nonBootstrappedSettings(
         addCommandAlias("run", "scala3-compiler/run"),
         // Clean everything by default


### PR DESCRIPTION
Backports #19451 to the LTS branch.

PR submitted by the release tooling.
[skip ci]