### PR TITLE
Map over refs of `ImportType`s in `TypeMap`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -69,7 +69,12 @@ class TreeTypeMap(
   }
 
   def mapType(tp: Type): Type =
-    mapOwnerThis(typeMap(tp).substSym(substFrom, substTo))
+    val substMap = new TypeMap():
+      def apply(tp: Type): Type = tp match
+        case tp: TermRef if tp.symbol.isImport => mapOver(tp)
+        case tp => tp.substSym(substFrom, substTo)
+    mapOwnerThis(substMap(typeMap(tp)))
+  end mapType
 
   private def updateDecls(prevStats: List[Tree], newStats: List[Tree]): Unit =
     if (prevStats.isEmpty) assert(newStats.isEmpty)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6295,6 +6295,12 @@ object Types extends TypeUtils {
       val ctx = this.mapCtx // optimization for performance
       given Context = ctx
       tp match {
+        case tp: TermRef if tp.symbol.isImport =>
+          // see tests/pos/i19493.scala for examples requiring mapping over imports
+          val ImportType(e) = tp.info: @unchecked
+          val e1 = singleton(apply(e.tpe))
+          newImportSymbol(tp.symbol.owner, e1).termRef
+
         case tp: NamedType =>
           if stopBecauseStaticOrLocal(tp) then tp
           else

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -565,6 +565,11 @@ class Inliner(val call: tpd.Tree)(using Context):
           def apply(t: Type) = t match {
             case t: ThisType => thisProxy.getOrElse(t.cls, t)
             case t: TypeRef => paramProxy.getOrElse(t, mapOver(t))
+            case t: TermRef if t.symbol.isImport =>
+              val ImportType(e) = t.widenTermRefExpr: @unchecked
+              paramProxy.get(e.tpe) match
+                case Some(p) => newImportSymbol(ctx.owner, singleton(p)).termRef
+                case None => mapOver(t)
             case t: SingletonType =>
               if t.termSymbol.isAllOf(InlineParam) then apply(t.widenTermRefExpr)
               else paramProxy.getOrElse(t, mapOver(t))

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -565,10 +565,6 @@ class Inliner(val call: tpd.Tree)(using Context):
           def apply(t: Type) = t match {
             case t: ThisType => thisProxy.getOrElse(t.cls, t)
             case t: TypeRef => paramProxy.getOrElse(t, mapOver(t))
-            case t: TermRef if t.symbol.isImport =>
-              val ImportType(e) = t.widenTermRefExpr: @unchecked
-              val e1 = singleton(apply(e.tpe))
-              newImportSymbol(ctx.owner, e1).termRef
             case t: SingletonType =>
               if t.termSymbol.isAllOf(InlineParam) then apply(t.widenTermRefExpr)
               else paramProxy.getOrElse(t, mapOver(t))

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -567,9 +567,8 @@ class Inliner(val call: tpd.Tree)(using Context):
             case t: TypeRef => paramProxy.getOrElse(t, mapOver(t))
             case t: TermRef if t.symbol.isImport =>
               val ImportType(e) = t.widenTermRefExpr: @unchecked
-              paramProxy.get(e.tpe) match
-                case Some(p) => newImportSymbol(ctx.owner, singleton(p)).termRef
-                case None => mapOver(t)
+              val e1 = singleton(apply(e.tpe))
+              newImportSymbol(ctx.owner, e1).termRef
             case t: SingletonType =>
               if t.termSymbol.isAllOf(InlineParam) then apply(t.widenTermRefExpr)
               else paramProxy.getOrElse(t, mapOver(t))

--- a/tests/pos-macros/i19436/Macro_1.scala
+++ b/tests/pos-macros/i19436/Macro_1.scala
@@ -1,0 +1,18 @@
+
+import scala.quoted.*
+import scala.compiletime.summonInline
+
+trait SomeImplicits:
+  given int: Int
+
+object Macro:
+
+  transparent inline def testSummon: SomeImplicits => Int = ${ testSummonImpl }
+
+  private def testSummonImpl(using Quotes): Expr[SomeImplicits => Int] =
+    import quotes.reflect.*
+    '{
+      (x: SomeImplicits) =>
+        import x.given
+        summonInline[Int]
+    }

--- a/tests/pos-macros/i19436/Test_2.scala
+++ b/tests/pos-macros/i19436/Test_2.scala
@@ -1,0 +1,2 @@
+
+def fn: Unit = Macro.testSummon

--- a/tests/pos/i19493.scala
+++ b/tests/pos/i19493.scala
@@ -1,0 +1,29 @@
+
+import scala.compiletime.{summonAll, summonInline}
+import deriving.Mirror
+
+type Sc[X] = X
+case class Row[T[_]](name: T[String])
+
+class DialectTypeMappers:
+  given String = ???
+
+inline def metadata(dialect: DialectTypeMappers)(using m: Mirror.Of[Row[Sc]]): m.MirroredElemTypes =
+  import dialect.given
+  summonAll[m.MirroredElemTypes]
+
+def f = metadata(???)
+
+
+object Minimization:
+
+  class GivesString:
+    given aString: String = ???
+
+  inline def foo(x: GivesString): Unit =
+    import x.aString
+    summon[String]
+    summonInline[String] // was error
+
+  foo(???)
+end Minimization

--- a/tests/pos/i19493.scala
+++ b/tests/pos/i19493.scala
@@ -1,4 +1,3 @@
-
 import scala.compiletime.{summonAll, summonInline}
 import deriving.Mirror
 
@@ -38,5 +37,13 @@ object Minimization:
 
   val a: A = ???
   a.bar
+
+
+  inline def baz() = (x: GivesString) =>
+    import x.aString
+    summon[String] // ok
+    summonInline[String] // was error
+
+  baz()
 
 end Minimization

--- a/tests/pos/i19493.scala
+++ b/tests/pos/i19493.scala
@@ -22,8 +22,21 @@ object Minimization:
 
   inline def foo(x: GivesString): Unit =
     import x.aString
-    summon[String]
+    summon[String] // ok
     summonInline[String] // was error
 
   foo(???)
+
+
+  trait A:
+    val x: GivesString
+
+    inline def bar: Unit =
+      import this.x.aString
+      summon[String] // ok
+      summonInline[String] // was error
+
+  val a: A = ???
+  a.bar
+
 end Minimization


### PR DESCRIPTION
The inliner replaces references to parameters by their corresponding proxys, including in singleton types. 
It did not handle the mapping over import types, the symbols of which way have depended on parameters.

Both i19493 and i19436 require mapping the type of the expr in an `ImportType` which is itself the info of a `TermRef`.
In the first issue, for the substitution of an inline def parameter proxy.
In the second issue, for the parameter of a lambda returned from an inline def.

Both can be handled in `TypeMap` by mapping over references to `ImportType`s.
The second case also requires modifying `TreeTypeMap#mapType` such that the logic mapping over imports is done within a `TypeMap` doing the symbol substitutions.

Also note these mappings are only necessary for `summonInline`s (which could have just been made non-inline) resolving 
post-inlining to givens imported within the inline definition.

Fix #19493
Fix #19436 