### PR TITLE
Backport "Fix #19202: Passing NotNullInfos to a mutable field of a Completer" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -785,7 +785,7 @@ class Namer { typer: Typer =>
     private var myNotNullInfos: List[NotNullInfo] | Null = null
 
     /** The context with which this completer was created */
-    given creationContext[T]: Context =
+    given creationContext[Dummy_so_its_a_def]: Context =
       if myNotNullInfos == null then ictx else ictx.withNotNullInfos(myNotNullInfos.nn)
 
     // make sure testing contexts are not captured by completers

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -22,6 +22,7 @@ import parsing.JavaParsers.JavaParser
 import parsing.Parsers.Parser
 import Annotations.*
 import Inferencing.*
+import Nullables.*
 import transform.ValueClasses.*
 import TypeErasure.erasure
 import reporting.*
@@ -781,8 +782,11 @@ class Namer { typer: Typer =>
 
     protected def localContext(owner: Symbol): FreshContext = ctx.fresh.setOwner(owner).setTree(original)
 
+    var myNotNullInfos: List[NotNullInfo] | Null = null
+
     /** The context with which this completer was created */
-    given creationContext: Context = ictx
+    given creationContext[T]: Context =
+      if myNotNullInfos == null then ictx else ictx.withNotNullInfos(myNotNullInfos.nn)
 
     // make sure testing contexts are not captured by completers
     assert(!ictx.reporter.isInstanceOf[ExploringReporter])

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -782,7 +782,7 @@ class Namer { typer: Typer =>
 
     protected def localContext(owner: Symbol): FreshContext = ctx.fresh.setOwner(owner).setTree(original)
 
-    var myNotNullInfos: List[NotNullInfo] | Null = null
+    private var myNotNullInfos: List[NotNullInfo] | Null = null
 
     /** The context with which this completer was created */
     given creationContext[T]: Context =
@@ -790,6 +790,9 @@ class Namer { typer: Typer =>
 
     // make sure testing contexts are not captured by completers
     assert(!ictx.reporter.isInstanceOf[ExploringReporter])
+
+    def setNotNullInfos(infos: List[NotNullInfo]): Unit =
+      myNotNullInfos = infos
 
     protected def typeSig(sym: Symbol): Type = original match
       case original: ValDef =>

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -782,6 +782,7 @@ class Namer { typer: Typer =>
 
     protected def localContext(owner: Symbol): FreshContext = ctx.fresh.setOwner(owner).setTree(original)
 
+    /** Stores the latest NotNullInfos (updated by `setNotNullInfos`) */
     private var myNotNullInfos: List[NotNullInfo] | Null = null
 
     /** The context with which this completer was created */

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3301,8 +3301,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             // The RHS of a val def should know about not null facts established
             // in preceding statements (unless the DefTree is completed ahead of time,
             // then it is impossible).
-            sym.info = Completer(completer.original)(
-              completer.creationContext.withNotNullInfos(ctx.notNullInfos))
+            completer.myNotNullInfos = ctx.notNullInfos
           true
         case _ =>
           // If it has been completed, then it must be because there is a forward reference

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3297,11 +3297,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     mdef.getAttachment(SymOfTree) match {
       case Some(sym) => sym.infoOrCompleter match {
         case completer: Namer#Completer =>
-          if (completer.creationContext.notNullInfos ne ctx.notNullInfos)
+          if completer.creationContext.notNullInfos ne ctx.notNullInfos then
             // The RHS of a val def should know about not null facts established
             // in preceding statements (unless the DefTree is completed ahead of time,
             // then it is impossible).
-            completer.myNotNullInfos = ctx.notNullInfos
+            completer.setNotNullInfos(ctx.notNullInfos)
           true
         case _ =>
           // If it has been completed, then it must be because there is a forward reference

--- a/tests/explicit-nulls/pos/i19202.scala
+++ b/tests/explicit-nulls/pos/i19202.scala
@@ -1,0 +1,27 @@
+class Test {
+  def test1(s: String | Null): Unit = {
+    if s == null then return
+
+    case class XXX()
+  }
+
+  def test2(s: String | Null): Unit = {
+    if s == "" then return
+
+    case class XXX()
+  }
+
+  def test3(s: String | Null): Unit = {
+    if s == null then return
+
+    case class XXX()
+    ()
+  }
+
+  def test4(s: String | Null): String | Null = {
+    if s == null then return ""
+
+    case class XXX()
+    "xxx"
+  }
+}

--- a/tests/pos/i19202.scala
+++ b/tests/pos/i19202.scala
@@ -1,0 +1,27 @@
+class Test {
+  def test1(s: String): Unit = {
+    if s == null then return
+
+    case class XXX()
+  }
+
+  def test2(s: String): Unit = {
+    if s == "" then return
+
+    case class XXX()
+  }
+
+  def test3(s: String): Unit = {
+    if s == null then return
+
+    case class XXX()
+    ()
+  }
+
+  def test4(s: String): String = {
+    if s == null then return ""
+
+    case class XXX()
+    "xxx"
+  }
+}


### PR DESCRIPTION
Backports #19463 to the LTS branch.

PR submitted by the release tooling.
[skip ci]