### PR TITLE
Backport "Disable i19170b on JDK8" to LTS

### DIFF
--- a/tests/run-staging/i19170b.scala
+++ b/tests/run-staging/i19170b.scala
@@ -8,7 +8,8 @@ class A(i: Int)
 def f(i: Expr[Int])(using Quotes): Expr[A] = { '{ new A($i) } }
 
 @main def Test = {
-  if !System.getProperty("os.name").contains("Windows") then
+  // The heuristic to give the extra information does not work on JDK 8
+  if System.getProperty("java.specification.version") != "1.8" then
     try
       val g: Int => A = staging.run { '{ (i: Int) => ${ f('{i}) } } }
       println(g(3))


### PR DESCRIPTION
Backports #19484 to the LTS branch.

PR submitted by the release tooling.
[skip ci]