### PR TITLE
Backport "Do not propagate `@tailrec` to exported methods" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1251,7 +1251,10 @@ class Namer { typer: Typer =>
               newSymbol(cls, forwarderName, mbrFlags, mbrInfo, coord = span)
 
           forwarder.info = avoidPrivateLeaks(forwarder)
-          forwarder.addAnnotations(sym.annotations.filterConserve(_.symbol != defn.BodyAnnot))
+          forwarder.addAnnotations(sym.annotations.filterConserve { annot =>
+            annot.symbol != defn.BodyAnnot
+            && annot.symbol != defn.TailrecAnnot
+          })
 
           if forwarder.isType then
             buf += tpd.TypeDef(forwarder.asType).withSpan(span)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1254,7 +1254,9 @@ class Namer { typer: Typer =>
           forwarder.addAnnotations(sym.annotations.filterConserve { annot =>
             annot.symbol != defn.BodyAnnot
             && annot.symbol != defn.TailrecAnnot
+            && annot.symbol != defn.MainAnnot
             && !annot.symbol.derivesFrom(defn.MacroAnnotationClass)
+            && !annot.symbol.derivesFrom(defn.MainAnnotationClass)
           })
 
           if forwarder.isType then

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1254,6 +1254,7 @@ class Namer { typer: Typer =>
           forwarder.addAnnotations(sym.annotations.filterConserve { annot =>
             annot.symbol != defn.BodyAnnot
             && annot.symbol != defn.TailrecAnnot
+            && !annot.symbol.derivesFrom(defn.MacroAnnotationClass)
           })
 
           if forwarder.isType then

--- a/tests/pos/export-main.scala
+++ b/tests/pos/export-main.scala
@@ -1,0 +1,5 @@
+object Foo:
+  @main def baz: Int = 1
+
+object Bar:
+  export Foo.baz // export Foo.baz but not create an new main entry point

--- a/tests/pos/i19505.scala
+++ b/tests/pos/i19505.scala
@@ -1,0 +1,10 @@
+import scala.annotation.tailrec
+
+object Foo:
+  @tailrec
+  def foo(n: Int): Int =
+    if n == 0 then 0
+    else foo(n-1)
+
+object Bar:
+  export Foo.foo // def foo here should not have `@tailrec`

--- a/tests/run-macros/annot-export/Macro_1.scala
+++ b/tests/run-macros/annot-export/Macro_1.scala
@@ -1,0 +1,13 @@
+import scala.annotation.{experimental, MacroAnnotation}
+import scala.quoted._
+import scala.collection.mutable.Map
+
+@experimental
+class returnClassName extends MacroAnnotation {
+  def transform(using Quotes)(tree: quotes.reflect.Definition): List[quotes.reflect.Definition] =
+    import quotes.reflect._
+    tree match
+      case DefDef(name, params, tpt, _) =>
+        val rhs = Literal(StringConstant(Symbol.spliceOwner.name.stripSuffix("$")))
+        List(DefDef.copy(tree)(name, params, tpt, Some(rhs)))
+}

--- a/tests/run-macros/annot-export/Test_2.scala
+++ b/tests/run-macros/annot-export/Test_2.scala
@@ -1,0 +1,10 @@
+object Bar:
+  @returnClassName
+  def f(): String = ??? // def f(): String = "Bar"
+
+object Baz:
+  export Bar.f // def f(): String = Bar.f(n)
+
+@main def Test =
+  assert(Bar.f() == "Bar")
+  assert(Baz.f() == "Bar")

--- a/tests/warn/i19505.scala
+++ b/tests/warn/i19505.scala
@@ -1,0 +1,8 @@
+import scala.annotation.tailrec
+
+object Foo:
+  @tailrec
+  def foo: Int = foo // warn: Infinite recursive call
+
+object Bar:
+  export Foo.foo // def foo here should not have `@tailrec`


### PR DESCRIPTION
Backports #19509 to the LTS branch.

PR submitted by the release tooling.
[skip ci]