### PR TITLE
Backport "Fix #19528: Actually remove Dynamic from interfaces of native JS classes." to LTS

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -643,7 +643,7 @@ class JSCodeGen()(using genCtx: Context) {
         kind,
         None,
         superClass,
-        genClassInterfaces(sym, forJSClass = false),
+        genClassInterfaces(sym, forJSClass = true),
         None,
         jsNativeLoadSpec,
         Nil,

--- a/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/CustomDynamicTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/jsinterop/CustomDynamicTestScala3.scala
@@ -1,0 +1,58 @@
+package org.scalajs.testsuite.jsinterop
+
+import scala.language.dynamics
+
+import org.junit.Assert.*
+import org.junit.Test
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.*
+
+class CustomDynamicTestScala3 {
+  import CustomDynamicTestScala3.*
+
+  @Test
+  def testCustomDynamicClass_Issue19528(): Unit = {
+    val obj = new CustomDynamicClass()
+
+    assertEquals(false, obj.hasOwnProperty("foo"))
+    obj.foo = "bar"
+    assertEquals("bar", obj.foo)
+    assertEquals(true, obj.hasOwnProperty("foo"))
+  }
+
+  @Test
+  def testCustomDynamicTrait_Issue19528(): Unit = {
+    val obj = new js.Object().asInstanceOf[CustomDynamicTrait]
+
+    assertEquals(false, obj.hasOwnProperty("foo"))
+    obj.foo = "bar"
+    assertEquals("bar", obj.foo)
+    assertEquals(true, obj.hasOwnProperty("foo"))
+  }
+}
+
+object CustomDynamicTestScala3 {
+  @js.native
+  @JSGlobal("Object")
+  class CustomDynamicClass extends js.Any with Dynamic {
+    @JSBracketAccess
+    def selectDynamic(name: String): js.Any = js.native
+    @JSBracketAccess
+    def updateDynamic(name: String)(value: js.Any): Unit = js.native
+
+    @JSBracketCall
+    def applyDynamic(name: String)(args: js.Any*): js.Any = js.native
+  }
+
+  @js.native
+  trait CustomDynamicTrait extends js.Any with Dynamic {
+    @JSBracketAccess
+    def selectDynamic(name: String): js.Any = js.native
+    @JSBracketAccess
+    def updateDynamic(name: String)(value: js.Any): Unit = js.native
+
+    @JSBracketCall
+    def applyDynamic(name: String)(args: js.Any*): js.Any = js.native
+  }
+}


### PR DESCRIPTION
Backports #19536 to the LTS branch.

PR submitted by the release tooling.
[skip ci]