### PR TITLE
Backport "Only cache base types when gadt state is empty" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2179,7 +2179,7 @@ object SymDenotations {
           Stats.record("basetype cache entries")
           if (!baseTp.exists) Stats.record("basetype cache NoTypes")
         }
-        if (!tp.isProvisional && !CapturingType.isUncachable(tp))
+        if !(tp.isProvisional || CapturingType.isUncachable(tp) || ctx.gadt.isNarrowing) then
           btrCache(tp) = baseTp
         else
           btrCache.remove(tp) // Remove any potential sentinel value

--- a/tests/pos/i19521.scala
+++ b/tests/pos/i19521.scala
@@ -1,0 +1,13 @@
+
+final abstract class PLet
+
+sealed trait Expr[+P]
+case class ELet[+A](name: String, expr: Expr[A]) extends Expr[A | PLet]
+
+def go[P](e: Expr[P]): P = e match
+  case ELet(_, _) =>
+    val x: Expr[P] | ELet[P] = ???
+    val y: Expr[P] = x // conforms iff using gadt constraints
+    // error before changes: cast from gadt reasoning was not inserted because
+    // `Expr[P]` was erronously cached as a baseType of `Expr[P] | ELet[P]` (only true with gadt constraints)
+    ???


### PR DESCRIPTION
Backports #19562 to the LTS branch.

PR submitted by the release tooling.
[skip ci]