### PR TITLE
Backport "Scaladoc: Fix "case case Foo" in enum's cases" to LTS

### DIFF
--- a/scaladoc-testcases/src/tests/enumSignatures.scala
+++ b/scaladoc-testcases/src/tests/enumSignatures.scala
@@ -4,14 +4,14 @@ package enumSignatures
 
 enum Enum1
 {
-  case A
-  case B
-  case C
+  case A //expected: case A extends Enum1
+  case B //expected: case B extends Enum1
+  case C //expected: case C extends Enum1
 }
 enum Enum2(val i: Int):
-  case A(s: String) extends Enum2/*<-*/(1)/*->*/
-  case B(t: String) extends Enum2/*<-*/(2)/*->*/
-  case C(u: String) extends Enum2/*<-*/(3)/*->*/
+  case A(s: String) extends Enum2(1) //expected: final case class A(s: String) extends Enum2
+  case B(t: String) extends Enum2(2) //expected: final case class B(t: String) extends Enum2
+  case C(u: String) extends Enum2(3) //expected: final case class C(u: String) extends Enum2
 
 enum Enum3(val param: Int):
   case A extends Enum3/*<-*/(1)/*->*/ with A
@@ -19,9 +19,9 @@ enum Enum3(val param: Int):
   case C extends Enum3/*<-*/(3)/*->*/
 
 enum Enum4[+T]:
-  case G(s: String)
+  case G(s: String) //expected: final case class G[+T](s: String)
   case B extends Enum4[Int] with A
-  case C[V](s: String) extends Enum4[V]
-  case D[T](s: String) extends Enum4[T]
+  case C[V](s: String) extends Enum4[V] //expected: final case class C[V](s: String) extends Enum4[V]
+  case D[T](s: String) extends Enum4[T] //expected: final case class D[T](s: String) extends Enum4[T]
 
 trait A

--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -60,7 +60,7 @@ enum Kind(val name: String):
   case Trait(override val typeParams: Seq[TypeParameter], override val argsLists: Seq[TermParameterList])
     extends Kind("trait") with Classlike
   case Enum(override val typeParams: Seq[TypeParameter], override val argsLists: Seq[TermParameterList]) extends Kind("enum") with Classlike
-  case EnumCase(kind: Object.type | Kind.Type | Val.type | Class) extends Kind("case")
+  case EnumCase(kind: Object.type | Kind.Type | Val.type | Class) extends Kind(kind.name)
   case Def(paramLists: Seq[Either[TermParameterList,TypeParameterList]])
     extends Kind("def")
   case Extension(on: ExtensionTarget, m: Kind.Def) extends Kind("def")
@@ -146,9 +146,9 @@ case class HierarchyGraph(edges: Seq[(LinkToType, LinkToType)], sealedNodes: Set
   def vertecies: Seq[LinkToType] = edges.flatten((a, b) => Seq(a, b)).distinct
   def verteciesWithId: Map[LinkToType, Int] = vertecies.zipWithIndex.toMap
   def +(edge: (LinkToType, LinkToType)): HierarchyGraph = this ++ Seq(edge)
-  def ++(edges: Seq[(LinkToType, LinkToType)]): HierarchyGraph = 
+  def ++(edges: Seq[(LinkToType, LinkToType)]): HierarchyGraph =
     this.copy(edges = this.edges.view.concat(edges).distinct.toSeq)
-    
+
 object HierarchyGraph:
   def empty = HierarchyGraph(Seq.empty)
   def withEdges(edges: Seq[(LinkToType, LinkToType)]) = HierarchyGraph.empty ++ edges

--- a/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureProvider.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/translators/ScalaSignatureProvider.scala
@@ -75,7 +75,7 @@ class ScalaSignatureProvider:
 
     MemberSignature(
       builder.modifiersAndVisibility(entry),
-      builder.kind(entry.kind),
+      List(),
       builder.name(entry.name, entry.dri),
       builder.keyword(" extends ").signature(modifiedType)
     )

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/TranslatableSignaturesTestCases.scala
@@ -45,7 +45,7 @@ class ExtensionMethodParamsSignature extends SignatureTest("extensionParams", Si
 
 class ClassModifiers extends SignatureTest("classModifiers", SignatureTest.classlikeKinds)
 
-class EnumSignatures extends SignatureTest("enumSignatures", SignatureTest.all)
+class EnumSignatures extends SignatureTest("enumSignatures", "case" +: SignatureTest.all)
 
 class StructuralTypes extends SignatureTest("structuralTypes", SignatureTest.members)
 


### PR DESCRIPTION
Backports #19519 to the LTS branch.

PR submitted by the release tooling.
[skip ci]