### PR TITLE
Backport "fix(#19377): show inherited abstract members in dedicated section" to LTS

### DIFF
--- a/scaladoc-testcases/src/tests/abstractmembersignatures.scala
+++ b/scaladoc-testcases/src/tests/abstractmembersignatures.scala
@@ -9,6 +9,8 @@ trait TestTrait:
 class TestClass:
   def shouldBeConcrete: Int = 1
 
+abstract class TestInheritedAbstractMembers extends TestTrait
+
 abstract class AbstractTestClass:
   def shouldBeAbstract: Int
   def shouldBeConcrete: Int = 1

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -323,6 +323,7 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
       val (allInherited, allDefined) = nonExperimental.partition(isInherited)
       val (depDefined, defined) = allDefined.partition(isDeprecated)
       val (depInherited, inherited) = allInherited.partition(isDeprecated)
+      val (abstractInherited, concreteInherited) = inherited.partition(isAbstract)
       val normalizedName = name.toLowerCase
       val definedWithGroup = if Set("methods", "fields").contains(normalizedName) then
           val (abstr, concr) = defined.partition(isAbstract)
@@ -335,7 +336,8 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
 
       definedWithGroup ++ List(
         actualGroup(s"Deprecated ${normalizedName}", depDefined),
-        actualGroup(s"Inherited ${normalizedName}", inherited),
+        actualGroup(s"Inherited ${normalizedName}", concreteInherited),
+        actualGroup(s"Inherited and Abstract ${normalizedName}", abstractInherited),
         actualGroup(s"Deprecated and Inherited ${normalizedName}", depInherited),
         actualGroup(name = s"Experimental ${normalizedName}", experimental)
       )

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/AbstractMemberSignaturesTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/AbstractMemberSignaturesTest.scala
@@ -18,10 +18,10 @@ class AbstractMembers extends ScaladocTest("abstractmembersignatures"):
   def runTest = {
     afterRendering {
       val actualSignatures = signaturesFromDocumentation()
-
       actualSignatures.foreach { (k, v) => k match
         case "Abstract methods" => assertTrue(v.forall(_._2 == "shouldBeAbstract"))
         case "Concrete methods" => assertTrue(v.forall(_._2 == "shouldBeConcrete"))
+        case "Inherited and Abstract methods" => assertTrue(v.forall(_._2 == "shouldBeAbstract"))
         case "Classlikes" => assertTrue(v.forall((m, n) => m.contains("abstract") == n.contains("Abstract")))
         case _ =>
       }


### PR DESCRIPTION
Backports #19552 to the LTS branch.

PR submitted by the release tooling.
[skip ci]