### PR TITLE
Backport "update old `issues.scala-lang.org` url" to LTS

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -13,7 +13,7 @@ object language:
    *  code should not rely on them.
    *
    *  Programmers are encouraged to try out experimental features and
-   *  [[http://issues.scala-lang.org report any bugs or API inconsistencies]]
+   *  [[https://github.com/lampepfl/dotty/issues report any bugs or API inconsistencies]]
    *  they encounter so they can be improved in future releases.
    *
    *  @group experimental


### PR DESCRIPTION
Backports #19606 to the LTS branch.

PR submitted by the release tooling.
[skip ci]