### PR TITLE
Backport "PC: Replace CC with underlying type in completions" to LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -246,7 +246,7 @@ class Completions(
            */
           if sym.isClass && sym.companionModule.exists then sym.companionModule.info
           else denot.info
-        val applyDenots = info.member(nme.apply).allSymbols.map(_.asSingleDenotation)
+        val applyDenots = info.member(nme.apply).allSymbols.map(_.asSeenFrom(info).asSingleDenotation)
         denot :: applyDenots
       else denot :: Nil
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionDocSuite.scala
@@ -215,7 +215,7 @@ class CompletionDocSuite extends BaseCompletionSuite:
       """
         |> Found documentation for scala/package.Vector.
         |Vector scala.collection.immutable
-        |Vector[A](elems: A*): CC[A]
+        |Vector[A](elems: A*): Vector[A]
         |""".stripMargin,
       includeDocs = true
     )
@@ -317,6 +317,6 @@ class CompletionDocSuite extends BaseCompletionSuite:
         |}
       """.stripMargin,
       """|myNumbers: Vector[Int]
-         |myNumbers(i: Int): A
+         |myNumbers(i: Int): Int
          |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -27,10 +27,10 @@ class CompletionSuite extends BaseCompletionSuite:
         |}""".stripMargin,
       """
         |List scala.collection.immutable
-        |List[A](elems: A*): CC[A]
+        |List[A](elems: A*): List[A]
         |List - java.awt
         |List - java.util
-        |ListMap[K, V](elems: (K, V)*): CC[K, V]
+        |ListMap[K, V](elems: (K, V)*): ListMap[K, V]
         |""".stripMargin,
       topLines = Some(5)
     )
@@ -180,7 +180,7 @@ class CompletionSuite extends BaseCompletionSuite:
         |  TrieMap@@
         |}""".stripMargin,
       """|TrieMap scala.collection.concurrent
-         |TrieMap[K, V](elems: (K, V)*): CC[K, V]
+         |TrieMap[K, V](elems: (K, V)*): TrieMap[K, V]
          |""".stripMargin
     )
 
@@ -1710,5 +1710,27 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin,
       """|test(p: Int => Boolean): List[Int]
          |""".stripMargin
+    )
+
+  @Test def `instantiate-type-vars-in-extra-apply-completions` =
+    check(
+      """|object M:
+         |  val fooBar = List(123)
+         |  foo@@
+         |""".stripMargin,
+      """|fooBar: List[Int]
+         |fooBar(n: Int): Int
+         |""".stripMargin
+    )
+
+  @Test def `show-underlying-type-instead-of-CC` =
+    check(
+      """|object M:
+         |  List@@
+         |""".stripMargin,
+      """|List[A](elems: A*): List[A]
+         |ListMap[K, V](elems: (K, V)*): ListMap[K, V]
+         |""".stripMargin,
+      filter = _.contains("[")
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionWorkspaceSuite.scala
@@ -811,7 +811,7 @@ class CompletionWorkspaceSuite extends BaseCompletionSuite:
          |""".stripMargin,
       """|fooBar: String
          |fooBar: List[Int]
-         |fooBar(n: Int): A
+         |fooBar(n: Int): Int
          |""".stripMargin,
     )
 


### PR DESCRIPTION
Backports #19638 to the LTS branch.

PR submitted by the release tooling.
[skip ci]