### PR TITLE
Backport "Fix module symbol recovery from `NoClassDefFoundError`" to LTS

### DIFF
--- a/tests/neg-macros/i19601/Macro.scala
+++ b/tests/neg-macros/i19601/Macro.scala
@@ -1,0 +1,42 @@
+package prelude
+import scala.quoted.*
+
+object Macros {
+  def validateInlineImpl[A: Type](assertionExpr: Expr[Assertion[A]], a: Expr[A])(using
+      Quotes
+  ): Expr[Unit] = {
+    import quotes.reflect.*
+    val crashRoot = assertionExpr.value
+    '{ () }
+
+  }
+  given [A](using Type[A]): FromExpr[Assertion[A]] with {
+    def unapply(assertion: Expr[Assertion[A]])(using Quotes): Option[Assertion[A]] = {
+      import quotes.reflect.*
+
+      assertion match {
+        case '{ Assertion.greaterThanOrEqualTo[A](${ LiteralUnlift(value) })($_) } =>
+          Some(Assertion.greaterThanOrEqualTo(value)(orderingForValue(value)))
+        case _ => None
+      }
+    }
+  }
+
+  object LiteralUnlift {
+    def unapply[A: Type](expr: Expr[A])(using Quotes): Option[A] = expr match {
+      case '{ ${ Expr(int) }: Int }       => Some(int)
+      case '{ Int.MaxValue }              => Some(Int.MaxValue.asInstanceOf[A])
+      case '{ Int.MinValue }              => Some(Int.MinValue.asInstanceOf[A])
+      case '{ ${ Expr(string) }: String } => Some(string)
+      case '{ ${ Expr(double) }: Double } => Some(double)
+      case '{ ${ Expr(float) }: Float }   => Some(float)
+      case '{ ${ Expr(long) }: Long }     => Some(long)
+      case '{ ${ Expr(short) }: Short }   => Some(short)
+      case '{ ${ Expr(byte) }: Byte }     => Some(byte)
+      case '{ ${ Expr(char) }: Char }     => Some(char)
+      case _                              => None
+    }
+  }
+
+  private def orderingForValue(any: Any)(using Quotes): Ordering[Any] = null.asInstanceOf[Ordering[Any]]
+}

--- a/tests/neg-macros/i19601/Test.scala
+++ b/tests/neg-macros/i19601/Test.scala
@@ -1,0 +1,44 @@
+package prelude
+
+sealed trait Assertion[-A]:
+  def unary_! : Assertion[A] = ???
+  def apply(a: A): Either[AssertionError, Unit] = ???
+object Assertion:
+  val anything: Assertion[Any] = ???
+  def greaterThanOrEqualTo[A](value: A)(implicit ordering: Ordering[A]): Assertion[A] = ???
+
+sealed trait AssertionError
+
+abstract class NewtypeCustom[A] {
+  type Type
+  protected inline def validateInline(inline value: A): Unit
+
+  inline def apply(inline a1: A): Type = {
+    validateInline(a1)
+    a1.asInstanceOf[Type]
+  }
+}
+abstract class Newtype[A] extends NewtypeCustom[A] {
+  def assertion: Assertion[A] = Assertion.anything
+  protected inline def validateInline(inline value: A): Unit = ${
+    Macros.validateInlineImpl[A]('assertion, 'value)
+  }
+}
+
+
+abstract class Subtype[A] extends Newtype[A] {
+  type Type <: A
+}
+
+
+package object newtypes {
+  type Natural = Natural.Type
+  object Natural extends Subtype[Int] {
+
+    override inline def assertion = Assertion.greaterThanOrEqualTo(0)
+
+    val one: Natural =  Natural(1) // triggers macro
+  }
+}
+
+// nopos-error: Cyclic macro dependencies in tests/pos-macros/i19601/Test.scala. Compilation stopped since no further progress can be made.


### PR DESCRIPTION
Backports #19645 to the LTS branch.

PR submitted by the release tooling.
[skip ci]