### PR TITLE
Make opaque type refinements of inline proxy objects abstract type constructors

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -364,9 +364,9 @@ class Inliner(val call: tpd.Tree)(using Context):
               case _ =>
                 Nil
             val refinements = openOpaqueAliases(cls.givenSelfType)
-            val refinedType = refinements.foldLeft(ref: Type) ((parent, refinement) =>
-              RefinedType(parent, refinement._1, TypeAlias(refinement._2))
-            )
+            val refinedType = refinements.foldLeft(ref: Type):
+              case (parent, (rname, ralias)) =>
+                RefinedType(parent, rname, RealTypeBounds(ralias, ralias))
             val refiningSym = newSym(InlineBinderName.fresh(), Synthetic, refinedType).asTerm
             val refiningDef = ValDef(refiningSym, tpd.ref(ref).cast(refinedType), inferred = true).withSpan(span)
             inlining.println(i"add opaque alias proxy $refiningDef for $ref in $tp")

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -67,6 +67,7 @@ mt-redux-norm.perspective.scala
 i18211.scala
 10867.scala
 named-tuples1.scala
+inline-match-opaque.scala
 
 # Opaque type
 i5720.scala

--- a/tests/pos/inline-match-opaque-2.scala
+++ b/tests/pos/inline-match-opaque-2.scala
@@ -1,0 +1,6 @@
+import scala.language.experimental.namedTuples
+
+object Test:
+  type NT = NamedTuple.Concat[(hi: Int), (bla: String)]
+  def foo(x: NT) =
+    x.hi // error

--- a/tests/pos/inline-match-opaque.scala
+++ b/tests/pos/inline-match-opaque.scala
@@ -1,0 +1,19 @@
+object Foo:
+  opaque type Wrapper[T] = T
+  def part[T](w: Wrapper[T]): T = w
+  inline def part2[T](w: Wrapper[T]): T = part(w) //part(w.asInstanceOf[Wrapper[T]]) also fixes the issue
+  type Rewrap[W] = Wrapper[Extra.Unwrap[W]]
+
+object Extra:
+  type Unwrap[W] = W match
+    case Foo.Wrapper[t] => t
+  type Rewrap[W] = Foo.Wrapper[Unwrap[W]]
+
+object Test:
+  type X = Extra.Rewrap[Foo.Wrapper[Int]]
+  def foo1(x: Foo.Wrapper[Extra.Unwrap[Foo.Wrapper[Int]]]) =
+    Foo.part(x) // ok
+    Foo.part2(x) // ok
+  def foo2(x: X) =
+    Foo.part(x) // ok
+    Foo.part2(x) // error


### PR DESCRIPTION
Change the rhs of the added refinements from `TypeAlias`es to `RealTypeBounds`s.
This allows the opaque types to remain abstract type constructors, which is necessary for the `MatchTypeCasePattern.AbstractTypeConstructor` logic.

In particular, an AppliedType where the tycon was a reference to the refinement, used to dealias before proceeding with the comparison of the tycons, which is a requirement of the aforementioned `AbstractTypeConstructor` case of the MatchReducer.

Fixes #20427
Alternative to #20457