### PR TITLE
Disallow some opaque type aliases in match type patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5309,12 +5309,14 @@ object Types extends TypeUtils {
 
   enum MatchTypeCaseError:
     case Alias(sym: Symbol)
+    case OpaqueAlias(sym: Symbol)
     case RefiningBounds(name: TypeName)
     case StructuralType(name: TypeName)
     case UnaccountedTypeParam(name: TypeName)
 
     def explanation(using Context) = this match
       case Alias(sym) => i"a type alias `${sym.name}`"
+      case OpaqueAlias(sym) => i"an opaque type alias `${sym.name}` in the scope where its alias is known"
       case RefiningBounds(name) => i"an abstract type member `$name` with bounds that need verification"
       case StructuralType(name) => i"an abstract type member `$name` that does not refine a member in its parent"
       case UnaccountedTypeParam(name) => i"an unaccounted type parameter `$name`"
@@ -5419,7 +5421,17 @@ object Types extends TypeUtils {
             else
               tycon.info match
                 case _: RealTypeBounds =>
-                  recAbstractTypeConstructor(pat)
+                  val tsym = tycon.typeSymbol
+                  if tsym.isOpaqueAlias
+                    && ctx.owner.isContainedIn(tsym.owner) // (1) opaque alias is known here, and
+                    && !ctx.owner.isAbstractOrAliasType    // (2) we are not in an embedded type
+                       // without (2), one cannot define a match type referring to an opaque type in the
+                       // scope of that opaque type. But that should be OK, we should simply not be
+                       // able to normalize such types in terms in the same scope.
+                  then
+                    MatchTypeCaseError.OpaqueAlias(tsym)
+                  else
+                    recAbstractTypeConstructor(pat)
                 case TypeAlias(tl @ HKTypeLambda(onlyParam :: Nil, resType: RefinedType)) =>
                   /* Unlike for eta-expanded classes, the typer does not automatically
                    * dealias poly type aliases to refined types. So we have to give them

--- a/tests/neg/named-tuples-strawman-2.check
+++ b/tests/neg/named-tuples-strawman-2.check
@@ -1,0 +1,7 @@
+-- [E191] Type Error: tests/neg/named-tuples-strawman-2.scala:28:24 ----------------------------------------------------
+28 |    inline def toTuple: DropNames[NT] = x.asInstanceOf // error
+   |                        ^^^^^^^^^^^^^
+   |                   The match type contains an illegal case:
+   |                       case NamedTupleOps.NamedTuple[_, x] => x
+   |                   The pattern contains an opaque type alias `NamedTuple` in the scope where its alias is known.
+   |                   (this error can be ignored for now with `-source:3.3`)

--- a/tests/neg/named-tuples-strawman-2.scala
+++ b/tests/neg/named-tuples-strawman-2.scala
@@ -1,0 +1,29 @@
+import compiletime.*
+import compiletime.ops.int.*
+import compiletime.ops.boolean.!
+
+object NamedTupleDecomposition:
+  import NamedTupleOps.*
+
+  /** The names of the named tuple type `NT` */
+  type Names[NT <: AnyNamedTuple] <: Tuple = NT match
+    case NamedTuple[n, _] => n
+
+  /** The value types of the named tuple type `NT` */
+  type DropNames[NT <: AnyNamedTuple] <: Tuple = NT match
+    case NamedTuple[_, x] => x
+
+object NamedTupleOps:
+
+  opaque type AnyNamedTuple = Any
+
+  opaque type NamedTuple[N <: Tuple, +X <: Tuple] >: X <: AnyNamedTuple = X
+
+  export NamedTupleDecomposition.*
+
+  object NamedTuple:
+    def apply[N <: Tuple, X <: Tuple](x: X): NamedTuple[N, X] = x
+
+  extension [NT <: AnyNamedTuple](x: NT)
+    inline def toTuple: DropNames[NT] = x.asInstanceOf // error
+    inline def names: Names[NT] = constValueTuple[Names[NT]]

--- a/tests/neg/opaque-matches.check
+++ b/tests/neg/opaque-matches.check
@@ -1,0 +1,15 @@
+-- [E191] Type Error: tests/neg/opaque-matches.scala:4:18 --------------------------------------------------------------
+4 |  type Fst[X] = X match   // error
+  |                ^
+  |                The match type contains an illegal case:
+  |                    case NT.NT[a, b] => a
+  |                The pattern contains a type alias `NT`.
+  |                (this error can be ignored for now with `-source:3.3`)
+5 |    case NT[a, b] => a
+-- [E191] Type Error: tests/neg/opaque-matches.scala:10:30 -------------------------------------------------------------
+10 |  inline def snd[NT](nt: NT): NTDecomposition.Snd[NT] = // error
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^
+   |                           The match type contains an illegal case:
+   |                               case NT.NT[a, b] => b
+   |                           The pattern contains an opaque type alias `NT` in the scope where its alias is known.
+   |                           (this error can be ignored for now with `-source:3.3`)

--- a/tests/neg/opaque-matches.scala
+++ b/tests/neg/opaque-matches.scala
@@ -1,0 +1,19 @@
+object NT:
+  opaque type NT[A, B] = B
+
+  type Fst[X] = X match   // error
+    case NT[a, b] => a
+
+  inline def fst[NT](nt: NT): Fst[NT] =
+    ???
+
+  inline def snd[NT](nt: NT): NTDecomposition.Snd[NT] = // error
+    ???
+
+object NTDecomposition:
+
+  type Snd[X] = X match
+    case NT.NT[a, b] => b
+
+
+


### PR DESCRIPTION
Disallow opaque type aliases in match type patterns in scopes where the alias is visible.