### PR TITLE
Backport "fix(#i18645): overload ext method body in braces didn't compile" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -394,7 +394,9 @@ object ProtoTypes {
       case closureDef(mdef) => hasInnerErrors(mdef.rhs)
       case _ =>
         t.existsSubTree { t1 =>
-          if t1.typeOpt.isError && t1.span.toSynthetic != t.span.toSynthetic then
+          if t1.typeOpt.isError
+            && t.span.toSynthetic != t1.span.toSynthetic
+            && t.typeOpt != t1.typeOpt then
             typr.println(i"error subtree $t1 of $t with ${t1.typeOpt}, spans = ${t1.span}, ${t.span}")
             true
           else

--- a/tests/pos/i18645.scala
+++ b/tests/pos/i18645.scala
@@ -1,0 +1,16 @@
+trait Printable {
+  def pprint(v: () => String): Unit = {
+    println(v())
+  }
+}
+
+extension (ctx: Printable)
+  def pprint(f: () => Int): Unit = {
+    ctx.pprint(() => f().toString)
+  }
+
+val x = new Printable {}
+
+def test =
+  x.pprint(() => ( 234 ))
+  x.pprint(() => { 123 }) 


### PR DESCRIPTION
Backports #19651 to the LTS branch.

PR submitted by the release tooling.
[skip ci]