### PR TITLE
Backport "Fix #19402: emit proper error in absence of using in given definitions" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3958,7 +3958,7 @@ object Parsers {
         val tparams = typeParamClauseOpt(ParamOwner.Given)
         newLineOpt()
         val vparamss =
-          if in.token == LPAREN && in.lookahead.isIdent(nme.using)
+          if in.token == LPAREN && (in.lookahead.isIdent(nme.using) || name != EmptyTermName)
           then termParamClauses(ParamOwner.Given)
           else Nil
         newLinesOpt()

--- a/tests/neg/i19402.scala
+++ b/tests/neg/i19402.scala
@@ -1,0 +1,11 @@
+object Test: 
+
+  class Bar(foo: Foo)
+  
+  class Foo
+
+  given (Foo) = ???
+  given (using a: Int): Int = ???
+  given [T](using a: T): T = ???
+  given bar(foo: Foo): Bar  = Bar(foo) // error: using is expected
+  


### PR DESCRIPTION
Backports #19714 to the LTS branch.

PR submitted by the release tooling.
[skip ci]