### PR TITLE
Fix failing `CompletionScalaCliSuite` tests due to circe releasing Scala Native 0.5 artifacts

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
@@ -3,6 +3,7 @@ package dotty.tools.pc.tests.completion
 import dotty.tools.pc.base.BaseCompletionSuite
 
 import org.junit.Test
+import org.junit.Ignore
 
 class CompletionScalaCliSuite extends BaseCompletionSuite:
 
@@ -44,6 +45,7 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |""".stripMargin,
     )
 
+  @Ignore
   @Test def `single-colon` =
     check(
       """|//> using lib "io.circe:circe-core_na@@
@@ -52,9 +54,6 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
       """|circe-core_native0.4_2.12
          |circe-core_native0.4_2.13
          |circe-core_native0.4_3
-         |circe-core_native0.5_2.12
-         |circe-core_native0.5_2.13
-         |circe-core_native0.5_3
          |""".stripMargin
     )
 
@@ -77,16 +76,16 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |""".stripMargin,
     )
 
+  @Ignore
   @Test def `multiple-libs` =
     check(
       """|//> using lib "io.circe::circe-core:0.14.0", "io.circe::circe-core_na@@"
          |package A
          |""".stripMargin,
-      """circe-core_native0.4
-        |circe-core_native0.5
-        |""".stripMargin
+      "circe-core_native0.4"
     )
 
+  @Ignore
   @Test def `script` =
     check(
       scriptWrapper(
@@ -98,9 +97,6 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
       """|circe-core_native0.4_2.12
          |circe-core_native0.4_2.13
          |circe-core_native0.4_3
-         |circe-core_native0.5_2.12
-         |circe-core_native0.5_2.13
-         |circe-core_native0.5_3
          |""".stripMargin,
       filename = "script.sc.scala",
       enablePackageWrap = false
@@ -142,13 +138,13 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |io.circul""".stripMargin
     )
 
+  @Ignore
   @Test def `multiple-deps2` =
     check(
       """|//> using libs "io.circe::circe-core:0.14.0", "io.circe::circe-core_na@@"
          |package A
          |""".stripMargin,
-      """circe-core_native0.4
-        |circe-core_native0.5""".stripMargin
+      "circe-core_native0.4"
     )
 
   private def scriptWrapper(code: String, filename: String): String =

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
@@ -28,7 +28,8 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
          |// //> using lib ???
          |//> using lib io.circe::circe-core_native0.4
          |package A
-         |""".stripMargin
+         |""".stripMargin,
+      assertSingleItem = false
     )
 
   @Test def `version-sort` =
@@ -51,6 +52,9 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
       """|circe-core_native0.4_2.12
          |circe-core_native0.4_2.13
          |circe-core_native0.4_3
+         |circe-core_native0.5_2.12
+         |circe-core_native0.5_2.13
+         |circe-core_native0.5_3
          |""".stripMargin
     )
 
@@ -78,7 +82,9 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
       """|//> using lib "io.circe::circe-core:0.14.0", "io.circe::circe-core_na@@"
          |package A
          |""".stripMargin,
-      "circe-core_native0.4"
+      """circe-core_native0.4
+        |circe-core_native0.5
+        |""".stripMargin
     )
 
   @Test def `script` =
@@ -92,6 +98,9 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
       """|circe-core_native0.4_2.12
          |circe-core_native0.4_2.13
          |circe-core_native0.4_3
+         |circe-core_native0.5_2.12
+         |circe-core_native0.5_2.13
+         |circe-core_native0.5_3
          |""".stripMargin,
       filename = "script.sc.scala",
       enablePackageWrap = false
@@ -138,7 +147,8 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
       """|//> using libs "io.circe::circe-core:0.14.0", "io.circe::circe-core_na@@"
          |package A
          |""".stripMargin,
-      "circe-core_native0.4"
+      """circe-core_native0.4
+        |circe-core_native0.5""".stripMargin
     )
 
   private def scriptWrapper(code: String, filename: String): String =


### PR DESCRIPTION
The recent release of circe for SN 0.5 changed the outputs of CompletionScalaCli suite. The PR fixes failing tests