### PR TITLE
Backport "Bump JLine 3.19.0 -> 3.24.1 & sbt 1.9.7 -> 1.9.9" to LTS

### DIFF
--- a/compiler/test-coursier/dotty/tools/coursier/CoursierScalaTests.scala
+++ b/compiler/test-coursier/dotty/tools/coursier/CoursierScalaTests.scala
@@ -76,7 +76,7 @@ class CoursierScalaTests:
 
     def emptyArgsEqualsRepl() =
       val output = CoursierScalaTests.csScalaCmd()
-      assertTrue(output.mkString("\n").contains("Unable to create a system terminal")) // Scala attempted to create REPL so we can assume it is working
+      assertTrue(output.mkString("\n").contains("Unable to create a terminal")) // Scala attempted to create REPL so we can assume it is working
     emptyArgsEqualsRepl()
 
     def run() =
@@ -133,7 +133,7 @@ class CoursierScalaTests:
 
     def replWithArgs() =
       val output = CoursierScalaTests.csScalaCmd("-source", "3.0-migration")
-      assertTrue(output.mkString("\n").contains("Unable to create a system terminal")) // Scala attempted to create REPL so we can assume it is working
+      assertTrue(output.mkString("\n").contains("Unable to create a terminal")) // Scala attempted to create REPL so we can assume it is working
     replWithArgs()
 
     def argumentFile() =

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -579,9 +579,9 @@ object Build {
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" % "scala-asm" % "9.6.0-scala-1", // used by the backend
         Dependencies.compilerInterface,
-        "org.jline" % "jline-reader" % "3.24.1",   // used by the REPL
-        "org.jline" % "jline-terminal" % "3.24.1",
-        "org.jline" % "jline-terminal-jna" % "3.24.1", // needed for Windows
+        "org.jline" % "jline-reader" % "3.25.1",   // used by the REPL
+        "org.jline" % "jline-terminal" % "3.25.1",
+        "org.jline" % "jline-terminal-jna" % "3.25.1", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -579,9 +579,9 @@ object Build {
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" % "scala-asm" % "9.6.0-scala-1", // used by the backend
         Dependencies.compilerInterface,
-        "org.jline" % "jline-reader" % "3.19.0",   // used by the REPL
-        "org.jline" % "jline-terminal" % "3.19.0",
-        "org.jline" % "jline-terminal-jna" % "3.19.0", // needed for Windows
+        "org.jline" % "jline-reader" % "3.24.1",   // used by the REPL
+        "org.jline" % "jline-terminal" % "3.24.1",
+        "org.jline" % "jline-terminal-jna" % "3.24.1", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9


### PR DESCRIPTION
Backports #19744 to the LTS branch.

PR submitted by the release tooling.
[skip ci]