### PR TITLE
Backport "Fix #19808: Don't force to compute the owner of a symbol when there is no denotation" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Nullables.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Nullables.scala
@@ -262,7 +262,7 @@ object Nullables:
     */
     def usedOutOfOrder(using Context): Boolean =
       val refSym = ref.symbol
-      val refOwner = refSym.owner
+      val refOwner = refSym.maybeOwner
 
       @tailrec def recur(s: Symbol): Boolean =
         s != NoSymbol

--- a/tests/explicit-nulls/pos/i19808.scala
+++ b/tests/explicit-nulls/pos/i19808.scala
@@ -1,0 +1,6 @@
+import scala.reflect.Selectable.reflectiveSelectable
+
+def saveRedir(what: {def validate: List[String]}) =
+  what.validate match
+    case Nil => ???
+    case xs  => ???

--- a/tests/pos/i19808.scala
+++ b/tests/pos/i19808.scala
@@ -1,0 +1,6 @@
+import scala.reflect.Selectable.reflectiveSelectable
+
+def saveRedir(what: {def validate: List[String]}) =
+  what.validate match
+    case Nil => ???
+    case xs  => ???


### PR DESCRIPTION
Backports #19813 to the LTS branch.

PR submitted by the release tooling.
[skip ci]