### PR TITLE
Backport "Fix #18816: Transfer the span of rewired `This` nodes in `fullyParameterizedDef`." to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
+++ b/compiler/src/dotty/tools/dotc/transform/FullParameterization.scala
@@ -206,7 +206,7 @@ trait FullParameterization {
           .subst(origLeadingTypeParamSyms ++ origOtherParamSyms, (trefs ++ argRefs).tpes)
           .substThisUnlessStatic(origClass, thisRef.tpe),
         treeMap = {
-          case tree: This if tree.symbol == origClass => thisRef
+          case tree: This if tree.symbol == origClass => thisRef.withSpan(tree.span)
           case tree => rewireTree(tree, Nil) orElse tree
         },
         oldOwners = origMeth :: Nil,


### PR DESCRIPTION
Backports #18840 to the LTS branch.

PR submitted by the release tooling.
[skip ci]