### PR TITLE
Refine ignored cases for unused params check

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -136,7 +136,7 @@ class CheckUnused private (phaseMode: CheckUnused.PhaseMode, suffix: String, _ke
 
   override def prepareForDefDef(tree: tpd.DefDef)(using Context): Context =
     unusedDataApply{ ud =>
-      if !tree.symbol.is(Private) then
+      if !tree.symbol.owner.isTopLevelDefinitionsObject && tree.symbol.owner.isClass && !tree.symbol.is(Private) then
         tree.termParamss.flatten.foreach { p =>
           ud.addIgnoredParam(p.symbol)
         }

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -575,7 +575,7 @@ Text => empty
 Language => Scala
 Symbols => 108 entries
 Occurrences => 127 entries
-Diagnostics => 6 entries
+Diagnostics => 7 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -830,6 +830,7 @@ See: https://docs.scala-lang.org/scala3/reference/dropped-features/this-qualifie
 This construct can be rewritten automatically under -rewrite -source 3.4-migration.
 [22:27..22:28): [warning] unused explicit parameter
 [24:10..24:11): [warning] unused explicit parameter
+[51:30..51:31): [warning] unused explicit parameter
 
 Synthetics:
 [51:16..51:27):List(1).map => *[Int]
@@ -3535,6 +3536,7 @@ Text => empty
 Language => Scala
 Symbols => 52 entries
 Occurrences => 137 entries
+Diagnostics => 2 entries
 Synthetics => 39 entries
 
 Symbols:
@@ -3729,6 +3731,10 @@ Occurrences:
 [56:8..56:10): m4 <- example/Synthetic#Contexts.m4().
 [57:12..57:15): Int -> scala/Int#
 [58:6..58:9): foo -> example/Synthetic#Contexts.foo().
+
+Diagnostics:
+[19:21..19:22): [warning] unused explicit parameter
+[41:4..41:5): [warning] unused explicit parameter
 
 Synthetics:
 [5:2..5:13):List(1).map => *[Int]

--- a/tests/warn/i15503e.scala
+++ b/tests/warn/i15503e.scala
@@ -31,7 +31,7 @@ package scala3main:
 package foo.test.lambda.param:
   val default_val = 1
   val a = (i: Int) => i // OK
-  val b = (i: Int) => default_val // OK
+  val b = (i: Int) => default_val // warn
   val c = (_: Int) => default_val // OK
 
 package foo.test.trivial:

--- a/tests/warn/i15503i.scala
+++ b/tests/warn/i15503i.scala
@@ -44,7 +44,7 @@ package foo.test.scala.annotation:
   val default_int = 12
 
   def a1(a: Int) = a // OK
-  def a2(a: Int) = default_int // ok
+  def a2(a: Int) = default_int // warn
 
   def a3(@unused a: Int) = default_int //OK
 

--- a/tests/warn/i20951.check
+++ b/tests/warn/i20951.check
@@ -1,0 +1,12 @@
+-- [E198] Unused Symbol Warning: tests/warn/i20951.scala:5:9 -----------------------------------------------------------
+5 |def test(x: Int): Int = dummy // warn
+  |         ^
+  |         unused explicit parameter
+-- [E198] Unused Symbol Warning: tests/warn/i20951.scala:8:32 ----------------------------------------------------------
+8 |  def f(): Unit = Option(1).map(x => dummy) // warn
+  |                                ^
+  |                                unused explicit parameter
+-- [E198] Unused Symbol Warning: tests/warn/i20951.scala:10:16 ---------------------------------------------------------
+10 |  private def h(x: Int): Int = dummy // warn
+   |                ^
+   |                unused explicit parameter

--- a/tests/warn/i20951.scala
+++ b/tests/warn/i20951.scala
@@ -1,0 +1,20 @@
+//> using options  -Wunused:params
+
+// We need the dummy variable: with a constant the unused:params does not trigger a warning but unused:all does.
+val dummy = 42
+def test(x: Int): Int = dummy // warn
+
+object Foo:
+  def f(): Unit = Option(1).map(x => dummy) // warn
+  def g(x: Int): Int = dummy // ok
+  private def h(x: Int): Int = dummy // warn
+  def main(args: Array[String]): Unit = {} // ok
+
+trait Bar:
+  def f(x: Int): Int = dummy // ok
+
+abstract class Baz:
+  def f(x: Int): Int = dummy // ok
+
+class Qux:
+  def f(x: Int): Int = dummy // ok

--- a/tests/warn/scala2-t11681.scala
+++ b/tests/warn/scala2-t11681.scala
@@ -88,13 +88,13 @@ trait Proofs {
 }
 
 trait Anonymous {
-  def f = (i: Int) => answer      // ok
+  def f = (i: Int) => answer      // warn
 
   def f1 = (_: Int) => answer     // OK
 
   def f2: Int => Int = _ + 1  // OK
 
-  def g = for (i <- List(1)) yield answer    // ok
+  def g = for (i <- List(1)) yield answer    // warn
 }
 trait Context[A]
 trait Implicits {


### PR DESCRIPTION
Fixes #20951

However I don't think the current implementation is perfect: `unused:params` does not trigger a warning when the return value of a method is a constant but then `unused:all` does trigger a warning: `unused local definition`. But maybe that should be solved in a different PR.

This will also trigger compiler warnings for the examples in #18289 but the warning is `unused explicit parameter` instead of `unused local definition`.