### PR TITLE
Backport "Restore pre-3.3.2 behavior of `inline implicit def`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -581,6 +581,7 @@ object Flags {
   val LazyGiven: FlagSet                     = Given | Lazy
   val InlineOrProxy: FlagSet                 = Inline | InlineProxy                           // An inline method or inline argument proxy */
   val InlineMethod: FlagSet                  = Inline | Method
+  val InlineImplicitMethod: FlagSet          = Implicit | InlineMethod
   val InlineParam: FlagSet                   = Inline | Param
   val InlineByNameProxy: FlagSet             = InlineProxy | Method
   val JavaEnumTrait: FlagSet                 = JavaDefined | Enum                             // A Java enum trait

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3939,10 +3939,12 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
       // Reasons NOT to eta expand:
       //  - we reference a constructor
+      //  - we reference an inline implicit def (see #19862)
       //  - we are in a pattern
       //  - the current tree is a synthetic apply which is not expandable (eta-expasion would simply undo that)
       if arity >= 0
          && !tree.symbol.isConstructor
+         && !tree.symbol.isAllOf(InlineImplicitMethod)
          && !ctx.mode.is(Mode.Pattern)
          && !(isSyntheticApply(tree) && !functionExpected)
       then

--- a/tests/pos/i19862.scala
+++ b/tests/pos/i19862.scala
@@ -1,0 +1,8 @@
+import scala.language.implicitConversions
+
+object Test:
+  implicit inline def uhOh[A](value: A): A =
+    compiletime.error("Should not have been called")
+  def test =
+    // Compiles because `uhOh` fails to eta-expand and we fallback to `Predef.$conforms[A, A]`
+    summon[Function1[Int, Int]]


### PR DESCRIPTION
Backports #19877 to the LTS branch.

PR submitted by the release tooling.
[skip ci]