### PR TITLE
Backport "Avoid eta-reduction of `(..., f: T => R, ...) => f.apply(..)` into `f`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/EtaReduce.scala
@@ -43,6 +43,7 @@ class EtaReduce extends MiniPhase:
               arg.isInstanceOf[Ident] && arg.symbol == param.symbol)
           && isPurePath(fn)
           && fn.tpe <:< tree.tpe
+          && !(fn.symbol.is(Flags.Param) && fn.symbol.owner == mdef.symbol) // Do not eta-educe `(..., f: T => R, ...) => f.apply(..)` into `f`
           && defn.isFunctionClass(fn.tpe.widen.typeSymbol) =>
         report.log(i"eta reducing $tree --> $fn")
         fn

--- a/tests/pos/i19962.scala
+++ b/tests/pos/i19962.scala
@@ -1,0 +1,4 @@
+def selfie0: (AnyRef => AnyRef) => AnyRef = (f:AnyRef => AnyRef) => f(f)
+def selfie1: Any = (f: Any => Any) => f(f)
+def selfie2: Any = (f: (Any, Any) => Any, g: (Any, Any) => Any) => f(f, g)
+def selfie3: Any = (f: (Any, Any) => Any, g: (Any, Any) => Any) => g(f, g)


### PR DESCRIPTION
Backports #19966 to the LTS branch.

PR submitted by the release tooling.
[skip ci]