### PR TITLE
Backport "Use final result type to check selector bound" to 3.5.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -728,7 +728,7 @@ object CheckUnused:
             if selector.isGiven then
               // Further check that the symbol is a given or implicit and conforms to the bound
               sym.isOneOf(Given | Implicit)
-                && (selector.bound.isEmpty || sym.info <:< selector.boundTpe)
+                && (selector.bound.isEmpty || sym.info.finalResultType <:< selector.boundTpe)
             else
               // Normal wildcard, check that the symbol is not a given (but can be implicit)
               !sym.is(Given)

--- a/tests/pos/i20860.scala
+++ b/tests/pos/i20860.scala
@@ -1,0 +1,3 @@
+def `i20860 use result to check selector bound`: Unit =
+  import Ordering.Implicits.given Ordering[?]
+  summon[Ordering[Seq[Int]]]


### PR DESCRIPTION
Backports #20989 to 3.5.0-RC3