### PR TITLE
Backport "Reduce projections of type aliases with class type prefixes" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2589,14 +2589,22 @@ object Types extends TypeUtils {
       case _ => true
     }
 
-    /** Reduce a type-ref `T { X = U; ... } # X`  to   `U`
-     *  provided `U` does not refer with a RecThis to the
-     *  refinement type `T { X = U; ... }`
+    /** Reduce a type ref P # X, where X is a type alias and P is a refined type or
+     *  a class type. If P is a refined type `T { X = U; ... }`, reduce P to U,
+     *  provided U does not refer with a RecThis to the same refined type. If P is a
+     *  class type, reduce it to the dealiasd version of P # X. This means that at typer
+     *  we create projections only for inner classes with class prefixes, since projections
+     *  of P # X where X is an abstract type are handled by skolemization. At later phases
+     *  these projections might arise, though.
      */
     def reduceProjection(using Context): Type =
       if (isType) {
         val reduced = prefix.lookupRefined(name)
-        if (reduced.exists) reduced else this
+        if reduced.exists then reduced
+        else prefix.stripTypeVar match
+          case pre: (AppliedType | TypeRef)
+          if prefix.typeSymbol.isClass && this.symbol.isAliasType => dealias
+          case _ => this
       }
       else this
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2603,7 +2603,7 @@ object Types extends TypeUtils {
         if reduced.exists then reduced
         else prefix.stripTypeVar match
           case pre: (AppliedType | TypeRef)
-          if prefix.typeSymbol.isClass && this.symbol.isAliasType => dealias
+          if prefix.dealias.typeSymbol.isClass && this.symbol.isAliasType => dealias
           case _ => this
       }
       else this

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -105,3 +105,7 @@ java-inherited-type1
 
 # recursion limit exceeded
 i7445b.scala
+
+# more aggresive reduce projection makes a difference
+i15525.scala
+

--- a/presentation-compiler/test/dotty/tools/pc/tests/highlight/TypeDocumentHighlightSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/highlight/TypeDocumentHighlightSuite.scala
@@ -2,7 +2,7 @@ package dotty.tools.pc.tests.highlight
 
 import dotty.tools.pc.base.BaseDocumentHighlightSuite
 
-import org.junit.Test
+import org.junit.{Test, Ignore}
 
 class TypeDocumentHighlightSuite extends BaseDocumentHighlightSuite:
 
@@ -147,7 +147,7 @@ class TypeDocumentHighlightSuite extends BaseDocumentHighlightSuite:
         |}""".stripMargin
     )
 
-  @Test def `projection1` =
+  @Ignore @Test def `projection1` =
     check(
       """|
          |class A {
@@ -158,7 +158,7 @@ class TypeDocumentHighlightSuite extends BaseDocumentHighlightSuite:
          |}""".stripMargin
     )
 
-  @Test def `projection2` =
+  @Ignore @Test def `projection2` =
     check(
       """|
          |class A {

--- a/tests/pos/i19892.scala
+++ b/tests/pos/i19892.scala
@@ -1,0 +1,26 @@
+abstract class ZPartialServerEndpoint[R, A, B, I, E, O, -C]
+    extends EndpointOps[A, I, E, O, C]{
+  override type ThisType[-_R] = ZPartialServerEndpoint[R, A, B, I, E, O, _R]
+  override type EndpointType[_A, _I, _E, _O, -_R] =ZPartialServerEndpoint[R, _A, B, _I, _E, _O, _R]
+}
+
+trait EndpointOps[A, I, E, O, -R] {
+  type EndpointType[_A, _I, _E, _O, -_R]
+  type ThisType[-_R]
+  def out[T]: EndpointType[A, I, E, T, R]
+  def description(d: String): ThisType[R]
+}
+
+object Test {
+  def basicEndpoint[R](): ZPartialServerEndpoint[R, Any, Any, Unit, Any, Unit, Any] = ???
+
+  // commonts next to `.out[Any]` contain information about compilation time when chaining up to N `out` functions
+  val case1 =
+     basicEndpoint() // 1.5s
+        .out[Any] // 1.6s
+        .out[Any] // 1.7s
+        .out[Any] // 2s
+        .out[Any] // 4s
+        .out[Any] // 33s
+        .out[Any] // aborted after 5 min
+}


### PR DESCRIPTION
Backports #19931 to the LTS branch.

PR submitted by the release tooling.
[skip ci]