### PR TITLE
Backport "Set the inlining phase in the Context used for checking macro trees" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -775,9 +775,19 @@ object TreeChecker {
 
   def checkMacroGeneratedTree(original: tpd.Tree, expansion: tpd.Tree)(using Context): Unit =
     if ctx.settings.XcheckMacros.value then
+      // We want make sure that transparent inline macros are checked in the same way that
+      // non transparent macros are, so we try to prepare a context which would make
+      // the checks behave the same way for both types of macros.
+      // 
+      // E.g. Different instances of skolem types are by definition not able to be a subtype of
+      // one another, however in practice this is only upheld during typer phase, and we do not want
+      // it to be upheld during this check.
+      // See issue: #17009
       val checkingCtx = ctx
         .fresh
         .setReporter(new ThrowingReporter(ctx.reporter))
+        .setPhase(ctx.base.inliningPhase)
+
       val phases = ctx.base.allPhases.toList
       val treeChecker = new LocalChecker(previousPhases(phases))
 

--- a/tests/pos-macros/i17009/Macro_1.scala
+++ b/tests/pos-macros/i17009/Macro_1.scala
@@ -1,0 +1,6 @@
+import scala.quoted._
+
+object Macro {
+  transparent inline def transform[T](inline expr: T): T = ${ transformImpl[T]('expr) }
+  def transformImpl[T: Type](f: Expr[T])(using Quotes): Expr[T] = f
+}

--- a/tests/pos-macros/i17009/Main_2.scala
+++ b/tests/pos-macros/i17009/Main_2.scala
@@ -1,0 +1,6 @@
+def processLine(line: String): Unit = {
+  Macro.transform {
+    line.split(" ").nn
+    ???
+  }
+}


### PR DESCRIPTION
Backports #20087 to the LTS branch.

PR submitted by the release tooling.