### PR TITLE
Backport "Fix TermRef prefixes not having their type healed" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/staging/HealType.scala
+++ b/compiler/src/dotty/tools/dotc/staging/HealType.scala
@@ -35,7 +35,7 @@ class HealType(pos: SrcPos)(using Context) extends TypeMap {
       case tp: TermRef =>
         val inconsistentRoot = levelInconsistentRootOfPath(tp)
         if inconsistentRoot.exists then levelError(inconsistentRoot, tp, pos)
-        else tp
+        else mapOver(tp)
       case tp: AnnotatedType =>
         derivedAnnotatedType(tp, apply(tp.parent), tp.annot)
       case _ =>

--- a/tests/pos-macros/i19767.scala
+++ b/tests/pos-macros/i19767.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+class ICons[K <: Singleton](val key: K)
+
+def filterX(using Quotes): Unit =
+  (??? : Expr[Any]) match
+    case '{ $y : ICons[k1] } => '{ ICons($y.key) }


### PR DESCRIPTION
Backports #20102 to the LTS branch.

PR submitted by the release tooling.
[skip ci]