### PR TITLE
Backport "Avoid conversion of `Unit` type into `()` term" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -153,7 +153,8 @@ object BetaReduce:
     val expansion1 = new TreeMap {
       override def transform(tree: Tree)(using Context) = tree.tpe.widenTermRefExpr match
         case ConstantType(const) if isPureExpr(tree) => cpy.Literal(tree)(const)
-        case tpe: TypeRef if tpe.derivesFrom(defn.UnitClass) && isPureExpr(tree) => cpy.Literal(tree)(Constant(()))
+        case tpe: TypeRef if tree.isTerm && tpe.derivesFrom(defn.UnitClass) && isPureExpr(tree) =>
+          cpy.Literal(tree)(Constant(()))
         case _ => super.transform(tree)
     }.transform(expansion)
 

--- a/tests/pos-macros/i20286/Macro_1.scala
+++ b/tests/pos-macros/i20286/Macro_1.scala
@@ -1,0 +1,24 @@
+import scala.quoted.*
+
+type P[+T] = ParsingRun[T]
+trait ParsingRun[+T] {
+  var successValue: Any
+  def freshSuccessUnit(): ParsingRun[Unit]
+
+}
+
+object MacroInlineImpls {
+  inline def flatMapXInline[T, V](
+      lhs: ParsingRun[T]
+  )(inline f: T => ParsingRun[V]): ParsingRun[V] = {
+    f(lhs.successValue.asInstanceOf[T])
+  }
+
+  def parsedSequence0[T: Type, V: Type, R: Type](
+      lhs: Expr[ParsingRun[T]],
+      rhs: Expr[ParsingRun[V]]
+  )(using quotes: Quotes): Expr[ParsingRun[R]] = {
+    import quotes.reflect.*
+    '{ $rhs.asInstanceOf[ParsingRun[R]] }
+  }
+}

--- a/tests/pos-macros/i20286/Test_2.scala
+++ b/tests/pos-macros/i20286/Test_2.scala
@@ -1,0 +1,17 @@
+implicit inline def LiteralStr(s: String)(implicit ctx: P[Any]): P[Unit] = ???
+
+extension [T](inline parse0: P[T]) {
+  inline def ~[V, R](inline other: P[V])(using
+      ctx: P[?]
+  ): P[R] = ${ MacroInlineImpls.parsedSequence0[T, V, R]('parse0, 'other) }
+
+  inline def flatMapX[V](inline f: T => P[V]): P[V] =
+    MacroInlineImpls.flatMapXInline[T, V](parse0)(f)
+}
+
+def deeper[$: P]: P[Int] = ???
+def newline[$: P]: P[Unit] = ???
+def blockBody[p: P]: P[Seq[Int]] = newline ~ deeper.flatMapX { i =>
+  val y = LiteralStr("")(using ???)
+  ???
+}


### PR DESCRIPTION
Backports #20295 to the LTS branch.

PR submitted by the release tooling.