### PR TITLE
Backport "Type desugared `transparent inline def unapply` call in the correct mode" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1413,7 +1413,8 @@ trait Applications extends Compatibility {
             report.error(em"Structural unapply is not supported", unapplyFn.srcPos)
             (unapplyFn, unapplyAppCall)
           case Apply(fn, `dummyArg` :: Nil) =>
-            val inlinedUnapplyFn = Inlines.inlinedUnapplyFun(fn)
+            val inlinedUnapplyFn = withoutMode(Mode.Pattern):
+              Inlines.inlinedUnapplyFun(fn)
             (inlinedUnapplyFn, inlinedUnapplyFn.appliedToArgs(`dummyArg` :: Nil))
           case Apply(fn, args) =>
             val (fn1, app) = rec(fn)

--- a/tests/pos/i20107.scala
+++ b/tests/pos/i20107.scala
@@ -1,0 +1,6 @@
+object foo:
+	transparent inline def unapply[F](e: F): Option[F] = Some(e.asInstanceOf[F])
+
+class A:
+  def test(x: Int) = x match
+    case foo(e) => e


### PR DESCRIPTION
Backports #20108 to the LTS branch.

PR submitted by the release tooling.
[skip ci]