### PR TITLE
Backport "Fix active param index for empty param lists" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -196,7 +196,8 @@ object Signatures {
     fun: tpd.Tree,
     isTypeApply: Boolean = false
   )(using Context): (Int, Int, List[Signature]) =
-    def treeQualifier(tree: tpd.Tree): tpd.Tree = tree match
+    def treeQualifier(tree: tpd.Tree): tpd.Tree =
+      tree match
         case Apply(qual, _) => treeQualifier(qual)
         case TypeApply(qual, _) => treeQualifier(qual)
         case AppliedTypeTree(qual, _) => treeQualifier(qual)
@@ -247,7 +248,9 @@ object Signatures {
       val alternativeSignatures = alternativesWithTypes
         .flatMap(toApplySignature(_, findOutermostCurriedApply(untpdPath), safeParamssListIndex))
 
-      val finalParamIndex = currentParamsIndex + previousArgs
+      val finalParamIndex =
+        if currentParamsIndex == -1 then -1
+        else previousArgs + currentParamsIndex
       (finalParamIndex, alternativeIndex, alternativeSignatures)
     else
       (0, 0, Nil)

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseSignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseSignatureHelpSuite.scala
@@ -43,7 +43,7 @@ abstract class BaseSignatureHelpSuite extends BasePCSuite:
         out
           .append(signature.getLabel)
           .append("\n")
-        if (result.getActiveSignature == i && result.getActiveParameter != null && signature.getParameters.size() > 0) {
+        if (result.getActiveSignature == i && result.getActiveParameter != null && result.getActiveParameter() >= 0 && signature.getParameters.size() > 0) {
           val param = signature.getParameters.get(result.getActiveParameter)
           val label = param.getLabel.getLeft()
           /* We need to find the label of the active parameter and show ^ at that spot

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
@@ -1533,3 +1533,28 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
         |foo(i: Boolean, s: String)(b: Int): Unit
         |""".stripMargin
     )
+
+  @Test def `proper-param-empty-list` =
+    check(
+      """
+        |object x {
+        |  def foo[K, V](): Unit = ???
+        |  foo(@@)
+        |}
+        |""".stripMargin,
+      "foo[K, V](): Unit"
+    )
+  
+  @Test def `proper-param-list-after-param-empty-list` =
+    check(
+      """
+        |object x {
+        |  def foo[K, V]()(x: Int): Unit = ???
+        |  foo()(@@)
+        |}
+        |""".stripMargin,
+      """
+      |foo[K, V]()(x: Int): Unit
+      |            ^^^^^^
+      """.stripMargin
+    )


### PR DESCRIPTION
Backports #20142 to the LTS branch.

PR submitted by the release tooling.
[skip ci]