### PR TITLE
Backport "Remove duplicate comma from Matchable selector warning" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -921,7 +921,7 @@ class MatchableWarning(tp: Type, pattern: Boolean)(using Context)
 extends TypeMsg(MatchableWarningID) {
   def msg(using Context) =
     val kind = if pattern then "pattern selector" else "value"
-    i"""${kind} should be an instance of Matchable,,
+    i"""${kind} should be an instance of Matchable,
        |but it has unmatchable type $tp instead"""
 
   def explain(using Context) =

--- a/tests/pos-with-compiler-cc/dotc/reporting/messages.scala
+++ b/tests/pos-with-compiler-cc/dotc/reporting/messages.scala
@@ -873,7 +873,7 @@ class MatchableWarning(tp: Type, pattern: Boolean)(using DetachedContext)
 extends TypeMsg(MatchableWarningID) {
   def msg(using Context) =
     val kind = if pattern then "pattern selector" else "value"
-    i"""${kind} should be an instance of Matchable,,
+    i"""${kind} should be an instance of Matchable,
        |but it has unmatchable type $tp instead"""
 
   def explain(using Context) =


### PR DESCRIPTION
Backports #20159 to the LTS branch.

PR submitted by the release tooling.
[skip ci]