### PR TITLE
Backport "Suppress "extension method will never be selected" for overrides" to LTS

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -28,6 +28,7 @@ i13433.scala
 i16649-irrefutable.scala
 strict-pattern-bindings-3.0-migration.scala
 i17255
+i17735.scala
 
 # Tree is huge and blows stack for printing Text
 i7034.scala

--- a/tests/pos/ext-override.scala
+++ b/tests/pos/ext-override.scala
@@ -1,0 +1,12 @@
+//> using options -Xfatal-warnings
+
+trait Foo[T]:
+  extension (x: T)
+    def hi: String
+
+class Bla:
+  def hi: String = "hi"
+object Bla:
+  given Foo[Bla] with
+    extension (x: Bla)
+      def hi: String = x.hi

--- a/tests/pos/i17735.scala
+++ b/tests/pos/i17735.scala
@@ -1,4 +1,4 @@
-// scalac: -Wvalue-discard
+//> using options -Xfatal-warnings -Wvalue-discard
 
 import scala.collection.mutable
 import scala.annotation.nowarn

--- a/tests/pos/i17735a.scala
+++ b/tests/pos/i17735a.scala
@@ -1,4 +1,4 @@
-// scalac: -Wvalue-discard -Wconf:msg=non-Unit:s
+//> using options -Xfatal-warnings -Wvalue-discard -Wconf:msg=non-Unit:s
 
 import scala.collection.mutable
 import scala.annotation.nowarn

--- a/tests/pos/i17741.scala
+++ b/tests/pos/i17741.scala
@@ -1,4 +1,4 @@
-// scalac: -Wnonunit-statement
+//> using options -Xfatal-warnings -Wnonunit-statement
 
 class Node()
 class Elem(

--- a/tests/pos/nowarnannot.scala
+++ b/tests/pos/nowarnannot.scala
@@ -1,3 +1,5 @@
+//> using options -Xfatal-warnings -Wvalue-discard
+
 case class F(i: Int)
 
 object Main {


### PR DESCRIPTION
Backports #20164 to the LTS branch.

PR submitted by the release tooling.
[skip ci]