### PR TITLE
Backport "Bump peaceiris/actions-gh-pages from 3 to 4" to LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -635,7 +635,7 @@ jobs:
           ./project/scripts/genDocs -doc-snapshot
 
       - name: Deploy Website to dotty-website
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           personal_token: ${{ env.DOTTY_WEBSITE_BOT_TOKEN }}
           publish_dir: docs/_site


### PR DESCRIPTION
Backports #20191 to the LTS branch.

PR submitted by the release tooling.
[skip ci]