### PR TITLE
Backport "Use `MirrorSource.reduce` result for `companionPath`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -464,26 +464,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     case ConstantType(value) => Literal(value)
   }
 
-  /** A path that corresponds to the given type `tp`. Error if `tp` is not a refinement
-   *  of an addressable singleton type.
-   */
-  def pathFor(tp: Type)(using Context): Tree = {
-    def recur(tp: Type): Tree = tp match {
-      case tp: NamedType =>
-        tp.info match {
-          case TypeAlias(alias) => recur(alias)
-          case _: TypeBounds => EmptyTree
-          case _ => singleton(tp)
-        }
-      case tp: TypeProxy => recur(tp.superType)
-      case _ => EmptyTree
-    }
-    recur(tp).orElse {
-      report.error(em"$tp is not an addressable singleton type")
-      TypeTree(tp)
-    }
-  }
-
   /** A tree representing a `newXYZArray` operation of the right
    *  kind for the given element type in `elemTpe`. No type arguments or
    *  `length` arguments are given.

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -116,21 +116,6 @@ class TypeUtils {
 
     def refinedWith(name: Name, info: Type)(using Context) = RefinedType(self, name, info)
 
-    /** The TermRef referring to the companion of the underlying class reference
-     *  of this type, while keeping the same prefix.
-     */
-    def mirrorCompanionRef(using Context): TermRef = self match {
-      case AndType(tp1, tp2) =>
-        val c1 = tp1.classSymbol
-        val c2 = tp2.classSymbol
-        if c1.isSubClass(c2) then tp1.mirrorCompanionRef
-        else tp2.mirrorCompanionRef // precondition: the parts of the AndType have already been checked to be non-overlapping
-      case self @ TypeRef(prefix, _) if self.symbol.isClass =>
-        prefix.select(self.symbol.companionModule).asInstanceOf[TermRef]
-      case self: TypeProxy =>
-        self.superType.mirrorCompanionRef
-    }
-
     /** Is this type a methodic type that takes at least one parameter? */
     def takesParams(using Context): Boolean = self.stripPoly match
       case mt: MethodType => mt.paramNames.nonEmpty || mt.resType.takesParams

--- a/tests/pos/i20187/A_1.scala
+++ b/tests/pos/i20187/A_1.scala
@@ -1,0 +1,19 @@
+import scala.deriving.Mirror
+
+enum E:
+  case Foo1()
+  case Foo2()
+
+class Outer:
+  case class Inner()
+val o = new Outer
+
+type F = E.Foo1
+type G = Tuple.Head[E.Foo1 *: E.Foo2 *: EmptyTuple]
+type H = Tuple.Head[o.Inner *: EmptyTuple]
+type I = Tuple.Last[E *: EmptyTuple]
+
+def local =
+  case class Bar()
+  type B = Tuple.Head[Bar *: EmptyTuple]
+  summon[Mirror.Of[B]]

--- a/tests/pos/i20187/B_2.scala
+++ b/tests/pos/i20187/B_2.scala
@@ -1,0 +1,7 @@
+import scala.deriving.Mirror
+
+def Test =
+  summon[Mirror.Of[F]] // ok
+  summon[Mirror.Of[G]] // was crash
+  summon[Mirror.Of[H]] // was crash
+  summon[Mirror.Of[I]] // was crash


### PR DESCRIPTION
Backports #20207 to the LTS branch.

PR submitted by the release tooling.
[skip ci]