### PR TITLE
Backport "Fix handling of AppliedType aliases in outerPrefix" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -343,25 +343,12 @@ object ExplicitOuter {
   private final val HoistableFlags = Method | Lazy | Module
 
   /** The outer prefix implied by type `tpe` */
-  private def outerPrefix(tpe: Type)(using Context): Type = tpe match {
-    case tpe: TypeRef =>
-      tpe.symbol match {
-        case cls: ClassSymbol =>
-          if (tpe.prefix eq NoPrefix) cls.owner.enclosingClass.thisType
-          else tpe.prefix
-        case _ =>
-          // Need to be careful to dealias before erasure, otherwise we lose prefixes.
-          atPhaseNoLater(erasurePhase)(outerPrefix(tpe.underlying))
-          // underlying is fine here and below since we are calling this after erasure.
-          // However, there is some weird stuff going on with parboiled2 where an
-          // AppliedType with a type alias as constructor is fed to outerPrefix.
-          // For some other unknown reason this works with underlying but not with superType.
-          // I was not able to minimize the problem and parboiled2 spits out way too much
-          // macro generated code to be able to pinpoint the root problem.
-      }
+  private def outerPrefix(tpe: Type)(using Context): Type = tpe match
+    case tpe: TypeRef if tpe.symbol.isClass =>
+      if tpe.prefix eq NoPrefix then tpe.symbol.owner.enclosingClass.thisType
+      else tpe.prefix
     case tpe: TypeProxy =>
       atPhaseNoLater(erasurePhase)(outerPrefix(tpe.superType))
-  }
 
   /** It's possible (i1755.scala gives an example) that the type
    *  given by outerPrefix contains a This-reference to a module outside

--- a/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExplicitOuter.scala
@@ -360,7 +360,7 @@ object ExplicitOuter {
           // macro generated code to be able to pinpoint the root problem.
       }
     case tpe: TypeProxy =>
-      outerPrefix(tpe.underlying)
+      atPhaseNoLater(erasurePhase)(outerPrefix(tpe.superType))
   }
 
   /** It's possible (i1755.scala gives an example) that the type

--- a/tests/pos/i20184.scala
+++ b/tests/pos/i20184.scala
@@ -1,0 +1,12 @@
+object Outer:
+  def Test =
+    object Inner:
+      var x: Int = 2
+      class Rgb():
+        def f = x
+
+    type Id[X] = X
+    type TRgb = Id[Inner.Rgb]
+
+    val ok = new Inner.Rgb()
+    val crash = new Id[Inner.Rgb]


### PR DESCRIPTION
Backports #20190 to the LTS branch.

PR submitted by the release tooling.
[skip ci]