### PR TITLE
Backport "Fix default args lookup for given classes" to LTS

### DIFF
--- a/tests/pos/20088.scala
+++ b/tests/pos/20088.scala
@@ -1,0 +1,6 @@
+trait Foo
+trait Bar
+
+given (using foo: Foo = new {}): Bar with {}
+
+def Test = summon[Bar]

--- a/tests/pos/20088b.scala
+++ b/tests/pos/20088b.scala
@@ -1,0 +1,6 @@
+trait Foo
+class Bar
+
+given (using foo: Foo = new {}): Bar()
+
+def Test = summon[Bar]


### PR DESCRIPTION
Backports #20256 to the LTS branch.

PR submitted by the release tooling.
[skip ci]