### PR TITLE
Backport "fix: prefer non-export definition locations" to LTS

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
@@ -274,6 +274,23 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
         |""".stripMargin
     )
 
+  @Test def exportTermExtension =
+    check(
+      """|package a
+         |class Test extends A {
+         |  assert("Hello".fo@@o == "HelloFoo")
+         |}
+         |
+         |trait A {
+         |  export B.*
+         |}
+         |
+         |object B {
+         |  extension (value: String) def <<foo>>: String = s"${value}Foo"
+         |}
+         |""".stripMargin
+    )
+
   @Test def `named-arg-local` =
     check(
       """|


### PR DESCRIPTION
Backports #20252 to the LTS branch.

PR submitted by the release tooling.
[skip ci]