### PR TITLE
Backport "Fix #18383: Never consider top-level `import`s as unused in the repl." to LTS

### DIFF
--- a/compiler/test-resources/repl/i18383
+++ b/compiler/test-resources/repl/i18383
@@ -1,0 +1,14 @@
+scala>:settings -Wunused:all
+
+scala> import scala.collection.*
+
+scala> class Foo { import scala.util.*; println("foo") }
+1 warning found
+-- Warning: --------------------------------------------------------------------
+1 | class Foo { import scala.util.*; println("foo") }
+  |                               ^
+  |                               unused import
+// defined class Foo
+
+scala> { import scala.util.*; "foo" }
+val res0: String = foo

--- a/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/compiler/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -20,6 +20,14 @@ class ReplCompilerTests extends ReplTest:
     assertEquals("def foo: 1", storedOutput().trim)
   }
 
+  @Test def i18383NoWarnOnUnusedImport: Unit = {
+    initially {
+      run("import scala.collection.*")
+    } andThen {
+      println(lines().mkString("* ", "\n  * ", ""))
+    }
+  }
+
   @Test def compileTwo =
     initially {
       run("def foo: 1 = 1")
@@ -425,4 +433,3 @@ class ReplHighlightTests extends ReplTest(ReplTest.defaultOptions.filterNot(_.st
       case class Tree(left: Tree, right: Tree)
       def deepTree(depth: Int): Tree
       deepTree(300)""")
-


### PR DESCRIPTION
Backports #20310 to the LTS branch.

PR submitted by the release tooling.
[skip ci]