### PR TITLE
Backport "Bring back ambiguity filter when we report an implicit not found error" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3811,7 +3811,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           */
         def issueErrors(fun: Tree, args: List[Tree]): Tree =
           // Prefer other errors over ambiguities. If nested in outer searches a missing
-          // implicit can be healed by simply dropping this alternative and tryng something
+          // implicit can be healed by simply dropping this alternative and trying something
           // else. But an ambiguity is sticky and propagates outwards. If we have both
           // a missing implicit on one argument and an ambiguity on another the whole
           // branch should be classified as a missing implicit.

--- a/tests/pos/i20344.scala
+++ b/tests/pos/i20344.scala
@@ -1,0 +1,28 @@
+trait Monad[F[_]] extends Invariant[F]
+
+trait Invariant[F[_]]
+object Invariant:
+  implicit def catsInstancesForList: Monad[List] = ???
+  implicit def catsInstancesForVector: Monad[Vector] = ???
+
+trait Shrink[T]
+object Shrink extends ShrinkLowPriorityImplicits:
+  trait Buildable[T,C]
+  implicit def shrinkContainer[C[_],T](implicit v: C[T] => Traversable[T], s: Shrink[T], b: Buildable[T,C[T]]): Shrink[C[T]] = ???
+trait ShrinkLowPriorityImplicits:
+  implicit def shrinkAny[T]: Shrink[T] = ???
+
+trait Distribution[F[_], -P, X] extends (P => F[X])
+type GenBeta[A, B, X] = [F[_]] =>> Distribution[F, Beta.Params[A, B], X]
+type Beta[R] = [F[_]] =>> GenBeta[R, R, R][F]
+
+object Beta:
+  trait Params[+A, +B]
+trait BetaInstances:
+  given schrodingerRandomBetaForDouble[F[_]: Monad]: Beta[Double][F] = ???
+
+object all extends BetaInstances
+
+@main def Test =
+  import all.given
+  summon[Shrink[Beta.Params[Double, Double]]]


### PR DESCRIPTION
Backports #20368 to the LTS branch.

PR submitted by the release tooling.
[skip ci]