### PR TITLE
Respect export alias for default arg forwarder

### DIFF
--- a/tests/run/i19587.scala
+++ b/tests/run/i19587.scala
@@ -1,0 +1,34 @@
+case class Foo(bar: String, baz: Int)
+object Foo:
+  def withDefaults(bar: String = "", baz: Int = 42) = Foo(bar, baz)
+
+object Test1:
+  export Foo.withDefaults
+
+object Test2:
+  export Foo.withDefaults as fooWithDefaults
+
+class Bar:
+  infix def bar(other: Bar) = 42
+
+object Baz:
+  val b = Bar()
+  export b.bar
+  export b.bar as baz
+
+@main def Test =
+  // this works
+  assert:
+    Test1.withDefaults("test1") == Foo("test1", 42)
+
+  // this doesn't work
+  assert:
+    Test2.fooWithDefaults("test2") == Foo("test2", 42)
+
+  val b = Bar()
+  println:
+    b bar Bar()
+  println:
+    Baz bar Bar()
+  println:
+    Baz baz Bar()


### PR DESCRIPTION
Fixes #19587 

The default arg getter for the forwarder needs the export alias name.