### PR TITLE
Backport "Bump scalacenter/sbt-dependency-submission from 2 to 3" to LTS

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: scalacenter/sbt-dependency-submission@v2
+      - uses: scalacenter/sbt-dependency-submission@v3


### PR DESCRIPTION
Backports #20440 to the LTS branch.

PR submitted by the release tooling.
[skip ci]