### PR TITLE
Backport "chore: Bump mtags to latest stable" to LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1131,10 +1131,9 @@ object Build {
       BuildInfoPlugin.buildInfoDefaultSettings
 
   lazy val presentationCompilerSettings = {
-    val mtagsVersion = "1.3.0+56-a06a024d-SNAPSHOT"
+    val mtagsVersion = "1.3.1"
 
     Seq(
-      resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",
         "io.get-coursier" % "interface" % "1.0.18",


### PR DESCRIPTION
Backports #20442 to the LTS branch.

PR submitted by the release tooling.
[skip ci]