### PR TITLE
Backport "Avoid the TypeVar.inst trap" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -313,7 +313,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
 
     override def tyconTypeParams(tp: AppliedType)(using Context): List[ParamInfo] =
       def tparams(tycon: Type): List[ParamInfo] = tycon match
-        case tycon: TypeVar if !tycon.inst.exists => tparams(tycon.origin)
+        case tycon: TypeVar if !tycon.isPermanentlyInstantiated => tparams(tycon.origin)
         case tycon: TypeParamRef if !hasBounds(tycon) =>
           val entryParams = entry(tycon).typeParams
           if entryParams.nonEmpty then entryParams
@@ -713,7 +713,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
         var newDepEntry = newEntry
         replacedTypeVar match
           case tvar: TypeVar =>
-            if tvar.inst.exists // `isInstantiated` would use ctx.typerState.constraint rather than the current constraint
+            if tvar.isPermanentlyInstantiated // `isInstantiated` would use ctx.typerState.constraint rather than the current constraint
             then
               // If the type variable has been instantiated, we need to forget about
               // the instantiation for old dependencies.
@@ -770,7 +770,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     @tailrec def allRemovable(last: Int): Boolean =
       if (last < 0) true
       else typeVar(entries, last) match {
-        case tv: TypeVar => tv.inst.exists && allRemovable(last - 1)
+        case tv: TypeVar => tv.isPermanentlyInstantiated && allRemovable(last - 1)
         case _ => false
       }
     allRemovable(paramCount(entries) - 1)
@@ -876,7 +876,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
       val limit = paramCount(entries)
       while i < limit do
         typeVar(entries, i) match
-          case tv: TypeVar if !tv.inst.exists => op(tv)
+          case tv: TypeVar if !tv.isPermanentlyInstantiated => op(tv)
           case _ =>
         i += 1
     }
@@ -885,12 +885,12 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
 
   /** The uninstantiated typevars of this constraint */
   def uninstVars: collection.Seq[TypeVar] = {
-    if (myUninstVars == null || myUninstVars.uncheckedNN.exists(_.inst.exists)) {
+    if (myUninstVars == null || myUninstVars.uncheckedNN.exists(_.isPermanentlyInstantiated)) {
       myUninstVars = new mutable.ArrayBuffer[TypeVar]
       boundsMap.foreachBinding { (poly, entries) =>
         for (i <- 0 until paramCount(entries))
           typeVar(entries, i) match {
-            case tv: TypeVar if !tv.inst.exists && isBounds(entries(i)) => myUninstVars.uncheckedNN += tv
+            case tv: TypeVar if !tv.isPermanentlyInstantiated && isBounds(entries(i)) => myUninstVars.uncheckedNN += tv
             case _ =>
           }
       }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1596,7 +1596,7 @@ object SymDenotations {
       case tp: RefinedType => hasSkolems(tp.parent) || hasSkolems(tp.refinedInfo)
       case tp: RecType => hasSkolems(tp.parent)
       case tp: TypeBounds => hasSkolems(tp.lo) || hasSkolems(tp.hi)
-      case tp: TypeVar => hasSkolems(tp.inst)
+      case tp: TypeVar => hasSkolems(tp.permanentInst)
       case tp: ExprType => hasSkolems(tp.resType)
       case tp: AppliedType => hasSkolems(tp.tycon) || tp.args.exists(hasSkolems)
       case tp: LambdaType => tp.paramInfos.exists(hasSkolems) || hasSkolems(tp.resType)

--- a/compiler/src/dotty/tools/dotc/core/TyperState.scala
+++ b/compiler/src/dotty/tools/dotc/core/TyperState.scala
@@ -230,7 +230,7 @@ class TyperState() {
           val tvars = tl.paramRefs.map(other.typeVarOfParam(_)).collect { case tv: TypeVar => tv }
           if this.isCommittable then
             tvars.foreach(tvar =>
-              if !tvar.inst.exists && !isOwnedAnywhere(this, tvar) then includeVar(tvar))
+              if !tvar.isPermanentlyInstantiated && !isOwnedAnywhere(this, tvar) then includeVar(tvar))
           typeComparer.addToConstraint(tl, tvars)
         }) &&
         // Integrate the additional constraints on type variables from `other`
@@ -286,10 +286,10 @@ class TyperState() {
       for tvar <- ownedVars do
         val tvarState = tvar.owningState.nn.get
         assert(tvarState eqn this, s"Inconsistent state in $this: it owns $tvar whose owningState is ${tvarState}")
-        assert(!tvar.inst.exists, s"Inconsistent state in $this: it owns $tvar which is already instantiated")
+        assert(!tvar.isPermanentlyInstantiated, s"Inconsistent state in $this: it owns $tvar which is already instantiated")
         val inst = constraint.instType(tvar)
         if inst.exists then
-          tvar.setInst(inst)
+          tvar.setPermanentInst(inst)
           val tl = tvar.origin.binder
           if constraint.isRemovable(tl) then toCollect += tl
       for tl <- toCollect do

--- a/tests/pos/i20154.scala
+++ b/tests/pos/i20154.scala
@@ -1,0 +1,15 @@
+sealed abstract class Kyo[+T, -S]
+opaque type <[+T, -S] >: T = T | Kyo[T, S]
+
+abstract class Effect[+E]:
+    type Command[_]
+
+case class Recurse[Command[_], Result[_], E <: Effect[E], T, S, S2](
+    h: ResultHandler[Command, Result, E, S],
+    v: T < (E & S & S2)
+)
+
+abstract class ResultHandler[Command[_], Result[_], E <: Effect[E], S]:
+  opaque type Handle[T, S2] >: (Result[T] < (S & S2)) = Result[T] < (S & S2) | Recurse[Command, Result, E, T, S, S2]
+
+  def handle[T, S2](h: ResultHandler[Command, Result, E, S], v: T < (E & S & S2)): Handle[T, S2] = Recurse(h, v)


### PR DESCRIPTION
Backports #20160 to the LTS branch.

PR submitted by the release tooling.
[skip ci]