### PR TITLE
Backport "bugfix: Exclude newer LSP4j, which is built on JDK 11" to LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1136,8 +1136,10 @@ object Build {
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",
         "io.get-coursier" % "interface" % "1.0.18",
-        "org.scalameta" % "mtags-interfaces" % mtagsVersion,
-        "com.google.guava" % "guava" % "33.2.1-jre"
+        ("org.scalameta" % "mtags-interfaces" % mtagsVersion)
+          .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j")
+          .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j.jsonrpc"),
+        "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.20.1",
       ),
       libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.12" % mtagsVersion % SourceDeps),
       ivyConfigurations += SourceDeps.hide,


### PR DESCRIPTION
Backports #20771 to the LTS branch.

PR submitted by the release tooling.
[skip ci]