### PR TITLE
Backport "Fix #20458: do not expose ClassInfo in quotes reflect widenTermRefByName" to LTS

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1781,7 +1781,10 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def =:=(that: TypeRepr): Boolean = self =:= that
         def <:<(that: TypeRepr): Boolean = self <:< that
         def widen: TypeRepr = self.widen
-        def widenTermRefByName: TypeRepr = self.widenTermRefExpr
+        def widenTermRefByName: TypeRepr =
+          self.widenTermRefExpr match
+            case dotc.core.Types.ClassInfo(prefix, sym, _, _, _) => prefix.select(sym)
+            case other => other
         def widenByName: TypeRepr = self.widenExpr
         def dealias: TypeRepr = self.dealias
         def simplified: TypeRepr = self.simplified

--- a/tests/pos-macros/i20458/Macro_1.scala
+++ b/tests/pos-macros/i20458/Macro_1.scala
@@ -1,0 +1,12 @@
+import scala.quoted._
+
+inline def matchCustom[F](): Unit = ${ matchCustomImpl[F] }
+
+private def matchCustomImpl[F: Type](using q: Quotes): Expr[Unit] = {
+  import q.reflect.*
+  val any = TypeRepr.of[Any].typeSymbol
+  assert(!any.termRef.widenTermRefByName.toString.contains("ClassInfo"))
+  any.termRef.widenTermRefByName.asType match
+    case '[t] => ()
+  '{ () }
+}

--- a/tests/pos-macros/i20458/Test_2.scala
+++ b/tests/pos-macros/i20458/Test_2.scala
@@ -1,0 +1,1 @@
+def main() = matchCustom()


### PR DESCRIPTION
Backports #20468 to the LTS branch.

PR submitted by the release tooling.
[skip ci]