### PR TITLE
Backport "Upgrade  Scala 2 to 2.13.14 (was 2.13.12)" to LTS

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1708,6 +1708,8 @@ object Build {
         "-Dplugin.version=" + version.value,
         "-Dplugin.scalaVersion=" + dottyVersion,
         "-Dplugin.scala2Version=" + stdlibVersion(Bootstrapped),
+        // The last version of Scala 2 that's cross-published for Scala.js 1.12 (version used by LTS)
+        "-Dplugin.scala2ForJSVersion=2.13.13",
         "-Dplugin.scalaJSVersion=" + scalaJSVersion,
         "-Dsbt.boot.directory=" + ((ThisBuild / baseDirectory).value / ".sbt-scripted").getAbsolutePath // Workaround sbt/sbt#3469
       ),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -124,8 +124,8 @@ object Build {
    *  scala-library.
    */
   def stdlibVersion(implicit mode: Mode): String = mode match {
-    case NonBootstrapped => "2.13.13"
-    case Bootstrapped => "2.13.13"
+    case NonBootstrapped => "2.13.14"
+    case Bootstrapped => "2.13.14"
   }
 
   val dottyOrganization = "org.scala-lang"
@@ -1141,7 +1141,7 @@ object Build {
           .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j.jsonrpc"),
         "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.20.1",
       ),
-      libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.13" % mtagsVersion % SourceDeps),
+      libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.14" % mtagsVersion % SourceDeps),
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       Compile / scalacOptions ++= Seq("-Yexplicit-nulls", "-Ysafe-init"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1002,7 +1002,21 @@ object Build {
           IO.createDirectory(trgDir)
           IO.unzip(scalaLibrarySourcesJar, trgDir)
 
-          ((trgDir ** "*.scala") +++ (trgDir ** "*.java")).get.toSet
+          val (ignoredSources, sources) =
+            ((trgDir ** "*.scala") +++ (trgDir ** "*.java")).get.toSet
+              .partition{file =>
+                // sources from https://github.com/scala/scala/tree/2.13.x/src/library-aux
+                val path = file.getPath.replace('\\', '/')
+                path.endsWith("scala-library-src/scala/Any.scala") ||
+                path.endsWith("scala-library-src/scala/AnyVal.scala") ||
+                path.endsWith("scala-library-src/scala/AnyRef.scala") ||
+                path.endsWith("scala-library-src/scala/Nothing.scala") ||
+                path.endsWith("scala-library-src/scala/Null.scala") ||
+                path.endsWith("scala-library-src/scala/Singleton.scala")
+              }
+          // These sources should be never compiled, filtering them out was not working correctly sometimes
+          ignoredSources.foreach(_.delete())
+          sources
         } (Set(scalaLibrarySourcesJar)).toSeq
       }.taskValue,
       (Compile / sourceGenerators) += Def.task {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -124,8 +124,8 @@ object Build {
    *  scala-library.
    */
   def stdlibVersion(implicit mode: Mode): String = mode match {
-    case NonBootstrapped => "2.13.12"
-    case Bootstrapped => "2.13.12"
+    case NonBootstrapped => "2.13.13"
+    case Bootstrapped => "2.13.13"
   }
 
   val dottyOrganization = "org.scala-lang"
@@ -1141,7 +1141,7 @@ object Build {
           .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j.jsonrpc"),
         "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.20.1",
       ),
-      libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.12" % mtagsVersion % SourceDeps),
+      libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.13" % mtagsVersion % SourceDeps),
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       Compile / scalacOptions ++= Seq("-Yexplicit-nulls", "-Ysafe-init"),

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -14,6 +14,12 @@ object MiMaFilters {
     ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.relaxedExtensionImports"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$relaxedExtensionImports$"),
     // end of New experimental features in 3.3.X
+
+    // New in 2.13.13
+    "scala.collection.mutable.ArrayBuffer.resizeUp", // private[mutable] def
+    // New in 2.13.14
+    "scala.util.Properties.consoleIsTerminal", // private[scala] lazy val
+    // end of new in Scala 2
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
   )

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -14,10 +14,6 @@ object MiMaFilters {
     ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.relaxedExtensionImports"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$relaxedExtensionImports$"),
     // end of New experimental features in 3.3.X
-
-    // New in 2.13.12 -- can be removed once scala/scala#10549 lands in 2.13.13
-    // and we take the upgrade here
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.immutable.MapNodeRemoveAllSetNodeIterator.next"),
   )
   val TastyCore: Seq[ProblemFilter] = Seq(
   )

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -14,13 +14,12 @@ object MiMaFilters {
     ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.relaxedExtensionImports"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$relaxedExtensionImports$"),
     // end of New experimental features in 3.3.X
-
-    // New in 2.13.13
-    "scala.collection.mutable.ArrayBuffer.resizeUp", // private[mutable] def
-    // New in 2.13.14
-    "scala.util.Properties.consoleIsTerminal", // private[scala] lazy val
-    // end of new in Scala 2
-  )
+    ) ++ Seq(
+      // New in 2.13.13
+      "scala.collection.mutable.ArrayBuffer.resizeUp", // private[mutable] def
+      // New in 2.13.14
+      "scala.util.Properties.consoleIsTerminal", // private[scala] lazy val
+    ).map(ProblemFilters.exclude[DirectMissingMethodProblem])
   val TastyCore: Seq[ProblemFilter] = Seq(
   )
   val Interfaces: Seq[ProblemFilter] = Seq(

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -14,12 +14,7 @@ object MiMaFilters {
     ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.stdLibPatches.language#experimental.relaxedExtensionImports"),
     ProblemFilters.exclude[MissingClassProblem]("scala.runtime.stdLibPatches.language$experimental$relaxedExtensionImports$"),
     // end of New experimental features in 3.3.X
-    ) ++ Seq(
-      // New in 2.13.13
-      "scala.collection.mutable.ArrayBuffer.resizeUp", // private[mutable] def
-      // New in 2.13.14
-      "scala.util.Properties.consoleIsTerminal", // private[scala] lazy val
-    ).map(ProblemFilters.exclude[DirectMissingMethodProblem])
+  )
   val TastyCore: Seq[ProblemFilter] = Seq(
   )
   val Interfaces: Seq[ProblemFilter] = Seq(

--- a/sbt-test/scala2-compat/erasure-scalajs/build.sbt
+++ b/sbt-test/scala2-compat/erasure-scalajs/build.sbt
@@ -1,7 +1,7 @@
 lazy val scala2Lib = project.in(file("scala2Lib"))
   .enablePlugins(ScalaJSPlugin)
   .settings(
-    scalaVersion := sys.props("plugin.scala2Version")
+    scalaVersion := sys.props("plugin.scala2ForJSVersion")
   )
 
 lazy val dottyApp = project.in(file("dottyApp"))


### PR DESCRIPTION
Backports #20902 to the LTS branch.

PR submitted by the release tooling.