### PR TITLE
expand classpath of pathing jars in scala_legacy command

### DIFF
--- a/dist/bin/scala_legacy
+++ b/dist/bin/scala_legacy
@@ -65,7 +65,7 @@ done
 # exec here would prevent onExit from being called, leaving terminal in unusable state
 compilerJavaClasspathArgs
 [ -z "${ConEmuPID-}" -o -n "${cygwin-}" ] && export MSYSTEM= PWD= # workaround for #12405
-eval "\"$JAVACMD\"" "${java_args[@]}" "-Dscala.home=\"$PROG_HOME\"" "-classpath \"$jvm_cp_args\"" "dotty.tools.MainGenericRunner" "-classpath \"$jvm_cp_args\"" "${scala_args[@]}"
+eval "\"$JAVACMD\"" "${java_args[@]}" "-Dscala.home=\"$PROG_HOME\"" "-classpath \"$jvm_cp_args\"" "-Dscala.expandjavacp=true" "dotty.tools.MainGenericRunner" "-classpath \"$jvm_cp_args\"" "${scala_args[@]}"
 scala_exit_status=$?
 
 


### PR DESCRIPTION
I think it still be best to delete the command, but we should ensure it works if we're going to ship it

this should have been part of #21121 