### PR TITLE
Backport "Correct Java signature for value classes appearing in type arguments" to LTS

### DIFF
--- a/tests/pos/i10347/C_2.java
+++ b/tests/pos/i10347/C_2.java
@@ -1,5 +1,5 @@
 public class C_2 {
   String hi = A.foo().head();
-  String hy = A.bar().head();
+  String hy = A.bar().head().s();
   String hj = A.baz("").head();
 }

--- a/tests/run/i10846.check
+++ b/tests/run/i10846.check
@@ -1,0 +1,3 @@
+i10846.V: scala.Option<i10846.V>
+i10846.U: scala.Option<i10846.U>
+i10846.W: scala.Option<i10846.W<scala.Function1<java.lang.Object, java.lang.String>>>

--- a/tests/run/i10846/i10846.scala
+++ b/tests/run/i10846/i10846.scala
@@ -1,0 +1,28 @@
+// scalajs: --skip
+
+package i10846 {
+  final class V(val x: Int) extends AnyVal
+  object V { def get: Option[V] = null }
+
+  final class U(val y: String) extends AnyVal
+  object U { def get: Option[U] = null }
+
+  final class W[T](val z: T) extends AnyVal
+  object W { def get: Option[W[Int => String]] = null }
+}
+
+
+object Test extends scala.App {
+  def check[T](implicit tt: reflect.ClassTag[T]): Unit = {
+    val companion = tt.runtimeClass.getClassLoader.loadClass(tt.runtimeClass.getName + '$')
+    val get = companion.getMethod("get")
+    assert(get.getReturnType == classOf[Option[_]])
+    println(s"${tt.runtimeClass.getName}: ${get.getGenericReturnType}")
+  }
+
+  import i10846._
+
+  check[V]
+  check[U]
+  check[W[_]]
+}


### PR DESCRIPTION
Backports #20463 to the LTS branch.

PR submitted by the release tooling.
[skip ci]