### PR TITLE
Backport "Use final result type to check selector bound" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -729,7 +729,7 @@ object CheckUnused:
             if selector.isGiven then
               // Further check that the symbol is a given or implicit and conforms to the bound
               sym.isOneOf(Given | Implicit)
-                && (selector.bound.isEmpty || sym.info <:< selector.boundTpe)
+                && (selector.bound.isEmpty || sym.info.finalResultType <:< selector.boundTpe)
             else
               // Normal wildcard, check that the symbol is not a given (but can be implicit)
               !sym.is(Given)

--- a/tests/pos/i20860.scala
+++ b/tests/pos/i20860.scala
@@ -1,0 +1,3 @@
+def `i20860 use result to check selector bound`: Unit =
+  import Ordering.Implicits.given Ordering[?]
+  summon[Ordering[Seq[Int]]]


### PR DESCRIPTION
Backports #20989 to the LTS branch.

PR submitted by the release tooling.
[skip ci]