### PR TITLE
Regression test for extension nullification, nowarn for different opacities

### DIFF
--- a/tests/warn/i21190.scala
+++ b/tests/warn/i21190.scala
@@ -1,0 +1,23 @@
+
+//> using options -Werror
+
+opaque type FromEnd = Int
+object FromEnd:
+  inline def apply(i: Int): FromEnd = i
+  extension (fe: FromEnd)
+    inline def value: Int = fe
+
+// Warning appears when extension is in same namespace as opaque type
+extension [A](a: Array[A])
+  inline def apply(fe: FromEnd): A =
+    a(a.length - 1 - FromEnd.value(fe))
+
+class R:
+  def run(): String =
+    val xs = Array(1, 2, 3)
+
+    s"""First element = ${xs(0)}
+       |Last element = ${xs(FromEnd(0))}""".stripMargin
+
+@main def test = println:
+  R().run()


### PR DESCRIPTION
Fixes #21190 

~Adjust~ test that params must not be of different opacity ~opaque~.

~Other aliases are permitted, but could check if they are effectively final. String alias can't be overridden.~

The tweak was https://github.com/scala/scala3/pull/22268 and the ticket was a duplicate. In the meantime, it also doesn't warn for any override, so the previous concern about aliases doesn't apply.