### PR TITLE
add child to parent in completion context

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -848,7 +848,7 @@ class Namer { typer: Typer =>
       else
         try
           completeInCreationContext(denot)
-          if (denot.isCompleted) registerIfChild(denot)
+          if (denot.isCompleted) registerIfChildInCreationContext(denot)
         catch
           case ex: CompilationUnit.SuspendException =>
             val completer = SuspendCompleter()
@@ -937,10 +937,12 @@ class Namer { typer: Typer =>
         denot.markAbsent()
     end invalidateIfClashingSynthetic
 
-    /** If completed symbol is an enum value or a named class, register it as a child
+    /** Intentionally left without `using Context` parameter.
+     *  This action should be performed in the context of where the completer was created.
+     *  If completed symbol is an enum value or a named class, register it as a child
      *  in all direct parent classes which are sealed.
      */
-    def registerIfChild(denot: SymDenotation)(using Context): Unit = {
+    def registerIfChildInCreationContext(denot: SymDenotation): Unit = {
       val sym = denot.symbol
 
       def register(child: Symbol, parentCls: ClassSymbol) = {
@@ -964,7 +966,7 @@ class Namer { typer: Typer =>
       end if
     }
 
-    /** Intentionally left without `implicit ctx` parameter. We need
+    /** Intentionally left without `using Context` parameter. We need
      *  to pick up the context at the point where the completer was created.
      */
     def completeInCreationContext(denot: SymDenotation): Unit = {

--- a/tests/pos/i21154/A.scala
+++ b/tests/pos/i21154/A.scala
@@ -1,0 +1,6 @@
+import Z.*
+
+object A:
+  val a: Option[AOptions] = ???
+  val b: Option[BOptions] = ???
+  val c: Option[COptions] = ???

--- a/tests/pos/i21154/Z.scala
+++ b/tests/pos/i21154/Z.scala
@@ -1,0 +1,9 @@
+//> using options -Ytest-pickler-check
+
+// in the original issue https://github.com/scala/scala3/issues/21154, the non-deterministic tasty
+// depends on the order of compilation of files, the use-site (A.scala) has to come first,
+// and the file defining the enum has to come second (Z.scala), A.scala in namer will force Z to complete.
+enum Z:
+  case AOptions()
+  case BOptions()
+  case COptions()

--- a/tests/pos/i21154/Z.tastycheck
+++ b/tests/pos/i21154/Z.tastycheck
@@ -1,0 +1,1340 @@
+Header:
+  version: <elided>
+  tooling: <elided>
+     UUID: <elided>
+
+Names (936 bytes, starting from <elided base index>):
+     0: ASTs
+     1: <empty>
+     2: Z
+     3: <init>
+     4: java
+     5: lang
+     6: java[Qualified . lang]
+     7: Object
+     8: java[Qualified . lang][Qualified . Object]
+     9: <init>[Signed Signature(List(),java.lang.Object) @<init>]
+    10: Enum
+    11: scala
+    12: reflect
+    13: scala[Qualified . reflect]
+    14: Unit
+    15: AOptions
+    16: BOptions
+    17: COptions
+    18: SourceFile
+    19: annotation
+    20: scala[Qualified . annotation]
+    21: internal
+    22: scala[Qualified . annotation][Qualified . internal]
+    23: scala[Qualified . annotation][Qualified . internal][Qualified . SourceFile]
+    24: String
+    25: java[Qualified . lang][Qualified . String]
+    26: <init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]
+    27: <elided source file name>
+    28: Child
+    29: scala[Qualified . annotation][Qualified . internal][Qualified . Child]
+    30: <init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]
+    31: Z[ModuleClass]
+    32: <init>[Signed Signature(List(),Z$) @<init>]
+    33: AnyRef
+    34: Sum
+    35: Mirror
+    36: Mirror[ModuleClass]
+    37: deriving
+    38: scala[Qualified . deriving]
+    39: _
+    40: writeReplace
+    41: runtime
+    42: scala[Qualified . runtime]
+    43: ModuleSerializationProxy
+    44: scala[Qualified . runtime][Qualified . ModuleSerializationProxy]
+    45: Class
+    46: java[Qualified . lang][Qualified . Class]
+    47: <init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]
+    48: <init>[Signed Signature(List(),Z) @<init>]
+    49: hashCode
+    50: Int
+    51: _hashCode
+    52: scala[Qualified . Int]
+    53: Product
+    54: scala[Qualified . Product]
+    55: _hashCode[Signed Signature(List(scala.Product),scala.Int) @_hashCode]
+    56: ScalaRunTime
+    57: ScalaRunTime[ModuleClass]
+    58: equals
+    59: x$0
+    60: Any
+    61: Boolean
+    62: ||
+    63: scala[Qualified . Boolean]
+    64: ||[Signed Signature(List(scala.Boolean),scala.Boolean) @||]
+    65: eq
+    66: eq[Signed Signature(List(java.lang.Object),scala.Boolean) @eq]
+    67: $asInstanceOf$
+    68: $asInstanceOf$[Signed Signature(List(1),java.lang.Object) @$asInstanceOf$]
+    69: unchecked
+    70: scala[Qualified . unchecked]
+    71: <init>[Signed Signature(List(),scala.unchecked) @<init>]
+    72: toString
+    73: _toString
+    74: _toString[Signed Signature(List(scala.Product),java.lang.String) @_toString]
+    75: canEqual
+    76: that
+    77: isInstanceOf
+    78: isInstanceOf[Signed Signature(List(1),scala.Boolean) @isInstanceOf]
+    79: productArity
+    80: productPrefix
+    81: Predef
+    82: productElement
+    83: n
+    84: IndexOutOfBoundsException
+    85: java[Qualified . lang][Qualified . IndexOutOfBoundsException]
+    86: <init>[Signed Signature(List(java.lang.String),java.lang.IndexOutOfBoundsException) @<init>]
+    87: toString[Signed Signature(List(),java.lang.String) @toString]
+    88: productElementName
+    89: copy
+    90: Z[ModuleClass][Qualified . AOptions]
+    91: <init>[Signed Signature(List(),Z$.AOptions) @<init>]
+    92: ordinal
+    93: AOptions[ModuleClass]
+    94: Z[ModuleClass][Qualified . AOptions][ModuleClass]
+    95: <init>[Signed Signature(List(),Z$.AOptions$) @<init>]
+    96: apply
+    97: unapply
+    98: x$1
+    99: MirroredMonoType
+   100: fromProduct
+   101: Z[ModuleClass][Qualified . BOptions]
+   102: <init>[Signed Signature(List(),Z$.BOptions) @<init>]
+   103: BOptions[ModuleClass]
+   104: Z[ModuleClass][Qualified . BOptions][ModuleClass]
+   105: <init>[Signed Signature(List(),Z$.BOptions$) @<init>]
+   106: Z[ModuleClass][Qualified . COptions]
+   107: <init>[Signed Signature(List(),Z$.COptions) @<init>]
+   108: COptions[ModuleClass]
+   109: Z[ModuleClass][Qualified . COptions][ModuleClass]
+   110: <init>[Signed Signature(List(),Z$.COptions$) @<init>]
+   111: fromOrdinal
+   112: util
+   113: java[Qualified . util]
+   114: NoSuchElementException
+   115: java[Qualified . util][Qualified . NoSuchElementException]
+   116: <init>[Signed Signature(List(java.lang.String),java.util.NoSuchElementException) @<init>]
+   117: +
+   118: +[Signed Signature(List(java.lang.Object),java.lang.String) @+]
+   119: enum Z has no case with ordinal: 
+   120: Positions
+   121: Comments
+   122: Attributes
+
+Trees (1886 bytes, starting from <elided base index>):
+     0: PACKAGE(1883)
+     3:   TERMREFpkg 1 [<empty>]
+     5:   TYPEDEF(132) 2 [Z]
+     9:     TEMPLATE(39)
+    11:       APPLY(10)
+    13:         SELECTin(8) 9 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+    16:           NEW
+    17:             TYPEREF 7 [Object]
+    19:               TERMREFpkg 6 [java[Qualified . lang]]
+    21:           SHAREDtype 17
+    23:       TYPEREF 10 [Enum]
+    25:         TERMREFpkg 13 [scala[Qualified . reflect]]
+    27:       DEFDEF(7) 3 [<init>]
+    30:         EMPTYCLAUSE
+    31:         TYPEREF 14 [Unit]
+    33:           TERMREFpkg 11 [scala]
+    35:         STABLE
+    36:       IMPORT(12)
+    38:         TERMREFsymbol 140
+    41:           THIS
+    42:             TYPEREFpkg 1 [<empty>]
+    44:         IMPORTED 15 [AOptions]
+    46:         IMPORTED 16 [BOptions]
+    48:         IMPORTED 17 [COptions]
+    50:     ENUM
+    51:     SEALED
+    52:     ABSTRACT
+    53:     ANNOTATION(16)
+    55:       TYPEREF 18 [SourceFile]
+    57:         TERMREFpkg 22 [scala[Qualified . annotation][Qualified . internal]]
+    59:       APPLY(10)
+    61:         SELECTin(6) 26 [<init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]]
+    64:           NEW
+    65:             SHAREDtype 55
+    67:           SHAREDtype 55
+    69:         STRINGconst 27 [<elided source file name>]
+    71:     ANNOTATION(25)
+    73:       TYPEREF 28 [Child]
+    75:         SHAREDtype 57
+    77:       APPLY(19)
+    79:         TYPEAPPLY(17)
+    81:           SELECTin(6) 30 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
+    84:             NEW
+    85:               SHAREDtype 73
+    87:             SHAREDtype 73
+    89:           TYPEREFsymbol 1280
+    92:             THIS
+    93:               TYPEREFsymbol 160
+    96:                 SHAREDtype 41
+    98:     ANNOTATION(19)
+   100:       SHAREDtype 73
+   102:       APPLY(15)
+   104:         TYPEAPPLY(13)
+   106:           SELECTin(6) 30 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
+   109:             NEW
+   110:               SHAREDtype 73
+   112:             SHAREDtype 73
+   114:           TYPEREFsymbol 769
+   117:             SHAREDtype 92
+   119:     ANNOTATION(19)
+   121:       SHAREDtype 73
+   123:       APPLY(15)
+   125:         TYPEAPPLY(13)
+   127:           SELECTin(6) 30 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
+   130:             NEW
+   131:               SHAREDtype 73
+   133:             SHAREDtype 73
+   135:           TYPEREFsymbol 223
+   138:             SHAREDtype 92
+   140:   VALDEF(18) 2 [Z]
+   143:     IDENTtpt 31 [Z[ModuleClass]]
+   145:       SHAREDtype 93
+   147:     APPLY(9)
+   149:       SELECTin(7) 32 [<init>[Signed Signature(List(),Z$) @<init>]]
+   152:         NEW
+   153:           SHAREDterm 143
+   156:         SHAREDtype 93
+   158:     OBJECT
+   159:     SYNTHETIC
+   160:   TYPEDEF(1723) 31 [Z[ModuleClass]]
+   164:     TEMPLATE(1701)
+   167:       APPLY(10)
+   169:         SELECTin(8) 9 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+   172:           NEW
+   173:             TYPEREF 33 [AnyRef]
+   175:               SHAREDtype 33
+   177:           SHAREDtype 17
+   179:       TYPEREF 34 [Sum]
+   181:         THIS
+   182:           TYPEREF 36 [Mirror[ModuleClass]]
+   184:             TERMREFpkg 38 [scala[Qualified . deriving]]
+   186:       SELFDEF 39 [_]
+   188:         SINGLETONtpt
+   189:           SHAREDtype 38
+   191:       DEFDEF(5) 3 [<init>]
+   194:         EMPTYCLAUSE
+   195:         SHAREDtype 31
+   197:         STABLE
+   198:       DEFDEF(23) 40 [writeReplace]
+   201:         EMPTYCLAUSE
+   202:         SHAREDtype 173
+   205:         APPLY(14)
+   207:           SELECTin(9) 47 [<init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]]
+   210:             NEW
+   211:               TYPEREF 43 [ModuleSerializationProxy]
+   213:                 TERMREFpkg 42 [scala[Qualified . runtime]]
+   215:             SHAREDtype 211
+   218:           CLASSconst
+   219:             SHAREDtype 38
+   221:         PRIVATE
+   222:         SYNTHETIC
+   223:       TYPEDEF(369) 15 [AOptions]
+   227:         TEMPLATE(362)
+   230:           APPLY(11)
+   232:             SELECTin(9) 48 [<init>[Signed Signature(List(),Z) @<init>]]
+   235:               NEW
+   236:                 TYPEREFsymbol 5
+   238:                   SHAREDtype 41
+   240:               SHAREDtype 236
+   243:           DEFDEF(5) 3 [<init>]
+   246:             EMPTYCLAUSE
+   247:             SHAREDtype 31
+   249:             STABLE
+   250:           DEFDEF(24) 49 [hashCode]
+   253:             EMPTYCLAUSE
+   254:             TYPEREF 50 [Int]
+   256:               SHAREDtype 33
+   258:             APPLY(14)
+   260:               TERMREF 55 [_hashCode[Signed Signature(List(scala.Product),scala.Int) @_hashCode]]
+   262:                 THIS
+   263:                   TYPEREF 57 [ScalaRunTime[ModuleClass]]
+   265:                     SHAREDtype 213
+   268:               QUALTHIS
+   269:                 IDENTtpt 15 [AOptions]
+   271:                   SHAREDtype 135
+   274:             OVERRIDE
+   275:             SYNTHETIC
+   276:           DEFDEF(96) 58 [equals]
+   279:             PARAM(5) 59 [x$0]
+   282:               TYPEREF 60 [Any]
+   284:                 SHAREDtype 33
+   286:             TYPEREF 61 [Boolean]
+   288:               SHAREDtype 33
+   290:             APPLY(80)
+   292:               SELECTin(30) 64 [||[Signed Signature(List(scala.Boolean),scala.Boolean) @||]]
+   295:                 APPLY(24)
+   297:                   SELECTin(9) 66 [eq[Signed Signature(List(java.lang.Object),scala.Boolean) @eq]]
+   300:                     QUALTHIS
+   301:                       IDENTtpt 15 [AOptions]
+   303:                         SHAREDtype 135
+   306:                     SHAREDtype 17
+   308:                   TYPEAPPLY(11)
+   310:                     SELECTin(7) 68 [$asInstanceOf$[Signed Signature(List(1),java.lang.Object) @$asInstanceOf$]]
+   313:                       TERMREFdirect 279
+   316:                       SHAREDtype 282
+   319:                     SHAREDtype 17
+   321:                 SHAREDtype 286
+   324:               MATCH(46)
+   326:                 SHAREDterm 313
+   329:                 CASEDEF(33)
+   331:                   BIND(30) 59 [x$0]
+   334:                     SHAREDtype 135
+   337:                     TYPED(23)
+   339:                       IDENT 39 [_]
+   341:                         ANNOTATEDtype(16)
+   343:                           SHAREDtype 135
+   346:                           APPLY(11)
+   348:                             SELECTin(9) 71 [<init>[Signed Signature(List(),scala.unchecked) @<init>]]
+   351:                               NEW
+   352:                                 TYPEREF 69 [unchecked]
+   354:                                   SHAREDtype 33
+   356:                               SHAREDtype 352
+   359:                       SHAREDtype 341
+   362:                     SYNTHETIC
+   363:                   TRUEconst
+   364:                 CASEDEF(6)
+   366:                   IDENT 39 [_]
+   368:                     SHAREDtype 282
+   371:                   FALSEconst
+   372:             OVERRIDE
+   373:             SYNTHETIC
+   374:           DEFDEF(21) 72 [toString]
+   377:             EMPTYCLAUSE
+   378:             TYPEREF 24 [String]
+   380:               SHAREDtype 19
+   382:             APPLY(11)
+   384:               TERMREF 74 [_toString[Signed Signature(List(scala.Product),java.lang.String) @_toString]]
+   386:                 SHAREDtype 262
+   389:               QUALTHIS
+   390:                 IDENTtpt 15 [AOptions]
+   392:                   SHAREDtype 135
+   395:             OVERRIDE
+   396:             SYNTHETIC
+   397:           DEFDEF(40) 75 [canEqual]
+   400:             PARAM(4) 76 [that]
+   403:               SHAREDtype 282
+   406:             SHAREDtype 286
+   409:             TYPEAPPLY(26)
+   411:               SELECTin(7) 78 [isInstanceOf[Signed Signature(List(1),scala.Boolean) @isInstanceOf]]
+   414:                 TERMREFdirect 400
+   417:                 SHAREDtype 282
+   420:               ANNOTATEDtype(15)
+   422:                 SHAREDtype 135
+   425:                 APPLY(10)
+   427:                   SELECTin(8) 71 [<init>[Signed Signature(List(),scala.unchecked) @<init>]]
+   430:                     NEW
+   431:                       SHAREDtype 352
+   434:                     SHAREDtype 352
+   437:             OVERRIDE
+   438:             SYNTHETIC
+   439:           DEFDEF(8) 79 [productArity]
+   442:             SHAREDtype 254
+   445:             INTconst 0
+   447:             OVERRIDE
+   448:             SYNTHETIC
+   449:           DEFDEF(11) 80 [productPrefix]
+   452:             TYPEREF 24 [String]
+   454:               TERMREF 81 [Predef]
+   456:                 SHAREDtype 33
+   458:             STRINGconst 15 [AOptions]
+   460:             OVERRIDE
+   461:             SYNTHETIC
+   462:           DEFDEF(49) 82 [productElement]
+   465:             PARAM(4) 83 [n]
+   468:               SHAREDtype 254
+   471:             SHAREDtype 282
+   474:             MATCH(35)
+   476:               TERMREFdirect 465
+   479:               CASEDEF(30)
+   481:                 IDENT 39 [_]
+   483:                   SHAREDtype 254
+   486:                 THROW
+   487:                   APPLY(22)
+   489:                     SELECTin(9) 86 [<init>[Signed Signature(List(java.lang.String),java.lang.IndexOutOfBoundsException) @<init>]]
+   492:                       NEW
+   493:                         TYPEREF 84 [IndexOutOfBoundsException]
+   495:                           SHAREDtype 19
+   497:                       SHAREDtype 493
+   500:                     APPLY(9)
+   502:                       SELECTin(7) 87 [toString[Signed Signature(List(),java.lang.String) @toString]]
+   505:                         SHAREDterm 476
+   508:                         SHAREDtype 282
+   511:             OVERRIDE
+   512:             SYNTHETIC
+   513:           DEFDEF(48) 88 [productElementName]
+   516:             PARAM(4) 83 [n]
+   519:               SHAREDtype 254
+   522:             SHAREDtype 452
+   525:             MATCH(34)
+   527:               TERMREFdirect 516
+   530:               CASEDEF(29)
+   532:                 IDENT 39 [_]
+   534:                   SHAREDtype 254
+   537:                 THROW
+   538:                   APPLY(21)
+   540:                     SELECTin(8) 86 [<init>[Signed Signature(List(java.lang.String),java.lang.IndexOutOfBoundsException) @<init>]]
+   543:                       NEW
+   544:                         SHAREDtype 493
+   547:                       SHAREDtype 493
+   550:                     APPLY(9)
+   552:                       SELECTin(7) 87 [toString[Signed Signature(List(),java.lang.String) @toString]]
+   555:                         SHAREDterm 527
+   558:                         SHAREDtype 282
+   561:             OVERRIDE
+   562:             SYNTHETIC
+   563:           DEFDEF(18) 89 [copy]
+   566:             EMPTYCLAUSE
+   567:             SHAREDtype 135
+   570:             APPLY(10)
+   572:               SELECTin(8) 91 [<init>[Signed Signature(List(),Z$.AOptions) @<init>]]
+   575:                 NEW
+   576:                   SHAREDtype 135
+   579:                 SHAREDtype 135
+   582:             SYNTHETIC
+   583:           DEFDEF(7) 92 [ordinal]
+   586:             SHAREDtype 254
+   589:             INTconst 0
+   591:             SYNTHETIC
+   592:         FINAL
+   593:         CASE
+   594:         ENUM
+   595:       VALDEF(22) 15 [AOptions]
+   598:         IDENTtpt 93 [AOptions[ModuleClass]]
+   600:           TYPEREFsymbol 619
+   603:             SHAREDtype 92
+   605:         APPLY(10)
+   607:           SELECTin(8) 95 [<init>[Signed Signature(List(),Z$.AOptions$) @<init>]]
+   610:             NEW
+   611:               SHAREDterm 598
+   614:             SHAREDtype 600
+   617:         OBJECT
+   618:         SYNTHETIC
+   619:       TYPEDEF(147) 93 [AOptions[ModuleClass]]
+   623:         TEMPLATE(141)
+   626:           APPLY(9)
+   628:             SELECTin(7) 9 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+   631:               NEW
+   632:                 SHAREDtype 173
+   635:               SHAREDtype 17
+   637:           TYPEREF 53 [Product]
+   639:             SHAREDtype 181
+   642:           SELFDEF 39 [_]
+   644:             SINGLETONtpt
+   645:               TERMREFsymbol 595
+   648:                 SHAREDtype 92
+   650:           DEFDEF(5) 3 [<init>]
+   653:             EMPTYCLAUSE
+   654:             SHAREDtype 31
+   656:             STABLE
+   657:           DEFDEF(23) 40 [writeReplace]
+   660:             EMPTYCLAUSE
+   661:             SHAREDtype 173
+   664:             APPLY(14)
+   666:               SELECTin(8) 47 [<init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]]
+   669:                 NEW
+   670:                   SHAREDtype 211
+   673:                 SHAREDtype 211
+   676:               CLASSconst
+   677:                 SHAREDtype 645
+   680:             PRIVATE
+   681:             SYNTHETIC
+   682:           DEFDEF(18) 96 [apply]
+   685:             EMPTYCLAUSE
+   686:             SHAREDtype 135
+   689:             APPLY(10)
+   691:               SELECTin(8) 91 [<init>[Signed Signature(List(),Z$.AOptions) @<init>]]
+   694:                 NEW
+   695:                   SHAREDtype 135
+   698:                 SHAREDtype 135
+   701:             SYNTHETIC
+   702:           DEFDEF(12) 97 [unapply]
+   705:             PARAM(5) 98 [x$1]
+   708:               SHAREDtype 135
+   711:               SYNTHETIC
+   712:             SINGLETONtpt
+   713:               TRUEconst
+   714:             TRUEconst
+   715:             SYNTHETIC
+   716:           DEFDEF(8) 72 [toString]
+   719:             SHAREDtype 378
+   722:             STRINGconst 15 [AOptions]
+   724:             OVERRIDE
+   725:             SYNTHETIC
+   726:           TYPEDEF(9) 99 [MirroredMonoType]
+   729:             TYPEBOUNDS(5)
+   731:               TYPEREFsymbol 223
+   734:                 SHAREDtype 38
+   736:             SYNTHETIC
+   737:           DEFDEF(28) 100 [fromProduct]
+   740:             PARAM(5) 59 [x$0]
+   743:               TYPEREF 53 [Product]
+   745:                 SHAREDtype 33
+   747:             TYPEREFsymbol 726
+   750:               THIS
+   751:                 SHAREDtype 600
+   754:             APPLY(10)
+   756:               SELECTin(8) 91 [<init>[Signed Signature(List(),Z$.AOptions) @<init>]]
+   759:                 NEW
+   760:                   SHAREDtype 135
+   763:                 SHAREDtype 135
+   766:             SYNTHETIC
+   767:         OBJECT
+   768:         SYNTHETIC
+   769:       TYPEDEF(343) 16 [BOptions]
+   773:         TEMPLATE(336)
+   776:           APPLY(10)
+   778:             SELECTin(8) 48 [<init>[Signed Signature(List(),Z) @<init>]]
+   781:               NEW
+   782:                 SHAREDtype 236
+   785:               SHAREDtype 236
+   788:           DEFDEF(5) 3 [<init>]
+   791:             EMPTYCLAUSE
+   792:             SHAREDtype 31
+   794:             STABLE
+   795:           DEFDEF(17) 49 [hashCode]
+   798:             EMPTYCLAUSE
+   799:             SHAREDtype 254
+   802:             APPLY(8)
+   804:               SHAREDtype 260
+   807:               QUALTHIS
+   808:                 IDENTtpt 16 [BOptions]
+   810:                   SHAREDtype 114
+   812:             OVERRIDE
+   813:             SYNTHETIC
+   814:           DEFDEF(90) 58 [equals]
+   817:             PARAM(4) 59 [x$0]
+   820:               SHAREDtype 282
+   823:             SHAREDtype 286
+   826:             APPLY(76)
+   828:               SELECTin(29) 64 [||[Signed Signature(List(scala.Boolean),scala.Boolean) @||]]
+   831:                 APPLY(23)
+   833:                   SELECTin(8) 66 [eq[Signed Signature(List(java.lang.Object),scala.Boolean) @eq]]
+   836:                     QUALTHIS
+   837:                       IDENTtpt 16 [BOptions]
+   839:                         SHAREDtype 114
+   841:                     SHAREDtype 17
+   843:                   TYPEAPPLY(11)
+   845:                     SELECTin(7) 68 [$asInstanceOf$[Signed Signature(List(1),java.lang.Object) @$asInstanceOf$]]
+   848:                       TERMREFdirect 817
+   851:                       SHAREDtype 282
+   854:                     SHAREDtype 17
+   856:                 SHAREDtype 286
+   859:               MATCH(43)
+   861:                 SHAREDterm 848
+   864:                 CASEDEF(30)
+   866:                   BIND(27) 59 [x$0]
+   869:                     SHAREDtype 114
+   871:                     TYPED(21)
+   873:                       IDENT 39 [_]
+   875:                         ANNOTATEDtype(14)
+   877:                           SHAREDtype 114
+   879:                           APPLY(10)
+   881:                             SELECTin(8) 71 [<init>[Signed Signature(List(),scala.unchecked) @<init>]]
+   884:                               NEW
+   885:                                 SHAREDtype 352
+   888:                               SHAREDtype 352
+   891:                       SHAREDtype 875
+   894:                     SYNTHETIC
+   895:                   TRUEconst
+   896:                 CASEDEF(6)
+   898:                   IDENT 39 [_]
+   900:                     SHAREDtype 282
+   903:                   FALSEconst
+   904:             OVERRIDE
+   905:             SYNTHETIC
+   906:           DEFDEF(17) 72 [toString]
+   909:             EMPTYCLAUSE
+   910:             SHAREDtype 378
+   913:             APPLY(8)
+   915:               SHAREDtype 384
+   918:               QUALTHIS
+   919:                 IDENTtpt 16 [BOptions]
+   921:                   SHAREDtype 114
+   923:             OVERRIDE
+   924:             SYNTHETIC
+   925:           DEFDEF(39) 75 [canEqual]
+   928:             PARAM(4) 76 [that]
+   931:               SHAREDtype 282
+   934:             SHAREDtype 286
+   937:             TYPEAPPLY(25)
+   939:               SELECTin(7) 78 [isInstanceOf[Signed Signature(List(1),scala.Boolean) @isInstanceOf]]
+   942:                 TERMREFdirect 928
+   945:                 SHAREDtype 282
+   948:               ANNOTATEDtype(14)
+   950:                 SHAREDtype 114
+   952:                 APPLY(10)
+   954:                   SELECTin(8) 71 [<init>[Signed Signature(List(),scala.unchecked) @<init>]]
+   957:                     NEW
+   958:                       SHAREDtype 352
+   961:                     SHAREDtype 352
+   964:             OVERRIDE
+   965:             SYNTHETIC
+   966:           DEFDEF(8) 79 [productArity]
+   969:             SHAREDtype 254
+   972:             INTconst 0
+   974:             OVERRIDE
+   975:             SYNTHETIC
+   976:           DEFDEF(8) 80 [productPrefix]
+   979:             SHAREDtype 452
+   982:             STRINGconst 16 [BOptions]
+   984:             OVERRIDE
+   985:             SYNTHETIC
+   986:           DEFDEF(48) 82 [productElement]
+   989:             PARAM(4) 83 [n]
+   992:               SHAREDtype 254
+   995:             SHAREDtype 282
+   998:             MATCH(34)
+  1000:               TERMREFdirect 989
+  1003:               CASEDEF(29)
+  1005:                 IDENT 39 [_]
+  1007:                   SHAREDtype 254
+  1010:                 THROW
+  1011:                   APPLY(21)
+  1013:                     SELECTin(8) 86 [<init>[Signed Signature(List(java.lang.String),java.lang.IndexOutOfBoundsException) @<init>]]
+  1016:                       NEW
+  1017:                         SHAREDtype 493
+  1020:                       SHAREDtype 493
+  1023:                     APPLY(9)
+  1025:                       SELECTin(7) 87 [toString[Signed Signature(List(),java.lang.String) @toString]]
+  1028:                         SHAREDterm 1000
+  1031:                         SHAREDtype 282
+  1034:             OVERRIDE
+  1035:             SYNTHETIC
+  1036:           DEFDEF(48) 88 [productElementName]
+  1039:             PARAM(4) 83 [n]
+  1042:               SHAREDtype 254
+  1045:             SHAREDtype 452
+  1048:             MATCH(34)
+  1050:               TERMREFdirect 1039
+  1053:               CASEDEF(29)
+  1055:                 IDENT 39 [_]
+  1057:                   SHAREDtype 254
+  1060:                 THROW
+  1061:                   APPLY(21)
+  1063:                     SELECTin(8) 86 [<init>[Signed Signature(List(java.lang.String),java.lang.IndexOutOfBoundsException) @<init>]]
+  1066:                       NEW
+  1067:                         SHAREDtype 493
+  1070:                       SHAREDtype 493
+  1073:                     APPLY(9)
+  1075:                       SELECTin(7) 87 [toString[Signed Signature(List(),java.lang.String) @toString]]
+  1078:                         SHAREDterm 1050
+  1081:                         SHAREDtype 282
+  1084:             OVERRIDE
+  1085:             SYNTHETIC
+  1086:           DEFDEF(15) 89 [copy]
+  1089:             EMPTYCLAUSE
+  1090:             SHAREDtype 114
+  1092:             APPLY(8)
+  1094:               SELECTin(6) 102 [<init>[Signed Signature(List(),Z$.BOptions) @<init>]]
+  1097:                 NEW
+  1098:                   SHAREDtype 114
+  1100:                 SHAREDtype 114
+  1102:             SYNTHETIC
+  1103:           DEFDEF(7) 92 [ordinal]
+  1106:             SHAREDtype 254
+  1109:             INTconst 1
+  1111:             SYNTHETIC
+  1112:         FINAL
+  1113:         CASE
+  1114:         ENUM
+  1115:       VALDEF(22) 16 [BOptions]
+  1118:         IDENTtpt 103 [BOptions[ModuleClass]]
+  1120:           TYPEREFsymbol 1139
+  1123:             SHAREDtype 92
+  1125:         APPLY(10)
+  1127:           SELECTin(8) 105 [<init>[Signed Signature(List(),Z$.BOptions$) @<init>]]
+  1130:             NEW
+  1131:               SHAREDterm 1118
+  1134:             SHAREDtype 1120
+  1137:         OBJECT
+  1138:         SYNTHETIC
+  1139:       TYPEDEF(138) 103 [BOptions[ModuleClass]]
+  1143:         TEMPLATE(132)
+  1146:           APPLY(9)
+  1148:             SELECTin(7) 9 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+  1151:               NEW
+  1152:                 SHAREDtype 173
+  1155:               SHAREDtype 17
+  1157:           SHAREDtype 637
+  1160:           SELFDEF 39 [_]
+  1162:             SINGLETONtpt
+  1163:               TERMREFsymbol 1115
+  1166:                 SHAREDtype 92
+  1168:           DEFDEF(5) 3 [<init>]
+  1171:             EMPTYCLAUSE
+  1172:             SHAREDtype 31
+  1174:             STABLE
+  1175:           DEFDEF(23) 40 [writeReplace]
+  1178:             EMPTYCLAUSE
+  1179:             SHAREDtype 173
+  1182:             APPLY(14)
+  1184:               SELECTin(8) 47 [<init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]]
+  1187:                 NEW
+  1188:                   SHAREDtype 211
+  1191:                 SHAREDtype 211
+  1194:               CLASSconst
+  1195:                 SHAREDtype 1163
+  1198:             PRIVATE
+  1199:             SYNTHETIC
+  1200:           DEFDEF(15) 96 [apply]
+  1203:             EMPTYCLAUSE
+  1204:             SHAREDtype 114
+  1206:             APPLY(8)
+  1208:               SELECTin(6) 102 [<init>[Signed Signature(List(),Z$.BOptions) @<init>]]
+  1211:                 NEW
+  1212:                   SHAREDtype 114
+  1214:                 SHAREDtype 114
+  1216:             SYNTHETIC
+  1217:           DEFDEF(11) 97 [unapply]
+  1220:             PARAM(4) 98 [x$1]
+  1223:               SHAREDtype 114
+  1225:               SYNTHETIC
+  1226:             SINGLETONtpt
+  1227:               TRUEconst
+  1228:             TRUEconst
+  1229:             SYNTHETIC
+  1230:           DEFDEF(8) 72 [toString]
+  1233:             SHAREDtype 378
+  1236:             STRINGconst 16 [BOptions]
+  1238:             OVERRIDE
+  1239:             SYNTHETIC
+  1240:           TYPEDEF(9) 99 [MirroredMonoType]
+  1243:             TYPEBOUNDS(5)
+  1245:               TYPEREFsymbol 769
+  1248:                 SHAREDtype 38
+  1250:             SYNTHETIC
+  1251:           DEFDEF(25) 100 [fromProduct]
+  1254:             PARAM(4) 59 [x$0]
+  1257:               SHAREDtype 743
+  1260:             TYPEREFsymbol 1240
+  1263:               THIS
+  1264:                 SHAREDtype 1120
+  1267:             APPLY(8)
+  1269:               SELECTin(6) 102 [<init>[Signed Signature(List(),Z$.BOptions) @<init>]]
+  1272:                 NEW
+  1273:                   SHAREDtype 114
+  1275:                 SHAREDtype 114
+  1277:             SYNTHETIC
+  1278:         OBJECT
+  1279:         SYNTHETIC
+  1280:       TYPEDEF(343) 17 [COptions]
+  1284:         TEMPLATE(336)
+  1287:           APPLY(10)
+  1289:             SELECTin(8) 48 [<init>[Signed Signature(List(),Z) @<init>]]
+  1292:               NEW
+  1293:                 SHAREDtype 236
+  1296:               SHAREDtype 236
+  1299:           DEFDEF(5) 3 [<init>]
+  1302:             EMPTYCLAUSE
+  1303:             SHAREDtype 31
+  1305:             STABLE
+  1306:           DEFDEF(17) 49 [hashCode]
+  1309:             EMPTYCLAUSE
+  1310:             SHAREDtype 254
+  1313:             APPLY(8)
+  1315:               SHAREDtype 260
+  1318:               QUALTHIS
+  1319:                 IDENTtpt 17 [COptions]
+  1321:                   SHAREDtype 89
+  1323:             OVERRIDE
+  1324:             SYNTHETIC
+  1325:           DEFDEF(90) 58 [equals]
+  1328:             PARAM(4) 59 [x$0]
+  1331:               SHAREDtype 282
+  1334:             SHAREDtype 286
+  1337:             APPLY(76)
+  1339:               SELECTin(29) 64 [||[Signed Signature(List(scala.Boolean),scala.Boolean) @||]]
+  1342:                 APPLY(23)
+  1344:                   SELECTin(8) 66 [eq[Signed Signature(List(java.lang.Object),scala.Boolean) @eq]]
+  1347:                     QUALTHIS
+  1348:                       IDENTtpt 17 [COptions]
+  1350:                         SHAREDtype 89
+  1352:                     SHAREDtype 17
+  1354:                   TYPEAPPLY(11)
+  1356:                     SELECTin(7) 68 [$asInstanceOf$[Signed Signature(List(1),java.lang.Object) @$asInstanceOf$]]
+  1359:                       TERMREFdirect 1328
+  1362:                       SHAREDtype 282
+  1365:                     SHAREDtype 17
+  1367:                 SHAREDtype 286
+  1370:               MATCH(43)
+  1372:                 SHAREDterm 1359
+  1375:                 CASEDEF(30)
+  1377:                   BIND(27) 59 [x$0]
+  1380:                     SHAREDtype 89
+  1382:                     TYPED(21)
+  1384:                       IDENT 39 [_]
+  1386:                         ANNOTATEDtype(14)
+  1388:                           SHAREDtype 89
+  1390:                           APPLY(10)
+  1392:                             SELECTin(8) 71 [<init>[Signed Signature(List(),scala.unchecked) @<init>]]
+  1395:                               NEW
+  1396:                                 SHAREDtype 352
+  1399:                               SHAREDtype 352
+  1402:                       SHAREDtype 1386
+  1405:                     SYNTHETIC
+  1406:                   TRUEconst
+  1407:                 CASEDEF(6)
+  1409:                   IDENT 39 [_]
+  1411:                     SHAREDtype 282
+  1414:                   FALSEconst
+  1415:             OVERRIDE
+  1416:             SYNTHETIC
+  1417:           DEFDEF(17) 72 [toString]
+  1420:             EMPTYCLAUSE
+  1421:             SHAREDtype 378
+  1424:             APPLY(8)
+  1426:               SHAREDtype 384
+  1429:               QUALTHIS
+  1430:                 IDENTtpt 17 [COptions]
+  1432:                   SHAREDtype 89
+  1434:             OVERRIDE
+  1435:             SYNTHETIC
+  1436:           DEFDEF(39) 75 [canEqual]
+  1439:             PARAM(4) 76 [that]
+  1442:               SHAREDtype 282
+  1445:             SHAREDtype 286
+  1448:             TYPEAPPLY(25)
+  1450:               SELECTin(7) 78 [isInstanceOf[Signed Signature(List(1),scala.Boolean) @isInstanceOf]]
+  1453:                 TERMREFdirect 1439
+  1456:                 SHAREDtype 282
+  1459:               ANNOTATEDtype(14)
+  1461:                 SHAREDtype 89
+  1463:                 APPLY(10)
+  1465:                   SELECTin(8) 71 [<init>[Signed Signature(List(),scala.unchecked) @<init>]]
+  1468:                     NEW
+  1469:                       SHAREDtype 352
+  1472:                     SHAREDtype 352
+  1475:             OVERRIDE
+  1476:             SYNTHETIC
+  1477:           DEFDEF(8) 79 [productArity]
+  1480:             SHAREDtype 254
+  1483:             INTconst 0
+  1485:             OVERRIDE
+  1486:             SYNTHETIC
+  1487:           DEFDEF(8) 80 [productPrefix]
+  1490:             SHAREDtype 452
+  1493:             STRINGconst 17 [COptions]
+  1495:             OVERRIDE
+  1496:             SYNTHETIC
+  1497:           DEFDEF(48) 82 [productElement]
+  1500:             PARAM(4) 83 [n]
+  1503:               SHAREDtype 254
+  1506:             SHAREDtype 282
+  1509:             MATCH(34)
+  1511:               TERMREFdirect 1500
+  1514:               CASEDEF(29)
+  1516:                 IDENT 39 [_]
+  1518:                   SHAREDtype 254
+  1521:                 THROW
+  1522:                   APPLY(21)
+  1524:                     SELECTin(8) 86 [<init>[Signed Signature(List(java.lang.String),java.lang.IndexOutOfBoundsException) @<init>]]
+  1527:                       NEW
+  1528:                         SHAREDtype 493
+  1531:                       SHAREDtype 493
+  1534:                     APPLY(9)
+  1536:                       SELECTin(7) 87 [toString[Signed Signature(List(),java.lang.String) @toString]]
+  1539:                         SHAREDterm 1511
+  1542:                         SHAREDtype 282
+  1545:             OVERRIDE
+  1546:             SYNTHETIC
+  1547:           DEFDEF(48) 88 [productElementName]
+  1550:             PARAM(4) 83 [n]
+  1553:               SHAREDtype 254
+  1556:             SHAREDtype 452
+  1559:             MATCH(34)
+  1561:               TERMREFdirect 1550
+  1564:               CASEDEF(29)
+  1566:                 IDENT 39 [_]
+  1568:                   SHAREDtype 254
+  1571:                 THROW
+  1572:                   APPLY(21)
+  1574:                     SELECTin(8) 86 [<init>[Signed Signature(List(java.lang.String),java.lang.IndexOutOfBoundsException) @<init>]]
+  1577:                       NEW
+  1578:                         SHAREDtype 493
+  1581:                       SHAREDtype 493
+  1584:                     APPLY(9)
+  1586:                       SELECTin(7) 87 [toString[Signed Signature(List(),java.lang.String) @toString]]
+  1589:                         SHAREDterm 1561
+  1592:                         SHAREDtype 282
+  1595:             OVERRIDE
+  1596:             SYNTHETIC
+  1597:           DEFDEF(15) 89 [copy]
+  1600:             EMPTYCLAUSE
+  1601:             SHAREDtype 89
+  1603:             APPLY(8)
+  1605:               SELECTin(6) 107 [<init>[Signed Signature(List(),Z$.COptions) @<init>]]
+  1608:                 NEW
+  1609:                   SHAREDtype 89
+  1611:                 SHAREDtype 89
+  1613:             SYNTHETIC
+  1614:           DEFDEF(7) 92 [ordinal]
+  1617:             SHAREDtype 254
+  1620:             INTconst 2
+  1622:             SYNTHETIC
+  1623:         FINAL
+  1624:         CASE
+  1625:         ENUM
+  1626:       VALDEF(22) 17 [COptions]
+  1629:         IDENTtpt 108 [COptions[ModuleClass]]
+  1631:           TYPEREFsymbol 1650
+  1634:             SHAREDtype 92
+  1636:         APPLY(10)
+  1638:           SELECTin(8) 110 [<init>[Signed Signature(List(),Z$.COptions$) @<init>]]
+  1641:             NEW
+  1642:               SHAREDterm 1629
+  1645:             SHAREDtype 1631
+  1648:         OBJECT
+  1649:         SYNTHETIC
+  1650:       TYPEDEF(138) 108 [COptions[ModuleClass]]
+  1654:         TEMPLATE(132)
+  1657:           APPLY(9)
+  1659:             SELECTin(7) 9 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+  1662:               NEW
+  1663:                 SHAREDtype 173
+  1666:               SHAREDtype 17
+  1668:           SHAREDtype 637
+  1671:           SELFDEF 39 [_]
+  1673:             SINGLETONtpt
+  1674:               TERMREFsymbol 1626
+  1677:                 SHAREDtype 92
+  1679:           DEFDEF(5) 3 [<init>]
+  1682:             EMPTYCLAUSE
+  1683:             SHAREDtype 31
+  1685:             STABLE
+  1686:           DEFDEF(23) 40 [writeReplace]
+  1689:             EMPTYCLAUSE
+  1690:             SHAREDtype 173
+  1693:             APPLY(14)
+  1695:               SELECTin(8) 47 [<init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]]
+  1698:                 NEW
+  1699:                   SHAREDtype 211
+  1702:                 SHAREDtype 211
+  1705:               CLASSconst
+  1706:                 SHAREDtype 1674
+  1709:             PRIVATE
+  1710:             SYNTHETIC
+  1711:           DEFDEF(15) 96 [apply]
+  1714:             EMPTYCLAUSE
+  1715:             SHAREDtype 89
+  1717:             APPLY(8)
+  1719:               SELECTin(6) 107 [<init>[Signed Signature(List(),Z$.COptions) @<init>]]
+  1722:                 NEW
+  1723:                   SHAREDtype 89
+  1725:                 SHAREDtype 89
+  1727:             SYNTHETIC
+  1728:           DEFDEF(11) 97 [unapply]
+  1731:             PARAM(4) 98 [x$1]
+  1734:               SHAREDtype 89
+  1736:               SYNTHETIC
+  1737:             SINGLETONtpt
+  1738:               TRUEconst
+  1739:             TRUEconst
+  1740:             SYNTHETIC
+  1741:           DEFDEF(8) 72 [toString]
+  1744:             SHAREDtype 378
+  1747:             STRINGconst 17 [COptions]
+  1749:             OVERRIDE
+  1750:             SYNTHETIC
+  1751:           TYPEDEF(9) 99 [MirroredMonoType]
+  1754:             TYPEBOUNDS(5)
+  1756:               TYPEREFsymbol 1280
+  1759:                 SHAREDtype 38
+  1761:             SYNTHETIC
+  1762:           DEFDEF(25) 100 [fromProduct]
+  1765:             PARAM(4) 59 [x$0]
+  1768:               SHAREDtype 743
+  1771:             TYPEREFsymbol 1751
+  1774:               THIS
+  1775:                 SHAREDtype 1631
+  1778:             APPLY(8)
+  1780:               SELECTin(6) 107 [<init>[Signed Signature(List(),Z$.COptions) @<init>]]
+  1783:                 NEW
+  1784:                   SHAREDtype 89
+  1786:                 SHAREDtype 89
+  1788:             SYNTHETIC
+  1789:         OBJECT
+  1790:         SYNTHETIC
+  1791:       DEFDEF(46) 111 [fromOrdinal]
+  1794:         PARAM(4) 92 [ordinal]
+  1797:           SHAREDtype 254
+  1800:         SHAREDtype 236
+  1803:         THROW
+  1804:           APPLY(32)
+  1806:             SELECTin(9) 116 [<init>[Signed Signature(List(java.lang.String),java.util.NoSuchElementException) @<init>]]
+  1809:               NEW
+  1810:                 TYPEREF 114 [NoSuchElementException]
+  1812:                   TERMREFpkg 113 [java[Qualified . util]]
+  1814:               SHAREDtype 1810
+  1817:             APPLY(19)
+  1819:               SELECTin(6) 118 [+[Signed Signature(List(java.lang.Object),java.lang.String) @+]]
+  1822:                 STRINGconst 119 [enum Z has no case with ordinal: ]
+  1824:                 SHAREDtype 378
+  1827:               APPLY(9)
+  1829:                 SELECTin(7) 87 [toString[Signed Signature(List(),java.lang.String) @toString]]
+  1832:                   TERMREFdirect 1794
+  1835:                   SHAREDtype 282
+  1838:         SYNTHETIC
+  1839:       TYPEDEF(7) 99 [MirroredMonoType]
+  1842:         TYPEBOUNDS(3)
+  1844:           SHAREDtype 236
+  1847:         SYNTHETIC
+  1848:       DEFDEF(18) 92 [ordinal]
+  1851:         PARAM(6) 59 [x$0]
+  1854:           TYPEREFsymbol 1839
+  1857:             SHAREDtype 92
+  1859:         SHAREDtype 254
+  1862:         SELECT 92 [ordinal]
+  1864:           TERMREFdirect 1851
+  1867:         SYNTHETIC
+  1868:     OBJECT
+  1869:     SYNTHETIC
+  1870:     ANNOTATION(14)
+  1872:       SHAREDtype 55
+  1874:       APPLY(10)
+  1876:         SELECTin(6) 26 [<init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]]
+  1879:           NEW
+  1880:             SHAREDtype 55
+  1882:           SHAREDtype 55
+  1884:         STRINGconst 27 [<elided source file name>]
+  1886:
+
+Positions (535 bytes, starting from <elided base index>):
+  lines: 10
+  line sizes:
+     38, 0, 98, 90, 106, 7, 17, 17, 17, 0
+  positions:
+     0: 337 .. 398
+     5: 337 .. 398
+     9: 347 .. 398
+    17: 342 .. 342
+    23: 347 .. 347
+    27: 347 .. 347
+    31: 347 .. 347
+    38: 347 .. 347
+    44: 347 .. 347
+    46: 347 .. 347
+    48: 347 .. 347
+    59: 337 .. 398
+    65: 337 .. 337
+    69: 337 .. 337
+    85: 342 .. 342
+    89: 342 .. 342
+   110: 342 .. 342
+   114: 342 .. 342
+   131: 342 .. 342
+   135: 342 .. 342
+   140: 337 .. 398
+   143: 347 .. 347
+   160: 337 .. 398
+   164: 347 .. 398
+   173: 347 .. 347
+   179: 347 .. 347
+   189: 347 .. 347
+   191: 347 .. 347
+   195: 347 .. 347
+   198: 342 .. 342
+   202: 342 .. 342
+   211: 342 .. 342
+   218: 342 .. 342
+   223: 347 .. 362
+   227: 360 .. 362
+   236: 362 .. 362
+   243: 360 .. 362
+   247: 360 .. 360
+   250: 352 .. 352
+   254: 352 .. 352
+   260: 352 .. 352
+   269: 352 .. 352
+   276: 352 .. 352
+   279: 352 .. 352
+   282: 352 .. 352
+   286: 352 .. 352
+   301: 352 .. 352
+   313: 352 .. 352
+   319: 352 .. 352
+   331: 352 .. 352
+   339: 352 .. 352
+   359: 352 .. 352
+   363: 352 .. 352
+   366: 352 .. 352
+   371: 352 .. 352
+   374: 352 .. 352
+   378: 352 .. 352
+   384: 352 .. 352
+   390: 352 .. 352
+   397: 352 .. 352
+   400: 352 .. 352
+   403: 352 .. 352
+   406: 352 .. 352
+   414: 352 .. 352
+   420: 352 .. 352
+   439: 352 .. 352
+   442: 352 .. 352
+   445: 352 .. 352
+   449: 352 .. 352
+   452: 352 .. 352
+   458: 352 .. 352
+   462: 352 .. 352
+   465: 352 .. 352
+   468: 352 .. 352
+   471: 352 .. 352
+   476: 352 .. 352
+   481: 352 .. 352
+   493: 352 .. 352
+   513: 352 .. 352
+   516: 352 .. 352
+   519: 352 .. 352
+   522: 352 .. 352
+   527: 352 .. 352
+   532: 352 .. 352
+   544: 352 .. 352
+   563: 347 .. 347
+   567: 347 .. 347
+   576: 347 .. 347
+   583: 362 .. 362
+   586: 362 .. 362
+   589: 362 .. 362
+   595: 347 .. 362
+   598: 347 .. 347
+   619: 347 .. 362
+   623: 347 .. 347
+   632: 347 .. 347
+   637: 347 .. 347
+   645: 347 .. 347
+   650: 347 .. 347
+   654: 347 .. 347
+   657: 352 .. 352
+   661: 352 .. 352
+   670: 352 .. 352
+   676: 352 .. 352
+   682: 347 .. 347
+   686: 347 .. 347
+   695: 347 .. 347
+   702: 347 .. 347
+   705: 347 .. 347
+   708: 347 .. 347
+   713: 347 .. 347
+   714: 347 .. 347
+   716: 347 .. 347
+   719: 347 .. 347
+   722: 347 .. 347
+   726: 352 .. 352
+   729: 352 .. 352
+   737: 352 .. 352
+   740: 352 .. 352
+   743: 352 .. 352
+   747: 352 .. 352
+   760: 352 .. 352
+   769: 365 .. 380
+   773: 378 .. 380
+   782: 380 .. 380
+   788: 378 .. 380
+   792: 378 .. 378
+   795: 370 .. 370
+   799: 370 .. 370
+   804: 370 .. 370
+   808: 370 .. 370
+   814: 370 .. 370
+   817: 370 .. 370
+   820: 370 .. 370
+   823: 370 .. 370
+   837: 370 .. 370
+   848: 370 .. 370
+   854: 370 .. 370
+   866: 370 .. 370
+   873: 370 .. 370
+   891: 370 .. 370
+   895: 370 .. 370
+   898: 370 .. 370
+   903: 370 .. 370
+   906: 370 .. 370
+   910: 370 .. 370
+   915: 370 .. 370
+   919: 370 .. 370
+   925: 370 .. 370
+   928: 370 .. 370
+   931: 370 .. 370
+   934: 370 .. 370
+   942: 370 .. 370
+   948: 370 .. 370
+   966: 370 .. 370
+   969: 370 .. 370
+   972: 370 .. 370
+   976: 370 .. 370
+   979: 370 .. 370
+   982: 370 .. 370
+   986: 370 .. 370
+   989: 370 .. 370
+   992: 370 .. 370
+   995: 370 .. 370
+  1000: 370 .. 370
+  1005: 370 .. 370
+  1017: 370 .. 370
+  1036: 370 .. 370
+  1039: 370 .. 370
+  1042: 370 .. 370
+  1045: 370 .. 370
+  1050: 370 .. 370
+  1055: 370 .. 370
+  1067: 370 .. 370
+  1086: 365 .. 365
+  1090: 365 .. 365
+  1098: 365 .. 365
+  1103: 380 .. 380
+  1106: 380 .. 380
+  1109: 380 .. 380
+  1115: 365 .. 380
+  1118: 365 .. 365
+  1139: 365 .. 380
+  1143: 365 .. 365
+  1152: 365 .. 365
+  1157: 365 .. 365
+  1163: 365 .. 365
+  1168: 365 .. 365
+  1172: 365 .. 365
+  1175: 370 .. 370
+  1179: 370 .. 370
+  1188: 370 .. 370
+  1194: 370 .. 370
+  1200: 365 .. 365
+  1204: 365 .. 365
+  1212: 365 .. 365
+  1217: 365 .. 365
+  1220: 365 .. 365
+  1223: 365 .. 365
+  1227: 365 .. 365
+  1228: 365 .. 365
+  1230: 365 .. 365
+  1233: 365 .. 365
+  1236: 365 .. 365
+  1240: 370 .. 370
+  1243: 370 .. 370
+  1251: 370 .. 370
+  1254: 370 .. 370
+  1257: 370 .. 370
+  1260: 370 .. 370
+  1273: 370 .. 370
+  1280: 383 .. 398
+  1284: 396 .. 398
+  1293: 398 .. 398
+  1299: 396 .. 398
+  1303: 396 .. 396
+  1306: 388 .. 388
+  1310: 388 .. 388
+  1315: 388 .. 388
+  1319: 388 .. 388
+  1325: 388 .. 388
+  1328: 388 .. 388
+  1331: 388 .. 388
+  1334: 388 .. 388
+  1348: 388 .. 388
+  1359: 388 .. 388
+  1365: 388 .. 388
+  1377: 388 .. 388
+  1384: 388 .. 388
+  1402: 388 .. 388
+  1406: 388 .. 388
+  1409: 388 .. 388
+  1414: 388 .. 388
+  1417: 388 .. 388
+  1421: 388 .. 388
+  1426: 388 .. 388
+  1430: 388 .. 388
+  1436: 388 .. 388
+  1439: 388 .. 388
+  1442: 388 .. 388
+  1445: 388 .. 388
+  1453: 388 .. 388
+  1459: 388 .. 388
+  1477: 388 .. 388
+  1480: 388 .. 388
+  1483: 388 .. 388
+  1487: 388 .. 388
+  1490: 388 .. 388
+  1493: 388 .. 388
+  1497: 388 .. 388
+  1500: 388 .. 388
+  1503: 388 .. 388
+  1506: 388 .. 388
+  1511: 388 .. 388
+  1516: 388 .. 388
+  1528: 388 .. 388
+  1547: 388 .. 388
+  1550: 388 .. 388
+  1553: 388 .. 388
+  1556: 388 .. 388
+  1561: 388 .. 388
+  1566: 388 .. 388
+  1578: 388 .. 388
+  1597: 383 .. 383
+  1601: 383 .. 383
+  1609: 383 .. 383
+  1614: 398 .. 398
+  1617: 398 .. 398
+  1620: 398 .. 398
+  1626: 383 .. 398
+  1629: 383 .. 383
+  1650: 383 .. 398
+  1654: 383 .. 383
+  1663: 383 .. 383
+  1668: 383 .. 383
+  1674: 383 .. 383
+  1679: 383 .. 383
+  1683: 383 .. 383
+  1686: 388 .. 388
+  1690: 388 .. 388
+  1699: 388 .. 388
+  1705: 388 .. 388
+  1711: 383 .. 383
+  1715: 383 .. 383
+  1723: 383 .. 383
+  1728: 383 .. 383
+  1731: 383 .. 383
+  1734: 383 .. 383
+  1738: 383 .. 383
+  1739: 383 .. 383
+  1741: 383 .. 383
+  1744: 383 .. 383
+  1747: 383 .. 383
+  1751: 388 .. 388
+  1754: 388 .. 388
+  1762: 388 .. 388
+  1765: 388 .. 388
+  1768: 388 .. 388
+  1771: 388 .. 388
+  1784: 388 .. 388
+  1791: 398 .. 398
+  1794: 398 .. 398
+  1797: 398 .. 398
+  1800: 398 .. 398
+  1810: 398 .. 398
+  1822: 398 .. 398
+  1832: 398 .. 398
+  1839: 342 .. 342
+  1842: 342 .. 342
+  1848: 342 .. 342
+  1851: 342 .. 342
+  1854: 342 .. 342
+  1859: 342 .. 342
+  1864: 342 .. 342
+  1874: 337 .. 398
+  1880: 337 .. 337
+  1884: 337 .. 337
+
+  source paths:
+     0: 27 [<elided source file name>]
+
+Attributes (2 bytes, starting from <elided base index>):
+  SOURCEFILEattr 27 [<elided source file name>]


### PR DESCRIPTION
This ensures that the positions of forced Child annotations always happens in the source file of the parent class, and not in another file that forced the completion to happen

fixes #21154 