### PR TITLE
Fix infinite loop bug in the mutable LongMap

### DIFF
--- a/scala2-library-cc/src/scala/collection/mutable/LongMap.scala
+++ b/scala2-library-cc/src/scala/collection/mutable/LongMap.scala
@@ -280,9 +280,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   def repack(): Unit = {
     var m = mask
     if (_size + _vacant >= 0.5*mask && !(_vacant > 0.2*mask)) m = ((m << 1) + 1) & IndexMask
-    while (m > 8 && 8*_size < m) m = m >>> 1
+    while (m > 8 && 8*_size < m && ((m >> 1) & MAX_MASK) >= _size) m = m >>> 1
     repack(m)
-  }
+  } //ensuring (res => _size <= res + 1)
 
   override def put(key: Long, value: V): Option[V] = {
     if (key == -key) {


### PR DESCRIPTION
This bug was discovered when I verified the mutable LongMap data structure with Stainless.
This work has been published at IJCAR24 (https://link.springer.com/chapter/10.1007/978-3-031-63498-7_18)

The bug appears in the computation of the new mask if `_size*8` overflows. The counter-example that stainless finds can be seen here, along with the buggy and fixed algorithm: https://github.com/epfl-lara/bolts/blob/53919b74b65793323eb1786b632cdb4dfecbd3e2/data-structures/maps/mutablemaps/src/main/scala/ch/epfl/chassot/BuggyNewMaskComputation.scala

The bug is triggered if `_size >= 2**28`. If triggered, the mask will be equal to 7, and the process will loop forever when inserting all key-value pairs back.