### PR TITLE
Fail when a poly function value has a different number of type params than the expected poly function

### DIFF
--- a/tests/neg/i20533.check
+++ b/tests/neg/i20533.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg/i20533.scala:5:8 -----------------------------------------------------------------------------------
+5 |    [X] => (x, y) => Map(x -> y) // error
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |    Provided polymorphic function value doesn't match the expected type [X, Y] => (x$1: X, x$2: Y) => Map[X, Y].
+  |    Expected type should be a polymorphic function with the same number of type and value parameters.

--- a/tests/neg/i20533.scala
+++ b/tests/neg/i20533.scala
@@ -1,0 +1,6 @@
+def mapF(h: [X, Y] => (X, Y) => Map[X, Y]): Unit = ???
+
+def test =
+  mapF(
+    [X] => (x, y) => Map(x -> y) // error
+  )


### PR DESCRIPTION
fixes #20533 