### PR TITLE
fix: Set lastDenot to NoDenotation when recomputing denotations from previous runs

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -122,7 +122,7 @@ object Symbols extends SymUtils {
     protected def recomputeDenot(lastd: SymDenotation)(using Context): SymDenotation = {
       util.Stats.record("Symbol.recomputeDenot")
       val newd = lastd.current.asInstanceOf[SymDenotation]
-      if newd.exists || lastd.initial.validFor.firstPhaseId <= ctx.phaseId then
+      if newd.exists || lastd.initial.validFor.firstPhaseId <= ctx.phaseId || lastd.initial.validFor.runId <= ctx.runId then
         lastDenot = newd
       else
         // We are trying to bring forward a symbol that is defined only at a later phase

--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -614,7 +614,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
         if (ord != 0) // there are unused bits in already existing flag
           offsetSymbol = claz.info.decl(offsetById)
             .suchThat(sym => sym.is(Synthetic) && sym.isTerm)
-             .symbol.asTerm
+            .symbol.asTerm
         else { // need to create a new flag
           offsetSymbol = newSymbol(claz, offsetById, Synthetic, defn.LongType).enteredAfter(this)
           offsetSymbol.nn.addAnnotation(Annotation(defn.ScalaStaticAnnot, offsetSymbol.nn.span))

--- a/tests/pos/i21271/Macro.scala
+++ b/tests/pos/i21271/Macro.scala
@@ -1,0 +1,12 @@
+import scala.quoted.*
+
+trait Schema
+object Schema:
+  lazy val sampleDate: String = "" // lazy val requried to reproduce
+
+  inline def derived: Schema =
+    annotations
+    new Schema {}
+
+inline def annotations: Int = ${ annotationsImpl }
+def annotationsImpl(using Quotes): Expr[Int] = Expr(1)

--- a/tests/pos/i21271/Test.scala
+++ b/tests/pos/i21271/Test.scala
@@ -1,0 +1,1 @@
+val inputValueSchema = Schema.derived


### PR DESCRIPTION
possible fix for #21271 