### PR TITLE
Only replace *new* errors by warnings under `-migration`

### DIFF
--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -99,7 +99,7 @@ object report:
 
   def errorOrMigrationWarning(msg: Message, pos: SrcPos, migrationVersion: MigrationVersion)(using Context): Unit =
     if sourceVersion.isAtLeast(migrationVersion.errorFrom) then
-      if !sourceVersion.isMigrating then error(msg, pos)
+      if sourceVersion != migrationVersion.errorFrom.prevMigrating then error(msg, pos)
       else if ctx.settings.rewrite.value.isEmpty then migrationWarning(msg, pos)
     else if sourceVersion.isAtLeast(migrationVersion.warnFrom) then warning(msg, pos)
 

--- a/tests/neg/migrate-once.scala
+++ b/tests/neg/migrate-once.scala
@@ -1,0 +1,5 @@
+//> using options -source:3.5-migration
+
+object Test:
+  for Some(x) <- Seq(Option(1)) yield x // error
+  // was warn before changes, but should warn only until 3.4-migration


### PR DESCRIPTION
This makes `errorOrMigrationWarning` monotonic from the sourceVersion onto ok < warn < error

For example, ForComprehensionPatternWithoutCase:
- became an error in 3.4,
- was hence a warning in 3.4-migration,
- but it should still be an error in 3.5-migration.