### PR TITLE
Wrap the arguments passed to the scalac task between "

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -844,7 +844,8 @@ object Build {
           extraClasspath ++= Seq(dottyCompiler, dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface)
         }
 
-        val fullArgs = main :: defaultOutputDirectory ::: (if (printTasty) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator)))
+        val wrappedArgs = (if (printTasty) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))).map(arg => "\""+ arg + "\"")
+        val fullArgs = main :: defaultOutputDirectory ::: wrappedArgs
 
         (Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
       }.evaluated,


### PR DESCRIPTION
When running `scalac` in the sbt shell, the following task will invoke the compiler's main method and forward the arguments as a single string. 

If we do the following:
```sh
sbt:scala3> scalac "test.scala" "-Wconf:msg=Given search preference:silent"
``` 
The compiiler will not correctly parse the provided arguments, resulting in the following behaviour:

```sh
[info] running (fork) dotty.tools.dotc.Main -d <redacted>/scala3/compiler/../out/default-last-scalac-out.jar -classpath <redacted>/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.14/scala-library-2.13.14.jar:<redacted>/scala3/library/../out/bootstrap/scala3-library-bootstrapped/scala-3.6.0-RC1-bin-SNAPSHOT-nonbootstrapped/scala3-library_3-3.6.0-RC1-bin-SNAPSHOT.jar test.scala -Wconf:msg=Given search preference:silent
source file not found: test.scala
source file not found: search
source file not found: preference:silent
```

This PR fixes the following discribed issue by wrapping each argument between `"` before calling the compiler's main method.
