### PR TITLE
Another given priority scheme to ensure transitivity

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Formatting.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Formatting.scala
@@ -2,8 +2,6 @@ package dotty.tools
 package dotc
 package printing
 
-import scala.language.unsafeNulls
-
 import scala.collection.mutable
 
 import core.*
@@ -52,7 +50,11 @@ object Formatting {
     object ShowAny extends Show[Any]:
       def show(x: Any): Shown = x
 
-    class ShowImplicits3:
+    class ShowImplicits4:
+      given [X: Show]: Show[X | Null] with
+        def show(x: X | Null) = if x == null then "null" else CtxShow(toStr(x.nn))
+
+    class ShowImplicits3 extends ShowImplicits4:
       given Show[Product] = ShowAny
 
     class ShowImplicits2 extends ShowImplicits3:
@@ -77,15 +79,10 @@ object Formatting {
       given [K: Show, V: Show]: Show[Map[K, V]] with
         def show(x: Map[K, V]) =
           CtxShow(x.map((k, v) => s"${toStr(k)} => ${toStr(v)}"))
-      end given
 
       given [H: Show, T <: Tuple: Show]: Show[H *: T] with
         def show(x: H *: T) =
           CtxShow(toStr(x.head) *: toShown(x.tail).asInstanceOf[Tuple])
-      end given
-
-      given [X: Show]: Show[X | Null] with
-        def show(x: X | Null) = if x == null then "null" else CtxShow(toStr(x.nn))
 
       given Show[FlagSet] with
         def show(x: FlagSet) = x.flagsString
@@ -148,8 +145,8 @@ object Formatting {
     private def treatArg(arg: Shown, suffix: String)(using Context): (String, String) = arg.runCtxShow match {
       case arg: Seq[?] if suffix.indexOf('%') == 0 && suffix.indexOf('%', 1) != -1 =>
         val end = suffix.indexOf('%', 1)
-        val sep = StringContext.processEscapes(suffix.substring(1, end))
-        (arg.mkString(sep), suffix.substring(end + 1))
+        val sep = StringContext.processEscapes(suffix.substring(1, end).nn)
+        (arg.mkString(sep), suffix.substring(end + 1).nn)
       case arg: Seq[?] =>
         (arg.map(showArg).mkString("[", ", ", "]"), suffix)
       case arg =>

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2988,7 +2988,7 @@ class MissingImplicitArgument(
 
     /** Default error message for non-nested ambiguous implicits. */
     def defaultAmbiguousImplicitMsg(ambi: AmbiguousImplicits) =
-      s"Ambiguous given instances: ${ambi.explanation}${location("of")}"
+      s"Ambiguous given instances: ${ambi.explanation}${location("of")}${ambi.priorityChangeWarningNote}"
 
     /** Default error messages for non-ambiguous implicits, or nested ambiguous
      *  implicits.

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1922,7 +1922,7 @@ trait Applications extends Compatibility {
               case _ => mapOver(t)
           (flip(tp1p) relaxed_<:< flip(tp2p)) || viewExists(tp1, tp2)
         else
-          if alt1IsImplicit != alt2IsImplicit then alt2IsImplicit
+          if alt1IsImplicit != alt2IsImplicit then false // don't know how to compare these
           else (tp2p relaxed_<:< tp1p) || viewExists(tp2, tp1)
     end isAsGoodValueType
 

--- a/compiler/test/dotty/tools/dotc/StringFormatterTest.scala
+++ b/compiler/test/dotty/tools/dotc/StringFormatterTest.scala
@@ -23,6 +23,7 @@ class StringFormatterTest extends AbstractStringFormatterTest:
   @Test def flagsTup   = check("(<static>,final)", i"${(JavaStatic, Final)}")
   @Test def seqOfTup2  = check("(final,given), (private,lazy)", i"${Seq((Final, Given), (Private, Lazy))}%, %")
   @Test def seqOfTup3  = check("(Foo,given, (right is approximated))", i"${Seq((Foo, Given, TypeComparer.ApproxState.None.addHigh))}%, %")
+  @Test def tupleNull   = check("(1,null)", i"${(1, null: String | Null)}")
 
   class StorePrinter extends Printer:
     var string: String = "<never set>"

--- a/tests/neg/given-triangle.check
+++ b/tests/neg/given-triangle.check
@@ -2,3 +2,11 @@
 15 |@main def Test = f  // error
    |                  ^
    |Ambiguous given instances: both given instance given_B and given instance given_C match type A of parameter a of method f
+   |
+   |Note: Given search preference for A between alternatives
+   |  (given_A : A)
+   |and
+   |  (given_B : B)
+   |will change.
+   |Current choice           : the second alternative
+   |New choice from Scala 3.6: the first alternative

--- a/tests/neg/i21212.check
+++ b/tests/neg/i21212.check
@@ -1,0 +1,4 @@
+-- [E172] Type Error: tests/neg/i21212.scala:8:52 ----------------------------------------------------------------------
+8 |  def test2(using a2: A)(implicit b2: B) = summon[A] // error: ambiguous
+  |                                                    ^
+  |Ambiguous given instances: both parameter b2 and parameter a2 match type Minimization.A of parameter x of method summon in object Predef

--- a/tests/neg/i21212.scala
+++ b/tests/neg/i21212.scala
@@ -1,0 +1,11 @@
+
+object Minimization:
+
+  trait A
+  trait B extends A
+
+  def test1(using a1: A)(using    b1: B) = summon[A] // picks (most general) a1
+  def test2(using a2: A)(implicit b2: B) = summon[A] // error: ambiguous
+  def test3(implicit       a3: A, b3: B) = summon[A] // picks (most specific) b3
+
+end Minimization

--- a/tests/neg/i21303/JavaEnum.java
+++ b/tests/neg/i21303/JavaEnum.java
@@ -1,0 +1,1 @@
+public enum JavaEnum { ABC, DEF, GHI }

--- a/tests/neg/i21303/Test.scala
+++ b/tests/neg/i21303/Test.scala
@@ -1,0 +1,33 @@
+//> using options -source 3.6-migration
+import scala.deriving.Mirror
+import scala.compiletime.*
+import scala.reflect.ClassTag
+import scala.annotation.implicitNotFound
+
+
+trait TSType[T]
+object TSType extends DefaultTSTypes with TSTypeMacros
+
+trait TSNamedType[T] extends TSType[T]
+
+trait DefaultTSTypes extends JavaTSTypes
+trait JavaTSTypes {
+  given javaEnumTSType[E <: java.lang.Enum[E]: ClassTag]: TSNamedType[E] = ???
+}
+object DefaultTSTypes extends DefaultTSTypes
+trait TSTypeMacros {
+  inline given [T: Mirror.Of]: TSType[T] = derived[T]
+  inline def derived[T](using m: Mirror.Of[T]): TSType[T] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
+    ???
+  }
+
+  private inline def summonAll[T <: Tuple]: List[TSType[_]] = {
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TSType[t]] :: summonAll[ts]
+    }
+  }
+}
+
+@main def Test = summon[TSType[JavaEnum]] // error

--- a/tests/neg/i2974.scala
+++ b/tests/neg/i2974.scala
@@ -1,0 +1,16 @@
+
+trait Foo[-T]
+trait Bar[-T] extends Foo[T]
+
+object Test {
+
+  locally:
+    implicit val fa: Foo[Int] = ???
+    implicit val ba: Bar[Int] = ???
+    summon[Foo[Int]] // ok
+
+  locally:
+    implicit val fa: Foo[Int] = ???
+    implicit val ba: Bar[Any] = ???
+    summon[Foo[Int]] // error: ambiguous
+}

--- a/tests/neg/scala-uri.check
+++ b/tests/neg/scala-uri.check
@@ -1,0 +1,14 @@
+-- [E172] Type Error: tests/neg/scala-uri.scala:30:59 ------------------------------------------------------------------
+30 |@main def Test = summon[QueryKeyValue[(String, None.type)]]  // error
+   |                                                           ^
+   |No best given instance of type QueryKeyValue[(String, None.type)] was found for parameter x of method summon in object Predef.
+   |I found:
+   |
+   |    QueryKeyValue.tuple2QueryKeyValue[String, None.type](QueryKey.stringQueryKey,
+   |      QueryValue.optionQueryValue[A](
+   |        /* ambiguous: both given instance stringQueryValue in trait QueryValueInstances1 and given instance noneQueryValue in trait QueryValueInstances1 match type QueryValue[A] */
+   |          summon[QueryValue[A]]
+   |      )
+   |    )
+   |
+   |But both given instance stringQueryValue in trait QueryValueInstances1 and given instance noneQueryValue in trait QueryValueInstances1 match type QueryValue[A].

--- a/tests/neg/scala-uri.scala
+++ b/tests/neg/scala-uri.scala
@@ -1,0 +1,30 @@
+import scala.language.implicitConversions
+
+trait QueryKey[A]
+object QueryKey extends QueryKeyInstances
+sealed trait QueryKeyInstances:
+  given stringQueryKey: QueryKey[String] = ???
+
+trait QueryValue[-A]
+object QueryValue extends QueryValueInstances
+sealed trait QueryValueInstances1:
+  given stringQueryValue: QueryValue[String] = ???
+  given noneQueryValue: QueryValue[None.type] = ???
+    // The noneQueryValue makes no sense at this priority. Since QueryValue
+    // is contravariant, QueryValue[None.type] is always better than QueryValue[Option[A]]
+    // no matter whether it's old or new resolution. So taking both owner and type
+    // score into account, it's always a draw. With the new disambiguation, we prefer
+    // the optionQueryValue[A], which gives an ambiguity down the road, because we don't
+    // know what the  wrapped type A is. Previously, we preferred QueryValue[None.type]
+    // because it is unconditional. The solution is to put QueryValue[None.type] in the
+    // same trait as QueryValue[Option[A]], as is shown in pos/scala-uri.scala.
+
+sealed trait QueryValueInstances extends QueryValueInstances1:
+  given optionQueryValue[A: QueryValue]: QueryValue[Option[A]] = ???
+
+trait QueryKeyValue[A]
+object QueryKeyValue:
+  given tuple2QueryKeyValue[K: QueryKey, V: QueryValue]: QueryKeyValue[(K, V)] = ???
+
+
+@main def Test = summon[QueryKeyValue[(String, None.type)]]  // error

--- a/tests/pos/given-priority.scala
+++ b/tests/pos/given-priority.scala
@@ -1,0 +1,24 @@
+/* These tests show various mechanisms available for implicit prioritization.
+ */
+import language.`3.6`
+
+class A  // The type for which we infer terms below
+class B extends A
+
+/* First, two schemes that require a pre-planned architecture for how and
+ * where given instances are defined.
+ *
+ * Traditional scheme: prioritize with location in class hierarchy
+ */
+class LowPriorityImplicits:
+  given g1: A()
+
+object NormalImplicits extends LowPriorityImplicits:
+  given g2: B()
+
+def test1 =
+  import NormalImplicits.given
+  val x = summon[A]
+  val _: B = x
+  val y = summon[B]
+  val _: B = y

--- a/tests/pos/i21212.scala
+++ b/tests/pos/i21212.scala
@@ -20,14 +20,3 @@ class UsingArguments[F[_]](using Temporal[F])(using err: MonadError[F, Throwable
   val bool: F[Boolean] = ???
   def works = toFunctorOps(bool).map(_ => ()) // warns under -source:3.5
 
-
-object Minimization:
-
-  trait A
-  trait B extends A
-
-  def test1(using a1: A)(using    b1: B) = summon[A] // picks (most general) a1
-  def test2(using a2: A)(implicit b2: B) = summon[A] // picks (most general) a2, was ambiguous
-  def test3(implicit       a3: A, b3: B) = summon[A] // picks (most specific) b3
-
-end Minimization

--- a/tests/pos/i21303/JavaEnum.java
+++ b/tests/pos/i21303/JavaEnum.java
@@ -1,0 +1,1 @@
+public enum JavaEnum { ABC, DEF, GHI }

--- a/tests/pos/i21303/Test.scala
+++ b/tests/pos/i21303/Test.scala
@@ -1,0 +1,32 @@
+import scala.deriving.Mirror
+import scala.compiletime.*
+import scala.reflect.ClassTag
+import scala.annotation.implicitNotFound
+
+
+trait TSType[T]
+object TSType extends DefaultTSTypes with TSTypeMacros
+
+trait TSNamedType[T] extends TSType[T]
+
+trait DefaultTSTypes extends JavaTSTypes
+trait JavaTSTypes {
+  given javaEnumTSType[E <: java.lang.Enum[E]: ClassTag]: TSType[E] = ???
+}
+object DefaultTSTypes extends DefaultTSTypes
+trait TSTypeMacros {
+  inline given [T: Mirror.Of]: TSType[T] = derived[T]
+  inline def derived[T](using m: Mirror.Of[T]): TSType[T] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
+    ???
+  }
+
+  private inline def summonAll[T <: Tuple]: List[TSType[_]] = {
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TSType[t]] :: summonAll[ts]
+    }
+  }
+}
+
+@main def Test = summon[TSType[JavaEnum]]

--- a/tests/pos/i21303a/JavaEnum.java
+++ b/tests/pos/i21303a/JavaEnum.java
@@ -1,0 +1,1 @@
+public enum JavaEnum { ABC, DEF, GHI }

--- a/tests/pos/i21303a/Test.scala
+++ b/tests/pos/i21303a/Test.scala
@@ -1,0 +1,35 @@
+import scala.deriving.Mirror
+import scala.compiletime.*
+import scala.reflect.ClassTag
+import scala.annotation.implicitNotFound
+
+
+trait TSType[T]
+object TSType extends DefaultTSTypes with TSTypeMacros
+
+trait TSNamedType[T] extends TSType[T]
+
+trait DefaultTSTypes extends JavaTSTypes
+trait JavaTSTypes {
+  given javaEnumTSType[E <: java.lang.Enum[E]: ClassTag]: TSType[E] = ???
+  given javaEnumTSNamedType[E <: java.lang.Enum[E]: ClassTag]: TSNamedType[E] = ???
+}
+object DefaultTSTypes extends DefaultTSTypes
+trait TSTypeMacros {
+  inline given [T: Mirror.Of]: TSType[T] = derived[T]
+  inline def derived[T](using m: Mirror.Of[T]): TSType[T] = {
+    val elemInstances = summonAll[m.MirroredElemTypes]
+    ???
+  }
+
+  private inline def summonAll[T <: Tuple]: List[TSType[_]] = {
+    inline erasedValue[T] match {
+      case _: EmptyTuple => Nil
+      case _: (t *: ts)  => summonInline[TSType[t]] :: summonAll[ts]
+    }
+  }
+}
+
+@main def Test =
+  summon[TSType[JavaEnum]]
+  summon[TSNamedType[JavaEnum]]

--- a/tests/pos/i21320.scala
+++ b/tests/pos/i21320.scala
@@ -1,0 +1,73 @@
+import scala.deriving.*
+import scala.compiletime.*
+
+trait ConfigMonoid[T]:
+  def zero: T
+  def orElse(main: T, defaults: T): T
+
+object ConfigMonoid:
+  given option[T]: ConfigMonoid[Option[T]] = ???
+
+  inline def zeroTuple[C <: Tuple]: Tuple =
+    inline erasedValue[C] match
+      case _: EmptyTuple => EmptyTuple
+      case _: (t *: ts) =>
+        summonInline[ConfigMonoid[t]].zero *: zeroTuple[ts]
+
+  inline def valueTuple[C <: Tuple, T](index: Int, main: T, defaults: T): Tuple =
+    inline erasedValue[C] match
+      case _: EmptyTuple => EmptyTuple
+      case _: (t *: ts) =>
+        def get(v: T) = v.asInstanceOf[Product].productElement(index).asInstanceOf[t]
+        summonInline[ConfigMonoid[t]].orElse(get(main), get(defaults)) *: valueTuple[ts, T](
+          index + 1,
+          main,
+          defaults
+        )
+
+  inline given derive[T](using m: Mirror.ProductOf[T]): ConfigMonoid[T] =
+    new ConfigMonoid[T]:
+      def zero: T = m.fromProduct(zeroTuple[m.MirroredElemTypes])
+      def orElse(main: T, defaults: T): T = m.fromProduct(valueTuple[m.MirroredElemTypes, T](0, main, defaults))
+
+
+
+final case class PublishOptions(
+  v1: Option[String] = None,
+  v2: Option[String] = None,
+  v3: Option[String] = None,
+  v4: Option[String] = None,
+  v5: Option[String] = None,
+  v6: Option[String] = None,
+  v7: Option[String] = None,
+  v8: Option[String] = None,
+  v9: Option[String] = None,
+  ci: PublishContextualOptions = PublishContextualOptions(),
+)
+object PublishOptions:
+  implicit val monoid: ConfigMonoid[PublishOptions] = ConfigMonoid.derive
+
+final case class PublishContextualOptions(
+  v1: Option[String] = None,
+  v2: Option[String] = None,
+  v3: Option[String] = None,
+  v4: Option[String] = None,
+  v5: Option[String] = None,
+  v6: Option[String] = None,
+  v7: Option[String] = None,
+  v8: Option[String] = None,
+  v9: Option[String] = None,
+  v10: Option[String] = None,
+  v11: Option[String] = None,
+  v12: Option[String] = None,
+  v13: Option[String] = None,
+  v14: Option[String] = None,
+  v15: Option[String] = None,
+  v16: Option[String] = None,
+  v17: Option[String] = None,
+  v18: Option[String] = None,
+  v19: Option[String] = None,
+  v20: Option[String] = None
+)
+object PublishContextualOptions:
+  given monoid: ConfigMonoid[PublishContextualOptions] = ConfigMonoid.derive

--- a/tests/pos/i2974.scala
+++ b/tests/pos/i2974.scala
@@ -7,6 +7,7 @@ object Test {
   implicit val ba: Bar[Int] = ???
 
   def test: Unit = {
-    implicitly[Foo[Int]]
+    val x = summon[Foo[Int]]
+    val _: Bar[Int] = x
   }
 }

--- a/tests/pos/scala-uri.scala
+++ b/tests/pos/scala-uri.scala
@@ -1,0 +1,22 @@
+// This works for implicit/implicit pairs but not for givens, see neg version.
+import scala.language.implicitConversions
+
+trait QueryKey[A]
+object QueryKey extends QueryKeyInstances
+sealed trait QueryKeyInstances:
+  implicit val stringQueryKey: QueryKey[String] = ???
+
+trait QueryValue[-A]
+object QueryValue extends QueryValueInstances
+sealed trait QueryValueInstances1:
+  implicit final val stringQueryValue: QueryValue[String] = ???
+  implicit final val noneQueryValue: QueryValue[None.type] = ???
+
+sealed trait QueryValueInstances extends QueryValueInstances1:
+  implicit final def optionQueryValue[A: QueryValue]: QueryValue[Option[A]] = ???
+
+trait QueryKeyValue[A]
+object QueryKeyValue:
+  implicit def tuple2QueryKeyValue[K: QueryKey, V: QueryValue]: QueryKeyValue[(K, V)] = ???
+
+@main def Test = summon[QueryKeyValue[(String, None.type)]]

--- a/tests/pos/slick-migration-api-example.scala
+++ b/tests/pos/slick-migration-api-example.scala
@@ -1,0 +1,23 @@
+trait Migration
+object Migration:
+  implicit class MigrationConcat[M <: Migration](m: M):
+    def &[N <: Migration, O](n: N)(implicit ccm: CanConcatMigrations[M, N, O]): O = ???
+
+trait ReversibleMigration extends Migration
+trait MigrationSeq extends Migration
+trait ReversibleMigrationSeq extends MigrationSeq with ReversibleMigration
+
+trait ToReversible[-A <: Migration]
+object ToReversible:
+  implicit val reversible: ToReversible[ReversibleMigration] = ???
+class CanConcatMigrations[-A, -B, +C]
+trait CanConcatMigrationsLow:
+  implicit def default[A <: Migration, B <: Migration]: CanConcatMigrations[A, B, MigrationSeq] = ???
+object CanConcatMigrations extends CanConcatMigrationsLow:
+  implicit def reversible[A <: Migration, B <: Migration](implicit reverseA: ToReversible[A],
+                                                          reverseB: ToReversible[B]): CanConcatMigrations[A, B, ReversibleMigrationSeq] = ???
+
+@main def Test =
+  val rm: ReversibleMigration = ???
+  val rms = rm & rm & rm
+  summon[rms.type <:< ReversibleMigrationSeq] // error Cannot prove that (rms : slick.migration.api.MigrationSeq) <:< slick.migration.api.ReversibleMigrationSeq.

--- a/tests/warn/i21036a.check
+++ b/tests/warn/i21036a.check
@@ -1,6 +1,10 @@
 -- Warning: tests/warn/i21036a.scala:7:17 ------------------------------------------------------------------------------
 7 |val y = summon[A] // warn
   |                 ^
-  |                 Given search preference for A between alternatives (b : B) and (a : A) will change
+  |                 Given search preference for A between alternatives
+  |                   (b : B)
+  |                 and
+  |                   (a : A)
+  |                 will change.
   |                 Current choice           : the first alternative
   |                 New choice from Scala 3.6: the second alternative

--- a/tests/warn/i21036b.check
+++ b/tests/warn/i21036b.check
@@ -1,6 +1,10 @@
 -- Warning: tests/warn/i21036b.scala:7:17 ------------------------------------------------------------------------------
 7 |val y = summon[A] // warn
   |                 ^
-  |                 Change in given search preference for A between alternatives (b : B) and (a : A)
+  |                 Given search preference for A between alternatives
+  |                   (b : B)
+  |                 and
+  |                   (a : A)
+  |                 has changed.
   |                 Previous choice          : the first alternative
   |                 New choice from Scala 3.6: the second alternative


### PR DESCRIPTION
It applies the following tweaks:

 - Do treat givens as higher priority than implicits. The previous logic was faulty, but is corrected now.
 - Drop special handling of NotGiven in prioritization. The previous logic pretended to do so, but was ineffective.
 - Do use the old priority scheme for implicit/implicit pairs.
 - Do use owner score for givens as a tie breaker if after all other tests we still have an ambiguity.