### PR TITLE
Add a 3.6-migration warning for MT lubbing

### DIFF
--- a/tests/warn/i21258.check
+++ b/tests/warn/i21258.check
@@ -1,0 +1,6 @@
+-- Migration Warning: tests/warn/i21258.scala:4:17 ---------------------------------------------------------------------
+4 |  type MT[X] = X match { // warn
+  |               ^
+  |               Match type upper bound inferred as String, where previously it was defaulted to Any
+5 |    case Int => String
+6 |  }

--- a/tests/warn/i21258.scala
+++ b/tests/warn/i21258.scala
@@ -1,0 +1,14 @@
+import scala.language.`3.6-migration`
+
+object Test {
+  type MT[X] = X match { // warn
+    case Int => String
+  }
+
+  def unboundUnreducibleSig[X](x: X): MT[X] = ???
+
+  type MT2[X] = X match { // no warning
+    case Int => String
+    case String => Any
+  }
+}


### PR DESCRIPTION
Fixes #21258, all the other parts having been addressed (reverting a change in binary erasure, which shipped in patch releases)