### PR TITLE
Report only non-overridden unimplemented members

### DIFF
--- a/tests/neg/i21335.check
+++ b/tests/neg/i21335.check
@@ -1,0 +1,8 @@
+-- Error: tests/neg/i21335.scala:7:6 -----------------------------------------------------------------------------------
+7 |class Z1 extends Bar1 // error
+  |      ^
+  |      class Z1 needs to be abstract, since override def bar(): Bar1 in trait Bar1 is not defined 
+-- Error: tests/neg/i21335.scala:12:6 ----------------------------------------------------------------------------------
+12 |class Z2 extends Bar2 // error
+   |      ^
+   |      class Z2 needs to be abstract, since def bar(): Bar2 in trait Bar2 is not defined 

--- a/tests/neg/i21335.scala
+++ b/tests/neg/i21335.scala
@@ -1,0 +1,12 @@
+trait Foo:
+  def bar(): Foo
+
+trait Bar1 extends Foo:
+  override def bar(): Bar1
+
+class Z1 extends Bar1 // error
+
+trait Bar2 extends Foo:
+  def bar(): Bar2
+
+class Z2 extends Bar2 // error


### PR DESCRIPTION
Previously, when a concrete class A had unimplemented members that are overridden, all overrides would be reported as unimplemented in the error message. This would produce error messages that are not accurate, and that suggest stubs that are not correct.

This patch fixes the issue by reporting in the error message only the unimplemented members that are not overridden by other unimplemented members.

Fixes #21335