### PR TITLE
fix: throw an error before assigning ErrorType when expanding constValue

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -429,6 +429,7 @@ object Inlines:
           val constVal = tryConstValue(tpe)
           if constVal.isEmpty then
             val msg = NotConstant("cannot take constValue", tpe)
+            report.error(msg, callTypeArgs.head.srcPos)
             ref(defn.Predef_undefined).withSpan(callTypeArgs.head.span).withType(ErrorType(msg))
           else
             constVal

--- a/tests/neg/i21359.scala
+++ b/tests/neg/i21359.scala
@@ -1,0 +1,6 @@
+import scala.compiletime.constValueTuple
+import scala.deriving.Mirror
+
+case class Hello(a: Int)
+val mirror = summon[Mirror.Of[Hello]]
+val test = constValueTuple[mirror.MirroredElemTypes] // error


### PR DESCRIPTION
fixes #21359 