### PR TITLE
Backport "Bump scala-cli to 1.4.1 + drop old cli management" to 3.5.1

### DIFF
--- a/dist/bin-native-overrides/cli-common-platform
+++ b/dist/bin-native-overrides/cli-common-platform
@@ -1,16 +1,3 @@
 #!/usr/bin/env bash
 
-if [[ ${cygwin-} || ${mingw-} || ${msys-} ]]; then
-    SCALA_CLI_VERSION=""
-    # iterate through lines in VERSION_SRC
-    while IFS= read -r line; do
-    # if line starts with "version:=" then extract the version
-    if [[ "$line" == cli_version:=* ]]; then
-        SCALA_CLI_VERSION="${line#cli_version:=}"
-        break
-    fi
-    done < "$PROG_HOME/EXTRA_PROPERTIES"
-    SCALA_CLI_CMD_BASH=("\"$PROG_HOME/bin/scala-cli\"" "--cli-version \"$SCALA_CLI_VERSION\"")
-else
-    SCALA_CLI_CMD_BASH=("\"$PROG_HOME/bin/scala-cli\"")
-fi
+SCALA_CLI_CMD_BASH=("\"$PROG_HOME/bin/scala-cli\"")

--- a/dist/bin-native-overrides/cli-common-platform.bat
+++ b/dist/bin-native-overrides/cli-common-platform.bat
@@ -1,22 +1,3 @@
 @echo off
 
-setlocal enabledelayedexpansion
-
-set "_SCALA_CLI_VERSION="
-@rem read for cli_version:=_SCALA_CLI_VERSION in EXTRA_PROPERTIES file
-FOR /F "usebackq delims=" %%G IN ("%_PROG_HOME%\EXTRA_PROPERTIES") DO (
-  SET "line=%%G"
-  IF "!line:~0,13!"=="cli_version:=" (
-    SET "_SCALA_CLI_VERSION=!line:~13!"
-    GOTO :foundCliVersion
-  )
-)
-
-@REM we didn't find it, so we should fail
-echo "ERROR: cli_version not found in EXTRA_PROPERTIES file"
-exit /b 1
-
-:foundCliVersion
-endlocal & set "SCALA_CLI_VERSION=%_SCALA_CLI_VERSION%"
-
-set SCALA_CLI_CMD_WIN="%_PROG_HOME%\bin\scala-cli.exe" "--cli-version" "%SCALA_CLI_VERSION%"
+set SCALA_CLI_CMD_WIN="%_PROG_HOME%\bin\scala-cli.exe"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -119,8 +119,6 @@ object Build {
 
   /** Version of Scala CLI to download */
   val scalaCliLauncherVersion = "1.4.0"
-  /** Version of Scala CLI to download (on Windows - last known validated version) */
-  val scalaCliLauncherVersionWindows = "1.4.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.10"
 
@@ -2176,10 +2174,8 @@ object Build {
       packArchiveName := (dist / packArchiveName).value + "-x86_64-pc-win32",
       republishBinOverrides += (dist / baseDirectory).value / "bin-native-overrides",
       republishFetchCoursier := (dist / republishFetchCoursier).value,
-      republishExtraProps += ("cli_version" -> scalaCliLauncherVersion),
-      mappings += (republishRepo.value / "EXTRA_PROPERTIES" -> "EXTRA_PROPERTIES"),
       republishLaunchers +=
-        ("scala-cli.exe" -> s"zip+https://github.com/VirtusLab/scala-cli/releases/download/v$scalaCliLauncherVersionWindows/scala-cli-x86_64-pc-win32.zip!/scala-cli.exe")
+        ("scala-cli.exe" -> s"zip+https://github.com/VirtusLab/scala-cli/releases/download/v$scalaCliLauncherVersion/scala-cli-x86_64-pc-win32.zip!/scala-cli.exe")
     )
 
   lazy val `dist-linux-x86_64` = project.in(file("dist/linux-x86_64")).asDist(Bootstrapped)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -118,7 +118,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.4.0"
+  val scalaCliLauncherVersion = "1.4.1"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.10"
 


### PR DESCRIPTION
Backports #21234 to Scala 3.5.1-RC2