### PR TITLE
Backport "Bump scala-cli to 1.4.3" to 3.5.1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -118,7 +118,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.4.1"
+  val scalaCliLauncherVersion = "1.4.3"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.10"
 


### PR DESCRIPTION
Backports #21338 to Scala 3.5.1-RC2