### PR TITLE
Use default self type more often

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -528,9 +528,11 @@ extension (cls: ClassSymbol)
                                  // and err on the side of impure.
               && selfType.exists && selfType.captureSet.isAlwaysEmpty
 
-  def baseClassHasExplicitSelfType(using Context): Boolean =
+  def baseClassHasExplicitNonUniversalSelfType(using Context): Boolean =
     cls.baseClasses.exists: bc =>
-      bc.is(CaptureChecked) && bc.givenSelfType.exists
+      bc.is(CaptureChecked)
+      && bc.givenSelfType.exists
+      && !bc.givenSelfType.captureSet.isUniversal
 
   def matchesExplicitRefsInBaseClass(refs: CaptureSet)(using Context): Boolean =
     cls.baseClasses.tail.exists: bc =>

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -572,7 +572,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
                 else if cls.isPureClass then
                   // is cls is known to be pure, nothing needs to be added to self type
                   selfInfo
-                else if !cls.isEffectivelySealed && !cls.baseClassHasExplicitSelfType then
+                else if !cls.isEffectivelySealed && !cls.baseClassHasExplicitNonUniversalSelfType then
                   // assume {cap} for completely unconstrained self types of publicly extensible classes
                   CapturingType(cinfo.selfType, CaptureSet.universal)
                 else

--- a/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
+++ b/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
@@ -16,13 +16,10 @@ package collection
 import scala.annotation.nowarn
 import language.experimental.captureChecking
 
-trait IndexedSeqViewOps[+A, +CC[_], +C] extends Any with SeqViewOps[A, CC, C] {
-  self: IndexedSeqViewOps[A, CC, C]^ =>
-}
+trait IndexedSeqViewOps[+A, +CC[_], +C] extends Any with SeqViewOps[A, CC, C]
 
 /** View defined in terms of indexing a range */
 trait IndexedSeqView[+A] extends IndexedSeqViewOps[A, View, View[A]] with SeqView[A] {
-  self: IndexedSeqView[A]^ =>
 
   override def view: IndexedSeqView[A]^{this} = this
 

--- a/scala2-library-cc/src/scala/collection/SeqView.scala
+++ b/scala2-library-cc/src/scala/collection/SeqView.scala
@@ -25,7 +25,6 @@ import scala.annotation.unchecked.uncheckedCaptures
  *  mapping a SeqView with an impure function gives an impure view).
  */
 trait SeqViewOps[+A, +CC[_], +C] extends Any with IterableOps[A, CC, C] {
-  self: SeqViewOps[A, CC, C]^ =>
 
   def length: Int
   def apply(x: Int): A
@@ -75,7 +74,6 @@ trait SeqViewOps[+A, +CC[_], +C] extends Any with IterableOps[A, CC, C] {
 }
 
 trait SeqView[+A] extends SeqViewOps[A, View, View[A]] with View[A] {
-  self: SeqView[A]^ =>
 
   override def view: SeqView[A]^{this} = this
 


### PR DESCRIPTION
We now also use cap as the default for the self type's capture set if a base class has an explicit self type, but that type's capture set is universal. This requires fewer self type annotations.