### PR TITLE
Expand Capability types T to T^ only if no explicit capture set is given

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -528,9 +528,11 @@ extension (cls: ClassSymbol)
                                  // and err on the side of impure.
               && selfType.exists && selfType.captureSet.isAlwaysEmpty
 
-  def baseClassHasExplicitSelfType(using Context): Boolean =
+  def baseClassHasExplicitNonUniversalSelfType(using Context): Boolean =
     cls.baseClasses.exists: bc =>
-      bc.is(CaptureChecked) && bc.givenSelfType.exists
+      bc.is(CaptureChecked)
+      && bc.givenSelfType.exists
+      && !bc.givenSelfType.captureSet.isUniversal
 
   def matchesExplicitRefsInBaseClass(refs: CaptureSet)(using Context): Boolean =
     cls.baseClasses.tail.exists: bc =>

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -632,7 +632,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         def addParamArgRefinements(core: Type, initCs: CaptureSet): (Type, CaptureSet) =
           var refined: Type = core
           var allCaptures: CaptureSet =
-            if core.derivesFromCapability then CaptureSet.universal else initCs
+            if core.derivesFromCapability then defn.universalCSImpliedByCapability else initCs
           for (getterName, argType) <- mt.paramNames.lazyZip(argTypes) do
             val getter = cls.info.member(getterName).suchThat(_.isRefiningParamAccessor).symbol
             if !getter.is(Private) && getter.hasTrackedParts then
@@ -809,7 +809,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         val localSet = capturedVars(sym)
         if !localSet.isAlwaysEmpty then
           curEnv = Env(sym, EnvKind.Regular, localSet, curEnv)
-          
+
         // ctx with AssumedContains entries for each Contains parameter
         val bodyCtx =
           var ac = CaptureSet.assumedContains
@@ -828,7 +828,7 @@ class CheckCaptures extends Recheck, SymTransformer:
               interpolateVarsIn(tree.tpt)
             curEnv = saved
     end recheckDefDef
-    
+
     /** If val or def definition with inferred (result) type is visible
      *  in other compilation units, check that the actual inferred type
      *  conforms to the expected type where all inferred capture sets are dropped.

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -570,7 +570,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
                 else if cls.isPureClass then
                   // is cls is known to be pure, nothing needs to be added to self type
                   selfInfo
-                else if !cls.isEffectivelySealed && !cls.baseClassHasExplicitSelfType then
+                else if !cls.isEffectivelySealed && !cls.baseClassHasExplicitNonUniversalSelfType then
                   // assume {cap} for completely unconstrained self types of publicly extensible classes
                   CapturingType(cinfo.selfType, CaptureSet.universal)
                 else

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1005,6 +1005,9 @@ class Definitions {
     @tu lazy val Caps_ContainsTrait: TypeSymbol = CapsModule.requiredType("Contains")
     @tu lazy val Caps_containsImpl: TermSymbol = CapsModule.requiredMethod("containsImpl")
 
+  /** The same as CaptureSet.universal but generated implicitly for references of Capability subtypes */
+  @tu lazy val universalCSImpliedByCapability = CaptureSet(captureRoot.termRef)
+
   @tu lazy val PureClass: Symbol = requiredClass("scala.Pure")
 
   // Annotation base classes

--- a/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
+++ b/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
@@ -16,13 +16,10 @@ package collection
 import scala.annotation.nowarn
 import language.experimental.captureChecking
 
-trait IndexedSeqViewOps[+A, +CC[_], +C] extends Any with SeqViewOps[A, CC, C] {
-  self: IndexedSeqViewOps[A, CC, C]^ =>
-}
+trait IndexedSeqViewOps[+A, +CC[_], +C] extends Any with SeqViewOps[A, CC, C]
 
 /** View defined in terms of indexing a range */
 trait IndexedSeqView[+A] extends IndexedSeqViewOps[A, View, View[A]] with SeqView[A] {
-  self: IndexedSeqView[A]^ =>
 
   override def view: IndexedSeqView[A]^{this} = this
 

--- a/scala2-library-cc/src/scala/collection/SeqView.scala
+++ b/scala2-library-cc/src/scala/collection/SeqView.scala
@@ -25,7 +25,6 @@ import scala.annotation.unchecked.uncheckedCaptures
  *  mapping a SeqView with an impure function gives an impure view).
  */
 trait SeqViewOps[+A, +CC[_], +C] extends Any with IterableOps[A, CC, C] {
-  self: SeqViewOps[A, CC, C]^ =>
 
   def length: Int
   def apply(x: Int): A
@@ -75,7 +74,6 @@ trait SeqViewOps[+A, +CC[_], +C] extends Any with IterableOps[A, CC, C] {
 }
 
 trait SeqView[+A] extends SeqViewOps[A, View, View[A]] with View[A] {
-  self: SeqView[A]^ =>
 
   override def view: SeqView[A]^{this} = this
 

--- a/tests/pos-custom-args/captures/cap-refine.scala
+++ b/tests/pos-custom-args/captures/cap-refine.scala
@@ -1,0 +1,12 @@
+//> using options -Werror
+import caps.Capability
+
+trait Buffer[T] extends Capability:
+  def append(x: T): this.type
+
+def f(buf: Buffer[Int]) =
+  val buf1 = buf.append(1).append(2)
+  val buf2: Buffer[Int]^{buf1} = buf1
+
+
+


### PR DESCRIPTION
If C is a class extending caps.Capability we used to always expand C to C^, even if there was an explicitly given capture set. For instance `C^{x}` got expanded to `C^{cap}^{x}` which caused a redundant capture x warning. 

We now do this expansion only if there is no explicitly given capture set.

@natsukagami I hope this helps the Async use case.
