### PR TITLE
Bump tasty format for 28.6.x

### DIFF
--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -324,7 +324,7 @@ object TastyFormat {
    *  compatibility, but remains backwards compatible, with all
    *  preceding `MinorVersion`.
    */
-  final val MinorVersion: Int = 5
+  final val MinorVersion: Int = 6
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing


### PR DESCRIPTION
[test_non_bootstrapped]

Fixes: https://github.com/scala/scala3/actions/runs/10366706352/job/28696553741