### PR TITLE
[CI] Publish build scans to develocity.scala-lang.org

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -29,6 +29,8 @@ jobs:
           cache: 'sbt'
       - name: Build MSI package
         run: sbt 'dist-win-x86_64/Windows/packageBin'
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Upload MSI Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -52,6 +52,8 @@ jobs:
       mac-aarch64-id   : ${{ steps.mac-aarch64.outputs.artifact-id }}
       win-x86_64-id    : ${{ steps.win-x86_64.outputs.artifact-id }}
       win-x86_64-digest: ${{ steps.win-x86_64-digest.outputs.digest }}
+    env:
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -112,5 +114,3 @@ jobs:
         run : |
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -o artifact.zip -L https://api.github.com/repos/scala/scala3/actions/artifacts/${{ steps.win-x86_64.outputs.artifact-id }}/zip
           echo "digest=$(sha256sum artifact.zip | cut -d " " -f 1)" >> "$GITHUB_OUTPUT"
-
-          

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ on:
 
 env:
   DOTTY_CI_RUN: true
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 # In this file, we set `--cpu-shares 4096` on every job. This might seem useless
 # since it means that every container has the same weight which should be
@@ -1013,7 +1014,7 @@ jobs:
     uses: ./.github/workflows/build-msi.yml
     if  : github.event_name == 'pull_request' && contains(github.event.pull_request.body, '[test_msi]')
     # TODO: ADD A JOB THAT DEPENDS ON THIS TO TEST THE MSI
-    
+
   build-sdk-package:
     uses: ./.github/workflows/build-sdk.yml
     with:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: scalacenter/sbt-dependency-submission@v3
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -43,6 +43,8 @@ jobs:
           ./project/scripts/sbt "scaladoc/generateReferenceDocumentation --no-regenerate-expected-links"
           ./project/scripts/docsLinksStability ./scaladoc/output/reference ./project/scripts/expected-links/reference-expected-links.txt
           cd ..
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
       - name: Push changes to scala3-reference-docs
         if: github.event_name == 'push'

--- a/.github/workflows/launchers.yml
+++ b/.github/workflows/launchers.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
 jobs:
   linux-x86_64:
     name: Deploy and Test on Linux x64 architecture

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -16,6 +16,7 @@ jobs:
   build:
     env:
       AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     runs-on: ubuntu-latest
     if: "github.event_name == 'merge_group'
          || (    github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Dotty
 =====
 [![Dotty CI](https://github.com/scala/scala3/workflows/Dotty/badge.svg?branch=main)](https://github.com/scala/scala3/actions?query=branch%3Amain)
 [![Join the chat at https://discord.com/invite/scala](https://img.shields.io/discord/632150470000902164)](https://discord.com/invite/scala)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://develocity.scala-lang.org)
 
 * [Documentation](https://docs.scala-lang.org/scala3/)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -908,6 +908,10 @@ object Build {
           sjsSources
         } (Set(scalaJSIRSourcesJar)).toSeq
       }.taskValue,
+
+      // Develocity's Build Cache does not work with our compilation tests
+      // at the moment.
+      Test / develocityBuildCacheClient := None,
   )
 
   def insertClasspathInArgs(args: List[String], cp: String): List[String] = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -273,19 +273,25 @@ object Build {
     // Configuration to publish build scans to develocity.scala-lang.org
     develocityConfiguration := {
       val isInsideCI = insideCI.value
-      val previousConfig = develocityConfiguration.value
-      val previousBuildScan = previousConfig.buildScan
-      previousConfig
+      val config = develocityConfiguration.value
+      val buildScan = config.buildScan
+      val buildCache = config.buildCache
+      config
         .withProjectId(ProjectId("scala3"))
-        .withServer(previousConfig.server.withUrl(Some(url("https://develocity.scala-lang.org"))))
+        .withServer(config.server.withUrl(Some(url("https://develocity.scala-lang.org"))))
         .withBuildScan(
-          previousBuildScan
+          buildScan
             .withPublishing(Publishing.onlyIf(_.authenticated))
             .withBackgroundUpload(!isInsideCI)
             .tag(if (isInsideCI) "CI" else "Local")
-            .withLinks(previousBuildScan.links ++ GithubEnv.develocityLinks)
-            .withValues(previousBuildScan.values ++ GithubEnv.develocityValues)
-            .withObfuscation(previousBuildScan.obfuscation.withIpAddresses(_.map(_ => "0.0.0.0")))
+            .withLinks(buildScan.links ++ GithubEnv.develocityLinks)
+            .withValues(buildScan.values ++ GithubEnv.develocityValues)
+            .withObfuscation(buildScan.obfuscation.withIpAddresses(_.map(_ => "0.0.0.0")))
+        )
+        .withBuildCache(
+          buildCache
+            .withLocal(buildCache.local.withEnabled(false))
+            .withRemote(buildCache.remote.withEnabled(false))
         )
     }
   )
@@ -910,7 +916,7 @@ object Build {
       }.taskValue,
 
       // Develocity's Build Cache does not work with our compilation tests
-      // at the moment.
+      // at the moment: it does not take compilation files as inputs.
       Test / develocityBuildCacheClient := None,
   )
 

--- a/project/GithubEnv.scala
+++ b/project/GithubEnv.scala
@@ -1,0 +1,30 @@
+import scala.util.Properties
+import sbt.url
+import java.net.URL
+
+
+// https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/variables#default-environment-variables
+object GithubEnv {
+  lazy val repositoryVar: Option[(String, String)] = envVar("GITHUB_REPOSITORY")
+  lazy val runIdVar: Option[(String, String)] = envVar("GITHUB_RUN_ID")
+  lazy val shaVar: Option[(String, String)] = envVar("GITHUB_SHA")
+  lazy val workflowVar: Option[(String, String)] = envVar("GITHUB_WORKFLOW")
+
+  lazy val runUrl: Option[(String, URL)] =
+    for {
+      (_, repository) <- repositoryVar
+      (_, runId) <- runIdVar
+    } yield "GITHUB_RUN" -> url(s"https://github.com/$repository/actions/runs/$runId")
+  lazy val treeUrl: Option[(String, URL)] =
+    for {
+      (_, repository) <- repositoryVar
+      (_, sha) <- shaVar
+    } yield "GITHUB_TREE" -> url(s"https://github.com/$repository/tree/$sha")
+
+
+  def develocityValues: Seq[(String, String)] = repositoryVar.toSeq ++ shaVar ++ workflowVar
+  def develocityLinks: Seq[(String, URL)] = runUrl.toSeq ++ treeUrl
+
+  private def envVar(key: String): Option[(String, String)] =
+    Properties.envOrNone(key).map(key -> _)
+}

--- a/project/GithubEnv.scala
+++ b/project/GithubEnv.scala
@@ -14,12 +14,12 @@ object GithubEnv {
     for {
       (_, repository) <- repositoryVar
       (_, runId) <- runIdVar
-    } yield "GITHUB_RUN" -> url(s"https://github.com/$repository/actions/runs/$runId")
+    } yield "GitHub Run" -> url(s"https://github.com/$repository/actions/runs/$runId")
   lazy val treeUrl: Option[(String, URL)] =
     for {
       (_, repository) <- repositoryVar
       (_, sha) <- shaVar
-    } yield "GITHUB_TREE" -> url(s"https://github.com/$repository/tree/$sha")
+    } yield "GitHub Commit" -> url(s"https://github.com/$repository/tree/$sha")
 
 
   def develocityValues: Seq[(String, String)] = repositoryVar.toSeq ++ shaVar ++ workflowVar

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,4 +22,4 @@ addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.0.1")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.1.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.2")
 addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
+
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.0.1")


### PR DESCRIPTION
For the Context, Gradle is supporting the Scala Center with a free instance of [Develocity](https://gradle.com/gradle-enterprise-solutions/) that we can use to analyze the build scans of our open-source projects.

This PR configures publishing of build scans for every GitHub workflow of the `scala/scala3` CI. All build scans will be publicly available on https://develocity.scala-lang.org/.

The `sbt-develocity` plugin can also do test retry and flaky test detection, which I will activate in a subsequent PR, on some test classes.