### PR TITLE
Undo patch of double-block apply

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -27,7 +27,7 @@ import ScriptParsers.*
 import Decorators.*
 import util.Chars
 import scala.annotation.tailrec
-import rewrites.Rewrites.{patch, overlapsPatch}
+import rewrites.Rewrites.{overlapsPatch, patch, unpatch}
 import reporting.*
 import config.Feature
 import config.Feature.{sourceVersion, migrateTo3}
@@ -2741,6 +2741,12 @@ object Parsers {
           simpleExprRest(tapp, location, canApply = true)
         case LPAREN | LBRACE | INDENT if canApply =>
           val app = atSpan(startOffset(t), in.offset) { mkApply(t, argumentExprs()) }
+          if in.rewriteToIndent then
+            app match
+              case Apply(Apply(_, List(Block(_, _))), List(blk @ Block(_, _))) =>
+                unpatch(blk.srcPos.sourcePos.source, Span(blk.span.start, blk.span.start + 1))
+                unpatch(blk.srcPos.sourcePos.source, Span(blk.span.end, blk.span.end + 1))
+              case _ =>
           simpleExprRest(app, location, canApply = true)
         case USCORE =>
           atSpan(startOffset(t), in.skipToken()) { PostfixOp(t, Ident(nme.WILDCARD)) }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -77,6 +77,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i17399.scala", unindentOptions.and("-rewrite")),
       compileFile("tests/rewrites/i20002.scala", defaultOptions.and("-indent", "-rewrite")),
       compileDir("tests/rewrites/annotation-named-pararamters", defaultOptions.and("-rewrite", "-source:3.6-migration")),
+      compileFile("tests/rewrites/i21382.scala", defaultOptions.and("-indent", "-rewrite")),
     ).checkRewrites()
   }
 

--- a/tests/rewrites/i21382.scala
+++ b/tests/rewrites/i21382.scala
@@ -1,0 +1,8 @@
+def check(element: Any)(expected: String): Unit = ???
+
+def test =
+  check {
+    ???
+  }{
+    42.toString
+  }


### PR DESCRIPTION
If `f{}{}` is candidate for rewrite, unpatch it.

We don't know exact spans, so just check endpoints to remove.

Fixes #21382 