### PR TITLE
Add migration rewrite for non-named arguments in Java annotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
@@ -43,6 +43,8 @@ object MigrationVersion:
   val WithOperator = MigrationVersion(`3.4`, future)
   val FunctionUnderscore = MigrationVersion(`3.4`, future)
 
+  val NonNamedArgumentInJavaAnnotation = MigrationVersion(`3.6`, `3.6`)
+
   val ImportWildcard = MigrationVersion(future, future)
   val ImportRename = MigrationVersion(future, future)
   val ParameterEnclosedByParenthesis = MigrationVersion(future, future)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -35,6 +35,7 @@ import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SourcePosition
 import scala.jdk.CollectionConverters.*
 import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.config.SourceVersion
 import DidYouMean.*
 
 /**  Messages
@@ -3293,6 +3294,7 @@ class NonNamedArgumentInJavaAnnotation(using Context) extends SyntaxMsg(NonNamed
 
   override protected def msg(using Context): String = 
     "Named arguments are required for Java defined annotations"
+    + Message.rewriteNotice("This", version = SourceVersion.`3.6-migration`)
 
   override protected def explain(using Context): String = 
     i"""Starting from Scala 3.6.0, named arguments are required for Java defined annotations.

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -910,7 +910,7 @@ object Checking {
           report.errorOrMigrationWarning(NonNamedArgumentInJavaAnnotation(), param, MigrationVersion.NonNamedArgumentInJavaAnnotation)
           if MigrationVersion.NonNamedArgumentInJavaAnnotation.needsPatch then
             annotationFieldNamesByIdx.get(paramIdx).foreach: paramName =>
-              patch(param.span, untpd.cpy.NamedArg(param)(paramName, param).show)
+              patch(param.span.startPos, s"$paramName = ")
         annot
       case _ => annot
   end checkNamedArgumentForJavaAnnotation

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -76,6 +76,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i17187.scala", unindentOptions.and("-rewrite")),
       compileFile("tests/rewrites/i17399.scala", unindentOptions.and("-rewrite")),
       compileFile("tests/rewrites/i20002.scala", defaultOptions.and("-indent", "-rewrite")),
+      compileDir("tests/rewrites/annotation-named-pararamters", defaultOptions.and("-rewrite", "-source:3.6-migration")),
     ).checkRewrites()
   }
 

--- a/tests/neg/i20554-a.check
+++ b/tests/neg/i20554-a.check
@@ -2,6 +2,7 @@
 3 |@Annotation(3, 4) // error // error : Java defined annotation should be called with named arguments
   |            ^
   |            Named arguments are required for Java defined annotations
+  |            This can be rewritten automatically under -rewrite -source 3.6-migration.
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -23,6 +24,7 @@
 3 |@Annotation(3, 4) // error // error : Java defined annotation should be called with named arguments
   |               ^
   |               Named arguments are required for Java defined annotations
+  |               This can be rewritten automatically under -rewrite -source 3.6-migration.
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/neg/i20554-b.check
+++ b/tests/neg/i20554-b.check
@@ -2,6 +2,7 @@
 3 |@SimpleAnnotation(1) // error: the parameters is not named 'value'
   |                  ^
   |                  Named arguments are required for Java defined annotations
+  |                  This can be rewritten automatically under -rewrite -source 3.6-migration.
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/rewrites/annotation-named-pararamters/MyAnnotation.java
+++ b/tests/rewrites/annotation-named-pararamters/MyAnnotation.java
@@ -1,0 +1,8 @@
+import java.util.concurrent.TimeUnit;
+
+public @interface MyAnnotation {
+  public TimeUnit D() default TimeUnit.DAYS;
+  TimeUnit C() default TimeUnit.DAYS;
+  String A() default "";
+  public String B() default "";
+}

--- a/tests/rewrites/annotation-named-pararamters/test.check
+++ b/tests/rewrites/annotation-named-pararamters/test.check
@@ -1,0 +1,6 @@
+import java.util.concurrent.TimeUnit
+@MyAnnotation() class Test1
+@MyAnnotation(D = TimeUnit.DAYS) class Test2
+@MyAnnotation(D = TimeUnit.DAYS, C = TimeUnit.DAYS) class Test3
+@MyAnnotation(D = TimeUnit.DAYS, C = TimeUnit.DAYS, A = "foo") class Test4
+@MyAnnotation(D = TimeUnit.DAYS, C = TimeUnit.DAYS, A = "foo", B = "bar") class Test5

--- a/tests/rewrites/annotation-named-pararamters/test.scala
+++ b/tests/rewrites/annotation-named-pararamters/test.scala
@@ -1,0 +1,6 @@
+import java.util.concurrent.TimeUnit
+@MyAnnotation() class Test1
+@MyAnnotation(TimeUnit.DAYS) class Test2
+@MyAnnotation(TimeUnit.DAYS, TimeUnit.DAYS) class Test3
+@MyAnnotation(TimeUnit.DAYS, TimeUnit.DAYS, "foo") class Test4
+@MyAnnotation(TimeUnit.DAYS, TimeUnit.DAYS, "foo", "bar") class Test5


### PR DESCRIPTION
Followup to #21329
It might be beneficial for Scala 3.6 migration to allow for an automatic rewrite of unnamed Java annotation parameters to ease the migration. 
We can assume that already compiling code is already using correct positions for annotation arguments. 
Based on that, we can use the order of the annotation decls and their indexes to assume the names of annotation arguments