### PR TITLE
Avoid using the current denotation in NamedType.disambiguate

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -961,7 +961,7 @@ object Denotations {
     }
 
     def staleSymbolError(using Context): Nothing =
-      if symbol.isPackageObject && ctx.run != null && ctx.run.nn.isCompilingSuspended
+      if symbol.lastKnownDenotation.isPackageObject && ctx.run != null && ctx.run.nn.isCompilingSuspended
       then throw StaleSymbolTypeError(symbol)
       else throw StaleSymbolException(staleSymbolMsg)
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2491,7 +2491,10 @@ object Types extends TypeUtils {
     }
 
     private def disambiguate(d: Denotation)(using Context): Denotation =
-      disambiguate(d, currentSignature, currentSymbol.targetName)
+      // this method might be triggered while the denotation is already being recomputed
+      // in NamedType, so it's better to use lastKnownDenotation instead, as targetName
+      // should not change between phases/runs
+      disambiguate(d, currentSignature, currentSymbol.lastKnownDenotation.targetName)
 
     private def disambiguate(d: Denotation, sig: Signature | Null, target: Name)(using Context): Denotation =
       if (sig != null)

--- a/tests/pos-macros/i20574/Exports.scala
+++ b/tests/pos-macros/i20574/Exports.scala
@@ -1,0 +1,3 @@
+object Exports{
+  export OverloadedInline.*
+}

--- a/tests/pos-macros/i20574/Macros.scala
+++ b/tests/pos-macros/i20574/Macros.scala
@@ -1,0 +1,20 @@
+import scala.quoted.*
+
+object Macros{
+
+  inline def A() : String = {
+     ${ A_impl }
+  }
+
+  def A_impl(using Quotes): Expr[String] = {
+    Expr("Whatever")
+  }
+
+  inline def B[T]: Int = {
+    ${ B_Impl[T] }
+  }
+
+  def B_Impl[T](using Quotes): Expr[Int] = {
+    Expr(0)
+  }
+}

--- a/tests/pos-macros/i20574/OverloadedInline.scala
+++ b/tests/pos-macros/i20574/OverloadedInline.scala
@@ -1,0 +1,13 @@
+import Macros.*
+
+object OverloadedInline{
+
+    A()
+    inline def overloaded_inline[T]: Unit = {
+        overloaded_inline[T](0)
+    }
+
+    inline def overloaded_inline[T](dummy: Int): Unit = {
+        val crash = B[T]
+    }
+}

--- a/tests/pos-macros/i20574/Test.scala
+++ b/tests/pos-macros/i20574/Test.scala
@@ -1,0 +1,5 @@
+import Exports.*
+
+object Test {
+   overloaded_inline[Unit]
+}


### PR DESCRIPTION
While recalculating denotation in NamedType (in `NamedType.memberDenot`, which itself can be called from `NamedType.computeDenot` or `NamedType.recomputeDenot`), it might call `NamedType.disambiguate` which uses a denotation to decide about the correct overloaded method. Using current denotation here might cause stale symbol errors, so instead we use the `lastKnownDenotation`, which should be enough for the use case here, as `targetName` should not change between phases/runs.

Later in the denotation recalculation a similar thing happens with `SourceLanguage.apply`, where we also now avoid using currentDenotation, as whether the symbol comes from java or Scala 2 should also not change between phases/runs.

Fixes #20574