### PR TITLE
feat: show inferred type on holes in hover [skip ci]

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
@@ -25,6 +25,8 @@ import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.pc.printer.ShortenedTypePrinter
 import dotty.tools.pc.printer.ShortenedTypePrinter.IncludeDefaultParam
 import dotty.tools.pc.utils.InteractiveEnrichments.*
+import dotty.tools.dotc.ast.untpd.InferredTypeTree
+import dotty.tools.dotc.core.StdNames
 
 object HoverProvider:
 
@@ -131,7 +133,12 @@ object HoverProvider:
             .flatMap(symTpe => search.symbolDocumentation(symTpe._1, contentType))
             .map(_.docstring())
             .mkString("\n")
-          printer.expressionType(exprTpw) match
+
+          val expresionTypeOpt = 
+            if symbol.name == StdNames.nme.??? then
+              InferExpectedType(search, driver, params).infer()
+            else printer.expressionType(exprTpw)
+          expresionTypeOpt match
             case Some(expressionType) =>
               val forceExpressionType =
                 !pos.span.isZeroExtent || (

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverHoleSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverHoleSuite.scala
@@ -1,0 +1,75 @@
+package dotty.tools.pc.tests.hover
+
+import dotty.tools.pc.base.BaseHoverSuite
+
+import org.junit.Test
+
+class HoverHoleSuite extends BaseHoverSuite:
+  @Test def basic =
+    check(
+      """object a {
+        |  val x: Int = ?@@??
+        |}
+        |""".stripMargin,
+      """|**Expression type**:
+         |```scala
+         |Int
+         |```
+         |**Symbol signature**:
+         |```scala
+         |def ???: Nothing
+         |```
+         |""".stripMargin
+    )
+
+  @Test def function =
+    check(
+      """object a {
+        |  def m(i: Int) = ???
+        |  val x = m(??@@?)
+        |}
+        |""".stripMargin,
+      """|**Expression type**:
+         |```scala
+         |Int
+         |```
+         |**Symbol signature**:
+         |```scala
+         |def ???: Nothing
+         |```
+         |""".stripMargin
+    )
+
+  @Test def constructor =
+    check(
+      """object a {
+        |  val x = List(1, ?@@??)
+        |}
+        |""".stripMargin,
+      """|**Expression type**:
+         |```scala
+         |Int
+         |```
+         |**Symbol signature**:
+         |```scala
+         |def ???: Nothing
+         |```
+         |""".stripMargin
+    )
+
+  @Test def bounds =
+    check(
+      """|trait Foo
+         |def foo[T <: Foo](a: T): Boolean = ???
+         |val _ = foo(?@@??)
+         |""".stripMargin,
+      """|**Expression type**:
+         |```scala
+         |Foo
+         |```
+         |**Symbol signature**:
+         |```scala
+         |def ???: Nothing
+         |```
+         |""".stripMargin
+    )


### PR DESCRIPTION
Low hanging fruit after: https://github.com/scala/scala3/pull/21390.

It seems useful to see the inferred "expected" type on holes, so this PR adds them to be visible on hover.
<img width="692" alt="Screenshot 2024-08-23 at 14 16 17" src="https://github.com/user-attachments/assets/c89d4d5a-1d48-4419-9d9c-41e27eb332a1">

This won't be perfect, as we can't always infer the expected type as we'd like to (see: `InferExpectedTypeSuite#flatmap`, so I'm sure we want to introduce that at all.

Side note: Probably we should write something different than `Expression type:` in hover here.

cc: @tgodzik