### PR TITLE
Try to fix stale symbol errors connected to lazyvals

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
+++ b/compiler/src/dotty/tools/dotc/transform/LazyVals.scala
@@ -477,6 +477,7 @@ class LazyVals extends MiniPhase with IdentityDenotTransformer {
         newSymbol(claz, offsetName(info.defs.size), Synthetic, defn.LongType).enteredAfter(this)
       case None =>
         newSymbol(claz, offsetName(0), Synthetic, defn.LongType).enteredAfter(this)
+    offsetSymbol.installAfter(this)
     offsetSymbol.nn.addAnnotation(Annotation(defn.ScalaStaticAnnot, offsetSymbol.nn.span))
     val fieldTree = thizClass.select(lazyNme.RLazyVals.getDeclaredField).appliedTo(Literal(Constant(containerName.mangledString)))
     val offsetTree = ValDef(offsetSymbol.nn, getOffset.appliedTo(fieldTree))

--- a/tests/pos/i21271/Macro.scala
+++ b/tests/pos/i21271/Macro.scala
@@ -1,0 +1,12 @@
+import scala.quoted.*
+
+trait Schema
+object Schema:
+  lazy val sampleDate: String = "" // lazy val requried to reproduce
+
+  inline def derived: Schema =
+    annotations
+    new Schema {}
+
+inline def annotations: Int = ${ annotationsImpl }
+def annotationsImpl(using Quotes): Expr[Int] = Expr(1)

--- a/tests/pos/i21271/Test.scala
+++ b/tests/pos/i21271/Test.scala
@@ -1,0 +1,1 @@
+val inputValueSchema = Schema.derived


### PR DESCRIPTION
The actual stale symbol error, while recent, seems correct to me. There is no reason why an earlier phase (Mixins) should see a denotation from a later phase (LazyVals) - if the opposite is true (like with the fix here) the bringForward method is able to recover with a NoDenotation, which I think is what we want.

Based on #21280