### PR TITLE
Check all top-level covariant capture sets in checkNotUniversal

### DIFF
--- a/tests/neg-custom-args/captures/i21401.check
+++ b/tests/neg-custom-args/captures/i21401.check
@@ -1,0 +1,10 @@
+-- Error: tests/neg-custom-args/captures/i21401.scala:15:22 ------------------------------------------------------------
+15 |  val a = usingIO[IO^](x => x) // error: The expression's type IO^ is not allowed to capture the root capability `cap`
+   |          ^^^^^^^^^^^^^^^^^^^^
+   |          The expression's type box IO^ is not allowed to capture the root capability `cap`.
+   |          This usually means that a capability persists longer than its allowed lifetime.
+-- Error: tests/neg-custom-args/captures/i21401.scala:16:70 ------------------------------------------------------------
+16 |  val leaked: [R, X <: Boxed[IO^] -> R] -> (op: X) -> R = usingIO[Res](mkRes) // error: The expression's type Res is not allowed to capture the root capability `cap` in its part box IO^
+   |                                                          ^^^^^^^^^^^^^^^^^^^
+   |              The expression's type Res is not allowed to capture the root capability `cap` in its part box IO^.
+   |              This usually means that a capability persists longer than its allowed lifetime.

--- a/tests/neg-custom-args/captures/i21401.scala
+++ b/tests/neg-custom-args/captures/i21401.scala
@@ -1,0 +1,19 @@
+import language.experimental.captureChecking
+
+trait IO:
+  def println(s: String): Unit
+def usingIO[R](op: IO^ => R): R = ???
+
+case class Boxed[+T](unbox: T)
+
+type Res = [R, X <: Boxed[IO^] -> R] -> (op: X) -> R
+def mkRes(x: IO^): Res =
+  [R, X <: Boxed[IO^] -> R] => (op: X) =>
+    val op1: Boxed[IO^] -> R = op
+    op1(Boxed[IO^](x))
+def test2() =
+  val a = usingIO[IO^](x => x) // error: The expression's type IO^ is not allowed to capture the root capability `cap`
+  val leaked: [R, X <: Boxed[IO^] -> R] -> (op: X) -> R = usingIO[Res](mkRes) // error: The expression's type Res is not allowed to capture the root capability `cap` in its part box IO^
+  val x: Boxed[IO^] = leaked[Boxed[IO^], Boxed[IO^] -> Boxed[IO^]](x => x)
+  val y: IO^{x*} = x.unbox
+  y.println("boom")


### PR DESCRIPTION
Fixes #21401