### PR TITLE
Avoid import suggestion thread hang if -Ximport-suggestion-timeout <= 1

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -148,9 +148,9 @@ trait ImportSuggestions:
    *   `name` that are applicable to `T`.
    */
   private def importSuggestions(pt: Type)(using Context): (List[TermRef], List[TermRef]) =
-    val timer = new Timer()
     val allotted = ctx.run.nn.importSuggestionBudget
     if allotted <= 1 then return (Nil, Nil)
+    val timer = new Timer()
     implicits.println(i"looking for import suggestions, timeout = ${allotted}ms")
     val start = System.currentTimeMillis()
     val deadLine = start + allotted


### PR DESCRIPTION
Without this change, if -Ximport-suggestion-timeout is set to 0 or 1, we
would create a Timer thread and never cancel it, making the whole
execution thread hang.
