### PR TITLE
SimplePattern errors should now be recovered as wildcard instead of unimplemented expr

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3198,7 +3198,7 @@ object Parsers {
         else {
           val start = in.lastOffset
           syntaxErrorOrIncomplete(IllegalStartOfSimplePattern(), expectedOffset)
-          errorTermTree(start)
+          atSpan(Span(start, in.offset)) { Ident(nme.WILDCARD) }
         }
     }
 

--- a/tests/neg/i5004.scala
+++ b/tests/neg/i5004.scala
@@ -2,5 +2,5 @@ object i0 {
 1 match {
 def this(): Int  // error
   def this()
-} // error
+}
 }

--- a/tests/neg/parser-stability-1.scala
+++ b/tests/neg/parser-stability-1.scala
@@ -1,4 +1,3 @@
 object x0 {
 x1 match  // error
 def this // error
-// error


### PR DESCRIPTION
We should not emit more errors that came from our error recovery term trees.

Previously, we've recovered those situations with unimplemented expression term added in https://github.com/scala/scala3/pull/19103
and before that it was just a `null`