### PR TITLE
Backport "fix: semanticdb symbol creation when `targetName` set" to 3.5.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
@@ -91,7 +91,8 @@ class SemanticSymbolBuilder:
         case _ =>
       end find
       val sig = sym.signature
-      find(_.signature == sig)
+      val targetName = sym.targetName
+      find(sym => sym.signature == sig && sym.targetName == targetName)
 
     def addDescriptor(sym: Symbol): Unit =
       if sym.is(ModuleClass) then

--- a/tests/semanticdb/expect/TargetName.expect.scala
+++ b/tests/semanticdb/expect/TargetName.expect.scala
@@ -1,0 +1,8 @@
+package example
+
+object TargetName/*<-example::TargetName.*/:
+  @annotation.targetName/*->scala::annotation::targetName#*/("m1")
+  def m/*<-example::TargetName.m().*/(i/*<-example::TargetName.m().(i)*/: Int/*->scala::Int#*/) = 1
+  @annotation.targetName/*->scala::annotation::targetName#*/("m2")
+  def m/*<-example::TargetName.m(+1).*/(i/*<-example::TargetName.m(+1).(i)*/: Int/*->scala::Int#*/) = 1
+  def m1/*<-example::TargetName.m1().*/(i/*<-example::TargetName.m1().(i)*/: String/*->scala::Predef.String#*/) = 1

--- a/tests/semanticdb/expect/TargetName.scala
+++ b/tests/semanticdb/expect/TargetName.scala
@@ -1,0 +1,8 @@
+package example
+
+object TargetName:
+  @annotation.targetName("m1")
+  def m(i: Int) = 1
+  @annotation.targetName("m2")
+  def m(i: Int) = 1
+  def m1(i: String) = 1

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3799,6 +3799,43 @@ Synthetics:
 		.map => *[Int]
 [3:1..3:5):List => *.apply[Int]
 
+expect/TargetName.scala
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => TargetName.scala
+Text => empty
+Language => Scala
+Symbols => 7 entries
+Occurrences => 15 entries
+
+Symbols:
+example/TargetName. => final object TargetName extends Object { self: TargetName.type => +4 decls }
+example/TargetName.m(). => @targetName method m (param i: Int): Int
+example/TargetName.m().(i) => param i: Int
+example/TargetName.m(+1). => @targetName method m (param i: Int): Int
+example/TargetName.m(+1).(i) => param i: Int
+example/TargetName.m1(). => method m1 (param i: String): Int
+example/TargetName.m1().(i) => param i: String
+
+Occurrences:
+[0:8..0:15): example <- example/
+[2:7..2:17): TargetName <- example/TargetName.
+[3:3..3:13): annotation -> scala/annotation/
+[3:14..3:24): targetName -> scala/annotation/targetName#
+[4:6..4:7): m <- example/TargetName.m().
+[4:8..4:9): i <- example/TargetName.m().(i)
+[4:11..4:14): Int -> scala/Int#
+[5:3..5:13): annotation -> scala/annotation/
+[5:14..5:24): targetName -> scala/annotation/targetName#
+[6:6..6:7): m <- example/TargetName.m(+1).
+[6:8..6:9): i <- example/TargetName.m(+1).(i)
+[6:11..6:14): Int -> scala/Int#
+[7:6..7:8): m1 <- example/TargetName.m1().
+[7:9..7:10): i <- example/TargetName.m1().(i)
+[7:12..7:18): String -> scala/Predef.String#
+
 expect/Traits.scala
 -------------------
 


### PR DESCRIPTION
Backports #20950 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]