### PR TITLE
Backport "Streamline `tryNormalize` with `underlyingMatchType`" to 3.5.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5159,11 +5159,7 @@ object Types extends TypeUtils {
     private var reductionContext: util.MutableMap[Type, Type] | Null = null
 
     override def tryNormalize(using Context): Type =
-      try
-        reduced.normalized
-      catch
-        case ex: Throwable =>
-          handleRecursive("normalizing", s"${scrutinee.show} match ..." , ex)
+      reduced.normalized
 
     private def thisMatchType = this
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -492,7 +492,7 @@ object Types extends TypeUtils {
     /** Does this application expand to a match type? */
     def isMatchAlias(using Context): Boolean = underlyingNormalizable.isMatch
 
-    def underlyingNormalizable(using Context): Type = stripped match
+    def underlyingNormalizable(using Context): Type = stripped.stripLazyRef match
       case tp: MatchType => tp
       case tp: AppliedType => tp.underlyingNormalizable
       case _ => NoType
@@ -3257,8 +3257,6 @@ object Types extends TypeUtils {
   case class LazyRef(private var refFn: (Context => (Type | Null)) | Null) extends UncachedProxyType with ValueType {
     private var myRef: Type | Null = null
     private var computed = false
-
-    override def tryNormalize(using Context): Type = ref.tryNormalize
 
     def ref(using Context): Type =
       if computed then

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4695,7 +4695,7 @@ object Types extends TypeUtils {
           case AliasingBounds(alias) if isMatchAlias =>
             trace(i"normalize $this", typr, show = true) {
               MatchTypeTrace.recurseWith(this) {
-                alias.applyIfParameterized(args.map(_.normalized)).tryNormalize
+                alias.applyIfParameterized(args).tryNormalize
                 /* `applyIfParameterized` may reduce several HKTypeLambda applications
                  * before the underlying MatchType is reached.
                  * Even if they do not involve any match type normalizations yet,

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5708,7 +5708,8 @@ object Types extends TypeUtils {
   /** Common supertype of `TypeAlias` and `MatchAlias` */
   abstract class AliasingBounds(val alias: Type) extends TypeBounds(alias, alias) {
 
-    def derivedAlias(alias: Type)(using Context): AliasingBounds
+    def derivedAlias(alias: Type)(using Context): AliasingBounds =
+      if alias eq this.alias then this else AliasingBounds(alias)
 
     override def computeHash(bs: Binders): Int = doHash(bs, alias)
     override def hashIsStable: Boolean = alias.hashIsStable
@@ -5730,10 +5731,7 @@ object Types extends TypeUtils {
 
   /**    = T
    */
-  class TypeAlias(alias: Type) extends AliasingBounds(alias) {
-    def derivedAlias(alias: Type)(using Context): AliasingBounds =
-      if (alias eq this.alias) this else TypeAlias(alias)
-  }
+  class TypeAlias(alias: Type) extends AliasingBounds(alias)
 
   /**    = T     where `T` is a `MatchType`
    *
@@ -5742,10 +5740,7 @@ object Types extends TypeUtils {
    *  If we assumed full substitutivity, we would have to reject all recursive match
    *  aliases (or else take the jump and allow full recursive types).
    */
-  class MatchAlias(alias: Type) extends AliasingBounds(alias) {
-    def derivedAlias(alias: Type)(using Context): AliasingBounds =
-      if (alias eq this.alias) this else MatchAlias(alias)
-  }
+  class MatchAlias(alias: Type) extends AliasingBounds(alias)
 
   object TypeBounds {
     def apply(lo: Type, hi: Type)(using Context): TypeBounds =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -492,12 +492,10 @@ object Types extends TypeUtils {
     /** Does this application expand to a match type? */
     def isMatchAlias(using Context): Boolean = underlyingMatchType.exists
 
-    def underlyingMatchType(using Context): Type = stripped match {
+    def underlyingMatchType(using Context): Type = stripped match
       case tp: MatchType => tp
-      case tp: HKTypeLambda => tp.resType.underlyingMatchType
       case tp: AppliedType => tp.underlyingMatchType
       case _ => NoType
-    }
 
     /** Is this a higher-kinded type lambda with given parameter variances?
      *  These lambdas are used as the RHS of higher-kinded abstract types or
@@ -4682,6 +4680,7 @@ object Types extends TypeUtils {
 
     /** Exists if the tycon is a TypeRef of an alias with an underlying match type.
      *  Anything else should have already been reduced in `appliedTo` by the TypeAssigner.
+     *  May reduce several HKTypeLambda applications before the underlying MatchType is reached.
      */
     override def underlyingMatchType(using Context): Type =
       if ctx.period != validUnderlyingMatch then
@@ -4689,28 +4688,15 @@ object Types extends TypeUtils {
         validUnderlyingMatch = validSuper
       cachedUnderlyingMatch
 
-    override def tryNormalize(using Context): Type = tycon.stripTypeVar match {
-      case tycon: TypeRef =>
-        def tryMatchAlias = tycon.info match
-          case AliasingBounds(alias) if isMatchAlias =>
-            trace(i"normalize $this", typr, show = true) {
-              MatchTypeTrace.recurseWith(this) {
-                alias.applyIfParameterized(args).tryNormalize
-                /* `applyIfParameterized` may reduce several HKTypeLambda applications
-                 * before the underlying MatchType is reached.
-                 * Even if they do not involve any match type normalizations yet,
-                 * we still want to record these reductions in the MatchTypeTrace.
-                 * They should however only be attempted if they eventually expand
-                 * to a match type, which is ensured by the `isMatchAlias` guard.
-                 */
-              }
-            }
-          case _ =>
-            NoType
-        tryCompiletimeConstantFold.orElse(tryMatchAlias)
-      case _ =>
-        NoType
-    }
+    override def tryNormalize(using Context): Type =
+      def tryMatchAlias =
+        if isMatchAlias then trace(i"normalize $this", typr, show = true):
+          if MatchTypeTrace.isRecording then
+            MatchTypeTrace.recurseWith(this)(superType.tryNormalize)
+          else
+            underlyingMatchType.tryNormalize
+        else NoType
+      tryCompiletimeConstantFold.orElse(tryMatchAlias)
 
     /** Is this an unreducible application to wildcard arguments?
      *  This is the case if tycon is higher-kinded. This means

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2031,7 +2031,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               case _ => false
             }
 
-        val result = pt.underlyingMatchType match {
+        val result = pt.underlyingNormalizable match {
           case mt: MatchType if isMatchTypeShaped(mt) =>
             typedDependentMatchFinish(tree, sel1, selType, tree.cases, mt)
           case _ =>

--- a/compiler/test/dotc/neg-best-effort-pickling.blacklist
+++ b/compiler/test/dotc/neg-best-effort-pickling.blacklist
@@ -15,6 +15,7 @@ illegal-match-types.scala
 i13780-1.scala
 i20317a.scala
 i11226.scala
+i974.scala
 
 # semantic db generation fails in the first compilation
 i1642.scala

--- a/tests/neg/i12049d.check
+++ b/tests/neg/i12049d.check
@@ -1,0 +1,14 @@
+-- [E007] Type Mismatch Error: tests/neg/i12049d.scala:14:52 -----------------------------------------------------------
+14 |val x: M[NotRelevant[Nothing], Relevant[Nothing]] = 2 // error
+   |                                                    ^
+   |                                                  Found:    (2 : Int)
+   |                                                  Required: M[NotRelevant[Nothing], Relevant[Nothing]]
+   |
+   |                                                  Note: a match type could not be fully reduced:
+   |
+   |                                                    trying to reduce  M[NotRelevant[Nothing], Relevant[Nothing]]
+   |                                                    trying to reduce  Relevant[Nothing]
+   |                                                    failed since selector Nothing
+   |                                                    is uninhabited (there are no values of that type).
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i12049d.scala
+++ b/tests/neg/i12049d.scala
@@ -1,0 +1,14 @@
+
+trait A
+trait B
+
+type M[X, Y] = Y match
+  case A => Int
+  case B => String
+
+type Relevant[Z] = Z match
+  case A => B
+type NotRelevant[Z] = Z match
+  case B => A
+
+val x: M[NotRelevant[Nothing], Relevant[Nothing]] = 2 // error

--- a/tests/pos/i20482.scala
+++ b/tests/pos/i20482.scala
@@ -1,0 +1,16 @@
+trait WrapperType[A]
+
+case class Foo[A]()
+
+case class Bar[A]()
+
+type FooToBar[D[_]] = [A] =>> D[Unit] match {
+  case Foo[Unit] => Bar[A]
+}
+
+case class Test()
+object Test {
+  implicit val wrapperType: WrapperType[Bar[Test]] = new WrapperType[Bar[Test]] {}
+}
+
+val test = summon[WrapperType[FooToBar[Foo][Test]]]

--- a/tests/pos/matchtype-unusedArg/A_1.scala
+++ b/tests/pos/matchtype-unusedArg/A_1.scala
@@ -1,0 +1,8 @@
+
+type Rec[X] = X match
+  case Int => Rec[X]
+
+type M[Unused, Y] = Y match
+  case String => Double
+
+def foo[X](d: M[Rec[X], "hi"]) = ???

--- a/tests/pos/matchtype-unusedArg/B_2.scala
+++ b/tests/pos/matchtype-unusedArg/B_2.scala
@@ -1,0 +1,2 @@
+
+def Test = foo[Int](3d) // crash before changes


### PR DESCRIPTION
Backports #20268 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]