### PR TITLE
Backport "fix: don't use color codes for pattern match code action" to 3.5.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -840,7 +840,7 @@ object SpaceEngine {
 
     if uncovered.nonEmpty then
       val deduped = dedup(uncovered)
-      report.warning(PatternMatchExhaustivity(deduped.map(display), m), m.selector)
+      report.warning(PatternMatchExhaustivity(deduped, m), m.selector)
   }
 
   private def reachabilityCheckable(sel: Tree)(using Context): Boolean =
@@ -903,7 +903,7 @@ object SpaceEngine {
   def checkMatch(m: Match)(using Context): Unit =
     checkMatchExhaustivityOnly(m)
     if reachabilityCheckable(m.selector) then checkReachability(m)
-  
+
   def checkMatchExhaustivityOnly(m: Match)(using Context): Unit =
     if exhaustivityCheckable(m.selector) then checkExhaustivity(m)
 }


### PR DESCRIPTION
Backports #21120 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]