### PR TITLE
Backport "Add _spec to dependabot" to 3.5.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       - hamzaremmal
     reviewers:
       - hamzaremmal
+  - package-ecosystem: bundler
+    directory: '/docs/_spec'
+    schedule:
+      interval: weekly
+    assignees:
+      - hamzaremmal
+    reviewers:
+      - hamzaremmal
+      


### PR DESCRIPTION
Backports #21227 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]