### PR TITLE
Backport "Bump VirtusLab/scala-cli-setup from 1.4.0 to 1.4.1" to 3.5.2

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: VirtusLab/scala-cli-setup@v1.4.0
+      - uses: VirtusLab/scala-cli-setup@v1.4.1
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ secrets.GRAPHQL_API_TOKEN }}


### PR DESCRIPTION
Backports #21233 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]