### PR TITLE
Backport "Bump webrick from 1.7.0 to 1.8.1 in /docs/_spec" to 3.5.2

### DIFF
--- a/docs/_spec/Gemfile.lock
+++ b/docs/_spec/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    webrick (1.7.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Backports #21232 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]