### PR TITLE
Backport "Fail when a poly function value has a different number of type params than the expected poly function" to 3.5.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2929,6 +2929,13 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       case pair if pending != null && pending.contains(pair) =>
         false
 
+      /* Nothing is not a class type in the spec but dotc represents it as if it were one.
+       * Get it out of the way early to avoid mistakes (see for example #20897).
+       * Nothing ⋔ T and T ⋔ Nothing for all T.
+       */
+      case (tp1, tp2) if tp1.isExactlyNothing || tp2.isExactlyNothing =>
+        true
+
       // Cases where there is an intersection or union on the right
       case (tp1, tp2: OrType) =>
         provablyDisjoint(tp1, tp2.tp1, pending) && provablyDisjoint(tp1, tp2.tp2, pending)
@@ -2941,14 +2948,21 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       case (tp1: AndType, tp2) =>
         provablyDisjoint(tp1.tp1, tp2, pending) || provablyDisjoint(tp1.tp2, tp2, pending)
 
+      /* Handle AnyKind now for the same reason as Nothing above: it is not a real class type.
+       * Other than the rules with Nothing, unions and intersections, there is structurally
+       * no rule such that AnyKind ⋔ T or T ⋔ AnyKind for any T.
+       */
+      case (tp1, tp2) if tp1.isDirectRef(AnyKindClass) || tp2.isDirectRef(AnyKindClass) =>
+        false
+
       // Cases involving type lambdas
       case (tp1: HKTypeLambda, tp2: HKTypeLambda) =>
         tp1.paramNames.sizeCompare(tp2.paramNames) != 0
           || provablyDisjoint(tp1.resultType, tp2.resultType, pending)
       case (tp1: HKTypeLambda, tp2) =>
-        !tp2.isDirectRef(defn.AnyKindClass)
+        true
       case (tp1, tp2: HKTypeLambda) =>
-        !tp1.isDirectRef(defn.AnyKindClass)
+        true
 
       /* Cases where both are unique values (enum cases or constant types)
        *
@@ -3052,17 +3066,13 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         else child
       }.filter(child => child.exists && child != cls)
 
-    // TODO? Special-case for Nothing and Null? We probably need Nothing/Null disjoint from Nothing/Null
     def eitherDerivesFromOther(cls1: Symbol, cls2: Symbol): Boolean =
       cls1.derivesFrom(cls2) || cls2.derivesFrom(cls1)
 
     def smallestNonTraitBase(cls: Symbol): Symbol =
       cls.asClass.baseClasses.find(!_.is(Trait)).get
 
-    if cls1 == defn.AnyKindClass || cls2 == defn.AnyKindClass then
-      // For some reason, A.derivesFrom(AnyKind) returns false, so we have to handle it specially
-      false
-    else if (eitherDerivesFromOther(cls1, cls2))
+    if (eitherDerivesFromOther(cls1, cls2))
       false
     else
       if (cls1.is(Final) || cls2.is(Final))

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1895,32 +1895,34 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val untpd.Function(vparams: List[untpd.ValDef] @unchecked, body) = fun: @unchecked
     val dpt = pt.dealias
 
-    // If the expected type is a polymorphic function with the same number of
-    // type and value parameters, then infer the types of value parameters from the expected type.
-    val inferredVParams = dpt match
-      case defn.PolyFunctionOf(poly @ PolyType(_, mt: MethodType))
-      if tparams.lengthCompare(poly.paramNames) == 0 && vparams.lengthCompare(mt.paramNames) == 0 =>
-        vparams.zipWithConserve(mt.paramInfos): (vparam, formal) =>
-          // Unlike in typedFunctionValue, `formal` cannot be a TypeBounds since
-          // it must be a valid method parameter type.
-          if vparam.tpt.isEmpty && isFullyDefined(formal, ForceDegree.failBottom) then
-            cpy.ValDef(vparam)(tpt = new untpd.InLambdaTypeTree(isResult = false, (tsyms, vsyms) =>
-              // We don't need to substitute `mt` by `vsyms` because we currently disallow
-              // dependencies between value parameters of a closure.
-              formal.substParams(poly, tsyms.map(_.typeRef)))
-            )
-          else vparam
-      case _ =>
-        vparams
-
-    val resultTpt = dpt match
+    dpt match
       case defn.PolyFunctionOf(poly @ PolyType(_, mt: MethodType)) =>
-        untpd.InLambdaTypeTree(isResult = true, (tsyms, vsyms) =>
-          mt.resultType.substParams(mt, vsyms.map(_.termRef)).substParams(poly, tsyms.map(_.typeRef)))
-      case _ => untpd.TypeTree()
-
-    val desugared = desugar.makeClosure(tparams, inferredVParams, body, resultTpt, tree.span)
-    typed(desugared, pt)
+        if tparams.lengthCompare(poly.paramNames) == 0 && vparams.lengthCompare(mt.paramNames) == 0 then
+          // If the expected type is a polymorphic function with the same number of
+          // type and value parameters, then infer the types of value parameters from the expected type.
+          val inferredVParams = vparams.zipWithConserve(mt.paramInfos): (vparam, formal) =>
+            // Unlike in typedFunctionValue, `formal` cannot be a TypeBounds since
+            // it must be a valid method parameter type.
+            if vparam.tpt.isEmpty && isFullyDefined(formal, ForceDegree.failBottom) then
+              cpy.ValDef(vparam)(tpt = new untpd.InLambdaTypeTree(isResult = false, (tsyms, vsyms) =>
+                // We don't need to substitute `mt` by `vsyms` because we currently disallow
+                // dependencies between value parameters of a closure.
+                formal.substParams(poly, tsyms.map(_.typeRef)))
+              )
+            else vparam
+          val resultTpt =
+            untpd.InLambdaTypeTree(isResult = true, (tsyms, vsyms) =>
+              mt.resultType.substParams(mt, vsyms.map(_.termRef)).substParams(poly, tsyms.map(_.typeRef)))
+          val desugared = desugar.makeClosure(tparams, inferredVParams, body, resultTpt, tree.span)
+          typed(desugared, pt)
+        else
+          val msg =
+            em"""|Provided polymorphic function value doesn't match the expected type $dpt.
+                 |Expected type should be a polymorphic function with the same number of type and value parameters."""
+          errorTree(EmptyTree, msg, tree.srcPos)
+      case _ =>
+        val desugared = desugar.makeClosure(tparams, vparams, body, untpd.TypeTree(), tree.span)
+        typed(desugared, pt)
   end typedPolyFunctionValue
 
   def typedClosure(tree: untpd.Closure, pt: Type)(using Context): Tree = {

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -67,6 +67,7 @@ mt-redux-norm.perspective.scala
 i18211.scala
 10867.scala
 named-tuples1.scala
+i20897.scala
 
 # Opaque type
 i5720.scala
@@ -134,4 +135,3 @@ parsercombinators-new-syntax.scala
 hylolib-deferred-given
 hylolib-cb
 hylolib
-

--- a/tests/neg/i20533.check
+++ b/tests/neg/i20533.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg/i20533.scala:5:8 -----------------------------------------------------------------------------------
+5 |    [X] => (x, y) => Map(x -> y) // error
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |    Provided polymorphic function value doesn't match the expected type [X, Y] => (x$1: X, x$2: Y) => Map[X, Y].
+  |    Expected type should be a polymorphic function with the same number of type and value parameters.

--- a/tests/neg/i20533.scala
+++ b/tests/neg/i20533.scala
@@ -1,0 +1,6 @@
+def mapF(h: [X, Y] => (X, Y) => Map[X, Y]): Unit = ???
+
+def test =
+  mapF(
+    [X] => (x, y) => Map(x -> y) // error
+  )

--- a/tests/pos/i20897.scala
+++ b/tests/pos/i20897.scala
@@ -1,0 +1,10 @@
+object Test:
+  type Disj[A, B] =
+    A match
+      case B => true
+      case _ => false
+
+  def f(a: Disj[1 | Nothing, 2 | Nothing]): Unit = ()
+
+  val t = f(false)
+end Test


### PR DESCRIPTION
Backports #21248 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]