### PR TITLE
Companions and nested classes are nest mates

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Flatten.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Flatten.scala
@@ -6,8 +6,10 @@ import DenotTransformers.SymTransformer
 import Contexts.*
 import Flags.*
 import SymDenotations.SymDenotation
+import Symbols.Symbol
 import collection.mutable
 import MegaPhase.MiniPhase
+import util.Property
 import util.Store
 
 import scala.compiletime.uninitialized
@@ -50,9 +52,31 @@ class Flatten extends MiniPhase with SymTransformer {
     }
 
   override def transformStats(stats: List[Tree])(using Context): List[Tree] =
+    import Flatten.{NestHost, NestMembers, initialTopLevelClass}
     if ctx.owner.is(Package) then
+      // among top-level stats, find class defs with module and set class as host
+      for d <- stats do
+        if d.isInstanceOf[TypeDef] && !d.symbol.is(ModuleClass) then
+          stats.find(_.symbol == d.symbol.scalacLinkedClass).foreach: module =>
+            module.putAttachment(NestHost, d.symbol)
+            val members = d.getAttachment(NestMembers).getOrElse(Nil)
+            d.putAttachment(NestMembers, module.symbol :: members)
+
       val defs = liftedDefs
       if defs != null then
+        // among lifted classes, make the original tlc a nest host, or if the tlc is a module, its companion if it exists
+        for d <- defs do
+          val sym = d.symbol
+          val tlc = sym.initialTopLevelClass
+          val cmp = if tlc.is(ModuleClass) then stats.find(_.symbol == tlc.scalacLinkedClass) else None
+          cmp.orElse(stats.find(_.symbol == tlc)) match
+            case Some(topTree) =>
+              d.getAttachment(NestHost) match
+                case Some(host) =>
+                case None => d.putAttachment(NestHost, topTree.symbol)
+              val members = topTree.getAttachment(NestMembers).map(sym :: _).getOrElse(sym :: Nil)
+              topTree.putAttachment(NestMembers, members)
+            case None => // error no top class in package statements
         val liftedStats = stats ++ defs
         defs.clear()
         liftedStats
@@ -66,3 +90,13 @@ class Flatten extends MiniPhase with SymTransformer {
 object Flatten:
   val name: String = "flatten"
   val description: String = "lift all inner classes to package scope"
+
+  val NestHost: Property.Key[Symbol] = Property.Key()
+  val NestMembers: Property.Key[List[Symbol]] = Property.Key()
+
+  extension (sym: SymDenotation) def initialTopLevelClass(using Context): Symbol =
+    def topLevel(d: SymDenotation): Symbol =
+      if d.isTopLevelClass then d.symbol
+      else topLevel(d.owner.initial)
+    val top = topLevel(sym.initial)
+    if top.isClass then top else top.moduleClass

--- a/tests/run/t6882.scala
+++ b/tests/run/t6882.scala
@@ -1,0 +1,88 @@
+//> using options --Xtarget:11
+// using jvm 11+
+// test: -jvm 11+
+// scalajs: --skip
+
+class C private (private val i: Int, private val j: Int) {
+  private val c = i + C.secret
+
+  @inline def f = j * 2
+}
+object C {
+  def unwrap(c: C): Int = c.c
+
+  def apply(i: Int, j: Int): C = new C(i, j)
+
+  private def secret = 5
+}
+
+class D(d0: String) {
+  private def d = d0
+  def e = new E
+  class E {
+    def e = D.this.d
+  }
+}
+object D {
+}
+
+object Top {
+  private def i = 42
+  class Nested {
+    def f = i
+  }
+  def j = new Nested().f
+}
+
+class TopHeavy {
+  private def i = TopHeavy.underlying
+}
+object TopHeavy {
+  private def underlying = 42
+  class Nested {
+    def f = new TopHeavy().i
+  }
+  def j = new Nested().f
+}
+
+class TippyTop {
+  private def secret = 42
+  class Medial {
+    class Nadir {
+      class Abyssal {
+        def answer = secret
+      }
+    }
+  }
+}
+
+object Test {
+  import java.lang.reflect.Modifier.{PRIVATE => Private}
+  def main(args: Array[String]): Unit = {
+    assert(C.unwrap(C(42, 27)) == 47)
+    for (m <- Class.forName("C$").getDeclaredMethods; n = m.getName if n.contains("secret")) {
+      assert(n == "secret", s"name was $n")
+      assert((m.getModifiers & Private) != 0, s"$n not private")
+    }
+    assert(new D("mystery").e.e == "mystery")
+    for (m <- Class.forName("D").getDeclaredMethods; n = m.getName if n.contains("d")) {
+      assert(n == "d")
+      assert((m.getModifiers & Private) != 0)
+    }
+    assert(Top.j == 42)
+    for (m <- Class.forName("Top$").getDeclaredMethods; n = m.getName if n.endsWith("i")) {
+      assert(n == "i", s"method $n != i")
+      assert((m.getModifiers & Private) != 0)
+    }
+    assert(TopHeavy.j == 42)
+    for (m <- Class.forName("TopHeavy$").getDeclaredMethods; n = m.getName if n.contains("underlying")) {
+      assert(n == "underlying", s"method $n != underlying")
+      assert((m.getModifiers & Private) != 0)
+    }
+    assert({val x = TippyTop(); val y = x.Medial(); val z = y.Nadir(); z.Abyssal().answer} == 42)
+    for (m <- Class.forName("TippyTop").getDeclaredMethods; n = m.getName if n.contains("secret")) {
+      assert(n == "secret", s"method $n != secret")
+      assert((m.getModifiers & Private) != 0)
+    }
+  }
+}


### PR DESCRIPTION
Forward port.

Needs a convenient spot to check `-Xtarget` setting, and a better way to find companions.

The mechanics of working with attachments and trees is a bit different from Scala 2.