### PR TITLE
Respect `[skip-ci]` comments in launchers and spec tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1013,9 +1013,15 @@ jobs:
     uses: ./.github/workflows/build-msi.yml
     if  : github.event_name == 'pull_request' && contains(github.event.pull_request.body, '[test_msi]')
     # TODO: ADD A JOB THAT DEPENDS ON THIS TO TEST THE MSI
-    
+
   build-sdk-package:
     uses: ./.github/workflows/build-sdk.yml
+    if:
+      (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]')) ||
+      (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3') ||
+      (github.event_name == 'schedule' && github.repository == 'scala/scala3') ||
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group'
     with:
       java-version: 8
 

--- a/.github/workflows/launchers.yml
+++ b/.github/workflows/launchers.yml
@@ -7,6 +7,8 @@ jobs:
   linux-x86_64:
     name: Deploy and Test on Linux x64 architecture
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -43,6 +45,8 @@ jobs:
   mac-x86_64:
     name: Deploy and Test on Mac x64 architecture
     runs-on: macos-13
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -62,6 +66,8 @@ jobs:
   mac-aarch64:
     name: Deploy and Test on Mac ARM64 architecture
     runs-on: macos-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -81,6 +87,8 @@ jobs:
   win-x86_64:
     name: Deploy and Test on Windows x64 architecture
     runs-on: windows-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -16,6 +16,10 @@ env:
 jobs:
   specification:
     runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]'))  ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3') ||
+        github.event_name == 'push' ||
+        github.event_name == 'merge_group'
     defaults:
       run:
         working-directory: ./docs/_spec


### PR DESCRIPTION
Currently,  Specification and Launchers CI would execute even when the `skip ci` tag message is part of the PR. The goal of this change is to ignore these jobs when annotated. 
The only remaining CI job running under skip ci is `Scala CLA check`