### PR TITLE
Backport "fix: Only implement a deferred given in a class if its parent won't implement it" to 3.5.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3019,7 +3019,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           body
 
     /** Implement givens that were declared with a `deferred` rhs.
-     *  The a given value matching the declared type is searched in a
+     *  The given value matching the declared type is searched in a
      *  context directly enclosing the current class, in which all given
      *  parameters of the current class are also defined.
      */
@@ -3035,6 +3035,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               cdef.srcPos)
             false
           else true
+
+        def willBeimplementedInParentClass(m: TermRef) =
+          val superCls = cls.superClass
+          superCls.exists && superCls.asClass.baseClasses.contains(m.symbol.owner)
 
         def givenImpl(mbr: TermRef): ValDef =
           val dcl = mbr.symbol
@@ -3065,6 +3069,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           cls.thisType.implicitMembers
             //.showing(i"impl def givens for $cls/$result")
             .filter(_.symbol.isAllOf(DeferredGivenFlags, butNot = Param))
+            .filter(!willBeimplementedInParentClass(_)) // only implement the given in the topmost class
             //.showing(i"impl def filtered givens for $cls/$result")
             .filter(isGivenValue)
             .map(givenImpl)

--- a/tests/pos/i21189-alt.scala
+++ b/tests/pos/i21189-alt.scala
@@ -1,0 +1,12 @@
+//> using options -source:future -language:experimental.modularity
+
+class MySortedSet[T : Ord] extends SortedSet[T]
+
+trait Ord[T]
+
+trait Sorted[T] extends ParentOfSorted[T]
+
+trait ParentOfSorted[T]:
+  given Ord[T] as ord = compiletime.deferred
+
+class SortedSet[T : Ord] extends Sorted[T]

--- a/tests/pos/i21189.scala
+++ b/tests/pos/i21189.scala
@@ -1,0 +1,10 @@
+//> using options -source:future -language:experimental.modularity
+
+class MySortedSet[T : Ord] extends SortedSet[T]
+
+trait Ord[T]
+
+trait Sorted[T]:
+  given Ord[T] as ord = compiletime.deferred
+
+class SortedSet[T : Ord] extends Sorted[T]


### PR DESCRIPTION
Backports #21206 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]