### PR TITLE
Backport "Fix syntax errors introduced by #21206" to 3.5.2

### DIFF
--- a/tests/pos/i21189-alt.scala
+++ b/tests/pos/i21189-alt.scala
@@ -7,6 +7,6 @@ trait Ord[T]
 trait Sorted[T] extends ParentOfSorted[T]
 
 trait ParentOfSorted[T]:
-  given Ord[T] as ord = compiletime.deferred
+  given ord: Ord[T] = compiletime.deferred
 
 class SortedSet[T : Ord] extends Sorted[T]

--- a/tests/pos/i21189.scala
+++ b/tests/pos/i21189.scala
@@ -5,6 +5,6 @@ class MySortedSet[T : Ord] extends SortedSet[T]
 trait Ord[T]
 
 trait Sorted[T]:
-  given Ord[T] as ord = compiletime.deferred
+  given orrd: Ord[T] = compiletime.deferred
 
 class SortedSet[T : Ord] extends Sorted[T]


### PR DESCRIPTION
Backports #21316 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]