### PR TITLE
[CI] Enable Develocity test retry selectively

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -276,6 +276,18 @@ object Build {
       val config = develocityConfiguration.value
       val buildScan = config.buildScan
       val buildCache = config.buildCache
+      // disable test retry on compilation test classes
+      val noRetryTestClasses = Set(
+        "dotty.tools.dotc.BestEffortOptionsTests",
+        "dotty.tools.dotc.CompilationTests",
+        "dotty.tools.dotc.FromTastyTests",
+        "dotty.tools.dotc.IdempotencyTests",
+        "dotty.tools.dotc.ScalaJSCompilationTests",
+        "dotty.tools.dotc.TastyBootstrapTests",
+        "dotty.tools.dotc.coverage.CoverageTests",
+        "dotty.tools.dotc.transform.PatmatExhaustivityTest",
+        "dotty.tools.repl.ScriptedTests"
+      )
       config
         .withProjectId(ProjectId("scala3"))
         .withServer(config.server.withUrl(Some(url("https://develocity.scala-lang.org"))))
@@ -292,6 +304,13 @@ object Build {
           buildCache
             .withLocal(buildCache.local.withEnabled(false))
             .withRemote(buildCache.remote.withEnabled(false))
+        )
+        .withTestRetryConfiguration(
+          config.testRetryConfiguration
+            .withFlakyTestPolicy(FlakyTestPolicy.Fail)
+            .withMaxRetries(1)
+            .withMaxFailures(10)
+            .withClassesFilter((className, _) => !noRetryTestClasses.contains(className))
         )
     }
   )


### PR DESCRIPTION
The `sbt-develocity` plugin offers the ability to retry failing tests, and to detect flaky ones. A flaky test is marked as flaky in the Develocity test report, which will help us track them across many CI executions. See for example the flaky test chart in the [Pekko dashboard](https://ge.apache.org/scans/tests?search.relativeStartTime=P90D&search.rootProjectNames=Pekko&search.tags=not:CI&search.timeZoneId=Europe%2FZurich).

This PR contains the following configuration:
- retry each failing test once (to be adjusted if needed)
- don't retry if more than 10 tests fail in the current test run (to be adjusted if needed)
- fail the build if a test is flaky
- disable test retry in a predefined set of test classes: the compilation test classes. In those classes, we don't have enough granularity for the test retry to be meaningful, because each test is responsible for compiling many independent files.

@dotta @c00ler @Duhemm @lrytz 