### PR TITLE
Backport "fix: Dealias NamedTuple's name types when resolving NamedTuple's element types" to 3.5.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -129,7 +129,7 @@ class TypeUtils:
     def namedTupleElementTypesUpTo(bound: Int, normalize: Boolean = true)(using Context): List[(TermName, Type)] =
       (if normalize then self.normalized else self).dealias match
         case defn.NamedTuple(nmes, vals) =>
-          val names = nmes.tupleElementTypesUpTo(bound, normalize).getOrElse(Nil).map:
+          val names = nmes.tupleElementTypesUpTo(bound, normalize).getOrElse(Nil).map(_.dealias).map:
             case ConstantType(Constant(str: String)) => str.toTermName
             case t => throw TypeError(em"Malformed NamedTuple: names must be string types, but $t was found.")
           val values = vals.tupleElementTypesUpTo(bound, normalize).getOrElse(Nil)

--- a/tests/pos/i21300.scala
+++ b/tests/pos/i21300.scala
@@ -1,0 +1,17 @@
+import scala.language.experimental.namedTuples
+
+class Test[S <: String & Singleton](name: S):
+
+  type NT = NamedTuple.NamedTuple[(S, "foo"), (Int, Long)]
+  def nt: NT = ???
+
+  type Name = S
+  
+  type NT2 = NamedTuple.NamedTuple[(Name, "foo"), (Int, Long)]
+  def nt2: NT2 = ???
+
+def test =
+  val foo = new Test("bar")
+  
+  foo.nt.bar
+  foo.nt2.bar


### PR DESCRIPTION
Backports #21331 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]