### PR TITLE
Backport "Add regression test for i19675" to 3.5.2

### DIFF
--- a/sbt-test/scala2-compat/i19675/UnrelatedDeprecationWarning.scala
+++ b/sbt-test/scala2-compat/i19675/UnrelatedDeprecationWarning.scala
@@ -1,0 +1,22 @@
+import com.twitter.finagle.Thrift
+import com.twitter.finagle.thrift.ThriftService
+import scala.reflect.ClassTag
+
+class Minim {
+  trait Foo[A]
+  
+  object Foo {
+    inline def make[A]: Foo[A] = ???
+  }
+
+  final class Unrelated()
+
+  object Unrelated {
+    val foo = Foo.make[Unrelated]
+  }
+
+  object Main {
+    def foo[S <: ThriftService](using ClassTag[S]) = 
+      Thrift.client.build[S]("asd")
+  }
+}

--- a/sbt-test/scala2-compat/i19675/build.sbt
+++ b/sbt-test/scala2-compat/i19675/build.sbt
@@ -1,0 +1,6 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+scalacOptions ++= Seq("-Wunused:imports", "-deprecation", "-Werror")
+libraryDependencies ++= Seq(
+  "com.twitter" %% "finagle-thrift" % "24.2.0"
+).map(_.cross(CrossVersion.for3Use2_13))

--- a/sbt-test/scala2-compat/i19675/test
+++ b/sbt-test/scala2-compat/i19675/test
@@ -1,0 +1,1 @@
+> compile


### PR DESCRIPTION
Backports #21159 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]