### PR TITLE
Backport "Fix uninitializing fields when evaluating a cached constructor call in global initialization checker" to 3.5.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -950,7 +950,6 @@ class Objects(using Context @constructorOnly):
 
         val instance = OfClass(klass, outerWidened, ctor, args.map(_.value), envWidened)
         callConstructor(instance, ctor, args)
-        instance
 
     case ValueSet(values) =>
       values.map(ref => instantiate(ref, klass, ctor, args)).join

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -908,7 +908,10 @@ class Objects(using Context @constructorOnly):
     Bottom
   }
 
-  /** Handle new expression `new p.C(args)`.
+  /**
+   * Handle new expression `new p.C(args)`.
+   * The actual instance might be cached without running the constructor. 
+   * See tests/init-global/pos/cache-constructor.scala
    *
    * @param outer       The value for `p`.
    * @param klass       The symbol of the class `C`.

--- a/tests/init-global/pos/cache-constructor.scala
+++ b/tests/init-global/pos/cache-constructor.scala
@@ -6,4 +6,3 @@ object A:
     val b2 = new Bar()
     val b3 = new Bar()
     b3.f = 1
-    

--- a/tests/init-global/pos/cache-constructor.scala
+++ b/tests/init-global/pos/cache-constructor.scala
@@ -1,0 +1,9 @@
+class Bar:
+    var f: Int = 0
+
+object A:
+    val b1 = new Bar()
+    val b2 = new Bar()
+    val b3 = new Bar()
+    b3.f = 1
+    


### PR DESCRIPTION
Backports #21403 to the 3.5.2 branch.

PR submitted by the release tooling.
[skip ci]