### PR TITLE
analyze object when selecting from package

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -864,7 +864,7 @@ class Objects(using Context @constructorOnly):
       Bottom
 
     case Bottom =>
-      if field.isStaticObject then ObjectRef(field.moduleClass.asClass)
+      if field.isStaticObject then accessObject(field.moduleClass.asClass)
       else Bottom
 
     case ValueSet(values) =>

--- a/tests/init-global/warn/cyclic-object.scala
+++ b/tests/init-global/warn/cyclic-object.scala
@@ -1,0 +1,9 @@
+package cyclicObject
+
+object O1 { // warn
+  val o = cyclicObject.O2
+}
+
+object O2 {
+  val o = cyclicObject.O1
+}


### PR DESCRIPTION
This PR is an updated version of #20424, which fixes a bug in the global initialization checker such that when accessing global object through full path, the checker immediately analyzes the initialization code of the corresponding object.

[test_scala2_library_tasty]