### PR TITLE
[scaladoc] fix: Only trim one newline when preprocessing the content of a markdown code snippet

### DIFF
--- a/scaladoc-testcases/docs/_docs/index.md
+++ b/scaladoc-testcases/docs/_docs/index.md
@@ -13,5 +13,12 @@ class Renderer(using RenderingContext)
 val renderer: Renderer = Renderer()
 ```
 
+```scala
+  trait Ord:
+    type Self
 
+  trait SemiGroup:
+    type Self
+    extension (x: Self) def combine(y: Self): Self
+```
 

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
@@ -65,7 +65,7 @@ object FlexmarkSnippetProcessor:
             content.add(s, 0)
             node.setContent(content)
 
-        val fullSnippet = Seq(snippetImports, snippet).mkString("\n").trim
+        val fullSnippet = Seq(snippetImports, snippet).mkString("\n").stripPrefix("\n")
         val snippetCompilationResult = cf(fullSnippet, lineOffset, argOverride) match {
           case Some(result @ SnippetCompilationResult(wrapped, _, _, messages)) =>
             node.setContentString(fullSnippet)


### PR DESCRIPTION
fixes #21429 