### PR TITLE
Handle NoType in TypeComparer.disjointnessBoundary

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3070,6 +3070,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         disjointnessBoundary(tp.effectiveBounds.hi)
       case tp: ErrorType =>
         defn.AnyType
+      case tp: NoType.type =>
+        defn.AnyType
     end disjointnessBoundary
 
     (disjointnessBoundary(tp1), disjointnessBoundary(tp2)) match

--- a/tests/neg/i20265-1.check
+++ b/tests/neg/i20265-1.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg/i20265-1.scala:4:6 ---------------------------------------------------------------------------------
+4 |  def apply(args: Tuple.Map[m.MirroredElemTypes, Expr]): Expr[T] = ??? // error
+  |      ^
+  |      non-private method apply in trait Ops refers to private given instance m
+  |      in its type signature (args: Tuple.Map[Ops.this.m.MirroredElemTypes, Expr]): Expr[T]

--- a/tests/neg/i20265-1.scala
+++ b/tests/neg/i20265-1.scala
@@ -1,0 +1,9 @@
+trait Expr[T]
+
+trait Ops[T](using m: scala.deriving.Mirror.ProductOf[T]) {
+  def apply(args: Tuple.Map[m.MirroredElemTypes, Expr]): Expr[T] = ??? // error
+}
+
+case class P(a: Int)
+object P extends Ops[P]
+

--- a/tests/neg/i20265.check
+++ b/tests/neg/i20265.check
@@ -1,0 +1,28 @@
+-- [E172] Type Error: tests/neg/i20265.scala:22:95 ---------------------------------------------------------------------
+22 |  println(summon[((String --> Unit) * (String --> Unit)) =:= Hinze[(String + String) --> Unit]]) // error
+   |                                                                                               ^
+   |                    Cannot prove that (String --> Unit) * (String --> Unit) =:= Hinze[String + String --> Unit].
+   |
+   |                    Note: a match type could not be fully reduced:
+   |
+   |                      trying to reduce  Hinze[String + String --> Unit]
+   |                      failed since selector (String + String --> Unit)#unfix
+   |                      does not match  case k1 + k2 --> v => Hinze[k1 --> v] * Hinze[k2 --> v]
+   |                      and cannot be shown to be disjoint from it either.
+   |                      Therefore, reduction cannot advance to the remaining case
+   |
+   |                        case k1 * k2 --> v => k1 --> Hinze[k2 --> v]
+-- [E172] Type Error: tests/neg/i20265.scala:23:66 ---------------------------------------------------------------------
+23 |  println(summon[String =:= Hinze[Fix[Lambda[String]#L] --> Unit]]) // error
+   |                                                                  ^
+   |                          Cannot prove that String =:= Hinze[Fix[[X] =>> String + String * X + X * X] --> Unit].
+   |
+   |                          Note: a match type could not be fully reduced:
+   |
+   |                            trying to reduce  Hinze[Fix[[X] =>> String + String * X + X * X] --> Unit]
+   |                            failed since selector (Fix[[X] =>> String + String * X + X * X] --> Unit)#unfix
+   |                            does not match  case k1 + k2 --> v => Hinze[k1 --> v] * Hinze[k2 --> v]
+   |                            and cannot be shown to be disjoint from it either.
+   |                            Therefore, reduction cannot advance to the remaining case
+   |
+   |                              case k1 * k2 --> v => k1 --> Hinze[k2 --> v]

--- a/tests/neg/i20265.scala
+++ b/tests/neg/i20265.scala
@@ -1,0 +1,23 @@
+//> using options -source:3.3
+
+trait Poly
+trait -->[X, Y] extends Poly
+trait +[X, Y] extends Poly
+trait *[X, Y] extends Poly
+
+type Hinze[X <: Fix[?]] = X#unfix match
+  case (k1 + k2) --> v => Hinze[(k1 --> v)] * Hinze[(k2 --> v)]
+  case (k1 * k2) --> v => k1 --> Hinze[(k2 --> v)]
+
+trait Lambda[V]:
+  type Abs[X] = V * X
+  type App[X] = X * X
+  type L[X] = V + Abs[X] + App[X]
+
+trait Fix[F[X]]:
+  type unfix = F[Fix[F]]
+
+@main
+def m =
+  println(summon[((String --> Unit) * (String --> Unit)) =:= Hinze[(String + String) --> Unit]]) // error
+  println(summon[String =:= Hinze[Fix[Lambda[String]#L] --> Unit]]) // error


### PR DESCRIPTION
Closes #20265

Note that the example in that issue already does not compile on 3.5.0 (and 3.4.3), failing with a reasonable error message. However, opting in to ignoring the issue with `-source:3.3` does cause a crash.

```
Compiling project (Scala 3.5.0, JVM (17))
[error] ./Main.scala:8:27
[error] The match type contains an illegal case:
[error]     case k1 + k2 --> v => Hinze[k1 --> v] * Hinze[k2 --> v]
[error] (this error can be ignored for now with `-source:3.3`)
[error] ./Main.scala:22:96
[error] Cannot prove that (String --> Unit) * (String --> Unit) =:= Hinze[String + String --> Unit].
[error]   println(summon[((String --> Unit) * (String --> Unit)) =:= Hinze[(String + String) --> Unit]])
[error]                                                                                                ^
[error] ./Main.scala:23:67
[error] Cannot prove that String =:= Hinze[Fix[[X] =>> String + String * X + X * X] --> Unit].
[error]   println(summon[String =:= Hinze[Fix[Lambda[String]#L] --> Unit]])
[error] 
```