### PR TITLE
[CI] Disable publishing failing scans

### DIFF
--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -55,7 +55,9 @@ cp tests/neg-macros/i6371/A_1.scala $OUT/A.scala
 cp tests/neg-macros/i6371/B_2.scala $OUT/B.scala
 "$SBT" "scalac $OUT/A.scala -d $OUT1"
 rm $OUT/A.scala
-"$SBT" "scalac -classpath $OUT1 -d $OUT1 $OUT/B.scala" > "$tmp" 2>&1 || echo "ok"
+# this command is expected to fail
+# setting -Dscan=false disables publishing scans to develocity.scala-lang.org
+"$SBT" "scalac -classpath $OUT1 -d $OUT1 $OUT/B.scala -Dscan=false" > "$tmp" 2>&1 || echo "ok"
 # cat "$tmp" # for debugging
 grep -qe "B.scala:2:7" "$tmp"
 grep -qe "This location contains code that was inlined from A.scala:3" "$tmp"


### PR DESCRIPTION
[This sbt command](https://github.com/scala/scala3/blob/e9e046db1d8a0329f28f52c7726dab66730dac7a/project/scripts/cmdTests#L58) is expected to fail. Consequently [its Develocity scan](https://develocity.scala-lang.org/s/cjyfzepco743i) always appear as failed, even though the CI job succeeds. This is confusing and it makes it harder to find real failing jobs.

The solution I propose in this PR is to disable publishing the scan of the command, using `-Dscan:false`.

Ping @dotta