### PR TITLE
Make toplevel opaque types transparent to the whole file

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1620,6 +1620,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
 
     def findEnclosingThis(moduleClass: Symbol, from: Symbol): Type =
       if ((from.owner eq moduleClass) && from.isPackageObject && from.is(Opaque)) from.thisType
+      else if (from eq moduleClass.owner) && moduleClass.isTopLevelDefinitionsObject && moduleClass.is(Opaque) then moduleClass.thisType
       else if (from.is(Package)) tp
       else if ((from eq moduleClass) && from.is(Opaque)) from.thisType
       else if (from eq NoSymbol) tp

--- a/tests/pos/i15050.ex1.scala
+++ b/tests/pos/i15050.ex1.scala
@@ -1,0 +1,7 @@
+import OpaqueBug.*
+def g(n: Counter): Counter = n
+object OpaqueBug:
+  opaque type Counter = Int
+  val initial: Counter = 42
+  def f(n: Int): Int = g(n) + initial
+  @main def run = println(f(21))

--- a/tests/pos/i15050.ex2.scala
+++ b/tests/pos/i15050.ex2.scala
@@ -1,0 +1,6 @@
+opaque type Counter = Int
+def g(n: Counter): Counter = n
+object OpaqueBug:
+  val initial: Counter = 42 // was error: Found: (42 : Int)
+  def f(n: Int): Int = g(n) + initial // was error: Found: (n : Int) Required: Counter
+  @main def run = println(f(21))


### PR DESCRIPTION
Fixes #15050
