### PR TITLE
Fixed false positive unreachable local object

### DIFF
--- a/tests/warn/i21218.scala
+++ b/tests/warn/i21218.scala
@@ -1,0 +1,10 @@
+def Test[U, A](thisElem: A, thatElem: U) = {
+  case object passedEnd
+  val any: Seq[Any] = ???
+  any.zip(any)
+    .map {
+      case (`passedEnd`, r: U @unchecked) => (thisElem, r)
+      case (l: A @unchecked, `passedEnd`) => (l, thatElem)
+      case t: (A, U) @unchecked           => t // false-positive warning
+    }
+}


### PR DESCRIPTION
I think this was fixed in PR 21000, but I didn't check.

Closes #21218
