### PR TITLE
Remove the `-rewrite` option for `typechecks` methods in Quotes

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -47,6 +47,10 @@ object Settings:
         values(idx) = x
         changed.add(idx)
         this
+
+    def reinitializedCopy(): SettingsState =
+      SettingsState(values.toSeq, changed.toSet)
+
   end SettingsState
 
   case class ArgsSummary(

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -342,10 +342,13 @@ object Inlines:
         if Inlines.isInlineable(codeArg1.symbol) then stripTyped(Inlines.inlineCall(codeArg1))
         else codeArg1
 
+      // We should not be rewriting tested strings
+      val noRewriteSettings = ctx.settings.rewrite.updateIn(ctx.settingsState.reinitializedCopy(), None)
+
       ConstFold(underlyingCodeArg).tpe.widenTermRefExpr match {
         case ConstantType(Constant(code: String)) =>
           val source2 = SourceFile.virtual("tasty-reflect", code)
-          inContext(ctx.fresh.setNewTyperState().setTyper(new Typer(ctx.nestingLevel + 1)).setSource(source2)) {
+          inContext(ctx.fresh.setSettings(noRewriteSettings).setNewTyperState().setTyper(new Typer(ctx.nestingLevel + 1)).setSource(source2)) {
             val tree2 = new Parser(source2).block()
             if ctx.reporter.allErrors.nonEmpty then
               ctx.reporter.allErrors.map((ErrorKind.Parser, _))

--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -135,3 +135,6 @@ parsercombinators-new-syntax.scala
 hylolib-deferred-given
 hylolib-cb
 hylolib
+
+# typecheckErrors method unpickling
+i21415.scala

--- a/compiler/test/dotc/run-test-pickling.blacklist
+++ b/compiler/test/dotc/run-test-pickling.blacklist
@@ -27,7 +27,6 @@ tuple-zip.scala
 tuples1.scala
 tuples1a.scala
 tuples1b.scala
-typeCheckErrors.scala
 typeclass-derivation-doc-example.scala
 typeclass-derivation1.scala
 typeclass-derivation2.scala
@@ -46,4 +45,7 @@ i12656.scala
 trait-static-forwarder
 i17255
 named-tuples-strawman-2.scala
+
+# typecheckErrors method unpickling
+typeCheckErrors.scala
 

--- a/tests/pos/i21415.scala
+++ b/tests/pos/i21415.scala
@@ -1,0 +1,8 @@
+//> using options -rewrite -source:3.4-migration
+import scala.compiletime.testing.typeCheckErrors
+
+def foo(arg: Int): Unit = ???
+
+@main def Test =
+  typeCheckErrors("Seq.empty[Int].foreach(foo.apply _)")
+  typeCheckErrors("Seq.empty[Int].foreach(foo.apply _)")


### PR DESCRIPTION
Fixes #21415

This is somewhat related to #21185, but I think it's better to merge this one separately first since it's an easy backport, which might not be the case with the other PR (since we are technically changing the semantics there)