### PR TITLE
Calm param autotupling for overloads

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1837,19 +1837,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       if (protoFormals.length == params.length) (protoFormals(i), isDefinedErased(i))
       else (errorType(WrongNumberOfParameters(tree, params.length, pt, protoFormals.length), tree.srcPos), false)
 
-    /** Is `formal` a product type which is elementwise compatible with `params`? */
-    def ptIsCorrectProduct(formal: Type) =
-      isFullyDefined(formal, ForceDegree.flipBottom) &&
-      defn.isProductSubType(formal) &&
-      tupleComponentTypes(formal).corresponds(params) {
-        (argType, param) =>
-          param.tpt.isEmpty || argType.widenExpr <:< typedAheadType(param.tpt).tpe
-      }
-
     var desugared: untpd.Tree = EmptyTree
     if protoFormals.length == 1 && params.length != 1 then
       val firstFormal = protoFormals.head.loBound
-      if ptIsCorrectProduct(firstFormal) then
+      if ptIsCorrectProduct(firstFormal, params) then
         val isGenericTuple =
           firstFormal.derivesFrom(defn.TupleClass)
           && !defn.isTupleClass(firstFormal.typeSymbol)

--- a/tests/run/i16108.scala
+++ b/tests/run/i16108.scala
@@ -1,0 +1,41 @@
+import scala.language.implicitConversions
+
+final class Functoid[+R](val function: Product => R)
+
+object Functoid {
+  implicit def apply[A, R](function: A => R): Functoid[R] = {
+    println(s"arity 1")
+    new Functoid({ case Tuple1(a: A @unchecked) => function(a) })
+  }
+  implicit def apply[A, B, R](function: (A, B) => R): Functoid[R] = {
+    println("arity 2")
+    new Functoid({ case (a: A @unchecked, b: B @unchecked) => function(a, b) })
+  }
+}
+
+final case class ContainerConfig(image: String, version: Int, cmd: String)
+
+final class ContainerResource
+
+object ContainerResource {
+  implicit final class DockerProviderExtensions(private val self: Functoid[ContainerResource]) extends AnyVal {
+    def modifyConfig(modify: Functoid[ContainerConfig => ContainerConfig]): Functoid[ContainerConfig => ContainerConfig] = modify
+    // removing this overload fixes the implicit conversion and returns `arity 2` print
+    def modifyConfig(modify: ContainerConfig => ContainerConfig): Functoid[ContainerConfig => ContainerConfig] = new Functoid(_ => modify)
+  }
+}
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val cfg = new Functoid(_ => new ContainerResource)
+      .modifyConfig {
+        // applying Functoid.apply explicitly instead of via implicit conversion also avoids untupling
+//        Functoid {
+        (image: String, version: Int) => (cfg: ContainerConfig) => cfg.copy(image, version)
+//        }
+      }
+      .function.apply(Tuple2("img", 9))
+      .apply(ContainerConfig("a", 0, "b"))
+    println(cfg)
+  }
+}


### PR DESCRIPTION
When resolving method overloads, we look to apply the same parameter
auto-tupling logic that we have in typedFunctionValue.  But we only
checked the function was unary without checking whether it was a tuple.
So I reused the same precondition.

Fixes #16108
