### PR TITLE
Backport "Allow SAM types to contain match alias refinements" to 3.3.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5577,7 +5577,7 @@ object Types extends TypeUtils {
 
       /** Copy type aliases refinements to `toTp` from `fromTp` */
       def withRefinements(toType: Type, fromTp: Type): Type = fromTp.dealias match
-        case RefinedType(fromParent, name, info: TypeAlias) if tp0.member(name).exists =>
+        case RefinedType(fromParent, name, info: AliasingBounds) if tp0.member(name).exists =>
           val parent1 = withRefinements(toType, fromParent)
           RefinedType(toType, name, info)
         case _ => toType

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -7,7 +7,7 @@ import Scopes.newScope
 import Contexts.*, Symbols.*, Types.*, Flags.*, Decorators.*, StdNames.*, Constants.*
 import MegaPhase.*
 import Names.TypeName
-import SymUtils.*
+import Symbols.*
 import NullOpsDecorator.*
 import ast.untpd
 

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -6,6 +6,8 @@ import core.*
 import Scopes.newScope
 import Contexts.*, Symbols.*, Types.*, Flags.*, Decorators.*, StdNames.*, Constants.*
 import MegaPhase.*
+import Names.TypeName
+import SymUtils.*
 import NullOpsDecorator.*
 import ast.untpd
 
@@ -50,16 +52,28 @@ class ExpandSAMs extends MiniPhase:
         case tpe if defn.isContextFunctionType(tpe) =>
           tree
         case SAMType(_, tpe) if tpe.isRef(defn.PartialFunctionClass) =>
-          val tpe1 = checkRefinements(tpe, fn)
-          toPartialFunction(tree, tpe1)
+          toPartialFunction(tree, tpe)
         case SAMType(_, tpe) if ExpandSAMs.isPlatformSam(tpe.classSymbol.asClass) =>
-          checkRefinements(tpe, fn)
           tree
         case tpe =>
-          val tpe1 = checkRefinements(tpe.stripNull, fn)
+          // A SAM type is allowed to have type aliases refinements (see
+          // SAMType#samParent) which must be converted into type members if
+          // the closure is desugared into a class.
+          val refinements = collection.mutable.ListBuffer[(TypeName, TypeAlias)]()
+          def collectAndStripRefinements(tp: Type): Type = tp match
+            case RefinedType(parent, name, info: TypeAlias) =>
+              val res = collectAndStripRefinements(parent)
+              refinements += ((name.asTypeName, info))
+              res
+            case _ => tp
+          val tpe1 = collectAndStripRefinements(tpe)
           val Seq(samDenot) = tpe1.possibleSamMethods
           cpy.Block(tree)(stats,
-              AnonClass(tpe1 :: Nil, fn.symbol.asTerm :: Nil, samDenot.symbol.asTerm.name :: Nil))
+            AnonClass(List(tpe1),
+              List(samDenot.symbol.asTerm.name -> fn.symbol.asTerm),
+              refinements.toList
+            )
+          )
       }
     case _ =>
       tree
@@ -169,14 +183,5 @@ class ExpandSAMs extends MiniPhase:
       val applyOrElseDef = transformFollowingDeep(DefDef(applyOrElseFn, applyOrElseRhs(_)(using ctx.withOwner(applyOrElseFn))))
       List(isDefinedAtDef, applyOrElseDef)
     }
-  }
-
-  private def checkRefinements(tpe: Type, tree: Tree)(using Context): Type = tpe.dealias match {
-    case RefinedType(parent, name, _) =>
-      if (name.isTermName && tpe.member(name).symbol.ownersIterator.isEmpty) // if member defined in the refinement
-        report.error(em"Lambda does not define $name", tree.srcPos)
-      checkRefinements(parent, tree)
-    case tpe =>
-      tpe
   }
 end ExpandSAMs

--- a/tests/pos/i20080.scala
+++ b/tests/pos/i20080.scala
@@ -1,0 +1,32 @@
+
+trait Zippable[-A, -B]:
+  type Out
+  def zip(left: A, right: B): Out
+
+object Zippable extends ZippableLowPrio:
+  given append[A <: Tuple, B]: (Zippable[A, B] { type Out = Tuple.Append[A, B] }) =
+    (left, right) => left :* right
+
+trait ZippableLowPrio:
+  given pair[A, B]: (Zippable[A, B] { type Out = (A, B) }) =
+    (left, right) => (left, right)
+
+
+object Minimization:
+
+  trait Fun1:
+    type Out
+    def apply(x: Any): Out
+  
+  type M[X] = X match
+    case String => X
+  
+  def test[A] =
+  
+    val _: Fun1 { type Out = M[A] } = new Fun1:
+      type Out = M[A]
+      def apply(x: Any): Out = ???
+  
+    val _: Fun1 { type Out = M[A] } = x => ???
+  
+    val _: Fun1 { type Out = A match {case String => A} } = x => ???

--- a/tests/run/i18315.scala
+++ b/tests/run/i18315.scala
@@ -1,0 +1,15 @@
+trait Sam1:
+  type T
+  def apply(x: T): T
+
+trait Sam2:
+  var x: Int = 1 // To force anonymous class generation
+  type T
+  def apply(x: T): T
+
+object Test:
+  def main(args: Array[String]): Unit =
+    val s1: Sam1 { type T = String } = x => x.trim
+    s1.apply("foo")
+    val s2: Sam2 { type T = Int } = x => x + 1
+    s2.apply(1)


### PR DESCRIPTION
Backports #20092 to Scala 3.3.4-RC2 LTS on top of #21553. Fixes regression introduced in 3.3.1 

No new Open Community Build regressions were detected for this changes