### PR TITLE
Fix stale symbols connected to lazy vals in macros

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package core
 
-import SymDenotations.{ SymDenotation, ClassDenotation, NoDenotation, LazyType, stillValid, acceptStale, traceInvalid }
+import SymDenotations.{ SymDenotation, ClassDenotation, NoDenotation, LazyType, stillValid, movedToCompanionClass, acceptStale, traceInvalid }
 import Contexts.*
 import Names.*
 import NameKinds.*
@@ -755,6 +755,11 @@ object Denotations {
       }
       if (!symbol.exists) return updateValidity()
       if (!coveredInterval.containsPhaseId(ctx.phaseId)) return NoDenotation
+      // Moved to a companion class, likely at a later phase (in MoveStatics)
+      this match {
+        case symd: SymDenotation if movedToCompanionClass(symd) => return NoDenotation
+        case _ =>
+      }
       if (ctx.debug) traceInvalid(this)
       staleSymbolError
     }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2680,6 +2680,10 @@ object SymDenotations {
         stillValidInOwner(denot)
     }
 
+  def movedToCompanionClass(denot: SymDenotation)(using Context): Boolean =
+    val ownerCompanion = denot.maybeOwner.companionClass
+    stillValid(ownerCompanion) && ownerCompanion.unforcedDecls.contains(denot.name, denot.symbol)
+
   private[SymDenotations] def stillValidInOwner(denot: SymDenotation)(using Context): Boolean = try
     val owner = denot.maybeOwner.denot
     stillValid(owner)

--- a/tests/pos-macros/i21271/Macro.scala
+++ b/tests/pos-macros/i21271/Macro.scala
@@ -1,0 +1,12 @@
+import scala.quoted.*
+
+trait Schema
+object Schema:
+  lazy val sampleDate: String = "" // lazy val requried to reproduce
+
+  inline def derived: Schema =
+    annotations
+    new Schema {}
+
+inline def annotations: Int = ${ annotationsImpl }
+def annotationsImpl(using Quotes): Expr[Int] = Expr(1)

--- a/tests/pos-macros/i21271/Test.scala
+++ b/tests/pos-macros/i21271/Test.scala
@@ -1,0 +1,1 @@
+val inputValueSchema = Schema.derived


### PR DESCRIPTION
While bringing forward the denotation to a new run, we now check if the symbol was moved from its owner to a companion object. If so, we return NoDenotation, as that denotation seems to be a leftover from pre-MoveStatics phases in a previous run.

Fixes #21271

In the issue reproduction, we had a symbol created in the `LazyVals` phase, which was then later moved to a companion class in `MoveStatics` in the first run. In the second run, this caused the leftover denotation for pre-MoveStatics phases of the first run to be tried to brought forward (since the phaseID became valid at that point), failing to do so (because that symbol should no longer exist as a member of the initial companion object at that point). 

It looks like before #19786, since this denotation was valid at a later phase, it would be visited somewhere before the  MegaPhase with `LazyVals` and replaced with a NoDenotation (pretty much by accident), which back then ended up being cached for the latter phases as well.

So in the fix here we check for that specific `MoveStatics` -caused case and, if found, update the symbol with a NoDenotation (just like before, but this time, on purpose). 