### PR TITLE
Temporary fix to CompletionScalaCliSuite

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionScalaCliSuite.scala
@@ -59,19 +59,19 @@ class CompletionScalaCliSuite extends BaseCompletionSuite:
 
   @Test def `version` =
     check(
-      """|//> using lib "io.circe::circe-core_sjs1:0.14.1@@"
+      """|//> using lib "io.circe::circe-core_sjs1:0.14.10@@"
          |package A
          |""".stripMargin,
-      "0.14.1"
+      "0.14.10"
     )
 
   // We don't to add `::` before version if `sjs1` is specified
   @Test def `version-edit` =
     checkEdit(
-      """|//> using lib "io.circe::circe-core_sjs1:0.14.1@@"
+      """|//> using lib "io.circe::circe-core_sjs1:0.14.10@@"
          |package A
          |""".stripMargin,
-      """|//> using lib "io.circe::circe-core_sjs1:0.14.1"
+      """|//> using lib "io.circe::circe-core_sjs1:0.14.10"
          |package A
          |""".stripMargin,
     )


### PR DESCRIPTION
The [release of `circe/circe` version 0.14.10 yesterday](https://index.scala-lang.org/circe/circe/artifacts/circe-core/0.14.10) broke the tests. This is just a temporary fix as imo, we should not have any external dependencies in this repository. The policy for testing needs to be defined.

[test_java8]
[test_scala2_library_tasty]

Closes #21561 