### PR TITLE
Revert "Drop redundant `butNot = Param` clause in isAnchor"

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -636,7 +636,7 @@ trait ImplicitRunInfo:
   private def isAnchor(sym: Symbol) =
     sym.isClass && !isExcluded(sym)
     || sym.isOpaqueAlias
-    || sym.is(Deferred)
+    || sym.is(Deferred, butNot = Param)
     || sym.info.isMatchAlias
 
   private def computeIScope(rootTp: Type): OfTypeImplicits =


### PR DESCRIPTION
This reverts commit 9d88c800ba518b184bb5f63259a782532d1abf96. 
Closes #21521

The `ClassTypeParamCreationFlags` include both `TypeParam` and `Deferred`. 
In effect, a class type parameter was considered an anchor for implicit search, by `sym.is(Deferred)` as a sufficient condition.

For a failing example, one can try asserting:
```scala
|| sym.is(Deferred).ensuring(_ == sym.is(Deferred, butNot = Param))
```
in `ImplicitRunInfo#isAnchor` and a test with `summon[Ordering[Int]]`.

In that example, at least, the flags happen to be set by `Scala2Unpickler#readDisambiguatedSymbol`:
https://github.com/scala/scala3/blob/614170f4545ea6da8f07e0c4b0f2fdfe01377270/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala#L560