### PR TITLE
[CI] Disable publishing failing scans (bis)

### DIFF
--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -57,7 +57,7 @@ cp tests/neg-macros/i6371/B_2.scala $OUT/B.scala
 rm $OUT/A.scala
 # this command is expected to fail
 # setting -Dscan=false disables publishing scans to develocity.scala-lang.org
-"$SBT" "scalac -classpath $OUT1 -d $OUT1 $OUT/B.scala -Dscan=false" > "$tmp" 2>&1 || echo "ok"
+"$SBT" "scalac -classpath $OUT1 -d $OUT1 $OUT/B.scala" -Dscan=false > "$tmp" 2>&1 || echo "ok"
 # cat "$tmp" # for debugging
 grep -qe "B.scala:2:7" "$tmp"
 grep -qe "This location contains code that was inlined from A.scala:3" "$tmp"


### PR DESCRIPTION
https://github.com/scala/scala3/pull/21528 did not work: failing scans are still published.

This should fix it.