### PR TITLE
Fix bug in init checker while compiling scodec-bits community project

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -523,6 +523,8 @@ class Objects(using Context @constructorOnly):
 
     def getHeapData()(using mutable: MutableData): Data = mutable.heap
 
+    def setHeap(newHeap: Data)(using mutable: MutableData): Unit = mutable.heap = newHeap
+
   /** Cache used to terminate the check  */
   object Cache:
     case class Config(thisV: Value, env: Env.Data, heap: Heap.Data)
@@ -538,6 +540,7 @@ class Objects(using Context @constructorOnly):
         val result = super.cachedEval(config, expr, cacheResult, default = Res(Bottom, Heap.getHeapData())) { expr =>
           Res(fun(expr), Heap.getHeapData())
         }
+        Heap.setHeap(result.heap)
         result.value
   end Cache
 

--- a/tests/init-global/pos/scodec-bits.scala
+++ b/tests/init-global/pos/scodec-bits.scala
@@ -1,0 +1,17 @@
+abstract class A {
+  def a: Long
+}
+
+object O {
+  case class B() extends A {
+    def a = 5L
+  }
+  case class C(a2: A) extends A {
+    var c: Long = a2.a
+    def a = c
+  }
+  def f(a: A): A = C(f(a))
+  def g(): A = f(B())
+
+  val x = g()
+}


### PR DESCRIPTION
This PR fixes a bug related to heap management in the global initialization checker that occurs when compiling the scodec-bits community project with the -Ysafe-init-global flag.

[test_scala2_library_tasty]