### PR TITLE
Treat more closure parameter types as inferred

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -158,9 +158,13 @@ sealed abstract class CaptureSet extends Showable:
    *                 as frozen.
    */
   def accountsFor(x: CaptureRef)(using Context): Boolean =
-    reporting.trace(i"$this accountsFor $x, ${x.captureSetOfInfo}?", show = true):
+    def debugInfo(using Context) = i"$this accountsFor $x, which has capture set ${x.captureSetOfInfo}"
+    def test(using Context) = reporting.trace(debugInfo):
       elems.exists(_.subsumes(x))
       || !x.isMaxCapability && x.captureSetOfInfo.subCaptures(this, frozen = true).isOK
+    comparer match
+      case comparer: ExplainingTypeComparer => comparer.traceIndented(debugInfo)(test)
+      case _ => test
 
   /** A more optimistic version of accountsFor, which does not take variable supersets
    *  of the `x` reference into account. A set might account for `x` if it accounts

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -691,20 +691,18 @@ object TypeOps:
       val hiBound = instantiate(bounds.hi, skolemizedArgTypes)
       val loBound = instantiate(bounds.lo, skolemizedArgTypes)
 
-      def check(tp1: Type, tp2: Type, which: String, bound: Type)(using Context) = {
-        val isSub = TypeComparer.explaining { cmp =>
-          val isSub = cmp.isSubType(tp1, tp2)
-          if !isSub then
-            if !ctx.typerState.constraint.domainLambdas.isEmpty then
-              typr.println(i"${ctx.typerState.constraint}")
-            if !ctx.gadt.symbols.isEmpty then
-              typr.println(i"${ctx.gadt}")
-            typr.println(cmp.lastTrace(i"checkOverlapsBounds($lo, $hi, $arg, $bounds)($which)"))
-            //trace.dumpStack()
-          isSub
-        }//(using ctx.fresh.setSetting(ctx.settings.verbose, true)) // uncomment to enable moreInfo in ExplainingTypeComparer recur
-        if !isSub then violations += ((arg, which, bound))
-      }
+      def check(tp1: Type, tp2: Type, which: String, bound: Type)(using Context) =
+        val isSub = TypeComparer.isSubType(tp1, tp2)
+        if !isSub then
+          // inContext(ctx.fresh.setSetting(ctx.settings.verbose, true)):  // uncomment to enable moreInfo in ExplainingTypeComparer
+            TypeComparer.explaining: cmp =>
+              if !ctx.typerState.constraint.domainLambdas.isEmpty then
+                typr.println(i"${ctx.typerState.constraint}")
+              if !ctx.gadt.symbols.isEmpty then
+                typr.println(i"${ctx.gadt}")
+              typr.println(cmp.lastTrace(i"checkOverlapsBounds($lo, $hi, $arg, $bounds)($which)"))
+            violations += ((arg, which, bound))
+
       check(lo, hiBound, "upper", hiBound)(using checkCtx)
       check(loBound, hi, "lower", loBound)(using checkCtx)
     }

--- a/tests/pos-custom-args/captures/i21347.scala
+++ b/tests/pos-custom-args/captures/i21347.scala
@@ -1,0 +1,11 @@
+//> using scala 3.6.0-RC1-bin-SNAPSHOT
+
+import language.experimental.captureChecking
+
+class Box[Cap^] {}
+
+def run[Cap^](f: Box[Cap]^{Cap^} => Unit): Box[Cap]^{Cap^} = ???
+
+def main() =
+  val b = run(_ => ())
+  // val b = run[caps.CapSet](_ => ()) // this compiles


### PR DESCRIPTION
This is necessary for types that contain possibly illegal @retains annotations since those annotations are only removed before pickling for InferredTypes.

Fixes #21437 