### PR TITLE
Simple performance improvement for Denotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -626,30 +626,6 @@ object Denotations {
             throw ex
         case _ => Signature.NotAMethod
 
-    private var myCurrentJavaSig: Signature = uninitialized
-    private var myCurrentJavaSigRunId: RunId = NoRunId
-    private var myCurrentScala2Sig: Signature = uninitialized
-    private var myCurrentScala2SigRunId: RunId = NoRunId
-    private var myCurrentSig: Signature = uninitialized
-    private var myCurrentSigRunId: RunId = NoRunId
-
-    def currentSignature(sourceLanguage: SourceLanguage)(using Context): Signature = sourceLanguage match
-      case SourceLanguage.Java =>
-        if myCurrentJavaSigRunId != ctx.runId then
-          myCurrentJavaSig = signature(sourceLanguage)
-          myCurrentJavaSigRunId = ctx.runId
-        myCurrentJavaSig
-      case SourceLanguage.Scala2 =>
-        if myCurrentScala2SigRunId != ctx.runId then
-          myCurrentScala2Sig = signature(sourceLanguage)
-          myCurrentScala2SigRunId = ctx.runId
-        myCurrentScala2Sig
-      case SourceLanguage.Scala3 =>
-        if myCurrentSigRunId != ctx.runId then
-          myCurrentSig = signature(sourceLanguage)
-          myCurrentSigRunId = ctx.runId
-        myCurrentSig
-
     def derivedSingleDenotation(symbol: Symbol, info: Type, pre: Type = this.prefix, isRefinedMethod: Boolean = this.isRefinedMethod)(using Context): SingleDenotation =
       if ((symbol eq this.symbol) && (info eq this.info) && (pre eq this.prefix) && (isRefinedMethod == this.isRefinedMethod)) this
       else newLikeThis(symbol, info, pre, isRefinedMethod)
@@ -1057,8 +1033,8 @@ object Denotations {
         val thisLanguage = SourceLanguage(symbol)
         val otherLanguage = SourceLanguage(other.symbol)
         val commonLanguage = SourceLanguage.commonLanguage(thisLanguage, otherLanguage)
-        val sig = currentSignature(commonLanguage)
-        val otherSig = other.currentSignature(commonLanguage)
+        val sig = signature(commonLanguage)
+        val otherSig = other.signature(commonLanguage)
         sig.matchDegree(otherSig) match
           case FullMatch =>
             !alwaysCompareTypes || info.matches(other.info)

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -626,6 +626,30 @@ object Denotations {
             throw ex
         case _ => Signature.NotAMethod
 
+    private var myCurrentJavaSig: Signature = uninitialized
+    private var myCurrentJavaSigRunId: RunId = NoRunId
+    private var myCurrentScala2Sig: Signature = uninitialized
+    private var myCurrentScala2SigRunId: RunId = NoRunId
+    private var myCurrentSig: Signature = uninitialized
+    private var myCurrentSigRunId: RunId = NoRunId
+
+    def currentSignature(sourceLanguage: SourceLanguage)(using Context): Signature = sourceLanguage match
+      case SourceLanguage.Java =>
+        if myCurrentJavaSigRunId != ctx.runId then
+          myCurrentJavaSig = signature(sourceLanguage)
+          myCurrentJavaSigRunId = ctx.runId
+        myCurrentJavaSig
+      case SourceLanguage.Scala2 =>
+        if myCurrentScala2SigRunId != ctx.runId then
+          myCurrentScala2Sig = signature(sourceLanguage)
+          myCurrentScala2SigRunId = ctx.runId
+        myCurrentScala2Sig
+      case SourceLanguage.Scala3 =>
+        if myCurrentSigRunId != ctx.runId then
+          myCurrentSig = signature(sourceLanguage)
+          myCurrentSigRunId = ctx.runId
+        myCurrentSig
+
     def derivedSingleDenotation(symbol: Symbol, info: Type, pre: Type = this.prefix, isRefinedMethod: Boolean = this.isRefinedMethod)(using Context): SingleDenotation =
       if ((symbol eq this.symbol) && (info eq this.info) && (pre eq this.prefix) && (isRefinedMethod == this.isRefinedMethod)) this
       else newLikeThis(symbol, info, pre, isRefinedMethod)
@@ -1033,8 +1057,8 @@ object Denotations {
         val thisLanguage = SourceLanguage(symbol)
         val otherLanguage = SourceLanguage(other.symbol)
         val commonLanguage = SourceLanguage.commonLanguage(thisLanguage, otherLanguage)
-        val sig = signature(commonLanguage)
-        val otherSig = other.signature(commonLanguage)
+        val sig = currentSignature(commonLanguage)
+        val otherSig = other.currentSignature(commonLanguage)
         sig.matchDegree(otherSig) match
           case FullMatch =>
             !alwaysCompareTypes || info.matches(other.info)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1311,7 +1311,8 @@ object Types extends TypeUtils {
     final def widen(using Context): Type = this match
       case _: TypeRef | _: MethodOrPoly => this // fast path for most frequent cases
       case tp: TermRef => // fast path for next most frequent case
-        if tp.isOverloaded then tp else tp.underlying.widen
+        val denot = tp.denot
+        if denot.isOverloaded then tp else denot.info.widen
       case tp: SingletonType => tp.underlying.widen
       case tp: ExprType => tp.resultType.widen
       case tp =>
@@ -1325,7 +1326,10 @@ object Types extends TypeUtils {
      *  base type by applying one or more `underlying` dereferences.
      */
     final def widenSingleton(using Context): Type = stripped match {
-      case tp: SingletonType if !tp.isOverloaded => tp.underlying.widenSingleton
+      case tp: TermRef =>
+        val denot = tp.denot
+        if denot.isOverloaded then this else denot.info.widenSingleton
+      case tp: SingletonType => tp.underlying.widenSingleton
       case _ => this
     }
 
@@ -1333,7 +1337,9 @@ object Types extends TypeUtils {
      *  base type, while also skipping Expr types.
      */
     final def widenTermRefExpr(using Context): Type = stripTypeVar match {
-      case tp: TermRef if !tp.isOverloaded => tp.underlying.widenExpr.widenTermRefExpr
+      case tp: TermRef =>
+        val denot = tp.denot
+        if denot.isOverloaded then this else denot.info.widenExpr.widenTermRefExpr
       case _ => this
     }
 


### PR DESCRIPTION
A simple performance improvement extracted from #21278

This PR:
* ~~caches `signature` in `SingleDenotation` for `matchDegree`;~~
* reduces `denot` calls in `widen`s.

This is a simpler approach which can reduce the compilation time of #20217 from 60s to about ~~20s~~ 40s.

I revert the signature cache to keep this PR simple, because I don't understand why it works.