### PR TITLE
Guard against recursive lower bounds in constraints

### DIFF
--- a/tests/neg/i21535.check
+++ b/tests/neg/i21535.check
@@ -1,0 +1,11 @@
+-- [E007] Type Mismatch Error: tests/neg/i21535.scala:7:4 --------------------------------------------------------------
+3 |  (if (true) then
+4 |    new A(66)
+5 |  else
+6 |    m1()
+7 |  ).m2(p1 = p); // error
+  |  ^
+  |  Found:    (Int | Short) @uncheckedVariance
+  |  Required: Int & Short
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21535.scala
+++ b/tests/neg/i21535.scala
@@ -1,0 +1,16 @@
+def test() = {
+  val p = 10.toShort
+  (if (true) then
+    new A(66)
+  else
+    m1()
+  ).m2(p1 = p); // error
+
+}
+
+def m1(): A[Short] = new A(10)
+
+class A[D](var f: D) {
+
+  def m2(p1: D = f, p2: D = f): Unit = {}
+}


### PR DESCRIPTION
We could get an indirect recursion going through a singleton type before.

Fixes #21535