### PR TITLE
Named arg may be deprecatedName

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1062,6 +1062,7 @@ class Definitions {
   @tu lazy val DeprecatedAnnot: ClassSymbol = requiredClass("scala.deprecated")
   @tu lazy val DeprecatedOverridingAnnot: ClassSymbol = requiredClass("scala.deprecatedOverriding")
   @tu lazy val DeprecatedInheritanceAnnot: ClassSymbol = requiredClass("scala.deprecatedInheritance")
+  @tu lazy val DeprecatedNameAnnot: ClassSymbol = requiredClass("scala.deprecatedName")
   @tu lazy val ImplicitAmbiguousAnnot: ClassSymbol = requiredClass("scala.annotation.implicitAmbiguous")
   @tu lazy val ImplicitNotFoundAnnot: ClassSymbol = requiredClass("scala.annotation.implicitNotFound")
   @tu lazy val InlineParamAnnot: ClassSymbol = requiredClass("scala.annotation.internal.InlineParam")

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -675,24 +675,25 @@ trait Applications extends Compatibility {
           if sym.hasAnnotation(defn.MappedAlternativeAnnot) then sym.rawParamss
           else sym.paramSymss
         paramss.find(_.exists(_.isTerm)) match
-        case Some(ps) if ps.exists(_.hasAnnotation(defn.DeprecatedNameAnnot)) =>
-          ps.flatMap: p =>
-            p.getAnnotation(defn.DeprecatedNameAnnot).map(p.name -> _)
-          .toMap
-        case _ => Map.empty
+          case Some(ps) if ps.exists(_.hasAnnotation(defn.DeprecatedNameAnnot)) =>
+            ps.flatMap: p =>
+              p.getAnnotation(defn.DeprecatedNameAnnot).map(p.name -> _)
+            .toMap
+          case _ => Map.empty
 
       extension (name: Name)
         def isMatchedBy(usage: Name): Boolean =
           name == usage
           || deprecatedNames.get(name).exists(_.deprecatedName == usage)
         def checkDeprecationOf(usage: Name, pos: SrcPos): Unit = if !ctx.isAfterTyper then
+          import report.deprecationWarning
           for dna <- deprecatedNames.get(name) do
             dna.deprecatedName match
-            case `name` | nme.NO_NAME if name == usage =>
-              report.deprecationWarning(em"naming parameter $usage is deprecated${dna.since}", pos)
-            case `usage` =>
-              report.deprecationWarning(em"the parameter name $usage is deprecated${dna.since}: use $name instead", pos)
-            case _ =>
+              case `name` | nme.NO_NAME if name == usage =>
+                deprecationWarning(em"naming parameter $usage is deprecated${dna.since}", pos)
+              case `usage` =>
+                deprecationWarning(em"the parameter name $usage is deprecated${dna.since}: use $name instead", pos)
+              case _ =>
         def alternative: Name =
           deprecatedNames.get(name).map(_.deprecatedName).getOrElse(nme.NO_NAME)
 
@@ -715,8 +716,7 @@ trait Applications extends Compatibility {
        */
       def handleNamed(pnames: List[Name], args: TreeList[T],
                       nameToArg: Map[Name, Trees.NamedArg[T]], toDrop: Set[Name],
-                      missingArgs: Boolean): TreeList[T] = {
-        pnames match
+                      missingArgs: Boolean): TreeList[T] = pnames match {
         case pname :: pnames if nameToArg.contains(pname) =>
           val arg = nameToArg(pname) // use the named argument for this parameter
           pname.checkDeprecationOf(pname, arg.srcPos)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -658,7 +658,7 @@ trait Applications extends Compatibility {
      *    - "does not have parameter" if a named parameter does not mention a formal
      *      parameter name.
      */
-    def reorder[T <: Untyped](args: TreeList[T]): TreeList[T] =
+    def reorder[T <: Untyped](args: TreeList[T]): TreeList[T] = {
 
       extension [A](list: List[A]) inline def dropOne = if list.isEmpty then list else list.tail // aka list.drop(1)
 
@@ -715,7 +715,7 @@ trait Applications extends Compatibility {
        */
       def handleNamed(pnames: List[Name], args: TreeList[T],
                       nameToArg: Map[Name, Trees.NamedArg[T]], toDrop: Set[Name],
-                      missingArgs: Boolean): TreeList[T] =
+                      missingArgs: Boolean): TreeList[T] = {
         pnames match
         case pname :: pnames if nameToArg.contains(pname) =>
           val arg = nameToArg(pname) // use the named argument for this parameter
@@ -750,6 +750,7 @@ trait Applications extends Compatibility {
           case nil => // no more args, continue to pick up any preceding named args
             if pnames.isEmpty then nil
             else handleNamed(pnames.dropOne, args = nil, nameToArg, toDrop, missingArgs)
+      }
 
       // Skip prefix of positional args, then handleNamed
       def handlePositional(pnames: List[Name], args: TreeList[T]): TreeList[T] =
@@ -765,7 +766,7 @@ trait Applications extends Compatibility {
         case nil => nil
 
       handlePositional(methodType.paramNames, args)
-    end reorder
+    } // end reorder
 
     /** Is `sym` a constructor of a Java-defined annotation? */
     def isJavaAnnotConstr(sym: Symbol): Boolean =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3108,6 +3108,16 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     completeAnnotations(ddef, sym)
     val paramss1 = paramss.nestedMapConserve(typed(_)).asInstanceOf[List[ParamClause]]
     for case ValDefs(vparams) <- paramss1 do
+      if !ctx.isAfterTyper && !sym.is(Synthetic) then
+        vparams.foldLeft(mutable.Set.empty[Name]): (seen, p) =>
+          if seen(p.name) then
+            report.error(em"parameter name must be distinct from deprecated name", p.srcPos)
+          for annot <- p.symbol.getAnnotation(defn.DeprecatedNameAnnot) do
+            val nm = annot.argumentConstantString(0).map(_.toTermName).getOrElse(nme.NO_NAME)
+            if seen(nm) then
+              report.error(em"deprecated parameter name must be distinct from other names", annot.tree.srcPos)
+            seen.addOne(nm)
+          seen.addOne(p.name)
       checkNoForwardDependencies(vparams)
     if (sym.isOneOf(GivenOrImplicit)) checkImplicitConversionDefOK(sym)
     val tpt1 = checkSimpleKinded(typedType(tpt))

--- a/tests/neg/i18122.check
+++ b/tests/neg/i18122.check
@@ -30,18 +30,18 @@
 23 |    bar1(ys = 1) // error: missing arg
    |    ^^^^^^^^^^^^
    |    missing argument for parameter x of method bar1 in object Test: (x: Int, ys: Int*): Unit
--- Error: tests/neg/i18122.scala:43:16 ---------------------------------------------------------------------------------
-43 |    bar1(x = 1, 2, ys = 3)  // error: positional after named
-   |                ^
-   |                positional after named argument
+-- Error: tests/neg/i18122.scala:43:22 ---------------------------------------------------------------------------------
+43 |    bar1(x = 1, 2, ys = 3)  // error: parameter ys is already instantiated
+   |                   ^^^^^^
+   |                   parameter ys of method bar1 in object Test: (x: Int, ys: Int*): Unit is already instantiated
 -- Error: tests/neg/i18122.scala:44:18 ---------------------------------------------------------------------------------
 44 |    bar1(1, 2, ys = 3)      // error: parameter ys is already instantiated
    |               ^^^^^^
    |               parameter ys of method bar1 in object Test: (x: Int, ys: Int*): Unit is already instantiated
--- Error: tests/neg/i18122.scala:45:16 ---------------------------------------------------------------------------------
-45 |    bar2(x = 1, 2, ys = 3)  // error: positional after named
-   |                ^
-   |                positional after named argument
+-- Error: tests/neg/i18122.scala:45:22 ---------------------------------------------------------------------------------
+45 |    bar2(x = 1, 2, ys = 3)  // error: parameter ys is already instantiated
+   |                   ^^^^^^
+   |                   parameter ys of method bar2 in object Test: (x: Int, ys: Int*): Unit is already instantiated
 -- Error: tests/neg/i18122.scala:46:17 ---------------------------------------------------------------------------------
 46 |    bar1(ys = 1, 2, x = 3)  // error: positional after named
    |                 ^

--- a/tests/neg/i18122.scala
+++ b/tests/neg/i18122.scala
@@ -40,9 +40,9 @@ object Test {
     bar2(x = 1, 2, 3)
     bar1(x = 1, ys = 2, 3)
     bar2(x = 1, ys = 2, 3)
-    bar1(x = 1, 2, ys = 3)  // error: positional after named
+    bar1(x = 1, 2, ys = 3)  // error: parameter ys is already instantiated
     bar1(1, 2, ys = 3)      // error: parameter ys is already instantiated
-    bar2(x = 1, 2, ys = 3)  // error: positional after named
+    bar2(x = 1, 2, ys = 3)  // error: parameter ys is already instantiated
     bar1(ys = 1, 2, x = 3)  // error: positional after named
     bar2(ys = 1, 2, x = 3)  // error: positional after named
   }

--- a/tests/neg/i19077.check
+++ b/tests/neg/i19077.check
@@ -1,0 +1,17 @@
+-- Error: tests/neg/i19077.scala:5:15 ----------------------------------------------------------------------------------
+5 |  f(1, 2, 3, x = 42) // error
+  |             ^^^^^^
+  |             parameter x of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+-- Error: tests/neg/i19077.scala:6:15 ----------------------------------------------------------------------------------
+6 |  f(1, 2, 3, w = 42) // error
+  |             ^^^^^^
+  |             parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+-- Error: tests/neg/i19077.scala:7:20 ----------------------------------------------------------------------------------
+7 |  f(1, 2, w = 42, z = 27) // error
+  |                  ^^^^^^
+  |                  parameter z of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+-- Error: tests/neg/i19077.scala:8:20 ----------------------------------------------------------------------------------
+8 |  f(1, 2, z = 42, w = 27) // error
+  |                  ^^^^^^
+  |                  parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+there was 1 deprecation warning; re-run with -deprecation for details

--- a/tests/neg/i19077.check
+++ b/tests/neg/i19077.check
@@ -1,17 +1,35 @@
--- Error: tests/neg/i19077.scala:5:15 ----------------------------------------------------------------------------------
-5 |  f(1, 2, 3, x = 42) // error
-  |             ^^^^^^
-  |             parameter x of method f: (x: Int, y: Int, z: Int): Int is already instantiated
--- Error: tests/neg/i19077.scala:6:15 ----------------------------------------------------------------------------------
-6 |  f(1, 2, 3, w = 42) // error
-  |             ^^^^^^
-  |             parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
--- Error: tests/neg/i19077.scala:7:20 ----------------------------------------------------------------------------------
-7 |  f(1, 2, w = 42, z = 27) // error
-  |                  ^^^^^^
-  |                  parameter z of method f: (x: Int, y: Int, z: Int): Int is already instantiated
--- Error: tests/neg/i19077.scala:8:20 ----------------------------------------------------------------------------------
-8 |  f(1, 2, z = 42, w = 27) // error
-  |                  ^^^^^^
-  |                  parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+-- Error: tests/neg/i19077.scala:4:35 ----------------------------------------------------------------------------------
+4 |def g(@deprecatedName("a") x: Int, a: Int) = x+a // error
+  |                                   ^^^^^^
+  |                                   parameter name must be distinct from deprecated name
+-- Error: tests/neg/i19077.scala:6:36 ----------------------------------------------------------------------------------
+6 |def h(@deprecatedName("a") x: Int, @deprecatedName("a") y: Int) = x+y // error
+  |                                   ^^^^^^^^^^^^^^^^^^^^
+  |                                   deprecated parameter name must be distinct from other names
+-- Error: tests/neg/i19077.scala:8:15 ----------------------------------------------------------------------------------
+8 |def i(x: Int, @deprecatedName("x") y: Int) = x+y // error
+  |              ^^^^^^^^^^^^^^^^^^^^
+  |              deprecated parameter name must be distinct from other names
+-- [E161] Naming Error: tests/neg/i19077.scala:10:35 -------------------------------------------------------------------
+10 |def j(x: Int, @deprecatedName("x") x: Int) = x // error
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |              x is already defined as parameter x
+   |
+   |              Note that overloaded methods must all be defined in the same group of toplevel definitions
+-- Error: tests/neg/i19077.scala:13:15 ---------------------------------------------------------------------------------
+13 |  f(1, 2, 3, x = 42) // error
+   |             ^^^^^^
+   |             parameter x of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+-- Error: tests/neg/i19077.scala:14:15 ---------------------------------------------------------------------------------
+14 |  f(1, 2, 3, w = 42) // error
+   |             ^^^^^^
+   |             parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+-- Error: tests/neg/i19077.scala:15:20 ---------------------------------------------------------------------------------
+15 |  f(1, 2, w = 42, z = 27) // error
+   |                  ^^^^^^
+   |                  parameter z of method f: (x: Int, y: Int, z: Int): Int is already instantiated
+-- Error: tests/neg/i19077.scala:16:20 ---------------------------------------------------------------------------------
+16 |  f(1, 2, z = 42, w = 27) // error
+   |                  ^^^^^^
+   |                  parameter w of method f: (x: Int, y: Int, z: Int): Int is already instantiated
 there was 1 deprecation warning; re-run with -deprecation for details

--- a/tests/neg/i19077.scala
+++ b/tests/neg/i19077.scala
@@ -1,0 +1,13 @@
+
+def f(@deprecatedName("x") x: Int, @deprecatedName y: Int, @deprecatedName("w") z: Int) = x+y+z
+
+@main def Test =
+  f(1, 2, 3, x = 42) // error
+  f(1, 2, 3, w = 42) // error
+  f(1, 2, w = 42, z = 27) // error
+  f(1, 2, z = 42, w = 27) // error
+
+object X { def m[T](i: Int)(s: String) = s*i; def m[T](i: Int)(d: Double) = d*i }
+
+object Y:
+  def f = X.m(42)(s = "") // overloading resolution objects to methRef.symbol.paramSymss

--- a/tests/neg/i19077.scala
+++ b/tests/neg/i19077.scala
@@ -1,6 +1,14 @@
 
 def f(@deprecatedName("x") x: Int, @deprecatedName y: Int, @deprecatedName("w") z: Int) = x+y+z
 
+def g(@deprecatedName("a") x: Int, a: Int) = x+a // error
+
+def h(@deprecatedName("a") x: Int, @deprecatedName("a") y: Int) = x+y // error
+
+def i(x: Int, @deprecatedName("x") y: Int) = x+y // error
+
+def j(x: Int, @deprecatedName("x") x: Int) = x // error
+
 @main def Test =
   f(1, 2, 3, x = 42) // error
   f(1, 2, 3, w = 42) // error

--- a/tests/warn/i19077.check
+++ b/tests/warn/i19077.check
@@ -1,0 +1,44 @@
+-- Deprecation Warning: tests/warn/i19077.scala:26:14 ------------------------------------------------------------------
+26 |  def g = f(y = 42) // warn but omit empty since
+   |            ^^^^^^
+   |            the parameter name y is deprecated: use x instead
+-- Deprecation Warning: tests/warn/i19077.scala:12:6 -------------------------------------------------------------------
+12 |  f(x = 1, 2, 3) // warn
+   |    ^^^^^
+   |    naming parameter x is deprecated
+-- Deprecation Warning: tests/warn/i19077.scala:13:9 -------------------------------------------------------------------
+13 |  f(1, y = 2, 3) // warn
+   |       ^^^^^
+   |       naming parameter y is deprecated
+-- Deprecation Warning: tests/warn/i19077.scala:14:12 ------------------------------------------------------------------
+14 |  f(1, 2, w = 3) // warn
+   |          ^^^^^
+   |          the parameter name w is deprecated: use z instead
+-- Deprecation Warning: tests/warn/i19077.scala:15:6 -------------------------------------------------------------------
+15 |  f(x = 1, w = 3, y = 2) // warn // warn // warn
+   |    ^^^^^
+   |    naming parameter x is deprecated
+-- Deprecation Warning: tests/warn/i19077.scala:15:20 ------------------------------------------------------------------
+15 |  f(x = 1, w = 3, y = 2) // warn // warn // warn
+   |                  ^^^^^
+   |                  naming parameter y is deprecated
+-- Deprecation Warning: tests/warn/i19077.scala:15:13 ------------------------------------------------------------------
+15 |  f(x = 1, w = 3, y = 2) // warn // warn // warn
+   |           ^^^^^
+   |           the parameter name w is deprecated: use z instead
+-- Deprecation Warning: tests/warn/i19077.scala:16:13 ------------------------------------------------------------------
+16 |  f(w = 3, x = 1, y = 2) // warn // warn // warn
+   |           ^^^^^
+   |           naming parameter x is deprecated
+-- Deprecation Warning: tests/warn/i19077.scala:16:20 ------------------------------------------------------------------
+16 |  f(w = 3, x = 1, y = 2) // warn // warn // warn
+   |                  ^^^^^
+   |                  naming parameter y is deprecated
+-- Deprecation Warning: tests/warn/i19077.scala:16:6 -------------------------------------------------------------------
+16 |  f(w = 3, x = 1, y = 2) // warn // warn // warn
+   |    ^^^^^
+   |    the parameter name w is deprecated: use z instead
+-- Deprecation Warning: tests/warn/i19077.scala:20:8 -------------------------------------------------------------------
+20 |  X.f(v = 42) // warn
+   |      ^^^^^^
+   |      the parameter name v is deprecated (since 3.3): use x instead

--- a/tests/warn/i19077.scala
+++ b/tests/warn/i19077.scala
@@ -1,0 +1,26 @@
+//> using options -deprecation
+
+def f(@deprecatedName("x") x: Int, @deprecatedName y: Int, @deprecatedName("w") z: Int) = x+y+z
+
+object X:
+  def f(@deprecatedName("v", since="3.3") x: Int) = x
+  def f(@deprecatedName("v") x: Int, y: Int) = x+y
+
+@main def Test =
+  f(1, 2, 3) // nowarn
+  f(1, 2, z = 3) // nowarn
+  f(x = 1, 2, 3) // warn
+  f(1, y = 2, 3) // warn
+  f(1, 2, w = 3) // warn
+  f(x = 1, w = 3, y = 2) // warn // warn // warn
+  f(w = 3, x = 1, y = 2) // warn // warn // warn
+
+  X.f(42)
+  X.f(x = 42)
+  X.f(v = 42) // warn
+  X.f(x = 42, y = 27)
+  X.f(y = 42, x = 27)
+
+object empty:
+  def f(@deprecatedName("y", since="") x: Int) = x
+  def g = f(y = 42) // warn but omit empty since


### PR DESCRIPTION
For a method definition
```
def f(@deprecatedName("x") x: Int, @deprecatedName y: Int, @deprecatedName("w") z: Int) = x+y+z
```
emit a deprecation warning if `x`, `y`, or `w` are named in an application.

Fixes #19077 

Supersedes https://github.com/scala/scala3/pull/19086

The check for a deprecated name is when an arg is deemed missing: that is when draining the list of args and the current arg is named. Instead of `missingArgs = true`, first check whether this arg is a deprecated name for the current parameter. Fix up that arg to use the canonical name and continue.

`handlePositional` also consumes leading named args that are in position. Common applications such as `f(i, b = true, j)` need not `handleNamed`.

Checking for a deprecated name is expensive but only happens for named args. (Looking for the deprecated name as a fallback would be fine, but every named arg is checked; that is not usually every arg.)