### PR TITLE
Fix treatment of separately compiled @native methods in FirstTransform

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Flags.scala
+++ b/compiler/src/dotty/tools/dotc/core/Flags.scala
@@ -569,6 +569,7 @@ object Flags {
   val ConstructorProxyModule: FlagSet        = ConstructorProxy | Module
   val DefaultParameter: FlagSet              = HasDefault | Param                             // A Scala 2x default parameter
   val DeferredInline: FlagSet                = Deferred | Inline
+  val DeferredMethod: FlagSet                = Deferred | Method
   val DeferredOrLazy: FlagSet                = Deferred | Lazy
   val DeferredOrLazyOrMethod: FlagSet        = Deferred | Lazy | Method
   val DeferredOrTermParamOrAccessor: FlagSet = Deferred | ParamAccessor | TermParam           // term symbols without right-hand sides

--- a/tests/pos/i20588/Baz_2.scala
+++ b/tests/pos/i20588/Baz_2.scala
@@ -1,0 +1,1 @@
+class Baz extends Foo

--- a/tests/pos/i20588/Foo_1.scala
+++ b/tests/pos/i20588/Foo_1.scala
@@ -1,0 +1,3 @@
+class Foo {
+  @native def test(): Unit
+}


### PR DESCRIPTION
We need to use a SymTransformer, fixing the method in the tree is not enough.

Fixes #20588 