### PR TITLE
Harden skip in Scanner

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -306,11 +306,15 @@ object Scanners {
         println(s"\nSTART SKIP AT ${sourcePos().line + 1}, $this in $currentRegion")
       var noProgress = 0
         // Defensive measure to ensure we always get out of the following while loop
-        // even if source file is weirly formatted (i.e. we never reach EOF
+        // even if source file is weirly formatted (i.e. we never reach EOF)
+      var prevOffset = offset
       while !atStop && noProgress < 3 do
-        val prevOffset = offset
         nextToken()
-        if offset == prevOffset then noProgress += 1 else noProgress = 0
+        if offset <= prevOffset then
+          noProgress += 1
+        else
+          prevOffset = offset
+          noProgress = 0
       if debugTokenStream then
         println(s"\nSTOP SKIP AT ${sourcePos().line + 1}, $this in $currentRegion")
       if token == OUTDENT then dropUntil(_.isInstanceOf[Indented])


### PR DESCRIPTION
After running metals for a while, I sometimes see a rogue java process at 100% even after I closed down sbt and vscode. With jstack I got the following stack trace:

    java.lang.Thread.State: RUNNABLE

	at dotty.tools.dotc.parsing.Scanners$Scanner.handleNewLine(Scanners.scala:613)

	at dotty.tools.dotc.parsing.Scanners$Scanner.nextToken(Scanners.scala:396)

	at dotty.tools.dotc.parsing.Scanners$Scanner.skip(Scanners.scala:312)

	at dotty.tools.dotc.parsing.Parsers$Parser.skip(Parsers.scala:280)

	at dotty.tools.dotc.parsing.Parsers$Parser.recur$2(Parsers.scala:376)

	at dotty.tools.dotc.parsing.Parsers$Parser.statSepOrEnd(Parsers.scala:380)

It could be that the loop in skip gives two alternate offsets that would not bump the progress counter. I changed the loop so that it catches infinite looping conditions more robustly.