### PR TITLE
Bump Inkuire version to fix it for the new Scala versions

### DIFF
--- a/project/DocumentationWebsite.scala
+++ b/project/DocumentationWebsite.scala
@@ -43,7 +43,7 @@ object DocumentationWebsite {
     import _root_.scala.concurrent._
     import _root_.scala.concurrent.duration.Duration
     import ExecutionContext.Implicits.global
-    val inkuireVersion = "v1.0.0-M7"
+    val inkuireVersion = "v1.0.0-M9"
     val inkuireLink = s"https://github.com/VirtusLab/Inkuire/releases/download/$inkuireVersion/inkuire.js"
     val inkuireDestinationFile = baseDest / "dotty_res" / "scripts" / "inkuire.js"
     sbt.IO.touch(inkuireDestinationFile)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/InkuireSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/InkuireSupport.scala
@@ -184,10 +184,10 @@ trait InkuireSupport(using DocContext) extends Resources:
     else ownerNameChain(sym.owner) :+ sym.normalizedName
 
   private def viableSymbol(s: Symbol): Boolean =
-      !s.flags.is(Flags.Private) &&
-        !s.flags.is(Flags.Protected) &&
-        !s.flags.is(Flags.Override) &&
-        !s.flags.is(Flags.Synthetic)
+    !s.flags.is(Flags.Private) &&
+      !s.flags.is(Flags.Protected) &&
+      !s.flags.is(Flags.Override) &&
+      !s.flags.is(Flags.Synthetic)
 
   private def varName(t: Inkuire.TypeLike): Option[String] = t match {
     case tpe: Inkuire.Type      => Some(tpe.name.name)


### PR DESCRIPTION
It seems like Inkuire depended on the way some type lambdas were encoded in TASTy which caused it to falsely reject a ton of valid functions. This update also includes a slight change to the ordering heuristic, so that more complicated names of functions are shown lower in the lost and synthetic names are shown last.

Inkuire changes:
- `1.0.0-M8` https://github.com/VirtusLab/Inkuire/releases/tag/v1.0.0-M8
- `1.0.0-M9` https://github.com/VirtusLab/Inkuire/releases/tag/v1.0.0-M9