### PR TITLE
Remove lazy modifier from Predef.assert

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -6,7 +6,7 @@ import scala.annotation.internal.RuntimeChecked
 object Predef:
   import compiletime.summonFrom
 
-  transparent inline def assert(inline assertion: Boolean, inline message: => Any): Unit =
+  transparent inline def assert(inline assertion: Boolean, inline message: Any): Unit =
     if !assertion then scala.runtime.Scala3RunTime.assertFailed(message)
 
   transparent inline def assert(inline assertion: Boolean): Unit =


### PR DESCRIPTION
Since message is inlined and gated behind the `if` check, it will still only get parsed on demand.