### PR TITLE
Remove locale dependent FileSystemException check

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -275,12 +275,11 @@ object SourceFile {
 
   def apply(file: AbstractFile | Null, codec: Codec): SourceFile =
     // Files.exists is slow on Java 8 (https://rules.sonarsource.com/java/tag/performance/RSPEC-3725),
-    // so cope with failure; also deal with path prefix "Not a directory".
+    // so cope with failure.
     val chars =
       try new String(file.toByteArray, codec.charSet).toCharArray
       catch
-        case _: NoSuchFileException => Array.empty[Char]
-        case fse: FileSystemException if fse.getMessage.endsWith("Not a directory") => Array.empty[Char]
+        case _: FileSystemException => Array.empty[Char]
 
     if isScript(file, chars) then
       ScriptSourceFile(file, chars)


### PR DESCRIPTION
In SourceFile, files that do not exist are expected and related exceptions should be ignored. There are two relevant cases:

    scala> java.nio.file.Files.newInputStream(java.nio.file.FileSystems.getDefault().getPath("does-not-exist"))
    java.nio.file.NoSuchFileException: does-not-exist

    scala> java.nio.file.Files.newInputStream(java.nio.file.FileSystems.getDefault().getPath("regular-file-instead-of-directory/filename"))
    java.nio.file.FileSystemException: regular-file-instead-of-directory/filename: Not a directory

Ideally, other I/O errors would be propagated to the caller.

However, there is no reliable way to distinguish them based on the exceptions alone. In particular, the message cannot be checked, because it depends on the operating system and it is localized.

Revert the addition of the check and just accept this.

---

Resolves the following concrete bug:

0. Use an operating system that localizes strerror, like Debian.
1. Check out https://github.com/lichess-org/lila before https://github.com/lichess-org/lila/commit/8610e6fa4444d61b33c887e2b0906f175ec348c8
2. `LANGUAGE=fr sbt compile`
3. ICE with `java.nio.file.FileSystemException: lila/src/main/scala/future.scala: N'est pas un dossier` ([stacktrace](https://gist.github.com/ornicar/4a7b136d2220f4c1fd43e920956f67b4))

Not sure how to exercise locale dependent issues in a unit test.

---

cc @som-snytt in case I misinterpreted 159da447b1ed61d8fa7f4896a8d84f4c661f0842 and distinguishing other I/O errors is not optional.