### PR TITLE
Avoid erasure/preErasure issues around Any in transformIsInstanceOf

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -256,7 +256,8 @@ object TypeTestsCasts {
             else foundClasses.exists(check)
           end checkSensical
 
-          if (expr.tpe <:< testType) && inMatch then
+          val tp = if expr.tpe.isPrimitiveValueType then defn.boxedType(expr.tpe) else expr.tpe
+          if tp <:< testType && inMatch then
             if expr.tpe.isNotNull then constant(expr, Literal(Constant(true)))
             else expr.testNotNull
           else {
@@ -358,11 +359,7 @@ object TypeTestsCasts {
                 report.error(em"$untestable cannot be used in runtime type tests", tree.srcPos)
                 constant(expr, Literal(Constant(false)))
               case _ =>
-                val erasedTestType =
-                  if testType.isAny && expr.tpe.isPrimitiveValueType then
-                    defn.AnyValType
-                  else
-                    erasure(testType)
+                val erasedTestType = erasure(testType)
                 transformIsInstanceOf(expr, erasedTestType, erasedTestType, flagUnrelated)
         }
 

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -358,7 +358,11 @@ object TypeTestsCasts {
                 report.error(em"$untestable cannot be used in runtime type tests", tree.srcPos)
                 constant(expr, Literal(Constant(false)))
               case _ =>
-                val erasedTestType = erasure(testType)
+                val erasedTestType =
+                  if testType.isAny && expr.tpe.isPrimitiveValueType then
+                    defn.AnyValType
+                  else
+                    erasure(testType)
                 transformIsInstanceOf(expr, erasedTestType, erasedTestType, flagUnrelated)
         }
 

--- a/tests/pos/i21544.scala
+++ b/tests/pos/i21544.scala
@@ -1,0 +1,2 @@
+class Test():
+  def m1(xs: List[Boolean]) = for (x: Any) <- xs yield x

--- a/tests/pos/i21544.scala
+++ b/tests/pos/i21544.scala
@@ -2,3 +2,12 @@ class Test():
   def m1(xs: List[Boolean]) = for (x: Any) <- xs yield x
   def m2(xs: List[Boolean]) = for (x: AnyVal) <- xs yield x
   def m3(xs: List[Boolean]) = for (x: Matchable) <- xs yield x
+
+  def v1(xs: List[AnyVal])    = for (x: Any) <- xs yield x
+  def v2(xs: List[AnyVal])    = for (x: AnyVal) <- xs yield x
+  def v3(xs: List[AnyVal])    = for (x: Matchable) <- xs yield x
+
+  def t1(xs: List[Matchable]) = for (x: Any) <- xs yield x
+  def t2(xs: List[Matchable]) = for (x: Matchable) <- xs yield x
+
+  def a1(xs: List[Any])       = for (x: Any) <- xs yield x

--- a/tests/pos/i21544.scala
+++ b/tests/pos/i21544.scala
@@ -1,2 +1,4 @@
 class Test():
   def m1(xs: List[Boolean]) = for (x: Any) <- xs yield x
+  def m2(xs: List[Boolean]) = for (x: AnyVal) <- xs yield x
+  def m3(xs: List[Boolean]) = for (x: Matchable) <- xs yield x


### PR DESCRIPTION
The testType Any is erased to Object, but the expr type Int isn't erased
to Integer, so then it fails as Int `!<:` Object.  We avoid the problem by
feeding in AnyVal, leading to a (possibly elided) non-null test only.

Fixes #21544
