### PR TITLE
Handle suspension due to macro call in arbitrary phases

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -378,14 +378,18 @@ object Phases {
               ()
             else
               run
-          catch case ex: Throwable if !ctx.run.enrichedErrorMessage =>
-            println(ctx.run.enrichErrorMessage(s"unhandled exception while running $phaseName on $unit"))
-            throw ex
+            buf += unitCtx.compilationUnit
+          catch
+            case _: CompilationUnit.SuspendException => // this unit will be run again in `Run#compileSuspendedUnits`
+            case ex: Throwable if !ctx.run.enrichedErrorMessage =>
+              println(ctx.run.enrichErrorMessage(s"unhandled exception while running $phaseName on $unit"))
+              throw ex
           finally ctx.run.advanceUnit()
-          buf += unitCtx.compilationUnit
         end if
       end for
-      buf.result()
+      val res = buf.result()
+      ctx.run.nn.checkSuspendedUnits(res)
+      res
     end runOn
 
     /** Convert a compilation unit's tree to a string; can be overridden */

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -36,13 +36,7 @@ class Inlining extends MacroTransform, IdentityDenotTransformer {
 
   override def run(using Context): Unit =
     if ctx.compilationUnit.needsInlining || ctx.compilationUnit.hasMacroAnnotations then
-      try super.run
-      catch case _: CompilationUnit.SuspendException => ()
-
-  override def runOn(units: List[CompilationUnit])(using Context): List[CompilationUnit] =
-    val newUnits = super.runOn(units).filterNot(_.suspended)
-    ctx.run.nn.checkSuspendedUnits(newUnits)
-    newUnits
+      super.run
 
   override def checkPostCondition(tree: Tree)(using Context): Unit =
     tree match {

--- a/tests/pos-macros/i18517/Caller.scala
+++ b/tests/pos-macros/i18517/Caller.scala
@@ -1,0 +1,17 @@
+package dummy
+
+trait BG {
+  val   description: { type Structure }
+  type  Structure =  description.Structure
+}
+
+abstract class Caller extends BG {
+  type Foo >: this.type <: this.type
+
+  transparent inline def generate2() =
+    ${Macro.impl() }
+
+  final val description = {
+    generate2()
+  }
+}

--- a/tests/pos-macros/i18517/Macro.scala
+++ b/tests/pos-macros/i18517/Macro.scala
@@ -1,0 +1,7 @@
+package dummy
+
+import scala.quoted.*
+
+object Macro:
+  def impl()(using quotes:Quotes) : Expr[Any] =
+    '{ null }

--- a/tests/pos-macros/i18517/User.scala
+++ b/tests/pos-macros/i18517/User.scala
@@ -1,0 +1,6 @@
+package dummy
+
+trait User:
+  final def bar(cell:Any) : Unit =
+    (cell: cell.type) match
+      case c: (Caller & cell.type) => ()


### PR DESCRIPTION
Previously we only supported suspension in Typer and Inliner. In the added test
case this happens in PostTyper, but I've seen it happen in Mixin too.

Fixes https://github.com/scala/scala3/issues/18517.