### PR TITLE
fix: Change the NamedTuple.apply method to transparent inline

### DIFF
--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -138,7 +138,7 @@ object NamedTupleDecomposition:
   import NamedTuple.*
   extension [N <: Tuple, V <: Tuple](x: NamedTuple[N, V])
       /** The value (without the name) at index `n` of this tuple */
-    inline def apply(n: Int): Tuple.Elem[V, n.type] =
+    transparent inline def apply(n: Int): Tuple.Elem[V, n.type] =
       inline x.toTuple match
         case tup: NonEmptyTuple => tup(n).asInstanceOf[Tuple.Elem[V, n.type]]
         case tup => tup.productElement(n).asInstanceOf[Tuple.Elem[V, n.type]]

--- a/tests/pos/i21413.scala
+++ b/tests/pos/i21413.scala
@@ -1,0 +1,6 @@
+//> using scala 3.nightly
+
+import scala.language.experimental.namedTuples
+
+val x = (aaa = 1).aaa
+


### PR DESCRIPTION
This fixes a problem with not being able to reference named tuple fields immediately from a named tuple literal

possible fix for #21413 