### PR TITLE
Fix #21669: Check parents non-empty before calling reduceLeft

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1963,7 +1963,10 @@ trait Applications extends Compatibility {
     def widenPrefix(alt: TermRef): Type = alt.prefix.widen match
       case pre: (TypeRef | ThisType) if pre.typeSymbol.is(Module) =>
         val ps = pre.parents
-        if ps.isEmpty then pre
+        if ps.isEmpty then
+          // The parents of a module class are non-empty, unless the module is a package.
+          assert(pre.typeSymbol.is(Package), pre)
+          pre
         else ps.reduceLeft(TypeComparer.andType(_, _))
       case wpre => wpre
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1962,7 +1962,9 @@ trait Applications extends Compatibility {
 
     def widenPrefix(alt: TermRef): Type = alt.prefix.widen match
       case pre: (TypeRef | ThisType) if pre.typeSymbol.is(Module) =>
-        pre.parents.reduceLeft(TypeComparer.andType(_, _))
+        val ps = pre.parents
+        if ps.isEmpty then pre
+        else ps.reduceLeft(TypeComparer.andType(_, _))
       case wpre => wpre
 
     /** If two alternatives have the same symbol, we pick the one with the most


### PR DESCRIPTION
Fix #21669

This part of code is from #20084

We should check `parents` is non-empty before calling `reduceLeft`.

I haven't been able to create a standalone test. To test locally:

`i21669.scala`
```scala
//> using dep "com.softwaremill.sttp.tapir::tapir-sttp-client:1.11.5"

import sttp.tapir.*
import sttp.tapir.client.sttp.SttpClientInterpreter

@main def run =
    lazy val pingGET = endpoint.get
        .in("ping")
        .out(stringBody)

    SttpClientInterpreter()
        .toRequest(pingGET, Some(uri"http://localhost:8080"))
```

```
> sbt publishLocal
> scala compile --server=false -S 3.6.0-RC1-bin-SNAPSHOT i21669.scala
-- [E008] Not Found Error: /dotty/i21669.scala:12:33 ------
12 |        .toRequest(pingGET, Some(uri"http://localhost:8080"))
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |value uri is not a member of StringContext, but could be made available as an extension method.
   |
   |One of the following imports might fix the problem:
   |
   |  import sttp.client3.UriContext
   |  import sttp.client3.quick.UriContext
   |  import sttp.model.Uri.UriContext
   |
1 error found
Compilation failed
```