### PR TITLE
Do not warn about expected missing positions in quotes.reflect.Symbol

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2698,9 +2698,10 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           if self.exists then
             val symPos = self.sourcePos
             if symPos.exists then Some(symPos)
-            else
+            else if self.source.exists then
               if xCheckMacro then report.warning(s"Missing symbol position (defaulting to position 0): $self\nThis is a compiler bug. Please report it.")
               Some(self.source.atSpan(dotc.util.Spans.Span(0)))
+            else None
           else None
 
         def docstring: Option[String] =

--- a/tests/pos-macros/i21672/Macro_1.scala
+++ b/tests/pos-macros/i21672/Macro_1.scala
@@ -1,0 +1,10 @@
+object Repro {
+  inline def apply(): Unit = ${ applyImpl }
+
+  import scala.quoted.*
+  def applyImpl(using q: Quotes): Expr[Unit] = {
+   import q.reflect.*
+   report.info(TypeRepr.of[Some[String]].typeSymbol.pos.toString)
+   '{ () }
+  }
+}

--- a/tests/pos-macros/i21672/Test_2.scala
+++ b/tests/pos-macros/i21672/Test_2.scala
@@ -1,0 +1,3 @@
+//> using options -Xfatal-warnings
+object Test:
+  Repro()


### PR DESCRIPTION
Related to https://github.com/scala/scala3/pull/19250

In the PR above it is said that trees and symbols always have to have a position. I think certain cases of the quotes.reflect.Symbol.pos method might have been overlooked, since the doc for Symbol.span (internally in the compiler) explicitly states that the Symbol might not have a position assigned if it was not loaded from source or TASTy. It is true however for quotes.reflect.Tree.pos - the trees always have a position since they _have to_ be loaded from source or TASTy.

Thankfully, quotes.reflect.Symbol.pos returns `Option[Symbol]`, so we can just return None in the cases where the position does not exist. Previously we would only return None if the symbol itself did not exist, however this was not specified anywhere in the Quotes docs, so I think it's fine to change that now (or at least better then any other alternatives), even if this change would go into 3.3.5.

As a comparison, the output of `println(TypeRepr.of[String].typeSymbol.pos.toString)` would be:
Before #19250: `Some(?)` (Some(NoSource) without set span/position - can cause crashes)
After #19250: `Some(?)` (Some(NoSource) with span/position - can still cause crashes)
After this PR: `None`


Fixes #21672 