### PR TITLE
Let show behave more robustly for Recheck

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -618,7 +618,13 @@ abstract class Recheck extends Phase, SymTransformer:
   override def show(tree: untpd.Tree)(using Context): String =
     atPhase(thisPhase):
       withMode(Mode.Printing):
-        super.show(addRecheckedTypes.transform(tree.asInstanceOf[tpd.Tree]))
+        val ttree0 = tree.asInstanceOf[tpd.Tree]
+        val ttree1 =
+          try
+              addRecheckedTypes.transform(ttree0)
+          catch
+              case _:TypeError => ttree0
+        super.show(ttree1)
 end Recheck
 
 /** A class that can be used to test basic rechecking without any customaization */

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -33,10 +33,13 @@ object Recheck:
 
   val addRecheckedTypes = new TreeMap:
     override def transform(tree: Tree)(using Context): Tree =
-      val tree1 = super.transform(tree)
-      tree.getAttachment(RecheckedType) match
-        case Some(tpe) => tree1.withType(tpe)
-        case None => tree1
+      try
+        val tree1 = super.transform(tree)
+        tree.getAttachment(RecheckedType) match
+          case Some(tpe) => tree1.withType(tpe)
+          case None => tree1
+      catch
+        case _:TypeError => tree
 
   extension (sym: Symbol)(using Context)
 
@@ -618,13 +621,7 @@ abstract class Recheck extends Phase, SymTransformer:
   override def show(tree: untpd.Tree)(using Context): String =
     atPhase(thisPhase):
       withMode(Mode.Printing):
-        val ttree0 = tree.asInstanceOf[tpd.Tree]
-        val ttree1 =
-          try
-              addRecheckedTypes.transform(ttree0)
-          catch
-              case _:TypeError => ttree0
-        super.show(ttree1)
+        super.show(addRecheckedTypes.transform(tree.asInstanceOf[tpd.Tree]))
 end Recheck
 
 /** A class that can be used to test basic rechecking without any customaization */


### PR DESCRIPTION
The pretty-printing logic for a Recheck phase
applies the phase to the tree. But if there was
a type error, then the pretty printing would
have previously crashed the compiler.

Fixes #21646 