### PR TITLE
Make named tuples a standard feature

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -34,7 +34,6 @@ object Feature:
   val pureFunctions = experimental("pureFunctions")
   val captureChecking = experimental("captureChecking")
   val into = experimental("into")
-  val namedTuples = experimental("namedTuples")
   val modularity = experimental("modularity")
   val betterMatchTypeExtractors = experimental("betterMatchTypeExtractors")
   val quotedPatternsWithPolymorphicFunctions = experimental("quotedPatternsWithPolymorphicFunctions")
@@ -66,7 +65,6 @@ object Feature:
     (pureFunctions, "Enable pure functions for capture checking"),
     (captureChecking, "Enable experimental capture checking"),
     (into, "Allow into modifier on parameter types"),
-    (namedTuples, "Allow named tuples"),
     (modularity, "Enable experimental modularity features"),
     (betterMatchTypeExtractors, "Enable better match type extractors"),
     (betterFors, "Enable improvements in `for` comprehensions")

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
@@ -25,7 +25,7 @@ object ScalaSettingsProperties:
     ScalaRelease.values.toList.map(_.show)
 
   def supportedSourceVersions: List[String] =
-    SourceVersion.values.toList.map(_.toString)
+    (SourceVersion.values.toList.diff(SourceVersion.illegalSourceVersionNames)).toList.map(_.toString)
 
   def supportedLanguageFeatures: List[ChoiceWithHelp[String]] =
     Feature.values.map((n, d) => ChoiceWithHelp(n.toString, d))

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -957,6 +957,12 @@ class Inliner(val call: tpd.Tree)(using Context):
             case None => tree
         case _ =>
           tree
+
+    /** For inlining only: Given `(x: T)` with expected type `x.type`, replace the tree with `x`.
+     */
+    override def healAdapt(tree: Tree, pt: Type)(using Context): Tree = (tree, pt) match
+      case (Typed(tree1, _), pt: SingletonType) if tree1.tpe <:< pt => tree1
+      case _ => tree
   end InlineTyper
 
   /** Drop any side-effect-free bindings that are unused in expansion or other reachable bindings.

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -651,7 +651,7 @@ object Parsers {
       else leading :: Nil
 
     def maybeNamed(op: () => Tree): () => Tree = () =>
-      if isIdent && in.lookahead.token == EQUALS && in.featureEnabled(Feature.namedTuples) then
+      if isIdent && in.lookahead.token == EQUALS && sourceVersion.isAtLeast(`3.6`) then
         atSpan(in.offset):
           val name = ident()
           in.nextToken()
@@ -2137,7 +2137,7 @@ object Parsers {
 
       if namedOK && isIdent && in.lookahead.token == EQUALS then
         commaSeparated(() => namedArgType())
-      else if tupleOK && isIdent && in.lookahead.isColon && in.featureEnabled(Feature.namedTuples) then
+      else if tupleOK && isIdent && in.lookahead.isColon && sourceVersion.isAtLeast(`3.6`) then
         commaSeparated(() => namedElem())
       else
         commaSeparated(() => argType())

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -789,7 +789,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     def tryNamedTupleSelection() =
       val namedTupleElems = qual.tpe.widenDealias.namedTupleElementTypes
       val nameIdx = namedTupleElems.indexWhere(_._1 == selName)
-      if nameIdx >= 0 && Feature.enabled(Feature.namedTuples) then
+      if nameIdx >= 0 && sourceVersion.isAtLeast(`3.6`) then
         typed(
           untpd.Apply(
             untpd.Select(untpd.TypedSplice(qual), nme.apply),

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4602,7 +4602,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
       def recover(failure: SearchFailureType) =
         if canDefineFurther(wtp) || canDefineFurther(pt) then readapt(tree)
-        else err.typeMismatch(tree, pt, failure)
+        else
+          val tree1 = healAdapt(tree, pt)
+          if tree1 ne tree then readapt(tree1)
+          else err.typeMismatch(tree, pt, failure)
 
       pt match
         case _: SelectionProto =>
@@ -4750,6 +4753,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       }
     }
   }
+
+  /** Hook for inheriting Typers to do a last-effort adaptation. If a different
+   *  tree is returned, we will readpat that one, ptherwise we issue a type error afterwards.
+   */
+  protected def healAdapt(tree: Tree, pt: Type)(using Context): Tree = tree
 
   /** True if this inline typer has already issued errors */
   def hasInliningErrors(using Context): Boolean = false

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4755,7 +4755,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
   }
 
   /** Hook for inheriting Typers to do a last-effort adaptation. If a different
-   *  tree is returned, we will readpat that one, ptherwise we issue a type error afterwards.
+   *  tree is returned, we will re-adapt that one, otherwise we issue a type error afterwards.
+``
    */
   protected def healAdapt(tree: Tree, pt: Type)(using Context): Tree = tree
 

--- a/docs/_docs/reference/other-new-features/named-tuples.md
+++ b/docs/_docs/reference/other-new-features/named-tuples.md
@@ -99,7 +99,7 @@ Bob match
 We allow named patterns not just for named tuples but also for case classes. For instance:
 ```scala
 city match
-  case c @ City(name = "London") => println(p.population)
+  case c @ City(name = "London") => println(c.population)
   case City(name = n, zip = 1026, population = pop) => println(pop)
 ```
 

--- a/docs/_docs/reference/other-new-features/named-tuples.md
+++ b/docs/_docs/reference/other-new-features/named-tuples.md
@@ -1,10 +1,10 @@
 ---
 layout: doc-page
 title: "Named Tuples"
-nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/named-tuples.html
+nightlyOf: https://docs.scala-lang.org/scala3/reference/other-new-features/named-tuples.html
 ---
 
-The elements of a tuple can now be named. Example:
+Starting in Scala 3.6, the elements of a tuple can be named. Example:
 ```scala
 type Person = (name: String, age: Int)
 val Bob: Person = (name = "Bob", age = 33)
@@ -94,6 +94,24 @@ Bob match
   case (age = x, name = y) => ...
 ```
 
+### Pattern Matching with Named Fields in General
+
+We allow named patterns not just for named tuples but also for case classes. For instance:
+```scala
+city match
+  case c @ City(name = "London") => println(p.population)
+  case City(name = n, zip = 1026, population = pop) => println(pop)
+```
+
+Named constructor patterns are analogous to named tuple patterns. In both cases
+
+ - every name must match the name some field of the selector,
+ - names can come in any order,
+ - not all fields of the selector need to be matched.
+
+Named patterns are compatible with extensible pattern matching simply because
+`unapply` results can be named tuples.
+
 ### Expansion
 
 Named tuples are in essence just a convenient syntax for regular tuples. In the internal representation, a named tuple type is represented at compile time as a pair of two tuples. One tuple contains the names as literal constant string types, the other contains the element types. The runtime representation of a named tuples consists of just the element values, whereas the names are forgotten. This is achieved  by declaring `NamedTuple`
@@ -118,108 +136,6 @@ The translation of named tuples to instances of `NamedTuple` is fixed by the spe
 
  - All tuple operations also work with named tuples "out of the box".
  - Macro libraries can rely on this expansion.
-
-### The NamedTuple.From Type
-
-The `NamedTuple` object contains a type definition
-```scala
-  type From[T] <: AnyNamedTuple
-```
-`From` is treated specially by the compiler. When `NamedTuple.From` is applied to
-an argument type that is an instance of a case class, the type expands to the named
-tuple consisting of all the fields of that case class.
-Here, _fields_ means: elements of the first parameter section. For instance, assuming
-```scala
-case class City(zip: Int, name: String, population: Int)
-```
-then `NamedTuple.From[City]` is the named tuple
-```scala
-(zip: Int, name: String, population: Int)
-```
-The same works for enum cases expanding to case classes, abstract types with case classes as upper bound, alias types expanding to case classes
-and singleton types with case classes as underlying type.
-
-`From` is also defined on named tuples. If `NT` is a named tuple type, then `From[NT] = NT`.
-
-
-### Restrictions
-
-The following restrictions apply to named tuple elements:
-
- 1. Either all elements of a tuple are named or none are named. It is illegal to mix named and unnamed elements in a tuple. For instance, the following is in error:
-    ```scala
-    val illFormed1 = ("Bob", age = 33)  // error
-    ```
- 2. Each element name in a named tuple must be unique. For instance, the following is in error:
-    ```scala
-    val illFormed2 = (name = "", age = 0, name = true)  // error
-    ```
- 3. Named tuples can be matched with either named or regular patterns. But regular tuples and other selector types can only be matched with regular tuple patterns. For instance, the following is in error:
-    ```scala
-    (tuple: Tuple) match
-        case (age = x) => // error
-    ```
- 4. Regular selector names `_1`, `_2`, ... are not allowed as names in named tuples.
-
-### Syntax
-
-The syntax of Scala is extended as follows to support named tuples:
-```
-SimpleType        ::=  ...
-                    |  ‘(’ NameAndType {‘,’ NameAndType} ‘)’
-NameAndType       ::=  id ':' Type
-
-SimpleExpr        ::=  ...
-                    |  '(' NamedExprInParens {‘,’ NamedExprInParens} ')'
-NamedExprInParens ::=  id '=' ExprInParens
-
-Patterns          ::=  Pattern {‘,’ Pattern}
-                    |  NamedPattern {‘,’ NamedPattern}
-NamedPattern      ::=  id '=' Pattern
-```
-
-### Named Pattern Matching
-
-We allow named patterns not just for named tuples but also for case classes.
-For instance:
-```scala
-city match
-  case c @ City(name = "London") => println(p.population)
-  case City(name = n, zip = 1026, population = pop) => println(pop)
-```
-
-Named constructor patterns are analogous to named tuple patterns. In both cases
-
- - either all fields are named or none is,
- - every name must match the name some field of the selector,
- - names can come in any order,
- - not all fields of the selector need to be matched.
-
-This revives SIP 43, with a much simpler desugaring than originally proposed.
-Named patterns are compatible with extensible pattern matching simply because
-`unapply` results can be named tuples.
-
-### Source Incompatibilities
-
-There are some source incompatibilities involving named tuples of length one.
-First, what was previously classified as an assignment could now be interpreted as a named tuple. Example:
-```scala
-var age: Int
-(age = 1)
-```
-This was an assignment in parentheses before, and is a named tuple of arity one now. It is however not idiomatic Scala code, since assignments are not usually enclosed in parentheses.
-
-Second, what was a named argument to an infix operator can now be interpreted as a named tuple.
-```scala
-class C:
-  infix def f(age: Int)
-val c: C
-```
-then
-```scala
-c f (age = 1)
-```
-will now construct a tuple as second operand instead of passing a named parameter.
 
 ### Computed Field Names
 
@@ -261,3 +177,89 @@ has type `Q[Int]` and it expands to
 ```scala
 city.selectDynamic("zipCode").asInstanceOf[Q[Int]]
 ```
+
+### The NamedTuple.From Type
+
+The `NamedTuple` object contains a type definition
+```scala
+  type From[T] <: AnyNamedTuple
+```
+`From` is treated specially by the compiler. When `NamedTuple.From` is applied to
+an argument type that is an instance of a case class, the type expands to the named
+tuple consisting of all the fields of that case class.
+Here, _fields_ means: elements of the first parameter section. For instance, assuming
+```scala
+case class City(zip: Int, name: String, population: Int)
+```
+then `NamedTuple.From[City]` is the named tuple
+```scala
+(zip: Int, name: String, population: Int)
+```
+The same works for enum cases expanding to case classes, abstract types with case classes as upper bound, alias types expanding to case classes
+and singleton types with case classes as underlying type (in terms of the implementation, the `classSymbol` of a type must be a case class).
+
+`From` is also defined on named tuples. If `NT` is a named tuple type, then `From[NT] = NT`.
+
+
+### Operations on Named Tuples
+
+The operations on named tuples are defined in object [scala.NamedTuple](https://www.scala-lang.org/api/3.x/scala/NamedTuple$.html).
+
+### Restrictions
+
+The following restrictions apply to named tuples and named pattern arguments:
+
+ 1. Either all elements of a tuple or constructor pattern are named or none are named. It is illegal to mix named and unnamed elements in a tuple. For instance, the following is in error:
+    ```scala
+    val illFormed1 = ("Bob", age = 33)  // error
+    ```
+ 2. Each element name in a named tuple or constructor pattern must be unique. For instance, the following is in error:
+    ```scala
+    val illFormed2 = (name = "", age = 0, name = true)  // error
+    ```
+ 3. Named tuples and case classes can be matched with either named or regular patterns. But regular tuples and other selector types can only be matched with regular tuple patterns. For instance, the following is in error:
+    ```scala
+    (tuple: Tuple) match
+        case (age = x) => // error
+    ```
+## Syntax Changes
+
+The syntax of Scala is extended as follows to support named tuples and
+named constructor arguments:
+```
+SimpleType        ::=  ...
+                    |  ‘(’ NameAndType {‘,’ NameAndType} ‘)’
+NameAndType       ::=  id ':' Type
+
+SimpleExpr        ::=  ...
+                    |  '(' NamedExprInParens {‘,’ NamedExprInParens} ')'
+NamedExprInParens ::=  id '=' ExprInParens
+
+Patterns          ::=  Pattern {‘,’ Pattern}
+                    |  NamedPattern {‘,’ NamedPattern}
+NamedPattern      ::=  id '=' Pattern
+```
+
+### Source Incompatibilities
+
+There are some source incompatibilities involving named tuples of length one.
+First, what was previously classified as an assignment could now be interpreted as a named tuple. Example:
+
+```scala
+var age: Int
+(age = 1)
+```
+This was an assignment in parentheses before, and is a named tuple of arity one now. It is however not idiomatic Scala code, since assignments are not usually enclosed in parentheses.
+
+Second, what was a named argument to an infix operator can now be interpreted as a named tuple.
+```scala
+class C:
+  infix def f(age: Int)
+val c: C
+```
+then
+```scala
+c f (age = 1)
+```
+will now construct a tuple as second operand instead of passing a named parameter.
+

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -68,6 +68,7 @@ subsection:
           - page: reference/other-new-features/export.md
           - page: reference/other-new-features/opaques.md
           - page: reference/other-new-features/opaques-details.md
+          - page: reference/other-new-features/named-tuples.md
           - page: reference/other-new-features/open-classes.md
           - page: reference/other-new-features/parameter-untupling.md
           - page: reference/other-new-features/parameter-untupling-spec.md
@@ -154,7 +155,6 @@ subsection:
           - page: reference/experimental/cc.md
           - page: reference/experimental/purefuns.md
           - page: reference/experimental/tupled-function.md
-          - page: reference/experimental/named-tuples.md
           - page: reference/experimental/modularity.md
           - page: reference/experimental/typeclasses.md
           - page: reference/experimental/runtimeChecked.md

--- a/library/src-bootstrapped/scala/NamedTuple.scala
+++ b/library/src-bootstrapped/scala/NamedTuple.scala
@@ -1,9 +1,6 @@
 package scala
-import scala.language.experimental.clauseInterleaving
-import annotation.experimental
 import compiletime.ops.boolean.*
 
-@experimental
 object NamedTuple:
 
   /** The type to which named tuples get mapped to. For instance,
@@ -133,7 +130,6 @@ object NamedTuple:
 end NamedTuple
 
 /** Separate from NamedTuple object so that we can match on the opaque type NamedTuple. */
-@experimental
 object NamedTupleDecomposition:
   import NamedTuple.*
   extension [N <: Tuple, V <: Tuple](x: NamedTuple[N, V])

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -97,6 +97,7 @@ object language:
      *  @see [[https://dotty.epfl.ch/docs/reference/experimental/named-tuples]]
      */
     @compileTimeOnly("`namedTuples` can only be used at compile time in import statements")
+    @deprecated("The experimental.namedTuples language import is no longer needed since the feature is now standard", since = "3.6")
     object namedTuples
 
     /** Experimental support for new features for better modularity, including

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1988,8 +1988,7 @@ class CompletionSuite extends BaseCompletionSuite:
 
   @Test def `namedTuple completions` =
     check(
-      """|import scala.language.experimental.namedTuples
-         |import scala.NamedTuple.*
+      """|import scala.NamedTuple.*
          |
          |val person = (name = "Jamie", city = "Lausanne")
          |
@@ -2000,8 +1999,7 @@ class CompletionSuite extends BaseCompletionSuite:
 
   @Test def `Selectable with namedTuple Fields member` =
     check(
-      """|import scala.language.experimental.namedTuples
-         |import scala.NamedTuple.*
+      """|import scala.NamedTuple.*
          |
          |class NamedTupleSelectable extends Selectable {
          |  type Fields <: AnyNamedTuple
@@ -2091,7 +2089,7 @@ class CompletionSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
-  @Test def `conflict-3` = 
+  @Test def `conflict-3` =
    check(
      """|package a
         |object A {

--- a/tests/neg/i20517.check
+++ b/tests/neg/i20517.check
@@ -1,7 +1,7 @@
--- [E007] Type Mismatch Error: tests/neg/i20517.scala:10:43 ------------------------------------------------------------
-10 |  def dep(foo: Foo[Any]): From[foo.type] = (elem = "") // error
-   |                                           ^^^^^^^^^^^
-   |                                           Found:    (elem : String)
-   |                                           Required: NamedTuple.From[(foo : Foo[Any])]
-   |
-   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i20517.scala:9:43 -------------------------------------------------------------
+9 |  def dep(foo: Foo[Any]): From[foo.type] = (elem = "") // error
+  |                                           ^^^^^^^^^^^
+  |                                           Found:    (elem : String)
+  |                                           Required: NamedTuple.From[(foo : Foo[Any])]
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i20517.scala
+++ b/tests/neg/i20517.scala
@@ -1,4 +1,3 @@
-import scala.language.experimental.namedTuples
 import NamedTuple.From
 
 case class Foo[+T](elem: T)

--- a/tests/neg/named-tuple-selectable.scala
+++ b/tests/neg/named-tuple-selectable.scala
@@ -1,5 +1,3 @@
-import scala.language.experimental.namedTuples
-
 class FromFields extends Selectable:
   type Fields = (i: Int)
   def selectDynamic(key: String) =

--- a/tests/neg/named-tuples-2.check
+++ b/tests/neg/named-tuples-2.check
@@ -1,8 +1,8 @@
--- Error: tests/neg/named-tuples-2.scala:5:9 ---------------------------------------------------------------------------
-5 |    case (name, age) => () // error
+-- Error: tests/neg/named-tuples-2.scala:4:9 ---------------------------------------------------------------------------
+4 |    case (name, age) => () // error
   |         ^
   |         this case is unreachable since type (String, Int, Boolean) is not a subclass of class Tuple2
--- Error: tests/neg/named-tuples-2.scala:6:9 ---------------------------------------------------------------------------
-6 |    case (n, a, m, x) => () // error
+-- Error: tests/neg/named-tuples-2.scala:5:9 ---------------------------------------------------------------------------
+5 |    case (n, a, m, x) => () // error
   |         ^
   |         this case is unreachable since type (String, Int, Boolean) is not a subclass of class Tuple4

--- a/tests/neg/named-tuples-2.scala
+++ b/tests/neg/named-tuples-2.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 def Test =
   val person = (name = "Bob", age = 33, married = true)
   person match

--- a/tests/neg/named-tuples-3.check
+++ b/tests/neg/named-tuples-3.check
@@ -1,5 +1,5 @@
--- [E007] Type Mismatch Error: tests/neg/named-tuples-3.scala:7:16 -----------------------------------------------------
-7 |val p: Person = f  // error
+-- [E007] Type Mismatch Error: tests/neg/named-tuples-3.scala:5:16 -----------------------------------------------------
+5 |val p: Person = f  // error
   |                ^
   |                Found:    NamedTuple.NamedTuple[(Int, Any), (Int, String)]
   |                Required: Person

--- a/tests/neg/named-tuples-3.scala
+++ b/tests/neg/named-tuples-3.scala
@@ -1,5 +1,3 @@
-import language.experimental.namedTuples
-
 def f: NamedTuple.NamedTuple[(Int, Any), (Int, String)] = ???
 
 type Person = (name: Int, age: String)

--- a/tests/neg/named-tuples.check
+++ b/tests/neg/named-tuples.check
@@ -1,101 +1,101 @@
--- Error: tests/neg/named-tuples.scala:9:19 ----------------------------------------------------------------------------
-9 |  val illformed = (_2 = 2) // error
+-- Error: tests/neg/named-tuples.scala:8:19 ----------------------------------------------------------------------------
+8 |  val illformed = (_2 = 2) // error
   |                   ^^^^^^
   |                   _2 cannot be used as the name of a tuple element because it is a regular tuple selector
--- Error: tests/neg/named-tuples.scala:10:20 ---------------------------------------------------------------------------
-10 |  type Illformed = (_1: Int) // error
-   |                    ^^^^^^^
-   |                    _1 cannot be used as the name of a tuple element because it is a regular tuple selector
--- Error: tests/neg/named-tuples.scala:11:40 ---------------------------------------------------------------------------
-11 |  val illformed2 = (name = "", age = 0, name = true)  // error
+-- Error: tests/neg/named-tuples.scala:9:20 ----------------------------------------------------------------------------
+9 |  type Illformed = (_1: Int) // error
+  |                    ^^^^^^^
+  |                    _1 cannot be used as the name of a tuple element because it is a regular tuple selector
+-- Error: tests/neg/named-tuples.scala:10:40 ---------------------------------------------------------------------------
+10 |  val illformed2 = (name = "", age = 0, name = true)  // error
    |                                        ^^^^^^^^^^^
    |                                        Duplicate tuple element name
--- Error: tests/neg/named-tuples.scala:12:45 ---------------------------------------------------------------------------
-12 |  type Illformed2 = (name: String, age: Int, name: Boolean) // error
+-- Error: tests/neg/named-tuples.scala:11:45 ---------------------------------------------------------------------------
+11 |  type Illformed2 = (name: String, age: Int, name: Boolean) // error
    |                                             ^^^^^^^^^^^^^
    |                                             Duplicate tuple element name
--- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:20:20 ------------------------------------------------------
-20 |  val _: NameOnly = person // error
+-- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:19:20 ------------------------------------------------------
+19 |  val _: NameOnly = person // error
    |                    ^^^^^^
    |                    Found:    (Test.person : (name : String, age : Int))
    |                    Required: Test.NameOnly
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:21:18 ------------------------------------------------------
-21 |  val _: Person = nameOnly // error
+-- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:20:18 ------------------------------------------------------
+20 |  val _: Person = nameOnly // error
    |                  ^^^^^^^^
    |                  Found:    (Test.nameOnly : (name : String))
    |                  Required: Test.Person
    |
    | longer explanation available when compiling with `-explain`
--- [E172] Type Error: tests/neg/named-tuples.scala:22:41 ---------------------------------------------------------------
-22 |  val _: Person = (name = "") ++ nameOnly // error
+-- [E172] Type Error: tests/neg/named-tuples.scala:21:41 ---------------------------------------------------------------
+21 |  val _: Person = (name = "") ++ nameOnly // error
    |                                         ^
    |    Cannot prove that Tuple.Disjoint[Tuple1[("name" : String)], Tuple1[("name" : String)]] =:= (true : Boolean).
--- [E008] Not Found Error: tests/neg/named-tuples.scala:23:9 -----------------------------------------------------------
-23 |  person._1 // error
+-- [E008] Not Found Error: tests/neg/named-tuples.scala:22:9 -----------------------------------------------------------
+22 |  person._1 // error
    |  ^^^^^^^^^
    |  value _1 is not a member of (name : String, age : Int)
--- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:25:36 ------------------------------------------------------
-25 |  val _: (age: Int, name: String) = person // error
+-- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:24:36 ------------------------------------------------------
+24 |  val _: (age: Int, name: String) = person // error
    |                                    ^^^^^^
    |                                    Found:    (Test.person : (name : String, age : Int))
    |                                    Required: (age : Int, name : String)
    |
    | longer explanation available when compiling with `-explain`
--- Error: tests/neg/named-tuples.scala:27:17 ---------------------------------------------------------------------------
-27 |  val (name = x, agee = y) = person // error
+-- Error: tests/neg/named-tuples.scala:26:17 ---------------------------------------------------------------------------
+26 |  val (name = x, agee = y) = person // error
    |                 ^^^^^^^^
    |                 No element named `agee` is defined in selector type (name : String, age : Int)
--- Error: tests/neg/named-tuples.scala:30:10 ---------------------------------------------------------------------------
-30 |    case (name = n, age = a) => () // error // error
+-- Error: tests/neg/named-tuples.scala:29:10 ---------------------------------------------------------------------------
+29 |    case (name = n, age = a) => () // error // error
    |          ^^^^^^^^
    |          No element named `name` is defined in selector type (String, Int)
--- Error: tests/neg/named-tuples.scala:30:20 ---------------------------------------------------------------------------
-30 |    case (name = n, age = a) => () // error // error
+-- Error: tests/neg/named-tuples.scala:29:20 ---------------------------------------------------------------------------
+29 |    case (name = n, age = a) => () // error // error
    |                    ^^^^^^^
    |                    No element named `age` is defined in selector type (String, Int)
--- [E172] Type Error: tests/neg/named-tuples.scala:32:27 ---------------------------------------------------------------
-32 |  val pp = person ++ (1, 2)  // error
+-- [E172] Type Error: tests/neg/named-tuples.scala:31:27 ---------------------------------------------------------------
+31 |  val pp = person ++ (1, 2)  // error
    |                           ^
    |            Cannot prove that Tuple.Disjoint[(("name" : String), ("age" : String)), Tuple] =:= (true : Boolean).
--- [E172] Type Error: tests/neg/named-tuples.scala:35:18 ---------------------------------------------------------------
-35 |  person ++ (1, 2) match // error
+-- [E172] Type Error: tests/neg/named-tuples.scala:34:18 ---------------------------------------------------------------
+34 |  person ++ (1, 2) match // error
    |                  ^
    |            Cannot prove that Tuple.Disjoint[(("name" : String), ("age" : String)), Tuple] =:= (true : Boolean).
--- Error: tests/neg/named-tuples.scala:38:17 ---------------------------------------------------------------------------
-38 |  val bad = ("", age = 10) // error
+-- Error: tests/neg/named-tuples.scala:37:17 ---------------------------------------------------------------------------
+37 |  val bad = ("", age = 10) // error
    |                 ^^^^^^^^
    |                 Illegal combination of named and unnamed tuple elements
--- Error: tests/neg/named-tuples.scala:41:20 ---------------------------------------------------------------------------
-41 |    case (name = n, age) => () // error
+-- Error: tests/neg/named-tuples.scala:40:20 ---------------------------------------------------------------------------
+40 |    case (name = n, age) => () // error
    |                    ^^^
    |                    Illegal combination of named and unnamed tuple elements
--- Error: tests/neg/named-tuples.scala:42:16 ---------------------------------------------------------------------------
-42 |    case (name, age = a) => () // error
+-- Error: tests/neg/named-tuples.scala:41:16 ---------------------------------------------------------------------------
+41 |    case (name, age = a) => () // error
    |                ^^^^^^^
    |                Illegal combination of named and unnamed tuple elements
--- Error: tests/neg/named-tuples.scala:45:10 ---------------------------------------------------------------------------
-45 |    case (age = x) => // error
+-- Error: tests/neg/named-tuples.scala:44:10 ---------------------------------------------------------------------------
+44 |    case (age = x) => // error
    |          ^^^^^^^
    |          No element named `age` is defined in selector type Tuple
--- [E172] Type Error: tests/neg/named-tuples.scala:47:27 ---------------------------------------------------------------
-47 |  val p2 = person ++ person // error
+-- [E172] Type Error: tests/neg/named-tuples.scala:46:27 ---------------------------------------------------------------
+46 |  val p2 = person ++ person // error
    |                           ^
    |Cannot prove that Tuple.Disjoint[(("name" : String), ("age" : String)), (("name" : String), ("age" : String))] =:= (true : Boolean).
--- [E172] Type Error: tests/neg/named-tuples.scala:48:43 ---------------------------------------------------------------
-48 |  val p3 = person ++ (first = 11, age = 33) // error
+-- [E172] Type Error: tests/neg/named-tuples.scala:47:43 ---------------------------------------------------------------
+47 |  val p3 = person ++ (first = 11, age = 33) // error
    |                                           ^
    |Cannot prove that Tuple.Disjoint[(("name" : String), ("age" : String)), (("first" : String), ("age" : String))] =:= (true : Boolean).
--- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:50:22 ------------------------------------------------------
-50 |  val p5 = person.zip((first = 11, age = 33)) // error
+-- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:49:22 ------------------------------------------------------
+49 |  val p5 = person.zip((first = 11, age = 33)) // error
    |                      ^^^^^^^^^^^^^^^^^^^^^^
    |                      Found:    (first : Int, age : Int)
    |                      Required: NamedTuple.NamedTuple[(("name" : String), ("age" : String)), Tuple]
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:61:32 ------------------------------------------------------
-61 |  val typo: (name: ?, age: ?) = (name = "he", ag = 1) // error
+-- [E007] Type Mismatch Error: tests/neg/named-tuples.scala:60:32 ------------------------------------------------------
+60 |  val typo: (name: ?, age: ?) = (name = "he", ag = 1) // error
    |                                ^^^^^^^^^^^^^^^^^^^^^
    |                                Found:    (name : String, ag : Int)
    |                                Required: (name : ?, age : ?)

--- a/tests/neg/named-tuples.scala
+++ b/tests/neg/named-tuples.scala
@@ -1,7 +1,6 @@
 import annotation.experimental
-import language.experimental.namedTuples
 
-@experimental object Test:
+object Test:
 
   type Person = (name: String, age: Int)
   val person = (name = "Bob", age = 33): (name: String, age: Int)

--- a/tests/new/test.scala
+++ b/tests/new/test.scala
@@ -1,5 +1,3 @@
-import language.experimental.namedTuples
-
 type Person = (name: String, age: Int)
 
 trait A:

--- a/tests/pos/fieldsOf.scala
+++ b/tests/pos/fieldsOf.scala
@@ -1,5 +1,3 @@
-import language.experimental.namedTuples
-
 case class Person(name: String, age: Int)
 
 type PF = NamedTuple.From[Person]

--- a/tests/pos/i20377.scala
+++ b/tests/pos/i20377.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 import NamedTuple.{NamedTuple, AnyNamedTuple}
 
 // Repros for bugs or questions

--- a/tests/pos/i21300.scala
+++ b/tests/pos/i21300.scala
@@ -1,17 +1,15 @@
-import scala.language.experimental.namedTuples
-
 class Test[S <: String & Singleton](name: S):
 
   type NT = NamedTuple.NamedTuple[(S, "foo"), (Int, Long)]
   def nt: NT = ???
 
   type Name = S
-  
+
   type NT2 = NamedTuple.NamedTuple[(Name, "foo"), (Int, Long)]
   def nt2: NT2 = ???
 
 def test =
   val foo = new Test("bar")
-  
+
   foo.nt.bar
   foo.nt2.bar

--- a/tests/pos/i21413.scala
+++ b/tests/pos/i21413.scala
@@ -1,0 +1,2 @@
+val x = (aaa = 1).aaa
+//val y = x.aaa

--- a/tests/pos/named-tuple-combinators.scala
+++ b/tests/pos/named-tuple-combinators.scala
@@ -1,4 +1,3 @@
-import scala.language.experimental.namedTuples
 
 object Test:
   // original code from issue https://github.com/scala/scala3/issues/20427

--- a/tests/pos/named-tuple-selectable.scala
+++ b/tests/pos/named-tuple-selectable.scala
@@ -1,4 +1,3 @@
-import scala.language.experimental.namedTuples
 
 class FromFields extends Selectable:
   type Fields = (xs: List[Int], poly: [T] => (x: List[T]) => Option[T])

--- a/tests/pos/named-tuple-selections.scala
+++ b/tests/pos/named-tuple-selections.scala
@@ -1,4 +1,3 @@
-import scala.language.experimental.namedTuples
 
 object Test1:
   // original code from issue https://github.com/scala/scala3/issues/20439

--- a/tests/pos/named-tuple-unstable.scala
+++ b/tests/pos/named-tuple-unstable.scala
@@ -1,4 +1,3 @@
-import scala.language.experimental.namedTuples
 import NamedTuple.{AnyNamedTuple, NamedTuple}
 
 trait Foo extends Selectable:

--- a/tests/pos/named-tuple-widen.scala
+++ b/tests/pos/named-tuple-widen.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 
 class A
 class B

--- a/tests/pos/named-tuples-ops-mirror.scala
+++ b/tests/pos/named-tuples-ops-mirror.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 import NamedTuple.*
 
 @FailsWith[HttpError]

--- a/tests/pos/named-tuples1.scala
+++ b/tests/pos/named-tuples1.scala
@@ -1,5 +1,4 @@
 import annotation.experimental
-import language.experimental.namedTuples
 
 @main def Test =
   val bob = (name = "Bob", age = 33): (name: String, age: Int)

--- a/tests/pos/namedtuple-src-incompat.scala
+++ b/tests/pos/namedtuple-src-incompat.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 var age = 22
 val x = (age = 1)
 val _: (age: Int) = x

--- a/tests/pos/tuple-ops.scala
+++ b/tests/pos/tuple-ops.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 import Tuple.*
 
 def test =

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -74,12 +74,6 @@ val experimentalDefinitionInLibrary = Set(
   // New feature: fromNullable for explicit nulls
   "scala.Predef$.fromNullable",
 
-  // New feature: named tuples
-  "scala.NamedTuple",
-  "scala.NamedTuple$",
-  "scala.NamedTupleDecomposition",
-  "scala.NamedTupleDecomposition$",
-
   // New feature: modularity
   "scala.Precise",
   "scala.annotation.internal.WitnessNames",

--- a/tests/run/named-patmatch.scala
+++ b/tests/run/named-patmatch.scala
@@ -1,5 +1,4 @@
 import annotation.experimental
-import language.experimental.namedTuples
 
 @main def Test =
   locally:

--- a/tests/run/named-patterns.scala
+++ b/tests/run/named-patterns.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 
 object Test1:
   class Person(val name: String, val age: Int)

--- a/tests/run/named-tuple-ops.scala
+++ b/tests/run/named-tuple-ops.scala
@@ -1,5 +1,4 @@
 //> using options -source future
-import language.experimental.namedTuples
 import scala.compiletime.asMatchable
 
 type City = (name: String, zip: Int, pop: Int)

--- a/tests/run/named-tuples-xxl.scala
+++ b/tests/run/named-tuples-xxl.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 import NamedTuple.toTuple
 
 type Person = (

--- a/tests/run/named-tuples.scala
+++ b/tests/run/named-tuples.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 import NamedTuple.*
 
 type Person = (name: String, age: Int)

--- a/tests/run/tyql.scala
+++ b/tests/run/tyql.scala
@@ -1,4 +1,3 @@
-import language.experimental.namedTuples
 import NamedTuple.{NamedTuple, AnyNamedTuple}
 
 /* This is a demonstrator that shows how to map regular for expressions to


### PR DESCRIPTION
 - Deprecate experimental language import
 - Make named tuple features conditional on -source >= 3.6 instead
 - Make the NamedTuple object non-experimental.
 - Move NamedTuple it to src-bootstrapped since it relies on clause interleaving which is only standard in 3.6 as well.
 - Drop the experimental.namedTuple import from tests