### PR TITLE
Define binary symbolic compiletime ops as `infix`

### DIFF
--- a/library/src/scala/compiletime/ops/any.scala
+++ b/library/src/scala/compiletime/ops/any.scala
@@ -13,7 +13,7 @@ object any:
    * ```
    * @syntax markdown
    */
-  type ==[X, Y] <: Boolean
+  infix type ==[X, Y] <: Boolean
 
   /** Inequality comparison of two singleton types.
    * ```scala
@@ -26,7 +26,7 @@ object any:
    * ```
    * @syntax markdown
    */
-  type !=[X, Y] <: Boolean
+  infix type !=[X, Y] <: Boolean
 
   /** Tests if a type is a constant.
    * ```scala

--- a/library/src/scala/compiletime/ops/boolean.scala
+++ b/library/src/scala/compiletime/ops/boolean.scala
@@ -25,7 +25,7 @@ object boolean:
    *  ```
    *  @syntax markdown
    */
-  type ^[X <: Boolean, Y <: Boolean] <: Boolean
+  infix type ^[X <: Boolean, Y <: Boolean] <: Boolean
 
   /** Conjunction of two `Boolean` singleton types.
    *  ```scala
@@ -37,7 +37,7 @@ object boolean:
    *  ```
    *  @syntax markdown
    */
-  type &&[X <: Boolean, Y <: Boolean] <: Boolean
+  infix type &&[X <: Boolean, Y <: Boolean] <: Boolean
 
   /** Disjunction of two `Boolean` singleton types.
    *  ```scala
@@ -49,4 +49,4 @@ object boolean:
    *  ```
    *  @syntax markdown
    */
-  type ||[X <: Boolean, Y <: Boolean] <: Boolean
+  infix type ||[X <: Boolean, Y <: Boolean] <: Boolean

--- a/library/src/scala/compiletime/ops/double.scala
+++ b/library/src/scala/compiletime/ops/double.scala
@@ -11,7 +11,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Double, Y <: Double] <: Double
+  infix type +[X <: Double, Y <: Double] <: Double
 
   /** Subtraction of two `Double` singleton types.
    *  ```scala
@@ -22,7 +22,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Double, Y <: Double] <: Double
+  infix type -[X <: Double, Y <: Double] <: Double
 
   /** Multiplication of two `Double` singleton types.
    *  ```scala
@@ -33,7 +33,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Double, Y <: Double] <: Double
+  infix type *[X <: Double, Y <: Double] <: Double
 
   /** Integer division of two `Double` singleton types.
    *  ```scala
@@ -44,7 +44,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Double, Y <: Double] <: Double
+  infix type /[X <: Double, Y <: Double] <: Double
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -55,7 +55,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Double, Y <: Double] <: Double
+  infix type %[X <: Double, Y <: Double] <: Double
 
   /** Less-than comparison of two `Double` singleton types.
    *  ```scala
@@ -67,7 +67,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Double, Y <: Double] <: Boolean
+  infix type <[X <: Double, Y <: Double] <: Boolean
 
   /** Greater-than comparison of two `Double` singleton types.
    *  ```scala
@@ -79,7 +79,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Double, Y <: Double] <: Boolean
+  infix type >[X <: Double, Y <: Double] <: Boolean
 
   /** Greater-or-equal comparison of two `Double` singleton types.
    *  ```scala
@@ -91,7 +91,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Double, Y <: Double] <: Boolean
+  infix type >=[X <: Double, Y <: Double] <: Boolean
 
   /** Less-or-equal comparison of two `Double` singleton types.
    *  ```scala
@@ -103,7 +103,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Double, Y <: Double] <: Boolean
+  infix type <=[X <: Double, Y <: Double] <: Boolean
 
   /** Absolute value of an `Double` singleton type.
    *  ```scala
@@ -114,7 +114,7 @@ object double:
    *  ```
    *  @syntax markdown
    */
-  type Abs[X <: Double] <: Double
+  infix type Abs[X <: Double] <: Double
 
   /** Negation of an `Double` singleton type.
    *  ```scala

--- a/library/src/scala/compiletime/ops/float.scala
+++ b/library/src/scala/compiletime/ops/float.scala
@@ -11,7 +11,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Float, Y <: Float] <: Float
+  infix type +[X <: Float, Y <: Float] <: Float
 
   /** Subtraction of two `Float` singleton types.
    *  ```scala
@@ -22,7 +22,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Float, Y <: Float] <: Float
+  infix type -[X <: Float, Y <: Float] <: Float
 
   /** Multiplication of two `Float` singleton types.
    *  ```scala
@@ -33,7 +33,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Float, Y <: Float] <: Float
+  infix type *[X <: Float, Y <: Float] <: Float
 
   /** Integer division of two `Float` singleton types.
    *  ```scala
@@ -44,7 +44,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Float, Y <: Float] <: Float
+  infix type /[X <: Float, Y <: Float] <: Float
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -55,7 +55,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Float, Y <: Float] <: Float
+  infix type %[X <: Float, Y <: Float] <: Float
 
   /** Less-than comparison of two `Float` singleton types.
    *  ```scala
@@ -67,7 +67,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Float, Y <: Float] <: Boolean
+  infix type <[X <: Float, Y <: Float] <: Boolean
 
   /** Greater-than comparison of two `Float` singleton types.
    *  ```scala
@@ -79,7 +79,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Float, Y <: Float] <: Boolean
+  infix type >[X <: Float, Y <: Float] <: Boolean
 
   /** Greater-or-equal comparison of two `Float` singleton types.
    *  ```scala
@@ -91,7 +91,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Float, Y <: Float] <: Boolean
+  infix type >=[X <: Float, Y <: Float] <: Boolean
 
   /** Less-or-equal comparison of two `Float` singleton types.
    *  ```scala
@@ -103,7 +103,7 @@ object float:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Float, Y <: Float] <: Boolean
+  infix type <=[X <: Float, Y <: Float] <: Boolean
 
   /** Absolute value of an `Float` singleton type.
    *  ```scala

--- a/library/src/scala/compiletime/ops/int.scala
+++ b/library/src/scala/compiletime/ops/int.scala
@@ -29,7 +29,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Int, Y <: Int] <: Int
+  infix type +[X <: Int, Y <: Int] <: Int
 
   /** Subtraction of two `Int` singleton types.
    *  ```scala
@@ -40,7 +40,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Int, Y <: Int] <: Int
+  infix type -[X <: Int, Y <: Int] <: Int
 
   /** Multiplication of two `Int` singleton types.
    *  ```scala
@@ -51,7 +51,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Int, Y <: Int] <: Int
+  infix type *[X <: Int, Y <: Int] <: Int
 
   /** Integer division of two `Int` singleton types.
    *  ```scala
@@ -62,7 +62,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Int, Y <: Int] <: Int
+  infix type /[X <: Int, Y <: Int] <: Int
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -73,7 +73,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Int, Y <: Int] <: Int
+  infix type %[X <: Int, Y <: Int] <: Int
 
   /** Binary left shift of `X` by `Y`.
    *  ```scala
@@ -84,7 +84,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type <<[X <: Int, Y <: Int] <: Int
+  infix type <<[X <: Int, Y <: Int] <: Int
 
   /** Binary right shift of `X` by `Y`.
    *  ```scala
@@ -95,7 +95,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >>[X <: Int, Y <: Int] <: Int
+  infix type >>[X <: Int, Y <: Int] <: Int
 
   /** Binary right shift of `X` by `Y`, filling the left with zeros.
    *  ```scala
@@ -106,7 +106,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >>>[X <: Int, Y <: Int] <: Int
+  infix type >>>[X <: Int, Y <: Int] <: Int
 
   /** Bitwise xor of `X` and `Y`.
    *  ```scala
@@ -117,7 +117,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type ^[X <: Int, Y <: Int] <: Int
+  infix type ^[X <: Int, Y <: Int] <: Int
 
   /** Less-than comparison of two `Int` singleton types.
    *  ```scala
@@ -129,7 +129,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Int, Y <: Int] <: Boolean
+  infix type <[X <: Int, Y <: Int] <: Boolean
 
   /** Greater-than comparison of two `Int` singleton types.
    *  ```scala
@@ -141,7 +141,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Int, Y <: Int] <: Boolean
+  infix type >[X <: Int, Y <: Int] <: Boolean
 
   /** Greater-or-equal comparison of two `Int` singleton types.
    *  ```scala
@@ -153,7 +153,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Int, Y <: Int] <: Boolean
+  infix type >=[X <: Int, Y <: Int] <: Boolean
 
   /** Less-or-equal comparison of two `Int` singleton types.
    *  ```scala
@@ -165,7 +165,7 @@ object int:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Int, Y <: Int] <: Boolean
+  infix type <=[X <: Int, Y <: Int] <: Boolean
 
   /** Bitwise and of `X` and `Y`.
    *  ```scala

--- a/library/src/scala/compiletime/ops/long.scala
+++ b/library/src/scala/compiletime/ops/long.scala
@@ -27,7 +27,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: Long, Y <: Long] <: Long
+  infix type +[X <: Long, Y <: Long] <: Long
 
   /** Subtraction of two `Long` singleton types.
    *  ```scala
@@ -38,7 +38,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type -[X <: Long, Y <: Long] <: Long
+  infix type -[X <: Long, Y <: Long] <: Long
 
   /** Multiplication of two `Long` singleton types.
    *  ```scala
@@ -49,7 +49,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type *[X <: Long, Y <: Long] <: Long
+  infix type *[X <: Long, Y <: Long] <: Long
 
   /** Integer division of two `Long` singleton types.
    *  ```scala
@@ -60,7 +60,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type /[X <: Long, Y <: Long] <: Long
+  infix type /[X <: Long, Y <: Long] <: Long
 
   /** Remainder of the division of `X` by `Y`.
    *  ```scala
@@ -71,7 +71,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type %[X <: Long, Y <: Long] <: Long
+  infix type %[X <: Long, Y <: Long] <: Long
 
   /** Binary left shift of `X` by `Y`.
    *  ```scala
@@ -82,7 +82,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type <<[X <: Long, Y <: Long] <: Long
+  infix type <<[X <: Long, Y <: Long] <: Long
 
   /** Binary right shift of `X` by `Y`.
    *  ```scala
@@ -93,7 +93,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >>[X <: Long, Y <: Long] <: Long
+  infix type >>[X <: Long, Y <: Long] <: Long
 
   /** Binary right shift of `X` by `Y`, filling the left with zeros.
    *  ```scala
@@ -104,7 +104,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >>>[X <: Long, Y <: Long] <: Long
+  infix type >>>[X <: Long, Y <: Long] <: Long
 
   /** Bitwise xor of `X` and `Y`.
    *  ```scala
@@ -115,7 +115,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type ^[X <: Long, Y <: Long] <: Long
+  infix type ^[X <: Long, Y <: Long] <: Long
 
   /** Less-than comparison of two `Long` singleton types.
    *  ```scala
@@ -127,7 +127,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type <[X <: Long, Y <: Long] <: Boolean
+  infix type <[X <: Long, Y <: Long] <: Boolean
 
   /** Greater-than comparison of two `Long` singleton types.
    *  ```scala
@@ -139,7 +139,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >[X <: Long, Y <: Long] <: Boolean
+  infix type >[X <: Long, Y <: Long] <: Boolean
 
   /** Greater-or-equal comparison of two `Long` singleton types.
    *  ```scala
@@ -151,7 +151,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type >=[X <: Long, Y <: Long] <: Boolean
+  infix type >=[X <: Long, Y <: Long] <: Boolean
 
   /** Less-or-equal comparison of two `Long` singleton types.
    *  ```scala
@@ -163,7 +163,7 @@ object long:
    *  ```
    *  @syntax markdown
    */
-  type <=[X <: Long, Y <: Long] <: Boolean
+  infix type <=[X <: Long, Y <: Long] <: Boolean
 
   /** Bitwise and of `X` and `Y`.
    *  ```scala

--- a/library/src/scala/compiletime/ops/string.scala
+++ b/library/src/scala/compiletime/ops/string.scala
@@ -11,7 +11,7 @@ object string:
    *  ```
    *  @syntax markdown
    */
-  type +[X <: String, Y <: String] <: String
+  infix type +[X <: String, Y <: String] <: String
 
   /** Length of a `String` singleton type.
    *  ```scala


### PR DESCRIPTION
That way they get pretty-printed as infix in error messages.