### PR TITLE
Always rewrite empty List() to Nil

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
@@ -76,7 +76,7 @@ class ArrayApply extends MiniPhase {
         tree.args match
           // <List or Seq>(a, b, c) ~> new ::(a, new ::(b, new ::(c, Nil))) but only for reference types
           case StripAscription(Apply(wrapArrayMeth, List(StripAscription(rest: JavaSeqLiteral)))) :: Nil
-              if defn.WrapArrayMethods().contains(wrapArrayMeth.symbol) =>
+              if rest.elems.isEmpty || defn.WrapArrayMethods().contains(wrapArrayMeth.symbol) =>
             Some(rest.elems)
           case _ => None
       else None

--- a/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
@@ -161,6 +161,42 @@ class ArrayApplyOptTest extends DottyBytecodeTest {
     }
   }
 
+  @Test def emptyListApplyAvoidsIntermediateArray =
+    checkApplyAvoidsIntermediateArray("EmptyList"):
+      """import scala.collection.immutable.Nil
+        |class Foo {
+        |  def meth1: List[String] = List()
+        |  def meth2: List[String] = Nil
+        |}
+      """.stripMargin
+
+  @Test def emptyRefListApplyAvoidsIntermediateArray =
+    checkApplyAvoidsIntermediateArray("EmptyListOfRef"):
+      """import scala.collection.immutable.Nil
+        |class Foo {
+        |  def meth1: List[String] = List[String]()
+        |  def meth2: List[String] = Nil
+        |}
+      """.stripMargin
+
+  @Test def emptyPrimitiveListApplyAvoidsIntermediateArray =
+    checkApplyAvoidsIntermediateArray("EmptyListOfInt"):
+      """import scala.collection.immutable.Nil
+        |class Foo {
+        |  def meth1: List[Int] = List()
+        |  def meth2: List[Int] = Nil
+        |}
+      """.stripMargin
+
+  @Test def primitiveListApplyAvoidsIntermediateArray =
+    checkApplyAvoidsIntermediateArray("ListOfInt"):
+      """import scala.collection.immutable.{ ::, Nil }
+        |class Foo {
+        |  def meth1: List[Int] = List(1, 2, 3)
+        |  def meth2: List[Int] = new ::(1, new ::(2, new ::(3, Nil)))
+        |}
+      """.stripMargin
+
   @Test def testListApplyAvoidsIntermediateArray = {
     checkApplyAvoidsIntermediateArray("List"):
       """import scala.collection.immutable.{ ::, Nil }


### PR DESCRIPTION
`List[String]()` was OK but not `List()` with `Nothing` inferred, which is how people write it.

Follow-up to https://github.com/scala/scala3/pull/17166

Noticed at https://github.com/scala/scala/pull/10876