### PR TITLE
Quotes type printing: take `infix` type modifier into account

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1150,8 +1150,17 @@ object SourceCode {
           case tp: TypeRef if tp.typeSymbol == Symbol.requiredClass("scala.<repeated>") =>
             this += "_*"
           case _ =>
-            printType(tp)
-            inSquare(printTypesOrBounds(args, ", "))
+            if !fullNames && args.lengthCompare(2) == 0 && tp.typeSymbol.flags.is(Flags.Infix) then
+              val lhs = args(0)
+              val rhs = args(1)
+              printType(lhs)
+              this += " "
+              printType(tp)
+              this += " "
+              printType(rhs)
+            else
+              printType(tp)
+              inSquare(printTypesOrBounds(args, ", "))
         }
 
       case AnnotatedType(tp, annot) =>

--- a/tests/run-macros/type-print.check
+++ b/tests/run-macros/type-print.check
@@ -1,0 +1,8 @@
+List[Int]
+scala.collection.immutable.List[scala.Int]
+scala.collection.immutable.List[scala.Int]
+scala.collection.immutable.List[scala.Int]
+Int Op String
+a.Test_2$package.Op[scala.Int, scala.Predef.String]
+a.Test_2$package.Op[scala.Int, scala.Predef.String]
+a.Test_2$package.Op[scala.Int, scala.Predef.String]

--- a/tests/run-macros/type-print/Macro_1.scala
+++ b/tests/run-macros/type-print/Macro_1.scala
@@ -1,0 +1,29 @@
+import scala.quoted.*
+
+inline def printTypeShort[T]: String =
+  ${ printTypeShortImpl[T] }
+
+inline def printType[T]: String =
+  ${ printTypeImpl[T] }
+
+inline def printTypeAnsi[T]: String =
+  ${ printTypeImpl[T] }
+
+inline def printTypeStructure[T]: String =
+  ${ printTypeImpl[T] }
+
+def printTypeShortImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprShortCode.show(TypeRepr.of[T]))
+
+def printTypeImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprCode.show(TypeRepr.of[T]))
+
+def printTypeAnsiImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprAnsiCode.show(TypeRepr.of[T]))
+
+def printTypeStructureImpl[T: Type](using Quotes): Expr[String] =
+  import quotes.reflect.*
+  Expr(Printer.TypeReprStructure.show(TypeRepr.of[T]))

--- a/tests/run-macros/type-print/Test_2.scala
+++ b/tests/run-macros/type-print/Test_2.scala
@@ -1,0 +1,15 @@
+package a {
+  infix type Op[A, B]
+}
+
+inline def printAll[T]: Unit =
+  println(printTypeShort[T])
+  println(printType[T])
+  println(printTypeAnsi[T])
+  println(printTypeStructure[T])
+
+@main
+def Test: Unit =
+  printAll[List[Int]]
+  import a.Op
+  printAll[Int Op String]


### PR DESCRIPTION
This is already how the regular compiler `.show` handles `infix` (in fact I'm not sure why quote type printing doesn't just use that).