### PR TITLE
Add Color.scala to black list

### DIFF
--- a/compiler/test/dotc/neg-init-global-scala2-library-tasty.blacklist
+++ b/compiler/test/dotc/neg-init-global-scala2-library-tasty.blacklist
@@ -18,3 +18,4 @@ global-list.scala
 t5366.scala
 mutable-read7.scala
 t9115.scala
+Color.scala


### PR DESCRIPTION
Add Color.scala to black list

The test added in #20356 seems to break `test_scala2_library_tasty`, due to a [problem](https://github.com/scala/bug/issues/13009) in Scala 2 library.

[test_scala2_library_tasty]