### PR TITLE
Always interpret underscores inside patterns as type bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1988,7 +1988,7 @@ object Parsers {
       if isSimpleLiteral then
         SingletonTypeTree(simpleLiteral())
       else if in.token == USCORE then
-        if ctx.settings.XkindProjector.value == "underscores" then
+        if ctx.settings.XkindProjector.value == "underscores" && !inMatchPattern then
           val start = in.skipToken()
           Ident(tpnme.USCOREkw).withSpan(Span(start, in.lastOffset, start))
         else

--- a/tests/pos/14952.scala
+++ b/tests/pos/14952.scala
@@ -1,0 +1,9 @@
+//> using options -Xkind-projector:underscores
+
+import Tuple.*
+
+type LiftP[F[_], T] <: Tuple =
+  T match {
+    case _ *: _ => F[Head[T]] *: LiftP[F, Tail[T]]
+    case _ => EmptyTuple
+  }

--- a/tests/pos/21400.scala
+++ b/tests/pos/21400.scala
@@ -1,0 +1,7 @@
+//> using options -Xkind-projector:underscores
+
+import scala.compiletime.ops.int.S
+
+type IndexOf[T <: Tuple, E] <: Int = T match
+  case E *: _  => 0
+  case _ *: es => 1 // S[IndexOf[es, E]]

--- a/tests/pos/21400b.scala
+++ b/tests/pos/21400b.scala
@@ -1,0 +1,10 @@
+//> using options -Xkind-projector:underscores
+
+import scala.quoted.Type
+import scala.quoted.Quotes
+
+def x[A](t: Type[A])(using Quotes): Boolean = t match
+  case '[_ *: _] =>
+    true
+  case _ =>
+    false


### PR DESCRIPTION
Always interpret underscores inside patterns as type bounds, even when `ctx.settings.XkindProjector.value == "underscores"`.

Fixes #14952 and fixes #21400.

Issue introduced in #12378.