### PR TITLE
Fix #21721: make case TypeBlock(_, _) not match non-type Block

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1413,7 +1413,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object TypeBlockTypeTest extends TypeTest[Tree, TypeBlock]:
       def unapply(x: Tree): Option[TypeBlock & x.type] = x match
-        case tpt: (tpd.Block & x.type) => Some(tpt)
+        case tpt: (tpd.Block & x.type) if x.isType => Some(tpt)
         case _ => None
     end TypeBlockTypeTest
 

--- a/tests/pos/i21721/Macro.scala
+++ b/tests/pos/i21721/Macro.scala
@@ -1,0 +1,12 @@
+import quoted.*
+
+object Macro:
+  inline def impl(inline expr: Any): Any =
+    ${implImpl('expr)}
+
+  def implImpl(expr: Expr[Any])(using q: Quotes): Expr[Any] =
+    import q.reflect.*
+    expr.asTerm.asInstanceOf[Inlined].body match
+      // this should not fail with a MatchError
+      case TypeBlock(_, _) => '{ "TypeBlock" }
+      case _ => '{ "Nothing" }

--- a/tests/pos/i21721/Test.scala
+++ b/tests/pos/i21721/Test.scala
@@ -1,0 +1,5 @@
+object Test:
+  // give a Block(...) to the macro
+  Macro.impl:
+    val a = 3
+    a


### PR DESCRIPTION
`TypeBlock`s are represented as normal `Blocks` in the Quotes API's implementation. The current `TypeTest` for `TypeBlock` is exactly the same as the `TypeTest` for `Block`, which means that `case TypeBlock(_, _)` "matches" every block. 

The implementation of `unapply` on `TypeBlockModule`, however, gives back `(List[TypeDef], TypeTree)`. It constructs the `List[TypeDef]` by mapping over every statement of the block, trying to turn it into a `TypeDef` by using a match with the pattern
```scala
  case alias: TypeDef => alias
```
This seems fine since `TypeBlock`s are supposed to be just a list of `TypeDefs` followed by a type as the last expression. Since the `TypeTest` matches any `Block` and not only `Blocks` that are `TypeBlocks`, the statements can be anything, not just `TypeDef`s, which lets the whole `case TypeBlock(_, _)` pattern die with a `MatchError`.

This commit fixes the problem by making the `TypeTest` check whether the `Block` is a type (which in turns checks whether the `Block`s expression is a type)

This is my first PR, please let me know if I should change anything or am completely going about fixing this the wrong way, etc.

Also, I could not run the complete test suite on my machine, it died even without making any changes. But I could at least run the positive compilation tests.

Closes #21721 