### PR TITLE
Draft: Overloading result-based pruning shouldn't prefer inapplicable alt

### DIFF
--- a/tests/pos/i21410.scala
+++ b/tests/pos/i21410.scala
@@ -1,0 +1,12 @@
+class A
+object Test:
+  type F[X] <: Any = X match
+    case A => Int
+
+  def foo[T](x: String): T = ???
+  def foo[U](x: U): F[U] = ???
+
+  val x1 = foo(A())
+  val y: Int = x1
+
+  val x2: Int = foo(A()) // error


### PR DESCRIPTION
If an overloaded alternative in `alts` does not end up being part of the `candidate` list in `resolveOverloaded1`, then it is not applicable to the current arguments and should not be considered by `adaptByResult`. This avoids discarding working solutions in favor of invalid ones when the working solution involves a match type in the method result type that will fail `resultConforms`.

Fixes #21410.