### PR TITLE
Fix ctx implicits under case unapplySeq

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2198,7 +2198,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
   /** Type a case. */
   def typedCase(tree: untpd.CaseDef, sel: Tree, wideSelType: Type, pt: Type)(using Context): CaseDef = {
     val originalCtx = ctx
-    val gadtCtx: Context = ctx.fresh.setFreshGADTBounds.setNewScope
+    val gadtCtx: Context = ctx.fresh.setFreshGADTBounds
 
     def caseRest(pat: Tree)(using Context) = {
       val pt1 = instantiateMatchTypeProto(pat, pt) match {
@@ -2228,7 +2228,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val pat1 = typedPattern(tree.pat, wideSelType)(using gadtCtx)
     caseRest(pat1)(
       using Nullables.caseContext(sel, pat1)(
-        using gadtCtx))
+        using gadtCtx.fresh.setNewScope))
   }
 
   def typedLabeled(tree: untpd.Labeled)(using Context): Labeled = {

--- a/tests/pos/i21742.1.scala
+++ b/tests/pos/i21742.1.scala
@@ -1,0 +1,5 @@
+case class C(n: Int, ds: Double*)
+class Test:
+  def m(using n: Int): Int = n + 1
+  def t(): Unit =
+    C(1, 2, 3, 4) match { case C(given Int, ds*) => m }

--- a/tests/pos/i21742.2.scala
+++ b/tests/pos/i21742.2.scala
@@ -1,0 +1,5 @@
+case class C(n: Int, ds: Seq[Double])
+class Test:
+  def m(using n: Int): Int = n + 1
+  def t(): Unit =
+    C(1, Seq(2, 3, 4)) match { case C(given Int, ds) => m }


### PR DESCRIPTION
A case class with a varargs has a unapplySeq extractor instead of
unapply.  When we type an unapply, in typedUnapply, we first look for
unapply methods before unapplySeq methods.  But when searching for
unapply, if a class method isn't found, then an extension method is
looked for, which causes context implicits to be cached.  The bindings
from a pattern (such as from an unapply or unapplySeq extractor) are
added to the context in indexPattern.  But Context's `implicitCache`
doesn't account for the scope changing.

I opted for giving the body its own scope context, rather than making
indexPattern reset the context implicits cache.

Fixes #21742
