### PR TITLE
REPL: JLine 3.27.0 (was 3.25.1)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -694,9 +694,9 @@ object Build {
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" % "scala-asm" % "9.7.0-scala-2", // used by the backend
         Dependencies.compilerInterface,
-        "org.jline" % "jline-reader" % "3.25.1",   // used by the REPL
-        "org.jline" % "jline-terminal" % "3.25.1",
-        "org.jline" % "jline-terminal-jna" % "3.25.1", // needed for Windows
+        "org.jline" % "jline-reader" % "3.27.0",   // used by the REPL
+        "org.jline" % "jline-terminal" % "3.27.0",
+        "org.jline" % "jline-terminal-jna" % "3.27.0", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 


### PR DESCRIPTION
the same upgrade is in flight in these other repos:

* https://github.com/scala/scala/pull/10882
* https://github.com/sbt/sbt/pull/7695
 
JLine release notes:

* https://github.com/jline/jline3/releases/tag/jline-3.27.0
* https://github.com/java-native-access/jna/blob/master/CHANGES.md#release-5150

a lot of bugfixes, nothing really stands out that I can see

we usually take these upgrades in the hopes they will improve things in small ways, especially for Windows users

I verified that the `repl` command inside our sbt build still works (on MacOS anyway)