### PR TITLE
Shade scalajs.ir under dotty.tools

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -25,13 +25,13 @@ import dotty.tools.dotc.transform.{Erasure, ValueClasses}
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.report
 
-import org.scalajs.ir
-import org.scalajs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{ClassName, MethodName, SimpleMethodName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Trees.OptimizerHints
-import org.scalajs.ir.Version.Unversioned
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{ClassName, MethodName, SimpleMethodName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir.Version.Unversioned
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils.*
 

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -15,12 +15,12 @@ import StdNames.*
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils.*
 
-import org.scalajs.ir
-import org.scalajs.ir.{Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{LocalName, LabelName, SimpleFieldName, FieldName, SimpleMethodName, MethodName, ClassName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.UTF8String
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{LocalName, LabelName, SimpleFieldName, FieldName, SimpleMethodName, MethodName, ClassName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.UTF8String
 
 import dotty.tools.backend.jvm.DottyBackendInterface.symExtensions
 

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -22,12 +22,12 @@ import TypeErasure.ErasedValueType
 import dotty.tools.dotc.util.{SourcePosition, SrcPos}
 import dotty.tools.dotc.report
 
-import org.scalajs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.DefaultModuleID
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Position.NoPosition
-import org.scalajs.ir.Trees.OptimizerHints
-import org.scalajs.ir.Version.Unversioned
+import dotty.tools.sjs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.DefaultModuleID
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Position.NoPosition
+import dotty.tools.sjs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir.Version.Unversioned
 
 import dotty.tools.dotc.transform.sjs.JSExportUtils.*
 import dotty.tools.dotc.transform.sjs.JSSymUtils.*
@@ -932,7 +932,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
         InstanceOfTypeTest(tpe.tycon.typeSymbol.typeRef)
 
       case _ =>
-        import org.scalajs.ir.Names
+        import dotty.tools.sjs.ir.Names
 
         (toIRType(tpe): @unchecked) match {
           case jstpe.AnyType => NoTypeTest

--- a/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
@@ -13,7 +13,7 @@ import dotty.tools.dotc.report
 import dotty.tools.dotc.util.{SourceFile, SourcePosition}
 import dotty.tools.dotc.util.Spans.Span
 
-import org.scalajs.ir
+import dotty.tools.sjs.ir
 
 /** Conversion utilities from dotty Positions to IR Positions. */
 class JSPositions()(using Context) {

--- a/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckReentrant.scala
@@ -43,7 +43,7 @@ class CheckReentrant extends MiniPhase {
     requiredClass("scala.annotation.internal.unshared"))
 
   private val scalaJSIRPackageClass = new CtxLazy(
-    getPackageClassIfDefined("org.scalajs.ir"))
+    getPackageClassIfDefined("dotty.tools.sjs.ir"))
 
   def isIgnored(sym: Symbol)(using Context): Boolean =
     sym.hasAnnotation(sharableAnnot()) ||

--- a/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/JSSymUtils.scala
@@ -17,7 +17,7 @@ import Types.*
 
 import dotty.tools.backend.sjs.JSDefinitions.jsdefn
 
-import org.scalajs.ir.{Trees => js}
+import dotty.tools.sjs.ir.{Trees => js}
 
 /** Additional extensions for `Symbol`s that are only relevant for Scala.js. */
 object JSSymUtils {

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSExports.scala
@@ -21,8 +21,8 @@ import dotty.tools.backend.sjs.JSDefinitions.jsdefn
 import JSExportUtils.*
 import JSSymUtils.*
 
-import org.scalajs.ir.Names.DefaultModuleID
-import org.scalajs.ir.Trees.TopLevelExportDef.isValidTopLevelExportName
+import dotty.tools.sjs.ir.Names.DefaultModuleID
+import dotty.tools.sjs.ir.Trees.TopLevelExportDef.isValidTopLevelExportName
 
 object PrepJSExports {
   import tpd.*

--- a/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
+++ b/compiler/src/dotty/tools/dotc/transform/sjs/PrepJSInterop.scala
@@ -23,7 +23,7 @@ import Types.*
 
 import JSSymUtils.*
 
-import org.scalajs.ir.Trees.JSGlobalRef
+import dotty.tools.sjs.ir.Trees.JSGlobalRef
 
 import dotty.tools.backend.sjs.JSDefinitions.jsdefn
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -616,18 +616,36 @@ object Build {
   def findArtifactPath(classpath: Def.Classpath, name: String): String =
     findArtifact(classpath, name).getAbsolutePath
 
+  /** Replace package names in package definitions, for shading.
+   * It assumes the full package def is written on a single line.
+   * It does not adapt the imports accordingly.
+   */
+  def replacePackage(lines: List[String])(replace: PartialFunction[String, String]): List[String] = {
+    def recur(lines: List[String]): List[String] =
+      lines match {
+        case head :: tail =>
+          if (head.startsWith("package ")) {
+            val packageName = head.stripPrefix("package ").trim
+            val newPackageName = replace.applyOrElse(packageName, (_: String) => packageName)
+            s"package $newPackageName" :: tail
+          } else head :: recur(tail)
+        case _ => lines
+      }
+    recur(lines)
+  }
+
   /** Insert UnsafeNulls Import after package */
-  def insertUnsafeNullsImport(lines: Seq[String]): Seq[String] = {
-    def recur(ls: Seq[String], foundPackage: Boolean): Seq[String] = ls match {
-      case Seq(l, rest @ _*) =>
+  def insertUnsafeNullsImport(lines: List[String]): List[String] = {
+    def recur(ls: List[String], foundPackage: Boolean): List[String] = ls match {
+      case l :: rest =>
         val lt = l.trim()
         if (foundPackage) {
           if (!(lt.isEmpty || lt.startsWith("package ")))
-            "import scala.language.unsafeNulls" +: ls
-          else l +: recur(rest, foundPackage)
+            "import scala.language.unsafeNulls" :: ls
+          else l :: recur(rest, foundPackage)
         } else {
           if (lt.startsWith("package ")) l +: recur(rest, true)
-          else l +: recur(rest, foundPackage)
+          else l :: recur(rest, foundPackage)
         }
       case _ => ls
     }
@@ -928,7 +946,10 @@ object Build {
           val sjsSources = (trgDir ** "*.scala").get.toSet
           sjsSources.foreach(f => {
             val lines = IO.readLines(f)
-            IO.writeLines(f, insertUnsafeNullsImport(lines))
+            val linesWithPackage = replacePackage(lines) {
+              case "org.scalajs.ir" => "dotty.tools.sjs.ir"
+            }
+            IO.writeLines(f, insertUnsafeNullsImport(linesWithPackage))
           })
           sjsSources
         } (Set(scalaJSIRSourcesJar)).toSeq

--- a/tests/pos-with-compiler-cc/backend/sjs/JSCodeGen.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSCodeGen.scala
@@ -25,12 +25,12 @@ import dotty.tools.dotc.transform.SymUtils._
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.report
 
-import org.scalajs.ir
-import org.scalajs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{ClassName, MethodName, SimpleMethodName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{ClassKind, Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{ClassName, MethodName, SimpleMethodName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Trees.OptimizerHints
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils._
 

--- a/tests/pos-with-compiler-cc/backend/sjs/JSEncoding.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSEncoding.scala
@@ -15,12 +15,12 @@ import StdNames._
 
 import dotty.tools.dotc.transform.sjs.JSSymUtils._
 
-import org.scalajs.ir
-import org.scalajs.ir.{Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{LocalName, LabelName, FieldName, SimpleMethodName, MethodName, ClassName}
-import org.scalajs.ir.OriginalName
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.UTF8String
+import dotty.tools.sjs.ir
+import dotty.tools.sjs.ir.{Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.{LocalName, LabelName, FieldName, SimpleMethodName, MethodName, ClassName}
+import dotty.tools.sjs.ir.OriginalName
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.UTF8String
 
 import dotty.tools.backend.jvm.DottyBackendInterface.symExtensions
 

--- a/tests/pos-with-compiler-cc/backend/sjs/JSExportsGen.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSExportsGen.scala
@@ -22,11 +22,11 @@ import TypeErasure.ErasedValueType
 import dotty.tools.dotc.util.{SourcePosition, SrcPos}
 import dotty.tools.dotc.report
 
-import org.scalajs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.DefaultModuleID
-import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Position.NoPosition
-import org.scalajs.ir.Trees.OptimizerHints
+import dotty.tools.sjs.ir.{Position, Names => jsNames, Trees => js, Types => jstpe}
+import dotty.tools.sjs.ir.Names.DefaultModuleID
+import dotty.tools.sjs.ir.OriginalName.NoOriginalName
+import dotty.tools.sjs.ir.Position.NoPosition
+import dotty.tools.sjs.ir.Trees.OptimizerHints
 
 import dotty.tools.dotc.transform.sjs.JSExportUtils._
 import dotty.tools.dotc.transform.sjs.JSSymUtils._
@@ -924,7 +924,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
         InstanceOfTypeTest(tpe.tycon.typeSymbol.typeRef)
 
       case _ =>
-        import org.scalajs.ir.Names
+        import dotty.tools.sjs.ir.Names
 
         (toIRType(tpe): @unchecked) match {
           case jstpe.AnyType => NoTypeTest

--- a/tests/pos-with-compiler-cc/backend/sjs/JSPositions.scala
+++ b/tests/pos-with-compiler-cc/backend/sjs/JSPositions.scala
@@ -13,7 +13,7 @@ import dotty.tools.dotc.report
 import dotty.tools.dotc.util.{SourceFile, SourcePosition}
 import dotty.tools.dotc.util.Spans.Span
 
-import org.scalajs.ir
+import dotty.tools.sjs.ir
 
 /** Conversion utilities from dotty Positions to IR Positions. */
 class JSPositions()(using Context) {


### PR DESCRIPTION
Because `scala3-compiler` contains a copy of `scalajs-ir`, they conflict with each other when being in the same classpath. This was found when trying to migrate the `sbt-scalajs` to sbt 2, because `sbt-scalajs` depends on `scalajs-ir` and on `sbt`, which depends on `scala3-compiler`. The related issue is https://github.com/sbt/sbt/issues/7709.

The solution is to shade the compiler version of `scalajs-ir` under its own package: `dotty.tool.sjs.ir`. The compiler uses the `scalajs-ir` internally but it does not need to expose it.