### PR TITLE
Add test for StackOverflow question 68877939

### DIFF
--- a/tests/pos/so68877939.scala
+++ b/tests/pos/so68877939.scala
@@ -1,0 +1,15 @@
+abstract class Quantity[A <: Quantity[A]]
+sealed trait UnitOfMeasure[A <: Quantity[A]]
+
+class Time extends Quantity[Time]
+object Minutes extends UnitOfMeasure[Time]
+
+class PowerRamp extends Quantity[PowerRamp]
+object KilowattsPerHour extends UnitOfMeasure[PowerRamp]
+
+type Test[X <: UnitOfMeasure[?]] = X match
+  case UnitOfMeasure[t] => t
+
+@main def main =
+  summon[Test[Minutes.type] =:= Time]
+  summon[Test[KilowattsPerHour.type] =:= PowerRamp]


### PR DESCRIPTION
https://stackoverflow.com/q/68877939/21927647

Answer to the question:

> You were not doing anything wrong, this was an implementation limitation.
>
> Your example compiles successfully since Scala 3.4, thanks to the changes introduced in SIP-56 "Proper specification for match types" ([text](https://docs.scala-lang.org/sips/match-types-spec.html#:~:text=This%20SIP%20proposes%20a%20proper,the%20specification%20of%20the%20language.), [PR](https://github.com/scala/scala3/pull/18262)).