### PR TITLE
Add the macro type-print test to run-macros-scala2-library-tasty.blacklist

### DIFF
--- a/compiler/test/dotc/run-macros-scala2-library-tasty.blacklist
+++ b/compiler/test/dotc/run-macros-scala2-library-tasty.blacklist
@@ -2,3 +2,4 @@
 tasty-extractors-1
 tasty-extractors-2
 tasty-extractors-types
+type-print


### PR DESCRIPTION
Just noticed the ci issues. The actual changes in the .check files concern `TypeRef(ThisType(TypeRef(NoPrefix(), "immutable")), "List")` (read from byte code) being shown as `TypeRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix(), "<root>")), "scala"), "collection"), "immutable"), "List")` (read from tasty), which is expected and also happens in the other excluded tests

[test_scala2_library_tasty] 