### PR TITLE
Add zip and unzip to the CI

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update && \
                        openjdk-17-jdk-headless \
                        openjdk-21-jdk-headless && \
     (curl -fsSL https://deb.nodesource.com/setup_18.x | bash -) && \
-    apt-get install -y nodejs
+    apt-get install -y nodejs && \
+    apt-get install -y zip unzip
 
 
 # Install sbt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
   test_non_bootstrapped:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -100,7 +100,7 @@ jobs:
   test:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -160,7 +160,7 @@ jobs:
   test_scala2_library_tasty:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -287,7 +287,7 @@ jobs:
     name: MiMa
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -338,7 +338,7 @@ jobs:
   community_build_a:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -395,7 +395,7 @@ jobs:
   community_build_b:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -452,7 +452,7 @@ jobs:
   community_build_c:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -509,7 +509,7 @@ jobs:
   test_sbt:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -554,7 +554,7 @@ jobs:
   test_java8:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -614,7 +614,7 @@ jobs:
   publish_nightly:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -677,7 +677,7 @@ jobs:
   nightly_documentation:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -723,7 +723,7 @@ jobs:
       contents: write  # for actions/create-release to create a release
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
       volumes:
         - ${{ github.workspace }}/../../cache/sbt:/root/.sbt
@@ -985,7 +985,7 @@ jobs:
   open_issue_on_failure:
     runs-on: [self-hosted, Linux]
     container:
-      image: lampepfl/dotty:2023-11-07
+      image: lampepfl/dotty:2024-10-18
     needs: [nightly_documentation, test_windows_full]
     # The `failure()` expression is true iff at least one of the dependencies
     # of this job (including transitive dependencies) has failed.


### PR DESCRIPTION
The `zip` and `unzip` command were missing inside the container which blocked the release of `3.6.0-RC1`

See: https://github.com/scala/scala3/actions/runs/11399553203/job/31721174836#step:10:55