### PR TITLE
Downgrade referenceVersion to 3.6.0 and add notes how referenceVersion should be set

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -91,7 +91,13 @@ object DottyJSPlugin extends AutoPlugin {
 object Build {
   import ScaladocConfigs._
 
-  val referenceVersion = "3.6.1"
+  /** Version of the Scala compiler used to build the artifacts.
+   *  Reference version should track the latest version pushed to Maven:
+   *  - In main branch it should be the last RC version (using experimental TASTy required for non-bootstrapped tests)
+   *  - In release branch it should be the last stable release
+   *  3.6.0-RC1 was released as 3.6.0 - it's having and experimental TASTy version
+   */
+  val referenceVersion = "3.6.0"
 
   val baseVersion = "3.6.2"
   // Will be required by some automation later


### PR DESCRIPTION
The main branch should always use a compiler with experimental tasty - it's required for non_boostrapped tests to pass. It's required because we cannot consume stable version of tasty from it's experimental subversion (it's assumed that stable version > experimental version for the same major/minor pair)

We pick 3.6.0 (released by mistake during 3.6.0-RC1) because that's the last non-stable version pushed to Maven. Typically we would use the last RC version

[test_non_bootstrapped]