### PR TITLE
Fix scaladoc graph highlight background color in dark mode

### DIFF
--- a/scaladoc/resources/dotty_res/scripts/ux.js
+++ b/scaladoc/resources/dotty_res/scripts/ux.js
@@ -10,7 +10,7 @@ const attrsToCopy = [
 
 /**
  * @typedef {Object} SavedPageState
- * @property {Strign} mainDiv
+ * @property {String} mainDiv
  * @property {String} leftColumn
  * @property {String} title
  * @property {Record<string, string>} attrs
@@ -322,7 +322,7 @@ function attachAllListeners() {
 
   if (location.hash) {
     var target = location.hash.substring(1);
-    // setting the 'expand' class on the top-level container causes undesireable styles
+    // setting the 'expand' class on the top-level container causes undesirable styles
     // to apply to the top-level docs, so we avoid this logic for that element.
     if (target != "container") {
       var selected = document.getElementById(location.hash.substring(1));
@@ -568,7 +568,7 @@ function showGraph() {
         .attr("offset", "30%");
       radialGradient
         .append("stop")
-        .attr("stop-color", "var(--background-default)")
+        .attr("stop-color", "var(--background-main)")
         .attr("offset", "100%");
 
       var inner = svg.append("g");


### PR DESCRIPTION
This PR should fix the background of the gradient that highlights the current type in the graph view in dark mode.

For example on https://www.scala-lang.org/api/current/scala/annotation/ClassfileAnnotation.html you see right now a black box around the class in the graph:

![grafik](https://github.com/user-attachments/assets/ddfae1f2-c8d5-43e4-ba8b-7bb625dfec35)

The right color to use here is `--background-main`:

![grafik](https://github.com/user-attachments/assets/1c316b25-c95d-48ca-a963-8b667ab21a2e)

In light mode the graph looks the same as before:

![grafik](https://github.com/user-attachments/assets/1f63a3ac-e57e-49de-827a-910795c1f443)


I also fixed two typos