### PR TITLE
Use bash shell when using here-strings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -664,6 +664,7 @@ jobs:
           echo "THISBUILD_VERSION=$ver" >> $GITHUB_ENV
 
       - name: Check is version matching pattern
+        shell: bash
         run: |
           if ! grep -Eo "3\.[0-9]+\.[0-9]+-RC[0-9]+-bin-[0-9]{8}-[a-zA-Z0-9]{7}-NIGHTLY" <<< "${{ env.THISBUILD_VERSION }}"; then
             echo "Version used by compiler to publish nightly release does not match expected pattern"


### PR DESCRIPTION

<img width="1032" alt="Screenshot 2024-10-20 at 07 14 49" src="https://github.com/user-attachments/assets/321ba7ce-9fd2-413c-aec3-14215fbee786">

[positive](https://github.com/WojciechMazur/dotty/actions/runs/11416876799/job/31768568868) test in #21810 also uses `bash` instead of `sh`

Closes #21815 