### PR TITLE
Nowarn extension matching nonpublic member

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1169,16 +1169,19 @@ object RefChecks {
         target.nonPrivateMember(sym.name)
         .filterWithPredicate:
           member =>
-          val memberIsImplicit = member.info.hasImplicitParams
-          val paramTps =
-            if memberIsImplicit then methTp.stripPoly.firstParamTypes
-            else methTp.firstExplicitParamTypes
+          val memberIsPublic = (member.symbol.flags & AccessFlags).isEmpty && !member.symbol.privateWithin.exists
+          memberIsPublic && {
+            val memberIsImplicit = member.info.hasImplicitParams
+            val paramTps =
+              if memberIsImplicit then methTp.stripPoly.firstParamTypes
+              else methTp.firstExplicitParamTypes
 
-          paramTps.isEmpty || memberIsImplicit && !methTp.hasImplicitParams || {
-            val memberParamTps = member.info.stripPoly.firstParamTypes
-            !memberParamTps.isEmpty
-            && memberParamTps.lengthCompare(paramTps) == 0
-            && memberParamTps.lazyZip(paramTps).forall((m, x) => x frozen_<:< m)
+            paramTps.isEmpty || memberIsImplicit && !methTp.hasImplicitParams || {
+              val memberParamTps = member.info.stripPoly.firstParamTypes
+              !memberParamTps.isEmpty
+              && memberParamTps.lengthCompare(paramTps) == 0
+              && memberParamTps.lazyZip(paramTps).forall((m, x) => x frozen_<:< m)
+            }
           }
         .exists
       if !target.typeSymbol.denot.isAliasType && !target.typeSymbol.denot.isOpaqueAlias && hidden

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -525,7 +525,6 @@ object RefChecks {
 
       // todo: align accessibility implication checking with isAccessible in Contexts
       def isOverrideAccessOK =
-        val memberIsPublic = (member.flags & AccessFlags).isEmpty && !member.privateWithin.exists
         def protectedOK = !other.is(Protected) || member.is(Protected)        // if o is protected, so is m
         def accessBoundaryOK =
           val ob = other.accessBoundary(member.owner)
@@ -534,7 +533,7 @@ object RefChecks {
           def companionBoundaryOK = ob.isClass && !ob.isLocalToBlock && mb.is(Module) && (ob.companionModule eq mb.companionModule)
           ob.isContainedIn(mb) || companionBoundaryOK    // m relaxes o's access boundary,
         def otherIsJavaProtected = other.isAllOf(JavaProtected)               // or o is Java defined and protected (see #3946)
-        memberIsPublic || protectedOK && (accessBoundaryOK || otherIsJavaProtected)
+        member.isPublic || protectedOK && (accessBoundaryOK || otherIsJavaProtected)
       end isOverrideAccessOK
 
       if !member.hasTargetName(other.targetName) then
@@ -1169,8 +1168,7 @@ object RefChecks {
         target.nonPrivateMember(sym.name)
         .filterWithPredicate:
           member =>
-          val memberIsPublic = (member.symbol.flags & AccessFlags).isEmpty && !member.symbol.privateWithin.exists
-          memberIsPublic && {
+          member.symbol.isPublic && {
             val memberIsImplicit = member.info.hasImplicitParams
             val paramTps =
               if memberIsImplicit then methTp.stripPoly.firstParamTypes

--- a/tests/warn/i21816.scala
+++ b/tests/warn/i21816.scala
@@ -1,0 +1,17 @@
+
+case class CC(a: String, b: String) extends Iterable[String] {
+  override def iterator: Iterator[String] = Iterator(a, b)
+}
+
+trait T {
+  extension (cc: CC) def className: String = "foo"
+}
+
+object O extends T {
+  def foo = {
+    val cc = CC("a", "b")
+    println(cc.className)
+  }
+}
+
+@main def main() = O.foo


### PR DESCRIPTION
Fixes #21816

Consider only public members when checking if an extension method actually extends.

A use site lint would be more thorough, when an extension is in scope but unused because of a visible matching member.
