### PR TITLE
Awesome warning for named arg clash with named tuple

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -214,6 +214,10 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case UnusedSymbolID // errorNumber: 198
   case TailrecNestedCallID //errorNumber: 199 - unused in LTS
   case FinalLocalDefID // errorNumber: 200
+  case NonNamedArgumentInJavaAnnotationID // errorNumber: 201 - unused in LTS
+  case QuotedTypeMissingID // errorNumber: 202 - unused in LTS
+  case AmbiguousNamedTupleAssignmentID // errorNumber: 203 - unused in LTS
+  case DeprecatedNamedInfixArgID // errorNumber: 204 - used ONLY in LTS
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3150,3 +3150,12 @@ object UnusedSymbol {
     def privateMembers(using Context): UnusedSymbol = new UnusedSymbol(i"unused private member")
     def patVars(using Context): UnusedSymbol = new UnusedSymbol(i"unused pattern variable")
 }
+
+class InfixNamedArgDeprecation()(using Context)
+  extends Message(DeprecatedNamedInfixArgID):
+    def kind = MessageKind.PotentialIssue
+    def msg(using Context) = "Named argument syntax is deprecated for infix application"
+    def explain(using Context) =
+      i"""The argument will be parsed as a named tuple in future.
+      |
+      |To avoid this warning, either remove the argument names or use dotted selection."""

--- a/tests/warn/infix-named-args.scala
+++ b/tests/warn/infix-named-args.scala
@@ -1,0 +1,7 @@
+//> using options -deprecation
+
+class C {
+  def f = 42 + (x = 1) // warn
+  def multi(x: Int, y: Int): Int = x + y
+  def g = new C() `multi` (x = 42, y = 27) // warn // warn
+}


### PR DESCRIPTION
Backport https://github.com/scala/scala3/pull/21565

Not sure of the correct workflow to get this on LTS.

I got ambitious and added a proper error ID, which will need to show up on HEAD, where it might go unused.