### PR TITLE
[Draft] A more dependent pattern matching prototype

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1625,7 +1625,8 @@ trait Applications extends Compatibility {
             val patternBound = maximizeType(unapplyArgType, unapplyFn.span.endPos)
             if (patternBound.nonEmpty) unapplyFn = addBinders(unapplyFn, patternBound)
             unapp.println(i"case 2 $unapplyArgType ${ctx.typerState.constraint}")
-            unapplyArgType
+            selType & unapplyArgType
+            // unapplyArgType
 
         val dummyArg = dummyTreeOfType(ownType)
         val (newUnapplyFn, unapplyApp) =
@@ -1637,7 +1638,7 @@ trait Applications extends Compatibility {
           .typedPatterns(qual, this)
         val result = assignType(cpy.UnApply(tree)(newUnapplyFn, unapplyImplicits(dummyArg, unapplyApp), unapplyPatterns), ownType)
         if (ownType.stripped eq selType.stripped) || ownType.isError then result
-        else tryWithTypeTest(Typed(result, TypeTree(ownType)), selType)
+        else tryWithTypeTest(Typed(result, TypeTree(unapplyArgType)), selType)
       case tp =>
         val unapplyErr = if (tp.isError) unapplyFn else notAnExtractor(unapplyFn)
         val typedArgsErr = unadaptedArgs.mapconserve(typed(_, defn.AnyType))

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -265,7 +265,7 @@ object Tuple {
 
   /** Convert an array into a tuple of unknown arity and types */
   def fromArray[T](xs: Array[T]): Tuple = {
-    val xs2 = xs match {
+    val xs2: Array[Object] = xs match {
       case xs: Array[Object] => xs
       case xs => xs.map(_.asInstanceOf[Object])
     }

--- a/tests/pos/dependent-pattern-match-type-test.scala
+++ b/tests/pos/dependent-pattern-match-type-test.scala
@@ -1,0 +1,17 @@
+//> using options -Xfatal-warnings
+
+import scala.reflect.TypeTest
+
+trait M:
+  type Tree <: AnyRef
+  type Apply <: Tree
+  given TypeTest[Tree, Apply] = ???
+  val Apply: ApplyModule
+  trait ApplyModule:
+    this: Apply.type =>
+    def unapply(x: Apply): (Tree, Tree) = ???
+
+  def quote(x: Tree) = x match
+    case Apply(f, args) =>
+      println(args)
+    case _ =>

--- a/tests/pos/dependent-pattern-match.scala
+++ b/tests/pos/dependent-pattern-match.scala
@@ -1,0 +1,59 @@
+trait A:
+  val x: Int
+  type T
+case class B(x: Int, y: Int) extends A:
+  type T = String
+  val z: T = "B"
+case class C(x: Int) extends A:
+  type T = Int
+  val z: T = 1
+
+object BParts:
+  def unapply(b: B): Option[(b.x.type, b.y.type)] = Some((b.x, b.y))
+
+def test1(a: A) = a match
+  case b @ B(x, y) =>
+    // b: a.type & B
+    // x: (a.type & B).x.type
+    // y: (a.type & B).y.type
+    val e1: a.type = b
+    val e2: a.x.type = b.x
+    val e3: a.x.type = x
+    val e4: b.x.type = x
+    x + y
+  case C(x) =>
+    val e1: a.x.type = x
+    x
+  case BParts(x, y) =>
+    val e1: a.x.type = x
+    x + y
+  case _ => 0
+
+def test2(a: A): a.T =
+  a match
+    case b: B =>
+      // b: a.type & B
+      // b.z: b.T = (a & B)#T = a.T & String
+      b.z
+    case c: C => c.z
+
+def test3(a: A): a.T =
+  a match
+    case b: B =>
+      // b: a.type & B; hence b.T <:< a.T & String
+      // We don't have a: b.type in the body,
+      // so we can't prove String <:< a.T
+      val x: b.T = b.z + ""
+      x
+    case c: C =>
+      val x: c.T = c.z + 0
+      x
+
+def test4(x: A, y: A) =
+  x match
+    case z: y.type =>
+      // if x.eq(y) then z = x = y,
+      // z: x.type & y.type
+      val a: x.type = z
+      val b: y.type = z
+    case _ =>


### PR DESCRIPTION
Sometime, it is useful to track the dependency between the selector and the pattern-bind variable.

```scala
case class A(x: String)

def test(a: A) = a match
  case b @ A(y) => ???
```

Given the example, in the body of the case, we should be able to tell: 
* `a` and `b` are the same reference;
* `a.x`, `b.x` and `y` are same as well.

This PR made following modifications:
* For a case class and `i`th parameter `x: T`, if `x` is not a `var`, generate `def _i: this.x = this.x`, instead of `def _i: T = this.x`.
* The default `unapply` for a case class `A` becomes `def unapply(a: A): a.type = a`.
* Do not widen stable `TermRef`s when typing patterns. If `pt` is a singleton type, we use intersection to add `pt` to the new pattern-bind variable.

With this PR, the following code can be type checked:

```scala
trait A:
  val x: Int
  type T

case class B(x: Int, y: Int) extends A:
  type T = String
  val z: T = "B"

case class C(x: Int) extends A:
  type T = Int
  val z: T = 1

object BParts:
  def unapply(b: B): Option[(b.x.type, b.y.type)] = Some((b.x, b.y))

def test1(a: A) = a match
  case b @ B(x, y) =>
    // b: a.type & B
    // x: (a.type & B).x.type
    // y: (a.type & B).y.type
    val e1: a.type = b
    val e2: a.x.type = b.x
    val e3: a.x.type = x
    val e4: b.x.type = x
    x + y
  case C(x) =>
    val e1: a.x.type = x
    x
  case BParts(x, y) =>
    val e1: a.x.type = x
    x + y
  case _ => 0

def test2(a: A): a.T =
  a match
    case b: B =>
      // b: a.type & B
      // b.z: b.T = (a & B)#T = a.T & String
      b.z
    case c: C => c.z

def test3(a: A): a.T =
  a match
    case b: B =>
      // b: a.type & B; hence b.T <:< a.T & String
      // We don't have a: b.type in the body,
      // so we can't prove String <:< a.T
      val x: b.T = b.z + ""
      x
    case c: C =>
      val x: c.T = c.z + 0
      x
```


