### PR TITLE
Better error message for polytypes wrapping capturing types

### DIFF
--- a/tests/neg-custom-args/captures/polyCaptures.check
+++ b/tests/neg-custom-args/captures/polyCaptures.check
@@ -1,0 +1,8 @@
+-- Error: tests/neg-custom-args/captures/polyCaptures.scala:4:22 -------------------------------------------------------
+4 |val runOpsCheck: [C^] -> (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps  // error
+  |                      ^
+  |          Implementation restriction: polymorphic function types cannot wrap function types that have capture sets
+-- Error: tests/neg-custom-args/captures/polyCaptures.scala:5:23 -------------------------------------------------------
+5 |val runOpsCheck2: [C^] => (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps // error
+  |                       ^
+  |          Implementation restriction: polymorphic function types cannot wrap function types that have capture sets

--- a/tests/neg-custom-args/captures/polyCaptures.scala
+++ b/tests/neg-custom-args/captures/polyCaptures.scala
@@ -1,0 +1,7 @@
+class Box[X](val elem: X)
+
+val runOps = [C^] => (b: Box[() ->{C^} Unit]) => b.elem()
+val runOpsCheck: [C^] -> (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps  // error
+val runOpsCheck2: [C^] => (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps // error
+
+


### PR DESCRIPTION
A type like

    [X] -> A ->{c} B

is currently not allowed since it expands to a PolyType wrapping a CapturingType and we have an implementation restriction that requires PolyTypes to wrap only FunctionTypes. It would be great if we could lift that implementation restriction. Until we do so, we should have a better error message, which this commit implements.