### PR TITLE
Fix use of class terms in match analysis

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -1121,6 +1121,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         recur(fn) ~ "(" ~ toTextGlobal(explicitArgs, ", ") ~ ")"
       case TypeApply(fn, args) => recur(fn) ~ "[" ~ toTextGlobal(args, ", ") ~ "]"
       case Select(qual, nme.CONSTRUCTOR) => recur(qual)
+      case id @ Ident(tpnme.BOUNDTYPE_ANNOT) => "@" ~ toText(id.symbol.name)
       case New(tpt) => recur(tpt)
       case _ =>
         val annotSym = sym.orElse(tree.symbol.enclosingClass)

--- a/tests/warn/i21845.orig.scala
+++ b/tests/warn/i21845.orig.scala
@@ -1,0 +1,33 @@
+trait Init[ScopeType]:
+  sealed trait Initialize[A1]
+  final class Bind[S, A1](val f: S => Initialize[A1], val in: Initialize[S])
+    extends Initialize[A1]
+  final class Value[A1](val value: () => A1) extends Initialize[A1]
+  final class ValidationCapture[A1](val key: ScopedKey[A1], val selfRefOk: Boolean)
+        extends Initialize[ScopedKey[A1]]
+  final class TransformCapture(val f: [x] => Initialize[x] => Initialize[x])
+        extends Initialize[[x] => Initialize[x] => Initialize[x]]
+  final class Optional[S, A1](val a: Option[Initialize[S]], val f: Option[S] => A1)
+        extends Initialize[A1]
+  object StaticScopes extends Initialize[Set[ScopeType]]
+
+  sealed trait Keyed[S, A1] extends Initialize[A1]
+  trait KeyedInitialize[A1] extends Keyed[A1, A1]
+  sealed case class ScopedKey[A](scope: ScopeType, key: AttributeKey[A]) extends KeyedInitialize[A]
+  sealed trait AttributeKey[A]
+
+abstract class EvaluateSettings[ScopeType]:
+    protected val init: Init[ScopeType]
+    import init._
+
+    val transform: [A] => Initialize[A] => Unit = [A] =>
+        (fa: Initialize[A]) =>
+          fa match
+            case k: Keyed[s, A]          => ???
+            case b: Bind[s, A]           => ???
+            case v: Value[A]             => ???
+            case v: ValidationCapture[a] => ??? // unrearchable warning
+            case t: TransformCapture     => ??? // unrearchable warning
+            case o: Optional[s, A]       => ??? // unrearchable warning
+            case StaticScopes            => ??? // unrearchable warning
+

--- a/tests/warn/i21845.scala
+++ b/tests/warn/i21845.scala
@@ -1,0 +1,15 @@
+trait Outer[O1]:
+  sealed trait Foo[A1]
+  final class Bar[A2] extends Foo[A2]
+  final class Baz[A4] extends Foo[Bar[A4]]
+  final class Qux     extends Foo[[a5] => Foo[a5] => Foo[a5]]
+
+trait Test[O2]:
+  val outer: Outer[O2]
+  import outer.*
+
+  def test[X](fa: Foo[X]): Unit =
+    fa match // was: inexhaustive: fail on _: (Outer[<?>] & (Test#outer : Outer[Test#O2]))#Qux
+      case _: Bar[X] => ???
+      case _: Baz[x] => ??? // was: unrearchable warning
+      case _: Qux    => ??? // was: unrearchable warning


### PR DESCRIPTION
When instantiating a subclass Outer.this.Bar, such that it's a subtype
of Test.this.outer.Foo[X], make sure to infer the term `outer` (even if
it's not a parameter).  Also make sure to use those singletons when
approximating the parent (to fix Outer.this.Qux instantiating).

Fixes #21845
