### PR TITLE
Make sure definition tree has the defined symbol

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -999,6 +999,7 @@ class TreeUnpickler(reader: TastyReader,
         }
       }
 
+      tree.ensureHasSym(sym)
       tree.setDefTree
     }
 

--- a/tests/pos/i21755.scala
+++ b/tests/pos/i21755.scala
@@ -1,0 +1,11 @@
+trait GraphTraversal  {
+  type NodeT
+
+  protected trait Properties {
+    def root: NodeT
+  }
+
+  abstract protected class TraverserMethods[A, +CC <: TraverserMethods[A, CC]]  { this: CC with Properties =>
+    def root: NodeT
+  }
+}


### PR DESCRIPTION
It turns out it could have the wrong symbol referring to a same-named definition in the superclass under some recursive definition of a self type. This caused a crash in pickler in #21755 because we now have two different definitions in two different classes that have the same symbol.

Fixes #21755