### PR TITLE
Resolve name when named imp is behind wild imps

### DIFF
--- a/tests/pos/i18529/JCode1.java
+++ b/tests/pos/i18529/JCode1.java
@@ -1,0 +1,9 @@
+package bug.code;
+
+import bug.util.List;
+import bug.util.*;
+import java.util.*;
+
+public class JCode1 {
+    public void m1(List<Integer> xs) { return; }
+}

--- a/tests/pos/i18529/JCode2.java
+++ b/tests/pos/i18529/JCode2.java
@@ -1,0 +1,9 @@
+package bug.code;
+
+import bug.util.*;
+import bug.util.List;
+import java.util.*;
+
+public class JCode2 {
+    public void m1(List<Integer> xs) { return; }
+}

--- a/tests/pos/i18529/List.java
+++ b/tests/pos/i18529/List.java
@@ -1,0 +1,3 @@
+package bug.util;
+
+public final class List<E> {}

--- a/tests/pos/i18529/SCode1.scala
+++ b/tests/pos/i18529/SCode1.scala
@@ -1,0 +1,9 @@
+package bug.code
+
+import bug.util.List
+import bug.util.*
+import java.util.*
+
+class SCode1 {
+  def work(xs: List[Int]): Unit = {}
+}

--- a/tests/pos/i18529/SCode2.scala
+++ b/tests/pos/i18529/SCode2.scala
@@ -1,0 +1,9 @@
+package bug.code
+
+import bug.util.*
+import bug.util.List
+import java.util.*
+
+class SCode2 {
+  def work(xs: List[Int]): Unit = {}
+}

--- a/tests/pos/i18529/Test.scala
+++ b/tests/pos/i18529/Test.scala
@@ -1,0 +1,1 @@
+class Test


### PR DESCRIPTION
When a named import (such as `import bug.util.List`) is defined before
two clashing wildcard imports (`import bug.util.*; import java.util.*`)
the name "List" should resolve to it, rather than a resolution error
being emitted.

This was due to the fact that `findRefRecur` didn't return the
precedence at which it found that import, `checkImportAlternatives` used
the `prevPrec` to `checkNewOrShadowed`.  Now we check against the entire
`foundResult`, allowing an early named import to be picked over later
wildcard imports.

Fixes #18529
