### PR TITLE
Don't point to the compiler backlog when a compiler plugin phase crashes

### DIFF
--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -169,7 +169,7 @@ object report:
       if ctx.phase.isInstanceOf[plugins.PluginPhase]
       then
         s"""|  An unhandled exception was thrown in the compiler plugin named "${ctx.phase.megaPhase}".
-            |  Please file a crash report in the compiler plugin backlog.
+            |  Please report the issue to the plugin's maintainers.
             |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
             |""".stripMargin
       else

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -165,13 +165,23 @@ object report:
       "compiler version"   -> dotty.tools.dotc.config.Properties.versionString,
       "settings"           -> settings.map(showSetting).mkString(" "),
     ))
+    val fileAReportMsg =
+      if ctx.phase.isInstanceOf[plugins.PluginPhase]
+      then
+        s"""|  Please file a crash report in the compiler plugin backlog.
+            |  The name of the compiler plugin which caused the crash is "${ctx.phase.megaPhase}".
+            |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
+            |""".stripMargin
+      else
+        s"""|  Please file a crash report here:
+            |  https://github.com/scala/scala3/issues/new/choose
+            |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
+            |""".stripMargin
     s"""
        |  $errorMessage
        |
        |  An unhandled exception was thrown in the compiler.
-       |  Please file a crash report here:
-       |  https://github.com/scala/scala3/issues/new/choose
-       |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
+       |$fileAReportMsg
        |
        |$info1
        |""".stripMargin

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -168,19 +168,19 @@ object report:
     val fileAReportMsg =
       if ctx.phase.isInstanceOf[plugins.PluginPhase]
       then
-        s"""|  Please file a crash report in the compiler plugin backlog.
-            |  The name of the compiler plugin which caused the crash is "${ctx.phase.megaPhase}".
+        s"""|  An unhandled exception was thrown in the compiler plugin named "${ctx.phase.megaPhase}".
+            |  Please file a crash report in the compiler plugin backlog.
             |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
             |""".stripMargin
       else
-        s"""|  Please file a crash report here:
+        s"""|  An unhandled exception was thrown in the compiler.
+            |  Please file a crash report here:
             |  https://github.com/scala/scala3/issues/new/choose
             |  For non-enriched exceptions, compile with -Xno-enrich-error-messages.
             |""".stripMargin
     s"""
        |  $errorMessage
        |
-       |  An unhandled exception was thrown in the compiler.
        |$fileAReportMsg
        |
        |$info1


### PR DESCRIPTION
closes #21783 