### PR TITLE
Fix #21295: Restrict `provablyDisjoint` with `Nothing`s in invariant type params.

### DIFF
--- a/tests/pos/i21295.scala
+++ b/tests/pos/i21295.scala
@@ -1,0 +1,8 @@
+sealed trait Foo[A]
+final class Bar extends Foo[Nothing]
+
+object Test:
+  type Extract[T] = T match
+    case Foo[_] => Int
+
+  val x: Extract[Bar] = 1


### PR DESCRIPTION
If `Foo[T]` is invariant in `T`, we previously concluded that `Foo[A] ⋔ Foo[B]` from `A ⋔ B`. That is however wrong if both `A` and `B` can be (instantiated to) `Nothing`.

We now rule out these occurrences in two ways:

* either we show that `T` corresponds to a field, like we do in the covariant case, or
* we show that `A` or `B` cannot possibly be `Nothing`.

The second condition is shaky at best. I would have preferred not to include it. However, introducing the former without the fallback on the latter breaks too many existing test cases.