### PR TITLE
Set developedVersion to 3.6.3.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -102,15 +102,15 @@ object Build {
   /** Version of the Scala compiler targeted in the current release cycle
    *  Contains a version without RC/SNAPSHOT/NIGHTLY specific suffixes
    *  Should be updated ONLY after release or cutoff for previous release cycle.
-   *  
-   *  Should only be referred from `dottyVersion` or settings/tasks requiring simplified version string, 
+   *
+   *  Should only be referred from `dottyVersion` or settings/tasks requiring simplified version string,
    *  eg. `compatMode` or Windows native distribution version.
    */
-  val developedVersion = "3.6.2"
+  val developedVersion = "3.6.3"
 
-  /** The version of the compiler including the RC prefix. 
+  /** The version of the compiler including the RC prefix.
    *  Defined as common base before calculating environment specific suffixes in `dottyVersion`
-   * 
+   *
    *  By default, during development cycle defined as `${developedVersion}-RC1`;
    *  During release candidate cycle incremented by the release officer before publishing a subsequent RC version;
    *  During final, stable release is set exactly to `developedVersion`.


### PR DESCRIPTION
 It was decided that 3.6.2 would be the first (official) stable release of the 3.6 series.
 
 3.6.2 would be based on 3.6.0/3.6.1 release but including backported fixes
 3.6.3 is treated as 1st real patch release, it's still being developed in current development cycle.