### PR TITLE
Backport "Improve, document and group versioning code in `Build.scala` " to 3.6.2

### DIFF
--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -14,8 +14,8 @@ on:
   workflow_call:
 
 env:
-  # NECESSARY FLAG TO CORRECTLY CONFIGURE THE VERSION FOR SCALA
-  RELEASEBUILD: yes
+  # Release only happends when triggering CI by pushing tag
+  RELEASEBUILD: ${{ startsWith(github.event.ref, 'refs/tags/') && 'yes' || 'no' }}
 
 jobs:
   build:


### PR DESCRIPTION
Backports #21837 to the 3.6.2 branch.

PR submitted by the release tooling.
[skip ci]