### PR TITLE
Backport "Add minimal set of tests for runner installed from .msi file" to 3.6.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1115,7 +1115,15 @@ jobs:
   build-msi-package:
     uses: ./.github/workflows/build-msi.yml
     if  : github.event_name == 'pull_request' && contains(github.event.pull_request.body, '[test_msi]')
-    # TODO: ADD A JOB THAT DEPENDS ON THIS TO TEST THE MSI
+
+  test-msi-package:
+    uses: ./.github/workflows/test-msi.yml
+    needs: [build-msi-package]
+    with:
+      # Ensure that version starts with prefix 3.
+      # In the future it can be adapted to compare with with git tag or version set in the build.s 
+      version: "3."
+      java-version: 8
 
   build-sdk-package:
     uses: ./.github/workflows/build-sdk.yml

--- a/.github/workflows/test-msi.yml
+++ b/.github/workflows/test-msi.yml
@@ -1,0 +1,77 @@
+###################################################################################################
+###                  THIS IS A REUSABLE WORKFLOW TO TEST SCALA WITH MSI RUNNER                  ###
+### HOW TO USE:                                                                                 ###
+###  Provide optional `version` to test if installed binaries are installed with                ###
+###  correct Scala version.                                                                     ###
+### NOTE: Requires `scala.msi` artifact uploaded within the same run                            ###
+###                                                                                             ###
+###################################################################################################
+
+name: Test 'scala' MSI Package
+run-name: Test 'scala' (${{ inputs.version }}) MSI Package
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      java-version:
+        required: true
+        type    : string
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java-version }}
+      - name: Download MSI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: scala.msi
+          path: .
+
+      # Run the MSI installer
+      # During normal installation msiexec would modify the PATH automatically. 
+      # However, it seems not to work in GH Actions. Append the PATH manually instead.
+      - name: Install Scala Runner
+        shell: pwsh
+        run: |
+          Start-Process 'msiexec.exe' -ArgumentList '/I "scala.msi" /L*V "install.log" /qb' -Wait
+          Get-Content 'install.log'
+          Add-Content $env:GITHUB_PATH "C:\Program Files (x86)\scala\bin"
+
+      # Run tests to ensure the Scala Runner was installed and works
+      - name: Test Scala Runner
+        shell: pwsh
+        run: |
+          scala --version
+          if (-not (scala --version | Select-String "Scala version \(default\): ${{ inputs.version }}")) {
+            Write-Host "Invalid Scala version of MSI installed runner, expected ${{ inputs.version }}"
+            Exit 1
+          }
+      - name : Test the `scalac` command
+        shell: pwsh
+        run: |
+          scalac --version
+          if (-not (scalac --version | Select-String "Scala compiler version ${{ inputs.version }}")) {
+            Write-Host "Invalid scalac version of MSI installed runner, expected ${{ inputs.version }}"
+            Exit 1
+          }
+      - name : Test the `scaladoc` command
+        shell: pwsh
+        run: |
+          scaladoc --version
+          if (-not (scaladoc --version | Select-String "Scaladoc version ${{ inputs.version }}")) {
+            Write-Host "Invalid scaladoc version of MSI installed runner, expected ${{ inputs.version }}"
+            Exit 1
+          }
+      - name : Uninstall the `scala` package
+        shell: pwsh
+        run: |
+          Start-Process 'msiexec.exe' -ArgumentList '/X "scala.msi" /L*V "uninstall.log" /qb' -Wait
+          Get-Content 'uninstall.log'
+        


### PR DESCRIPTION
Backports #21835 to the 3.6.2 branch.

PR submitted by the release tooling.
[skip ci]