### PR TITLE
Backport "Disable automatic release in `publish_release` " to 3.6.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1089,7 +1089,7 @@ jobs:
           asset_content_type: text/plain
 
       - name: Publish Release
-        run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
+        run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleUpload"
 
 
   open_issue_on_failure:
@@ -1121,7 +1121,7 @@ jobs:
     needs: [build-msi-package]
     with:
       # Ensure that version starts with prefix 3.
-      # In the future it can be adapted to compare with with git tag or version set in the build.s 
+      # In the future it can be adapted to compare with with git tag or version set in the project/Build.scala
       version: "3."
       java-version: 8
 


### PR DESCRIPTION
Backports #21873 to the 3.6.2 branch.

PR submitted by the release tooling.
[skip ci]