### PR TITLE
Fix #21914: Don't project nested wildcard patterns to nullable

### DIFF
--- a/tests/patmat/i12530.check
+++ b/tests/patmat/i12530.check
@@ -1,1 +1,2 @@
 6: Match case Unreachable
+14: Match case Unreachable

--- a/tests/patmat/null.check
+++ b/tests/patmat/null.check
@@ -1,4 +1,4 @@
 6: Match case Unreachable
 13: Pattern Match
-18: Match case Unreachable
 20: Pattern Match
+21: Match case Unreachable

--- a/tests/patmat/null.scala
+++ b/tests/patmat/null.scala
@@ -18,5 +18,6 @@ class Test {
     case Some(null)     =>
     case None           =>
     case y              =>
+    case _              =>
   }
 }

--- a/tests/warn/i20121.scala
+++ b/tests/warn/i20121.scala
@@ -5,8 +5,8 @@ case class CC_B[A](a: A) extends T_A[A, X]
 
 val v_a: T_A[X, X] = CC_B(null)
 val v_b = v_a match
-  case CC_B(_) => 0
-  case _       => 1 // warn: null only
+  case CC_B(_) => 0 // warn: unreachable
+  case _       => 1
     // for CC_B[A] to match T_A[X, X]
     // A := X
     // so require X, aka T_A[Byte, Byte]

--- a/tests/warn/i20122.scala
+++ b/tests/warn/i20122.scala
@@ -7,7 +7,7 @@ case class CC_E(a: CC_C[Char, Byte])
 
 val v_a: T_B[Int, CC_A] = CC_B(CC_E(CC_C(null)))
 val v_b = v_a match
-  case CC_B(CC_E(CC_C(_))) => 0
+  case CC_B(CC_E(CC_C(_))) => 0 // warn: unreachable
   case _                   => 1
     // for CC_B[A, C] to match T_B[C, CC_A]
     // C <: Int, ok

--- a/tests/warn/i20123.scala
+++ b/tests/warn/i20123.scala
@@ -8,7 +8,7 @@ case class CC_G[A, C](c: C) extends T_A[A, C]
 val v_a: T_A[Boolean, T_B[Boolean]] = CC_G(null)
 val v_b = v_a match {
   case CC_D()  => 0
-  case CC_G(_) => 1
+  case CC_G(_) => 1 // warn: unreachable
     // for CC_G[A, C] to match T_A[Boolean, T_B[Boolean]]
     // A := Boolean, which is ok
     // C := T_B[Boolean],


### PR DESCRIPTION
Fix #21914

The wildcard patterns are projected to nullable #21850, which increases the running time exponentially for complex patterns, due to the way we simplify and minus spaces. 

However, the current space analyse setup is only able to track nullable value at top level, so we should not project nested wildcard patterns (not at top level) to nullable. 

The warnings in `tests/warn/i20121.scala`, `tests/warn/i20122.scala`, and `tests/warn/i20123.scala` will become wrong again, but there is no simple solution to fix them quickly.

I couldn't create a minimised test for #21914, but I have verified locally the compile time becomes normal again with this fix.