### PR TITLE
Handle old given syntax where identifier and type are seperated by new line

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1010,13 +1010,25 @@ object Parsers {
       skipParams()
       lookahead.isColon
       && {
+        lookahead.nextToken()
         !sourceVersion.isAtLeast(`3.6`)
         || { // in the new given syntax, a `:` at EOL after an identifier represents a single identifier given
              // Example:
              //    given C:
              //      def f = ...
-          lookahead.nextToken()
           !lookahead.isAfterLineEnd
+        } || {
+            // Support for for pre-3.6 syntax where type is put on the next line
+            // Examples:
+            //     given namedGiven:
+            //       X[T] with {}
+            //     given otherGiven:
+            //       X[T] = new X[T]{}
+          lookahead.isIdent && {
+            lookahead.nextToken()
+            skipParams()
+            lookahead.token == WITH || lookahead.token == EQUALS
+          }
         }
       }
 

--- a/tests/pos/i21768.scala
+++ b/tests/pos/i21768.scala
@@ -1,0 +1,12 @@
+
+trait Foo[T]:
+  def foo(v: T): Unit
+
+given myFooOfInt:
+  Foo[Int] with
+  def foo(v: Int): Unit = ???
+
+given myFooOfLong:
+  Foo[Long] = new Foo[Long] {
+    def foo(v: Long): Unit = ???
+  }


### PR DESCRIPTION
Fixes #21768 

Fixes usages of `with {...}` and `= new {}` declarations presented in tests. 
