### PR TITLE
Backport "Refine the bounds of the `Tuple.Filter` type lambda predicate .." to 3.6

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -166,7 +166,7 @@ object Tuple {
    *  ```
    *  @syntax markdown
    */
-  type Filter[Tup <: Tuple, P[_] <: Boolean] <: Tuple = Tup match {
+  type Filter[Tup <: Tuple, P[_ <: Union[Tup]] <: Boolean] <: Tuple = Tup match {
     case EmptyTuple => EmptyTuple
     case h *: t => P[h] match {
       case true => h *: Filter[t, P]

--- a/tests/neg/tuple-filter-compat.scala
+++ b/tests/neg/tuple-filter-compat.scala
@@ -1,0 +1,12 @@
+
+type OldFilter[Tup <: Tuple, P[_] <: Boolean] = Nothing
+type NewFilter[Tup <: Tuple, P[_ <: Tuple.Union[Tup]] <: Boolean] = Nothing
+
+trait A:
+  type X >: OldFilter <: OldFilter
+
+trait B1 extends A:
+  type X = OldFilter // ok
+
+trait B2 extends A:
+  type X = NewFilter // error: breaking change

--- a/tests/pos/tuple-filter.scala
+++ b/tests/pos/tuple-filter.scala
@@ -1,10 +1,16 @@
+import scala.compiletime.ops.int.<
+
 type P[x] <: Boolean = x match {
   case 3 => false
   case _ => true
 }
+
 type RejectAll[x] = false
+
+type Pos[X <: Int] = 0 < X
 
 def Test =
   summon[Tuple.Filter[(1, 2, 3, 4), P] =:= (1, 2, 4)]
   summon[Tuple.Filter[(1, 2, 3, 4), RejectAll] =:= EmptyTuple]
   summon[Tuple.Filter[EmptyTuple, P] =:= EmptyTuple]
+  summon[Tuple.Filter[(1, -2, 3, -4), Pos] =:= (1, 3)]


### PR DESCRIPTION
Backports #21286 to the 3.6.2.

PR submitted by the release tooling.
[skip ci]