### PR TITLE
Backport "Move `NonEmptyTuple` members into `Tuple`" to 3.6

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -31,6 +31,30 @@ sealed trait Tuple extends Product {
   inline def *: [H, This >: this.type <: Tuple] (x: H): H *: This =
     runtime.Tuples.cons(x, this).asInstanceOf[H *: This]
 
+  /** Get the i-th element of this tuple.
+   *  Equivalent to productElement but with a precise return type.
+   */
+  inline def apply[This >: this.type <: Tuple](n: Int): Elem[This, n.type] =
+    runtime.Tuples.apply(this, n).asInstanceOf[Elem[This, n.type]]
+
+  /** Get the head of this tuple */
+  inline def head[This >: this.type <: Tuple]: Head[This] =
+    runtime.Tuples.apply(this, 0).asInstanceOf[Head[This]]
+
+  /** Get the initial part of the tuple without its last element */
+  inline def init[This >: this.type <: Tuple]: Init[This] =
+    runtime.Tuples.init(this).asInstanceOf[Init[This]]
+
+  /** Get the last of this tuple */
+  inline def last[This >: this.type <: Tuple]: Last[This] =
+    runtime.Tuples.last(this).asInstanceOf[Last[This]]
+
+  /** Get the tail of this tuple.
+   *  This operation is O(this.size)
+   */
+  inline def tail[This >: this.type <: Tuple]: Tail[This] =
+    runtime.Tuples.tail(this).asInstanceOf[Tail[This]]
+
   /** Return a new tuple by concatenating `this` tuple with `that` tuple.
    *  This operation is O(this.size + that.size)
    */
@@ -304,33 +328,7 @@ case object EmptyTuple extends Tuple {
 }
 
 /** Tuple of arbitrary non-zero arity */
-sealed trait NonEmptyTuple extends Tuple {
-  import Tuple.*
-
-  /** Get the i-th element of this tuple.
-   *  Equivalent to productElement but with a precise return type.
-   */
-  inline def apply[This >: this.type <: NonEmptyTuple](n: Int): Elem[This, n.type] =
-    runtime.Tuples.apply(this, n).asInstanceOf[Elem[This, n.type]]
-
-  /** Get the head of this tuple */
-  inline def head[This >: this.type <: NonEmptyTuple]: Head[This] =
-    runtime.Tuples.apply(this, 0).asInstanceOf[Head[This]]
-
-  /** Get the initial part of the tuple without its last element */
-  inline def init[This >: this.type <: NonEmptyTuple]: Init[This] =
-    runtime.Tuples.init(this).asInstanceOf[Init[This]]
-
-  /** Get the last of this tuple */
-  inline def last[This >: this.type <: NonEmptyTuple]: Last[This] =
-    runtime.Tuples.last(this).asInstanceOf[Last[This]]
-
-  /** Get the tail of this tuple.
-   *  This operation is O(this.size)
-   */
-  inline def tail[This >: this.type <: NonEmptyTuple]: Tail[This] =
-    runtime.Tuples.tail(this).asInstanceOf[Tail[This]]
-}
+sealed trait NonEmptyTuple extends Tuple
 
 @showAsInfix
 sealed abstract class *:[+H, +T <: Tuple] extends NonEmptyTuple

--- a/library/src/scala/runtime/Tuples.scala
+++ b/library/src/scala/runtime/Tuples.scala
@@ -350,7 +350,7 @@ object Tuples {
     }
   }
 
-  def tail(self: NonEmptyTuple): Tuple = (self: Any) match {
+  def tail(self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlTail(xxl)
     case _ => specialCaseTail(self)
   }
@@ -558,16 +558,16 @@ object Tuples {
     }
   }
 
-  def init(self: NonEmptyTuple): Tuple = (self: Any) match {
+  def init(self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlInit(xxl)
     case _ => specialCaseInit(self)
   }
 
-  def last(self: NonEmptyTuple): Any = (self: Any) match {
+  def last(self: Tuple): Any = (self: Any) match {
     case self: Product => self.productElement(self.productArity - 1)
   }
 
-  def apply(self: NonEmptyTuple, n: Int): Any =
+  def apply(self: Tuple, n: Int): Any =
     self.productElement(n)
 
   // Benchmarks showed that this is faster than doing (it1 zip it2).copyToArray(...)


### PR DESCRIPTION
Backports #21291 to the 3.6.2.

PR submitted by the release tooling.
[skip ci]