### PR TITLE
Backport "Allow autotupling if fn's param is a type param" to 3.6

### DIFF
--- a/tests/pos/i21682.1.scala
+++ b/tests/pos/i21682.1.scala
@@ -1,0 +1,15 @@
+sealed abstract class Gen[+T1]
+given [T2]: Conversion[T2, Gen[T2]] = ???
+
+trait Show[T3]
+given Show[Boolean] = ???
+given [A1: Show, B1: Show, C1: Show]: Show[(A1, B1, C1)] = ???
+
+object ForAll:
+  def apply[A2: Show, B2](f: A2 => B2): Unit = ???
+  def apply[A3: Show, B3: Show, C3](f: (A3, B3) => C3): Unit = ???
+  def apply[A4: Show, B4](gen: Gen[A4])(f: A4 => B4): Unit = ???
+
+@main def Test =
+  ForAll: (b1: Boolean, b2: Boolean, b3: Boolean) =>
+    ???

--- a/tests/pos/i21682.2.scala
+++ b/tests/pos/i21682.2.scala
@@ -1,0 +1,7 @@
+object ForAll:
+  def apply[A1, B](f: A1 => B): Unit = ???
+  def apply[A1, A2, B](f: (A1, A2) => B): Unit = ???
+
+@main def Test =
+  ForAll: (b1: Boolean, b2: Boolean, b3: Boolean) =>
+    ???

--- a/tests/pos/i21682.3.scala
+++ b/tests/pos/i21682.3.scala
@@ -1,0 +1,4 @@
+class Test:
+  def foo[A1 >: (Nothing, Boolean, Nothing) <: (Any, Boolean, Any), B](f: A1 => B): Unit = ???
+  def test(): Unit =
+    val res4 = this.foo((b1: Boolean, b2: Boolean, b3: Boolean) => ???)


### PR DESCRIPTION
Backports #21741 to the 3.6.2.

PR submitted by the release tooling.
[skip ci]