### PR TITLE
Backport "Handle old given syntax where identifier and type are seperated by new line" to 3.6

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1001,6 +1001,18 @@ object Parsers {
              //      def f = ...
           lookahead.nextToken()
           !lookahead.isAfterLineEnd
+        } || {
+            // Support for for pre-3.6 syntax where type is put on the next line
+            // Examples:
+            //     given namedGiven:
+            //       X[T] with {}
+            //     given otherGiven:
+            //       X[T] = new X[T]{}
+          lookahead.isIdent && {
+            lookahead.nextToken()
+            skipParams()
+            lookahead.token == WITH || lookahead.token == EQUALS
+          }
         }
       }
 

--- a/tests/pos/i21768.scala
+++ b/tests/pos/i21768.scala
@@ -1,0 +1,12 @@
+
+trait Foo[T]:
+  def foo(v: T): Unit
+
+given myFooOfInt:
+  Foo[Int] with
+  def foo(v: Int): Unit = ???
+
+given myFooOfLong:
+  Foo[Long] = new Foo[Long] {
+    def foo(v: Long): Unit = ???
+  }


### PR DESCRIPTION
Backports #21957 to the 3.6.2.

PR submitted by the release tooling.
[skip ci]