### PR TITLE
Backport "Warn when named tuples resemble assignments" to 3.6

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1639,8 +1639,6 @@ object desugar {
       if ctx.mode.is(Mode.Type) then
         AppliedTypeTree(ref(defn.NamedTupleTypeRef), namesTuple :: tup :: Nil)
       else
-        if names.length == 1 && ctx.scope.lookup(names.head).is(Flags.Mutable) then
-          report.migrationWarning(AmbiguousNamedTupleAssignment(names.head, elemValues.head), tree.srcPos)
         Apply(
           Apply(
             TypeApply(

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -216,6 +216,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case FinalLocalDefID // errorNumber: 200
   case NonNamedArgumentInJavaAnnotationID // errorNumber: 201
   case QuotedTypeMissingID // errorNumber: 202
+  case AmbiguousNamedTupleAssignmentID // errorNumber: 203
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3343,3 +3343,12 @@ final class QuotedTypeMissing(tpe: Type)(using Context) extends StagingMessage(Q
         |"""
 
 end QuotedTypeMissing
+
+final class AmbiguousNamedTupleAssignment(key: Name, value: untpd.Tree)(using Context) extends SyntaxMsg(AmbiguousNamedTupleAssignmentID):
+  override protected def msg(using Context): String =
+    i"""Ambiguous syntax: this is interpreted as a named tuple with one element,
+      |not as an assignment.
+      |
+      |To assign a value, use curly braces: `{${key} = ${value}}`."""
+  
+  override protected def explain(using Context): String = ""

--- a/tests/pos/21681d.scala
+++ b/tests/pos/21681d.scala
@@ -1,0 +1,16 @@
+def test1() =
+  class Person:
+    def age: Int = ???
+    def age_=(x: Int): Unit = ???
+
+  val person = Person()
+  
+  (person.age = 29) // no warn (interpreted as `person.age_=(29)`)
+
+def test2() =
+  class Person:
+    var age: Int = 28
+
+  val person = Person()
+  
+  (person.age = 29) // no warn (interpreted as `person.age_=(29)`)

--- a/tests/warn/21681.check
+++ b/tests/warn/21681.check
@@ -1,0 +1,7 @@
+-- [E203] Syntax Migration Warning: tests/warn/21681.scala:3:2 ---------------------------------------------------------
+3 |  (age = 29) // warn
+  |  ^^^^^^^^^^
+  |  Ambiguous syntax: this is interpreted as a named tuple with one element,
+  |  not as an assignment.
+  |
+  |  To assign a value, use curly braces: `{age = 29}`.

--- a/tests/warn/21681.scala
+++ b/tests/warn/21681.scala
@@ -1,0 +1,3 @@
+def main() =
+  var age: Int = 28
+  (age = 29) // warn

--- a/tests/warn/21681b.check
+++ b/tests/warn/21681b.check
@@ -1,0 +1,7 @@
+-- [E203] Syntax Migration Warning: tests/warn/21681b.scala:3:2 --------------------------------------------------------
+3 |  (age = 29) // warn
+  |  ^^^^^^^^^^
+  |  Ambiguous syntax: this is interpreted as a named tuple with one element,
+  |  not as an assignment.
+  |
+  |  To assign a value, use curly braces: `{age = 29}`.

--- a/tests/warn/21681b.scala
+++ b/tests/warn/21681b.scala
@@ -1,0 +1,3 @@
+object Test:
+  var age: Int = 28
+  (age = 29) // warn

--- a/tests/warn/21681c.check
+++ b/tests/warn/21681c.check
@@ -1,0 +1,7 @@
+-- [E203] Syntax Migration Warning: tests/warn/21681c.scala:5:2 --------------------------------------------------------
+5 |  (age = 29) // warn
+  |  ^^^^^^^^^^
+  |  Ambiguous syntax: this is interpreted as a named tuple with one element,
+  |  not as an assignment.
+  |
+  |  To assign a value, use curly braces: `{age = 29}`.

--- a/tests/warn/21681c.scala
+++ b/tests/warn/21681c.scala
@@ -1,0 +1,5 @@
+object Test:
+  def age: Int = ???
+  def age_=(x: Int): Unit = ()
+  age = 29
+  (age = 29) // warn

--- a/tests/warn/21770.check
+++ b/tests/warn/21770.check
@@ -1,0 +1,7 @@
+-- [E203] Syntax Migration Warning: tests/warn/21770.scala:5:9 ---------------------------------------------------------
+5 |  f(i => (cache = Some(i))) // warn
+  |         ^^^^^^^^^^^^^^^^^
+  |         Ambiguous syntax: this is interpreted as a named tuple with one element,
+  |         not as an assignment.
+  |
+  |         To assign a value, use curly braces: `{cache = Some(i)}`.

--- a/tests/warn/21770.scala
+++ b/tests/warn/21770.scala
@@ -1,0 +1,5 @@
+def f(g: Int  => Unit) = g(0)
+
+def test = 
+  var cache: Option[Int] = None
+  f(i => (cache = Some(i))) // warn


### PR DESCRIPTION
Backports #21823 to the 3.6.2.

PR submitted by the release tooling.
[skip ci]