### PR TITLE
Backport "fix: reversed wconf parsing order to mirror scala 2" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/WConf.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/WConf.scala
@@ -119,7 +119,7 @@ object WConf:
   def fromSettings(settings: List[String]): Either[List[String], WConf] =
     if (settings.isEmpty) Right(WConf(Nil))
     else
-      val parsedConfs: List[Either[List[String], (List[MessageFilter], Action)]] = settings.map(conf =>
+      val parsedConfs: List[Either[List[String], (List[MessageFilter], Action)]] = settings.reverse.map(conf =>
         val filtersAndAction = conf.split(':')
         if filtersAndAction.length != 2 then Left(List("exactly one `:` expected (<filter>&...&<filter>:<action>)"))
         else

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -89,7 +89,6 @@ class ScalaSettingsTests:
     val nowr = new Diagnostic.Warning("This is a problem.".toMessage, util.NoSourcePosition)
     assertEquals(Action.Silent, sut.action(nowr))
 
-  @Ignore("LTS backport rejected: https://github.com/scala/scala3/pull/18503")
   @Test def `i18367 rightmost WConf flags take precedence over flags to the left`: Unit =
     import reporting.{Action, Diagnostic}
     val sets = new ScalaSettings


### PR DESCRIPTION
Backports #18503 to the LTS branch.

PR submitted by the release tooling.
[skip ci]