### PR TITLE
Allow macro annotations to recover from suspension

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1083,9 +1083,7 @@ class Inliner(val call: tpd.Tree)(using Context):
           hints.nn += i"suspension triggered by macro call to ${sym.showLocated} in ${sym.associatedFile}"
       if suspendable then
         if ctx.settings.YnoSuspendedUnits.value then
-          return ref(defn.Predef_undefined)
-            .withType(ErrorType(em"could not expand macro, suspended units are disabled by -Yno-suspended-units"))
-            .withSpan(splicePos.span)
+          return errorTree(ref(defn.Predef_undefined), em"could not expand macro, suspended units are disabled by -Yno-suspended-units", splicePos)
         else
           ctx.compilationUnit.suspend(hints.nn.toList.mkString(", ")) // this throws a SuspendException
 

--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -127,6 +127,8 @@ object MacroAnnotations:
       //       Replace this case with the nested cases.
       case ex0: InvocationTargetException =>
         ex0.getCause match
+          case ex: CompilationUnit.SuspendException =>
+            throw ex
           case ex: scala.quoted.runtime.StopMacroExpansion =>
             if !ctx.reporter.hasErrors then
               report.error("Macro expansion was aborted by the macro without any errors reported. Macros should issue errors to end-users when aborting a macro expansion with StopMacroExpansion.", annot.tree)
@@ -137,7 +139,7 @@ object MacroAnnotations:
             val stack0 = ex.getStackTrace.takeWhile(_.getClassName != this.getClass().getName())
             val stack = stack0.take(1 + stack0.lastIndexWhere(_.getMethodName == "transform"))
             val msg =
-              em"""Failed to evaluate macro.
+              em"""Failed to evaluate macro annotation '$annot'.
                   |  Caused by ${ex.getClass}: ${if (ex.getMessage == null) "" else ex.getMessage}
                   |    ${stack.mkString("\n    ")}
                   |"""

--- a/tests/neg-macros/annot-crash.check
+++ b/tests/neg-macros/annot-crash.check
@@ -2,7 +2,7 @@
 -- Error: tests/neg-macros/annot-crash/Test_2.scala:1:0 ----------------------------------------------------------------
 1 |@crash // error
   |^^^^^^
-  |Failed to evaluate macro.
+  |Failed to evaluate macro annotation '@crash'.
   |  Caused by class scala.NotImplementedError: an implementation is missing
   |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
   |    crash.transform(Macro_1.scala:7)


### PR DESCRIPTION
This changes makes the execution of the test case in #20353 stable across different run