### PR TITLE
Attempt to beta reduce only if parameters and arguments have same shape

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InlinePatterns.scala
@@ -60,9 +60,11 @@ class InlinePatterns extends MiniPhase:
         template.body match
           case List(ddef @ DefDef(`name`, _, _, _)) =>
             val bindings = new ListBuffer[DefTree]()
-            val expansion1 = BetaReduce.reduceApplication(ddef, argss, bindings)
-            val bindings1 = bindings.result()
-            seq(bindings1, expansion1)
+            BetaReduce.reduceApplication(ddef, argss, bindings) match
+              case Some(expansion1) =>
+                val bindings1 = bindings.result()
+                seq(bindings1, expansion1)
+              case None => tree
           case _ => tree
       case _ => tree
 

--- a/tests/neg/i21952.scala
+++ b/tests/neg/i21952.scala
@@ -1,0 +1,1 @@
+val _ = (new Function[(Int, Int), Int] {def apply(a: Int, b: Int): Int = a * b})(2, 3) // error


### PR DESCRIPTION


It's possible to define Functions with wrong apply methods by hand which will give an error but pass on a function that does fails beta reduction.

Fixes #21952