### PR TITLE
Cancel stale CI executions when CI is re-triggered in the same branch/PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ on:
 # - terminate previous on-push CI run after merging new PR to main 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   DOTTY_CI_RUN: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,14 @@ on:
     - cron: '0 3 * * *'  # Every day at 3 AM
   workflow_dispatch:
 
+# Cancels any in-progress runs within the same group identified by workflow name and GH reference (branch or tag) 
+# For example it would:
+# - terminate previous PR CI execution after pushing more changes to the same PR branch
+# - terminate previous on-push CI run after merging new PR to main 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   DOTTY_CI_RUN: true
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}


### PR DESCRIPTION
Cancels any in-progress runs within the same group identified by workflow name and GH reference (branch or tag) 
For example it would:
- terminate previous PR CI execution after pushing more changes to the same PR branch
- terminate previous on-push CI run after merging new PR to the main 

Motivated by a long CI queue ([taking even up to 10h](https://github.com/scala/scala3/actions/runs/11897305378) ) and limited amount of self-hosted runners. Currently merging PR to main triggers a new on-push CI run (taking ~1.5h) - merging multiple PR in a row schedules a separate CI run (that is probably never going to be investigated if it fails)

The second empty commit shows how cancelation is done. [Previously triggered CI run](https://github.com/WojciechMazur/dotty/actions/runs/11909640484) is cancelled, any enqueued or currently executed jobs are stopped and annotated with message `Canceling since a higher priority waiting request for 'Dotty-refs/pull/21974/merge' exists` 