### PR TITLE
fix: Remove "One of these files" error

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2552,9 +2552,6 @@ object SymDenotations {
                  |  $chosen
                  |and also in
                  |  $f"""
-            if youngest.size > 1 then
-              throw TypeError(em"""${ambiguousFilesMsg(youngest.tail.head)}
-                                  |One of these files should be removed from the classpath.""")
 
             // Warn if one of the older files comes from a different container.
             // In that case picking the youngest file is not necessarily what we want,

--- a/sbt-test/jar-dependencies/jar/a/A.scala
+++ b/sbt-test/jar-dependencies/jar/a/A.scala
@@ -1,0 +1,6 @@
+package example:
+  trait A:
+    def foo: String = ???
+
+package object example extends A:
+  def foo(x: String): String = ???

--- a/sbt-test/jar-dependencies/jar/b/B.scala
+++ b/sbt-test/jar-dependencies/jar/b/B.scala
@@ -1,0 +1,3 @@
+import example.*
+
+@main def main = foo

--- a/sbt-test/jar-dependencies/jar/build.sbt
+++ b/sbt-test/jar-dependencies/jar/build.sbt
@@ -1,0 +1,8 @@
+ThisBuild / organization := "com.example"
+
+lazy val a = project
+
+lazy val b = project
+  .settings(
+    Compile / unmanagedJars += (a / Compile / packageBin).map(Attributed.blank).value
+  )

--- a/sbt-test/jar-dependencies/jar/project/DottyInjectedPlugin.scala
+++ b/sbt-test/jar-dependencies/jar/project/DottyInjectedPlugin.scala
@@ -1,0 +1,12 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion"),
+    scalacOptions ++= List("-Werror", "-Wunused:imports"),
+  )
+}

--- a/sbt-test/jar-dependencies/jar/test
+++ b/sbt-test/jar-dependencies/jar/test
@@ -1,0 +1,3 @@
+# https://github.com/scala/scala3/issues/17394
+
+> b/compile


### PR DESCRIPTION
## Problem
Fixes https://github.com/scala/scala3/issues/21973
Fixes https://github.com/scala/scala3/issues/17394 
Ref https://github.com/sbt/sbt/issues/7726
Ref https://github.com/scala/scala3/pull/7652

Currently the ambiguous symbol detection raises false positives when used together with `-Wunused:imports`. sbt 2.x plugins are running into this bug.

## Solution
Remove the faulty ambiguous symbol detection for now.