### PR TITLE
Setup build for Scala 3.6.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -97,7 +97,7 @@ object Build {
    *  - In release branch it should be the last stable release
    *  3.6.0-RC1 was released as 3.6.0 - it's having and experimental TASTy version
    */
-  val referenceVersion = "3.6.0"
+  val referenceVersion = "3.6.2-RC1"
 
   /** Version of the Scala compiler targeted in the current release cycle
    *  Contains a version without RC/SNAPSHOT/NIGHTLY specific suffixes

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -106,7 +106,7 @@ object Build {
    *  Should only be referred from `dottyVersion` or settings/tasks requiring simplified version string,
    *  eg. `compatMode` or Windows native distribution version.
    */
-  val developedVersion = "3.6.3"
+  val developedVersion = "3.6.4"
 
   /** The version of the compiler including the RC prefix.
    *  Defined as common base before calculating environment specific suffixes in `dottyVersion`


### PR DESCRIPTION
* Set developed version to `3.6.4` - target for next development cycle
* Set reference version to `3.6.2-RC1`
