### PR TITLE
Ignore pushes to branches prefixed with `backport-` in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ on:
       - 'gh-readonly-queue/**'
       - 'release-**'
       - 'lts-**'
+      - 'backport-**'
   pull_request:
   merge_group:
   schedule:


### PR DESCRIPTION
We're going to use a changed branch naming schema for backporting branches in backporting scripts to avoid problems with branch protection rules:
`backport-lts-{pr_number}` instead of `lts-backport-{pr_number}`.
When backporting PRs in a batch we only want to run the build for the last PR in a batch. We don't care about builds for particular branches