### PR TITLE
Backport "Streamline `tryNormalize` with `underlyingMatchType`" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4517,7 +4517,14 @@ object Types extends TypeUtils {
           case MatchAlias(alias) =>
             trace(i"normalize $this", typr, show = true) {
               MatchTypeTrace.recurseWith(this) {
-                alias.applyIfParameterized(args.map(_.normalized)).tryNormalize
+                alias.applyIfParameterized(args).tryNormalize
+                /* `applyIfParameterized` may reduce several HKTypeLambda applications
+                 * before the underlying MatchType is reached.
+                 * Even if they do not involve any match type normalizations yet,
+                 * we still want to record these reductions in the MatchTypeTrace.
+                 * They should however only be attempted if they eventually expand
+                 * to a match type, which is ensured by the `isMatchAlias` guard.
+                 */
               }
             }
           case _ =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4958,11 +4958,7 @@ object Types extends TypeUtils {
     private var reductionContext: util.MutableMap[Type, Type] = _
 
     override def tryNormalize(using Context): Type =
-      try
-        reduced.normalized
-      catch
-        case ex: Throwable =>
-          handleRecursive("normalizing", s"${scrutinee.show} match ..." , ex)
+      reduced.normalized
 
     def reduced(using Context): Type = atPhaseNoLater(elimOpaquePhase) {
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -461,7 +461,7 @@ object Types extends TypeUtils {
     /** Does this application expand to a match type? */
     def isMatchAlias(using Context): Boolean = underlyingNormalizable.isMatch
 
-    def underlyingNormalizable(using Context): Type = stripped match
+    def underlyingNormalizable(using Context): Type = stripped.stripLazyRef match
       case tp: MatchType => tp
       case tp: AppliedType => tp.underlyingNormalizable
       case _ => NoType
@@ -3110,8 +3110,6 @@ object Types extends TypeUtils {
   case class LazyRef(private var refFn: (Context => (Type | Null)) | Null) extends UncachedProxyType with ValueType {
     private var myRef: Type | Null = null
     private var computed = false
-
-    override def tryNormalize(using Context): Type = ref.tryNormalize
 
     def ref(using Context): Type =
       if computed then

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -461,11 +461,6 @@ object Types extends TypeUtils {
     /** Does this application expand to a match type? */
     def isMatchAlias(using Context): Boolean = underlyingNormalizable.isMatch
 
-    def underlyingNormalizable(using Context): Type = stripped.stripLazyRef match
-      case tp: MatchType => tp
-      case tp: AppliedType => tp.underlyingNormalizable
-      case _ => NoType
-
     /** Is this a higher-kinded type lambda with given parameter variances?
      *  These lambdas are used as the RHS of higher-kinded abstract types or
      *  type aliases. The variance info is strictly needed only for abstract types.
@@ -1480,20 +1475,23 @@ object Types extends TypeUtils {
       }
       deskolemizer(this)
 
-    /** The result of normalization using `tryNormalize`, or the type itself if
-     *  tryNormlize yields NoType
-     */
-    final def normalized(using Context): Type = {
-      val normed = tryNormalize
-      if (normed.exists) normed else this
-    }
+    /** The result of normalization, or the type itself if none apply. */
+    final def normalized(using Context): Type = tryNormalize.orElse(this)
 
     /** If this type has an underlying match type or applied compiletime.ops,
      *  then the result after applying all toplevel normalizations, otherwise NoType.
      */
     def tryNormalize(using Context): Type = underlyingNormalizable match
-      case mt: MatchType => mt.tryNormalize
+      case mt: MatchType => mt.reduced.normalized
       case tp: AppliedType => tp.tryCompiletimeConstantFold
+      case _ => NoType
+
+    /** Perform successive strippings, and beta-reductions of applied types until
+     *  a match type or applied compiletime.ops is reached, if any, otherwise NoType.
+     */
+    def underlyingNormalizable(using Context): Type = stripped.stripLazyRef match
+      case tp: MatchType => tp
+      case tp: AppliedType => tp.underlyingNormalizable
       case _ => NoType
 
     private def widenDealias1(keep: AnnotatedType => Context ?=> Boolean)(using Context): Type = {
@@ -4517,9 +4515,10 @@ object Types extends TypeUtils {
         case nil => x
       foldArgs(op(x, tycon), args)
 
-    /** Exists if the tycon is a TypeRef of an alias with an underlying match type.
-     *  Anything else should have already been reduced in `appliedTo` by the TypeAssigner.
-     *  May reduce several HKTypeLambda applications before the underlying MatchType is reached.
+    /** Exists if the tycon is a TypeRef of an alias with an underlying match type,
+     *  or a compiletime applied type. Anything else should have already been
+     *  reduced in `appliedTo` by the TypeAssigner. This may reduce several
+     *  HKTypeLambda applications before the underlying normalizable type is reached.
      */
     override def underlyingNormalizable(using Context): Type =
       if ctx.period != validUnderlyingNormalizable then tycon match
@@ -4957,8 +4956,6 @@ object Types extends TypeUtils {
     private var myReduced: Type | Null = null
     private var reductionContext: util.MutableMap[Type, Type] = _
 
-    override def tryNormalize(using Context): Type =
-      reduced.normalized
 
     def reduced(using Context): Type = atPhaseNoLater(elimOpaquePhase) {
 

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1488,11 +1488,13 @@ object Types extends TypeUtils {
       if (normed.exists) normed else this
     }
 
-    /** If this type can be normalized at the top-level by rewriting match types
-     *  of S[n] types, the result after applying all toplevel normalizations,
-     *  otherwise NoType
+    /** If this type has an underlying match type or applied compiletime.ops,
+     *  then the result after applying all toplevel normalizations, otherwise NoType.
      */
-    def tryNormalize(using Context): Type = NoType
+    def tryNormalize(using Context): Type = underlyingNormalizable match
+      case mt: MatchType => mt.tryNormalize
+      case tp: AppliedType => tp.tryCompiletimeConstantFold
+      case _ => NoType
 
     private def widenDealias1(keep: AnnotatedType => Context ?=> Boolean)(using Context): Type = {
       val res = this.widen.dealias1(keep, keepOpaques = false)
@@ -4532,14 +4534,9 @@ object Types extends TypeUtils {
       cachedUnderlyingNormalizable
 
     override def tryNormalize(using Context): Type =
-      def tryMatchAlias =
-        if isMatchAlias then trace(i"normalize $this", typr, show = true):
-          if MatchTypeTrace.isRecording then
-            MatchTypeTrace.recurseWith(this)(superType.tryNormalize)
-          else
-            underlyingNormalizable.tryNormalize
-        else NoType
-      tryCompiletimeConstantFold.orElse(tryMatchAlias)
+      if isMatchAlias && MatchTypeTrace.isRecording then
+        MatchTypeTrace.recurseWith(this)(superType.tryNormalize)
+      else super.tryNormalize
 
     /** Is this an unreducible application to wildcard arguments?
      *  This is the case if tycon is higher-kinded. This means

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1789,7 +1789,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               case _ => false
             }
 
-        val result = pt match {
+        val result = pt.underlyingNormalizable match {
           case mt: MatchType if isMatchTypeShaped(mt) =>
             typedDependentMatchFinish(tree, sel1, selType, tree.cases, mt)
           case MatchType.InDisguise(mt) if isMatchTypeShaped(mt) =>

--- a/compiler/test/dotc/neg-best-effort-pickling.blacklist
+++ b/compiler/test/dotc/neg-best-effort-pickling.blacklist
@@ -1,0 +1,22 @@
+export-in-extension.scala
+i12456.scala
+i8623.scala
+i1642.scala
+i16696.scala
+constructor-proxy-values.scala
+i9328.scala
+i15414.scala
+i6796.scala
+i14013.scala
+toplevel-cyclic
+curried-dependent-ift.scala
+i17121.scala
+illegal-match-types.scala
+i13780-1.scala
+i20317a.scala
+i11226.scala
+i974.scala
+
+# semantic db generation fails in the first compilation
+i1642.scala
+i15158.scala

--- a/tests/neg/i12049d.check
+++ b/tests/neg/i12049d.check
@@ -1,0 +1,14 @@
+-- [E007] Type Mismatch Error: tests/neg/i12049d.scala:14:52 -----------------------------------------------------------
+14 |val x: M[NotRelevant[Nothing], Relevant[Nothing]] = 2 // error
+   |                                                    ^
+   |                                                  Found:    (2 : Int)
+   |                                                  Required: M[NotRelevant[Nothing], Relevant[Nothing]]
+   |
+   |                                                  Note: a match type could not be fully reduced:
+   |
+   |                                                    trying to reduce  M[NotRelevant[Nothing], Relevant[Nothing]]
+   |                                                    trying to reduce  Relevant[Nothing]
+   |                                                    failed since selector Nothing
+   |                                                    is uninhabited (there are no values of that type).
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i12049d.scala
+++ b/tests/neg/i12049d.scala
@@ -1,0 +1,14 @@
+
+trait A
+trait B
+
+type M[X, Y] = Y match
+  case A => Int
+  case B => String
+
+type Relevant[Z] = Z match
+  case A => B
+type NotRelevant[Z] = Z match
+  case B => A
+
+val x: M[NotRelevant[Nothing], Relevant[Nothing]] = 2 // error

--- a/tests/pos/i20482.scala
+++ b/tests/pos/i20482.scala
@@ -1,0 +1,16 @@
+trait WrapperType[A]
+
+case class Foo[A]()
+
+case class Bar[A]()
+
+type FooToBar[D[_]] = [A] =>> D[Unit] match {
+  case Foo[Unit] => Bar[A]
+}
+
+case class Test()
+object Test {
+  implicit val wrapperType: WrapperType[Bar[Test]] = new WrapperType[Bar[Test]] {}
+}
+
+val test = summon[WrapperType[FooToBar[Foo][Test]]]

--- a/tests/pos/matchtype-unusedArg/A_1.scala
+++ b/tests/pos/matchtype-unusedArg/A_1.scala
@@ -1,0 +1,8 @@
+
+type Rec[X] = X match
+  case Int => Rec[X]
+
+type M[Unused, Y] = Y match
+  case String => Double
+
+def foo[X](d: M[Rec[X], "hi"]) = ???

--- a/tests/pos/matchtype-unusedArg/B_2.scala
+++ b/tests/pos/matchtype-unusedArg/B_2.scala
@@ -1,0 +1,2 @@
+
+def Test = foo[Int](3d) // crash before changes


### PR DESCRIPTION
Backports #20268 to the LTS branch.

PR submitted by the release tooling.
[skip ci]