### PR TITLE
Consider all arguments in Annotations.refersToParamOf

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -73,7 +73,7 @@ object Annotations {
 
     /** Does this annotation refer to a parameter of `tl`? */
     def refersToParamOf(tl: TermLambda)(using Context): Boolean =
-      val args = arguments
+      val args = tpd.allArguments(tree)
       if args.isEmpty then false
       else tree.existsSubTree:
         case id: (Ident | This) => id.tpe.stripped match

--- a/tests/pos/dependent-annot-type-param.scala
+++ b/tests/pos/dependent-annot-type-param.scala
@@ -1,0 +1,5 @@
+class annot[T] extends annotation.Annotation
+class Box[T]()
+def f(x: Int): Int @annot[Box[x.type]] = x
+def test =
+  val foo = f(42)


### PR DESCRIPTION
We should also include type arguments in `Annotations.refersToParamOf`.