### PR TITLE
[ISSUE-#19208] If scaladocs on file protocol don't do SPA routing.

### DIFF
--- a/scaladoc/resources/dotty_res/scripts/ux.js
+++ b/scaladoc/resources/dotty_res/scripts/ux.js
@@ -167,6 +167,11 @@ function attachAllListeners() {
       if (url.origin !== window.location.origin) {
         return;
       }
+      // ISSUE-19208, treat as normal link when lacking HTTP server,
+      // otherwise GET request blocked by CORS protections.
+      if (window.location.protocol.startsWith("file")) {
+        return;
+      }
       if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
         return;
       }


### PR DESCRIPTION
If we detect scaladocs are being served locally
(i.e page on the "file" protocol)
then we let the link click event go back to normal handling.

Otherwise unless a user has allowed pages on the file protocol to access other files
https://github.com/chromium/chromium/blob/b6c23ba2056e65081f8a5bcbf73b176baaa42645/content/public/common/content_switches.cc#L15 for example with the allow-file-access-from-files flag in chrome then SPA routing won't work.

Fixes #19208.