### PR TITLE
Update Scala CLI to 1.5.4 & `coursier` to 2.1.18

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -164,7 +164,7 @@ object Build {
   /** Version of Scala CLI to download */
   val scalaCliLauncherVersion = "1.5.4"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.13"
+  val coursierJarVersion = "2.1.18"
 
   object CompatMode {
     final val BinaryCompatible = 0

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -162,7 +162,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.5.1"
+  val scalaCliLauncherVersion = "1.5.4"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.13"
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.5.4
https://github.com/coursier/coursier/releases/tag/v2.1.18
cc @WojciechMazur 