### PR TITLE
Backport "Make context bounds for poly functions a standard feature" to 3.6

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3492,7 +3492,7 @@ object Parsers {
           val hkparams = typeParamClauseOpt(ParamOwner.Hk)
           val bounds =
             if paramOwner.acceptsCtxBounds then typeAndCtxBounds(name)
-            else if in.featureEnabled(Feature.modularity) && paramOwner == ParamOwner.Type then typeAndCtxBounds(name)
+            else if sourceVersion.isAtLeast(`3.6`) && paramOwner == ParamOwner.Type then typeAndCtxBounds(name)
             else typeBounds()
           TypeDef(name, lambdaAbstract(hkparams, bounds)).withMods(mods)
         }

--- a/tests/pos/contextbounds-for-poly-functions.scala
+++ b/tests/pos/contextbounds-for-poly-functions.scala
@@ -1,6 +1,3 @@
-import scala.language.experimental.modularity
-import scala.language.future
-
 trait Ord[X]:
   def compare(x: X, y: X): Int
   type T

--- a/tests/run/contextbounds-for-poly-functions.scala
+++ b/tests/run/contextbounds-for-poly-functions.scala
@@ -1,6 +1,3 @@
-import scala.language.experimental.modularity
-import scala.language.future
-
 trait Show[X]:
   def show(x: X): String
 


### PR DESCRIPTION
Backports #22019 to the 3.6.2.

PR submitted by the release tooling.
[skip ci]