### PR TITLE
Backport "Update Scala CLI to 1.5.4 (was 1.5.1) & `coursier` to 2.1.18 (was 2.1.13)" to 3.6

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -156,9 +156,9 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.5.1"
+  val scalaCliLauncherVersion = "1.5.4"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.13"
+  val coursierJarVersion = "2.1.18"
 
   object CompatMode {
     final val BinaryCompatible = 0


### PR DESCRIPTION
Backports #22021 to the 3.6.2.

PR submitted by the release tooling.