### PR TITLE
Fix .toTuple insertion

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -145,6 +145,15 @@ class TypeUtils:
       case defn.NamedTuple(_, _) => true
       case _ => false
 
+    def derivesFromNamedTuple(using Context): Boolean = self match
+      case defn.NamedTuple(_, _) => true
+      case tp: MatchType =>
+        tp.bound.derivesFromNamedTuple || tp.reduced.derivesFromNamedTuple
+      case tp: TypeProxy => tp.superType.derivesFromNamedTuple
+      case tp: AndType => tp.tp1.derivesFromNamedTuple || tp.tp2.derivesFromNamedTuple
+      case tp: OrType => tp.tp1.derivesFromNamedTuple && tp.tp2.derivesFromNamedTuple
+      case _ => false
+
     /** Drop all named elements in tuple type */
     def stripNamedTuple(using Context): Type = self.normalized.dealias match
       case defn.NamedTuple(_, vals) =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4641,7 +4641,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         case _: SelectionProto =>
           tree // adaptations for selections are handled in typedSelect
         case _ if ctx.mode.is(Mode.ImplicitsEnabled) && tree.tpe.isValueType =>
-          if tree.tpe.widen.isNamedTupleType && pt.derivesFrom(defn.TupleClass) then
+          if tree.tpe.derivesFromNamedTuple && pt.derivesFrom(defn.TupleClass) then
             readapt(typed(untpd.Select(untpd.TypedSplice(tree), nme.toTuple)))
           else if pt.isRef(defn.AnyValClass, skipRefined = false)
               || pt.isRef(defn.ObjectClass, skipRefined = false)

--- a/tests/pos/named-tuple-downcast.scala
+++ b/tests/pos/named-tuple-downcast.scala
@@ -1,0 +1,20 @@
+type Person = (name: String, age: Int)
+
+val Bob: Person = (name = "Bob", age = 33)
+
+type SI = (String, Int)
+
+def id[X](x: X): X = x
+val x: (String, Int) = Bob
+val y: SI = id(Bob)
+val and: Person & String = ???
+val _: SI = and
+val or: Person | (name: "Bob", age: 33) = ???
+val _: SI = or
+
+class C[P <: Person](p: P):
+  val x: (String, Int) = p
+
+
+
+


### PR DESCRIPTION
SIP 58 postulates an implicit insertion ot `.toTuple` when the target is a tuple and the source is a named tuple. This was previously not fully implemented. The implementation did not follow aliases or upper bounds when deciding whether something was a named tuple. This is fixed in this PR.
