### PR TITLE
Add a check for correct Array shape in quotes.reflect.ClassOfConstant

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2519,7 +2519,17 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
 
     object ClassOfConstant extends ClassOfConstantModule:
       def apply(x: TypeRepr): ClassOfConstant =
-        // TODO check that the type is a valid class when creating this constant or let Ycheck do it?
+        // We only check if the supplied TypeRepr is valid if it contains an Array,
+        // as so far only that Array could cause issues
+        def correctTypeApplicationForArray(typeRepr: TypeRepr): Boolean =
+            val isArray = typeRepr.typeSymbol != dotc.core.Symbols.defn.ArrayClass
+            typeRepr match
+              case AppliedType(_, Nil) => isArray
+              case _ => isArray
+        xCheckMacroAssert(
+          correctTypeApplicationForArray(x),
+          "Illegal empty Array type constructor. Please supply a type parameter."
+        )
         dotc.core.Constants.Constant(x)
       def unapply(constant: ClassOfConstant): Some[TypeRepr] = Some(constant.typeValue)
     end ClassOfConstant

--- a/tests/neg-macros/i21916.check
+++ b/tests/neg-macros/i21916.check
@@ -1,0 +1,15 @@
+
+-- Error: tests/neg-macros/i21916/Test_2.scala:1:33 --------------------------------------------------------------------
+1 |@main def Test: Unit = Macro.test() // error
+  |                       ^^^^^^^^^^^^
+  |                   Exception occurred while executing macro expansion.
+  |                   java.lang.AssertionError: Illegal empty Array type constructor. Please supply a type parameter.
+  |                   	at Macro$.testImpl(Macro_1.scala:8)
+  |
+  |---------------------------------------------------------------------------------------------------------------------
+  |Inline stack trace
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  |This location contains code that was inlined from Macro_1.scala:3
+3 |  inline def test() = ${testImpl}
+  |                      ^^^^^^^^^^^
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i21916/Macro_1.scala
+++ b/tests/neg-macros/i21916/Macro_1.scala
@@ -1,0 +1,9 @@
+import scala.quoted._
+object Macro:
+  inline def test() = ${testImpl}
+  def testImpl(using Quotes): Expr[Any] = {
+    import quotes.reflect._
+    val tpe = TypeRepr.of[Array[Byte]] match
+      case AppliedType(tycons, _) => tycons
+    Literal(ClassOfConstant(tpe)).asExpr
+  }

--- a/tests/neg-macros/i21916/Test_2.scala
+++ b/tests/neg-macros/i21916/Test_2.scala
@@ -1,0 +1,1 @@
+@main def Test: Unit = Macro.test() // error


### PR DESCRIPTION
Closes #21916
I tried to supply the ClassOfConstant with multiple other broken Types, but I was unable to break it beyond the linked issue, so I ended up adding the check for only that one case. This makes sense - the backend (and thus erasure) needs to know if the Array type parameter is a primitive type, but in other cases the erasure phase needs to know only the type constructor.

It's impossible to call classOf through the quoted code (`'{classOf[t]}` with a boundless t will error out), so we don't need that additional check there.

There does appear to be an issue with being able to set `'{List[Array]}` resulting in a crash, but that is beyond the scope of this fix - I will prepare a separate issue for that.
