### PR TITLE
Do not lift annotation arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -144,7 +144,7 @@ trait TreeInfo[T <: Untyped] { self: Trees.Instance[T] =>
   def allTermArguments(tree: Tree): List[Tree] = unsplice(tree) match {
     case Apply(fn, args) => allTermArguments(fn) ::: args
     case TypeApply(fn, args) => allTermArguments(fn)
-    case Block(_, expr) => allTermArguments(expr)
+    case Block(Nil, expr) => allTermArguments(expr)
     case _ => Nil
   }
 
@@ -152,7 +152,7 @@ trait TreeInfo[T <: Untyped] { self: Trees.Instance[T] =>
   def allArguments(tree: Tree): List[Tree] = unsplice(tree) match {
     case Apply(fn, args) => allArguments(fn) ::: args
     case TypeApply(fn, args) => allArguments(fn) ::: args
-    case Block(_, expr) => allArguments(expr)
+    case Block(Nil, expr) => allArguments(expr)
     case _ => Nil
   }
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -1124,7 +1124,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     def recur(t: untpd.Tree): Text = t match
       case Apply(fn, Nil) => recur(fn)
       case Apply(fn, args) =>
-        val explicitArgs = args.filterNot(_.symbol.name.is(DefaultGetterName))
+        val explicitArgs = args.filterNot(untpd.stripNamedArg(_).symbol.name.is(DefaultGetterName))
         recur(fn) ~ "(" ~ toTextGlobal(explicitArgs, ", ") ~ ")"
       case TypeApply(fn, args) => recur(fn) ~ "[" ~ toTextGlobal(args, ", ") ~ "]"
       case Select(qual, nme.CONSTRUCTOR) => recur(qual)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -513,7 +513,7 @@ trait Applications extends Compatibility {
         case tp => args.size
       }
 
-      !isJavaAnnotConstr(methRef.symbol) &&
+      !isAnnotConstr(methRef.symbol) &&
       args.size < requiredArgNum(funType)
     }
 
@@ -661,6 +661,11 @@ trait Applications extends Compatibility {
     /** Is `sym` a constructor of a Java-defined annotation? */
     def isJavaAnnotConstr(sym: Symbol): Boolean =
       sym.is(JavaDefined) && sym.isConstructor && sym.owner.is(JavaAnnotation)
+
+
+    /** Is `sym` a constructor of an annotation? */
+    def isAnnotConstr(sym: Symbol): Boolean =
+      sym.isConstructor && sym.owner.isAnnotation
 
     /** Match re-ordered arguments against formal parameters
      *  @param n   The position of the first parameter in formals in `methType`.

--- a/tests/printing/dependent-annot-default-args.check
+++ b/tests/printing/dependent-annot-default-args.check
@@ -1,0 +1,25 @@
+[[syntax trees at end of                     typer]] // tests/printing/dependent-annot-default-args.scala
+package <empty> {
+  class annot(x: Any, y: Any) extends annotation.Annotation() {
+    private[this] val x: Any
+    private[this] val y: Any
+  }
+  final lazy module val annot: annot = new annot()
+  final module class annot() extends AnyRef() { this: annot.type =>
+    def $lessinit$greater$default$2: Any @uncheckedVariance = 42
+  }
+  final lazy module val dependent-annot-default-args$package:
+    dependent-annot-default-args$package =
+    new dependent-annot-default-args$package()
+  final module class dependent-annot-default-args$package() extends Object() {
+    this: dependent-annot-default-args$package.type =>
+    def f(x: Int): Int @annot(x) = x
+    def test: Unit =
+      {
+        val y: Int = ???
+        val z: Int @annot(y) = f(y)
+        ()
+      }
+  }
+}
+

--- a/tests/printing/dependent-annot-default-args.scala
+++ b/tests/printing/dependent-annot-default-args.scala
@@ -1,0 +1,5 @@
+class annot(x: Any, y: Any = 42) extends annotation.Annotation
+def f(x: Int): Int @annot(x) = x
+def test =
+  val y: Int = ???
+  val z = f(y)


### PR DESCRIPTION
When typing

```scala
class Fork(value: Int = -1, jvmArgs: Array[String] = Array("nope")) extends annotation.Annotation
@Fork(jvmArgs = Array("I'm", "hot")) class Test() extends Object() {}
```

the annotation arguments are currently lifted, so that the annotation tree of `@Fork(jvmArgs = Array("I'm", "hot")) ` becomes:

```scala
{
  val jvmArgs$1: Array[String] = Array.apply[String](["I\'m","hot" : String]*)(scala.reflect.ClassTag.apply[String](classOf[String]))
  val value$1: Int @uncheckedVariance = Fork.$lessinit$greater$default$1
  new Fork(value$1, jvmArgs = jvmArgs$1)
}
```

This breaks the assumption that annotation trees are always of the form `new annot(…)`.

It's currently worked around in `allTermArguments` where we ignore block statements:

https://github.com/scala/scala3/blob/0afabd6e5a506cc833ff01d3000cc8f206ba8255/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala#L144-L148

This however falls short in different situations; as this completely ignore argument trees.

---

To fix this, I propose to not lift argument that are annotation arguments.

There is precedent for this: we actually already do it for Java annotations:

https://github.com/scala/scala3/blob/0afabd6e5a506cc833ff01d3000cc8f206ba8255/compiler/src/dotty/tools/dotc/typer/Applications.scala#L502-L518