### PR TITLE
Add tighter bounds on `AnyNamedTuple`

### DIFF
--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -11,7 +11,7 @@ object NamedTuple:
   opaque type NamedTuple[N <: Tuple, +V <: Tuple] >: V <: AnyNamedTuple = V
 
   /** A type which is a supertype of all named tuples */
-  opaque type AnyNamedTuple = Any
+  opaque type AnyNamedTuple >: Tuple <: Product = Product
 
   def apply[N <: Tuple, V <: Tuple](x: V): NamedTuple[N, V] = x
 


### PR DESCRIPTION
`AnyNamedTuple` should have a `Tuple` lower bound and a `Product` upper-bound