### PR TITLE
Do not lift annotation arguments (bis)

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -963,6 +963,8 @@ trait Applications extends Compatibility {
                 case (arg: NamedArg, _) => arg
                 case (arg, name)        => NamedArg(name, arg)
               }
+          else if isAnnotConstr(methRef.symbol) then
+            typedArgs
           else if !sameSeq(args, orderedArgs) && !typedArgs.forall(isSafeArg) then
             // need to lift arguments to maintain evaluation order in the
             // presence of argument reorderings.

--- a/tests/printing/dependent-annot-default-args.check
+++ b/tests/printing/dependent-annot-default-args.check
@@ -8,16 +8,39 @@ package <empty> {
   final module class annot() extends AnyRef() { this: annot.type =>
     def $lessinit$greater$default$2: Any @uncheckedVariance = 42
   }
+  class annot2(x: Any, y: Array[Any]) extends annotation.Annotation() {
+    private[this] val x: Any
+    private[this] val y: Array[Any]
+  }
+  final lazy module val annot2: annot2 = new annot2()
+  final module class annot2() extends AnyRef() { this: annot2.type =>
+    def $lessinit$greater$default$1: Any @uncheckedVariance = -1
+    def $lessinit$greater$default$2: Array[Any] @uncheckedVariance =
+      Array.apply[Any](["Hello" : Any]*)(scala.reflect.ClassTag.Any)
+  }
   final lazy module val dependent-annot-default-args$package:
     dependent-annot-default-args$package =
     new dependent-annot-default-args$package()
   final module class dependent-annot-default-args$package() extends Object() {
     this: dependent-annot-default-args$package.type =>
     def f(x: Int): Int @annot(x) = x
+    def f2(x: Int):
+      Int @annot2(
+        y = Array.apply[Any](["Hello",x : Any]*)(scala.reflect.ClassTag.Any))
+     = x
     def test: Unit =
       {
         val y: Int = ???
         val z: Int @annot(y) = f(y)
+        val z2:
+          Int @annot2(
+            y = Array.apply[Any](["Hello",y : Any]*)(scala.reflect.ClassTag.Any)
+            )
+         = f2(y)
+        @annot(44) val z3: Int = 45
+        @annot2(
+          y = Array.apply[Any](["Hello",y : Any]*)(scala.reflect.ClassTag.Any))
+          val z4: Int = 45
         ()
       }
   }

--- a/tests/printing/dependent-annot-default-args.scala
+++ b/tests/printing/dependent-annot-default-args.scala
@@ -1,5 +1,15 @@
 class annot(x: Any, y: Any = 42) extends annotation.Annotation
+class annot2(x: Any = -1, y: Array[Any] = Array("Hello")) extends annotation.Annotation
+
 def f(x: Int): Int @annot(x) = x
+def f2(x: Int): Int @annot2(y = Array("Hello", x)) = x
+
 def test =
   val y: Int = ???
+
   val z = f(y)
+  val z2 = f2(y)
+
+  @annot(44) val z3 = 45
+  @annot2(y = Array("Hello", y)) val z4 = 45
+


### PR DESCRIPTION
Completing #22035, we also need to special case `TypedApply`.

However, we don't systemically create `NamedArgs` there if the annotation is not a Java annotation, hence the two sperate cases.