### PR TITLE
Restore execution of parallel backend tests

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -262,7 +262,6 @@ class CompilationTests {
   }
 
   // parallel backend tests
-  @Ignore("Temporarily disabled due to frequent timeouts")
   @Test def parallelBackend: Unit = {
     given TestGroup = TestGroup("parallelBackend")
     val parallelism = Runtime.getRuntime().availableProcessors().min(16)


### PR DESCRIPTION
Restores parallel backend tests fixed in https://github.com/scala/scala3/pull/19298