### PR TITLE
Fix nightly build by updating a named tuple test with language import

### DIFF
--- a/tests/pos/named-tuple-downcast.scala
+++ b/tests/pos/named-tuple-downcast.scala
@@ -1,3 +1,5 @@
+import scala.language.experimental.namedTuples
+
 type Person = (name: String, age: Int)
 
 val Bob: Person = (name = "Bob", age = 33)


### PR DESCRIPTION
Because of the change from #22045, the test `tests/pos/named-tuple-downcast.scala` from #22028 need to be updated with `import scala.language.experimental.namedTuples`.

Fix #22058