### PR TITLE
Backport "Bump redcarpet from 3.5.1 to 3.6.0 in /docs/_spec" to LTS

### DIFF
--- a/docs/_spec/Gemfile
+++ b/docs/_spec/Gemfile
@@ -5,4 +5,4 @@ gem "jekyll", "3.6.3"
 gem "webrick"
 gem "rouge"
 # gem 's3_website'
-gem "redcarpet", "3.5.1"
+gem "redcarpet", "3.6.0"

--- a/docs/_spec/Gemfile.lock
+++ b/docs/_spec/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
+    redcarpet (3.6.0)
     rouge (2.2.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -49,7 +49,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (= 3.6.3)
-  redcarpet (= 3.5.1)
+  redcarpet (= 3.6.0)
   rouge
   webrick
 


### PR DESCRIPTION
Backports #21231 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]