### PR TITLE
Backport "Fix #20897: Make `Nothing ⋔ Nothing`, as per spec." to LTS

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.blacklist
+++ b/compiler/test/dotc/pos-test-pickling.blacklist
@@ -57,6 +57,7 @@ i15158.scala
 i15155.scala
 i15827.scala
 i18211.scala
+i20897.scala
 
 # Opaque type
 i5720.scala
@@ -112,4 +113,3 @@ i15525.scala
 i19955a.scala
 i19955b.scala
 i20053b.scala
-

--- a/tests/pos/i20897.scala
+++ b/tests/pos/i20897.scala
@@ -1,0 +1,10 @@
+object Test:
+  type Disj[A, B] =
+    A match
+      case B => true
+      case _ => false
+
+  def f(a: Disj[1 | Nothing, 2 | Nothing]): Unit = ()
+
+  val t = f(false)
+end Test


### PR DESCRIPTION
Backports #21241 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]