### PR TITLE
Backport "fix: don't add suffix if brackets already present" to LTS

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -65,6 +65,10 @@ class Completions(
        */
       case (fun) :: (appl: GenericApply) :: _ if appl.fun == fun =>
         false
+      /* In case of `T@@[]` we should not add snippets.
+       */
+      case tpe :: (appl: AppliedTypeTree) :: _ if appl.tpt == tpe =>
+        false
       case _ :: (withcursor @ Select(fun, name)) :: (appl: GenericApply) :: _
           if appl.fun == withcursor && name.decoded == Cursor.value =>
         false

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSnippetSuite.scala
@@ -451,3 +451,34 @@ class CompletionSnippetSuite extends BaseCompletionSuite:
       """.stripMargin,
       filter = _.contains("bar: Int")
     )
+
+  @Test def `brackets-already-present` =
+    check(
+      """|package a
+         |case class AAA[T]()
+         |object O {
+         |  val l: AA@@[Int] = ???
+         |}
+         |""".stripMargin,
+      """|AAA a
+         |ArrowAssoc scala.Predef
+         |""".stripMargin,
+    )
+
+  @Test def `brackets-already-present-edit` =
+    checkEdit(
+      """|package a
+         |case class AAA[T]()
+         |object O {
+         |  val l: AA@@[Int] = ???
+         |}
+         |""".stripMargin,
+      """|package a
+         |case class AAA[T]()
+         |object O {
+         |  val l: AAA[Int] = ???
+         |}
+         |""".stripMargin,
+      assertSingleItem = false,
+    )
+


### PR DESCRIPTION
Backports #21259 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]