### PR TITLE
Fix LTS: Revert partially changes made in #21992

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
@@ -135,11 +135,7 @@ class CodeGen(val int: DottyBackendInterface, val primitives: DottyPrimitives)( 
       ctx.withIncCallback: cb =>
         if isLocal then
           cb.generatedLocalClass(sourceFile, clsFile.jpath)
-        else if !cb.enabled() then
-          // callback is not enabled, so nonLocalClasses were not reported in ExtractAPI
-          val fullClassName = atPhase(sbtExtractDependenciesPhase) {
-            ExtractDependencies.classNameAsString(claszSymbol)
-          }
+        else 
           cb.generatedNonLocalClass(sourceFile, clsFile.jpath, className, fullClassName)
     }
   }


### PR DESCRIPTION
PR #21992 was merged without executing tests and broke the lts branch CI. 
 These should not be include in the LTS becouse chnges to ExtractDependencies were not yet backported. Keep sbt tests
 
 Unblocks #22094 and #22095