### PR TITLE
Fix #22051: only trust the type application part for case class unapplies

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -56,7 +56,7 @@ object TypeTestsCasts {
    *  9. if `X` is `T1 | T2`, checkable(T1, P) && checkable(T2, P).
    *  10. otherwise, ""
    */
-  def whyUncheckable(X: Type, P: Type, span: Span)(using Context): String = atPhase(Phases.refchecksPhase.next) {
+  def whyUncheckable(X: Type, P: Type, span: Span, trustTypeApplication: Boolean)(using Context): String = atPhase(Phases.refchecksPhase.next) {
     extension (inline s1: String) inline def &&(inline s2: String): String = if s1 == "" then s2 else s1
     extension (inline b: Boolean) inline def |||(inline s: String): String = if b then "" else s
 
@@ -143,7 +143,7 @@ object TypeTestsCasts {
           case defn.ArrayOf(tpE)   => recur(tpE, tpT)
           case _                   => recur(defn.AnyType, tpT)
         }
-      case tpe @ AppliedType(tycon, targs)     =>
+      case tpe @ AppliedType(tycon, targs) if !trustTypeApplication =>
         X.widenDealias match {
           case OrType(tp1, tp2) =>
             // This case is required to retrofit type inference,
@@ -366,8 +366,7 @@ object TypeTestsCasts {
         if (sym.isTypeTest) {
           val argType = tree.args.head.tpe
           val isTrusted = tree.hasAttachment(PatternMatcher.TrustedTypeTestKey)
-          if !isTrusted then
-            checkTypePattern(expr.tpe, argType, expr.srcPos)
+          checkTypePattern(expr.tpe, argType, expr.srcPos, isTrusted)
           transformTypeTest(expr, argType,
             flagUnrelated = enclosingInlineds.isEmpty) // if test comes from inlined code, dont't flag it even if it always false
         }
@@ -392,10 +391,10 @@ object TypeTestsCasts {
   def checkBind(tree: Bind)(using Context) =
     checkTypePattern(defn.ThrowableType, tree.body.tpe, tree.srcPos)
 
-  private def checkTypePattern(exprTpe: Type, castTpe: Type, pos: SrcPos)(using Context) =
+  private def checkTypePattern(exprTpe: Type, castTpe: Type, pos: SrcPos, trustTypeApplication: Boolean = false)(using Context) =
     val isUnchecked = exprTpe.widenTermRefExpr.hasAnnotation(defn.UncheckedAnnot)
     if !isUnchecked then
-      val whyNot = whyUncheckable(exprTpe, castTpe, pos.span)
+      val whyNot = whyUncheckable(exprTpe, castTpe, pos.span, trustTypeApplication)
       if whyNot.nonEmpty then
         report.uncheckedWarning(UncheckedTypePattern(castTpe, whyNot), pos)
 

--- a/tests/neg/i22051.scala
+++ b/tests/neg/i22051.scala
@@ -1,0 +1,19 @@
+//> using options -Werror
+
+def boundary[T](body: (T => RuntimeException) => T): T =
+  case class Break(value: T) extends RuntimeException
+  try body(Break.apply)
+  catch case Break(t) => t // error: pattern matching on local classes is unsound currently
+
+def test =
+  boundary[Int]: EInt =>
+    val v: String = boundary[String]: EString =>
+      throw EInt(3)
+    v.length // a runtime error: java.lang.ClassCastException
+
+def boundaryCorrectBehaviour[T](body: (T => RuntimeException) => T): T =
+  object local:
+    // A correct implementation, but is still treated as a local class right now
+    case class Break(value: T) extends RuntimeException
+  try body(local.Break.apply)
+  catch case local.Break(t) => t // error

--- a/tests/warn/i22051.scala
+++ b/tests/warn/i22051.scala
@@ -1,9 +1,7 @@
-//> using options -Werror
-
 def boundary[T](body: (T => RuntimeException) => T): T =
   case class Break(value: T) extends RuntimeException
   try body(Break.apply)
-  catch case Break(t) => t // error: pattern matching on local classes is unsound currently
+  catch case Break(t) => t // warn: pattern matching on local classes is unsound currently
 
 def test =
   boundary[Int]: EInt =>
@@ -16,4 +14,4 @@ def boundaryCorrectBehaviour[T](body: (T => RuntimeException) => T): T =
     // A correct implementation, but is still treated as a local class right now
     case class Break(value: T) extends RuntimeException
   try body(local.Break.apply)
-  catch case local.Break(t) => t // error
+  catch case local.Break(t) => t // warn


### PR DESCRIPTION
Although the current local class implementation is still unsound, this PR should bring back the warning.

Fix #22051

```scala
def boundary[T](body: (T => RuntimeException) => T): T =
  case class Break(value: T) extends RuntimeException
  try body(Break.apply)
  catch case Break(t) => t // error: pattern matching on local classes is unsound currently

def test =
  boundary[Int]: EInt =>
    val v: String = boundary[String]: EString =>
      throw EInt(3)
    v.length // a runtime error: java.lang.ClassCastException
```

```scala
-- [E092] Pattern Match Unchecked Warning: tests/neg/i22051.scala:6:13 ---------
6 |  catch case Break(t) => t // error: pattern matching on local classes is unsound currently
  |             ^
  |the type test for Break cannot be checked at runtime because it's a local class
  |
  | longer explanation available when compiling with `-explain`
```