### PR TITLE
Add test cases project for presentation compiler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ val `dist-linux-aarch64` = Build.`dist-linux-aarch64`
 val `community-build` = Build.`community-build`
 val `sbt-community-build` = Build.`sbt-community-build`
 val `scala3-presentation-compiler` = Build.`scala3-presentation-compiler`
+val `scala3-presentation-compiler-testcases` = Build.`scala3-presentation-compiler-testcases`
 
 val sjsSandbox = Build.sjsSandbox
 val sjsJUnitTests = Build.sjsJUnitTests

--- a/presentation-compiler-testcases/src/tests/macros/20560.scala
+++ b/presentation-compiler-testcases/src/tests/macros/20560.scala
@@ -1,0 +1,16 @@
+package tests.macros
+
+import scala.quoted.{Expr, Quotes}
+
+object Macro20560:
+  transparent inline def loadJavaSqlDriver: Int = ${ loadJavaSqlDriverImpl }
+
+  private def loadJavaSqlDriverImpl(using Quotes): Expr[42] =
+    Class.forName("java.sql.Driver")
+    '{42}
+
+  transparent inline def loadJavaSqlInexisting: Int = ${ loadJavaSqlInexistingImpl }
+
+  private def loadJavaSqlInexistingImpl(using Quotes): Expr[42] =
+    Class.forName("java.sql.Inexisting")
+    '{42}

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -25,9 +25,9 @@ import org.junit.runner.RunWith
 import scala.meta.pc.CompletionItemPriority
 
 object TestResources:
-  val scalaLibrary = BuildInfo.ideTestsDependencyClasspath.map(_.toPath).toSeq
+  val classpath = BuildInfo.ideTestsDependencyClasspath.map(_.toPath).toSeq
   val classpathSearch =
-    ClasspathSearch.fromClasspath(scalaLibrary, ExcludedPackagesHandler.default)
+    ClasspathSearch.fromClasspath(classpath, ExcludedPackagesHandler.default)
 
 @RunWith(classOf[ReusableClassRunner])
 abstract class BasePCSuite extends PcAssertions:
@@ -38,11 +38,11 @@ abstract class BasePCSuite extends PcAssertions:
   val executorService: ScheduledExecutorService =
     Executors.newSingleThreadScheduledExecutor()
   val testingWorkspaceSearch = TestingWorkspaceSearch(
-    TestResources.scalaLibrary.map(_.toString)
+    TestResources.classpath.map(_.toString)
   )
 
   lazy val presentationCompiler: PresentationCompiler =
-    val myclasspath: Seq[Path] = TestResources.scalaLibrary
+    val myclasspath: Seq[Path] = TestResources.classpath
     val scalacOpts = scalacOptions(myclasspath)
     val search = new MockSymbolSearch(
       testingWorkspaceSearch,

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -596,6 +596,21 @@ class HoverTermSuite extends BaseHoverSuite:
         |""".stripMargin
     )
 
+  @Test def `i20560`=
+    check(
+      "val re@@s = tests.macros.Macro20560.loadJavaSqlDriver",
+      """```scala
+        |val res: Int
+        |```
+        |""".stripMargin
+    )
+
+  @Test def `i20560-2`=
+    check(
+      "val re@@s = tests.macros.Macro20560.loadJavaSqlInexisting",
+      "", // crashes in the Macro; no type info
+    )
+
   @Test def `import-rename` =
     check(
       """

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1425,7 +1425,7 @@ object Build {
 
   lazy val `scala3-presentation-compiler` = project.in(file("presentation-compiler"))
     .withCommonSettings(Bootstrapped)
-    .dependsOn(`scala3-compiler-bootstrapped`, `scala3-library-bootstrapped`)
+    .dependsOn(`scala3-compiler-bootstrapped`, `scala3-library-bootstrapped`, `scala3-presentation-compiler-testcases`)
     .settings(presentationCompilerSettings)
     .settings(scala3PresentationCompilerBuildInfo)
     .settings(
@@ -1436,6 +1436,7 @@ object Build {
   def scala3PresentationCompilerBuildInfo =
     Seq(
       ideTestsDependencyClasspath := {
+        val testCasesLib = (`scala3-presentation-compiler-testcases` / Compile / classDirectory).value
         val dottyLib = (`scala3-library-bootstrapped` / Compile / classDirectory).value
         val scalaLib =
           (`scala3-library-bootstrapped` / Compile / dependencyClasspath)
@@ -1443,7 +1444,7 @@ object Build {
             .map(_.data)
             .filter(_.getName.matches("scala-library.*\\.jar"))
             .toList
-        dottyLib :: scalaLib
+        testCasesLib :: dottyLib :: scalaLib
         // Nil
       },
       Compile / buildInfoPackage := "dotty.tools.pc.buildinfo",
@@ -1502,6 +1503,10 @@ object Build {
       }.taskValue,
     )
   }
+
+  lazy val `scala3-presentation-compiler-testcases` = project.in(file("presentation-compiler-testcases"))
+    .dependsOn(`scala3-compiler-bootstrapped`)
+    .settings(commonBootstrappedSettings)
 
   lazy val `scala3-language-server` = project.in(file("language-server")).
     dependsOn(dottyCompiler(Bootstrapped)).


### PR DESCRIPTION
This PR adds a mechanism to test the presentation compiler with snippets using arbitrary pre-compiled files. To do so, it adds a new project `scala3-presentation-compiler-testcases`, compiled with the bootstrapped compiler, which is used as a dependency of `scala3-presentation-compiler`. The resulting class path is added to the `ideTestsDependencyClasspath` build info so that the test cases can be used from the presentation compiler tests.

This PR also adds a test case for #20560. It shows that there is no hover info for the resulting type of a `transparent inline` macro when it fails to execute. However, the macro succeeds when loading the class `java.sql.Driver`, so that still doesn't tell us what the problem is with #20560…