### PR TITLE
Do not return java outline dummy constructor in `primaryConstructor`

### DIFF
--- a/tests/run-macros/i20052.check
+++ b/tests/run-macros/i20052.check
@@ -1,0 +1,5 @@
+method <init> (Flags.JavaDefined | Flags.Method) List(List((x$0,scala.Int)))
+method <init> (Flags.JavaDefined | Flags.Method) List(List())
+method <init> (Flags.JavaDefined | Flags.Method | Flags.Private) List(List())
+method <init> (Flags.JavaDefined | Flags.Method | Flags.Private) List(List())
+method <init> (Flags.JavaDefined | Flags.Method) List(List((A,_ >: scala.Nothing <: <special-ops>.<FromJavaObject>)), List((x$0,A)))

--- a/tests/run-macros/i20052/JavaClass.java
+++ b/tests/run-macros/i20052/JavaClass.java
@@ -1,0 +1,4 @@
+public class JavaClass {
+  public JavaClass(int a) {}
+  public JavaClass(float a) {}
+}

--- a/tests/run-macros/i20052/JavaClassEmpty.java
+++ b/tests/run-macros/i20052/JavaClassEmpty.java
@@ -1,0 +1,1 @@
+public class JavaClassEmpty {}

--- a/tests/run-macros/i20052/JavaClassParam.java
+++ b/tests/run-macros/i20052/JavaClassParam.java
@@ -1,0 +1,3 @@
+public class JavaClassParam<A> {
+  public JavaClassParam(A a) {}
+}

--- a/tests/run-macros/i20052/JavaClassPrivate.java
+++ b/tests/run-macros/i20052/JavaClassPrivate.java
@@ -1,0 +1,3 @@
+class JavaClassPrivate {
+  private JavaClassPrivate() {}
+}

--- a/tests/run-macros/i20052/JavaClassStartsWithPrivate.java
+++ b/tests/run-macros/i20052/JavaClassStartsWithPrivate.java
@@ -1,0 +1,4 @@
+class JavaClassStartsWithPrivate {
+  private JavaClassStartsWithPrivate() {}
+  public JavaClassStartsWithPrivate(int a) {}
+}

--- a/tests/run-macros/i20052/Macro.scala
+++ b/tests/run-macros/i20052/Macro.scala
@@ -1,0 +1,16 @@
+import scala.quoted.*
+
+object Macro {
+  inline def logPrimaryConstructor[A]: String = ${ logPrimaryConstructorImpl[A] }
+
+  def logPrimaryConstructorImpl[A](using Type[A], Quotes): Expr[String] = {
+    import quotes.reflect.*
+
+    val primaryConstructor = TypeRepr.of[A].typeSymbol.primaryConstructor
+    val flags = primaryConstructor.flags.show
+    val paramSymss = primaryConstructor.paramSymss
+    val clauses = paramSymss.map(_.map(param => (param.name, TypeRepr.of[A].memberType(param).show)))
+    val str = s"${primaryConstructor} (${primaryConstructor.flags.show}) ${clauses}"
+    Expr(str)
+  }
+}

--- a/tests/run-macros/i20052/Test_2.scala
+++ b/tests/run-macros/i20052/Test_2.scala
@@ -1,0 +1,6 @@
+@main def Test() =
+  println(Macro.logPrimaryConstructor[JavaClass])
+  println(Macro.logPrimaryConstructor[JavaClassEmpty])
+  println(Macro.logPrimaryConstructor[JavaClassPrivate])
+  println(Macro.logPrimaryConstructor[JavaClassStartsWithPrivate])
+  println(Macro.logPrimaryConstructor[JavaClassParam[Int]])


### PR DESCRIPTION
Fixes #20052
Java outline parser phase for various reasons adds a dummy constructor to java classes compiling simultenously from scalac. Since they provide no information to the user and are overall misleading (with always having the same fake flags and parameters), we filter them out and return the first constructor that can be found in the source.
This is also what happened up to this point when running the macro with a java classfile on the classpath instead, since those dummy constructors cannot be found there.