### PR TITLE
Backport "Fix trailing comma Ident's span" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -735,7 +735,10 @@ object Scanners {
                  && currentRegion.commasExpected
                  && (token == RPAREN || token == RBRACKET || token == RBRACE || token == OUTDENT)
               then
-                () /* skip the trailing comma */
+                // encountered a trailing comma
+                // reset only the lastOffset
+                // so that the tree's span is correct
+                lastOffset = prev.lastOffset
               else
                 reset()
         case END =>

--- a/tests/neg/i16872.check
+++ b/tests/neg/i16872.check
@@ -1,0 +1,36 @@
+-- [E006] Not Found Error: tests/neg/i16872.scala:8:6 ------------------------------------------------------------------
+8 |      aa, // error
+  |      ^^
+  |      Not found: aa
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i16872.scala:9:6 ------------------------------------------------------------------
+9 |      bb, // error
+  |      ^^
+  |      Not found: bb
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i16872.scala:10:6 -----------------------------------------------------------------
+10 |      cc, // error
+   |      ^^
+   |      Not found: cc
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i16872.scala:16:6 -----------------------------------------------------------------
+16 |      dd, // error
+   |      ^^
+   |      Not found: dd
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i16872.scala:17:6 -----------------------------------------------------------------
+17 |      ee, // error
+   |      ^^
+   |      Not found: ee - did you mean eq? or perhaps ne?
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E006] Not Found Error: tests/neg/i16872.scala:18:6 -----------------------------------------------------------------
+18 |      ff, // error
+   |      ^^
+   |      Not found: ff
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i16872.scala
+++ b/tests/neg/i16872.scala
@@ -1,0 +1,19 @@
+// Using a checkfile to verify where the carets point to.
+// Originally they were pointing to "cc," and "ff,"
+// including the trailing comma
+
+class Test:
+  def t1 =
+    (
+      aa, // error
+      bb, // error
+      cc, // error
+    )
+
+  def meth(a: Int, b: Int, c: Int) = a + b + c
+  def t2 =
+    meth(
+      dd, // error
+      ee, // error
+      ff, // error
+    )


### PR DESCRIPTION
Backports #20445 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]