### PR TITLE
Backport "SimplePattern errors should now be recovered as wildcard instead of unimplemented expr" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3035,7 +3035,7 @@ object Parsers {
         else {
           val start = in.lastOffset
           syntaxErrorOrIncomplete(IllegalStartOfSimplePattern(), expectedOffset)
-          errorTermTree(start)
+          atSpan(Span(start, in.offset)) { Ident(nme.WILDCARD) }
         }
     }
 

--- a/tests/neg/i5004.scala
+++ b/tests/neg/i5004.scala
@@ -2,5 +2,5 @@ object i0 {
 1 match {
 def this(): Int  // error
   def this()
-} // error
+}
 }

--- a/tests/neg/parser-stability-1.scala
+++ b/tests/neg/parser-stability-1.scala
@@ -1,4 +1,3 @@
 object x0 {
 x1 match  // error
 def this // error
-// error


### PR DESCRIPTION
Backports #21438 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]