### PR TITLE
Backport "Fix #21392: Adjust `canComparePredefined(Nothing, T)` in explicit nulls" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -186,7 +186,8 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
         // val x: String = null.asInstanceOf[String]
         // if (x == null) {} // error: x is non-nullable
         // if (x.asInstanceOf[String|Null] == null) {} // ok
-        cls1 == defn.NullClass && cls1 == cls2
+        if cls1 == defn.NullClass || cls2 == defn.NullClass then cls1 == cls2
+        else cls1 == defn.NothingClass || cls2 == defn.NothingClass
       else if cls1 == defn.NullClass then
         cls1 == cls2 || cls2.derivesFrom(defn.ObjectClass)
       else if cls2 == defn.NullClass then

--- a/tests/explicit-nulls/pos/i21392.scala
+++ b/tests/explicit-nulls/pos/i21392.scala
@@ -1,0 +1,16 @@
+//> using options -language:strictEquality
+
+import scala.collection.LinearSeq
+
+def foo[T](a: LinearSeq[T]) = a match
+  case Nil => -1
+  case head +: tail => head
+
+enum Foo derives CanEqual:
+  case Bar
+  case Baz(x: String)
+
+
+def foo(a: Foo) = a match
+  case Foo.Bar => -1
+  case _ => 0


### PR DESCRIPTION
Backports #21504 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]