### PR TITLE
Backport "Remove artificial `CURSOR` added to code in the completions" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
+++ b/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
@@ -75,23 +75,40 @@ object NavigateAST {
   def pathTo(span: Span, from: List[Positioned], skipZeroExtent: Boolean = false)(using Context): List[Positioned] = {
     def childPath(it: Iterator[Any], path: List[Positioned]): List[Positioned] = {
       var bestFit: List[Positioned] = path
-      while (it.hasNext) {
-        val path1 = it.next() match {
-          // FIXME this has to be changed to deterministicaly find recoveed tree
-          case untpd.Select(qual, name) if name == StdNames.nme.??? => path
+      while (it.hasNext) do
+        val path1 = it.next() match
+          case sel: untpd.Select if isTreeFromRecovery(sel) => path
           case p: Positioned if !p.isInstanceOf[Closure[?]] => singlePath(p, path)
           case m: untpd.Modifiers => childPath(m.productIterator, path)
           case xs: List[?] => childPath(xs.iterator, path)
           case _ => path
-        }
-        if ((path1 ne path) &&
-            ((bestFit eq path) ||
-             bestFit.head.span != path1.head.span &&
-             envelops(bestFit.head.span, path1.head.span)))
+
+        if (path1 ne path) && ((bestFit eq path) || isBetterFit(bestFit, path1)) then
           bestFit = path1
-      }
+
       bestFit
     }
+
+    /**
+      * When choosing better fit we compare spans. If candidate span has starting or ending point inside (exclusive)
+      * current best fit it is selected as new best fit. This means that same spans are failing the first predicate.
+      *
+      * In case when spans start and end at same offsets we prefer non synthethic one.
+      */
+    def isBetterFit(currentBest: List[Positioned], candidate: List[Positioned]): Boolean =
+      if currentBest.isEmpty && candidate.nonEmpty then true
+      else if currentBest.nonEmpty && candidate.nonEmpty then
+        val bestSpan= currentBest.head.span
+        val candidateSpan = candidate.head.span
+
+        bestSpan != candidateSpan &&
+          envelops(bestSpan, candidateSpan) ||
+          bestSpan.contains(candidateSpan) && bestSpan.isSynthetic && !candidateSpan.isSynthetic
+      else false
+
+
+    def isTreeFromRecovery(p: untpd.Select): Boolean =
+      p.name == StdNames.nme.??? && p.qualifier.symbol.name == StdNames.nme.Predef && p.span.isSynthetic
 
     def envelops(a: Span, b: Span): Boolean =
       !b.exists || a.exists && (

--- a/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
+++ b/compiler/src/dotty/tools/dotc/ast/NavigateAST.scala
@@ -98,7 +98,7 @@ object NavigateAST {
     def isBetterFit(currentBest: List[Positioned], candidate: List[Positioned]): Boolean =
       if currentBest.isEmpty && candidate.nonEmpty then true
       else if currentBest.nonEmpty && candidate.nonEmpty then
-        val bestSpan= currentBest.head.span
+        val bestSpan = currentBest.head.span
         val candidateSpan = candidate.head.span
 
         bestSpan != candidateSpan &&

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -119,16 +119,17 @@ object Completion:
       case _ =>
         ""
 
+  def naiveCompletionPrefix(text: String, offset: Int): String =
+    var i = offset - 1
+    while i >= 0 && text(i).isUnicodeIdentifierPart do i -= 1
+    i += 1 // move to first character
+    text.slice(i, offset)
+
   /**
    * Inspect `path` to determine the completion prefix. Only symbols whose name start with the
    * returned prefix should be considered.
    */
   def completionPrefix(path: List[untpd.Tree], pos: SourcePosition)(using Context): String =
-    def fallback: Int =
-      var i = pos.point - 1
-      while i >= 0 && Character.isUnicodeIdentifierPart(pos.source.content()(i)) do i -= 1
-      i + 1
-
     path match
       case GenericImportSelector(sel) =>
         if sel.isGiven then completionPrefix(sel.bound :: Nil, pos)
@@ -146,7 +147,7 @@ object Completion:
       case (tree: untpd.RefTree) :: _ if tree.name != nme.ERROR =>
         tree.name.toString.take(pos.span.point - tree.span.point)
 
-      case _ => pos.source.content.slice(fallback, pos.point).mkString
+      case _ => naiveCompletionPrefix(pos.source.content().mkString, pos.point)
 
 
   end completionPrefix

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -398,7 +398,7 @@ object Parsers {
       false
     }
 
-    def errorTermTree(start: Offset): Tree = atSpan(start, in.offset, in.offset) { unimplementedExpr }
+    def errorTermTree(start: Offset): Tree = atSpan(Span(start, in.offset)) { unimplementedExpr }
 
     private var inFunReturnType = false
     private def fromWithinReturnType[T](body: => T): T = {

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1705,6 +1705,15 @@ class CompletionTest {
        ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
      ))
 
+  @Test def testtest: Unit =
+    code"""|object M {
+           |  def sel$m1
+           |}
+           |"""
+     .completion(m1, Set(
+       ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
+     ))
+
   @Test def noEnumCompletionInNewContext: Unit =
     code"""|enum TestEnum:
            |  case TestCase

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1705,15 +1705,6 @@ class CompletionTest {
        ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
      ))
 
-  @Test def testtest: Unit =
-    code"""|object M {
-           |  def sel$m1
-           |}
-           |"""
-     .completion(m1, Set(
-       ("getOrElse", Method, "[V1 >: String](key: Int, default: => V1): V1"),
-     ))
-
   @Test def noEnumCompletionInNewContext: Unit =
     code"""|enum TestEnum:
            |  case TestCase

--- a/language-server/test/dotty/tools/languageserver/HoverTest.scala
+++ b/language-server/test/dotty/tools/languageserver/HoverTest.scala
@@ -227,7 +227,7 @@ class HoverTest {
   @Test def enums: Unit = {
     code"""|package example
            |enum TestEnum3:
-           | case ${m1}A${m2} // no tooltip
+           |  case ${m1}A${m2} // no tooltip
            |
            |"""
       .hover(m1 to m2, hoverContent("example.TestEnum3"))

--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -13,7 +13,6 @@ import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourceFile
-import dotty.tools.pc.AutoImports.*
 import dotty.tools.pc.completions.CompletionPos
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 

--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -66,7 +66,8 @@ final class AutoImportsProvider(
     val results = symbols.result.filter(isExactMatch(_, name))
 
     if results.nonEmpty then
-      val correctedPos = CompletionPos.infer(pos, params, path, false).toSourcePosition
+      val correctedPos =
+        CompletionPos.infer(pos, params, path, wasCursorApplied = false).toSourcePosition
       val mkEdit =
         path match
           // if we are in import section just specify full name

--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -67,7 +67,7 @@ final class AutoImportsProvider(
     val results = symbols.result.filter(isExactMatch(_, name))
 
     if results.nonEmpty then
-      val correctedPos = CompletionPos.infer(pos, params, path).toSourcePosition
+      val correctedPos = CompletionPos.infer(pos, params, path, false).toSourcePosition
       val mkEdit =
         path match
           // if we are in import section just specify full name

--- a/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
@@ -7,9 +7,11 @@ import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.reporting.Diagnostic
 import dotty.tools.dotc.util.SourceFile
 
+import scala.compiletime.uninitialized
+
 /**
- * MetalsDriver is a wrapper class that provides a compilation cache for InteractiveDriver.
- * MetalsDriver skips running compilation if
+ * CachingDriver is a wrapper class that provides a compilation cache for InteractiveDriver.
+ * CachingDriver skips running compilation if
  * - the target URI of `run` is the same as the previous target URI
  * - the content didn't change since the last compilation.
  *
@@ -25,11 +27,9 @@ import dotty.tools.dotc.util.SourceFile
  * To avoid the complexity related to currentCtx,
  * we decided to cache only when the target URI only if the same as the previous run.
  */
-class MetalsDriver(
-    override val settings: List[String]
-) extends InteractiveDriver(settings):
+class CachingDriver(override val settings: List[String]) extends InteractiveDriver(settings):
 
-  @volatile private var lastCompiledURI: URI = _
+  @volatile private var lastCompiledURI: URI = uninitialized
 
   private def alreadyCompiled(uri: URI, content: Array[Char]): Boolean =
     compilationUnits.get(uri) match
@@ -53,4 +53,4 @@ class MetalsDriver(
     lastCompiledURI = uri
     diags
 
-end MetalsDriver
+end CachingDriver

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -14,7 +14,6 @@ import scala.meta.internal.pc.LabelPart.*
 import scala.meta.pc.InlayHintsParams
 import scala.meta.pc.SymbolSearch
 
-import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.core.Flags

--- a/presentation-compiler/src/main/dotty/tools/pc/Scala3CompilerAccess.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/Scala3CompilerAccess.scala
@@ -8,13 +8,14 @@ import scala.meta.internal.pc.CompilerAccess
 import scala.meta.pc.PresentationCompilerConfig
 
 import dotty.tools.dotc.reporting.StoreReporter
+import dotty.tools.dotc.interactive.InteractiveDriver
 
 class Scala3CompilerAccess(
     config: PresentationCompilerConfig,
     sh: Option[ScheduledExecutorService],
     newCompiler: () => Scala3CompilerWrapper
 )(using ec: ExecutionContextExecutor, rc: ReportContext)
-    extends CompilerAccess[StoreReporter, MetalsDriver](
+    extends CompilerAccess[StoreReporter, InteractiveDriver](
       config,
       sh,
       newCompiler,

--- a/presentation-compiler/src/main/dotty/tools/pc/Scala3CompilerWrapper.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/Scala3CompilerWrapper.scala
@@ -4,11 +4,12 @@ import scala.meta.internal.pc.CompilerWrapper
 import scala.meta.internal.pc.ReporterAccess
 
 import dotty.tools.dotc.reporting.StoreReporter
+import dotty.tools.dotc.interactive.InteractiveDriver
 
-class Scala3CompilerWrapper(driver: MetalsDriver)
-    extends CompilerWrapper[StoreReporter, MetalsDriver]:
+class Scala3CompilerWrapper(driver: InteractiveDriver)
+    extends CompilerWrapper[StoreReporter, InteractiveDriver]:
 
-  override def compiler(): MetalsDriver = driver
+  override def compiler(): InteractiveDriver = driver
 
   override def resetReporter(): Unit =
     val ctx = driver.currentCtx

--- a/presentation-compiler/src/main/dotty/tools/pc/ScriptFirstImportPosition.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScriptFirstImportPosition.scala
@@ -1,6 +1,5 @@
 package dotty.tools.pc
 
-import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Comments.Comment
 
 object ScriptFirstImportPosition:

--- a/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
@@ -1,6 +1,5 @@
 package dotty.tools.pc
 
-import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Symbols.*

--- a/presentation-compiler/src/main/dotty/tools/pc/SymbolInformationProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SymbolInformationProvider.scala
@@ -7,8 +7,6 @@ import scala.meta.pc.PcSymbolKind
 import scala.meta.pc.PcSymbolProperty
 
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.core.Denotations.Denotation
-import dotty.tools.dotc.core.Denotations.MultiDenotation
 import dotty.tools.dotc.core.Flags
 import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.StdNames.nme
@@ -19,6 +17,7 @@ import dotty.tools.pc.utils.InteractiveEnrichments.allSymbols
 import dotty.tools.pc.utils.InteractiveEnrichments.stripBackticks
 import scala.meta.internal.pc.PcSymbolInformation
 import scala.meta.internal.pc.SymbolInfo
+import dotty.tools.dotc.core.Denotations.{Denotation, MultiDenotation}
 
 class SymbolInformationProvider(using Context):
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -5,7 +5,6 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 import scala.collection.mutable
-import scala.meta.internal.metals.Fuzzy
 import scala.meta.internal.metals.ReportContext
 import scala.meta.internal.mtags.CoursierComplete
 import scala.meta.internal.pc.{IdentifierComparator, MemberOrdering, CompletionFuzzy}
@@ -27,15 +26,12 @@ import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.interactive.Completion
 import dotty.tools.dotc.interactive.Completion.Mode
-import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.util.SrcPos
 import dotty.tools.pc.AutoImports.AutoImportsGenerator
 import dotty.tools.pc.buildinfo.BuildInfo
 import dotty.tools.pc.completions.OverrideCompletions.OverrideExtractor
 import dotty.tools.pc.utils.InteractiveEnrichments.*
-import dotty.tools.dotc.core.Denotations.SingleDenotation
-import dotty.tools.dotc.interactive.Interactive
 
 class Completions(
     text: String,
@@ -281,7 +277,6 @@ class Completions(
         val affix = if methodDenot.symbol.isConstructor && existsApply then
           adjustedPath match
             case (select @ Select(qual, _)) :: _ =>
-              val start = qual.span.start
               val insertRange = select.sourcePos.startPos.withEnd(completionPos.queryEnd).toLsp
 
               suffix
@@ -664,7 +659,7 @@ class Completions(
       .collect { case symbolic: CompletionValue.Symbolic => symbolic }
       .groupBy(_.symbol.fullName) // we somehow have to ignore proxy type
 
-    val filteredSymbolicCompletions = symbolicCompletionsMap.filter: (name, denots) =>
+    val filteredSymbolicCompletions = symbolicCompletionsMap.filter: (name, _) =>
       lazy val existsTypeWithoutSuffix: Boolean = !symbolicCompletionsMap
         .get(name.toTypeName)
         .forall(_.forall(sym => sym.snippetAffix.suffixes.nonEmpty))

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/InterpolatorCompletions.scala
@@ -224,7 +224,7 @@ object InterpolatorCompletions:
       buildTargetIdentifier: String
   )(using ctx: Context, reportsContext: ReportContext): List[CompletionValue] =
     val litStartPos = lit.span.start
-    val litEndPos = lit.span.end - Cursor.value.length()
+    val litEndPos = lit.span.end - (if completionPos.withCURSOR then Cursor.value.length else 0)
     val position = completionPos.originalCursorPosition
     val span = position.span
     val nameStart =

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
@@ -27,7 +27,6 @@ import dotty.tools.dotc.core.Types.TermRef
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.core.Types.TypeBounds
 import dotty.tools.dotc.core.Types.WildcardType
-import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.pc.IndexedContext
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 import scala.annotation.tailrec
@@ -295,7 +294,6 @@ object NamedArgCompletions:
       )
     }
 
-    // FIXME pass query here
     val prefix = ident
       .map(_.name.toString)
       .getOrElse("")

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
@@ -170,7 +170,7 @@ object NamedArgCompletions:
                   .zipWithIndex
                   .forall { case (pair, index) =>
                     FuzzyArgMatcher(m.tparams)
-                      .doMatch(allArgsProvided = index != 0)
+                      .doMatch(allArgsProvided = index != 0, ident)
                       .tupled(pair)
                   } =>
             m
@@ -385,12 +385,13 @@ class FuzzyArgMatcher(tparams: List[Symbols.Symbol])(using Context):
    * We check the args types not the result type.
    */
   def doMatch(
-      allArgsProvided: Boolean
+      allArgsProvided: Boolean,
+      ident: Option[Ident]
   )(expectedArgs: List[Symbols.Symbol], actualArgs: List[Tree]) =
     (expectedArgs.length == actualArgs.length ||
       (!allArgsProvided && expectedArgs.length >= actualArgs.length)) &&
       actualArgs.zipWithIndex.forall {
-        case (Ident(name), _) => true
+        case (arg: Ident, _) if ident.contains(arg) => true
         case (NamedArg(name, arg), _) =>
           expectedArgs.exists { expected =>
             expected.name == name && (!arg.hasType || arg.typeOpt.unfold

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
@@ -582,7 +582,7 @@ object OverrideCompletions:
             )
           )
         // class Main extends Val:
-        //    he@@
+        //   he@@
         case (id: Ident) :: (t: Template) :: (td: TypeDef) :: _
             if t.parents.nonEmpty =>
           Some(
@@ -592,6 +592,20 @@ object OverrideCompletions:
               id.sourcePos.start,
               false,
               Some(id.name.show),
+            )
+          )
+
+        // class Main extends Val:
+        //   hello@ // this transforms into this.hello, thus is a Select
+        case (sel @ Select(th: This, name)) :: (t: Template) :: (td: TypeDef) :: _
+            if t.parents.nonEmpty && th.qual.name == td.name =>
+          Some(
+            (
+              td,
+              None,
+              sel.sourcePos.start,
+              false,
+              Some(name.show),
             )
           )
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
@@ -530,8 +530,11 @@ object OverrideCompletions:
   object OverrideExtractor:
     def unapply(path: List[Tree])(using Context) =
       path match
-        // class FooImpl extends Foo:
-        //   def x|
+        // abstract class Val:
+        //   def hello: Int = 2
+        //
+        // class Main extends Val:
+        //   def h|
         case (dd: (DefDef | ValDef)) :: (t: Template) :: (td: TypeDef) :: _
             if t.parents.nonEmpty =>
           val completing =
@@ -547,12 +550,13 @@ object OverrideCompletions:
             )
           )
 
-        // class FooImpl extends Foo:
+        // abstract class Val:
+        //   def hello: Int = 2
+        //
+        // class Main extends Val:
         //   ov|
         case (ident: Ident) :: (t: Template) :: (td: TypeDef) :: _
-            if t.parents.nonEmpty && "override".startsWith(
-              ident.name.show.replace(Cursor.value, "")
-            ) =>
+            if t.parents.nonEmpty && "override".startsWith(ident.name.show.replace(Cursor.value, "")) =>
           Some(
             (
               td,
@@ -563,15 +567,13 @@ object OverrideCompletions:
             )
           )
 
+        // abstract class Val:
+        //   def hello: Int = 2
+        //
         // class Main extends Val:
         //    def@@
         case (id: Ident) :: (t: Template) :: (td: TypeDef) :: _
-            if t.parents.nonEmpty && "def".startsWith(
-              id.name.decoded.replace(
-                Cursor.value,
-                "",
-              )
-            ) =>
+            if t.parents.nonEmpty && "def".startsWith(id.name.decoded.replace(Cursor.value, "")) =>
           Some(
             (
               td,
@@ -581,6 +583,10 @@ object OverrideCompletions:
               None,
             )
           )
+
+        // abstract class Val:
+        //   def hello: Int = 2
+        //
         // class Main extends Val:
         //   he@@
         case (id: Ident) :: (t: Template) :: (td: TypeDef) :: _
@@ -595,6 +601,9 @@ object OverrideCompletions:
             )
           )
 
+        // abstract class Val:
+        //   def hello: Int = 2
+        //
         // class Main extends Val:
         //   hello@ // this transforms into this.hello, thus is a Select
         case (sel @ Select(th: This, name)) :: (t: Template) :: (td: TypeDef) :: _

--- a/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/printer/ShortenedTypePrinter.scala
@@ -24,8 +24,6 @@ import dotty.tools.dotc.printing.RefinedPrinter
 import dotty.tools.dotc.printing.Texts.Text
 import dotty.tools.pc.AutoImports.AutoImportsGenerator
 import dotty.tools.pc.AutoImports.ImportSel
-import dotty.tools.pc.AutoImports.ImportSel.Direct
-import dotty.tools.pc.AutoImports.ImportSel.Rename
 import dotty.tools.pc.IndexedContext
 import dotty.tools.pc.IndexedContext.Result
 import dotty.tools.pc.Params

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseInlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseInlayHintsSuite.scala
@@ -8,9 +8,7 @@ import scala.meta.internal.metals.CompilerRangeParams
 import scala.language.unsafeNulls
 
 import dotty.tools.pc.utils.TestInlayHints
-import dotty.tools.pc.utils.TextEdits
 
-import org.eclipse.lsp4j.TextEdit
 
 class BaseInlayHintsSuite extends BasePCSuite {
 

--- a/presentation-compiler/test/dotty/tools/pc/base/ReusableClassRunner.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/ReusableClassRunner.scala
@@ -13,22 +13,17 @@ class ReusableClassRunner(testClass: Class[BasePCSuite])
     testClass.getDeclaredConstructor().newInstance()
 
   override def createTest(): AnyRef = instance
-  override def withBefores(
-      method: FrameworkMethod,
-      target: Object,
-      statement: Statement
-  ): Statement =
-    statement
 
   override def withAfters(
       method: FrameworkMethod,
       target: Object,
       statement: Statement
   ): Statement =
+    val newStatement = super.withAfters(method, target, statement)
     new Statement():
       override def evaluate(): Unit =
         try
-          statement.evaluate()
+          newStatement.evaluate()
         finally
           if (isLastTestCase(method)) then instance.clean()
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/CompilerCachingSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/CompilerCachingSuite.scala
@@ -1,0 +1,166 @@
+package dotty.tools.pc.tests
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.pc.base.BasePCSuite
+import dotty.tools.pc.ScalaPresentationCompiler
+import org.junit.{Before, Test}
+
+import scala.language.unsafeNulls
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.metals.CompilerOffsetParams
+import scala.meta.pc.OffsetParams
+import scala.concurrent.Future
+import scala.concurrent.Await
+import scala.meta.pc.VirtualFileParams
+import scala.concurrent.duration.*
+
+import java.util.Collections
+import java.nio.file.Paths
+import java.util.concurrent.CompletableFuture
+
+
+class CompilerCachingSuite extends BasePCSuite:
+
+  val timeout = 5.seconds
+
+  private def checkCompilationCount(params: VirtualFileParams, expected: Int): Unit =
+    presentationCompiler match
+      case pc: ScalaPresentationCompiler =>
+        val compilations= pc.compilerAccess.withNonInterruptableCompiler(Some(params))(-1, EmptyCancelToken) { driver =>
+          driver.compiler().currentCtx.runId
+        }.get(timeout.length, timeout.unit)
+        assertEquals(expected, compilations, s"Expected $expected compilations but got $compilations")
+      case _ => throw IllegalStateException("Presentation compiler should always be of type of ScalaPresentationCompiler")
+
+  private def getContext(params: VirtualFileParams): Context =
+    presentationCompiler match
+      case pc: ScalaPresentationCompiler =>
+        pc.compilerAccess.withNonInterruptableCompiler(Some(params))(null, EmptyCancelToken) { driver =>
+          driver.compiler().currentCtx
+        }.get(timeout.length, timeout.unit)
+      case _ => throw IllegalStateException("Presentation compiler should always be of type of ScalaPresentationCompiler")
+
+  @Before
+  def beforeEach: Unit =
+    presentationCompiler.restart()
+
+    // We want to run art least one compilation, so runId points at 3.
+    // This will ensure that we use the same driver, not recreate fresh one on each call
+    val dryRunParams = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "dryRun", 1, EmptyCancelToken)
+    checkCompilationCount(dryRunParams, 2)
+    val freshContext = getContext(dryRunParams)
+    presentationCompiler.complete(dryRunParams).get(timeout.length, timeout.unit)
+    checkCompilationCount(dryRunParams, 3)
+    val dryRunContext = getContext(dryRunParams)
+    assert(freshContext != dryRunContext)
+
+
+  @Test
+  def `cursor-compilation-does-not-corrupt-cache`: Unit =
+
+    val fakeParamsCursor = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "def hello = new", 15, EmptyCancelToken)
+    val fakeParams = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "def hello = ne", 14, EmptyCancelToken)
+
+    val contextPreCompilation = getContext(fakeParams)
+
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextPostFirst = getContext(fakeParams)
+    assert(contextPreCompilation != contextPostFirst)
+    checkCompilationCount(fakeParams, 4)
+
+    presentationCompiler.complete(fakeParamsCursor).get(timeout.length, timeout.unit)
+    val contextPostCursor = getContext(fakeParamsCursor)
+    assert(contextPreCompilation != contextPostCursor)
+    assert(contextPostFirst == contextPostCursor)
+    checkCompilationCount(fakeParamsCursor, 4)
+
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextPostSecond = getContext(fakeParams)
+    assert(contextPreCompilation != contextPostSecond)
+    assert(contextPostFirst == contextPostCursor)
+    assert(contextPostCursor == contextPostSecond)
+    checkCompilationCount(fakeParamsCursor, 4)
+
+  @Test
+  def `compilation-for-same-snippet-is-cached`: Unit =
+    val fakeParams = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "def hello = ne", 14, EmptyCancelToken)
+
+    val contextPreCompilation = getContext(fakeParams)
+
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextPostFirst = getContext(fakeParams)
+    assert(contextPreCompilation != contextPostFirst)
+    checkCompilationCount(fakeParams, 4)
+
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextPostSecond = getContext(fakeParams)
+    assert(contextPreCompilation != contextPostFirst)
+    assert(contextPostSecond == contextPostFirst)
+    checkCompilationCount(fakeParams, 4)
+
+  @Test
+  def `compilation-for-different-snippet-is-not-cached`: Unit =
+
+    val fakeParams = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "def hello = prin", 16, EmptyCancelToken)
+    val fakeParams2 = CompilerOffsetParams(Paths.get("Test2.scala").toUri(), "def hello = prin", 16, EmptyCancelToken)
+    val fakeParams3 = CompilerOffsetParams(Paths.get("Test2.scala").toUri(), "def hello = print", 17, EmptyCancelToken)
+
+    checkCompilationCount(fakeParams, 3)
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    checkCompilationCount(fakeParams, 4)
+
+    presentationCompiler.complete(fakeParams2).get(timeout.length, timeout.unit)
+    checkCompilationCount(fakeParams2, 5)
+
+    presentationCompiler.complete(fakeParams3).get(timeout.length, timeout.unit)
+    checkCompilationCount(fakeParams3, 6)
+
+
+  private val testFunctions: List[OffsetParams => CompletableFuture[_]] = List(
+    presentationCompiler.complete(_),
+    presentationCompiler.convertToNamedArguments(_, Collections.emptyList()),
+    presentationCompiler.autoImports("a", _, false),
+    presentationCompiler.definition(_),
+    presentationCompiler.didChange(_),
+    presentationCompiler.documentHighlight(_),
+    presentationCompiler.hover(_),
+    presentationCompiler.implementAbstractMembers(_),
+    presentationCompiler.insertInferredType(_),
+    presentationCompiler.semanticTokens(_),
+    presentationCompiler.prepareRename(_),
+    presentationCompiler.rename(_, "a"),
+    presentationCompiler.signatureHelp(_),
+    presentationCompiler.typeDefinition(_)
+  )
+
+
+  @Test
+  def `different-api-calls-reuse-cache`: Unit =
+    val fakeParams = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "def hello = ne", 13, EmptyCancelToken)
+
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextBefore = getContext(fakeParams)
+
+    val differentContexts = testFunctions.map: f =>
+      f(fakeParams).get(timeout.length, timeout.unit)
+      checkCompilationCount(fakeParams, 4)
+      getContext(fakeParams)
+    .toSet
+
+    assert(differentContexts == Set(contextBefore))
+
+  @Test
+  def `different-api-calls-reuse-cache-parallel`: Unit =
+    import scala.jdk.FutureConverters.*
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val fakeParams = CompilerOffsetParams(Paths.get("Test.scala").toUri(), "def hello = ne", 13, EmptyCancelToken)
+
+    presentationCompiler.complete(fakeParams).get(timeout.length, timeout.unit)
+    val contextBefore = getContext(fakeParams)
+
+    val futures = testFunctions.map: f =>
+      f(fakeParams).asScala.map(_ => getContext(fakeParams))
+
+    val res = Await.result(Future.sequence(futures), timeout).toSet
+    assert(res == Set(contextBefore))

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
@@ -614,8 +614,9 @@ class CompletionArgSuite extends BaseCompletionSuite:
     check(
       s"""|case class Context()
           |
-          |def foo(arg1: (Context) ?=> Int, arg2: Int): String = ???
-          |val m = foo(ar@@)
+          |object Main:
+          |  def foo(arg1: (Context) ?=> Int, arg2: Int): String = ???
+          |  val m = foo(ar@@)
           |""".stripMargin,
       """|arg1 = : (Context) ?=> Int
          |arg2 = : Int
@@ -627,8 +628,9 @@ class CompletionArgSuite extends BaseCompletionSuite:
     check(
       s"""|case class Context()
           |
-          |def foo(arg1: Context ?=> Int, arg2: Context ?=> Int): String = ???
-          |val m = foo(arg1 = ???, a@@)
+          |object Main:
+          |  def foo(arg1: Context ?=> Int, arg2: Context ?=> Int): String = ???
+          |  val m = foo(arg1 = ???, a@@)
           |""".stripMargin,
       """|arg2 = : (Context) ?=> Int
          |""".stripMargin,
@@ -639,8 +641,9 @@ class CompletionArgSuite extends BaseCompletionSuite:
     check(
       s"""|case class Context()
           |
-          |def foo(arg1: (Boolean, Context) ?=> Int ?=> String, arg2: (Boolean, Context) ?=> Int ?=> String): String = ???
-          |val m = foo(arg1 = ???, a@@)
+          |object Main:
+          |  def foo(arg1: (Boolean, Context) ?=> Int ?=> String, arg2: (Boolean, Context) ?=> Int ?=> String): String = ???
+          |  val m = foo(arg1 = ???, a@@)
           |""".stripMargin,
       """|arg2 = : (Boolean, Context) ?=> (Int) ?=> String
          |""".stripMargin,
@@ -786,10 +789,11 @@ class CompletionArgSuite extends BaseCompletionSuite:
 
   @Test def `overloaded-with-param` =
     check(
-      """|def m(idd : String, abb: Int): Int = ???
-         |def m(inn : Int, uuu: Option[Int]): Int = ???
-         |def m(inn : Int, aaa: Int): Int = ???
-         |def k: Int = m(1, a@@)
+      """|object Main:
+         |  def m(idd : String, abb: Int): Int = ???
+         |  def m(inn : Int, uuu: Option[Int]): Int = ???
+         |  def m(inn : Int, aaa: Int): Int = ???
+         |  def k: Int = m(1, a@@)
          |""".stripMargin,
       """|aaa = : Int
          |assert(assertion: Boolean): Unit
@@ -799,10 +803,11 @@ class CompletionArgSuite extends BaseCompletionSuite:
 
   @Test def `overloaded-with-named-param` =
     check(
-      """|def m(idd : String, abb: Int): Int = ???
-         |def m(inn : Int, uuu: Option[Int]): Int = ???
-         |def m(inn : Int, aaa: Int): Int = ???
-         |def k: Int = m(inn = 1, a@@)
+      """|object Main:
+         |  def m(idd : String, abb: Int): Int = ???
+         |  def m(inn : Int, uuu: Option[Int]): Int = ???
+         |  def m(inn : Int, aaa: Int): Int = ???
+         |  def k: Int = m(inn = 1, a@@)
          |""".stripMargin,
       """|aaa = : Int
          |assert(assertion: Boolean): Unit
@@ -812,7 +817,7 @@ class CompletionArgSuite extends BaseCompletionSuite:
 
   @Test def `overloaded-generic` =
     check(
-      """|object M:
+      """|object Main:
          |  val g = 3
          |  val l : List[Int] = List(1,2,3)
          |  def m[T](inn : List[T], yy: Int, aaa: Int, abb: Option[Int]): Int = ???
@@ -899,10 +904,11 @@ class CompletionArgSuite extends BaseCompletionSuite:
 
   @Test def `overloaded-function-param` =
     check(
-      """|def m[T](i: Int)(inn: T => Int, abb: Option[Int]): Int = ???
-         |def m[T](i: Int)(inn: T => Int, aaa: Int): Int = ???
-         |def m[T](i: Int)(inn: T => String, acc: List[Int]): Int = ???
-         |def k = m(1)(inn = identity[Int], a@@)
+      """|object Main:
+         |  def m[T](i: Int)(inn: T => Int, abb: Option[Int]): Int = ???
+         |  def m[T](i: Int)(inn: T => Int, aaa: Int): Int = ???
+         |  def m[T](i: Int)(inn: T => String, acc: List[Int]): Int = ???
+         |  def k = m(1)(inn = identity[Int], a@@)
          |""".stripMargin,
       """|aaa = : Int
          |abb = : Option[Int]
@@ -913,10 +919,11 @@ class CompletionArgSuite extends BaseCompletionSuite:
 
   @Test def `overloaded-function-param2` =
     check(
-      """|def m[T](i: Int)(inn: T => Int, abb: Option[Int]): Int = ???
-         |def m[T](i: Int)(inn: T => Int, aaa: Int): Int = ???
-         |def m[T](i: String)(inn: T => Int, acc: List[Int]): Int = ???
-         |def k = m(1)(inn = identity[Int], a@@)
+      """|object Main:
+         |  def m[T](i: Int)(inn: T => Int, abb: Option[Int]): Int = ???
+         |  def m[T](i: Int)(inn: T => Int, aaa: Int): Int = ???
+         |  def m[T](i: String)(inn: T => Int, acc: List[Int]): Int = ???
+         |  def k = m(1)(inn = identity[Int], a@@)
          |""".stripMargin,
       """|aaa = : Int
          |abb = : Option[Int]
@@ -978,9 +985,10 @@ class CompletionArgSuite extends BaseCompletionSuite:
 
   @Test def `overloaded-function-param3` =
     check(
-      """|def m[T](inn: Int => T, abb: Option[Int]): Int = ???
-         |def m[T](inn: String => T, aaa: Int): Int = ???
-         |def k = m(identity[Int], a@@)
+      """|object Main:
+         |  def m[T](inn: Int => T, abb: Option[Int]): Int = ???
+         |  def m[T](inn: String => T, aaa: Int): Int = ???
+         |  def k = m(identity[Int], a@@)
          |""".stripMargin,
       """|abb = : Option[Int]
          |""".stripMargin,
@@ -1109,7 +1117,7 @@ class CompletionArgSuite extends BaseCompletionSuite:
 
   @Test def `comparison` =
     check(
-      """package a
+      """
         |object w {
         |  abstract class T(x: Int) {
         |    def met(x: Int): Unit = {

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtraConstructorSuite.scala
@@ -1,14 +1,10 @@
 package dotty.tools.pc.tests.completion
 
-import scala.meta.pc.SymbolDocumentation
 import scala.language.unsafeNulls
 
 import dotty.tools.pc.base.BaseCompletionSuite
-import dotty.tools.pc.utils.MockEntries
 
 import org.junit.Test
-import org.junit.Ignore
-import scala.collection.immutable.ListMapBuilder
 
 class CompletionExtraConstructorSuite extends BaseCompletionSuite:
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionInterpolatorSuite.scala
@@ -112,7 +112,7 @@ class CompletionInterpolatorSuite extends BaseCompletionSuite:
          |""".stripMargin.triplequoted,
       """|object Main {
          |  val myName = ""
-         |  s"$myName $$"
+         |  s"$myName$0 $$"
          |}
          |""".stripMargin.triplequoted,
       filterText = "myName"

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -529,8 +529,6 @@ class CompletionSuite extends BaseCompletionSuite:
       """.stripMargin,
       """|until(end: Int): Range
          |until(end: Int, step: Int): Range
-         |until(end: Long): Exclusive[Long]
-         |until(end: Long, step: Long): Exclusive[Long]
          |""".stripMargin,
       stableOrder = false
     )
@@ -1605,7 +1603,7 @@ class CompletionSuite extends BaseCompletionSuite:
 
   @Test def `multi-export` =
     check(
-      """export scala.collection.{AbstractMap, Set@@}
+      """export scala.collection.{AbstractMap, Se@@}
         |""".stripMargin,
       """Set scala.collection
         |SetOps scala.collection
@@ -1618,7 +1616,9 @@ class CompletionSuite extends BaseCompletionSuite:
         |StrictOptimizedSetOps scala.collection
         |StrictOptimizedSortedSetOps scala.collection
         |GenSet = scala.collection.Set[X]
-        |""".stripMargin
+        |""".stripMargin,
+      filter = _.contains("Set")
+
     )
 
   @Test def `multi-imports` =
@@ -1637,6 +1637,7 @@ class CompletionSuite extends BaseCompletionSuite:
         |StrictOptimizedSortedSetOps scala.collection
         |GenSet = scala.collection.Set[X]
         |""".stripMargin,
+      filter = _.contains("Set")
     )
 
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
@@ -28,7 +28,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
       MockLocation("scala/Predef.Ensuring#ensuring(+2).", "Predef.scala"),
       MockLocation("scala/Predef.Ensuring#ensuring(+3).", "Predef.scala"),
       MockLocation("scala/collection/immutable/List#`::`().", "List.scala"),
-      MockLocation("scala/collection/IterableFactory#apply().", "Factory.scala")
+      MockLocation("scala/package.List.", "List.scala")
     )
 
   override def definitions(offsetParams: OffsetParams): List[Location] =
@@ -123,7 +123,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
     check(
       """|
          |object Main {
-         |  /*scala/collection/IterableFactory#apply(). Factory.scala*/@@List(1)
+         |  /*scala/package.List. List.scala*/@@List(1)
          |}
          |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
@@ -28,7 +28,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
       MockLocation("scala/Predef.Ensuring#ensuring(+2).", "Predef.scala"),
       MockLocation("scala/Predef.Ensuring#ensuring(+3).", "Predef.scala"),
       MockLocation("scala/collection/immutable/List#`::`().", "List.scala"),
-      MockLocation("scala/package.List.", "List.scala")
+      MockLocation("scala/package.List.", "package.scala")
     )
 
   override def definitions(offsetParams: OffsetParams): List[Location] =
@@ -123,7 +123,7 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
     check(
       """|
          |object Main {
-         |  /*scala/package.List. List.scala*/@@List(1)
+         |  /*scala/package.List. package.scala*/@@List(1)
          |}
          |""".stripMargin
     )

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -694,3 +694,11 @@ class HoverTermSuite extends BaseHoverSuite:
         |""".stripMargin,
       "extension [T](a: T) def *:[U <: Tuple](b: Wrap[U]): Wrap[T *: U]".hover
     )
+
+  @Test def `dont-ignore-???-in-path`: Unit =
+    check(
+      """object Obj:
+        |  val x = ?@@??
+        |""".stripMargin,
+      """def ???: Nothing""".stripMargin.hover
+  )

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -269,9 +269,9 @@ class HoverTermSuite extends BaseHoverSuite:
         |  } yield x
         |}
         |""".stripMargin,
-      """|Option[Int]
-         |override def headOption: Option[A]
-         |""".stripMargin.hover
+      """|```scala
+         |override def headOption: Option[Int]
+         |```""".stripMargin.hover
     )
 
   @Test def `object` =

--- a/presentation-compiler/test/dotty/tools/pc/utils/DefSymbolCollector.scala
+++ b/presentation-compiler/test/dotty/tools/pc/utils/DefSymbolCollector.scala
@@ -3,7 +3,7 @@ package dotty.tools.pc.utils
 import scala.meta.pc.VirtualFileParams
 
 import dotty.tools.dotc.ast.tpd.*
-import dotty.tools.dotc.ast.{Trees, tpd}
+import dotty.tools.dotc.ast.Trees
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourcePosition

--- a/presentation-compiler/test/dotty/tools/pc/utils/MockSymbolSearch.scala
+++ b/presentation-compiler/test/dotty/tools/pc/utils/MockSymbolSearch.scala
@@ -8,7 +8,6 @@ import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.*
 import scala.meta.internal.metals.{ClasspathSearch, WorkspaceSymbolQuery}
 import scala.meta.pc.ContentType
-import scala.meta.pc.SymbolSearch.Result
 import scala.meta.pc.{
   ParentSymbols,
   SymbolDocumentation,

--- a/presentation-compiler/test/dotty/tools/pc/utils/PcAssertions.scala
+++ b/presentation-compiler/test/dotty/tools/pc/utils/PcAssertions.scala
@@ -4,7 +4,6 @@ import scala.language.unsafeNulls
 
 import dotty.tools.pc.completions.CompletionSource
 import dotty.tools.dotc.util.DiffUtil
-import dotty.tools.pc.utils.InteractiveEnrichments.*
 
 import org.hamcrest
 import org.hamcrest.*
@@ -127,7 +126,6 @@ trait PcAssertions:
     def getDetailedMessage(diff: String): String =
       val lines = diff.linesIterator.toList
       val sources = completionSources.padTo(lines.size, CompletionSource.Empty)
-      val maxLength = lines.map(_.length).maxOption.getOrElse(0)
       var completionIndex = 0
       lines.map: line =>
         if line.startsWith(Console.BOLD + Console.RED) || line.startsWith("  ") then

--- a/presentation-compiler/test/dotty/tools/pc/utils/TestInlayHints.scala
+++ b/presentation-compiler/test/dotty/tools/pc/utils/TestInlayHints.scala
@@ -4,7 +4,6 @@ import scala.collection.mutable.ListBuffer
 
 import scala.meta.internal.jdk.CollectionConverters._
 import dotty.tools.pc.utils.InteractiveEnrichments.*
-import dotty.tools.pc.utils.TextEdits
 
 import org.eclipse.lsp4j.InlayHint
 import org.eclipse.lsp4j.TextEdit


### PR DESCRIPTION
Backports #20899 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]