### PR TITLE
Backport "Re-use attachment in exportForwarders to handle ambiguous overloads" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1411,10 +1411,11 @@ class Namer { typer: Typer =>
           forwarders.derivedCons(forwarder2, avoidClashes(forwarders2))
         case Nil => forwarders
 
-      addForwarders(selectors, Nil)
-      val forwarders = avoidClashes(buf.toList)
-      exp.pushAttachment(ExportForwarders, forwarders)
-      forwarders
+      exp.getAttachment(ExportForwarders).getOrElse:
+        addForwarders(selectors, Nil)
+        val forwarders = avoidClashes(buf.toList)
+        exp.pushAttachment(ExportForwarders, forwarders)
+        forwarders
     end exportForwarders
 
     /** Add forwarders as required by the export statements in this class */

--- a/tests/neg/i21071.check
+++ b/tests/neg/i21071.check
@@ -1,0 +1,9 @@
+-- [E051] Reference Error: tests/neg/i21071.scala:9:2 ------------------------------------------------------------------
+9 |  foo { // error
+  |  ^^^
+  |  Ambiguous overload. The overloaded alternatives of method foo in object MySuite with types
+  |   (a: String): Nothing
+  |   (a: List[String]): Nothing
+  |  both match arguments ((??? : => Nothing))
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21071.scala
+++ b/tests/neg/i21071.scala
@@ -1,0 +1,21 @@
+trait Service {
+  def method: String
+}
+
+object MySuite {
+  def foo(a: List[String]) = ???
+  def foo(a: String) = ???
+
+  foo { // error
+
+    new Service {
+      private val underlying: Service = ???
+      private val s = "foo"
+
+      export underlying.*
+      export s.toLowerCase
+    }
+
+    ???
+  }
+}


### PR DESCRIPTION
Backports #21518 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]