### PR TITLE
Backport "add tracking of NotNullInfo for Match, Case, Try trees (fix #21380)" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1857,7 +1857,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       }
       .asInstanceOf[List[CaseDef]]
     var nni = sel.notNullInfo
-    if(cases1.nonEmpty) nni = nni.seq(cases1.map(_.notNullInfo).reduce(_.alt(_)))
+    if cases1.nonEmpty then nni = nni.seq(cases1.map(_.notNullInfo).reduce(_.alt(_)))
     assignType(cpy.Match(tree)(sel, cases1), sel, cases1).cast(pt).withNotNullInfo(nni)
   }
 
@@ -1866,7 +1866,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val cases1 = harmonic(harmonize, pt)(typedCases(cases, sel, wideSelType, pt.dropIfProto))
       .asInstanceOf[List[CaseDef]]
     var nni = sel.notNullInfo
-    if(cases1.nonEmpty) nni = nni.seq(cases1.map(_.notNullInfo).reduce(_.alt(_)))
+    if cases1.nonEmpty then nni = nni.seq(cases1.map(_.notNullInfo).reduce(_.alt(_)))
     assignType(cpy.Match(tree)(sel, cases1), sel, cases1).withNotNullInfo(nni)
   }
 
@@ -1937,13 +1937,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         // will end up taking too much memory. If it does, we should just limit
         // how much GADT constraints we infer - it's always sound to infer less.
         pat1.putAttachment(InferredGadtConstraints, ctx.gadt)
-      if (pt1.isValueType) // insert a cast if body does not conform to expected type if we disregard gadt bounds
+      if pt1.isValueType then // insert a cast if body does not conform to expected type if we disregard gadt bounds
         body1 = body1.ensureConforms(pt1)(using originalCtx)
-      val nni = pat1.notNullInfo.seq(
-        guard1.notNullInfoIf(false).alt(
-          guard1.notNullInfoIf(true).seq(body1.notNullInfo)
-        )
-      )
+      val nni = pat1.notNullInfo
+        .seq(guard1.notNullInfoIf(false).alt(guard1.notNullInfoIf(true)))
+        .seq(body1.notNullInfo)
       assignType(cpy.CaseDef(tree)(pat1, guard1, body1), pat1, body1).withNotNullInfo(nni)
     }
 
@@ -2048,16 +2046,25 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       untpd.Block(makeCanThrow(capabilityProof), expr)
 
   def typedTry(tree: untpd.Try, pt: Type)(using Context): Try = {
+    // We want to type check tree.expr first to comput NotNullInfo, but `addCanThrowCapabilities`
+    // uses the types of patterns in `tree.cases` to determine the capabilities.
+    // Hence, we create a copy of cases with empty body and type check that first, then type check
+    // the rest of the tree in order.
+    val casesEmptyBody1 = tree.cases.mapconserve(cpy.CaseDef(_)(body = EmptyTree))
+    val casesEmptyBody2 = typedCases(casesEmptyBody1, EmptyTree, defn.ThrowableType, WildcardType)
+
     val expr2 :: cases2x = harmonic(harmonize, pt) {
-      val cases1 = typedCases(tree.cases, EmptyTree, defn.ThrowableType, pt.dropIfProto)
-      val expr1 = typed(addCanThrowCapabilities(tree.expr, cases1), pt.dropIfProto)
+      val expr1 = typed(addCanThrowCapabilities(tree.expr, casesEmptyBody2), pt.dropIfProto)
+      val casesCtx = ctx.addNotNullInfo(expr1.notNullInfo.retractedInfo)
+      val cases1 = typedCases(tree.cases, EmptyTree, defn.ThrowableType, pt.dropIfProto)(using casesCtx)
       expr1 :: cases1
     }: @unchecked
-    val finalizer1 = typed(tree.finalizer, defn.UnitType)
     val cases2 = cases2x.asInstanceOf[List[CaseDef]]
-    val nni = expr2.notNullInfo.retractedInfo.seq(
-      cases2.map(_.notNullInfo.retractedInfo).fold(NotNullInfo.empty)(_.alt(_))
-    ).seq(finalizer1.notNullInfo)
+
+    var nni = expr2.notNullInfo.retractedInfo
+    if cases2.nonEmpty then nni = nni.seq(cases2.map(_.notNullInfo).reduce(_.alt(_)))
+    val finalizer1 = typed(tree.finalizer, defn.UnitType)(using ctx.addNotNullInfo(nni))
+    nni = nni.seq(finalizer1.notNullInfo)
     assignType(cpy.Try(tree)(expr2, cases2, finalizer1), expr2, cases2).withNotNullInfo(nni)
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2048,14 +2048,16 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       untpd.Block(makeCanThrow(capabilityProof), expr)
 
   def typedTry(tree: untpd.Try, pt: Type)(using Context): Try = {
-    // We want to type check tree.expr first to comput NotNullInfo, but `addCanThrowCapabilities`
-    // uses the types of patterns in `tree.cases` to determine the capabilities.
-    // Hence, we create a copy of cases with empty body and type check that first, then type check
-    // the rest of the tree in order.
-    val casesEmptyBody1 = tree.cases.mapconserve(cpy.CaseDef(_)(body = EmptyTree))
-    val casesEmptyBody2 = typedCases(casesEmptyBody1, EmptyTree, defn.ThrowableType, WildcardType)
-
     val expr2 :: cases2x = harmonic(harmonize, pt) {
+      // We want to type check tree.expr first to comput NotNullInfo, but `addCanThrowCapabilities`
+      // uses the types of patterns in `tree.cases` to determine the capabilities.
+      // Hence, we create a copy of cases with empty body and type check that first, then type check
+      // the rest of the tree in order.
+      // It may seem that invalid references can be created if the type of the pattern contains
+      // type binds, but this is not a valid `CanThrow` capability (checked by `addCanThrowCapabilities`),
+      // so it is not a problem.
+      val casesEmptyBody1 = tree.cases.mapconserve(cpy.CaseDef(_)(body = EmptyTree))
+      val casesEmptyBody2 = typedCases(casesEmptyBody1, EmptyTree, defn.ThrowableType, WildcardType)
       val expr1 = typed(addCanThrowCapabilities(tree.expr, casesEmptyBody2), pt.dropIfProto)
       val casesCtx = ctx.addNotNullInfo(expr1.notNullInfo.retractedInfo)
       val cases1 = typedCases(tree.cases, EmptyTree, defn.ThrowableType, pt.dropIfProto)(using casesCtx)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1929,7 +1929,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       }
       val pat1 = indexPattern(tree).transform(pat)
       val guard1 = typedExpr(tree.guard, defn.BooleanType)
-      var body1 = ensureNoLocalRefs(typedExpr(tree.body, pt1), pt1, ctx.scope.toList)
+      var body1 = ensureNoLocalRefs(
+        typedExpr(tree.body, pt1)(using ctx.addNotNullInfo(guard1.notNullInfoIf(true))),
+        pt1, ctx.scope.toList)
       if ctx.gadt.isNarrowing then
         // Store GADT constraint to later retrieve it (in PostTyper, for now).
         // GADT constraints are necessary to correctly check bounds of type app,
@@ -1940,7 +1942,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       if pt1.isValueType then // insert a cast if body does not conform to expected type if we disregard gadt bounds
         body1 = body1.ensureConforms(pt1)(using originalCtx)
       val nni = pat1.notNullInfo
-        .seq(guard1.notNullInfoIf(false).alt(guard1.notNullInfoIf(true)))
+        .seq(guard1.notNullInfoIf(true))
         .seq(body1.notNullInfo)
       assignType(cpy.CaseDef(tree)(pat1, guard1, body1), pat1, body1).withNotNullInfo(nni)
     }
@@ -2062,7 +2064,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     val cases2 = cases2x.asInstanceOf[List[CaseDef]]
 
     var nni = expr2.notNullInfo.retractedInfo
-    if cases2.nonEmpty then nni = nni.seq(cases2.map(_.notNullInfo).reduce(_.alt(_)))
+    if cases2.nonEmpty then nni = nni.seq(cases2.map(_.notNullInfo.retractedInfo).reduce(_.alt(_)))
     val finalizer1 = typed(tree.finalizer, defn.UnitType)(using ctx.addNotNullInfo(nni))
     nni = nni.seq(finalizer1.notNullInfo)
     assignType(cpy.Try(tree)(expr2, cases2, finalizer1), expr2, cases2).withNotNullInfo(nni)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1856,14 +1856,18 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         case1
       }
       .asInstanceOf[List[CaseDef]]
-    assignType(cpy.Match(tree)(sel, cases1), sel, cases1).cast(pt)
+    var nni = sel.notNullInfo
+    if(cases1.nonEmpty) nni = nni.seq(cases1.map(_.notNullInfo).reduce(_.alt(_)))
+    assignType(cpy.Match(tree)(sel, cases1), sel, cases1).cast(pt).withNotNullInfo(nni)
   }
 
   // Overridden in InlineTyper for inline matches
   def typedMatchFinish(tree: untpd.Match, sel: Tree, wideSelType: Type, cases: List[untpd.CaseDef], pt: Type)(using Context): Tree = {
     val cases1 = harmonic(harmonize, pt)(typedCases(cases, sel, wideSelType, pt.dropIfProto))
       .asInstanceOf[List[CaseDef]]
-    assignType(cpy.Match(tree)(sel, cases1), sel, cases1)
+    var nni = sel.notNullInfo
+    if(cases1.nonEmpty) nni = nni.seq(cases1.map(_.notNullInfo).reduce(_.alt(_)))
+    assignType(cpy.Match(tree)(sel, cases1), sel, cases1).withNotNullInfo(nni)
   }
 
   def typedCases(cases: List[untpd.CaseDef], sel: Tree, wideSelType: Type, pt: Type)(using Context): List[CaseDef] =
@@ -1935,7 +1939,12 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         pat1.putAttachment(InferredGadtConstraints, ctx.gadt)
       if (pt1.isValueType) // insert a cast if body does not conform to expected type if we disregard gadt bounds
         body1 = body1.ensureConforms(pt1)(using originalCtx)
-      assignType(cpy.CaseDef(tree)(pat1, guard1, body1), pat1, body1)
+      val nni = pat1.notNullInfo.seq(
+        guard1.notNullInfoIf(false).alt(
+          guard1.notNullInfoIf(true).seq(body1.notNullInfo)
+        )
+      )
+      assignType(cpy.CaseDef(tree)(pat1, guard1, body1), pat1, body1).withNotNullInfo(nni)
     }
 
     val pat1 = typedPattern(tree.pat, wideSelType)(using gadtCtx)
@@ -2046,7 +2055,10 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     }: @unchecked
     val finalizer1 = typed(tree.finalizer, defn.UnitType)
     val cases2 = cases2x.asInstanceOf[List[CaseDef]]
-    assignType(cpy.Try(tree)(expr2, cases2, finalizer1), expr2, cases2)
+    val nni = expr2.notNullInfo.retractedInfo.seq(
+      cases2.map(_.notNullInfo.retractedInfo).fold(NotNullInfo.empty)(_.alt(_))
+    ).seq(finalizer1.notNullInfo)
+    assignType(cpy.Try(tree)(expr2, cases2, finalizer1), expr2, cases2).withNotNullInfo(nni)
   }
 
   def typedTry(tree: untpd.ParsedTry, pt: Type)(using Context): Try =

--- a/tests/explicit-nulls/neg/i21380.scala
+++ b/tests/explicit-nulls/neg/i21380.scala
@@ -1,0 +1,19 @@
+@main def test() = {
+  var x: String | Null = null
+  if (false) {
+    x = ""
+
+  } else {
+    x = ""
+  }
+  try {
+    x = ""
+    throw new Exception()
+  }
+  catch {
+    case e: Exception => {
+      x = null
+    }
+  }
+  x.replace("", "") // error
+}

--- a/tests/explicit-nulls/neg/i21380b.scala
+++ b/tests/explicit-nulls/neg/i21380b.scala
@@ -3,7 +3,7 @@ def test1 =
   x = ""
   1 match
     case 1 => x = null
-    case _ => x = x.trim() // ok
+    case _ => x = x.trim() // error // LTS specific
   x.replace("", "") // error
 
 def test2(i: Int) =
@@ -11,11 +11,11 @@ def test2(i: Int) =
   i match
     case 1 => x = "1"
     case _ => x = " "
-  x.replace("", "") // ok
+  x.replace("", "") // error // LTS specific
 
 def test3(i: Int) =
   var x: String | Null = null
   i match
     case 1 if x != null => ()
     case _ => x = " "
-  x.trim() // ok
+  x.trim() // error // LTS specific

--- a/tests/explicit-nulls/neg/i21380b.scala
+++ b/tests/explicit-nulls/neg/i21380b.scala
@@ -12,3 +12,10 @@ def test2(i: Int) =
     case 1 => x = "1"
     case _ => x = " "
   x.replace("", "") // ok
+
+def test3(i: Int) =
+  var x: String | Null = null
+  i match
+    case 1 if x != null => ()
+    case _ => x = " "
+  x.trim() // ok

--- a/tests/explicit-nulls/neg/i21380b.scala
+++ b/tests/explicit-nulls/neg/i21380b.scala
@@ -1,8 +1,14 @@
-@main def test() = {
+def test1 =
   var x: String | Null = null
   x = ""
-  1 match {
+  1 match
     case 1 => x = null
-  }
+    case _ => x = x.trim() // ok
   x.replace("", "") // error
-}
+
+def test2(i: Int) =
+  var x: String | Null = null
+  i match
+    case 1 => x = "1"
+    case _ => x = " "
+  x.replace("", "") // ok

--- a/tests/explicit-nulls/neg/i21380b.scala
+++ b/tests/explicit-nulls/neg/i21380b.scala
@@ -1,0 +1,8 @@
+@main def test() = {
+  var x: String | Null = null
+  x = ""
+  1 match {
+    case 1 => x = null
+  }
+  x.replace("", "") // error
+}

--- a/tests/explicit-nulls/neg/i21380c.scala
+++ b/tests/explicit-nulls/neg/i21380c.scala
@@ -1,0 +1,34 @@
+def test1(i: Int): Int =
+  var x: String | Null = null
+  if i == 0 then x = ""
+  else x = ""
+  try
+    x = x.replace(" ", "") // ok
+    throw new Exception()
+  catch
+    case e: Exception =>
+      x = x.replaceAll(" ", "") // error
+      x = null
+  x.length // error
+
+def test2: Int =
+  var x: String | Null = null
+  try throw new Exception()
+  finally x = ""
+  x.length // ok
+
+def test3 =
+  var x: String | Null = ""
+  try throw new Exception()
+  catch case e: Exception =>
+    x = (??? : String | Null)
+  finally
+    val l = x.length // error
+
+def test4: Int =
+  var x: String | Null = null
+  try throw new Exception()
+  catch
+    case npe: NullPointerException => x = ""
+    case _ => x = ""
+  x.length // ok

--- a/tests/explicit-nulls/neg/i21380c.scala
+++ b/tests/explicit-nulls/neg/i21380c.scala
@@ -3,7 +3,7 @@ def test1(i: Int): Int =
   if i == 0 then x = ""
   else x = ""
   try
-    x = x.replace(" ", "") // ok
+    x = x.replace(" ", "") // error // LTS specific
     throw new Exception()
   catch
     case e: Exception =>
@@ -15,7 +15,7 @@ def test2: Int =
   var x: String | Null = null
   try throw new Exception()
   finally x = ""
-  x.length // ok
+  x.length // error // LTS specific
 
 def test3 =
   var x: String | Null = ""

--- a/tests/explicit-nulls/neg/i21380c.scala
+++ b/tests/explicit-nulls/neg/i21380c.scala
@@ -31,4 +31,15 @@ def test4: Int =
   catch
     case npe: NullPointerException => x = ""
     case _ => x = ""
-  x.length // ok
+  x.length // error
+  // Although the catch block here is exhaustive,
+  // it is possible that the exception is thrown and not caught.
+  // Therefore, the code after the try block can only rely on the retracted info.
+
+def test5: Int =
+  var x: String | Null = null
+  try
+    x = ""
+    throw new Exception()
+  catch
+    case npe: NullPointerException => val i: Int = x.length // error


### PR DESCRIPTION
Backports #21389 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]