### PR TITLE
Backport "Revert "Drop redundant `butNot = Param` clause in isAnchor"" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -597,7 +597,7 @@ trait ImplicitRunInfo:
   private def isAnchor(sym: Symbol) =
     sym.isClass && !isExcluded(sym)
     || sym.isOpaqueAlias
-    || sym.is(Deferred)
+    || sym.is(Deferred, butNot = Param)
     || sym.info.isInstanceOf[MatchAlias]
 
   private def computeIScope(rootTp: Type): OfTypeImplicits =


### PR DESCRIPTION
Backports #21566 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]