### PR TITLE
Backport "Survive inaccessible types when computing implicit scope" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -73,6 +73,8 @@ class MissingType(val pre: Type, val name: Name)(using Context) extends TypeErro
       case _ if givenSelf.exists && givenSelf.member(name).exists =>
         i"""$name exists as a member of the self type $givenSelf of $cls
            |but it cannot be called on a receiver whose type does not extend $cls"""
+      case _ if pre.baseClasses.exists(_.findMember(name, pre, Private, EmptyFlags).exists) =>
+        i"$name is a private member in a base class"
       case _ =>
         missingClassFile
 

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -781,6 +781,10 @@ trait ImplicitRunInfo:
           override def stopAt = StopAt.Static
           private val seen = util.HashSet[Type]()
 
+          override def derivedTypeBounds(tp: TypeBounds, lo: Type, hi: Type): Type =
+            if lo.exists && hi.exists then super.derivedTypeBounds(tp, lo, hi)
+            else NoType // Survive inaccessible types, for instance in i21543.scala.
+
           def applyToUnderlying(t: TypeProxy) =
             if seen.contains(t) then
               WildcardType

--- a/tests/neg/i21543.check
+++ b/tests/neg/i21543.check
@@ -1,0 +1,22 @@
+-- [E007] Type Mismatch Error: tests/neg/i21543.scala:10:15 ------------------------------------------------------------
+10 |      Cmd(List("1", "2")) // error // error
+   |               ^^^
+   |               Found:    ("1" : String)
+   |               Required: Event
+   |
+   |               Note that I could not resolve reference Event.
+   |               Event is a private member in a base class
+   |                                
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i21543.scala:10:20 ------------------------------------------------------------
+10 |      Cmd(List("1", "2")) // error // error
+   |                    ^^^
+   |                    Found:    ("2" : String)
+   |                    Required: Event
+   |
+   |                    Note that I could not resolve reference Event.
+   |                    Event is a private member in a base class
+   |                                     
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21543.scala
+++ b/tests/neg/i21543.scala
@@ -7,7 +7,7 @@ object CompilerCrash {
 
   new Scope {
     val commands = List(
-      Cmd(List("1", "2"))
+      Cmd(List("1", "2")) // error // error
     )
   }
 }

--- a/tests/neg/i21543.scala
+++ b/tests/neg/i21543.scala
@@ -1,0 +1,13 @@
+object CompilerCrash {
+  trait Scope {
+    private type Event = String
+
+    case class Cmd(events: List[Event])
+  }
+
+  new Scope {
+    val commands = List(
+      Cmd(List("1", "2"))
+    )
+  }
+}


### PR DESCRIPTION
Backports #21589 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]