### PR TITLE
Backport "Harden skip in Scanner" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -305,11 +305,15 @@ object Scanners {
         println(s"\nSTART SKIP AT ${sourcePos().line + 1}, $this in $currentRegion")
       var noProgress = 0
         // Defensive measure to ensure we always get out of the following while loop
-        // even if source file is weirly formatted (i.e. we never reach EOF
+        // even if source file is weirly formatted (i.e. we never reach EOF)
+      var prevOffset = offset
       while !atStop && noProgress < 3 do
-        val prevOffset = offset
         nextToken()
-        if offset == prevOffset then noProgress += 1 else noProgress = 0
+        if offset <= prevOffset then
+          noProgress += 1
+        else
+          prevOffset = offset
+          noProgress = 0
       if debugTokenStream then
         println(s"\nSTOP SKIP AT ${sourcePos().line + 1}, $this in $currentRegion")
       if token == OUTDENT then dropUntil(_.isInstanceOf[Indented])


### PR DESCRIPTION
Backports #21607 to the 3.3.5.

PR submitted by the release tooling.