### PR TITLE
Backport "Avoid cyclic errors forcing default arg types" to LTS

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -625,6 +625,10 @@ trait Applications extends Compatibility {
             fail(MissingArgument(methodType.paramNames(n), methString))
 
           def tryDefault(n: Int, args1: List[Arg]): Unit = {
+            if !success then
+              missingArg(n) // fail fast before forcing the default arg tpe, to avoid cyclic errors
+              return
+
             val sym = methRef.symbol
             val testOnly = this.isInstanceOf[TestApplication[?]]
 

--- a/tests/neg/19414-desugared.check
+++ b/tests/neg/19414-desugared.check
@@ -8,7 +8,6 @@
    |      writer =
    |        /* ambiguous: both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B] */
    |          summon[Writer[B]]
-   |      ,
-   |    this.given_BodySerializer_B$default$2[B])
+   |    )
    |
    |But both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B].

--- a/tests/neg/19414.check
+++ b/tests/neg/19414.check
@@ -8,7 +8,6 @@
    |      evidence$1 =
    |        /* ambiguous: both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B] */
    |          summon[Writer[B]]
-   |      ,
-   |    this.given_BodySerializer_B$default$2[B])
+   |    )
    |
    |But both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B].

--- a/tests/neg/given-ambiguous-default-2.check
+++ b/tests/neg/given-ambiguous-default-2.check
@@ -1,9 +1,9 @@
 -- [E172] Type Error: tests/neg/given-ambiguous-default-2.scala:18:23 --------------------------------------------------
 18 |def f: Unit = summon[C] // error: Ambiguous given instances
    |                       ^
-   |No best given instance of type C was found for parameter x of method summon in object Predef.
-   |I found:
+   |            No best given instance of type C was found for parameter x of method summon in object Predef.
+   |            I found:
    |
-   |    given_C(a = /* ambiguous: both given instance a1 and given instance a2 match type A */summon[A], this.given_C$default$2)
+   |                given_C(a = /* ambiguous: both given instance a1 and given instance a2 match type A */summon[A])
    |
-   |But both given instance a1 and given instance a2 match type A.
+   |            But both given instance a1 and given instance a2 match type A.

--- a/tests/pos/i21568.scala
+++ b/tests/pos/i21568.scala
@@ -1,0 +1,6 @@
+class Lang(name: String)
+object Lang {
+  val Default = Lang("")
+  def apply(language: String): Lang = ???
+  def apply(maybeLang: Option[String], default: Lang = Default): Lang = ???
+}


### PR DESCRIPTION
Backports #21597 to the 3.3.5.

PR submitted by the release tooling.
[skip ci]