### PR TITLE
Fix CLA checks after domain change of CLA check server

### DIFF
--- a/project/scripts/check-cla.sh
+++ b/project/scripts/check-cla.sh
@@ -5,7 +5,7 @@ echo "Pull request submitted by $AUTHOR";
 if [[ "$AUTHOR" == "github-actions[bot]" || "$AUTHOR" == "dependabot[bot]" ]] ; then
   echo "CLA check for $AUTHOR successful";
 else
-  signed=$(curl -s "https://contribute.akka.io/contribute/cla/scala/check/$AUTHOR" | jq -r ".signed");
+  signed=$(curl -L -s "https://contribute.akka.io/contribute/cla/scala/check/$AUTHOR" | jq -r ".signed");
   if [ "$signed" = "true" ] ; then
     echo "CLA check for $AUTHOR successful";
   else

--- a/project/scripts/check-cla.sh
+++ b/project/scripts/check-cla.sh
@@ -5,16 +5,16 @@ echo "Pull request submitted by $AUTHOR";
 if [[ "$AUTHOR" == "github-actions[bot]" || "$AUTHOR" == "dependabot[bot]" ]] ; then
   echo "CLA check for $AUTHOR successful";
 else
-  signed=$(curl -s "https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR" | jq -r ".signed");
+  signed=$(curl -s "https://contribute.akka.io/contribute/cla/scala/check/$AUTHOR" | jq -r ".signed");
   if [ "$signed" = "true" ] ; then
     echo "CLA check for $AUTHOR successful";
   else
     echo "CLA check for $AUTHOR failed";
     echo "Please sign the Scala CLA to contribute to the Scala compiler.";
-    echo "Go to https://www.lightbend.com/contribute/cla/scala and then";
+    echo "Go to https://contribute.akka.io/contribute/cla/scala and then";
     echo "comment on the pull request to ask for a new check.";
     echo "";
-    echo "Check if CLA is signed: https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR";
+    echo "Check if CLA is signed: https://contribute.akka.io/contribute/cla/scala/check/$AUTHOR";
     exit 1;
   fi;
 fi;


### PR DESCRIPTION
`https://www.lightbend.com/contribute/cla/scala/check/` now is a redirect to `https://contribute.akka.io/contribute/cla/scala/check`. 
It's breaking CLA check becouse curl by default does not follow redirects