### PR TITLE
Elide capabilities implied by Capability subtypes when printing

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -177,11 +177,16 @@ class PlainPrinter(_ctx: Context) extends Printer {
    *  capturing function types.
    */
   protected def toTextCapturing(parent: Type, refsText: Text, boxText: Text): Text =
-    changePrec(InfixPrec):
-      boxText ~ toTextLocal(parent) ~ "^"
-      ~ (refsText provided refsText != rootSetText)
+    def coreText = boxText ~ toTextLocal(parent)
+    if parent.derivesFrom(defn.Caps_Capability)
+      && refsText == impliedByCapabilitySetText
+      && !printDebug
+    then coreText
+    else changePrec(InfixPrec):
+      coreText~ "^" ~ (refsText provided refsText != rootSetText)
 
   final protected def rootSetText = Str("{cap}") // TODO Use disambiguation
+  final protected def impliedByCapabilitySetText = Str("{cap}")
 
   def toText(tp: Type): Text = controlled {
     homogenize(tp) match {

--- a/tests/neg-custom-args/captures/byname.check
+++ b/tests/neg-custom-args/captures/byname.check
@@ -8,10 +8,10 @@
 -- Error: tests/neg-custom-args/captures/byname.scala:19:5 -------------------------------------------------------------
 19 |  h(g()) // error
    |    ^^^
-   |    reference (cap2 : Cap^) is not included in the allowed capture set {cap1}
+   |    reference (cap2 : Cap) is not included in the allowed capture set {cap1}
    |    of an enclosing function literal with expected type () ?->{cap1} I
 -- Error: tests/neg-custom-args/captures/byname.scala:22:12 ------------------------------------------------------------
 22 |  h2(() => g())() // error
    |           ^^^
-   |           reference (cap2 : Cap^) is not included in the allowed capture set {cap1}
+   |           reference (cap2 : Cap) is not included in the allowed capture set {cap1}
    |           of an enclosing function literal with expected type () ->{cap1} I

--- a/tests/neg-custom-args/captures/cc-this5.check
+++ b/tests/neg-custom-args/captures/cc-this5.check
@@ -1,7 +1,7 @@
 -- Error: tests/neg-custom-args/captures/cc-this5.scala:16:20 ----------------------------------------------------------
 16 |    def f = println(c)  // error
    |                    ^
-   |                    reference (c : Cap^) is not included in the allowed capture set {}
+   |                    reference (c : Cap) is not included in the allowed capture set {}
    |                    of the enclosing class A
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-this5.scala:21:15 -------------------------------------
 21 |    val x: A = this // error

--- a/tests/neg-custom-args/captures/effect-swaps.check
+++ b/tests/neg-custom-args/captures/effect-swaps.check
@@ -25,5 +25,5 @@
 -- Error: tests/neg-custom-args/captures/effect-swaps.scala:66:15 ------------------------------------------------------
 66 |        Result.make: // error: local reference leaks
    |        ^^^^^^^^^^^
-   |local reference contextual$9 from (using contextual$9: boundary.Label[Result[box Future[box T^?]^{fr, contextual$9}, box E^?]]^):
+   |local reference contextual$9 from (using contextual$9: boundary.Label[Result[box Future[box T^?]^{fr, contextual$9}, box E^?]]):
    |  box Future[box T^?]^{fr, contextual$9} leaks into outer capture set of type parameter T of method make in object Result

--- a/tests/neg-custom-args/captures/explain-under-approx.check
+++ b/tests/neg-custom-args/captures/explain-under-approx.check
@@ -1,14 +1,14 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/explain-under-approx.scala:12:10 -------------------------
 12 |  col.add(Future(() => 25)) // error
    |          ^^^^^^^^^^^^^^^^
-   |          Found:    Future[Int]{val a: (async : Async^)}^{async}
+   |          Found:    Future[Int]{val a: (async : Async)}^{async}
    |          Required: Future[Int]^{col.futs*}
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/explain-under-approx.scala:15:11 -------------------------
 15 |  col1.add(Future(() => 25)) // error
    |           ^^^^^^^^^^^^^^^^
-   |           Found:    Future[Int]{val a: (async : Async^)}^{async}
+   |           Found:    Future[Int]{val a: (async : Async)}^{async}
    |           Required: Future[Int]^{col1.futs*}
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/extending-cap-classes.check
+++ b/tests/neg-custom-args/captures/extending-cap-classes.check
@@ -1,21 +1,21 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/extending-cap-classes.scala:7:15 -------------------------
 7 |  val x2: C1 = new C2 // error
   |               ^^^^^^
-  |               Found:    C2^
+  |               Found:    C2
   |               Required: C1
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/extending-cap-classes.scala:8:15 -------------------------
 8 |  val x3: C1 = new C3 // error
   |               ^^^^^^
-  |               Found:    C3^
+  |               Found:    C3
   |               Required: C1
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/extending-cap-classes.scala:13:15 ------------------------
 13 |  val z2: C1 = y2 // error
    |               ^^
-   |               Found:    (y2 : C2^)
+   |               Found:    (y2 : C2)
    |               Required: C1
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21614.check
+++ b/tests/neg-custom-args/captures/i21614.check
@@ -1,8 +1,8 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21614.scala:12:33 ---------------------------------------
 12 |  files.map((f: F) => new Logger(f)) // error, Q: can we make this pass (see #19076)?
    |                                 ^
-   |                                 Found:    (f : F^)
-   |                                 Required: File^
+   |                                 Found:    (f : F)
+   |                                 Required: File
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21614.scala:15:12 ---------------------------------------


### PR DESCRIPTION
When printing a type `C^` where `C` extends `Capability`, don't show the `^`. This is overridden under -Yprint-debug.