### PR TITLE
Limit exposure to ConcurrentModificationException when sys props are replaced or mutated

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -53,7 +53,8 @@ object PathResolver {
     def classPathEnv: String        =  envOrElse("CLASSPATH", "")
     def sourcePathEnv: String       =  envOrElse("SOURCEPATH", "")
 
-    def javaBootClassPath: String   = propOrElse("sun.boot.class.path", searchForBootClasspath)
+    //using propOrNone/getOrElse instead of propOrElse so that searchForBootClasspath is lazy evaluated
+    def javaBootClassPath: String   = propOrNone("sun.boot.class.path") getOrElse searchForBootClasspath
 
     def javaExtDirs: String         = propOrEmpty("java.ext.dirs")
     def scalaHome: String           = propOrEmpty("scala.home")


### PR DESCRIPTION
port of https://github.com/scala/scala/commit/f6859f28bb49193fde83e6020a6a89ce926a91e8 to fix https://github.com/sbt/sbt/issues/7873