### PR TITLE
[CI]: Fix Chocolatey publish workflow

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           name: scala.nupkg
       - name: Publish the package to Chocolatey
-        run: choco push scala.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.API-KEY }}
+        run: choco push scala.${{inputs.version}}.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.API-KEY }}
         


### PR DESCRIPTION
[skip ci]

Tested during hotfix release to Chocolatey during Scala 3.6.2 release: https://github.com/scala/scala3/actions/runs/12259635569/job/34202317793