### PR TITLE
fix: update `scala-cli.jar` path

### DIFF
--- a/dist/libexec/cli-common-platform
+++ b/dist/libexec/cli-common-platform
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-SCALA_CLI_CMD_BASH=("\"$JAVACMD\"" "-jar \"$PROG_HOME/bin/scala-cli.jar\"")
+SCALA_CLI_CMD_BASH=("\"$JAVACMD\"" "-jar \"$PROG_HOME/libexec/scala-cli.jar\"")

--- a/dist/libexec/cli-common-platform.bat
+++ b/dist/libexec/cli-common-platform.bat
@@ -2,4 +2,4 @@
 
 @rem we need to escape % in the java command path, for some reason this doesnt work in common.bat
 set "_JAVACMD=!_JAVACMD:%%=%%%%!"
-set SCALA_CLI_CMD_WIN="%_JAVACMD%" "-jar" "%_PROG_HOME%\bin\scala-cli.jar"
+set SCALA_CLI_CMD_WIN="%_JAVACMD%" "-jar" "%_PROG_HOME%\libexec\scala-cli.jar"


### PR DESCRIPTION
update scala-cli.jar path ref per https://github.com/scala/scala3/pull/21427

seeing some test failure in https://github.com/Homebrew/homebrew-core/pull/200691

```
Error: Unable to access jarfile /opt/homebrew/Cellar/scala/3.6.2/libexec/bin/scala-cli.jar
```