### PR TITLE
Update reference, MiMa previous version and sync TASTy version

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2447,7 +2447,6 @@ object Build {
         versionScheme := Some("semver-spec"),
         Test / envVars ++= Map(
           "EXPECTED_TASTY_VERSION" -> expectedTastyVersion,
-          "BASE_VERSION" -> baseVersion
         ),
         if (mode == Bootstrapped) Def.settings(
           commonMiMaSettings,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -149,9 +149,9 @@ object Build {
    *  For a developedVersion `3.M.P` the mimaPreviousDottyVersion should be set to:
    *   - `3.M.0`     if `P > 0`
    *   - `3.(M-1).0` if `P = 0`
-   *  3.6.1 is an exception from this rule - 3.6.0 was a broken release
+   *  3.6.2 is an exception from this rule - 3.6.0 was a broken release, 3.6.1 was hotfix (unstable) release
    */
-  val mimaPreviousDottyVersion = "3.6.1"
+  val mimaPreviousDottyVersion = "3.6.2"
 
   /** LTS version against which we check binary compatibility.
    *

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -97,7 +97,7 @@ object Build {
    *  - In release branch it should be the last stable release
    *  3.6.0-RC1 was released as 3.6.0 - it's having and experimental TASTy version
    */
-  val referenceVersion = "3.6.0"
+  val referenceVersion = "3.6.3-RC1"
 
   /** Version of the Scala compiler targeted in the current release cycle
    *  Contains a version without RC/SNAPSHOT/NIGHTLY specific suffixes

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -324,7 +324,7 @@ object TastyFormat {
    *  compatibility, but remains backwards compatible, with all
    *  preceding `MinorVersion`.
    */
-  final val MinorVersion: Int = 6
+  final val MinorVersion: Int = 7
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing

--- a/tasty/test/dotty/tools/tasty/BuildTastyVersionTest.scala
+++ b/tasty/test/dotty/tools/tasty/BuildTastyVersionTest.scala
@@ -1,0 +1,65 @@
+package dotty.tools.tasty
+
+import org.junit.Assert._
+import org.junit.Test
+
+import TastyBuffer._
+
+// Tests ensuring TASTY version emitted by compiler is matching expected TASTY version
+class BuildTastyVersionTest {
+  
+  val CurrentTastyVersion = TastyVersion(TastyFormat.MajorVersion, TastyFormat.MinorVersion, TastyFormat.ExperimentalVersion)
+  
+  // Needs to be defined in build Test/envVars
+  val ExpectedTastyVersionEnvVar = "EXPECTED_TASTY_VERSION"
+  val BaseVersionEnvVar = "BASE_VERSION"
+  
+  @Test def testBuildTastyVersion(): Unit = {
+    val expectedVersion = sys.env.get(ExpectedTastyVersionEnvVar)
+      .getOrElse(fail(s"Env variable $ExpectedTastyVersionEnvVar not defined"))
+      .match {
+        case s"$major.$minor-experimental-$experimental" => TastyVersion(major.toInt, minor.toInt, experimental.toInt)
+        case s"$major.$minor" if minor.forall(_.isDigit) => TastyVersion(major.toInt, minor.toInt, 0)
+        case other => fail(s"Invalid TASTY version string: $other")
+      }
+    assertEquals(CurrentTastyVersion, expectedVersion)
+  }
+  
+  // Tested only in nightly / release builds
+  // Protects from publishing artifacts with incorrect TASTY version
+  @Test def testReleasedTastyVersion(): Unit = {
+    lazy val (minor, patch, isRC) = sys.env.get(BaseVersionEnvVar)
+      .getOrElse(fail(s"Env variable $BaseVersionEnvVar not defined"))
+      .match {
+        case s"3.$minor.$patch-${_}" => (minor.toInt, patch.toInt, true)
+        case s"3.$minor.$patch"      => (minor.toInt, patch.toInt, false)
+        case other => fail(s"Invalid Scala base version string: $other")
+      }
+  
+    if sys.env.get("NIGHTLYBUILD").contains("yes") then {
+      assertTrue(
+        "TASTY needs to be experimental in nightly builds",
+        CurrentTastyVersion.isExperimental
+      )
+      assertEquals(
+        CurrentTastyVersion.minor,
+        if patch == 0 then minor else (minor + 1)
+      )
+    } else if sys.env.get("RELEASEBUILD").contains("yes") then {
+      assertEquals(
+        "Minor versions of TASTY vesion and Scala version should match in stable release",
+        CurrentTastyVersion.minor, minor
+      )
+      if isRC then
+        assertEquals(
+          "TASTy should be experimental when releasing a new minor version RC",
+          CurrentTastyVersion.isExperimental, patch == 0
+        )  
+      else 
+        assertFalse(
+          "Stable version cannot use experimental TASTY", 
+          CurrentTastyVersion.isExperimental
+        )
+    }
+  }
+}

--- a/tasty/test/dotty/tools/tasty/BuildTastyVersionTest.scala
+++ b/tasty/test/dotty/tools/tasty/BuildTastyVersionTest.scala
@@ -12,7 +12,6 @@ class BuildTastyVersionTest {
   
   // Needs to be defined in build Test/envVars
   val ExpectedTastyVersionEnvVar = "EXPECTED_TASTY_VERSION"
-  val BaseVersionEnvVar = "BASE_VERSION"
   
   @Test def testBuildTastyVersion(): Unit = {
     val expectedVersion = sys.env.get(ExpectedTastyVersionEnvVar)
@@ -23,43 +22,5 @@ class BuildTastyVersionTest {
         case other => fail(s"Invalid TASTY version string: $other")
       }
     assertEquals(CurrentTastyVersion, expectedVersion)
-  }
-  
-  // Tested only in nightly / release builds
-  // Protects from publishing artifacts with incorrect TASTY version
-  @Test def testReleasedTastyVersion(): Unit = {
-    lazy val (minor, patch, isRC) = sys.env.get(BaseVersionEnvVar)
-      .getOrElse(fail(s"Env variable $BaseVersionEnvVar not defined"))
-      .match {
-        case s"3.$minor.$patch-${_}" => (minor.toInt, patch.toInt, true)
-        case s"3.$minor.$patch"      => (minor.toInt, patch.toInt, false)
-        case other => fail(s"Invalid Scala base version string: $other")
-      }
-  
-    if sys.env.get("NIGHTLYBUILD").contains("yes") then {
-      assertTrue(
-        "TASTY needs to be experimental in nightly builds",
-        CurrentTastyVersion.isExperimental
-      )
-      assertEquals(
-        CurrentTastyVersion.minor,
-        if patch == 0 then minor else (minor + 1)
-      )
-    } else if sys.env.get("RELEASEBUILD").contains("yes") then {
-      assertEquals(
-        "Minor versions of TASTY vesion and Scala version should match in stable release",
-        CurrentTastyVersion.minor, minor
-      )
-      if isRC then
-        assertEquals(
-          "TASTy should be experimental when releasing a new minor version RC",
-          CurrentTastyVersion.isExperimental, patch == 0
-        )  
-      else 
-        assertFalse(
-          "Stable version cannot use experimental TASTY", 
-          CurrentTastyVersion.isExperimental
-        )
-    }
   }
 }


### PR DESCRIPTION
* Update reference version to 3.6.3-RC1 (from 3.6.0)
* Update mima previous binary verison to 3.6.2 (instead of unofficial 3.6.1) 
* Set TASTy version to `28.7-experimental-1` - it should have been set when branching of 3.6.3. 
* We now document better how and when tasty version should be set 
* Add additional runtime test to ensure we don't emit invalid TASTy version during Release / NIGHTLY releases and the expected version set in build matches version defined in TastyFormat - resolves #13447
 
Reference version and TASTy version bump needs to be performed at the same time (otherwise usage of compiler with stable TASTY would lead to failure in from-tasty non-bootstrapped tests)

[test_non_bootstrapped]
