### PR TITLE
Disable safe.directory git checks in the container image

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update && \
                        openjdk-21-jdk-headless && \
     (curl -fsSL https://deb.nodesource.com/setup_18.x | bash -) && \
     apt-get install -y nodejs && \
-    apt-get install -y zip unzip
+    apt-get install -y zip unzip && \
+    # Ensure Git can do stuff in the working directory
+    git config --system --add safe.directory '*'
 
 
 # Install sbt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,6 @@ jobs:
       ## Workaround for https://github.com/actions/runner/issues/2033 (See https://github.com/scala/scala3/pull/19720)
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -133,7 +132,6 @@ jobs:
 
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -190,7 +188,6 @@ jobs:
 
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -229,7 +226,6 @@ jobs:
       - name: Reset existing repo
         shell: cmd
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Git Checkout
@@ -273,7 +269,6 @@ jobs:
       - name: Reset existing repo
         shell: cmd
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Git Checkout
@@ -319,7 +314,6 @@ jobs:
 
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -374,7 +368,6 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -391,7 +384,6 @@ jobs:
 
       - name: Test
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git submodule sync
           git submodule update --init --recursive --jobs 7
           ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestA"
@@ -431,7 +423,6 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -448,7 +439,6 @@ jobs:
 
       - name: Test
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git submodule sync
           git submodule update --init --recursive --jobs 7
           ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestB"
@@ -488,7 +478,6 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -505,7 +494,6 @@ jobs:
 
       - name: Test
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git submodule sync
           git submodule update --init --recursive --jobs 7
           ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestC"
@@ -541,7 +529,6 @@ jobs:
 
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -593,7 +580,6 @@ jobs:
 
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -648,7 +634,6 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -706,7 +691,6 @@ jobs:
     steps:
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script
@@ -723,7 +707,6 @@ jobs:
 
       - name: Generate Website
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           ./project/scripts/genDocs -doc-snapshot
 
       - name: Deploy Website to https://dotty.epfl.ch
@@ -764,7 +747,6 @@ jobs:
         run: echo "/usr/lib/jvm/java-8-openjdk-amd64/bin" >> $GITHUB_PATH
       - name: Reset existing repo
         run: |
-          git config --global --add safe.directory /__w/scala3/scala3
           git -c "http.https://github.com/.extraheader=" fetch --recurse-submodules=no "https://github.com/scala/scala3" && git reset --hard FETCH_HEAD || true
 
       - name: Checkout cleanup script


### PR DESCRIPTION
`git config --system --add safe.directory $PWD` is required in our setup when using containers in the CI. However, setting it once per job is not enough - it is not persisted between steps. 

It coused problems during 3.6.3-RC1 release - https://github.com/scala/scala3/actions/runs/12253895253/job/34194840440#step:15:25 

It also leads to swallowed exceptions when republishing SDK https://github.com/scala/scala3/actions/runs/12253895253/job/34194840440#step:15:25 

It is also a blocker for tests in LTS fork, in safe directory should be set to $PWD in every fork - https://github.com/scala/scala3-lts/pull/23/files 

We can disabled the safe.directory checks globally in the published docker image. 
Tested in a fork repository: https://github.com/WojciechMazur/dotty/pull/2/checks 

Before merging requires: 
 [ ] - Publishing new version of `lampepfl:dotty` container image 
 [ ] - Updating CI in this branch to use updated container image