### PR TITLE
Only count associated files of direct members of package objects in dropStale

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2539,7 +2539,9 @@ object SymDenotations {
           )
         if compiledNow.exists then compiledNow
         else
-          val assocFiles = multi.aggregate(d => Set(d.symbol.associatedFile.nn), _ union _)
+          val assocFiles = multi
+            .filterWithPredicate(_.symbol.maybeOwner.isPackageObject)
+            .aggregate(d => Set(d.symbol.associatedFile.nn), _ union _)
           if assocFiles.size == 1 then
             multi // they are all overloaded variants from the same file
           else

--- a/tests/pos/i17394/_1.scala
+++ b/tests/pos/i17394/_1.scala
@@ -1,0 +1,9 @@
+package example:
+  def xd: Int = ???
+
+package bar:
+  trait A:
+    def foo: String = ???
+
+package object example extends bar.A:
+  def foo(x: String): String = ???

--- a/tests/pos/i17394/_2.scala
+++ b/tests/pos/i17394/_2.scala
@@ -1,0 +1,4 @@
+import example.*
+
+@main def main =
+  val _ = foo

--- a/tests/pos/i17394b/_1.scala
+++ b/tests/pos/i17394b/_1.scala
@@ -1,0 +1,9 @@
+package example:
+  def xd: Int = ???
+
+package bar:
+  trait A:
+    def foo: String = ???
+
+package object example extends bar.A:
+  def foo(x: String): String = ???

--- a/tests/pos/i17394b/_2.scala
+++ b/tests/pos/i17394b/_2.scala
@@ -1,0 +1,5 @@
+//> using options -Wunused:imports
+
+import example.{given, *}
+
+@main def main = ()


### PR DESCRIPTION
possible fix for #17394 