### PR TITLE
Fix layout of released SDK archives, restore intermiediete top-level directory 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -801,19 +801,16 @@ jobs:
             distDir="$3"
 
             # Build binaries
-            ./project/scripts/sbt "${sbtProject}/Universal/stage"
+            ./project/scripts/sbt "all ${sbtProject}/Universal/packageBin ${sbtProject}/Universal/packageZipTarball"
 
             outputPath="${distDir}/target/universal/stage"
             artifactName="scala3-${{ env.RELEASE_TAG }}${distroSuffix}"
             zipArchive="${artifactName}.zip"
             tarGzArchive="${artifactName}.tar.gz"
 
-            cwd=$(pwd)
-            (cd $outputPath && zip -r ${zipArchive} . && mv ${zipArchive} "${cwd}/")
-            tar -czf ${tarGzArchive} -C "$outputPath" .
-
             # Caluclate SHA for each of archive files
             for file in "${zipArchive}" "${tarGzArchive}"; do
+              mv $outputPath/$file $file
               sha256sum "${file}" > "${file}.sha256"
             done
           }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -803,14 +803,11 @@ jobs:
             # Build binaries
             ./project/scripts/sbt "all ${sbtProject}/Universal/packageBin ${sbtProject}/Universal/packageZipTarball"
 
-            outputPath="${distDir}/target/universal/stage"
             artifactName="scala3-${{ env.RELEASE_TAG }}${distroSuffix}"
-            zipArchive="${artifactName}.zip"
-            tarGzArchive="${artifactName}.tar.gz"
 
             # Caluclate SHA for each of archive files
-            for file in "${zipArchive}" "${tarGzArchive}"; do
-              mv $outputPath/$file $file
+            for file in "${artifactName}.zip" "${artifactName}.tar.gz"; do
+              mv ${distDir}/target/universal/$file $file
               sha256sum "${file}" > "${file}.sha256"
             done
           }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2257,7 +2257,14 @@ object Build {
     // ========
     Universal / stage := (Universal / stage).dependsOn(republish).value,
     Universal / packageBin := (Universal / packageBin).dependsOn(republish).value,
-    Universal / packageZipTarball := (Universal / packageZipTarball).dependsOn(republish).value,
+    Universal / packageZipTarball := (Universal / packageZipTarball).dependsOn(republish)
+      .map { archiveFile =>
+        // Rename .tgz to .tar.gz for consistency with previous versions
+        val renamedFile = archiveFile.getParentFile() / archiveFile.getName.replaceAll("\\.tgz$", ".tar.gz")
+        IO.move(archiveFile, renamedFile)
+        renamedFile
+      }
+      .value,
     // ========
     Universal / mappings ++= directory(dist.base / "bin"),
     Universal / mappings ++= directory(republishRepo.value / "maven2"),


### PR DESCRIPTION
Fixes #22194 

Restores top-level directory `scala3-${version}` that is present in artifacts published before Scala 3.6, removed during hotfix  3.6.1 release. 
We now follow the [Well formed SDK archives layout](https://github.com/sdkman/sdkman-cli/wiki/Well-formed-SDK-archives). Removing the top-level directory even though at first glance looked like an improvement was in fact introducing problems to multiple package managers and build tools. 

Follow up actionable: 
 - [x] - Republish release artifacts for Scala 3.6.2 
 - [x] - Revert https://github.com/coursier/apps/pull/256