### PR TITLE
REPL: JLine: follow recommendation to use JNI, not JNA; also JLine 3.27.1 (was 3.27.0)

### DIFF
--- a/dist/libexec/common-shared
+++ b/dist/libexec/common-shared
@@ -28,7 +28,7 @@ function onExit() {
 # to reenable echo if we are interrupted before completing.
 trap onExit INT TERM EXIT
 
-unset cygwin mingw msys darwin conemu
+unset cygwin mingw msys darwin
 
 # COLUMNS is used together with command line option '-pageWidth'.
 if command -v tput >/dev/null 2>&1; then
@@ -57,8 +57,6 @@ esac
 
 unset CYGPATHCMD
 if [[ ${cygwin-} || ${mingw-} || ${msys-} ]]; then
-  # ConEmu terminal is incompatible with jna-5.*.jar
-  [[ (${CONEMUANSI-} || ${ConEmuANSI-}) ]] && conemu=true
   # cygpath is used by various windows shells: cygwin, git-sdk, gitbash, msys, etc.
   CYGPATHCMD=`which cygpath 2>/dev/null`
   case "$TERM" in

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -765,7 +765,7 @@ object Build {
         Dependencies.compilerInterface,
         "org.jline" % "jline-reader" % "3.27.0",   // used by the REPL
         "org.jline" % "jline-terminal" % "3.27.0",
-        "org.jline" % "jline-terminal-jna" % "3.27.0", // needed for Windows
+        "org.jline" % "jline-terminal-jni" % "3.27.0", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -763,9 +763,9 @@ object Build {
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" % "scala-asm" % "9.7.0-scala-2", // used by the backend
         Dependencies.compilerInterface,
-        "org.jline" % "jline-reader" % "3.27.0",   // used by the REPL
-        "org.jline" % "jline-terminal" % "3.27.0",
-        "org.jline" % "jline-terminal-jni" % "3.27.0", // needed for Windows
+        "org.jline" % "jline-reader" % "3.27.1",   // used by the REPL
+        "org.jline" % "jline-terminal" % "3.27.1",
+        "org.jline" % "jline-terminal-jni" % "3.27.1", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 


### PR DESCRIPTION
as per the https://github.com/jline/jline3 readme
 
and as per discussion and linked items on #22201 

fixes #22201

note that as far as I can tell, the stuff I removed from libexec/common-shared is dead code

@philwalk dunno if you're still around but judging from #12405 you might be a good reviewer here

note that I believe we _don't_ need to also port https://github.com/scala/scala/pull/10889 here, since we are already using separate JLine JARs rather than the all-in-one JAR

I've chosen not to upgrade all the way to JLine 3.28.0 at the moment, as it is quite new (2 days ago) and doesn't appear to have any fixes that might be critical.