### PR TITLE
Partial Fix #21242: Add REPL init script setting

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -126,6 +126,7 @@ trait CommonScalaSettings:
   val encoding: Setting[String] = StringSetting(RootSetting, "encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding, aliases = List("--encoding"))
   val usejavacp: Setting[Boolean] = BooleanSetting(RootSetting, "usejavacp", "Utilize the java.class.path in classpath resolution.", aliases = List("--use-java-class-path"))
   val scalajs: Setting[Boolean] = BooleanSetting(RootSetting, "scalajs", "Compile in Scala.js mode (requires scalajs-library.jar on the classpath).", aliases = List("--scalajs"))
+  val replInitScript: Setting[String] = StringSetting(RootSetting, "repl-init-script", "code", "The code will be run on REPL startup.", "")
 end CommonScalaSettings
 
 /** -P "plugin" settings. Various tools might support plugins. */

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -126,7 +126,7 @@ trait CommonScalaSettings:
   val encoding: Setting[String] = StringSetting(RootSetting, "encoding", "encoding", "Specify character encoding used by source files.", Properties.sourceEncoding, aliases = List("--encoding"))
   val usejavacp: Setting[Boolean] = BooleanSetting(RootSetting, "usejavacp", "Utilize the java.class.path in classpath resolution.", aliases = List("--use-java-class-path"))
   val scalajs: Setting[Boolean] = BooleanSetting(RootSetting, "scalajs", "Compile in Scala.js mode (requires scalajs-library.jar on the classpath).", aliases = List("--scalajs"))
-  val replInitScript: Setting[String] = StringSetting(RootSetting, "repl-init-script", "code", "The code will be run on REPL startup.", "")
+  val replInitScript: Setting[String] = StringSetting(RootSetting, "repl-init-script", "code", "The code will be run on REPL startup.", "", aliases = List("--repl-init-script"))
 end CommonScalaSettings
 
 /** -P "plugin" settings. Various tools might support plugins. */

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -116,7 +116,12 @@ class ReplDriver(settings: Array[String],
   }
 
   /** the initial, empty state of the REPL session */
-  final def initialState: State = State(0, 0, Map.empty, Set.empty, false, rootCtx)
+  final def initialState: State =
+    val emptyState = State(0, 0, Map.empty, Set.empty, false, rootCtx)
+    val initScript = rootCtx.settings.replInitScript.value(using rootCtx)
+    initScript.trim() match
+      case "" => emptyState
+      case script => run(script)(using emptyState)
 
   /** Reset state of repl to the initial state
    *

--- a/compiler/test-resources/repl/init-script-flag
+++ b/compiler/test-resources/repl/init-script-flag
@@ -1,0 +1,5 @@
+scala>:reset --repl-init-script:'println("Hello from init script!")'
+Resetting REPL state with the following settings:
+  --repl-init-script:println("Hello from init script!")
+
+Hello from init script!


### PR DESCRIPTION
Partial fix #21242

Test with flag at REPL startup: 

```scala
> ./bin/scalaQ --repl-init-script 'println("Hello from init script!"); val i = 2 * 2'
[warning] MainGenericRunner class is deprecated since Scala 3.5.0, and Scala CLI features will not work.
[warning] Please be sure to update to the Scala CLI launcher to use the new features.
[warning] Check the Scala 3.5.0 release notes to troubleshoot your installation.
Hello from init script!
val i: Int = 4
Welcome to Scala 3.6.4-RC1-bin-SNAPSHOT-nonbootstrapped-git-5ea7c13 (17.0.12, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> 

```

Test inside REPL:

```scala
sbt:scala3> repl
Welcome to Scala 3.6.4-RC1-bin-SNAPSHOT-nonbootstrapped-git-20e6f11 (17.0.12, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> :reset --repl-init-script:'println("Hello from init script!")'
Resetting REPL state with the following settings:
  --repl-init-script:println("Hello from init script!")

Hello from init script!
                                                                                                                                            
scala> 
```

scala-cli can use this flag to passing init code to REPL.