### PR TITLE
Merge -Xno-decode-stacktraces with -Xno-enrich-error-messages

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -353,8 +353,7 @@ private sealed trait XSettings:
   val XreadComments: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xread-docs", "Read documentation from tasty.")
 
   /** Area-specific debug output */
-  val XnoDecodeStacktraces: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xno-decode-stacktraces", "Show raw StackOverflow stacktraces, instead of decoding them into triggering operations.")
-  val XnoEnrichErrorMessages: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xno-enrich-error-messages", "Show raw error messages, instead of enriching them with contextual information.")
+  val XnoEnrichErrorMessages: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xno-enrich-error-messages", "Show raw error messages, instead of enriching them with contextual information.", aliases = List("Xno-decode-stacktraces"))
   val XdebugMacros: Setting[Boolean] = BooleanSetting(AdvancedSetting, "Xdebug-macros", "Show debug info when quote pattern match fails")
 
   /** Pipeline compilation options */

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -137,7 +137,7 @@ object handleRecursive:
     e
 
   def apply(op: String, details: => String, exc: Throwable, weight: Int = 1)(using Context): Nothing =
-    if ctx.settings.XnoDecodeStacktraces.value then
+    if ctx.settings.XnoEnrichErrorMessages.value then
       throw exc
     else exc match
       case _: RecursionOverflow =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -392,7 +392,7 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
         }
       catch
         case ex: Throwable =>
-          if !ctx.settings.XnoDecodeStacktraces.value
+          if !ctx.settings.XnoEnrichErrorMessages.value
             && handleRecursive.underlyingStackOverflowOrNull(ex) != null then
             throw StackSizeExceeded(mdef)
           else


### PR DESCRIPTION
The two mean very similar things and -Xno-enrich-error-messages is better documented, so more people will know to reach for it.

Keep -Xno-decode-stacktraces as an alias for -Xno-enrich-error-messages for now in order to maintain backwards compatibility