### PR TITLE
fix: add sbt/setup-sbt for the dependency graph workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}


### PR DESCRIPTION
IT turns out that https://github.com/scalacenter/sbt-dependency-submission doesn't include sbt if it's missing

Related to #22224

[skip ci]