### PR TITLE
Refactor handling of rechecked types

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -24,9 +24,6 @@ import CheckCaptures.CheckerAPI
 /** Operations accessed from CheckCaptures */
 trait SetupAPI:
 
-  /** The operation to recheck a ValDef or DefDef */
-  type DefRecheck = (tpd.ValOrDefDef, Symbol) => Context ?=> Type
-
   /** Setup procedure to run for each compilation unit
    *   @param tree       the typed tree of the unit to check
    *   @param checker    the capture checker which will run subsequently.


### PR DESCRIPTION
 - Always store new types on rechecking
 - Store them in a hashmap which is associated with the rechecker of the current compilation unit
 - After rechecking is done, the map is forgotten, unless keepTypes is true. Under keepTypes, the map is kept in an attachment of the unit's root tree.

Change in nomenclature:

    knownType --> nuType
    rememberType --> setNuType
    hasRememberedType --> hasNuType