### PR TITLE
Documentation only: update Example code linked to obsolete content in  macros-spec.md 

### DIFF
--- a/docs/_docs/reference/metaprogramming/staging.md
+++ b/docs/_docs/reference/metaprogramming/staging.md
@@ -98,9 +98,9 @@ scala -with-compiler -classpath out Test
 ## Example
 
 Now take exactly the same example as in [Macros](./macros.md). Assume that we
-do not want to pass an array statically but generate code at run-time and pass
+do not want to pass a base double value statically but generate code at run-time and pass
 the value, also at run-time. Note, how we make a future-stage function of type
-`Expr[Array[Int] => Int]` in line 6 below. Using `staging.run { ... }` we can evaluate an
+`Expr[Double => Double]` in line 6 below. Using `staging.run { ... }` we can evaluate an
 expression at runtime. Within the scope of `staging.run` we can also invoke `show` on an expression
 to get a source-like representation of the expression.
 
@@ -110,12 +110,12 @@ import scala.quoted.*
 // make available the necessary compiler for runtime code generation
 given staging.Compiler = staging.Compiler.make(getClass.getClassLoader)
 
-val f: Array[Int] => Int = staging.run {
-  val stagedSum: Expr[Array[Int] => Int] =
-    '{ (arr: Array[Int]) => ${sum('arr)}}
-  println(stagedSum.show) // Prints "(arr: Array[Int]) => { var sum = 0; ... }"
-  stagedSum
+val power3: Double => Double = staging.run {
+  val stagedPower3: Expr[Double => Double] =
+    '{ (x: Double) => ${ unrolledPowerCode('x, 3) } }
+  println(stagedPower3.show) // Prints "((x: scala.Double) => x.*(x.*(x)))"
+  stagedPower3
 }
 
-f.apply(Array(1, 2, 3)) // Returns 6
+power3.apply(2.0) // Returns 8.0
 ```


### PR DESCRIPTION
An example code in macros-spec.md was updated in commit d8c9714, but staging.md is still referring the old code. This small change removes reference to old code.