### PR TITLE
Presentation compiler: diagnostic provider

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
@@ -1,0 +1,70 @@
+package dotty.tools.pc
+
+import org.eclipse.lsp4j
+import org.eclipse.lsp4j.DiagnosticSeverity
+import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.interfaces.Diagnostic as DiagnosticInterfaces
+import dotty.tools.dotc.reporting.Diagnostic
+import dotty.tools.dotc.semanticdb.DiagnosticOps.toSemanticDiagnostic
+import dotty.tools.pc.utils.InteractiveEnrichments.toLsp
+
+import scala.meta.pc.VirtualFileParams
+import com.google.gson.Gson
+import ch.epfl.scala.bsp4j
+import dotty.tools.dotc.reporting.CodeAction
+import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
+import scala.jdk.CollectionConverters.*
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.reporting.Message
+import dotty.tools.dotc.interfaces.DiagnosticRelatedInformation
+import org.eclipse.lsp4j.Location
+import dotty.tools.dotc.reporting.ErrorMessageID
+import org.eclipse.lsp4j.DiagnosticTag
+
+class DiagnosticProvider(driver: InteractiveDriver, params: VirtualFileParams):
+
+  def diagnostics(): List[lsp4j.Diagnostic] =
+    val diags = driver.run(params.uri().nn, params.text().nn)
+    given Context = driver.currentCtx
+    diags.flatMap(toLsp)
+
+  private def toLsp(diag: Diagnostic)(using Context): Option[lsp4j.Diagnostic] =
+    Option.when(diag.pos.exists):
+      val lspDiag = lsp4j.Diagnostic(
+        diag.pos.toLsp,
+        diag.msg.message,
+        toDiagnosticSeverity(diag.level),
+        "presentation compiler",
+      )
+      lspDiag.setCode(diag.msg.errorId.errorNumber)
+
+      val scalaDiagnostic = new bsp4j.ScalaDiagnostic()
+      val actions = diag.msg.actions.map(toBspScalaAction).asJava
+      // lspDiag.setRelatedInformation(???) Currently not emitted by the compiler
+      lspDiag.setData(actions)
+      if diag.msg.errorId == ErrorMessageID.UnusedSymbolID then
+        lspDiag.setTags(List(DiagnosticTag.Unnecessary).asJava)
+
+      lspDiag
+
+  private def toBspScalaAction(action: CodeAction): bsp4j.ScalaAction =
+    val bspAction = bsp4j.ScalaAction(action.title)
+    action.description.foreach(bspAction.setDescription)
+    val workspaceEdit = bsp4j.ScalaWorkspaceEdit(action.patches.map(toBspTextEdit).asJava)
+    bspAction.setEdit(workspaceEdit)
+    bspAction
+
+  private def toBspTextEdit(actionPatch: ActionPatch): bsp4j.ScalaTextEdit =
+    val startPos = bsp4j.Position(actionPatch.srcPos.startLine, actionPatch.srcPos.startColumn)
+    val endPos   = bsp4j.Position(actionPatch.srcPos.endLine, actionPatch.srcPos.endColumn)
+    val range = bsp4j.Range(startPos, endPos)
+    bsp4j.ScalaTextEdit(range, actionPatch.replacement)
+
+
+  private def toDiagnosticSeverity(severity: Int): DiagnosticSeverity =
+    severity match
+      case DiagnosticInterfaces.ERROR   => DiagnosticSeverity.Error
+      case DiagnosticInterfaces.WARNING => DiagnosticSeverity.Warning
+      case DiagnosticInterfaces.INFO    => DiagnosticSeverity.Information
+      case _                            => DiagnosticSeverity.Information
+

--- a/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
@@ -5,19 +5,14 @@ import org.eclipse.lsp4j.DiagnosticSeverity
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.interfaces.Diagnostic as DiagnosticInterfaces
 import dotty.tools.dotc.reporting.Diagnostic
-import dotty.tools.dotc.semanticdb.DiagnosticOps.toSemanticDiagnostic
 import dotty.tools.pc.utils.InteractiveEnrichments.toLsp
 
 import scala.meta.pc.VirtualFileParams
-import com.google.gson.Gson
 import ch.epfl.scala.bsp4j
 import dotty.tools.dotc.reporting.CodeAction
 import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
 import scala.jdk.CollectionConverters.*
 import dotty.tools.dotc.core.Contexts.Context
-import dotty.tools.dotc.reporting.Message
-import dotty.tools.dotc.interfaces.DiagnosticRelatedInformation
-import org.eclipse.lsp4j.Location
 import dotty.tools.dotc.reporting.ErrorMessageID
 import org.eclipse.lsp4j.DiagnosticTag
 
@@ -40,8 +35,9 @@ class DiagnosticProvider(driver: InteractiveDriver, params: VirtualFileParams):
 
       val scalaDiagnostic = new bsp4j.ScalaDiagnostic()
       val actions = diag.msg.actions.map(toBspScalaAction).asJava
+      scalaDiagnostic.setActions(actions)
       // lspDiag.setRelatedInformation(???) Currently not emitted by the compiler
-      lspDiag.setData(actions)
+      lspDiag.setData(scalaDiagnostic)
       if diag.msg.errorId == ErrorMessageID.UnusedSymbolID then
         lspDiag.setTags(List(DiagnosticTag.Unnecessary).asJava)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
@@ -6,20 +6,15 @@ import dotty.tools.pc.base.BasePCSuite
 import dotty.tools.pc.utils.RangeReplace
 
 import java.net.URI
-import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
 import scala.meta.internal.jdk.CollectionConverters.*
 import scala.meta.internal.metals.CompilerVirtualFileParams
 import scala.meta.internal.metals.EmptyCancelToken
-import scala.meta.internal.pc.PcReferencesRequest
 
 import org.junit.Test
-import scala.collection.mutable.ListBuffer
 import org.eclipse.lsp4j.DiagnosticSeverity
-import scala.concurrent.duration.*
 import dotty.tools.pc.utils.TestExtensions.getOffset
 
 class DiagnosticProviderSuite extends BasePCSuite with RangeReplace {
-  private val rangeRegex = "<<.*>>".r
   case class TestDiagnostic(startIndex: Int, endIndex: Int, msg: String, severity: DiagnosticSeverity)
 
   def check(

--- a/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
@@ -1,0 +1,69 @@
+package dotty.tools.pc.tests
+
+import scala.language.unsafeNulls
+
+import dotty.tools.pc.base.BasePCSuite
+import dotty.tools.pc.utils.RangeReplace
+
+import java.net.URI
+import org.eclipse.lsp4j.jsonrpc.messages.{Either => JEither}
+import scala.meta.internal.jdk.CollectionConverters.*
+import scala.meta.internal.metals.CompilerVirtualFileParams
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.pc.PcReferencesRequest
+
+import org.junit.Test
+import scala.collection.mutable.ListBuffer
+import org.eclipse.lsp4j.DiagnosticSeverity
+import scala.concurrent.duration.*
+import dotty.tools.pc.utils.TestExtensions.getOffset
+
+class DiagnosticProviderSuite extends BasePCSuite with RangeReplace {
+  private val rangeRegex = "<<.*>>".r
+  case class TestDiagnostic(startIndex: Int, endIndex: Int, msg: String, severity: DiagnosticSeverity)
+
+  def check(
+    text: String,
+    expected: List[TestDiagnostic]
+  ): Unit =
+    val diagnostics = presentationCompiler
+      .didChange(CompilerVirtualFileParams(URI.create("file:/Diagnostic.scala"), text, EmptyCancelToken))
+      .get()
+      .asScala
+
+    val actual = diagnostics.map(d => TestDiagnostic(d.getRange().getStart().getOffset(text), d.getRange().getEnd().getOffset(text), d.getMessage(), d.getSeverity()))
+    assertEquals(expected, actual, s"Expected [${expected.mkString(", ")}] but got [${actual.mkString(", ")}]")
+
+  @Test def simple1 =
+    check(
+      """|class Bar(i: It)
+         |""".stripMargin,
+      List(TestDiagnostic(13, 15, "Not found: type It - did you mean Int.type? or perhaps Int?", DiagnosticSeverity.Error))
+    )
+
+  // @Test def `implicit-args-2` =
+  //   check(
+  //     """|package example
+  //       |
+  //       |class Bar(i: Int)
+  //       |class Foo(implicit b: Bar)
+  //       |
+  //       |object Hello {
+  //       |  implicit val ba@@rr: Bar = new Bar(1)
+  //       |  val foo = new Foo<<>>
+  //       |}
+  //       |""".stripMargin
+  //   )
+
+  // @Test def `case-class` =
+  //   check(
+  //     """|case class Ma@@in(i: Int)
+  //        |""".stripMargin
+  //   )
+
+  // @Test def `case-class-with-implicit` =
+  //   check(
+  //     """"|case class A()(implicit val fo@@o: Int)
+  //         |""".stripMargin
+  //   )
+}

--- a/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
@@ -36,34 +36,9 @@ class DiagnosticProviderSuite extends BasePCSuite with RangeReplace {
 
   @Test def simple1 =
     check(
-      """|class Bar(i: It)
+      """|class Bar(i: <<It>>)
          |""".stripMargin,
       List(TestDiagnostic(13, 15, "Not found: type It - did you mean Int.type? or perhaps Int?", DiagnosticSeverity.Error))
     )
 
-  // @Test def `implicit-args-2` =
-  //   check(
-  //     """|package example
-  //       |
-  //       |class Bar(i: Int)
-  //       |class Foo(implicit b: Bar)
-  //       |
-  //       |object Hello {
-  //       |  implicit val ba@@rr: Bar = new Bar(1)
-  //       |  val foo = new Foo<<>>
-  //       |}
-  //       |""".stripMargin
-  //   )
-
-  // @Test def `case-class` =
-  //   check(
-  //     """|case class Ma@@in(i: Int)
-  //        |""".stripMargin
-  //   )
-
-  // @Test def `case-class-with-implicit` =
-  //   check(
-  //     """"|case class A()(implicit val fo@@o: Int)
-  //         |""".stripMargin
-  //   )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1487,6 +1487,7 @@ object Build {
           .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j")
           .exclude("org.eclipse.lsp4j","org.eclipse.lsp4j.jsonrpc"),
         "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "0.20.1",
+        "ch.epfl.scala" % "bsp4j" % "2.1.1",
       ),
       libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.15" % mtagsVersion % SourceDeps),
       ivyConfigurations += SourceDeps.hide,


### PR DESCRIPTION
Adds a capability to provide instant diagnostics for the opened buffers with almost 0 cost.

This can be utilised by tools, such as metals or Scastie, to provide diagnostics without saving a buffer and relying on build server to provide them.

It also publishes warnings and code actions if they are present. 

One important bit is that the diagnostics are a subset of build server diagnostics, because presentation compiler runs only phases until typer, thus any diagnostic emitted in later phases will not be published. This should be a minimal problem as most issues come from Typer phase.

In the future, we should experiment with other phases such as `CheckUnused` to provide unused diagnostics along with quick fixes. This is a very powerful addition, as we can then try to reimplement remaining features such as organise imports, to not rely on Scalafix to do it and operate directly on compiler diagnostics. This will have to be well tested, as any extra phase added to the `InteractiveCompiler` will slow down all other features that rely on it such as hovers, completions etc, so this is basically a tradeoff.

Screencast is more than 1000 words.

https://github.com/user-attachments/assets/377fe9a6-0e90-40b9-b11b-a173dd88115f

