### PR TITLE
chore: Add @nowarn annotation to LazyVals.

### DIFF
--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -96,13 +96,13 @@ object LazyVals {
       println(s"CAS($t, $offset, $e, $v, $ord)")
     val mask = ~(LAZY_VAL_MASK << ord * BITS_PER_LAZY_VAL)
     val n = (e & mask) | (v.toLong << (ord * BITS_PER_LAZY_VAL))
-    unsafe.compareAndSwapLong(t, offset, e, n)
+    unsafe.compareAndSwapLong(t, offset, e, n): @nowarn("cat=deprecation")
   }
 
   def objCAS(t: Object, offset: Long, exp: Object, n: Object): Boolean = {
     if (debug)
       println(s"objCAS($t, $exp, $n)")
-    unsafe.compareAndSwapObject(t, offset, exp, n)
+    unsafe.compareAndSwapObject(t, offset, exp, n): @nowarn("cat=deprecation")
   }
 
   def setFlag(t: Object, offset: Long, v: Int, ord: Int): Unit = {
@@ -147,7 +147,7 @@ object LazyVals {
   def get(t: Object, off: Long): Long = {
     if (debug)
       println(s"get($t, $off)")
-    unsafe.getLongVolatile(t, off)
+    unsafe.getLongVolatile(t, off): @nowarn("cat=deprecation")
   }
 
   // kept for backward compatibility


### PR DESCRIPTION
Unsafe is planned to be removed in future  Java versions.

Motivication:

Makes it compile on JDK 23
refs: https://openjdk.org/jeps/471

Modification:
Add `@nowarn("cat=deprecation")`

Result:
Compiles successfully on JDK 23