### PR TITLE
Backport "Limit exposure to ConcurrentModificationException when sys props are replaced or mutated" to 3.6

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -53,7 +53,8 @@ object PathResolver {
     def classPathEnv: String        =  envOrElse("CLASSPATH", "")
     def sourcePathEnv: String       =  envOrElse("SOURCEPATH", "")
 
-    def javaBootClassPath: String   = propOrElse("sun.boot.class.path", searchForBootClasspath)
+    //using propOrNone/getOrElse instead of propOrElse so that searchForBootClasspath is lazy evaluated
+    def javaBootClassPath: String   = propOrNone("sun.boot.class.path") getOrElse searchForBootClasspath
 
     def javaExtDirs: String         = propOrEmpty("java.ext.dirs")
     def scalaHome: String           = propOrEmpty("scala.home")


### PR DESCRIPTION
Backports #22180 to the 3.6.3.

PR submitted by the release tooling.
[skip ci]