### PR TITLE
Handle capture variables in `stripCapturing`

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -359,6 +359,8 @@ extension (tp: Type)
       parent.stripCapturing
     case atd @ AnnotatedType(parent, annot) =>
       atd.derivedAnnotatedType(parent.stripCapturing, annot)
+    case tp if tp.derivesFrom(defn.Caps_CapSet) =>
+      defn.Caps_CapSet.typeRef
     case _ =>
       tp
 

--- a/tests/pos-custom-args/captures/i22103-alt.scala
+++ b/tests/pos-custom-args/captures/i22103-alt.scala
@@ -1,0 +1,8 @@
+import language.experimental.captureChecking
+import caps.*
+
+trait F[+Cap^]
+def expect[C^](x: F[C]): x.type = x
+
+def test[C^](x: F[C], io: () => Unit): Unit =
+  val t1 = expect[CapSet^{C^}](x)

--- a/tests/pos-custom-args/captures/i22103.scala
+++ b/tests/pos-custom-args/captures/i22103.scala
@@ -1,0 +1,15 @@
+import language.experimental.captureChecking
+import caps.*
+
+abstract class Source[+T, Cap^]:
+  def transformValuesWith[U](f: (T -> U)^{Cap^}): Source[U, Cap]^{this, f} = ???
+
+def race[T, Cap^](sources: Source[T, Cap]^{Cap^}*): Source[T, Cap]^{Cap^} = ???
+
+def either[T1, T2, Cap^](
+    //io: () => Unit,
+    src1: Source[T1, Cap]^{Cap^},
+    src2: Source[T2, Cap]^{Cap^}): Source[Either[T1, T2], Cap]^{Cap^} =
+  val left = src1.transformValuesWith(Left(_))
+  val right = src2.transformValuesWith(Right(_))
+  race[Either[T1, T2], CapSet^{Cap^}](left, right) // <- rejected


### PR DESCRIPTION
Partly fixes #22103

Given a capture set variable `C` defined with `C <: CapSet^`, `TypeRef(C).stripCapturing` previously does nothing, which is apparently wrong. For "normal" type variables there is not a problem since type variables are always pure, so stripping can do nothing for them. But this won't work for capture set variable.

This PR fixes this behavior by stripping capture variables like `C` to `CapSet`.