### PR TITLE
Fix inline reduction for CaseDef guards with asInstanceOf

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -362,7 +362,7 @@ class InlineReducer(inliner: Inliner)(using Context):
         val (caseBindings, from, to) = substBindings(caseBindingMap.toList, mutable.ListBuffer(), Nil, Nil)
         val (guardOK, canReduceGuard) =
           if cdef.guard.isEmpty then (true, true)
-          else typer.typed(cdef.guard.subst(from, to), defn.BooleanType) match {
+          else stripInlined(typer.typed(cdef.guard.subst(from, to), defn.BooleanType)) match {
             case ConstantValue(v: Boolean) => (v, true)
             case _ => (false, false)
           }

--- a/tests/pos/i22300.scala
+++ b/tests/pos/i22300.scala
@@ -1,0 +1,16 @@
+class Foo:
+
+  inline def inlineMatch[T]: String =
+    inline compiletime.erasedValue[T] match
+      case _: EmptyTuple               => ""
+      case _: (h *: _) if checkType[h](0) => ""
+
+  private inline def checkType[T](i: Int): Boolean =
+    inline compiletime.erasedValue[T] match
+      case _: Int => true
+      case _      => false
+
+val foo = Foo()
+
+@main def main () =
+  foo.inlineMatch[(Int, Boolean)]


### PR DESCRIPTION
Fixes #22300
In [Inliner.scala](https://github.com/scala/scala3/blob/1f0c576ce6d80138309dbba2e9972ee566ceac11/compiler/src/dotty/tools/dotc/inlines/Inliner.scala#L603) we add asInstanceOf to references to private inline methods to make sure we later are able to know which method is referenced (if e.g. we inline out of the scope where that method would be visible). This added asInstanceOf caused issue when inlining CaseDef guards, as instead of a simple constant literal we get an Inlined node with an added binding, like this:
```scala
{
  val A_this: A = A_this.asInstanceOf[A]
  true:Boolean
}
```
We fix that by just unpacking that Inlined node (and we do not need that binding for constant literals, so we can just ignore it).