### PR TITLE
Drop `EmptyTuple` handling from `NamedTupleDecomposition.apply`

### DIFF
--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -139,9 +139,7 @@ object NamedTupleDecomposition:
   extension [N <: Tuple, V <: Tuple](x: NamedTuple[N, V])
       /** The value (without the name) at index `n` of this tuple */
     inline def apply(n: Int): Elem[NamedTuple[N, V], n.type] =
-      inline x.toTuple match
-        case tup: NonEmptyTuple => tup(n).asInstanceOf[Elem[NamedTuple[N, V], n.type]]
-        case tup => tup.productElement(n).asInstanceOf[Elem[NamedTuple[N, V], n.type]]
+      x.toTuple.apply(n).asInstanceOf[Elem[NamedTuple[N, V], n.type]]
 
     /** The number of elements in this tuple */
     inline def size: Size[NamedTuple[N, V]] = x.toTuple.size

--- a/tests/pos/i22324.scala
+++ b/tests/pos/i22324.scala
@@ -1,0 +1,10 @@
+import scala.language.experimental.namedTuples
+
+opaque type System = (wires: Any)
+
+extension (system: System)
+  inline def foo = system.wires
+end extension
+
+val simulation: System = ???
+val _ = simulation.foo // was error


### PR DESCRIPTION
We previously needed to handle the case where the result of `toTuple` was an `EmptyTuple` separately from the rest, since `apply` used to be only defined for `NonEmptyTuple`s. This was changed in #21291, making the inline match in `NamedTupleDecomposition.apply` no longer necessary.

The underlying issue with the proxies introduced to handle opaque types with inline defs is likely still present. Nevertheless, it is probably best to fix this specific instance of the problem with NamedTuples as soon as possible.

Fixes #22324