### PR TITLE
Fix crash when initializing val in ByName closure

### DIFF
--- a/tests/init/pos/byname.scala
+++ b/tests/init/pos/byname.scala
@@ -1,0 +1,17 @@
+trait T:
+  def bar(i: => Int): Int
+
+class A extends T:
+  override def bar(i: => Int): Int = i + 1
+
+class B extends T:
+  override def bar(i: => Int): Int = i + 2
+
+object A:
+  val a: T = if ??? then new A else new B
+  def foo(b: List[Int]) = a.bar(b match {
+    case x :: xs => 1
+    case Nil => 0
+  })
+
+  val f = foo(Nil)


### PR DESCRIPTION
This PR creates a new Env when evaluating a by name closure, fixing a crash due to duplicate initialization of the same value.