### PR TITLE
Avoid infinite recursion when looking for suggestions

### DIFF
--- a/tests/neg/22145.check
+++ b/tests/neg/22145.check
@@ -1,0 +1,4 @@
+-- [E008] Not Found Error: tests/neg/22145.scala:5:7 -------------------------------------------------------------------
+5 |  base.foo() // error
+  |  ^^^^^^^^
+  |  value foo is not a member of foo.Collection

--- a/tests/neg/22145.scala
+++ b/tests/neg/22145.scala
@@ -1,0 +1,8 @@
+package foo
+
+trait Collection:
+  val base: Collection = ???
+  base.foo() // error
+
+  object O extends Collection:
+    def foo(): Int = ???

--- a/tests/neg/22145b.check
+++ b/tests/neg/22145b.check
@@ -1,0 +1,36 @@
+-- [E008] Not Found Error: tests/neg/22145b.scala:15:19 ----------------------------------------------------------------
+15 |      require(base.isWithin(p, start, end), "position is out of bounds") // error
+   |              ^^^^^^^^^^^^^
+   |              value isWithin is not a member of Collection.this.Self
+-- [E008] Not Found Error: tests/neg/22145b.scala:28:59 ----------------------------------------------------------------
+28 |      def positionAfter(p: Position): Position = self.base.positionAfter(p) // error
+   |                                                 ^^^^^^^^^^^^^^^^^^^^^^^
+   |value positionAfter is not a member of Collection.this.Self.
+   |An extension method was tried, but could not be fully constructed:
+   |
+   |    this.positionAfter(self.base)
+   |
+   |    failed with:
+   |
+   |        Found:    (self.base : Collection.this.Self)
+   |        Required: foo.Collection.given_is_Slice_Collection.Self²
+   |        
+   |        where:    Self  is a type in trait Collection
+   |                  Self² is a type in object given_is_Slice_Collection which is an alias of Collection.this.Slice
+   |        
+-- [E008] Not Found Error: tests/neg/22145b.scala:29:50 ----------------------------------------------------------------
+29 |      def apply(p: Position): Element = self.base.apply(p) // error
+   |                                        ^^^^^^^^^^^^^^^
+   |value apply is not a member of Collection.this.Self.
+   |An extension method was tried, but could not be fully constructed:
+   |
+   |    this.apply(self.base)
+   |
+   |    failed with:
+   |
+   |        Found:    (self.base : Collection.this.Self)
+   |        Required: foo.Collection.given_is_Slice_Collection.Self²
+   |        
+   |        where:    Self  is a type in trait Collection
+   |                  Self² is a type in object given_is_Slice_Collection which is an alias of Collection.this.Slice
+   |        

--- a/tests/neg/22145b.scala
+++ b/tests/neg/22145b.scala
@@ -1,0 +1,40 @@
+package foo
+
+import language.experimental.modularity
+
+trait Collection:
+  me =>
+
+  type Self
+  type Position
+  type Element
+
+  final class Slice(private[Collection] val base: Self, val start: Position, val end: Position):
+
+    final def apply(p: Position): Element =
+      require(base.isWithin(p, start, end), "position is out of bounds") // error
+      base.apply(p)
+
+  end Slice
+
+  given Slice is Collection:
+
+    type Position = me.Position
+    type Element = me.Element
+
+    extension (self: Self)
+      def start: Position = self.start
+      def end: Position = self.end
+      def positionAfter(p: Position): Position = self.base.positionAfter(p) // error
+      def apply(p: Position): Element = self.base.apply(p) // error
+
+  end given
+
+  extension (self: Self)
+
+    def start: Position
+    def end: Position
+    def positionAfter(p: Position): Position
+    def apply(p: Position): Element
+
+  end extension

--- a/tests/neg/22145c.check
+++ b/tests/neg/22145c.check
@@ -1,0 +1,4 @@
+-- [E008] Not Found Error: tests/neg/22145c.scala:4:35 -----------------------------------------------------------------
+4 |  def bar(base: Collection) = base.foo // error
+  |                              ^^^^^^^^
+  |                              value foo is not a member of foo.Collection

--- a/tests/neg/22145c.scala
+++ b/tests/neg/22145c.scala
@@ -1,0 +1,8 @@
+package foo
+
+trait Collection:
+  def bar(base: Collection) = base.foo // error
+  object a extends Collection:
+    def foo: Int = 0
+  object b extends Collection:
+    def foo: Int = 1

--- a/tests/neg/22145d.check
+++ b/tests/neg/22145d.check
@@ -1,0 +1,9 @@
+-- [E008] Not Found Error: tests/neg/22145d.scala:10:4 -----------------------------------------------------------------
+10 |  2.f() // error
+   |  ^^^
+   |  value f is not a member of Int, but could be made available as an extension method.
+   |
+   |  The following import might fix the problem:
+   |
+   |    import foo.O2.f
+   |

--- a/tests/neg/22145d.scala
+++ b/tests/neg/22145d.scala
@@ -1,0 +1,10 @@
+package foo
+
+class C[T]:
+  extension (x: T) def f(): Int = 1
+
+object O1 extends C[String]
+object O2 extends C[Int]
+
+def main =
+  2.f() // error

--- a/tests/neg/22145e.check
+++ b/tests/neg/22145e.check
@@ -1,0 +1,9 @@
+-- [E008] Not Found Error: tests/neg/22145e.scala:11:4 -----------------------------------------------------------------
+11 |  2.f() // error
+   |  ^^^
+   |  value f is not a member of Int, but could be made available as an extension method.
+   |
+   |  The following import might fix the problem:
+   |
+   |    import foo.O2.Ext.f
+   |

--- a/tests/neg/22145e.scala
+++ b/tests/neg/22145e.scala
@@ -1,0 +1,11 @@
+package foo
+
+class C[T]:
+  object Ext:
+    extension (x: T) def f(): Int = 1
+
+object O1 extends C[String]
+object O2 extends C[Int]
+
+def main =
+  2.f() // error

--- a/tests/neg/22145f.check
+++ b/tests/neg/22145f.check
@@ -1,0 +1,10 @@
+-- [E008] Not Found Error: tests/neg/22145f.scala:11:6 -----------------------------------------------------------------
+11 |    2.f() // error
+   |    ^^^
+   |    value f is not a member of Int, but could be made available as an extension method.
+   |
+   |    One of the following imports might fix the problem:
+   |
+   |      import C.this.O1.O2.Ext.f
+   |      import C.this.O2.Ext.f
+   |

--- a/tests/neg/22145f.scala
+++ b/tests/neg/22145f.scala
@@ -1,0 +1,11 @@
+package foo
+
+class C[T]:
+  object Ext:
+    extension (x: T) def f(): Int = 1
+
+  object O1 extends C[String]
+  object O2 extends C[Int]
+
+  def g =
+    2.f() // error

--- a/tests/neg/22145g.check
+++ b/tests/neg/22145g.check
@@ -1,0 +1,4 @@
+-- [E008] Not Found Error: tests/neg/22145g.scala:10:4 -----------------------------------------------------------------
+10 |  2.f() // error
+   |  ^^^
+   |  value f is not a member of Int

--- a/tests/neg/22145g.scala
+++ b/tests/neg/22145g.scala
@@ -1,0 +1,10 @@
+package foo
+
+class C[T]:
+  extension (x: T) def f(): Int = 1
+
+object O:
+  val c0: C[String] = new C[String]
+  val c1: C[Int] = new C[Int]
+  // Currently no import suggestions here
+  2.f() // error


### PR DESCRIPTION
Keep a a set of seen parent symbols between `rootsIn` and `rootsStrictlyIn` to avoid infinitely growing paths that refer to the same value, such as `Collection.this.O.O.O.O.O.O.O....` when computing import suggestions for:

```scala
trait Collection:
  val base: Collection = ???
  base.foo()

  object O extends Collection:
    def foo(): Int = ???
```

Fixes #22145.