### PR TITLE
Fix #21841: Check more that an `unapplySeq` on a `NonEmptyTuple` is valid.

### DIFF
--- a/tests/neg/i21841.check
+++ b/tests/neg/i21841.check
@@ -1,0 +1,6 @@
+-- [E108] Declaration Error: tests/neg/i21841.scala:20:13 --------------------------------------------------------------
+20 |    case v[T](l, r) => ()  // error
+   |         ^^^^^^^^^^
+   | [31mOption[(Test.Expr[Test.T], Test.Expr[Test.T])][0m is not a valid result type of an unapplySeq method of an [35mextractor[0m.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21841.scala
+++ b/tests/neg/i21841.scala
@@ -1,0 +1,22 @@
+object Test {
+
+  sealed trait T
+  sealed trait Arrow[A, B]
+
+  type ArgsTo[S1, Target] <: NonEmptyTuple = S1 match {
+    case Arrow[a, Target] => Tuple1[Expr[a]]
+    case Arrow[a, b] => Expr[a] *: ArgsTo[b, Target]
+  }
+
+  sealed trait Expr[S] :
+    def unapplySeq[Target](e: Expr[Target]): Option[ArgsTo[S, Target]] = ???
+
+  case class Variable[S](id: String) extends Expr[S]
+
+  val v = Variable[Arrow[T, Arrow[T, T]]]("v")
+  val e : Expr[T] = ???
+
+  e match
+    case v[T](l, r) => ()  // error
+    case _ => ()
+}


### PR DESCRIPTION
Review by @odersky because you seem to have been in the area recently with named tuples:
https://github.com/scala/scala3/commit/0fbdb497c40aee5b3e17c22bf9030f55ddcc3bca