### PR TITLE
Backport "REPL: JLine: follow recommendation to use JNI, not JNA; also JLine 3.27.1 (was 3.27.0)" to LTS 

### DIFF
--- a/dist/bin/common
+++ b/dist/bin/common
@@ -26,7 +26,7 @@ function onExit() {
 # to reenable echo if we are interrupted before completing.
 trap onExit INT TERM EXIT
 
-unset cygwin mingw msys darwin conemu
+unset cygwin mingw msys darwin
 
 # COLUMNS is used together with command line option '-pageWidth'.
 if command -v tput >/dev/null 2>&1; then
@@ -55,8 +55,6 @@ esac
 
 unset CYGPATHCMD
 if [[ ${cygwin-} || ${mingw-} || ${msys-} ]]; then
-  # ConEmu terminal is incompatible with jna-5.*.jar
-  [[ (${CONEMUANSI-} || ${ConEmuANSI-}) ]] && conemu=true
   # cygpath is used by various windows shells: cygwin, git-sdk, gitbash, msys, etc.
   CYGPATHCMD=`which cygpath 2>/dev/null`
   case "$TERM" in

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -584,7 +584,7 @@ object Build {
         Dependencies.compilerInterface,
         "org.jline" % "jline-reader" % "3.27.0",   // used by the REPL
         "org.jline" % "jline-terminal" % "3.27.0",
-        "org.jline" % "jline-terminal-jna" % "3.27.0", // needed for Windows
+        "org.jline" % "jline-terminal-jni" % "3.27.0", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -582,9 +582,9 @@ object Build {
       libraryDependencies ++= Seq(
         "org.scala-lang.modules" % "scala-asm" % "9.7.0-scala-2", // used by the backend
         Dependencies.compilerInterface,
-        "org.jline" % "jline-reader" % "3.27.0",   // used by the REPL
-        "org.jline" % "jline-terminal" % "3.27.0",
-        "org.jline" % "jline-terminal-jni" % "3.27.0", // needed for Windows
+        "org.jline" % "jline-reader" % "3.27.1",   // used by the REPL
+        "org.jline" % "jline-terminal" % "3.27.1",
+        "org.jline" % "jline-terminal-jni" % "3.27.1", // needed for Windows
         ("io.get-coursier" %% "coursier" % "2.0.16" % Test).cross(CrossVersion.for3Use2_13),
       ),
 


### PR DESCRIPTION
Backports #22205 to Scala 3.3.5-RC2 LTS