### PR TITLE
Prepare build for Scala 3.7.0 development

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -31,7 +31,7 @@ enum SourceVersion:
   def isAtMost(v: SourceVersion) = stable.ordinal <= v.ordinal
 
 object SourceVersion extends Property.Key[SourceVersion]:
-  def defaultSourceVersion = `3.6`
+  def defaultSourceVersion = `3.7`
 
   /** language versions that may appear in a language import, are deprecated, but not removed from the standard library. */
   val illegalSourceVersionNames = List("3.1-migration", "never").map(_.toTermName)

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -13,6 +13,7 @@ enum SourceVersion:
   case `3.5-migration`, `3.5`
   case `3.6-migration`, `3.6`
   case `3.7-migration`, `3.7`
+  case `3.8-migration`, `3.8`
   // !!! Keep in sync with scala.runtime.stdlibPatches.language !!!
   case `future-migration`, `future`
 

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -330,6 +330,20 @@ object language:
   @compileTimeOnly("`3.7` can only be used at compile time in import statements")
   object `3.7`
 
+    /** Set source version to 3.8-migration.
+    *
+    * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
+    */
+  @compileTimeOnly("`3.8-migration` can only be used at compile time in import statements")
+  object `3.8-migration`
+
+  /** Set source version to 3.8
+    *
+    * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
+    */
+  @compileTimeOnly("`3.8` can only be used at compile time in import statements")
+  object `3.8`
+
 
   // !!! Keep in sync with dotty.tools.dotc.config.SourceVersion !!!
   // Also add tests in `tests/pos/source-import-3-x.scala` and `tests/pos/source-import-3-x-migration.scala`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -109,7 +109,7 @@ object Build {
    *
    *  Warning: Change of this variable might require updating `expectedTastyVersion`
    */
-  val developedVersion = "3.6.4"
+  val developedVersion = "3.7.0"
 
   /** The version of the compiler including the RC prefix.
    *  Defined as common base before calculating environment specific suffixes in `dottyVersion`


### PR DESCRIPTION
Scala 3.6.4 has been cutoff, next released version is Scala 3.7.0 