### PR TITLE
Relax check file match with stack trace

### DIFF
--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -4,9 +4,7 @@ package dotc
 
 import scala.language.unsafeNulls
 
-import org.junit.{ Test, BeforeClass, AfterClass }
-import org.junit.Assert._
-import org.junit.Assume._
+import org.junit.{ Test, AfterClass }
 import org.junit.experimental.categories.Category
 
 import scala.concurrent.duration._
@@ -96,7 +94,7 @@ class BootstrappedOnlyCompilationTests {
   // Negative tests ------------------------------------------------------------
 
   @Test def negMacros: Unit = {
-    implicit val testGroup: TestGroup = TestGroup("compileNegWithCompiler")
+    given TestGroup = TestGroup("negMacros")
     compileFilesInDir("tests/neg-macros", defaultOptions.and("-Xcheck-macros"))
       .checkExpectedErrors()
   }

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -4,13 +4,10 @@ package vulpix
 
 import scala.language.unsafeNulls
 
-import java.io.{File => JFile, IOException, PrintStream, ByteArrayOutputStream}
-import java.lang.System.{lineSeparator => EOL}
-import java.net.URL
+import java.io.File => JFile
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
-import java.nio.file.{Files, NoSuchFileException, Path, Paths}
+import java.nio.file.{Files, NoSuchFileException, Paths}
 import java.nio.charset.{Charset, StandardCharsets}
-import java.text.SimpleDateFormat
 import java.util.{HashMap, Timer, TimerTask}
 import java.util.concurrent.{ExecutionException, TimeUnit, TimeoutException, Executors => JExecutors}
 
@@ -18,21 +15,16 @@ import scala.collection.mutable
 import scala.io.{Codec, Source}
 import scala.jdk.CollectionConverters.*
 import scala.util.{Random, Try, Failure => TryFailure, Success => TrySuccess, Using}
-import scala.util.control.NonFatal
-import scala.util.matching.Regex
 import scala.collection.mutable.ListBuffer
 
 import dotc.{Compiler, Driver}
 import dotc.core.Contexts.*
-import dotc.decompiler
 import dotc.report
 import dotc.interfaces.Diagnostic.ERROR
 import dotc.reporting.{Reporter, TestReporter}
 import dotc.reporting.Diagnostic
-import dotc.config.Config
-import dotc.util.{DiffUtil, SourceFile, SourcePosition, Spans, NoSourcePosition}
+import dotc.util.{SourceFile, SourcePosition, Spans, NoSourcePosition}
 import io.AbstractFile
-import dotty.tools.vulpix.TestConfiguration.defaultOptions
 
 /** A parallel testing suite whose goal is to integrate nicely with JUnit
  *
@@ -1452,7 +1444,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
    *  By default, files are compiled in alphabetical order. An optional seed
    *  can be used for randomization.
    */
-  def compileDir(f: String, flags: TestFlags, randomOrder: Option[Int] = None, recursive: Boolean = true)(implicit testGroup: TestGroup): CompilationTest = {
+  def compileDir(f: String, flags: TestFlags, randomOrder: Option[Int] = None, recursive: Boolean = true)(using testGroup: TestGroup): CompilationTest = {
     val outDir = defaultOutputDir + testGroup + JFile.separator
     val sourceDir = new JFile(f)
     checkRequirements(f, sourceDir, outDir)

--- a/compiler/test/dotty/tools/vulpix/TestGroup.scala
+++ b/compiler/test/dotty/tools/vulpix/TestGroup.scala
@@ -2,14 +2,15 @@ package dotty.tools.vulpix
 
 /** Test groups are used to ensure that the output of tests do not overlap.
  *
- *  It can be used to disambiguate ouputs of tests that test the same file but with different options as shown in the following example.
+ *  A test group can be used to disambiguate outputs of tests that test the same file
+ *  but with different options as shown in the following example.
+ *
  *    compileFilesInDir("tests/pos", defaultOptions)(TestGroup("compileStdLib")) // will output in ./out/compileStdLib/...
  *    compileFilesInDir("tests/pos", defaultOptimised)(TestGroup("optimised/testOptimised")) // will output in ./out/optimised/testOptimised/...
  */
-class TestGroup(val name: String) extends AnyVal {
-  override def toString: String = name
-}
 
-object TestGroup {
-  def apply(name: String): TestGroup = new TestGroup(name)
-}
+opaque type TestGroup = String
+
+object TestGroup:
+  inline def apply(inline name: String): TestGroup = name
+  extension (inline group: TestGroup) inline def name: String = group

--- a/tests/neg-macros/i19842-a.check
+++ b/tests/neg-macros/i19842-a.check
@@ -17,6 +17,6 @@
   |Inline stack trace
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from Test.scala:5
-5 |    implicit inline def implicitMakeSerializer[T]: Serializer[T] = ${ Macros.makeSerializer[T] }
-  |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 |  inline given [T] => Serializer[T] = ${ Macros.makeSerializer[T] }
+  |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i19842-a/Macro.scala
+++ b/tests/neg-macros/i19842-a/Macro.scala
@@ -4,8 +4,8 @@ import scala.annotation.{experimental, targetName}
 import scala.quoted.*
 import scala.util.Try
 
-object Macros {
-  def makeSerializer[T: Type](using Quotes): Expr[Serializer[T]] = {
+object Macros:
+  def makeSerializer[T: Type](using Quotes): Expr[Serializer[T]] =
     import quotes.reflect.*
 
     val tpe: TypeRepr = TypeRepr.of[T]
@@ -14,7 +14,7 @@ object Macros {
     val modSym: Symbol = Symbol.newModule(
       Symbol.spliceOwner,
       name,
-      Flags.Implicit,
+      Flags.Given,
       Flags.EmptyFlags,
       List(TypeRepr.of[Object], TypeRepr.of[Serializer[T]]),
       _ => Nil,
@@ -25,5 +25,3 @@ object Macros {
       ClassDef.module(modSym, List(TypeTree.of[Serializer[T]]), Nil)
 
     Block(List(modValDef, modClassDef), Ref(modSym)).asExprOf[Serializer[T]]
-  }
-}

--- a/tests/neg-macros/i19842-a/Test.scala
+++ b/tests/neg-macros/i19842-a/Test.scala
@@ -2,7 +2,7 @@
 trait Serializer[@specialized T]
 
 object Serializer:
-    implicit inline def implicitMakeSerializer[T]: Serializer[T] = ${ Macros.makeSerializer[T] }
+  inline given [T] => Serializer[T] = ${ Macros.makeSerializer[T] }
 
 case class ValidationCls(string: String)
 


### PR DESCRIPTION
A handful of tests under neg-macros include a stack trace in the check file, which makes them sensitive to irrelevant changes in distant source code.

This commit conservatively ignores line numbers in stack trace output when doing line text comparisons of test output.

A future improvement would be for `suppressAllOutput` to be a filter that can suppress output or normalize it on a per-need basis.

The test group name is corrected to `negMacros`.