### PR TITLE
Fix annotations being not expected in the middle of an array type by java parser

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -260,7 +260,8 @@ object JavaParsers {
       t
     }
 
-    def optArrayBrackets(tpt: Tree): Tree =
+    def optArrayBrackets(tpt: Tree): Tree = {
+      annotations()
       if (in.token == LBRACKET) {
         val tpt1 = atSpan(tpt.span.start, in.offset) { arrayOf(tpt) }
         in.nextToken()
@@ -268,6 +269,7 @@ object JavaParsers {
         optArrayBrackets(tpt1)
       }
       else tpt
+    }
 
     def basicType(): Tree =
       atSpan(in.offset) {
@@ -341,7 +343,7 @@ object JavaParsers {
     }
 
     def annotations(): List[Tree] = {
-      var annots = new ListBuffer[Tree]
+      val annots = new ListBuffer[Tree]
       while (in.token == AT) {
         in.nextToken()
         annotation() match {

--- a/tests/pos/i19642/Valid.java
+++ b/tests/pos/i19642/Valid.java
@@ -1,0 +1,17 @@
+package lib;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({ METHOD, FIELD, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@Documented
+public @interface Valid {}

--- a/tests/pos/i19642/i19642.java
+++ b/tests/pos/i19642/i19642.java
@@ -1,0 +1,9 @@
+package app;
+
+import java.util.Optional;
+import lib.*;
+
+public class i19642 {
+  private String @lib.Valid [] flatArray;
+  private String @lib.Valid [] @lib.Valid [] nestedArray;
+}


### PR DESCRIPTION
Closes #19642

Currently Java parser doesn't expect annotation between type name and square brackets in an array type, or between pairs of square brackets in nested array types.

I added a call to corresponding parser method `annotations` when parsing array types.

I also changed an unnecessary `var` to `val`, as IDEA suggested.