### PR TITLE
Do not expose ClassInfo in memberType in reflect API

### DIFF
--- a/tests/neg-macros/i15159.check
+++ b/tests/neg-macros/i15159.check
@@ -1,0 +1,17 @@
+
+-- Error: tests/neg-macros/i15159/Test_2.scala:5:16 --------------------------------------------------------------------
+5 |  TestMacro.test[A] // error
+  |  ^^^^^^^^^^^^^^^^^
+  |  Exception occurred while executing macro expansion.
+  |  java.lang.AssertionError: class X is not a member of A
+  |  	at TestMacro$.testImpl$$anonfun$1(Macro_1.scala:8)
+  |  	at scala.collection.immutable.List.map(List.scala:247)
+  |  	at TestMacro$.testImpl(Macro_1.scala:7)
+  |
+  |---------------------------------------------------------------------------------------------------------------------
+  |Inline stack trace
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  |This location contains code that was inlined from Macro_1.scala:3
+3 |  inline def test[T]: Unit = ${ testImpl[T] }
+  |                             ^^^^^^^^^^^^^^^^
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i15159/Macro_1.scala
+++ b/tests/neg-macros/i15159/Macro_1.scala
@@ -1,0 +1,10 @@
+import scala.quoted.*
+object TestMacro:
+  inline def test[T]: Unit = ${ testImpl[T] }
+  def testImpl[T: Type](using Quotes): Expr[Unit] =
+    import quotes.reflect.*
+    val tpe = TypeRepr.of[T]
+    tpe.typeSymbol.children.map { childSymbol =>
+      tpe.memberType(childSymbol) // not a member of tpe
+    }
+    '{ () }

--- a/tests/neg-macros/i15159/Test_2.scala
+++ b/tests/neg-macros/i15159/Test_2.scala
@@ -1,0 +1,6 @@
+sealed trait A
+case class X(i: Int) extends A
+
+object Test extends App {
+  TestMacro.test[A] // error
+}

--- a/tests/pos-macros/i13319/Macro_1.scala
+++ b/tests/pos-macros/i13319/Macro_1.scala
@@ -1,0 +1,12 @@
+import scala.quoted._
+object Macro:
+  inline def apply[A]: Unit = ${impl[A]}
+
+  private def impl[A: Type](using Quotes): Expr[String] =
+    import quotes.reflect._
+    val t = TypeRepr.of[A]
+    Expr.ofList(t.baseClasses.drop(1).filter(_.flags.is(Flags.Trait)).map { baseSymbol =>
+        t.memberType(baseSymbol).asType  match { case '[t] => 42}
+        Expr("")
+    })
+    Expr("")

--- a/tests/pos-macros/i13319/Test_2.scala
+++ b/tests/pos-macros/i13319/Test_2.scala
@@ -1,0 +1,1 @@
+@main def Test = Macro[Option[String]]

--- a/tests/run-macros/i22395.check
+++ b/tests/run-macros/i22395.check
@@ -1,0 +1,1 @@
+TypeRef(AppliedType(TypeRef(ThisType(TypeRef(ThisType(TypeRef(NoPrefix,module class <root>)),module class <empty>)),Foo),List(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),Int))),class Nested)

--- a/tests/run-macros/i22395/Macro_1.scala
+++ b/tests/run-macros/i22395/Macro_1.scala
@@ -1,0 +1,14 @@
+import scala.quoted._
+
+inline def test(): String = ${testImpl}
+def testImpl(using Quotes) = {
+  import quotes.reflect._
+  val fooSymbol = TypeRepr.of[Foo[Int]].typeSymbol
+  val nestedSymbol = fooSymbol.typeMember("Nested")
+
+  Expr(TypeRepr.of[Foo[Int]].memberType(nestedSymbol).toString)
+}
+
+
+trait Foo[X]:
+  sealed abstract class Nested extends Foo[Int]

--- a/tests/run-macros/i22395/Test_2.scala
+++ b/tests/run-macros/i22395/Test_2.scala
@@ -1,0 +1,2 @@
+@main def Test =
+  println(test())


### PR DESCRIPTION
fixes #22395 
fixes #13319
fixes #15159

The `asSeenFrom` method, used in `TypeRepr.memberType` sometimes can return ClassInfo instances, which we do not expose in the reflect API. This is either caused by nonsensical calls (calls with symbols unrelated to the type), or as in case of issue #22395, correct calls on nested classes.

Since ClassInfo gives us precise type prefix and symbol, we transform that ClassInfo into a TypeRef (which is how types pointing to classes are usually represented in the reflect API).

Previously (in https://github.com/scala/scala3/pull/15161) there were attempts to completely limit calling memberType to the direct members of the type (to avoid the nonsensical calls), however that causes major regressions in both the compilation tests, and (in my opinion) functionality (as explained in the comment). So instead we check if the passed symbol if any owner of the passed symbol is a member of the typeRepr (basically, we allow obtaining the types of a nested members). With the above fix, this check is not strictly necessary, but I think it might help avoid confusion about how memberType is supposed to be used.