### PR TITLE
[LTS only] Fix synchronization of -java-output-versions with JVM backend

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -9,6 +9,7 @@ import dotty.tools.dotc.config.SourceVersion
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.rewrites.Rewrites
 import dotty.tools.io.{AbstractFile, Directory, JDK9Reflectors, PlainDirectory}
+import dotty.tools.backend.jvm.BackendUtils.classfileVersionMap
 import Setting.ChoiceWithHelp
 
 import scala.util.chaining.*
@@ -19,8 +20,8 @@ class ScalaSettings extends SettingGroup with AllScalaSettings
 
 object ScalaSettings:
   // Keep synchronized with `classfileVersion` in `BackendUtils`
-  private val minTargetVersion = 8
-  private val maxTargetVersion = 22
+  private lazy val minTargetVersion = classfileVersionMap.keysIterator.min
+  private lazy val maxTargetVersion = classfileVersionMap.keysIterator.max
 
   def supportedTargetVersions: List[String] =
     (minTargetVersion to maxTargetVersion).toList.map(_.toString)


### PR DESCRIPTION
Fixes a bug in Scala settings after https://github.com/scala/scala3/pull/22111 which edited wrong `ScalaSettings.scala` file - the backport to LTS updated max JDK version in the `pos/compiler-with-cc` tests directory instead of the one in the main sources. 

The fix would follow a Scala 3.3.5-RC3 release on Monday