### PR TITLE
Fix mapping of annotations

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -65,7 +65,7 @@ object Annotations {
             if tm.isRange(x) then x
             else
               val tp1 = tm(tree.tpe)
-              foldOver(if !tp1.exists || (tp1 frozen_=:= tree.tpe) then x else tp1, tree)
+              foldOver(if !tp1.exists || tp1.eql(tree.tpe) then x else tp1, tree)
         val diff = findDiff(NoType, args)
         if tm.isRange(diff) then EmptyAnnotation
         else if diff.exists then derivedAnnotation(tm.mapOver(tree))

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6322,6 +6322,8 @@ object Types extends TypeUtils {
       override def stopAt = thisMap.stopAt
       def apply(tp: Type) = f(thisMap(tp))
     }
+
+    override def toString = s"${getClass.getSimpleName}@$hashCode" // otherwise would print as <function1>
   }
 
   /** A type map that maps also parents and self type of a ClassInfo */

--- a/tests/pos-custom-args/captures/setup/a_1.scala
+++ b/tests/pos-custom-args/captures/setup/a_1.scala
@@ -1,0 +1,6 @@
+// a.scala
+import language.experimental.captureChecking
+import scala.caps.CapSet
+
+trait A:
+  def f[C^](x: AnyRef^{C^}): Unit

--- a/tests/pos-custom-args/captures/setup/b_1.scala
+++ b/tests/pos-custom-args/captures/setup/b_1.scala
@@ -1,0 +1,5 @@
+import language.experimental.captureChecking
+import scala.caps.CapSet
+
+class B extends A:
+  def f[C^](x: AnyRef^{C^}): Unit = ???

--- a/tests/pos-custom-args/captures/setup/b_2.scala
+++ b/tests/pos-custom-args/captures/setup/b_2.scala
@@ -1,0 +1,5 @@
+import language.experimental.captureChecking
+import scala.caps.CapSet
+
+class B extends A:
+  def f[C^](x: AnyRef^{C^}): Unit = ???


### PR DESCRIPTION
We previously did not do an (expensive) TreeTypeMap on an annotation if the mapped versions of all types of subtrees of the annotation tree were =:= to the original types. But it turns out this is too coarse. In the test we have capture set variables where we intend to map a TypeRef to a TypeParamRef but the two were considered as =:= because of the bounds they had. So no mapping took place.

We now use `eql` instead of =:=, which is structural comparison with `eq` for references to corresponding binders.