### PR TITLE
Fix chocolatey-test when used in stable releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -911,14 +911,14 @@ jobs:
     uses: ./.github/workflows/build-chocolatey.yml
     needs: [ build-sdk-package ]
     with:
-      version: 3.6.0-local # TODO: FIX THIS
+      version: 3.6.0-SNAPSHOT # Fake version, used only for choco tests
       url    : https://api.github.com/repos/scala/scala3/actions/artifacts/${{ needs.build-sdk-package.outputs.win-x86_64-id }}/zip
       digest : ${{ needs.build-sdk-package.outputs.win-x86_64-digest }}
 
   test-chocolatey-package:
     uses: ./.github/workflows/test-chocolatey.yml
     with:
-      version     : 3.6.0-local # TODO: FIX THIS
+      version     : 3.6.0-SNAPSHOT # Fake version, used only for choco tests
       java-version: 8
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.body, '[test_chocolatey]')
     needs: [ build-chocolatey-package ]

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -21,7 +21,10 @@ on:
 
 env:
   CHOCOLATEY-REPOSITORY: chocolatey-pkgs
-  DOTTY_CI_INSTALLATION: ${{ secrets.GITHUB_TOKEN }}
+  # Controls behaviour of chocolatey{Install,Uninstall}.ps1 scripts
+  # During snapshot releases it uses a different layout and requires access token to GH Actions artifacts
+  # During stable releases it uses publically available archives
+  DOTTY_CI_INSTALLATION: ${{ endsWith(inputs.version, '-SNAPSHOT') && secrets.GITHUB_TOKEN || '' }}
 
 jobs:
   test:


### PR DESCRIPTION
Release scripts were previously failing in `test-chocolatey`. These were using incorrect layout assuming that we're downloading jar from GH Actions. 

```pwsh
if ($env:DOTTY_CI_INSTALLATION) {
```
would now be evaluated as empty string which for if-condition would be evaluated as `false`.