### PR TITLE
No outdent at eof

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -617,6 +617,7 @@ object Scanners {
             if nextWidth < lastWidth then currentRegion = topLevelRegion(nextWidth)
           else if !isLeadingInfixOperator(nextWidth) && !statCtdTokens.contains(lastToken) && lastToken != INDENT then
             currentRegion match
+              case _ if token == EOF => // no OUTDENT at EOF
               case r: Indented =>
                 insert(OUTDENT, offset)
                 handleNewIndentWidth(r.enclosing, ir =>

--- a/tests/pos/i22332.scala
+++ b/tests/pos/i22332.scala
@@ -1,0 +1,5 @@
+
+object Foo:
+  val foo = 42
+ // one space
+ 


### PR DESCRIPTION
Fixes #22332 

The reference does not mention `<eof>`.  `<outdent>` insertion does not require a particular next token, though some next tokens affect it (that is, leading infix or tokens that close an indentation region). It does require a "first token on the next line", for which we may take `<eof>` as the lack of a token.

Of course, ordinary error messages say `eof`.

The same text with an opening brace is unchanged:
```
5 |
  | ^
  | '}' expected, but eof found
```