### PR TITLE
Implicit parameters should warn at call site in >= 3.7

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -867,7 +867,7 @@ object desugar {
       val nu = vparamss.foldLeft(makeNew(classTypeRef)) { (nu, vparams) =>
         val app = Apply(nu, vparams.map(refOfDef))
         vparams match {
-          case vparam :: _ if vparam.mods.is(Given) || vparam.name.is(ContextBoundParamName) =>
+          case vparam :: _ if vparam.mods.isOneOf(GivenOrImplicit) || vparam.name.is(ContextBoundParamName) =>
             app.setApplyKind(ApplyKind.Using)
           case _ => app
         }

--- a/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
@@ -32,6 +32,7 @@ enum MigrationVersion(val warnFrom: SourceVersion, val errorFrom: SourceVersion)
   case ParameterEnclosedByParenthesis extends MigrationVersion(future, future)
   case XmlLiteral extends MigrationVersion(future, future)
   case GivenSyntax extends MigrationVersion(future, never)
+  case ImplicitParamsWithoutUsing extends MigrationVersion(`3.7`, future)
 
   require(warnFrom.ordinal <= errorFrom.ordinal)
 

--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -132,7 +132,10 @@ trait Migrations:
     if tp.companion == ImplicitMethodType && pt.applyKind != ApplyKind.Using && pt.args.nonEmpty then
       val rewriteMsg = Message.rewriteNotice("This code", mversion.patchFrom)
       report.errorOrMigrationWarning(
-        em"Implicit parameters should be provided with a `using` clause.$rewriteMsg", 
+        em"""Implicit parameters should be provided with a `using` clause.$rewriteMsg
+            |To disable the warning, please use the following option: 
+            |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
+            |""", 
         pt.args.head.srcPos, mversion)
       if mversion.needsPatch then
         patch(Span(pt.args.head.span.start), "using ")

--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -126,4 +126,16 @@ trait Migrations:
         patch(Span(pt.args.head.span.start), "using ")
   end contextBoundParams
 
+  /** Report implicit parameter lists and rewrite implicit parameter list to contextual params */
+  def implicitParams(tree: Tree, tp: MethodOrPoly, pt: FunProto)(using Context): Unit =
+    val mversion = mv.ImplicitParamsWithoutUsing
+    if tp.companion == ImplicitMethodType && pt.applyKind != ApplyKind.Using && pt.args.nonEmpty then
+      val rewriteMsg = Message.rewriteNotice("This code", mversion.patchFrom)
+      report.errorOrMigrationWarning(
+        em"Implicit parameters should be provided with a `using` clause.$rewriteMsg", 
+        pt.args.head.srcPos, mversion)
+      if mversion.needsPatch then
+        patch(Span(pt.args.head.span.start), "using ")
+  end implicitParams
+
 end Migrations

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4164,6 +4164,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         def methodStr = methPart(tree).symbol.showLocated
         if matchingApply(wtp, pt) then
           migrate(contextBoundParams(tree, wtp, pt))
+          migrate(implicitParams(tree, wtp, pt))
           if needsTupledDual(wtp, pt) then adapt(tree, pt.tupledDual, locked)
           else tree
         else if wtp.isContextualMethod then

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -83,6 +83,7 @@ class CompilationTests {
       compileFile("tests/rewrites/ambiguous-named-tuple-assignment.scala", defaultOptions.and("-rewrite", "-source:3.6-migration")),
       compileFile("tests/rewrites/i21382.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/unused.scala", defaultOptions.and("-rewrite", "-Wunused:all")),
+      compileFile("tests/rewrites/i22440.scala", defaultOptions.and("-rewrite"))
     ).checkRewrites()
   }
 

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -611,7 +611,7 @@ class DottyLanguageServer extends LanguageServer
   private def inProjectsSeeing(baseDriver: InteractiveDriver,
                                definitions: List[SourceTree],
                                symbols: List[Symbol]): List[(InteractiveDriver, Context, List[Symbol])] = {
-    val projects = projectsSeeing(definitions)(baseDriver.currentCtx)
+    val projects = projectsSeeing(definitions)(using baseDriver.currentCtx)
     projects.toList.map { config =>
       val remoteDriver = drivers(config)
       val ctx = remoteDriver.currentCtx

--- a/language-server/src/dotty/tools/languageserver/worksheet/WorksheetService.scala
+++ b/language-server/src/dotty/tools/languageserver/worksheet/WorksheetService.scala
@@ -24,7 +24,7 @@ trait WorksheetService { thisServer: DottyLanguageServer =>
         val sendMessage = (pos: SourcePosition, msg: String) =>
           client.publishOutput(WorksheetRunOutput(params.textDocument, range(pos).get, msg))
 
-        runWorksheet(driver, uri, sendMessage, cancelChecker)(driver.currentCtx)
+        runWorksheet(driver, uri, sendMessage, cancelChecker)(using driver.currentCtx)
         cancelChecker.checkCanceled()
         WorksheetRunResult(success = true)
       } catch {

--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -143,7 +143,7 @@ object Signature:
 case class LinkToType(signature: Signature, dri: DRI, kind: Kind)
 
 case class HierarchyGraph(edges: Seq[(LinkToType, LinkToType)], sealedNodes: Set[LinkToType] = Set.empty):
-  def vertecies: Seq[LinkToType] = edges.flatten((a, b) => Seq(a, b)).distinct
+  def vertecies: Seq[LinkToType] = edges.flatten(using (a, b) => Seq(a, b)).distinct
   def verteciesWithId: Map[LinkToType, Int] = vertecies.zipWithIndex.toMap
   def +(edge: (LinkToType, LinkToType)): HierarchyGraph = this ++ Seq(edge)
   def ++(edges: Seq[(LinkToType, LinkToType)]): HierarchyGraph =

--- a/staging/src/scala/quoted/staging/QuoteDriver.scala
+++ b/staging/src/scala/quoted/staging/QuoteDriver.scala
@@ -43,7 +43,7 @@ private class QuoteDriver(appClassloader: ClassLoader) extends Driver:
 
     val compiledExpr =
       try
-        new QuoteCompiler().newRun(ctx).compileExpr(exprBuilder)
+        new QuoteCompiler().newRun(using ctx).compileExpr(exprBuilder)
       catch case ex: dotty.tools.FatalError =>
         val enrichedMessage =
           s"""An unhandled exception was thrown in the staging compiler.

--- a/tests/neg/i22440.check
+++ b/tests/neg/i22440.check
@@ -3,3 +3,5 @@
   |            ^
   |            Implicit parameters should be provided with a `using` clause.
   |            This code can be rewritten automatically under -rewrite -source 3.7-migration.
+  |            To disable the warning, please use the following option: 
+  |              "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"

--- a/tests/neg/i22440.check
+++ b/tests/neg/i22440.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg/i22440.scala:4:12 ----------------------------------------------------------------------------------
+4 |val _ = foo(1) // error
+  |            ^
+  |            Implicit parameters should be provided with a `using` clause.
+  |            This code can be rewritten automatically under -rewrite -source 3.7-migration.

--- a/tests/neg/i22440.scala
+++ b/tests/neg/i22440.scala
@@ -1,0 +1,4 @@
+//> using options -source future
+
+def foo(implicit x: Int) = x
+val _ = foo(1) // error

--- a/tests/pos/i22440.scala
+++ b/tests/pos/i22440.scala
@@ -1,0 +1,4 @@
+//> using options "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
+
+def foo(implicit x: Int) = x
+val _ = foo(1) // warn

--- a/tests/rewrites/i22440.check
+++ b/tests/rewrites/i22440.check
@@ -1,0 +1,5 @@
+//> using options -source 3.7-migration
+
+def foo(implicit x: Int) = ()
+val _ = foo(using 1)
+val _ = foo    (using 1)

--- a/tests/rewrites/i22440.scala
+++ b/tests/rewrites/i22440.scala
@@ -1,0 +1,5 @@
+//> using options -source 3.7-migration
+
+def foo(implicit x: Int) = ()
+val _ = foo(1)
+val _ = foo    (1)

--- a/tests/warn/i22440.check
+++ b/tests/warn/i22440.check
@@ -3,3 +3,5 @@
   |            ^
   |            Implicit parameters should be provided with a `using` clause.
   |            This code can be rewritten automatically under -rewrite -source 3.7-migration.
+  |            To disable the warning, please use the following option: 
+  |              "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"

--- a/tests/warn/i22440.check
+++ b/tests/warn/i22440.check
@@ -1,0 +1,5 @@
+-- Warning: tests/warn/i22440.scala:4:12 -------------------------------------------------------------------------------
+4 |val _ = foo(1) // warn
+  |            ^
+  |            Implicit parameters should be provided with a `using` clause.
+  |            This code can be rewritten automatically under -rewrite -source 3.7-migration.

--- a/tests/warn/i22440.scala
+++ b/tests/warn/i22440.scala
@@ -1,0 +1,4 @@
+//> using options -source 3.7
+
+def foo(implicit x: Int) = x
+val _ = foo(1) // warn


### PR DESCRIPTION
Closes #22440


TODO:

- [x] Add test with `-Wconf`
- [x] Handle desugaring to generate valid code:
```scala
  abstract class Base(implicit config: Int)
  case class A(x: Int)(implicit config: Int) extends Base
```

should not be desugared to (anymore):

```scala
abstract class Base(implicit config: Int) extends Object() {
      private[this] implicit val config: Int
    }
    case class A(x: Int)(implicit config: Int) extends Test.Base()(config),
      _root_.scala.Product, _root_.scala.Serializable {
      val x: Int
      private[this] implicit val config: Int
      def copy(x: Int)(implicit config: Int): Test.A = new Test.A(x)(config)
      def copy$default$1: Int @uncheckedVariance = A.this.x
      def _1: Int = this.x
    }
    final lazy module val A: Test.A = new Test.A()
    final module class A() extends AnyRef() { this: Test.A.type =>
      def apply(x: Int)(implicit config: Int): Test.A = new Test.A(x)(config)
      def unapply(x$1: Test.A): Test.A = x$1
      override def toString: String = "A"
    }
```

but rather:
```scala
abstract class Base(implicit config: Int) extends Object() {
      private[this] implicit val config: Int
    }
    case class A(x: Int)(implicit config: Int) extends Test.Base()(using config),
      _root_.scala.Product, _root_.scala.Serializable {
      val x: Int
      private[this] implicit val config: Int
      def copy(x: Int)(implicit config: Int): Test.A = new Test.A(x)(using config)
      def copy$default$1: Int @uncheckedVariance = A.this.x
      def _1: Int = this.x
    }
    final lazy module val A: Test.A = new Test.A()
    final module class A() extends AnyRef() { this: Test.A.type =>
      def apply(x: Int)(implicit config: Int): Test.A = new Test.A(x)(using config)
      def unapply(x$1: Test.A): Test.A = x$1
      override def toString: String = "A"
    }
```