### PR TITLE
Update Scala CLI to 1.6.1 (was 1.5.4) & `coursier` to 2.1.24 (was 2.1.18)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -184,9 +184,9 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.5.4"
+  val scalaCliLauncherVersion = "1.6.1"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.18"
+  val coursierJarVersion = "2.1.24"
 
   object CompatMode {
     final val BinaryCompatible = 0


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.6.1
https://github.com/coursier/coursier/releases/tag/v2.1.24

Should be included in Scala 3.7.0.