### PR TITLE
Special case NamedTuple.From for arguments derived from Tuple

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeEval.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeEval.scala
@@ -111,6 +111,15 @@ object TypeEval:
               nestedPairs(fieldLabels) :: nestedPairs(fieldTypes) :: Nil
         else arg.widenDealias match
           case arg @ defn.NamedTuple(_, _) => Some(arg)
+          case arg if arg.derivesFrom(defn.TupleClass) =>
+            val fieldTypesOpt = tupleElementTypes(arg)
+            fieldTypesOpt match
+              case Some(fieldTypes) =>
+                val fieldLabels = fieldTypes.zipWithIndex.map((_, i) => ConstantType(Constant(s"_$i")))
+                Some:
+                  defn.NamedTupleTypeRef.appliedTo:
+                    nestedPairs(fieldLabels) :: nestedPairs(fieldTypes) :: Nil
+              case _ => None
           case _ => None
 
       def constantFold1[T](extractor: Type => Option[T], op: T => Any): Option[Type] =

--- a/tests/pos/i22036.scala
+++ b/tests/pos/i22036.scala
@@ -1,0 +1,13 @@
+//> using options -experimental -language:experimental.namedTuples
+import language.experimental.namedTuples
+
+type Foo[T] = T
+val x: NamedTuple.From[Tuple.Map[(Int, Int), Foo]] = ???
+val res = x._1
+
+type Z = NamedTuple.From[(Foo[Int], Foo[Int])]
+val x2: Z  = ???
+val res2 = x2._1
+
+val x3: Foo[NamedTuple.From[Tuple.Map[(Int, Int), Foo]]]  = ???
+val res3 = x3._1


### PR DESCRIPTION
Fixes #22036 

Some questions:
- `NamedTuple.From(<TupleN>)` works as is, so maybe there's a better way to fully normalize/evaluate the arguments to `NamedTuple.From` at the start of `fieldsOf`, instead of special casing types derived from Tuple?
- is there a better way to extract the expected keys (ConstantType(Constant(`_<n>))` than just hard coding "_"?