### PR TITLE
Fix for #22461 Empty ClassPath attribute in one or more classpath jars causes crash

### DIFF
--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -50,7 +50,7 @@ class Jar(file: File) {
   def mainClass: Option[String]     = manifest.map(_(Name.MAIN_CLASS))
   /** The manifest-defined classpath String if available. */
   def classPathString: Option[String] =
-    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH) if !cp.isBlank()) yield cp
+    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH) if !cp.trim().isEmpty()) yield cp
   def classPathElements: List[String] = classPathString match {
     case Some(s)  => s.split("\\s+").toList
     case _        => Nil

--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -50,7 +50,7 @@ class Jar(file: File) {
   def mainClass: Option[String]     = manifest.map(_(Name.MAIN_CLASS))
   /** The manifest-defined classpath String if available. */
   def classPathString: Option[String] =
-    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH)) yield cp
+    for (m <- manifest ; cp <- m.attrs.get(Name.CLASS_PATH) if !cp.isBlank()) yield cp
   def classPathElements: List[String] = classPathString match {
     case Some(s)  => s.split("\\s+").toList
     case _        => Nil


### PR DESCRIPTION
Change to how an empty or `null` jar manifest `ClassPath:` property is handled:

in dotty.tools.dotc.classpath.ClassPathFactory:

- `classesInExpandedPath(...)` returns and empty `IndexedSeq` rather than crash
- `isJarOrZip` returns `false` on a `null` reference rather than crash

in dotty.tools.dotc.classpath.FileUtils:

- `createSourcePath`  fails with an error message on a `null` file parameter.

In the context of #22461, this causes an empty `ClassPath:` property to be treated the same as a mispelled or missing classpath entry, which are silently ignored, matching the behaviour of legacy scripts.

Closes #22461

