### PR TITLE
Correctly detect colon lambda eol indent for optional brace of argument

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1090,6 +1090,7 @@ object Parsers {
       def isArrowIndent() =
         lookahead.isArrow
         && {
+          lookahead.observeArrowEOL()
           lookahead.nextToken()
           lookahead.token == INDENT || lookahead.token == EOF
         }
@@ -2654,9 +2655,13 @@ object Parsers {
 
     def closureRest(start: Int, location: Location, params: List[Tree]): Tree =
       atSpan(start, in.offset) {
+        if location == Location.InColonArg then
+          in.observeArrowEOL()
         if in.token == CTXARROW then
           if params.isEmpty then
             syntaxError(em"context function literals require at least one formal parameter", Span(start, in.lastOffset))
+          in.nextToken()
+        else if in.token == ARROWeol then
           in.nextToken()
         else
           accept(ARROW)

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -202,10 +202,9 @@ object Tokens extends TokensCommon {
   inline val COLONeol = 89;         enter(COLONeol, ":", ": at eol")
     // A `:` recognized as starting an indentation block
   inline val SELFARROW = 90;        enter(SELFARROW, "=>") // reclassified ARROW following self-type
-  inline val ARROWeol = 99;         enter(ARROWeol, "=>", "=> at eol") // lambda ARROW at eol followed by indent
 
   /** XML mode */
-  inline val XMLSTART = 100;        enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
+  inline val XMLSTART = 99;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
 
   final val alphaKeywords: TokenSet = tokenRange(IF, END)
   final val symbolicKeywords: TokenSet = tokenRange(USCORE, CTXARROW)
@@ -283,7 +282,7 @@ object Tokens extends TokensCommon {
   final val closingRegionTokens = BitSet(RBRACE, RPAREN, RBRACKET, CASE) | statCtdTokens
 
   final val canStartIndentTokens: BitSet =
-    statCtdTokens | BitSet(COLONeol, WITH, EQUALS, ARROWeol, ARROW, CTXARROW, LARROW, WHILE, TRY, FOR, IF, THROW, RETURN)
+    statCtdTokens | BitSet(COLONeol, WITH, EQUALS, ARROW, CTXARROW, LARROW, WHILE, TRY, FOR, IF, THROW, RETURN)
 
   /** Faced with the choice between a type and a formal parameter, the following
    *  tokens determine it's a formal parameter.

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -202,9 +202,10 @@ object Tokens extends TokensCommon {
   inline val COLONeol = 89;         enter(COLONeol, ":", ": at eol")
     // A `:` recognized as starting an indentation block
   inline val SELFARROW = 90;        enter(SELFARROW, "=>") // reclassified ARROW following self-type
+  inline val ARROWeol = 99;         enter(ARROWeol, "=>", "=> at eol") // lambda ARROW at eol followed by indent
 
   /** XML mode */
-  inline val XMLSTART = 99;         enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
+  inline val XMLSTART = 100;        enter(XMLSTART, "$XMLSTART$<") // TODO: deprecate
 
   final val alphaKeywords: TokenSet = tokenRange(IF, END)
   final val symbolicKeywords: TokenSet = tokenRange(USCORE, CTXARROW)
@@ -282,7 +283,7 @@ object Tokens extends TokensCommon {
   final val closingRegionTokens = BitSet(RBRACE, RPAREN, RBRACKET, CASE) | statCtdTokens
 
   final val canStartIndentTokens: BitSet =
-    statCtdTokens | BitSet(COLONeol, WITH, EQUALS, ARROW, CTXARROW, LARROW, WHILE, TRY, FOR, IF, THROW, RETURN)
+    statCtdTokens | BitSet(COLONeol, WITH, EQUALS, ARROWeol, ARROW, CTXARROW, LARROW, WHILE, TRY, FOR, IF, THROW, RETURN)
 
   /** Faced with the choice between a type and a formal parameter, the following
    *  tokens determine it's a formal parameter.

--- a/tests/neg/i22193.scala
+++ b/tests/neg/i22193.scala
@@ -1,0 +1,44 @@
+
+def fn2(arg: String, arg2: String)(f: String => Unit): Unit = f(arg)
+
+def fn3(arg: String, arg2: String)(f: => Unit): Unit = f
+
+def test1() =
+
+  fn2(arg = "blue sleeps faster than tuesday", arg2 = "the quick brown fox jumped over the lazy dog"): env =>
+    val x = env
+    println(x)
+
+  fn2( // error not a legal formal parameter for a function literal
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"): env =>
+  val x = env // error
+  println(x)
+
+  fn2( // error
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"): env =>
+    val x = env // error
+    println(x)
+
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"):
+  env => // error indented definitions expected, identifier env found
+      val x = env
+      println(x)
+
+def test2() =
+
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"
+  ): env =>
+    val x = env
+    println(x)
+
+  fn3( // error missing argument list for value of type (=> Unit) => Unit
+    arg = "blue sleeps faster than tuesday",
+    arg2 = "the quick brown fox jumped over the lazy dog"):
+  val x = "Hello" // error
+  println(x) // error

--- a/tests/neg/i22193.scala
+++ b/tests/neg/i22193.scala
@@ -5,6 +5,7 @@ def fn3(arg: String, arg2: String)(f: => Unit): Unit = f
 
 def test1() =
 
+  // ok baseline
   fn2(arg = "blue sleeps faster than tuesday", arg2 = "the quick brown fox jumped over the lazy dog"): env =>
     val x = env
     println(x)
@@ -15,12 +16,6 @@ def test1() =
   val x = env // error
   println(x)
 
-  fn2( // error
-      arg = "blue sleeps faster than tuesday",
-      arg2 = "the quick brown fox jumped over the lazy dog"): env =>
-    val x = env // error
-    println(x)
-
   fn2(
       arg = "blue sleeps faster than tuesday",
       arg2 = "the quick brown fox jumped over the lazy dog"):
@@ -29,13 +24,6 @@ def test1() =
       println(x)
 
 def test2() =
-
-  fn2(
-      arg = "blue sleeps faster than tuesday",
-      arg2 = "the quick brown fox jumped over the lazy dog"
-  ): env =>
-    val x = env
-    println(x)
 
   fn3( // error missing argument list for value of type (=> Unit) => Unit
     arg = "blue sleeps faster than tuesday",

--- a/tests/pos/i22193.scala
+++ b/tests/pos/i22193.scala
@@ -22,6 +22,12 @@ def test() =
        val x = env
        println(x)
 
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"): env =>
+    val x = env
+    println(x)
+
   // does compile
   fn2(
       arg = "blue sleeps faster than tuesday",
@@ -37,6 +43,13 @@ def test() =
   ): env =>
       val x = env
       println(x)
+
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"
+  ): env =>
+    val x = env
+    println(x)
 
   fn3(
     arg = "blue sleeps faster than tuesday",
@@ -55,3 +68,11 @@ def regress(x: Int) =
   x match
   case 42 =>
   case _ =>
+
+// previously lookahead calculated indent width at the colon
+def k(xs: List[Int]) =
+  xs.foldLeft(
+      0)
+                                            : (acc, x) =>
+        acc + x
+

--- a/tests/pos/i22193.scala
+++ b/tests/pos/i22193.scala
@@ -1,0 +1,57 @@
+
+def fn2(arg: String, arg2: String)(f: String => Unit): Unit = f(arg)
+
+def fn3(arg: String, arg2: String)(f: => Unit): Unit = f
+
+def test() =
+
+  fn2(arg = "blue sleeps faster than tuesday", arg2 = "the quick brown fox jumped over the lazy dog"): env =>
+    val x = env
+    println(x)
+
+  // doesn't compile
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"): env =>
+      val x = env
+      println(x)
+
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"): env =>
+       val x = env
+       println(x)
+
+  // does compile
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"):
+    env =>
+      val x = env
+      println(x)
+
+  // does compile
+  fn2(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"
+  ): env =>
+      val x = env
+      println(x)
+
+  fn3(
+    arg = "blue sleeps faster than tuesday",
+    arg2 = "the quick brown fox jumped over the lazy dog"):
+    val x = "Hello"
+    println(x)
+
+  fn3(
+      arg = "blue sleeps faster than tuesday",
+      arg2 = "the quick brown fox jumped over the lazy dog"):
+      val x = "Hello"
+      println(x)
+
+// don't turn innocent empty cases into functions
+def regress(x: Int) =
+  x match
+  case 42 =>
+  case _ =>

--- a/tests/pos/i22193.scala
+++ b/tests/pos/i22193.scala
@@ -63,6 +63,30 @@ def test() =
       val x = "Hello"
       println(x)
 
+  fn3( // arg at 3, body at 3
+     arg = "blue sleeps faster than tuesday",
+     arg2 = "the quick brown fox jumped over the lazy dog"):
+     val x = "Hello"
+     println(x)
+
+  fn3( // arg at 3, body at 1: not sure if sig indent of 1 is allowed, saw some comments from odersky
+     arg = "blue sleeps faster than tuesday",
+     arg2 = "the quick brown fox jumped over the lazy dog"):
+   val x = "Hello"
+   println(x)
+
+  fn3( // arg at 3, body at 2: even if sig indent of 1 is not allowed, body is at fn3+2, not arg2-1
+     arg = "blue sleeps faster than tuesday",
+     arg2 = "the quick brown fox jumped over the lazy dog"):
+    val x = "Hello"
+    println(x)
+
+  fn3( // arg at 3, body at 4
+     arg = "blue sleeps faster than tuesday",
+     arg2 = "the quick brown fox jumped over the lazy dog"):
+      val x = "Hello"
+      println(x)
+
 // don't turn innocent empty cases into functions
 def regress(x: Int) =
   x match
@@ -76,3 +100,42 @@ def k(xs: List[Int]) =
                                             : (acc, x) =>
         acc + x
 
+def `test kit`(xs: List[Int]): Unit =
+  def addOne(i: Int): Int = i + 1
+  def isPositive(i: Int): Boolean = i > 0
+  // doesn't compile but would be nice
+  // first body is indented "twice", or, rather, first outdent establishes an intermediate indentation level
+  xs.map: x =>
+      x + 1
+    .filter: x =>
+      x > 0
+  xs.map:
+      addOne
+    .filter:
+      isPositive
+
+  // does compile
+  xs
+    .map: x =>
+      x + 1
+    .filter: x =>
+      x > 0
+
+  // does compile but doesn't look good, at least, to some people
+  xs.map: x =>
+      x + 1
+  .filter: x =>
+      x > 0
+
+def `tested kit`(xs: List[Int]): Unit =
+  {
+    def addOne(i: Int): Int = i.+(1)
+    def isPositive(i: Int): Boolean = i.>(0)
+    xs.map[Int]((x: Int) => x.+(1)).filter((x: Int) => x.>(0))
+    xs.map[Int]((i: Int) => addOne(i)).filter((i: Int) => isPositive(i))
+    xs.map[Int]((x: Int) => x.+(1)).filter((x: Int) => x.>(0))
+    {
+      xs.map[Int]((x: Int) => x.+(1)).filter((x: Int) => x.>(0))
+      ()
+    }
+  }


### PR DESCRIPTION
Fixes #22193 

The lookahead scanner used by `followingIsLambdaAfterColon` would recalculate the indentation width of its top region from the current offset, which is the colon token. That would cause detection of indentation to fail on the next line. This commit preserves the indentation width for that purpose. Subsequent parsing of the function literal proceeds normally.