### PR TITLE
Fix stack overflow errors when generating opaque type proxies

### DIFF
--- a/tests/pos/i22468.scala
+++ b/tests/pos/i22468.scala
@@ -1,0 +1,10 @@
+import Result.*
+opaque type Result[+E, +A] = Success[A] | Error[E]
+
+object Result:
+  opaque type Success[+A] = A
+  sealed abstract class Error[+E]
+
+  extension [E, A](self: Result[E, A])
+    inline def transform[B]: B = ???
+    def problem: Boolean = transform[Boolean]


### PR DESCRIPTION
Fixes #22468  
Before the regressive PR, we would check via the generated opaqueProxies list whether one was already generated. In that PR, we tried allowing generating proxies for rhs of currently generated proxy. Since we have to add the generated proxy to opaqueProxies only after that step, this could cause infinite recursion (and adding the proxies earlier could cause another infinite loop).

To fix that, we add another collection for termrefs which we already visited this way, but which is not used in the `mapOpaques` function.