### PR TITLE
improvement: use heuristic to figure out `nameSpan` if `pointDelta` too big

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -461,8 +461,11 @@ object Trees {
         else if qualifier.span.exists && qualifier.span.start > span.point then // right associative
           val realName = name.stripModuleClassSuffix.lastPart
           Span(span.start, span.start + realName.length, point)
-        else
-          Span(point, span.end, point)
+        else if span.pointMayBeIncorrect then
+          val realName = name.stripModuleClassSuffix.lastPart
+          val probablyPoint = span.end - realName.length
+          Span(probablyPoint, span.end, probablyPoint)
+        else Span(point, span.end, point)
       else span
   }
 

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -59,6 +59,9 @@ object Spans {
       if (poff == SyntheticPointDelta) start else start + poff
     }
 
+    def pointMayBeIncorrect =
+      pointDelta == 0 && end - start >= SyntheticPointDelta
+
     /** The difference between point and start in this span */
     def pointDelta: Int =
       (coords >>> (StartEndBits * 2)).toInt

--- a/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
@@ -1464,90 +1464,13 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite:
 
   @Test def i3053 =
     check(
-      """import Aaaa.*
+      s"""import Aaaa.*
         |
         |def classDef2(cdef: List[Int]): Int = {
         |  def aaa(ddef: Thicket2): List[Int] = ddef match {
         |    case Thicket2(_) => ???
         |  }
-        |
-        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
-        |    * inline classes
-        |    */
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |
-        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
-        |    * inline classes
-        |    */
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |
-        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
-        |    * inline classes
-        |    */
-        |  // Annotations on class _type_ parameters are set on the derived parameters
-        |  // but not on the constructor parameters. The reverse is true for
-        |  // annotations on class _value_ parameters.
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |
-        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
-        |    * inline classes
-        |    */
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |
-        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
-        |    * inline classes
-        |    */
-        |
-        |  // Annotations on class _type_ parameters are set on the derived parameters
-        |  // but not on the constructor parameters. The reverse is true for
-        |  // annotations on class _value_ parameters.
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |
-        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
-        |    * inline classes
-        |    */
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |
-        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
-        |    * inline classes
-        |    */
-        |  // Annotations on class _type_ parameters are set on the derived parameters
-        |  // but not on the constructor parameters. The reverse is true for
-        |  // annotations on class _value_ parameters.
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
-        |  // The original type and value parameters in the constructor already have the flags
-        |  // needed to be type members (i.e. param, and possibly also private and local unless
-        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
-        |  // go in `constr`, the constructor after desugaring.
+        |${("//" + "x" * 64 + "\n") * 64}
         |  1
         |}.<<showing2>>("aaa")
         |

--- a/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
@@ -1462,5 +1462,106 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite:
         |""".stripMargin
     )
 
+  @Test def i3053 =
+    check(
+      """import Aaaa.*
+        |
+        |def classDef2(cdef: List[Int]): Int = {
+        |  def aaa(ddef: Thicket2): List[Int] = ddef match {
+        |    case Thicket2(_) => ???
+        |  }
+        |
+        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
+        |    * inline classes
+        |    */
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |
+        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
+        |    * inline classes
+        |    */
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |
+        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
+        |    * inline classes
+        |    */
+        |  // Annotations on class _type_ parameters are set on the derived parameters
+        |  // but not on the constructor parameters. The reverse is true for
+        |  // annotations on class _value_ parameters.
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |
+        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
+        |    * inline classes
+        |    */
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |
+        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
+        |    * inline classes
+        |    */
+        |
+        |  // Annotations on class _type_ parameters are set on the derived parameters
+        |  // but not on the constructor parameters. The reverse is true for
+        |  // annotations on class _value_ parameters.
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |
+        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
+        |    * inline classes
+        |    */
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |
+        |  /** Does `tree' look like a reference to AnyVal? Temporary test before we have
+        |    * inline classes
+        |    */
+        |  // Annotations on class _type_ parameters are set on the derived parameters
+        |  // but not on the constructor parameters. The reverse is true for
+        |  // annotations on class _value_ parameters.
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |  // The original type and value parameters in the constructor already have the flags
+        |  // needed to be type members (i.e. param, and possibly also private and local unless
+        |  // prefixed by type or val). `tparams` and `vparamss` are the type parameters that
+        |  // go in `constr`, the constructor after desugaring.
+        |  1
+        |}.<<showing2>>("aaa")
+        |
+        |case class Thicket2(trees: List[Int]) {}
+        |
+        |object Aaaa {
+        |  extension [T](x: T)
+        |    def <<show@@ing2>>[U](aaa: String): T = {
+        |      x
+        |    }
+        |}
+        |
+        |""".stripMargin
+    )
+
 
 end DocumentHighlightSuite


### PR DESCRIPTION
This is a hacky workaround when `pointDelta >= SyntheticPointDelta`, see:
https://github.com/scala/scala3/blob/6d9b0f14f18b89d1719fd5346284eae9cc6e39bc/compiler/src/dotty/tools/dotc/util/Spans.scala#L161


Fix for: https://github.com/scalameta/metals/issues/3053