### PR TITLE
Discourage default arg for extension receiver

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -393,14 +393,18 @@ object desugar {
           rhs
       cpy.TypeDef(tparam)(rhs = dropInRhs(tparam.rhs))
 
-    def paramssNoRHS = mapParamss(meth.paramss)(identity): vparam =>
-      if vparam.rhs.isEmpty then vparam
-      else cpy.ValDef(vparam)(rhs = EmptyTree).withMods(vparam.mods | HasDefault)
+    def paramssNoRHS = mapParamss(meth.paramss)(identity) {
+      vparam =>
+        if vparam.rhs.isEmpty then vparam
+        else cpy.ValDef(vparam)(rhs = EmptyTree).withMods(vparam.mods | HasDefault)
+    }
 
     def getterParamss(n: Int): List[ParamClause] =
-      mapParamss(takeUpTo(paramssNoRHS, n))
-        (tparam => dropContextBounds(toMethParam(tparam, KeepAnnotations.All)))
-        (vparam => toMethParam(vparam, KeepAnnotations.All, keepDefault = false))
+      mapParamss(takeUpTo(paramssNoRHS, n)) {
+        tparam => dropContextBounds(toMethParam(tparam, KeepAnnotations.All))
+      } {
+        vparam => toMethParam(vparam, KeepAnnotations.All, keepDefault = false)
+      }
 
     def defaultGetters(paramss: List[ParamClause], n: Int): List[DefDef] = paramss match
       case ValDefs(vparam :: vparams) :: paramss1 =>

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -221,6 +221,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case GivenSearchPriorityID // errorNumber: 205
   case EnumMayNotBeValueClassesID // errorNumber: 206
   case IllegalUnrollPlacementID // errorNumber: 207
+  case ExtensionHasDefaultID // errorNumber: 208
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2514,6 +2514,15 @@ class ExtensionNullifiedByMember(method: Symbol, target: Symbol)(using Context)
        |
        |The extension may be invoked as though selected from an arbitrary type if conversions are in play."""
 
+class ExtensionHasDefault(method: Symbol)(using Context)
+  extends Message(ExtensionHasDefaultID):
+  def kind = MessageKind.PotentialIssue
+  def msg(using Context) =
+    i"""Extension method ${hl(method.name.toString)} should not have a default argument for its receiver."""
+  def explain(using Context) =
+    i"""Although extensions are ordinary methods, they must be invoked as a selection.
+       |Therefore, the receiver cannot be omitted. A default argument for that parameter would never be used."""
+
 class TraitCompanionWithMutableStatic()(using Context)
   extends SyntaxMsg(TraitCompanionWithMutableStaticID) {
   def msg(using Context) = i"Companion of traits cannot define mutable @static fields"

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2520,8 +2520,10 @@ class ExtensionHasDefault(method: Symbol)(using Context)
   def msg(using Context) =
     i"""Extension method ${hl(method.name.toString)} should not have a default argument for its receiver."""
   def explain(using Context) =
-    i"""Although extensions are ordinary methods, they must be invoked as a selection.
-       |Therefore, the receiver cannot be omitted. A default argument for that parameter would never be used."""
+    i"""The receiver cannot be omitted when an extension method is invoked as a selection.
+       |A default argument for that parameter would never be used in that case.
+       |An extension method can be invoked as a regular method, but if that is the intended usage,
+       |it should not be defined as an extension."""
 
 class TraitCompanionWithMutableStatic()(using Context)
   extends SyntaxMsg(TraitCompanionWithMutableStaticID) {

--- a/tests/warn/i12460.check
+++ b/tests/warn/i12460.check
@@ -5,8 +5,10 @@
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  | Although extensions are ordinary methods, they must be invoked as a selection.
-  | Therefore, the receiver cannot be omitted. A default argument for that parameter would never be used.
+  | The receiver cannot be omitted when an extension method is invoked as a selection.
+  | A default argument for that parameter would never be used in that case.
+  | An extension method can be invoked as a regular method, but if that is the intended usage,
+  | it should not be defined as an extension.
    ---------------------------------------------------------------------------------------------------------------------
 -- [E208] Potential Issue Warning: tests/warn/i12460.scala:5:37 --------------------------------------------------------
 5 |extension (using String)(s: String = "hello, world") def revert = s.reverse.toUpperCase // warn
@@ -15,6 +17,8 @@
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-  | Although extensions are ordinary methods, they must be invoked as a selection.
-  | Therefore, the receiver cannot be omitted. A default argument for that parameter would never be used.
+  | The receiver cannot be omitted when an extension method is invoked as a selection.
+  | A default argument for that parameter would never be used in that case.
+  | An extension method can be invoked as a regular method, but if that is the intended usage,
+  | it should not be defined as an extension.
    ---------------------------------------------------------------------------------------------------------------------

--- a/tests/warn/i12460.check
+++ b/tests/warn/i12460.check
@@ -1,0 +1,20 @@
+-- [E208] Potential Issue Warning: tests/warn/i12460.scala:3:23 --------------------------------------------------------
+3 |extension (s: String = "hello, world") def invert = s.reverse.toUpperCase // warn
+  |                       ^
+  |                       Extension method invert should not have a default argument for its receiver.
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Although extensions are ordinary methods, they must be invoked as a selection.
+  | Therefore, the receiver cannot be omitted. A default argument for that parameter would never be used.
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E208] Potential Issue Warning: tests/warn/i12460.scala:5:17 --------------------------------------------------------
+5 |extension (using String)(s: String = "hello, world") def revert = s.reverse.toUpperCase // warn
+  |                 ^
+  |                 Extension method revert should not have a default argument for its receiver.
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Although extensions are ordinary methods, they must be invoked as a selection.
+  | Therefore, the receiver cannot be omitted. A default argument for that parameter would never be used.
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/warn/i12460.check
+++ b/tests/warn/i12460.check
@@ -8,10 +8,10 @@
   | Although extensions are ordinary methods, they must be invoked as a selection.
   | Therefore, the receiver cannot be omitted. A default argument for that parameter would never be used.
    ---------------------------------------------------------------------------------------------------------------------
--- [E208] Potential Issue Warning: tests/warn/i12460.scala:5:17 --------------------------------------------------------
+-- [E208] Potential Issue Warning: tests/warn/i12460.scala:5:37 --------------------------------------------------------
 5 |extension (using String)(s: String = "hello, world") def revert = s.reverse.toUpperCase // warn
-  |                 ^
-  |                 Extension method revert should not have a default argument for its receiver.
+  |                                     ^
+  |                                     Extension method revert should not have a default argument for its receiver.
   |---------------------------------------------------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/warn/i12460.scala
+++ b/tests/warn/i12460.scala
@@ -1,0 +1,7 @@
+//> using options -explain
+
+extension (s: String = "hello, world") def invert = s.reverse.toUpperCase // warn
+
+extension (using String)(s: String = "hello, world") def revert = s.reverse.toUpperCase // warn
+
+extension (s: String) def divert(m: String  = "hello, world") = (s+m).reverse.toUpperCase // ok

--- a/tests/warn/i12460.scala
+++ b/tests/warn/i12460.scala
@@ -1,7 +1,9 @@
-//> using options -explain
+//> using options -explain -Ystop-after:refchecks
 
 extension (s: String = "hello, world") def invert = s.reverse.toUpperCase // warn
 
 extension (using String)(s: String = "hello, world") def revert = s.reverse.toUpperCase // warn
 
-extension (s: String) def divert(m: String  = "hello, world") = (s+m).reverse.toUpperCase // ok
+extension (s: String)
+  def divert(m: String = "hello, world") = (s+m).reverse.toUpperCase // ok
+  def divertimento(using String)(m: String = "hello, world") = (s+m).reverse.toUpperCase // ok


### PR DESCRIPTION
Fixes #12460 

I shied away from making it an error, as that is a language change that violates the rule that extension methods are ordinary methods. There are other restrictions, but an extension always allows explicit invocation `m()(x)` that could leverage a default.

The caret is wrong on the second test case (~todo~). Edit: span of default getter was union of first parameter and the param RHS, so that the synthetic position of the getter symbol was a point at the first parameter. Now the getter tree gets the span of the RHS. (That span is non-synthetic, but the definition is still synthetic. The name pos of a synthetic is the point.)