### PR TITLE
[CI]: Publish LTS nightlies form scala/scala3-lts repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -630,7 +630,10 @@ jobs:
         - ${{ github.workspace }}/../../cache/general:/root/.cache
     strategy:
       matrix:
-        branch: [main, lts-3.3]
+        series: [
+          {repository: scala/scala3, branch: main}, # Scala Next nightly
+          {repository: scala/scala3-lts, branch: lts-3.3} # Scala LTS nightly
+        ]
     needs: [test_non_bootstrapped, test, mima, community_build_a, community_build_b, community_build_c, test_sbt, test_java8]
     if: "(github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository == 'scala/scala3'"
     env:
@@ -660,7 +663,8 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ matrix.branch }}
+          repository: ${{ matrix.series.repository }}
+          ref: ${{ matrix.series.branch }}
 
       - name: Add SBT proxy repositories
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true


### PR DESCRIPTION
LTS backports are done to https://github.com/scala/scala3-lts initially. 
When making a LTS release cutoff (RC1) we synchronize main repos (scala/scala3) branch (lts-3.3) are before creaing a release branch from it. After the release LTS repository is synchronized with the main repos latest release branch.

The change allows to perform Scala 3 LTS nightly releses without need for excessive synchronization of the 2 repos