### PR TITLE
Do not enter Scala 2 extension methods and let dotty "generate" them

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -536,8 +536,7 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
             // We discard the private val representing a case accessor. We only enter the case accessor def.
             // We do need to load these symbols to read properly unpickle the annotations on the symbol (see sbt-test/scala2-compat/i19421).
             !flags.isAllOf(CaseAccessor | PrivateLocal, butNot = Method) &&
-            // We don't enter Value Classes' extension methods from pickles, but we do
-            // generate in the ExtensionMethods phase, at the same time as we do for Scala 3
+            // Skip entering extension methods: they will be recreated by the ExtensionMethods phase.
             // Same trick is used by tasty-query (see
             //https://github.com/scalacenter/tasty-query/blob/fdefadcabb2f21d5c4b71f728b81c68f6fddcc0f/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala#L261-L273
             //)

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -535,7 +535,15 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
                 true) &&
             // We discard the private val representing a case accessor. We only enter the case accessor def.
             // We do need to load these symbols to read properly unpickle the annotations on the symbol (see sbt-test/scala2-compat/i19421).
-            !flags.isAllOf(CaseAccessor | PrivateLocal, butNot = Method)
+            !flags.isAllOf(CaseAccessor | PrivateLocal, butNot = Method) &&
+            // We don't enter Value Classes' extension methods from pickles, but we do
+            // generate in the ExtensionMethods phase, at the same time as we do for Scala 3
+            // Same trick is used by tasty-query (see
+            //https://github.com/scalacenter/tasty-query/blob/fdefadcabb2f21d5c4b71f728b81c68f6fddcc0f/tasty-query/shared/src/main/scala/tastyquery/reader/pickles/PickleReader.scala#L261-L273
+            //)
+            // This trick is also useful when reading the Scala 2 Standard library from tasty, since
+            // the extension methods will not be present, and it avoid having to distinguish between Scala2 pickles and Scala2 tasty (stdlib)
+            !(owner.is(ModuleClass) && sym.name.endsWith("$extension"))
 
         if (canEnter)
           owner.asClass.enter(sym, symScope(owner))

--- a/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExtensionMethods.scala
@@ -74,12 +74,10 @@ class ExtensionMethods extends MiniPhase with DenotTransformer with FullParamete
             sym.validFor = thisPhase.validFor
           }
 
-          // Create extension methods, except if the class comes from Scala 2
-          // because it adds extension methods before pickling.
-          if !valueClass.is(Scala2x, butNot = Scala2Tasty) then
-            for (decl <- valueClass.classInfo.decls)
-              if isMethodWithExtension(decl) then
-                enterInModuleClass(createExtensionMethod(decl, moduleClassSym.symbol))
+          // Create extension methods
+          for (decl <- valueClass.classInfo.decls)
+            if isMethodWithExtension(decl) then
+              enterInModuleClass(createExtensionMethod(decl, moduleClassSym.symbol))
 
           // Create synthetic methods to cast values between the underlying type
           // and the ErasedValueType. These methods are removed in ElimErasedValueType.


### PR DESCRIPTION
Scala 2 generates extension methods for Value Classes before pickling while Scala 3 generates them after.
Now that we are working on compiling the Scala 2 stdlib with dotty (#22480), and therefore generating tasty files for the stdlib, we will have to distinguish between scala 2 that was unpickled and scala 2 code coming from tasty. For that, we currently have a flag, but it is not very useful apart from some very specific details where a workaround exists. This PR, removes one of 2 places where this flag is used. The [second place](https://github.com/scala/scala3/blob/aa9db1f682de634743af6d7077d5ed752430a487/compiler/src/dotty/tools/dotc/transform/YCheckPositions.scala#L51) will be removed once we inline the missing symbol in `Predef.scala` (after #22480) is merged.