### PR TITLE
Consider source code as Scala 2 under `-Ycompile-scala2-library`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -861,7 +861,7 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
       assert(isModifierTag(tag))
       writeByte(tag)
     }
-    assert(!flags.is(Scala2x))
+    if flags.is(Scala2x) then assert(attributes.scala2StandardLibrary)
     if (flags.is(Private)) writeModTag(PRIVATE)
     if (flags.is(Protected)) writeModTag(PROTECTED)
     if (flags.is(Final, butNot = Module)) writeModTag(FINAL)

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -256,7 +256,10 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
               for publicInBinaryAnnot <- publicInBinaryAnnotOpt do sym.addAnnotation(publicInBinaryAnnot)
             else
               sym.keepAnnotationsCarrying(thisPhase, Set(defn.GetterMetaAnnot, defn.FieldMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
-          if sym.isScala2Macro && !ctx.settings.XignoreScala2Macros.value then
+          if sym.isScala2Macro && !ctx.settings.XignoreScala2Macros.value &&
+             sym != defn.StringContext_raw &&
+             sym != defn.StringContext_f &&
+             sym != defn.StringContext_s then
             if !sym.owner.unforcedDecls.exists(p => !p.isScala2Macro && p.name == sym.name && p.signature == sym.signature)
                // Allow scala.reflect.materializeClassTag to be able to compile scala/reflect/package.scala
                // This should be removed on Scala 3.x

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -246,7 +246,9 @@ class Namer { typer: Typer =>
 
     tree match {
       case tree: TypeDef if tree.isClassDef =>
-        val flags = checkFlags(tree.mods.flags)
+        var flags = checkFlags(tree.mods.flags)
+        if ctx.settings.YcompileScala2Library.value then
+          flags |= Scala2x
         val name = checkNoConflict(tree.name, flags.is(Private), tree.span).asTypeName
         val cls =
           createOrRefine[ClassSymbol](tree, name, flags, ctx.owner,

--- a/project/Scala2LibraryBootstrappedMiMaFilters.scala
+++ b/project/Scala2LibraryBootstrappedMiMaFilters.scala
@@ -66,17 +66,10 @@ object Scala2LibraryBootstrappedMiMaFilters {
         ProblemFilters.exclude[FinalMethodProblem]("scala.io.Source.NoPositioner"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.io.Source.RelaxedPosition"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.io.Source.RelaxedPositioner"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.SortedMapOps.coll"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.TreeMap.empty"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.immutable.TreeMap.fromSpecific"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.mutable.ArrayBuilder#ofUnit.addAll"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.mutable.TreeMap.empty"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.collection.mutable.TreeMap.fromSpecific"),
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.reflect.ManifestFactory#NothingManifest.newArray"),
         ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.reflect.ManifestFactory#NullManifest.newArray"),
         ProblemFilters.exclude[MissingFieldProblem]("scala.collection.ArrayOps#ReverseIterator.xs"),
         ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.NonLocalReturnControl.value"),
-        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.collection.immutable.SortedMapOps.coll"),
       ) ++
       Seq( // DirectMissingMethodProblem
         "scala.collection.LinearSeqIterator#LazyCell.this",

--- a/project/Scala2LibraryBootstrappedMiMaFilters.scala
+++ b/project/Scala2LibraryBootstrappedMiMaFilters.scala
@@ -66,8 +66,6 @@ object Scala2LibraryBootstrappedMiMaFilters {
         ProblemFilters.exclude[FinalMethodProblem]("scala.io.Source.NoPositioner"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.io.Source.RelaxedPosition"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.io.Source.RelaxedPositioner"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.reflect.ManifestFactory#NothingManifest.newArray"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.reflect.ManifestFactory#NullManifest.newArray"),
         ProblemFilters.exclude[MissingFieldProblem]("scala.collection.ArrayOps#ReverseIterator.xs"),
         ProblemFilters.exclude[MissingFieldProblem]("scala.runtime.NonLocalReturnControl.value"),
       ) ++

--- a/scala2-library-cc/src/scala/collection/concurrent/TrieMap.scala
+++ b/scala2-library-cc/src/scala/collection/concurrent/TrieMap.scala
@@ -1071,6 +1071,7 @@ object TrieMap extends MapFactory[TrieMap] {
 
 // non-final as an extension point for parallel collections
 private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: TrieMap[K, V], mustInit: Boolean = true) extends AbstractIterator[(K, V)] {
+  this:TrieMapIterator[K, V]^ =>
   private val stack = new Array[Array[BasicNode]](7)
   private val stackpos = new Array[Int](7)
   private var depth = -1
@@ -1161,7 +1162,7 @@ private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: 
   /** Returns a sequence of iterators over subsets of this iterator.
     *  It's used to ease the implementation of splitters for a parallel version of the TrieMap.
     */
-  protected def subdivide(): Seq[Iterator[(K, V)]] = if (subiter ne null) {
+  protected def subdivide(): Seq[Iterator[(K, V)]^{this}] = if (subiter ne null) {
     // the case where an LNode is being iterated
     val it = newIterator(level + 1, ct, _mustInit = false)
     it.depth = -1

--- a/scala2-library-cc/src/scala/collection/immutable/Range.scala
+++ b/scala2-library-cc/src/scala/collection/immutable/Range.scala
@@ -643,6 +643,7 @@ private class RangeIterator(
   lastElement: Int,
   initiallyEmpty: Boolean
 ) extends AbstractIterator[Int] with Serializable {
+  this: RangeIterator^ =>
   private[this] var _hasNext: Boolean = !initiallyEmpty
   private[this] var _next: Int = start
   override def knownSize: Int = if (_hasNext) (lastElement - _next) / step + 1 else 0
@@ -656,7 +657,7 @@ private class RangeIterator(
     value
   }
 
-  override def drop(n: Int): Iterator[Int] = {
+  override def drop(n: Int): Iterator[Int]^{this} = {
     if (n > 0) {
       val longPos = _next.toLong + step * n
       if (step > 0) {


### PR DESCRIPTION
When compiling under `-Ycompile-scala2-library`, we should consider the source code as Scala 2. This change will allow using Scala 2's erasure instead of Scala 3's.


Related to #22480