### PR TITLE
Activate Develocity's Build Cache

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -346,7 +346,7 @@ object Build {
         )
         .withBuildCache(
           buildCache
-            .withLocal(buildCache.local.withEnabled(false))
+            .withLocal(buildCache.local.withEnabled(true).withStoreEnabled(true))
             .withRemote(buildCache.remote.withEnabled(false))
         )
         .withTestRetry(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -339,7 +339,7 @@ object Build {
           buildScan
             .withPublishing(Publishing.onlyIf(_.authenticated))
             .withBackgroundUpload(!isInsideCI)
-            .tag(if (isInsideCI) "CI" else "Local")
+            .withTag(if (isInsideCI) "CI" else "Local")
             .withLinks(buildScan.links ++ GithubEnv.develocityLinks)
             .withValues(buildScan.values ++ GithubEnv.develocityValues)
             .withObfuscation(buildScan.obfuscation.withIpAddresses(_.map(_ => "0.0.0.0")))
@@ -349,8 +349,8 @@ object Build {
             .withLocal(buildCache.local.withEnabled(false))
             .withRemote(buildCache.remote.withEnabled(false))
         )
-        .withTestRetryConfiguration(
-          config.testRetryConfiguration
+        .withTestRetry(
+          config.testRetry
             .withFlakyTestPolicy(FlakyTestPolicy.Fail)
             .withMaxRetries(if (isInsideCI) 1 else 0)
             .withMaxFailures(10)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1116,7 +1116,7 @@ object Build {
     libraryDependencies += "org.scala-lang" % "scala-library" % stdlibVersion,
     (Compile / scalacOptions) ++= Seq(
       // Needed so that the library sources are visible when `dotty.tools.dotc.core.Definitions#init` is called
-      "-sourcepath", (Compile / sourceDirectories).value.map(_.getAbsolutePath).distinct.mkString(File.pathSeparator),
+      "-sourcepath", (Compile / sourceDirectories).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),
       "-Yexplicit-nulls",
     ),
     (Compile / doc / scalacOptions) ++= ScaladocConfigs.DefaultGenerationSettings.value.settings,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -347,7 +347,7 @@ object Build {
         .withBuildCache(
           buildCache
             .withLocal(buildCache.local.withEnabled(true).withStoreEnabled(true))
-            .withRemote(buildCache.remote.withEnabled(false))
+            .withRemote(buildCache.remote.withEnabled(true).withStoreEnabled(isInsideCI))
         )
         .withTestRetry(
           config.testRetry

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -356,7 +356,10 @@ object Build {
             .withMaxFailures(10)
             .withClassesFilter((className, _) => !noRetryTestClasses.contains(className))
         )
-    }
+    },
+    // Deactivate Develocity's test caching because it caches all tests or nothing.
+    // Also at the moment, it does not take compilation files as inputs.
+    Test / develocityBuildCacheClient := None,
   )
 
   // Settings shared globally (scoped in Global). Used in build.sbt
@@ -1015,10 +1018,6 @@ object Build {
           sjsSources
         } (Set(scalaJSIRSourcesJar)).toSeq
       }.taskValue,
-
-      // Develocity's Build Cache does not work with our compilation tests
-      // at the moment: it does not take compilation files as inputs.
-      Test / develocityBuildCacheClient := None,
   )
 
   def insertClasspathInArgs(args: List[String], cp: String): List[String] = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,6 +10,7 @@ import complete.DefaultParsers._
 import pl.project13.scala.sbt.JmhPlugin
 import pl.project13.scala.sbt.JmhPlugin.JmhKeys.Jmh
 import com.gradle.develocity.agent.sbt.DevelocityPlugin.autoImport._
+import com.gradle.develocity.agent.sbt.api.experimental.buildcache
 import com.typesafe.sbt.packager.Keys._
 import com.typesafe.sbt.packager.MappingsHelper.directory
 import com.typesafe.sbt.packager.universal.UniversalPlugin
@@ -607,7 +608,10 @@ object Build {
       assert(docScalaInstance.loaderCompilerOnly == base.loaderCompilerOnly)
       docScalaInstance
     },
-    Compile / doc / scalacOptions ++= scalacOptionsDocSettings()
+    Compile / doc / scalacOptions ++= scalacOptionsDocSettings(),
+    // force recompilation of bootstrapped modules when the compiler changes
+    Compile / compile / buildcache.develocityTaskCacheKeyComponents +=
+      (`scala3-compiler` / Compile / compile / buildcache.develocityTaskCacheKey).taskValue
   )
 
   lazy val commonBenchmarkSettings = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,4 +22,4 @@ addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.1.1")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.1.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,8 @@ addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 
 addSbtPlugin("com.gradle" % "sbt-develocity" % "1.1.2")
+
+resolvers +=
+  "Develocity Artifactory" at "https://repo.grdev.net/artifactory/public/"
+
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2-rc-2")


### PR DESCRIPTION
1. Enable read and write to local cache for all users
2. Enable read from remote cache for all users
3. Enable write to remote cache on CI only
4. Disable test caching on all projects: We generally don't rerun tests if nothing changed. When users do run the tests locally, they probably want to see their executions.

ping @hamzaremmal 