### PR TITLE
No indent in named arg pattern

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -682,11 +682,14 @@ object Parsers {
         ts.toList
       else leading :: Nil
 
-    def maybeNamed(op: () => Tree): () => Tree = () =>
+    def maybeNamed(location: Location, op: () => Tree): () => Tree = () =>
       if isIdent && in.lookahead.token == EQUALS && sourceVersion.enablesNamedTuples then
         atSpan(in.offset):
           val name = ident()
           in.nextToken()
+          if location.inPattern && in.token == INDENT then
+            in.currentRegion = in.currentRegion.outer
+            in.nextToken()
           NamedArg(name, op())
       else op()
 
@@ -2985,7 +2988,7 @@ object Parsers {
           if isErased then isFormalParams = true
           if isFormalParams then binding(Modifiers())
           else
-            val t = maybeNamed(exprInParens)()
+            val t = maybeNamed(Location.InParens, exprInParens)()
             if t.isInstanceOf[ValDef] then isFormalParams = true
             t
         commaSeparatedRest(exprOrBinding(), exprOrBinding)
@@ -3448,8 +3451,8 @@ object Parsers {
      *                      |  NamedPattern {‘,’ NamedPattern}
      *  NamedPattern      ::=  id '=' Pattern
      */
-    def patterns(location: Location = Location.InPattern): List[Tree] =
-      commaSeparated(maybeNamed(() => pattern(location)))
+    def patterns(location: Location = Location.InPattern): List[Tree] = // default used from Markup
+      commaSeparated(maybeNamed(location, () => pattern(location)))
         // check that patterns are all named or all unnamed is done at desugaring
 
     def patternsOpt(location: Location = Location.InPattern): List[Tree] =

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -687,9 +687,14 @@ object Parsers {
         atSpan(in.offset):
           val name = ident()
           in.nextToken()
-          if location.inPattern && in.token == INDENT then
-            in.currentRegion = in.currentRegion.outer
-            in.nextToken()
+          // Named pattern arguments don't support indented blocks,
+          // so drop the indent region added after '=' and ignore the indent token.
+          if location.inPattern && in.token == INDENT && !in.currentRegion.isOutermost then
+            in.currentRegion match
+              case Indented(_, EQUALS, outer) =>
+                in.currentRegion = outer
+                in.nextToken()
+              case _ =>
           NamedArg(name, op())
       else op()
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -692,7 +692,7 @@ object Parsers {
           if location.inPattern && in.token == INDENT && !in.currentRegion.isOutermost then
             in.currentRegion match
               case Indented(_, EQUALS, outer) =>
-                in.currentRegion = outer
+                in.currentRegion = outer.nn // we already checked !isOutermost
                 in.nextToken()
               case _ =>
           NamedArg(name, op())

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -654,8 +654,13 @@ object Scanners {
                 if skipping then
                   if r.enclosing.isClosedByUndentAt(nextWidth) then
                     insert(OUTDENT, offset)
-                else if r.isInstanceOf[InBraces] && !closingRegionTokens.contains(token) then
-                  report.warning(IndentationWarning(isLeft = true, missing = RBRACE), sourcePos())
+                else
+                  val checkable = r match
+                    case _: InBraces => true
+                    case InParens(LPAREN, _) => true
+                    case _ => false
+                  if checkable && !closingRegionTokens.contains(token) then
+                    report.warning(IndentationWarning(isLeft = true, missing = RBRACE), sourcePos())
         else if lastWidth < nextWidth
              || lastWidth == nextWidth && (lastToken == MATCH || lastToken == CATCH) && token == CASE then
           if canStartIndentTokens.contains(lastToken) then

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -660,7 +660,7 @@ object Scanners {
                     case InParens(LPAREN, _) => true
                     case _ => false
                   if checkable && !closingRegionTokens.contains(token) then
-                    report.warning(IndentationWarning(isLeft = true, missing = RBRACE), sourcePos())
+                    report.warning(IndentationWarning(isLeft = true, missing = r.closedBy), sourcePos())
         else if lastWidth < nextWidth
              || lastWidth == nextWidth && (lastToken == MATCH || lastToken == CATCH) && token == CASE then
           if canStartIndentTokens.contains(lastToken) then

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -1061,7 +1061,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
             addParamssText(
               addParamssText(keywordStr("extension "), leadingParamss)
               ~~ (defKeyword ~~ valDefText(nameIdText(tree))).close,
-             trailingParamss)
+              trailingParamss)
           else
             addParamssText(defKeyword ~~ valDefText(nameIdText(tree)), tree.paramss)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
@@ -86,18 +86,18 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
 
   @Test def `filter-by-type-old` =
     check(
-     """|package example
-        |
-        |object enrichments:
-        |  implicit class A(num: Int):
-        |    def identity2: Int = num + 1
-        |  implicit class B(str: String):
-        |    def identity: String = str
-        |
-        |def main = "foo".iden@@
-        |""".stripMargin,
+      """|package example
+         |
+         |object enrichments:
+         |  implicit class A(num: Int):
+         |    def identity2: Int = num + 1
+         |  implicit class B(str: String):
+         |    def identity: String = str
+         |
+         |def main = "foo".iden@@
+         |""".stripMargin,
       """|identity: String (implicit)
-        |""".stripMargin, // identity2 won't be available
+         |""".stripMargin, // identity2 won't be available
       filter = _.contains("(implicit)")
     )
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionExtensionSuite.scala
@@ -86,7 +86,7 @@ class CompletionExtensionSuite extends BaseCompletionSuite:
 
   @Test def `filter-by-type-old` =
     check(
-      """|package example
+     """|package example
         |
         |object enrichments:
         |  implicit class A(num: Int):

--- a/scaladoc/test/dotty/tools/scaladoc/site/TemplateFileTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/TemplateFileTests.scala
@@ -212,26 +212,26 @@ class TemplateFileTests:
     testTemplate(
       """# Hello {{ msg }}!""",
       ext = "md"
-    ) { t =>
+    ): t =>
       assertEquals(
         """<section id="hello-there">
-        |<h1 class="h500"><a href="#hello-there" class="anchor"></a>Hello there!</h1>
-        |</section>""".stripMargin,
-      t.resolveInner(RenderingContext(Map("msg" -> "there"))).code.trim())
-    }
+          |<h1 class="h500"><a href="#hello-there" class="anchor"></a>Hello there!</h1>
+          |</section>""".stripMargin,
+        t.resolveInner(RenderingContext(Map("msg" -> "there"))).code.trim()
+      )
 
   @Test
   def mixedTemplates() : Unit =
     testTemplate(
       """# Hello {{ msg }}!""",
       ext = "md"
-    ) { t =>
+    ): t =>
       assertEquals(
         """<section id="hello-there2">
-        |<h1 class="h500"><a href="#hello-there2" class="anchor"></a>Hello there2!</h1>
-        |</section>""".stripMargin,
-      t.resolveInner(RenderingContext(Map("msg" -> "there2"))).code.trim())
-    }
+          |<h1 class="h500"><a href="#hello-there2" class="anchor"></a>Hello there2!</h1>
+          |</section>""".stripMargin,
+        t.resolveInner(RenderingContext(Map("msg" -> "there2"))).code.trim()
+      )
 
   @Test
   def htmlOnly(): Unit =

--- a/tests/neg/syntax-error-recovery.check
+++ b/tests/neg/syntax-error-recovery.check
@@ -96,7 +96,5 @@
    | longer explanation available when compiling with `-explain`
 -- Warning: tests/neg/syntax-error-recovery.scala:61:2 -----------------------------------------------------------------
 61 |  println(bam)
-   |  ^^^^^^^
-   |  Alphanumeric method println is not declared infix; it should not be used as infix operator.
-   |  Instead, use method syntax .println(...) or backticked identifier `println`.
-   |  The latter can be rewritten automatically under -rewrite -source 3.4-migration.
+   |  ^
+   |  Line is indented too far to the left, or a ')' is missing

--- a/tests/neg/syntax-error-recovery.check
+++ b/tests/neg/syntax-error-recovery.check
@@ -94,7 +94,9 @@
    |          Not found: bam
    |
    | longer explanation available when compiling with `-explain`
--- Warning: tests/neg/syntax-error-recovery.scala:61:2 -----------------------------------------------------------------
+-- [E229] Syntax Warning: tests/neg/syntax-error-recovery.scala:61:2 ---------------------------------------------------
 61 |  println(bam)
    |  ^
    |  Line is indented too far to the left, or a ')' is missing
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/pos/i24474.scala
+++ b/tests/pos/i24474.scala
@@ -1,0 +1,28 @@
+case class Foo(arg1: Int, arg2: Int)
+case class Bar(arg1: Int, arg2: Option[Int])
+
+object OK:
+  Foo(1, 2) match
+    case Foo(arg1 =
+    5
+    ) =>
+
+object Test:
+  Foo(1, 2) match
+    case Foo(arg1 =
+      5 // was: error: pattern expected
+    ) =>
+
+object Nest:
+  Bar(1, Option(2)) match
+    case Bar(arg2 =
+      Some(value =
+        42
+      )
+    ) =>
+
+object Detupled:
+  (fst = 1, snd = 2) match
+    case (fst =
+      5
+    ) =>

--- a/tests/warn/i22527.check
+++ b/tests/warn/i22527.check
@@ -1,0 +1,30 @@
+-- [E229] Syntax Warning: tests/warn/i22527.scala:60:10 ----------------------------------------------------------------
+60 |          y, // warn
+   |          ^
+   |          Line is indented too far to the left, or a ')' is missing
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E229] Syntax Warning: tests/warn/i22527.scala:61:10 ----------------------------------------------------------------
+61 |          z, // warn
+   |          ^
+   |          Line is indented too far to the left, or a ')' is missing
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E229] Syntax Warning: tests/warn/i22527.scala:72:2 -----------------------------------------------------------------
+72 |  42 // warn
+   |  ^
+   |  Line is indented too far to the left, or a ')' is missing
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E229] Syntax Warning: tests/warn/i22527.scala:79:0 -----------------------------------------------------------------
+79 |k: // warn
+   |^
+   |Line is indented too far to the left, or a ')' is missing
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E190] Potential Issue Warning: tests/warn/i22527.scala:40:6 --------------------------------------------------------
+40 |      true, "fail") // warn value discard
+   |      ^^^^
+   |      Discarded non-Unit value of type Boolean. Add `: Unit` to discard silently.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/warn/i22527.scala
+++ b/tests/warn/i22527.scala
@@ -57,8 +57,8 @@ def k(xs: List[Int], y: Int, z: Int) =
             x
           + y
             + z,
-          y, // NO warn
-          z, // NO warn
+          y, // warn
+          z, // warn
           )
     )
 
@@ -69,13 +69,13 @@ object `arrow eol`:
   def test =
     f(
       g(_ + 1),
-  42 // NO warn
+  42 // warn
     )
   def test2 =
     f(
       g:
         x =>
           x + 1,
-k: // NO warn
+k: // warn
         42
     )


### PR DESCRIPTION
In a named arg in a pattern, ignore indentation after `=`.

Fixes #24474 
