### PR TITLE
Let inlining report compiletime.error text

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -195,7 +195,7 @@ object Inlines:
           tree,
           em"""|Maximal number of $reason (${setting.value}) exceeded,
                |Maybe this is caused by a recursive inline method?
-               |You can use ${setting.name} to change the limit.""",
+               |You can use ${setting.name} to change the limit""",
           (tree :: enclosingInlineds).last.srcPos
         )
     if ctx.base.stopInlining && enclosingInlineds.isEmpty then
@@ -533,8 +533,13 @@ object Inlines:
           inContext(evCtx) {
             val evidence = evTyper.inferImplicitArg(tpe, callTypeArgs.head.span)
             evidence.tpe match
+              case fail: Implicits.LateMismatchedImplicit =>
+                val addendum = fail.errors match
+                  case Nil  => ""
+                  case errs => errs.map(_.msg).mkString("a search with errors:\n  ", "\n  ", "")
+                errorTree(call, evTyper.missingArgMsg(evidence, tpe, addendum))
               case fail: Implicits.SearchFailureType =>
-                errorTree(call, evTyper.missingArgMsg(evidence, tpe, ""))
+                errorTree(call, evTyper.missingArgMsg(evidence, tpe, where = ""))
               case _ =>
                 evidence
           }

--- a/tests/neg/i13044.check
+++ b/tests/neg/i13044.check
@@ -1,12 +1,69 @@
 -- [E172] Type Error: tests/neg/i13044.scala:61:40 ---------------------------------------------------------------------
 61 |   implicit def typeSchema: Schema[A] = Schema.gen // error
    |                                        ^^^^^^^^^^
-   |                                 No given instance of type Schema[B] was found.
-   |                                 I found:
+   |                        No given instance of type Schema[B] was found for a search with errors:
+   |                          No given instance of type Schema[C] was found for a search with errors:
+   |                          No given instance of type Schema[D] was found for a search with errors:
+   |                          No given instance of type Schema[E] was found for a search with errors:
+   |                          No given instance of type Schema[Option[F]] was found for a search with errors:
+   |                          No given instance of type Schema[Some[F]] was found for a search with errors:
+   |                          No given instance of type Schema[F] was found for a search with errors:
+   |                          No given instance of type Schema[G] was found for a search with errors:
+   |                          No given instance of type Schema[H] was found for a search with errors:
+   |                          No given instance of type Schema[X1] was found for a search with errors:
+   |                          Maximal number of successive inlines (32) exceeded,
+   |                        Maybe this is caused by a recursive inline method?
+   |                        You can use -Xmax-inlines to change the limit.
+   |                        I found:
    |
-   |                                     Schema.gen[B]
+   |                            Schema.gen[X1]
    |
-   |                                 But given instance gen in trait SchemaDerivation does not match type Schema[B].
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[X1]..
+   |                        I found:
+   |
+   |                            Schema.gen[H]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[H]..
+   |                        I found:
+   |
+   |                            Schema.gen[G]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[G]..
+   |                        I found:
+   |
+   |                            Schema.gen[F]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[F]..
+   |                        I found:
+   |
+   |                            Schema.gen[Some[F]]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[Some[F]]..
+   |                        I found:
+   |
+   |                            Schema.gen[Option[F]]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[Option[F]]..
+   |                        I found:
+   |
+   |                            Schema.gen[E]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[E]..
+   |                        I found:
+   |
+   |                            Schema.gen[D]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[D]..
+   |                        I found:
+   |
+   |                            Schema.gen[C]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[C]..
+   |                        I found:
+   |
+   |                            Schema.gen[B]
+   |
+   |                        But given instance gen in trait SchemaDerivation does not match type Schema[B].
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/tests/neg/i15788.check
+++ b/tests/neg/i15788.check
@@ -1,0 +1,32 @@
+-- Error: tests/neg/i15788.scala:32:10 ---------------------------------------------------------------------------------
+32 |  f[Test2] // error at inlining
+   |          ^
+   |          Field 'a' not found
+-- Error: tests/neg/i15788.scala:35:15 ---------------------------------------------------------------------------------
+35 |  summonInline[Test[Test2]].test // error
+   |               ^
+   |               Field 'a' not found
+-- [E172] Type Error: tests/neg/i15788.scala:38:3 ----------------------------------------------------------------------
+38 |  g[Test2] // error
+   |  ^^^^^^^^
+   |  No given instance of type Test[Test2] was found for a search with errors:
+   |    Field 'a' not found.
+   |  I found:
+   |
+   |      Test.given_Test_A[Test2](
+   |        Test2.$asInstanceOf[
+   |          scala.deriving.Mirror.Product{
+   |            type MirroredMonoType = Test2; type MirroredType = Test2; type MirroredLabel = ("Test2" : String);
+   |              type MirroredElemTypes = (String, Int); type MirroredElemLabels = (("v" : String), ("w" : String))
+   |          }
+   |        ]
+   |      )
+   |
+   |  But given instance given_Test_A in object Test does not match type Test[Test2].
+   |--------------------------------------------------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from i15788.scala:29
+29 |  inline def g[P <: Product]: String = summonInline[Test[P]].test
+   |                                       ^^^^^^^^^^^^^^^^^^^^^
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i15788.scala
+++ b/tests/neg/i15788.scala
@@ -1,0 +1,38 @@
+
+import scala.compiletime.*
+import scala.deriving.Mirror
+
+trait Test[A]:
+  def test: String
+
+object Test:
+
+  inline def findA[T <: Tuple]: Unit =
+    inline erasedValue[T] match
+    case _: EmptyTuple  => error("Field 'a' not found")
+    case _: ("a" *: tl) => ()
+    case _: (_ *: tl)   => findA[tl]
+
+  inline given [A <: Product] => (mm: Mirror.ProductOf[A]) => Test[A] = new {
+    override def test: String =
+      findA[mm.MirroredElemLabels]
+      "test"
+  }
+end Test
+
+final case class Test1(a: String, b: Int)
+final case class Test2(v: String, w: Int)
+
+@main def main =
+  inline def f[P <: Product](using g: Test[P]): String = g.test
+
+  inline def g[P <: Product]: String = summonInline[Test[P]].test
+
+  f[Test1]
+  f[Test2] // error at inlining
+
+  summonInline[Test[Test1]].test
+  summonInline[Test[Test2]].test // error
+
+  g[Test1]
+  g[Test2] // error

--- a/tests/neg/i15788b.scala
+++ b/tests/neg/i15788b.scala
@@ -1,0 +1,41 @@
+
+import scala.compiletime.*
+import scala.deriving.Mirror
+
+trait Test[A]:
+  def test: String
+
+object Test:
+
+  inline def findA[T <: Tuple]: Unit =
+    inline erasedValue[T] match
+    case _: EmptyTuple  => error("Field 'a' not found")
+    case _: ("a" *: tl) => ()
+    case _: (_ *: tl)   => findA[tl]
+
+  inline given [A <: Product] => (mm: Mirror.ProductOf[A]) => Test[A] = new {
+    override def test: String =
+      findA[mm.MirroredElemLabels]
+      "test"
+  }
+  inline given[B <: Product](using mm: Mirror.ProductOf[B]): Test[B] = new {
+    override def test: String = "all"
+  }
+end Test
+
+final case class Test1(a: String, b: Int)
+final case class Test2(v: String, w: Int)
+
+@main def main =
+  inline def f[P <: Product](using g: Test[P]): String = g.test
+
+  inline def g[P <: Product]: String = summonInline[Test[P]].test
+
+  f[Test1] // error ambiguous at typer
+  f[Test2] // error
+
+  summonInline[Test[Test1]].test // error
+  summonInline[Test[Test2]].test // error
+
+  g[Test1] // typechecks but not inlined
+  g[Test2]

--- a/tests/neg/i15788c.scala
+++ b/tests/neg/i15788c.scala
@@ -1,0 +1,34 @@
+import scala.compiletime.*
+import scala.deriving.Mirror
+
+trait Test[A]:
+  def test: String
+
+object Test:
+
+  inline def findA[T <: Tuple]: Unit =
+    inline erasedValue[T] match
+    case _: EmptyTuple  => error("Field 'a' not found")
+    case _: ("a" *: tl) => ()
+    case _: (_ *: tl)   => findA[tl]
+
+  inline given [A <: Product] => (mm: Mirror.ProductOf[A]) => Test[A] = new {
+    override def test: String =
+      findA[mm.MirroredElemLabels]
+      "test"
+  }
+  inline given[B <: Product](using mm: Mirror.ProductOf[B]): Test[B] = new {
+    override def test: String = "all"
+  }
+end Test
+
+final case class Test1(a: String, b: Int)
+final case class Test2(v: String, w: Int)
+
+@main def main =
+  inline def f[P <: Product](using g: Test[P]): String = g.test
+
+  inline def g[P <: Product]: String = summonInline[Test[P]].test
+
+  g[Test1] // error at inlining
+  g[Test2] // ok, only one given is applicable

--- a/tests/neg/i15788d.scala
+++ b/tests/neg/i15788d.scala
@@ -1,0 +1,37 @@
+import scala.compiletime.*
+import scala.deriving.Mirror
+
+trait Test[A]:
+  def test: String
+
+object Test:
+
+  inline def findA[T <: Tuple]: Unit =
+    inline erasedValue[T] match
+    case _: EmptyTuple  => error("Field 'a' not found")
+    case _: ("a" *: tl) => ()
+    case _: (_ *: tl)   => findA[tl]
+
+  inline given [A <: Product] => (mm: Mirror.ProductOf[A]) => Test[A] = new {
+    override def test: String =
+      findA[mm.MirroredElemLabels]
+      "test"
+  }
+end Test
+
+final case class Test1(a: String, b: Int)
+final case class Test2(v: String, w: Int)
+
+@main def main =
+  transparent inline def f[P <: Product](using g: Test[P]): String = g.test
+
+  transparent inline def g[P <: Product]: String = summonInline[Test[P]].test
+
+  f[Test1]
+  f[Test2] // error at inlining
+
+  summonInline[Test[Test1]].test
+  summonInline[Test[Test2]].test // error
+
+  g[Test1]
+  g[Test2] // error

--- a/tests/neg/i15788e.scala
+++ b/tests/neg/i15788e.scala
@@ -1,0 +1,37 @@
+import scala.compiletime.*
+import scala.deriving.Mirror
+
+trait Test[A]:
+  def test: String
+
+object Test:
+
+  transparent inline def findA[T <: Tuple]: Unit =
+    inline erasedValue[T] match
+    case _: EmptyTuple  => error("Field 'a' not found")
+    case _: ("a" *: tl) => (): Unit
+    case _: (_ *: tl)   => findA[tl]
+
+  transparent inline given [A <: Product] => (mm: Mirror.ProductOf[A]) => Test[A] = new {
+    override def test: String =
+      findA[mm.MirroredElemLabels]
+      "test"
+  }
+end Test
+
+final case class Test1(a: String, b: Int)
+final case class Test2(v: String, w: Int)
+
+@main def main =
+  transparent inline def f[P <: Product](using inline g: Test[P]): String = g.test
+
+  transparent inline def g[P <: Product]: String = summonInline[Test[P]].test
+
+  f[Test1]
+  f[Test2] // error at inlining
+
+  summonInline[Test[Test1]].test
+  summonInline[Test[Test2]].test // error
+
+  g[Test1]
+  g[Test2] // error


### PR DESCRIPTION
After typer, add error diagnostics to a special `LateMismatchedImplicit`, so that inlining can add the text to the "missing arg" message. (It piggy-backs on the otherwise unused "location" string. The existing English grammar works out okay.) This limits the "surface area" of this channel. 

The current reference does not suggest that `error` works only at typer phase:

> The error method is used to produce user-defined compile errors during inline expansion.

The reference is liberal about how the user text is represented:

> If an inline expansion results in a call error(msgStr) the compiler produces an error message containing the given msgStr.

This commit is more conservative than the previous fix for macro errors, since existing clients can ignore the special `MismatchedImplicit` type, and `msg` formatting is unchanged.

Fixes #15788 