### PR TITLE
Constructor proxy is restricted if class is protected

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/NamerOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NamerOps.scala
@@ -149,9 +149,11 @@ object NamerOps:
    */
   def addConstructorApplies(scope: MutableScope, cls: ClassSymbol, modcls: ClassSymbol)(using Context): scope.type =
     def proxy(constr: Symbol): Symbol =
+      var flags = ApplyProxyFlags | (constr.flagsUNSAFE & AccessFlags)
+      if cls.is(Protected) && !modcls.is(Protected) then flags |= Protected
       newSymbol(
         modcls, nme.apply,
-        ApplyProxyFlags | (constr.flagsUNSAFE & AccessFlags),
+        flags,
         ApplyProxyCompleter(constr),
         cls.privateWithin,
         constr.coord)
@@ -175,9 +177,11 @@ object NamerOps:
 
   /** A new symbol that is the constructor companion for class `cls` */
   def classConstructorCompanion(cls: ClassSymbol)(using Context): TermSymbol =
+    var flags = ConstructorCompanionFlags
+    if cls.is(Protected) then flags |= Protected
     val companion = newModuleSymbol(
         cls.owner, cls.name.toTermName,
-        ConstructorCompanionFlags, ConstructorCompanionFlags,
+        flags, flags,
         constructorCompanionCompleter(cls),
         coord = cls.coord,
         compUnitInfo = cls.compUnitInfo)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1198,9 +1198,8 @@ trait Applications extends Compatibility {
             //
             //    summonFrom {
             //      case given A[t] =>
-            //        summonFrom
+            //        summonFrom:
             //          case given `t` => ...
-            //        }
             //    }
             //
             // the second `summonFrom` should expand only once the first `summonFrom` is

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4173,9 +4173,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           readapt(tree.appliedToNone) // insert () to primary constructors
         else
           errorTree(tree, em"Missing arguments for $methodStr")
-      case _ => tryInsertApplyOrImplicit(tree, pt, locked) {
-        errorTree(tree, MethodDoesNotTakeParameters(tree))
-      }
+      case _ =>
+        tryInsertApplyOrImplicit(tree, pt, locked):
+          errorTree(tree, MethodDoesNotTakeParameters(tree))
     }
 
     def adaptNoArgsImplicitMethod(wtp: MethodType): Tree = {

--- a/docs/_docs/reference/other-new-features/creator-applications.md
+++ b/docs/_docs/reference/other-new-features/creator-applications.md
@@ -39,8 +39,11 @@ The precise rules are as follows:
     - the class has a companion object (which might have been generated in step 1), and
     - that companion object does not already define a member named `apply`.
 
-    Each generated `apply` method forwards to one constructor of the class. It has the
-    same type and value parameters as the constructor.
+    Each generated `apply` method forwards to one constructor of the class.
+    It has the same type and value parameters as the constructor,
+    as well as the same access restriction as the class.
+    If the class is `protected`, then either the companion object must be `protected`
+    or the `apply` method will be made `protected`.
 
 Constructor proxy companions cannot be used as values by themselves. A proxy companion object must
 be selected with `apply` (or be applied to arguments, in which case the `apply` is implicitly

--- a/tests/neg/i22560.scala
+++ b/tests/neg/i22560.scala
@@ -1,0 +1,22 @@
+
+class A:
+  protected class B
+
+// This fails to compile, as expected
+val x = A().B() // error
+
+object C:
+  protected val p = "protected"
+  protected def getString() = "Hello!"
+  protected class D:
+    def d = D() // ok
+
+// This fails to compile
+// val y = C.p
+
+// And this also fails to compile
+// val z = C.getString()
+
+// However, this compiles just fine.
+val alpha = C.D() // error
+val beta = new C.D() // error

--- a/tests/neg/i22560b.scala
+++ b/tests/neg/i22560b.scala
@@ -7,3 +7,12 @@ class Enumeration:
 class Test extends Enumeration:
   val Hearts = Val(27) // error
   val Diamonds = Val() // error
+
+package p:
+  private[p] class C(i: Int) // ctor proxy gets privateWithin of class
+  private[p] class D(i: Int)
+  object D
+
+package q:
+  def f() = p.C(42) // error
+  def g() = p.D(42) // error

--- a/tests/neg/i22560b.scala
+++ b/tests/neg/i22560b.scala
@@ -1,0 +1,9 @@
+
+class Enumeration:
+  protected class Val(i: Int):
+    def this() = this(42)
+  object Val
+
+class Test extends Enumeration:
+  val Hearts = Val(27) // error
+  val Diamonds = Val() // error

--- a/tests/pos/i22560.scala
+++ b/tests/pos/i22560.scala
@@ -1,0 +1,22 @@
+
+package companionless:
+
+  class Enumeration:
+    protected class Val(i: Int):
+      def this() = this(42)
+
+  class Test extends Enumeration:
+    val Hearts = Val(27)
+    val Diamonds = Val()
+
+
+package companioned:
+
+  class Enumeration:
+    protected class Val(i: Int):
+      def this() = this(42)
+    protected object Val
+
+  class Test extends Enumeration:
+    val Hearts = Val(27)
+    val Diamonds = Val()


### PR DESCRIPTION
Calling a constructor proxy should be at least as restricted as using `new`.

Add `Protected` to a constructor companion if the class is protected.

If the companion exists but is not protected, then make the constructor proxy protected.

Explicit `new` already errored for access.

Fixes #22560 