### PR TITLE
Add error-checking when fetching rhs of trees from TASTy

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -263,6 +263,29 @@ class CompilationTests {
 
       tests.foreach(_.delete())
     }
+
+    /* This tests for errors in the program's TASTy trees.
+     * The test consists of three files: (a) v1/A, (b) v1/B, and (c) v0/A. (a) and (b) are
+     * compatible, but (b) and (c) are not. If (b) and (c) are compiled together, there should be
+     * an error when reading the files' TASTy trees. */
+    locally {
+      val tastyErrorGroup = TestGroup("checkInit/tasty-error")
+      val tastyErrorOptions = options.without("-Xfatal-warnings")
+
+      val a0Dir = defaultOutputDir + tastyErrorGroup + "/A/v0/A"
+      val a1Dir = defaultOutputDir + tastyErrorGroup + "/A/v1/A"
+      val b1Dir = defaultOutputDir + tastyErrorGroup + "/B/v1/B"
+
+      val tests = List(
+        compileFile("tests/init/tasty-error/v1/A.scala", tastyErrorOptions)(tastyErrorGroup),
+        compileFile("tests/init/tasty-error/v1/B.scala", tastyErrorOptions.withClasspath(a1Dir))(tastyErrorGroup),
+        compileFile("tests/init/tasty-error/v0/A.scala", tastyErrorOptions)(tastyErrorGroup),
+      ).map(_.keepOutput.checkCompile())
+
+      compileFile("tests/init/tasty-error/Main.scala", tastyErrorOptions.withClasspath(a0Dir).withClasspath(b1Dir))(tastyErrorGroup).checkExpectedErrors()
+
+      tests.foreach(_.delete())
+    }
   }
 
   // parallel backend tests

--- a/tests/init/tasty-error/Main.scala
+++ b/tests/init/tasty-error/Main.scala
@@ -1,0 +1,1 @@
+class Main extends B{} // anypos-error

--- a/tests/init/tasty-error/v0/A.scala
+++ b/tests/init/tasty-error/v0/A.scala
@@ -1,0 +1,3 @@
+class A {
+  def fail(a: Int, b: Int): Int = a
+}

--- a/tests/init/tasty-error/v1/A.scala
+++ b/tests/init/tasty-error/v1/A.scala
@@ -1,0 +1,3 @@
+class A {
+  def fail(a: Int): Int = a
+}

--- a/tests/init/tasty-error/v1/B.scala
+++ b/tests/init/tasty-error/v1/B.scala
@@ -1,0 +1,4 @@
+class B {
+  val a: A = new A
+  val x = a.fail(0)
+}


### PR DESCRIPTION
This PR would fix the error raised in https://github.com/scala/scala3/issues/22442.
The error arises when reading incompatible TASTy trees. This PR checks if an error occurs when fetching the rhs of ValOrDefDef trees and gives a warning.