### PR TITLE
Add warning for :kind command

### DIFF
--- a/compiler/src/dotty/tools/repl/ParseResult.scala
+++ b/compiler/src/dotty/tools/repl/ParseResult.scala
@@ -52,6 +52,13 @@ object Load {
   val command: String = ":load"
 }
 
+/** `:kind <type>` display the kind of a type. see also :help kind
+ */
+case class KindOf(expr: String) extends Command
+object KindOf {
+  val command: String = ":kind"
+}
+
 /** To find out the type of an expression you may simply do:
  *
  * ```
@@ -138,6 +145,7 @@ object ParseResult {
     Help.command -> (_  => Help),
     Reset.command -> (arg  => Reset(arg)),
     Imports.command -> (_  => Imports),
+    KindOf.command -> (arg => KindOf(arg)),
     Load.command -> (arg => Load(arg)),
     TypeOf.command -> (arg => TypeOf(arg)),
     DocOf.command -> (arg => DocOf(arg)),

--- a/compiler/src/dotty/tools/repl/ReplDriver.scala
+++ b/compiler/src/dotty/tools/repl/ReplDriver.scala
@@ -510,6 +510,10 @@ class ReplDriver(settings: Array[String],
         state
       }
 
+    case KindOf(expr) =>
+      out.println(s"""The :kind command is not currently supported.""")
+      state
+
     case TypeOf(expr) =>
       expr match {
         case "" => out.println(s":type <expression>")

--- a/compiler/test-resources/repl/i21655
+++ b/compiler/test-resources/repl/i21655
@@ -1,0 +1,2 @@
+scala>:kind
+The :kind command is not currently supported.

--- a/compiler/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/compiler/test/dotty/tools/repl/TabcompleteTests.scala
@@ -213,6 +213,7 @@ class TabcompleteTests extends ReplTest {
         ":exit",
         ":help",
         ":imports",
+        ":kind",
         ":load",
         ":quit",
         ":reset",


### PR DESCRIPTION
After discussion with the core team, it was decided to postpone implementation of the `:kind` command for #21655. For now, emit a warning.