### PR TITLE
Best-effort: fix compiler crash when using betasty with missing java classfiles

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/SemanticSymbolBuilder.scala
@@ -90,9 +90,15 @@ class SemanticSymbolBuilder:
           b.append('+').append(idx + 1)
         case _ =>
       end find
-      val sig = sym.signature
-      val targetName = sym.targetName
-      find(sym => sym.signature == sig && sym.targetName == targetName)
+      try
+        val sig = sym.signature
+        val targetName = sym.targetName
+        find(sym => sym.signature == sig && sym.targetName == targetName)
+      catch
+        // sym.signature might not exist
+        // this solves tests/best-effort/compiler-semanticdb-crash
+        case _: MissingType if ctx.usedBestEffortTasty =>
+
 
     def addDescriptor(sym: Symbol): Unit =
       if sym.is(ModuleClass) then

--- a/compiler/test/dotc/neg-best-effort-pickling.excludelist
+++ b/compiler/test/dotc/neg-best-effort-pickling.excludelist
@@ -13,11 +13,11 @@ curried-dependent-ift.scala
 i17121.scala
 illegal-match-types.scala
 i13780-1.scala
-i20317a.scala
-i11226.scala
-i974.scala
-i13864.scala
+
+i20317a.scala # recursion limit exceeded
+i11226.scala # missing type
+i974.scala # cyclic reference
+i13864.scala # missing symbol in pickling
 
 # semantic db generation fails in the first compilation
-i1642.scala
-i15158.scala
+i15158.scala # cyclic reference - stack overflow

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1212,7 +1212,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
      *  of betasty files.
      */
     def checkNoBestEffortError()(implicit summaryReport: SummaryReporting): this.type = {
-      val test = new NoBestEffortErrorsTest(targets, times, threadLimit, shouldFail || shouldSuppressOutput).executeTestSuite()
+      val test = new NoBestEffortErrorsTest(targets, times, threadLimit, shouldFail).executeTestSuite()
 
       cleanup()
 
@@ -1761,7 +1761,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       val bestEffortDir = new JFile(step1OutDir, s"META-INF${JFile.separator}best-effort")
 
       val step2Compilation = JointCompilationSource(
-        testGroup.name, step2SourceFiles, flags.and(withBetastyFlag).and(semanticDbFlag), step2OutDir, fromTasty = WithBestEffortTasty(bestEffortDir)
+        testGroup.name, step2SourceFiles, flags.and(bestEffortFlag).and(withBetastyFlag).and(semanticDbFlag), step2OutDir, fromTasty = WithBestEffortTasty(bestEffortDir)
       )
       (step1Compilation, step2Compilation, bestEffortDir)
     }.unzip3
@@ -1770,7 +1770,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
       new CompilationTest(step1Targets).keepOutput,
       new CompilationTest(step2Targets).keepOutput,
       bestEffortDirs,
-      true
+      shouldDelete = true
     )
   }
 
@@ -1824,7 +1824,7 @@ trait ParallelTesting extends RunnerOrchestration { self =>
 
     def noCrashWithCompilingDependencies()(implicit summaryReport: SummaryReporting): this.type = {
       step1.checkNoBestEffortError() // Compile all files to generate the class files with best effort tasty
-      step2.checkCompile() // Compile with best effort tasty
+      step2.checkNoBestEffortError() // Compile with best effort tasty
 
       this
     }

--- a/tests/best-effort/compiler-semanticdb-crash/err/ClassNode.java
+++ b/tests/best-effort/compiler-semanticdb-crash/err/ClassNode.java
@@ -1,0 +1,11 @@
+package dotty.tools.backend.jvm;
+
+public class ClassNode {
+
+    public ClassNode(int api) {
+    }
+
+    public ClassNode visitMethod(int access) {
+        return null;
+    }
+}

--- a/tests/best-effort/compiler-semanticdb-crash/err/Main.scala
+++ b/tests/best-effort/compiler-semanticdb-crash/err/Main.scala
@@ -1,0 +1,4 @@
+package dotty.tools.backend.jvm
+
+val errorGenerator: Int = "0"
+def readClass(bytes: Array[Byte]): ClassNode = ???

--- a/tests/best-effort/compiler-semanticdb-crash/main/Test.scala
+++ b/tests/best-effort/compiler-semanticdb-crash/main/Test.scala
@@ -1,0 +1,1 @@
+def c = dotty.tools.backend.jvm.readClass(Array())


### PR DESCRIPTION
Fixes the 
```
exception occurred while extractSemanticDBExtractSemanticInfo /Users/tgodzik/Documents/dotty/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala

  An unhandled exception was thrown in the compiler.
  Please file a crash report here:
  https://github.com/scala/scala3/issues/new/choose
  For non-enriched exceptions, compile with -Xno-enrich-error-messages.


     while compiling: /Users/tgodzik/Documents/dotty/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala
        during phase: parser
                mode: Mode(ImplicitsEnabled,ReadPositions,SafeNulls)
     library version: version 2.13.16
    compiler version: version 3.6.4-RC1
            settings: -Wconf List(cat=deprecation&origin=scala\.collection\.mutable\.AnyRefMap.*:s) -Wsafe-init true -Xsemanticdb true -Ybest-effort true -Yexplicit-nulls true -Ywith-best-effort-tasty true -classpath /Users/tgodzik/Documents/dotty/compiler/
```
crash when best effort is used in the compiler on erroring code (where we lose access to java classifies)