### PR TITLE
Quotes reflect: Allow to return DefDef from a val symbol tree

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/reflect/FromSymbol.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/reflect/FromSymbol.scala
@@ -45,8 +45,14 @@ object FromSymbol {
     case tpd.EmptyTree => tpd.DefDef(sym)
   }
 
-  def valDefFromSym(sym: TermSymbol)(using Context): tpd.ValDef = sym.defTree match {
+  def valDefFromSym(sym: TermSymbol)(using Context): tpd.ValOrDefDef = sym.defTree match {
     case tree: tpd.ValDef => tree
+    case tree: tpd.DefDef =>
+      // `Getters` phase replaces val class members with defs,
+      // so we may see a defdef here if we are running this on a symbol compiled
+      // in the same compilation (but before suspension, so that
+      // the symbol could have reached `Getters`).
+      tree
     case tpd.EmptyTree => tpd.ValDef(sym)
   }
 

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -4267,11 +4267,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
         /** Tree of this definition
          *
-         *  If this symbol `isClassDef` it will return `a `ClassDef`,
-         *  if this symbol `isTypeDef` it will return `a `TypeDef`,
-         *  if this symbol `isValDef` it will return `a `ValDef`,
-         *  if this symbol `isDefDef` it will return `a `DefDef`
-         *  if this symbol `isBind` it will return `a `Bind`,
+         *  If this symbol `isClassDef` it will return a `ClassDef`,
+         *  if this symbol `isTypeDef` it will return a `TypeDef`,
+         *  if this symbol `isDefDef` it will return a `DefDef`,
+         *  if this symbol `isBind` it will return a `Bind`,
+         *  if this symbol `isValDef` it will return a `ValDef`,
+         *     or a `DefDef` (as the compiler can replace val class members with defs during compilation),
          *  else will throw
          *
          *  **Warning**: avoid using this method in macros.

--- a/tests/pos-macros/i22584/Macro.scala
+++ b/tests/pos-macros/i22584/Macro.scala
@@ -1,0 +1,30 @@
+//> using options -Yretain-trees
+
+import scala.quoted.*
+
+object Macros {
+
+  inline def myMacro[A]: Unit = ${ myMacroImpl[A] }
+
+  private def myMacroImpl[A](using quotes: Quotes, tpe: Type[A]): Expr[Unit] = {
+    import quotes.reflect.*
+
+    val typeRepr = TypeRepr.of[A]
+    val typeSymbol = typeRepr.typeSymbol
+
+    val caseFieldSymbols: List[Symbol] = typeSymbol.fieldMembers
+    val caseFieldValOrDefDefs: List[ValDef | DefDef] =
+      caseFieldSymbols.sortBy(_.toString).map {
+        _.tree match {
+          case valDef: ValDef => valDef
+          case defDef: DefDef => defDef
+          case _              => report.errorAndAbort("???")
+        }
+      }
+
+    val expected = "List(DefDef(boolean,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Boolean)],Select(This(Ident(MyClass1)),boolean)), DefDef(finalVal,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class lang)),class String)],Select(This(Ident(MyClass1)),finalVal)), DefDef(int,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Int)],Select(This(Ident(MyClass1)),int)), DefDef(string,List(List()),TypeTree[TypeRef(ThisType(TypeRef(NoPrefix,module class lang)),class String)],Select(This(Ident(MyClass1)),string)))"
+    assert(caseFieldValOrDefDefs.toString == expected)
+
+    '{ () }
+  }
+}

--- a/tests/pos-macros/i22584/Main.scala
+++ b/tests/pos-macros/i22584/Main.scala
@@ -1,0 +1,4 @@
+import Types.*
+
+@main def main() =
+  Macros.myMacro[MyClass1]

--- a/tests/pos-macros/i22584/Types.scala
+++ b/tests/pos-macros/i22584/Types.scala
@@ -1,0 +1,9 @@
+object Types {
+  final case class MyClass1(
+    int: Int,
+    string: String,
+    boolean: Boolean,
+  ) {
+    final val finalVal: String = "result"
+  }
+}


### PR DESCRIPTION
Fixes #22584 
During the `Getters` phase, the compiler replaces class member vals with defs. Meanwhile `.tree` returns a tree most recently associated with a symbol (if currently compiled), or one read from tasty (if compiled before).  An interesting thing happens in the issue - since all of the files are tried being compiled in one compilation run, the file with a macro call is suspended, and then the macro and the MyClass class definition are compiled to the end (also including the `Getters` phase, where the tree stops being a ValDef). 

Initially I thought about manually replacing that returned DefDef with a ValDef in quotes reflection (like what happens when the tree is not available), but that would have been pointless - there would be little use of calling `.tree` on a symbol if we cannot read the rhs of the definition. Returning raw DefDef seems like a less bad choice, especially `.tree` is meant to be for power users anyway, and is full of other, more dangerous warts.  