### PR TITLE
Allow observing an indent after conditional

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -105,7 +105,7 @@ object Parsers {
   private val InCase: Region => Region = Scanners.InCase(_)
   private val InCond: Region => Region = Scanners.InParens(LPAREN, _)
   private val InFor : Region => Region = Scanners.InBraces(_)
-  private val InBrk : Region => Region = _.match
+  private val InBrk : Region => Region =
     case p: Scanners.InParens => Scanners.Indented(p.indentWidth, p.prefix, p)
     case r => r
 
@@ -2328,27 +2328,25 @@ object Parsers {
     def condExpr(altToken: Token): Tree =
       val t: Tree =
         if in.token == LPAREN then
-          var t: Tree =
-            inSepRegion(InBrk): // allow inferred NEWLINE for observeIndented below
-              atSpan(in.offset):
-                makeTupleOrParens(inParensWithCommas(commaSeparated(exprInParens)))
-          if in.token != altToken then
-            if toBeContinued(altToken) then
-              t = inSepRegion(InCond) {
+          inSepRegion(InBrk): // allow inferred NEWLINE for observeIndented below
+            atSpan(in.offset):
+              makeTupleOrParens(inParensWithCommas(commaSeparated(exprInParens)))
+          .pipe: t =>
+            if in.token == altToken then t
+            else if toBeContinued(altToken) then
+              inSepRegion(InCond):
                 expr1Rest(
                   postfixExprRest(
                     simpleExprRest(t, Location.ElseWhere),
                     Location.ElseWhere),
                   Location.ElseWhere)
-              }
             else
               if rewriteToNewSyntax(t.span) then
-                dropParensOrBraces(t.span.start, s"${tokenString(altToken)}")
+                dropParensOrBraces(t.span.start, tokenString(altToken))
               in.observeIndented()
               return t
-          t
         else if in.isNestedStart then
-          try expr() finally newLinesOpt()
+          expr().tap(_ => newLinesOpt())
         else
           inSepRegion(InCond)(expr())
       if rewriteToOldSyntax(t.span.startPos) then revertToParens(t)

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -105,7 +105,7 @@ object Parsers {
   private val InCase: Region => Region = Scanners.InCase(_)
   private val InCond: Region => Region = Scanners.InParens(LPAREN, _)
   private val InFor : Region => Region = Scanners.InBraces(_)
-  private val InBrk : Region => Region =
+  private val InOldCond: Region => Region = // old-style Cond to allow indent when InParens, see #22608
     case p: Scanners.InParens => Scanners.Indented(p.indentWidth, p.prefix, p)
     case r => r
 
@@ -2328,7 +2328,7 @@ object Parsers {
     def condExpr(altToken: Token): Tree =
       val t: Tree =
         if in.token == LPAREN then
-          inSepRegion(InBrk): // allow inferred NEWLINE for observeIndented below
+          inSepRegion(InOldCond): // allow inferred NEWLINE for observeIndented below
             atSpan(in.offset):
               makeTupleOrParens(inParensWithCommas(commaSeparated(exprInParens)))
           .pipe: t =>

--- a/tests/pos/i22608.scala
+++ b/tests/pos/i22608.scala
@@ -1,0 +1,48 @@
+
+def f(i: Int) = i
+def g(i: Int, j: Int) = i+j
+
+def t =
+  val y = f(
+    if (true)// then
+      val x = 1
+      5
+    else 7
+  )
+  y
+
+def u(j: Int) =
+  val y = g(
+    if (true)// then
+      val x = 1
+      5
+    else 7,
+    j
+  )
+  y
+
+def b(k: Boolean): Int =
+  f(
+    if (
+       k
+    && b(!k) > 0
+    ) then 27
+    else 42
+  )
+
+def p(b: Boolean) =
+  import collection.mutable.ListBuffer
+  val xs, ys = ListBuffer.empty[String]
+  (if (b)
+    xs
+  else
+    ys) += "hello, world"
+  (xs.toString, ys.toString)
+
+def q(b: Boolean) =
+  import collection.mutable.ListBuffer
+  val xs, ys = ListBuffer.empty[String]
+  (if (b)
+   then xs
+   else ys) += "hello, world"
+  (xs.toString, ys.toString)


### PR DESCRIPTION
Normally do not infer NEWLINE within parens,
but special case old syntax for conditionals,
so that it can observe indented syntax.
The mechanism is to inject an Indented region
when parsing a parenthesized condition which is
within an InParens region, such as an arg list.
The effect is not to advance past EOL after `(true)`.

Fixes #22608 