### PR TITLE
Fix issue with static `this` references erroring in quoted code

### DIFF
--- a/tests/neg/i22592.scala
+++ b/tests/neg/i22592.scala
@@ -1,0 +1,14 @@
+import scala.quoted.*
+
+trait Foo:
+  def inherited = ()
+
+class Bar extends Foo:
+  def local = ()
+  def localArg(arg: Any) = ()
+
+  def macro1(using Quotes): Expr[Unit] = '{ local } // error
+  def macro3(using Quotes): Expr[Unit] = '{ inherited } // error
+  def macro4(using Quotes): Expr[Unit] = '{ this.local } // error
+  def macro5(using Quotes): Expr[Unit] = '{ this.inherited } // error
+  def macro6(using Quotes): Expr[Unit] = '{ localArg(this) } // error // error

--- a/tests/pos/i22592.scala
+++ b/tests/pos/i22592.scala
@@ -1,0 +1,15 @@
+import scala.quoted.*
+
+trait Foo:
+  def inherited = ()
+
+object Bar extends Foo:
+  def local = ()
+  def localArg(arg: Any) = ()
+
+  def macro1(using Quotes): Expr[Unit] = '{ local }
+  def macro2(using Quotes): Expr[Unit] = '{ Bar.inherited }
+  def macro3(using Quotes): Expr[Unit] = '{ inherited }
+  def macro4(using Quotes): Expr[Unit] = '{ this.local }
+  def macro5(using Quotes): Expr[Unit] = '{ this.inherited }
+  def macro6(using Quotes): Expr[Unit] = '{ localArg(this) }


### PR DESCRIPTION
Previously, inherited methods, even if accessed via static objects, were not able to be used in quotations, unless explicitly pointed to with a non-`this` prefix. This was due to the fact that during the cross-stage safety check, first the method itself was checked for if it was static (which for the inherited method, it was not), and if not, the prefix was checked further, erroring on any `this` tree found along the way.

This was fixed by allowing `this` trees if they point to static objects. This way not only is the initial issue fixed, but also we are able to freely reference static methods with `this`, like '{this.objectMethod} (whereas previously, only `'{Object.objectMethod}` or `'{objectMethod}` were allowed, despite them all pointing to the same static method).

Fixes #22592 