### PR TITLE
Merge stale changes from language reference stable

### DIFF
--- a/docs/_docs/reference/other-new-features/matchable.md
+++ b/docs/_docs/reference/other-new-features/matchable.md
@@ -12,7 +12,7 @@ The Scala 3 standard library has a type [`IArray`](https://scala-lang.org/api/3.
 arrays that is defined like this:
 
 ```scala
-  opaque type IArray[+T] = Array[_ <: T]
+  opaque type IArray[+T] = Array[? <: T]
 ```
 
 The `IArray` type offers extension methods for `length` and `apply`, but not for `update`; hence it seems values of type `IArray` cannot be updated.


### PR DESCRIPTION
Replaces #20076

It should target `main` instead of read-only `language-referecne-stable` branch. At this point we cannot simply rebase it without having access to original author repostiory (to force push)

[skip ci]