### PR TITLE
Fix opaque types leaking rhs when inlined and found in type params (and a related stale symbol issue) 

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -538,6 +538,14 @@ object Types extends TypeUtils {
     final def foreachPart(p: Type => Unit, stopAt: StopAt = StopAt.None)(using Context): Unit =
       new ForeachAccumulator(p, stopAt).apply((), this)
 
+    final def foreachPartWithoutTypeParams(p: Type => Unit, stopAt: StopAt = StopAt.None)(using Context): Unit =
+      new ForeachAccumulator(p, stopAt) {
+        override def apply(x: Unit, tp: Type) = tp match
+          case AppliedType(tycon, _) => super.apply(x, tycon)
+          case other => super.apply(x, other)
+      }.apply((), this)
+
+
     /** The parts of this type which are type or term refs and which
      *  satisfy predicate `p`.
      *

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -399,7 +399,7 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  type aliases, add proxy definitions to `opaqueProxies` that expose these aliases.
    */
   private def addOpaqueProxies(tp: Type, span: Span, forThisProxy: Boolean)(using Context): Unit =
-    tp.foreachPart {
+    tp.foreachPartWithoutTypeParams {
       case ref: TermRef =>
         for cls <- ref.widen.baseClasses do
           if cls.containsOpaques

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -674,7 +674,7 @@ object SpaceEngine {
           val superType = child.typeRef.superType
           if typeArgs.exists(_.isBottomType) && superType.isInstanceOf[ClassInfo] then
             val parentClass = superType.asInstanceOf[ClassInfo].declaredParents.find(_.classSymbol == parent).get
-            val paramTypeMap = Map.from(parentClass.argTypes.map(_.typeSymbol).zip(typeArgs))
+            val paramTypeMap = Map.from(parentClass.argInfos.map(_.typeSymbol).zip(typeArgs))
             val substArgs = child.typeRef.typeParamSymbols.map(param => paramTypeMap.getOrElse(param, WildcardType))
             substArgs
           else Nil

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -712,7 +712,7 @@ class Namer { typer: Typer =>
               enterSymbol(classConstructorCompanion(classSym.asClass))
             else
               for moduleSym <- companionVals do
-                if moduleSym.is(Module) && !moduleSym.isDefinedInCurrentRun then
+                if moduleSym.lastKnownDenotation.is(Module) && !moduleSym.isDefinedInCurrentRun then
                   val companion =
                     if needsConstructorProxies(classSym) then
                       classConstructorCompanion(classSym.asClass)

--- a/tests/pos-macros/i20449/Macro.scala
+++ b/tests/pos-macros/i20449/Macro.scala
@@ -1,0 +1,3 @@
+import scala.quoted.*
+transparent inline def getTypeInfo[T]() = ${ getTypeInfoImpl[T] }
+def getTypeInfoImpl[T: Type](using ctx: Quotes): Expr[Unit] = '{ () }

--- a/tests/pos-macros/i20449/Main.scala
+++ b/tests/pos-macros/i20449/Main.scala
@@ -1,0 +1,6 @@
+
+class Wrapper1[A]
+val a = {
+  getTypeInfo[Any]()
+  val wrapper2 = Wrapper1[Any]()
+}

--- a/tests/pos/i22518.scala
+++ b/tests/pos/i22518.scala
@@ -1,0 +1,9 @@
+sealed trait Foo[T]
+class Bar extends Foo[?]
+
+def mkFoo[T]: Foo[T] =
+  ???
+
+def test: Unit =
+  mkFoo match
+    case _ => ()

--- a/tests/run-macros/i20449.check
+++ b/tests/run-macros/i20449.check
@@ -1,0 +1,50 @@
+------ UserName.T - Directly -------
+Original: Main_2$package.UserName.T
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ UserName.T - Directly -------
+Original: Main_2$package.UserName
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ ForeignWrapper1[UserName.T] -------
+Original: Main_2$package.UserName.T
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ ForeignWrapper2[UserName.T] -------
+Original: Main_2$package.UserName.T
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ ForeignWrapper1[UserName] -------
+Original: Main_2$package.UserName
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ ForeignWrapper2[UserName] -------
+Original: Main_2$package.UserName
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ Wrapper1[UserName.T] -------
+Original: Main_2$package.UserName.T
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ Wrapper2[UserName.T] -------
+Original: Main_2$package.UserName.T
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ Wrapper1[UserName] -------
+Original: Main_2$package.UserName
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    
+------ Wrapper2[UserName] -------
+Original: Main_2$package.UserName
+Dealias: Main_2$package.UserName.T
+Dealias dealias: Main_2$package.UserName.T
+    

--- a/tests/run-macros/i20449/Macro_1.scala
+++ b/tests/run-macros/i20449/Macro_1.scala
@@ -1,0 +1,29 @@
+import scala.quoted.*
+
+class ForeignWrapper1[-A] {
+  inline def getTypeInfo(inline source: String): String =
+    ${ getTypeInfoImpl[A]('source) }
+  def createWrapper2 = ForeignWrapper2(this)
+}
+
+class ForeignWrapper2[-A](val self: ForeignWrapper1[A]) {
+  inline def getTypeInfo(inline source: String): String =
+    ${getTypeInfoImpl[A]('source)}
+}
+
+transparent inline def getTypeInfo[T](inline source: String) =
+  ${ getTypeInfoImpl[T]('source) }
+
+def getTypeInfoImpl[T: Type](source: Expr[String])(using ctx: Quotes) : Expr[String] = {
+  import ctx.reflect.*
+
+  val tpe = TypeRepr.of[T]
+  val str =
+    s"""|------ ${source.valueOrAbort} -------
+       |Original: ${tpe.show}
+       |Dealias: ${tpe.dealias.show}
+       |Dealias dealias: ${tpe.dealias.dealias.show}
+    """.stripMargin
+
+  Expr(str)
+}

--- a/tests/run-macros/i20449/Main_2.scala
+++ b/tests/run-macros/i20449/Main_2.scala
@@ -1,0 +1,41 @@
+object UserName {
+  opaque type T = String
+
+  def apply(s: String): T = s
+}
+
+type UserName = UserName.T
+
+class Wrapper1[-A] {
+  inline def getTypeInfo(inline source: String): String =
+    ${ getTypeInfoImpl[A]('source) }
+  def createWrapper2 = Wrapper2(this)
+}
+
+class Wrapper2[-A](val self: Wrapper1[A]) {
+  inline def getTypeInfo(inline source: String): String =
+    ${getTypeInfoImpl[A]('source)}
+}
+
+
+@main def Test() = {
+  println(getTypeInfo[UserName.T]("UserName.T - Directly"))
+  println(getTypeInfo[UserName]("UserName.T - Directly"))
+
+  val foreignWrapper = ForeignWrapper1[UserName.T]()
+  println(foreignWrapper.getTypeInfo("ForeignWrapper1[UserName.T]"))
+  println(foreignWrapper.createWrapper2.getTypeInfo("ForeignWrapper2[UserName.T]"))
+
+  val foreignWrapper2 = ForeignWrapper1[UserName]()
+  println(foreignWrapper2.getTypeInfo("ForeignWrapper1[UserName]"))
+  println(foreignWrapper2.createWrapper2.getTypeInfo("ForeignWrapper2[UserName]"))
+
+  val wrapper = Wrapper1[UserName.T]()
+  println(wrapper.getTypeInfo("Wrapper1[UserName.T]"))
+  println(wrapper.createWrapper2.getTypeInfo("Wrapper2[UserName.T]"))
+
+  val wrapper2 = Wrapper1[UserName]()
+  println(wrapper2.getTypeInfo("Wrapper1[UserName]"))
+  println(wrapper2.createWrapper2.getTypeInfo("Wrapper2[UserName]"))
+
+}


### PR DESCRIPTION
This PR fixes the 2 issues found in #20449, split into 2 commits.

The first commit fixes the stale symbol related issue found if the files from the issue minimization are compiled together. After suspending and retrying compilation, the classDefs that are defined directly in packages previously would sometimes not have companion objects regenerated, instead relying on the stale symbols from the previous run, causing them not to to pass the `reallyExists` check when looking for a specific ref. Now we make sure to go through lastKnwonDenotation, since the current one may not exists and may not point us to a Module flag when checking if to regenerate.

The second commit fixes the opaque type alias rhs leaking in a macro. That was caused by building proxies for all parts of the type, including type arguments to opaque types - from the perspective of a type like `Object[OpaqueType]`, the opaque type rhs should not be visible.