### PR TITLE
Drop `betterMatchTypeExtractors` from Feature

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -35,7 +35,6 @@ object Feature:
   val into = experimental("into")
   val namedTuples = experimental("namedTuples")
   val modularity = experimental("modularity")
-  val betterMatchTypeExtractors = experimental("betterMatchTypeExtractors")
   val quotedPatternsWithPolymorphicFunctions = experimental("quotedPatternsWithPolymorphicFunctions")
   val betterFors = experimental("betterFors")
   val packageObjectValues = experimental("packageObjectValues")
@@ -66,7 +65,6 @@ object Feature:
     (into, "Allow into modifier on parameter types"),
     (namedTuples, "Allow named tuples"),
     (modularity, "Enable experimental modularity features"),
-    (betterMatchTypeExtractors, "Enable better match type extractors"),
     (betterFors, "Enable improvements in `for` comprehensions")
   )
 


### PR DESCRIPTION
We will not align this feature with what was done in #21686 and as indicated in the deprecation message of `scala.language.experimental.betternMatchTypeExtractors`