### PR TITLE
Revert "Add type avoidance to inferred MT bound lubbing"

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2665,7 +2665,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       val lub = cases1.foldLeft(defn.NothingType: Type): (acc, case1) =>
         if !acc.exists then NoType
         else if case1.body.tpe.isProvisional then NoType
-        else acc | TypeOps.avoid(case1.body.tpe, case1.pat.bindTypeSymbols)
+        else acc | case1.body.tpe
       if lub.exists then
         if !lub.isAny then
           val msg = em"Match type upper bound inferred as $lub, where previously it was defaulted to Any"

--- a/tests/pos/i21256.scala
+++ b/tests/pos/i21256.scala
@@ -1,5 +1,0 @@
-object Test {
-  type MTWithBind[X] = X match {
-    case List[t] => t
-  }
-}


### PR DESCRIPTION
This partially reverts #22142 from Scala 3.6.4 

Withdraws regressions observed in #22661 until proper fix would be available in 3.7