### PR TITLE
fix: don't search for members in pc info when irrelevant

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/SymbolInformationProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SymbolInformationProvider.scala
@@ -55,7 +55,13 @@ class SymbolInformationProvider(using Context):
         val classOwner =
           sym.ownersIterator.drop(1).find(s => s.isClass || s.is(Flags.Module))
         val overridden = sym.denot.allOverriddenSymbols.toList
-        val memberDefAnnots = sym.info.membersBasedOnFlags(Flags.Method, Flags.EmptyFlags).flatMap(_.allSymbols).flatMap(_.denot.annotations)
+        val memberDefAnnots =
+          if classSym.exists then
+            classSym.info
+              .membersBasedOnFlags(Flags.Method, Flags.EmptyFlags)
+              .flatMap(_.allSymbols)
+              .flatMap(_.denot.annotations)
+          else Nil
 
         val pcSymbolInformation =
           PcSymbolInformation(


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/7251

`membersBasedOnFlags` on type alias without rhs was throwing an error