### PR TITLE
Try to fix escaping quotes for REPL test

### DIFF
--- a/compiler/test/dotty/tools/scripting/BashExitCodeTests.scala
+++ b/compiler/test/dotty/tools/scripting/BashExitCodeTests.scala
@@ -74,7 +74,7 @@ class BashExitCodeTests:
   @Test def vPhases       = scala("-Vphases")(0)
 
   @Test def replEval      =
-    repl("--repl-quit-after-init", "--repl-init-script", "\"println(\\\"Hello from init script!\\\"); val i = 2 * 2\"")(0)
+    repl("--repl-quit-after-init", "--repl-init-script", "'val i = 2 * 2; val j = i + 2'")(0)
 
   /** A utility for running two commands in a row, like you do in bash. */
   extension (inline u1: Unit) inline def & (inline u2: Unit): Unit = { u1; u2 }

--- a/compiler/test/dotty/tools/scripting/BashExitCodeTests.scala
+++ b/compiler/test/dotty/tools/scripting/BashExitCodeTests.scala
@@ -74,9 +74,7 @@ class BashExitCodeTests:
   @Test def vPhases       = scala("-Vphases")(0)
 
   @Test def replEval      =
-    // Do not run this test on Windows since it is wrongly escaped (#22689)
-    assumeFalse(System.getProperty("os.name").startsWith("Windows"));
-    repl("--repl-quit-after-init", "--repl-init-script", "\'println(\"Hello from init script!\"); val i = 2 * 2\'")(0)
+    repl("--repl-quit-after-init", "--repl-init-script", "\"println(\\\"Hello from init script!\\\"); val i = 2 * 2\"")(0)
 
   /** A utility for running two commands in a row, like you do in bash. */
   extension (inline u1: Unit) inline def & (inline u2: Unit): Unit = { u1; u2 }


### PR DESCRIPTION
[test_windows_full]

Follow-up of #22693

Since windows command will wrap the test command in another pair of quotes, I decide to switch to simple test argument...