### PR TITLE
Refuse trailing type parameters in extractors

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -2421,12 +2421,14 @@ class ClassCannotExtendEnum(cls: Symbol, parent: Symbol)(using Context) extends 
 }
 
 class NotAnExtractor(tree: untpd.Tree)(using Context) extends PatternMatchMsg(NotAnExtractorID) {
-  def msg(using Context) = i"$tree cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method"
+  def msg(using Context) = i"$tree cannot be used as an extractor in a pattern because it lacks an ${hl("unapply")} or ${hl("unapplySeq")} method with the appropriate signature"
   def explain(using Context) =
-    i"""|An ${hl("unapply")} method should be defined in an ${hl("object")} as follow:
+    i"""|An ${hl("unapply")} method should be in an ${hl("object")}, take a single explicit term parameter, and:
         |  - If it is just a test, return a ${hl("Boolean")}. For example ${hl("case even()")}
         |  - If it returns a single sub-value of type T, return an ${hl("Option[T]")}
         |  - If it returns several sub-values T1,...,Tn, group them in an optional tuple ${hl("Option[(T1,...,Tn)]")}
+        |
+        |Additionaly, ${hl("unapply")} or ${hl("unapplySeq")} methods cannot take type parameters after their explicit term parameter.
         |
         |Sometimes, the number of sub-values isn't fixed and we would like to return a sequence.
         |For this reason, you can also define patterns through ${hl("unapplySeq")} which returns ${hl("Option[Seq[T]]")}.

--- a/tests/neg/22550.check
+++ b/tests/neg/22550.check
@@ -1,0 +1,37 @@
+-- [E127] Pattern Match Error: tests/neg/22550.scala:8:9 ---------------------------------------------------------------
+8 |    case Matches(x) => println(x) // error // error
+  |         ^^^^^^^
+  |Matches cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method with the appropriate signature
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | An unapply method should be in an object, take a single explicit term parameter, and:
+  |   - If it is just a test, return a Boolean. For example case even()
+  |   - If it returns a single sub-value of type T, return an Option[T]
+  |   - If it returns several sub-values T1,...,Tn, group them in an optional tuple Option[(T1,...,Tn)]
+  |
+  | Additionaly, unapply or unapplySeq methods cannot take type parameters after their explicit term parameter.
+  |
+  | Sometimes, the number of sub-values isn't fixed and we would like to return a sequence.
+  | For this reason, you can also define patterns through unapplySeq which returns Option[Seq[T]].
+  | This mechanism is used for instance in pattern case List(x1, ..., xn)
+   ---------------------------------------------------------------------------------------------------------------------
+-- [E006] Not Found Error: tests/neg/22550.scala:8:31 ------------------------------------------------------------------
+8 |    case Matches(x) => println(x) // error // error
+  |                               ^
+  |                               Not found: x
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Each identifier in Scala needs a matching declaration. There are two kinds of
+  | identifiers: type identifiers and value identifiers. Value identifiers are introduced
+  | by `val`, `def`, or `object` declarations. Type identifiers are introduced by `type`,
+  | `class`, `enum`, or `trait` declarations.
+  |
+  | Identifiers refer to matching declarations in their environment, or they can be
+  | imported from elsewhere.
+  |
+  | Possible reasons why no matching declaration was found:
+  |  - The declaration or the use is mis-spelt.
+  |  - An import is missing.
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/22550.scala
+++ b/tests/neg/22550.scala
@@ -1,0 +1,8 @@
+//> using options -explain
+
+object Matches:
+  def unapply(y: Any)[T]: Option[Any] = None
+
+def main =
+  42 match
+    case Matches(x) => println(x) // error // error

--- a/tests/neg/22550b.check
+++ b/tests/neg/22550b.check
@@ -1,0 +1,37 @@
+-- [E127] Pattern Match Error: tests/neg/22550b.scala:16:9 -------------------------------------------------------------
+16 |    case Matches[Unit](x) => println(x) // error // error
+   |         ^^^^^^^^^^^^
+   |Matches[Unit] cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method with the appropriate signature
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | An unapply method should be in an object, take a single explicit term parameter, and:
+   |   - If it is just a test, return a Boolean. For example case even()
+   |   - If it returns a single sub-value of type T, return an Option[T]
+   |   - If it returns several sub-values T1,...,Tn, group them in an optional tuple Option[(T1,...,Tn)]
+   |
+   | Additionaly, unapply or unapplySeq methods cannot take type parameters after their explicit term parameter.
+   |
+   | Sometimes, the number of sub-values isn't fixed and we would like to return a sequence.
+   | For this reason, you can also define patterns through unapplySeq which returns Option[Seq[T]].
+   | This mechanism is used for instance in pattern case List(x1, ..., xn)
+    --------------------------------------------------------------------------------------------------------------------
+-- [E006] Not Found Error: tests/neg/22550b.scala:16:37 ----------------------------------------------------------------
+16 |    case Matches[Unit](x) => println(x) // error // error
+   |                                     ^
+   |                                     Not found: x
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Each identifier in Scala needs a matching declaration. There are two kinds of
+   | identifiers: type identifiers and value identifiers. Value identifiers are introduced
+   | by `val`, `def`, or `object` declarations. Type identifiers are introduced by `type`,
+   | `class`, `enum`, or `trait` declarations.
+   |
+   | Identifiers refer to matching declarations in their environment, or they can be
+   | imported from elsewhere.
+   |
+   | Possible reasons why no matching declaration was found:
+   |  - The declaration or the use is mis-spelt.
+   |  - An import is missing.
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/22550b.scala
+++ b/tests/neg/22550b.scala
@@ -1,0 +1,16 @@
+//> using options -explain
+
+case class Data[A]()
+
+trait TCl[A, B]
+
+object Matches:
+  def unapply[A](adt: Data[?])[B](using
+      ft: TCl[A, B]
+  ): Option[Data[A]] = None
+
+given TCl[Unit, String] = new TCl {}
+
+def main =
+  Data() match
+    case Matches[Unit](x) => println(x) // error // error

--- a/tests/neg/bad-unapplies.check
+++ b/tests/neg/bad-unapplies.check
@@ -10,13 +10,13 @@
 -- [E127] Pattern Match Error: tests/neg/bad-unapplies.scala:23:9 ------------------------------------------------------
 23 |    case B("2") => // error (cannot be used as an extractor)
    |         ^
-   |         B cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method
+   |B cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method with the appropriate signature
    |
    | longer explanation available when compiling with `-explain`
 -- [E127] Pattern Match Error: tests/neg/bad-unapplies.scala:24:9 ------------------------------------------------------
 24 |    case D("2") => // error (cannot be used as an extractor)
    |         ^
-   |         D cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method
+   |D cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method with the appropriate signature
    |
    | longer explanation available when compiling with `-explain`
 -- [E050] Type Error: tests/neg/bad-unapplies.scala:25:9 ---------------------------------------------------------------

--- a/tests/neg/i18684.check
+++ b/tests/neg/i18684.check
@@ -67,14 +67,16 @@
 -- [E127] Pattern Match Error: tests/neg/i18684.scala:12:6 -------------------------------------------------------------
 12 |  val inner(x) = 3 // error
    |      ^^^^^
-   |      Test.inner cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method
+   |Test.inner cannot be used as an extractor in a pattern because it lacks an unapply or unapplySeq method with the appropriate signature
    |--------------------------------------------------------------------------------------------------------------------
    | Explanation (enabled by `-explain`)
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   | An unapply method should be defined in an object as follow:
+   | An unapply method should be in an object, take a single explicit term parameter, and:
    |   - If it is just a test, return a Boolean. For example case even()
    |   - If it returns a single sub-value of type T, return an Option[T]
    |   - If it returns several sub-values T1,...,Tn, group them in an optional tuple Option[(T1,...,Tn)]
+   |
+   | Additionaly, unapply or unapplySeq methods cannot take type parameters after their explicit term parameter.
    |
    | Sometimes, the number of sub-values isn't fixed and we would like to return a sequence.
    | For this reason, you can also define patterns through unapplySeq which returns Option[Seq[T]].


### PR DESCRIPTION
This PR restrict selection of extractors to ignore methods that have trailing type parameters, as application of these can't be represented with `tpd.UnApply`. Fixes #22550.

Note: it was discussed during the compiler meeting of 2025-02-26 that `unapply` methods (and other magic methods) should not be linted at definition site, like the first version of this PR did. Instead, non-conforming extractors should crash at use site. This is what this second version implements.