### PR TITLE
Infix operation desugaring should preserve original span

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1771,7 +1771,7 @@ object desugar {
       val sel = Select(fn, op.name).withSpan(selectPos)
       if (left.sourcePos.endLine < op.sourcePos.startLine)
         sel.pushAttachment(MultiLineInfix, ())
-      arg match
+      val apply = arg match
         case Parens(arg) =>
           Apply(sel, assignToNamedArg(arg) :: Nil)
         case Tuple(args) if args.exists(_.isInstanceOf[Assign]) =>
@@ -1780,6 +1780,7 @@ object desugar {
           Apply(sel, arg :: Nil).setApplyKind(ApplyKind.InfixTuple)
         case _ =>
           Apply(sel, arg :: Nil)
+      apply.withSpan(Span(left.span.start, right.span.end, point = op.span.start))
 
     val apply = if op.name.isRightAssocOperatorName then
       makeOp(right, left, Span(op.span.start, right.span.end))

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1771,7 +1771,7 @@ object desugar {
       val sel = Select(fn, op.name).withSpan(selectPos)
       if (left.sourcePos.endLine < op.sourcePos.startLine)
         sel.pushAttachment(MultiLineInfix, ())
-      val apply = arg match
+      arg match
         case Parens(arg) =>
           Apply(sel, assignToNamedArg(arg) :: Nil)
         case Tuple(args) if args.exists(_.isInstanceOf[Assign]) =>
@@ -1780,14 +1780,13 @@ object desugar {
           Apply(sel, arg :: Nil).setApplyKind(ApplyKind.InfixTuple)
         case _ =>
           Apply(sel, arg :: Nil)
-      apply.withSpan(Span(left.span.start, right.span.end, point = op.span.start))
 
     val apply = if op.name.isRightAssocOperatorName then
       makeOp(right, left, Span(op.span.start, right.span.end))
     else
-      makeOp(left, right, Span(left.span.start, op.span.end, op.span.start))
+      makeOp(left, right, Span(left.span.start, op.span.end, point = op.span.start))
     apply.pushAttachment(WasTypedInfix, ())
-    return apply
+    apply.withSpan(Span(left.span.start, right.span.end, point = op.span.start))
   }
 
   /** Translate throws type `A throws E1 | ... | En` to

--- a/tests/coverage/pos/Enum.scoverage.check
+++ b/tests/coverage/pos/Enum.scoverage.check
@@ -60,14 +60,14 @@ Class
 covtest.Planet
 surfaceGravity
 359
-386
+387
 15
 /
 Apply
 false
 0
 false
-G * mass / (radius * radius
+G * mass / (radius * radius)
 
 3
 Enum.scala

--- a/tests/coverage/run/lifting-bool/test.scoverage.check
+++ b/tests/coverage/run/lifting-bool/test.scoverage.check
@@ -230,14 +230,14 @@ Object
 <empty>.test$package
 Test
 249
-278
+279
 11
 &&
 Apply
 false
 0
 false
-true && (false && notCalled()
+true && (false && notCalled())
 
 13
 lifting-bool/test.scala

--- a/tests/explicit-nulls/neg/byname-nullables1.check
+++ b/tests/explicit-nulls/neg/byname-nullables1.check
@@ -1,4 +1,4 @@
--- Error: tests/explicit-nulls/neg/byname-nullables1.scala:10:6 --------------------------------------------------------
+-- Error: tests/explicit-nulls/neg/byname-nullables1.scala:10:12 -------------------------------------------------------
 10 |    f(x.fld != null) // error
    |      ^^^^^^^^^^^^^
    |      This argument was typed using flow assumptions about mutable variables

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -1,19 +1,19 @@
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:23:11 --------------------------------------
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:23:28 --------------------------------------
 23 |    cur = (() => f.write()) :: Nil  // error
-   |           ^^^^^^^^^^^^^^^^^^^^^^^
-   |           Found:    List[() ->{f} Unit]
-   |           Required: List[() ->{C} Unit]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^
+   |          Found:    List[() ->{f} Unit]
+   |          Required: List[() ->{C} Unit]
    |
-   |           Note that capability `f` cannot flow into capture set {C}.
+   |          Note that capability `f` cannot flow into capture set {C}.
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:34:7 ---------------------------------------
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:34:24 --------------------------------------
 34 |      (() => f.write()) :: Nil // error
-   |       ^^^^^^^^^^^^^^^^^^^^^^^
-   |       Found:    List[() ->{f} Unit]
-   |       Required: List[() ->{C} Unit]^{}
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^
+   |      Found:    List[() ->{f} Unit]
+   |      Required: List[() ->{C} Unit]^{}
    |
-   |       Note that capability `f` cannot flow into capture set {C} of value cur.
+   |      Note that capability `f` cannot flow into capture set {C} of value cur.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:54:27 --------------------------------------

--- a/tests/neg-custom-args/captures/sepchecks2.check
+++ b/tests/neg-custom-args/captures/sepchecks2.check
@@ -1,23 +1,3 @@
--- Error: tests/neg-custom-args/captures/sepchecks2.scala:10:10 --------------------------------------------------------
-10 |  println(c) // error
-   |          ^
-   |          Separation failure: Illegal access to {c} which is hidden by the previous definition
-   |          of value xs with type List[box () => Unit].
-   |          This type hides capabilities  {c}
--- Error: tests/neg-custom-args/captures/sepchecks2.scala:13:25 --------------------------------------------------------
-13 |  foo((() => println(c)) :: Nil, c) // error
-   |      ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |      Separation failure: argument of type  List[box () ->{c} Unit]
-   |      to method foo: (xs: List[box () => Unit], y: Object^): Nothing
-   |      corresponds to capture-polymorphic formal parameter xs of type  List[box () => Unit]
-   |      and hides capabilities  {c}.
-   |      Some of these overlap with the captures of the second argument with type  (c : Object^).
-   |
-   |        Hidden set of current argument        : {c}
-   |        Hidden footprint of current argument  : {c}
-   |        Capture set of second argument        : {c}
-   |        Footprint set of second argument      : {c}
-   |        The two sets overlap at               : {c}
 -- Error: tests/neg-custom-args/captures/sepchecks2.scala:14:10 --------------------------------------------------------
 14 |  val x1: (Object^, Object^) = (c, c) // error
    |          ^^^^^^^^^^^^^^^^^^

--- a/tests/neg-custom-args/captures/sepchecks2.check
+++ b/tests/neg-custom-args/captures/sepchecks2.check
@@ -1,3 +1,23 @@
+-- Error: tests/neg-custom-args/captures/sepchecks2.scala:10:10 --------------------------------------------------------
+10 |  println(c) // error
+   |          ^
+   |          Separation failure: Illegal access to {c} which is hidden by the previous definition
+   |          of value xs with type List[box () => Unit].
+   |          This type hides capabilities  {c}
+-- Error: tests/neg-custom-args/captures/sepchecks2.scala:13:25 --------------------------------------------------------
+13 |  foo((() => println(c)) :: Nil, c) // error
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      Separation failure: argument of type  List[box () ->{c} Unit]
+   |      to method foo: (xs: List[box () => Unit], y: Object^): Nothing
+   |      corresponds to capture-polymorphic formal parameter xs of type  List[box () => Unit]
+   |      and hides capabilities  {c}.
+   |      Some of these overlap with the captures of the second argument with type  (c : Object^).
+   |
+   |        Hidden set of current argument        : {c}
+   |        Hidden footprint of current argument  : {c}
+   |        Capture set of second argument        : {c}
+   |        Footprint set of second argument      : {c}
+   |        The two sets overlap at               : {c}
 -- Error: tests/neg-custom-args/captures/sepchecks2.scala:14:10 --------------------------------------------------------
 14 |  val x1: (Object^, Object^) = (c, c) // error
    |          ^^^^^^^^^^^^^^^^^^

--- a/tests/neg-scalajs/js-native-members.check
+++ b/tests/neg-scalajs/js-native-members.check
@@ -56,7 +56,7 @@
 13 |  def c: Int = 3 // error
    |               ^
    |               Concrete members of JS native types may only call js.native.
--- Error: tests/neg-scalajs/js-native-members.scala:14:23 --------------------------------------------------------------
+-- Error: tests/neg-scalajs/js-native-members.scala:14:25 --------------------------------------------------------------
 14 |  def d(x: Int): Int = x + 1 // error
    |                       ^^^^^
    |                       Concrete members of JS native types may only call js.native.

--- a/tests/neg-scalajs/js-native-val-defs.check
+++ b/tests/neg-scalajs/js-native-val-defs.check
@@ -6,7 +6,7 @@
 11 |  def b: Int = 3 // error
    |               ^
    |               @js.native members may only call js.native.
--- Error: tests/neg-scalajs/js-native-val-defs.scala:14:23 -------------------------------------------------------------
+-- Error: tests/neg-scalajs/js-native-val-defs.scala:14:25 -------------------------------------------------------------
 14 |  def c(x: Int): Int = x + 1 // error
    |                       ^^^^^
    |                       @js.native members may only call js.native.

--- a/tests/neg-scalajs/js-trait-members.check
+++ b/tests/neg-scalajs/js-trait-members.check
@@ -22,7 +22,7 @@
 12 |  var c2: Int = 5 // error
    |  ^^^^^^^^^^^^^^^
    |  Members of non-native JS traits must either be abstract, or their right-hand-side must be `js.undefined`.
--- Error: tests/neg-scalajs/js-trait-members.scala:14:24 ---------------------------------------------------------------
+-- Error: tests/neg-scalajs/js-trait-members.scala:14:26 ---------------------------------------------------------------
 14 |  def d1(x: Int): Int = x + 1 // error
    |                        ^^^^^
    |                        In non-native JS traits, defs with parentheses must be abstract.

--- a/tests/neg/into-inferred.check
+++ b/tests/neg/into-inferred.check
@@ -1,4 +1,4 @@
--- [E007] Type Mismatch Error: tests/neg/into-inferred.scala:33:32 -----------------------------------------------------
+-- [E007] Type Mismatch Error: tests/neg/into-inferred.scala:33:44 -----------------------------------------------------
 33 |  val l1: List[into[Keyword]] = l :+ "then" :+ "else"  // error
    |                                ^^^^^^^^^^^^^^^^^^^^^
    |                                Found:    List[Conversion.into[Keyword] | String]

--- a/tests/run/typeCheckErrors.check
+++ b/tests/run/typeCheckErrors.check
@@ -1,1 +1,1 @@
-List(Error(value check is not a member of Unit,compileError("1" * 2).check(""),22,Typer), Error(argument to compileError must be a statically known String but was: augmentString("1") * 2,compileError("1" * 2).check(""),13,Typer))
+List(Error(value check is not a member of Unit,compileError("1" * 2).check(""),22,Typer), Error(argument to compileError must be a statically known String but was: augmentString("1") * 2,compileError("1" * 2).check(""),17,Typer))

--- a/tests/warn/21557.check
+++ b/tests/warn/21557.check
@@ -1,10 +1,10 @@
--- [E190] Potential Issue Warning: tests/warn/21557.scala:9:16 ---------------------------------------------------------
+-- [E190] Potential Issue Warning: tests/warn/21557.scala:9:18 ---------------------------------------------------------
 9 |  val x: Unit = 1 + 1 // warn
   |                ^^^^^
   |                Discarded non-Unit value of type Int. Add `: Unit` to discard silently.
   |
   | longer explanation available when compiling with `-explain`
--- [E176] Potential Issue Warning: tests/warn/21557.scala:10:2 ---------------------------------------------------------
+-- [E176] Potential Issue Warning: tests/warn/21557.scala:10:4 ---------------------------------------------------------
 10 |  1 + 1 // warn
    |  ^^^^^
    |  unused value of type (2 : Int)

--- a/tests/warn/nonunit-statement.check
+++ b/tests/warn/nonunit-statement.check
@@ -14,7 +14,7 @@
 30 |  copy()                  // warn
    |  ^^^^^^
    |  unused value of type K
--- [E176] Potential Issue Warning: tests/warn/nonunit-statement.scala:37:2 ---------------------------------------------
+-- [E176] Potential Issue Warning: tests/warn/nonunit-statement.scala:37:5 ---------------------------------------------
 37 |  27 +: xs                // warn
    |  ^^^^^^^^
    |  unused value of type List[Int]
@@ -60,7 +60,7 @@
  97 |      println("true")
  98 |...
 103 |    }
--- [E176] Potential Issue Warning: tests/warn/nonunit-statement.scala:116:4 --------------------------------------------
+-- [E176] Potential Issue Warning: tests/warn/nonunit-statement.scala:116:8 --------------------------------------------
 116 |    set += a     // warn because cannot know whether the `set` was supposed to be consumed or assigned
     |    ^^^^^^^^
     |    unused value of type scala.collection.mutable.LinkedHashSet[A]

--- a/tests/warn/warn-value-discard.check
+++ b/tests/warn/warn-value-discard.check
@@ -6,8 +6,8 @@
 37 |    mutable.Set.empty[String].subtractOne("") // warn
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |    discarded non-Unit value of type scala.collection.mutable.Set[String]. Add `: Unit` to discard silently.
--- [E175] Potential Issue Warning: tests/warn/warn-value-discard.scala:57:4 --------------------------------------------
-57 |    mutable.Set.empty[String] += "" // warn
+-- [E175] Potential Issue Warning: tests/warn/warn-value-discard.scala:59:30 -------------------------------------------
+59 |    mutable.Set.empty[String] += "" // warn
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |    discarded non-Unit value of type scala.collection.mutable.Set[String]. Add `: Unit` to discard silently.
 -- [E175] Potential Issue Warning: tests/warn/warn-value-discard.scala:15:35 -------------------------------------------

--- a/tests/warn/warn-value-discard.check
+++ b/tests/warn/warn-value-discard.check
@@ -6,8 +6,8 @@
 37 |    mutable.Set.empty[String].subtractOne("") // warn
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |    discarded non-Unit value of type scala.collection.mutable.Set[String]. Add `: Unit` to discard silently.
--- [E175] Potential Issue Warning: tests/warn/warn-value-discard.scala:59:30 -------------------------------------------
-59 |    mutable.Set.empty[String] += "" // warn
+-- [E175] Potential Issue Warning: tests/warn/warn-value-discard.scala:57:30 -------------------------------------------
+57 |    mutable.Set.empty[String] += "" // warn
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |    discarded non-Unit value of type scala.collection.mutable.Set[String]. Add `: Unit` to discard silently.
 -- [E175] Potential Issue Warning: tests/warn/warn-value-discard.scala:15:35 -------------------------------------------


### PR DESCRIPTION
Found during debugging of https://github.com/scala/scala3/issues/22566

Basically, we created new apply based on `arg` inside `Parens` that led to shorter span.
```scala
        case Parens(arg) =>
          Apply(sel, assignToNamedArg(arg) :: Nil)
```