### PR TITLE
Dealias before checking for member in lint

### DIFF
--- a/tests/warn/ext-override.scala
+++ b/tests/warn/ext-override.scala
@@ -1,4 +1,4 @@
-//> using options -Xfatal-warnings
+//> using options -Werror
 
 trait Foo[T]:
   extension (x: T)

--- a/tests/warn/i16743.scala
+++ b/tests/warn/i16743.scala
@@ -66,7 +66,7 @@ trait DungeonDweller:
 trait SadDungeonDweller:
   def f[A](x: Dungeon.IArray[A]) = 27 // x.length // just to confirm, length is not a member
 
-trait Quote:
+trait Quote: // see tests/warn/ext-override.scala
   type Tree <: AnyRef
   given TreeMethods: TreeMethods
   trait TreeMethods:

--- a/tests/warn/i22232.scala
+++ b/tests/warn/i22232.scala
@@ -23,6 +23,7 @@ object Upperbound3:
 object NonUpperbound1:
   opaque type MyString[+T] = String
   extension (arr: MyString[Byte]) def length: Int = 0 // nowarn
+
 object NonUpperbound2:
   opaque type MyString[+T] = String
   extension [T <: MyString[Byte]](arr: T) def length2: Int = 0 // nowarn
@@ -30,3 +31,7 @@ object NonUpperbound2:
 object NonUpperbound3:
   opaque type MyString[+T] = String
   extension [T](arr: T) def length: Int = 0 // nowarn
+
+object NonUpperbound4:
+  opaque type MyString = String
+  extension (arr: MyString) def length: Int = 0 // nowarn

--- a/tests/warn/i22705.scala
+++ b/tests/warn/i22705.scala
@@ -1,0 +1,28 @@
+//> using options -Werror
+
+object Native {
+  class Obj:
+    def f: String = "F"
+}
+
+object Types {
+
+  opaque type Node = Native.Obj
+
+  type S = Node
+
+  object S:
+    def apply(): S = new Node
+
+  extension (s: S)
+    def f: String = "S"
+}
+
+import Types.*
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val v: S = S()
+    println(v.f)
+  }
+}

--- a/tests/warn/i22706.scala
+++ b/tests/warn/i22706.scala
@@ -1,0 +1,30 @@
+//> using options -Werror
+
+object Native {
+  class O {
+    def f: String = "F"
+  }
+  class M extends O
+}
+
+object Types {
+  opaque type N = Native.O
+  opaque type GS = Native.M
+
+  type S = N | GS
+
+  object S:
+    def apply(): S = new N
+
+  extension (s: S)
+    def f: String = "S"
+}
+
+import Types.*
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val v: S = S()
+    println(v.f)
+  }
+}

--- a/tests/warn/i22727.scala
+++ b/tests/warn/i22727.scala
@@ -1,0 +1,14 @@
+//> using options -Werror
+
+object Main {
+  type IXY = (Int, Int)
+
+  extension (xy: IXY) {
+    def map(f: Int => Int): (Int, Int) = (f(xy._1), f(xy._2))
+  }
+
+  def main(args: Array[String]): Unit = {
+    val a = (0, 1)
+    println(a)
+  }
+}


### PR DESCRIPTION
Fixes #22705
Fixes #22706 
Fixes #22727 

Follow-up to https://github.com/scala/scala3/pull/22502 by inserting a `dealias` when arriving at `target` type.

Refactored the body of `hidden` to make it easier to read. Adjusted the doc for the same reason.

As a reminder to self, the original reason for special handling of aliases was due to subclassing, but overrides are excluded. (One could restore that warning for edge cases.)

The long doc explaining the handling of leading implicits is moved to the end (as an appendix).

Despite best efforts, I was unable to make the doc longer than the code.