### PR TITLE
3.6.4/issue/22692 unused import

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -726,8 +726,10 @@ object CheckUnused:
             else
               selData.allSymbolsForNamed.contains(sym)
         else
+          if altName.exists(alt => alt.toTermName != sym.name.toTermName) then // rename is never a wildcard import
+            false
           // Wildcard
-          if selData.excludedMembers.contains(altName.getOrElse(sym.name).toTermName) then
+          else if selData.excludedMembers.contains(altName.getOrElse(sym.name).toTermName) then
             // Wildcard with exclusions that match the symbol
             false
           else if !selData.qualTpe.member(sym.name).hasAltWith(_.symbol == sym) then

--- a/tests/warn/i22692.scala
+++ b/tests/warn/i22692.scala
@@ -1,0 +1,8 @@
+
+//> using options -Wunused:all
+
+import javax.swing.*
+import javax.swing.event as swingEvent
+
+type b = AbstractButton
+type t = swingEvent.AncestorListener


### PR DESCRIPTION
Fixes #22692 

If the explicit name is different from the symbol name, then it must have been a rename on import.

That is never satisfied by a wildcard selector.
