### PR TITLE
Rename on import is never wildcard

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -284,8 +284,11 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
         case sel :: sels =>
           val matches =
             if sel.isWildcard then
+              // if name is different from sym.name, it must be a rename on import, not a wildcard selector
+              !name.exists(_.toTermName != sym.name.toTermName)
               // the qualifier must have the target symbol as a member
-              hasAltMember(sym.name) && {
+              && hasAltMember(sym.name)
+              && {
                 if sel.isGiven then // Further check that the symbol is a given or implicit and conforms to the bound
                      sym.isOneOf(GivenOrImplicit)
                   && (sel.bound.isEmpty || sym.info.finalResultType <:< sel.boundTpe)

--- a/tests/warn/i15503a.scala
+++ b/tests/warn/i15503a.scala
@@ -321,3 +321,10 @@ object Suppressed:
 object Suppressing:
   import Suppressed.* // no warn, see options
   def f = 42
+
+package i22692:
+  import javax.swing.*
+  import javax.swing.event as swingEvent // no warn, regression test for warning in 3.6
+
+  type b = AbstractButton
+  type t = swingEvent.AncestorListener


### PR DESCRIPTION
Forward port https://github.com/scala/scala3/pull/22710

For a symbol referenced by an alternate name, there must be renaming selector in scope (because the code typechecks), and that import is necessarily higher precedence than a wildcard and will be preferred.

However, it's ~wrong~ unnecessary to track the wildcard as a candidate solution. The laborious conversion to terms is necessary because the `name` does not remember whether it was a rename (i.e., due to an `OriginalName` attachment). Note that if the name test is more expensive than the current cost, then this commit would be less efficient; a mantra of the refactor was to defer the cost of executing a test.