### PR TITLE
fix: make pc actions work for re-exported symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1543,7 +1543,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    * @param selectorPredicate A test to find the selector to use.
    * @return The symbols imported.
    */
-  def importedSymbols(imp: Import,
+  def importedSymbols(imp: ImportOrExport,
                       selectorPredicate: untpd.ImportSelector => Boolean = util.common.alwaysTrue)
                      (using Context): List[Symbol] =
     imp.selectors.find(selectorPredicate) match

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1344,7 +1344,7 @@ class Namer { typer: Typer =>
             val ddef = tpd.DefDef(forwarder.asTerm, prefss => {
               val forwarderCtx = ctx.withOwner(forwarder)
               val (pathRefss, methRefss) = prefss.splitAt(extensionParamsCount(path.tpe.widen))
-              val ref = path.appliedToArgss(pathRefss).select(sym.asTerm)
+              val ref = path.appliedToArgss(pathRefss).select(sym.asTerm).withSpan(span.focus)
               val rhs = ref.appliedToArgss(adaptForwarderParams(Nil, sym.info, methRefss))
                 .etaExpandCFT(using forwarderCtx)
               if forwarder.isInlineMethod then

--- a/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
@@ -135,7 +135,7 @@ object MetalsInteractive:
           (sym, sym.info, None)
         )
 
-      case (imp: Import) :: _ =>
+      case (imp: ImportOrExport) :: _ =>
         importedSymbols(imp, _.span.contains(pos.span)).map(sym =>
           (sym, sym.info, None)
         )

--- a/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
@@ -63,7 +63,8 @@ trait PcCollector[T]:
           o.span.exists && o.span.point == named.symbol.owner.span.point
         )
 
-    def soughtOrOverride(sym: Symbol) =
+    def soughtOrOverride(sym0: Symbol) =
+      val sym = if sym0.is(Flags.Exported) then sym0.sourceSymbol else sym0
       sought(sym) || sym.allOverriddenSymbols.exists(sought(_))
 
     def soughtTreeFilter(tree: Tree): Boolean =
@@ -76,7 +77,7 @@ trait PcCollector[T]:
         case df: NamedDefTree
             if soughtOrOverride(df.symbol) && !df.symbol.isSetter =>
           true
-        case imp: Import if owners(imp.expr.symbol) => true
+        case imp: ImportOrExport if owners(imp.expr.symbol) => true
         case _ => false
 
     def soughtFilter(f: Symbol => Boolean): Boolean =
@@ -115,11 +116,13 @@ trait PcCollector[T]:
          */
         case ident: Ident if ident.isCorrectSpan && filter(ident) =>
           // symbols will differ for params in different ext methods, but source pos will be the same
-          if soughtFilter(_.sourcePos == ident.symbol.sourcePos)
+          val symbol = if ident.symbol.is(Flags.Exported) then ident.symbol.sourceSymbol else ident.symbol
+          if soughtFilter(_.sourcePos == symbol.sourcePos)
           then
             occurrences + collect(
               ident,
-              ident.sourcePos
+              ident.sourcePos,
+              Some(symbol)
             )
           else occurrences
         /**
@@ -228,7 +231,7 @@ trait PcCollector[T]:
          * For traversing import selectors:
          * import scala.util.<<Try>>
          */
-        case imp: Import if filter(imp) =>
+        case imp: ImportOrExport if filter(imp) =>
           imp.selectors
             .collect {
               case sel: ImportSelector

--- a/presentation-compiler/src/main/dotty/tools/pc/PcSymbolSearch.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcSymbolSearch.scala
@@ -49,7 +49,7 @@ trait PcSymbolSearch:
   lazy val soughtSymbols: Option[(Set[Symbol], SourcePosition)] =
     soughtSymbols(path)
 
-  def soughtSymbols(path: List[Tree]): Option[(Set[Symbol], SourcePosition)] =
+  private def soughtSymbols(path: List[Tree]): Option[(Set[Symbol], SourcePosition)] =
     val sought = path match
       /* reference of an extension paramter
        * extension [EF](<<xs>>: List[EF])
@@ -148,7 +148,7 @@ trait PcSymbolSearch:
       /* Import selectors:
        * import scala.util.Tr@@y
        */
-      case (imp: Import) :: _ if imp.span.contains(pos.span) =>
+      case (imp: ImportOrExport) :: _ if imp.span.contains(pos.span) =>
         imp
           .selector(pos.span)
           .map(sym => (symbolAlternatives(sym), sym.sourcePos))

--- a/presentation-compiler/src/main/dotty/tools/pc/WithCompilationUnit.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/WithCompilationUnit.scala
@@ -76,7 +76,9 @@ class WithCompilationUnit(
         }
       else Set.empty
     val all =
-      if sym.is(Flags.ModuleClass) then
+      if sym.is(Flags.Exported) then
+        Set(sym, sym.sourceSymbol)
+      else if sym.is(Flags.ModuleClass) then
         Set(sym, sym.companionModule, sym.companionModule.companion)
       else if sym.isClass then
         Set(sym, sym.companionModule, sym.companion.moduleClass)

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -339,7 +339,7 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
     end enclosedChildren
   end extension
 
-  extension (imp: Import)
+  extension (imp: ImportOrExport)
     def selector(span: Span)(using Context): Option[Symbol] =
       for sel <- imp.selectors.find(_.span.contains(span))
       yield imp.expr.symbol.info.member(sel.name).symbol

--- a/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
@@ -28,7 +28,8 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
       MockLocation("scala/Predef.Ensuring#ensuring(+2).", "Predef.scala"),
       MockLocation("scala/Predef.Ensuring#ensuring(+3).", "Predef.scala"),
       MockLocation("scala/collection/immutable/List#`::`().", "List.scala"),
-      MockLocation("scala/package.List.", "package.scala")
+      MockLocation("scala/package.List.", "package.scala"),
+      MockLocation("scala/collection/immutable/Vector.", "Vector.scala"),
     )
 
   override def definitions(offsetParams: OffsetParams): List[Location] =
@@ -611,3 +612,38 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
         |""".stripMargin
     )
 
+  @Test def i7256 =
+    check(
+      """|object Test:
+         |  def <<methodA>>: Unit = ???
+         |export Test.me@@thodA
+         |""".stripMargin
+    )
+
+  @Test def `i7256-2` =
+    check(
+      """|object Test:
+         |  def <<methodA>>: Unit = ???
+         |  def methodB: Unit = ???
+         |export Test.{me@@thodA, methodB}
+         |""".stripMargin
+    )
+
+  @Test def `i7256-3` =
+    check(
+      """|object Test:
+         |  def <<methodA>>: Unit = ???
+         |  def methodB: Unit = ???
+         |export Test.{methodA, methodB}
+         |
+         |val i = met@@hodA
+         |""".stripMargin
+    )
+
+  @Test def i7427 =
+    check(
+      """|package a
+         |object Repro:
+         |    export scala.collection.immutable.V/*scala/collection/immutable/Vector. Vector.scala*/@@ector
+         |""".stripMargin
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/highlight/DocumentHighlightSuite.scala
@@ -1486,5 +1486,45 @@ class DocumentHighlightSuite extends BaseDocumentHighlightSuite:
         |""".stripMargin
     )
 
+  @Test def i7256 =
+    check(
+      """|package a
+         |object Test:
+         |  def <<methodA>>: Unit = ???
+         |export Test.<<me@@thodA>>
+         |val i = <<methodA>>
+         |""".stripMargin
+    )
+
+  @Test def `i7256-2` =
+    check(
+      """|object Test:
+         |  def <<methodA>>: Unit = ???
+         |  def methodB: Unit = ???
+         |export Test.{<<me@@thodA>>, methodB}
+         |val i = <<methodA>>
+         |""".stripMargin
+    )
+
+
+  @Test def `i7256-3` =
+    check(
+      """|object Test:
+         |  def <<methodA>>: Unit = ???
+         |  def methodB: Unit = ???
+         |export Test.<<methodA>>
+         |val i = <<met@@hodA>>
+         |val j = <<methodA>>
+         |""".stripMargin
+    )
+
+  @Test def `i7256-4` =
+    check(
+      """|object Test:
+         |  class <<Foo>>
+         |  object <<Foo>>
+         |export Test.<<F@@oo>>
+         |""".stripMargin
+    )
 
 end DocumentHighlightSuite

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverDefnSuite.scala
@@ -262,3 +262,20 @@ class HoverDefnSuite extends BaseHoverSuite:
       """|type Numeric: Numeric
          |""".stripMargin.hover
     )
+
+  @Test def i7256 =
+    check(
+      """|object Test:
+         |  def methodA: Unit = ???
+         |export Test.me@@thodA
+         |""".stripMargin,
+      """|**Expression type**:
+         |```scala
+         |=> Unit
+         |```
+         |**Symbol signature**:
+         |```scala
+         |def methodA: Unit
+         |```
+         |""".stripMargin
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/tokens/SemanticTokensSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/tokens/SemanticTokensSuite.scala
@@ -463,3 +463,11 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite:
          |  end <<foo>>/*class,definition*/
          |""".stripMargin
    )
+
+  @Test def i7256 =
+    check(
+      """|object <<Test>>/*class*/:
+         |  def <<methodA>>/*method,definition*/: <<Unit>>/*class,abstract*/ = <<???>>/*method*/
+         |export <<Test>>/*class*/.<<methodA>>/*method*/
+         |""".stripMargin
+    )


### PR DESCRIPTION
fixes: https://github.com/scalameta/metals/issues/7256
fixes: https://github.com/scalameta/metals/issues/7427