### PR TITLE
Remove ^ in capture set syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -97,10 +97,10 @@ object Mode {
    *  Since this mode is only used during annotation typing,
    *  we can reuse the value of `ImplicitExploration` to save bits.
    */
-  val InCaptureSet: Mode = newMode(13, "InCaptureSet")
+  val InCaptureSet: Mode = ImplicitExploration
 
   /** We are currently unpickling Scala2 info */
-  val Scala2Unpickling: Mode = newMode(14, "Scala2Unpickling")
+  val Scala2Unpickling: Mode = newMode(13, "Scala2Unpickling")
 
   /** Signifies one of two possible situations:
    *   1. We are currently checking bounds to be non-empty, so we should not

--- a/compiler/src/dotty/tools/dotc/core/Mode.scala
+++ b/compiler/src/dotty/tools/dotc/core/Mode.scala
@@ -91,8 +91,16 @@ object Mode {
    */
   val ImplicitExploration: Mode = newMode(12, "ImplicitExploration")
 
+  /** We are currently inside a capture set.
+   *  A term name could be a capture variable, so we need to
+   *  check that it is valid to use as type name.
+   *  Since this mode is only used during annotation typing,
+   *  we can reuse the value of `ImplicitExploration` to save bits.
+   */
+  val InCaptureSet: Mode = newMode(13, "InCaptureSet")
+
   /** We are currently unpickling Scala2 info */
-  val Scala2Unpickling: Mode = newMode(13, "Scala2Unpickling")
+  val Scala2Unpickling: Mode = newMode(14, "Scala2Unpickling")
 
   /** Signifies one of two possible situations:
    *   1. We are currently checking bounds to be non-empty, so we should not

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1594,7 +1594,7 @@ object Parsers {
     }
 
     /** CaptureRef  ::=  { SimpleRef `.` } SimpleRef [`*`]
-     *                |  [ { SimpleRef `.` } SimpleRef `.` ] id `^`
+     *                |  [ { SimpleRef `.` } SimpleRef `.` ] id
      */
     def captureRef(): Tree =
       val ref = dotSelectors(simpleRef())
@@ -1602,12 +1602,6 @@ object Parsers {
         in.nextToken()
         atSpan(startOffset(ref)):
           PostfixOp(ref, Ident(nme.CC_REACH))
-      else if isIdent(nme.UPARROW) then
-        in.nextToken()
-        atSpan(startOffset(ref)):
-          convertToTypeId(ref) match
-            case ref: RefTree => makeCapsOf(ref)
-            case ref => ref
       else ref
 
     /**  CaptureSet ::=  `{` CaptureRef {`,` CaptureRef} `}`    -- under captureChecking

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -36,6 +36,7 @@ import annotation.threadUnsafe
 
 import scala.util.control.NonFatal
 import dotty.tools.dotc.inlines.Inlines
+import dotty.tools.dotc.cc.isRetains
 
 object Applications {
   import tpd.*
@@ -1114,7 +1115,9 @@ trait Applications extends Compatibility {
             val fun2 = Applications.retypeSignaturePolymorphicFn(fun1, methType)
             simpleApply(fun2, proto)
           case funRef: TermRef =>
-            val app = ApplyTo(tree, fun1, funRef, proto, pt)
+            // println(i"typedApply: $funRef, ${tree.args}, ${funRef.symbol.maybeOwner.isRetains}")
+            val applyCtx = if funRef.symbol.maybeOwner.isRetains then ctx.addMode(Mode.InCaptureSet) else ctx
+            val app = ApplyTo(tree, fun1, funRef, proto, pt)(using applyCtx)
             convertNewGenericArray(
               widenEnumCase(
                 postProcessByNameArgs(funRef, app).computeNullable(),

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -715,7 +715,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         && ctx.owner.owner.unforcedDecls.lookup(tree.name).exists
     then // we are in the arguments of a this(...) constructor call
       errorTree(tree, em"$tree is not accessible from constructor arguments")
-    else if ctx.mode.is(Mode.InCaptureSet) then
+    else if name.isTermName && ctx.mode.is(Mode.InCaptureSet) then
       // If we are in a capture set and the identifier is not a term name,
       // try to type it with the same name but as a type
       typed(untpd.makeCapsOf(untpd.cpy.Ident(tree)(name.toTypeName)), pt)
@@ -927,7 +927,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     // Otherwise, if we are in a capture set, try to type it as a capture variable
     // reference (as selecting a type name).
     def trySelectTypeInCaptureSet() =
-      if ctx.mode.is(Mode.InCaptureSet) && tree0.name.isTypeName then
+      if tree0.name.isTermName && ctx.mode.is(Mode.InCaptureSet) then
         typedSelectWithAdapt(untpd.cpy.Select(tree0)(qual, tree0.name.toTypeName), pt, qual)
       else EmptyTree
 

--- a/tests/neg-custom-args/captures/capset-bound.scala
+++ b/tests/neg-custom-args/captures/capset-bound.scala
@@ -5,7 +5,7 @@ class IO
 case class File(io: IO^)
 
 def test(io1: IO^, io2: IO^) =
-  def f[C >: CapSet^{io1} <: CapSet^](file: File^{C^}) = ???
+  def f[C >: CapSet^{io1} <: CapSet^](file: File^{C}) = ???
   val f1: File^{io1} = ???
   val f2: File^{io2} = ???
   val f3: File^{io1, io2} = ???

--- a/tests/neg-custom-args/captures/capset-bound2.scala
+++ b/tests/neg-custom-args/captures/capset-bound2.scala
@@ -2,7 +2,7 @@ import caps.*
 
 class IO
 
-def f[C^](io: IO^{C^}) = ???
+def f[C^](io: IO^{C}) = ???
 
 def test =
   f[CapSet](???)
@@ -10,4 +10,3 @@ def test =
   f[CapSet^](???)
   f[Nothing](???) // error
   f[String](???) // error
-  

--- a/tests/neg-custom-args/captures/capset-members.scala
+++ b/tests/neg-custom-args/captures/capset-members.scala
@@ -3,7 +3,7 @@ import caps.*
 trait Abstract[X^]:
   type C >: X <: CapSet^
   // Don't test the return type using Unit, because it is a pure type.
-  def boom(): AnyRef^{C^}
+  def boom(): AnyRef^{C}
 
 class Concrete extends Abstract[CapSet^{}]:
   type C = CapSet^{}
@@ -27,4 +27,3 @@ class Concrete5(a: AnyRef^, b: AnyRef^) extends Abstract[CapSet^{a}]:
 
 class Concrete6(a: AnyRef^, b: AnyRef^) extends Abstract[CapSet^{a}]:
   def boom(): AnyRef^{b} = b // error
-  

--- a/tests/neg-custom-args/captures/capture-parameters.scala
+++ b/tests/neg-custom-args/captures/capture-parameters.scala
@@ -2,8 +2,7 @@ import caps.*
 
 class C
 
-def test[X^, Y^, Z >: X <: Y](x: C^{X^}, y: C^{Y^}, z: C^{Z^}) =
-  val x2z: C^{Z^} = x
-  val z2y: C^{Y^} = z
-  val x2y: C^{Y^} = x // error
-  
+def test[X^, Y^, Z >: X <: Y](x: C^{X}, y: C^{Y}, z: C^{Z}) =
+  val x2z: C^{Z} = x
+  val z2y: C^{Y} = z
+  val x2y: C^{Y} = x // error

--- a/tests/neg-custom-args/captures/capture-poly.scala
+++ b/tests/neg-custom-args/captures/capture-poly.scala
@@ -5,8 +5,8 @@ trait Foo extends Capability
 trait CaptureSet:
   type C >: CapSet <: CapSet^
 
-def capturePoly[C^](a: Foo^{C^}): Foo^{C^} = a
-def capturePoly2(c: CaptureSet)(a: Foo^{c.C^}): Foo^{c.C^} = a
+def capturePoly[C^](a: Foo^{C}): Foo^{C} = a
+def capturePoly2(c: CaptureSet)(a: Foo^{c.C}): Foo^{c.C} = a
 
 def test =
   val x: Foo^ = ???
@@ -15,8 +15,8 @@ def test =
   object X extends CaptureSet:
     type C = CapSet^{x}
 
-  val z1: Foo^{X.C^} = x
-  val z2: Foo^{X.C^} = y // error
+  val z1: Foo^{X.C} = x
+  val z2: Foo^{X.C} = y // error
 
   val z3: Foo^{x} = capturePoly(x)
   val z4: Foo^{x} = capturePoly(y) // error

--- a/tests/neg-custom-args/captures/capture-vars-subtyping.scala
+++ b/tests/neg-custom-args/captures/capture-vars-subtyping.scala
@@ -3,32 +3,32 @@ import caps.*
 
 def test[C^] =
   val a: C = ???
-  val b: CapSet^{C^} = a
+  val b: CapSet^{C} = a
   val c: C = b
-  val d: CapSet^{C^, c} = a
+  val d: CapSet^{C, c} = a
 
 // TODO: make "CapSet-ness" of type variables somehow contagious?
 // Then we don't have to spell out the bounds explicitly...
 def testTrans[C^, D >: CapSet <: C, E >: CapSet <: D, F >: C <: CapSet^] =
   val d1: D = ???
-  val d2: CapSet^{D^} = d1
+  val d2: CapSet^{D} = d1
   val d3: D = d2
   val e1: E = ???
-  val e2: CapSet^{E^} = e1
+  val e2: CapSet^{E} = e1
   val e3: E = e2
   val d4: D = e1
   val c1: C = d1
   val c2: C = e1
   val f1: F = c1
-  val d_e_f1: CapSet^{D^,E^,F^} = d1
-  val d_e_f2: CapSet^{D^,E^,F^} = e1
-  val d_e_f3: CapSet^{D^,E^,F^} = f1
+  val d_e_f1: CapSet^{D,E,F} = d1
+  val d_e_f2: CapSet^{D,E,F} = e1
+  val d_e_f3: CapSet^{D,E,F} = f1
   val f2: F = d_e_f1
   val c3: C = d_e_f1 // error
   val c4: C = f1     // error
   val e4: E = f1     // error
   val e5: E = d1     // error
-  val c5: CapSet^{C^} = e1
+  val c5: CapSet^{C} = e1
 
 
 trait A[+T]
@@ -37,12 +37,12 @@ trait B[-C]
 
 def testCong[C^, D^] =
   val a: A[C] = ???
-  val b: A[CapSet^{C^}] = a
-  val c: A[CapSet^{D^}] = a // error
-  val d: A[CapSet^{C^,D^}] = a
+  val b: A[CapSet^{C}] = a
+  val c: A[CapSet^{D}] = a // error
+  val d: A[CapSet^{C,D}] = a
   val e: A[C] = d // error
   val f: B[C] = ???
-  val g: B[CapSet^{C^}] = f
+  val g: B[CapSet^{C}] = f
   val h: B[C] = g
-  val i: B[CapSet^{C^,D^}] = h // error
+  val i: B[CapSet^{C,D}] = h // error
   val j: B[C] = i

--- a/tests/neg-custom-args/captures/capture-vars-subtyping2.scala
+++ b/tests/neg-custom-args/captures/capture-vars-subtyping2.scala
@@ -10,32 +10,32 @@ trait BoundsTest:
 
   def testTransMixed[A^,
                     B >: CapSet <: A,
-                    C >: CapSet <: CapSet^{B^},
+                    C >: CapSet <: CapSet^{B},
                     D >: CapSet <: C,
-                    E >: CapSet <: CapSet^{D^},
-                    F >: CapSet <: CapSet^{A^,b},
-                    X >: CapSet <: CapSet^{F^,D^},
-                    Y >: CapSet^{F^} <: CapSet^{F^,A^,b},
-                    Z >: CapSet^{b} <: CapSet^{b,Y^}] =
+                    E >: CapSet <: CapSet^{D},
+                    F >: CapSet <: CapSet^{A,b},
+                    X >: CapSet <: CapSet^{F,D},
+                    Y >: CapSet^{F} <: CapSet^{F,A,b},
+                    Z >: CapSet^{b} <: CapSet^{b,Y}] =
     val e: E = ???
-    val e2: CapSet^{E^} = e
+    val e2: CapSet^{E} = e
     val ed: D = e
-    val ed2: CapSet^{D^} = e
+    val ed2: CapSet^{D} = e
     val ec: C = e
-    val ec2: CapSet^{C^} = e
+    val ec2: CapSet^{C} = e
     val eb: B = e
-    val eb2: CapSet^{B^} = e
+    val eb2: CapSet^{B} = e
     val ea: A = e
-    val ea2: CapSet^{A^} = e
+    val ea2: CapSet^{A} = e
     val ex: X = e            // error
-    val ex2: CapSet^{X^} = e // error
+    val ex2: CapSet^{X} = e // error
     val f: F = ???
-    val f2: CapSet^{F^} = f
+    val f2: CapSet^{F} = f
     val y: Y = f
-    val y2: CapSet^{Y^} = f
+    val y2: CapSet^{Y} = f
     val cb: CapSet^{b} = ???
     val z: Z = cb
-    val z2: CapSet^{Z^} = cb
+    val z2: CapSet^{Z} = cb
 
   def callTransMixed =
     val x, y, z: Bar^ = ???

--- a/tests/neg-custom-args/captures/cc-poly-1.scala
+++ b/tests/neg-custom-args/captures/cc-poly-1.scala
@@ -6,7 +6,7 @@ object Test:
   class C extends Capability
   class D
 
-  def f[X^](x: D^{X^}): D^{X^} = x
+  def f[X^](x: D^{X}): D^{X} = x
 
   def test(c1: C, c2: C) =
     f[Any](D()) // error

--- a/tests/neg-custom-args/captures/cc-poly-2.scala
+++ b/tests/neg-custom-args/captures/cc-poly-2.scala
@@ -6,7 +6,7 @@ object Test:
   class C extends Capability
   class D
 
-  def f[X^](x: D^{X^}): D^{X^} = x
+  def f[X^](x: D^{X}): D^{X} = x
 
   def test(c1: C, c2: C) =
     val d: D^ = D()

--- a/tests/neg-custom-args/captures/i21313.scala
+++ b/tests/neg-custom-args/captures/i21313.scala
@@ -6,7 +6,7 @@ trait Async:
 def foo(x: Async) = x.await(???) // error
 
 trait Source[+T, Cap^]:
-  final def await(using ac: Async^{Cap^}) = ac.await[T, Cap](this) // Contains[Cap, ac] is assured because {ac} <: Cap.
+  final def await(using ac: Async^{Cap}) = ac.await[T, Cap](this) // Contains[Cap, ac] is assured because {ac} <: Cap.
 
 def test(using ac1: Async^, ac2: Async^, x: String) =
   val src1 = new Source[Int, CapSet^{ac1}] {}

--- a/tests/neg-custom-args/captures/i21347.scala
+++ b/tests/neg-custom-args/captures/i21347.scala
@@ -1,6 +1,6 @@
 import language.experimental.captureChecking
 
-def runOps[C^](ops: List[() ->{C^} Unit]): Unit =
+def runOps[C^](ops: List[() ->{C} Unit]): Unit =
   ops.foreach: op => // error
     op()
 

--- a/tests/neg-custom-args/captures/i21868.scala
+++ b/tests/neg-custom-args/captures/i21868.scala
@@ -2,11 +2,11 @@ import caps.*
 
 trait AbstractWrong:
   type C <: CapSet
-  def f(): Unit^{C^} // error
+  def f(): Unit^{C} // error
 
 trait Abstract1:
   type C >: CapSet <: CapSet^
-  def f(): Unit^{C^}
+  def f(): Unit^{C}
 
 // class Abstract2:
 //   type C^

--- a/tests/neg-custom-args/captures/i21868b.scala
+++ b/tests/neg-custom-args/captures/i21868b.scala
@@ -7,7 +7,7 @@ class File
 
 trait Abstract:
   type C >: CapSet <: CapSet^
-  def f(file: File^{C^}): Unit
+  def f(file: File^{C}): Unit
 
 class Concrete1 extends Abstract:
   type C = CapSet
@@ -23,7 +23,7 @@ class Concrete3(io: IO^) extends Abstract:
 
 trait Abstract2(tracked val io: IO^):
   type C >: CapSet <: CapSet^{io}
-  def f(file: File^{C^}): Unit
+  def f(file: File^{C}): Unit
 
 class Concrete4(io: IO^) extends Abstract2(io):
   type C = CapSet
@@ -35,7 +35,7 @@ class Concrete5(io1: IO^, io2: IO^) extends Abstract2(io1):
 
 trait Abstract3[X^]:
   type C >: CapSet <: X
-  def f(file: File^{C^}): Unit
+  def f(file: File^{C}): Unit
 
 class Concrete6(io: IO^) extends Abstract3[CapSet^{io}]:
   type C = CapSet

--- a/tests/neg-custom-args/captures/i22005.scala
+++ b/tests/neg-custom-args/captures/i22005.scala
@@ -4,5 +4,5 @@ class IO
 class File(io: IO^)
 
 class Handler[C^]:
-  def f(file: File^): File^{C^} = file // error
-  def g(file: File^{C^}): File^ = file // ok
+  def f(file: File^): File^{C} = file // error
+  def g(file: File^{C}): File^ = file // ok

--- a/tests/neg-custom-args/captures/polyCaptures.check
+++ b/tests/neg-custom-args/captures/polyCaptures.check
@@ -1,8 +1,8 @@
 -- Error: tests/neg-custom-args/captures/polyCaptures.scala:4:22 -------------------------------------------------------
-4 |val runOpsCheck: [C^] -> (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps  // error
+4 |val runOpsCheck: [C^] -> (ops: List[() ->{C} Unit]) ->{C} Unit = runOps  // error
   |                      ^
   |          Implementation restriction: polymorphic function types cannot wrap function types that have capture sets
 -- Error: tests/neg-custom-args/captures/polyCaptures.scala:5:23 -------------------------------------------------------
-5 |val runOpsCheck2: [C^] => (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps // error
+5 |val runOpsCheck2: [C^] => (ops: List[() ->{C} Unit]) ->{C} Unit = runOps // error
   |                       ^
   |          Implementation restriction: polymorphic function types cannot wrap function types that have capture sets

--- a/tests/neg-custom-args/captures/polyCaptures.scala
+++ b/tests/neg-custom-args/captures/polyCaptures.scala
@@ -1,7 +1,7 @@
 class Box[X](val elem: X)
 
-val runOps = [C^] => (b: Box[() ->{C^} Unit]) => b.elem()
-val runOpsCheck: [C^] -> (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps  // error
-val runOpsCheck2: [C^] => (ops: List[() ->{C^} Unit]) ->{C^} Unit = runOps // error
+val runOps = [C^] => (b: Box[() ->{C} Unit]) => b.elem()
+val runOpsCheck: [C^] -> (ops: List[() ->{C} Unit]) ->{C} Unit = runOps  // error
+val runOpsCheck2: [C^] => (ops: List[() ->{C} Unit]) ->{C} Unit = runOps // error
 
 

--- a/tests/neg-custom-args/captures/use-capset.check
+++ b/tests/neg-custom-args/captures/use-capset.check
@@ -1,8 +1,8 @@
--- Error: tests/neg-custom-args/captures/use-capset.scala:5:50 ---------------------------------------------------------
-5 |private def g[C^] = (xs: List[Object^{C^}]) => xs.head // error
-  |                                               ^^^^^^^
-  |                                               Capture set parameter C leaks into capture scope of method g.
-  |                                               To allow this, the type C should be declared with a @use annotation
+-- Error: tests/neg-custom-args/captures/use-capset.scala:5:49 ---------------------------------------------------------
+5 |private def g[C^] = (xs: List[Object^{C}]) => xs.head // error
+  |                                              ^^^^^^^
+  |                                              Capture set parameter C leaks into capture scope of method g.
+  |                                              To allow this, the type C should be declared with a @use annotation
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:11:22 -----------------------------------
 11 |  val _: () -> Unit = h // error: should be ->{io}
    |                      ^

--- a/tests/neg-custom-args/captures/use-capset.scala
+++ b/tests/neg-custom-args/captures/use-capset.scala
@@ -1,10 +1,10 @@
 import caps.{use, CapSet}
 
-def f[C^](@use xs: List[Object^{C^}]): Unit = ???
+def f[C^](@use xs: List[Object^{C}]): Unit = ???
 
-private def g[C^] = (xs: List[Object^{C^}]) => xs.head // error
+private def g[C^] = (xs: List[Object^{C}]) => xs.head // error
 
-private def g2[@use C^] = (xs: List[Object^{C^}]) => xs.head // ok
+private def g2[@use C^] = (xs: List[Object^{C}]) => xs.head // ok
 
 def test(io: Object^)(@use xs: List[Object^{io}]): Unit =
   val h = () => f(xs)

--- a/tests/pos-custom-args/captures/cc-poly-1.scala
+++ b/tests/pos-custom-args/captures/cc-poly-1.scala
@@ -7,9 +7,9 @@ import caps.{CapSet, Capability}
   class C extends Capability
   class D
 
-  def f[X^](x: D^{X^}): D^{X^} = x
-  def g[X^](x: D^{X^}, y: D^{X^}): D^{X^} = x
-  def h[X^](): D^{X^} = ???
+  def f[X^](x: D^{X}): D^{X} = x
+  def g[X^](x: D^{X}, y: D^{X}): D^{X} = x
+  def h[X^](): D^{X} = ???
 
   def test(c1: C, c2: C) =
     val d: D^{c1, c2} = D()

--- a/tests/pos-custom-args/captures/cc-poly-source-capability.scala
+++ b/tests/pos-custom-args/captures/cc-poly-source-capability.scala
@@ -12,11 +12,11 @@ import caps.use
   class Listener
 
   class Source[X^]:
-    private var listeners: Set[Listener^{X^}] = Set.empty
-    def register(x: Listener^{X^}): Unit =
+    private var listeners: Set[Listener^{X}] = Set.empty
+    def register(x: Listener^{X}): Unit =
       listeners += x
 
-    def allListeners: Set[Listener^{X^}] = listeners
+    def allListeners: Set[Listener^{X}] = listeners
 
   def test1(async1: Async, @use others: List[Async]) =
     val src = Source[CapSet^{async1, others*}]

--- a/tests/pos-custom-args/captures/cc-poly-source.scala
+++ b/tests/pos-custom-args/captures/cc-poly-source.scala
@@ -10,11 +10,11 @@ import caps.use
   class Listener
 
   class Source[X^]:
-    private var listeners: Set[Listener^{X^}] = Set.empty
-    def register(x: Listener^{X^}): Unit =
+    private var listeners: Set[Listener^{X}] = Set.empty
+    def register(x: Listener^{X}): Unit =
       listeners += x
 
-    def allListeners: Set[Listener^{X^}] = listeners
+    def allListeners: Set[Listener^{X}] = listeners
 
   def test1(lbl1: Label^, lbl2: Label^) =
     val src = Source[CapSet^{lbl1, lbl2}]

--- a/tests/pos-custom-args/captures/cc-poly-varargs.scala
+++ b/tests/pos-custom-args/captures/cc-poly-varargs.scala
@@ -1,13 +1,13 @@
 abstract class Source[+T, Cap^]
 
 extension[T, Cap^](src: Source[T, Cap]^)
-  def transformValuesWith[U](f: (T -> U)^{Cap^}): Source[U, Cap]^{src, f} = ???
+  def transformValuesWith[U](f: (T -> U)^{Cap}): Source[U, Cap]^{src, f} = ???
 
-def race[T, Cap^](sources: Source[T, Cap]^{Cap^}*): Source[T, Cap]^{Cap^} = ???
+def race[T, Cap^](sources: Source[T, Cap]^{Cap}*): Source[T, Cap]^{Cap} = ???
 
 def either[T1, T2, Cap^](
-    src1: Source[T1, Cap]^{Cap^},
-    src2: Source[T2, Cap]^{Cap^}): Source[Either[T1, T2], Cap]^{Cap^} =
+    src1: Source[T1, Cap]^{Cap},
+    src2: Source[T2, Cap]^{Cap}): Source[Either[T1, T2], Cap]^{Cap} =
   val left = src1.transformValuesWith(Left(_))
   val right = src2.transformValuesWith(Right(_))
   race(left, right)

--- a/tests/pos-custom-args/captures/gears-problem-poly.scala
+++ b/tests/pos-custom-args/captures/gears-problem-poly.scala
@@ -7,8 +7,8 @@ trait Future[+T]:
 trait Channel[+T]:
   def read(): Ok[T]
 
-class Collector[T, C^](val futures: Seq[Future[T]^{C^}]):
-  val results: Channel[Future[T]^{C^}] = ???
+class Collector[T, C^](val futures: Seq[Future[T]^{C}]):
+  val results: Channel[Future[T]^{C}] = ???
 end Collector
 
 class Result[+T, +E]:
@@ -17,10 +17,10 @@ class Result[+T, +E]:
 case class Err[+E](e: E) extends Result[Nothing, E]
 case class Ok[+T](x: T) extends Result[T, Nothing]
 
-extension [T, C^](@use fs: Seq[Future[T]^{C^}])
+extension [T, C^](@use fs: Seq[Future[T]^{C}])
   def awaitAllPoly =
     val collector = Collector(fs)
-    val fut: Future[T]^{C^} = collector.results.read().get
+    val fut: Future[T]^{C} = collector.results.read().get
 
 extension [T](@use fs: Seq[Future[T]^])
   def awaitAll = fs.awaitAllPoly

--- a/tests/pos-custom-args/captures/i21313.scala
+++ b/tests/pos-custom-args/captures/i21313.scala
@@ -3,17 +3,17 @@ import caps.CapSet
 trait Async:
   def await[T, Cap^](using caps.Contains[Cap, this.type])(src: Source[T, Cap]^): T =
     val x: Async^{this} = ???
-    val y: Async^{Cap^} = x
+    val y: Async^{Cap} = x
     val ac: Async^ = ???
     def f(using caps.Contains[Cap, ac.type]) =
       val x2: Async^{this} = ???
-      val y2: Async^{Cap^} = x2
+      val y2: Async^{Cap} = x2
       val x3: Async^{ac} = ???
-      val y3: Async^{Cap^} = x3
+      val y3: Async^{Cap} = x3
     ???
 
 trait Source[+T, Cap^]:
-  final def await(using ac: Async^{Cap^}) = ac.await[T, Cap](this) // Contains[Cap, ac] is assured because {ac} <: Cap.
+  final def await(using ac: Async^{Cap}) = ac.await[T, Cap](this) // Contains[Cap, ac] is assured because {ac} <: Cap.
 
 def test(using ac1: Async^, ac2: Async^, x: String) =
   val src1 = new Source[Int, CapSet^{ac1}] {}

--- a/tests/pos-custom-args/captures/i21347.scala
+++ b/tests/pos-custom-args/captures/i21347.scala
@@ -4,7 +4,7 @@ import language.experimental.captureChecking
 
 class Box[Cap^] {}
 
-def run[Cap^](f: Box[Cap]^{Cap^} => Unit): Box[Cap]^{Cap^} = ???
+def run[Cap^](f: Box[Cap]^{Cap} => Unit): Box[Cap]^{Cap} = ???
 
 def main() =
   val b = run(_ => ())

--- a/tests/pos-custom-args/captures/i21507.scala
+++ b/tests/pos-custom-args/captures/i21507.scala
@@ -1,10 +1,10 @@
 import language.experimental.captureChecking
 
 trait Box[Cap^]:
-  def store(f: (() -> Unit)^{Cap^}): Unit
+  def store(f: (() -> Unit)^{Cap}): Unit
 
-def run[Cap^](f: Box[Cap]^{Cap^} => Unit): Box[Cap]^{Cap^} =
+def run[Cap^](f: Box[Cap]^{Cap} => Unit): Box[Cap]^{Cap} =
   new Box[Cap]:
-    private var item: () ->{Cap^} Unit = () => ()
-    def store(f: () ->{Cap^} Unit): Unit =
+    private var item: () ->{Cap} Unit = () => ()
+    def store(f: () ->{Cap} Unit): Unit =
       item = f  // was error, now ok

--- a/tests/pos-custom-args/captures/setup/a_1.scala
+++ b/tests/pos-custom-args/captures/setup/a_1.scala
@@ -3,4 +3,4 @@ import language.experimental.captureChecking
 import scala.caps.CapSet
 
 trait A:
-  def f[C^](x: AnyRef^{C^}): Unit
+  def f[C^](x: AnyRef^{C}): Unit

--- a/tests/pos-custom-args/captures/setup/b_1.scala
+++ b/tests/pos-custom-args/captures/setup/b_1.scala
@@ -2,4 +2,4 @@ import language.experimental.captureChecking
 import scala.caps.CapSet
 
 class B extends A:
-  def f[C^](x: AnyRef^{C^}): Unit = ???
+  def f[C^](x: AnyRef^{C}): Unit = ???

--- a/tests/pos-custom-args/captures/setup/b_2.scala
+++ b/tests/pos-custom-args/captures/setup/b_2.scala
@@ -2,4 +2,4 @@ import language.experimental.captureChecking
 import scala.caps.CapSet
 
 class B extends A:
-  def f[C^](x: AnyRef^{C^}): Unit = ???
+  def f[C^](x: AnyRef^{C}): Unit = ???


### PR DESCRIPTION
This PR simplifies the capture set syntax by removing unnecessary `^` symbols in capture sets. 
This change is the first step making the syntax cleaner and more consistent for capture polymorphism.

1. Added a new `InCaptureSet` mode in `Mode.scala` to handle capture set annotation typing;
2. Modified the parser to remove the `^` suffix from capture set syntax
3. If `InCaptureSet` is set and a term ident or select is not found, retry typing as a type wrapped in `CapsOf`.