### PR TITLE
Restore resolving prefixes of implicit Ident

### DIFF
--- a/tests/warn/i22744.scala
+++ b/tests/warn/i22744.scala
@@ -1,0 +1,35 @@
+
+//> using options -Wunused:privates -Werror
+
+object test {
+  private trait Foo[A] { val value: A }
+
+  private object Foo { // no warn prefix of implicit value
+    given int: Foo[Int] = new Foo[Int] { val value = 1 }
+  }
+
+  val i = summon[Foo[Int]].value
+}
+
+object supplement {
+  private trait Foo[A] { val value: A }
+
+  private object Foo { // no warn prefix of implicit value
+    given int: Foo[Int] = new Foo[Int] { val value = 1 }
+  }
+
+  private def fooValue[A](using f: Foo[A]): A = f.value
+
+  val i = fooValue[Int]
+}
+
+package p:
+  private trait Foo[A] { val value: A }
+
+  private object Foo { // no warn prefix of implicit value
+    given int: Foo[Int] = new Foo[Int] { val value = 1 }
+  }
+
+  private def fooValue[A](using f: Foo[A]): A = f.value
+
+  val i = fooValue[Int]


### PR DESCRIPTION
Fixes #22744 

This code was originally for derived, but is also needed for implicits (where private objects are in the path).

https://github.com/scala/scala3/pull/17095