### PR TITLE
No warning for parameter of overriding method

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -580,6 +580,7 @@ object CheckUnused:
       end checkExplicit
       // begin
       if !infos.skip(m)
+        && !m.nextOverriddenSymbol.exists
         && !allowed
       then
         checkExplicit()

--- a/tests/warn/i15503e.scala
+++ b/tests/warn/i15503e.scala
@@ -70,10 +70,10 @@ package foo.test.i16865:
   trait Bar extends Foo
 
   object Ex extends Bar:
-    def fn(a: Int, b: Int): Int = b + 3 // warn
+    def fn(a: Int, b: Int): Int = b + 3 // no warn (override)
 
   object Ex2 extends Bar:
-    override def fn(a: Int, b: Int): Int = b + 3 // warn
+    override def fn(a: Int, b: Int): Int = b + 3 // no warn (override)
 
 final class alpha(externalName: String) extends StaticAnnotation // no warn annotation arg
 

--- a/tests/warn/i22742.scala
+++ b/tests/warn/i22742.scala
@@ -1,0 +1,10 @@
+//> using options -Wunused:all -Werror
+
+trait Foldable[F[_]]:
+  def foldLeft[A, B](fa: F[A], b: B)(f: (B, A) => B): B
+
+type Id[A] = A
+
+given foldableId: Foldable[Id] =
+  new Foldable[Id]:
+    def foldLeft[A, B](fa: Id[A], b: B)(f: (B, A) => B): B = b

--- a/tests/warn/scala2-t11681.scala
+++ b/tests/warn/scala2-t11681.scala
@@ -23,7 +23,7 @@ trait BadAPI extends InterFace {
     a
   }
   override def call(a: Int,
-                    b: String, // warn now
+                    b: String, // no warn (override)
                     c: Double): Int = {
     println(c)
     a

--- a/tests/warn/unused-params.scala
+++ b/tests/warn/unused-params.scala
@@ -23,7 +23,7 @@ trait BadAPI extends InterFace {
     a
   }
   override def call(a: Int,
-                    b: String, // warn
+                    b: String, // no warn (override)
                     c: Double): Int = {
     println(c)
     a
@@ -136,7 +136,7 @@ trait BadMix { self: InterFace =>
 }
 
 class Unequal {
-  override def equals(other: Any) = toString.nonEmpty   // warn
+  override def equals(other: Any) = toString.nonEmpty   // no warn (override)
 }
 
 class Seriously {


### PR DESCRIPTION
Quiet the unused parameter warning when the method is an override.

Fixes #22742 
