### PR TITLE
Fail compilation if multiple conflicting top-level private defs/vals are in the same package

### DIFF
--- a/tests/neg/i22721.check
+++ b/tests/neg/i22721.check
@@ -1,0 +1,4 @@
+-- [E161] Naming Error: tests/neg/i22721/test2.scala:3:4 ---------------------------------------------------------------
+3 |val foobar: Int = 0 // error
+  |^^^^^^^^^^^^^^^^^^^
+  |foobar is already defined as value foobar in tests/neg/i22721/test1.scala

--- a/tests/neg/i22721.check
+++ b/tests/neg/i22721.check
@@ -1,4 +1,6 @@
--- [E161] Naming Error: tests/neg/i22721/test2.scala:3:4 ---------------------------------------------------------------
-3 |val foobar: Int = 0 // error
-  |^^^^^^^^^^^^^^^^^^^
-  |foobar is already defined as value foobar in tests/neg/i22721/test1.scala
+-- [E161] Naming Error: tests/neg/i22721/test2.scala:3:12 --------------------------------------------------------------
+3 |private def foobar: Int = 0 // error
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |foobar is already defined as method foobar in tests/neg/i22721/test1.scala
+  |
+  |Note that overloaded methods must all be defined in the same group of toplevel definitions

--- a/tests/neg/i22721/test1.scala
+++ b/tests/neg/i22721/test1.scala
@@ -1,0 +1,4 @@
+package example
+
+private def foobar: String = "foo"
+object test1 { def x = foobar }

--- a/tests/neg/i22721/test2.scala
+++ b/tests/neg/i22721/test2.scala
@@ -1,0 +1,4 @@
+package example
+
+private def foobar: Int = 0 // error
+object test2 { def x = foobar }

--- a/tests/neg/toplevel-overload/moredefs_1.scala
+++ b/tests/neg/toplevel-overload/moredefs_1.scala
@@ -2,4 +2,4 @@ trait B
 
 def f(x: B) = s"B" // error: has already been compiled
 
-private def g(): Unit = () // OK, since it is private
+private def g(): Unit = () // error: has already been compiled (def is visible in package)


### PR DESCRIPTION
Fixes #22721
Now the private top level definitions act basically the same as package private. To be honest, I am not completely certain that this is what's supposed to happen here, but:
* it would make the top level definitions access modifiers act the same as for class/objects
* that's what the reference seems to imply: https://docs.scala-lang.org/scala3/reference/dropped-features/package-objects.html:
```
3. The notion of private is independent of whether a definition is wrapped or not. A private top-level definition is always visible from everywhere in the enclosing package.
4. If several top-level definitions are overloaded variants with the same name, they must all come from the same source file.
```
Private top level definitions should be visible from other files (as long as they share a package), and if multiple share the same name, they should be in the same files (so it seems they should error out if found in different files).