### PR TITLE
Disable cache require clean on CI

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -349,6 +349,7 @@ object Build {
           buildCache
             .withLocal(buildCache.local.withEnabled(true).withStoreEnabled(true))
             .withRemote(buildCache.remote.withEnabled(true).withStoreEnabled(isInsideCI))
+            .withRequireClean(!isInsideCI)
         )
         .withTestRetry(
           config.testRetry


### PR DESCRIPTION
 This removes the need to write `clean; compile` everywhere in the Github jobs.