### PR TITLE
Disable require clean and fix caching of bootstrapped compilation

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -349,6 +349,7 @@ object Build {
           buildCache
             .withLocal(buildCache.local.withEnabled(true).withStoreEnabled(true))
             .withRemote(buildCache.remote.withEnabled(true).withStoreEnabled(isInsideCI))
+            .withRequireClean(!isInsideCI)
         )
         .withTestRetry(
           config.testRetry


### PR DESCRIPTION
It adds the full classpath of scala3-compiler as compilation input of all bootstrapped modules. Whenever the compiler classpath changes, it triggers a full recompilation of all bootstrapped modules.