### PR TITLE
Add capture-checking annotations to `scala.util.boundary`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -532,6 +532,7 @@ object StdNames {
     val isEmpty: N              = "isEmpty"
     val isInstanceOf_ : N       = "isInstanceOf"
     val isInstanceOfPM: N       = "$isInstanceOf$"
+    val isSameLabelAs : N       = "isSameLabelAs"
     val java: N                 = "java"
     val key: N                  = "key"
     val label: N                = "label"

--- a/compiler/src/dotty/tools/dotc/transform/DropBreaks.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DropBreaks.scala
@@ -63,10 +63,10 @@ class DropBreaks extends MiniPhase:
        */
       def unapply(expr: Tree)(using Context): Option[(Symbol, Symbol)] = stripTyped(expr) match
         case If(
-          Apply(Select(Select(ex: Ident, label), eq), (lbl @ Ident(local)) :: Nil),
+          Apply(Select(ex: Ident, isSameLabelAs), (lbl @ Ident(local)) :: Nil),
           Select(ex2: Ident, value),
           Apply(throww, (ex3: Ident) :: Nil))
-        if label == nme.label && eq == nme.eq && local == nme.local && value == nme.value
+        if isSameLabelAs == nme.isSameLabelAs && local == nme.local && value == nme.value
             && throww.symbol == defn.throwMethod
             && ex.symbol == ex2.symbol && ex.symbol == ex3.symbol =>
           Some((ex.symbol, lbl.symbol))

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -39,7 +39,7 @@ object boundary:
     /*message*/ null, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false):
 
     /** Compare the given [[Label]] to the one this [[Break]] was constructed with. */
-    inline def isSameLabelAs(other: Label[T]) = label eq other
+    def isSameLabelAs(other: Label[T]) = label eq other
 
   object Break:
     def apply[T](label: Label[T], value: T) =

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -1,0 +1,27 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/boundary.scala:8:31 --------------------------------------
+8 |      boundary.break(l2)(using l1) // error
+  |                               ^^
+  |                               Found:    (local : scala.util.boundary.Label[scala.util.boundary.Label[Unit]]^)
+  |                               Required: scala.util.boundary.Label[box scala.util.boundary.Label[Unit]^{local²}]^
+  |
+  |                               where:    local  is a value locally defined in object test
+  |                                         local² is a value locally defined in object test
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/boundary.scala:6:32 --------------------------------------
+ 6 |  boundary[boundary.Label[Unit]]: l1 ?=> // error
+   |  ^
+   |  Found:    scala.util.boundary.Break[scala.util.boundary.Label[Unit]] @unchecked
+   |  Required: scala.util.boundary.Break[box scala.util.boundary.Label[Unit]^] @unchecked
+ 7 |    boundary[Unit]: l2 ?=>
+ 8 |      boundary.break(l2)(using l1) // error
+ 9 |    ???
+   |--------------------------------------------------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from boundary.scala:73
+73 |    catch case ex: Break[T] @unchecked =>
+   |                   ^
+    --------------------------------------------------------------------------------------------------------------------
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/boundary.scala
+++ b/tests/neg-custom-args/captures/boundary.scala
@@ -1,0 +1,9 @@
+import language.experimental.captureChecking
+
+import scala.util.boundary
+
+object test:
+  boundary[boundary.Label[Unit]]: l1 ?=> // error
+    boundary[Unit]: l2 ?=>
+      boundary.break(l2)(using l1) // error
+    ???


### PR DESCRIPTION
Adds capture-tracking annotations to `scala.util.boundary`.

The following changes are made:
- `Label[T]` is now a capability, directly inheriting `caps.Capability`.
- `Break` exception:
  - now does not expose the `.label` field. **This is a source-breaking change**. - however, `label` is still `private[boundary]`, which should make it TASTy- and binary-compatible.
  - While we don't expect any code to inspect the values inside a `Break` exception, if some code is manually implementing `boundary.apply`'s logic, we instead provide a `isSameLabelAs` method, that compares the given `Label[T]` with the inner `Label` without leaking it.
- **Note that catching `Break` exceptions may still possibly cause them to escape the `boundary`.**

To demonstrate that capture-checking works, a test is included.
