### PR TITLE
Skip splice level checking for <refinement> symbols

### DIFF
--- a/compiler/src/dotty/tools/dotc/staging/HealType.scala
+++ b/compiler/src/dotty/tools/dotc/staging/HealType.scala
@@ -76,7 +76,7 @@ class HealType(pos: SrcPos)(using Context) extends TypeMap {
     tp match
       case tp @ NamedType(NoPrefix, _) if level > levelOf(tp.symbol) => tp.symbol
       case tp: NamedType if !tp.symbol.isStatic => levelInconsistentRootOfPath(tp.prefix)
-      case tp: ThisType if level > levelOf(tp.cls) => tp.cls
+      case tp: ThisType if level > levelOf(tp.cls) && !tp.cls.isRefinementClass => tp.cls
       case _ => NoSymbol
 
   /** Try to heal reference to type `T` used in a higher level than its definition.

--- a/tests/pos/i22648.scala
+++ b/tests/pos/i22648.scala
@@ -1,0 +1,14 @@
+import scala.quoted.*
+
+def fooImpl(using Quotes): Expr[Any] =
+  '{
+    new AnyRef {
+      type T = Unit
+      def make: T = ()
+      def take(t: T): Unit = ()
+    }: {
+      type T
+      def make: T
+      def take(t: T): Unit
+    }
+  }


### PR DESCRIPTION
This is safe to skip because <refinement> symbols can only be a part of type refinement self referencing prefix, where it is impossible to splice anything.

For some context, this is how the test case looks in typer:
```scala
{
  final class $anon() extends AnyRef() {
    type T = Unit
    def make: T = ()
    def take(t: T): Unit = ()
  }
  new $anon():
    {z1 => Object{type T; def make: z1.T; def take(t: z1.T): Unit}}
}:
  Object
    {
      type T >: Nothing <: Any
      def make: <refinement>.this.T
      def take(t: <refinement>.this.T): Unit
    }
```
The compiler sometimes instead of creating a recursive type directly (`{z1 => ...}`), creates <refinement> symbols which reference an enclosing refinement, replacing those with recursive types later.  
Fixes #22648