### PR TITLE
Remove trace in adaptBoxed

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1333,8 +1333,6 @@ class CheckCaptures extends Recheck, SymTransformer:
             return actual
           case _ =>
 
-        trace(adaptStr, capt, show = true) {
-
         // Decompose the actual type into the inner shape type, the capture set and the box status
         val actualShape = if actual.isFromJavaObject then actual else actual.stripCapturing
         val actualIsBoxed = actual.isBoxedCapturing
@@ -1403,7 +1401,6 @@ class CheckCaptures extends Recheck, SymTransformer:
           else adaptedShape
             .capturing(if alwaysConst then CaptureSet(captures.elems) else captures)
             .forceBoxStatus(resultIsBoxed)
-        }
       end recur
 
       recur(actual, expected, covariant)


### PR DESCRIPTION
The project currently doesn't clean compile with tracing enabled because there is a `return` in a `trace` block in `CheckCaptures.scala`, which is a non-local return when tracing is enabled.

```
[info] compiling 595 Scala sources and 8 Java sources to /localhome/bovel/scala3/compiler/target/scala-3.6.4-RC1/classes ...
[warn] -- Warning: /localhome/bovel/scala3/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala:1387:14 
[warn] 1387 |              return actual
[warn]      |              ^^^^^^^^^^^^^
[warn]      |Non local returns are no longer supported; use `boundary` and `boundary.break` in `scala.util` instead
[error] No warnings can be incurred under -Werror (or -Xfatal-warnings)
[warn] one warning found
[error] one error found
[error] (scala3-compiler / Compile / compileIncremental) Compilation failed
[error] Total time: 26 s, completed Mar 13, 2025, 10:09:01 AM
```

Interestingly, first compiling with `tracingEnabled = false` and then switching to `true` works 🤔 
