### PR TITLE
chore: add support for 'abstract override' modifier

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/api.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/api.scala
@@ -43,6 +43,7 @@ enum Modifier(val name: String, val prefix: Boolean):
   case Open extends Modifier("open", true)
   case Transparent extends Modifier("transparent", true)
   case Infix extends Modifier("infix", true)
+  case AbsOverride extends Modifier("abstract override", true)
 
 case class ExtensionTarget(name: String, typeParams: Seq[TypeParameter], argsLists: Seq[TermParameterList], signature: Signature, dri: DRI, position: Long)
 case class ImplicitConversion(from: DRI, to: DRI)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/SymOps.scala
@@ -98,7 +98,8 @@ object SymOps:
         Flags.Open -> Modifier.Open,
         Flags.Override -> Modifier.Override,
         Flags.Case -> Modifier.Case,
-        Flags.Opaque -> Modifier.Opaque
+        Flags.Opaque -> Modifier.Opaque,
+        Flags.AbsOverride -> Modifier.AbsOverride,
       ).collect {
         case (flag, mod) if sym.flags.is(flag) => mod
       }


### PR DESCRIPTION
Closes #22780 

I'm not sure where to add a test for this, but I've run it locally and it works as expected:

<img width="1728" alt="Screenshot 2025-03-14 at 01 48 41" src="https://github.com/user-attachments/assets/40c0a80d-5152-4eb2-8c77-2699186cf81a" />
