### PR TITLE
Show the Autofill completion case as what would be auto-filled

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -261,13 +261,17 @@ object CompletionValue:
   end NamedArg
 
   case class Autofill(
-      value: String
+      value: String,
+      _label: String,
   ) extends CompletionValue:
+    private inline val descriptionText = "Autofill with default values"
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Enum
     override def completionItemDataKind: Integer = CompletionSource.OverrideKind.ordinal
     override def insertText: Option[String] = Some(value)
-    override def label: String = "Autofill with default values"
+    override def label: String = _label
+    override def description(printer: ShortenedTypePrinter)(using Context): String = descriptionText
+    override def filterText: Option[String] = Some(label + " " + descriptionText)
 
   case class Keyword(label: String, override val insertText: Option[String])
       extends CompletionValue:

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionValue.scala
@@ -262,16 +262,12 @@ object CompletionValue:
 
   case class Autofill(
       value: String,
-      _label: String,
+      override val label: String,
   ) extends CompletionValue:
-    private inline val descriptionText = "Autofill with default values"
     override def completionItemKind(using Context): CompletionItemKind =
       CompletionItemKind.Enum
     override def completionItemDataKind: Integer = CompletionSource.OverrideKind.ordinal
     override def insertText: Option[String] = Some(value)
-    override def label: String = _label
-    override def description(printer: ShortenedTypePrinter)(using Context): String = descriptionText
-    override def filterText: Option[String] = Some(label + " " + descriptionText)
 
   case class Keyword(label: String, override val insertText: Option[String])
       extends CompletionValue:

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
@@ -339,9 +339,16 @@ object NamedArgCompletions:
               s"${param.nameBackticked.replace("$", "$$")} = $${${index + 1}${findDefaultValue(param)}}"
           }
           .mkString(", ")
+        val labelText = allParams
+          .collect {
+            case param if !param.symbol.is(Flags.HasDefault) =>
+              s"${param.nameBackticked.replace("$", "$$")} = ???"
+          }
+          .mkString(", ")
         List(
           CompletionValue.Autofill(
-            editText
+            editText,
+            labelText,
           )
         )
       else List.empty

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
@@ -1128,3 +1128,16 @@ class CompletionArgSuite extends BaseCompletionSuite:
       """x: Int
         |x = : Any""".stripMargin,
     )
+
+  @Test def `autofill-arguments-case-class` =
+    check(
+      """
+        |case class A(x: Int, y: Int)
+        |
+        |def main() =
+        |  A(x@@)
+        |""".stripMargin,
+      """x = : Int
+        |x = ???, y = ???Autofill with default values""".stripMargin,
+      // this looks strange due to the Autofill message belonging to the description
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
@@ -1138,6 +1138,6 @@ class CompletionArgSuite extends BaseCompletionSuite:
         |  A(x@@)
         |""".stripMargin,
       """x = : Int
-        |x = ???, y = ???Autofill with default values""".stripMargin,
+        |x = ???, y = ???""".stripMargin,
       // this looks strange due to the Autofill message belonging to the description
     )


### PR DESCRIPTION
## Partial Fix for scalameta/metals#7274

We have in our completion provider an option to automatically fill a case class constructor with named parameters:

```scala
case class A(x: Int, y: Int)

val a = A(@@)
          ^^ // would fill in here
val a = A(x = ???, y = ???)
          //  ^^^      ^^^  cursor marks added, so tabs can be used to move between the fields
```

However previously it was labeled `Autofill with default values`, which would never pass editors' filters based on the
current state of input (most likely the name of a field).
The only way to find this option was to type something matching the `Autofill with default values` label, which explains the
`auto` in the above issue.

We now provide the actual provided fields as the label, so the above would show `x = ???, y = ???` instead, which is both
more intuitive for the user, and more friendly to editors.

~~As a fallback, the hidden text sent to editors for filtering still contains `Autofill with default values`, so typing `auto`
or any old variant would still work as before.~~
