### PR TITLE
Better selection of name for ReassignmentToVal error message

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1389,7 +1389,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         def lhs1 = adapt(lhsCore, LhsProto, locked)
 
         def reassignmentToVal =
-          report.error(ReassignmentToVal(lhsCore.symbol.name), tree.srcPos)
+          val lhsName = lhsCore match {
+            case nameTree: NameTree => nameTree.name
+            case _ => lhsCore.symbol.name
+          }
+          report.error(ReassignmentToVal(lhsName), tree.srcPos)
           cpy.Assign(tree)(lhsCore, typed(tree.rhs, lhs1.tpe.widen)).withType(defn.UnitType)
 
         def canAssign(sym: Symbol) =

--- a/tests/neg/i22671.check
+++ b/tests/neg/i22671.check
@@ -1,0 +1,18 @@
+-- [E052] Type Error: tests/neg/i22671.scala:6:6 -----------------------------------------------------------------------
+6 |  X.x = 27 // error
+  |  ^^^^^^^^
+  |  Reassignment to val x
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:10:4 ----------------------------------------------------------------------
+10 |  x = 27 // error
+   |  ^^^^^^
+   |  Reassignment to val x
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E052] Type Error: tests/neg/i22671.scala:14:4 ----------------------------------------------------------------------
+14 |  x = 27 // error
+   |  ^^^^^^
+   |  Reassignment to val x
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i22671.scala
+++ b/tests/neg/i22671.scala
@@ -1,0 +1,14 @@
+object X:
+  def x: Int = 42
+  def x(y: Int): Int = x + y
+
+def test1 =
+  X.x = 27 // error
+
+def test2 =
+  import X.x
+  x = 27 // error
+
+def test3 =
+  val x = 42
+  x = 27 // error


### PR DESCRIPTION
Use name from tree when it is a NameTree for the ReassignmentToVal error message

Fixes #22671