### PR TITLE
Patch empty implicit parens on error recovery

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -512,9 +512,9 @@ object Trees {
 
   /** The kind of application */
   enum ApplyKind:
-    case Regular      // r.f(x)
-    case Using        // r.f(using x)
-    case InfixTuple   // r f (x1, ..., xN) where N != 1;  needs to be treated specially for an error message in typedApply
+    case Regular    // r.f(x)
+    case Using      // r.f(using x)
+    case InfixTuple // r f (x1, ..., xN) where N != 1; needs to be treated specially for an error message in typedApply
 
   /** fun(args) */
   case class Apply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -14,7 +14,7 @@ import printing.Highlighting.*
 import printing.Formatting
 import ErrorMessageID.*
 import ast.Trees
-import config.{Feature, ScalaVersion}
+import config.{Feature, MigrationVersion, ScalaVersion}
 import transform.patmat.Space
 import transform.patmat.SpaceEngine
 import typer.ErrorReporting.{err, matchReductionAddendum, substitutableTypeSymbolsInScope}
@@ -1591,6 +1591,14 @@ class MissingArgument(pname: Name, methString: String)(using Context)
     if pname.firstPart contains '$' then s"not enough arguments for $methString"
     else s"missing argument for parameter $pname of $methString"
   def explain(using Context) = ""
+
+class MissingImplicitParameterInEmptyArguments(pname: Name, methString: String)(using Context)
+  extends MissingArgument(pname, methString):
+  override def msg(using Context) =
+    val mv = MigrationVersion.ImplicitParamsWithoutUsing
+    super.msg.concat(Message.rewriteNotice("This code", mv.patchFrom)) // patch emitted up the stack
+  override def explain(using Context) =
+    "Old-style implicit argument lists may be omitted but not empty; this syntax was corrected in 3.7."
 
 class MissingArgumentList(method: String, sym: Symbol)(using Context)
   extends TypeMsg(MissingArgumentListID) {

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1258,7 +1258,8 @@ trait Applications extends Compatibility {
             }
           else
             tryEither(simpleApply(fun1, proto)): (failedVal, failedState) =>
-              // a bug allowed empty parens to expand to implicit args, offer rewrite only on migration, then retry
+              // a bug allowed empty parens to expand to implicit args, offer rewrite only on migration,
+              // then retry with using to emulate the bug since rewrites are ignored on error.
               if proto.args.isEmpty && maybePatchBadParensForImplicit(failedState) then
                 tryWithUsing(fun1, proto).getOrElse:
                   failedState.commit()

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -625,7 +625,8 @@ object ProtoTypes {
       else new FunProto(args, resType)(typer, applyKind, state)(using newCtx)
 
     def withApplyKind(applyKind: ApplyKind) =
-      new FunProto(args, resType)(typer, applyKind, state)
+      if applyKind == this.applyKind then this
+      else new FunProto(args, resType)(typer, applyKind, state)
   }
 
   /** A prototype for expressions that appear in function position

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -623,6 +623,9 @@ object ProtoTypes {
     override def withContext(newCtx: Context): ProtoType =
       if newCtx `eq` protoCtx then this
       else new FunProto(args, resType)(typer, applyKind, state)(using newCtx)
+
+    def withApplyKind(applyKind: ApplyKind) =
+      new FunProto(args, resType)(typer, applyKind, state)
   }
 
   /** A prototype for expressions that appear in function position

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -86,7 +86,8 @@ class CompilationTests {
       compileFile("tests/rewrites/i22440.scala", defaultOptions.and("-rewrite")),
       compileFile("tests/rewrites/i22731.scala", defaultOptions.and("-rewrite", "-source:3.7-migration")),
       compileFile("tests/rewrites/i22731b.scala", defaultOptions.and("-rewrite", "-source:3.7-migration")),
-      compileFile("tests/rewrites/implicit-to-given.scala", defaultOptions.and("-rewrite", "-Yimplicit-to-given"))
+      compileFile("tests/rewrites/implicit-to-given.scala", defaultOptions.and("-rewrite", "-Yimplicit-to-given")),
+      compileFile("tests/rewrites/i22792.scala", defaultOptions.and("-rewrite")),
     ).checkRewrites()
   }
 

--- a/tests/neg/i22439.check
+++ b/tests/neg/i22439.check
@@ -2,6 +2,9 @@
 7 |  f() // error f() missing arg
   |  ^^^
   |  missing argument for parameter i of method f: (implicit i: Int, j: Int): Int
+  |  This code can be rewritten automatically under -rewrite -source 3.7-migration.
+  |
+  | longer explanation available when compiling with `-explain`
 -- [E050] Type Error: tests/neg/i22439.scala:8:2 -----------------------------------------------------------------------
 8 |  g() // error g(given_Int, given_Int)() doesn't take more params
   |  ^
@@ -24,3 +27,6 @@
 21 |  val (ws, zs) = vs.unzip() // error!
    |                 ^^^^^^^^^^
    |missing argument for parameter asPair of method unzip in trait StrictOptimizedIterableOps: (implicit asPair: ((Int, Int)) => (A1, A2)): (List[A1], List[A2])
+   |This code can be rewritten automatically under -rewrite -source 3.7-migration.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i22792.check
+++ b/tests/neg/i22792.check
@@ -1,0 +1,10 @@
+-- [E171] Type Error: tests/neg/i22792.scala:8:30 ----------------------------------------------------------------------
+8 |@main def Test = new Foo().run() // error
+  |                 ^^^^^^^^^^^^^^^
+  |                 missing argument for parameter ev of method run in class Foo: (implicit ev: Permit): Unit
+  |                 This code can be rewritten automatically under -rewrite -source 3.7-migration.
+  |---------------------------------------------------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | Old-style implicit argument lists may be omitted but not empty; this syntax was corrected in 3.7.
+   ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i22792.scala
+++ b/tests/neg/i22792.scala
@@ -1,0 +1,8 @@
+//> using options -explain
+
+trait Permit
+class Foo:
+  def run(implicit ev: Permit): Unit = ???
+
+given Permit = ???
+@main def Test = new Foo().run() // error

--- a/tests/rewrites/i22792.check
+++ b/tests/rewrites/i22792.check
@@ -8,4 +8,8 @@ class Foo:
 given Permit = ???
 @main def Test = new Foo().run
 
-def otherSyntax = Foo()
+def ctorProxy = Foo().run
+
+def otherSyntax = new Foo().apply // Foo().apply does not work
+
+def kwazySyntax = new Foo() . run // that was fun

--- a/tests/rewrites/i22792.check
+++ b/tests/rewrites/i22792.check
@@ -3,6 +3,9 @@
 trait Permit
 class Foo:
   def run(implicit ev: Permit): Unit = ???
+  def apply(implicit ev: Permit): Unit = ???
 
 given Permit = ???
 @main def Test = new Foo().run
+
+def otherSyntax = Foo()

--- a/tests/rewrites/i22792.check
+++ b/tests/rewrites/i22792.check
@@ -1,0 +1,8 @@
+//> using options -source 3.7-migration
+
+trait Permit
+class Foo:
+  def run(implicit ev: Permit): Unit = ???
+
+given Permit = ???
+@main def Test = new Foo().run

--- a/tests/rewrites/i22792.scala
+++ b/tests/rewrites/i22792.scala
@@ -3,6 +3,9 @@
 trait Permit
 class Foo:
   def run(implicit ev: Permit): Unit = ???
+  def apply(implicit ev: Permit): Unit = ???
 
 given Permit = ???
 @main def Test = new Foo().run()
+
+def otherSyntax = Foo()()

--- a/tests/rewrites/i22792.scala
+++ b/tests/rewrites/i22792.scala
@@ -8,4 +8,8 @@ class Foo:
 given Permit = ???
 @main def Test = new Foo().run()
 
-def otherSyntax = Foo()()
+def ctorProxy = Foo().run()
+
+def otherSyntax = new Foo()() // Foo().apply does not work
+
+def kwazySyntax = new Foo() . run  (  /* your args here! */  ) // that was fun

--- a/tests/rewrites/i22792.scala
+++ b/tests/rewrites/i22792.scala
@@ -1,0 +1,8 @@
+//> using options -source 3.7-migration
+
+trait Permit
+class Foo:
+  def run(implicit ev: Permit): Unit = ???
+
+given Permit = ???
+@main def Test = new Foo().run()


### PR DESCRIPTION
Offer a rewrite for an erroneous application `f()` where the parameter list is `implicit` and a parameter lacks a default arg.

This was never official syntax, but was accepted from 3.3.4/3.4.2 due to a bug. The rewrite is for 3.7-migration, using the existing `MigrationVersion.ImplicitParamsWithoutUsing`, since that is a similar bit of syntax.

Fixes #22792 
