### PR TITLE
chore: do not run the backporting workflow on forks

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   add-to-backporting-project:
-    if: "!contains(github.event.push.head_commit.message, '[Next only]')"
+    if: "!contains(github.event.push.head_commit.message, '[Next only]') &&
+         github.repository == 'scala/scala3'"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I'm using my own fork of the scala3 repo (`hamzaremmal/scala3`) and each time I sync it from the upstream (`scala/scala3`) I start having CI errors.

This PR changes the behaviour of the backporting workflow to only run on `scala/scala3` as it should.

[skip ci]