### PR TITLE
Two fixes to handling of abstract types with cap bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1574,36 +1574,13 @@ class CheckCaptures extends Recheck, SymTransformer:
     */
     def checkOverrides = new TreeTraverser:
       class OverridingPairsCheckerCC(clazz: ClassSymbol, self: Type, tree: Tree)(using Context) extends OverridingPairsChecker(clazz, self):
-        /** Check subtype with box adaptation.
-        *  This function is passed to RefChecks to check the compatibility of overriding pairs.
-        *  @param sym  symbol of the field definition that is being checked
-
-        override def checkSubType(actual: Type, expected: Type)(using Context): Boolean =
-          val expected1 = alignDependentFunction(addOuterRefs(expected, actual, tree.srcPos), actual.stripCapturing)
-          val actual1 =
-            val saved = curEnv
-            try
-              curEnv = Env(clazz, EnvKind.NestedInOwner, capturedVars(clazz), outer0 = curEnv)
-              val adapted =
-                adaptBoxed(actual, expected1, tree, covariant = true, alwaysConst = true)
-              actual match
-                case _: MethodType =>
-                  // We remove the capture set resulted from box adaptation for method types,
-                  // since class methods are always treated as pure, and their captured variables
-                  // are charged to the capture set of the class (which is already done during
-                  // box adaptation).
-                  adapted.stripCapturing
-                case _ => adapted
-            finally curEnv = saved
-          actual1 frozen_<:< expected1
-        */
 
         /** Omit the check if one of {overriding,overridden} was nnot capture checked */
         override def needsCheck(overriding: Symbol, overridden: Symbol)(using Context): Boolean =
           !setup.isPreCC(overriding) && !setup.isPreCC(overridden)
 
         /** Perform box adaptation for override checking */
-        override def adapt(member: Symbol, memberTp: Type, otherTp: Type)(using Context): Option[(Type, Type)] =
+        override def adaptOverridePair(member: Symbol, memberTp: Type, otherTp: Type)(using Context): Option[(Type, Type)] =
           if member.isType then
             memberTp match
               case TypeAlias(_) =>
@@ -1613,26 +1590,36 @@ class CheckCaptures extends Recheck, SymTransformer:
                     Some((memberTp, otherTp.unboxed))
                   case _ => None
               case _ => None
-          else
-            val expected1 = alignDependentFunction(addOuterRefs(otherTp, memberTp, tree.srcPos), memberTp.stripCapturing)
-            val actual1 =
-              val saved = curEnv
-              try
-                curEnv = Env(clazz, EnvKind.NestedInOwner, capturedVars(clazz), outer0 = curEnv)
-                val adapted =
-                  adaptBoxed(memberTp, expected1, tree, covariant = true, alwaysConst = true)
-                memberTp match
-                  case _: MethodType =>
-                    // We remove the capture set resulted from box adaptation for method types,
-                    // since class methods are always treated as pure, and their captured variables
-                    // are charged to the capture set of the class (which is already done during
-                    // box adaptation).
-                    adapted.stripCapturing
-                  case _ => adapted
-              finally curEnv = saved
-            if (actual1 eq memberTp) && (expected1 eq otherTp) then None
-            else Some((actual1, expected1))
-        end adapt
+          else memberTp match
+            case memberTp @ ExprType(memberRes) =>
+              adaptOverridePair(member, memberRes, otherTp) match
+                case Some((mres, otp)) => Some((memberTp.derivedExprType(mres), otp))
+                case None => None
+            case _ => otherTp match
+              case otherTp @ ExprType(otherRes) =>
+                adaptOverridePair(member, memberTp, otherRes) match
+                  case Some((mtp, ores)) => Some((mtp, otherTp.derivedExprType(ores)))
+                  case None => None
+              case _ =>
+                val expected1 = alignDependentFunction(addOuterRefs(otherTp, memberTp, tree.srcPos), memberTp.stripCapturing)
+                val actual1 =
+                  val saved = curEnv
+                  try
+                    curEnv = Env(clazz, EnvKind.NestedInOwner, capturedVars(clazz), outer0 = curEnv)
+                    val adapted =
+                      adaptBoxed(memberTp, expected1, tree, covariant = true, alwaysConst = true)
+                    memberTp match
+                      case _: MethodType =>
+                        // We remove the capture set resulted from box adaptation for method types,
+                        // since class methods are always treated as pure, and their captured variables
+                        // are charged to the capture set of the class (which is already done during
+                        // box adaptation).
+                        adapted.stripCapturing
+                      case _ => adapted
+                  finally curEnv = saved
+                if (actual1 eq memberTp) && (expected1 eq otherTp) then None
+                else Some((actual1, expected1))
+        end adaptOverridePair
 
         override def checkInheritedTraitParameters: Boolean = false
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1585,9 +1585,18 @@ class CheckCaptures extends Recheck, SymTransformer:
             memberTp match
               case TypeAlias(_) =>
                 otherTp match
-                  case otherTp: RealTypeBounds
-                  if otherTp.hi.isBoxedCapturing || otherTp.lo.isBoxedCapturing =>
-                    Some((memberTp, otherTp.unboxed))
+                  case otherTp: RealTypeBounds =>
+                    if otherTp.hi.isBoxedCapturing || otherTp.lo.isBoxedCapturing then
+                      Some((memberTp, otherTp.unboxed))
+                    else otherTp.hi match
+                      case hi @ CapturingType(parent: TypeRef, refs)
+                      if parent.symbol == defn.Caps_CapSet && refs.isUniversal =>
+                        Some((
+                          memberTp,
+                          otherTp.derivedTypeBounds(
+                            otherTp.lo,
+                            hi.derivedCapturingType(parent, root.Fresh().singletonCaptureSet))))
+                      case _ => None
                   case _ => None
               case _ => None
           else memberTp match

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1341,7 +1341,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         else if !owner.exists then false
         else isPure(owner.info) && isPureContext(owner.owner, limit)
 
-      // Augment expeced capture set `erefs` by all references in actual capture
+      // Augment expected capture set `erefs` by all references in actual capture
       // set `arefs` that are outside some `C.this.type` reference in `erefs` for an enclosing
       // class `C`. If an added reference is not a ThisType itself, add it to the capture set
       // (i.e. use set) of the `C`. This makes sure that any outer reference implicitly subsumed
@@ -1577,7 +1577,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         /** Check subtype with box adaptation.
         *  This function is passed to RefChecks to check the compatibility of overriding pairs.
         *  @param sym  symbol of the field definition that is being checked
-        */
+
         override def checkSubType(actual: Type, expected: Type)(using Context): Boolean =
           val expected1 = alignDependentFunction(addOuterRefs(expected, actual, tree.srcPos), actual.stripCapturing)
           val actual1 =
@@ -1596,10 +1596,43 @@ class CheckCaptures extends Recheck, SymTransformer:
                 case _ => adapted
             finally curEnv = saved
           actual1 frozen_<:< expected1
+        */
 
         /** Omit the check if one of {overriding,overridden} was nnot capture checked */
         override def needsCheck(overriding: Symbol, overridden: Symbol)(using Context): Boolean =
           !setup.isPreCC(overriding) && !setup.isPreCC(overridden)
+
+        /** Perform box adaptation for override checking */
+        override def adapt(member: Symbol, memberTp: Type, otherTp: Type)(using Context): Option[(Type, Type)] =
+          if member.isType then
+            memberTp match
+              case TypeAlias(_) =>
+                otherTp match
+                  case otherTp: RealTypeBounds
+                  if otherTp.hi.isBoxedCapturing || otherTp.lo.isBoxedCapturing =>
+                    Some((memberTp, otherTp.unboxed))
+                  case _ => None
+              case _ => None
+          else
+            val expected1 = alignDependentFunction(addOuterRefs(otherTp, memberTp, tree.srcPos), memberTp.stripCapturing)
+            val actual1 =
+              val saved = curEnv
+              try
+                curEnv = Env(clazz, EnvKind.NestedInOwner, capturedVars(clazz), outer0 = curEnv)
+                val adapted =
+                  adaptBoxed(memberTp, expected1, tree, covariant = true, alwaysConst = true)
+                memberTp match
+                  case _: MethodType =>
+                    // We remove the capture set resulted from box adaptation for method types,
+                    // since class methods are always treated as pure, and their captured variables
+                    // are charged to the capture set of the class (which is already done during
+                    // box adaptation).
+                    adapted.stripCapturing
+                  case _ => adapted
+              finally curEnv = saved
+            if (actual1 eq memberTp) && (expected1 eq otherTp) then None
+            else Some((actual1, expected1))
+        end adapt
 
         override def checkInheritedTraitParameters: Boolean = false
 
@@ -1875,7 +1908,9 @@ class CheckCaptures extends Recheck, SymTransformer:
           def traverse(t: Tree)(using Context) = t match
             case tree: InferredTypeTree =>
             case tree: New =>
-            case tree: TypeTree => checkAppliedTypesIn(tree.withType(tree.nuType))
+            case tree: TypeTree =>
+              CCState.withCapAsRoot:
+                checkAppliedTypesIn(tree.withType(tree.nuType))
             case _ => traverseChildren(t)
         checkApplied.traverse(unit)
     end postCheck

--- a/compiler/src/dotty/tools/dotc/cc/root.scala
+++ b/compiler/src/dotty/tools/dotc/cc/root.scala
@@ -162,7 +162,9 @@ object root:
     case _ if root.isCap => Some(Kind.Global)
     case _ => None
 
-  /** Map each occurrence of cap to a different Sep.Cap instance */
+  /** Map each occurrence of cap to a different Fresh instance
+   *  Exception: CapSet^ stays as it is.
+   */
   class CapToFresh(owner: Symbol)(using Context) extends BiTypeMap, FollowAliasesMap:
     thisMap =>
 
@@ -171,6 +173,8 @@ object root:
       else t match
         case t: CaptureRef if t.isCap =>
           Fresh.withOwner(owner)
+        case t @ CapturingType(parent: TypeRef, _) if parent.symbol == defn.Caps_CapSet =>
+          t
         case t @ CapturingType(_, _) =>
           mapOver(t)
         case t @ AnnotatedType(parent, ann) =>

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -426,7 +426,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
             if (tp1.prefix.isStable) return tryLiftedToThis1
           case _ =>
             if isCaptureVarComparison then
-              return subCaptures(tp1.captureSet, tp2.captureSet).isOK
+              return CCState.withCapAsRoot:
+                subCaptures(tp1.captureSet, tp2.captureSet).isOK
             if (tp1 eq NothingType) || isBottom(tp1) then
               return true
         }
@@ -575,7 +576,8 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           && (isBottom(tp1) || GADTusage(tp2.symbol))
 
         if isCaptureVarComparison then
-          return subCaptures(tp1.captureSet, tp2.captureSet).isOK
+          return CCState.withCapAsRoot:
+            subCaptures(tp1.captureSet, tp2.captureSet).isOK
 
         isSubApproxHi(tp1, info2.lo) && (trustBounds || isSubApproxHi(tp1, info2.hi))
         || compareGADT

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -1167,10 +1167,9 @@ object Types extends TypeUtils {
      *
      *  @param isSubType      a function used for checking subtype relationships.
      */
-    final def overrides(that: Type, matchLoosely: => Boolean, checkClassInfo: Boolean = true,
-                        isSubType: (Type, Type) => Context ?=> Boolean = (tp1, tp2) => tp1 frozen_<:< tp2)(using Context): Boolean = {
+    final def overrides(that: Type, matchLoosely: => Boolean, checkClassInfo: Boolean = true)(using Context): Boolean = {
       !checkClassInfo && this.isInstanceOf[ClassInfo]
-      || isSubType(this.widenExpr, that.widenExpr)
+      || (this.widenExpr frozen_<:< that.widenExpr)
       || matchLoosely && {
         val this1 = this.widenNullaryMethod
         val that1 = that.widenNullaryMethod

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -210,8 +210,7 @@ object OverridingPairs:
    *  @param isSubType  A function to be used for checking subtype relationships
    *                    between term fields.
    */
-  def isOverridingPair(member: Symbol, memberTp: Type, other: Symbol, otherTp: Type, fallBack: => Boolean = false,
-                       isSubType: (Type, Type) => Context ?=> Boolean = (tp1, tp2) => tp1 frozen_<:< tp2)(using Context): Boolean =
+  def isOverridingPair(member: Symbol, memberTp: Type, other: Symbol, otherTp: Type, fallBack: => Boolean = false)(using Context): Boolean =
     if member.isType then // intersection of bounds to refined types must be nonempty
       memberTp.bounds.hi.hasSameKindAs(otherTp.bounds.hi)
       && (
@@ -227,6 +226,6 @@ object OverridingPairs:
       )
     else
       member.name.is(DefaultGetterName) // default getters are not checked for compatibility
-      || memberTp.overrides(otherTp, member.matchNullaryLoosely || other.matchNullaryLoosely || fallBack, isSubType = isSubType)
+      || memberTp.overrides(otherTp, member.matchNullaryLoosely || other.matchNullaryLoosely || fallBack)
 
 end OverridingPairs

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -214,15 +214,14 @@ object OverridingPairs:
     if member.isType then // intersection of bounds to refined types must be nonempty
       memberTp.bounds.hi.hasSameKindAs(otherTp.bounds.hi)
       && (
-        CCState.withCapAsRoot: // If upper bound is CapSet^ any capture set of lower bound is OK
-          (memberTp frozen_<:< otherTp)
-          || !member.owner.derivesFrom(other.owner)
-              && {
-                // if member and other come from independent classes or traits, their
-                // bounds must have non-empty-intersection
-                val jointBounds = (memberTp.bounds & otherTp.bounds).bounds
-                jointBounds.lo frozen_<:< jointBounds.hi
-              }
+        (memberTp frozen_<:< otherTp)
+        || !member.owner.derivesFrom(other.owner)
+            && {
+              // if member and other come from independent classes or traits, their
+              // bounds must have non-empty-intersection
+              val jointBounds = (memberTp.bounds & otherTp.bounds).bounds
+              jointBounds.lo frozen_<:< jointBounds.hi
+            }
       )
     else
       member.name.is(DefaultGetterName) // default getters are not checked for compatibility

--- a/tests/pos-custom-args/captures/check-override-typebounds.scala
+++ b/tests/pos-custom-args/captures/check-override-typebounds.scala
@@ -1,0 +1,16 @@
+import language.experimental.captureChecking
+
+trait A:
+  type T <: caps.Capability
+
+class B extends A:
+  type T = C
+
+class C extends caps.Capability
+
+
+trait A2:
+  type T[Cap^]
+
+  def takesCap[Cap^](t: T[Cap]): Unit
+


### PR DESCRIPTION
 1. Strip implied cap.rd sets from Capability types in extends and bounds

    I.e. We do not add an implicit cap.rd in

       class C extends Capability
       type T <: C

 2. Don't map CapSet^ to CapSet^{fresh}. Assume `^` is root in some comparisons with CapSet.