### PR TITLE
Bump Scala CLI to v1.7.1 (was v1.7.0)

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: VirtusLab/scala-cli-setup@v1.7.0
+      - uses: VirtusLab/scala-cli-setup@v1.7.1
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ secrets.GRAPHQL_API_TOKEN }}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -189,7 +189,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.7.0"
+  val scalaCliLauncherVersion = "1.7.1"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.24"
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.7.1
https://github.com/VirtusLab/scala-cli-setup/releases/tag/v1.7.1