### PR TITLE
WIP: Keep skolem types when unpickling/bringing a denotation to a new run, in more cases

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -507,7 +507,8 @@ class TreeUnpickler(reader: TastyReader,
     private def readSymNameRef()(using Context): Type = {
       val sym = readSymRef()
       val prefix = readType()
-      val res = NamedType(prefix, sym)
+      def pre = if TypeOps.isLegalPrefix(prefix) then prefix else QualSkolemType(prefix)
+      val res = NamedType(pre, sym)
       prefix match {
         case prefix: ThisType if (prefix.cls eq sym.owner) && !sym.is(Opaque) =>
           res.withDenot(sym.denot)

--- a/compiler/test/dotc/run-test-pickling.excludelist
+++ b/compiler/test/dotc/run-test-pickling.excludelist
@@ -50,3 +50,5 @@ named-tuples-strawman-2.scala
 typeCheckErrors.scala
 i18150.scala
 
+# issue caused by -Xprint-types
+decorators

--- a/tests/pos-macros/i22585-b/Macro.scala
+++ b/tests/pos-macros/i22585-b/Macro.scala
@@ -1,0 +1,18 @@
+import scala.quoted.*
+
+object Hammer2 {
+  inline def makeProductHammerMacro[I, O](): Hammer[I, O] =
+    ${ makeProductHammerMacroImpl[I, O] }
+
+  def makeProductHammerMacroImpl[I: Type, O: Type](using Quotes): Expr[Hammer[I, O]] =
+    '{ makeHammer[I, O]() }
+
+  inline def makeHammer[S, O](): Hammer[S, O] =
+    new Hammer[S, O] {
+      lazy val (hammer: Hammer[?, Int], idx: Int) = ???
+
+      override def hammer(input: S): O = {
+        hammer.hammer(???.asInstanceOf).asInstanceOf[O]
+      }
+    }
+}

--- a/tests/pos-macros/i22585-b/Test.scala
+++ b/tests/pos-macros/i22585-b/Test.scala
@@ -1,0 +1,9 @@
+trait Hammer[I, O] {
+  def hammer(input: I): O
+}
+
+object HammerSpec {
+  case class A(x: Int)
+  case class B(x: Int)
+  Hammer2.makeProductHammerMacro[A, B]()
+}

--- a/tests/pos-macros/i22585-c/Macro.scala
+++ b/tests/pos-macros/i22585-c/Macro.scala
@@ -1,0 +1,22 @@
+import scala.quoted.*
+
+trait Hammer[I, O] {
+  def hammer(input: I): O
+}
+
+object Hammer {
+  inline def makeProductHammerMacro[I, O](): Hammer[I, O] =
+    ${ makeProductHammerMacroImpl[I, O] }
+
+  def makeProductHammerMacroImpl[I: Type, O: Type](using Quotes): Expr[Hammer[I, O]] =
+    '{ makeHammer[I, O]() }
+
+  inline def makeHammer[S, O](): Hammer[S, O] =
+    new Hammer[S, O] {
+      lazy val (hammer: Hammer[?, Int], idx: Int) = ???
+
+      override def hammer(input: S): O = {
+        hammer.hammer(???.asInstanceOf).asInstanceOf[O]
+      }
+    }
+}

--- a/tests/pos-macros/i22585-c/Test.scala
+++ b/tests/pos-macros/i22585-c/Test.scala
@@ -1,0 +1,5 @@
+object HammerSpec {
+  case class A(x: Int)
+  case class B(x: Int)
+  Hammer.makeProductHammerMacro[A, B]()
+}

--- a/tests/pos/i22585-a/inline_1.scala
+++ b/tests/pos/i22585-a/inline_1.scala
@@ -1,0 +1,16 @@
+import scala.quoted.*
+
+trait Hammer[I, O] {
+  def hammer(input: I): O
+}
+
+object Hammer {
+  inline def makeHammer[S, O](): Hammer[S, O] =
+    new Hammer[S, O] {
+      lazy val (hammer: Hammer[?, Int], idx: Int) = ???
+
+      override def hammer(input: S): O = {
+        hammer.hammer(???.asInstanceOf).asInstanceOf[O]
+      }
+    }
+}

--- a/tests/pos/i22585-a/main_2.scala
+++ b/tests/pos/i22585-a/main_2.scala
@@ -1,0 +1,5 @@
+object HammerSpec {
+  case class A(x: Int)
+  case class B(x: Int)
+  Hammer.makeHammer[A, B]()
+}


### PR DESCRIPTION
Attempts to fix #22585 

The source of the issue is in the inlined makeHammer method, where the `hammer` method Is generated.
Initially, `hammer.hammer(???.asInstanceOf).asInstanceOf[O]` Is typed as 

```scala
<
  {
    <
      <
        <
          <
            <<this:($anon.this : Object with Hammer[Any, Any] {...})>.
              hammer:(=> Hammer[?, Int])>
          .hammer:((input: <?1:Hammer[?, Int]>.I): Int)>
        (
          <<<???:(=> Nothing)>.asInstanceOf:([X0]: X0)>[
            <?1:Hammer[?, Int]>.I]:<?1:Hammer[?, Int]>.I>
        ):Int>
      .asInstanceOf:([X0]: X0)>
    [Any]:Any>
  }
:Any>
```
So `hammer.hammer` is a function with a skolemtype (`(input: <?1:Hammer[?, Int]>.I): Int`) and `???.asInstanceOf `is the same skolemtype (`<?1:Hammer[?, Int]>.I>`).

The issues arrived when we either would try to inline this from unpicked tasty (test case `tests/pos/i22585-a`), or if we suspended compilation (e.g. because of a macro method usage) and tried to inline it in a new run, after compiling the inlined method.

In the first case, we would previously not unpickle the applied type parameter to ???.asInstanceOf to a skolemtype, (but the function input would) so a type checker would fail there.
In the second case, we would remember the skolemtype in the ???.asInstanceOf, but the `hammer.hammer` function denotation, while being brought to a new run, would recalculate the type, losing the skolemtype in the process (and then failing the type checking).

This PR currently provides naive fixes to both things, but the unpicking part seems to suffer from a few issues:
* Expectations for java tasty are not being uphold (we unpickle legal stable java paths into skolem types).
* Some errors related to incremental compilation appear on the CI (although I was not able to reproduce them locally yet)
