### PR TITLE
bugfix: Fix issues with annotations not detected

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
@@ -160,7 +160,7 @@ trait PcCollector[T]:
           def collectEndMarker =
             EndMarker.getPosition(df, pos, sourceText).map:
               collect(EndMarker(df.symbol), _)
-          val annots = collectTrees(df.mods.annotations)
+          val annots = collectTrees(df.symbol.annotations.map(_.tree))
           val traverser =
             new PcCollector.DeepFolderWithParent[Set[T]](
               collectNamesWithParent
@@ -215,8 +215,8 @@ trait PcCollector[T]:
          * @<<JsonNotification>>("")
          * def params() = ???
          */
-        case mdf: MemberDef if mdf.mods.annotations.nonEmpty =>
-          val trees = collectTrees(mdf.mods.annotations)
+        case mdf: MemberDef if mdf.symbol.annotations.nonEmpty =>
+          val trees = collectTrees(mdf.symbol.annotations.map(_.tree))
           val traverser =
             new PcCollector.DeepFolderWithParent[Set[T]](
               collectNamesWithParent

--- a/presentation-compiler/test/dotty/tools/pc/tests/tokens/SemanticTokensSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/tokens/SemanticTokensSuite.scala
@@ -40,6 +40,24 @@ class SemanticTokensSuite extends BaseSemanticTokensSuite:
           |""".stripMargin
     )
 
+  @Test def `metals-6823` =
+      check(
+        s"""|package <<example>>/*namespace*/
+            |
+            | @<<main>>/*class*/ def <<main1>>/*method,definition*/(): <<Unit>>/*class,abstract*/ =
+            |     val <<array>>/*variable,definition,readonly*/ = <<Array>>/*class*/(1, 2, 3)
+            |     <<println>>/*method*/(<<array>>/*variable,readonly*/)
+            |
+            |@<<main>>/*class*/ def <<main2>>/*method,definition*/(): <<Unit>>/*class,abstract*/ =
+            |   val <<list>>/*variable,definition,readonly*/ = <<List>>/*class*/(1, 2, 3)
+            |   <<println>>/*method*/(<<list>>/*variable,readonly*/)
+            |
+            |@<<main>>/*class*/ def <<main3>>/*method,definition*/(): <<Unit>>/*class,abstract*/ =
+            |   val <<list>>/*variable,definition,readonly*/ = <<List>>/*class*/(1, 2, 3)
+            |   <<println>>/*method*/(<<list>>/*variable,readonly*/)
+            |""".stripMargin
+      )
+
   @Test def `Comment(Single-Line, Multi-Line)` =
     check(
       s"""|package <<example>>/*namespace*/


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/6823

Not sure why tree.mods.annotations is sometimes empty, but I couldn't find a reason after landing in a rabbit hole.