### PR TITLE
Approximate annotated types in `wildApprox`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -1017,6 +1017,15 @@ object ProtoTypes {
         paramInfos = tl.paramInfos.mapConserve(wildApprox(_, theMap, seen, internal1).bounds),
         resType = wildApprox(tl.resType, theMap, seen, internal1)
       )
+    case tp @ AnnotatedType(parent, _) =>
+      // This case avoids approximating types in the annotation tree, which can
+      // cause the type assigner to fail.
+      // See #22893 and tests/pos/annot-default-arg-22874.scala.
+      val parentApprox = wildApprox(parent, theMap, seen, internal)
+      if tp.isRefining then
+        WildcardType(TypeBounds.upper(parentApprox))
+      else
+        parentApprox
     case _ =>
       (if (theMap != null && seen.eq(theMap.seen)) theMap else new WildApproxMap(seen, internal))
         .mapOver(tp)

--- a/tests/pos/annot-default-arg-22874.scala
+++ b/tests/pos/annot-default-arg-22874.scala
@@ -1,0 +1,7 @@
+package defaultArgBug
+
+class staticAnnot(arg: Int) extends scala.annotation.StaticAnnotation
+class refiningAnnot(arg: Int) extends scala.annotation.RefiningAnnotation
+
+def f1(a: Int, b: Int @staticAnnot(a + a) = 42): Int = b
+def f2(a: Int, b: Int @refiningAnnot(a + a) = 42): Int = b


### PR DESCRIPTION
Fixes #22874.

`wildApprox` approximates parameter references and type variables by wildcards. When doing so for an `AnnotatedType`, this can produce trees with wildcards types, causing the type assigner to fail. For example, consider `Apply(fn, args)` where `fn` has type `TermParamRef`.  Applying `wildApprox` will approximate the type of `fn` to a wildcard, leading [the type assigner for `Apply`](https://github.com/scala/scala3/blob/cb97c40930d335e0fca38238682d218c3e718bd8/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala#L298) to emit an error stating that `<?>` does not take parameters.

This issue is somehow similar to the one described in https://github.com/scala/scala3/pull/19957#issuecomment-2305262773, which was fixed by https://github.com/scala/scala3/pull/21941 (and re-worked in #22839).

This PR fixes the issue by approximating annotated types in `wildApprox`: annotated types are approximated by their parent types if they are not refining, or by wildcards upper-bounded by their parent types if they are.