### PR TITLE
improvement: Rework IndexedContext to reuse the previously calculated scopes

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -48,6 +48,16 @@ case class Completion(label: String, description: String, symbols: List[Symbol])
 
 object Completion:
 
+  def scopeContext(pos: SourcePosition)(using Context): CompletionResult =
+    val tpdPath = Interactive.pathTo(ctx.compilationUnit.tpdTree, pos.span)
+    val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
+    inContext(completionContext):
+      val untpdPath = Interactive.resolveTypedOrUntypedPath(tpdPath, pos)
+      val mode = completionMode(untpdPath, pos, forSymbolSearch = true)
+      val rawPrefix = completionPrefix(untpdPath, pos)
+      val completer = new Completer(mode, pos, untpdPath, _ => true)
+      completer.scopeCompletions
+
   /** Get possible completions from tree at `pos`
    *
    *  @return offset and list of symbols for possible completions
@@ -60,7 +70,6 @@ object Completion:
       val mode = completionMode(untpdPath, pos)
       val rawPrefix = completionPrefix(untpdPath, pos)
       val completions = rawCompletions(pos, mode, rawPrefix, tpdPath, untpdPath)
-
       postProcessCompletions(untpdPath, completions, rawPrefix)
 
   /** Get possible completions from tree at `pos`
@@ -89,7 +98,7 @@ object Completion:
    *
    * Otherwise, provide no completion suggestion.
    */
-  def completionMode(path: List[untpd.Tree], pos: SourcePosition): Mode = path match
+  def completionMode(path: List[untpd.Tree], pos: SourcePosition, forSymbolSearch: Boolean = false): Mode = path match
     // Ignore `package foo@@` and `package foo.bar@@`
     case ((_: tpd.Select) | (_: tpd.Ident)):: (_ : tpd.PackageDef) :: _  => Mode.None
     case GenericImportSelector(sel) =>
@@ -102,11 +111,14 @@ object Completion:
     case untpd.Literal(Constants.Constant(_: String)) :: _ => Mode.Term | Mode.Scope // literal completions
     case (ref: untpd.RefTree) :: _ =>
       val maybeSelectMembers = if ref.isInstanceOf[untpd.Select] then Mode.Member else Mode.Scope
-
-      if (ref.name.isTermName) Mode.Term | maybeSelectMembers
+      if (forSymbolSearch) then Mode.Term | Mode.Type | maybeSelectMembers
+      else if (ref.name.isTermName) Mode.Term | maybeSelectMembers
       else if (ref.name.isTypeName) Mode.Type | maybeSelectMembers
       else Mode.None
 
+    case (_: tpd.TypeTree | _: tpd.MemberDef) :: _ if forSymbolSearch => Mode.Type | Mode.Term
+    case (_: tpd.CaseDef) :: _ if forSymbolSearch => Mode.Type | Mode.Term
+    case Nil if forSymbolSearch =>  Mode.Type | Mode.Term
     case _ => Mode.None
 
   /** When dealing with <errors> in varios palces we check to see if they are
@@ -174,12 +186,12 @@ object Completion:
         case _ => None
 
   private object StringContextApplication:
-    def unapply(path: List[tpd.Tree]): Option[tpd.Apply] = 
+    def unapply(path: List[tpd.Tree]): Option[tpd.Apply] =
       path match
         case tpd.Select(qual @ tpd.Apply(tpd.Select(tpd.Select(_, StdNames.nme.StringContext), _), _), _) :: _ =>
           Some(qual)
         case _ => None
-      
+
 
   /** Inspect `path` to determine the offset where the completion result should be inserted. */
   def completionOffset(untpdPath: List[untpd.Tree]): Int =
@@ -230,14 +242,14 @@ object Completion:
     val result = adjustedPath match
       // Ignore synthetic select from `This` because in code it was `Ident`
       // See example in dotty.tools.languageserver.CompletionTest.syntheticThis
-      case tpd.Select(qual @ tpd.This(_), _) :: _ if qual.span.isSynthetic      => completer.scopeCompletions
+      case tpd.Select(qual @ tpd.This(_), _) :: _ if qual.span.isSynthetic      => completer.scopeCompletions.names
       case StringContextApplication(qual) =>
-        completer.scopeCompletions ++ completer.selectionCompletions(qual) 
-      case tpd.Select(qual, _) :: _               if qual.typeOpt.hasSimpleKind => 
+        completer.scopeCompletions.names ++ completer.selectionCompletions(qual)
+      case tpd.Select(qual, _) :: _               if qual.typeOpt.hasSimpleKind =>
         completer.selectionCompletions(qual)
       case tpd.Select(qual, _) :: _                                             => Map.empty
       case (tree: tpd.ImportOrExport) :: _                                      => completer.directMemberCompletions(tree.expr)
-      case _                                                                    => completer.scopeCompletions
+      case _                                                                    => completer.scopeCompletions.names
 
     interactiv.println(i"""completion info with pos    = $pos,
                           |                     term   = ${completer.mode.is(Mode.Term)},
@@ -338,6 +350,7 @@ object Completion:
          (completionMode.is(Mode.Term) && (sym.isTerm || sym.is(ModuleClass))
       || (completionMode.is(Mode.Type) && (sym.isType || sym.isStableMember)))
     )
+  end isValidCompletionSymbol
 
   given ScopeOrdering(using Context): Ordering[Seq[SingleDenotation]] with
     val order =
@@ -371,7 +384,7 @@ object Completion:
      *    (even if the import follows it syntactically)
      *  - a more deeply nested import shadowing a member or a local definition causes an ambiguity
      */
-    def scopeCompletions(using context: Context): CompletionMap =
+    def scopeCompletions(using context: Context): CompletionResult =
 
       /** Temporary data structure representing denotations with the same name introduced in a given scope
        *  as a member of a type, by a local definition or by an import clause
@@ -382,13 +395,18 @@ object Completion:
           ScopedDenotations(denots.filter(includeFn), ctx)
 
       val mappings = collection.mutable.Map.empty[Name, List[ScopedDenotations]].withDefaultValue(List.empty)
+      val renames = collection.mutable.Map.empty[Symbol, Name]
       def addMapping(name: Name, denots: ScopedDenotations) =
         mappings(name) = mappings(name) :+ denots
 
       ctx.outersIterator.foreach { case ctx @ given Context =>
         if ctx.isImportContext then
-          importedCompletions.foreach { (name, denots) =>
+          val imported = importedCompletions
+          imported.names.foreach { (name, denots) =>
             addMapping(name, ScopedDenotations(denots, ctx, include(_, name)))
+          }
+          imported.renames.foreach { (name, newName) =>
+            renames(name) = newName
           }
         else if ctx.owner.isClass then
           accessibleMembers(ctx.owner.thisType)
@@ -433,7 +451,6 @@ object Completion:
           // most deeply nested member or local definition if not shadowed by an import
           case Some(local) if local.ctx.scope == first.ctx.scope =>
             resultMappings += name -> local.denots
-
           case None if isSingleImport || isImportedInDifferentScope || isSameSymbolImportedDouble =>
             resultMappings += name -> first.denots
           case None if notConflictingWithDefaults =>
@@ -443,7 +460,7 @@ object Completion:
         }
       }
 
-      resultMappings
+      CompletionResult(resultMappings, renames.toMap)
     end scopeCompletions
 
     /** Widen only those types which are applied or are exactly nothing
@@ -485,15 +502,20 @@ object Completion:
     /** Completions introduced by imports directly in this context.
      *  Completions from outer contexts are not included.
      */
-    private def importedCompletions(using Context): CompletionMap =
+    private def importedCompletions(using Context): CompletionResult =
       val imp = ctx.importInfo
+      val renames = collection.mutable.Map.empty[Symbol, Name]
 
       if imp == null then
-        Map.empty
+        CompletionResult(Map.empty, Map.empty)
       else
         def fromImport(name: Name, nameInScope: Name): Seq[(Name, SingleDenotation)] =
           imp.site.member(name).alternatives
-            .collect { case denot if include(denot, nameInScope) => nameInScope -> denot }
+            .collect { case denot if include(denot, nameInScope) =>
+               if name != nameInScope then
+                 renames(denot.symbol) = nameInScope
+               nameInScope -> denot
+            }
 
         val givenImports = imp.importedImplicits
           .map { ref => (ref.implicitName: Name, ref.underlyingRef.denot.asSingleDenotation) }
@@ -519,7 +541,8 @@ object Completion:
               fromImport(original.toTypeName, nameInScope.toTypeName)
             }.toSeq.groupByName
 
-        givenImports ++ wildcardMembers ++ explicitMembers
+        val results = givenImports ++ wildcardMembers ++ explicitMembers
+        CompletionResult(results, renames.toMap)
     end importedCompletions
 
     /** Completions from implicit conversions including old style extensions using implicit classes */
@@ -597,7 +620,7 @@ object Completion:
 
       // 1. The extension method is visible under a simple name, by being defined or inherited or imported in a scope enclosing the reference.
       val termCompleter = new Completer(Mode.Term, pos, untpdPath, matches)
-      val extMethodsInScope = termCompleter.scopeCompletions.toList.flatMap:
+      val extMethodsInScope = termCompleter.scopeCompletions.names.toList.flatMap:
         case (name, denots) => denots.collect:
           case d: SymDenotation if d.isTerm && d.termRef.symbol.is(Extension) => (d.termRef, name.asTermName)
 
@@ -699,6 +722,7 @@ object Completion:
 
   private type CompletionMap = Map[Name, Seq[SingleDenotation]]
 
+  case class CompletionResult(names: Map[Name, Seq[SingleDenotation]], renames: Map[Symbol, Name])
   /**
    * The completion mode: defines what kinds of symbols should be included in the completion
    * results.

--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -44,8 +44,8 @@ final class AutoImportsProvider(
     val path =
       Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using newctx)
 
-    val indexedContext = IndexedContext(
-      Interactive.contextOfPath(path)(using newctx)
+    val indexedContext = IndexedContext(pos)(
+      using Interactive.contextOfPath(path)(using newctx)
     )
     import indexedContext.ctx
 
@@ -96,7 +96,7 @@ final class AutoImportsProvider(
                 text,
                 tree,
                 unit.comments,
-                indexedContext.importContext,
+                indexedContext,
                 config
               )
             (sym: Symbol) => generator.forSymbol(sym)

--- a/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
@@ -51,7 +51,7 @@ final class ExtractMethodProvider(
     given locatedCtx: Context =
       val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
       Interactive.contextOfPath(path)(using newctx)
-    val indexedCtx = IndexedContext(locatedCtx)
+    val indexedCtx = IndexedContext(pos)(using locatedCtx)
     val printer =
       ShortenedTypePrinter(search, IncludeDefaultParam.Never)(using indexedCtx)
     def prettyPrint(tpe: Type) =

--- a/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
@@ -49,7 +49,7 @@ object HoverProvider:
     val path = unit
       .map(unit => Interactive.pathTo(unit.tpdTree, pos.span))
       .getOrElse(Interactive.pathTo(driver.openedTrees(uri), pos))
-    val indexedContext = IndexedContext(ctx)
+    val indexedContext = IndexedContext(pos)(using ctx)
 
     def typeFromPath(path: List[Tree]) =
       if path.isEmpty then NoType else path.head.typeOpt
@@ -96,7 +96,7 @@ object HoverProvider:
 
       val printerCtx = Interactive.contextOfPath(path)
       val printer = ShortenedTypePrinter(search, IncludeDefaultParam.Include)(
-        using IndexedContext(printerCtx)
+        using IndexedContext(pos)(using printerCtx)
       )
       MetalsInteractive.enclosingSymbolsWithExpressionType(
         enclosing,
@@ -134,7 +134,7 @@ object HoverProvider:
             .map(_.docstring())
             .mkString("\n")
 
-          val expresionTypeOpt = 
+          val expresionTypeOpt =
             if symbol.name == StdNames.nme.??? then
               InferExpectedType(search, driver, params).infer()
             else printer.expressionType(exprTpw)

--- a/presentation-compiler/src/main/dotty/tools/pc/InferExpectedType.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferExpectedType.scala
@@ -51,7 +51,7 @@ class InferExpectedType(
           )
         val locatedCtx =
           Interactive.contextOfPath(tpdPath)(using newctx)
-        val indexedCtx = IndexedContext(locatedCtx)
+        val indexedCtx = IndexedContext(pos)(using locatedCtx)
         val printer =
           ShortenedTypePrinter(search, IncludeDefaultParam.ResolveLater)(using indexedCtx)
         InterCompletionType.inferType(path)(using newctx).map{

--- a/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
@@ -75,7 +75,7 @@ final class InferredTypeProvider(
       Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
 
     given locatedCtx: Context = driver.localContext(params)
-    val indexedCtx = IndexedContext(locatedCtx)
+    val indexedCtx = IndexedContext(pos)(using locatedCtx)
     val autoImportsGen = AutoImports.generator(
       pos,
       sourceText,

--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -51,7 +51,7 @@ class PcDefinitionProvider(
       Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
 
     given ctx: Context = driver.localContext(params)
-    val indexedContext = IndexedContext(ctx)
+    val indexedContext = IndexedContext(pos)(using ctx)
     val result =
       if findTypeDef then findTypeDefinitions(path, pos, indexedContext, uri)
       else findDefinitions(path, pos, indexedContext, uri)

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -125,7 +125,7 @@ class PcInlayHintsProvider(
     val tpdPath =
       Interactive.pathTo(unit.tpdTree, pos.span)
 
-    val indexedCtx = IndexedContext(Interactive.contextOfPath(tpdPath))
+    val indexedCtx = IndexedContext(pos)(using Interactive.contextOfPath(tpdPath))
     val printer = ShortenedTypePrinter(
       symbolSearch
     )(using indexedCtx)
@@ -149,7 +149,7 @@ class PcInlayHintsProvider(
     InlayHints.makeLabelParts(parts, tpeStr)
   end toLabelParts
 
-  private val definitions = IndexedContext(ctx).ctx.definitions
+  private val definitions = IndexedContext(pos)(using ctx).ctx.definitions
   private def syntheticTupleApply(tree: Tree): Boolean =
     tree match
       case sel: Select =>

--- a/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
@@ -37,7 +37,7 @@ object SignatureHelpProvider:
         val path = Interactive.pathTo(unit.tpdTree, pos.span)(using driver.currentCtx)
 
         val localizedContext = Interactive.contextOfPath(path)(using driver.currentCtx)
-        val indexedContext = IndexedContext(driver.currentCtx)
+        val indexedContext = IndexedContext(pos)(using driver.currentCtx)
 
         given Context = localizedContext.fresh
           .setCompilationUnit(unit)

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -107,7 +107,7 @@ class CompletionProvider(
 
 
         val locatedCtx = Interactive.contextOfPath(tpdPath)(using newctx)
-        val indexedCtx = IndexedContext(locatedCtx)
+        val indexedCtx = IndexedContext(pos)(using locatedCtx)
 
         val completionPos = CompletionPos.infer(pos, params, adjustedPath, wasCursorApplied)(using locatedCtx)
 
@@ -222,7 +222,6 @@ class CompletionProvider(
       if config.isDetailIncludedInLabel then completion.labelWithDescription(printer)
       else completion.label
     val ident = underlyingCompletion.insertText.getOrElse(underlyingCompletion.label)
-
     lazy val isInStringInterpolation =
       path match
         // s"My name is $name"

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -569,6 +569,7 @@ class Completions(
         then
           indexedContext.lookupSym(sym) match
             case IndexedContext.Result.InScope => false
+            case IndexedContext.Result.Missing if indexedContext.rename(sym).isDefined => false
             case _ if completionMode.is(Mode.ImportOrExport) =>
               visit(
                 CompletionValue.Workspace(

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/NamedArgCompletions.scala
@@ -139,7 +139,7 @@ object NamedArgCompletions:
 
     // fallback for when multiple overloaded methods match the supplied args
     def fallbackFindMatchingMethods() =
-      def maybeNameAndIndexedContext(
+      def matchingMethodsSymbols(
           method: Tree
       ): List[Symbol] =
         method match
@@ -155,11 +155,11 @@ object NamedArgCompletions:
               case single: SingleDenotation => List(single.symbol)
               case multi: MultiDenotation => multi.allSymbols
             }.getOrElse(Nil)
-          case Apply(fun, _) => maybeNameAndIndexedContext(fun)
+          case Apply(fun, _) => matchingMethodsSymbols(fun)
           case _ => Nil
       val matchingMethods =
         for
-          potentialMatch <- maybeNameAndIndexedContext(method)
+          potentialMatch <- matchingMethodsSymbols(method)
           if potentialMatch.is(Flags.Method) &&
                 potentialMatch.vparamss.length >= argss.length &&
                 Try(potentialMatch.isAccessibleFrom(apply.symbol.info)).toOption

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
@@ -191,7 +191,7 @@ object OverrideCompletions:
               template :: path
             case path => path
 
-        val indexedContext = IndexedContext(
+        val indexedContext = IndexedContext(pos)(using
           Interactive.contextOfPath(path)(using newctx)
         )
         import indexedContext.ctx

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -177,6 +177,9 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
     def companion: Symbol =
       if sym.is(Module) then sym.companionClass else sym.companionModule
 
+    def dealiasType: Symbol =
+      if sym.isType then sym.info.deepDealias.typeSymbol else sym
+
     def nameBackticked: String = nameBackticked(Set.empty[String])
 
     def nameBackticked(backtickSoftKeyword: Boolean = true): String =

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -166,7 +166,7 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
       @tailrec
       def loop(acc: List[String], sym: Symbol): List[String] =
         if sym == NoSymbol || sym.isRoot || sym.isEmptyPackage then acc
-        else if sym.isPackageObject then loop(acc, sym.owner)
+        else if sym.isPackageObject || sym.isConstructor then loop(acc, sym.owner)
         else
           val v = this.nameBackticked(sym)(exclusions)
           loop(v :: acc, sym.owner)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionArgSuite.scala
@@ -826,8 +826,8 @@ class CompletionArgSuite extends BaseCompletionSuite:
          |""".stripMargin,
       """|aaa = : Int
          |aaa = g : Int
-         |abb = : Option[Int]
          |abb = : Int
+         |abb = : Option[Int]
          |abb = g : Int
          |""".stripMargin,
       topLines = Some(5),

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCaseSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionCaseSuite.scala
@@ -37,7 +37,7 @@ class CompletionCaseSuite extends BaseCompletionSuite:
         |class Cat extends Animal
         |class Dog extends Animal
         |object Elephant extends Animal
-        |class HasFeet[A, B](e: T, f: B) extends Animal
+        |class HasFeet[A, B](e: A, f: B) extends Animal
         |class HasMouth[T](e: T) extends Animal
         |case class HasWings[T](e: T) extends Animal
         |case object Seal extends Animal
@@ -146,14 +146,12 @@ class CompletionCaseSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
-  // TODO: `Left` has conflicting name in Scope, we should fix it so the result is the same as for scala 2
-  // Issue: https://github.com/scalameta/metals/issues/4368
   @Test def `sealed-conflict` =
     check(
       """
         |object A {
         |  val e: Either[Int, String] = ???
-        |  type Left = String
+        |  val Left = 123
         |  e match {
         |    case@@
         |  }

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionContextSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionContextSuite.scala
@@ -25,3 +25,41 @@ class CompletionContextSuite extends BaseCompletionSuite:
         |""".stripMargin,
       filter = futureCompletionResult.contains
     )
+
+  @Test def multipleFoos =
+    checkEdit(
+      """|
+         |package a{
+         |  class Foo
+         |}
+         |package b{
+         |  class Foo
+         |}
+         |package c{
+         |  class Foo
+         |}
+         |package d{
+         |  import a.{Foo => Bar}
+         |  import b.Foo
+         |
+         |  val x = new Foo@@ // I want to import c.Foo
+         |}""".stripMargin,
+      """|
+         |package a{
+         |  class Foo
+         |}
+         |package b{
+         |  class Foo
+         |}
+         |package c{
+         |  class Foo
+         |}
+         |package d{
+         |  import a.{Foo => Bar}
+         |  import b.Foo
+         |
+         |  val x = new c.Foo // I want to import c.Foo
+         |}""".stripMargin,
+      assertSingleItem = false,
+      filter = (label: String) => label.contains("Foo - c")
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
@@ -655,7 +655,7 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
         |    val y/*: S<<scala/collection/Set#>>[Char<<scala/Char#>>]*/ = f
         |    ???
         |  }
-        |  val x/*: AB<<scala/collection/AbstractMap#>>[Int<<scala/Int#>>, String<<scala/Predef.String#>>]*/ = test(Set/*[Int<<scala/Int#>>]*/(1), Set/*[Char<<scala/Char#>>]*/('a'))
+        |  val x/*: AB<<scala/collection/AbstractMap#>>[Int<<scala/Int#>>, String<<java/lang/String#>>]*/ = test(Set/*[Int<<scala/Int#>>]*/(1), Set/*[Char<<scala/Char#>>]*/('a'))
         |}
         |""".stripMargin,
     )


### PR DESCRIPTION

It turns out the work being done in IndexedContext was already done in Completions, but better, since it doesn't try to read files as the separate logic does.

There is still some improvement to be done to not calculate it twice, but in order to keep this PR as simple as possible I will skip that for now.