### PR TITLE
chore: update develocity to 1.2-rc5

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,6 +23,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 
 resolvers += "Develocity Artifactory" at "https://repo.grdev.net/artifactory/public/"
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2-rc-2")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2-rc-5")
 
 addSbtPlugin("com.github.sbt" % "sbt-jdi-tools" % "1.2.0")


### PR DESCRIPTION
We update to the latest RC of develocity, which fixes some bugs found during the testing phase.