### PR TITLE
Test chars safely when highlighting

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -732,16 +732,17 @@ object Parsers {
 
     def testChar(idx: Int, p: Char => Boolean): Boolean = {
       val txt = source.content
-      idx < txt.length && p(txt(idx))
+      idx >= 0 && idx < txt.length && p(txt(idx))
     }
 
     def testChar(idx: Int, c: Char): Boolean = {
       val txt = source.content
-      idx < txt.length && txt(idx) == c
+      idx >= 0 && idx < txt.length && txt(idx) == c
     }
 
     def testChars(from: Int, str: String): Boolean =
-      str.isEmpty ||
+      str.isEmpty
+      ||
       testChar(from, str.head) && testChars(from + 1, str.tail)
 
     def skipBlanks(idx: Int, step: Int = 1): Int =

--- a/compiler/test/dotty/tools/utils.scala
+++ b/compiler/test/dotty/tools/utils.scala
@@ -124,6 +124,7 @@ private val toolArg = raw"(?://|/\*| \*) ?(?i:(${ToolName.values.mkString("|")})
 private val directiveOptionsArg = raw"//> using options (.*)".r.unanchored
 private val directiveJavacOptions = raw"//> using javacOpt (.*)".r.unanchored
 private val directiveTargetOptions = raw"//> using target.platform (jvm|scala-js)".r.unanchored
+private val directiveUnsupported = raw"//> using (scala) (.*)".r.unanchored
 private val directiveUnknown = raw"//> using (.*)".r.unanchored
 
 // Inspect the lines for compiler options of the form
@@ -141,6 +142,7 @@ def toolArgsParse(lines: List[String], filename: Option[String]): List[(String,S
     case directiveOptionsArg(args) => List(("scalac", args))
     case directiveJavacOptions(args) => List(("javac", args))
     case directiveTargetOptions(platform) => List(("target", platform))
+    case directiveUnsupported(name, args) => Nil
     case directiveUnknown(rest) => sys.error(s"Unknown directive: `//> using ${CommandLineParser.tokenize(rest).headOption.getOrElse("''")}`${filename.fold("")(f => s" in file $f")}")
     case _ => Nil
   }

--- a/tests/neg/i22906.check
+++ b/tests/neg/i22906.check
@@ -1,0 +1,6 @@
+Flag -indent set repeatedly
+-- Error: tests/neg/i22906.scala:6:15 ----------------------------------------------------------------------------------
+6 |    {`1`: Int  =>  5} // error
+  |               ^
+  |               parentheses are required around the parameter of a lambda
+  |               This construct can be rewritten automatically under -rewrite -source 3.0-migration.

--- a/tests/neg/i22906.scala
+++ b/tests/neg/i22906.scala
@@ -1,0 +1,6 @@
+//> using options -rewrite -indent
+//> nominally using scala 3.7.0-RC1
+// does not reproduce under "vulpix" test rig, which enforces certain flag sets?
+
+def program: Int => Int =
+    {`1`: Int  =>  5} // error


### PR DESCRIPTION
The arrow test at lastOffset - 3 is out-of-range when highlighting, which parses a snippet of source.

Fixes #22906 

Reproduces under scala-cli `-rewrite -indent` but not under vulpix. (It would be nice to know why.) (Needless to add, it shouldn't be a research project to get the test rig to just run a compilation. There is programmatic flag-setting that defies expectations.)

This commit also allows a test to `using scala` by ignoring it, as a convenience. When the directive parsing is completely aligned with scala-cli, it should completely ignore what is not supported, so that test files can be used both ways.