### PR TITLE
Fail not inlined inline method calls early

### DIFF
--- a/tests/neg/i13044.check
+++ b/tests/neg/i13044.check
@@ -1,63 +1,18 @@
--- Error: tests/neg/i13044.scala:61:40 ---------------------------------------------------------------------------------
-61 |   implicit def typeSchema: Schema[A] = Schema.gen // error // error
+-- [E172] Type Error: tests/neg/i13044.scala:61:40 ---------------------------------------------------------------------
+61 |   implicit def typeSchema: Schema[A] = Schema.gen // error
    |                                        ^^^^^^^^^^
-   |                                        given instance gen is declared as `inline`, but was not inlined
+   |                                 No given instance of type Schema[B] was found.
+   |                                 I found:
    |
-   |                                        Try increasing `-Xmax-inlines` above 32
+   |                                     Schema.gen[B]
+   |
+   |                                 But given instance gen in trait SchemaDerivation does not match type Schema[B].
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    |This location contains code that was inlined from i13044.scala:17
 17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:17
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    |This location contains code that was inlined from i13044.scala:17
 18 |        builder :: recurse[ts]
@@ -68,79 +23,6 @@
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
    |This location contains code that was inlined from i13044.scala:17
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-    --------------------------------------------------------------------------------------------------------------------
--- Error: tests/neg/i13044.scala:61:40 ---------------------------------------------------------------------------------
-61 |   implicit def typeSchema: Schema[A] = Schema.gen // error // error
-   |                                        ^^^^^^^^^^
-   |                                        method recurse is declared as `inline`, but was not inlined
-   |
-   |                                        Try increasing `-Xmax-inlines` above 32
-   |--------------------------------------------------------------------------------------------------------------------
-   |Inline stack trace
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-18 |        builder :: recurse[ts]
-   |                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-33 |  inline given gen[A]: Schema[A] = derived
-   |                                   ^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-17 |        val builder = summonInline[Schema[t]].asInstanceOf[Schema[Any]]
-   |                                   ^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-18 |        builder :: recurse[ts]
-   |                   ^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
-29 |        lazy val fields = recurse[m.MirroredElemTypes]
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from i13044.scala:18
 33 |  inline given gen[A]: Schema[A] = derived
    |                                   ^^^^^^^
     --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i13044.scala
+++ b/tests/neg/i13044.scala
@@ -58,5 +58,5 @@ case class B(c: C)
 case class A(a: A, b: B)
 
 object TestApp {
-   implicit def typeSchema: Schema[A] = Schema.gen // error // error
+   implicit def typeSchema: Schema[A] = Schema.gen // error
 }

--- a/tests/neg/i22423.check
+++ b/tests/neg/i22423.check
@@ -1,0 +1,24 @@
+-- Error: tests/neg/i22423.scala:35:14 ---------------------------------------------------------------------------------
+35 |  exportReader[Settings] // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^
+   |  cannot reduce summonFrom with
+   |   patterns :  case given reader @ _:ConfigReader[List[String]]
+   |--------------------------------------------------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from i22423.scala:12
+12 |    summonFrom { case reader: ConfigReader[A] => reader }
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from i22423.scala:12
+15 |    summonConfigReader[List[String]]
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from i22423.scala:12
+ 8 |    readCaseClass()
+   |    ^^^^^^^^^^^^^^^
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from i22423.scala:12
+30 |inline given exportReader[A]: Exported[ConfigReader[A]] = Exported(HintsAwareConfigReaderDerivation.deriveReader[A])
+   |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i22423.scala
+++ b/tests/neg/i22423.scala
@@ -1,0 +1,35 @@
+//> using options -Xmax-inlines:7
+import scala.deriving.Mirror
+import scala.compiletime._
+import scala.compiletime.ops.int._
+
+object HintsAwareConfigReaderDerivation {
+  inline def deriveReader[A]: ConfigReader[A] =
+    readCaseClass()
+    ???
+
+  private inline def summonConfigReader[A]: ConfigReader[A] =
+    summonFrom { case reader: ConfigReader[A] => reader }
+
+  private inline def readCaseClass(): Unit =
+    summonConfigReader[List[String]]
+    val a1: Int = ???
+    val a2: EmptyTuple = ???
+    a1 *: a2
+    ???
+}
+
+trait ConfigReader[A]
+object ConfigReader {
+  implicit def traversableReader[A, F[A] <: TraversableOnce[A]](implicit configConvert: ConfigReader[A]): ConfigReader[F[A]] = ???
+  implicit def exportedReader[A](implicit exported: Exported[ConfigReader[A]]): ConfigReader[A] = exported.instance
+  case class Exported[A](instance: A)
+}
+
+import ConfigReader._
+inline given exportReader[A]: Exported[ConfigReader[A]] = Exported(HintsAwareConfigReaderDerivation.deriveReader[A])
+
+case class Settings(rules: List[String])
+
+val settings =
+  exportReader[Settings] // error


### PR DESCRIPTION
All of them would be achieved with implicit resolution, during which the global state (ctx.base) would have stopInlining set to true, but the corresponding error might not have been shown as part of that implicit resolution - now we reset that value after failing the implicit, if it was not already set before typing the implicit.

In a previous PR https://github.com/scala/scala3/pull/13783, an issue #13044 where a similar situation occurred was fixed by adding a check for a not inlined inline method call in erasure, and reporting the error there. For #i22423, this check was not early enough, leading to a crash in the same phase for symbols using specialErasure. Adding an additional check there would not be enough, as this particular minimisation also fails post-inlining Ychecks. Even outside of that, I also believe it's better to fail this early anyway, and also allow implicit resolution to try to pick another option if we each the mainline limit in another option.

Fixes #22423