### PR TITLE
Fix insertion of `using` in applications with trailing lambda syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -513,6 +513,21 @@ object Trees {
     case Using        // r.f(using x)
     case InfixTuple   // r f (x1, ..., xN) where N != 1;  needs to be treated specially for an error message in typedApply
 
+  /** The syntax used to pass the arguments in an application. */
+  enum ApplyStyle:
+    /** The arguments are passed in parentheses, e.g. `f(x)`. */
+    case Parentheses
+    /** A single argument is passed as a trailing lambda with braces, e.g.
+      * `f { x => ... }`.
+      */
+    case TrailingBraces
+    /** A single argument is passed as a trailing lambda with colon and
+      * indentation, e.g. `f: x => ...`.
+      */
+    case TrailingColon
+    /** The syntax used to pass the arguments is unknown. */
+    case Unknown
+
   /** fun(args) */
   case class Apply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
     extends GenericApply[T] {
@@ -527,6 +542,13 @@ object Trees {
      */
     def applyKind: ApplyKind =
       attachmentOrElse(untpd.KindOfApply, ApplyKind.Regular)
+
+    def setApplyStyle(style: ApplyStyle) =
+      putAttachment(untpd.StyleOfApply, style)
+      this
+
+    def applyStyle: ApplyStyle =
+      attachmentOrElse(untpd.StyleOfApply, ApplyStyle.Unknown)
   }
 
   /** fun[args] */

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1662,5 +1662,5 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
 
   protected def FunProto(args: List[Tree], resType: Type)(using Context) =
-    ProtoTypes.FunProtoTyped(args, resType)(ctx.typer, ApplyKind.Regular)
+    ProtoTypes.FunProtoTyped(args, resType)(ctx.typer, ApplyKind.Regular, ApplyStyle.Unknown)
 }

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -386,6 +386,9 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   /** Property key for contextual Apply trees of the form `fn given arg` */
   val KindOfApply: Property.StickyKey[ApplyKind] = Property.StickyKey()
 
+  /** Property key to attach an [[ApplyStyle]] to [[Apply]] trees. */
+  val StyleOfApply: Property.StickyKey[ApplyStyle] = Property.StickyKey()
+
   // ------ Creation methods for untyped only -----------------
 
   def Ident(name: Name)(implicit src: SourceFile): Ident = new Ident(name)
@@ -859,5 +862,5 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   }
 
   protected def FunProto(args: List[Tree], resType: Type)(using Context) =
-    ProtoTypes.FunProto(args, resType)(ctx.typer, ApplyKind.Regular)
+    ProtoTypes.FunProto(args, resType)(ctx.typer, ApplyKind.Regular, ApplyStyle.Unknown)
 }

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1085,7 +1085,7 @@ trait Applications extends Compatibility {
           // Do ignore other expected result types, since there might be an implicit conversion
           // on the result. We could drop this if we disallow unrestricted implicit conversions.
       val originalProto =
-        new FunProto(tree.args, resultProto)(this, tree.applyKind)(using argCtx(tree))
+        new FunProto(tree.args, resultProto)(this, tree.applyKind, tree.applyStyle)(using argCtx(tree))
       record("typedApply")
       val fun1 = typedExpr(tree.fun, originalProto)
 

--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -133,12 +133,18 @@ trait Migrations:
       val rewriteMsg = Message.rewriteNotice("This code", mversion.patchFrom)
       report.errorOrMigrationWarning(
         em"""Implicit parameters should be provided with a `using` clause.$rewriteMsg
-            |To disable the warning, please use the following option: 
+            |To disable the warning, please use the following option:
             |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
-            |""", 
+            |""",
         pt.args.head.srcPos, mversion)
       if mversion.needsPatch then
-        patch(Span(pt.args.head.span.start), "using ")
+        // In order to insert a `using`, the application needs to be done with
+        // parentheses syntax. See issue #22927 and related tests.
+        patch(Span(tree.span.end, pt.args.head.span.start), "(using ")
+        if pt.applyStyle != ApplyStyle.Parentheses then
+          // If the application wasn't done with the parentheses syntax, we need
+          // to add a trailing closing parenthesis.
+          patch(Span(pt.args.head.span.end), ")")
   end implicitParams
 
 end Migrations

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1861,7 +1861,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               val nestedCtx = outerCtx.fresh.setNewTyperState()
               inContext(nestedCtx) {
                 val protoArgs = args map (_ withType WildcardType)
-                val callProto = FunProto(protoArgs, WildcardType)(this, app.applyKind)
+                val callProto = FunProto(protoArgs, WildcardType)(this, app.applyKind, app.applyStyle)
                 val expr1 = typedExpr(expr, callProto)
                 if nestedCtx.reporter.hasErrors then NoType
                 else inContext(outerCtx) {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -88,7 +88,9 @@ class CompilationTests {
       compileFile("tests/rewrites/ambiguous-named-tuple-assignment.scala", defaultOptions.and("-rewrite", "-source:3.6-migration")),
       compileFile("tests/rewrites/i21382.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/unused.scala", defaultOptions.and("-rewrite", "-Wunused:all")),
-      compileFile("tests/rewrites/i22440.scala", defaultOptions.and("-rewrite"))
+      compileFile("tests/rewrites/i22440.scala", defaultOptions.and("-rewrite")),
+      compileFile("tests/rewrites/i22927.scala", defaultOptions.and("-rewrite", "-source:3.7-migration")),
+      compileFile("tests/rewrites/i22927b.scala", defaultOptions.and("-rewrite", "-source:3.7-migration"))
     ).checkRewrites()
   }
 

--- a/tests/neg/i22440.check
+++ b/tests/neg/i22440.check
@@ -3,5 +3,5 @@
   |            ^
   |            Implicit parameters should be provided with a `using` clause.
   |            This code can be rewritten automatically under -rewrite -source 3.7-migration.
-  |            To disable the warning, please use the following option: 
+  |            To disable the warning, please use the following option:
   |              "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"

--- a/tests/rewrites/i22440.check
+++ b/tests/rewrites/i22440.check
@@ -2,4 +2,4 @@
 
 def foo(implicit x: Int) = ()
 val _ = foo(using 1)
-val _ = foo    (using 1)
+val _ = foo(using 1)

--- a/tests/rewrites/i22927.check
+++ b/tests/rewrites/i22927.check
@@ -1,0 +1,11 @@
+class Input(x: String)
+
+trait Decoder[T]
+
+object Decoder:
+  inline def apply[T](implicit f: () => Unit): Decoder[T] = ???
+
+object Input:
+  given Decoder[Input] = Decoder(using { () =>
+    Input("")
+  })

--- a/tests/rewrites/i22927.scala
+++ b/tests/rewrites/i22927.scala
@@ -1,0 +1,13 @@
+class Input(x: String)
+
+trait Decoder[T]
+
+object Decoder {
+  inline def apply[T](implicit f: () => Unit): Decoder[T] = ???
+}
+
+object Input {
+  given Decoder[Input] = Decoder { () =>
+    Input("")
+  }
+}

--- a/tests/rewrites/i22927b.check
+++ b/tests/rewrites/i22927b.check
@@ -1,0 +1,51 @@
+
+def foo(implicit f: () => Unit): Unit = ???
+def bar(a: Int)(implicit f: () => Unit): Unit = ???
+
+@main def main =
+  // Trailing lambdas with braces:
+  foo(using { () => 43 })
+  foo(using { () => val x = 42; 43 })
+  foo(using { () => val x = 42; 43 })
+  foo(using {() => val x = 42; 43})
+  bar(1)(using { () =>
+    val x = 42
+    43 })
+
+  // Parentheses:
+  foo(using () => 43 )
+  foo(using () =>
+    val x = 42
+    43
+  )
+  foo(using () =>
+    val x = 42
+    43
+  )
+  foo(using () =>
+    val x = 42
+    43
+  )
+  bar(1)(using () =>
+    val x = 42
+    43 )
+
+  // Trailing lambdas with column and indentation:
+  foo(using () =>
+    43)
+  foo(using () =>
+    val x = 42
+    43)
+  foo(using () =>
+    val x = 42
+    43)
+  foo(using () =>
+    val x = 42
+    43)
+  foo(using () =>
+      val x = 42
+      43)
+  bar(1)(using () =>
+    val x = 42
+    43)
+

--- a/tests/rewrites/i22927b.scala
+++ b/tests/rewrites/i22927b.scala
@@ -1,0 +1,54 @@
+
+def foo(implicit f: () => Unit): Unit = ???
+def bar(a: Int)(implicit f: () => Unit): Unit = ???
+
+@main def main =
+  // Trailing lambdas with braces:
+  foo { () => 43 }
+  foo { () => val x = 42; 43 }
+  foo{ () => val x = 42; 43 }
+  foo {() => val x = 42; 43}
+  bar(1) { () =>
+    val x = 42
+    43 }
+
+  // Parentheses:
+  foo ( () => 43 )
+  foo ( () =>
+    val x = 42
+    43
+  )
+  foo( () =>
+    val x = 42
+    43
+  )
+  foo (() =>
+    val x = 42
+    43
+  )
+  bar(1) ( () =>
+    val x = 42
+    43 )
+
+  // Trailing lambdas with column and indentation:
+  foo: () =>
+    43
+  foo : () =>
+    val x = 42
+    43
+  foo :() =>
+    val x = 42
+    43
+  foo
+  : () =>
+    val x = 42
+    43
+  foo
+  :
+    () =>
+      val x = 42
+      43
+  bar(1) : () =>
+    val x = 42
+    43
+

--- a/tests/warn/i22440.check
+++ b/tests/warn/i22440.check
@@ -3,5 +3,5 @@
   |            ^
   |            Implicit parameters should be provided with a `using` clause.
   |            This code can be rewritten automatically under -rewrite -source 3.7-migration.
-  |            To disable the warning, please use the following option: 
+  |            To disable the warning, please use the following option:
   |              "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"


### PR DESCRIPTION
Fixes #22731.

Work-in-progress.

Started during today's Compiler Spree with @ajafri2001.