### PR TITLE
Backport "Deprecate `Yno-kind-polymorphism`" to 3.7

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -443,7 +443,8 @@ private sealed trait YSettings:
   val YwithBestEffortTasty: Setting[Boolean] = BooleanSetting(ForkSetting, "Ywith-best-effort-tasty", "Allow to compile using best-effort tasty files. If such file is used, the compiler will stop after the pickler phase.")
 
   // Experimental language features
-  val YnoKindPolymorphism: Setting[Boolean] = BooleanSetting(ForkSetting, "Yno-kind-polymorphism", "Disable kind polymorphism.")
+  @deprecated(message = "This flag has no effect and will be removed in a future version.", since = "3.7.0")
+  val YnoKindPolymorphism: Setting[Boolean] = BooleanSetting(ForkSetting, "Yno-kind-polymorphism", "Disable kind polymorphism. (This flag has no effect)", deprecation = Deprecation.removed())
   val YexplicitNulls: Setting[Boolean] = BooleanSetting(ForkSetting, "Yexplicit-nulls", "Make reference types non-nullable. Nullable types can be expressed with unions: e.g. String|Null.")
   val YnoFlexibleTypes: Setting[Boolean] = BooleanSetting(ForkSetting, "Yno-flexible-types", "Disable turning nullable Java return types and parameter types into flexible types, which behave like abstract types with a nullable lower bound and non-nullable upper bound.")
   val YcheckInitGlobal: Setting[Boolean] = BooleanSetting(ForkSetting, "Ysafe-init-global", "Check safe initialization of global objects.")

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -449,10 +449,7 @@ class Definitions {
 
   @tu lazy val AnyKindClass: ClassSymbol = {
     val cls = newCompleteClassSymbol(ScalaPackageClass, tpnme.AnyKind, AbstractFinal | Permanent, Nil, newScope(0))
-    if (!ctx.settings.YnoKindPolymorphism.value)
-      // Enable kind-polymorphism by exposing scala.AnyKind
-      cls.entered
-    cls
+    cls.entered
   }
   def AnyKindType: TypeRef = AnyKindClass.typeRef
 

--- a/docs/_docs/reference/other-new-features/kind-polymorphism.md
+++ b/docs/_docs/reference/other-new-features/kind-polymorphism.md
@@ -43,5 +43,4 @@ It is declared `abstract` and `final`, so it can be neither instantiated nor ext
 
 `AnyKind` plays a special role in Scala's subtype system: It is a supertype of all other types no matter what their kind is. It is also assumed to be kind-compatible with all other types. Furthermore, `AnyKind` is treated as a higher-kinded type (so it cannot be used as a type of values), but at the same time it has no type parameters (so it cannot be instantiated).
 
-**Note:** This feature is considered experimental but stable and it can be disabled under compiler flag
-(i.e. `-Yno-kind-polymorphism`).
+**Note:** This feature is now stable. The compiler flag `-Yno-kind-polymorphism` is deprecated as of 3.7.0, has no effect (is ignored), and will be removed in a future version.

--- a/tests/neg/no-kind-polymorphism-anykind.scala
+++ b/tests/neg/no-kind-polymorphism-anykind.scala
@@ -1,3 +1,0 @@
-//> using options -Yno-kind-polymorphism
-
-trait Foo[T <: AnyKind] // error: Not found: type AnyKind

--- a/tests/pos/deprecated-no-kind-polymorphism-anykind.scala
+++ b/tests/pos/deprecated-no-kind-polymorphism-anykind.scala
@@ -1,0 +1,5 @@
+// This test is kept as a placeholder for historical reasons.
+// The -Yno-kind-polymorphism flag is now deprecated and has no effect.
+// Kind polymorphism with AnyKind is always enabled.
+
+trait Foo[T <: AnyKind] // This now works as AnyKind is always defined


### PR DESCRIPTION
Backports #22814 to the 3.7.0-RC2.

PR submitted by the release tooling.
[skip ci]