### PR TITLE
Backport "Fail compilation if multiple conflicting top-level private defs/vals are in the same package" to 3.7

### DIFF
--- a/tests/neg/i22721.check
+++ b/tests/neg/i22721.check
@@ -1,0 +1,6 @@
+-- [E161] Naming Error: tests/neg/i22721/test2.scala:3:12 --------------------------------------------------------------
+3 |private def foobar: Int = 0 // error
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |foobar is already defined as method foobar in tests/neg/i22721/test1.scala
+  |
+  |Note that overloaded methods must all be defined in the same group of toplevel definitions

--- a/tests/neg/i22721/test1.scala
+++ b/tests/neg/i22721/test1.scala
@@ -1,0 +1,4 @@
+package example
+
+private def foobar: String = "foo"
+object test1 { def x = foobar }

--- a/tests/neg/i22721/test2.scala
+++ b/tests/neg/i22721/test2.scala
@@ -1,0 +1,4 @@
+package example
+
+private def foobar: Int = 0 // error
+object test2 { def x = foobar }

--- a/tests/neg/toplevel-overload/moredefs_1.scala
+++ b/tests/neg/toplevel-overload/moredefs_1.scala
@@ -2,4 +2,4 @@ trait B
 
 def f(x: B) = s"B" // error: has already been compiled
 
-private def g(): Unit = () // OK, since it is private
+private def g(): Unit = () // error: has already been compiled (def is visible in package)


### PR DESCRIPTION
Backports #22759 to the 3.7.0-RC2.

PR submitted by the release tooling.