### PR TITLE
Fix insertion of `using` in applications with trailing lambda syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -130,27 +130,25 @@ trait Migrations:
   def implicitParams(tree: Tree, tp: MethodOrPoly, pt: FunProto)(using Context): Unit =
     val mversion = mv.ImplicitParamsWithoutUsing
     if tp.companion == ImplicitMethodType && pt.applyKind != ApplyKind.Using && pt.args.nonEmpty then
-      val rewriteMsg = Message.rewriteNotice("This code", mversion.patchFrom)
+      // The application can only be rewritten if it uses parentheses syntax.
+      // See issue #22927 and related tests.
+      val hasParentheses =
+        ctx.source.content
+          .slice(tree.span.end, pt.args.head.span.start)
+          .exists(_ == '(')
+      val rewriteMsg =
+        if hasParentheses then
+          Message.rewriteNotice("This code", mversion.patchFrom)
+        else
+          ""
       report.errorOrMigrationWarning(
         em"""Implicit parameters should be provided with a `using` clause.$rewriteMsg
             |To disable the warning, please use the following option: 
             |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
             |""", 
         pt.args.head.srcPos, mversion)
-      if mversion.needsPatch then
-        // In order to insert a `using`, the application needs to be done with
-        // parentheses syntax. See issue #22927 and related tests.
-        patch(Span(tree.span.end, pt.args.head.span.start), "(using ")
-        // Tentative heuristic: the application was done with parentheses syntax
-        // if there is a `(` between the function and the first argument.
-        val hasParentheses =
-          ctx.source.content
-            .slice(tree.span.end, pt.args.head.span.start)
-            .exists(_ == '(')
-        if !hasParentheses then
-          // If the application wasn't done with the parentheses syntax, we need
-          // to add a trailing closing parenthesis.
-          patch(Span(pt.args.head.span.end), ")")
+      if hasParentheses && mversion.needsPatch then
+        patch(Span(pt.args.head.span.start), "using ")
   end implicitParams
 
 end Migrations

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -88,7 +88,9 @@ class CompilationTests {
       compileFile("tests/rewrites/ambiguous-named-tuple-assignment.scala", defaultOptions.and("-rewrite", "-source:3.6-migration")),
       compileFile("tests/rewrites/i21382.scala", defaultOptions.and("-indent", "-rewrite")),
       compileFile("tests/rewrites/unused.scala", defaultOptions.and("-rewrite", "-Wunused:all")),
-      compileFile("tests/rewrites/i22440.scala", defaultOptions.and("-rewrite"))
+      compileFile("tests/rewrites/i22440.scala", defaultOptions.and("-rewrite")),
+      compileFile("tests/rewrites/i22731.scala", defaultOptions.and("-rewrite", "-source:3.7-migration")),
+      compileFile("tests/rewrites/i22731b.scala", defaultOptions.and("-rewrite", "-source:3.7-migration")),
     ).checkRewrites()
   }
 

--- a/tests/rewrites/i22731.check
+++ b/tests/rewrites/i22731.check
@@ -1,0 +1,11 @@
+class Input(x: String)
+
+trait Decoder[T]
+
+object Decoder:
+  inline def apply[T](implicit f: () => Unit): Decoder[T] = ???
+
+object Input:
+  given Decoder[Input] = Decoder(using { () =>
+    Input("")
+  })

--- a/tests/rewrites/i22731.check
+++ b/tests/rewrites/i22731.check
@@ -6,6 +6,6 @@ object Decoder:
   inline def apply[T](implicit f: () => Unit): Decoder[T] = ???
 
 object Input:
-  given Decoder[Input] = Decoder(using { () =>
+  given Decoder[Input] = Decoder { () =>
     Input("")
-  })
+  }

--- a/tests/rewrites/i22731.scala
+++ b/tests/rewrites/i22731.scala
@@ -1,0 +1,13 @@
+class Input(x: String)
+
+trait Decoder[T]
+
+object Decoder {
+  inline def apply[T](implicit f: () => Unit): Decoder[T] = ???
+}
+
+object Input {
+  given Decoder[Input] = Decoder { () =>
+    Input("")
+  }
+}

--- a/tests/rewrites/i22731b.check
+++ b/tests/rewrites/i22731b.check
@@ -2,48 +2,49 @@ def foo(implicit f: () => Unit): Unit = ???
 def bar(a: Int)(implicit f: () => Unit): Unit = ???
 
 @main def main =
-  // Trailing lambdas with braces:
-  foo(using { () => 43 })
-  foo(using { () => val x = 42; 43 })
-  foo(using { () => val x = 42; 43 })
-  foo(using {() => val x = 42; 43})
-  bar(1)(using { () =>
-    val x = 42
-    43 })
-
-  // Parentheses:
-  foo(using () => 43 )
-  foo(using () =>
+  // `using` can automatically be added when the application is done with parentheses
+  foo ( using () => 43 )
+  foo ( using () =>
     val x = 42
     43
   )
-  foo(using () =>
+  foo( using () =>
     val x = 42
     43
   )
-  foo(using () =>
+  foo (using () =>
     val x = 42
     43
   )
-  bar(1)(using () =>
+  bar(1) ( using () =>
     val x = 42
     43 )
 
-  // Trailing lambdas with column and indentation:
-  foo(using () =>
-    43)
-  foo(using () =>
+  // `using` cannot automatically be added when the application is done with trailing lambda syntax
+  foo { () => 43 }
+  foo { () => val x = 42; 43 }
+  foo{ () => val x = 42; 43 }
+  foo {() => val x = 42; 43}
+  bar(1) { () =>
     val x = 42
-    43)
-  foo(using () =>
+    43 }
+  foo: () =>
+    43
+  foo : () =>
     val x = 42
-    43)
-  foo(using () =>
+    43
+  foo :() =>
     val x = 42
-    43)
-  foo(using () =>
+    43
+  foo
+  : () =>
+    val x = 42
+    43
+  foo
+  :
+    () =>
       val x = 42
-      43)
-  bar(1)(using () =>
+      43
+  bar(1) : () =>
     val x = 42
-    43)
+    43

--- a/tests/rewrites/i22731b.check
+++ b/tests/rewrites/i22731b.check
@@ -1,0 +1,49 @@
+def foo(implicit f: () => Unit): Unit = ???
+def bar(a: Int)(implicit f: () => Unit): Unit = ???
+
+@main def main =
+  // Trailing lambdas with braces:
+  foo(using { () => 43 })
+  foo(using { () => val x = 42; 43 })
+  foo(using { () => val x = 42; 43 })
+  foo(using {() => val x = 42; 43})
+  bar(1)(using { () =>
+    val x = 42
+    43 })
+
+  // Parentheses:
+  foo(using () => 43 )
+  foo(using () =>
+    val x = 42
+    43
+  )
+  foo(using () =>
+    val x = 42
+    43
+  )
+  foo(using () =>
+    val x = 42
+    43
+  )
+  bar(1)(using () =>
+    val x = 42
+    43 )
+
+  // Trailing lambdas with column and indentation:
+  foo(using () =>
+    43)
+  foo(using () =>
+    val x = 42
+    43)
+  foo(using () =>
+    val x = 42
+    43)
+  foo(using () =>
+    val x = 42
+    43)
+  foo(using () =>
+      val x = 42
+      43)
+  bar(1)(using () =>
+    val x = 42
+    43)

--- a/tests/rewrites/i22731b.scala
+++ b/tests/rewrites/i22731b.scala
@@ -2,16 +2,7 @@ def foo(implicit f: () => Unit): Unit = ???
 def bar(a: Int)(implicit f: () => Unit): Unit = ???
 
 @main def main =
-  // Trailing lambdas with braces:
-  foo { () => 43 }
-  foo { () => val x = 42; 43 }
-  foo{ () => val x = 42; 43 }
-  foo {() => val x = 42; 43}
-  bar(1) { () =>
-    val x = 42
-    43 }
-
-  // Parentheses:
+  // `using` can automatically be added when the application is done with parentheses
   foo ( () => 43 )
   foo ( () =>
     val x = 42
@@ -29,7 +20,14 @@ def bar(a: Int)(implicit f: () => Unit): Unit = ???
     val x = 42
     43 )
 
-  // Trailing lambdas with column and indentation:
+  // `using` cannot automatically be added when the application is done with trailing lambda syntax
+  foo { () => 43 }
+  foo { () => val x = 42; 43 }
+  foo{ () => val x = 42; 43 }
+  foo {() => val x = 42; 43}
+  bar(1) { () =>
+    val x = 42
+    43 }
   foo: () =>
     43
   foo : () =>

--- a/tests/rewrites/i22731b.scala
+++ b/tests/rewrites/i22731b.scala
@@ -1,0 +1,52 @@
+def foo(implicit f: () => Unit): Unit = ???
+def bar(a: Int)(implicit f: () => Unit): Unit = ???
+
+@main def main =
+  // Trailing lambdas with braces:
+  foo { () => 43 }
+  foo { () => val x = 42; 43 }
+  foo{ () => val x = 42; 43 }
+  foo {() => val x = 42; 43}
+  bar(1) { () =>
+    val x = 42
+    43 }
+
+  // Parentheses:
+  foo ( () => 43 )
+  foo ( () =>
+    val x = 42
+    43
+  )
+  foo( () =>
+    val x = 42
+    43
+  )
+  foo (() =>
+    val x = 42
+    43
+  )
+  bar(1) ( () =>
+    val x = 42
+    43 )
+
+  // Trailing lambdas with column and indentation:
+  foo: () =>
+    43
+  foo : () =>
+    val x = 42
+    43
+  foo :() =>
+    val x = 42
+    43
+  foo
+  : () =>
+    val x = 42
+    43
+  foo
+  :
+    () =>
+      val x = 42
+      43
+  bar(1) : () =>
+    val x = 42
+    43

--- a/tests/warn/i22731.check
+++ b/tests/warn/i22731.check
@@ -1,0 +1,13 @@
+-- Warning: tests/warn/i22731.scala:5:11 -------------------------------------------------------------------------------
+5 |  foo ( () => 43 ) // warn
+  |        ^^^^^^^^
+  |        Implicit parameters should be provided with a `using` clause.
+  |        This code can be rewritten automatically under -rewrite -source 3.7-migration.
+  |        To disable the warning, please use the following option: 
+  |          "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
+-- Warning: tests/warn/i22731.scala:7:6 --------------------------------------------------------------------------------
+7 |  foo { () => 43 } // warn
+  |      ^^^^^^^^^^^^
+  |      Implicit parameters should be provided with a `using` clause.
+  |      To disable the warning, please use the following option: 
+  |        "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"

--- a/tests/warn/i22731.scala
+++ b/tests/warn/i22731.scala
@@ -1,0 +1,7 @@
+def foo(implicit f: () => Unit): Unit = ???
+
+@main def main =
+  // `using` can automatically be added when the application is done with parentheses
+  foo ( () => 43 ) // warn
+  // `using` cannot automatically be added when the application is done with trailing lambda syntax
+  foo { () => 43 } // warn


### PR DESCRIPTION
Fixes #22731