### PR TITLE
Exit on main arg parse error

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
+++ b/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
@@ -5,7 +5,7 @@ import core.*
 import Symbols.*, Types.*, Contexts.*, Decorators.*, util.Spans.*, Flags.*, Constants.*
 import StdNames.{nme, tpnme}
 import ast.Trees.*
-import Names.Name
+import Names.{Name, termName}
 import Comments.Comment
 import NameKinds.DefaultGetterName
 import Annotations.Annotation
@@ -94,7 +94,12 @@ object MainProxies {
       val handler = CaseDef(
         Typed(errVar, TypeTree(defn.CLP_ParseError.typeRef)),
         EmptyTree,
-        Apply(ref(defn.CLP_showError.termRef), errVar :: Nil))
+        Block(
+          List(Apply(ref(defn.CLP_showError.termRef), errVar :: Nil)),
+          Apply(Select(Select(Select(Ident(termName("java")), termName("lang")), termName("System")), termName("exit")),
+            List(Literal(Constant(1))))
+        )
+      )
       val body = Try(call, handler :: Nil, EmptyTree)
       val mainArg = ValDef(nme.args, TypeTree(defn.ArrayType.appliedTo(defn.StringType)), EmptyTree)
         .withFlags(Param)

--- a/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
+++ b/compiler/src/dotty/tools/dotc/ast/MainProxies.scala
@@ -96,8 +96,9 @@ object MainProxies {
         EmptyTree,
         Block(
           List(Apply(ref(defn.CLP_showError.termRef), errVar :: Nil)),
-          Apply(Select(Select(Select(Ident(termName("java")), termName("lang")), termName("System")), termName("exit")),
-            List(Literal(Constant(1))))
+          Throw(errVar)
+        //Apply(Select(Select(Select(Ident(termName("java")), termName("lang")), termName("System")), termName("exit")),
+        //  List(Literal(Constant(1))))
         )
       )
       val body = Try(call, handler :: Nil, EmptyTree)

--- a/compiler/test/dotty/tools/vulpix/ChildJVMMain.java
+++ b/compiler/test/dotty/tools/vulpix/ChildJVMMain.java
@@ -12,10 +12,15 @@ public class ChildJVMMain {
     static final String MessageStart = "##THIS IS THE START FOR ME, HELLO##";
     static final String MessageEnd = "##THIS IS THE END FOR ME, GOODBYE##";
 
-    private static void runMain(String dir) throws Exception {
+    private static void runMain(String line) throws Exception {
         Method meth = null;
-        Object[] args = new Object[]{ new String[]{ } };
+        String[] args = new String[]{ };
         try {
+	    String[] tokens = line.split("\\s+", 2);
+	    String dir = tokens[0];
+	    if (tokens.length > 1) {
+	      args = tokens[1].split("\\s+");
+	    }
             String jcp = System.getProperty("java.class.path");
             String sep = File.pathSeparator;
             System.setProperty("java.class.path", jcp == null ? dir : dir + sep + jcp);
@@ -37,15 +42,15 @@ public class ChildJVMMain {
         }
         System.out.println(MessageStart);
 
-        meth.invoke(null, args);
+        meth.invoke(null, new Object[] { args });
     }
 
     public static void main(String[] args) throws Exception {
-      BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in));
+        BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in));
 
-      while (true) {
-          runMain(stdin.readLine());
-          System.out.println(MessageEnd);
-      }
+        while (true) {
+            runMain(stdin.readLine());
+            System.out.println(MessageEnd);
+        }
     }
 }

--- a/library/src/scala/util/CommandLineParser.scala
+++ b/library/src/scala/util/CommandLineParser.scala
@@ -9,7 +9,7 @@ object CommandLineParser {
    *  @param idx  The index of the argument that's faulty (starting from 0)
    *  @param msg  The error message
    */
-  class ParseError(val idx: Int, val msg: String) extends Exception(msg)
+  class ParseError(val idx: Int, val msg: String) extends Exception(msg, null, false, false)
 
   /** Parse command line argument `s`, which has index `n`, as a value of type `T`
    *  @throws ParseError if argument cannot be converted to type `T`.

--- a/library/src/scala/util/CommandLineParser.scala
+++ b/library/src/scala/util/CommandLineParser.scala
@@ -1,23 +1,22 @@
 package scala.util
 
+import scala.util.control.ControlThrowable
+
 /** A utility object to support command line parsing for @main methods */
 object CommandLineParser {
 
   /** An exception raised for an illegal command line
-    *  @param idx  The index of the argument that's faulty (starting from 0)
-    *  @param msg  The error message
-    */
-  class ParseError(val idx: Int, val msg: String) extends Exception
+   *  @param idx  The index of the argument that's faulty (starting from 0)
+   *  @param msg  The error message
+   */
+  class ParseError(val idx: Int, val msg: String) extends Exception(msg)
 
   /** Parse command line argument `s`, which has index `n`, as a value of type `T`
    *  @throws ParseError if argument cannot be converted to type `T`.
    */
-  def parseString[T](str: String, n: Int)(using fs: FromString[T]): T = {
+  def parseString[T](str: String, n: Int)(using fs: FromString[T]): T =
     try fs.fromString(str)
-    catch {
-      case ex: IllegalArgumentException => throw ParseError(n, ex.toString)
-    }
-  }
+    catch case ex: IllegalArgumentException => throw ParseError(n, ex.toString)
 
   /** Parse `n`'th argument in `args` (counting from 0) as a value of type `T`
    *  @throws ParseError if argument does not exist or cannot be converted to type `T`.

--- a/tests/printing/infix-operations.check
+++ b/tests/printing/infix-operations.check
@@ -31,6 +31,7 @@ package <empty> {
         {
           case error @ _:scala.util.CommandLineParser.ParseError =>
             scala.util.CommandLineParser.showError(error)
+            throw error
         }
   }
 }

--- a/tests/run/Pouring.check
+++ b/tests/run/Pouring.check
@@ -1,1 +1,2 @@
-Illegal command line: more arguments expected
+Moves: Vector(Empty(0), Empty(1), Fill(0), Fill(1), Pour(0,1), Pour(1,0))
+Solution: Some(Fill(1) Pour(1,0) Empty(0) Pour(1,0) Fill(1) Pour(1,0) --> Vector(4, 6))

--- a/tests/run/Pouring.scala
+++ b/tests/run/Pouring.scala
@@ -1,3 +1,5 @@
+// java: 6 4 7
+
 type Glass = Int
 type Levels = Vector[Int]
 


### PR DESCRIPTION
Could be a better way to construct the expr, there is `Definitions.SystemModule`.

Could use a test.

As a user, I never want to see stack trace from the arg mechanism. Parse error could take a cause, perhaps.

Fixes #16040 