### PR TITLE
Mitigate change in status of scala.caps

### DIFF
--- a/tests/neg/i22890.check
+++ b/tests/neg/i22890.check
@@ -1,0 +1,7 @@
+-- [E161] Naming Error: tests/neg/i22890/caps_1.java:3:0 ---------------------------------------------------------------
+3 |class caps { // error: caps is already defined as package caps
+  |^
+  |caps is already defined as package scala.caps
+package scala contains object and package with same name: caps.
+This indicates that there are several versions of the Scala standard library on the classpath.
+The build should be reconfigured so that only one version of the standard library is on the classpath.

--- a/tests/neg/i22890/Test_2.scala
+++ b/tests/neg/i22890/Test_2.scala
@@ -1,0 +1,3 @@
+@main def Test =
+  println("hello")
+// nopos-warn

--- a/tests/neg/i22890/caps_1.java
+++ b/tests/neg/i22890/caps_1.java
@@ -1,0 +1,5 @@
+package scala;
+
+class caps { // error: caps is already defined as package caps
+  static public void foo() {}
+}


### PR DESCRIPTION
`scala.caps` was an object until 3.6, it is a package from 3.7. Without special handling this would cause a TypeError to be thrown if a build has several versions of the Scala standard library on the classpath. This was the case for 29 projects in the open CB. These projects should be updated. But until that's the case we issue a warning instead of a hard failure.