### PR TITLE
Fix fromProduct synthesized code for parameter-dependent case classes

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4059,12 +4059,13 @@ object Types extends TypeUtils {
     def isParamDependent(using Context): Boolean =
       paramDependencyStatus == TrueDeps
 
-    /** Like resultDependent || paramDependent, but without attempt to eliminate
-     *  dependencies with de-aliasing
-     */
-    def looksDependent(using Context): Boolean =
+    /** Like isResultDependent, but without attempt to eliminate dependencies with de-aliasing */
+    def looksResultDependent(using Context): Boolean =
       (dependencyStatus & StatusMask) != NoDeps
-      || (paramDependencyStatus & StatusMask) != NoDeps
+
+    /** Like isParamDependent, but without attempt to eliminate dependencies with de-aliasing */
+    def looksParamDependent(using Context): Boolean =
+      (paramDependencyStatus & StatusMask) != NoDeps
 
     def newParamRef(n: Int): TermParamRef = new TermParamRefImpl(this, n)
 

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -189,7 +189,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         val isContextual = tp.isImplicitMethod
         val capturesRoot = refs == rootSetText
         if cc.isCaptureCheckingOrSetup
-            && tp.allParamNamesSynthetic && !tp.looksDependent
+            && tp.allParamNamesSynthetic
+            && !tp.looksResultDependent && !tp.looksParamDependent
             && !showUniqueIds && !printDebug && !printFresh
           then
           // cc.Setup converts all functions to dependent functions. Undo that when printing.

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -81,9 +81,9 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     val existing = sym.matchingMember(clazz.thisType)
     if ctx.settings.YcompileScala2Library.value && clazz.isValueClass && (sym == defn.Any_equals || sym == defn.Any_hashCode) then
       NoSymbol
-    else if existing != sym && !existing.is(Deferred) then 
-      existing 
-    else 
+    else if existing != sym && !existing.is(Deferred) then
+      existing
+    else
       NoSymbol
   end existingDef
 
@@ -569,8 +569,9 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       newSymbol(ctx.owner, pref.paramName.freshened, Synthetic,
         pref.underlying.translateFromRepeated(toArray = false), coord = ctx.owner.span.focus)
     val bindingRefs = bindingSyms.map(TermRef(NoPrefix, _))
-    // Fix the infos for dependent parameters
-    if constrMeth.isParamDependent then
+    // Fix the infos for dependent parameters. We also need to include false dependencies that would
+    // be fixed by de-aliasing since we do no such de-aliasing here. See i22944.scala.
+    if constrMeth.looksParamDependent then
       bindingSyms.foreach: bindingSym =>
         bindingSym.info = bindingSym.info.substParams(constrMeth, bindingRefs)
 

--- a/tests/pos/i22944.scala
+++ b/tests/pos/i22944.scala
@@ -1,0 +1,39 @@
+trait Wrapper {
+  type Member
+}
+
+object Wrapper {
+
+  type Aux[M] =
+    Wrapper {
+      type Member = M
+    }
+
+}
+
+// note: the `private` and `private val` are probably not necessary
+final case class Demo[M] private (
+    private val service: Wrapper.Aux[M],
+    private val endpoints: Vector[service.Member]
+)
+
+trait Servo[Alg[_[_]]] {
+
+  type Operation[I]
+}
+
+object Servo {
+
+  type Aux[Alg[_[_]], Op[_]] =
+    Servo[Alg] {
+      type Operation[I] = Op[I]
+    }
+
+}
+
+trait MyEndpoint[Op[_]]
+
+final case class BSPBuilder2[Alg[_[_]], Op[_]] private (
+    private val service: Servo.Aux[Alg, Op],
+    private val endpoints: Vector[MyEndpoint[service.Operation]]
+)


### PR DESCRIPTION
The parameter dependency test has to include also false dependencies that can be eliminated by de-aliasing.

Fixes #22944