### PR TITLE
fix: show hover for synthetics if explicitly used

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/MetalsInteractive.scala
@@ -230,13 +230,6 @@ object MetalsInteractive:
         if head.symbol.is(Exported) then
           val sym = head.symbol.sourceSymbol
           List((sym, sym.info, None))
-        else if head.symbol.is(Synthetic) then
-          enclosingSymbolsWithExpressionType(
-            tail,
-            pos,
-            indexed,
-            skipCheckOnName
-          )
         else if head.symbol != NoSymbol then
           if skipCheckOnName ||
             MetalsInteractive.isOnName(
@@ -245,6 +238,13 @@ object MetalsInteractive:
               indexed.ctx.source
             )
           then List((head.symbol, head.typeOpt, None))
+          else if head.symbol.is(Synthetic) then
+            enclosingSymbolsWithExpressionType(
+              tail,
+              pos,
+              indexed,
+              skipCheckOnName
+            )
           /* Type tree for List(1) has an Int type variable, which has span
            * but doesn't exist in code.
            * https://github.com/scala/scala3/issues/15937

--- a/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala
@@ -744,3 +744,17 @@ class HoverTermSuite extends BaseHoverSuite:
          |""".stripMargin,
       "name: String".hover
     )
+
+  @Test def `value-of`: Unit =
+    check(
+      """|enum Foo(val key: String) {
+         |  case Bar extends Foo("b")
+         |  case Baz extends Foo("z")
+         |}
+         |
+         |object Foo {
+         |  def parse(key: String) = Foo.va@@lueOf("b")
+         |
+         |""".stripMargin,
+         "def valueOf($name: String): Foo".hover
+    )


### PR DESCRIPTION
resolves: https://github.com/scalameta/metals/issues/7266