### PR TITLE
Improve checking LHS of Assign

### DIFF
--- a/tests/warn/i15503a.scala
+++ b/tests/warn/i15503a.scala
@@ -460,3 +460,11 @@ package ancient:
     }
   }
 end ancient
+
+object `i22970 assign lhs was ignored`:
+  object X:
+    var global = 0
+  object Main:
+    import X.global // no warn
+    def main(args: Array[String]): Unit =
+      global = 1


### PR DESCRIPTION
Fixes #22970

Simple example showing how awkward this is compared to a traversal, where there is more control when descending.

Previously, it "ignored" the LHS of Assign to avoid taking `x = y` as ref to `x` instead of assignment to.

Now, "mark" the LHS as assignment, so `transformIdent` and `Select` set a "mode" flag, such that `x` is correctly taken as either a ref or assign to `x`.

Probably there is more complex syntax to handle as LHS, but I haven't had coffee yet.