### PR TITLE
Fix setup of class constructors

### DIFF
--- a/tests/neg-custom-args/captures/leaky.check
+++ b/tests/neg-custom-args/captures/leaky.check
@@ -1,0 +1,32 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/leaky.scala:14:2 -----------------------------------------
+14 |  val f: Any ->{a} Any = _ =>  // error
+   |  ^
+   |  Found:    test.runnable.Transform{val fun: Any ->{a} Any}^{a}
+   |  Required: test.runnable.Transform
+15 |    a.print()
+16 |    ()
+17 |  Transform(f)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/leaky.scala:20:2 -----------------------------------------
+20 |  val f: Any ->{a} Any = _ => // error
+   |  ^
+   |  Found:    test.runnable.Transform{val fun: Any ->{a} Any}^{a}
+   |  Required: test.runnable.Transform
+21 |    a.print()
+22 |    ()
+23 |  val x = Transform(f)
+24 |  x
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/leaky.scala:27:2 -----------------------------------------
+27 |  val f: Any ->{a} Any = _ =>  // error
+   |  ^
+   |  Found:    test.runnable.Transform{val fun: Any ->{a} Any}^{a}
+   |  Required: test.runnable.Transform
+28 |    a.print()
+29 |    ()
+30 |  val x = Transform.app(f)
+31 |  x
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/leaky.scala
+++ b/tests/neg-custom-args/captures/leaky.scala
@@ -1,0 +1,37 @@
+package test.runnable
+import language.experimental.captureChecking
+
+case class A() extends caps.Capability:
+  def print() = println("leaking...")
+
+class Transform(fun: Any => Any):
+  def run() = fun(())
+object Transform:
+  def app(f: Any => Any): Transform { val fun: Any->{f} Any } ^ {f} =
+    Transform(f)
+
+def leak(a: A): Transform^{} =
+  val f: Any ->{a} Any = _ =>  // error
+    a.print()
+    ()
+  Transform(f)
+
+def leak1(a: A): Transform^{} =
+  val f: Any ->{a} Any = _ => // error
+    a.print()
+    ()
+  val x = Transform(f)
+  x
+
+def leak2(a: A): Transform^{} =
+  val f: Any ->{a} Any = _ =>  // error
+    a.print()
+    ()
+  val x = Transform.app(f)
+  x
+
+def withA[T](body: A => T): T = body(A())
+
+@main def Main() =
+  val t = withA(leak)
+  t.run()


### PR DESCRIPTION
Fix the containsCovarRetains criterion that decides when to make a parameter not private for the purposes of capture checking. We were missing a dealias, so `A => B` was not detected to contain a capture set.

Also avoid refining with the same name twice in inferred types.