### PR TITLE
Remove premature caching of lookups for unused lint

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -436,7 +436,7 @@ object CheckUnused:
         if inliners == 0
           && languageImport(imp.expr).isEmpty
           && !imp.isGeneratedByEnum
-          && !ctx.outer.owner.name.isReplWrapperName
+          && !ctx.owner.name.isReplWrapperName
         then
           imps.put(imp, ())
       case tree: Bind =>

--- a/tests/warn/i22971.scala
+++ b/tests/warn/i22971.scala
@@ -1,0 +1,34 @@
+//> using options -Wunused:imports
+
+package p:
+
+  trait Base
+  class Class extends Base
+
+  abstract class Entity[T: GetType]
+
+  class Thing extends Entity[Class]
+
+  trait GetType[T]
+
+  object GetType {
+    //implicit object GetTypeClass extends GetType[Class]
+    implicit val GetTypeClass: GetType[Class] = new GetType[Class] {}
+  }
+  object Main {
+    def main(args: Array[String]): Unit = {
+      import GetType.*
+      val e = GetTypeClass
+    }
+  }
+
+package q:
+
+  class C:
+    def f =
+      import p.*
+      GetType.GetTypeClass
+    def g =
+      import p.GetType.*
+      GetTypeClass
+  class D extends p.Entity[p.Class]


### PR DESCRIPTION
Caching a lookup of c in a.b.c is ok at a.b.
A lookup from a.p should not see the cached value.

Fixes #22971 