### PR TITLE
Drill into QuotePattern bindings symbol info

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -741,11 +741,11 @@ object Trees {
   }
 
   /** A tree representing a quote pattern `'{ type binding1; ...; body }` or `'[ type binding1; ...; body ]`.
-   *  `QuotePattern`s are created the type checker when typing an `untpd.Quote` in a pattern context.
+   *  `QuotePattern`s are created by the type checker when typing an `untpd.Quote` in a pattern context.
    *
    *  `QuotePattern`s are checked are encoded into `unapply`s  in the `staging` phase.
    *
-   *   The `bindings` contain the list of quote pattern type variable definitions (`Bind`s) in the oreder in
+   *   The `bindings` contain the list of quote pattern type variable definitions (`Bind`s) in the order in
    *   which they are defined in the source.
    *
    *   @param  bindings  Type variable definitions (`Bind` tree)

--- a/tests/warn/i22981.scala
+++ b/tests/warn/i22981.scala
@@ -1,0 +1,9 @@
+//> using options -Werror -Wunused:all
+import scala.quoted.*
+
+object test {
+  import scala.concurrent.duration.FiniteDuration
+
+  def applyImpl[A: Type](using Quotes): Expr[Unit] =
+    Type.of[A] match { case '[type d <: FiniteDuration; d] => '{ () } }
+}


### PR DESCRIPTION
Fixes #22981

The phase examines trees, not every type. Maybe this is just a matter of adding a case to `Other` trees. This fix also works at `transformBind`.

Alternatively, it reflects the strategy of the phase in 3.6, that if the mini-phase API doesn't offer structural support, then it might as well do a custom traversal. Then the question is whether mini-phase is just overhead of dispatch.

Besides checking imports, types could appear only in (possibly inferred) types.
