### PR TITLE
Add experimental.packageObjectValues language setting

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -61,7 +61,8 @@ object Feature:
     (pureFunctions, "Enable pure functions for capture checking"),
     (captureChecking, "Enable experimental capture checking"),
     (into, "Allow into modifier on parameter types"),
-    (modularity, "Enable experimental modularity features")
+    (modularity, "Enable experimental modularity features"),
+    (packageObjectValues, "Enable experimental package objects as values"),
   )
 
   // legacy language features from Scala 2 that are no longer supported.

--- a/tests/pos/packageObjectValues.scala
+++ b/tests/pos/packageObjectValues.scala
@@ -1,0 +1,7 @@
+//> using options -language:experimental.packageObjectValues
+
+package object p { }
+
+object Test:
+  val x = p
+


### PR DESCRIPTION
By an ovsersight this was available only as a language import.

Fixes #22830