### PR TITLE
Warn if match in block is not used for PartialFunction

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -224,6 +224,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case ExtensionHasDefaultID // errorNumber: 208
   case FormatInterpolationErrorID // errorNumber: 209
   case ValueClassCannotExtendAliasOfAnyValID // errorNumber: 210
+  case MatchIsNotPartialFunctionID // errorNumber: 211
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ExpandSAMs.scala
@@ -126,10 +126,16 @@ class ExpandSAMs extends MiniPhase:
     // The right hand side from which to construct the partial function. This is always a Match.
     // If the original rhs is already a Match (possibly in braces), return that.
     // Otherwise construct a match `x match case _ => rhs` where `x` is the parameter of the closure.
-    def partialFunRHS(tree: Tree): Match = tree match
+    def partialFunRHS(tree: Tree): Match =
+      inline def checkMatch(): Unit =
+        tree match
+        case Block(_, m: Match) => report.warning(reporting.MatchIsNotPartialFunction(), m.srcPos)
+        case _ =>
+      tree match
       case m: Match => m
       case Block(Nil, expr) => partialFunRHS(expr)
       case _ =>
+        checkMatch()
         Match(ref(param.symbol),
           CaseDef(untpd.Ident(nme.WILDCARD).withType(param.symbol.info), EmptyTree, tree) :: Nil)
 

--- a/tests/warn/i21649.scala
+++ b/tests/warn/i21649.scala
@@ -1,0 +1,16 @@
+//> using options -explain
+// do warn if function literal adaptation has match in non-empty block
+
+import scala.util.*
+import PartialFunction.condOpt
+
+val f: PartialFunction[String, Boolean] = _.toUpperCase match { case "TRUE" => true }
+
+val g: PartialFunction[String, Boolean] = x =>
+  val uc = x.toUpperCase
+  uc match // warn
+  case "TRUE" => true
+
+def kollekt = List("1", "two", "3").collect(x => Try(x.toInt) match { case Success(i) => i })
+
+def lesen = List("1", "two", "3").flatMap(x => condOpt(Try(x.toInt)) { case Success(i) => i })


### PR DESCRIPTION
Fixes #21649 

Addresses the immediate user issue. (Confusion about compiler behavior.)

Follow-up is improve doc for `PartialFunction` and improve spec for pattern-matching anonymous function to include non-trivial selector expression.

Actually, first follow-up will be to address:
```Scala
scala> def f: PartialFunction[(Int, Int), Int] = (x, y) => (2*x, y) match { case (x, y) if x < 5 => x + y }
1 warning found
-- [E210] Syntax Warning: ------------------------------------------------------
1 |def f: PartialFunction[(Int, Int), Int] = (x, y) => (2*x, y) match { case (x, y) if x < 5 => x + y }
  |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |match expression in result of block will not be used to synthesize partial function
  |
  | longer explanation available when compiling with `-explain`
def f: PartialFunction[(Int, Int), Int]
```
oh that's because of how parameters are untupled, no doubt. Compare
```Scala
scala> def f: PartialFunction[(Int, Int), Int] = p => (2*p._1, p._2) match { case (x, y) if x < 5 => x + y }
def f: PartialFunction[(Int, Int), Int]
```