### PR TITLE
doc: make TypeTest example compiling

### DIFF
--- a/docs/_docs/reference/other-new-features/type-test.md
+++ b/docs/_docs/reference/other-new-features/type-test.md
@@ -63,7 +63,7 @@ We could create a type test at call site where the type test can be performed wi
 val tt: TypeTest[Any, String] =
   new TypeTest[Any, String]:
     def unapply(s: Any): Option[s.type & String] = s match
-      case s: String => Some(s)
+      case q: (s.type & String) => Some(q)
       case _ => None
 
 f[AnyRef, String]("acb")(using tt)

--- a/docs/_spec/TODOreference/other-new-features/type-test.md
+++ b/docs/_spec/TODOreference/other-new-features/type-test.md
@@ -63,7 +63,7 @@ We could create a type test at call site where the type test can be performed wi
 val tt: TypeTest[Any, String] =
   new TypeTest[Any, String]:
     def unapply(s: Any): Option[s.type & String] = s match
-      case s: String => Some(s)
+      case q: (s.type & String) => Some(q)
       case _ => None
 
 f[AnyRef, String]("acb")(using tt)


### PR DESCRIPTION
Current example is not compiling:

```scala
import scala.reflect.{ClassTag, TypeTest}

val tt: TypeTest[Any, String] =
  new TypeTest[Any, String]:
    def unapply(s: Any): Option[s.type & String] = s match
      case s: String => Some(s) // compiler error Found: (s : String) Required: (s² : Any) & String
      case _ => None
```

https://scastie.scala-lang.org/road21/jq3j9XsUTdeshqbHxDXv3w