### PR TITLE
Disallow context function types as value-class parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -778,6 +778,8 @@ object Checking {
         }
         clParamAccessors match {
           case param :: params =>
+            if (defn.isContextFunctionType(param.info))
+              report.error("value classes are not allowed for context function types", param.srcPos)
             if (param.is(Mutable))
               report.error(ValueClassParameterMayNotBeAVar(clazz, param), param.srcPos)
             if (param.info.isInstanceOf[ExprType])

--- a/tests/neg/i22752.scala
+++ b/tests/neg/i22752.scala
@@ -1,0 +1,4 @@
+class Inner(body: Int ?=> Int) extends AnyVal: // error
+  def rescue: Int ?=> Int = ???
+
+class Inner2(body: Int => Int) extends AnyVal // ok


### PR DESCRIPTION
Fixes #22752 