### PR TITLE
improvement: Avoid recompiling in non-boostrapped projects

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -445,15 +445,6 @@ object Build {
         "Automatic-Module-Name" -> s"${dottyOrganization.replaceAll("-",".")}.${moduleName.value.replaceAll("-",".")}"
       ),
 
-    // add extraDevelocityCacheInputFiles in cache key components
-    Compile / compile / buildcache.develocityTaskCacheKeyComponents +=
-      (Compile / extraDevelocityCacheInputFiles / outputFileStamps).taskValue,
-    Test / test / buildcache.develocityTaskCacheKeyComponents +=
-      (Test / extraDevelocityCacheInputFiles / outputFileStamps).taskValue,
-    Test / testOnly / buildcache.develocityInputTaskCacheKeyComponents +=
-      (Test / extraDevelocityCacheInputFiles / outputFileStamps).taskValue,
-    Test / testQuick / buildcache.develocityInputTaskCacheKeyComponents +=
-      (Test / extraDevelocityCacheInputFiles / outputFileStamps).taskValue
   )
 
   // Settings used for projects compiled only with Java
@@ -623,7 +614,17 @@ object Build {
     Compile / doc / scalacOptions ++= scalacOptionsDocSettings(),
     // force recompilation of bootstrapped modules when the compiler changes
     Compile / extraDevelocityCacheInputFiles ++=
-      (`scala3-compiler` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
+      (`scala3-compiler` / Compile / fullClasspathAsJars).value.map(_.data.toPath),
+
+    // add extraDevelocityCacheInputFiles in cache key components
+    Compile / compile / buildcache.develocityTaskCacheKeyComponents +=
+      (Compile / extraDevelocityCacheInputFiles / outputFileStamps).taskValue,
+    Test / test / buildcache.develocityTaskCacheKeyComponents +=
+      (Test / extraDevelocityCacheInputFiles / outputFileStamps).taskValue,
+    Test / testOnly / buildcache.develocityInputTaskCacheKeyComponents +=
+      (Test / extraDevelocityCacheInputFiles / outputFileStamps).taskValue,
+    Test / testQuick / buildcache.develocityInputTaskCacheKeyComponents +=
+      (Test / extraDevelocityCacheInputFiles / outputFileStamps).taskValue
   )
 
   lazy val commonBenchmarkSettings = Seq(


### PR DESCRIPTION
Otherwise we seem to recompile more than needed:
```
[info] Build triggered by /Users/tgodzik/Documents/dotty/presentation-compiler/test/dotty/tools/pc/tests/hover/HoverTermSuite.scala. Running 'scala3-presentation-compiler/testOnly dotty.tools.pc.tests.hover.HoverTermSuite -- *named-tuples5'.
[info] compiling 27 Scala sources to /Users/tgodzik/Documents/dotty/compiler/target/scala-3.7.0-RC3/classes ...
[info] compiling 4 Java sources to /Users/tgodzik/Documents/dotty/sbt-bridge/src/target/classes ...
[info] compiling 1 Scala source to /Users/tgodzik/Documents/dotty/out/bootstrap/scala3-presentation-compiler/scala-3.7.1-RC1-bin-SNAPSHOT-nonbootstrapped/test-classes ...
```
after changes to a test in PC

I am not 100% why this was needed.