### PR TITLE
Keep unused annot on params

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -247,8 +247,10 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             if sym.is(Param) then
               registerIfUnrolledParam(sym)
               // @unused is getter/setter but we want it on ordinary method params
-              if !sym.owner.is(Method) || sym.owner.isConstructor then
-                sym.keepAnnotationsCarrying(thisPhase, Set(defn.ParamMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
+              // @param should be consulted only for fields
+              val unusing = sym.getAnnotation(defn.UnusedAnnot)
+              sym.keepAnnotationsCarrying(thisPhase, Set(defn.ParamMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
+              unusing.foreach(sym.addAnnotation)
             else if sym.is(ParamAccessor) then
               // @publicInBinary is not a meta-annotation and therefore not kept by `keepAnnotationsCarrying`
               val publicInBinaryAnnotOpt = sym.getAnnotation(defn.PublicInBinaryAnnot)

--- a/tests/warn/i23033.scala
+++ b/tests/warn/i23033.scala
@@ -1,0 +1,13 @@
+//> using options -Werror -Wunused:all
+
+import scala.annotation.unused
+import scala.concurrent.ExecutionContext
+import scala.util.NotGiven
+
+object Test {
+  given [T](using @unused ev: NotGiven[T <:< Int]): AnyRef with {}
+}
+object Useful:
+  given [T](using @unused ec: ExecutionContext): AnyRef with {}
+object Syntax:
+  given [T] => (@unused ec: ExecutionContext) => AnyRef


### PR DESCRIPTION
Fixes #23033 

This commit just ensures unused annotation is retained for parameters. The previous tweak excluded constructor params (probably out of fear).

My limited understanding is that the meta annots decide what to do for fields: which elements receive the annotation.

For a class param, I assumed you don't know whether a param incurs a field until constructors. Does a using param always incur a field?

For the fix, follow the example of `publicInBinary` to retain the annotation.

A justification is that if I ask not to warn, I always mean don't warn about any of the things, so extra unused annotations is benign.

Should unused have the param meta annot? It is redundant because if there is a field, you will always use the param through a paramaccessor, which is either the field itself or the getter, and both will be annotated unused.