### PR TITLE
Improved edit span for import

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -702,6 +702,7 @@ object CheckUnused:
       else
         // If the rest of the line is blank, include it in the final edit position. (Delete trailing whitespace.)
         // If for deletion, and the prefix of the line is also blank, then include that, too. (Del blank line.)
+        // If deleting a blank line and surrounded by blank lines, remove an adjoining blank line.
         def editPosAt(srcPos: SrcPos, forDeletion: Boolean): SrcPos =
           val start = srcPos.span.start
           val end = srcPos.span.end
@@ -714,7 +715,21 @@ object CheckUnused:
           val bump = if (deleteLine) 1 else 0 // todo improve to include offset of next line, endline + 1
           val p0 = srcPos.span
           val p1 = if (next >= 0 && emptyRight) p0.withEnd(next + bump) else p0
-          val p2 = if (deleteLine) p1.withStart(prev + 1) else p1
+          val p2 =
+            if deleteLine then
+              var newStart = prev + 1
+              if srcPos.line > 1 then
+                val source = srcPos.sourcePos.source
+                import source.{lineToOffset, lineToOffsetOpt, offsetToLine}
+                val startLine = offsetToLine(start)
+                val endLine = offsetToLine(end)
+                val preceding = lineToOffset(startLine - 1)
+                lineToOffsetOpt(endLine + 2) match
+                case Some(succeeding) if lineToOffset(startLine) - preceding == 1 && succeeding - end == 2 =>
+                  newStart = preceding
+                case _ =>
+              p1.withStart(newStart)
+            else p1
           srcPos.sourcePos.withSpan(p2)
         def actionsOf(actions: (SrcPos, String)*): List[CodeAction] =
           val patches = actions.map((srcPos, replacement) => ActionPatch(srcPos.sourcePos, replacement)).toList

--- a/tests/rewrites/unused.check
+++ b/tests/rewrites/unused.check
@@ -53,3 +53,16 @@ package p11:
 package p12:
   import java.lang.System, java.lang.Runnable
   class C extends Runnable { def run() = System.out.println() }
+
+package p13:
+  import java.lang.{Runnable,
+
+                    System}, System.out
+  class C extends Runnable { def run() = out.println() }
+
+package p14:
+  import collection.mutable
+
+  import mutable.ListBuffer
+
+  def buf = ListBuffer.empty[String]

--- a/tests/rewrites/unused.scala
+++ b/tests/rewrites/unused.scala
@@ -59,3 +59,20 @@ package p11:
 package p12:
   import collection.mutable, java.lang.System, java.lang.Runnable
   class C extends Runnable { def run() = System.out.println() }
+
+package p13:
+  import java.lang.{Runnable,
+
+                    Thread, // leave one blank line instead of two
+
+                    System}, System.out
+  class C extends Runnable { def run() = out.println() }
+
+package p14:
+  import collection.mutable
+
+  import java.lang.{Runnable, Thread}
+
+  import mutable.ListBuffer
+
+  def buf = ListBuffer.empty[String]


### PR DESCRIPTION
Left less vertical space when deleting lines of import.

Extracted from local branch of https://github.com/scala/scala3/pull/22316