### PR TITLE
Fix incorrect warning on type ascription for backquoted identifiers

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3177,7 +3177,11 @@ object Parsers {
     def pattern1(location: Location = Location.InPattern): Tree =
       val p = pattern2(location)
       if in.isColon then
-        val isVariableOrNumber = isVarPattern(p) || p.isInstanceOf[Number]
+        val isVariable = unsplice(p) match {
+          case x: Ident => x.name.isVarPattern
+          case _ => false
+        }
+        val isVariableOrNumber = isVariable || p.isInstanceOf[Number]
         if !isVariableOrNumber then
           report.errorOrMigrationWarning(
             em"""Type ascriptions after patterns other than:

--- a/tests/neg/i15784.check
+++ b/tests/neg/i15784.check
@@ -10,3 +10,17 @@
   |                      Not found: A
   |
   | longer explanation available when compiling with `-explain`
+-- Warning: tests/neg/i15784.scala:7:8 ---------------------------------------------------------------------------------
+7 |  case X: Int => X  // warn
+  |        ^
+  |        Type ascriptions after patterns other than:
+  |          * variable pattern, e.g. `case x: String =>`
+  |          * number literal pattern, e.g. `case 10.5: Double =>`
+  |        are no longer supported. Remove the type ascription or move it to a separate variable pattern.
+-- Warning: tests/neg/i15784.scala:10:12 -------------------------------------------------------------------------------
+10 |  case `Int`: Int => `Int` // warn
+   |            ^
+   |            Type ascriptions after patterns other than:
+   |              * variable pattern, e.g. `case x: String =>`
+   |              * number literal pattern, e.g. `case 10.5: Double =>`
+   |            are no longer supported. Remove the type ascription or move it to a separate variable pattern.

--- a/tests/neg/i15784.scala
+++ b/tests/neg/i15784.scala
@@ -2,3 +2,9 @@ def i15784 = List(42) match
   case List(_, Rest @ `a`) => Rest // error
   case List(_, Rest @ A) => Rest // error 
   case _ => ???
+
+def case2 = 42 match
+  case X: Int => X  // warn
+
+def case3 = 42 match
+  case `Int`: Int => `Int` // warn

--- a/tests/pos/i15784.scala
+++ b/tests/pos/i15784.scala
@@ -1,8 +1,19 @@
-def i15784 = List(42) match
+//> using options -Werror
+
+def case1 = List(42) match
   case List(_, rest @ _*) => rest
+  case _ => ???
+
+def case2 = List(42) match
   case List(_, Rest @ _*) => Rest
+  case _ => ???
+
+def case3 = List(42) match
   case List(_, `Rest` @ _*) => Rest
   case _ => ???
 
-def i15784_auxiliary = 42 match
+def case4 = 42 match
   case `type` : Int => `type`
+
+def case5 = 42 match
+  case X @ (_: Int) => 32


### PR DESCRIPTION
closes #22989
