### PR TITLE
[chore]: Set developed version to 3.7.2

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -114,7 +114,7 @@ object Build {
    *
    *  Warning: Change of this variable might require updating `expectedTastyVersion`
    */
-  val developedVersion = "3.7.1"
+  val developedVersion = "3.7.2"
 
   /** The version of the compiler including the RC prefix.
    *  Defined as common base before calculating environment specific suffixes in `dottyVersion`


### PR DESCRIPTION
Release branch for 3.7.1 has been cut off at 48e83284826bdf026c2855bbaefd27f517db50c0 
3.7.1-RC1 release is waiting for final release of Scala 3.7.0. The reference version and MiMa previous version would also be updated when this happens