### PR TITLE
Temporarly disable released Tasty version checks, due to delayed 3.7.0 release

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -142,7 +142,8 @@ object Build {
    *      - in stable release is always non-experimetnal
    */
   val expectedTastyVersion = "28.7-experimental-1"
-  checkReleasedTastyVersion()
+  // TODO: Restore test when upgrading reference compiler to 3.7.0 stable
+  // checkReleasedTastyVersion()
 
   /** Final version of Scala compiler, controlled by environment variables. */
   val dottyVersion = {


### PR DESCRIPTION
Missing 3.7.0 stable artifacts, prevent us from upgrade of reference compiler and changes to expected TASTy version. 
Would be reverted when upgrading reference compiler to 3.7.0 and 3.7.1-RC1 

Fixes #23092