### PR TITLE
chore: add `transparent` modifier to already assumed transparent types

### DIFF
--- a/library/src/scala/AnyVal.scala
+++ b/library/src/scala/AnyVal.scala
@@ -53,6 +53,6 @@ package scala
  * still must allocate a value class instance at runtime. These limitations and circumstances are
  * explained in greater detail in the [[https://docs.scala-lang.org/overviews/core/value-classes.html Value Classes and Universal Traits]].
  */
-abstract class AnyVal extends Any {
+transparent abstract class AnyVal extends Any {
   def getClass(): Class[_ <: AnyVal] = null
 }

--- a/library/src/scala/Product.scala
+++ b/library/src/scala/Product.scala
@@ -17,7 +17,7 @@ package scala
  *  their subclasses [[scala.Tuple1]] through [[scala.Tuple22]].  In addition,
  *  all case classes implement `Product` with synthetically generated methods.
  */
-trait Product extends Any with Equals {
+transparent trait Product extends Any with Equals {
   /** The size of this product.
     *  @return     for a product `A(x,,1,,, ..., x,,k,,)`, returns `k`
     */

--- a/library/src/scala/collection/BitSet.scala
+++ b/library/src/scala/collection/BitSet.scala
@@ -82,7 +82,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 }
 
 /** Base implementation type of bitsets */
-trait BitSetOps[+C <: BitSet with BitSetOps[C]]
+transparent trait BitSetOps[+C <: BitSet with BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] { self =>
   import BitSetOps._
 

--- a/library/src/scala/collection/IndexedSeq.scala
+++ b/library/src/scala/collection/IndexedSeq.scala
@@ -32,7 +32,7 @@ trait IndexedSeq[+A] extends Seq[A]
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
 
 /** Base trait for indexed Seq operations */
-trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
+transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self =>
 
   def iterator: Iterator[A] = view.iterator
 

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -131,7 +131,7 @@ trait Iterable[+A] extends IterableOnce[A]
   *  The order in which operations are performed on elements is unspecified
   *  and may be nondeterministic.
   */
-trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with IterableOnceOps[A, CC, C] {
+transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with IterableOnceOps[A, CC, C] {
   /**
     * @return This collection as an `Iterable[A]`. No new collection will be built if `this` is already an `Iterable[A]`.
     */

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -320,7 +320,7 @@ object IterableOnce {
   * @define exactlyOnce
   *              Each element appears exactly once in the computation.
   */
-trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
+transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   /////////////////////////////////////////////////////////////// Abstract methods that must be implemented
 
   /** Produces a $coll containing cumulative results of applying the

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -32,7 +32,7 @@ trait LinearSeq[+A] extends Seq[A]
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](immutable.LinearSeq)
 
 /** Base trait for linear Seq operations */
-trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeqOps[A, CC, C]] extends Any with SeqOps[A, CC, C] {
+transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeqOps[A, CC, C]] extends Any with SeqOps[A, CC, C] {
 
   /** @inheritdoc
    *
@@ -259,7 +259,7 @@ trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeq
   }
 }
 
-trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with StrictOptimizedLinearSeqOps[A, CC, C]] extends Any with LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] {
+transparent trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with StrictOptimizedLinearSeqOps[A, CC, C]] extends Any with LinearSeqOps[A, CC, C] with StrictOptimizedSeqOps[A, CC, C] {
   // A more efficient iterator implementation than the default LinearSeqIterator
   override def iterator: Iterator[A] = new AbstractIterator[A] {
     private[this] var current = StrictOptimizedLinearSeqOps.this

--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -98,7 +98,7 @@ trait Map[K, +V]
   */
 // Note: the upper bound constraint on CC is useful only to
 // erase CC to IterableOps instead of Object
-trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
+transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   extends IterableOps[(K, V), Iterable, C]
     with PartialFunction[K, V] {
 

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -74,7 +74,7 @@ object Seq extends SeqFactory.Delegate[Seq](immutable.Seq)
   * @define coll sequence
   * @define Coll `Seq`
   */
-trait SeqOps[+A, +CC[_], +C] extends Any
+transparent trait SeqOps[+A, +CC[_], +C] extends Any
   with IterableOps[A, CC, C] { self =>
 
   override def view: SeqView[A] = new SeqView.Id[A](this)

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -85,7 +85,7 @@ trait Set[A]
   * @define coll set
   * @define Coll `Set`
   */
-trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
+transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends IterableOps[A, CC, C]
      with (A => Boolean) {
 

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -47,7 +47,7 @@ trait SortedMap[K, +V]
   }
 }
 
-trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
+transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends MapOps[K, V, Map, C]
      with SortedOps[K, C] {
 

--- a/library/src/scala/collection/SortedOps.scala
+++ b/library/src/scala/collection/SortedOps.scala
@@ -14,7 +14,7 @@ package scala.collection
 
 
 /** Base trait for sorted collections */
-trait SortedOps[A, +C] {
+transparent trait SortedOps[A, +C] {
 
   def ordering: Ordering[A]
 

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -45,7 +45,7 @@ trait SortedSet[A] extends Set[A]
 
 }
 
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
      with SortedOps[A, C] {
 

--- a/library/src/scala/collection/StrictOptimizedIterableOps.scala
+++ b/library/src/scala/collection/StrictOptimizedIterableOps.scala
@@ -24,7 +24,7 @@ import scala.runtime.Statics
   * @tparam CC Collection type constructor
   * @tparam C  Collection type
   */
-trait StrictOptimizedIterableOps[+A, +CC[_], +C]
+transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   extends Any
     with IterableOps[A, CC, C] {
 

--- a/library/src/scala/collection/StrictOptimizedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedMapOps.scala
@@ -20,7 +20,7 @@ package scala.collection
   * @tparam CC Collection type constructor
   * @tparam C  Collection type
   */
-trait StrictOptimizedMapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
+transparent trait StrictOptimizedMapOps[K, +V, +CC[_, _] <: IterableOps[_, AnyConstr, _], +C]
   extends MapOps[K, V, CC, C]
     with StrictOptimizedIterableOps[(K, V), Iterable, C] {
 

--- a/library/src/scala/collection/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSeqOps.scala
@@ -16,7 +16,7 @@ package scala.collection
   * Trait that overrides operations on sequences in order
   * to take advantage of strict builders.
   */
-trait StrictOptimizedSeqOps [+A, +CC[_], +C]
+transparent trait StrictOptimizedSeqOps [+A, +CC[_], +C]
   extends Any
     with SeqOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {

--- a/library/src/scala/collection/StrictOptimizedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSetOps.scala
@@ -19,7 +19,7 @@ package scala.collection
   * @tparam CC Collection type constructor
   * @tparam C  Collection type
   */
-trait StrictOptimizedSetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
+transparent trait StrictOptimizedSetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends SetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {
 

--- a/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -22,7 +22,7 @@ import scala.annotation.implicitNotFound
   * @tparam CC Collection type constructor
   * @tparam C  Collection type
   */
-trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
+transparent trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends SortedMapOps[K, V, CC, C]
     with StrictOptimizedMapOps[K, V, Map, C] {
 

--- a/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -23,7 +23,7 @@ import scala.annotation.unchecked.uncheckedVariance
   * @tparam CC Collection type constructor
   * @tparam C  Collection type
   */
-trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+transparent trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SortedSetOps[A, CC, C]
     with StrictOptimizedSetOps[A, Set, C] {
 

--- a/library/src/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/library/src/scala/collection/generic/DefaultSerializationProxy.scala
@@ -74,7 +74,7 @@ private[collection] case object SerializeEnd
   * it directly without using this trait if you need a non-standard factory or if you want to use a different
   * serialization scheme.
   */
-trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
+transparent trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
   protected[this] def writeReplace(): AnyRef = {
     val f: Factory[Any, Any] = this match {
       case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](using it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]

--- a/library/src/scala/collection/generic/IsIterable.scala
+++ b/library/src/scala/collection/generic/IsIterable.scala
@@ -109,7 +109,7 @@ package generic
  * (Note that in practice the `IsIterable[Range]` instance is already provided by
  * the standard library, and it is defined as an `IsSeq[Range]` instance)
  */
-trait IsIterable[Repr] extends IsIterableOnce[Repr] {
+transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
 
   /** The type returned by transformation operations that preserve the same elements
     * type (e.g. `filter`, `take`).
@@ -149,7 +149,7 @@ object IsIterable extends IsIterableLowPriority {
 
 }
 
-trait IsIterableLowPriority {
+transparent trait IsIterableLowPriority {
 
   // Makes `IsSeq` instances visible in `IsIterable` companion
   implicit def isSeqLikeIsIterable[Repr](implicit

--- a/library/src/scala/collection/generic/IsIterableOnce.scala
+++ b/library/src/scala/collection/generic/IsIterableOnce.scala
@@ -37,7 +37,7 @@ package generic
  *    // == List(2, 4)
  * }}}
  */
-trait IsIterableOnce[Repr] {
+transparent trait IsIterableOnce[Repr] {
 
   /** The type of elements we can traverse over (e.g. `Int`). */
   type A
@@ -61,7 +61,7 @@ object IsIterableOnce extends IsIterableOnceLowPriority {
 
 }
 
-trait IsIterableOnceLowPriority {
+transparent trait IsIterableOnceLowPriority {
 
   // Makes `IsIterable` instance visible in `IsIterableOnce` companion
   implicit def isIterableLikeIsIterableOnce[Repr](implicit

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -26,7 +26,7 @@ import scala.collection.immutable.{IntMap, LongMap}
   * @see [[scala.collection.generic.IsIterable]]
   * @tparam Repr Collection type (e.g. `Map[Int, String]`)
   */
-trait IsMap[Repr] extends IsIterable[Repr] {
+transparent trait IsMap[Repr] extends IsIterable[Repr] {
 
   /** The type of keys */
   type K

--- a/library/src/scala/collection/generic/IsSeq.scala
+++ b/library/src/scala/collection/generic/IsSeq.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
   *
   * @see [[scala.collection.generic.IsIterable]]
   */
-trait IsSeq[Repr] extends IsIterable[Repr] {
+transparent trait IsSeq[Repr] extends IsIterable[Repr] {
 
   @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
   override val conversion: Repr => SeqOps[A, Iterable, C] = apply(_)

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -59,7 +59,7 @@ trait Map[K, +V]
   * @define coll immutable map
   * @define Coll `immutable.Map`
   */
-trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
+transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C] {
 
@@ -149,7 +149,7 @@ trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]
 
 }
 
-trait StrictOptimizedMapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
+transparent trait StrictOptimizedMapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   extends MapOps[K, V, CC, C]
     with collection.StrictOptimizedMapOps[K, V, CC, C]
     with StrictOptimizedIterableOps[(K, V), Iterable, C] {

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -28,7 +28,7 @@ trait Seq[+A] extends Iterable[A]
   * @define coll immutable sequence
   * @define Coll `immutable.Seq`
   */
-trait SeqOps[+A, +CC[_], +C] extends Any with collection.SeqOps[A, CC, C]
+transparent trait SeqOps[+A, +CC[_], +C] extends Any with collection.SeqOps[A, CC, C]
 
 /**
   * $factoryInfo
@@ -117,7 +117,7 @@ object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector) {
 }
 
 /** Base trait for immutable indexed Seq operations */
-trait IndexedSeqOps[+A, +CC[_], +C]
+transparent trait IndexedSeqOps[+A, +CC[_], +C]
   extends SeqOps[A, CC, C]
     with collection.IndexedSeqOps[A, CC, C] {
 
@@ -147,7 +147,7 @@ object LinearSeq extends SeqFactory.Delegate[LinearSeq](List) {
   }
 }
 
-trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeqOps[A, CC, C]]
+transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] with LinearSeqOps[A, CC, C]]
   extends Any with SeqOps[A, CC, C]
     with collection.LinearSeqOps[A, CC, C]
 

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -30,7 +30,7 @@ trait Set[A] extends Iterable[A]
   * @define coll immutable set
   * @define Coll `immutable.Set`
   */
-trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
+transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C] {
 
   /** Creates a new set with an additional element, unless the element is
@@ -71,7 +71,7 @@ trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   override final def -- (that: IterableOnce[A]): C = removedAll(that)
 }
 
-trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
+transparent trait StrictOptimizedSetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends SetOps[A, CC, C]
     with collection.StrictOptimizedSetOps[A, CC, C]
     with StrictOptimizedIterableOps[A, CC, C] {

--- a/library/src/scala/collection/immutable/SortedMap.scala
+++ b/library/src/scala/collection/immutable/SortedMap.scala
@@ -83,7 +83,7 @@ trait SortedMap[K, +V]
   override def withDefaultValue[V1 >: V](d: V1): SortedMap[K, V1] = new SortedMap.WithDefault[K, V1](this, _ => d)
 }
 
-trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
+transparent trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends MapOps[K, V, Map, C] with collection.SortedMapOps[K, V, CC, C] { self =>
 
   protected def coll: C with CC[K, V]
@@ -118,7 +118,7 @@ trait SortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _]
   override def transform[W](f: (K, V) => W): CC[K, W] = map({ case (k, v) => (k, f(k, v)) })(ordering)
 }
 
-trait StrictOptimizedSortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
+transparent trait StrictOptimizedSortedMapOps[K, +V, +CC[X, +Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends SortedMapOps[K, V, CC, C]
     with collection.StrictOptimizedSortedMapOps[K, V, CC, C]
     with StrictOptimizedMapOps[K, V, Map, C] {

--- a/library/src/scala/collection/immutable/SortedSet.scala
+++ b/library/src/scala/collection/immutable/SortedSet.scala
@@ -30,14 +30,14 @@ trait SortedSet[A]
   * @define coll immutable sorted set
   * @define Coll `immutable.SortedSet`
   */
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
      with collection.SortedSetOps[A, CC, C] {
 
   def unsorted: Set[A]
 }
 
-trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+transparent trait StrictOptimizedSortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SortedSetOps[A, CC, C]
     with collection.StrictOptimizedSortedSetOps[A, CC, C]
     with StrictOptimizedSetOps[A, Set, C] {

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -18,7 +18,7 @@ import scala.collection.generic.CommonErrors
 
 /** Trait that overrides operations to take advantage of strict builders.
  */
-trait StrictOptimizedSeqOps[+A, +CC[_], +C]
+transparent trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   extends Any
     with SeqOps[A, CC, C]
     with collection.StrictOptimizedSeqOps[A, CC, C]

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -568,7 +568,7 @@ object ArrayDeque extends StrictOptimizedSeqFactory[ArrayDeque] {
   }
 }
 
-trait ArrayDequeOps[A, +CC[_], +C <: AnyRef] extends StrictOptimizedSeqOps[A, CC, C] {
+transparent trait ArrayDequeOps[A, +CC[_], +C <: AnyRef] extends StrictOptimizedSeqOps[A, CC, C] {
   protected def array: Array[AnyRef]
 
   final override def clone(): C = klone()

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -24,7 +24,7 @@ trait IndexedSeq[T] extends Seq[T]
 @SerialVersionUID(3L)
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](ArrayBuffer)
 
-trait IndexedSeqOps[A, +CC[_], +C <: AnyRef]
+transparent trait IndexedSeqOps[A, +CC[_], +C <: AnyRef]
   extends scala.collection.IndexedSeqOps[A, CC, C]
     with SeqOps[A, CC, C] {
 

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -62,7 +62,7 @@ trait Map[K, V]
   * @define coll mutable map
   * @define Coll `mutable.Map`
   */
-trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
+transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
     with collection.MapOps[K, V, CC, C]
     with Cloneable[C]

--- a/library/src/scala/collection/mutable/Seq.scala
+++ b/library/src/scala/collection/mutable/Seq.scala
@@ -35,7 +35,7 @@ object Seq extends SeqFactory.Delegate[Seq](ArrayBuffer)
   * @define coll mutable sequence
   * @define Coll `mutable.Seq`
   */
-trait SeqOps[A, +CC[_], +C <: AnyRef]
+transparent trait SeqOps[A, +CC[_], +C <: AnyRef]
   extends collection.SeqOps[A, CC, C]
     with Cloneable[C] {
 

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -28,7 +28,7 @@ trait Set[A]
   * @define coll mutable set
   * @define Coll `mutable.Set`
   */
-trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
+transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C]
     with IterableOps[A, CC, C] // only needed so we can use super[IterableOps] below
     with Cloneable[C]

--- a/library/src/scala/collection/mutable/SortedMap.scala
+++ b/library/src/scala/collection/mutable/SortedMap.scala
@@ -51,7 +51,7 @@ trait SortedMap[K, V]
   override def withDefaultValue(d: V): SortedMap[K, V] = new SortedMap.WithDefault[K, V](this, _ => d)
 }
 
-trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
+transparent trait SortedMapOps[K, V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _], +C <: SortedMapOps[K, V, CC, C]]
   extends collection.SortedMapOps[K, V, CC, C]
     with MapOps[K, V, Map, C] {
 

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -31,7 +31,7 @@ trait SortedSet[A]
   * @define coll mutable sorted set
   * @define Coll `mutable.SortedSet`
   */
-trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
+transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
     with collection.SortedSetOps[A, CC, C] {
 


### PR DESCRIPTION
`dotc` already assumes that some of the types in stdlib are transparent. We now drop the assumption and add the `transparent` modifier to the source.

For reference, the list of assumed transparent types:
https://github.com/scala/scala3/blob/5ac8a32b9ab3f92c9086fa27ef279f00255ea358/compiler/src/dotty/tools/dotc/core/Definitions.scala#L2051-L2092