### PR TITLE
Update build dependency jgit to 7.2.0.202503040940-r

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
 // Used by VersionUtil to get gitHash and commitDate
-libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "4.11.0.201803080745-r"
+libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "7.2.0.202503040940-r"
 
 libraryDependencies += Dependencies.`jackson-databind`


### PR DESCRIPTION
## Description

Notably it adds support for recognizing [git worktrees](https://www.tomups.com/posts/git-worktrees/).
Trying to compile the compiler would fail under a worktree on the old version, due to jgit not recognizing
it as a repository.

Old version is over 7 years old at this point.
