### PR TITLE
Invent given pattern name in for comprehension

### DIFF
--- a/tests/neg/i23119.check
+++ b/tests/neg/i23119.check
@@ -1,0 +1,6 @@
+-- [E161] Naming Error: tests/neg/i23119.scala:7:4 ---------------------------------------------------------------------
+7 |    given Option[List[Int]] = Some(List(x)) // error
+  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |    given_Option_List is already defined as given instance given_Option_List
+  |
+  |    Note that overloaded methods must all be defined in the same group of toplevel definitions

--- a/tests/neg/i23119.check
+++ b/tests/neg/i23119.check
@@ -1,6 +1,20 @@
--- [E161] Naming Error: tests/neg/i23119.scala:7:4 ---------------------------------------------------------------------
-7 |    given Option[List[Int]] = Some(List(x)) // error
+-- [E161] Naming Error: tests/neg/i23119.scala:8:4 ---------------------------------------------------------------------
+8 |    given Option[List[Int]] = Some(List(x)) // error
   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |    given_Option_List is already defined as given instance given_Option_List
   |
-  |    Note that overloaded methods must all be defined in the same group of toplevel definitions
+  |    Provide an explicit, unique name to given definitions,
+  |    since the names assigned to anonymous givens may clash. For example:
+  |
+  |          given myGiven: Option[List[String]]  // define an instance
+  |          given myGiven @ Option[List[String]] // as a pattern variable
+-- [E161] Naming Error: tests/neg/i23119.scala:18:8 --------------------------------------------------------------------
+18 |  given [A] => List[A] = ??? // error
+   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |  given_List_A is already defined as given instance given_List_A
+   |
+   |  Provide an explicit, unique name to given definitions,
+   |  since the names assigned to anonymous givens may clash. For example:
+   |
+   |        given myGiven: [A] => List[A]  // define an instance
+   |        given myGiven @ [A] => List[A] // as a pattern variable

--- a/tests/neg/i23119.scala
+++ b/tests/neg/i23119.scala
@@ -1,0 +1,13 @@
+
+@main def test = println:
+  for x <- 1 to 2
+    // works with explicit name
+    //ols @ given Option[List[String]] = Some(List(x.toString))
+    given Option[List[String]] = Some(List(x.toString))
+    given Option[List[Int]] = Some(List(x)) // error
+  yield summon[Option[List[String]]].map(ss => ss.corresponds(given_Option_List.get)((a, b) => a == b.toString))
+
+// The naming clash is noticed when defining local values for "packaging":
+//  given_Option_List is already defined as given instance given_Option_List
+// Previously the naming clash was noticed when extracting values in the map or do function:
+//  duplicate pattern variable: given_Option_List

--- a/tests/neg/i23119.scala
+++ b/tests/neg/i23119.scala
@@ -1,3 +1,4 @@
+//> using options -explain
 
 @main def test = println:
   for x <- 1 to 2
@@ -11,3 +12,8 @@
 //  given_Option_List is already defined as given instance given_Option_List
 // Previously the naming clash was noticed when extracting values in the map or do function:
 //  duplicate pattern variable: given_Option_List
+
+def also =
+  given [A] => List[A] = ???
+  given [A] => List[A] = ??? // error
+  ()

--- a/tests/pos/i23119.scala
+++ b/tests/pos/i23119.scala
@@ -1,0 +1,29 @@
+//> using options -Wunused:patvars -Werror
+
+def make: IndexedSeq[FalsePositive] =
+  for {
+    i <- 1 to 2
+    given Int = i
+    fp = FalsePositive()
+  } yield fp
+
+def broken =
+  for
+    i <- List(42)
+    (x, y) = "hello" -> "world"
+  yield
+    s"$x, $y" * i
+
+def alt: IndexedSeq[FalsePositive] =
+  given String = "hi"
+  for
+    given Int <- 1 to 2
+    j: Int = summon[Int] // simple assign because irrefutable
+    _ = j + 1
+    k :: Nil = j :: Nil : @unchecked // pattern in one var
+    fp = FalsePositive(using k)
+  yield fp
+
+class FalsePositive(using Int):
+  def usage(): Unit =
+    println(summon[Int])


### PR DESCRIPTION
Fixes #23119 

A given pattern in a for comprehension results in a fresh val in the body of the mapping function, but it should have the same (arbitrary) name as in the rest of the expansion.

This commit gives the given its usual given name (in `makeIdPat`) so that the unused check can check it.

Currently, without `-preview`, showing that `$1$` is called `given_Int` by typer:
```
➜  scala-cli repl --server=false -S 3.7.2-RC1 -Vprint:typer,refchecks -Wunused:all
Welcome to Scala 3.7.2-RC1 (17.0.15, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> for given Int <- 1 to 2; j: Int = summon[Int] yield j
1 warning found
[[syntax trees at end of                     typer]] // rs$line$1
package <empty> {
  final lazy module val rs$line$1: rs$line$1 = new rs$line$1()
  final module class rs$line$1() extends Object() { this: rs$line$1.type =>
    val res0: IndexedSeq[Int] =
      intWrapper(1).to(2).map[(Int, Int)]((x$1: Int) =>
        x$1:Int @unchecked match
          {
            case given $1$ @ _:Int =>
              val j: Int = $1$
              Tuple2.apply[Int, Int]($1$, j)
          }
      ).map[Int]((x$1: (Int, Int)) =>
        x$1:(x$1 : (Int, Int)) @unchecked match
          {
            case Tuple2.unapply[Int, Int](given given_Int @ _:Int, j @ _:Int)
               => j:Int
          }
      )
  }
}
```

Without `-preview`, this commit:
```
scala> for given Int <- 1 to 2; j: Int = summon[Int] yield j
[[syntax trees at end of                     typer]] // rs$line$1
package <empty> {
  final lazy module val rs$line$1: rs$line$1 = new rs$line$1()
  final module class rs$line$1() extends Object() { this: rs$line$1.type =>
    val res0: IndexedSeq[Int] =
      intWrapper(1).to(2).map[(Int, Int)]((x$1: Int) =>
        x$1:Int @unchecked match
          {
            case given given_Int @ _:Int =>
              val j: Int = given_Int
              Tuple2.apply[Int, Int](given_Int, j)
          }
      ).map[Int]((x$1: (Int, Int)) =>
        x$1:(x$1 : (Int, Int)) @unchecked match
          {
            case Tuple2.unapply[Int, Int](given given_Int @ _:Int, j @ _:Int)
               => j:Int
          }
      )
  }
}
```
With `-preview`, the tupling map is eliminated early:
```
scala> for given Int <- 1 to 2; j: Int = summon[Int] yield j
[[syntax trees at end of                     typer]] // rs$line$1
package <empty> {
  final lazy module val rs$line$1: rs$line$1 = new rs$line$1()
  final module class rs$line$1() extends Object() { this: rs$line$1.type =>
    val res0: IndexedSeq[Int] =
      intWrapper(1).to(2).map[Int]((x$1: Int) =>
        x$1:Int @unchecked match
          {
            case given given_Int @ _:Int =>
              val j: Int = given_Int
              j:Int
          }
      )
  }
}
```