### PR TITLE
Revert "chore: deprecate `scala.annotation.transparentTrait`"

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1048,6 +1048,7 @@ class Definitions {
   @tu lazy val NowarnAnnot: ClassSymbol = requiredClass("scala.annotation.nowarn")
   @tu lazy val UnusedAnnot: ClassSymbol = requiredClass("scala.annotation.unused")
   @tu lazy val UnrollAnnot: ClassSymbol = requiredClass("scala.annotation.unroll")
+  @tu lazy val TransparentTraitAnnot: ClassSymbol = requiredClass("scala.annotation.transparentTrait")
   @tu lazy val NativeAnnot: ClassSymbol = requiredClass("scala.native")
   @tu lazy val RepeatedAnnot: ClassSymbol = requiredClass("scala.annotation.internal.Repeated")
   @tu lazy val RuntimeCheckedAnnot: ClassSymbol = requiredClass("scala.annotation.internal.RuntimeChecked")

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1220,7 +1220,9 @@ object SymDenotations {
       || accessBoundary(defn.RootClass).isProperlyContainedIn(symbol.topLevelClass)
 
     final def isTransparentClass(using Context): Boolean =
-      is(TransparentType) || defn.isAssumedTransparent(symbol)
+      is(TransparentType)
+      || defn.isAssumedTransparent(symbol)
+      || isClass && hasAnnotation(defn.TransparentTraitAnnot)
 
     /** The class containing this denotation which has the given effective name. */
     final def enclosingClassNamed(name: Name)(using Context): Symbol = {

--- a/docs/_docs/reference/other-new-features/transparent-traits.md
+++ b/docs/_docs/reference/other-new-features/transparent-traits.md
@@ -59,7 +59,7 @@ will have type `Int | String` instead of the widened type `Any`.
 
 ## Which Traits and Classes Are Transparent?
 
-Traits and classes are declared transparent by adding the modifier `transparent`.
+Traits and classes are declared transparent by adding the modifier `transparent`. Scala 2 traits and classes can also be declared transparent by adding a [`@transparentTrait`](https://scala-lang.org/api/3.x/scala/annotation/transparentTrait.html) annotation. This annotation is defined in [`scala.annotation`](https://scala-lang.org/api/3.x/scala/annotation.html). It will be deprecated and phased out once Scala 2/3 interoperability is no longer needed.
 
 The following classes and traits are automatically treated as transparent:
 ```scala

--- a/library/src/scala/annotation/transparentTrait.scala
+++ b/library/src/scala/annotation/transparentTrait.scala
@@ -5,5 +5,4 @@ package scala.annotation
  *  are not inferred when combined with other types in an intersection.
  *  See reference/other-new-features/transparent-traits.html for details.
  */
-@deprecated(message = "Transparent traits/classes via annotations is no longer supported. Use instead the `transparent` modifier", since = "3.8.0")
 final class transparentTrait extends StaticAnnotation

--- a/library/src/scala/reflect/Enum.scala
+++ b/library/src/scala/reflect/Enum.scala
@@ -1,7 +1,7 @@
 package scala.reflect
 
 /** A base trait of all Scala enum definitions */
-transparent trait Enum extends Any, Product, Serializable:
+@annotation.transparentTrait trait Enum extends Any, Product, Serializable:
 
   /** A number uniquely identifying a case of an enum */
   def ordinal: Int

--- a/library/src/scala/runtime/EnumValue.scala
+++ b/library/src/scala/runtime/EnumValue.scala
@@ -1,6 +1,6 @@
 package scala.runtime
 
-transparent trait EnumValue extends Product, Serializable:
+@annotation.transparentTrait trait EnumValue extends Product, Serializable:
   override def canEqual(that: Any) = this eq that.asInstanceOf[AnyRef]
   override def productArity: Int = 0
   override def productElement(n: Int): Any =


### PR DESCRIPTION
Reverts scala/scala3#23116

That PR should have waited until 3.8.0 to be merged.