### PR TITLE
Add experimental NamedTuple copyFrom method

### DIFF
--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -3,6 +3,7 @@ package scala
 import annotation.showAsInfix
 import compiletime.*
 import compiletime.ops.int.*
+import scala.annotation.experimental
 
 /** Tuple of arbitrary arity */
 sealed trait Tuple extends Product {
@@ -280,6 +281,32 @@ object Tuple {
       case true => false
       case false => Disjoint[xs, Y]
     case EmptyTuple => true
+
+  @experimental
+  type ContainsAll[X <: Tuple, Y <: Tuple] <: Boolean = X match
+    case x *: xs => Contains[Y, x] match
+      case true  => ContainsAll[xs, Y]
+      case false => false
+    case EmptyTuple => true
+
+  @experimental
+  type IndexOfOptionOnto[X, N <: Tuple, Acc <: Int] <: Option[Int] = N match
+    case X *: _ => Some[Acc]
+    case _ *: ns => IndexOfOptionOnto[X, ns, S[Acc]]
+    case EmptyTuple => None.type
+
+  @experimental
+  type IndexOfOption[X, N <: Tuple] = IndexOfOptionOnto[X, N, 0]
+
+  @experimental
+  type Indices[X <: Tuple, Y <: Tuple] = IndicesOnto[X, Y, 0, EmptyTuple]
+
+  @experimental
+  type IndicesOnto[X <: Tuple, Y <: Tuple, Idx <: Int, Acc <: Tuple] <: Tuple = X match
+    case x *: xs => IndexOfOption[x, Y] match
+      case Some[i] => IndicesOnto[xs, Y, S[Idx], i *: Acc]
+      case _ => IndicesOnto[xs, Y, S[Idx], (-1 * S[Idx]) *: Acc] // no problem if Int overflow
+    case EmptyTuple => Reverse[Acc]
 
   /** Empty tuple */
   def apply(): EmptyTuple = EmptyTuple

--- a/library/src/scala/runtime/Tuples.scala
+++ b/library/src/scala/runtime/Tuples.scala
@@ -1,5 +1,7 @@
 package scala.runtime
 
+import scala.annotation.experimental
+
 object Tuples {
 
   inline val MaxSpecialized = 22
@@ -282,6 +284,21 @@ object Tuples {
     case EmptyTuple => 0
     case self: Product => self.productArity
   }
+
+  @experimental
+  def copy(self: Tuple, that: Tuple, indices: Tuple): Tuple = indices match
+    case EmptyTuple => self
+    case _ =>
+      val is = indices.productIterator.asInstanceOf[Iterator[Int]]
+      val arr = IArray.from(
+        is.map: i =>
+          if i < 0 then
+            val i0 = Math.abs(i) - 1 // nice that it is correct even for min value
+            self.productElement(i0)
+          else
+            that.productElement(i)
+      )
+      Tuple.fromIArray(arr)
 
   // Tail for Tuple1 to Tuple22
   private def specialCaseTail(self: Tuple): Tuple = {

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -13,6 +13,9 @@ object MiMaFilters {
         // Scala.js-only class
         ProblemFilters.exclude[FinalClassProblem]("scala.scalajs.runtime.AnonFunctionXXL"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.scalajs.runtime.AnonFunctionXXL.this"),
+
+        // NamedTuples copy method
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Tuples.copy")
       ),
 
       // Additions since last LTS

--- a/tests/neg/named-tuple-ops-copy.scala
+++ b/tests/neg/named-tuple-ops-copy.scala
@@ -1,0 +1,16 @@
+//> using options -experimental
+
+trait Mod
+
+given Conversion[String, Mod] = _ => new Mod {}
+
+type Foo = (name: String, mod: Mod)
+case class Foo0(name: String, mod: Mod)
+
+@main def Test =
+  val foo: Foo = (name = "foo", mod = "some_mod")
+  val foo_updated: Foo = foo.copyFrom((mod = "bar")) // error, stays as String
+
+
+  val foo0: Foo0 = Foo0(name = "foo", mod = "some_mod")
+  val foo0_updated: Foo0 = foo0.copy(mod = "bar") // ok - does the conversion

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -105,7 +105,21 @@ val experimentalDefinitionInLibrary = Set(
   "scala.Predef$.runtimeChecked", "scala.annotation.internal.RuntimeChecked",
 
   // New feature: SIP 61 - @unroll annotation
-  "scala.annotation.unroll"
+  "scala.annotation.unroll",
+
+  // New experimental method - copyFrom in NamedTuple.scala (and supporting definitions)
+  "scala.NamedTuple$.copyFrom", "scala.NamedTuple$.Copy",
+  "scala.NamedTuple$.Decompose",
+  "scala.NamedTupleDecomposition$.Copy0",
+  "scala.NamedTupleDecomposition$.Decompose",
+  "scala.NamedTupleDecomposition$.LookupName",
+  "scala.NamedTupleDecomposition$.copyFrom",
+  "scala.Tuple$.ContainsAll",
+  "scala.Tuple$.IndexOfOption",
+  "scala.Tuple$.IndexOfOptionOnto",
+  "scala.Tuple$.Indices",
+  "scala.Tuple$.IndicesOnto",
+  "scala.runtime.Tuples$.copy",
 )
 
 

--- a/tests/run/named-tuple-ops-copy.scala
+++ b/tests/run/named-tuple-ops-copy.scala
@@ -1,0 +1,29 @@
+//> using options -experimental
+
+type City = (name: String, zip: Int, pop: Int)
+type Coord = (x: Double, y: Double)
+type Labels = (x: String, y: String)
+
+@main def Test =
+  val city: City = (name = "Lausanne", zip = 1000, pop = 140000)
+  val coord: Coord = (x = 1.0, y = 0.0)
+  val labels: Labels = (x = "west", y = "north")
+
+  // first field updated
+  val coord_update = coord.copyFrom((x = 2.0))
+  val _: Coord = coord_update
+  assert(coord_update.x == 2.0 && coord_update.y == 0.0)
+
+  // last field updated
+  val city_update = city.copyFrom((pop = 150000))
+  val _: City = city_update
+  assert(city_update.name == "Lausanne" && city_update.zip == 1000 && city_update.pop == 150000)
+
+  // replace field types
+  val coord_to_labels = coord.copyFrom((x = "east", y = "south"))
+  val _: Labels = coord_to_labels
+  assert(coord_to_labels.x == "east" && coord_to_labels.y == "south")
+
+  // out of order
+  val city_update2 = city.copyFrom((pop = 150000, name = "Lausanne", zip = 1000))
+  val _: City = city_update2


### PR DESCRIPTION
`copyFrom` chosen as it has a slight difference i.e. the argument should be surrounded in extra parentheses. Also, it can not be used for target typing of fields.