### PR TITLE
Disallow empty parameter clauses in `extension` definition

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3673,7 +3673,10 @@ object Parsers {
       // begin termParamClause
       inParensWithCommas {
         if in.token == RPAREN && paramOwner != ParamOwner.ExtensionPrefix && !impliedMods.is(Given)
-        then Nil
+        then
+          if paramOwner.takesOnlyUsingClauses then
+            syntaxError(em"`using` expected")
+          Nil
         else
           val clause =
             if paramOwner == ParamOwner.ExtensionPrefix
@@ -4468,7 +4471,10 @@ object Parsers {
         leadParamss += extParams
         isUsingClause(extParams)
       do ()
-      leadParamss ++= termParamClauses(ParamOwner.ExtensionFollow, numLeadParams)
+      // Empty parameter clauses are filtered out. They are already reported as syntax errors and are not
+      // allowed here.
+      val extFollowParams = termParamClauses(ParamOwner.ExtensionFollow, numLeadParams).filterNot(_.isEmpty)
+      leadParamss ++= extFollowParams
       if in.isColon then
         syntaxError(em"no `:` expected here")
         in.nextToken()

--- a/tests/neg/extensions-can-only-have-using.scala
+++ b/tests/neg/extensions-can-only-have-using.scala
@@ -1,0 +1,3 @@
+extension(x: Any)() // error
+  def f = 42
+val x = Nil.f


### PR DESCRIPTION
docs/_docs/internals/syntax.md doesn't seem to indicate that this a valid syntax. Before this patch the following extension:
```scala
extension(x: Any)() // error
  def f = 42
```
...could be called as `1.f()`.  After this patch extension above raises a syntax error and compiler recovers by ignoring empty clause altogether.

Side-note: recovery described above happens in `extension()`, `termParamClause` still returns an empty list. 