### PR TITLE
[ci]: Stop creating automatic backport PR from `language-reference-stable` to `main`

### DIFF
--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -70,22 +70,3 @@ jobs:
           fi
           cd ..
 
-  backport-to-main:
-    name: Create pull request with backport to main
-    permissions:
-      pull-requests: write  # for repo-sync/pull-request to create a PR
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: repo-sync/pull-request@v2
-        with:
-          destination_branch: main
-          pr_label: area:documentation
-          pr_title: Sync with the stable documentation branch
-          pr_body: |
-            This pull request is syncing the main with changes from language-reference-stable.
-
-            It was created automatically after ${{ github.event.head_commit.id }} by @${{ github.event.head_commit.author.username }}
-          pr_assignee: ${{ github.event.head_commit.author.username }}
-


### PR DESCRIPTION
The [created PRs](https://github.com/scala/scala3/pull/23152) be this job were potentially erroneous, allowing to overwrite changes on main. These are also typically outof date - language-reference-stable tracks at least 1 stable release before the current main.  

Instead possible backports should be done manually