### PR TITLE
chore: bump sbt-develocity to 1.2.2-rc1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,6 +22,9 @@ addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.0.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.0")
 
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2")
+resolvers +=
+  "Develocity Artifactory" at "https://repo.grdev.net/artifactory/public/"
+
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.2.2-rc-1")
 
 addSbtPlugin("com.github.sbt" % "sbt-jdi-tools" % "1.2.0")


### PR DESCRIPTION
The new version of the plugin fixes an issue with the cleanup of the local cache that the scala infrastructure suffers from.