### PR TITLE
Bump Scala CLI to v1.8.0 (was v1.7.1)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -188,7 +188,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.7.1"
+  val scalaCliLauncherVersion = "1.8.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.24"
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.8.0

Notable changes:
- Scala.js set to 1.19.0
- Scala LTS bumped to 3.3.6
- `runner` and `test-runner` modules are now built with Scala 3.3.6, and thus only support Scala 3.3+ (support for 2.13 and 2.12 remain unchanged). For builds using Scala 3.0, 3.1 and 3.2, and older `runner`/`test-runner` is used (v1.7.1, specifically). 
- A number of compiler options no longer require being passed with `-O`, when used from the command line.
- Scala CLI now detects multiple test frameworks under the `test` sub-command, rather than just one.
- It is also possible to pre-define multiple test frameworks in a Scala CLI project.
```scala
//> using test.frameworks org.scalatest.tools.Framework munit.Framework custom.CustomFramework
```

@WojciechMazur @tgodzik we might want to backport this into 3.7.1, if we do another RC.