### PR TITLE
Fix completion mode filtering + optimize scopeCompletions

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -370,7 +370,7 @@ object Completion:
    *  For the results of all `xyzCompletions` methods term names and type names are always treated as different keys in the same map
    *  and they never conflict with each other.
    */
-  class Completer(val mode: Mode, pos: SourcePosition, untpdPath: List[untpd.Tree], matches: Name => Boolean):
+  class Completer(val mode: Mode, pos: SourcePosition, untpdPath: List[untpd.Tree], matches: Name => Boolean)(using Context):
     /** Completions for terms and types that are currently in scope:
      *  the members of the current class, local definitions and the symbols that have been imported,
      *  recursively adding completions from outer scopes.
@@ -384,7 +384,7 @@ object Completion:
      *    (even if the import follows it syntactically)
      *  - a more deeply nested import shadowing a member or a local definition causes an ambiguity
      */
-    def scopeCompletions(using context: Context): CompletionResult =
+    lazy val scopeCompletions: CompletionResult =
 
       /** Temporary data structure representing denotations with the same name introduced in a given scope
        *  as a member of a type, by a local definition or by an import clause
@@ -619,8 +619,7 @@ object Completion:
       // There are four possible ways for an extension method to be applicable
 
       // 1. The extension method is visible under a simple name, by being defined or inherited or imported in a scope enclosing the reference.
-      val termCompleter = new Completer(Mode.Term, pos, untpdPath, matches)
-      val extMethodsInScope = termCompleter.scopeCompletions.names.toList.flatMap:
+      val extMethodsInScope = scopeCompletions.names.toList.flatMap:
         case (name, denots) => denots.collect:
           case d: SymDenotation if d.isTerm && d.termRef.symbol.is(Extension) => (d.termRef, name.asTermName)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2257,3 +2257,21 @@ class CompletionSuite extends BaseCompletionSuite:
         |""".stripMargin,
       ""
     )
+
+  @Test def `no-extension-completion-on-packages` =
+    check(
+      """object M:
+        |  scala.runt@@
+        |""".stripMargin,
+      """runtime scala
+        |PartialFunction scala""".stripMargin // those are the actual members of scala
+    )
+
+  @Test def `no-extension-completions-on-package-objects` =
+    check(
+      """package object magic { def test: Int = ??? }
+        |object M:
+        |  magic.@@
+        |""".stripMargin,
+      "test: Int"
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2250,3 +2250,10 @@ class CompletionSuite extends BaseCompletionSuite:
         |""".stripMargin,
       ""
     )
+
+  @Test def `no-completions-on-package-selection` =
+    check(
+      """package one.@@
+        |""".stripMargin,
+      ""
+    )


### PR DESCRIPTION
I've changed scopeCompletions to lazy val to memoize because I beliveve we don't need to recompute it. The actual fix is at the comment. There is no need to create a new Completer just to filter all of remaining completions at later stage.

Fixes #23150