### PR TITLE
Improve GADT reasoning for pattern alternatives

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2834,6 +2834,9 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         gadtConstrs += ctx.gadt
         res
       .mapconserve(ensureValueTypeOrWildcard)
+    // Look for the necessary constraint that is subsumed by all alternatives.
+    // Use that constraint as the outcome if possible, otherwise fallback to not using
+    // GADT reasoning for soundness.
     TypeComparer.necessaryGadtConstraint(gadtConstrs.toList, preGadt) match
       case Some(constr) => nestedCtx.gadtState.restore(constr)
       case None => nestedCtx.gadtState.restore(preGadt)

--- a/tests/neg/gadt-alt-expr1.scala
+++ b/tests/neg/gadt-alt-expr1.scala
@@ -1,0 +1,13 @@
+enum Expr[+T]:
+  case I1() extends Expr[Int]
+  case I2() extends Expr[Int]
+  case B() extends Expr[Boolean]
+import Expr.*
+def foo[T](e: Expr[T]): T =
+  e match
+    case I1() | I2() => 42  // ok
+    case B() => true
+def bar[T](e: Expr[T]): T =
+  e match
+    case I1() | B() => 42  // error
+    case I2() => 0

--- a/tests/neg/gadt-alt-expr2.scala
+++ b/tests/neg/gadt-alt-expr2.scala
@@ -1,0 +1,15 @@
+enum Expr[+T]:
+  case I1() extends Expr[Int]
+  case I2() extends Expr[Int]
+  case I3() extends Expr[Int]
+  case I4() extends Expr[Int]
+  case I5() extends Expr[Int]
+  case B() extends Expr[Boolean]
+import Expr.*
+def test1[T](e: Expr[T]): T =
+  e match
+    case I1() | I2() | I3() | I4() | I5() => 42  // ok
+    case B() => true
+def test2[T](e: Expr[T]): T =
+  e match
+    case I1() | I2() | I3() | I4() | I5() | B() => 42  // error

--- a/tests/neg/gadt-alt-expr3.scala
+++ b/tests/neg/gadt-alt-expr3.scala
@@ -1,0 +1,34 @@
+trait A
+trait B extends A
+trait C extends B
+trait D
+enum Expr[+T]:
+  case IsA() extends Expr[A]
+  case IsB() extends Expr[B]
+  case IsC() extends Expr[C]
+  case IsD() extends Expr[D]
+import Expr.*
+def test1[T](e: Expr[T]): T = e match
+  case IsA() => new A {}
+  case IsB() => new B {}
+  case IsC() => new C {}
+def test2[T](e: Expr[T]): T = e match
+  case IsA() | IsB() =>
+    // IsA() implies T >: A
+    // IsB() implies T >: B
+    // So T >: B is chosen
+    new B {}
+  case IsC() => new C {}
+def test3[T](e: Expr[T]): T = e match
+  case IsA() | IsB() | IsC() =>
+    // T >: C is chosen
+    new C {}
+def test4[T](e: Expr[T]): T = e match
+  case IsA() | IsB() | IsC() =>
+    new B {}  // error
+def test5[T](e: Expr[T]): T = e match
+  case IsA() | IsB() =>
+    new A {}  // error
+def test6[T](e: Expr[T]): T = e match
+  case IsA() | IsC() | IsD() =>
+    new C {}  // error

--- a/tests/neg/gadt-alt-expr4.scala
+++ b/tests/neg/gadt-alt-expr4.scala
@@ -1,0 +1,19 @@
+trait A
+trait B extends A
+trait C extends B
+enum Expr[T]:
+  case IsA() extends Expr[A]
+  case IsB() extends Expr[B]
+  case IsC() extends Expr[C]
+import Expr.*
+def test1[T](e: Expr[T]): T = e match
+  case IsA() => new A {}
+  case IsB() => new B {}
+  case IsC() => new C {}
+def test2[T](e: Expr[T]): T = e match
+  case IsA() | IsB() =>
+    // IsA() implies T =:= A
+    // IsB() implies T =:= B
+    // No necessary constraint can be found
+    new B {}  // error
+  case IsC() => new C {}

--- a/tests/neg/gadt-alt-expr5.scala
+++ b/tests/neg/gadt-alt-expr5.scala
@@ -1,0 +1,14 @@
+trait A
+trait B extends A
+trait C extends B
+enum Expr[-T]:
+  case IsA() extends Expr[A]
+  case IsB() extends Expr[B]
+  case IsC() extends Expr[C]
+import Expr.*
+def test1[T](e: Expr[T]): Unit = e match
+  case IsA() | IsB() =>
+    val t1: T = ???
+    val t2: A = t1
+    val t3: B = t1  // error
+  case IsC() =>

--- a/tests/neg/gadt-alternatives.scala
+++ b/tests/neg/gadt-alternatives.scala
@@ -6,4 +6,4 @@ import Expr.*
 def eval[T](e: Expr[T]): T = e match
   case StringVal(_) | IntVal(_) => "42"  // error
 def eval1[T](e: Expr[T]): T = e match
-  case IntValAlt(_) | IntVal(_) => 42  // error // limitation
+  case IntValAlt(_) | IntVal(_) => 42  // previously error, now ok

--- a/tests/pos/gadt-alt-doc1.scala
+++ b/tests/pos/gadt-alt-doc1.scala
@@ -1,0 +1,8 @@
+trait Document[Doc <: Document[Doc]]
+sealed trait Conversion[Doc, V]
+
+case class C[Doc <: Document[Doc]]() extends Conversion[Doc, Doc]
+
+def Test[Doc <: Document[Doc], V](conversion: Conversion[Doc, V]) =
+  conversion match
+    case C() | C() => ??? // error


### PR DESCRIPTION
fixes #22882.

Previously, for a pattern alternative:
```
scrutinee match
  case P1(...) | P2(...) => ...
```
we ignore GADT constraints derived from it, which is too restrictive. Now we try to find a GADT constraint that is subsumed by all and use it, and only ignore GADT constraints when such a constraint cannot be found.