### PR TITLE
chore: filter allowed source versions by import and by settings

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
@@ -24,7 +24,8 @@ object ScalaSettingsProperties:
     ScalaRelease.values.toList.map(_.show)
 
   def supportedSourceVersions: List[String] =
-    (SourceVersion.values.toList.diff(SourceVersion.illegalSourceVersionNames)).toList.map(_.toString)
+    SourceVersion.values.diff(SourceVersion.illegalInSettings)
+      .map(_.toString).toList
 
   def supportedLanguageFeatures: List[ChoiceWithHelp[String]] =
     Feature.values.map((n, d) => ChoiceWithHelp(n.toString, d))

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -40,10 +40,18 @@ enum SourceVersion:
   def enablesBetterFors(using Context) = isAtLeast(`3.7`) && isPreviewEnabled
 
 object SourceVersion extends Property.Key[SourceVersion]:
-  def defaultSourceVersion = `3.7`
+  
+  /* The default source version used by the built compiler */
+  val defaultSourceVersion = `3.7`
+
+  /* Illegal source versions that may not appear in the settings `-source:<...>` */
+  val illegalInSettings = List(`never`)
+
+  /* Illegal source versions that may not appear as an import `import scala.language.<...>` */
+  val illegalInImports  = List(`never`)
 
   /** language versions that may appear in a language import, are deprecated, but not removed from the standard library. */
-  val illegalSourceVersionNames = List("3.1-migration", "never").map(_.toTermName)
+  val illegalSourceVersionNames = illegalInImports.map(_.toString.toTermName)
 
   /** language versions that the compiler recognises. */
   val validSourceVersionNames = values.toList.map(_.toString.toTermName)

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -8,7 +8,8 @@ import Feature.isPreviewEnabled
 import util.Property
 
 enum SourceVersion:
-  case `3.0-migration`, `3.0`, `3.1` // Note: do not add `3.1-migration` here, 3.1 is the same language as 3.0.
+  case `3.0-migration`, `3.0` 
+  case `3.1-migration`, `3.1`
   case `3.2-migration`, `3.2`
   case `3.3-migration`, `3.3`
   case `3.4-migration`, `3.4`
@@ -45,10 +46,10 @@ object SourceVersion extends Property.Key[SourceVersion]:
   val defaultSourceVersion = `3.7`
 
   /* Illegal source versions that may not appear in the settings `-source:<...>` */
-  val illegalInSettings = List(`never`)
+  val illegalInSettings = List(`3.1-migration`, `never`)
 
   /* Illegal source versions that may not appear as an import `import scala.language.<...>` */
-  val illegalInImports  = List(`never`)
+  val illegalInImports  = List(`3.1-migration`, `never`)
 
   /** language versions that may appear in a language import, are deprecated, but not removed from the standard library. */
   val illegalSourceVersionNames = illegalInImports.map(_.toString.toTermName)

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -299,4 +299,11 @@ class ScalaSettingsTests:
     )
     assertEquals(result, Right(reporting.Action.Error))
 
+  @Test def `illegal source versions are not accepted when parsing the settings`: Unit =
+    for source <- SourceVersion.illegalInSettings do
+      val settings = ScalaSettings
+      val result = settings.processArguments(List("-source", source.toString()), true)
+      assertEquals(0, result.warnings.length)
+      assertEquals(1, result.errors.length)
+
 end ScalaSettingsTests


### PR DESCRIPTION
Closes #23214 

We also split the logic to handle illegal imports separately as in #23082, we want to authorise `2.13` in imports but not in the settings