### PR TITLE
Fix incorrect warning with -no-indent

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -721,7 +721,7 @@ object Parsers {
     def checkNextNotIndented(): Unit =
       if in.isNewLine then
         val nextIndentWidth = in.indentWidth(in.next.offset)
-        if in.currentRegion.indentWidth < nextIndentWidth then
+        if in.currentRegion.indentWidth < nextIndentWidth && in.currentRegion.closedBy == OUTDENT then
           warning(em"Line is indented too far to the right, or a `{` or `:` is missing", in.next.offset)
 
 /* -------- REWRITES ----------------------------------------------------------- */

--- a/tests/pos/i21749.scala
+++ b/tests/pos/i21749.scala
@@ -1,0 +1,9 @@
+//> using options -Xfatal-warnings -no-indent
+
+object Test {
+  1 match {
+    case 1 =>
+      case class Test(name: String)
+      Nil
+  }
+}


### PR DESCRIPTION
This PR change the condition to emit the warning “Line is indented too far to the right, or a `{` or `:` is missing” introduced in #7270 to only emit it if we are inside an `Indented` region. This fixes #21749.