### PR TITLE
Backport "Bump Scala CLI to v1.8.0 (was v1.7.1)" to 3.7.1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -189,7 +189,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.7.1"
+  val scalaCliLauncherVersion = "1.8.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.24"
 


### PR DESCRIPTION
Backports #23168 to the 3.7.1-RC2.

PR submitted by the release tooling.