### PR TITLE
Add @retainsArg to read-only and reach capabilities

### DIFF
--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -87,6 +87,7 @@ sealed trait Exists extends Capability
 
 @experimental
 object internal:
+  import annotation.retainsArg
 
   /** A wrapper indicating a type variable in a capture argument list of a
    *  @retains annotation. E.g. `^{x, Y^}` is represented as `@retains(x, capsOf[Y])`.
@@ -98,13 +99,13 @@ object internal:
    *  as `caps.reachCapability(x)`. When converted to CaptureRef types in capture sets
    *  they are  represented as `x.type @annotation.internal.reachCapability`.
    */
-  extension (x: Any) def reachCapability: Any = x
+  extension (x: Any @retainsArg) def reachCapability: Any = x
 
   /** Read-only capabilities x.rd which appear as terms in @retains annotations are encoded
    *  as `caps.readOnlyCapability(x)`. When converted to CaptureRef types in capture sets
    *  they are  represented as `x.type @annotation.internal.readOnlyCapability`.
    */
-  extension (x: Any) def readOnlyCapability: Any = x
+  extension (x: Any @retainsArg) def readOnlyCapability: Any = x
 
   /** An internal annotation placed on a refinement created by capture checking.
    *  Refinements with this annotation unconditionally override any

--- a/tests/pos-custom-args/captures/i20231.scala
+++ b/tests/pos-custom-args/captures/i20231.scala
@@ -1,4 +1,14 @@
+import caps.cap
+
 class Async
 class C(val x: Async ?=> Unit)
 def foo(x: Async ?=> Unit): C^{x} = C(x)
 def foo(x: Async ?=> Unit)(using Async): C^{x} = C(x)
+
+// should also work for reach and read-only capabilities
+class D(val x: Async ?=> Unit) extends caps.Mutable
+def bar1(x: Async ?=> Unit): D^{cap, x*} = D(x)
+def bar1(x: Async ?=> Unit)(using Async): D^{cap, x*} = D(x)
+def bar2(x: Async ?=> Unit): D^{cap.rd, x.rd} = D(x)
+def bar2(x: Async ?=> Unit)(using Async): D^{cap.rd, x.rd} = D(x)
+


### PR DESCRIPTION
- Mark `reachCapability` and `readOnlyCapability` as `@retainsArg`, similar to #20232.
- Update tests for retainsArg
