### PR TITLE
Tighten condition when to do SAM type conversion

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2030,7 +2030,8 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           case mt: MethodType =>
             pt.findFunctionType match {
               case SAMType(samMeth, samParent)
-              if !defn.isFunctionNType(samParent) && mt <:< samMeth =>
+              if !ctx.erasedTypes && !defn.isFunctionNType(samParent)
+                  && mt <:< samMeth && !mt.isImplicitMethod =>
                 if defn.isContextFunctionType(mt.resultType) then
                   report.error(
                     em"""Implementation restriction: cannot convert this expression to `$samParent`

--- a/tests/neg-custom-args/captures/i23234.scala
+++ b/tests/neg-custom-args/captures/i23234.scala
@@ -1,0 +1,5 @@
+abstract class MyFun:
+  def apply(x: Int): Int
+
+object Test:
+  val myFun: MyFun = (x: Int) ?=> x + 10 // error


### PR DESCRIPTION
 - No conversion from contextual lambdas
 - No conversion after erasure

Fixes #23234