### PR TITLE
Skip over JEP 445 compact compilation units

### DIFF
--- a/tests/neg/i18584/T.java
+++ b/tests/neg/i18584/T.java
@@ -1,0 +1,9 @@
+// test: -jvm 25+
+
+int k = 0;
+File f = null;
+java.io.File g = f;
+@Deprecated void main() { return; }
+public record Person(String name, int age) { }
+public class H { }
+public static int k() { return 1; }

--- a/tests/neg/i18584/Test.scala
+++ b/tests/neg/i18584/Test.scala
@@ -1,0 +1,5 @@
+class Test {
+  new U
+  new H() // error
+  new T.H() // error
+}

--- a/tests/neg/i18584/U.java
+++ b/tests/neg/i18584/U.java
@@ -1,0 +1,1 @@
+public class U { }

--- a/tests/pos/i18584/T.java
+++ b/tests/pos/i18584/T.java
@@ -1,0 +1,9 @@
+// test: -jvm 25+
+
+int k = 0;
+File f = null;
+java.io.File g = f;
+@Deprecated void main() { return; }
+public record Person(String name, int age) { }
+public class H { }
+public static int k() { return 1; }

--- a/tests/pos/i18584/Test.scala
+++ b/tests/pos/i18584/Test.scala
@@ -1,0 +1,3 @@
+class Test {
+  new U
+}

--- a/tests/pos/i18584/U.java
+++ b/tests/pos/i18584/U.java
@@ -1,0 +1,1 @@
+public class U { }


### PR DESCRIPTION
Compact compilation units are not referrible, so we can skip over them.

Fixes https://github.com/scala/scala3/issues/18584