### PR TITLE
chore: mark `eq` and `ne` in Predef as `infix`

### DIFF
--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -56,12 +56,12 @@ object Predef:
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `eq` rather than only `==`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. */
-    inline def eq(inline y: AnyRef | Null): Boolean =
+    inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `ne` rather than only `!=`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. */
-    inline def ne(inline y: AnyRef | Null): Boolean =
+    inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
 
   extension (opt: Option.type)


### PR DESCRIPTION
For consistency with #23252

Note that `infix` here is not need because that parent's symbol is changed to `scala.Predef`, which is considered Scala 2 code.
I guess we can define extension methods in scala 2, at least from dotty internal's point of view 😅 