### PR TITLE
Refactorings for CC error reporting

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CCState.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CCState.scala
@@ -3,7 +3,7 @@ package dotc
 package cc
 
 import core.*
-import CaptureSet.{CompareResult, VarState}
+import CaptureSet.VarState
 import collection.mutable
 import reporting.Message
 import Contexts.Context

--- a/compiler/src/dotty/tools/dotc/cc/CCState.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CCState.scala
@@ -3,7 +3,7 @@ package dotc
 package cc
 
 import core.*
-import CaptureSet.{CompareResult, CompareFailure, VarState}
+import CaptureSet.{CompareResult, VarState}
 import collection.mutable
 import reporting.Message
 import Contexts.Context
@@ -15,24 +15,6 @@ class CCState:
   import CCState.*
 
   // ------ Error diagnostics -----------------------------
-
-  /** Error reprting notes produces since the last call to `test` */
-  var notes: List[ErrorNote] = Nil
-
-  def addNote(note: ErrorNote): Unit =
-    if !notes.exists(_.getClass == note.getClass) then
-      notes = note :: notes
-
-  def test(op: => CompareResult): CompareResult =
-    val saved = notes
-    notes = Nil
-    try op match
-      case res: CompareFailure => res.withNotes(notes)
-      case res => res
-    finally notes = saved
-
-  def testOK(op: => Boolean): CompareResult =
-    test(if op then CompareResult.OK else CompareResult.Fail(Nil))
 
   /** Warnings relating to upper approximations of capture sets with
    *  existentially bound variables.

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -558,7 +558,7 @@ object Capabilities:
             case y: ResultCap => vs.unify(x, y)
             case _ => y.derivesFromSharedCapability
           if !result then
-            ccState.addNote(CaptureSet.ExistentialSubsumesFailure(x, y))
+            TypeComparer.addErrorNote(CaptureSet.ExistentialSubsumesFailure(x, y))
           result
         case GlobalCap =>
           y match

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -138,8 +138,8 @@ object Capabilities:
    *                 for diagnostics
    */
   case class FreshCap private (owner: Symbol, origin: Origin)(using @constructorOnly ctx: Context) extends RootCapability:
-    val hiddenSet = CaptureSet.HiddenSet(owner)
-    hiddenSet.owningCap = this
+    val hiddenSet = CaptureSet.HiddenSet(owner, this: @unchecked)
+      // fails initialization check without the @unchecked
 
     override def equals(that: Any) = that match
       case that: FreshCap => this eq that

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -58,6 +58,7 @@ object Capabilities:
   trait RootCapability extends Capability:
     val rootId = nextRootId
     nextRootId += 1
+    def descr(using Context): String
 
   /** The base trait of all capabilties represented as types */
   trait CoreCapability extends TypeProxy, Capability:
@@ -120,6 +121,7 @@ object Capabilities:
    */
   @sharable // We override below all operations that access internal capability state
   object GlobalCap extends RootCapability:
+    def descr(using Context) = "the universal root capability"
     override val maybe = Maybe(this)
     override val readOnly = ReadOnly(this)
     override def reach = unsupported("cap.reach")
@@ -142,6 +144,14 @@ object Capabilities:
     override def equals(that: Any) = that match
       case that: FreshCap => this eq that
       case _ => false
+
+    def descr(using Context) =
+      val originStr = origin match
+        case Origin.InDecl(sym) if sym.exists =>
+          origin.explanation
+        case _ =>
+          i" created in ${hiddenSet.owner.sanitizedDescription}${origin.explanation}"
+      i"a fresh root capability$originStr"
 
   object FreshCap:
     def apply(origin: Origin)(using Context): FreshCap | GlobalCap.type =
@@ -225,6 +235,9 @@ object Capabilities:
             rcap.myOrigin = primary
             primary.variants += rcap
             rcap
+
+    def descr(using Context) =
+      i"a root capability associated with the result type of $binder"
   end ResultCap
 
   /** A trait for references in CaptureSets. These can be NamedTypes, ThisTypes or ParamRefs,

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -154,7 +154,7 @@ extension (tp: Type)
    *  the two capture sets are combined.
    */
   def capturing(cs: CaptureSet)(using Context): Type =
-    if (cs.isAlwaysEmpty || cs.isConst && cs.subCaptures(tp.captureSet, VarState.Separate).isOK)
+    if (cs.isAlwaysEmpty || cs.isConst && cs.subCaptures(tp.captureSet, VarState.Separate))
         && !cs.keepAlways
     then tp
     else tp match

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -41,9 +41,6 @@ def depFun(args: List[Type], resultType: Type, isContextual: Boolean, paramNames
 /** An exception thrown if a @retains argument is not syntactically a Capability */
 class IllegalCaptureRef(tpe: Type)(using Context) extends Exception(tpe.show)
 
-/** A base trait for data producing addenda to error messages */
-trait ErrorNote
-
 /** The currently valid CCState */
 def ccState(using Context): CCState =
   Phases.checkCapturesPhase.asInstanceOf[CheckCaptures].ccState1

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -950,16 +950,15 @@ object CaptureSet:
    *  which are already subject through snapshotting and rollbacks in VarState.
    *  It's advantageous if we don't need to deal with other pieces of state there.
    */
-  class HiddenSet(initialOwner: Symbol)(using @constructorOnly ictx: Context)
+  class HiddenSet(initialOwner: Symbol, val owningCap: FreshCap)(using @constructorOnly ictx: Context)
   extends Var(initialOwner):
-    var owningCap: FreshCap = uninitialized // initialized when owning FreshCap is created
     var givenOwner: Symbol = initialOwner
 
     override def owner = givenOwner
 
-    //assert(id != 4)
+    //assert(id != 3)
 
-    description = i"elements subsumed by $owningCap"
+    description = i"of elements subsumed by a fresh cap in $initialOwner"
 
     private def aliasRef: FreshCap | Null =
       if myElems.size == 1 then

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1300,7 +1300,6 @@ class CheckCaptures extends Recheck, SymTransformer:
               i"""the existential capture root in ${ex.originalBinder.resType}
                  |cannot subsume the capability $other$since"""
           i"""
-             |
              |Note that ${msg.toString}"""
 
 

--- a/compiler/src/dotty/tools/dotc/core/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymUtils.scala
@@ -118,6 +118,16 @@ class SymUtils:
 
     def isGenericProduct(using Context): Boolean = whyNotGenericProduct.isEmpty
 
+    def sanitizedDescription(using Context): String =
+      if self.isConstructor then
+        i"constructor of ${self.owner.sanitizedDescription}"
+      else if self.isAnonymousFunction then
+        i"anonymous function of type ${self.info}"
+      else if self.name.toString.contains('$') then
+        self.owner.sanitizedDescription
+      else
+        self.show
+
     /** Is this an old style implicit conversion?
      *  @param directOnly            only consider explicitly written methods
      *  @param forImplicitClassOnly  only consider methods generated from implicit classes

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -59,7 +59,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
   private var monitored = false
 
   private var maxErrorLevel: Int = -1
-  private var errorNotes: List[(Int, ErrorNote)] = Nil
+  protected var errorNotes: List[(Int, ErrorNote)] = Nil
 
   private var needsGc = false
 
@@ -433,7 +433,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           case _ =>
             if isCaptureVarComparison then
               return CCState.withCapAsRoot:
-                subCaptures(tp1.captureSet, tp2.captureSet).isOK
+                subCaptures(tp1.captureSet, tp2.captureSet)
             if (tp1 eq NothingType) || isBottom(tp1) then
               return true
         }
@@ -541,7 +541,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       case tp1 @ CapturingType(parent1, refs1) =>
         def compareCapturing =
           if tp2.isAny then true
-          else if subCaptures(refs1, tp2.captureSet).isOK && sameBoxed(tp1, tp2, refs1)
+          else if subCaptures(refs1, tp2.captureSet) && sameBoxed(tp1, tp2, refs1)
             || !ctx.mode.is(Mode.CheckBoundsOrSelfType) && tp1.isAlwaysPure
           then
             val tp2a =
@@ -583,7 +583,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
 
         if isCaptureVarComparison then
           return CCState.withCapAsRoot:
-            subCaptures(tp1.captureSet, tp2.captureSet).isOK
+            subCaptures(tp1.captureSet, tp2.captureSet)
 
         isSubApproxHi(tp1, info2.lo) && (trustBounds || isSubApproxHi(tp1, info2.hi))
         || compareGADT
@@ -668,12 +668,12 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                 && isSubInfo(info1.resultType, info2.resultType.subst(info2, info1))
               case (info1 @ CapturingType(parent1, refs1), info2: Type)
               if info2.stripCapturing.isInstanceOf[MethodOrPoly] =>
-                subCaptures(refs1, info2.captureSet).isOK && sameBoxed(info1, info2, refs1)
+                subCaptures(refs1, info2.captureSet) && sameBoxed(info1, info2, refs1)
                   && isSubInfo(parent1, info2)
               case (info1: Type, CapturingType(parent2, refs2))
               if info1.stripCapturing.isInstanceOf[MethodOrPoly] =>
                 val refs1 = info1.captureSet
-                (refs1.isAlwaysEmpty || subCaptures(refs1, refs2).isOK) && sameBoxed(info1, info2, refs1)
+                (refs1.isAlwaysEmpty || subCaptures(refs1, refs2)) && sameBoxed(info1, info2, refs1)
                   && isSubInfo(info1, parent2)
               case _ =>
                 isSubType(info1, info2)
@@ -867,12 +867,12 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
               // Eamples where this arises is capt-capibility.scala and function-combinators.scala
               val singletonOK = tp1 match
                 case tp1: SingletonType
-                if subCaptures(tp1.underlying.captureSet, refs2, CaptureSet.VarState.Separate).isOK =>
+                if subCaptures(tp1.underlying.captureSet, refs2, CaptureSet.VarState.Separate) =>
                   recur(tp1.widen, tp2)
                 case _ =>
                   false
               singletonOK
-              || subCaptures(refs1, refs2).isOK
+              || subCaptures(refs1, refs2)
                   && sameBoxed(tp1, tp2, refs1)
                   && (recur(tp1.widen.stripCapturing, parent2)
                      || tp1.isInstanceOf[SingletonType] && recur(tp1, parent2)
@@ -2830,7 +2830,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     if frozenConstraint then CaptureSet.VarState.Closed() else CaptureSet.VarState()
 
   protected def subCaptures(refs1: CaptureSet, refs2: CaptureSet,
-      vs: CaptureSet.VarState = makeVarState())(using Context): CaptureSet.CompareResult =
+      vs: CaptureSet.VarState = makeVarState())(using Context): Boolean =
     try
       refs1.subCaptures(refs2, vs)
     catch case ex: AssertionError =>
@@ -2843,7 +2843,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    */
   protected def sameBoxed(tp1: Type, tp2: Type, refs1: CaptureSet)(using Context): Boolean =
     (tp1.isBoxedCapturing == tp2.isBoxedCapturing)
-    || refs1.subCaptures(CaptureSet.empty, makeVarState()).isOK
+    || refs1.subCaptures(CaptureSet.empty, makeVarState())
 
   // ----------- Diagnostics --------------------------------------------------
 
@@ -3254,16 +3254,40 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    *  the same class as `note`.
    */
   def addErrorNote(note: ErrorNote): Unit =
-    if errorNotes.forall(_._2.getClass != note.getClass) then
+    if errorNotes.forall(_._2.kind != note.kind) then
       errorNotes = (recCount, note) :: errorNotes
       assert(maxErrorLevel <= recCount)
       maxErrorLevel = recCount
+
+  private[TypeComparer] inline
+  def isolated[T](inline op: Boolean, inline mapResult: Boolean => T)(using Context): T =
+    val savedNotes = errorNotes
+    val savedLevel = maxErrorLevel
+    errorNotes = Nil
+    maxErrorLevel = -1
+    try mapResult(op)
+    finally
+      errorNotes = savedNotes
+      maxErrorLevel = savedLevel
+
+  /** Run `op` on current type comparer, maping its Boolean result to
+   *  a CompareResult with possible outcomes OK and Fail(...)`. In case
+   *  of failure pass the accumulated errorNotes of this type comparer to
+   *  in the Fail value.
+   */
+  def compareResult(op: => Boolean)(using Context): CompareResult =
+    isolated(op, res =>
+      if res then CompareResult.OK else CompareResult.Fail(errorNotes.map(_._2)))
 }
 
 object TypeComparer {
 
   /** A base trait for data producing addenda to error messages */
-  trait ErrorNote
+  trait ErrorNote:
+    /** A disciminating kind. An error note is not added if it has the same kind
+     *  as an already existing error note.
+     */
+    def kind: Class[?] = getClass
 
   /** A richer compare result, returned by `testSubType` and `test`. */
   enum CompareResult:
@@ -3280,7 +3304,6 @@ object TypeComparer {
     else res match
       case ClassInfo(_, cls, _, _, _) => cls.showLocated
       case bounds: TypeBounds => i"type bounds [$bounds]"
-      case CaptureSet.CompareResult.OK => "OK"
       case res: printing.Showable => res.show
       case _ => String.valueOf(res).nn
 
@@ -3435,7 +3458,7 @@ object TypeComparer {
   def reduceMatchWith[T](op: MatchReducer => T)(using Context): T =
     comparing(_.reduceMatchWith(op))
 
-  def subCaptures(refs1: CaptureSet, refs2: CaptureSet, vs: CaptureSet.VarState)(using Context): CaptureSet.CompareResult =
+  def subCaptures(refs1: CaptureSet, refs2: CaptureSet, vs: CaptureSet.VarState)(using Context): Boolean =
     comparing(_.subCaptures(refs1, refs2, vs))
 
   def inNestedLevel(op: => Boolean)(using Context): Boolean =
@@ -3444,15 +3467,16 @@ object TypeComparer {
   def addErrorNote(note: ErrorNote)(using Context): Unit =
     comparer.addErrorNote(note)
 
-  /** Run `op` on current type comparer, maping its Boolean result to
-   *  a CompareResult with possible outcomes OK and Fail(...)`. In case
-   *  of failure pass the accumulated errorNotes of this type comparer to
-   *  in the Fail value.
-   */
-  def test(op: => Boolean)(using Context): CompareResult =
-    comparing: comparer =>
-      if op then CompareResult.OK
-      else CompareResult.Fail(comparer.errorNotes.map(_._2))
+  def updateErrorNotes(f: PartialFunction[ErrorNote, ErrorNote])(using Context): Unit =
+    comparer.errorNotes = comparer.errorNotes.mapConserve: p =>
+      val (level, note) = p
+      if f.isDefinedAt(note) then (level, f(note)) else p
+
+  def compareResult(op: => Boolean)(using Context): CompareResult =
+    comparing(_.compareResult(op))
+
+  inline def noNotes(inline op: Boolean)(using Context): Boolean =
+    comparer.isolated(op, x => x)
 }
 
 object MatchReducer:
@@ -3857,9 +3881,11 @@ class ExplainingTypeComparer(initctx: Context, short: Boolean) extends TypeCompa
   private val b = new StringBuilder
   private var lastForwardGoal: String | Null = null
 
-  private def appendFailure(x: String) =
+  private def appendFailure(notes: List[ErrorNote]) =
     if lastForwardGoal != null then  // last was deepest goal that failed
-      b.append(s"  = $x")
+      b.append(s"  = false")
+      for case note: printing.Showable <- notes do
+        b.append(i": $note")
       lastForwardGoal = null
 
   override def traceIndented[T](str: String)(op: => T): T =
@@ -3875,9 +3901,9 @@ class ExplainingTypeComparer(initctx: Context, short: Boolean) extends TypeCompa
       if short then
         res match
           case false =>
-            appendFailure("false")
-          case res: CaptureSet.CompareResult if res != CaptureSet.CompareResult.OK =>
-            appendFailure(show(res))
+            appendFailure(errorNotes.map(_._2))
+          case CompareResult.Fail(notes) =>
+            appendFailure(notes)
           case _ =>
             b.length = curLength // don't show successful subtraces
       else
@@ -3927,7 +3953,7 @@ class ExplainingTypeComparer(initctx: Context, short: Boolean) extends TypeCompa
       super.gadtAddBound(sym, b, isUpper)
     }
 
-  override def subCaptures(refs1: CaptureSet, refs2: CaptureSet, vs: CaptureSet.VarState)(using Context): CaptureSet.CompareResult =
+  override def subCaptures(refs1: CaptureSet, refs2: CaptureSet, vs: CaptureSet.VarState)(using Context): Boolean =
     traceIndented(i"subcaptures $refs1 <:< $refs2 in ${vs.toString}") {
       super.subCaptures(refs1, refs2, vs)
     }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -19,7 +19,7 @@ import typer.Inferencing.*
 import typer.IfBottom
 import reporting.TestingReporter
 import cc.{CapturingType, derivedCapturingType, CaptureSet, captureSet, isBoxed, isBoxedCapturing}
-import CaptureSet.{CompareResult, IdentityCaptRefMap, VarState}
+import CaptureSet.{IdentityCaptRefMap, VarState}
 
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
@@ -161,7 +161,7 @@ object TypeOps:
         TypeComparer.lub(simplify(l, theMap), simplify(r, theMap), isSoft = tp.isSoft)
       case tp @ CapturingType(parent, refs) =>
         if !ctx.mode.is(Mode.Type)
-            && refs.subCaptures(parent.captureSet, VarState.Separate).isOK
+            && refs.subCaptures(parent.captureSet, VarState.Separate)
             && (tp.isBoxed || !parent.isBoxedCapturing)
               // fuse types with same boxed status and outer boxed with any type
         then

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -39,7 +39,7 @@ import reporting.{trace, Message}
 import java.lang.ref.WeakReference
 import compiletime.uninitialized
 import cc.*
-import CaptureSet.{CompareResult, IdentityCaptRefMap}
+import CaptureSet.IdentityCaptRefMap
 import Capabilities.*
 
 import scala.annotation.internal.sharable

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4581,7 +4581,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             tree
           }
         else TypeComparer.testSubType(tree.tpe.widenExpr, pt) match
-          case CompareResult.Fail =>
+          case CompareResult.Fail(_) =>
             wtp match
               case wtp: MethodType => missingArgs(wtp)
               case _ =>

--- a/tests/neg-custom-args/captures/capt-depfun.check
+++ b/tests/neg-custom-args/captures/capt-depfun.check
@@ -6,6 +6,10 @@
    |
    |                                         where:    => refers to a fresh root capability in the type of value dc
    |
+   |
+   |                                         Note that the existential capture root in Str^{x} => Str^{x}
+   |                                         cannot subsume the capability <cap of (x: C^): Str^{x} => Str^{x}>
+   |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/capt-depfun.scala:11:24 -------------------------------------------------------
 11 |  val dc: ((Str^{y, z}) => Str^{y, z}) = ac(g()) // error // error: separatioon

--- a/tests/neg-custom-args/captures/capt-depfun.check
+++ b/tests/neg-custom-args/captures/capt-depfun.check
@@ -6,10 +6,6 @@
    |
    |                                         where:    => refers to a fresh root capability in the type of value dc
    |
-   |
-   |                                         Note that the existential capture root in Str^{x} => Str^{x}
-   |                                         cannot subsume the capability <cap of (x: C^): Str^{x} => Str^{x}>
-   |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/capt-depfun.scala:11:24 -------------------------------------------------------
 11 |  val dc: ((Str^{y, z}) => Str^{y, z}) = ac(g()) // error // error: separatioon

--- a/tests/neg-custom-args/captures/cc-existential-conformance.check
+++ b/tests/neg-custom-args/captures/cc-existential-conformance.check
@@ -19,7 +19,6 @@
   |                           where:    ^  refers to a fresh root capability in the type of value y
   |                                     ^² refers to a root capability associated with the result type of (x: A): B^²
   |
-  |
   |                           Note that the existential capture root in B^
   |                           cannot subsume the capability cap
   |
@@ -44,7 +43,6 @@
    |
    |                        where:    ^  refers to a fresh root capability in the type of value y
    |                                  ^² refers to a root capability associated with the result type of (x: A): B^²
-   |
    |
    |                        Note that the existential capture root in B^
    |                        cannot subsume the capability cap

--- a/tests/neg-custom-args/captures/effect-swaps-explicit.check
+++ b/tests/neg-custom-args/captures/effect-swaps-explicit.check
@@ -24,7 +24,6 @@
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
    |
-   |
    |Note that reference contextual$9.type
    |cannot be included in outer capture set ?
 70 |            fr.await.ok

--- a/tests/neg-custom-args/captures/effect-swaps.check
+++ b/tests/neg-custom-args/captures/effect-swaps.check
@@ -24,7 +24,6 @@
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          cap is the universal root capability
    |
-   |
    |Note that reference contextual$9.type
    |cannot be included in outer capture set ?
 70 |            fr.await.ok

--- a/tests/neg-custom-args/captures/erased-methods2.check
+++ b/tests/neg-custom-args/captures/erased-methods2.check
@@ -8,7 +8,6 @@
    |          ?=>² refers to a root capability associated with the result type of (using erased x$1: CT[Ex3]^): (erased x$2: CT[Ex2]^) ?=>² Unit
    |          ^    refers to the universal root capability
    |
-   |
    |Note that the existential capture root in (erased x$2: CT[Ex2]^) ?=> Unit
    |cannot subsume the capability x$1.type since that capability is not a SharedCapability
 21 |     ?=> (x$2: CT[Ex2]^)
@@ -27,7 +26,6 @@
    |          ?=>² refers to a root capability associated with the result type of (using erased x$1: CT[Ex3]^): (erased x$1: CT[Ex2]^) ?=>² (erased x$2: CT[Ex1]^) ?=>³ Unit
    |          ?=>³ refers to a root capability associated with the result type of (using erased x$1: CT[Ex2]^): (erased x$2: CT[Ex1]^) ?=>³ Unit
    |          ^    refers to the universal root capability
-   |
    |
    |Note that the existential capture root in (erased x$1: CT[Ex2]^) ?=> (erased x$2: CT[Ex1]^) ?=> Unit
    |cannot subsume the capability x$1.type since that capability is not a SharedCapability

--- a/tests/neg-custom-args/captures/filevar.check
+++ b/tests/neg-custom-args/captures/filevar.check
@@ -7,7 +7,6 @@
    |where:    =>  refers to a root capability associated with the result type of (using l: scala.caps.Capability^{cap.rd}): (f: File^{l}) => Unit
    |          cap is the universal root capability
    |
-   |
    |Note that reference l.type
    |cannot be included in outer capture set ? of parameter f
 16 |    val o = Service()

--- a/tests/neg-custom-args/captures/heal-tparam-cs.check
+++ b/tests/neg-custom-args/captures/heal-tparam-cs.check
@@ -7,7 +7,6 @@
    |where:    => refers to a fresh root capability created in value test1 when checking argument to parameter op of method localCap
    |          ^  refers to the universal root capability
    |
-   |
    |Note that reference c.type
    |cannot be included in outer capture set ?
 11 |    () => { c.use() }
@@ -22,7 +21,6 @@
    |
    |    where:    => refers to a root capability associated with the result type of (c: Capp^): () => Unit
    |              ^  refers to the universal root capability
-   |
    |
    |    Note that the existential capture root in () => Unit
    |    cannot subsume the capability x$0.type since that capability is not a SharedCapability

--- a/tests/neg-custom-args/captures/i15923.check
+++ b/tests/neg-custom-args/captures/i15923.check
@@ -8,7 +8,6 @@
    |          cap  is the universal root capability
    |          cap² is a root capability associated with the result type of (x$0: Cap^{lcap}): box Id[box Cap^{cap².rd}]^?
    |
-   |
    |Note that reference <cap of (x$0: Cap^{lcap}): box Id[box Cap^{cap.rd}]^?>.rd
    |cannot be included in outer capture set ?
    |

--- a/tests/neg-custom-args/captures/i15923a.check
+++ b/tests/neg-custom-args/captures/i15923a.check
@@ -9,7 +9,6 @@
   |          ^   refers to the universal root capability
   |          ^²  refers to a root capability associated with the result type of (): box Id[box Cap^²]^?
   |
-  |
   |Note that reference <cap of (): box Id[box Cap^]^?>
   |cannot be included in outer capture set ?
   |

--- a/tests/neg-custom-args/captures/i15923b.check
+++ b/tests/neg-custom-args/captures/i15923b.check
@@ -7,7 +7,6 @@
   |where:    => refers to a fresh root capability created in value leak when checking argument to parameter op of method withCap
   |          ^  refers to the universal root capability
   |
-  |
   |Note that reference lcap.type
   |cannot be included in outer capture set ?
   |

--- a/tests/neg-custom-args/captures/i16226.check
+++ b/tests/neg-custom-args/captures/i16226.check
@@ -21,7 +21,6 @@
    |          =>³ refers to a fresh root capability in the result type of method mapd
    |          ^   refers to a root capability associated with the result type of (ref: LazyRef[A]^{io}, f: A => B): LazyRef[B]^
    |
-   |
    |Note that the existential capture root in LazyRef[B]^
    |cannot subsume the capability f1.type since that capability is not a SharedCapability
    |

--- a/tests/neg-custom-args/captures/i21614.check
+++ b/tests/neg-custom-args/captures/i21614.check
@@ -16,7 +16,6 @@
    |where:    =>  refers to a fresh root capability created in method mkLoggers2 when checking argument to parameter f of method map
    |          cap is a root capability associated with the result type of (_$1: box File^{files*}): box Logger{val f: File^{_$1}}^{cap.rd, _$1}
    |
-   |
    |Note that reference <cap of (_$1: box File^{files*}): box Logger{val f: File^?}^?>.rd
    |cannot be included in outer capture set ?
    |

--- a/tests/neg-custom-args/captures/i21920.check
+++ b/tests/neg-custom-args/captures/i21920.check
@@ -7,7 +7,6 @@
    |where:    => refers to a fresh root capability created in value cell when checking argument to parameter f of method open
    |          ^  refers to the universal root capability
    |
-   |
    |Note that reference <cap of (): IterableOnce[box File^?]^>
    |cannot be included in outer capture set ?
    |

--- a/tests/neg-custom-args/captures/leaking-iterators.check
+++ b/tests/neg-custom-args/captures/leaking-iterators.check
@@ -7,7 +7,6 @@
    |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |
    |Note that reference log.type
    |cannot be included in outer capture set ?
 57 |    xs.iterator.map: x =>

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -86,7 +86,6 @@
    |                  where:    ^  refers to the universal root capability
    |                            ^² refers to a root capability associated with the result type of (x: File^): File^²
    |
-   |
    |                  Note that the existential capture root in File^
    |                  cannot subsume the capability x.type since that capability is not a SharedCapability
    |

--- a/tests/neg-custom-args/captures/scope-extrude-mut.check
+++ b/tests/neg-custom-args/captures/scope-extrude-mut.check
@@ -1,0 +1,9 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scope-extrude-mut.scala:9:8 ------------------------------
+9 |    a = a1  // error
+  |        ^^
+  |        Found:    A^{a1.rd}
+  |        Required: A^
+  |
+  |        where:    ^ refers to a fresh root capability in the type of variable a
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/scope-extrude-mut.scala
+++ b/tests/neg-custom-args/captures/scope-extrude-mut.scala
@@ -1,0 +1,9 @@
+import language.experimental.captureChecking
+
+class A extends caps.Mutable
+
+class B:
+  private var a: A^ = A()
+  def b() =
+    val a1 = A()
+    a = a1  // error

--- a/tests/neg-custom-args/captures/scoped-caps.check
+++ b/tests/neg-custom-args/captures/scoped-caps.check
@@ -19,7 +19,6 @@
   |                                   ^² refers to a fresh root capability in the type of value g
   |                                   ^³ refers to a root capability associated with the result type of (x: A^): B^³
   |
-  |
   |                         Note that the existential capture root in B^
   |                         cannot subsume the capability cap
   |
@@ -54,7 +53,6 @@
    |                        where:    ^  refers to the universal root capability
    |                                  ^² refers to a root capability associated with the result type of (x: A^): B^²
    |
-   |
    |                        Note that the existential capture root in B^
    |                        cannot subsume the capability x.type since that capability is not a SharedCapability
    |
@@ -68,7 +66,6 @@
    |               where:    ^   refers to a fresh root capability in the type of value h
    |                         ^²  refers to a root capability associated with the result type of (x: S^{cap.rd}): B^²
    |                         cap is the universal root capability
-   |
    |
    |               Note that the existential capture root in B^
    |               cannot subsume the capability cap

--- a/tests/neg-custom-args/captures/simple-using.check
+++ b/tests/neg-custom-args/captures/simple-using.check
@@ -7,7 +7,6 @@
   |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method usingLogFile
   |          ^  refers to the universal root capability
   |
-  |
   |Note that reference f.type
   |cannot be included in outer capture set ?
   |

--- a/tests/neg-custom-args/captures/try.check
+++ b/tests/neg-custom-args/captures/try.check
@@ -39,7 +39,6 @@
    |where:    => refers to a fresh root capability created in value xx when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
    |
-   |
    |Note that reference x.type
    |cannot be included in outer capture set ?
 36 |    (x: CanThrow[Exception]) =>
@@ -57,7 +56,6 @@
    |
    |where:    => refers to a fresh root capability created in value global when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
-   |
    |
    |Note that reference x.type
    |cannot be included in outer capture set ?

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -7,7 +7,6 @@
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |
    |Note that reference f.type
    |cannot be included in outer capture set ?
    |
@@ -20,7 +19,6 @@
    |
    |where:    => refers to a fresh root capability created in value later2 when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
-   |
    |
    |Note that reference f.type
    |cannot be included in outer capture set ?
@@ -35,7 +33,6 @@
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingFile
    |          ^  refers to the universal root capability
    |
-   |
    |Note that reference f.type
    |cannot be included in outer capture set ?
    |
@@ -48,7 +45,6 @@
    |
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingFile
    |          ^  refers to the universal root capability
-   |
    |
    |Note that reference _$1.type
    |cannot be included in outer capture set ?

--- a/tests/neg-custom-args/captures/vars.check
+++ b/tests/neg-custom-args/captures/vars.check
@@ -27,7 +27,6 @@
    |
    |        where:    ^ refers to the universal root capability
    |
-   |
    |        Note that reference cap3.type
    |        cannot be included in outer capture set ?
 37 |    def g(x: String): String = if cap3 == cap3 then "" else "a"

--- a/tests/pending/neg-custom-args/sep-tvar-follow.scala
+++ b/tests/pending/neg-custom-args/sep-tvar-follow.scala
@@ -1,0 +1,10 @@
+import language.experimental.captureChecking
+trait Ref
+def swap(x1: Ref^, x2: Ref^): Unit = ()
+def foo(a: Ref^)[X](op: (z: Ref^) -> X^{z}): X^{a} = op(a)
+def test1(a: Ref^): Unit =
+  def bad(x: Ref^)(y: Ref^{a}): Unit = swap(x, y)
+  val t1 = bad
+  def t2[X] = foo(a)[X]
+  val t3 = t2[(y: Ref^{a}) -> Unit](t1)
+  t3(a)  // boom


### PR DESCRIPTION
Be more systematic which error are added to messages. 

Harmonize treatment in TypeComparer, CaptureSet, and Capability. Now, all their comparison operations return boolean results and can additionally install error notes in the current TypeComparer. Error notes
are shown if they are relevant for the overall outcome of the comparison.

