### PR TITLE
Hide constructor proxies at PostTyper

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -704,6 +704,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
         case _ =>
       if parents1 ne info.parents then info.derivedClassInfo(declaredParents = parents1)
       else tp
+    case _ if sym.is(ConstructorProxy) => NoType
     case _ => tp
 
   private def argTypeOfCaseClassThatNeedsAbstractFunction1(sym: Symbol)(using Context): Option[List[Type]] =


### PR DESCRIPTION
Constructor proxies should all have been expanded at Typer. No need to keep them past PostTyper. This is a trial balloon to see whether we can do something similar for capture variable proxies.