### PR TITLE
Fix irrefutability checking in `for` with untupling

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1924,9 +1924,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           // to
           //   (a1, ..., aN) => e
           val params1 = desugar.patternsToParams(elems)
+          val matchCheck = scrut.getAttachment(desugar.CheckIrrefutable)
+            .getOrElse(desugar.MatchCheck.IrrefutablePatDef)
           desugared = if params1.hasSameLengthAs(elems)
             then cpy.Function(tree)(params1, rhs)
-            else desugar.makeCaseLambda(cases, desugar.MatchCheck.IrrefutablePatDef, protoFormals.length)
+            else desugar.makeCaseLambda(cases, matchCheck, protoFormals.length)
         case _ =>
 
     if desugared.isEmpty then

--- a/tests/neg/irrefutable-genfrom.scala
+++ b/tests/neg/irrefutable-genfrom.scala
@@ -1,0 +1,12 @@
+object Test:
+  def one: Unit =
+    for
+      // Was already an error as expected
+      (i, Some(_)) <- List.empty[Int] zip List.empty[Option[String]] // error
+    do ()
+
+  def two: Unit =
+    for
+      // Used to be a warning
+      (i, Some(_)) <- List.empty[Int] lazyZip List.empty[Option[String]] // error
+    do ()


### PR DESCRIPTION
Before this PR, the two for comprehensions in the added test case behaved differently:

```scala
-- Error: tests/neg/irrefutable-genfrom.scala:5:10 -----------------------------
5 |      (i, Some(_)) <- List.empty[Int] zip List.empty[Option[String]] // error
  |          ^^^^^^^
  |pattern's type Some[String] is more specialized than the right hand side expression's type Option[String]
  |
  |If the narrowing is intentional, this can be communicated by adding the `case` keyword before the full pattern,
  |which will result in a filtering for expression (using `withFilter`).
  |This patch can be rewritten automatically under -rewrite -source 3.2-migration.
-- Warning: tests/neg/irrefutable-genfrom.scala:11:6 ---------------------------
11 |      (i, Some(_)) <- List.empty[Int] lazyZip List.empty[Option[String]] // error
   |      ^
   |pattern's type Some[String] is more specialized than the right hand side expression's type Option[String]
   |
   |If the narrowing is intentional, this can be communicated by adding `: @unchecked` after the expression,
   |which may result in a MatchError at runtime.
   |This patch can be rewritten automatically under -rewrite -source 3.2-migration.
```

The second one was incorrect: just like the first one, we should use the `case` keyword to make the pattern partial since we're in a for comprehension, but this information was lost when calling `makeCaseLambda` in `typedFunctionValue`. To fix this, we need to retrieve the attachment in the scrutinee (it was added there by `makeSelector` called from `makeCaseLambda` called from `makeLambda` called from `makeFor` in `Desugar.scala`).