### PR TITLE
Allow caps in result types of functions to be mapped to reaches

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -103,6 +103,21 @@ sealed abstract class CaptureSet extends Showable:
   final def containsTerminalCapability(using Context) =
     elems.exists(_.isTerminalCapability)
 
+  /** Does this capture set contain a ResultCap element? */
+  final def containsResultCapability(using Context) =
+    elems.exists(_.core.isInstanceOf[ResultCap])
+
+  /** Does this capture set contain a GlobalCap or FreshCap, and at the same time
+   *  does not contain a ResultCap?
+   */
+  final def containsCapOrFresh(using Context) =
+    !containsResultCapability
+    && elems.exists: elem =>
+      elem.core match
+        case GlobalCap => true
+        case _: FreshCap => true
+        case _ => false
+
   final def containsCap(using Context) =
     elems.exists(_.core eq GlobalCap)
 

--- a/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
+++ b/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
@@ -46,13 +46,13 @@ object ccConfig:
    */
   inline val postCheckCapturesets = false
 
-  /** If true, turn on separation checking */
-  def useSepChecks(using Context): Boolean =
-    Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.8`)
-
   /** If true, do level checking for FreshCap instances */
   def useFreshLevels(using Context): Boolean =
     Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.7`)
+
+  /** If true, turn on separation checking */
+  def useSepChecks(using Context): Boolean =
+    Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.8`)
 
   /** Not used currently. Handy for trying out new features */
   def newScheme(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -222,7 +222,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
       boxText
       ~ toTextLocal(parent)
       ~ "^"
-      ~ toTextGeneralCaptureSet(refs).provided(!isUniversalCaptureSet(refs))
+      ~ toTextGeneralCaptureSet(refs).provided(!isUniversalCaptureSet(refs) || ccVerbose)
 
   def toText(tp: Type): Text = controlled {
     homogenize(tp) match {

--- a/tests/neg-custom-args/captures/cc-existential-conformance.check
+++ b/tests/neg-custom-args/captures/cc-existential-conformance.check
@@ -13,14 +13,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-existential-conformance.scala:9:29 --------------------
 9 |  val z: A -> (x: A) -> B^ = y // error
   |                             ^
-  |                           Found:    (y : A -> A -> B^)
-  |                           Required: A -> (x: A) -> B^²
+  |                             Found:    A -> A -> B^{y*}
+  |                             Required: A -> (x: A) -> B^
   |
-  |                           where:    ^  refers to a fresh root capability in the type of value y
-  |                                     ^² refers to a root capability associated with the result type of (x: A): B^²
+  |                             where:    ^ refers to a root capability associated with the result type of (x: A): B^
   |
-  |                           Note that the existential capture root in B^
-  |                           cannot subsume the capability cap
+  |                             Note that the existential capture root in B^
+  |                             cannot subsume the capability y* since that capability is not a SharedCapability
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-existential-conformance.scala:13:19 -------------------
@@ -38,13 +37,12 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-existential-conformance.scala:14:24 -------------------
 14 |  val z: (x: A) -> B^ = y // error
    |                        ^
-   |                        Found:    (y : A -> B^)
-   |                        Required: (x: A) -> B^²
+   |                        Found:    A -> B^{y*}
+   |                        Required: (x: A) -> B^
    |
-   |                        where:    ^  refers to a fresh root capability in the type of value y
-   |                                  ^² refers to a root capability associated with the result type of (x: A): B^²
+   |                        where:    ^ refers to a root capability associated with the result type of (x: A): B^
    |
    |                        Note that the existential capture root in B^
-   |                        cannot subsume the capability cap
+   |                        cannot subsume the capability y* since that capability is not a SharedCapability
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/existential-mapping.check
+++ b/tests/neg-custom-args/captures/existential-mapping.check
@@ -18,11 +18,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:12:20 --------------------------
 12 |  val _:  C^ -> C = x2 // error
    |                    ^^
-   |                    Found:    (x2 : C^ -> C^²)
+   |                    Found:    C^ -> C^{x2*}
    |                    Required: C^ -> C
    |
-   |                    where:    ^  refers to the universal root capability
-   |                              ^² refers to a fresh root capability in the type of value x2
+   |                    where:    ^ refers to the universal root capability
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:15:30 --------------------------
@@ -38,11 +37,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:18:25 --------------------------
 18 |  val _: A^ -> C^ -> C = x4 // error
    |                         ^^
-   |                         Found:    (x4 : A^ -> C^ -> C^²)
+   |                         Found:    A^ -> C^ -> C^{x4*}
    |                         Required: A^ -> C^ -> C
    |
-   |                         where:    ^  refers to the universal root capability
-   |                                   ^² refers to a fresh root capability in the type of value x4
+   |                         where:    ^ refers to the universal root capability
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:21:30 --------------------------
@@ -58,13 +56,12 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:24:30 --------------------------
 24 |  val _: A^ -> (x: C^) => C = x6 // error
    |                              ^^
-   |                       Found:    (x6 : A^ -> (x: C^) => C^²)
-   |                       Required: A^ -> (x: C^) =>² C
+   |                        Found:    A^ -> (x: C^) ->{x6*} C^²
+   |                        Required: A^ -> (x: C^) => C
    |
-   |                       where:    =>  refers to a fresh root capability in the type of value x6
-   |                                 =>² refers to a fresh root capability in the type of value _$6
-   |                                 ^   refers to the universal root capability
-   |                                 ^²  refers to a root capability associated with the result type of (x: C^): C^²
+   |                        where:    => refers to a fresh root capability in the type of value _$6
+   |                                  ^  refers to the universal root capability
+   |                                  ^² refers to a root capability associated with the result type of (x: C^): C^²
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:27:25 --------------------------
@@ -82,25 +79,21 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:30:20 --------------------------
 30 |  val _:  C^ => C = y2 // error
    |                    ^^
-   |                    Found:    (y2 : C^ => C^²)
-   |                    Required: C^ =>² C
+   |                    Found:    C^ ->{y2} C^{y2*}
+   |                    Required: C^ => C
    |
-   |                    where:    =>  refers to a fresh root capability in the type of value y2
-   |                              =>² refers to a fresh root capability in the type of value _$8
-   |                              ^   refers to the universal root capability
-   |                              ^²  refers to a fresh root capability in the type of value y2
+   |                    where:    => refers to a fresh root capability in the type of value _$8
+   |                              ^  refers to the universal root capability
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:33:30 --------------------------
 33 |  val _: A^ => (x: C^) => C = y3 // error
    |                              ^^
-   |                       Found:    (y3 : A^ => (x: C^) =>² C^²)
-   |                       Required: A^ =>³ (x: C^) =>⁴ C
+   |                       Found:    A^ ->{y3} (x: C^) ->{y3*} C^²
+   |                       Required: A^ => (x: C^) =>² C
    |
-   |                       where:    =>  refers to a fresh root capability in the type of value y3
-   |                                 =>² refers to a fresh root capability in the type of value y3
-   |                                 =>³ refers to a fresh root capability in the type of value _$9
-   |                                 =>⁴ refers to a fresh root capability in the type of value _$9
+   |                       where:    =>  refers to a fresh root capability in the type of value _$9
+   |                                 =>² refers to a fresh root capability in the type of value _$9
    |                                 ^   refers to the universal root capability
    |                                 ^²  refers to a root capability associated with the result type of (x: C^): C^²
    |
@@ -108,15 +101,12 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:36:25 --------------------------
 36 |  val _: A^ => C^ => C = y4 // error
    |                         ^^
-   |                         Found:    (y4 : A^ => C^ =>² C^²)
-   |                         Required: A^ =>³ C^ =>⁴ C
+   |                         Found:    A^ ->{y4} C^ ->{y4*} C^{y4*}
+   |                         Required: A^ => C^ =>² C
    |
-   |                         where:    =>  refers to a fresh root capability in the type of value y4
-   |                                   =>² refers to a fresh root capability in the type of value y4
-   |                                   =>³ refers to a fresh root capability in the type of value _$10
-   |                                   =>⁴ refers to a fresh root capability in the type of value _$10
+   |                         where:    =>  refers to a fresh root capability in the type of value _$10
+   |                                   =>² refers to a fresh root capability in the type of value _$10
    |                                   ^   refers to the universal root capability
-   |                                   ^²  refers to a fresh root capability in the type of value y4
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:39:30 --------------------------
@@ -134,13 +124,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/existential-mapping.scala:42:30 --------------------------
 42 |  val _: A^ => (x: C^) => C = y6 // error
    |                              ^^
-   |                       Found:    (y6 : A^ => (x: C^) =>² C^²)
-   |                       Required: A^ =>³ (x: C^) =>⁴ C
+   |                       Found:    A^ ->{y6} (x: C^) ->{y6*} C^²
+   |                       Required: A^ => (x: C^) =>² C
    |
-   |                       where:    =>  refers to a fresh root capability in the type of value y6
-   |                                 =>² refers to a fresh root capability in the type of value y6
-   |                                 =>³ refers to a fresh root capability in the type of value _$12
-   |                                 =>⁴ refers to a fresh root capability in the type of value _$12
+   |                       where:    =>  refers to a fresh root capability in the type of value _$12
+   |                                 =>² refers to a fresh root capability in the type of value _$12
    |                                 ^   refers to the universal root capability
    |                                 ^²  refers to a root capability associated with the result type of (x: C^): C^²
    |

--- a/tests/neg-custom-args/captures/reach-in-results.scala
+++ b/tests/neg-custom-args/captures/reach-in-results.scala
@@ -1,0 +1,7 @@
+import language.experimental.captureChecking
+trait File
+def usingFile[R](op: File^ => R): R = op(new File {})
+def id(x: File^): File^{x} = x
+def test1(): Unit =
+  val op: File^ -> File^ = id // error, this should be disallowed
+  val g: File^ -> File^{op*} = op  // otherwise we can brand arbitrary File as simply capturing op*

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -65,18 +65,6 @@
    |                                     ^² refers to a fresh root capability in the type of value id
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:62:38 --------------------------------------
-62 |  val leaked = usingFile[File^{id*}]: f => // error // error
-   |                                      ^
-   |Found:    (f: File^?) ->? box File^?
-   |Required: (f: File^) => box File^{id*}
-   |
-   |where:    => refers to a fresh root capability created in value leaked when checking argument to parameter f of method usingFile
-   |          ^  refers to the universal root capability
-63 |    val f1: File^{id*} = id(f)
-64 |    f1
-   |
-   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:67:32 --------------------------------------
 67 |  val id: (x: File^) -> File^ = x => x // error
    |                                ^^^^^^
@@ -91,9 +79,9 @@
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:70:38 --------------------------------------
-70 |  val leaked = usingFile[File^{id*}]: f => // error // error
+70 |  val leaked = usingFile[File^{id*}]: f => // error
    |                                      ^
-   |Found:    (f: File^?) ->? box File^?
+   |Found:    (f: File^?) ->? box File^{id*}
    |Required: (f: File^) => box File^{id*}
    |
    |where:    => refers to a fresh root capability created in value leaked when checking argument to parameter f of method usingFile
@@ -117,11 +105,3 @@
    |          ^  refers to the universal root capability
    |
    | longer explanation available when compiling with `-explain`
--- Error: tests/neg-custom-args/captures/reaches.scala:62:31 -----------------------------------------------------------
-62 |  val leaked = usingFile[File^{id*}]: f => // error // error
-   |                               ^^^
-   |                               id* cannot be tracked since its deep capture set is empty
--- Error: tests/neg-custom-args/captures/reaches.scala:70:31 -----------------------------------------------------------
-70 |  val leaked = usingFile[File^{id*}]: f => // error // error
-   |                               ^^^
-   |                               id* cannot be tracked since its deep capture set is empty

--- a/tests/neg-custom-args/captures/reaches.scala
+++ b/tests/neg-custom-args/captures/reaches.scala
@@ -59,7 +59,7 @@ def attack2 =
   val id: File^ -> File^ = x => x // error
     // val id: File^ -> File^{fresh}
 
-  val leaked = usingFile[File^{id*}]: f => // error // error
+  val leaked = usingFile[File^{id*}]: f => // now ok
     val f1: File^{id*} = id(f)
     f1
 
@@ -67,7 +67,7 @@ def attack3 =
   val id: (x: File^) -> File^ = x => x // error
     // val id: File^ -> EX C.File^C
 
-  val leaked = usingFile[File^{id*}]: f => // error // error
+  val leaked = usingFile[File^{id*}]: f => // error
     val f1: File^{id*} = id(f)
     f1
 

--- a/tests/neg-custom-args/captures/refine-reach-shallow.scala
+++ b/tests/neg-custom-args/captures/refine-reach-shallow.scala
@@ -2,7 +2,7 @@ import language.experimental.captureChecking
 trait IO
 def test1(): Unit =
   val f: IO^ => IO^ = x => x // error
-  val g: IO^ => IO^{f*} = f  // error
+  val g: IO^ => IO^{f*} = f  // now OK
 def test2(): Unit =
   val f: [R] -> (IO^ => R) -> R = ???
   val ff = f
@@ -15,5 +15,5 @@ def test4(): Unit =
   val ys: List[IO^{xs*}] = xs  // ok
 def test5(): Unit =
   val f: [R] -> (IO^ -> R) -> IO^ = ???
-  val g: [R] -> (IO^ -> R) -> IO^{f*} = f  // error // error
-  val h: [R] -> (IO^{f*} -> R) -> IO^ = f  // error // error
+  val g: [R] -> (IO^ -> R) -> IO^{f*} = f  // error
+  val h: [R] -> (IO^{f*} -> R) -> IO^ = f  // error

--- a/tests/neg-custom-args/captures/scoped-caps.check
+++ b/tests/neg-custom-args/captures/scoped-caps.check
@@ -12,15 +12,14 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:9:25 -----------------------------------
 9 |  val _: (x: A^) -> B^ = g // error
   |                         ^
-  |                         Found:    (g : A^ -> B^²)
-  |                         Required: (x: A^) -> B^³
+  |                         Found:    A^ -> B^{g*}
+  |                         Required: (x: A^) -> B^²
   |
   |                         where:    ^  refers to the universal root capability
-  |                                   ^² refers to a fresh root capability in the type of value g
-  |                                   ^³ refers to a root capability associated with the result type of (x: A^): B^³
+  |                                   ^² refers to a root capability associated with the result type of (x: A^): B^²
   |
   |                         Note that the existential capture root in B^
-  |                         cannot subsume the capability cap
+  |                         cannot subsume the capability g* since that capability is not a SharedCapability
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:10:20 ----------------------------------
@@ -32,16 +31,6 @@
    |                    where:    ^  refers to the universal root capability
    |                              ^² refers to a root capability associated with the result type of (x: A^): B^²
    |                              ^³ refers to a fresh root capability in the type of value _$3
-   |
-   | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:12:20 ----------------------------------
-12 |  val _: A^ -> B^ = x => g(x)      // error, since g is pure, g(x): B^{x} , which does not match B^{fresh}
-   |                    ^^^^^^^^^
-   |                    Found:    (x: A^) ->? B^{x}
-   |                    Required: (x: A^) -> B^²
-   |
-   |                    where:    ^  refers to the universal root capability
-   |                              ^² refers to a fresh root capability in the type of value _$5
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:13:25 ----------------------------------
@@ -60,46 +49,47 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:16:24 ----------------------------------
 16 |  val _: (x: S) -> B^ = h          // error: direct conversion fails
    |                        ^
-   |               Found:    (h : S -> B^)
-   |               Required: (x: S^{cap.rd}) -> B^²
+   |                Found:    S^{cap.rd} -> B^{h*}
+   |                Required: (x: S^{cap.rd}) -> B^
    |
-   |               where:    ^   refers to a fresh root capability in the type of value h
-   |                         ^²  refers to a root capability associated with the result type of (x: S^{cap.rd}): B^²
-   |                         cap is the universal root capability
+   |                where:    ^   refers to a root capability associated with the result type of (x: S^{cap.rd}): B^
+   |                          cap is the universal root capability
    |
-   |               Note that the existential capture root in B^
-   |               cannot subsume the capability cap
+   |                Note that the existential capture root in B^
+   |                cannot subsume the capability h* since that capability is not a SharedCapability
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:22:19 ----------------------------------
-22 |  val _: S -> B^ = j               // error
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:17:24 ----------------------------------
+17 |  val _: (x: S) -> B^ = (x: S) => h(x)  // error: eta expansion fails
+   |                        ^^^^^^^^^^^^^^
+   |                Found:    (x: S^{cap.rd}) ->? B^{h*}
+   |                Required: (x: S^{cap.rd}) -> B^
+   |
+   |                where:    ^   refers to a root capability associated with the result type of (x: S^{cap.rd}): B^
+   |                          cap is the universal root capability
+   |
+   |                Note that the existential capture root in B^
+   |                cannot subsume the capability h* since that capability is not a SharedCapability
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:26:19 ----------------------------------
+26 |  val _: S -> B^ = j               // error
    |                   ^
    |                Found:    (j : (x: S) -> B^)
    |                Required: S^{cap.rd} -> B^²
    |
    |                where:    ^   refers to a root capability associated with the result type of (x: S^{cap.rd}): B^
-   |                          ^²  refers to a fresh root capability in the type of value _$11
+   |                          ^²  refers to a fresh root capability in the type of value _$13
    |                          cap is the universal root capability
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:23:19 ----------------------------------
-23 |  val _: S -> B^ = x => j(x)       // error
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:27:19 ----------------------------------
+27 |  val _: S -> B^ = x => j(x)       // error
    |                   ^^^^^^^^^
    |                   Found:    (x: S^{cap.rd}) ->? B^{x}
    |                   Required: (x: S^{cap.rd}) -> B^
    |
-   |                   where:    ^   refers to a fresh root capability in the type of value _$12
+   |                   where:    ^   refers to a fresh root capability in the type of value _$14
    |                             cap is the universal root capability
-   |
-   | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:26:20 ----------------------------------
-26 |  val _: A^ => B^ = x => g2(x)  // error: g2(x): B^{g2, x}, and the `x` cannot be subsumed by fresh
-   |                    ^^^^^^^^^^
-   |                    Found:    (x: A^) ->{g2} B^{g2, x}
-   |                    Required: (x: A^) => B^²
-   |
-   |                    where:    => refers to a fresh root capability in the type of value _$13
-   |                              ^  refers to the universal root capability
-   |                              ^² refers to a fresh root capability in the type of value _$13
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/scoped-caps.scala
+++ b/tests/neg-custom-args/captures/scoped-caps.scala
@@ -9,12 +9,16 @@ def test(io: Object^): Unit =
   val _: (x: A^) -> B^ = g // error
   val _: A^ -> B^ = f // error
   val _: A^ -> B^ = g
-  val _: A^ -> B^ = x => g(x)      // error, since g is pure, g(x): B^{x} , which does not match B^{fresh}
+  val _: A^ -> B^ = x => g(x)      // now ok, was error: since g is pure, g(x): B^{x} , which does not match B^{fresh}
   val _: (x: A^) -> B^ = x => f(x) // error: existential in B cannot subsume `x` since `x` is not shared
 
   val h: S -> B^ = ???
   val _: (x: S) -> B^ = h          // error: direct conversion fails
-  val _: (x: S) -> B^ = x => h(x)  // but eta expansion succeeds (for SharedCapabilities)
+  val _: (x: S) -> B^ = (x: S) => h(x)  // error: eta expansion fails
+
+  val h2: S -> S = ???
+  val _: (x: S) -> S = h2               // direct conversion OK for shared S
+  val _: (x: S) -> S = (x: S) => h2(x)  // eta conversion is also OK
 
   val j: (x: S) -> B^ = ???
   val _: (x: S) -> B^ = j
@@ -23,6 +27,9 @@ def test(io: Object^): Unit =
   val _: S -> B^ = x => j(x)       // error
 
   val g2: A^ => B^ = ???
-  val _: A^ => B^ = x => g2(x)  // error: g2(x): B^{g2, x}, and the `x` cannot be subsumed by fresh
+  val _: A^ => B^ = x =>
+    val y = g2(x)  // now ok since g2(x): B^{g2*}
+    val _: B^{g2*} = y
+    y
   val g3: A^ => B^ = ???
-  val _: A^{io} => B^ = x => g3(x)  // ok, now g3(x): B^{g3, x}, which is widened to B^{g3, io}
+  val _: A^{io} => B^ = x => g3(x)  // now g3(x): B^{g3*}

--- a/tests/neg-custom-args/captures/sep-use2.check
+++ b/tests/neg-custom-args/captures/sep-use2.check
@@ -47,16 +47,43 @@
 24 |    { f(c) } // error
    |        ^
    |Separation failure: argument of type  (c : Object^)
-   |to a function of type Object^ ->{c} Object^
+   |to a function of type Object^ ->{f} Object^{f*}
    |corresponds to capture-polymorphic formal parameter v1 of type  Object^²
    |and hides capabilities  {c}.
    |Some of these overlap with the captures of the function prefix.
    |
    |  Hidden set of current argument        : {c}
    |  Hidden footprint of current argument  : {c}
-   |  Capture set of function prefix        : {f}
-   |  Footprint set of function prefix      : {f, c}
+   |  Capture set of function prefix        : {f*}
+   |  Footprint set of function prefix      : {f*, c}
    |  The two sets overlap at               : {c}
    |
    |where:    ^  refers to a fresh root capability in the type of parameter c
    |          ^² refers to a fresh root capability created in value x4 when checking argument to parameter v1 of method apply
+-- Error: tests/neg-custom-args/captures/sep-use2.scala:23:10 ----------------------------------------------------------
+23 |  val x4: Object^ = // error: ^ hides f*, needs @consume
+   |          ^^^^^^^
+   |          Separation failure: value x4's type Object^ hides parameter f.
+   |          The parameter needs to be annotated with @consume to allow this.
+-- Error: tests/neg-custom-args/captures/sep-use2.scala:28:8 -----------------------------------------------------------
+28 |    { f(c) } // error
+   |        ^
+   |Separation failure: argument of type  (c : Object^)
+   |to a function of type Object^ ->{f} Object^{f*}
+   |corresponds to capture-polymorphic formal parameter v1 of type  Object^²
+   |and hides capabilities  {c}.
+   |Some of these overlap with the captures of the function prefix.
+   |
+   |  Hidden set of current argument        : {c}
+   |  Hidden footprint of current argument  : {c}
+   |  Capture set of function prefix        : {f*}
+   |  Footprint set of function prefix      : {f*, c}
+   |  The two sets overlap at               : {c}
+   |
+   |where:    ^  refers to a fresh root capability in the type of parameter c
+   |          ^² refers to a fresh root capability created in value x4 when checking argument to parameter v1 of method apply
+-- Error: tests/neg-custom-args/captures/sep-use2.scala:27:10 ----------------------------------------------------------
+27 |  val x4: Object^ = // error: ^ hides f* which refers to c, so c needs @consume
+   |          ^^^^^^^
+   |          Separation failure: value x4's type Object^ hides parameter c.
+   |          The parameter needs to be annotated with @consume to allow this.

--- a/tests/neg-custom-args/captures/sep-use2.scala
+++ b/tests/neg-custom-args/captures/sep-use2.scala
@@ -20,8 +20,13 @@ def test2(@consume c: Object^, f: (x: Object^) ->{c} Object^) =
     { f(c) } // error // error
 
 def test3(@consume c: Object^, f: Object^ ->{c} Object^) =
-  val x4: Object^ = // ^ hides c and f*
+  val x4: Object^ = // error: ^ hides f*, needs @consume
     { f(c) } // error
+
+def test4(c: Object^, @consume f: Object^ ->{c} Object^) =
+  val x4: Object^ = // error: ^ hides f* which refers to c, so c needs @consume
+    { f(c) } // error
+
 
 
 

--- a/tests/pos-custom-args/captures/reach-in-results.scala
+++ b/tests/pos-custom-args/captures/reach-in-results.scala
@@ -1,0 +1,21 @@
+import language.experimental.captureChecking
+
+class IO extends caps.Capability
+
+def test(io: IO^): Unit =
+  val f = (x: () => IO^) => x()
+  val _: (x: () => IO^) => IO^{x} = f//(x: () => IO^) => f(x)
+  def g(x: IO^ => IO^) = x(io)
+  def h(x: (y: IO^) => IO^) = x(io)
+
+  val a: () -> IO^ = ???
+  val _: () -> IO^{a*} = a
+  val b: (x: IO^) -> IO^ = ???
+  val _: (x: IO^) -> IO^ = b
+  val c: IO^ -> IO^ = ???
+  val cc: IO^ -> IO^{c*} = c
+
+def testByName(io: IO^): Unit =
+  def f(x: => () => IO^) = x()
+  def g(x: => IO^ => IO^) = x(io)
+  def h(x: => (y: IO^) => IO^) = x(io)


### PR DESCRIPTION

Allow caps in result types of functions to be mapped to reach capabilities

Example: If we have `val f: A => C^` then `f` has type `A => C^{f*}`. Before it had that type only if `A` was pure. On the other hand, result caps are not replaced anymore. We used to have for `val f: (x: A) => C^` with `A` pure that `f: (x: A) => C^{f*}`. That's no longer the case. In this case, `f` now has type `f: (x: A) => C^` with the `^` understood to be existentially bound.

This aligns the implementation with the Capless paper.