### PR TITLE
Always transform Inlined.call in CheckUnused

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1499,9 +1499,8 @@ object Trees {
     protected def skipTransform(tree: Tree)(using Context): Boolean = false
 
     /** For untyped trees, this is just the identity.
-     *  For typed trees, a context derived form `ctx` that records `call` as the
-     *  innermost enclosing call for which the inlined version is currently
-     *  processed.
+     *  For typed trees, a context derived from `ctx` that records `call` as the
+     *  innermost enclosing call for which the inlined version is currently processed.
      */
     protected def inlineContext(tree: Inlined)(using Context): Context = ctx
 

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -142,13 +142,14 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
     case _ =>
     tree
 
+  // bindings and expansion are always transformed.
+  // Inlined.call was not necessarily witnessed, due to transparent inline or macros at inlining.
   override def prepareForInlined(tree: Inlined)(using Context): Context =
     refInfos.inlined.push(tree.call.srcPos)
     ctx
   override def transformInlined(tree: Inlined)(using Context): tree.type =
-    //transformAllDeep(tree.expansion) // traverse expansion with nonempty inlined stack to avoid registering defs
     val _ = refInfos.inlined.pop()
-    if !tree.call.isEmpty && phaseMode.eq(PhaseMode.Aggregate) then
+    if !tree.call.isEmpty then
       transformAllDeep(tree.call)
     tree
 

--- a/library/src/scala/compiletime/package.scala
+++ b/library/src/scala/compiletime/package.scala
@@ -184,11 +184,11 @@ inline def summonAll[T <: Tuple]: T =
 def byName[T](x: => T): T = x
 
 /** Casts a value to be `Matchable`. This is needed if the value's type is an unconstrained
-  *  type parameter and the value is the scrutinee of a match expression.
-  *  This is normally disallowed since it violates parametricity and allows
-  *  to uncover implementation details that were intended to be hidden.
-  *  The `asMatchable` escape hatch should be used sparingly. It's usually
-  *  better to constrain the scrutinee type to be `Matchable` in the first place.
-  */
+ *  type parameter and the value is the scrutinee of a match expression.
+ *  This is normally disallowed since it violates parametricity and allows
+ *  to uncover implementation details that were intended to be hidden.
+ *  The `asMatchable` escape hatch should be used sparingly. It's usually
+ *  better to constrain the scrutinee type to be `Matchable` in the first place.
+ */
 extension [T](x: T)
   transparent inline def asMatchable: x.type & Matchable = x.asInstanceOf[x.type & Matchable]


### PR DESCRIPTION
Fixes #23201 

Previously, CheckUnused transformed the `call` tree of an `Inlined` node only after typer (and not after inlining), but inlining also results in non-trivial `call` trees.

Needs a minimized test, where an import is required for expansion but is unused at typer.