### PR TITLE
Lambda-owned param ref in ctor incurs no field

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -58,35 +58,36 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
   // 3. It is accessed on an object other than `this`
   // 4. It is a mutable parameter accessor
   // 5. It has a wildcard initializer `_`
-  private def markUsedPrivateSymbols(tree: RefTree)(using Context): Unit =
+  private def markUsedPrivateSymbols(tree: RefTree)(using Context): Unit = {
 
     val sym = tree.symbol
     def retain() = retainedPrivateVals.add(sym)
 
     if sym.exists && sym.owner.isClass && sym.mightBeDropped then
       tree match
-      case Ident(_) | Select(This(_), _) =>
-        val method = ctx.owner.enclosingMethod
-        // template exprs are moved (below) to constructor, where lifted anonfun will take its captured env as an arg
-        inline def methodOwnerIsLocalDummyOrSibling =
-          val owner = method.owner
-          owner.isLocalDummy || owner.owner == sym.owner && !owner.isOneOf(MethodOrLazy)
-        inline def inAnonFunInCtor =
-             method.isAnonymousFunction
-          && methodOwnerIsLocalDummyOrSibling
-          && !sym.owner.is(Module) // lambdalift doesn't transform correctly (to do)
-        val inConstructor =
-             (method.isPrimaryConstructor || inAnonFunInCtor)
-          && ctx.owner.enclosingClass == sym.owner
-        val noField =
-             inConstructor
-          && (sym.is(ParamAccessor) || seenPrivateVals.contains(sym))
-          // used inside constructor, accessed on this,
-          // could use constructor argument instead, no need to retain field
-        if !noField then
+        case Ident(_) | Select(This(_), _) =>
+          val method = ctx.owner.enclosingMethod
+          // template exprs are moved (below) to constructor, where lifted anonfun will take its captured env as an arg
+          inline def methodOwnerIsLocalDummyOrSibling =
+            val owner = method.owner
+            owner.isLocalDummy || owner.owner == sym.owner && !owner.isOneOf(MethodOrLazy)
+          inline def inAnonFunInCtor =
+               method.isAnonymousFunction
+            && methodOwnerIsLocalDummyOrSibling
+            && !sym.owner.is(Module) // lambdalift doesn't transform correctly (to do)
+          val inConstructor =
+               (method.isPrimaryConstructor || inAnonFunInCtor)
+            && ctx.owner.enclosingClass == sym.owner
+          val noField =
+               inConstructor
+            && (sym.is(ParamAccessor) || seenPrivateVals.contains(sym))
+            // used inside constructor, accessed on this,
+            // could use constructor argument instead, no need to retain field
+          if !noField then
+            retain()
+        case _ =>
           retain()
-      case _ =>
-        retain()
+  }
 
   override def transformIdent(tree: tpd.Ident)(using Context): tpd.Tree = {
     markUsedPrivateSymbols(tree)
@@ -219,7 +220,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
 
     // Split class body into statements that go into constructor and
     // definitions that are kept as members of the class.
-    def splitStats(stats: List[Tree]): Unit = stats match
+    def splitStats(stats: List[Tree]): Unit = stats match {
       case stat :: stats =>
         val sym = stat.symbol
         stat match {
@@ -234,7 +235,8 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
               if !stat.rhs.isEmpty then
                 sym.copySymDenotation(
                   initFlags = sym.flags &~ Private,
-                  owner = constr.symbol).installAfter(thisPhase)
+                  owner = constr.symbol
+                ).installAfter(thisPhase)
                 constrStats += intoConstr(stat, sym)
           case stat @ DefDef(name, _, tpt, _) if stat.symbol.isGetter && !stat.symbol.is(Lazy) =>
             assert(isRetained(sym), sym)
@@ -277,6 +279,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
         }
         splitStats(stats)
       case Nil =>
+    }
     end splitStats
 
     /** Check that we do not have both a private field with name `x` and a private field

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -45,10 +45,10 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
     // to more symbols being retained as parameters. Test case in run/capturing.scala.
 
   /** The private vals that are known to be retained as class fields */
-  private val retainedPrivateVals = mutable.Set.empty[Symbol]
+  private val retainedPrivateVals = mutable.Set[Symbol]()
 
   /** The private vals whose definition comes before the current focus */
-  private val seenPrivateVals = mutable.Set.empty[Symbol]
+  private val seenPrivateVals = mutable.Set[Symbol]()
 
   // Collect all private parameter accessors and value definitions that need
   // to be retained. There are several reasons why a parameter accessor or
@@ -57,36 +57,39 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
   // 2. It is accessed before it is defined
   // 3. It is accessed on an object other than `this`
   // 4. It is a mutable parameter accessor
-  // 5. It has a wildcard initializer `_`
+  // 5. It is has a wildcard initializer `_`
   private def markUsedPrivateSymbols(tree: RefTree)(using Context): Unit = {
 
     val sym = tree.symbol
     def retain() = retainedPrivateVals.add(sym)
 
-    if sym.exists && sym.owner.isClass && sym.mightBeDropped then
-      tree match
-        case Ident(_) | Select(This(_), _) =>
-          val method = ctx.owner.enclosingMethod
-          // template exprs are moved (below) to constructor, where lifted anonfun will take its captured env as an arg
-          inline def methodOwnerIsLocalDummyOrSibling =
-            val owner = method.owner
-            owner.isLocalDummy || owner.owner == sym.owner && !owner.isOneOf(MethodOrLazy)
-          inline def inAnonFunInCtor =
-               method.isAnonymousFunction
-            && methodOwnerIsLocalDummyOrSibling
-            && !sym.owner.is(Module) // lambdalift doesn't transform correctly (to do)
-          val inConstructor =
-               (method.isPrimaryConstructor || inAnonFunInCtor)
-            && ctx.owner.enclosingClass == sym.owner
-          val noField =
-               inConstructor
-            && (sym.is(ParamAccessor) || seenPrivateVals.contains(sym))
-            // used inside constructor, accessed on this,
-            // could use constructor argument instead, no need to retain field
-          if !noField then
-            retain()
-        case _ =>
-          retain()
+    if (sym.exists && sym.owner.isClass && mightBeDropped(sym)) {
+      val owner = sym.owner.asClass
+
+        tree match {
+          case Ident(_) | Select(This(_), _) =>
+            val method = ctx.owner.enclosingMethod
+            // template exprs are moved below to constructor, where lifted anonfun will take its captured env as an arg
+            inline def methodOwnerIsLocalDummyOrSibling =
+              val owner = method.owner
+              owner.isLocalDummy || owner.owner == sym.owner && !owner.isOneOf(MethodOrLazy)
+            inline def inAnonFunInCtor =
+                 method.isAnonymousFunction
+              && methodOwnerIsLocalDummyOrSibling
+              && !sym.owner.is(Module) // lambdalift doesn't transform correctly (to do)
+            val inConstructor =
+                 (method.isPrimaryConstructor || inAnonFunInCtor)
+              && ctx.owner.enclosingClass == sym.owner
+            val noField =
+                 inConstructor
+              && (sym.is(ParamAccessor) || seenPrivateVals.contains(sym))
+              // used inside constructor, accessed on this,
+              // could use constructor argument instead, no need to retain field
+            if !noField then
+              retain()
+          case _ => retain()
+      }
+    }
   }
 
   override def transformIdent(tree: tpd.Ident)(using Context): tpd.Tree = {
@@ -100,7 +103,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
   }
 
   override def transformValDef(tree: tpd.ValDef)(using Context): tpd.Tree = {
-    if tree.symbol.mightBeDropped then seenPrivateVals += tree.symbol
+    if (mightBeDropped(tree.symbol)) seenPrivateVals += tree.symbol
     tree
   }
 
@@ -129,7 +132,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
   /** Class members that can be eliminated if referenced only from their own
    *  constructor.
    */
-  extension (sym: Symbol) private def mightBeDropped(using Context) =
+  private def mightBeDropped(sym: Symbol)(using Context) =
     sym.is(Private, butNot = MethodOrLazy) && !sym.isAllOf(MutableParamAccessor)
 
   private final val MutableParamAccessor = Mutable | ParamAccessor
@@ -190,9 +193,8 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
         transform(tree).changeOwnerAfter(prevOwner, constr.symbol, thisPhase)
     }
 
-    // mightBeDropped is trivially false for NoSymbol -> NoSymbol isRetained
     def isRetained(acc: Symbol) =
-      !acc.mightBeDropped || retainedPrivateVals(acc)
+      !mightBeDropped(acc) || retainedPrivateVals(acc)
 
     val constrStats, clsStats = new mutable.ListBuffer[Tree]
 
@@ -216,29 +218,30 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
       }
     }
 
-    val dropped = mutable.Set.empty[Symbol]
+    val dropped = mutable.Set[Symbol]()
 
     // Split class body into statements that go into constructor and
     // definitions that are kept as members of the class.
     def splitStats(stats: List[Tree]): Unit = stats match {
-      case stat :: stats =>
-        val sym = stat.symbol
+      case stat :: stats1 =>
         stat match {
-          case stat @ ValDef(name, tpt, _) if !sym.is(Lazy) && !sym.hasAnnotation(defn.ScalaStaticAnnot) =>
+          case stat @ ValDef(name, tpt, _) if !stat.symbol.is(Lazy) && !stat.symbol.hasAnnotation(defn.ScalaStaticAnnot) =>
+            val sym = stat.symbol
             if (isRetained(sym)) {
               if (!stat.rhs.isEmpty && !isWildcardArg(stat.rhs))
                 constrStats += Assign(ref(sym), intoConstr(stat.rhs, sym)).withSpan(stat.span)
               clsStats += cpy.ValDef(stat)(rhs = EmptyTree)
             }
-            else
+            else if (!stat.rhs.isEmpty) {
               dropped += sym
-              if !stat.rhs.isEmpty then
-                sym.copySymDenotation(
-                  initFlags = sym.flags &~ Private,
-                  owner = constr.symbol
-                ).installAfter(thisPhase)
-                constrStats += intoConstr(stat, sym)
+              sym.copySymDenotation(
+                initFlags = sym.flags &~ Private,
+                owner = constr.symbol).installAfter(thisPhase)
+              constrStats += intoConstr(stat, sym)
+            } else
+              dropped += sym
           case stat @ DefDef(name, _, tpt, _) if stat.symbol.isGetter && !stat.symbol.is(Lazy) =>
+            val sym = stat.symbol
             assert(isRetained(sym), sym)
             if sym.isConstExprFinalVal then
               if stat.rhs.isInstanceOf[Literal] then
@@ -277,10 +280,9 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
           case _ =>
             constrStats += intoConstr(stat, tree.symbol)
         }
-        splitStats(stats)
+        splitStats(stats1)
       case Nil =>
     }
-    end splitStats
 
     /** Check that we do not have both a private field with name `x` and a private field
      *  with name `FieldName(x)`. These will map to the same JVM name and therefore cause
@@ -310,15 +312,14 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
         dropped += acc
         Nil
       }
-      else if (acc.field.exists && !isRetained(acc.field)) { // It may happen for unit fields, tests/run/i6987.scala
+      else if (!isRetained(acc.field)) { // It may happen for unit fields, tests/run/i6987.scala
         dropped += acc.field
         Nil
       }
       else {
         val param = acc.subst(accessors, paramSyms)
-        if param.hasAnnotation(defn.ConstructorOnlyAnnot) then
-          val msg = em"${acc.name} is marked `@constructorOnly` but it is retained as a field in ${acc.owner}"
-          report.error(msg, acc.srcPos)
+        if (param.hasAnnotation(defn.ConstructorOnlyAnnot))
+          report.error(em"${acc.name} is marked `@constructorOnly` but it is retained as a field in ${acc.owner}", acc.srcPos)
         val target = if (acc.is(Method)) acc.field else acc
         if (!target.exists) Nil // this case arises when the parameter accessor is an alias
         else {

--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -66,28 +66,30 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
     if (sym.exists && sym.owner.isClass && mightBeDropped(sym)) {
       val owner = sym.owner.asClass
 
-        tree match {
-          case Ident(_) | Select(This(_), _) =>
-            val method = ctx.owner.enclosingMethod
-            // template exprs are moved below to constructor, where lifted anonfun will take its captured env as an arg
-            inline def methodOwnerIsLocalDummyOrSibling =
-              val owner = method.owner
-              owner.isLocalDummy || owner.owner == sym.owner && !owner.isOneOf(MethodOrLazy)
-            inline def inAnonFunInCtor =
-                 method.isAnonymousFunction
-              && methodOwnerIsLocalDummyOrSibling
-              && !sym.owner.is(Module) // lambdalift doesn't transform correctly (to do)
-            val inConstructor =
-                 (method.isPrimaryConstructor || inAnonFunInCtor)
-              && ctx.owner.enclosingClass == sym.owner
-            val noField =
-                 inConstructor
-              && (sym.is(ParamAccessor) || seenPrivateVals.contains(sym))
-              // used inside constructor, accessed on this,
-              // could use constructor argument instead, no need to retain field
-            if !noField then
-              retain()
-          case _ => retain()
+      tree match {
+        case Ident(_) | Select(This(_), _) =>
+          val method = ctx.owner.enclosingMethod
+          // template exprs are moved below to constructor; lifted anonfun takes captured env as an arg
+          def checkAnonFun(meth: Symbol): Boolean =
+            meth.isAnonymousFunction
+            && {
+              val owner = meth.owner
+                 owner.isLocalDummy
+              || owner.owner == sym.owner && !owner.isOneOf(MethodOrLazy)
+              || checkAnonFun(owner.enclosingMethod)
+            }
+          // restriction on module because lambdalift doesn't transform correctly (to do)
+          val inConstructor =
+               (method.isPrimaryConstructor || !sym.owner.is(Module) && checkAnonFun(method))
+            && ctx.owner.enclosingClass == sym.owner
+          val noField =
+               inConstructor
+            && (sym.is(ParamAccessor) || seenPrivateVals.contains(sym))
+            // used inside constructor, accessed on this,
+            // could use constructor argument instead, no need to retain field
+          if !noField then
+            retain()
+        case _ => retain()
       }
     }
   }

--- a/tests/neg/i22979.scala
+++ b/tests/neg/i22979.scala
@@ -1,0 +1,11 @@
+
+import annotation.*
+
+class C(@constructorOnly s: String): // error
+  def g: Any => String = _ => s
+  def f[A](xs: List[A]): List[String] = xs.map(g)
+
+import scala.util.boundary
+
+class Leak()(using @constructorOnly l: boundary.Label[String]): // error
+  lazy val broken = Option("stop").foreach(boundary.break(_))

--- a/tests/pos/i22979.scala
+++ b/tests/pos/i22979.scala
@@ -1,0 +1,23 @@
+
+import annotation.*
+
+class C(@constructorOnly s: String):
+  val g: Any => String = _ => s
+  def f[A](xs: List[A]): List[String] = xs.map(g)
+
+import scala.util.boundary
+
+class Leak()(using @constructorOnly l: boundary.Label[String]):
+  Option("stop").foreach(boundary.break(_))
+
+
+class Lapse:
+  def f = Lapse.DefaultSentinelFn()
+object Lapse:
+  private val DefaultSentinel: AnyRef = new AnyRef
+  private val DefaultSentinelFn: () => AnyRef = () => DefaultSentinel
+
+class scalafan(@constructorOnly str: String) {
+  val scream = Array.fill(10)(str + "!")
+  def screamTenTimes: Unit = scream.foreach(println)
+}

--- a/tests/pos/i22979.scala
+++ b/tests/pos/i22979.scala
@@ -5,6 +5,12 @@ class C(@constructorOnly s: String):
   val g: Any => String = _ => s
   def f[A](xs: List[A]): List[String] = xs.map(g)
 
+  val gg: Any => Any = (x: Any) => (y: Any) => s
+
+  (y => s): (Any => Any) // pure expr
+  println(s)
+end C
+
 import scala.util.boundary
 
 class Leak()(using @constructorOnly l: boundary.Label[String]):

--- a/tests/run/i22979/Leak.scala
+++ b/tests/run/i22979/Leak.scala
@@ -1,0 +1,13 @@
+import annotation.*
+
+class Leak()(using @constructorOnly l: boundary.Label[String]) {
+  Seq("a", "b").foreach(_ => boundary.break("stop"))
+}
+
+object boundary {
+  final class Break[T] private[boundary](val label: Label[T], val value: T)
+    extends RuntimeException(
+          /*message*/ null, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false)
+  final class Label[-T]
+  def break[T](value: T)(using label: Label[T]): Nothing = throw new Break(label, value)
+}

--- a/tests/run/i22979/test.scala
+++ b/tests/run/i22979/test.scala
@@ -1,0 +1,23 @@
+// scalajs: --skip
+
+import util.Try
+
+@main def Test =
+  assert(Try(classOf[Leak].getDeclaredField("l")).isFailure)
+  assert(classOf[Leak].getFields.length == 0)
+  //classOf[Leak].getFields.map(_.getName).foreach(println) //DEBUG
+  assert(classOf[C].getFields.length == 0)
+  //classOf[Lapse.type].getFields.map(_.getName).foreach(println) //DEBUG
+
+class C:
+  private val x = 42
+  println(x)
+  println(List(27).map(_ + x))
+
+// The easy tweak for lambdas does not work for module owner.
+// The lambdalifted anonfun is not transformed correctly.
+class Lapse:
+  def f = Lapse.DefaultSentinelFn()
+object Lapse:
+  private val DefaultSentinel: AnyRef = new AnyRef
+  private val DefaultSentinelFn: () => AnyRef = () => DefaultSentinel


### PR DESCRIPTION
Fixes #22979 

In Constructors, marking usages was too restrictive in checking that a ref is enclosed by the primary constructor, because anonfuns in the template have not been moved to the constructor yet. This commit allows refs from an anonfun owned by the "local dummy" or by an eager member of the sym's owner (the enclosing class), that is, it's an initializer.