### PR TITLE
[CI] Switch releasing to Sontype Central instead of legacy Sonatype OSS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,10 @@ on:
     - cron: '0 3 * * *'  # Every day at 3 AM
   workflow_dispatch:
 
-# Cancels any in-progress runs within the same group identified by workflow name and GH reference (branch or tag) 
+# Cancels any in-progress runs within the same group identified by workflow name and GH reference (branch or tag)
 # For example it would:
 # - terminate previous PR CI execution after pushing more changes to the same PR branch
-# - terminate previous on-push CI run after merging new PR to main 
+# - terminate previous on-push CI run after merging new PR to main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -692,7 +692,7 @@ jobs:
       - name: Publish Nightly
         if: "steps.not_yet_published.outcome == 'success'"
         run: |
-          ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleRelease"
+          ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonaRelease"
 
   nightly_documentation:
     runs-on: [self-hosted, Linux]
@@ -862,7 +862,7 @@ jobs:
           scala3-${{ env.RELEASE_TAG }}.msi 
 
       - name: Publish Release
-        run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonatypeBundleUpload"
+        run: ./project/scripts/sbtPublish ";project scala3-bootstrapped ;publishSigned ;sonaUpload"
 
 
   open_issue_on_failure:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,7 +27,6 @@ import dotty.tools.sbtplugin.ScalaLibraryPlugin
 
 import sbt.plugins.SbtPlugin
 import sbt.ScriptedPlugin.autoImport._
-import xerial.sbt.Sonatype.autoImport._
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 import org.scalajs.sbtplugin.ScalaJSPlugin
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
@@ -2193,7 +2192,11 @@ object Build {
   lazy val publishSettings = Seq(
     publishMavenStyle := true,
     isSnapshot := version.value.contains("SNAPSHOT"),
-    publishTo := sonatypePublishToBundle.value,
+    publishTo := {
+      val centralSnapshots = "https://central.sonatype.com/repository/maven-snapshots/"
+      if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+      else localStaging.value
+    },
     publishConfiguration ~= (_.withOverwrite(true)),
     publishLocalConfiguration ~= (_.withOverwrite(true)),
     projectID ~= {id =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.11.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,6 @@ libraryDependencySchemes +=
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.19.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
-
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.5")


### PR DESCRIPTION
Upgrades sbt to 1.11.0 and uses it's new builtin capabilities for Sonatype Central publishing. 
Replaces previous usage of `xerial/sbt-sonatype` plugin

Resolves #23287