### PR TITLE
Fix #23113: Treat private classes as sealed

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1735,7 +1735,7 @@ object SymDenotations {
             c.ensureCompleted()
       end completeChildrenIn
 
-      if is(Sealed) || isAllOf(JavaEnum) && isClass then
+      if (is(Sealed) || is(Private) || isAllOf(JavaEnum)) && isClass then
         if !is(ChildrenQueried) then
           // Make sure all visible children are completed, so that
           // they show up in Child annotations. A possible child is visible if it

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -975,7 +975,7 @@ class Namer { typer: Typer =>
       val sym = denot.symbol
 
       def register(child: Symbol, parentCls: ClassSymbol) = {
-        if (parentCls.is(Sealed))
+        if (parentCls.is(Sealed) || parentCls.is(Private))
           if ((child.isInaccessibleChildOf(parentCls) || child.isAnonymousClass) && !sym.hasAnonymousChild)
             addChild(parentCls, parentCls)
           else if (!parentCls.is(ChildrenQueried))

--- a/tests/pos/i23113.scala
+++ b/tests/pos/i23113.scala
@@ -1,0 +1,29 @@
+//> using options -Werror
+
+object Repro {
+  sealed abstract class Listener
+
+  final case class Empty()
+    extends Listener
+
+  final case class Waiting(next: Promise)
+    extends Listener
+
+  def foo[A](l: Listener): Unit = {
+    l match {
+      case Empty() => ()
+      case w @ Waiting(_) => ()
+    }
+  }
+}
+
+sealed trait Promise
+
+object Promise {
+
+  def apply(): Promise = new PromiseImpl()
+
+  private abstract class PromiseBase extends Promise
+
+  private final class PromiseImpl() extends PromiseBase
+}


### PR DESCRIPTION
closes: #23113
Currently, child annotations are only attached when the parent class is sealed. This PR extends that behavior to include private classes as well.