### PR TITLE
Take inferred or explicit refinement result for unused check

### DIFF
--- a/tests/warn/i22681.scala
+++ b/tests/warn/i22681.scala
@@ -6,12 +6,10 @@ trait T:
 
 class C:
   def f: Runnable { def u: Int } = new Runnable with T:
-    private def v = 42 // avoid g judged too trivial to warn
     def run() = ()
-    def g = v // warn effectively private member is unused
-    def t = v // nowarn
-    def u = v // nowarn because leaked by refinement
+    def g = 42 // warn effectively private member is unused
+    def t = 42 // nowarn
+    def u = 42 // nowarn because leaked by refinement
   val v: Runnable { def u: Int } = new Runnable:
-    private def v = 42 // avoid g judged too trivial to warn
     def run() = ()
-    def u = v // nowarn because leaked by refinement
+    def u = 42 // nowarn because leaked by refinement

--- a/tests/warn/i23323.scala
+++ b/tests/warn/i23323.scala
@@ -1,0 +1,14 @@
+//> using options -Wunused:all
+
+class C:
+  val x = new reflect.Selectable:
+    def f = 42
+    def g = 27
+  val y: Selectable = new reflect.Selectable:
+    def f = 42 // warn
+    def g = 27 // warn
+  val z = new scala.Selectable:
+    def f = 42
+    def g = 27
+    def selectDynamic(name: String): Any = ???
+    def applyDynamic(name: String)(args: Any*): Any = ???


### PR DESCRIPTION
Previously, the check considered an explicit refinement to "nowarn" the corresponding member of an anonymous class.

Since an anonymous `Selectable` will infer a refinement type, use the type for the relaxed warning.

Arguably, it would still be useful to warn for the `scala.Selectable` case, where it may be that `selectDynamic` is the preferred interface, but that is not done here. As with other anonymous classes, an explicit type can be used instead (to request a warning for `Selectable` or silence a warning for other classes).

Fixes #23323 