### PR TITLE
Adapt types according to read-only status

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CCState.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CCState.scala
@@ -70,13 +70,16 @@ class CCState:
 
   // ------ Iteration count of capture checking run
 
-  private var iterCount = 1
+  private var iterCount = 0
 
   def iterationId = iterCount
 
   def nextIteration[T](op: => T): T =
     iterCount += 1
     try op finally iterCount -= 1
+
+  def start(): Unit =
+    iterCount = 1
 
   // ------ Global counters -----------------------
 

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -330,6 +330,12 @@ object Capabilities:
     final def isExclusive(using Context): Boolean =
       !isReadOnly && (isTerminalCapability || captureSetOfInfo.isExclusive)
 
+    /** Similar to isExlusive, but also includes capabilties with capture
+     *  set variables in their info whose status is still open.
+     */
+    final def maybeExclusive(using Context): Boolean =
+      !isReadOnly && (isTerminalCapability || captureSetOfInfo.maybeExclusive)
+
     final def isWellformed(using Context): Boolean = this match
       case self: CoreCapability => self.isTrackableRef
       case _ => true

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -22,11 +22,18 @@ private val Captures: Key[CaptureSet] = Key()
 def isCaptureChecking(using Context): Boolean =
   ctx.phaseId == Phases.checkCapturesPhase.id
 
-/** Are we at checkCaptures or Setup phase? */
+/** Are we in the CheckCaptures or Setup phase? */
 def isCaptureCheckingOrSetup(using Context): Boolean =
-  val ccId = Phases.checkCapturesPhase.id
-  val ctxId = ctx.phaseId
-  ctxId == ccId || ctxId == ccId - 1
+  val ccPhase = Phases.checkCapturesPhase
+  ccPhase.exists
+  && {
+    val ccId = ccPhase.id
+    val ctxId = ctx.phaseId
+    ctxId == ccId
+    || ctxId == ccId - 1 && ccState.iterationId > 0
+      // Note: just checking phase id is not enough since Setup would
+      // also be the phase after pattern matcher.
+  }
 
 /** A dependent function type with given arguments and result type
  *  TODO Move somewhere else where we treat all function type related ops together.

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -930,11 +930,15 @@ object CaptureSet:
     deps += cs2
 
     override def tryInclude(elem: Capability, origin: CaptureSet)(using Context, VarState): Boolean =
-      val present =
+      val inIntersection =
         if origin eq cs1 then cs2.accountsFor(elem)
         else if origin eq cs2 then cs1.accountsFor(elem)
         else true
-      !present || accountsFor(elem) || addNewElem(elem)
+      !inIntersection
+      || accountsFor(elem)
+      || addNewElem(elem)
+        && ((origin eq cs1) || cs1.tryInclude(elem, this))
+        && ((origin eq cs2) || cs2.tryInclude(elem, this))
 
     override def computeApprox(origin: CaptureSet)(using Context): CaptureSet =
       if (origin eq cs1) || (origin eq cs2) then

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -136,6 +136,8 @@ sealed abstract class CaptureSet extends Showable:
   final def isReadOnly(using Context): Boolean =
     elems.forall(_.isReadOnly)
 
+  final def isAlwaysReadOnly(using Context): Boolean = isConst && isReadOnly
+
   final def isExclusive(using Context): Boolean =
     elems.exists(_.isExclusive)
 
@@ -1385,8 +1387,8 @@ object CaptureSet:
     def apply(t: Type) = mapOver(t)
 
     override def fuse(next: BiTypeMap)(using Context) = next match
-      case next: Inverse if next.inverse.getClass == getClass => assert(false); Some(IdentityTypeMap)
-      case next: NarrowingCapabilityMap if next.getClass == getClass => assert(false)
+      case next: Inverse if next.inverse.getClass == getClass => Some(IdentityTypeMap)
+      case next: NarrowingCapabilityMap if next.getClass == getClass => Some(this)
       case _ => None
 
     class Inverse extends BiTypeMap:
@@ -1395,8 +1397,8 @@ object CaptureSet:
       def inverse = NarrowingCapabilityMap.this
       override def toString = NarrowingCapabilityMap.this.toString ++ ".inverse"
       override def fuse(next: BiTypeMap)(using Context) = next match
-        case next: NarrowingCapabilityMap if next.inverse.getClass == getClass => assert(false); Some(IdentityTypeMap)
-        case next: NarrowingCapabilityMap if next.getClass == getClass => assert(false)
+        case next: NarrowingCapabilityMap if next.inverse.getClass == getClass => Some(IdentityTypeMap)
+        case next: NarrowingCapabilityMap if next.getClass == getClass => Some(this)
         case _ => None
 
     lazy val inverse = Inverse()

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1360,6 +1360,8 @@ object CaptureSet:
           else empty
         case CapturingType(parent, refs) =>
           recur(parent) ++ refs
+        case tp @ AnnotatedType(parent, ann) if ann.symbol.isRetains =>
+          recur(parent) ++ ann.tree.toCaptureSet
         case tpd @ defn.RefinedFunctionOf(rinfo: MethodType) if followResult =>
           ofType(tpd.parent, followResult = false)            // pick up capture set from parent type
           ++ recur(rinfo.resType)                             // add capture set of result

--- a/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
@@ -39,6 +39,7 @@ object CapturingType:
       case parent @ CapturingType(parent1, refs1) if boxed || !parent.isBoxed =>
         apply(parent1, refs ++ refs1, boxed)
       case _ =>
+        if parent.derivesFromMutable then refs.setMutable()
         AnnotatedType(parent, CaptureAnnotation(refs, boxed)(defn.RetainsAnnot))
 
   /** An extractor for CapturingTypes. Capturing types are recognized if
@@ -83,5 +84,10 @@ object CapturingType:
     ctx.mode.is(Mode.IgnoreCaptures) && decomposeCapturingType(tp).isDefined
 
 end CapturingType
+
+object CapturingOrRetainsType:
+   def unapply(tp: AnnotatedType)(using Context): Option[(Type, CaptureSet)] =
+    if ctx.mode.is(Mode.IgnoreCaptures) then None
+    else CapturingType.decomposeCapturingType(tp, alsoRetains = true)
 
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1751,6 +1751,7 @@ class CheckCaptures extends Recheck, SymTransformer:
     private val setup: SetupAPI = thisPhase.prev.asInstanceOf[Setup]
 
     override def checkUnit(unit: CompilationUnit)(using Context): Unit =
+      ccState.start()
       setup.setupUnit(unit.tpdTree, this)
       collectCapturedMutVars.traverse(unit.tpdTree)
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1231,7 +1231,8 @@ class CheckCaptures extends Recheck, SymTransformer:
       val saved = curEnv
       tree match
         case _: RefTree | closureDef(_) if pt.isBoxedCapturing =>
-          curEnv = Env(curEnv.owner, EnvKind.Boxed, CaptureSet.Var(curEnv.owner, level = ccState.currentLevel), curEnv)
+          curEnv = Env(curEnv.owner, EnvKind.Boxed,
+            CaptureSet.Var(curEnv.owner, level = ccState.currentLevel), curEnv)
         case _ =>
       val res =
         try
@@ -1575,6 +1576,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           && !expected.isSingleton
           && !expected.isBoxedCapturing =>
         actual.derivedCapturingType(parent, refs.readOnly)
+          .showing(i"improv ro $actual vs $expected = $result", capt)
       case _ =>
         actual
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1571,7 +1571,7 @@ class CheckCaptures extends Recheck, SymTransformer:
       case actual @ CapturingType(parent, refs)
       if parent.derivesFrom(defn.Caps_Mutable)
           && expected.isValueType
-          && !expected.isMutableType
+          && !expected.derivesFromMutable
           && !expected.isSingleton
           && !expected.isBoxedCapturing =>
         actual.derivedCapturingType(parent, refs.readOnly)

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1568,17 +1568,81 @@ class CheckCaptures extends Recheck, SymTransformer:
      *  to narrow to the read-only set, since that set can be propagated
      *  by the type variable instantiation.
      */
-    private def improveReadOnly(actual: Type, expected: Type)(using Context): Type = actual match
-      case actual @ CapturingType(parent, refs)
-      if parent.derivesFrom(defn.Caps_Mutable)
-          && expected.isValueType
-          && !expected.derivesFromMutable
-          && !expected.isSingleton
-          && !expected.isBoxedCapturing =>
-        actual.derivedCapturingType(parent, refs.readOnly)
-          .showing(i"improv ro $actual vs $expected = $result", capt)
+    private def improveReadOnly(actual: Type, expected: Type)(using Context): Type = reporting.trace(i"improv ro $actual vs $expected"):
+      actual.dealiasKeepAnnots match
+      case actual @ CapturingType(parent, refs) =>
+        val parent1 = improveReadOnly(parent, expected)
+        val refs1 =
+          if parent1.derivesFrom(defn.Caps_Mutable)
+              && expected.isValueType
+              && (!expected.derivesFromMutable || expected.captureSet.isAlwaysReadOnly)
+              && !expected.isSingleton
+              && actual.isBoxedCapturing == expected.isBoxedCapturing
+          then refs.readOnly
+          else refs
+        actual.derivedCapturingType(parent1, refs1)
+      case actual @ FunctionOrMethod(aargs, ares) =>
+        expected.dealias.stripCapturing match
+          case FunctionOrMethod(eargs, eres) =>
+            actual.derivedFunctionOrMethod(aargs, improveReadOnly(ares, eres))
+          case _ =>
+            actual
+      case actual @ AppliedType(atycon, aargs) =>
+        def improveArgs(aargs: List[Type], eargs: List[Type], formals: List[ParamInfo]): List[Type] =
+          aargs match
+            case aargs @ (aarg :: aargs1) =>
+              val aarg1 =
+                if formals.head.paramVariance.is(Covariant)
+                then improveReadOnly(aarg, eargs.head)
+                else aarg
+              aargs.derivedCons(aarg1, improveArgs(aargs1, eargs.tail, formals.tail))
+            case Nil =>
+              aargs
+        val expected1 = expected.dealias.stripCapturing
+        val esym = expected1.typeSymbol
+        expected1 match
+          case AppliedType(etycon, eargs) =>
+            if atycon.typeSymbol == esym then
+              actual.derivedAppliedType(atycon,
+                improveArgs(aargs, eargs, etycon.typeParams))
+            else if esym.isClass then
+              // This case is tricky: Try to lift actual to the base type with class `esym`,
+              // improve the resulting arguments, and figure out if anything can be
+              // deduced from that for the original arguments.
+              actual.baseType(esym) match
+                case base @ AppliedType(_, bargs) =>
+                  // If any of the base type arguments can be improved, check
+                  // whether they are the same as an original argument, and in this
+                  // case improve the original argument.
+                  val iargs = improveArgs(bargs, eargs, etycon.typeParams)
+                  if iargs ne bargs then
+                    val updates =
+                      for
+                        (barg, iarg) <- bargs.lazyZip(iargs)
+                        if barg ne iarg
+                        aarg <- aargs.find(_ eq barg)
+                      yield (aarg, iarg)
+                    if updates.nonEmpty then AppliedType(atycon, aargs.map(updates.toMap))
+                    else actual
+                  else actual
+                case _ => actual
+            else actual
+          case _ =>
+            actual
+      case actual @ RefinedType(aparent, aname, ainfo) =>
+        expected.dealias.stripCapturing match
+          case RefinedType(eparent, ename, einfo) if aname == ename =>
+            actual.derivedRefinedType(
+              improveReadOnly(aparent, eparent),
+              aname,
+              improveReadOnly(ainfo, einfo))
+          case _ =>
+            actual
+      case actual @ AnnotatedType(parent, ann) =>
+        actual.derivedAnnotatedType(improveReadOnly(parent, expected), ann)
       case _ =>
         actual
+    end improveReadOnly
 
     /* Currently not needed since it forms part of `adapt`
     private def improve(actual: Type, prefix: Type)(using Context): Type =

--- a/compiler/src/dotty/tools/dotc/cc/RetainingType.scala
+++ b/compiler/src/dotty/tools/dotc/cc/RetainingType.scala
@@ -8,7 +8,8 @@ import ast.tpd.*
 import Annotations.Annotation
 import Decorators.i
 
-/** A builder and extractor for annotated types with @retains or @retainsByName annotations.
+/** A builder and extractor for annotated types with @retains or @retainsByName annotations
+ *  excluding CapturingTypes.
  */
 object RetainingType:
 
@@ -21,11 +22,8 @@ object RetainingType:
     val sym = tp.annot.symbol
     if sym.isRetainsLike then
       tp.annot match
-        case _: CaptureAnnotation =>
-          assert(ctx.mode.is(Mode.IgnoreCaptures), s"bad retains $tp at ${ctx.phase}")
-          None
-        case ann =>
-          Some((tp.parent, ann.tree.retainedSet))
+        case _: CaptureAnnotation => None
+        case ann => Some((tp.parent, ann.tree.retainedSet))
     else
       None
 end RetainingType

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -422,7 +422,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           case _ =>
         tp
 
-      /** Map references to capability classes C to C^,
+      /** Map references to capability classes C to C^{cap.rd},
        *  normalize captures and map to dependent functions.
        */
       def defaultApply(t: Type) =
@@ -618,6 +618,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             traverse(body)
           catches.foreach(traverse)
           traverse(finalizer)
+        case tree: New =>
         case _ =>
           traverseChildren(tree)
       postProcess(tree)

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -367,7 +367,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
      */
     def stripImpliedCaptureSet(tp: Type): Type = tp match
       case tp @ CapturingType(parent, refs)
-      if (refs eq CaptureSet.csImpliedByCapability) && !tp.isBoxedCapturing =>
+      if refs.isInstanceOf[CaptureSet.CSImpliedByCapability] && !tp.isBoxedCapturing =>
         parent
       case tp: AliasingBounds =>
         tp.derivedAlias(stripImpliedCaptureSet(tp.alias))
@@ -430,7 +430,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           && !t.isSingleton
           && (!sym.isConstructor || (t ne tp.finalResultType))
             // Don't add ^ to result types of class constructors deriving from Capability
-        then CapturingType(t, CaptureSet.csImpliedByCapability, boxed = false)
+        then CapturingType(t, CaptureSet.CSImpliedByCapability(), boxed = false)
         else normalizeCaptures(mapFollowingAliases(t))
 
       def innerApply(t: Type) =

--- a/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
+++ b/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
@@ -55,7 +55,7 @@ object ccConfig:
     Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.8`)
 
   /** Not used currently. Handy for trying out new features */
-  def newScheme(using Context): Boolean =
-    Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.7`)
+  def newScheme(using ctx: Context): Boolean =
+    ctx.settings.XdropComments.value
 
 end ccConfig

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2902,7 +2902,13 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       if tp1.derivesFromMutable && !tp2.derivesFromMutable
       then refs1.readOnly
       else refs1
-    subCaptures(refs1Adapted, refs2)
+    val subc = subCaptures(refs1Adapted, refs2)
+    if !subc then
+      errorNotes match
+        case (level, CaptureSet.MutAdaptFailure(cs, NoType, NoType)) :: rest =>
+          errorNotes = (level, CaptureSet.MutAdaptFailure(cs, tp1, tp2)) :: rest
+        case _ =>
+    subc
     && (tp1.isBoxedCapturing == tp2.isBoxedCapturing)
         || refs1.subCaptures(CaptureSet.empty, makeVarState())
 

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1010,7 +1010,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           if isCaptureCheckingOrSetup then
             tp1
               .match
-                case tp1: Capability if tp1.isTracked =>
+                case tp1: Capability if isCaptureCheckingOrSetup && tp1.isTracked =>
                   CapturingType(tp1w.stripCapturing, tp1.singletonCaptureSet)
                 case _ =>
                   tp1w
@@ -2110,7 +2110,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    * since `T >: Int` is subsumed by both alternatives in the first match clause.
    *
    * However, the following should not:
-   * 
+   *
    *   def foo[T](e: Expr[T]): T = e match
    *     case I1(_) | B(_) => 42
    *

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -17,6 +17,7 @@ import scala.annotation.switch
 import config.{Config, Feature}
 import ast.tpd
 import cc.*
+import CaptureSet.Mutability
 import Capabilities.*
 
 class PlainPrinter(_ctx: Context) extends Printer {
@@ -173,7 +174,9 @@ class PlainPrinter(_ctx: Context) extends Printer {
       val core: Text =
         if !cs.isConst && cs.elems.isEmpty then "?"
         else "{" ~ Text(cs.processElems(_.toList.map(toTextCapability)), ", ") ~ "}"
-           //     ~ Str("?").provided(!cs.isConst)
+           ~ Str(".reader").provided(ccVerbose && cs.mutability == Mutability.Reader)
+           ~ Str("?").provided(ccVerbose && !cs.isConst)
+           ~ Str(s"#${cs.asVar.id}").provided(showUniqueIds && !cs.isConst)
       core ~ cs.optionalInfo
 
   private def toTextRetainedElem(ref: Type): Text = ref match

--- a/tests/neg-custom-args/captures/capture-vars-subtyping.scala
+++ b/tests/neg-custom-args/captures/capture-vars-subtyping.scala
@@ -1,4 +1,5 @@
 import language.experimental.captureChecking
+import language.`3.7` // no separation checking, TODO enable
 import caps.*
 
 def test[C^] =

--- a/tests/neg-custom-args/captures/capture-vars-subtyping2.scala
+++ b/tests/neg-custom-args/captures/capture-vars-subtyping2.scala
@@ -25,7 +25,8 @@ trait BoundsTest:
     val ec2: CapSet^{C} = e
     val eb: B = e
     val eb2: CapSet^{B} = e
-    val ea: A = e
+    locally:
+      val ea: A = e
     val ea2: CapSet^{A} = e
     val ex: X = e            // error
     val ex2: CapSet^{X} = e // error

--- a/tests/neg-custom-args/captures/lazyref.check
+++ b/tests/neg-custom-args/captures/lazyref.check
@@ -39,7 +39,7 @@
    |             ^^^^
    |             Separation failure: Illegal access to {cap1} which is hidden by the previous definition
    |             of value ref2 with type LazyRef[Int]{val elem: () => Int}^{cap2, ref1}.
-   |             This type hides capabilities  {cap1}
+   |             This type hides capabilities  {LazyRef.this.elem, cap1}
    |
    |             where:    => refers to a fresh root capability in the type of value elem
 -- Error: tests/neg-custom-args/captures/lazyref.scala:26:9 ------------------------------------------------------------
@@ -47,7 +47,7 @@
    |         ^^^^
    |         Separation failure: Illegal access to {cap1} which is hidden by the previous definition
    |         of value ref3 with type LazyRef[Int]{val elem: () => Int}^{cap2, ref1}.
-   |         This type hides capabilities  {ref2*, cap1}
+   |         This type hides capabilities  {LazyRef.this.elem, ref2*, cap1}
    |
    |         where:    => refers to a fresh root capability in the type of value elem
 -- Error: tests/neg-custom-args/captures/lazyref.scala:26:17 -----------------------------------------------------------
@@ -55,7 +55,7 @@
    |                 ^^^^
    |                 Separation failure: Illegal access to {cap2} which is hidden by the previous definition
    |                 of value ref3 with type LazyRef[Int]{val elem: () => Int}^{cap2, ref1}.
-   |                 This type hides capabilities  {ref2*, cap1}
+   |                 This type hides capabilities  {LazyRef.this.elem, ref2*, cap1}
    |
    |                 where:    => refers to a fresh root capability in the type of value elem
 -- Error: tests/neg-custom-args/captures/lazyref.scala:27:11 -----------------------------------------------------------
@@ -63,7 +63,7 @@
    |           ^^^^
    |           Separation failure: Illegal access to {cap1, ref1} which is hidden by the previous definition
    |           of value ref3 with type LazyRef[Int]{val elem: () => Int}^{cap2, ref1}.
-   |           This type hides capabilities  {ref2*, cap1}
+   |           This type hides capabilities  {LazyRef.this.elem, ref2*, cap1}
    |
    |           where:    => refers to a fresh root capability in the type of value elem
 -- Error: tests/neg-custom-args/captures/lazyref.scala:28:11 -----------------------------------------------------------
@@ -71,7 +71,7 @@
    |           ^^^^
    |           Separation failure: Illegal access to {cap1, cap2, ref1} which is hidden by the previous definition
    |           of value ref3 with type LazyRef[Int]{val elem: () => Int}^{cap2, ref1}.
-   |           This type hides capabilities  {ref2*, cap1}
+   |           This type hides capabilities  {LazyRef.this.elem, ref2*, cap1}
    |
    |           where:    => refers to a fresh root capability in the type of value elem
 -- Error: tests/neg-custom-args/captures/lazyref.scala:29:9 ------------------------------------------------------------
@@ -79,6 +79,6 @@
    |         ^
    |         Separation failure: Illegal access to {cap2} which is hidden by the previous definition
    |         of value ref3 with type LazyRef[Int]{val elem: () => Int}^{cap2, ref1}.
-   |         This type hides capabilities  {ref2*, cap1}
+   |         This type hides capabilities  {LazyRef.this.elem, ref2*, cap1}
    |
    |         where:    => refers to a fresh root capability in the type of value elem

--- a/tests/neg-custom-args/captures/matrix.check
+++ b/tests/neg-custom-args/captures/matrix.check
@@ -1,0 +1,32 @@
+-- Error: tests/neg-custom-args/captures/matrix.scala:27:10 ------------------------------------------------------------
+27 |  mul(m1, m2, m2) // error: will fail separation checking
+   |          ^^
+   |Separation failure: argument of type  Matrix^{m2.rd}
+   |to method mul: (x: Matrix^{cap.rd}, y: Matrix^{cap.rd}, z: Matrix^): Unit
+   |corresponds to capture-polymorphic formal parameter y of type  Matrix^{cap.rd}
+   |and hides capabilities  {m2.rd}.
+   |Some of these overlap with the captures of the third argument with type  (m2 : Matrix^).
+   |
+   |  Hidden set of current argument        : {m2.rd}
+   |  Hidden footprint of current argument  : {m2.rd}
+   |  Capture set of third argument         : {m2}
+   |  Footprint set of third argument       : {m2}
+   |  The two sets overlap at               : {m2}
+   |
+   |where:    cap is a fresh root capability created in method Test when checking argument to parameter y of method mul
+-- Error: tests/neg-custom-args/captures/matrix.scala:30:11 ------------------------------------------------------------
+30 |  mul1(m1, m2, m2) // error: will fail separation checking
+   |           ^^
+   |Separation failure: argument of type  Matrix^{m2.rd}
+   |to method mul1: (x: Matrix^{cap.rd}, y: Matrix^{cap.rd}, z: Matrix^): Unit
+   |corresponds to capture-polymorphic formal parameter y of type  Matrix^{cap.rd}
+   |and hides capabilities  {m2.rd}.
+   |Some of these overlap with the captures of the third argument with type  (m2 : Matrix^).
+   |
+   |  Hidden set of current argument        : {m2.rd}
+   |  Hidden footprint of current argument  : {m2.rd}
+   |  Capture set of third argument         : {m2}
+   |  Footprint set of third argument       : {m2}
+   |  The two sets overlap at               : {m2}
+   |
+   |where:    cap is a fresh root capability created in method Test when checking argument to parameter y of method mul1

--- a/tests/neg-custom-args/captures/matrix.scala
+++ b/tests/neg-custom-args/captures/matrix.scala
@@ -7,7 +7,7 @@ trait Rdr[T]:
 class Ref[T](init: T) extends Rdr[T], Mutable:
   private var current = init
   def get: T = current
-  mut def put(x: T): Unit = current = x
+  update def put(x: T): Unit = current = x
 
 abstract class IMatrix:
   def apply(i: Int, j: Int): Double
@@ -15,7 +15,7 @@ abstract class IMatrix:
 class Matrix(nrows: Int, ncols: Int) extends IMatrix, Mutable:
   val arr = Array.fill(nrows, ncols)(0.0)
   def apply(i: Int, j: Int): Double = arr(i)(j)
-  mut def update(i: Int, j: Int, x: Double): Unit = arr(i)(j) = x
+  update def update(i: Int, j: Int, x: Double): Unit = arr(i)(j) = x
 
 
 def mul(x: Matrix, y: Matrix, z: Matrix^): Unit = ???

--- a/tests/neg-custom-args/captures/matrix.scala
+++ b/tests/neg-custom-args/captures/matrix.scala
@@ -24,7 +24,10 @@ def mul1(x: Matrix^{cap.rd}, y: Matrix^{cap.rd}, z: Matrix^): Unit = ???
 def Test(c: Object^): Unit =
   val m1 = Matrix(10, 10)
   val m2 = Matrix(10, 10)
+  mul(m1, m2, m2) // error: will fail separation checking
   mul(m1, m1, m2) // should be ok
+
+  mul1(m1, m2, m2) // error: will fail separation checking
   mul(m1, m1, m2) // should be ok
 
   def f2(): Matrix^ = Matrix(10, 10)

--- a/tests/neg-custom-args/captures/ro-mut-conformance.check
+++ b/tests/neg-custom-args/captures/ro-mut-conformance.check
@@ -1,0 +1,14 @@
+-- Error: tests/neg-custom-args/captures/ro-mut-conformance.scala:8:4 --------------------------------------------------
+8 |  a.set(42)  // error
+  |  ^^^^^
+  |  cannot call update method set from (a : Ref),
+  |  since its capture set {a} is read-only
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ro-mut-conformance.scala:10:21 ---------------------------
+10 |  val t: Ref^{cap} = a  // error
+   |                     ^
+   |                     Found:    (a : Ref)
+   |                     Required: Ref^
+   |
+   |                     where:    ^ refers to a fresh root capability in the type of value t
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/ro-mut-conformance.check
+++ b/tests/neg-custom-args/captures/ro-mut-conformance.check
@@ -11,4 +11,7 @@
    |
    |                     where:    ^ refers to a fresh root capability in the type of value t
    |
+   |                     Note that {cap} is an exclusive capture set of the mutable type Ref^,
+   |                     it cannot subsume a read-only capture set of the mutable type (a : Ref).
+   |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/ro-mut-conformance.scala
+++ b/tests/neg-custom-args/captures/ro-mut-conformance.scala
@@ -1,0 +1,11 @@
+import language.experimental.captureChecking
+import caps.*
+class Ref extends Mutable:
+  private var _data: Int = 0
+  def get: Int = _data
+  mut def set(x: Int): Unit = _data = x
+def test1(a: Ref^{cap.rd}): Unit =
+  a.set(42)  // error
+def test2(a: Ref^{cap.rd}): Unit =
+  val t: Ref^{cap} = a  // error
+  t.set(42)

--- a/tests/neg-custom-args/captures/ro-mut-conformance.scala
+++ b/tests/neg-custom-args/captures/ro-mut-conformance.scala
@@ -3,7 +3,7 @@ import caps.*
 class Ref extends Mutable:
   private var _data: Int = 0
   def get: Int = _data
-  mut def set(x: Int): Unit = _data = x
+  update def set(x: Int): Unit = _data = x
 def test1(a: Ref^{cap.rd}): Unit =
   a.set(42)  // error
 def test2(a: Ref^{cap.rd}): Unit =

--- a/tests/neg-custom-args/captures/scope-extrude-mut.check
+++ b/tests/neg-custom-args/captures/scope-extrude-mut.check
@@ -1,9 +1,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scope-extrude-mut.scala:9:8 ------------------------------
 9 |    a = a1  // error
   |        ^^
-  |        Found:    A^{a1.rd}
-  |        Required: A^
+  |        Found:    (a1 : A^)
+  |        Required: A^²
   |
-  |        where:    ^ refers to a fresh root capability in the type of variable a
+  |        where:    ^  refers to a fresh root capability created in value a1 when constructing mutable A
+  |                  ^² refers to a fresh root capability in the type of variable a
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/sep-counter.check
+++ b/tests/neg-custom-args/captures/sep-counter.check
@@ -4,7 +4,7 @@
    |                   Separation failure in method mkCounter's result type Pair[box Ref^, box Ref^²].
    |                   One part,  box Ref^, hides capabilities  {cap}.
    |                   Another part,  box Ref^²,  captures capabilities  {cap}.
-   |                   The two sets overlap at  cap of value c.
+   |                   The two sets overlap at  cap of method mkCounter.
    |
    |                   where:    ^   refers to a fresh root capability in the result type of method mkCounter
    |                             ^²  refers to a fresh root capability in the result type of method mkCounter

--- a/tests/neg-custom-args/captures/sep-curried-redux.scala
+++ b/tests/neg-custom-args/captures/sep-curried-redux.scala
@@ -4,7 +4,7 @@ import caps.*
 class Ref[T](init: T) extends Mutable:
   private var value: T = init
   def get: T = value
-  mut def set(newValue: T): Unit = value = newValue
+  update def set(newValue: T): Unit = value = newValue
 
 // a library function that assumes that a and b MUST BE separate
 def swap[T](a: Ref[Int]^, b: Ref[Int]^): Unit = ???

--- a/tests/neg-custom-args/captures/sep-curried-redux.scala
+++ b/tests/neg-custom-args/captures/sep-curried-redux.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+import caps.*
+
+class Ref[T](init: T) extends Mutable:
+  private var value: T = init
+  def get: T = value
+  mut def set(newValue: T): Unit = value = newValue
+
+// a library function that assumes that a and b MUST BE separate
+def swap[T](a: Ref[Int]^, b: Ref[Int]^): Unit = ???
+
+def test4(): Unit =
+  val a: Ref[Int]^ = Ref(0)
+  val foo: (x: Ref[Int]^) -> (y: Ref[Int]^) ->{x} Unit =
+    x => y => swap(x, y)
+  val f = foo(a)
+  f(a) // error
+

--- a/tests/pending/pos-custom-args/captures/SizeCompareOps-redux.scala
+++ b/tests/pending/pos-custom-args/captures/SizeCompareOps-redux.scala
@@ -1,0 +1,22 @@
+package collection
+trait IterableOps[+A, +CC[_], +C] extends Any:
+  def sizeCompare(size: Int): Int
+
+object IterableOps:
+
+  type AnyConstr[X] = Any
+
+  final class SizeCompareOps private[collection](val it: IterableOps[_, AnyConstr, _]^) extends AnyVal:
+    this: SizeCompareOps^{it} =>
+    /** Tests if the size of the collection is less than some value. */
+    @inline def <(size: Int): Boolean = it.sizeCompare(size) < 0
+    /** Tests if the size of the collection is less than or equal to some value. */
+    @inline def <=(size: Int): Boolean = it.sizeCompare(size) <= 0
+    /** Tests if the size of the collection is equal to some value. */
+    @inline def ==(size: Int): Boolean = it.sizeCompare(size) == 0
+    /** Tests if the size of the collection is not equal to some value. */
+    @inline def !=(size: Int): Boolean = it.sizeCompare(size) != 0
+    /** Tests if the size of the collection is greater than or equal to some value. */
+    @inline def >=(size: Int): Boolean = it.sizeCompare(size) >= 0
+    /** Tests if the size of the collection is greater than some value. */
+    @inline def >(size: Int): Boolean = it.sizeCompare(size) > 0

--- a/tests/pos-custom-args/captures/deep-adapt.scala
+++ b/tests/pos-custom-args/captures/deep-adapt.scala
@@ -7,7 +7,7 @@ trait Rdr[T]:
 class Ref[T](init: T) extends Rdr[T], Mutable:
   private var current = init
   def get: T = current
-  mut def put(x: T): Unit = current = x
+  update def put(x: T): Unit = current = x
 
 case class Pair[+A, +B](x: A, y: B)
 class Swap[+A, +B](x: A, y: B) extends Pair[B, A](y, x)

--- a/tests/pos-custom-args/captures/deep-adapt.scala
+++ b/tests/pos-custom-args/captures/deep-adapt.scala
@@ -1,0 +1,23 @@
+import caps.Mutable
+import caps.cap
+
+trait Rdr[T]:
+  def get: T
+
+class Ref[T](init: T) extends Rdr[T], Mutable:
+  private var current = init
+  def get: T = current
+  mut def put(x: T): Unit = current = x
+
+case class Pair[+A, +B](x: A, y: B)
+class Swap[+A, +B](x: A, y: B) extends Pair[B, A](y, x)
+
+def Test(c: Object^): Unit =
+  val refs = List(Ref(1), Ref(2))
+  val rdrs: List[Ref[Int]^{cap.rd}] = refs
+  val rdrs2: Seq[Ref[Int]^{cap.rd}] = refs
+
+  val swapped = Swap(Ref(1), Ref("hello"))
+  val _: Swap[Ref[Int]^{cap.rd}, Ref[String]^{cap.rd}] = swapped
+  val _: Pair[Ref[String]^{cap.rd}, Ref[Int]^{cap.rd}] @unchecked = swapped
+

--- a/tests/pos-custom-args/captures/matrix.scala
+++ b/tests/pos-custom-args/captures/matrix.scala
@@ -1,0 +1,37 @@
+import caps.Mutable
+import caps.cap
+import language.`3.7` // fails separation checking right now
+
+trait Rdr[T]:
+  def get: T
+
+class Ref[T](init: T) extends Rdr[T], Mutable:
+  private var current = init
+  def get: T = current
+  mut def put(x: T): Unit = current = x
+
+abstract class IMatrix:
+  def apply(i: Int, j: Int): Double
+
+class Matrix(nrows: Int, ncols: Int) extends IMatrix, Mutable:
+  val arr = Array.fill(nrows, ncols)(0.0)
+  def apply(i: Int, j: Int): Double = arr(i)(j)
+  mut def update(i: Int, j: Int, x: Double): Unit = arr(i)(j) = x
+
+
+def mul(x: Matrix, y: Matrix, z: Matrix^): Unit = ???
+def mul1(x: Matrix^{cap.rd}, y: Matrix^{cap.rd}, z: Matrix^): Unit = ???
+
+def Test(c: Object^): Unit =
+  val m1 = Matrix(10, 10)
+  val m2 = Matrix(10, 10)
+  mul(m1, m2, m2) // error: will fail separation checking
+  mul(m1, m1, m2) // should be ok
+
+  mul1(m1, m2, m2) // error: will fail separation checking
+  mul(m1, m1, m2) // should be ok
+
+  def f2(): Matrix^ = Matrix(10, 10)
+
+  val i1: IMatrix^{cap.rd} = m1
+  val i2: IMatrix^{cap.rd} = f2()

--- a/tests/pos-custom-args/captures/matrix.scala
+++ b/tests/pos-custom-args/captures/matrix.scala
@@ -7,7 +7,7 @@ trait Rdr[T]:
 class Ref[T](init: T) extends Rdr[T], Mutable:
   private var current = init
   def get: T = current
-  mut def put(x: T): Unit = current = x
+  update def put(x: T): Unit = current = x
 
 abstract class IMatrix:
   def apply(i: Int, j: Int): Double
@@ -15,7 +15,7 @@ abstract class IMatrix:
 class Matrix(nrows: Int, ncols: Int) extends IMatrix, Mutable:
   val arr = Array.fill(nrows, ncols)(0.0)
   def apply(i: Int, j: Int): Double = arr(i)(j)
-  mut def update(i: Int, j: Int, x: Double): Unit = arr(i)(j) = x
+  update def update(i: Int, j: Int, x: Double): Unit = arr(i)(j) = x
 
 
 def mul(x: Matrix, y: Matrix, z: Matrix^): Unit = ???


### PR DESCRIPTION
Extend type adaptation to read-only status.

Two big improvements:

 - we also adapt if the target type is a mutable type with a read-only capture set. So the following compiles:
   ```scala
   class Ref extends Mutable { ... }
   val x: Ref^{cap.rd} = Ref()
   ```
 - we also adapt deeply inside a type. So the following compiles:

   ```scala
    val refs = List(Ref(), Ref())
    val rdrs: List[Ref^{cap.rd}] = refs
   ```
   We even try to track arguments through base types, so the following also compiles:
   ```scala
   val rdrs2: Seq[Ref^{cap.rd}] = refs
   ```
   But there are some limits, correlating actual and expected type through base types and as-seen-from is hard. 

In the end I had to abandon the original idea to roll everyhting into subtyping. I got the basics to work, but the problem then was that we use deep capture sets in separation checking, and those were not adapted. To do this, we'd have to somehow figure out what a dcs relative to an expected type is. This looks deeply non-trivial, and would probably in the end come down to techniques similar to the adaptation in this PR. So the benefit of also adding and inferring qualifiers to capture sets are not clear.

EDIT: We do need qualifiers for soundness as @Linyxus example below shows. It's now in `ro-mut-conformance.scala`.
So the adaptation commit has been rebased on the mutability qualifiers branch.



