### PR TITLE
Bump Scala CLI to v1.8.1 (was v1.8.0)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -187,7 +187,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.8.0"
+  val scalaCliLauncherVersion = "1.8.1"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.24"
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.8.1