### PR TITLE
Fix insufficient number width allocated when using `-print-lines`

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/Texts.scala
+++ b/compiler/src/dotty/tools/dotc/printing/Texts.scala
@@ -139,7 +139,8 @@ object Texts {
 
     def mkString(width: Int = Int.MaxValue, withLineNumbers: Boolean = false): String = {
       val sb = new StringBuilder
-      val numberWidth = if (withLineNumbers) (2 * maxLine.toString.length) + 2 else 0
+      // width display can be upto a range "n-n" where 1 <= n <= maxLine+1
+      val numberWidth = if (withLineNumbers) (2 * (maxLine + 1).toString.length) + 2 else 0
       layout(width - numberWidth).print(sb, numberWidth)
       sb.toString
     }

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -357,7 +357,7 @@ class TypeMismatch(val found: Type, expected: Type, val inTree: Option[untpd.Tre
     ++ addenda.dropWhile(_.isEmpty).headOption.getOrElse(importSuggestions)
 
   override def explain(using Context) =
-    val treeStr = inTree.map(x => s"\nTree: ${x.show}").getOrElse("")
+    val treeStr = inTree.map(x => s"\nTree:\n\n${x.show}\n").getOrElse("")
     treeStr + "\n" + super.explain
 
 end TypeMismatch

--- a/tests/neg/19680.check
+++ b/tests/neg/19680.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: new Config()
+  | Tree:
+  |
+  | new Config()
+  |
   | I tried to show that
   |   Config
   | conforms to

--- a/tests/neg/19680b.check
+++ b/tests/neg/19680b.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: "hello"
+  | Tree:
+  |
+  | "hello"
+  |
   | I tried to show that
   |   ("hello" : String)
   | conforms to

--- a/tests/neg/hidden-type-errors.check
+++ b/tests/neg/hidden-type-errors.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: t12717.A.bar("XXX")
+  | Tree:
+  |
+  | t12717.A.bar("XXX")
+  |
   | I tried to show that
   |   String
   | conforms to

--- a/tests/neg/i18737.check
+++ b/tests/neg/i18737.check
@@ -7,7 +7,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: v
+  | Tree:
+  |
+  | v
+  |
   | I tried to show that
   |   (v : String & Long)
   | conforms to
@@ -32,7 +35,10 @@
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
-  | Tree: v
+  | Tree:
+  |
+  | v
+  |
   | I tried to show that
   |   (v : String | Long)
   | conforms to


### PR DESCRIPTION

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

## Fix #22505

The main problem of the crash was the combination of `-print-lines` and `-explain`,
along with the rare case where we need to display the `9-10` range for the line-range `9..10`
(which was represented in the codebase as `8..9`), that was given insufficient number width to begin with.

Alongside the change, I also added newlines before the TypeMismatch explanation's tree output.
This can be debated, but without it `-explain -print-lines` looks like this:

```scala
-- [E007] Type Mismatch Error: /tmp/tmp.jNWSWbUu4O/src/main/scala/Main.scala:4:21 
 4 |  val tmp: List[B] = for (
   |                     ^
   |                     Found:    IndexedSeq[B]
   |                     Required: List[B]
 5 |    i <- (0 to l.size - 1);
 6 |//       j <- (i + 1 to l.size - 1);
 7 |    a <- (0 to l(i).size - 1);
 8 |//      b   <- (0 to l(j).size - 1);
 9 |    res <- f(l(i)(a))
10 |  ) yield res
   |----------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
   | Tree:   5|intWrapper(0).to(l.size - 1).flatMap[B]((i: Int) =>
   |     7|  intWrapper(0).to(l.apply(i).size - 1).flatMap[B]((a: Int) =>
   |  9-10|    f.apply(l.apply(i).apply(a)).map[B]((res: B) => res))
   | )
   | I tried to show that
   |   IndexedSeq[B]
   | conforms to
   |   List[B]
   | but none of the attempts shown below succeeded:
   |
   |   ==> IndexedSeq[B]  <:  List[B]  = false
   |
   | The tests were made under the empty constraint
    ----------------------------------------------------------------------------
```

The error looks much nicer (imo!) with the change:

```scala
   |----------------------------------------------------------------------------
   | Explanation (enabled by `-explain`)
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |
   | Tree:
   |
   |     5|intWrapper(0).to(l.size - 1).flatMap[B]((i: Int) =>
   |     7|  intWrapper(0).to(l.apply(i).size - 1).flatMap[B]((a: Int) =>
   |  9-10|    f.apply(l.apply(i).apply(a)).map[B]((res: B) => res))
   | )
   |
   | I tried to show that
   |   IndexedSeq[B]
   | conforms to
   |   List[B]
   | but none of the attempts shown below succeeded:
   |
   |   ==> IndexedSeq[B]  <:  List[B]  = false
   |
   | The tests were made under the empty constraint
    ----------------------------------------------------------------------------
```

(I have no idea how to add a line range to the last `)`, perhaps something can be changed
in the `.show` implementation, but it seems complicated...)

### Changes

- Change max number width to accomodate the full number range
- Put the TypeMismatch explanation tree on its own lines

<!-- TODO description of the change -->


<!-- Ideally should have a called "Fix #XYZ: A SHORT FIX DESCRIPTION" -->
