### PR TITLE
Partial function synthesis changesOwner of selector

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -865,7 +865,7 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
   /** An extractor for def of a closure contained the block of the closure. */
   object closureDef {
     def unapply(tree: Tree)(using Context): Option[DefDef] = tree match {
-      case Block((meth : DefDef) :: Nil, closure: Closure) if meth.symbol == closure.meth.symbol =>
+      case Block((meth: DefDef) :: Nil, closure: Closure) if meth.symbol == closure.meth.symbol =>
         Some(meth)
       case Block(Nil, expr) =>
         unapply(expr)

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -375,7 +375,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    *      new parents { termForwarders; typeAliases }
    *
    *  @param parents        a non-empty list of class types
-   *  @param termForwarders a non-empty list of forwarding definitions specified by their name and the definition they forward to.
+   *  @param termForwarders a non-empty list of forwarding definitions specified by their name
+   *                        and the definition they forward to.
    *  @param typeMembers    a possibly-empty list of type members specified by their name and their right hand side.
    *  @param adaptVarargs   if true, allow matching a vararg superclass constructor
    *                        with a missing argument in superArgs, and synthesize an

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6048,7 +6048,8 @@ object Types extends TypeUtils {
     end samParent
 
     def samClass(tp: Type)(using Context): Symbol = tp match
-      case tp @ ClassInfo(_, cls, _, _, _) =>
+      case tp: ClassInfo =>
+        val cls = tp.cls
         def takesNoArgs(tp: Type) =
           !tp.classSymbol.primaryConstructor.exists
               // e.g. `ContextFunctionN` does not have constructors

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6048,19 +6048,18 @@ object Types extends TypeUtils {
     end samParent
 
     def samClass(tp: Type)(using Context): Symbol = tp match
-      case tp: ClassInfo =>
-        val cls = tp.cls
+      case tp @ ClassInfo(_, cls, _, _, _) =>
         def takesNoArgs(tp: Type) =
           !tp.classSymbol.primaryConstructor.exists
               // e.g. `ContextFunctionN` does not have constructors
-          || tp.applicableConstructors(Nil, adaptVarargs = true).lengthCompare(1) == 0
+          || tp.applicableConstructors(argTypes = Nil, adaptVarargs = true).lengthCompare(1) == 0
               // we require a unique constructor so that SAM expansion is deterministic
         val noArgsNeeded: Boolean =
           takesNoArgs(tp)
-          && (!tp.cls.is(Trait) || takesNoArgs(tp.parents.head))
+          && (!cls.is(Trait) || takesNoArgs(tp.parents.head))
         def isInstantiable =
-          !tp.cls.isOneOf(FinalOrSealed) && (tp.appliedRef <:< tp.selfType)
-        if noArgsNeeded && isInstantiable then tp.cls
+          !cls.isOneOf(FinalOrSealed) && (tp.appliedRef <:< tp.selfType)
+        if noArgsNeeded && isInstantiable then cls
         else NoSymbol
       case tp: AppliedType =>
         samClass(tp.superType)

--- a/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
@@ -45,9 +45,9 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
 
   /** A map from local methods and classes to the owners to which they will be lifted as members.
    *  For methods and classes that do not have any dependencies this will be the enclosing package.
-   *  symbols with packages as lifted owners will subsequently represented as static
+   *  Symbols with packages as lifted owners will be subsequently represented as static
    *  members of their toplevel class, unless their enclosing class was already static.
-   *  Note: During tree transform (which runs at phase LambdaLift + 1), liftedOwner
+   *  Note: During tree transform (which runs at phase LambdaLift + 1), logicOwner
    *  is also used to decide whether a method had a term owner before.
    */
   private val logicOwner = new LinkedHashMap[Symbol, Symbol]
@@ -75,8 +75,8 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
     || owner.is(Trait) && isLocal(owner)
     || sym.isConstructor && isLocal(owner)
 
-  /** Set `liftedOwner(sym)` to `owner` if `owner` is more deeply nested
-   *  than the previous value of `liftedowner(sym)`.
+  /** Set `logicOwner(sym)` to `owner` if `owner` is more deeply nested
+   *  than the previous value of `logicOwner(sym)`.
    */
   private def narrowLogicOwner(sym: Symbol, owner: Symbol)(using Context): Unit =
     if sym.maybeOwner.isTerm
@@ -89,7 +89,7 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
 
   /** Mark symbol `sym` as being free in `enclosure`, unless `sym` is defined
    *  in `enclosure` or there is an intermediate class properly containing `enclosure`
-   *  in which `sym` is also free. Also, update `liftedOwner` of `enclosure` so
+   *  in which `sym` is also free. Also, update `logicOwner` of `enclosure` so
    *  that `enclosure` can access `sym`, or its proxy in an intermediate class.
    *  This means:
    *
@@ -284,7 +284,7 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
       changedFreeVars
     do ()
 
-  /** Compute final liftedOwner map by closing over caller dependencies */
+  /** Compute final logicOwner map by closing over caller dependencies */
   private def computeLogicOwners()(using Context): Unit =
     while
       changedLogicOwner = false

--- a/docs/_spec/08-pattern-matching.md
+++ b/docs/_spec/08-pattern-matching.md
@@ -616,7 +616,7 @@ new scala.PartialFunction[´S´, ´T´] {
   def apply(´x´: ´S´): ´T´ = x match {
     case ´p_1´ => ´b_1´ ... case ´p_n´ => ´b_n´
   }
-  def isDefinedAt(´x´: ´S´): Boolean = {
+  def isDefinedAt(´x´: ´S´): Boolean = x match {
     case ´p_1´ => true ... case ´p_n´ => true
     case _ => false
   }
@@ -625,6 +625,22 @@ new scala.PartialFunction[´S´, ´T´] {
 
 Here, ´x´ is a fresh name and ´T´ is the least upper bound of the types of all ´b_i´.
 The final default case in the `isDefinedAt` method is omitted if one of the patterns ´p_1, ..., p_n´ is already a variable or wildcard pattern.
+
+As a convenience, the partial function may be written using function literal notation:
+
+```scala
+(´x: S´) => e(´x´) match {
+  case ´p_1´ => ´b_1´ ... case ´p_n´ => ´b_n´
+}
+```
+where the selector expression is used for matches in the expansion.
+The body of the function must consist solely of the match expression.
+
+This syntax permits annotating the selector:
+
+```scala
+(´x: S´) => (e(´x´): @unchecked) match { ... }
+```
 
 ###### Example
 Here's an example which uses `foldLeft` to compute the scalar product of two vectors:

--- a/tests/pos/i23025.scala
+++ b/tests/pos/i23025.scala
@@ -1,0 +1,5 @@
+
+class A {
+  def f: PartialFunction[Int, Int] =
+    a => { (try a catch { case e : Throwable => throw e}) match { case n => n } }
+}

--- a/tests/pos/i23054.scala
+++ b/tests/pos/i23054.scala
@@ -1,0 +1,15 @@
+
+object Bug:
+
+  def m0(f: PartialFunction[Char, Unit]): Unit = ()
+
+  def m1(): Unit =
+    m0: x =>
+      "abc".filter(_ == x) match
+        case _ => ()
+
+  def m2(): Unit =
+    m0: x =>
+      x match
+        case _ => ()
+

--- a/tests/pos/i23310.scala
+++ b/tests/pos/i23310.scala
@@ -1,0 +1,16 @@
+
+object Example {
+    val pf: PartialFunction[Unit, Unit] = s => (s match {
+      case a => a
+    }) match {
+      case a => ()
+    }
+}
+
+object ExampleB:
+  def test =
+    List(42).collect:
+      _.match
+        case x => x
+      .match
+        case y => y + 27


### PR DESCRIPTION
The selector expression may be non-trivial.

Fixes #23054 
Fixes #23025 
Fixes #23310 

The fix is the small refactor to `matchExpr.changeOwner` where previously only the cases were included.

Another small refactor addresses an unused var.

There is a mild attempt to remedy the missing spec verbiage via a kind of post-script intended to suggest that it is a mere relaxation of the existing mechanism.