### PR TITLE
Fix handling of @use and @consume in class parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -375,15 +375,18 @@ object Capabilities:
       case tp1: FreshCap => tp1.ccOwner
       case _ => NoSymbol
 
-    final def isParamPath(using Context): Boolean = this match
+    final def paramPathRoot(using Context): Type = core match
       case tp1: NamedType =>
         tp1.prefix match
           case _: ThisType | NoPrefix =>
-            tp1.symbol.is(Param) || tp1.symbol.is(ParamAccessor)
-          case prefix: CoreCapability => prefix.isParamPath
-          case _ => false
-      case _: ParamRef => true
-      case _ => false
+            if tp1.symbol.is(Param) || tp1.symbol.is(ParamAccessor) then tp1
+            else NoType
+          case prefix: CoreCapability => prefix.paramPathRoot
+          case _ => NoType
+      case tp1: ParamRef => tp1
+      case _ => NoType
+
+    final def isParamPath(using Context): Boolean = paramPathRoot.exists
 
     final def ccOwner(using Context): Symbol = this match
       case self: ThisType => self.cls

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -59,9 +59,6 @@ object CheckCaptures:
 
     def isOutermost = outer0 == null
 
-    /** If an environment is open it tracks free references */
-    def isOpen(using Context) = !captured.isAlwaysEmpty && kind != EnvKind.Boxed
-
     def outersIterator: Iterator[Env] = new:
       private var cur = Env.this
       def hasNext = !cur.isOutermost
@@ -528,7 +525,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         case _ =>
 
       def recur(cs: CaptureSet, env: Env, lastEnv: Env | Null): Unit =
-        if env.isOpen && !env.owner.isStaticOwner && !cs.isAlwaysEmpty then
+        if env.kind != EnvKind.Boxed && !env.owner.isStaticOwner && !cs.isAlwaysEmpty then
           // Only captured references that are visible from the environment
           // should be included.
           val included = cs.filter: c =>
@@ -556,7 +553,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         def isRetained(ref: Capability): Boolean = ref.pathRoot match
           case root: ThisType => ctx.owner.isContainedIn(root.cls)
           case _ => true
-        if sym.exists && curEnv.isOpen then
+        if sym.exists && curEnv.kind != EnvKind.Boxed then
           markFree(capturedVars(sym).filter(isRetained), tree)
 
     /** If `tp` (possibly after widening singletons) is an ExprType

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1106,7 +1106,6 @@ class CheckCaptures extends Recheck, SymTransformer:
       try
         // Setup environment to reflect the new owner.
         val envForOwner: Map[Symbol, Env] = curEnv.outersIterator
-          .takeWhile(e => !capturedVars(e.owner).isAlwaysEmpty) // no refs can leak beyond this point
           .map(e => (e.owner, e))
           .toMap
         def restoreEnvFor(sym: Symbol): Env =
@@ -1142,8 +1141,7 @@ class CheckCaptures extends Recheck, SymTransformer:
         checkSubset(capturedVars(parent.tpe.classSymbol), localSet, parent.srcPos,
           i"\nof the references allowed to be captured by $cls")
       val saved = curEnv
-      if localSet ne CaptureSet.empty then
-        curEnv = Env(cls, EnvKind.Regular, localSet, curEnv)
+      curEnv = Env(cls, EnvKind.Regular, localSet, curEnv)
       try
         val thisSet = cls.classInfo.selfType.captureSet.withDescription(i"of the self type of $cls")
         checkSubset(localSet, thisSet, tree.srcPos) // (2)

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -463,7 +463,7 @@ class CheckCaptures extends Recheck, SymTransformer:
       def checkUseDeclared(c: Capability, env: Env, lastEnv: Env | Null) =
         if lastEnv != null && env.nestedClosure.exists && env.nestedClosure == lastEnv.owner then
           assert(ccConfig.deferredReaches) // access is from a nested closure under deferredReaches, so it's OK
-        else c.pathRoot match
+        else c.paramPathRoot match
           case ref: NamedType if !ref.symbol.isUseParam =>
             val what = if ref.isType then "Capture set parameter" else "Local reach capability"
             report.error(

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1107,7 +1107,7 @@ class Definitions {
   @tu lazy val NonBeanMetaAnnots: Set[Symbol] =
     Set(FieldMetaAnnot, GetterMetaAnnot, ParamMetaAnnot, SetterMetaAnnot, CompanionClassMetaAnnot, CompanionMethodMetaAnnot)
   @tu lazy val NonBeanParamAccessorAnnots: Set[Symbol] =
-    Set(PublicInBinaryAnnot)
+    Set(PublicInBinaryAnnot, UseAnnot, ConsumeAnnot)
   @tu lazy val MetaAnnots: Set[Symbol] =
     NonBeanMetaAnnots + BeanGetterMetaAnnot + BeanSetterMetaAnnot
 

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -252,11 +252,16 @@ object SymDenotations {
     final def filterAnnotations(p: Annotation => Boolean)(using Context): Unit =
       annotations = annotations.filterConserve(p)
 
-    def annotationsCarrying(meta: Set[Symbol], orNoneOf: Set[Symbol] = Set.empty)(using Context): List[Annotation] =
-      annotations.filterConserve(_.hasOneOfMetaAnnotation(meta, orNoneOf = orNoneOf))
+    def annotationsCarrying(meta: Set[Symbol],
+        orNoneOf: Set[Symbol] = Set.empty,
+        andAlso: Set[Symbol] = Set.empty)(using Context): List[Annotation] =
+      annotations.filterConserve: annot =>
+        annot.hasOneOfMetaAnnotation(meta, orNoneOf = orNoneOf)
+        || andAlso.contains(annot.symbol)
 
-    def keepAnnotationsCarrying(phase: DenotTransformer, meta: Set[Symbol], orNoneOf: Set[Symbol] = Set.empty)(using Context): Unit =
-      updateAnnotationsAfter(phase, annotationsCarrying(meta, orNoneOf = orNoneOf))
+    def keepAnnotationsCarrying(phase: DenotTransformer, meta: Set[Symbol],
+        orNoneOf: Set[Symbol] = Set.empty, andAlso: Set[Symbol] = Set.empty)(using Context): Unit =
+      updateAnnotationsAfter(phase, annotationsCarrying(meta, orNoneOf, andAlso))
 
     def updateAnnotationsAfter(phase: DenotTransformer, annots: List[Annotation])(using Context): Unit =
       if annots ne annotations then

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -255,10 +255,8 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
               sym.keepAnnotationsCarrying(thisPhase, Set(defn.ParamMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
               unusing.foreach(sym.addAnnotation)
             else if sym.is(ParamAccessor) then
-              // @publicInBinary is not a meta-annotation and therefore not kept by `keepAnnotationsCarrying`
-              val publicInBinaryAnnotOpt = sym.getAnnotation(defn.PublicInBinaryAnnot)
-              sym.keepAnnotationsCarrying(thisPhase, Set(defn.GetterMetaAnnot, defn.FieldMetaAnnot))
-              for publicInBinaryAnnot <- publicInBinaryAnnotOpt do sym.addAnnotation(publicInBinaryAnnot)
+              sym.keepAnnotationsCarrying(thisPhase, Set(defn.GetterMetaAnnot, defn.FieldMetaAnnot),
+                andAlso = defn.NonBeanParamAccessorAnnots)
             else
               sym.keepAnnotationsCarrying(thisPhase, Set(defn.GetterMetaAnnot, defn.FieldMetaAnnot), orNoneOf = defn.NonBeanMetaAnnots)
           if sym.isScala2Macro && !ctx.settings.XignoreScala2Macros.value &&

--- a/tests/neg-custom-args/captures/i23303.check
+++ b/tests/neg-custom-args/captures/i23303.check
@@ -1,0 +1,10 @@
+-- Error: tests/neg-custom-args/captures/i23303.scala:6:36 -------------------------------------------------------------
+6 |    def execute: Unit = ops.foreach(f => f()) // error
+  |                                    ^^^^^^^^
+  |                                 Local reach capability Runner.this.ops* leaks into capture scope of class Runner.
+  |                                 To allow this, the value ops should be declared with a @use annotation
+-- Error: tests/neg-custom-args/captures/i23303.scala:9:22 -------------------------------------------------------------
+9 |    () => ops.foreach(f => f()) // error
+  |                      ^^^^^^^^
+  |                      Local reach capability ops* leaks into capture scope of method Runner2.
+  |                      To allow this, the parameter ops should be declared with a @use annotation

--- a/tests/neg-custom-args/captures/i23303.scala
+++ b/tests/neg-custom-args/captures/i23303.scala
@@ -1,13 +1,13 @@
 import language.experimental.captureChecking
 import caps.use
 
-/*class Test:
+class Test:
   class Runner(ops: List[() => Unit]):
     def execute: Unit = ops.foreach(f => f()) // error
 
   def Runner2(ops: List[() => Unit]) =
     () => ops.foreach(f => f()) // error
-*/
+
 
 class Test2:
   class Runner(@use ops: List[() => Unit]):

--- a/tests/neg-custom-args/captures/i23303.scala
+++ b/tests/neg-custom-args/captures/i23303.scala
@@ -1,0 +1,17 @@
+import language.experimental.captureChecking
+import caps.use
+
+/*class Test:
+  class Runner(ops: List[() => Unit]):
+    def execute: Unit = ops.foreach(f => f()) // error
+
+  def Runner2(ops: List[() => Unit]) =
+    () => ops.foreach(f => f()) // error
+*/
+
+class Test2:
+  class Runner(@use ops: List[() => Unit]):
+    def execute: Unit = ops.foreach(f => f()) //ok
+
+  private def Runner2(@use ops: List[() => Unit]) =
+    () => ops.foreach(f => f()) // ok


### PR DESCRIPTION
Multiple fixes, both to keep the annotations in place for capture checking, and to consult them 
when we do leak checking.

Fixes #23303
