### PR TITLE
Nowarn receiver of extension taking params

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -535,7 +535,10 @@ object CheckUnused:
           val alias = m.owner.info.member(sym.name)
           if alias.exists then
             val aliasSym = alias.symbol
-            if aliasSym.isAllOf(PrivateParamAccessor, butNot = CaseAccessor) && !infos.refs(alias.symbol) then
+            if aliasSym.isAllOf(PrivateParamAccessor, butNot = CaseAccessor)
+              && !infos.refs(alias.symbol)
+              && !usedByDefaultGetter(sym, m)
+            then
               if aliasSym.is(Local) then
                 if ctx.settings.WunusedHas.explicits then
                   warnAt(pos)(UnusedSymbol.explicitParams(aliasSym))
@@ -565,7 +568,7 @@ object CheckUnused:
 
     // does the param have an alias in a default arg method that is used?
     def usedByDefaultGetter(param: Symbol, meth: Symbol): Boolean =
-      val cls = meth.enclosingClass
+      val cls = if meth.isPrimaryConstructor then meth.enclosingClass.companionModule else meth.enclosingClass
       val MethName = meth.name
       cls.info.decls.exists: d =>
         d.name match
@@ -602,7 +605,10 @@ object CheckUnused:
             val checking =
                  aliasSym.isAllOf(PrivateParamAccessor, butNot = CaseAccessor)
               || aliasSym.isAllOf(Protected | ParamAccessor, butNot = CaseAccessor) && m.owner.is(Given)
-            if checking && !infos.refs(alias.symbol) then
+            if checking
+              && !infos.refs(alias.symbol)
+              && !usedByDefaultGetter(sym, m)
+            then
               warnAt(pos)(UnusedSymbol.implicitParams(aliasSym))
         else if !usedByDefaultGetter(sym, m) then
           warnAt(pos)(UnusedSymbol.implicitParams(sym))

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -568,7 +568,7 @@ object CheckUnused:
 
     // does the param have an alias in a default arg method that is used?
     def usedByDefaultGetter(param: Symbol, meth: Symbol): Boolean =
-      val cls = if meth.isPrimaryConstructor then meth.enclosingClass.companionModule else meth.enclosingClass
+      val cls = if meth.isConstructor then meth.enclosingClass.companionModule else meth.enclosingClass
       val MethName = meth.name
       cls.info.decls.exists: d =>
         d.name match

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -544,11 +544,11 @@ object CheckUnused:
                   warnAt(pos)(UnusedSymbol.privateMembers)
         else if ctx.settings.WunusedHas.explicits
           && !sym.is(Synthetic) // param to setter is unused bc there is no field yet
-          && !(sym.owner.is(ExtensionMethod) && {
-            m.paramSymss.dropWhile(_.exists(_.isTypeParam)) match
-            case (h :: Nil) :: Nil => h == sym // param is the extended receiver
+          && !(sym.owner.is(ExtensionMethod) &&
+            m.paramSymss.dropWhile(_.exists(_.isTypeParam)).match
+            case (h :: Nil) :: _ => h == sym // param is the extended receiver
             case _ => false
-          })
+          )
           && !sym.name.isInstanceOf[DerivedName]
           && !ctx.platform.isMainMethod(m)
         then

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -530,7 +530,7 @@ object CheckUnused:
         // A class param is unused if its param accessor is unused.
         // (The class param is not assigned to a field until constructors.)
         // A local param accessor warns as a param; a private accessor as a private member.
-        // Avoid warning for case class elements because they are aliased via unapply.
+        // Avoid warning for case class elements because they are aliased via unapply (i.e. may be extracted).
         if m.isPrimaryConstructor then
           val alias = m.owner.info.member(sym.name)
           if alias.exists then
@@ -551,6 +551,7 @@ object CheckUnused:
           )
           && !sym.name.isInstanceOf[DerivedName]
           && !ctx.platform.isMainMethod(m)
+          && !usedByDefaultGetter(sym, m)
         then
           warnAt(pos)(UnusedSymbol.explicitParams(sym))
       end checkExplicit
@@ -561,6 +562,16 @@ object CheckUnused:
       then
         checkExplicit()
     end checkParam
+
+    // does the param have an alias in a default arg method that is used?
+    def usedByDefaultGetter(param: Symbol, meth: Symbol): Boolean =
+      val cls = meth.enclosingClass
+      val MethName = meth.name
+      cls.info.decls.exists: d =>
+        d.name match
+        case DefaultGetterName(MethName, _) =>
+          d.paramSymss.exists(_.exists(p => p.name == param.name && infos.refs(p)))
+        case _ => false
 
     def checkImplicit(sym: Symbol, pos: SrcPos) =
       val m = sym.owner
@@ -593,7 +604,7 @@ object CheckUnused:
               || aliasSym.isAllOf(Protected | ParamAccessor, butNot = CaseAccessor) && m.owner.is(Given)
             if checking && !infos.refs(alias.symbol) then
               warnAt(pos)(UnusedSymbol.implicitParams(aliasSym))
-        else
+        else if !usedByDefaultGetter(sym, m) then
           warnAt(pos)(UnusedSymbol.implicitParams(sym))
 
     def checkLocal(sym: Symbol, pos: SrcPos) =

--- a/tests/warn/i15503e.scala
+++ b/tests/warn/i15503e.scala
@@ -92,4 +92,4 @@ object UnwrapTyped:
     error("Compiler bug: `codeOf` was not evaluated by the compiler")
 
 object `default usage`:
-  def f(i: Int)(j: Int = i * 2) = j // warn I guess
+  def f(i: Int)(j: Int = i * 2) = j // ~warn~ I guess (see tests/warn/i23349.scala)

--- a/tests/warn/i23349.scala
+++ b/tests/warn/i23349.scala
@@ -1,4 +1,4 @@
-//> using options -Wunused:explicits
+//> using options -Wunused:explicits,implicits
 
 // An external class that doesn't get its own `copy` method.
 class Foo(val a: String, val b: Int)
@@ -12,4 +12,9 @@ extension (self: Foo)
 //
 // Example 2: implement `copyFoo` with parameter groups.
 //
-def copyFoo(foo: Foo)(a: String = foo.a, b: Int = foo.b): Foo = Foo(a, b) // warn
+def copyFoo(foo: Foo)(a: String = foo.a, b: Int = foo.b): Foo = Foo(a, b)
+
+class C:
+  def copyFoo(foo: Foo, bar: String)(a: String = foo.a, b: Int = foo.b)(c: String = bar): Foo = Foo(a, b) // warn c
+  def copyUsing(using foo: Foo, bar: String)(a: String = foo.a, b: Int = foo.b)(c: String = bar): Foo = // warn c
+    Foo(a, b)

--- a/tests/warn/i23349.scala
+++ b/tests/warn/i23349.scala
@@ -24,3 +24,7 @@ class K(k: Int)(s: String = "*"*k):
 
 class KU(using k: Int)(s: String = "*"*k):
   override val toString = s
+
+class KK(s: String):
+  def this(k: Int)(s: String = "*"*k) = this(s)
+  override val toString = s

--- a/tests/warn/i23349.scala
+++ b/tests/warn/i23349.scala
@@ -18,3 +18,9 @@ class C:
   def copyFoo(foo: Foo, bar: String)(a: String = foo.a, b: Int = foo.b)(c: String = bar): Foo = Foo(a, b) // warn c
   def copyUsing(using foo: Foo, bar: String)(a: String = foo.a, b: Int = foo.b)(c: String = bar): Foo = // warn c
     Foo(a, b)
+
+class K(k: Int)(s: String = "*"*k):
+  override val toString = s
+
+class KU(using k: Int)(s: String = "*"*k):
+  override val toString = s

--- a/tests/warn/i23349.scala
+++ b/tests/warn/i23349.scala
@@ -1,0 +1,15 @@
+//> using options -Wunused:explicits
+
+// An external class that doesn't get its own `copy` method.
+class Foo(val a: String, val b: Int)
+
+//
+// Example 1: add `copy` method via an extension method.
+//
+extension (self: Foo)
+  def copy(a: String = self.a, b: Int = self.b): Foo = Foo(a, b) // nowarn
+
+//
+// Example 2: implement `copyFoo` with parameter groups.
+//
+def copyFoo(foo: Foo)(a: String = foo.a, b: Int = foo.b): Foo = Foo(a, b) // warn


### PR DESCRIPTION
Fixes #23349 

Extensions are regular methods, but the "receiver" parameter is exempt from the unused check. By error, previously `x.m` was exempt but not `x.f(y)`.

(The reason for the exemption may be that the method expressed as a member of the receiver type may make no reference to `this`, without warning.)

Check for parameters used only in default arg expressions. A parameter may be aliased in a default arg getter method, so a usage of that getter param counts as a usage of the method param (or class param). Defaults of class params are found in the class companion.