### PR TITLE
bugfix: Check for error before checking members of product type in getUnapplySelectors

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -218,7 +218,7 @@ object Applications {
       val isProduct = args match
         case x :: xs => x.isInstanceOf[untpd.NamedArg] || xs.nonEmpty
         case _ => false
-      if isProduct && !tp.derivesFrom(defn.SeqClass) then
+      if isProduct && !tp.derivesFrom(defn.SeqClass) && !tp.isError then
         productUnapplySelectors(tp).getOrElse:
           // There are unapplys with return types which have `get` and `_1, ..., _n`
           // as members, but which are not subtypes of Product. So `productUnapplySelectors`

--- a/tests/pos/i23156.scala
+++ b/tests/pos/i23156.scala
@@ -1,0 +1,6 @@
+object Unpack {
+  (1, 2) match {
+    case Unpack(first, _) => first
+  }
+  def unapply(e: (Int, Int)): Option[T] = ???
+}


### PR DESCRIPTION
Fixes #23156 

I'm not 100% sure this is the best way to check for error types, so would appreciate any guidance!