### PR TITLE
Fix false exhaustivity warning for pattern returning NamedTuple

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -570,7 +570,7 @@ object SpaceEngine {
     // Case unapplySeq:
     // 1. return the type `List[T]` where `T` is the element type of the unapplySeq return type `Seq[T]`
 
-    val resTp = wildApprox(ctx.typeAssigner.safeSubstMethodParams(mt, scrutineeTp :: Nil).finalResultType)
+    val resTp = wildApprox(ctx.typeAssigner.safeSubstMethodParams(mt, scrutineeTp :: Nil).finalResultType).stripNamedTuple
 
     val sig =
       if (resTp.isRef(defn.BooleanClass))

--- a/tests/pos/i23158.scala
+++ b/tests/pos/i23158.scala
@@ -1,0 +1,11 @@
+//> using options -Werror
+
+object Unpack {
+  final case class Pair(a: Int, b: Int)
+  def unapply(e: Pair): NamedTuple.NamedTuple[("a", "b"), (Int, Int)] = ???
+
+  val x: Pair = ???
+  x match {
+    case Unpack(_, _) => ???
+  }
+}


### PR DESCRIPTION
---
name: "\U0001F527 Fix issue"
about: Open a new pull request for the Dotty Compiler that fixes an issue from the issue tracker
title: 'Fix #XYZ: A SHORT FIX DESCRIPTION'
assignees: ''

---

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

## Fix #23158

The fix is made based on us doing stripNamedTuple in other parts close
by. Seems like made should in a single place, but I lack the bigger
understanding to figure our where that would be.

<!-- TODO description of the change -->


<!-- Ideally should have a called "Fix #XYZ: A SHORT FIX DESCRIPTION" -->
