### PR TITLE
Check OrType in interpolated toString lint

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/localopt/FormatChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/localopt/FormatChecker.scala
@@ -228,22 +228,20 @@ class TypedFormatChecker(partsElems: List[Tree], parts: List[String], args: List
       case _ => true
 
     def lintToString(arg: Type): Unit =
-      def check(tp: Type): Boolean = tp.widen match
+      def checkIsStringify(tp: Type): Boolean = tp.widen match
         case OrType(tp1, tp2) =>
-          check(tp1) || check(tp2)
+          checkIsStringify(tp1) || checkIsStringify(tp2)
         case tp =>
-          if tp =:= defn.StringType then
-            false
-          else if tp =:= defn.UnitType then
-            warningAt(CC)("interpolated Unit value")
-            true
-          else if !tp.isPrimitiveValueType then
-            warningAt(CC)("interpolation uses toString")
-            true
-          else
-            false
-      if ctx.settings.Whas.toStringInterpolated && kind == StringXn && check(arg) then
-        ()
+          !(tp =:= defn.StringType)
+          && {
+              tp =:= defn.UnitType
+              && { warningAt(CC)("interpolated Unit value"); true }
+            ||
+              !tp.isPrimitiveValueType
+              && { warningAt(CC)("interpolation uses toString"); true }
+          }
+      if ctx.settings.Whas.toStringInterpolated && kind == StringXn then
+        checkIsStringify(arg): Unit
 
     // what arg type if any does the conversion accept
     def acceptableVariants: List[Type] =

--- a/tests/warn/tostring-interpolated.scala
+++ b/tests/warn/tostring-interpolated.scala
@@ -11,14 +11,18 @@ trait T {
 
   def format = f"${c.x}%d in $c or $c%s" // warn using c.toString // warn
 
-  def bool = f"$c%b" // warn just a null check
-
-  def oops = s"${null} slipped thru my fingers" // warn
-
   def ok = s"${c.toString}"
 
   def sb = new StringBuilder().append("hello")
   def greeting = s"$sb, world" // warn
+
+  def literally = s"Hello, ${"world"}" // nowarn literal, widened to String
+
+  def bool = f"$c%b" // warn just a null check (quirk of Java format)
+
+  def oops = s"${null} slipped thru my fingers" // warn although conforms to String
+
+  def exceptionally = s"Hello, ${???}" // warn although conforms to String
 }
 
 class Mitigations {
@@ -29,8 +33,47 @@ class Mitigations {
 
   def ok = s"$s is ok"
   def jersey = s"number $i"
-  def unitized = s"unfortunately $shown" // maybe tell them about unintended ()?
+  def unitized = s"unfortunately $shown" // warn accidental unit value
+  def funitized = f"unfortunately $shown" // warn accidental unit value
 
   def nopct = f"$s is ok"
   def nofmt = f"number $i"
+}
+
+class Branches {
+
+  class C {
+    val shouldCaps = true
+    val greeting = s"Hello ${if (shouldCaps) "WORLD" else "world"}"
+  }
+
+  class D {
+    val shouldCaps = true
+    object world { override def toString = "world" }
+    val greeting = s"Hello ${if (shouldCaps) "WORLD" else world}" // warn
+  }
+
+  class E {
+    def x = 42
+    val greeting = s"Hello ${x match { case 42 => "WORLD" case 27 => "world" case _ => ??? }}"
+  }
+
+  class F {
+    def x = 42
+    object world { override def toString = "world" }
+    val greeting = s"Hello ${
+      x match { // warn
+        case 17 => "Welt"
+        case 42 => "WORLD"
+        case 27 => world
+        case _ => ??? }
+    }"
+  }
+
+  class Z {
+    val shouldCaps = true
+    val greeting = s"Hello ${if (shouldCaps) ??? else null}" // warn
+    val farewell = s"Bye-bye ${if (shouldCaps) "Bob" else null}" // warn
+  }
+
 }


### PR DESCRIPTION
Fixes #23361 

If an arg to a interpolator is a conditional or match, the expression type may be an `OrType`, so check both parts for non-Strings for which `toString` is used for interpolation.
