### PR TITLE
Fix #23224: Optimize simple tuple extraction

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2774,6 +2774,16 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if !isFullyDefined(pt, ForceDegree.all) then
       return errorTree(tree, em"expected type of $tree is not fully defined")
     val body1 = typed(tree.body, pt)
+
+    // If the body is a named tuple pattern, we need to use pt for symbol type,
+    // because the desugared body is a regular tuple unapply.
+    def isNamedTuplePattern =
+      ctx.mode.is(Mode.Pattern)
+      && pt.dealias.isNamedTupleType
+      && tree.body.match
+          case untpd.Tuple((_: NamedArg) :: _) => true
+          case _ => false
+
     body1 match {
       case UnApply(fn, Nil, arg :: Nil)
       if fn.symbol.exists && (fn.symbol.owner.derivesFrom(defn.TypeTestClass) || fn.symbol.owner == defn.ClassTagClass) && !body1.tpe.isError =>
@@ -2799,8 +2809,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             body1.isInstanceOf[RefTree] && !isWildcardArg(body1)
             || body1.isInstanceOf[Literal]
           val symTp =
-            if isStableIdentifierOrLiteral || pt.dealias.isNamedTupleType then pt
-              // need to combine tuple element types with expected named type
+            if isStableIdentifierOrLiteral || isNamedTuplePattern then pt
             else if isWildcardStarArg(body1)
                     || pt == defn.ImplicitScrutineeTypeRef
                     || body1.tpe <:< pt  // There is some strange interaction with gadt matching.

--- a/tests/pos/simple-tuple-extract.scala
+++ b/tests/pos/simple-tuple-extract.scala
@@ -1,0 +1,34 @@
+
+class Test:
+  def f1: (Int, Int, Int) = (1, 2, 3)
+  def f2: (x: Int, y: Int) = (3, 4)
+
+  def test1 =
+    val (a, b, c) = f1
+    // Desugared to:
+    // val $2$: (Int, Int, Int) =
+    //   this.f1:(Int, Int, Int) @unchecked match
+    //     {
+    //       case $1$ @ Tuple3.unapply[Int, Int, Int](_, _, _) =>
+    //         $1$:(Int, Int, Int)
+    //     }
+    // val a: Int = $2$._1
+    // val b: Int = $2$._2
+    // val c: Int = $2$._3
+    a + b + c
+
+  def test2 =
+    val (_, d, e) = f1
+    e + e
+
+  def test3 =
+    val (_, f, _) = f1
+    f + f
+
+  def test4 =
+    val (x, y) = f2
+    x + y
+
+  def test5 =
+    val (_, a) = f2
+    a + a


### PR DESCRIPTION
Fix #23224:

Optimize simple tuple extraction to avoid creating unnecessary tuple objects.

Also change the bind pattern typing for named tuples. Now, if the pattern contains named argument, the bind variable will have named tuple type, otherwise, it will have regular tuple type.