### PR TITLE
bugfix: Don't check scope members if not needed

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -53,9 +53,9 @@ object Completion:
     val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
     inContext(completionContext):
       val untpdPath = Interactive.resolveTypedOrUntypedPath(tpdPath, pos)
-      val mode = completionMode(untpdPath, pos, forSymbolSearch = true)
       val rawPrefix = completionPrefix(untpdPath, pos)
-      val completer = new Completer(mode, pos, untpdPath, _ => true)
+      // Lazy mode is to avoid too many checks as it's mostly for printing types
+      val completer = new Completer(Mode.Lazy, pos, untpdPath, _ => true)
       completer.scopeCompletions
 
   /** Get possible completions from tree at `pos`
@@ -98,7 +98,7 @@ object Completion:
    *
    * Otherwise, provide no completion suggestion.
    */
-  def completionMode(path: List[untpd.Tree], pos: SourcePosition, forSymbolSearch: Boolean = false): Mode = path match
+  def completionMode(path: List[untpd.Tree], pos: SourcePosition): Mode = path match
     // Ignore `package foo@@` and `package foo.bar@@`
     case ((_: tpd.Select) | (_: tpd.Ident)):: (_ : tpd.PackageDef) :: _  => Mode.None
     case GenericImportSelector(sel) =>
@@ -111,14 +111,9 @@ object Completion:
     case untpd.Literal(Constants.Constant(_: String)) :: _ => Mode.Term | Mode.Scope // literal completions
     case (ref: untpd.RefTree) :: _ =>
       val maybeSelectMembers = if ref.isInstanceOf[untpd.Select] then Mode.Member else Mode.Scope
-      if (forSymbolSearch) then Mode.Term | Mode.Type | maybeSelectMembers
-      else if (ref.name.isTermName) Mode.Term | maybeSelectMembers
+      if (ref.name.isTermName) Mode.Term | maybeSelectMembers
       else if (ref.name.isTypeName) Mode.Type | maybeSelectMembers
       else Mode.None
-
-    case (_: tpd.TypeTree | _: tpd.MemberDef) :: _ if forSymbolSearch => Mode.Type | Mode.Term
-    case (_: tpd.CaseDef) :: _ if forSymbolSearch => Mode.Type | Mode.Term
-    case Nil if forSymbolSearch =>  Mode.Type | Mode.Term
     case _ => Mode.None
 
   /** When dealing with <errors> in varios palces we check to see if they are
@@ -651,7 +646,7 @@ object Completion:
     private def include(denot: SingleDenotation, nameInScope: Name)(using Context): Boolean =
       matches(nameInScope) &&
       completionsFilter(NoType, nameInScope) &&
-      isValidCompletionSymbol(denot.symbol, mode, isNew)
+      (mode.is(Mode.Lazy) || isValidCompletionSymbol(denot.symbol, mode, isNew))
 
     private def extractRefinements(site: Type)(using Context): Seq[SingleDenotation] =
       site match
@@ -681,7 +676,7 @@ object Completion:
 
       val members = site.memberDenots(completionsFilter, appendMemberSyms).collect {
         case mbr if include(mbr, mbr.name)
-                    && mbr.symbol.isAccessibleFrom(site) => mbr
+                    && (mode.is(Mode.Lazy) || mbr.symbol.isAccessibleFrom(site)) => mbr
       }
       val refinements = extractRefinements(site).filter(mbr => include(mbr, mbr.name))
 
@@ -743,4 +738,6 @@ object Completion:
     val Scope: Mode = new Mode(8)
 
     val Member: Mode = new Mode(16)
+
+    val Lazy: Mode = new Mode(32)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/edit/InsertInferredTypeSuite.scala
@@ -657,14 +657,13 @@ class InsertInferredTypeSuite extends BaseCodeActionSuite:
          |object O{
          |  val <<foo>> = A.Foo(new A.`x-x`)
          |}""".stripMargin,
-      """|import A.Foo
-         |import A.`x-x`
+      """|import A.`x-x`
          |object A{
          |  class `x-x`
          |  case class Foo[A](i: A)
          |}
          |object O{
-         |  val foo: Foo[`x-x`] = A.Foo(new A.`x-x`)
+         |  val foo: A.Foo[`x-x`] = A.Foo(new A.`x-x`)
          |}
          |""".stripMargin
     )


### PR DESCRIPTION
This was causing a significant slowdown in most cases for lichess/lila and scope completions are mostly for printing, so we don't need to check so heavily if a member is valid.