### PR TITLE
Print update modifier when printing update method definitions

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -994,8 +994,9 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
   protected def valDefToText[T <: Untyped](tree: ValDef[T]): Text = {
     dclTextOr(tree) {
       modText(tree.mods, tree.symbol, keywordStr(if (tree.mods.is(Mutable)) "var" else "val"), isType = false) ~~
-        valDefText(nameIdText(tree)) ~ optAscription(tree.tpt) ~
-        withEnclosingDef(tree) { rhsValDef(tree) }
+        valDefText(nameIdText(tree))
+        ~ optAscription(tree.tpt)
+        ~ withEnclosingDef(tree) { rhsValDef(tree) }
     }
   }
 
@@ -1170,6 +1171,7 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
     if (rawFlags.is(Param)) flagMask = flagMask &~ Given
     val flags = rawFlags & flagMask
     var flagsText = toTextFlags(sym, flags)
+    if sym.isUpdateMethod then flagsText ~~= keywordStr("update")
     val annotTexts =
       if sym.exists then
         sym.annotationsUNSAFE.filterNot(ann => dropAnnotForModText(ann.symbol)).map(toText)

--- a/tests/neg-custom-args/captures/i23389.scala
+++ b/tests/neg-custom-args/captures/i23389.scala
@@ -1,0 +1,36 @@
+import language.experimental.captureChecking
+import caps.*
+
+package test1:
+
+  trait Collection[T] extends Mutable:
+    update def add(elem: T): Unit
+    update def remove(elem: T): Unit
+    def get(index: Int): Option[T]
+
+  object Collection:
+    def empty[T]: Collection[T] = ???
+
+  trait Foo:
+    val thunks: Collection[() => Unit] // that's fine
+
+  object FooImpl1 extends Foo:
+    val thunks: Collection[() => Unit] = Collection.empty // error
+    val thunks2: Collection[() => Unit] = Collection.empty[() => Unit] // error
+    val thunks3: Collection[() => Unit] = Collection.empty[() => Unit] // error
+
+package test2:
+
+  trait Collection[+T] extends Mutable:
+    def get(index: Int): Option[T]
+
+  object Collection:
+    def empty[T]: Collection[T] = ???
+
+  trait Foo:
+    val thunks: Collection[() => Unit] // that's fine
+
+  object FooImpl1 extends Foo:
+    val thunks: Collection[() => Unit] = Collection.empty // error
+    val thunks2: Collection[() => Unit] = Collection.empty[() => Unit] // error
+    val thunks3: Collection[() => Unit] = Collection.empty[() => Unit] // error


### PR DESCRIPTION
I verified by printing i23389.scala with -Xprint:cc. I did not manage to make up a test case for this.