### PR TITLE
Fix bisect scripts - Maven metadata.xml releases are no longer ordered by release date

### DIFF
--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -13,6 +13,8 @@ import java.io.File
 import java.nio.file.attribute.PosixFilePermissions
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 val usageMessage = """
   |Usage:
@@ -156,7 +158,6 @@ case class ReleasesRange(first: Option[String], last: Option[String]):
       val index = releases.indexWhere(_.version == version)
       assert(index > 0, s"${version} matches no nightly compiler release")
       index
-
     val startIdx = first.map(releaseIndex(_)).getOrElse(0)
     val endIdx = last.map(releaseIndex(_) + 1).getOrElse(releases.length)
     val filtered = releases.slice(startIdx, endIdx).toVector
@@ -183,12 +184,15 @@ object Releases:
     re.findAllMatchIn(xml.mkString)
       .flatMap{ m => Option(m.group(1)).map(Release.apply) }
       .toVector
+      .sortBy: release =>
+        (release.version, release.date)
 
   def fromRange(range: ReleasesRange): Vector[Release] = range.filter(allReleases)
 
 case class Release(version: String):
   private val re = raw".+-bin-(\d{8})-(\w{7})-NIGHTLY".r
-  def date: String =
+  def date: LocalDate = LocalDate.parse(dateString, DateTimeFormatter.BASIC_ISO_DATE)
+  def dateString: String =
     version match
       case re(date, _) => date
       case _ => sys.error(s"Could not extract date from release name: $version")


### PR DESCRIPTION
Fixes bisect script which stopped to work correctly with latest https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/maven-metadata.xml revisions where releases are no longer sorted by date