### PR TITLE
Fix errors in the global initialization checker when compiling bootstrapped dotty

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -151,12 +151,12 @@ class Objects(using Context @constructorOnly):
     def hasVar(sym: Symbol)(using Heap.MutableData): Boolean = Heap.containsVal(this, sym)
 
     def initVal(field: Symbol, value: Value)(using Context, Heap.MutableData) = log("Initialize " + field.show + " = " + value + " for " + this, printer) {
-      assert(!field.is(Flags.Mutable), "Field is mutable: " + field.show)
+      assert(field.is(Flags.Param) || !field.is(Flags.Mutable), "Field is mutable: " + field.show)
       Heap.writeJoinVal(this, field, value)
     }
 
     def initVar(field: Symbol, value: Value)(using Context, Heap.MutableData) = log("Initialize " + field.show + " = " + value + " for " + this, printer) {
-      assert(field.is(Flags.Mutable), "Field is not mutable: " + field.show)
+      assert(field.is(Flags.Mutable, butNot = Flags.Param), "Field is not mutable: " + field.show)
       Heap.writeJoinVal(this, field, value)
     }
 
@@ -421,12 +421,12 @@ class Objects(using Context @constructorOnly):
       def hasVar(sym: Symbol)(using EnvMap.EnvMapMutableData): Boolean = EnvMap.containsVal(this, sym)
 
       def initVal(field: Symbol, value: Value)(using Context, EnvMap.EnvMapMutableData) = log("Initialize " + field.show + " = " + value + " for " + this, printer) {
-        assert(!field.is(Flags.Mutable), "Field is mutable: " + field.show)
+        assert(field.is(Flags.Param) || !field.is(Flags.Mutable), "Field is mutable: " + field.show)
         EnvMap.writeJoinVal(this, field, value)
       }
 
       def initVar(field: Symbol, value: Value)(using Context, EnvMap.EnvMapMutableData) = log("Initialize " + field.show + " = " + value + " for " + this, printer) {
-        assert(field.is(Flags.Mutable), "Field is not mutable: " + field.show)
+        assert(field.is(Flags.Mutable, butNot = Flags.Param), "Field is not mutable: " + field.show)
         EnvMap.writeJoinVal(this, field, value)
       }
 
@@ -527,12 +527,12 @@ class Objects(using Context @constructorOnly):
       _of(Map.empty, byNameParam, thisV, outerEnv)
 
     def setLocalVal(x: Symbol, value: Value)(using scope: Scope, ctx: Context, heap: Heap.MutableData, envMap: EnvMap.EnvMapMutableData): Unit =
-      assert(!x.isOneOf(Flags.Param | Flags.Mutable), "Only local immutable variable allowed")
+      assert(x.is(Flags.Param) || !x.is(Flags.Mutable), "Only local immutable variable allowed")
       scope match
       case env: EnvRef =>
         env.initVal(x, value)
       case ref: Ref =>
-        ref.initVal(x, value) // TODO: This is possible for match statement in class body. Report warning?
+        ref.initVal(x, value) // This is possible for match statement in class body.
 
     def setLocalVar(x: Symbol, value: Value)(using scope: Scope, ctx: Context, heap: Heap.MutableData, envMap: EnvMap.EnvMapMutableData): Unit =
       assert(x.is(Flags.Mutable, butNot = Flags.Param), "Only local mutable variable allowed")
@@ -540,7 +540,7 @@ class Objects(using Context @constructorOnly):
       case env: EnvRef =>
         env.initVar(x, value)
       case ref: Ref =>
-        ref.initVar(x, value) // TODO: This is possible for match statement in class body. Report warning?
+        ref.initVar(x, value) // This is possible for match statement in class body.
 
     /**
      * Resolve the environment by searching for a given symbol.
@@ -986,15 +986,7 @@ class Objects(using Context @constructorOnly):
         // Assume such method is pure. Check return type, only try to analyze body if return type is not safe
         val target = resolve(v.typeSymbol.asClass, meth)
         val targetType = target.denot.info
-        assert(targetType.isInstanceOf[ExprType] || targetType.isInstanceOf[MethodType],
-          "Unexpected type! Receiver = " + v.show + ", meth = " + target + ", type = " + targetType)
-        val returnType =
-          if targetType.isInstanceOf[ExprType] then
-            // corresponds to parameterless method like `def meth: ExprType[T]`
-            // See pos/toDouble.scala
-            targetType.asInstanceOf[ExprType].resType
-          else
-            targetType.asInstanceOf[MethodType].resType
+        val returnType = targetType.finalResultType
         val typeSymbol = SafeValue.getSafeTypeSymbol(returnType)
         if typeSymbol.isDefined then
           // since method is pure and return type is safe, no need to analyze method body
@@ -1326,7 +1318,8 @@ class Objects(using Context @constructorOnly):
                 report.warning("[Internal error] top-level class should have `Package` as outer, class = " + klass.show + ", outer = " + outer.show + ", " + Trace.show, Trace.position)
                 (Bottom, Env.NoEnv)
               else
-                val outerCls = klass.owner.enclosingClass.asClass
+                // enclosingClass is specially handled for java static terms, so use `lexicallyEnclosingClass` here
+                val outerCls = klass.owner.lexicallyEnclosingClass.asClass
                 // When `klass` is directly nested in `outerCls`, `outerCls`.enclosingMethod returns its primary constructor
                 if klass.owner.enclosingMethod == outerCls.primaryConstructor then
                   (outer, Env.NoEnv)

--- a/tests/init-global/pos/enum.scala
+++ b/tests/init-global/pos/enum.scala
@@ -1,0 +1,17 @@
+enum FileExtension(val toLowerCase: String):
+  case Tasty extends FileExtension("tasty")
+  case Betasty extends FileExtension("betasty")
+  case Class extends FileExtension("class")
+  case Jar extends FileExtension("jar")
+  case Scala extends FileExtension("scala")
+  case ScalaScript extends FileExtension("sc")
+  case Java extends FileExtension("java")
+  case Zip extends FileExtension("zip")
+  case Inc extends FileExtension("inc")
+  case Empty extends FileExtension("")
+
+  /** Fallback extension */
+  case External(override val toLowerCase: String) extends FileExtension(toLowerCase)
+
+object O:
+  val a = FileExtension.Empty


### PR DESCRIPTION
With this fix, the global initialization checker can be run when compiling bootstrapped dotty and reported warnings in the dotty source code