### PR TITLE
Set context owner to the method for `paramsToCap`

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -667,7 +667,8 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
               def newInfo(using Context) = // will be run in this or next phase
                 toResultInResults(sym, report.error(_, tree.srcPos)):
                   if sym.is(Method) then
-                    paramsToCap(methodType(paramSymss, localReturnType))
+                    inContext(ctx.withOwner(sym)):
+                      paramsToCap(methodType(paramSymss, localReturnType))
                   else tree.tpt.nuType
               if tree.tpt.isInstanceOf[InferredTypeTree]
                   && !sym.is(Param) && !sym.is(ParamAccessor)

--- a/tests/neg-custom-args/captures/i23431.check
+++ b/tests/neg-custom-args/captures/i23431.check
@@ -1,0 +1,36 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23431.scala:8:13 ----------------------------------------
+8 |      myIO = io  // error, level mismatch
+  |             ^^
+  |             Found:    (io : IO^)
+  |             Required: IO^²
+  |
+  |             where:    ^  refers to a fresh root capability in the type of parameter io
+  |                       ^² refers to a fresh root capability in the type of variable myIO
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23431.scala:11:13 ---------------------------------------
+11 |      myIO = io2  // error, level mismatch
+   |             ^^^
+   |             Found:    (io2 : IO^)
+   |             Required: IO^²
+   |
+   |             where:    ^  refers to a fresh root capability in the type of parameter io2
+   |                       ^² refers to a fresh root capability in the type of variable myIO
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23431.scala:12:12 ---------------------------------------
+12 |    withIO: io3 =>  // error
+   |            ^
+   |Found:    (io3: IO^?) ->? Unit
+   |Required: IO^ => Unit
+   |
+   |where:    => refers to a fresh root capability created in anonymous function of type (io1: IO^): Unit when checking argument to parameter op of method withIO
+   |          ^  refers to the universal root capability
+13 |      myIO = io3
+   |
+   | longer explanation available when compiling with `-explain`
+-- Error: tests/neg-custom-args/captures/i23431.scala:6:14 -------------------------------------------------------------
+6 |    var myIO: IO^ = io1  // error: separation
+  |              ^^^
+  |              Separation failure: variable myIO's type IO^ hides parameter io1.
+  |              The parameter needs to be annotated with @consume to allow this.

--- a/tests/neg-custom-args/captures/i23431.scala
+++ b/tests/neg-custom-args/captures/i23431.scala
@@ -1,0 +1,13 @@
+import language.experimental.captureChecking
+trait IO
+def withIO(op: IO^ => Unit): Unit = ???
+def test(): Unit =
+  withIO: io1 =>
+    var myIO: IO^ = io1  // error: separation
+    def setIO(io: IO^): Unit =
+      myIO = io  // error, level mismatch
+    withIO(setIO)
+    withIO: (io2: IO^) =>
+      myIO = io2  // error, level mismatch
+    withIO: io3 =>  // error
+      myIO = io3


### PR DESCRIPTION
Fixes #23431.