### PR TITLE
Enforce new given syntax under -source future

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
@@ -31,7 +31,7 @@ enum MigrationVersion(val warnFrom: SourceVersion, val errorFrom: SourceVersion)
   case ImportRename extends MigrationVersion(future, future)
   case ParameterEnclosedByParenthesis extends MigrationVersion(future, future)
   case XmlLiteral extends MigrationVersion(future, future)
-  case GivenSyntax extends MigrationVersion(future, never)
+  case GivenSyntax extends MigrationVersion(future, future)
   case ImplicitParamsWithoutUsing extends MigrationVersion(`3.7`, future)
 
   require(warnFrom.ordinal <= errorFrom.ordinal)

--- a/tests/neg/abstract-givens-new.scala
+++ b/tests/neg/abstract-givens-new.scala
@@ -4,7 +4,7 @@ class C:
 
 trait T:
   given Int is C // ok
-  given intC: Int is C // warn
+  given intC: Int is C // error
   given intC2: (Int is C)() // ok
   given intC3: Int is C {} // also ok
 

--- a/tests/neg/context-bounds-migration-future.check
+++ b/tests/neg/context-bounds-migration-future.check
@@ -4,7 +4,3 @@
   |  method foo does not take more parameters
   |
   | longer explanation available when compiling with `-explain`
--- Warning: tests/neg/context-bounds-migration-future.scala:6:6 --------------------------------------------------------
-6 |given [T]: C[T] = C[T]()
-  |      ^
-  |      This old given syntax is no longer supported; use `=>` instead of `:`

--- a/tests/neg/context-bounds-migration-future.scala
+++ b/tests/neg/context-bounds-migration-future.scala
@@ -3,7 +3,7 @@
 class C[T]
 def foo[X: C] = ()
 
-given [T]: C[T] = C[T]()
+given [T] => C[T] = C[T]()
 
 def Test =
   foo(C[Int]()) // error

--- a/tests/neg/old-givens.scala
+++ b/tests/neg/old-givens.scala
@@ -5,14 +5,14 @@ trait Ord[T]:
 class C[T]
 
 trait T:
-  given intC: C[Int] // warn
+  given intC: C[Int] // error
   given intC2: C[Int] () // OK
 
-  given [T]: Ord[T] with  // warn // warn
+  given [T]: Ord[T] with  // error // error
     def compare(x: T, y: T): Boolean = ???
 
-  given [T](using Ord[T]): Ord[List[T]] with // warn // warn
+  given [T](using Ord[T]): Ord[List[T]] with // error // error
     def compare(x: List[T], y: List[T]): Boolean = ???
 
-  def f[T: Ord : C]() = ???  // warn
+  def f[T: Ord : C]() = ???  // error
 

--- a/tests/pos/hylolib-deferred-given/AnyCollection.scala
+++ b/tests/pos/hylolib-deferred-given/AnyCollection.scala
@@ -48,7 +48,7 @@ given anyCollectionIsCollection: [T] => (tIsValue: Value[T]) => Collection[AnyCo
   //given elementIsValue: Value[Element] = tIsValue
 
   type Position = AnyValue
-  given positionIsValue: Value[Position] = anyValueIsValue
+  override given positionIsValue: Value[Position] = anyValueIsValue
 
   extension (self: AnyCollection[T]) {
 

--- a/tests/pos/hylolib-deferred-given/BitArray.scala
+++ b/tests/pos/hylolib-deferred-given/BitArray.scala
@@ -341,7 +341,7 @@ given bitArrayIsCollection: Collection[BitArray] {
   //given elementIsValue: Value[Boolean] = booleanIsValue
 
   type Position = BitArray.Position
-  given positionIsValue: Value[BitArray.Position] = bitArrayPositionIsValue
+  override given positionIsValue: Value[BitArray.Position] = bitArrayPositionIsValue
 
   extension (self: BitArray) {
 

--- a/tests/pos/hylolib-deferred-given/Collection.scala
+++ b/tests/pos/hylolib-deferred-given/Collection.scala
@@ -10,7 +10,7 @@ trait Collection[Self] {
 
   /** The type of a position in the collection. */
   type Position
-  given positionIsValue: Value[Position]
+  given positionIsValue: Value[Position] = compiletime.deferred
 
   extension (self: Self) {
 

--- a/tests/pos/hylolib-deferred-given/HyArray.scala
+++ b/tests/pos/hylolib-deferred-given/HyArray.scala
@@ -185,7 +185,7 @@ given hyArrayIsCollection: [T] => (tIsValue: Value[T]) => Collection[HyArray[T]]
   //given elementIsValue: Value[T] = tIsValue
 
   type Position = Int
-  given positionIsValue: Value[Int] = intIsValue
+  override given positionIsValue: Value[Int] = intIsValue
 
   extension (self: HyArray[T]) {
 

--- a/tests/pos/hylolib-deferred-given/Slice.scala
+++ b/tests/pos/hylolib-deferred-given/Slice.scala
@@ -32,7 +32,7 @@ given sliceIsCollection: [T] => (c: Collection[T]) => Collection[Slice[T]] {
   //given elementIsValue: Value[Element] = c.elementIsValue
 
   type Position = c.Position
-  given positionIsValue: Value[Position] = c.positionIsValue
+  override given positionIsValue: Value[Position] = c.positionIsValue
 
   extension (self: Slice[T]) {
 

--- a/tests/pos/parsercombinators-ctx-bounds.scala
+++ b/tests/pos/parsercombinators-ctx-bounds.scala
@@ -25,8 +25,9 @@ given apply: [C, E] => Combinator[Apply[C, E]] {
   }
 }
 
-given combine[A: Combinator, B: [X] =>> Combinator[X] { type Context = A.Context }]
-    : Combinator[Combine[A, B]] with
+given combine
+  : [A: Combinator, B: [X] =>> Combinator[X] { type Context = A.Context }]
+    => Combinator[Combine[A, B]]:
   type Context = A.Context
   type Element = (A.Element, B.Element)
   extension(self: Combine[A, B])

--- a/tests/pos/parsercombinators-givens-2.scala
+++ b/tests/pos/parsercombinators-givens-2.scala
@@ -26,16 +26,14 @@ given apply: [C, E] => Combinator[Apply[C, E]] {
   }
 }
 
-given combine[A, B, C](using
-    f: Combinator[A] { type Context = C },
-    s: Combinator[B] { type Context = C }
-): Combinator[Combine[A, B]] with {
+given combine: [A, B, C]
+    => (f: Combinator[A] { type Context = C }, s: Combinator[B] { type Context = C })
+    => Combinator[Combine[A, B]]:
   type Context = f.Context
   type Element = (f.Element, s.Element)
   extension(self: Combine[A, B]) {
     def parse(context: Context): Option[Element] = ???
   }
-}
 
 extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
   if buf.isEmpty then None

--- a/tests/pos/parsercombinators-givens.scala
+++ b/tests/pos/parsercombinators-givens.scala
@@ -26,16 +26,14 @@ given apply: [C, E] => Combinator[Apply[C, E]] {
   }
 }
 
-given combine[A, B](using
-    tracked val f: Combinator[A],
-    tracked val s: Combinator[B] { type Context = f.Context }
-): Combinator[Combine[A, B]] with {
+given combine
+  : [A, B]
+    => (tracked val f: Combinator[A], tracked val s: Combinator[B] { type Context = f.Context })
+    => Combinator[Combine[A, B]]:
   type Context = f.Context
   type Element = (f.Element, s.Element)
-  extension(self: Combine[A, B]) {
+  extension (self: Combine[A, B])
     def parse(context: Context): Option[Element] = ???
-  }
-}
 
 extension [A] (buf: mutable.ListBuffer[A]) def popFirst() =
   if buf.isEmpty then None

--- a/tests/pos/parsercombinators-this.scala
+++ b/tests/pos/parsercombinators-this.scala
@@ -28,8 +28,9 @@ given apply: [C, E] => Combinator {
   }
 }
 
-given combine[A: Combinator, B: Combinator { type Context = A.Context }]
-    : Combinator with
+given combine
+  : [A: Combinator, B: Combinator { type Context = A.Context }]
+    => Combinator:
   type Self = Combine[A, B]
   type Context = A.Context
   type Element = (A.Element, B.Element)


### PR DESCRIPTION
It warned before, but did not error. However, the idea is that under -source future we should enforce the new rules that we have defined everywhere.