### PR TITLE
Exclude named parameters inlay hints for java defined

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -434,7 +434,7 @@ object Parameters:
   def unapply(tree: Tree)(using params: InlayHintsParams, ctx: Context): Option[(Boolean, List[(Name, SourcePosition, Boolean)])] = 
     def shouldSkipFun(fun: Tree)(using Context): Boolean = 
       fun match
-        case sel: Select => isForComprehensionMethod(sel) || sel.symbol.name == nme.unapply
+        case sel: Select => isForComprehensionMethod(sel) || sel.symbol.name == nme.unapply || sel.symbol.is(Flags.JavaDefined)
         case _ => false
 
     def isInfixFun(fun: Tree, args: List[Tree])(using Context): Boolean = 

--- a/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
@@ -1261,4 +1261,20 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
          |}
          |""".stripMargin
     )
+
+   @Test def `java-method-call` =
+    check(
+     """|object Main {
+        |  val str = "hello"
+        |  val sub = str.substring(1, 3)
+        |  val replaced = str.replace('l', 'x')
+        |}
+        |""".stripMargin,
+     """|object Main {
+        |  val str/*: String<<java/lang/String#>>*/ = "hello"
+        |  val sub/*: String<<java/lang/String#>>*/ = str.substring(1, 3)
+        |  val replaced/*: String<<java/lang/String#>>*/ = str.replace('l', 'x')
+        |}
+        |""".stripMargin
+    )
 }


### PR DESCRIPTION
We don't want to show named parameters inlay hints for java defined `(x$0, x$1 ...)`.