### PR TITLE
Bring back part of PruneErasedDefs

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -92,7 +92,8 @@ class Compiler {
          new ExplicitSelf,           // Make references to non-trivial self types explicit as casts
          new StringInterpolatorOpt,  // Optimizes raw and s and f string interpolators by rewriting them to string concatenations or formats
          new DropBreaks) ::          // Optimize local Break throws by rewriting them
-    List(new UninitializedDefs,      // Replaces `compiletime.uninitialized` by `_`
+    List(new PruneErasedDefs,        // Make erased symbols private
+         new UninitializedDefs,      // Replaces `compiletime.uninitialized` by `_`
          new InlinePatterns,         // Remove placeholders of inlined patterns
          new VCInlineMethods,        // Inlines calls to value class methods
          new SeqLiterals,            // Express vararg arguments as arrays

--- a/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PruneErasedDefs.scala
@@ -1,0 +1,35 @@
+package dotty.tools.dotc
+package transform
+
+import core.*
+import Contexts.*
+import DenotTransformers.SymTransformer
+import Flags.*
+import SymDenotations.*
+import Symbols.*
+import typer.RefChecks
+import MegaPhase.MiniPhase
+
+/** This phase makes all erased term members of classes private so that they cannot
+ *  conflict with non-erased members. This is needed so that subsequent phases like
+ *  ResolveSuper that inspect class members work correctly and so that we do not
+ *  generate bridges for such members. See pos/i23451.scala for a test case.
+ */
+class PruneErasedDefs extends MiniPhase with SymTransformer:
+  override def phaseName: String = PruneErasedDefs.name
+
+  override def description: String = PruneErasedDefs.description
+
+  override def changesMembers: Boolean = true   // makes erased members private
+
+  override def runsAfterGroupsOf: Set[String] = Set(RefChecks.name, ExplicitOuter.name)
+
+  override def transformSym(sym: SymDenotation)(using Context): SymDenotation =
+    if !sym.is(Private) && sym.isEffectivelyErased && sym.isTerm && sym.owner.isClass
+    then sym.copySymDenotation(initFlags = sym.flags | Private)
+    else sym
+
+object PruneErasedDefs:
+  val name: String =  "pruneErasedDefs"
+  val description: String = "drop erased definitions and simplify erased expressions"
+end PruneErasedDefs

--- a/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ResolveSuper.scala
@@ -37,7 +37,8 @@ class ResolveSuper extends MiniPhase with IdentityDenotTransformer { thisPhase =
 
   override def description: String = ResolveSuper.description
 
-  override def runsAfter: Set[String] = Set(ElimByName.name) // verified empirically, need to figure out what the reason is.
+  override def runsAfter: Set[String] = Set(ElimByName.name, // verified empirically, need to figure out what the reason is.
+                               PruneErasedDefs.name) // Erased decls make `isCurrent` work incorrectly
 
   override def changesMembers: Boolean = true // the phase adds super accessors
 

--- a/sbt-bridge/test/xsbt/CompileProgressSpecification.scala
+++ b/sbt-bridge/test/xsbt/CompileProgressSpecification.scala
@@ -63,7 +63,7 @@ class CompileProgressSpecification {
         "staging",
         "splicing",
         "pickleQuotes",
-        "MegaPhase{uninitialized,...,arrayConstructors}",
+        "MegaPhase{pruneErasedDefs,...,arrayConstructors}",
         "erasure",
         "constructors",
         "genBCode"

--- a/tests/coverage/pos/macro-late-suspend/test.scoverage.check
+++ b/tests/coverage/pos/macro-late-suspend/test.scoverage.check
@@ -18,23 +18,6 @@
 # - description (can be multi-line)
 # '' sign
 # ------------------------------------------
-0
-macro-late-suspend/UsesTest.scala
-example
-UsesTest$package
-Object
-example.UsesTest$package
-<init>
-22
-22
-3
-<none>
-Literal
-true
-0
-false
-
-
 1
 macro-late-suspend/VisitorMacros.scala
 example
@@ -85,4 +68,21 @@ false
 0
 false
 mkVisitorType[Test]
+
+4
+macro-late-suspend/UsesTest.scala
+example
+UsesTest$package
+Object
+example.UsesTest$package
+<init>
+22
+22
+3
+<none>
+Literal
+true
+0
+false
+
 

--- a/tests/pos/i23451.scala
+++ b/tests/pos/i23451.scala
@@ -1,0 +1,12 @@
+trait Inliner[A]:
+    inline def apply[T]: A
+
+class SummonInliner[F[_]] extends Inliner[ForSome[F]]:
+    inline def apply[T]: ForSome[F] = ForSome(compiletime.summonInline[F[T]])
+
+type ForSome[F[_]] = ForSome.Type[F]
+object ForSome:
+    type Type[F[_]] = Unwrap[F, ?]
+    class Unwrap[F[_], A](val unwrap: F[A]) extends AnyVal
+
+    inline def apply[F[_], A](v: F[A]): Type[F] = Unwrap(v)


### PR DESCRIPTION
Do make erased symbols private. This is needed so that we don't get false overriding relationships for effectively erased symbols.

Fixes #23451 