### PR TITLE
fix error in product-sequence match in global init checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1804,6 +1804,9 @@ class Objects(using Context @constructorOnly):
             val seqPats = pats.drop(selectors.length - 1)
             val toSeqRes = call(resToMatch, selectors.last, Nil, resultTp, superType = NoType, needResolve = true)
             val toSeqResTp = resultTp.memberInfo(selectors.last).finalResultType
+            elemTp = unapplySeqTypeElemTp(toSeqResTp)
+            // elemTp must conform to the signature in sequence match
+            assert(elemTp.exists, "Product sequence match fails on " + pat + " since last element type of product is " + toSeqResTp)
             evalSeqPatterns(toSeqRes, toSeqResTp, elemTp, seqPats)
           end if
           // TODO: refactor the code of product sequence match, avoid passing NoType to parameter elemTp in evalSeqPatterns

--- a/tests/init-global/pos/unapplySeq-product-sequence-match.scala
+++ b/tests/init-global/pos/unapplySeq-product-sequence-match.scala
@@ -1,0 +1,29 @@
+trait Node {
+  val prefix = 5
+  val child = Array(3)
+}
+
+class SpecialNode extends Node
+
+class Group extends Node
+
+class C extends Node
+
+object Elem {
+  def apply(prefix: Int, children: Int*) = new C
+  def unapplySeq(n: Node) = n match {
+    case _: SpecialNode | _: Group => None
+    case _                         => Some((n.prefix, n.child.toSeq))
+  }
+}
+
+object O {
+  def updateNode(node: Node): Node =
+    node match {
+      case Elem(prefix, children @ _*) =>
+        Elem(prefix, children*)
+      case other => other
+    }
+
+  val a = updateNode(new Group)
+}


### PR DESCRIPTION
Global init checker has a bug in modelling product sequence match in `unapplySeq`. The `elemTp` passed to `evalSeqPattern` should be the element type in the last selector of the original `resultTp`