### PR TITLE
-Yprofile-trace properly report macro splicing source

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1144,9 +1144,10 @@ class Inliner(val call: tpd.Tree)(using Context):
         else
           ctx.compilationUnit.suspend(hints.nn.toList.mkString(", ")) // this throws a SuspendException
 
-    val evaluatedSplice = inContext(quoted.MacroExpansion.context(inlinedFrom)) {
-      Splicer.splice(body, splicePos, inlinedFrom.srcPos, MacroClassLoader.fromContext)
-    }
+    val evaluatedSplice =
+      inContext(quoted.MacroExpansion.context(inlinedFrom)):
+        ctx.profiler.onMacroSplice(inlinedFrom.symbol):
+          Splicer.splice(body, splicePos, inlinedFrom.srcPos, MacroClassLoader.fromContext)
     val inlinedNormalizer = new TreeMap {
       override def transform(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
         case tree @ Inlined(_, Nil, expr) if tree.inlinedFromOuterScope && enclosingInlineds.isEmpty => transform(expr)

--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -53,7 +53,7 @@ object Splicer {
         inContext(sliceContext) {
           val oldContextClassLoader = Thread.currentThread().getContextClassLoader
           Thread.currentThread().setContextClassLoader(classLoader)
-          try ctx.profiler.onMacroSplice(owner){
+          try {
             val interpreter = new SpliceInterpreter(splicePos, classLoader)
 
             // Some parts of the macro are evaluated during the unpickling performed in quotedExprToTree


### PR DESCRIPTION
Previously when we had some code like:

def userCode: Unit =
  ...
  val x = myExpensiveMacro()
  ...

The profiler reported the time spent executing the macro as `«method userCode»` which is misleading. This commit changes it to be reported as `«method myExpensiveMacro»`. This is particularly useful in bottom-up profiling to find which macros we spend the most amount of time in.