### PR TITLE
-Yprofile-trace profiles all inline calls

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1146,8 +1146,7 @@ class Inliner(val call: tpd.Tree)(using Context):
 
     val evaluatedSplice =
       inContext(quoted.MacroExpansion.context(inlinedFrom)):
-        ctx.profiler.onMacroSplice(inlinedFrom.symbol):
-          Splicer.splice(body, splicePos, inlinedFrom.srcPos, MacroClassLoader.fromContext)
+        Splicer.splice(body, splicePos, inlinedFrom.srcPos, MacroClassLoader.fromContext)
     val inlinedNormalizer = new TreeMap {
       override def transform(tree: tpd.Tree)(using Context): tpd.Tree = tree match {
         case tree @ Inlined(_, Nil, expr) if tree.inlinedFromOuterScope && enclosingInlineds.isEmpty => transform(expr)

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -100,7 +100,7 @@ object Inlines:
    *  @return   An `Inlined` node that refers to the original call and the inlined bindings
    *            and body that replace it.
    */
-  def inlineCall(tree: Tree)(using Context): Tree =
+  def inlineCall(tree: Tree)(using Context): Tree = ctx.profiler.onInlineCall(tree.symbol):
     if tree.symbol.denot != SymDenotations.NoDenotation
       && tree.symbol.effectiveOwner == defn.CompiletimeTestingPackage.moduleClass
     then

--- a/compiler/src/dotty/tools/dotc/profile/Profiler.scala
+++ b/compiler/src/dotty/tools/dotc/profile/Profiler.scala
@@ -115,12 +115,12 @@ sealed trait Profiler {
   protected def beforeImplicitSearch(pt: Type): TracedEventId  = TracedEventId.Empty
   protected def afterImplicitSearch(event: TracedEventId): Unit = ()
 
-  inline def onMacroSplice[T](macroSym: Symbol)(inline body: T): T =
-    val event = beforeMacroSplice(macroSym)
+  inline def onInlineCall[T](inlineSym: Symbol)(inline body: T): T =
+    val event = beforeInlineCall(inlineSym)
     try body
-    finally afterMacroSplice(event)
-  protected def beforeMacroSplice(macroSym: Symbol): TracedEventId = TracedEventId.Empty
-  protected def afterMacroSplice(event: TracedEventId): Unit = ()
+    finally afterInlineCall(event)
+  protected def beforeInlineCall(inlineSym: Symbol): TracedEventId = TracedEventId.Empty
+  protected def afterInlineCall(event: TracedEventId): Unit = ()
 
   inline def onCompletion[T](root: Symbol, associatedFile: => AbstractFile)(inline body: T): T =
     val (event, completionName) = beforeCompletion(root, associatedFile)
@@ -176,7 +176,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter)(using Context) 
 
   enum Category:
     def name: String = this.toString().toLowerCase()
-    case Run, Phase, File, TypeCheck, Implicit, Macro, Completion
+    case Run, Phase, File, TypeCheck, Implicit, Inline, Completion
   private [profile] val chromeTrace =
     if ctx.settings.YprofileTrace.isDefault
     then null
@@ -315,8 +315,8 @@ private [profile] class RealProfiler(reporter : ProfileReporter)(using Context) 
   override def beforeImplicitSearch(pt: Type): TracedEventId = traceDurationStart(Category.Implicit, s"?[${symbolName(pt.typeSymbol)}]", colour = "yellow")
   override def afterImplicitSearch(event: TracedEventId): Unit = traceDurationEnd(Category.Implicit, event, colour = "yellow")
 
-  override def beforeMacroSplice(macroSym: Symbol): TracedEventId = traceDurationStart(Category.Macro, s"«${symbolName(macroSym)}»", colour = "olive")
-  override def afterMacroSplice(event: TracedEventId): Unit = traceDurationEnd(Category.Macro, event, colour = "olive")
+  override def beforeInlineCall(inlineSym: Symbol): TracedEventId = traceDurationStart(Category.Inline, s"«${symbolName(inlineSym)}»", colour = "olive")
+  override def afterInlineCall(event: TracedEventId): Unit = traceDurationEnd(Category.Inline, event, colour = "olive")
 
   override def beforeCompletion(root: Symbol, associatedFile: => AbstractFile): (TracedEventId, String) =
     if chromeTrace == null


### PR DESCRIPTION
Previously we only profiled macro expansion, but even non-macro inline calls can have a significant impact on performance (e.g. if we're doing typeclass derivation) and are worth tracking. This does not seem to significantly impact the size of traces in practice.