### PR TITLE
Update reference syntax documentation with named tuples

### DIFF
--- a/docs/_docs/reference/syntax.md
+++ b/docs/_docs/reference/syntax.md
@@ -199,6 +199,7 @@ SimpleType        ::=  SimpleLiteral
                     |  Singleton ‘.’ id
                     |  Singleton ‘.’ ‘type’
                     |  ‘(’ [Types] ‘)’
+                    |  ‘(’ NameAndType {‘,’ NameAndType} ‘)’
                     |  Refinement
                     |  SimpleType TypeArgs
                     |  SimpleType ‘#’ id
@@ -220,6 +221,7 @@ ContextBounds     ::=  ContextBound
                     |  '{' ContextBound {',' ContextBound} '}'
 ContextBound      ::=  Type ['as' id]
 Types             ::=  Type {‘,’ Type}
+NameAndType       ::=  id ‘:’ Type
 ```
 
 ### Expressions
@@ -268,6 +270,7 @@ SimpleExpr        ::=  SimpleRef
                     |  ‘new’ ConstrApp {‘with’ ConstrApp} [TemplateBody]
                     |  ‘new’ TemplateBody
                     |  ‘(’ [ExprsInParens] ‘)’
+                    |  ‘(’ NamedExprInParens {‘,’ NamedExprInParens} ‘)’
                     |  SimpleExpr ‘.’ id
                     |  SimpleExpr ‘.’ MatchClause
                     |  SimpleExpr TypeArgs
@@ -287,6 +290,7 @@ ExprInParens      ::=  PostfixExpr ‘:’ Type |  Expr
 ParArgumentExprs  ::=  ‘(’ [ExprsInParens] ‘)’
                     |  ‘(’ ‘using’ ExprsInParens ‘)’
                     |  ‘(’ [ExprsInParens ‘,’] PostfixExpr ‘*’ ‘)’
+NamedExprInParens ::=  id ‘=’ ExprInParens
 ArgumentExprs     ::=  ParArgumentExprs
                     |  BlockExpr
 BlockExpr         ::=  <<< (CaseClauses | Block) >>>
@@ -333,7 +337,9 @@ SimplePattern1    ::=  SimpleRef
                     |  SimplePattern1 ‘.’ id
 PatVar            ::=  varid
                     |  ‘_’
+NamedPattern      ::=  id ‘=’ Pattern
 Patterns          ::=  Pattern {‘,’ Pattern}
+                    |  NamedPattern {‘,’ NamedPattern}
 
 ArgumentPatterns  ::=  ‘(’ [Patterns] ‘)’
                     |  ‘(’ [Patterns ‘,’] PatVar ‘*’ ‘)’


### PR DESCRIPTION
Fix #22237 

Given named tuple is a stable feature since 3.7, I updated the `docs/_docs/reference/syntax.md`.