### PR TITLE
Use result of lambda type of implicit in CheckUnused

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -926,7 +926,7 @@ object CheckUnused:
     def isCanEqual: Boolean =
       sym.isOneOf(GivenOrImplicit) && sym.info.finalResultType.baseClasses.exists(_.derivesFrom(defn.CanEqualClass))
     def isMarkerTrait: Boolean =
-      sym.info.hiBound.allMembers.forall: d =>
+      sym.info.hiBound.resultType.allMembers.forall: d =>
         val m = d.symbol
         !m.isTerm || m.isSelfSym || m.is(Method) && (m.owner == defn.AnyClass || m.owner == defn.ObjectClass)
     def isEffectivelyPrivate: Boolean =

--- a/tests/warn/i15503f.scala
+++ b/tests/warn/i15503f.scala
@@ -1,4 +1,4 @@
-//> using options  -Wunused:implicits
+//> using options -Wunused:implicits
 
 /* This goes around the "trivial method" detection */
 val default_int = 1
@@ -67,6 +67,8 @@ package givens:
   trait Y:
     def doY: String
 
+  trait Z
+
   given X:
     def doX = 7
 
@@ -84,6 +86,9 @@ package givens:
 
   given namely: (x: X) => Y: // warn protected param to given class
     def doY = "8"
+
+  def f(using => X) = println() // warn
+  def g(using => Z) = println() // nowarn marker trait
 end givens
 
 object i22895:

--- a/tests/warn/i23494.scala
+++ b/tests/warn/i23494.scala
@@ -1,0 +1,15 @@
+//> using options -Wunused:implicits
+
+import scala.deriving.Mirror
+
+abstract class EnumerationValues[A]:
+  type Out
+
+object EnumerationValues:
+  type Aux[A, B] = EnumerationValues[A] { type Out = B }
+
+  def apply[A, B](): EnumerationValues.Aux[A, B] = new EnumerationValues[A]:
+    override type Out = B
+
+  given sum[A, B <: Tuple](using mirror: Mirror.SumOf[A] { type MirroredElemTypes = B }): EnumerationValues.Aux[A, A] =
+    EnumerationValues[A, A]()


### PR DESCRIPTION
Fixes #23494 

When inspecting unused implicit parameters, the check skips parameters which are "marker traits". It tests for any members of the type (or its upper bound) which are not "universal members". This commit uses the `resultType` to avoid an error
```
invalid new prefix
```
while computing members where the type is a `LambdaType`.

A future improvement would be not to request `allMembers`, since the check only needs to find one that is not universal.