### PR TITLE
Encode path of class

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -1310,9 +1310,9 @@ object Denotations {
   }
 
   /** The current denotation of the static reference given by path,
-    *  or a MissingRef or NoQualifyingRef instance, if it does not exist.
-    *  if generateStubs is set, generates stubs for missing top-level symbols
-    */
+   *  or a MissingRef or NoQualifyingRef instance, if it does not exist.
+   *  if generateStubs is set, generates stubs for missing top-level symbols
+   */
   def staticRef(path: Name, generateStubs: Boolean = true, isPackage: Boolean = false)(using Context): Denotation = {
     def select(prefix: Denotation, selector: Name): Denotation = {
       val owner = prefix.disambiguate(_.info.isParameterless)

--- a/compiler/src/dotty/tools/dotc/core/Phases.scala
+++ b/compiler/src/dotty/tools/dotc/core/Phases.scala
@@ -505,15 +505,14 @@ object Phases {
       * Enrich crash messages.
       */
     final def monitor(doing: String)(body: Context ?=> Unit)(using Context): Boolean =
-      val unit = ctx.compilationUnit
-      if ctx.run.enterUnit(unit) then
+      ctx.run.enterUnit(ctx.compilationUnit)
+      && {
         try {body; true}
         catch case NonFatal(ex) if !ctx.run.enrichedErrorMessage =>
-          report.echo(ctx.run.enrichErrorMessage(s"exception occurred while $doing $unit"))
+          report.echo(ctx.run.enrichErrorMessage(s"exception occurred while $doing ${ctx.compilationUnit}"))
           throw ex
         finally ctx.run.advanceUnit()
-      else
-        false
+      }
 
     inline def runSubPhase[T](id: Run.SubPhase)(inline body: (Run.SubPhase, Context) ?=> T)(using Context): T =
       given Run.SubPhase = id

--- a/compiler/src/dotty/tools/dotc/fromtasty/TastyFileUtil.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/TastyFileUtil.scala
@@ -15,7 +15,7 @@ object TastyFileUtil {
    *    package foo
    *    class Foo
    *  ```
-   *  then `getClassName("./out/foo/Foo.tasty") returns `Some("./out")`
+   *  then `getClassPath("./out/foo/Foo.tasty") returns `Some("./out")`
    */
   def getClassPath(file: AbstractFile, fromBestEffortTasty: Boolean = false): Option[String] =
     getClassName(file, fromBestEffortTasty).map { className =>
@@ -33,19 +33,16 @@ object TastyFileUtil {
    *  ```
    *  then `getClassName("./out/foo/Foo.tasty") returns `Some("foo.Foo")`
    */
-  def getClassName(file: AbstractFile, withBestEffortTasty: Boolean = false): Option[String] = {
+  def getClassName(file: AbstractFile, withBestEffortTasty: Boolean = false): Option[String] =
     assert(file.exists)
     assert(file.hasTastyExtension || (withBestEffortTasty && file.hasBetastyExtension))
     val bytes = file.toByteArray
     val names = new TastyClassName(bytes, file.hasBetastyExtension).readName()
-    names.map { case (packageName, className) =>
-      val fullName = packageName match {
-        case EMPTY_PACKAGE => s"${className.lastPart}"
-        case _ => s"$packageName.${className.lastPart}"
-      }
-      fullName
-    }
-  }
+    names.map: (packageName, className) =>
+      if packageName == EMPTY_PACKAGE then
+        s"${className.lastPart.encode}"
+      else
+        s"${packageName.encode}.${className.lastPart.encode}"
 }
 
 

--- a/compiler/test/dotc/neg-best-effort-unpickling.excludelist
+++ b/compiler/test/dotc/neg-best-effort-unpickling.excludelist
@@ -27,3 +27,6 @@ i23402b.scala
 
 # Unhandled TypeError exception
 i23504.scala
+
+# owner of anon, where package object has funky name
+i20511-1.scala

--- a/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
+++ b/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
@@ -2,44 +2,42 @@ package dotty
 package tools
 package dotc
 
-import scala.concurrent.duration._
-import dotty.tools.vulpix._
-import org.junit.{ Test, AfterClass }
+import dotty.tools.vulpix.*
 import reporting.TestReporter
-import java.io.{File => JFile}
 
+import scala.concurrent.duration.*
 import scala.language.unsafeNulls
 
+import java.io.{File => JFile}
+import org.junit.{AfterClass, Test}
+
 class BestEffortOptionsTests {
-  import ParallelTesting._
-  import vulpix.TestConfiguration._
-  import BestEffortOptionsTests._
-  import CompilationTest.aggregateTests
+  import ParallelTesting.*
+  import vulpix.TestConfiguration.*
+  import BestEffortOptionsTests.*
 
   // Since TASTy and beTASTy files are read in a lazy manner (only when referenced by the source .scala file)
   // we test by using the "-from-tasty" option. This guarantees that the tasty files will be read
   // (and that the Best Effort TASTy reader will be tested), but we unfortunately skip the useful
   // interactions a tree derived from beTASTy could have with other frontend phases.
-  @Test def negTestFromBestEffortTasty: Unit = {
+  @Test def negTestFromBestEffortTasty: Unit =
     // Can be reproduced with
     // > sbt
-    // > scalac --Ybest-effort -Xsemanticdb <source>
-    // > scalac --from-tasty -Ywith-best-effort-tasty META_INF/best-effort/<betasty>
+    // > scalac -Ybest-effort -Xsemanticdb <source>
+    // > scalac -from-tasty -Ywith-best-effort-tasty META_INF/best-effort/<betasty>
 
-    implicit val testGroup: TestGroup = TestGroup("negTestFromBestEffortTasty")
+    given TestGroup = TestGroup("negTestFromBestEffortTasty")
     compileBestEffortTastyInDir(s"tests${JFile.separator}neg", bestEffortBaselineOptions,
       picklingFilter = FileFilter.exclude(TestSources.negBestEffortPicklingExcludelisted),
       unpicklingFilter = FileFilter.exclude(TestSources.negBestEffortUnpicklingExcludelisted)
     ).checkNoCrash()
-  }
 
   // Tests an actual use case of this compilation mode, where symbol definitions of the downstream
   // projects depend on the best effort tasty files generated with the Best Effort dir option
-  @Test def bestEffortIntergrationTest: Unit = {
-    implicit val testGroup: TestGroup = TestGroup("bestEffortIntegrationTests")
+  @Test def bestEffortIntegrationTest: Unit =
+    given TestGroup = TestGroup("bestEffortIntegrationTests")
     compileBestEffortIntegration(s"tests${JFile.separator}best-effort", bestEffortBaselineOptions)
       .noCrashWithCompilingDependencies()
-  }
 }
 
 object BestEffortOptionsTests extends ParallelTesting {

--- a/scaladoc-testcases/src/tests/encoded.name.scala
+++ b/scaladoc-testcases/src/tests/encoded.name.scala
@@ -1,0 +1,2 @@
+
+def exampleMember = "hello, world"

--- a/scaladoc/src/scala/tasty/inspector/TastyInspector.scala
+++ b/scaladoc/src/scala/tasty/inspector/TastyInspector.scala
@@ -11,7 +11,7 @@ import scala.quoted.runtime.impl.QuotesImpl
 import dotty.tools.dotc.Compiler
 import dotty.tools.dotc.Driver
 import dotty.tools.dotc.Run
-import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Contexts.{Context, ctx}
 import dotty.tools.dotc.core.Mode
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.fromtasty._
@@ -53,21 +53,19 @@ object ScaladocInternalTastyInspector:
     tastyFiles.foreach(checkFile(_, "tasty"))
     jars.foreach(checkFile(_, "jar"))
 
-  /**
-  * Added for Scaladoc-only.
-  * Meant to fix regressions introduces by the switch from old to new TastyInspector:
-  *  https://github.com/scala/scala3/issues/18231
-  *  https://github.com/scala/scala3/issues/20476
-  * Stable TastyInspector API does not support passing compiler context.
-  */
+  /** Added for Scaladoc-only.
+   *  Meant to fix regressions introduces by the switch from old to new TastyInspector:
+   *    - https://github.com/scala/scala3/issues/18231
+   *    - https://github.com/scala/scala3/issues/20476
+   *  Stable TastyInspector API does not support passing compiler context.
+   */
   def inspectAllTastyFilesInContext(tastyFiles: List[String], jars: List[String], dependenciesClasspath: List[String])(inspector: Inspector)(using Context): Boolean =
     checkFiles(tastyFiles, jars)
     val classes = tastyFiles ::: jars
-    classes match
-      case Nil => true
-      case _ =>
-        val reporter = inspectorDriver(inspector).process(inspectorArgs(dependenciesClasspath, classes), summon[Context])
-        !reporter.hasErrors
+    classes.isEmpty
+    || !inspectorDriver(inspector)
+        .process(inspectorArgs(dependenciesClasspath, classes), ctx)
+        .hasErrors
 
   /** Load and process TASTy files using TASTy reflect
    *
@@ -90,7 +88,7 @@ object ScaladocInternalTastyInspector:
       override def phaseName: String = "tastyInspector"
 
       override def runOn(units: List[CompilationUnit])(using ctx0: Context): List[CompilationUnit] =
-        // NOTE: although this is a phase, do not expect this to be ran with an xsbti.CompileProgress
+        // NOTE: although this is a phase, do not expect this to be run with an xsbti.CompileProgress
         val ctx = QuotesCache.init(ctx0.fresh)
         runOnImpl(units)(using ctx)
 


### PR DESCRIPTION
Fixes #22866 

`TastyFileUtil.getClassName` [sic] encodes its path result so that `a.b` is not taken as two segments.