### PR TITLE
chore: add the `scala-library` projects (non-bootstrapped and bootstrapped)

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  compile-nonbootstrapped:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -26,3 +26,21 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Compile `scala-library-nonbootstrapped`
         run: ./project/scripts/sbt scala-library-nonbootstrapped/compile
+
+  compile-bootstrapped:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala-library-bootstrapped`
+        run: ./project/scripts/sbt scala-library-bootstrapped/compile
+

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -1,0 +1,28 @@
+name: Compile Full Standard Library
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala-library-nonbootstrapped`
+        run: ./project/scripts/sbt scala-library-nonbootstrapped/compile

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ val `scala3-bootstrapped` = Build.`scala3-bootstrapped`
 val `scala3-interfaces` = Build.`scala3-interfaces`
 val `scala3-compiler` = Build.`scala3-compiler`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
+val `scala-library-nonbootstrapped` = Build.`scala-library-nonbootstrapped`
 val `scala3-library` = Build.`scala3-library`
 val `scala3-library-bootstrapped` = Build.`scala3-library-bootstrapped`
 val `scala3-library-bootstrappedJS` = Build.`scala3-library-bootstrappedJS`

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ val `scala3-interfaces` = Build.`scala3-interfaces`
 val `scala3-compiler` = Build.`scala3-compiler`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
 val `scala-library-nonbootstrapped` = Build.`scala-library-nonbootstrapped`
+val `scala-library-bootstrapped` = Build.`scala-library-bootstrapped`
 val `scala3-library` = Build.`scala3-library`
 val `scala3-library-bootstrapped` = Build.`scala3-library-bootstrapped`
 val `scala3-library-bootstrappedJS` = Build.`scala3-library-bootstrappedJS`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1411,6 +1411,33 @@ object Build {
       )
     )
 
+  // ==============================================================================================
+  // =================================== SCALA STANDARD LIBRARY ===================================
+  // ==============================================================================================
+
+  /* Configuration of the org.scala-lang:scala-library:*.**.**-nonboostrapped project */
+  lazy val `scala-library-nonbootstrapped` = project.in(file("library"))
+    .settings(
+      name          := "scala-library-nonbootstrapped",
+      moduleName    := "scala-library",
+      version       := dottyNonBootstrappedVersion,
+      versionScheme := Some("semver-spec"),
+      scalaVersion  := referenceVersion, // nonbootstrapped artifacts are compiled with the reference compiler (already officially published)
+      crossPaths    := false, // org.scala-lang:scala-library doesn't have a crosspath
+      // NOTE: The only difference here is that we drop `-Werror` and semanticDB for now
+      Compile / scalacOptions := Seq("-deprecation", "-feature", "-unchecked", "-encoding", "UTF8", "-language:implicitConversions"),
+      // Add the source directories for the stdlib (non-boostrapped)
+      Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / "src"),
+      Compile / unmanagedSourceDirectories += baseDirectory.value / "src-non-bootstrapped",
+      // Only publish compilation artifacts, no test artifacts
+      Compile / publishArtifact := true,
+      Test    / publishArtifact := false,
+      // Do not allow to publish this project for now
+      publish / skip := true,
+      // Project specific target folder. sbt doesn't like having two projects using the same target folder
+      target := target.value / "scala-library-nonbootstrapped",
+    )
+
   def dottyLibrary(implicit mode: Mode): Project = mode match {
     case NonBootstrapped => `scala3-library`
     case Bootstrapped => `scala3-library-bootstrapped`


### PR DESCRIPTION
Add the configuration for the `scala-library` project in sbt.
For now, this configuration is disabled and doesn't publish anything until we enable it in 3.8.0