### PR TITLE
TypeApplications methods are extensions instead of old-style enrichment

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -19,9 +19,9 @@ object TypeApplications {
   type TypeParamInfo = ParamInfo.Of[TypeName]
 
   /** Assert type is not a TypeBounds instance and return it unchanged */
-  def noBounds(tp: Type): Type = tp match {
-    case tp: TypeBounds => throw new AssertionError("no TypeBounds allowed")
-    case _ => tp
+  def noBounds(tp: Type): tp.type = {
+    assert(!tp.isInstanceOf[TypeBounds], "no TypeBounds allowed")
+    tp
   }
 
   /** Extractor for
@@ -156,11 +156,12 @@ object TypeApplications {
   }
 }
 
-import TypeApplications.*
+/** Extensions that model type application.
+ */
+class TypeApplications {
+  import TypeApplications.*
 
-/** A decorator that provides methods for modeling type application */
-class TypeApplications(val self: Type) extends AnyVal {
-
+  extension (self: Type) { // braces to avoid indenting existing code
   /** The type parameters of this type are:
    *  For a ClassInfo type, the type parameters of its class.
    *  For a typeref referring to a class, the type parameters of the class.
@@ -562,7 +563,7 @@ class TypeApplications(val self: Type) extends AnyVal {
     case _ => self.dropDependentRefinement.dealias.argInfos
 
   /** Argument types where existential types in arguments are disallowed */
-  def argTypes(using Context): List[Type] = argInfos mapConserve noBounds
+  def argTypes(using Context): List[Type] = argInfos.mapConserve(noBounds)
 
   /** Argument types where existential types in arguments are approximated by their lower bound */
   def argTypesLo(using Context): List[Type] = argInfos.mapConserve(_.loBound)
@@ -596,4 +597,6 @@ class TypeApplications(val self: Type) extends AnyVal {
       .orElse(self.baseType(defn.ArrayClass))
       .argInfos.headOption.getOrElse(NoType)
   }
+  }
+  end extension
 }

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -11,7 +11,7 @@ import Names.Name
 import StdNames.nme
 import config.Feature
 
-class TypeUtils:
+class TypeUtils extends TypeApplications:
   /** A decorator that provides methods on types
    *  that are needed in the transformer pipeline.
    */

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2174,8 +2174,7 @@ object Types extends TypeUtils {
     /** Is the `hash` of this type the same for all possible sequences of enclosing binders? */
     def hashIsStable: Boolean = true
   }
-
-  // end Type
+  end Type
 
 // ----- Type categories ----------------------------------------------
 
@@ -7309,9 +7308,7 @@ object Types extends TypeUtils {
     case _ => false
   }
 
-  // ----- Helpers and Decorator implicits --------------------------------------
-
-  implicit def decorateTypeApplications(tpe: Type): TypeApplications = new TypeApplications(tpe)
+  // ----- Helpers and Decorators --------------------------------------
 
   extension (tps1: List[Type]) {
     @tailrec def hashIsStable: Boolean =

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1912,9 +1912,9 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
           dotc.core.Symbols.defn.isTupleNType(self)
         def select(sym: Symbol): TypeRepr = self.select(sym)
         def appliedTo(targ: TypeRepr): TypeRepr =
-          dotc.core.Types.decorateTypeApplications(self).appliedTo(targ)
+          Types.appliedTo(self)(targ)
         def appliedTo(targs: List[TypeRepr]): TypeRepr =
-          dotc.core.Types.decorateTypeApplications(self).appliedTo(targs)
+          Types.appliedTo(self)(targs)
         def substituteTypes(from: List[Symbol], to: List[TypeRepr]): TypeRepr =
           self.subst(from, to)
 


### PR DESCRIPTION
Using extension methods reduces byte code compared to current conversion.

`TypeUtils extends TypeApplications`. Extensions are available by `import Types.*`.

The previous implicit conversion is removed.