### PR TITLE
Deskolemize after fully defining type

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -459,9 +459,13 @@ class PlainPrinter(_ctx: Context) extends Printer {
         if (idx >= 0) selfRecName(idx + 1)
         else "{...}.this" // TODO move underlying type to an addendum, e.g. ... z3 ... where z3: ...
       case tp: SkolemType =>
-        if (homogenizedView) toText(tp.info)
-        else if (ctx.settings.XprintTypes.value) "<" ~ toText(tp.repr) ~ ":" ~ toText(tp.info) ~ ">"
-        else toText(tp.repr)
+        def reprStr = toText(tp.repr) ~ hashStr(tp)
+        if homogenizedView then
+          toText(tp.info)
+        else if ctx.settings.XprintTypes.value then
+          "<" ~ reprStr ~ ":" ~ toText(tp.info) ~ ">"
+        else
+          toText(tp.repr)
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -2245,8 +2245,9 @@ class Namer { typer: Typer =>
     // it would be erased to BoxedUnit.
     def dealiasIfUnit(tp: Type) = if (tp.isRef(defn.UnitClass)) defn.UnitType else tp
 
-    def cookedRhsType = dealiasIfUnit(rhsType).deskolemized
+    def cookedRhsType = dealiasIfUnit(rhsType)
     def lhsType = fullyDefinedType(cookedRhsType, "right-hand side", mdef.srcPos)
+      .deskolemized
     //if (sym.name.toString == "y") println(i"rhs = $rhsType, cooked = $cookedRhsType")
     if (inherited.exists)
       if sym.isInlineVal || isTracked then lhsType else inherited

--- a/tests/pending/pos/i23489.scala
+++ b/tests/pending/pos/i23489.scala
@@ -1,0 +1,13 @@
+import scala.language.experimental.modularity
+
+class Box1[T <: Singleton](val x: T)
+class Box2[T : Singleton](x: => T)
+def id(x: Int): x.type = x
+def readInt(): Int = ???
+
+def Test = ()
+  val x = Box1(id(readInt()))
+
+  val _: Box1[? <: Int] = x
+
+  val y = Box2(id(readInt())) // error


### PR DESCRIPTION
The order was the opposite before. That led to skolem types escaping in the constraint and then being installed in the inferred type of a val or def. See #23489 for a test case where this shows up.

This PR does not fix #23489 since it does not solve the problem of two skolems being generated for the same argument.
