### PR TITLE
Handle multiple type parameter lists in value class methods

### DIFF
--- a/compiler/test/dotc/pos-test-pickling.excludelist
+++ b/compiler/test/dotc/pos-test-pickling.excludelist
@@ -139,7 +139,7 @@ parsercombinators-new-syntax.scala
 hylolib-deferred-given
 hylolib-cb
 hylolib
-i23266.scala
+i23299.scala
 
 # typecheckErrors method unpickling
 i21415.scala

--- a/tests/pos/i23266.scala
+++ b/tests/pos/i23266.scala
@@ -1,17 +1,8 @@
+//> using scala 3.7.0
 
-def kek(t: Table, ids: t.Id*) = ???
+class Foo(v: Any) extends AnyVal:
+  def bar[X](bar: X)[Y]: Any = v
 
-trait Table {
-  type Id = String
-}
-
-object Table1 extends Table {
-  val id: Id = "table1_id"
-}
-
-class Table2() extends Table {
-  val id: Id = "table2_id"
-}
-
-val x = kek(Table1, Table1.id)
-val y = kek(Table2(), Table2().id)
+@main def run: Unit =
+  val f = new Foo("lol")
+  println(f.bar[String]("")[Boolean])

--- a/tests/pos/i23299.scala
+++ b/tests/pos/i23299.scala
@@ -1,0 +1,17 @@
+
+def kek(t: Table, ids: t.Id*) = ???
+
+trait Table {
+  type Id = String
+}
+
+object Table1 extends Table {
+  val id: Id = "table1_id"
+}
+
+class Table2() extends Table {
+  val id: Id = "table2_id"
+}
+
+val x = kek(Table1, Table1.id)
+val y = kek(Table2(), Table2().id)


### PR DESCRIPTION
VCInlineMethods needed to be extended to this case.

Fixes #23266

Also rename previous i23266.scala to i23299.scala to reflect the proper issue for it.