### PR TITLE
chore: use pinned scala3 files instead of the directories in the build

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1127,7 +1127,8 @@ object Build {
     libraryDependencies += "org.scala-lang" % "scala-library" % stdlibVersion,
     (Compile / scalacOptions) ++= Seq(
       // Needed so that the library sources are visible when `dotty.tools.dotc.core.Definitions#init` is called
-      "-sourcepath", (Compile / sourceDirectories).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),
+      // NOTE: Do not use `sourceDirectories` since `sources` are currently pinned until `3.8.0`
+      "-sourcepath", (Compile / sources).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),
       "-Yexplicit-nulls",
     ),
     (Compile / doc / scalacOptions) ++= ScaladocConfigs.DefaultGenerationSettings.value.settings,


### PR DESCRIPTION
Follows #23517

The compiler adds the `sourceDirectories` as an option so that it can load the definitions from the stdlib.
Now, instead of adding the directories, we just add the pinned files.

This has been missing when I merged locally the scala 2 history. With this change, everything behaves as expected when I opened #23517.