### PR TITLE
Simple enhancement for pattern matching with capturing types

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -14,9 +14,11 @@ import Flags.*, Constants.*
 import Decorators.*
 import NameKinds.{PatMatStdBinderName, PatMatAltsName, PatMatResultName}
 import config.Printers.patmatch
+import config.Feature
 import reporting.*
 import ast.*
 import util.Property.*
+import cc.{CapturingType, Capabilities}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -427,8 +429,11 @@ object PatternMatcher {
               && !hasExplicitTypeArgs(extractor)
             case _ => false
           }
+          val castTp = if Feature.ccEnabled
+            then CapturingType(tpt.tpe, scrutinee.termRef.singletonCaptureSet)
+            else tpt.tpe
           TestPlan(TypeTest(tpt, isTrusted), scrutinee, tree.span,
-            letAbstract(ref(scrutinee).cast(tpt.tpe)) { casted =>
+            letAbstract(ref(scrutinee).cast(castTp)) { casted =>
               nonNull += casted
               patternPlan(casted, pat, onSuccess)
             })

--- a/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
+++ b/scala2-library-cc/src/scala/collection/IndexedSeqView.scala
@@ -160,7 +160,7 @@ object IndexedSeqView {
 
   @SerialVersionUID(3L)
   class Reverse[A](underlying: SomeIndexedSeqOps[A]^) extends SeqView.Reverse[A](underlying) with IndexedSeqView[A] {
-    override def reverse: IndexedSeqView[A] = underlying match {
+    override def reverse: IndexedSeqView[A]^{underlying} = underlying match {
       case x: IndexedSeqView[A] => x
       case _ => super.reverse
     }

--- a/scala2-library-cc/src/scala/collection/View.scala
+++ b/scala2-library-cc/src/scala/collection/View.scala
@@ -156,12 +156,9 @@ object View extends IterableFactory[View] {
             new Filter(filter.underlying, a => filter.p(a) && p(a), isFlipped)
               .asInstanceOf[Filter[A]^{underlying, p}]
               // !!! asInstanceOf needed once paths were added, see path-patmat-should-be-pos.scala for minimization
-        //case filter: Filter[A]^{underlying} if filter.isFlipped == isFlipped =>
-        //  unsafeAssumeSeparate:
             // See filter-iterable.scala for a test where a variant of Filter
             // works without the unsafeAssumeSeparate. But it requires significant
             // changes compared to the version here. See also Filter in colltest5.CollectionStrawManCC5_1.
-        //    new Filter(filter.underlying, a => filter.p(a) && p(a), isFlipped)
         case _ => new Filter(underlying, p, isFlipped)
       }
   }

--- a/scala2-library-cc/src/scala/collection/View.scala
+++ b/scala2-library-cc/src/scala/collection/View.scala
@@ -152,8 +152,9 @@ object View extends IterableFactory[View] {
     def apply[A](underlying: Iterable[A]^, p: A => Boolean, isFlipped: Boolean): Filter[A]^{underlying, p} =
       underlying match {
         case filter: Filter[A] if filter.isFlipped == isFlipped =>
-          new Filter(filter.underlying, a => filter.p(a) && p(a), isFlipped)
-            .asInstanceOf[Filter[A]^{underlying, p}]
+          unsafeAssumeSeparate:
+            new Filter(filter.underlying, a => filter.p(a) && p(a), isFlipped)
+              .asInstanceOf[Filter[A]^{underlying, p}]
               // !!! asInstanceOf needed once paths were added, see path-patmat-should-be-pos.scala for minimization
         //case filter: Filter[A]^{underlying} if filter.isFlipped == isFlipped =>
         //  unsafeAssumeSeparate:

--- a/scala2-library-cc/src/scala/collection/mutable/CheckedIndexedSeqView.scala
+++ b/scala2-library-cc/src/scala/collection/mutable/CheckedIndexedSeqView.scala
@@ -101,7 +101,7 @@ private[mutable] object CheckedIndexedSeqView {
   @SerialVersionUID(3L)
   class Reverse[A](underlying: SomeIndexedSeqOps[A]^)(protected val mutationCount: () ->{cap.rd} Int)
     extends IndexedSeqView.Reverse[A](underlying) with CheckedIndexedSeqView[A] {
-    override def reverse: IndexedSeqView[A] = underlying match {
+    override def reverse: IndexedSeqView[A]^{underlying} = underlying match {
       case x: IndexedSeqView[A] => x
       case _ => super.reverse
     }

--- a/tests/neg-custom-args/captures/match.scala
+++ b/tests/neg-custom-args/captures/match.scala
@@ -1,0 +1,21 @@
+import language.experimental.captureChecking
+
+trait A
+
+case class B(x: AnyRef^) extends A
+
+def test =
+  val x: AnyRef^ = new AnyRef
+  val a: A^{x} = B(x)
+
+  val y1: A = a match
+    case b: B => b // error: (b: B) becomes B^{x} implicitly
+
+  val y2: A^{x} = a match
+    case b: B => b // ok
+
+  val x3: AnyRef = a match
+    case B(x2: AnyRef) => x2 // error: we lose some information about field x, but it still cannot be pure
+
+  val x4: AnyRef = a match
+    case b: B => b.x // error

--- a/tests/neg-custom-args/captures/match.scala
+++ b/tests/neg-custom-args/captures/match.scala
@@ -12,7 +12,10 @@ def test =
     case b: B => b // error: (b: B) becomes B^{x} implicitly
 
   val y2: A^{x} = a match
-    case b: B => b // ok
+    case b: B =>
+      val bb: B^{b} = b
+      val aa: A^{a} = bb
+      b // ok
 
   val x3: AnyRef = a match
     case B(x2: AnyRef) => x2 // error: we lose some information about field x, but it still cannot be pure

--- a/tests/run-custom-args/captures/colltest5/CollectionStrawManCC5_1.scala
+++ b/tests/run-custom-args/captures/colltest5/CollectionStrawManCC5_1.scala
@@ -457,13 +457,12 @@ object CollectionStrawMan5 {
       def apply[A](underlying: Iterable[A]^, pp: A => Boolean, isFlipped: Boolean): Filter[A]^{underlying, pp} =
         underlying match
           case filter: Filter[A] =>
-            new Filter(filter.underlying, a => filter.p(a) && pp(a))
-              .asInstanceOf[Filter[A]^{underlying, pp}]
-            //unsafeAssumeSeparate:
+            unsafeAssumeSeparate:
+              new Filter(filter.underlying, a => filter.p(a) && pp(a))
+                .asInstanceOf[Filter[A]^{underlying, pp}]
               // See filter-iterable.scala for a test where a variant of Filter
               // works without the unsafeAssumeSeparate. But it requires significant
               // changes compared to the version here.
-              //new Filter(filter.underlying, a => filter.p(a) && pp(a))
           case _ => new Filter(underlying, pp)
 
     case class Partition[A](val underlying: Iterable[A]^, p: A => Boolean) {


### PR DESCRIPTION
The bind variable should carry the capture set from the selector during pattern matching.

```scala
import language.experimental.captureChecking

trait A

case class B(x: AnyRef^) extends A

def test =
  val x: AnyRef^ = new AnyRef
  val a: A^{x} = B(x)

  val y1: A = a match
    case b: B => b // error: (b: B) becomes B^{x} implicitly

  val y2: A^{x} = a match
    case b: B => b // ok

  val x3: AnyRef = a match
    case B(x2: AnyRef) => x2 // error: we lose some information about field x, but it still cannot be pure

  val x4: AnyRef = a match
    case b: B => b.x // error
```