### PR TITLE
Rewrite underscore with optional space

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -88,6 +88,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i22731b.scala", defaultOptions.and("-rewrite", "-source:3.7-migration")),
       compileFile("tests/rewrites/implicit-to-given.scala", defaultOptions.and("-rewrite", "-Yimplicit-to-given")),
       compileFile("tests/rewrites/i22792.scala", defaultOptions.and("-rewrite")),
+      compileFile("tests/rewrites/i23449.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
     ).checkRewrites()
   }
 

--- a/tests/rewrites/i23449.check
+++ b/tests/rewrites/i23449.check
@@ -1,0 +1,14 @@
+trait T
+class C[A]
+
+def f(x: C[? <: T]) = ()
+
+def g(x: C[? >: T]) = ()
+
+def h(x: C[? <: T]) = ()
+
+def k(x: C[? >: T]) = ()
+
+def m(x: C[? >: Nothing <: T]) = ()
+
+def n(x: C[    ? >: Nothing <: T   ]) = ()

--- a/tests/rewrites/i23449.scala
+++ b/tests/rewrites/i23449.scala
@@ -1,0 +1,14 @@
+trait T
+class C[A]
+
+def f(x: C[_<:T]) = ()
+
+def g(x: C[_>:T]) = ()
+
+def h(x: C[_<: T]) = ()
+
+def k(x: C[_ >: T]) = ()
+
+def m(x: C[_>:Nothing<:T]) = ()
+
+def n(x: C[    _>:Nothing     <:T   ]) = ()


### PR DESCRIPTION
Fixes #23449 

For the anomalous case where the usual space is missing, print the type bounds for the patch.

This is not quite pretty printing, see the test of weird spaces inside the brackets.