### PR TITLE
Safe val test

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -240,6 +240,21 @@ class CompilationTests {
       compileFilesInDir("tests/init-global/warn-tasty", defaultOptions.and("-Ysafe-init-global"), FileFilter.exclude(TestSources.negInitGlobalScala2LibraryTastyExcludelisted)).checkWarnings()
       compileFilesInDir("tests/init-global/pos-tasty", defaultOptions.and("-Ysafe-init-global", "-Xfatal-warnings"), FileFilter.exclude(TestSources.posInitGlobalScala2LibraryTastyExcludelisted)).checkCompile()
     end if
+    locally {
+      val tastyErrorGroup = TestGroup("checkInitGlobal/safe-value-tasty")
+      val options = defaultOptions.and("-Wsafe-init", "-Xfatal-warnings")
+      val tastyErrorOptions = options.without("-Xfatal-warnings")
+
+      val outDirDef = defaultOutputDir + tastyErrorGroup + "/SafeValuesDef/safe-value-tasty/SafeValuesDef"
+
+      val tests = List(
+        compileFile("tests/init-global/pos-tasty/safe-value-tasty/def/SafeValuesDef.scala", tastyErrorOptions)(tastyErrorGroup),
+      ).map(_.keepOutput.checkCompile())
+
+      compileFile("tests/init-global/pos-tasty/safe-value-tasty/SafeValuesUse.scala", tastyErrorOptions.withClasspath(outDirDef))(tastyErrorGroup).checkCompile()
+
+      tests.foreach(_.delete())
+    }
   }
 
   // initialization tests

--- a/tests/init-global/pos-tasty/safe-value-tasty/SafeValuesUse.scala
+++ b/tests/init-global/pos-tasty/safe-value-tasty/SafeValuesUse.scala
@@ -1,0 +1,5 @@
+object A { // These are safe values, so no warning should be emitted
+  TestSafeValues.HashCodeLength
+  TestSafeValues.BitPartitionSize
+  TestSafeValues.MaxDepth
+} 

--- a/tests/init-global/pos-tasty/safe-value-tasty/def/SafeValuesDef.scala
+++ b/tests/init-global/pos-tasty/safe-value-tasty/def/SafeValuesDef.scala
@@ -1,0 +1,5 @@
+object TestSafeValues {
+  val HashCodeLength = 32
+  val BitPartitionSize = 5
+  val MaxDepth = HashCodeLength.toDouble
+} 

--- a/tests/init-global/pos-tasty/safe-value.scala
+++ b/tests/init-global/pos-tasty/safe-value.scala
@@ -1,0 +1,11 @@
+object TestSafeValues {
+  val HashCodeLength = 32
+  val BitPartitionSize = 5
+  val MaxDepth = HashCodeLength.toDouble
+}
+
+object A { // These are a safe values, so no warning should be emitted
+    TestSafeValues.HashCodeLength 
+    TestSafeValues.BitPartitionSize
+    TestSafeValues.MaxDepth 
+}

--- a/tests/init-global/pos-tasty/test-safe-value.scala
+++ b/tests/init-global/pos-tasty/test-safe-value.scala
@@ -1,0 +1,7 @@
+package scala.collection.immutable
+
+object A { // These are a safe values, so no warning should be emitted
+    Node.HashCodeLength 
+    Node.BitPartitionSize
+    Node.MaxDepth 
+}


### PR DESCRIPTION
Added a safe value test for global object initialization that is not supposed to give warnings when compiled.
At the moment, the test is not working as expected and it is not generating warnings even with the incorrect init checker which should produce warnings.