### PR TITLE
Backport "chore: add `-Yno-stdlib-patches` flag for the stdlib migration" to 3.7.2

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -397,6 +397,7 @@ private sealed trait YSettings:
   val Ylog: Setting[List[String]] = PhasesSetting(ForkSetting, "Ylog", "Log operations during")
   val YlogClasspath: Setting[Boolean] = BooleanSetting(ForkSetting, "Ylog-classpath", "Output information about what classpath is being applied.")
   val YdisableFlatCpCaching: Setting[Boolean] = BooleanSetting(ForkSetting, "YdisableFlatCpCaching", "Do not cache flat classpath representation of classpath elements from jars across compiler instances.")
+  val YnoStdlibPatches: Setting[Boolean] = BooleanSetting(ForkSetting, "Yno-stdlib-patches", "Do not patch stdlib files (temporary and only to be used for the stdlib migration)", false)
 
   val Yscala2Unpickler: Setting[String] = StringSetting(ForkSetting, "Yscala2-unpickler", "", "Control where we may get Scala 2 symbols from. This is either \"always\", \"never\", or a classpath.", "always")
 

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1468,6 +1468,11 @@ class Definitions {
    *  is read from a classfile.
    */
   def patchStdLibClass(denot: ClassDenotation)(using Context): Unit =
+    // Do not patch the stdlib files if we explicitly disable it
+    // This is only to be used during the migration of the stdlib
+    if ctx.settings.YnoStdlibPatches.value then 
+      return
+
     def patch2(denot: ClassDenotation, patchCls: Symbol): Unit =
       val scope = denot.info.decls.openForMutations
 

--- a/tests/neg/no-patches.check
+++ b/tests/neg/no-patches.check
@@ -1,0 +1,12 @@
+-- [E008] Not Found Error: tests/neg/no-patches.scala:3:23 -------------------------------------------------------------
+3 |val _ = scala.language.`3.4` // error: we do not patch `scala.language`
+  |        ^^^^^^^^^^^^^^^^^^^^
+  |        value 3.4 is not a member of object language
+-- [E008] Not Found Error: tests/neg/no-patches.scala:4:36 -------------------------------------------------------------
+4 |val _ = scala.language.experimental.captureChecking // error: we do not patch `scala.language.experimental`
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |        value captureChecking is not a member of object language.experimental
+-- [E008] Not Found Error: tests/neg/no-patches.scala:5:15 -------------------------------------------------------------
+5 |val _ = Predef.summon[DummyImplicit] // error: we do not patch `scala.Predef`
+  |        ^^^^^^^^^^^^^
+  |        value summon is not a member of object Predef

--- a/tests/neg/no-patches.scala
+++ b/tests/neg/no-patches.scala
@@ -1,0 +1,5 @@
+//> using options -Yno-stdlib-patches
+
+val _ = scala.language.`3.4` // error: we do not patch `scala.language`
+val _ = scala.language.experimental.captureChecking // error: we do not patch `scala.language.experimental`
+val _ = Predef.summon[DummyImplicit] // error: we do not patch `scala.Predef`


### PR DESCRIPTION
Backports #23540 to the 3.7.2-RC2.

PR submitted by the release tooling.