### PR TITLE
Improve use of boolean defaults

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -234,6 +234,7 @@ object GenericSignatures {
 
     @noinline
     def jsig(tp0: Type, toplevel: Boolean = false, unboxedVCs: Boolean = true): Unit = {
+      inline def jsig1(tp0: Type): Unit = jsig(tp0, toplevel = false, unboxedVCs = true)
 
       val tp = tp0.dealias
       tp match {
@@ -242,41 +243,41 @@ object GenericSignatures {
           val erasedUnderlying = fullErasure(ref.underlying.bounds.hi)
           // don't emit type param name if the param is upper-bounded by a primitive type (including via a value class)
           if erasedUnderlying.isPrimitiveValueType then
-            jsig(erasedUnderlying, toplevel, unboxedVCs)
+            jsig(erasedUnderlying, toplevel = toplevel, unboxedVCs = unboxedVCs)
           else typeParamSig(ref.paramName.lastPart)
 
         case defn.ArrayOf(elemtp) =>
           if (isGenericArrayElement(elemtp, isScala2 = false))
-            jsig(defn.ObjectType)
+            jsig1(defn.ObjectType)
           else
             builder.append(ClassfileConstants.ARRAY_TAG)
             elemtp match
-              case TypeBounds(lo, hi) => jsig(hi.widenDealias)
-              case _ => jsig(elemtp)
+              case TypeBounds(lo, hi) => jsig1(hi.widenDealias)
+              case _ => jsig1(elemtp)
 
         case RefOrAppliedType(sym, pre, args) =>
           if (sym == defn.PairClass && tupleArity(tp) > Definitions.MaxTupleArity)
-            jsig(defn.TupleXXLClass.typeRef)
+            jsig1(defn.TupleXXLClass.typeRef)
           else if (isTypeParameterInSig(sym, sym0)) {
             assert(!sym.isAliasType || sym.info.isLambdaSub, "Unexpected alias type: " + sym)
             typeParamSig(sym.name.lastPart)
           }
           else if (defn.specialErasure.contains(sym))
-            jsig(defn.specialErasure(sym).typeRef)
+            jsig1(defn.specialErasure(sym).typeRef)
           else if (sym == defn.UnitClass || sym == defn.BoxedUnitModule)
-            jsig(defn.BoxedUnitClass.typeRef)
+            jsig1(defn.BoxedUnitClass.typeRef)
           else if (sym == defn.NothingClass)
             builder.append("Lscala/runtime/Nothing$;")
           else if (sym == defn.NullClass)
             builder.append("Lscala/runtime/Null$;")
           else if (sym.isPrimitiveValueClass)
-            if (!unboxedVCs) jsig(defn.ObjectType)
-            else if (sym == defn.UnitClass) jsig(defn.BoxedUnitClass.typeRef)
+            if (!unboxedVCs) jsig1(defn.ObjectType)
+            else if (sym == defn.UnitClass) jsig1(defn.BoxedUnitClass.typeRef)
             else builder.append(defn.typeTag(sym.info))
           else if (sym.isDerivedValueClass) {
             if (unboxedVCs) {
               val erasedUnderlying = fullErasure(tp)
-              jsig(erasedUnderlying, toplevel)
+              jsig(erasedUnderlying, toplevel = toplevel, unboxedVCs = true)
             } else classSig(sym, pre, args)
           }
           else if (defn.isSyntheticFunctionClass(sym)) {
@@ -286,20 +287,20 @@ object GenericSignatures {
           else if sym.isClass then
             classSig(sym, pre, args)
           else
-            jsig(erasure(tp), toplevel, unboxedVCs)
+            jsig(erasure(tp), toplevel = toplevel, unboxedVCs = unboxedVCs)
 
         case ExprType(restpe) if toplevel =>
           builder.append("()")
           methodResultSig(restpe)
 
         case ExprType(restpe) =>
-          jsig(defn.FunctionType(0).appliedTo(restpe))
+          jsig1(defn.FunctionType(0).appliedTo(restpe))
 
         case mtd: MethodOrPoly =>
           val (tparams, vparams, rte) = collectMethodParams(mtd)
           if (toplevel && !sym0.isConstructor) polyParamSig(tparams)
           builder.append('(')
-          for vparam <- vparams do jsig(vparam)
+          for vparam <- vparams do jsig1(vparam)
           builder.append(')')
           methodResultSig(rte)
 
@@ -316,7 +317,7 @@ object GenericSignatures {
           val (reprParents, _) = splitIntersection(parents)
           val repr =
             reprParents.find(_.typeSymbol.is(TypeParam)).getOrElse(reprParents.head)
-          jsig(repr, unboxedVCs = unboxedVCs)
+          jsig(repr, toplevel = false, unboxedVCs = unboxedVCs)
 
         case ci: ClassInfo =>
           val tParams = tp.typeParams

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -455,8 +455,8 @@ object SpaceEngine {
         val inArray = tycon.isRef(defn.ArrayClass) || tp.translucentSuperType.isRef(defn.ArrayClass)
         val args2 =
           if isTyped && !inArray then args.map(_ => WildcardType)
-          else args.map(arg => erase(arg, inArray = inArray, isValue = false))
-        tp.derivedAppliedType(erase(tycon, inArray, isValue = false), args2)
+          else args.map(arg => erase(arg, inArray = inArray, isValue = false, isTyped = false))
+        tp.derivedAppliedType(erase(tycon, inArray = inArray, isValue = false, isTyped = false), args2)
 
       case tp @ OrType(tp1, tp2) =>
         OrType(erase(tp1, inArray, isValue, isTyped), erase(tp2, inArray, isValue, isTyped), tp.isSoft)


### PR DESCRIPTION
A couple of cases where recursing with default booleans was especially confusing.

Spellcheck would like to change booleans to beanpoles.

I know the project hates so-called style PRs.

But if I see something morally wrong, I cannot but act upon it.

I must confirm that inlined helper such as `jsig1` allows `tailrec`. Maybe it's enough to annotate jsig? Edit: I see goto 0 only. With tailrec, it complains about the RHS of the helper `inline def jsig1`, which is spurious.