### PR TITLE
chore: make metals believe scala-library-bootstrapped is a scala 3 project

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1450,6 +1450,9 @@ object Build {
       moduleName    := "scala-library",
       version       := dottyVersion,
       versionScheme := Some("semver-spec"),
+      // sbt defaults to scala 2.12.x and metals will report issues as it doesn't consider the project a scala 3 project 
+      // (not the actual version we use to compile the project)
+      scalaVersion  := referenceVersion,
       crossPaths    := false, // org.scala-lang:scala-library doesn't have a crosspath
       // Add the source directories for the stdlib (non-boostrapped)
       Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / "src"),


### PR DESCRIPTION
If we don't set explicitly the scala version, sbt will default to `2.12` which will be then used by metals, even when we actually override the scalaInstance when bootstrapping. In this PR, we actually make sure that the stdlib bootstrapped uses a Scala 3 version so that metals won't confuse it with a scala 2.12 project.

<img width="1200" height="42" alt="Screenshot 2025-07-18 at 20 45 30" src="https://github.com/user-attachments/assets/bc1a66c0-48c3-4dea-9d64-3f651170ef72" />
