### PR TITLE
chore: make incremental compilation work with stdlib plugin and enable it in the new stdlib

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1419,6 +1419,7 @@ object Build {
 
   /* Configuration of the org.scala-lang:scala-library:*.**.**-nonboostrapped project */
   lazy val `scala-library-nonbootstrapped` = project.in(file("library"))
+    .enablePlugins(ScalaLibraryPlugin)
     .settings(
       name          := "scala-library-nonbootstrapped",
       moduleName    := "scala-library",
@@ -1448,6 +1449,7 @@ object Build {
 
   /* Configuration of the org.scala-lang:scala-library:*.**.**-boostrapped project */
   lazy val `scala-library-bootstrapped` = project.in(file("library"))
+    .enablePlugins(ScalaLibraryPlugin)
     .settings(
       name          := "scala-library-bootstrapped",
       moduleName    := "scala-library",
@@ -1474,8 +1476,11 @@ object Build {
       publish / skip := true,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala-library-bootstrapped",
+      // we need to have the `scala-library` artifact as a dependency for `ScalaLibraryPlugin` to work
+      // this was the only way to not get the artifact evicted by sbt. Even a custom configuration didn't work
+      // NOTE: true is the default value, just making things clearer here
+      managedScalaInstance := true,
       // Configure the nonbootstrapped compiler
-      managedScalaInstance := false,
       scalaInstance := {
         val externalLibraryDeps = (`scala3-library` / Compile / externalDependencyClasspath).value.map(_.data).toSet
         val externalCompilerDeps = (`scala3-compiler` / Compile / externalDependencyClasspath).value.map(_.data).toSet
@@ -1494,7 +1499,7 @@ object Build {
         val compilerJars = Seq(tastyCore, scala3Interfaces, scala3Compiler) ++ (externalCompilerDeps -- externalLibraryDeps)
 
         Defaults.makeScalaInstance(
-          scalaVersion.value,
+          dottyNonBootstrappedVersion,
           libraryJars = libraryJars,
           allCompilerJars = compilerJars,
           allDocJars = Seq.empty,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1476,7 +1476,7 @@ object Build {
       publish / skip := true,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala-library-bootstrapped",
-      // we need to have the `scala-library` artifact as a dependency for `ScalaLibraryPlugin` to work
+      // we need to have the `scala-library` artifact in the classpath for `ScalaLibraryPlugin` to work
       // this was the only way to not get the artifact evicted by sbt. Even a custom configuration didn't work
       // NOTE: true is the default value, just making things clearer here
       managedScalaInstance := true,


### PR DESCRIPTION
Two main things here:
- We changed the `ScalaLibraryPlugin` to be able to work smoothly with the incremental compilation
- We enable the plugin in the new stdlib projects.

Some resources:
- Hijacking the compilation analysis: https://github.com/playframework/play-enhancer/blob/74fd35ff0ed18ec2084405d1a6124898cc22e857/plugin/src/main/scala-sbt-1.0/com/typesafe/play/sbt/enhancer/PlayEnhancer.scala
- sbt docs: https://www.scala-sbt.org/1.x/docs/Understanding-Recompilation.html#Bytecode+Enhancers