### PR TITLE
chore: ensure stdlib always produces Java 17 >= artifacts

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1437,6 +1437,9 @@ object Build {
         // Needed so that the library sources are visible when `dotty.tools.dotc.core.Definitions#init` is called
         "-sourcepath", (Compile / sourceDirectories).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),
       ),
+      // Make sure that the produced artifacts have the minimum JVM version in the bytecode
+      Compile / javacOptions  ++= Seq("--target", Versions.minimumJVMVersion),
+      Compile / scalacOptions ++= Seq("--java-output-version", Versions.minimumJVMVersion),
       // Only publish compilation artifacts, no test artifacts
       Compile / publishArtifact := true,
       Test    / publishArtifact := false,
@@ -1467,6 +1470,9 @@ object Build {
         // Needed so that the library sources are visible when `dotty.tools.dotc.core.Definitions#init` is called
         "-sourcepath", (Compile / sourceDirectories).value.map(_.getCanonicalPath).distinct.mkString(File.pathSeparator),
       ),
+      // Make sure that the produced artifacts have the minimum JVM version in the bytecode
+      Compile / javacOptions  ++= Seq("--target", Versions.minimumJVMVersion),
+      Compile / scalacOptions ++= Seq("--java-output-version", Versions.minimumJVMVersion),
       // Only publish compilation artifacts, no test artifacts
       Compile / publishArtifact := true,
       Test    / publishArtifact := false,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,0 +1,6 @@
+object Versions {
+
+  /* The Minimum JVM version the artifact should be able to use */
+  val minimumJVMVersion = "17"
+
+}


### PR DESCRIPTION
We make sure that we always generate classifies that are compatible with the minimum JVM version.

Related to #19750, https://www.scala-lang.org/blog/next-scala-lts.html and https://www.scala-lang.org/news/next-scala-lts-jdk.html