### PR TITLE
Add quick fix to add .nn

### DIFF
--- a/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
+++ b/compiler/test/dotty/tools/dotc/reporting/CodeActionTest.scala
@@ -179,6 +179,20 @@ class CodeActionTest extends DottyTest:
       ctxx = ctxx
       )
 
+  @Test def addNN =
+    val ctxx = newContext
+    ctxx.setSetting(ctxx.settings.YexplicitNulls, true)
+    checkCodeAction(
+      code =
+        """val s: String|Null = ???
+          | val t: String = s""".stripMargin,
+        title = "Add .nn",
+      expected =
+        """val s: String|Null = ???
+          | val t: String = (s).nn""".stripMargin,
+      ctxx = ctxx
+      )
+
   // Make sure we're not using the default reporter, which is the ConsoleReporter,
   // meaning they will get reported in the test run and that's it.
   private def newContext =


### PR DESCRIPTION
An extension to #23461 that adds a quick fix to add a .nn. For example, if the code were
```scala
val t: String | Null = ???
val s: String = t
```
the quick fix would transform the code to
```scala
val t: String | Null = ???
val s: String = t.nn
```
The code is WIP (I've put some ugly workarounds to get it to work). Right now, it adds brackets whenever the root node is an Apply. This is needed for infix functions (both those with ApplyKind InfixTuple and those that are written as such in the source code, such as + which is desugared to an ApplyKind Regular I think), but there may be other edge cases where brackets are needed. I've discussed these edges cases a bit with @olhotak and @HarrisL2, but it's possible that we've missed some (or I've forgotten to add them).