### PR TITLE
chore: add `tasty-core-nonbootstrapped` in the new build

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -79,3 +79,20 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Compile `scala3-library-bootstrapped`
         run: ./project/scripts/sbt scala3-library-bootstrapped-new/compile
+
+  tasty-core-nonbootstrapped:
+    runs-on: ubuntu-latest
+    ##needs: [scala3-library-nonbootstrapped] Add when we add support for caching here
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `tasty-core-nonbootstrapped`
+        run: ./project/scripts/sbt tasty-core-nonbootstrapped/compile

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ val `scala2-library-tasty` = Build.`scala2-library-tasty`
 val `scala2-library-cc` = Build.`scala2-library-cc`
 val `scala2-library-cc-tasty` = Build.`scala2-library-cc-tasty`
 val `tasty-core` = Build.`tasty-core`
+val `tasty-core-nonbootstrapped` = Build.`tasty-core-nonbootstrapped`
 val `tasty-core-bootstrapped` = Build.`tasty-core-bootstrapped`
 val `tasty-core-scala2` = Build.`tasty-core-scala2`
 val scaladoc = Build.scaladoc


### PR DESCRIPTION
- We add the non-bootstrapped version of `tasty-core` to the new build