### PR TITLE
chore: add `scala3-compiler-nonbootstrapped` to the new build

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -79,3 +79,20 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Compile `scala3-library-bootstrapped`
         run: ./project/scripts/sbt scala3-library-bootstrapped-new/compile
+
+  tasty-core-nonbootstrapped:
+    runs-on: ubuntu-latest
+    ##needs: [scala3-library-nonbootstrapped] Add when we add support for caching here
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `tasty-core-nonbootstrapped`
+        run: ./project/scripts/sbt tasty-core-nonbootstrapped/compile

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -96,3 +96,20 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Compile `tasty-core-nonbootstrapped`
         run: ./project/scripts/sbt tasty-core-nonbootstrapped/compile
+
+  scala3-compiler-nonbootstrapped:
+    runs-on: ubuntu-latest
+    ##needs: [tasty-core-nonbootstrapped, scala3-library-nonbootstrapped] Add when we add support for caching here
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-compiler-nonbootstrapped`
+        run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/compile

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ val scala3 = Build.scala3
 val `scala3-bootstrapped` = Build.`scala3-bootstrapped`
 val `scala3-interfaces` = Build.`scala3-interfaces`
 val `scala3-compiler` = Build.`scala3-compiler`
+val `scala3-compiler-nonbootstrapped` = Build.`scala3-compiler-nonbootstrapped`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
 val `scala-library-nonbootstrapped` = Build.`scala-library-nonbootstrapped`
 val `scala3-library-nonbootstrapped` = Build.`scala3-library-nonbootstrapped`

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ val `scala2-library-tasty` = Build.`scala2-library-tasty`
 val `scala2-library-cc` = Build.`scala2-library-cc`
 val `scala2-library-cc-tasty` = Build.`scala2-library-cc-tasty`
 val `tasty-core` = Build.`tasty-core`
+val `tasty-core-nonbootstrapped` = Build.`tasty-core-nonbootstrapped`
 val `tasty-core-bootstrapped` = Build.`tasty-core-bootstrapped`
 val `tasty-core-scala2` = Build.`tasty-core-scala2`
 val scaladoc = Build.scaladoc


### PR DESCRIPTION
- Adds the non-bootstrapped `scala3-compiler` to the new build

Depends on #23599