### PR TITLE
Fix illegal positions being generated in SpliceInterpreter

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Splicer.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Splicer.scala
@@ -255,7 +255,7 @@ object Splicer {
           case tree: Inlined if tree.inlinedFromOuterScope => tree.expansion
           case _ => body
         }
-        new ExprImpl(Inlined(EmptyTree, Nil, QuoteUtils.changeOwnerOfTree(body1, ctx.owner)).withSpan(body1.span), SpliceScope.getCurrent)
+        new ExprImpl(Inlined(EmptyTree, Nil, QuoteUtils.changeOwnerOfTree(body1, ctx.owner)).cloneIn(body1.source).withSpan(body1.span), SpliceScope.getCurrent)
 
       // Interpret level -1 `Type.of[T]`
       case Apply(TypeApply(fn, quoted :: Nil), _) if fn.symbol == defn.QuotedTypeModule_of =>

--- a/tests/run-macros/i21910.check
+++ b/tests/run-macros/i21910.check
@@ -1,0 +1,3 @@
+70..71 of tests/run-macros/i21910/Outer.scala with length 73
+70..71 of tests/run-macros/i21910/Outer.scala with length 73
+44..57 of tests/run-macros/i21910/Main.scala with length 58

--- a/tests/run-macros/i21910/Inner.scala
+++ b/tests/run-macros/i21910/Inner.scala
@@ -1,0 +1,16 @@
+import scala.quoted.*
+
+object Inner:
+  inline def pos(inline x: Any): Unit =
+    ${ posImpl('x) }
+
+  def posImpl(x: Expr[Any])(using Quotes): Expr[Unit] =
+    import quotes.reflect.*
+    def printPos(p: Position): Expr[Unit] =
+      val str = Expr(s"${p.start}..${p.end} of ${p.sourceFile.path} with length ${p.sourceFile.content.get.length}")
+      '{println($str)}
+    '{
+      ${printPos(x.asTerm.pos)}
+      ${printPos(x.asTerm.asInstanceOf[Inlined].body.pos)}
+      ${printPos(x.asTerm.asInstanceOf[Inlined].body.asInstanceOf[Inlined].body.pos)}
+    }

--- a/tests/run-macros/i21910/Main.scala
+++ b/tests/run-macros/i21910/Main.scala
@@ -1,0 +1,3 @@
+@main def Test(): Unit =
+  Outer.outer:
+    println("hi")

--- a/tests/run-macros/i21910/Outer.scala
+++ b/tests/run-macros/i21910/Outer.scala
@@ -1,0 +1,3 @@
+object Outer:
+  inline def outer(inline x: Any): Unit =
+    Inner.pos(x)


### PR DESCRIPTION
Fixes #21910

The issue was caused by the splice (`${ posImpl('x) }`) interpretation (of `'x`), which after extracting the value would wrap it with `Inlined` and incorrectly set the position without setting the source file.