### PR TITLE
Add all remaining non-bootstrapped projects

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -113,3 +113,20 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Compile `scala3-compiler-nonbootstrapped`
         run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/compile
+
+  scala3-sbt-bridge-nonbootstrapped:
+    runs-on: ubuntu-latest
+    ##needs: [scala3-compiler-nonbootstrapped] Add when we add support for caching here
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-sbt-bridge-nonbootstrapped`
+        run: ./project/scripts/sbt scala3-sbt-bridge-nonbootstrapped/compile

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 val scala3 = Build.scala3
+val `scala3-nonbootstrapped` = Build.`scala3-nonbootstrapped`
 val `scala3-bootstrapped` = Build.`scala3-bootstrapped`
 val `scala3-interfaces` = Build.`scala3-interfaces`
 val `scala3-compiler` = Build.`scala3-compiler`

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ val `scala3-library` = Build.`scala3-library`
 val `scala3-library-bootstrapped` = Build.`scala3-library-bootstrapped`
 val `scala3-library-bootstrappedJS` = Build.`scala3-library-bootstrappedJS`
 val `scala3-sbt-bridge` = Build.`scala3-sbt-bridge`
+val `scala3-sbt-bridge-nonbootstrapped` = Build.`scala3-sbt-bridge-nonbootstrapped`
 val `scala3-sbt-bridge-tests` = Build.`scala3-sbt-bridge-tests`
 val `scala3-staging` = Build.`scala3-staging`
 val `scala3-tasty-inspector` = Build.`scala3-tasty-inspector`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1364,6 +1364,26 @@ object Build {
     )
 
   // ==============================================================================================
+  // ================================= NON-BOOTSTRAPPED PROJECTS ==================================
+  // ==============================================================================================
+
+  lazy val `scala3-nonbootstrapped` = project
+    .aggregate(`scala3-interfaces`, `scala3-library-nonbootstrapped` , `scala-library-nonbootstrapped`,
+      `tasty-core-nonbootstrapped`, `scala3-compiler-nonbootstrapped`)
+    .settings(
+      name          := "scala3-nonbootstrapped",
+      moduleName    := "scala3-nonbootstrapped",
+      version       := dottyNonBootstrappedVersion,
+      // Nothing to be published by this project, it is only an aggregate
+      Compile / publishArtifact := false,
+      Test    / publishArtifact := false,
+      // Nothing to be published by this project
+      publish / skip := true,
+      // Project specific target folder. sbt doesn't like having two projects using the same target folder
+      target := target.value / "scala3-nonbootstrapped",
+    )
+
+  // ==============================================================================================
   // =================================== SCALA STANDARD LIBRARY ===================================
   // ==============================================================================================
 
@@ -1429,6 +1449,7 @@ object Build {
       Test / compile := (`scala-library-nonbootstrapped` / Test / compile).value,
       Test / doc     := (`scala-library-nonbootstrapped` / Test / doc).value,
       Test / run     := (`scala-library-nonbootstrapped` / Test / run).evaluated,
+      Test / test    := (`scala-library-nonbootstrapped` / Test / test).value,
       // Packaging configuration of the stdlib
       Compile / packageBin / publishArtifact := true,
       Compile / packageDoc / publishArtifact := false,
@@ -1449,7 +1470,7 @@ object Build {
       moduleName    := "scala-library",
       version       := dottyVersion,
       versionScheme := Some("semver-spec"),
-      // sbt defaults to scala 2.12.x and metals will report issues as it doesn't consider the project a scala 3 project 
+      // sbt defaults to scala 2.12.x and metals will report issues as it doesn't consider the project a scala 3 project
       // (not the actual version we use to compile the project)
       scalaVersion  := referenceVersion,
       crossPaths    := false, // org.scala-lang:scala-library doesn't have a crosspath
@@ -1517,7 +1538,7 @@ object Build {
       moduleName    := "scala3-library",
       version       := dottyVersion,
       versionScheme := Some("semver-spec"),
-      // sbt defaults to scala 2.12.x and metals will report issues as it doesn't consider the project a scala 3 project 
+      // sbt defaults to scala 2.12.x and metals will report issues as it doesn't consider the project a scala 3 project
       // (not the actual version we use to compile the project)
       scalaVersion  := referenceVersion,
       crossPaths    := true, // org.scala-lang:scala3-library has a crosspath
@@ -1584,7 +1605,7 @@ object Build {
         val lm = dependencyResolution.value
         val log = streams.value.log
         val retrieveDir = streams.value.cacheDirectory / "scala3-compiler" / scalaVersion.value
-        val comp = lm.retrieve("org.scala-lang" % "scala3-compiler_3" % 
+        val comp = lm.retrieve("org.scala-lang" % "scala3-compiler_3" %
           scalaVersion.value, scalaModuleInfo = None, retrieveDir, log)
           .fold(w => throw w.resolveException, identity)
         Defaults.makeScalaInstance(
@@ -1668,7 +1689,7 @@ object Build {
         val lm = dependencyResolution.value
         val log = streams.value.log
         val retrieveDir = streams.value.cacheDirectory / "scala3-compiler" / scalaVersion.value
-        val comp = lm.retrieve("org.scala-lang" % "scala3-compiler_3" % 
+        val comp = lm.retrieve("org.scala-lang" % "scala3-compiler_3" %
           scalaVersion.value, scalaModuleInfo = None, retrieveDir, log)
           .fold(w => throw w.resolveException, identity)
         Defaults.makeScalaInstance(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1391,11 +1391,14 @@ object Build {
       // Make sure that the produced artifacts have the minimum JVM version in the bytecode
       Compile / javacOptions  ++= Seq("--target", Versions.minimumJVMVersion),
       Compile / scalacOptions ++= Seq("--java-output-version", Versions.minimumJVMVersion),
+      // Packaging configuration of the stdlib
+      Compile / packageBin / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := true,
       // Only publish compilation artifacts, no test artifacts
-      Compile / publishArtifact := true,
       Test    / publishArtifact := false,
-      // Do not allow to publish this project for now
-      publish / skip := true,
+      // non-bootstrapped stdlib is publishable (only locally)
+      publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala-library-nonbootstrapped",
     )
@@ -1426,11 +1429,14 @@ object Build {
       Test / compile := (`scala-library-nonbootstrapped` / Test / compile).value,
       Test / doc     := (`scala-library-nonbootstrapped` / Test / doc).value,
       Test / run     := (`scala-library-nonbootstrapped` / Test / run).evaluated,
+      // Packaging configuration of the stdlib
+      Compile / packageBin / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := true,
       // Only publish compilation artifacts, no test artifacts
-      Compile / publishArtifact := true,
       Test    / publishArtifact := false,
       // Do not allow to publish this project for now
-      publish / skip := true,
+      publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library-nonbootstrapped",
     )
@@ -1562,11 +1568,14 @@ object Build {
       // Make sure that the produced artifacts have the minimum JVM version in the bytecode
       Compile / javacOptions  ++= Seq("--target", Versions.minimumJVMVersion),
       Compile / scalacOptions ++= Seq("--java-output-version", Versions.minimumJVMVersion),
+      // Packaging configuration of the stdlib
+      Compile / packageBin / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := true,
       // Only publish compilation artifacts, no test artifacts
-      Compile / publishArtifact := true,
       Test    / publishArtifact := false,
       // Do not allow to publish this project for now
-      publish / skip := true,
+      publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "tasty-core-nonbootstrapped",
       // sbt adds all the projects to scala-tool config which breaks building the scalaInstance
@@ -1623,11 +1632,14 @@ object Build {
       // Make sure that the produced artifacts have the minimum JVM version in the bytecode
       Compile / javacOptions  ++= Seq("--target", Versions.minimumJVMVersion),
       Compile / scalacOptions ++= Seq("--java-output-version", Versions.minimumJVMVersion),
+      // Packaging configuration of the stdlib
+      Compile / packageBin / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := true,
       // Only publish compilation artifacts, no test artifacts
-      Compile / publishArtifact := true,
       Test    / publishArtifact := false,
       // Do not allow to publish this project for now
-      publish / skip := true,
+      publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-compiler-nonbootstrapped",
       // Generate compiler.properties, used by sbt


### PR DESCRIPTION
- Add root project `scala3-nonbootstrapped`
- Add non-bootstrapped sbt-bridge (`scala3-sbt-bridge-nonbootstrapped`)
- Allow publishing the projects such that we can publish them locally to build now the bootstrapped projects.