### PR TITLE
Fix issue with certain polyfunctions not properly matching in macros

### DIFF
--- a/compiler/src/scala/quoted/runtime/impl/QuoteMatcher.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuoteMatcher.scala
@@ -460,10 +460,10 @@ class QuoteMatcher(debug: Boolean) {
                     */
                   def matchTypeDef(sctypedef: TypeDef, pttypedef: TypeDef): MatchingExprs = sctypedef match
                     case TypeDef(_, TypeBoundsTree(sclo, schi, EmptyTree))
-                      if sclo.tpe == defn.NothingType && schi.tpe == defn.AnyType =>
+                      if sclo.tpe.isNothingType && schi.tpe.isAny =>
                       pttypedef match
                         case TypeDef(_, TypeBoundsTree(ptlo, pthi, EmptyTree))
-                          if sclo.tpe == defn.NothingType && schi.tpe == defn.AnyType =>
+                          if sclo.tpe.isNothingType && schi.tpe.isAny =>
                           matched
                         case _ => notMatched
                     case _ => notMatched

--- a/tests/pos-macros/i23589/Macro_1.scala
+++ b/tests/pos-macros/i23589/Macro_1.scala
@@ -1,0 +1,11 @@
+import scala.quoted.*
+import scala.language.experimental.quotedPatternsWithPolymorphicFunctions
+
+inline def testMacro(inline body: Any) = ${test('body)}
+def test(outsideBody: Expr[Any])(using Quotes): Expr[Unit] =
+  val insideBody = '{[B] => (a : B, b : B) => (a, b)}
+  outsideBody match
+    case '{ [A] => (x : A, y : A) => $b[A](x, y): (A, A) } => ()
+  insideBody match
+    case '{ [A] => (x : A, y : A) => $b[A](x, y): (A, A) } => ()
+  '{()}

--- a/tests/pos-macros/i23589/Main_2.scala
+++ b/tests/pos-macros/i23589/Main_2.scala
@@ -1,0 +1,3 @@
+//> using options -experimental
+@main def main() =
+  testMacro([B] => (a : B, b : B) => (a, b))


### PR DESCRIPTION
Fixes #23589
previously the contents of TypeBoundsTree were directly compared with the types of defn.Nothing and defn.Any, which caused an issue where:
* `def.Nothing.tpe` equals `TypeRef(ThisType(TypeRef(NoPrefix,module class scala)),class Nothing)`
* while the analogous type unpicked from quoted code was `TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object scala),Nothing)` 

Same situation with the upper type bound `Any`. `isAny` and `isNothingType` accept both types, so they are now used instead. 