### PR TITLE
Fix completions for Quotes

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -615,8 +615,9 @@ object Completion:
 
       // 1. The extension method is visible under a simple name, by being defined or inherited or imported in a scope enclosing the reference.
       val extMethodsInScope = scopeCompletions.names.toList.flatMap:
-        case (name, denots) => denots.collect:
-          case d: SymDenotation if d.isTerm && d.termRef.symbol.is(Extension) => (d.termRef, name.asTermName)
+        case (name, denots) =>
+          denots.collect:
+            case d if d.isTerm && d.symbol.is(Extension) => (d.symbol.termRef, name.asTermName)
 
       // 2. The extension method is a member of some given instance that is visible at the point of the reference.
       val givensInScope = ctx.implicits.eligible(defn.AnyType).map(_.implicitRef.underlyingRef)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2275,3 +2275,16 @@ class CompletionSuite extends BaseCompletionSuite:
         |""".stripMargin,
       "test: Int"
     )
+
+  @Test def `macros` =
+    check(
+      """
+        |object Macro:
+        |  import scala.quoted.*
+        |  def dbgImpl[A](a: Expr[A])(using Quotes): Expr[A] =
+        |    import quotes.reflect.*
+        |    a.asTer@@
+        |
+        |""".stripMargin,
+      "asTerm: Term"
+    )


### PR DESCRIPTION
Some denotation were not collected because they were `UniqueRefDenotation` and we matched for `SymDenotation`