### PR TITLE
chore: add `scala3-staging` and `scala3-tasty-inspector` to the new build

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -183,6 +183,23 @@ jobs:
       - name: Compile `scala3-sbt-bridge-bootstrapped`
         run: ./project/scripts/sbt scala3-sbt-bridge-bootstrapped/compile
 
+  scala3-staging:
+    runs-on: ubuntu-latest
+    ##needs: [scala3-compiler-bootstrapped] Add when we add support for caching here
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-staging`
+        run: ./project/scripts/sbt scala3-staging-new/compile
+
   #################################################################################################
   ########################################### TEST JOBS ###########################################
   #################################################################################################

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -200,6 +200,25 @@ jobs:
       - name: Compile `scala3-staging`
         run: ./project/scripts/sbt scala3-staging-new/compile
 
+  scala3-tasty-inspector:
+    runs-on: ubuntu-latest
+    ##needs: [scala3-compiler-bootstrapped] Add when we add support for caching here
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-staging`
+        run: ./project/scripts/sbt scala3-staging-new/compile
+      - name: Compile `scala3-tasty-inspector`
+        run: ./project/scripts/sbt scala3-tasty-inspector-new/compile
+
   #################################################################################################
   ########################################### TEST JOBS ###########################################
   #################################################################################################

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ val `scala3-sbt-bridge-tests` = Build.`scala3-sbt-bridge-tests`
 val `scala3-staging` = Build.`scala3-staging`
 val `scala3-staging-new` = Build.`scala3-staging-new`
 val `scala3-tasty-inspector` = Build.`scala3-tasty-inspector`
+val `scala3-tasty-inspector-new` = Build.`scala3-tasty-inspector-new`
 val `scala3-language-server` = Build.`scala3-language-server`
 val `scala3-bench` = Build.`scala3-bench`
 val `scala3-bench-bootstrapped` = Build.`scala3-bench-bootstrapped`

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val `scala3-sbt-bridge-bootstrapped` = Build.`scala3-sbt-bridge-bootstrapped`
 val `scala3-sbt-bridge-nonbootstrapped` = Build.`scala3-sbt-bridge-nonbootstrapped`
 val `scala3-sbt-bridge-tests` = Build.`scala3-sbt-bridge-tests`
 val `scala3-staging` = Build.`scala3-staging`
+val `scala3-staging-new` = Build.`scala3-staging-new`
 val `scala3-tasty-inspector` = Build.`scala3-tasty-inspector`
 val `scala3-language-server` = Build.`scala3-language-server`
 val `scala3-bench` = Build.`scala3-bench`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1450,7 +1450,8 @@ object Build {
 
   lazy val `scala3-bootstrapped-new` = project
     .aggregate(`scala3-interfaces`, `scala3-library-bootstrapped-new` , `scala-library-bootstrapped`,
-      `tasty-core-bootstrapped-new`, `scala3-compiler-bootstrapped-new`, `scala3-sbt-bridge-bootstrapped`)
+      `tasty-core-bootstrapped-new`, `scala3-compiler-bootstrapped-new`, `scala3-sbt-bridge-bootstrapped`,
+      `scala3-staging-new`)
     .settings(
       name          := "scala3-bootstrapped",
       moduleName    := "scala3-bootstrapped",
@@ -1494,7 +1495,6 @@ object Build {
         "org.scala-lang" % "scala-reflect",
         "org.scala-lang" % "scala-compiler",
       ),
-      //
       // Packaging configuration of `scala3-sbt-bridge`
       Compile / packageBin / publishArtifact := true,
       Compile / packageDoc / publishArtifact := false,
@@ -1505,6 +1505,63 @@ object Build {
       publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-sbt-bridge-bootstrapped",
+      // Configure to use the non-bootstrapped compiler
+      scalaInstance := {
+        val externalCompilerDeps = (`scala3-compiler-nonbootstrapped` / Compile / externalDependencyClasspath).value.map(_.data).toSet
+
+        // IMPORTANT: We need to use actual jars to form the ScalaInstance and not
+        // just directories containing classfiles because sbt maintains a cache of
+        // compiler instances. This cache is invalidated based on timestamps
+        // however this is only implemented on jars, directories are never
+        // invalidated.
+        val tastyCore = (`tasty-core-nonbootstrapped` / Compile / packageBin).value
+        val scalaLibrary = (`scala-library-nonbootstrapped` / Compile / packageBin).value
+        val scala3Interfaces = (`scala3-interfaces` / Compile / packageBin).value
+        val scala3Compiler = (`scala3-compiler-nonbootstrapped` / Compile / packageBin).value
+
+        Defaults.makeScalaInstance(
+          dottyNonBootstrappedVersion,
+          libraryJars     = Array(scalaLibrary),
+          allCompilerJars = Seq(tastyCore, scala3Interfaces, scala3Compiler) ++ externalCompilerDeps,
+          allDocJars      = Seq.empty,
+          state.value,
+          scalaInstanceTopLoader.value
+        )
+      },
+      scalaCompilerBridgeBinaryJar := {
+        Some((`scala3-sbt-bridge-nonbootstrapped` / Compile / packageBin).value)
+      },
+    )
+
+  /* Configuration of the org.scala-lang:scala3-staging:*.**.**-bootstrapped project */
+  lazy val `scala3-staging-new` = project.in(file("staging"))
+    // We want the compiler to be present in the compiler classpath when compiling this project but not
+    // when compiling a project that depends on scala3-staging (see sbt-test/sbt-dotty/quoted-example-project),
+    // but we always need it to be present on the JVM classpath at runtime.
+    .dependsOn(`scala3-compiler-bootstrapped-new` % "provided; compile->runtime; test->test")
+    .settings(
+      name          := "scala3-staging",
+      moduleName    := "scala3-staging",
+      version       := dottyVersion,
+      versionScheme := Some("semver-spec"),
+      scalaVersion  := referenceVersion,
+      crossPaths    := true, // org.scala-lang:scala3-staging has a crosspath
+      autoScalaLibrary := false, // do not add a dependency to stdlib, we depend transitively on the stdlib from `scala3-compiler-bootstrapped`
+      // Add the source directories for the sbt-bridge (boostrapped)
+      Compile / unmanagedSourceDirectories := Seq(baseDirectory.value / "src"),
+      Test    / unmanagedSourceDirectories := Seq(baseDirectory.value / "test"),
+      // NOTE: The only difference here is that we drop `-Werror` and semanticDB for now
+      Compile / scalacOptions := Seq("-deprecation", "-feature", "-unchecked", "-encoding", "UTF8", "-language:implicitConversions"),
+      // Make sure that the produced artifacts have the minimum JVM version in the bytecode
+      Compile / javacOptions  ++= Seq("--target", Versions.minimumJVMVersion),
+      Compile / scalacOptions ++= Seq("--java-output-version", Versions.minimumJVMVersion),
+      // Packaging configuration of `scala3-staging`
+      Compile / packageBin / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := true,
+      // Only publish compilation artifacts, no test artifacts
+      Test    / publishArtifact := false,
+      publish / skip := false,
       // Configure to use the non-bootstrapped compiler
       scalaInstance := {
         val externalCompilerDeps = (`scala3-compiler-nonbootstrapped` / Compile / externalDependencyClasspath).value.map(_.data).toSet


### PR DESCRIPTION
Note that the tests haven't been configured yet as they depend on the test configuration of the compiler.