### PR TITLE
Prepare build for Scala 3.8.0 development

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -49,7 +49,7 @@ enum SourceVersion:
 object SourceVersion extends Property.Key[SourceVersion]:
 
   /* The default source version used by the built compiler */
-  val defaultSourceVersion = `3.7`
+  val defaultSourceVersion = `3.8`
 
   /* Illegal source versions that may not appear in the settings `-source:<...>` */
   val illegalInSettings = List(`2.13`, `3.1-migration`, `never`)

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -17,6 +17,7 @@ enum SourceVersion:
   case `3.6-migration`, `3.6`
   case `3.7-migration`, `3.7`
   case `3.8-migration`, `3.8`
+  case `3.9-migration`, `3.9`
   // Add 3.x-migration and 3.x here
   // !!! Keep in sync with scala.runtime.stdlibPatches.language !!!
   case `2.13`

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -364,6 +364,19 @@ object language:
   @compileTimeOnly("`3.8` can only be used at compile time in import statements")
   object `3.8`
 
+      /** Set source version to 3.9-migration.
+    *
+    * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
+    */
+  @compileTimeOnly("`3.9-migration` can only be used at compile time in import statements")
+  object `3.9-migration`
+
+  /** Set source version to 3.9
+    *
+    * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
+    */
+  @compileTimeOnly("`3.9` can only be used at compile time in import statements")
+  object `3.9`
 
   // !!! Keep in sync with dotty.tools.dotc.config.SourceVersion !!!
   // Also add tests in `tests/pos/source-import-3-x.scala` and `tests/pos/source-import-3-x-migration.scala`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -63,7 +63,7 @@ object Build {
    *
    *  Warning: Change of this variable might require updating `expectedTastyVersion`
    */
-  val developedVersion = "3.7.3"
+  val developedVersion = "3.8.0"
 
   /** The version of the compiler including the RC prefix.
    *  Defined as common base before calculating environment specific suffixes in `dottyVersion`


### PR DESCRIPTION
Scala 3.7.3 is being cutoff from current main branch, and we're starting Scala 3.8.0 development cycle. 

See previous cutoff PR #22378