### PR TITLE
Backport "Skip bypassing unapply for scala 2 case classes to allow for single-element named tuple in unapply" to 3.7.3

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -343,7 +343,8 @@ object PatternMatcher {
               receiver.ensureConforms(defn.NonEmptyTupleTypeRef), // If scrutinee is a named tuple, cast to underlying tuple
               Literal(Constant(i)))
 
-        if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length && args.length != 1)
+        val wasNamedArg = args.length == 1 && args.head.removeAttachment(FirstTransform.WasNamedArg).isDefined
+        if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length && !wasNamedArg)
           def tupleSel(sym: Symbol) =
             // If scrutinee is a named tuple, cast to underlying tuple, so that we can
             // continue to select with _1, _2, ...
@@ -388,7 +389,7 @@ object PatternMatcher {
                   letAbstract(get) { getResult =>
                     def isUnaryNamedTupleSelectArg(arg: Tree) =
                       get.tpe.widenDealias.isNamedTupleType
-                      && arg.removeAttachment(FirstTransform.WasNamedArg).isDefined
+                      && wasNamedArg 
                     // Special case: Normally, we pull out the argument wholesale if
                     // there is only one. But if the argument is a named argument for
                     // a single-element named tuple, we have to select the field instead.

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -343,7 +343,7 @@ object PatternMatcher {
               receiver.ensureConforms(defn.NonEmptyTupleTypeRef), // If scrutinee is a named tuple, cast to underlying tuple
               Literal(Constant(i)))
 
-        if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length)
+        if (isSyntheticScala2Unapply(unapp.symbol) && caseAccessors.length == args.length && args.length != 1)
           def tupleSel(sym: Symbol) =
             // If scrutinee is a named tuple, cast to underlying tuple, so that we can
             // continue to select with _1, _2, ...

--- a/tests/run/i23131.scala
+++ b/tests/run/i23131.scala
@@ -4,6 +4,3 @@ def Test =
   Some((name = "Bob")) match {
     case Some(name = a) => println(a)
   }
-//  (name = "Bob") match { // works fine
-//    case (name = a) => println (a)
-//  }

--- a/tests/run/i23131.scala
+++ b/tests/run/i23131.scala
@@ -1,0 +1,9 @@
+import scala.NamedTuple
+@main
+def Test =
+  Some((name = "Bob")) match {
+    case Some(name = a) => println(a)
+  }
+//  (name = "Bob") match { // works fine
+//    case (name = a) => println (a)
+//  }


### PR DESCRIPTION
Backports #23603 to the 3.7.3-RC1.

PR submitted by the release tooling.
[skip ci]