### PR TITLE
Handle assertion error in TyperState

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -162,6 +162,7 @@ trait Migrations:
   private def checkParentheses(tree: Tree, pt: FunProto)(using Context): Boolean =
     val ptSpan = pt.args.head.span
     ptSpan.exists
+    && tree.span.exists
     && ctx.source.content
       .slice(tree.span.end, ptSpan.start)
       .exists(_ == '(')


### PR DESCRIPTION
#23609 triggers an assertion error in TyperState. The relevant explanation seems to be in ProtoTypes.scala:
```scala
            // To respect the pre-condition of `mergeConstraintWith` and keep
            // `protoTyperState` committable we must ensure that it does not
            // contain any type variable which don't already exist in the passed
            // TyperState. This is achieved by instantiating any such type
            // variable. NOTE: this does not suffice to discard type variables
            // in ancestors of `protoTyperState`, if this situation ever
            // comes up, an assertion in TyperState will trigger and this code
            // will need to be generalized.
```
We should go to the bottom of it and fix the assertion. But before that's done this PR offers a temporary hack to catch the exception when it is triggered from a new code path created by PR #23532. This should fix the regression reported in #23609. We should leave the issue open as a reminder that we still need a better fix.

Also: handle crash due to missing span in a migration helper.