### PR TITLE
Defend against AliasingBounds

### DIFF
--- a/tests/warn/i22232.check
+++ b/tests/warn/i22232.check
@@ -19,8 +19,15 @@
    |                          because String already has a member with the same name and compatible parameter types.
    |
    | longer explanation available when compiling with `-explain`
--- [E194] Potential Issue Warning: tests/warn/i22232.scala:17:46 -------------------------------------------------------
-17 |  extension [T <: MyString[Byte]](arr: T) def length: Int = 0 // warn
+-- [E194] Potential Issue Warning: tests/warn/i22232.scala:21:39 -------------------------------------------------------
+21 |  extension (arr: MyStuff[String]) def add(s: String): MyStuff[String] = ??? // warn
+   |                                       ^
+   |                          Extension method add will never be selected from type MyList
+   |                          because MyList already has a member with the same name and compatible parameter types.
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E194] Potential Issue Warning: tests/warn/i22232.scala:25:46 -------------------------------------------------------
+25 |  extension [T <: MyString[Byte]](arr: T) def length: Int = 0 // warn
    |                                              ^
    |                          Extension method length will never be selected from type String
    |                          because String already has a member with the same name and compatible parameter types.

--- a/tests/warn/i22232.scala
+++ b/tests/warn/i22232.scala
@@ -12,6 +12,14 @@ object Upperbound1:
   opaque type MyString[+T] <: String = String
   extension (arr: MyString[Byte]) def length: Int = 0 // warn
 
+object Upperbound1a:
+  trait MyList[+A]:
+    def add[B >: A](x: B): MyList[B]
+  class MyListImpl[+A] extends MyList[A]:
+    def add[B >: A](x: B): MyList[B] = ???
+  opaque type MyStuff[+T] <: MyList[T] = MyListImpl[T]
+  extension (arr: MyStuff[String]) def add(s: String): MyStuff[String] = ??? // warn
+
 object Upperbound2:
   opaque type MyString[+T] <: String = String
   extension [T <: MyString[Byte]](arr: T) def length: Int = 0 // warn

--- a/tests/warn/i23293.scala
+++ b/tests/warn/i23293.scala
@@ -1,0 +1,3 @@
+trait SelectByName[Field <: String & Singleton, Rec <: Tuple]:
+  type Out
+  extension (r: Rec) def apply[F <: Field]: Out // warn not crash

--- a/tests/warn/i23666.scala
+++ b/tests/warn/i23666.scala
@@ -1,0 +1,15 @@
+
+type Tuple = scala.Tuple
+
+infix type =:= [A, B] = A => B
+
+object `=:=` :
+   given [A] => A =:= A = a => a
+
+extension [T <: Tuple] (tuple: T)
+
+   def reverse[A, B](using ev: T =:= (A, B)): (B, A) = // warn
+      val ab = ev(tuple)
+      (ab._2, ab._1)
+
+   def toList: List[Nothing] = Nil // warn


### PR DESCRIPTION
Fixes #23666 

Improve use of existing API. The fix is instead of using param's `symbol.info`, use `symbol.typeRef.dealias` and follow upper bounds, with a special case in the "subsumes" check for type param; and also a guard to not dealias an opaque type by using its bounds.
