### PR TITLE
Do not generate certain interface mixin forwarders if not necessary

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -68,11 +68,18 @@ class MixinOps(cls: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
     def generateSerializationForwarder: Boolean =
        (meth.name == nme.readResolve || meth.name == nme.writeReplace) && meth.info.paramNamess.flatten.isEmpty
 
+    // Even when mixinForwarderChoices option is true, we might not want to generate certain
+    // mixin forwarders to avoid discrepancies between java getInterfaces() and getGenericInterfaces(),
+    // as adding some unnecessary mixin forwarders forces us to extend the `interfaces` array
+    // of the generated class in its classfile
+    def isJavaInterfaceIndirectlyExtended =
+      meth.owner.isAllOf(Flags.JavaInterface) && !cls.parentSyms.contains(meth.owner)
+
     !meth.isConstructor
     && meth.is(Method, butNot = PrivateOrAccessorOrDeferred)
     && (!meth.is(JavaDefined) || !meth.owner.is(Sealed) || meth.owner.children.contains(cls))
     && (
-         ctx.settings.mixinForwarderChoices.isTruthy
+      (ctx.settings.mixinForwarderChoices.isTruthy && !isJavaInterfaceIndirectlyExtended)
       || meth.owner.is(Scala2x)
       || needsDisambiguation
       || hasNonInterfaceDefinition

--- a/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MixinOps.scala
@@ -92,11 +92,18 @@ class MixinOps(cls: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
     def generateSerializationForwarder: Boolean =
        (meth.name == nme.readResolve || meth.name == nme.writeReplace) && meth.info.paramNamess.flatten.isEmpty
 
+    // Even when mixinForwarderChoices option is true, we might not want to generate certain
+    // mixin forwarders to avoid discrepancies between java getInterfaces() and getGenericInterfaces(),
+    // as adding some unnecessary mixin forwarders forces us to extend the `interfaces` array
+    // of the generated class in its classfile
+    def isJavaInterfaceIndirectlyExtended =
+      meth.owner.isAllOf(Flags.JavaInterface) && !cls.parentSyms.contains(meth.owner)
+
     !meth.isConstructor
     && meth.is(Method, butNot = PrivateOrAccessorOrDeferred)
     && (!meth.is(JavaDefined) || !meth.owner.is(Sealed) || meth.owner.children.contains(cls))
     && (
-         ctx.settings.mixinForwarderChoices.isTruthy
+      (ctx.settings.mixinForwarderChoices.isTruthy && !isJavaInterfaceIndirectlyExtended)
       || meth.owner.is(Scala2x)
       || needsForwarder
       || generateJUnitForwarder

--- a/tests/run/i21177a/BaseRootJava.java
+++ b/tests/run/i21177a/BaseRootJava.java
@@ -1,0 +1,4 @@
+public interface BaseRootJava  {
+    default void someMethod() {
+    }
+}

--- a/tests/run/i21177a/GenericBaseIntermidiateJava.java
+++ b/tests/run/i21177a/GenericBaseIntermidiateJava.java
@@ -1,0 +1,2 @@
+public interface GenericBaseIntermidiateJava<T> extends BaseRootJava {
+}

--- a/tests/run/i21177a/Test.scala
+++ b/tests/run/i21177a/Test.scala
@@ -1,0 +1,12 @@
+class ChildScala extends GenericBaseIntermidiateJava[Int] {
+  // override def someMethod() = ???
+}
+object Test {
+  def main(args: Array[String]): Unit = {
+    val c = classOf[ChildScala]
+    assert(
+      c.getGenericInterfaces.length == c.getInterfaces.length,
+      s"mismatch between ${c.getGenericInterfaces.mkString("Array(", ", ", ")")} and ${c.getInterfaces.mkString("Array(", ", ", ")")}"
+    )
+  }
+}

--- a/tests/run/i21177b/A.java
+++ b/tests/run/i21177b/A.java
@@ -1,0 +1,1 @@
+interface A { default int m() { return 1; } }

--- a/tests/run/i21177b/Test.scala
+++ b/tests/run/i21177b/Test.scala
@@ -1,0 +1,11 @@
+abstract class B { def m(): Int }
+trait T extends B with A
+class C extends T
+
+object Test {
+  def main(args: Array[String]): Unit = {
+    val cls = classOf[C]
+    assert(cls.getInterfaces().length == cls.getGenericInterfaces().length)
+    new C().m() // lack of the mixin forwarder for m() will crash this on runtime
+  }
+}


### PR DESCRIPTION
Fixes #21177
This affects indirectly extended java interfaces, bringing the behavior closer to how scala 2 handles it. After this commit, the methods from those interfaces will not be generated, if they are unnecessary (e.g., where there is no conflict between parents when calling that method) even if `-Xmixin-force-forwarders` is set to true. Those previously added mixin forwarders caused meant that since specific parents were referenced in those methods, they had to be added to the `interfaces` array in the generated classfile (without being added to the signature, which caused an issue with getInterfaces and getGenericInterfaces not being equal).

Alternative solution would be to keep the mixing forwarder generation as it was, but change the signature generation in the GenBCode phase, but:
a) the current solution is how scala 2 does it
b) While I am not sure which solution is better in terms of binary compatibility, I feel like changing the signature would be worse

Also I copied one test from scala 2 codebase to make sure that we indeed generate the mixin forwarder if we actually need to