### PR TITLE
Fix auto-untupling for generic tuple types

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -280,7 +280,7 @@ object Applications {
         case argType :: Nil
         if args.lengthCompare(1) > 0
             && Feature.autoTuplingEnabled
-            && defn.isTupleNType(argType) =>
+            && (defn.isTupleNType(argType) || argType.isSmallGenericTuple) =>
           untpd.Tuple(args) :: Nil
         case _ =>
           args

--- a/tests/pos/generic-untupling.scala
+++ b/tests/pos/generic-untupling.scala
@@ -1,0 +1,8 @@
+
+def foo(x: Option[(Int, Boolean)]) = x match
+  case Some(a, b) => ??? // was ok
+  case None => ???
+
+def bar(x: Option[Int *: Boolean *: EmptyTuple]) = x match
+  case Some(a, b) => ??? // was error, now ok
+  case None => ???


### PR DESCRIPTION
This makes the behaviour of auto-untupling consistent between the usual and generic tuples.

Related to https://github.com/scala/scala3/pull/23602