### PR TITLE
Closes #23681: Unnecessary reference duplicate in backend 

### DIFF
--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -1168,7 +1168,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
 
       val m1Meth = getMethod(fooClass, "m1")
 
-      assertSameCode(m1Meth, List(
+      assertSameCode(m1Meth,List(
         VarOp(ALOAD, 1),
         VarOp(ASTORE, 2),
         VarOp(ALOAD, 2),
@@ -1189,29 +1189,27 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         VarOp(ILOAD, 5),
         Op(IRETURN),
         Label(19),
+        VarOp(ALOAD, 2),
         Field(GETSTATIC, "scala/package$", "MODULE$", "Lscala/package$;"),
         Invoke(INVOKEVIRTUAL, "scala/package$", "Nil", "()Lscala/collection/immutable/Nil$;", false),
-        VarOp(ALOAD, 2),
-        VarOp(ASTORE, 7),
         Op(DUP),
-        Jump(IFNONNULL, Label(31)),
+        Jump(IFNONNULL, Label(29)),
         Op(POP),
-        VarOp(ALOAD, 7),
-        Jump(IFNULL, Label(36)),
-        Jump(GOTO, Label(40)),
-        Label(31),
-        VarOp(ALOAD, 7),
+        Jump(IFNULL, Label(34)),
+        Jump(GOTO, Label(38)),
+        Label(29),
+        Op(SWAP),
         Invoke(INVOKEVIRTUAL, "java/lang/Object", "equals", "(Ljava/lang/Object;)Z", false),
-        Jump(IFEQ, Label(40)),
-        Label(36),
+        Jump(IFEQ, Label(38)),
+        Label(34),
         IntOp(BIPUSH, 20),
         Op(IRETURN),
-        Label(40),
+        Label(38),
         TypeOp(NEW, "scala/MatchError"),
         Op(DUP),
         VarOp(ALOAD, 2),
         Invoke(INVOKESPECIAL, "scala/MatchError", "<init>", "(Ljava/lang/Object;)V", false),
-        Op(ATHROW),
+        Op(ATHROW)
       ))
 
       // ---------------


### PR DESCRIPTION
## Compiler version
Scala 3.8.0-RC1-bin-20250731-fe6b7eb-NIGHTLY, JVM (21)

## Minimized code

```scala
//> using scala 3.nightly

def spin = while  true do {}

class A

@main def main =
  //creating a large object
  var large: Array[Double] | Null = Array.fill(10_000_000)(1.0)
  val other = A()

  //comparing it with another object (on the rhs)
  println((other == large))

  //dropping the reference to the large object
  large = null

  //spin to check memory usage
  spin
```

## Output
The memory grabbed by the `large` object is not freed, even though there is no variable holding it.

## Root cause

I suspect this is because of the current backend behaviour when generating the byte code for an == operation (in [BCodeBodyBuilder.scala:genEqEqPrimitive](https://github.com/scala/scala3/blob/19a147769ddbee7144edd002a61f9b30836add99/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala#L1716)):
```scala
val eqEqTempLocal = locals.makeLocal(ObjectRef, nme.EQEQ_LOCAL_VAR.mangledString, defn.ObjectType, r.span)
```
It currently creates a copy of the right-hand side of the "==", so that it can be used later without reevaluating it. However, this copy can create a new GC root, and is a potential memory leak, invisible to the user.

## Suggested fix

I suggest to replace this local variable copy by some stack operations, which might also be slightly faster.

current backend code:

```scala
val eqEqTempLocal = locals.makeLocal(ObjectRef, nme.EQEQ_LOCAL_VAR.mangledString, defn.ObjectType, r.span)
val lNull    = new asm.Label
val lNonNull = new asm.Label

genLoad(l, ObjectRef) //  load lhs
stack.push(ObjectRef)
genLoad(r, ObjectRef) // load rhs
stack.pop()
locals.store(eqEqTempLocal) // store rhs in a local variable
bc dup ObjectRef // duplicate top stack variable (lhs)
genCZJUMP(lNull, lNonNull, Primitives.EQ, ObjectRef, targetIfNoJump = lNull) // compare lhs with NULL

markProgramPoint(lNull)
bc drop ObjectRef // drop top stack variable (lhs)
locals.load(eqEqTempLocal) // load rhs then compare with NULL
genCZJUMP(success, failure, Primitives.EQ, ObjectRef, targetIfNoJump = lNonNull)

markProgramPoint(lNonNull)
locals.load(eqEqTempLocal) // load rhs then compare with lhs
genCallMethod(defn.Any_equals, InvokeStyle.Virtual)
genCZJUMP(success, failure, Primitives.NE, BOOL, targetIfNoJump)
```

I suggest replacing with the following simple stack operations, with the resulting operand stack in comment:
```diff
-          val eqEqTempLocal = locals.makeLocal(ObjectRef, nme.EQEQ_LOCAL_VAR.mangledString, defn.ObjectType, r.span)
           val lNull    = new asm.Label
           val lNonNull = new asm.Label
 
-          genLoad(l, ObjectRef)
+          genLoad(r, ObjectRef) //  load rhs --> (r)
           stack.push(ObjectRef)
-          genLoad(r, ObjectRef)
+          genLoad(l, ObjectRef) // load lhs --> (l,r)
           stack.pop()
-          locals.store(eqEqTempLocal)
           bc dup ObjectRef // duplicate top stack variable --> (l,l,r)
           genCZJUMP(lNull, lNonNull, Primitives.EQ, ObjectRef, targetIfNoJump = lNull) // compare lhs with NULL --> (l,r)
 
           markProgramPoint(lNull)
           bc drop ObjectRef // drop top stack variable --> (r)
-          locals.load(eqEqTempLocal)
           genCZJUMP(success, failure, Primitives.EQ, ObjectRef, targetIfNoJump = lNonNull) // --> (-)
 
           markProgramPoint(lNonNull)
-          locals.load(eqEqTempLocal)
+          emit(asm.Opcodes.SWAP) //swap l and r for correct .equals ordering --> (r,l)
           genCallMethod(defn.Any_equals, InvokeStyle.Virtual) // --> (-)
           genCZJUMP(success, failure, Primitives.NE, BOOL, targetIfNoJump)
```
The test [DottyBytecodeTests:patmatControlFlow](https://github.com/scala/scala3/blob/19a147769ddbee7144edd002a61f9b30836add99/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala#L1150) is modified to match the new bytecode.

