### PR TITLE
Better printing of capabilities in error messages

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -788,6 +788,9 @@ object Capabilities:
           case _: Maybe => MaybeCapability(c1)
           case _ => c1
 
+    def showAsCapability(using Context) =
+      i"capability ${ctx.printer.toTextCapability(this).show}"
+
     def toText(printer: Printer): Text = printer.toTextCapability(this)
   end Capability
 

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -1014,6 +1014,69 @@ object Capabilities:
     def inverse = Inverse()
   end Internalize
 
+  /** The local dual of a result type of a closure type.
+   *  @param binder  the method type of the anonymous function whose result is mapped
+   *  @pre           the context's owner is the anonymous function
+   */
+  class Internalize(binder: MethodType)(using Context) extends BiTypeMap:
+    thisMap =>
+
+    val sym = ctx.owner
+    assert(sym.isAnonymousFunction)
+    val paramSyms = atPhase(ctx.phase.prev):
+      // We need to ask one phase before since `sym` should not be completed as a side effect.
+      // The result of Internalize is used to se the result type of an anonymous function, and
+      // the new info of that function is built with the result.
+      sym.paramSymss.head
+    val resultToFresh = EqHashMap[ResultCap, FreshCap]()
+    val freshToResult = EqHashMap[FreshCap, ResultCap]()
+
+    override def apply(t: Type) =
+      if variance < 0 then t
+      else t match
+        case t: ParamRef =>
+          if t.binder == this.binder then paramSyms(t.paramNum).termRef else t
+        case _ => mapOver(t)
+
+    override def mapCapability(c: Capability, deep: Boolean): Capability = c match
+      case r: ResultCap if r.binder == this.binder =>
+        resultToFresh.get(r) match
+          case Some(f) => f
+          case None =>
+            val f = FreshCap(Origin.LocalInstance(binder.resType))
+            resultToFresh(r) = f
+            freshToResult(f) = r
+            f
+      case _ =>
+        super.mapCapability(c, deep)
+
+    class Inverse extends BiTypeMap:
+      def apply(t: Type): Type =
+        if variance < 0 then t
+        else t match
+          case t: TermRef if paramSyms.contains(t) =>
+            binder.paramRefs(paramSyms.indexOf(t.symbol))
+          case _ => mapOver(t)
+
+      override def mapCapability(c: Capability, deep: Boolean): Capability = c match
+        case f: FreshCap if f.owner == sym =>
+          freshToResult.get(f) match
+            case Some(r) => r
+            case None =>
+              val r = ResultCap(binder)
+              resultToFresh(r) = f
+              freshToResult(f) = r
+              r
+        case _ => super.mapCapability(c, deep)
+
+      def inverse = thisMap
+      override def toString = thisMap.toString + ".inverse"
+    end Inverse
+
+    override def toString = "InternalizeClosureResult"
+    def inverse = Inverse()
+  end Internalize
+
   /** Map top-level free existential variables one-to-one to Fresh instances */
   def resultToFresh(tp: Type, origin: Origin)(using Context): Type =
     val subst = new TypeMap:

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1300,24 +1300,23 @@ object CaptureSet:
         case cs: Var =>
           if !cs.levelOK(elem) then
             val levelStr = elem match
-              case ref: TermRef => i", defined in ${ref.symbol.maybeOwner}"
-              case _ => ""
-            i"""capability ${elem}$levelStr
-                |cannot be included in outer capture set $cs"""
+              case ref: TermRef => i", defined in ${ref.symbol.maybeOwner}\n"
+              case _ => " "
+            i"""${elem.showAsCapability}${levelStr}cannot be included in outer capture set $cs"""
           else if !elem.tryClassifyAs(cs.classifier) then
-            i"""capability ${elem} is not classified as ${cs.classifier}, therefore it
+            i"""${elem.showAsCapability} is not classified as ${cs.classifier}, therefore it
                 |cannot be included in capture set $cs of ${cs.classifier.name} elements"""
           else if cs.isBadRoot(elem) then
             elem match
               case elem: FreshCap =>
-                i"""local capability $elem created in ${elem.ccOwner}
+                i"""local ${elem.showAsCapability} created in ${elem.ccOwner}
                   |cannot be included in outer capture set $cs"""
               case _ =>
-                i"universal capability $elem cannot be included in capture set $cs"
+                i"universal ${elem.showAsCapability} cannot be included in capture set $cs"
           else
-            i"capability $elem cannot be included in capture set $cs"
+            i"${elem.showAsCapability} cannot be included in capture set $cs"
         case _ =>
-          i"capability $elem is not included in capture set $cs$why"
+          i"${elem.showAsCapability} is not included in capture set $cs$why"
 
     override def toText(printer: Printer): Text =
       inContext(printer.printerContext):

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -20,6 +20,8 @@ import CCState.*
 import TypeOps.AvoidMap
 import compiletime.uninitialized
 import Capabilities.*
+import Names.Name
+import NameKinds.CapsetName
 
 /** A class for capture sets. Capture sets can be constants or variables.
  *  Capture sets support inclusion constraints <:< where <:< is subcapturing.
@@ -738,6 +740,17 @@ object CaptureSet:
 
     var description: String = ""
 
+    private var myRepr: Name | Null = null
+
+    /** A represtentation of this capture set as a unique name. We print
+     *  empty capture set variables in this representation. Bimapped sets have
+     *  the representation of their source set.
+     */
+    def repr(using Context): Name = {
+      if (myRepr == null) myRepr = CapsetName.fresh()
+      myRepr.nn
+    }
+
     /** Check that all maps recorded in skippedMaps map `elem` to itself
      *  or something subsumed by it.
      */
@@ -1028,6 +1041,7 @@ object CaptureSet:
     override def isMaybeSet: Boolean = bimap.isInstanceOf[MaybeMap]
     override def toString = s"BiMapped$id($source, elems = $elems)"
     override def summarize = bimap.getClass.toString
+    override def repr(using Context): Name = source.repr
   end BiMapped
 
   /** A variable with elements given at any time as { x <- source.elems | p(x) } */

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -328,6 +328,7 @@ object NameKinds {
   val ExceptionBinderName: UniqueNameKind    = new UniqueNameKind("ex")
   val ExistentialBinderName: UniqueNameKind  = new UniqueNameKind("ex$")
   val SkolemName: UniqueNameKind             = new UniqueNameKind("?")
+  val CapsetName: UniqueNameKind             = new UniqueNameKind("'s")
   val SuperArgName: UniqueNameKind           = new UniqueNameKind("$superArg$")
   val DocArtifactName: UniqueNameKind        = new UniqueNameKind("$doc")
   val UniqueInlineName: UniqueNameKind       = new UniqueNameKind("$i")

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -243,8 +243,6 @@ class PlainPrinter(_ctx: Context) extends Printer {
           selectionString(tp)
         else
           toTextPrefixOf(tp) ~ selectionString(tp)
-      case tp: TermParamRef =>
-        ParamRefNameString(tp) ~ hashStr(tp.binder) ~ ".type"
       case tp: TypeParamRef =>
         val suffix =
           if showNestingLevel then

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -173,10 +173,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
     else if cs == CaptureSet.Fluid then "<fluid>"
     else
       val core: Text =
-        if !cs.isConst && cs.elems.isEmpty then "?"
-        else "{" ~ Text(cs.processElems(_.toList.map(toTextCapability)), ", ") ~ "}"
+        if !cs.isConst && cs.elems.isEmpty then cs.asVar.repr.show
+        else
+          Str("'").provided(ccVerbose && !cs.isConst)
+           ~ "{" ~ Text(cs.processElems(_.toList.map(toTextCapability)), ", ") ~ "}"
            ~ Str(".reader").provided(ccVerbose && cs.mutability == Mutability.Reader)
-           ~ Str("?").provided(ccVerbose && !cs.isConst)
            ~ Str(s"#${cs.asVar.id}").provided(showUniqueIds && !cs.isConst)
       core ~ cs.optionalInfo
 

--- a/docs/_docs/reference/experimental/cc.md
+++ b/docs/_docs/reference/experimental/cc.md
@@ -43,10 +43,12 @@ followed by `^`. We'll see that this turns the parameter into a _capability_ who
 
 If we now try to define the problematic value `later`, we get a static error:
 ```
-   |  val later = usingLogFile { f => () => f.write(0) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |The expression's type () => Unit is not allowed to capture the root capability `cap`.
-   |This usually means that a capability persists longer than its allowed lifetime.
+   |val later = usingLogFile { f => () => f.write(0) } // error
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |Found:    (f: java.io.FileOutputStream^?) ->? () ->{f} Unit
+   |Required: java.io.FileOutputStream^ => () ->? Unit
+   |
+   |Note that capability f cannot be included in outer capture set ?.
 ```
 In this case, it was easy to see that the `logFile` capability escapes in the closure passed to `usingLogFile`. But capture checking also works for more complex cases.
 For instance, capture checking is able to distinguish between the following safe code:

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -27,7 +27,7 @@ class CompletionTest {
 
   @Test def completionFromNewScalaPredef: Unit = {
     code"class Foo { val foo = summ${m1} }"
-      .completion(("summon", Method, "[T](using x: T): x.type"))
+      .completion(("summon", Method, "[T](using x: T): (x : T)"))
   }
 
   @Test def completionFromScalaPackage: Unit = {

--- a/tests/neg-custom-args/captures/box-adapt-cases.check
+++ b/tests/neg-custom-args/captures/box-adapt-cases.check
@@ -9,7 +9,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/box-adapt-cases.scala:29:10 ------------------------------
 29 |  x.value(cap => cap.use())  // error
    |          ^^^^^^^^^^^^^^^^
-   |          Found:    (cap: Cap^?) ->{io, fs} Int
+   |          Found:    (cap: Cap^'s1) ->{io, fs} Int
    |          Required: Cap^{io, fs} ->{io} Int
    |          Note that capability fs is not included in capture set {io}.
    |

--- a/tests/neg-custom-args/captures/box-adapt-cases.check
+++ b/tests/neg-custom-args/captures/box-adapt-cases.check
@@ -3,7 +3,7 @@
    |          ^^^^^^^^^^^^^^^^
    |          Found:    (cap: Cap^{io}) ->{io} Int
    |          Required: Cap^{io} -> Int
-   |          Note that capability (io : Cap^) is not included in capture set {}.
+   |          Note that capability io is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/box-adapt-cases.scala:29:10 ------------------------------
@@ -11,6 +11,6 @@
    |          ^^^^^^^^^^^^^^^^
    |          Found:    (cap: Cap^?) ->{io, fs} Int
    |          Required: Cap^{io, fs} ->{io} Int
-   |          Note that capability (fs : Cap^) is not included in capture set {io}.
+   |          Note that capability fs is not included in capture set {io}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/byname.check
+++ b/tests/neg-custom-args/captures/byname.check
@@ -18,7 +18,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:19:5 ----------------------------------------
 19 |  h(g()) // error
    |    ^^^
-   |    Found:    () ?->{cap2} I^?
+   |    Found:    () ?->{cap2} I^'s1
    |    Required: () ?->{cap1} I
    |    Note that capability cap2 is not included in capture set {cap1}.
    |
@@ -26,7 +26,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:22:5 ----------------------------------------
 22 |  h2(() => g())() // error
    |     ^^^^^^^^^
-   |     Found:    () ->{cap2} I^?
+   |     Found:    () ->{cap2} I^'s2
    |     Required: () ->{cap1} I
    |     Note that capability cap2 is not included in capture set {cap1}.
    |

--- a/tests/neg-custom-args/captures/byname.check
+++ b/tests/neg-custom-args/captures/byname.check
@@ -12,7 +12,7 @@
    |
    |where:    ?=> refers to a fresh root capability created in method test when checking argument to parameter ff of method h
    |
-   |Note that capability (cap1 : Cap) is not included in capture set {cap2}.
+   |Note that capability cap1 is not included in capture set {cap2}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:19:5 ----------------------------------------
@@ -20,7 +20,7 @@
    |    ^^^
    |    Found:    () ?->{cap2} I^?
    |    Required: () ?->{cap1} I
-   |    Note that capability (cap2 : Cap) is not included in capture set {cap1}.
+   |    Note that capability cap2 is not included in capture set {cap1}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:22:5 ----------------------------------------
@@ -28,6 +28,6 @@
    |     ^^^^^^^^^
    |     Found:    () ->{cap2} I^?
    |     Required: () ->{cap1} I
-   |     Note that capability (cap2 : Cap) is not included in capture set {cap1}.
+   |     Note that capability cap2 is not included in capture set {cap1}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/capt-depfun.check
+++ b/tests/neg-custom-args/captures/capt-depfun.check
@@ -6,6 +6,6 @@
    |
    |                                         where:    => refers to a fresh root capability in the type of value dc
    |
-   |                                         Note that capability (y : C^) is not included in capture set {}.
+   |                                         Note that capability y is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/capt1.check
+++ b/tests/neg-custom-args/captures/capt1.check
@@ -3,7 +3,7 @@
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |  Found:    () ->{x} C
   |  Required: () -> C
-  |  Note that capability (x : C^) is not included in capture set {}.
+  |  Note that capability x is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/capt1.scala:8:2 ------------------------------------------
@@ -11,7 +11,7 @@
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |  Found:    () ->{x} C^?
   |  Required: Matchable
-  |  Note that capability (x : C^) is not included in capture set {}.
+  |  Note that capability x is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/capt1.scala:15:2 -----------------------------------------
@@ -19,7 +19,7 @@
    |  ^
    |  Found:    (y: Int) ->{x} Int
    |  Required: Matchable
-   |  Note that capability (x : C^) is not included in capture set {}.
+   |  Note that capability x is not included in capture set {}.
 16 |  f
    |
    | longer explanation available when compiling with `-explain`
@@ -28,7 +28,7 @@
    |  ^
    |  Found:    A^{x}
    |  Required: A
-   |  Note that capability (x : C^) is not included in capture set {}.
+   |  Note that capability x is not included in capture set {}.
 23 |    def m() = if x == null then y else y
 24 |  F(22)
    |
@@ -38,7 +38,7 @@
    |  ^
    |  Found:    A^{x}
    |  Required: A
-   |  Note that capability (x : C^) is not included in capture set {}.
+   |  Note that capability x is not included in capture set {}.
 28 |    def m() = if x == null then y else y
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/capt1.check
+++ b/tests/neg-custom-args/captures/capt1.check
@@ -9,7 +9,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/capt1.scala:8:2 ------------------------------------------
 8 |  () => if x == null then y else y  // error
   |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |  Found:    () ->{x} C^?
+  |  Found:    () ->{x} C^'s1
   |  Required: Matchable
   |  Note that capability x is not included in capture set {}.
   |
@@ -52,7 +52,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/capt1.scala:36:24 ----------------------------------------
 36 |  val z2 = h[() -> Cap](() => x) // error // error
    |                        ^^^^^^^
-   |Found:    () ->? C^
+   |Found:    () ->'s2 C^
    |Required: () -> C^²
    |
    |where:    ^  refers to a root capability associated with the result type of (): C^
@@ -65,7 +65,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/capt1.scala:37:5 -----------------------------------------
 37 |    (() => C()) // error
    |     ^^^^^^^^^
-   |Found:    () ->? C^
+   |Found:    () ->'s3 C^
    |Required: () -> C^²
    |
    |where:    ^  refers to a root capability associated with the result type of (): C^

--- a/tests/neg-custom-args/captures/cc-glb.check
+++ b/tests/neg-custom-args/captures/cc-glb.check
@@ -3,6 +3,6 @@
   |                   ^^
   |                   Found:    (x1 : (Foo[T] & Foo[Any])^{io})
   |                   Required: Foo[T]
-  |                   Note that capability (io : Cap^) is not included in capture set {}.
+  |                   Note that capability io is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/cc-poly-2.check
+++ b/tests/neg-custom-args/captures/cc-poly-2.check
@@ -14,6 +14,6 @@
    |                    ^
    |                    Found:    (x : Test.D^{d})
    |                    Required: Test.D^{c1}
-   |                    Note that capability (d : Test.D^) is not included in capture set {c1}.
+   |                    Note that capability d is not included in capture set {c1}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/cc-this.check
+++ b/tests/neg-custom-args/captures/cc-this.check
@@ -3,7 +3,7 @@
    |               ^^^^
    |               Found:    (C.this : C^{C.this.x})
    |               Required: C
-   |               Note that capability (C.this.x : () => Int) is not included in capture set {}.
+   |               Note that capability C.this.x is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/cc-this.scala:12:15 -----------------------------------------------------------

--- a/tests/neg-custom-args/captures/cc-this5.check
+++ b/tests/neg-custom-args/captures/cc-this5.check
@@ -8,7 +8,7 @@
    |               ^^^^
    |               Found:    (A.this : A^{c})
    |               Required: A
-   |               Note that capability (c : Cap) is not included in capture set {}.
+   |               Note that capability c is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E058] Type Mismatch Error: tests/neg-custom-args/captures/cc-this5.scala:7:9 ---------------------------------------

--- a/tests/neg-custom-args/captures/class-contra.check
+++ b/tests/neg-custom-args/captures/class-contra.check
@@ -3,6 +3,6 @@
    |                                        ^
    |                                        Found:    (a : T^{x, y})
    |                                        Required: T^{k.f}
-   |                                        Note that capability (x : C^) is not included in capture set {k.f}.
+   |                                        Note that capability x is not included in capture set {k.f}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/class-level-attack.check
+++ b/tests/neg-custom-args/captures/class-level-attack.check
@@ -13,7 +13,7 @@
    |
    |                          where:    ^ refers to a fresh root capability in the type of value r
    |
-   |                          Note that capability (x : IO^) is not included in capture set {cap}
+   |                          Note that capability x is not included in capture set {cap}
    |                          because (x : IO^) in method set is not visible from cap in value r.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/contracap.check
+++ b/tests/neg-custom-args/captures/contracap.check
@@ -1,11 +1,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/contracap.scala:15:48 ------------------------------------
 15 |  val g: (Ref[Int]^{a}, Ref[Int]^{a}) -> Unit = f // error
    |                                                ^
-   |                                      Found:    (f : (Ref[Int]^, Ref[Int]^) -> Unit)
-   |                                      Required: (Ref[Int]^{a}, Ref[Int]^{a}) -> Unit
+   |                                                Found:    (f : (Ref[Int]^, Ref[Int]^) -> Unit)
+   |                                                Required: (Ref[Int]^{a}, Ref[Int]^{a}) -> Unit
    |
-   |                                      where:    ^ refers to the universal root capability
+   |                                                where:    ^ refers to the universal root capability
    |
-   |                                      Note that capability (a : Ref[Int]^) is not included in capture set {cap}.
+   |                                                Note that capability a is not included in capture set {cap}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/depfun-reach.check
+++ b/tests/neg-custom-args/captures/depfun-reach.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/depfun-reach.scala:12:27 ---------------------------------
 12 |    List(() => op.foreach((f,g) => { f(); g() })) // error (???)
    |                           ^^^^^^^^^^^^^^^^^^^^
-   |Found:    (x$1: (() ->? Unit, () ->? Unit)^?) ->? Unit
+   |Found:    (x$1: (() ->'s1 Unit, () ->'s2 Unit)^'s3) ->'s4 Unit
    |Required: ((() ->{op*} Unit, () ->{op*} Unit)) => Unit
    |
    |where:    => refers to a fresh root capability created in anonymous function of type (): Unit when checking argument to parameter op of method foreach

--- a/tests/neg-custom-args/captures/effect-swaps-explicit.check
+++ b/tests/neg-custom-args/captures/effect-swaps-explicit.check
@@ -4,7 +4,7 @@
    |      ^
    |      Found:    Result.Ok[Future[T^?]^{fr, contextual$1}]
    |      Required: Result[Future[T], Nothing]
-   |      Note that capability (fr : Future[Result[T, E]]^) is not included in capture set {}.
+   |      Note that capability fr is not included in capture set {}.
 65 |          fr.await.ok
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
@@ -24,8 +24,7 @@
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
    |
-   |Note that capability contextual$9.type
-   |cannot be included in outer capture set ?.
+   |Note that capability contextual$9 cannot be included in outer capture set ?.
 70 |            fr.await.ok
    |
    | longer explanation available when compiling with `-explain`
@@ -38,7 +37,7 @@
    |where:    ?=> refers to a fresh root capability created in method fail5 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
    |
-   |Note that capability (fr : Future[Result[T, E]]^) is not included in capture set {}.
+   |Note that capability fr is not included in capture set {}.
 74 |          Future: fut ?=>
 75 |            fr.await.ok
    |

--- a/tests/neg-custom-args/captures/effect-swaps-explicit.check
+++ b/tests/neg-custom-args/captures/effect-swaps-explicit.check
@@ -2,7 +2,7 @@
 63 |      Result:
 64 |        Future: // error, type mismatch
    |      ^
-   |      Found:    Result.Ok[Future[T^?]^{fr, contextual$1}]
+   |      Found:    Result.Ok[Future[T^'s1]^{fr, contextual$1}]
    |      Required: Result[Future[T], Nothing]
    |      Note that capability fr is not included in capture set {}.
 65 |          fr.await.ok
@@ -18,20 +18,20 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/effect-swaps-explicit.scala:69:10 ------------------------
 69 |          Future: fut ?=> // error, type mismatch
    |          ^
-   |Found:    (contextual$9: boundary.Label[Result[Future[T^?]^?, E^?]^?]^?) ?->{fr, async} Future[T^?]^{fr, contextual$9}
-   |Required: (boundary.Label[Result[Future[T^?]^?, E^?]]^) ?=> Future[T^?]^?
+   |Found:    (contextual$9: boundary.Label[Result[Future[T^'s2]^'s3, E^'s4]^'s5]^'s6) ?->{fr, async} Future[T^'s7]^{fr, contextual$9}
+   |Required: (boundary.Label[Result[Future[T^'s8]^'s9, E^'s10]]^) ?=> Future[T^'s8]^'s9
    |
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
    |
-   |Note that capability contextual$9 cannot be included in outer capture set ?.
+   |Note that capability contextual$9 cannot be included in outer capture set 's9.
 70 |            fr.await.ok
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/effect-swaps-explicit.scala:73:35 ------------------------
 73 |        Result.make[Future[T], E]: lbl ?=> // error: type mismatch
    |                                   ^
-   |Found:    (lbl: boundary.Label[Result[Future[T^?]^?, E^?]^?]^?) ?->{fr, async} Future[T^?]^{fr, lbl}
+   |Found:    (lbl: boundary.Label[Result[Future[T^'s11]^'s12, E^'s13]^'s14]^'s15) ?->{fr, async} Future[T^'s16]^{fr, lbl}
    |Required: (boundary.Label[Result[Future[T], E]]^) ?=> Future[T]
    |
    |where:    ?=> refers to a fresh root capability created in method fail5 when checking argument to parameter body of method make

--- a/tests/neg-custom-args/captures/effect-swaps.check
+++ b/tests/neg-custom-args/captures/effect-swaps.check
@@ -4,7 +4,7 @@
    |      ^
    |      Found:    Result.Ok[Future[T^?]^{fr, contextual$1}]
    |      Required: Result[Future[T], Nothing]
-   |      Note that capability (fr : Future[Result[T, E]]^) is not included in capture set {}.
+   |      Note that capability fr is not included in capture set {}.
 65 |          fr.await.ok
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
@@ -24,8 +24,7 @@
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
    |
-   |Note that capability contextual$9.type
-   |cannot be included in outer capture set ?.
+   |Note that capability contextual$9 cannot be included in outer capture set ?.
 70 |            fr.await.ok
    |
    | longer explanation available when compiling with `-explain`
@@ -38,7 +37,7 @@
    |where:    ?=> refers to a fresh root capability created in method fail5 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
    |
-   |Note that capability (fr : Future[Result[T, E]]^) is not included in capture set {}.
+   |Note that capability fr is not included in capture set {}.
 74 |          Future: fut ?=>
 75 |            fr.await.ok
    |

--- a/tests/neg-custom-args/captures/effect-swaps.check
+++ b/tests/neg-custom-args/captures/effect-swaps.check
@@ -2,7 +2,7 @@
 63 |      Result:
 64 |        Future: // error, type mismatch
    |      ^
-   |      Found:    Result.Ok[Future[T^?]^{fr, contextual$1}]
+   |      Found:    Result.Ok[Future[T^'s1]^{fr, contextual$1}]
    |      Required: Result[Future[T], Nothing]
    |      Note that capability fr is not included in capture set {}.
 65 |          fr.await.ok
@@ -18,20 +18,20 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/effect-swaps.scala:69:10 ---------------------------------
 69 |          Future: fut ?=> // error, type mismatch
    |          ^
-   |Found:    (contextual$9: boundary.Label[Result[Future[T^?]^?, E^?]^?]^?) ?->{fr, async} Future[T^?]^{fr, contextual$9}
-   |Required: (boundary.Label[Result[Future[T^?]^?, E^?]]^) ?=> Future[T^?]^?
+   |Found:    (contextual$9: boundary.Label[Result[Future[T^'s2]^'s3, E^'s4]^'s5]^'s6) ?->{fr, async} Future[T^'s7]^{fr, contextual$9}
+   |Required: (boundary.Label[Result[Future[T^'s8]^'s9, E^'s10]]^) ?=> Future[T^'s8]^'s9
    |
    |where:    ?=> refers to a fresh root capability created in method fail4 when checking argument to parameter body of method make
    |          ^   refers to the universal root capability
    |
-   |Note that capability contextual$9 cannot be included in outer capture set ?.
+   |Note that capability contextual$9 cannot be included in outer capture set 's9.
 70 |            fr.await.ok
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/effect-swaps.scala:73:35 ---------------------------------
 73 |        Result.make[Future[T], E]: lbl ?=> // error: type mismatch
    |                                   ^
-   |Found:    (lbl: boundary.Label[Result[Future[T^?]^?, E^?]^?]^?) ?->{fr, async} Future[T^?]^{fr, lbl}
+   |Found:    (lbl: boundary.Label[Result[Future[T^'s11]^'s12, E^'s13]^'s14]^'s15) ?->{fr, async} Future[T^'s16]^{fr, lbl}
    |Required: (boundary.Label[Result[Future[T], E]]^) ?=> Future[T]
    |
    |where:    ?=> refers to a fresh root capability created in method fail5 when checking argument to parameter body of method make

--- a/tests/neg-custom-args/captures/eta.check
+++ b/tests/neg-custom-args/captures/eta.check
@@ -3,6 +3,6 @@
   |         ^
   |         Found:    (g : () -> A)
   |         Required: () -> Proc^{f}
-  |         Note that capability (f : Proc^) is not included in capture set {}.
+  |         Note that capability f is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/filevar.check
+++ b/tests/neg-custom-args/captures/filevar.check
@@ -1,12 +1,12 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/filevar.scala:15:12 --------------------------------------
 15 |  withFile: f =>       // error with level checking, was OK under both schemes before
    |            ^
-   |Found:    (f: File^?) ->? Unit
+   |Found:    (f: File^'s1) ->'s2 Unit
    |Required: (f: File^{l}) => Unit
    |
    |where:    => refers to a fresh root capability created in anonymous function of type (using l²: scala.caps.Capability): File^{l²} -> Unit when instantiating expected result type (f: File^{l}) ->{cap} Unit of function literal
    |
-   |Note that capability l cannot be included in outer capture set ? of parameter f.
+   |Note that capability l cannot be included in outer capture set 's1 of parameter f.
 16 |    val o = Service()
 17 |    o.file = f
 18 |    o.log

--- a/tests/neg-custom-args/captures/filevar.check
+++ b/tests/neg-custom-args/captures/filevar.check
@@ -6,8 +6,7 @@
    |
    |where:    => refers to a fresh root capability created in anonymous function of type (using l²: scala.caps.Capability): File^{l²} -> Unit when instantiating expected result type (f: File^{l}) ->{cap} Unit of function literal
    |
-   |Note that capability l.type
-   |cannot be included in outer capture set ? of parameter f.
+   |Note that capability l cannot be included in outer capture set ? of parameter f.
 16 |    val o = Service()
 17 |    o.file = f
 18 |    o.log
@@ -16,4 +15,4 @@
 -- Warning: tests/neg-custom-args/captures/filevar.scala:11:55 ---------------------------------------------------------
 11 |def withFile[T](op: (l: caps.Capability) ?-> (f: File^{l}) => T): T =
    |                                                       ^
-   |                                                       redundant capture: File already accounts for l.type
+   |                                        redundant capture: File already accounts for (l : scala.caps.Capability)

--- a/tests/neg-custom-args/captures/heal-tparam-cs.check
+++ b/tests/neg-custom-args/captures/heal-tparam-cs.check
@@ -1,13 +1,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:10:23 -------------------------------
 10 |  val test1 = localCap { c => // error
    |                       ^
-   |Found:    (c: Capp^?) ->? () ->{c} Unit
-   |Required: (c: Capp^) => () ->? Unit
+   |Found:    (c: Capp^'s1) ->'s2 () ->{c} Unit
+   |Required: (c: Capp^) => () ->'s3 Unit
    |
    |where:    => refers to a fresh root capability created in value test1 when checking argument to parameter op of method localCap
    |          ^  refers to the universal root capability
    |
-   |Note that capability c cannot be included in outer capture set ?.
+   |Note that capability c cannot be included in outer capture set 's3.
 11 |    () => { c.use() }
 12 |  }
    |
@@ -15,13 +15,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:15:13 -------------------------------
 15 |    localCap { c =>  // error
    |    ^
-   |    Found:    (x$0: Capp^?) ->? () ->{x$0} Unit
+   |    Found:    (x$0: Capp^'s4) ->'s5 () ->{x$0} Unit
    |    Required: (c: Capp^) -> () => Unit
    |
    |    where:    => refers to a root capability associated with the result type of (c: Capp^): () => Unit
    |              ^  refers to the universal root capability
    |
-   |    Note that capability x$0 is not included in capture set {<cap of (x$0: Capp^?): () ->{x$0} Unit>}.
+   |    Note that capability x$0 is not included in capture set {<cap of (x$0: Capp^'s4): () ->{x$0} Unit>}.
 16 |      (c1: Capp^) => () => { c1.use() }
 17 |    }
    |
@@ -29,7 +29,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:25:13 -------------------------------
 25 |    localCap { c =>  // error
    |    ^
-   |    Found:    (x$0: Capp^?) ->? () ->{x$0} Unit
+   |    Found:    (x$0: Capp^'s6) ->'s7 () ->{x$0} Unit
    |    Required: (c: Capp^{io}) -> () ->{net} Unit
    |    Note that capability x$0 is not included in capture set {net}.
 26 |      (c1: Capp^{io}) => () => { c1.use() }

--- a/tests/neg-custom-args/captures/heal-tparam-cs.check
+++ b/tests/neg-custom-args/captures/heal-tparam-cs.check
@@ -7,8 +7,7 @@
    |where:    => refers to a fresh root capability created in value test1 when checking argument to parameter op of method localCap
    |          ^  refers to the universal root capability
    |
-   |Note that capability c.type
-   |cannot be included in outer capture set ?.
+   |Note that capability c cannot be included in outer capture set ?.
 11 |    () => { c.use() }
 12 |  }
    |
@@ -22,7 +21,7 @@
    |    where:    => refers to a root capability associated with the result type of (c: Capp^): () => Unit
    |              ^  refers to the universal root capability
    |
-   |    Note that capability x$0.type is not included in capture set {<cap of (x$0: Capp^?): () ->{x$0} Unit>}.
+   |    Note that capability x$0 is not included in capture set {<cap of (x$0: Capp^?): () ->{x$0} Unit>}.
 16 |      (c1: Capp^) => () => { c1.use() }
 17 |    }
    |
@@ -32,7 +31,7 @@
    |    ^
    |    Found:    (x$0: Capp^?) ->? () ->{x$0} Unit
    |    Required: (c: Capp^{io}) -> () ->{net} Unit
-   |    Note that capability x$0.type is not included in capture set {net}.
+   |    Note that capability x$0 is not included in capture set {net}.
 26 |      (c1: Capp^{io}) => () => { c1.use() }
 27 |    }
    |
@@ -42,7 +41,7 @@
    |          ^^^^^^^^^^^^^^
    |          Found:    () ->{io} Unit
    |          Required: () -> Unit
-   |          Note that capability (io : Capp^) is not included in capture set {}.
+   |          Note that capability io is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:44:10 -------------------------------
@@ -50,6 +49,6 @@
    |          ^^^^^^^^^^^^^^
    |          Found:    () ->{io} Unit
    |          Required: () -> Unit
-   |          Note that capability (io : Capp^) is not included in capture set {}.
+   |          Note that capability io is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i15772.check
+++ b/tests/neg-custom-args/captures/i15772.check
@@ -37,7 +37,7 @@
    |  ^
    |  Found:    (x : () ->{filesList, sayHello} Unit)
    |  Required: () -> Unit
-   |  Note that capability (filesList : List[File]^{io}) is not included in capture set {}.
+   |  Note that capability filesList is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/i15772.scala:34:10 ------------------------------------------------------------

--- a/tests/neg-custom-args/captures/i15923.check
+++ b/tests/neg-custom-args/captures/i15923.check
@@ -1,25 +1,25 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i15923.scala:27:23 ---------------------------------------
 27 |    val leak = withCap(cap => mkId(cap))  // error (was: no error here since type aliases don't box)
    |                       ^^^^^^^^^^^^^^^^
-   |Found:    (cap: test2.Cap^?) ->? [T] => (op: test2.Cap^? ->? T) ->? T
-   |Required: test2.Cap^{lcap} => [T] => (op²: test2.Cap^? ->? T) ->? T
+   |Found:    (cap: test2.Cap^'s1) ->'s2 [T] => (op: test2.Cap^'s3 ->'s4 T) ->'s5 T
+   |Required: test2.Cap^{lcap} => [T] => (op²: test2.Cap^'s6 ->'s7 T) ->'s8 T
    |
-   |where:    =>  refers to a fresh root capability created in anonymous function of type (using lcap²: scala.caps.Capability): test2.Cap^{lcap²} -> [T] => (op³: test2.Cap^{lcap²} => T) -> T when instantiating expected result type test2.Cap^{lcap} ->{cap²} [T] => (op²: test2.Cap^? ->? T) ->? T of function literal
+   |where:    =>  refers to a fresh root capability created in anonymous function of type (using lcap²: scala.caps.Capability): test2.Cap^{lcap²} -> [T] => (op³: test2.Cap^{lcap²} => T) -> T when instantiating expected result type test2.Cap^{lcap} ->{cap²} [T] => (op²: test2.Cap^'s6 ->'s7 T) ->'s8 T of function literal
    |          op  is a reference to a value parameter
    |          op² is a reference to a value parameter
    |
-   |Note that capability lcap cannot be included in outer capture set ? of parameter cap.
+   |Note that capability lcap cannot be included in outer capture set 's1 of parameter cap.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i15923.scala:12:21 ---------------------------------------
 12 |  val leak = withCap(cap => mkId(cap)) // error
    |                     ^^^^^^^^^^^^^^^^
-   |Found:    (cap: Cap^?) ->? Id[Cap^?]^?
-   |Required: Cap^{lcap} => Id[Cap^?]^?
+   |Found:    (cap: Cap^'s9) ->'s10 Id[Cap^'s11]^'s12
+   |Required: Cap^{lcap} => Id[Cap^'s13]^'s14
    |
-   |where:    => refers to a fresh root capability created in anonymous function of type (using lcap²: scala.caps.Capability): Cap^{lcap²} -> Id[Cap] when instantiating expected result type Cap^{lcap} ->{cap²} Id[Cap^?]^? of function literal
+   |where:    => refers to a fresh root capability created in anonymous function of type (using lcap²: scala.caps.Capability): Cap^{lcap²} -> Id[Cap] when instantiating expected result type Cap^{lcap} ->{cap²} Id[Cap^'s13]^'s14 of function literal
    |
-   |Note that capability lcap cannot be included in outer capture set ? of parameter cap.
+   |Note that capability lcap cannot be included in outer capture set 's9 of parameter cap.
    |
    | longer explanation available when compiling with `-explain`
 -- Warning: tests/neg-custom-args/captures/i15923.scala:21:56 ----------------------------------------------------------

--- a/tests/neg-custom-args/captures/i15923.check
+++ b/tests/neg-custom-args/captures/i15923.check
@@ -8,8 +8,7 @@
    |          op  is a reference to a value parameter
    |          op² is a reference to a value parameter
    |
-   |Note that capability lcap.type
-   |cannot be included in outer capture set ? of parameter cap.
+   |Note that capability lcap cannot be included in outer capture set ? of parameter cap.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i15923.scala:12:21 ---------------------------------------
@@ -20,15 +19,14 @@
    |
    |where:    => refers to a fresh root capability created in anonymous function of type (using lcap²: scala.caps.Capability): Cap^{lcap²} -> Id[Cap] when instantiating expected result type Cap^{lcap} ->{cap²} Id[Cap^?]^? of function literal
    |
-   |Note that capability lcap.type
-   |cannot be included in outer capture set ? of parameter cap.
+   |Note that capability lcap cannot be included in outer capture set ? of parameter cap.
    |
    | longer explanation available when compiling with `-explain`
 -- Warning: tests/neg-custom-args/captures/i15923.scala:21:56 ----------------------------------------------------------
 21 |    def withCap[X](op: (lcap: caps.Capability) ?-> Cap^{lcap} => X): X = {
    |                                                        ^^^^
-   |                                                     redundant capture: test2.Cap already accounts for lcap.type
+   |                                redundant capture: test2.Cap already accounts for (lcap : scala.caps.Capability)
 -- Warning: tests/neg-custom-args/captures/i15923.scala:6:54 -----------------------------------------------------------
 6 |  def withCap[X](op: (lcap: caps.Capability) ?-> Cap^{lcap} => X): X = {
   |                                                      ^^^^
-  |                                                      redundant capture: Cap already accounts for lcap.type
+  |                                        redundant capture: Cap already accounts for (lcap : scala.caps.Capability)

--- a/tests/neg-custom-args/captures/i15923a.check
+++ b/tests/neg-custom-args/captures/i15923a.check
@@ -8,7 +8,6 @@
   |          =>² refers to a root capability associated with the result type of (lcap: Cap^): () =>² Id[Cap^?]^?
   |          ^   refers to the universal root capability
   |
-  |Note that capability <cap of (): Id[Cap^?]^?>
-  |cannot be included in outer capture set ?.
+  |Note that capability <cap of (): Id[Cap^?]^?> cannot be included in outer capture set ?.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i15923a.check
+++ b/tests/neg-custom-args/captures/i15923a.check
@@ -1,13 +1,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i15923a.scala:7:21 ---------------------------------------
 7 |  val leak = withCap(lcap => () => mkId(lcap)) // error
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^
-  |Found:    (lcap: Cap^?) ->? () ->? Id[Cap^?]^?
-  |Required: (lcap: Cap^) => () =>² Id[Cap^?]^?
+  |Found:    (lcap: Cap^'s1) ->'s2 () ->'s3 Id[Cap^'s4]^'s5
+  |Required: (lcap: Cap^) => () =>² Id[Cap^'s6]^'s7
   |
   |where:    =>  refers to a fresh root capability created in value leak when checking argument to parameter op of method withCap
-  |          =>² refers to a root capability associated with the result type of (lcap: Cap^): () =>² Id[Cap^?]^?
+  |          =>² refers to a root capability associated with the result type of (lcap: Cap^): () =>² Id[Cap^'s6]^'s7
   |          ^   refers to the universal root capability
   |
-  |Note that capability <cap of (): Id[Cap^?]^?> cannot be included in outer capture set ?.
+  |Note that capability <cap of (): Id[Cap^'s4]^'s5> cannot be included in outer capture set 's6.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i15923b.check
+++ b/tests/neg-custom-args/captures/i15923b.check
@@ -2,11 +2,11 @@
 8 |  val leak = withCap(f) // error
   |                     ^
   |Found:    (x$0: Cap^) -> Id[Cap^{x$0}]
-  |Required: (lcap: Cap^) => Id[Cap^?]^?
+  |Required: (lcap: Cap^) => Id[Cap^'s1]^'s2
   |
   |where:    => refers to a fresh root capability created in value leak when checking argument to parameter op of method withCap
   |          ^  refers to the universal root capability
   |
-  |Note that capability lcap cannot be included in outer capture set ?.
+  |Note that capability lcap cannot be included in outer capture set 's1.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i15923b.check
+++ b/tests/neg-custom-args/captures/i15923b.check
@@ -7,7 +7,6 @@
   |where:    => refers to a fresh root capability created in value leak when checking argument to parameter op of method withCap
   |          ^  refers to the universal root capability
   |
-  |Note that capability lcap.type
-  |cannot be included in outer capture set ?.
+  |Note that capability lcap cannot be included in outer capture set ?.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i16226.check
+++ b/tests/neg-custom-args/captures/i16226.check
@@ -1,29 +1,36 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i16226.scala:13:4 ----------------------------------------
 13 |    (ref1, f1) => map[A, B](ref1, f1) // error
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (ref1: LazyRef[A^?]{val elem: () ->? A^?}^?, f1: A^? ->? B^?) ->? LazyRef[B^?]{val elem: () => B^?}^{f1, ref1}
+   |Found:    (ref1: LazyRef[A^'s1]{val elem: () ->'s2 A^'s3}^'s4, f1: A^'s5 ->'s6 B^'s7) ->'s8
+   |  LazyRef[B^'s9]{val elem: () => B^'s10}^{f1, ref1}
    |Required: (LazyRef[A]^{io}, A =>² B) =>³ LazyRef[B]^
    |
-   |where:    =>  refers to a root capability associated with the result type of (ref1: LazyRef[A^?]{val elem: () ->? A^?}^?, f1: A^? ->? B^?): LazyRef[B^?]{val elem: () => B^?}^{f1, ref1}
+   |where:    =>  refers to a root capability associated with the result type of (ref1: LazyRef[A^'s1]{val elem: () ->'s2 A^'s3}^'s4, f1: A^'s5 ->'s6 B^'s7):
+   |  LazyRef[B^'s9]{val elem: () => B^'s10}^{f1, ref1}
    |          =>² refers to the universal root capability
    |          =>³ refers to a fresh root capability in the result type of method mapc
    |          ^   refers to a fresh root capability in the result type of method mapc
    |
    |Note that capability f1 is not included in capture set {cap}
-   |because (f1 : A^? ->? B^?) is not visible from cap in method mapc.
+   |because (f1 : A^'s5 ->'s6 B^'s7) is not visible from cap in method mapc.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i16226.scala:15:4 ----------------------------------------
 15 |    (ref1, f1) => map[A, B](ref1, f1) // error
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (ref1: LazyRef[A^?]{val elem: () ->? A^?}^?, f1: A^? ->? B^?) ->? LazyRef[B^?]{val elem: () => B^?}^{f1, ref1}
+   |Found:    (ref1: LazyRef[A^'s11]{val elem: () ->'s12 A^'s13}^'s14, f1: A^'s15 ->'s16 B^'s17) ->'s18
+   |  LazyRef[B^'s19]{val elem: () => B^'s20}^{f1, ref1}
    |Required: (ref: LazyRef[A]^{io}, f: A =>² B) =>³ LazyRef[B]^
    |
-   |where:    =>  refers to a root capability associated with the result type of (ref1: LazyRef[A^?]{val elem: () ->? A^?}^?, f1: A^? ->? B^?): LazyRef[B^?]{val elem: () => B^?}^{f1, ref1}
+   |where:    =>  refers to a root capability associated with the result type of (ref1: LazyRef[A^'s11]{val elem: () ->'s12 A^'s13}^'s14, f1: A^'s15 ->'s16 B^'s17):
+   |  LazyRef[B^'s19]{val elem: () => B^'s20}^{f1, ref1}
    |          =>² refers to the universal root capability
    |          =>³ refers to a fresh root capability in the result type of method mapd
    |          ^   refers to a root capability associated with the result type of (ref: LazyRef[A]^{io}, f: A =>² B): LazyRef[B]^
    |
-   |Note that capability f1 is not included in capture set {<cap of (ref1: LazyRef[A^?]{val elem: () ->? A^?}^?, f1: A^? ->? B^?): LazyRef[B^?]{val elem: () => B^?}^{f1, ref1}>}.
+   |Note that capability f1 is not included in capture set {<cap of
+   |  (ref1: LazyRef[A^'s11]{val elem: () ->'s12 A^'s13}^'s14, f1: A^'s15 ->'s16 B^'s17):
+   |    LazyRef[B^'s19]{val elem: () => B^'s20}^{f1, ref1}
+   |>}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i16226.check
+++ b/tests/neg-custom-args/captures/i16226.check
@@ -9,8 +9,8 @@
    |          =>³ refers to a fresh root capability in the result type of method mapc
    |          ^   refers to a fresh root capability in the result type of method mapc
    |
-   |Note that capability f1.type is not included in capture set {cap}
-   |because f1.type is not visible from cap in method mapc.
+   |Note that capability f1 is not included in capture set {cap}
+   |because (f1 : A^? ->? B^?) is not visible from cap in method mapc.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i16226.scala:15:4 ----------------------------------------
@@ -24,6 +24,6 @@
    |          =>³ refers to a fresh root capability in the result type of method mapd
    |          ^   refers to a root capability associated with the result type of (ref: LazyRef[A]^{io}, f: A =>² B): LazyRef[B]^
    |
-   |Note that capability f1.type is not included in capture set {<cap of (ref1: LazyRef[A^?]{val elem: () ->? A^?}^?, f1: A^? ->? B^?): LazyRef[B^?]{val elem: () => B^?}^{f1, ref1}>}.
+   |Note that capability f1 is not included in capture set {<cap of (ref1: LazyRef[A^?]{val elem: () ->? A^?}^?, f1: A^? ->? B^?): LazyRef[B^?]{val elem: () => B^?}^{f1, ref1}>}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i19330.check
+++ b/tests/neg-custom-args/captures/i19330.check
@@ -8,7 +8,7 @@
    |    ^
    |    Found:    () ->{t} Logger^{t*}
    |    Required: x.T
-   |    Note that capability (t : () => Logger^) is not included in capture set {}.
+   |    Note that capability t is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i19330.scala:22:22 ---------------------------------------

--- a/tests/neg-custom-args/captures/i19470.check
+++ b/tests/neg-custom-args/captures/i19470.check
@@ -3,6 +3,6 @@
   |         ^^^^^^^^
   |         Found:    Inv[IO^{f?}]
   |         Required: Inv[IO^?]^?
-  |         Note that capability (f : () => IO^) is not included in capture set {f?}.
+  |         Note that capability f is not included in capture set {f?}.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i19470.check
+++ b/tests/neg-custom-args/captures/i19470.check
@@ -2,7 +2,7 @@
 9 |    List(foo(f())) // error
   |         ^^^^^^^^
   |         Found:    Inv[IO^{f?}]
-  |         Required: Inv[IO^?]^?
+  |         Required: Inv[IO^'s1]^'s2
   |         Note that capability f is not included in capture set {f?}.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21313.check
+++ b/tests/neg-custom-args/captures/i21313.check
@@ -10,6 +10,6 @@
    |
    |where:    ^ refers to a fresh root capability created in method test when checking argument to parameter src of method await
    |
-   |Note that capability (ac1 : Async^) cannot be included in capture set {ac2} of value src2.
+   |Note that capability ac1 cannot be included in capture set {ac2} of value src2.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21347.check
+++ b/tests/neg-custom-args/captures/i21347.check
@@ -3,7 +3,7 @@
   |  ^^^^^^^^^^^^^^^^^^^^^^
   |  Found:    () ->{f} Unit
   |  Required: () -> Unit
-  |  Note that capability (f : () => Unit) is not included in capture set {}.
+  |  Note that capability f is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/i21347.scala:11:15 ------------------------------------------------------------

--- a/tests/neg-custom-args/captures/i21401.check
+++ b/tests/neg-custom-args/captures/i21401.check
@@ -22,8 +22,8 @@
    |          ^  refers to the universal root capability
    |          ^² refers to a fresh root capability created in value a when checking argument to parameter op of method usingIO
    |
-   |Note that capability x.type is not included in capture set {cap}
-   |because x.type is not visible from cap in value a.
+   |Note that capability x is not included in capture set {cap}
+   |because (x : IO^?) is not visible from cap in value a.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/i21401.scala:16:66 ------------------------------------------------------------

--- a/tests/neg-custom-args/captures/i21401.check
+++ b/tests/neg-custom-args/captures/i21401.check
@@ -15,7 +15,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21401.scala:15:23 ---------------------------------------
 15 |  val a = usingIO[IO^](x => x) // error // error
    |                       ^^^^^^
-   |Found:    (x: IO^?) ->? IO^{x}
+   |Found:    (x: IO^'s1) ->'s2 IO^{x}
    |Required: IO^ => IO^²
    |
    |where:    => refers to a fresh root capability created in value a when checking argument to parameter op of method usingIO
@@ -23,7 +23,7 @@
    |          ^² refers to a fresh root capability created in value a when checking argument to parameter op of method usingIO
    |
    |Note that capability x is not included in capture set {cap}
-   |because (x : IO^?) is not visible from cap in value a.
+   |because (x : IO^'s1) is not visible from cap in value a.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/i21401.scala:16:66 ------------------------------------------------------------
@@ -50,14 +50,14 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21401.scala:17:67 ---------------------------------------
 17 |  val x: Boxed[IO^] = leaked[Boxed[IO^], Boxed[IO^] -> Boxed[IO^]](x => x) // error // error // error
    |                                                                   ^^^^^^
-   |      Found:    (x: Boxed[IO^]^?) ->? Boxed[IO^²]
-   |      Required: Boxed[IO^] -> Boxed[IO^³]
+   |    Found:    (x: Boxed[IO^]^'s3) ->'s4 Boxed[IO^²]
+   |    Required: Boxed[IO^] -> Boxed[IO^³]
    |
-   |      where:    ^  refers to the universal root capability
-   |                ^² refers to a root capability associated with the result type of (x: Boxed[IO^]^?): Boxed[IO^²]
-   |                ^³ refers to a fresh root capability created in value x²
+   |    where:    ^  refers to the universal root capability
+   |              ^² refers to a root capability associated with the result type of (x: Boxed[IO^]^'s3): Boxed[IO^²]
+   |              ^³ refers to a fresh root capability created in value x²
    |
-   |      Note that capability <cap of (x: Boxed[IO^]^?): Boxed[IO^]> is not included in capture set {cap}
-   |      because <cap of (x: Boxed[IO^]^?): Boxed[IO^]> is not visible from cap in value x.
+   |    Note that capability <cap of (x: Boxed[IO^]^'s3): Boxed[IO^]> is not included in capture set {cap}
+   |    because <cap of (x: Boxed[IO^]^'s3): Boxed[IO^]> is not visible from cap in value x.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21614.check
+++ b/tests/neg-custom-args/captures/i21614.check
@@ -16,8 +16,8 @@
    |Required: File^{C} => Logger{val f: File^?}^?
    |
    |where:    =>  refers to a fresh root capability created in method mkLoggers2 when checking argument to parameter f of method map
-   |          cap is a root capability associated with the result type of (_$1: File^?): Logger{val f: File^{_$1}}^{cap.rd, _$1}
+   |          cap is a root capability associated with the result type of (_$1: File^'s1): Logger{val f: File^{_$1}}^{cap.rd, _$1}
    |
-   |Note that capability <cap of (_$1: File^{files*}): Logger{val f: File^?}^?>.rd cannot be included in outer capture set ?.
+   |Note that capability <cap of (_$1: File^{files*}): Logger{val f: File^'s2}^'s3>.rd cannot be included in outer capture set 's3.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21614.check
+++ b/tests/neg-custom-args/captures/i21614.check
@@ -12,12 +12,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21614.scala:15:12 ---------------------------------------
 15 |  files.map(new Logger(_)) // error, Q: can we improve the error message?
    |            ^^^^^^^^^^^^^
-   |Found:    (_$1: File^?) ->{C} Logger{val f: File^{_$1}}^{cap.rd, _$1}
-   |Required: File^{C} => Logger{val f: File^?}^?
+   |Found:    (_$1: File^'s1) ->{C} Logger{val f: File^{_$1}}^{cap.rd, _$1}
+   |Required: File^{C} => Logger{val f: File^'s2}^'s3
    |
    |where:    =>  refers to a fresh root capability created in method mkLoggers2 when checking argument to parameter f of method map
    |          cap is a root capability associated with the result type of (_$1: File^'s1): Logger{val f: File^{_$1}}^{cap.rd, _$1}
    |
-   |Note that capability <cap of (_$1: File^{files*}): Logger{val f: File^'s2}^'s3>.rd cannot be included in outer capture set 's3.
+   |Note that capability C is not classified as trait SharedCapability, therefore it
+   |cannot be included in capture set 's1 of parameter _$1 of SharedCapability elements.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21614.check
+++ b/tests/neg-custom-args/captures/i21614.check
@@ -18,7 +18,6 @@
    |where:    =>  refers to a fresh root capability created in method mkLoggers2 when checking argument to parameter f of method map
    |          cap is a root capability associated with the result type of (_$1: File^?): Logger{val f: File^{_$1}}^{cap.rd, _$1}
    |
-   |Note that capability C is not classified as trait SharedCapability, therefore it
-   |cannot be included in capture set ? of parameter _$1 of SharedCapability elements.
+   |Note that capability <cap of (_$1: File^{files*}): Logger{val f: File^?}^?>.rd cannot be included in outer capture set ?.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21620.check
+++ b/tests/neg-custom-args/captures/i21620.check
@@ -15,7 +15,7 @@
   |                               ^
   |                               Found:    (f : () ->{x} () ->{x} Unit)
   |                               Required: () -> () ->{x} Unit
-  |                               Note that capability (x : C^) is not included in capture set {}.
+  |                               Note that capability x is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21620.scala:20:33 ---------------------------------------
@@ -23,6 +23,6 @@
    |                                 ^
    |                                 Found:    (f : () ->{x} () ->{x} Unit)
    |                                 Required: () -> () ->{x} Unit
-   |                                 Note that capability (x : C^) is not included in capture set {}.
+   |                                 Note that capability x is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21920.check
+++ b/tests/neg-custom-args/captures/i21920.check
@@ -1,12 +1,12 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21920.scala:34:35 ---------------------------------------
 34 |  val cell: Cell[File] = File.open(f => Cell(() => Seq(f))) // error
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (f: File^?) ->? Cell[File^?]{val head: () ->? IterableOnce[File^?]^?}^?
-   |Required: File^ => Cell[File^?]{val head: () ->? IterableOnce[File^?]^?}^?
+   |Found:    (f: File^'s1) ->'s2 Cell[File^'s3]{val head: () ->'s4 IterableOnce[File^'s5]^'s6}^'s7
+   |Required: File^ => Cell[File^'s8]{val head: () ->'s9 IterableOnce[File^'s10]^'s11}^'s12
    |
    |where:    => refers to a fresh root capability created in value cell when checking argument to parameter f of method open
    |          ^  refers to the universal root capability
    |
-   |Note that capability <cap of (): IterableOnce[File^?]^> cannot be included in outer capture set ?.
+   |Note that capability <cap of (): IterableOnce[File^'s13]^> cannot be included in outer capture set 's13.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21920.check
+++ b/tests/neg-custom-args/captures/i21920.check
@@ -7,7 +7,6 @@
    |where:    => refers to a fresh root capability created in value cell when checking argument to parameter f of method open
    |          ^  refers to the universal root capability
    |
-   |Note that capability <cap of (): IterableOnce[File^?]^>
-   |cannot be included in outer capture set ?.
+   |Note that capability <cap of (): IterableOnce[File^?]^> cannot be included in outer capture set ?.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i23207.check
+++ b/tests/neg-custom-args/captures/i23207.check
@@ -3,7 +3,7 @@
    |             ^^^^^
    |             Found:    (box.x : (b : B^{io})^{b})
    |             Required: A
-   |             Note that capability (io : AnyRef^) is not included in capture set {}.
+   |             Note that capability io is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23207.scala:18:13 ---------------------------------------
@@ -11,7 +11,7 @@
    |             ^
    |             Found:    (c : B^{b})
    |             Required: A
-   |             Note that capability (b : B^{io}) is not included in capture set {}.
+   |             Note that capability b is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23207.scala:23:2 ----------------------------------------
@@ -19,7 +19,7 @@
    |  ^
    |  Found:    A^{io}
    |  Required: A
-   |  Note that capability (io : AnyRef^) is not included in capture set {}.
+   |  Note that capability io is not included in capture set {}.
 24 |    val hide: AnyRef^{io} = io
 25 |  val b = new B
 26 |  val c = b.getBox.x

--- a/tests/neg-custom-args/captures/i23431.check
+++ b/tests/neg-custom-args/captures/i23431.check
@@ -27,7 +27,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23431.scala:12:12 ---------------------------------------
 12 |    withIO: io3 =>  // error
    |            ^
-   |Found:    (io3: IO^?) ->? Unit
+   |Found:    (io3: IO^'s1) ->'s2 Unit
    |Required: IO^ => Unit
    |
    |where:    => refers to a fresh root capability created in anonymous function of type (io1: IO^): Unit when checking argument to parameter op of method withIO

--- a/tests/neg-custom-args/captures/lazylist.check
+++ b/tests/neg-custom-args/captures/lazylist.check
@@ -1,9 +1,9 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:17:15 -------------------------------------
 17 |  def tail = xs() // error
    |             ^^^^
-   |       Found:    lazylists.LazyList[T]^{LazyCons.this.xs}
-   |       Required: lazylists.LazyList[T]
-   |       Note that capability (LazyCons.this.xs : () => lazylists.LazyList[T]^) is not included in capture set {}.
+   |             Found:    lazylists.LazyList[T]^{LazyCons.this.xs}
+   |             Required: lazylists.LazyList[T]
+   |             Note that capability LazyCons.this.xs is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:35:29 -------------------------------------
@@ -11,31 +11,31 @@
    |                             ^^^^
    |               Found:    (ref1 : lazylists.LazyCons[Int]{val xs: () ->{cap1} lazylists.LazyList[Int]^{}}^{cap1})
    |               Required: lazylists.LazyList[Int]
-   |               Note that capability (cap1 : lazylists.CC^) is not included in capture set {}.
+   |               Note that capability cap1 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:37:36 -------------------------------------
 37 |  val ref2c: LazyList[Int]^{ref1} = ref2 // error
    |                                    ^^^^
-   |                              Found:    (ref2 : lazylists.LazyList[Int]^{cap2, ref1})
-   |                              Required: lazylists.LazyList[Int]^{ref1}
-   |                              Note that capability (cap2 : lazylists.CC^) is not included in capture set {ref1}.
+   |                                    Found:    (ref2 : lazylists.LazyList[Int]^{cap2, ref1})
+   |                                    Required: lazylists.LazyList[Int]^{ref1}
+   |                                    Note that capability cap2 is not included in capture set {ref1}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:39:36 -------------------------------------
 39 |  val ref3c: LazyList[Int]^{cap2} = ref3 // error
    |                                    ^^^^
-   |Found:    (ref3 : lazylists.LazyList[Int]^{cap2, ref1})
-   |Required: lazylists.LazyList[Int]^{cap2}
-   |Note that capability (ref1 : lazylists.LazyCons[Int]{val xs: () ->{cap1} lazylists.LazyList[Int]^{}}^{cap1}) is not included in capture set {cap2}.
+   |                                    Found:    (ref3 : lazylists.LazyList[Int]^{cap2, ref1})
+   |                                    Required: lazylists.LazyList[Int]^{cap2}
+   |                                    Note that capability ref1 is not included in capture set {cap2}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:41:42 -------------------------------------
 41 |  val ref4c: LazyList[Int]^{cap1, ref3} = ref4 // error
    |                                          ^^^^
-   |                        Found:    (ref4 : lazylists.LazyList[Int]^{cap3, cap1, cap2})
-   |                        Required: lazylists.LazyList[Int]^{cap1, ref3}
-   |                        Note that capability (cap3 : lazylists.CC^) is not included in capture set {cap1, ref3}.
+   |                                          Found:    (ref4 : lazylists.LazyList[Int]^{cap3, cap1, cap2})
+   |                                          Required: lazylists.LazyList[Int]^{cap1, ref3}
+   |                                          Note that capability cap3 is not included in capture set {cap1, ref3}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E164] Declaration Error: tests/neg-custom-args/captures/lazylist.scala:22:6 ----------------------------------------

--- a/tests/neg-custom-args/captures/lazylists1.check
+++ b/tests/neg-custom-args/captures/lazylists1.check
@@ -1,8 +1,8 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylists1.scala:25:66 -----------------------------------
 25 |      def concat(other: LazyList[A]^{f}): LazyList[A]^{this, f} = ??? : (LazyList[A]^{xs, f}) // error
    |                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |                       Found:    LazyList[A]^{xs, f}
-   |                       Required: LazyList[A]^{Mapped.this, f}
-   |                       Note that capability (xs : LazyList[A]^) is not included in capture set {Mapped.this, f}.
+   |                                        Found:    LazyList[A]^{xs, f}
+   |                                        Required: LazyList[A]^{Mapped.this, f}
+   |                                        Note that capability xs is not included in capture set {Mapped.this, f}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lazylists2.check
+++ b/tests/neg-custom-args/captures/lazylists2.check
@@ -3,7 +3,7 @@
    |    ^
    |    Found:    LazyList[B^?]^{f, xs}
    |    Required: LazyList[B]^{f}
-   |    Note that capability (xs : LazyList[A]^) is not included in capture set {f}.
+   |    Note that capability xs is not included in capture set {f}.
 19 |      this: (Mapped^{xs, f}) =>
 20 |      def isEmpty = false
 21 |      def head: B = f(xs.head)
@@ -16,7 +16,7 @@
    |    ^
    |    Found:    LazyList[B^?]^{f, xs}
    |    Required: LazyList[B]^{xs}
-   |    Note that capability (f : A => B) is not included in capture set {xs}.
+   |    Note that capability f is not included in capture set {xs}.
 28 |      this: Mapped^{xs, f} =>
 29 |      def isEmpty = false
 30 |      def head: B = f(xs.head)
@@ -37,7 +37,7 @@
    |    ^
    |    Found:    LazyList[B^?]^{f, xs}
    |    Required: LazyList[B]^{xs}
-   |    Note that capability (f : A => B) is not included in capture set {xs}.
+   |    Note that capability f is not included in capture set {xs}.
 46 |      this: (Mapped^{xs, f}) =>
 47 |      def isEmpty = false
 48 |      def head: B = f(xs.head)

--- a/tests/neg-custom-args/captures/lazylists2.check
+++ b/tests/neg-custom-args/captures/lazylists2.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylists2.scala:18:4 ------------------------------------
 18 |    final class Mapped extends LazyList[B]:  // error
    |    ^
-   |    Found:    LazyList[B^?]^{f, xs}
+   |    Found:    LazyList[B^'s1]^{f, xs}
    |    Required: LazyList[B]^{f}
    |    Note that capability xs is not included in capture set {f}.
 19 |      this: (Mapped^{xs, f}) =>
@@ -14,7 +14,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylists2.scala:27:4 ------------------------------------
 27 |    final class Mapped extends LazyList[B]:  // error
    |    ^
-   |    Found:    LazyList[B^?]^{f, xs}
+   |    Found:    LazyList[B^'s2]^{f, xs}
    |    Required: LazyList[B]^{xs}
    |    Note that capability f is not included in capture set {xs}.
 28 |      this: Mapped^{xs, f} =>
@@ -35,7 +35,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylists2.scala:45:4 ------------------------------------
 45 |    final class Mapped extends LazyList[B]:  // error
    |    ^
-   |    Found:    LazyList[B^?]^{f, xs}
+   |    Found:    LazyList[B^'s3]^{f, xs}
    |    Required: LazyList[B]^{xs}
    |    Note that capability f is not included in capture set {xs}.
 46 |      this: (Mapped^{xs, f}) =>

--- a/tests/neg-custom-args/captures/lazyref.check
+++ b/tests/neg-custom-args/captures/lazyref.check
@@ -3,31 +3,31 @@
    |                            ^^^^
    |                            Found:    (ref1 : LazyRef[Int]{val elem: () ->{cap1} Int}^{cap1})
    |                            Required: LazyRef[Int]
-   |                            Note that capability (cap1 : CC^) is not included in capture set {}.
+   |                            Note that capability cap1 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazyref.scala:22:35 --------------------------------------
 22 |  val ref2c: LazyRef[Int]^{cap2} = ref2 // error
    |                                   ^^^^
-   |Found:    LazyRef[Int]{val elem: () ->{ref2*} Int}^{ref2}
-   |Required: LazyRef[Int]^{cap2}
-   |Note that capability (ref2 : LazyRef[Int]{val elem: () => Int}^{cap2, ref1}) is not included in capture set {cap2}.
+   |                                   Found:    LazyRef[Int]{val elem: () ->{ref2*} Int}^{ref2}
+   |                                   Required: LazyRef[Int]^{cap2}
+   |                                   Note that capability ref2 is not included in capture set {cap2}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazyref.scala:24:35 --------------------------------------
 24 |  val ref3c: LazyRef[Int]^{ref1} = ref3 // error
    |                                   ^^^^
-   |Found:    LazyRef[Int]{val elem: () ->{ref3*} Int}^{ref3}
-   |Required: LazyRef[Int]^{ref1}
-   |Note that capability (ref3 : LazyRef[Int]{val elem: () => Int}^{cap2, ref1}) is not included in capture set {ref1}.
+   |                                   Found:    LazyRef[Int]{val elem: () ->{ref3*} Int}^{ref3}
+   |                                   Required: LazyRef[Int]^{ref1}
+   |                                   Note that capability ref3 is not included in capture set {ref1}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazyref.scala:30:35 --------------------------------------
 30 |  val ref4c: LazyRef[Int]^{cap1} = ref4 // error
    |                                   ^^^^
-   |Found:    LazyRef[Int]{val elem: () ->{ref4*} Int}^{ref4}
-   |Required: LazyRef[Int]^{cap1}
-   |Note that capability (ref4 : LazyRef[Int]{val elem: () => Int}^{cap2, ref1}) is not included in capture set {cap1}.
+   |                                   Found:    LazyRef[Int]{val elem: () ->{ref4*} Int}^{ref4}
+   |                                   Required: LazyRef[Int]^{cap1}
+   |                                   Note that capability ref4 is not included in capture set {cap1}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/lazyref.scala:8:24 ------------------------------------------------------------

--- a/tests/neg-custom-args/captures/leak-problem-2.check
+++ b/tests/neg-custom-args/captures/leak-problem-2.check
@@ -3,6 +3,6 @@
   |    ^^^^^^^^^^^^^^^^^^^^^
   |    Found:    Source[T^?]^{src1, src2}
   |    Required: Source[T]
-  |    Note that capability (src1 : Source[T]^) is not included in capture set {}.
+  |    Note that capability src1 is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/leak-problem-2.check
+++ b/tests/neg-custom-args/captures/leak-problem-2.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/leak-problem-2.scala:8:8 ---------------------------------
 8 |  = race(Seq(src1, src2)) // error
   |    ^^^^^^^^^^^^^^^^^^^^^
-  |    Found:    Source[T^?]^{src1, src2}
+  |    Found:    Source[T^'s1]^{src1, src2}
   |    Required: Source[T]
   |    Note that capability src1 is not included in capture set {}.
   |

--- a/tests/neg-custom-args/captures/leaking-iterators.check
+++ b/tests/neg-custom-args/captures/leaking-iterators.check
@@ -7,8 +7,7 @@
    |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability log.type
-   |cannot be included in outer capture set ?.
+   |Note that capability log cannot be included in outer capture set ?.
 57 |    xs.iterator.map: x =>
 58 |      log.write(x)
 59 |      x * x

--- a/tests/neg-custom-args/captures/leaking-iterators.check
+++ b/tests/neg-custom-args/captures/leaking-iterators.check
@@ -1,13 +1,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/leaking-iterators.scala:56:16 ----------------------------
 56 |  usingLogFile: log => // error
    |                ^
-   |Found:    (log: java.io.FileOutputStream^?) ->? cctest.Iterator[Int]^{log}
-   |Required: java.io.FileOutputStream^ => cctest.Iterator[Int]^?
+   |Found:    (log: java.io.FileOutputStream^'s1) ->'s2 cctest.Iterator[Int]^{log}
+   |Required: java.io.FileOutputStream^ => cctest.Iterator[Int]^'s3
    |
    |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability log cannot be included in outer capture set ?.
+   |Note that capability log cannot be included in outer capture set 's3.
 57 |    xs.iterator.map: x =>
 58 |      log.write(x)
 59 |      x * x

--- a/tests/neg-custom-args/captures/leaky.check
+++ b/tests/neg-custom-args/captures/leaky.check
@@ -3,7 +3,7 @@
    |  ^
    |  Found:    test.runnable.Transform{val fun: Any ->{a} Any}^{a}
    |  Required: test.runnable.Transform
-   |  Note that capability (a : test.runnable.A) is not included in capture set {}.
+   |  Note that capability a is not included in capture set {}.
 15 |    a.print()
 16 |    ()
 17 |  Transform(f)
@@ -14,7 +14,7 @@
    |  ^
    |  Found:    test.runnable.Transform{val fun: Any ->{a} Any}^{a}
    |  Required: test.runnable.Transform
-   |  Note that capability (a : test.runnable.A) is not included in capture set {}.
+   |  Note that capability a is not included in capture set {}.
 21 |    a.print()
 22 |    ()
 23 |  val x = Transform(f)
@@ -26,7 +26,7 @@
    |  ^
    |  Found:    test.runnable.Transform{val fun: Any ->{a} Any}^{a}
    |  Required: test.runnable.Transform
-   |  Note that capability (a : test.runnable.A) is not included in capture set {}.
+   |  Note that capability a is not included in capture set {}.
 28 |    a.print()
 29 |    ()
 30 |  val x = Transform.app(f)

--- a/tests/neg-custom-args/captures/levels.check
+++ b/tests/neg-custom-args/captures/levels.check
@@ -10,6 +10,6 @@
    |           ^
    |           Found:    (x: String) ->{cap3} String
    |           Required: String -> String
-   |           Note that capability (cap3 : CC^) is not included in capture set {}.
+   |           Note that capability cap3 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lubs.check
+++ b/tests/neg-custom-args/captures/lubs.check
@@ -3,7 +3,7 @@
    |             ^^
    |             Found:    (x1 : D^{d1})
    |             Required: D
-   |             Note that capability (d1 : D^{c1}) is not included in capture set {}.
+   |             Note that capability d1 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lubs.scala:18:13 -----------------------------------------
@@ -11,7 +11,7 @@
    |             ^^
    |             Found:    (x2 : D^{d1})
    |             Required: D
-   |             Note that capability (d1 : D^{c1}) is not included in capture set {}.
+   |             Note that capability d1 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lubs.scala:19:13 -----------------------------------------
@@ -19,6 +19,6 @@
    |             ^^
    |             Found:    (x3 : D^{d1, d2})
    |             Required: D
-   |             Note that capability (d1 : D^{c1}) is not included in capture set {}.
+   |             Note that capability d1 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/nestedclass.check
+++ b/tests/neg-custom-args/captures/nestedclass.check
@@ -3,6 +3,6 @@
    |               ^^
    |               Found:    (xs : C^{cap1})
    |               Required: C
-   |               Note that capability (cap1 : CC^) is not included in capture set {}.
+   |               Note that capability cap1 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:22:13 --------------------------------------
 22 |  usingFile: f => // error
    |             ^
-   |Found:    (f: File^?) ->? Unit
+   |Found:    (f: File^'s1) ->'s2 Unit
    |Required: File^ => Unit
    |
    |where:    => refers to a fresh root capability created in method runAll0 when checking argument to parameter f of method usingFile
@@ -14,7 +14,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:32:13 --------------------------------------
 32 |  usingFile: f => // error
    |             ^
-   |Found:    (f: File^?) ->? Unit
+   |Found:    (f: File^'s3) ->'s4 Unit
    |Required: File^ => Unit
    |
    |where:    => refers to a fresh root capability created in method runAll1 when checking argument to parameter f of method usingFile
@@ -68,7 +68,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:59:27 --------------------------------------
 59 |  val id: File^ -> File^ = x => x // error
    |                           ^^^^^^
-   |                  Found:    (x: File^) ->? File^²
+   |                  Found:    (x: File^) ->'s5 File^²
    |                  Required: File^ -> File^³
    |
    |                  where:    ^  refers to the universal root capability
@@ -82,7 +82,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:69:38 --------------------------------------
 69 |  val leaked = usingFile[File^{id*}]: f => // error
    |                                      ^
-   |Found:    (f: File^?) ->? File^{id*}
+   |Found:    (f: File^'s6) ->'s7 File^{id*}
    |Required: File^ => File^{id*}
    |
    |where:    => refers to a fresh root capability created in value leaked when checking argument to parameter f of method usingFile
@@ -96,8 +96,8 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:87:10 --------------------------------------
 87 |  ps.map((x, y) => compose1(x, y)) // error
    |          ^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (x$1: (A^ ->? A^?, A^ ->? A^?)^?) ->? A^? ->? A^?
-   |Required: ((A ->{ps*} A, A ->{ps*} A)) => A^? ->? A^?
+   |Found:    (x$1: (A^ ->'s8 A^'s9, A^ ->'s10 A^'s11)^'s12) ->'s13 A^'s14 ->'s15 A^'s16
+   |Required: ((A ->{ps*} A, A ->{ps*} A)) => A^'s17 ->'s18 A^'s19
    |
    |where:    => refers to a fresh root capability created in method mapCompose when checking argument to parameter f of method map
    |          ^  refers to the universal root capability

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -108,8 +108,8 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:90:10 --------------------------------------
 90 |  ps.map((x, y) => compose1(x, y)) // error
    |          ^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (x$1: (A^ ->? A^?, A^ ->? A^?)^?) ->? A^? ->? A^?
-   |Required: ((A ->{C} A, A ->{C} A)) => A^? ->? A^?
+   |Found:    (x$1: (A^ ->'s20 A^'s21, A^ ->'s22 A^'s23)^'s24) ->'s25 A^'s26 ->'s27 A^'s28
+   |Required: ((A ->{C} A, A ->{C} A)) => A^'s29 ->'s30 A^'s31
    |
    |where:    => refers to a fresh root capability created in method mapCompose2 when checking argument to parameter f of method map
    |          ^  refers to the universal root capability

--- a/tests/neg-custom-args/captures/reaches2.check
+++ b/tests/neg-custom-args/captures/reaches2.check
@@ -1,8 +1,8 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches2.scala:10:10 -------------------------------------
 10 |  ps.map((x, y) => compose1(x, y)) // error
    |          ^^^^^^^^^^^^^^^^^^^^^^^
-   |          Found:    (x$1: (A^? ->{ps*} A^?, A^? ->{ps*} A^?)^?) ->{ps*} A^? ->{ps*} A^?
-   |          Required: ((A ->{ps*} A, A ->{ps*} A)) -> A^? ->{ps*} A^?
+   |          Found:    (x$1: (A^'s1 ->{ps*} A^'s2, A^'s3 ->{ps*} A^'s4)^'s5) ->{ps*} A^'s6 ->{ps*} A^'s7
+   |          Required: ((A ->{ps*} A, A ->{ps*} A)) -> A^'s6 ->{ps*} A^'s7
    |          Note that capability ps* is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/readOnly.check
+++ b/tests/neg-custom-args/captures/readOnly.check
@@ -11,7 +11,7 @@
    |                       ^^^^
    |                       Found:    (putA : Int ->{a} Unit)
    |                       Required: Int -> Unit
-   |                       Note that capability (a : Ref^) is not included in capture set {}.
+   |                       Note that capability a is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/readOnly.scala:20:23 ----------------------------------------------------------

--- a/tests/neg-custom-args/captures/real-try.check
+++ b/tests/neg-custom-args/captures/real-try.check
@@ -31,7 +31,7 @@
 -- Error: tests/neg-custom-args/captures/real-try.scala:26:10 ----------------------------------------------------------
 26 |  val y = try  // error
    |          ^
-   |   The result of `try` cannot have type () => Cell[Unit]^? since
+   |   The result of `try` cannot have type () => Cell[Unit]^'s1 since
    |   that type captures the root capability `cap`.
    |   This is often caused by a locally generated exception capability leaking as part of its result.
    |
@@ -43,7 +43,7 @@
 -- Error: tests/neg-custom-args/captures/real-try.scala:32:10 ----------------------------------------------------------
 32 |  val b = try // error
    |          ^
-   |   The result of `try` cannot have type Cell[() => Unit]^? since
+   |   The result of `try` cannot have type Cell[() => Unit]^'s2 since
    |   the part () => Unit of that type captures the root capability `cap`.
    |   This is often caused by a locally generated exception capability leaking as part of its result.
    |

--- a/tests/neg-custom-args/captures/ro-mut-conformance.check
+++ b/tests/neg-custom-args/captures/ro-mut-conformance.check
@@ -11,6 +11,6 @@
    |
    |                     where:    ^ refers to a fresh root capability classified as Mutable in the type of value t
    |
-   |                     Note that capability (a : Ref) is not included in capture set {}.
+   |                     Note that capability a is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/scoped-caps.check
+++ b/tests/neg-custom-args/captures/scoped-caps.check
@@ -106,7 +106,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:28:19 ----------------------------------
 28 |  val _: S -> B^ = x => j(x)       // error
    |                   ^^^^^^^^^
-   |                   Found:    (x: S^) ->? B^²
+   |                   Found:    (x: S^) ->'s1 B^²
    |                   Required: S^ -> B^³
    |
    |                   where:    ^  refers to the universal root capability

--- a/tests/neg-custom-args/captures/scoped-caps.check
+++ b/tests/neg-custom-args/captures/scoped-caps.check
@@ -48,7 +48,7 @@
    |                              ^² refers to a root capability associated with the result type of (x: A^): B^²
    |                              ^³ refers to a fresh root capability in the type of value _$5
    |
-   |                    Note that capability (g : A^ -> B^) is not included in capture set {}.
+   |                    Note that capability g is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:16:24 ----------------------------------
@@ -73,7 +73,7 @@
    |                                  ^² refers to a root capability associated with the result type of (x: S^): B^²
    |                                  ^³ refers to a root capability associated with the result type of (x: S^): B^³
    |
-   |                        Note that capability (h : S -> B^) is not included in capture set {}.
+   |                        Note that capability h is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:21:23 ----------------------------------
@@ -86,7 +86,7 @@
    |                                 ^² refers to a root capability associated with the result type of (x: S^): S^²
    |                                 ^³ refers to a root capability associated with the result type of (x: S^): S^³
    |
-   |                       Note that capability (h2 : S -> S) is not included in capture set {}.
+   |                       Note that capability h2 is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:27:19 ----------------------------------

--- a/tests/neg-custom-args/captures/sep-curried.check
+++ b/tests/neg-custom-args/captures/sep-curried.check
@@ -1,12 +1,12 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/sep-curried.scala:48:43 ----------------------------------
 48 |  val f: (y: Ref[Int]^{a}) ->{a} Unit = foo(a) // error
    |                                        ^^^^^^
-   |                                      Found:    (y: Ref[Int]^) ->{a} Unit
-   |                                      Required: (y: Ref[Int]^{a}) ->{a} Unit
+   |                                        Found:    (y: Ref[Int]^) ->{a} Unit
+   |                                        Required: (y: Ref[Int]^{a}) ->{a} Unit
    |
-   |                                      where:    ^ refers to the universal root capability
+   |                                        where:    ^ refers to the universal root capability
    |
-   |                                      Note that capability (a : Ref[Int]^) is not included in capture set {cap}.
+   |                                        Note that capability a is not included in capture set {cap}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/sep-curried.scala:16:6 --------------------------------------------------------

--- a/tests/neg-custom-args/captures/simple-using.check
+++ b/tests/neg-custom-args/captures/simple-using.check
@@ -1,12 +1,12 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/simple-using.scala:8:15 ----------------------------------
 8 |  usingLogFile { f => () => f.write(2) } // error
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^
-  |Found:    (f: java.io.FileOutputStream^?) ->? () ->{f} Unit
-  |Required: java.io.FileOutputStream^ => () ->? Unit
+  |Found:    (f: java.io.FileOutputStream^'s1) ->'s2 () ->{f} Unit
+  |Required: java.io.FileOutputStream^ => () ->'s3 Unit
   |
   |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method usingLogFile
   |          ^  refers to the universal root capability
   |
-  |Note that capability f cannot be included in outer capture set ?.
+  |Note that capability f cannot be included in outer capture set 's3.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/simple-using.check
+++ b/tests/neg-custom-args/captures/simple-using.check
@@ -7,7 +7,6 @@
   |where:    => refers to a fresh root capability created in method test when checking argument to parameter op of method usingLogFile
   |          ^  refers to the universal root capability
   |
-  |Note that capability f.type
-  |cannot be included in outer capture set ?.
+  |Note that capability f cannot be included in outer capture set ?.
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/try.check
+++ b/tests/neg-custom-args/captures/try.check
@@ -15,8 +15,8 @@
    |          ^  refers to the universal root capability
    |          ^² refers to a fresh root capability created in value a when checking argument to parameter op of method handle
    |
-   |Note that capability x.type is not included in capture set {cap}
-   |because x.type is not visible from cap in value a.
+   |Note that capability x is not included in capture set {cap}
+   |because (x : CT[Exception]^) is not visible from cap in value a.
 24 |    (x: CanThrow[Exception]) => x
 25 |  }{
    |
@@ -30,7 +30,7 @@
    |where:    => refers to a fresh root capability created in value b when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
    |
-   |Note that capability x.type is not included in capture set {}.
+   |Note that capability x is not included in capture set {}.
 30 |    (x: CanThrow[Exception]) => () => raise(new Exception)(using x)
 31 |  } {
    |
@@ -44,8 +44,7 @@
    |where:    => refers to a fresh root capability created in value xx when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
    |
-   |Note that capability x.type
-   |cannot be included in outer capture set ?.
+   |Note that capability x cannot be included in outer capture set ?.
 36 |    (x: CanThrow[Exception]) =>
 37 |      () =>
 38 |        raise(new Exception)(using x)
@@ -62,8 +61,7 @@
    |where:    => refers to a fresh root capability created in value global when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
    |
-   |Note that capability x.type
-   |cannot be included in outer capture set ?.
+   |Note that capability x cannot be included in outer capture set ?.
 48 |  (x: CanThrow[Exception]) =>
 49 |    () =>
 50 |      raise(new Exception)(using x)

--- a/tests/neg-custom-args/captures/try.check
+++ b/tests/neg-custom-args/captures/try.check
@@ -8,7 +8,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/try.scala:23:49 ------------------------------------------
 23 |  val a = handle[Exception, CanThrow[Exception]] { // error // error
    |                                                 ^
-   |Found:    (x: CT[Exception]^) ->? CT[Exception]^{x}
+   |Found:    (x: CT[Exception]^) ->'s1 CT[Exception]^{x}
    |Required: CT[Exception]^ => CT[Exception]^²
    |
    |where:    => refers to a fresh root capability created in value a when checking argument to parameter op of method handle
@@ -24,7 +24,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/try.scala:29:43 ------------------------------------------
 29 |  val b = handle[Exception, () -> Nothing] { // error
    |                                           ^
-   |Found:    (x: CT[Exception]^) ->? () ->{x} Nothing
+   |Found:    (x: CT[Exception]^) ->'s2 () ->{x} Nothing
    |Required: CT[Exception]^ => () -> Nothing
    |
    |where:    => refers to a fresh root capability created in value b when checking argument to parameter op of method handle
@@ -38,13 +38,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/try.scala:35:18 ------------------------------------------
 35 |  val xx = handle {  // error
    |                  ^
-   |Found:    (x: CT[Exception]^) ->? () ->{x} Int
-   |Required: CT[Exception]^ => () ->? Int
+   |Found:    (x: CT[Exception]^) ->'s3 () ->{x} Int
+   |Required: CT[Exception]^ => () ->'s4 Int
    |
    |where:    => refers to a fresh root capability created in value xx when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
    |
-   |Note that capability x cannot be included in outer capture set ?.
+   |Note that capability x cannot be included in outer capture set 's4.
 36 |    (x: CanThrow[Exception]) =>
 37 |      () =>
 38 |        raise(new Exception)(using x)
@@ -55,13 +55,13 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/try.scala:47:31 ------------------------------------------
 47 |val global: () -> Int = handle { // error
    |                               ^
-   |Found:    (x: CT[Exception]^) ->? () ->{x} Int
-   |Required: CT[Exception]^ => () ->? Int
+   |Found:    (x: CT[Exception]^) ->'s5 () ->{x} Int
+   |Required: CT[Exception]^ => () ->'s6 Int
    |
    |where:    => refers to a fresh root capability created in value global when checking argument to parameter op of method handle
    |          ^  refers to the universal root capability
    |
-   |Note that capability x cannot be included in outer capture set ?.
+   |Note that capability x cannot be included in outer capture set 's6.
 48 |  (x: CanThrow[Exception]) =>
 49 |    () =>
 50 |      raise(new Exception)(using x)

--- a/tests/neg-custom-args/captures/unsound-reach-4.check
+++ b/tests/neg-custom-args/captures/unsound-reach-4.check
@@ -8,7 +8,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/unsound-reach-4.scala:20:29 ------------------------------
 20 |  val backdoor: Foo[File^] = new Bar // error (follow-on, since the parent Foo[File^] of bar is illegal).
    |                             ^^^^^^^
-   |                             Found:    Bar^?
+   |                             Found:    Bar^'s1
    |                             Required: Foo[File^]
    |
    |                             where:    ^ refers to a fresh root capability in the type of value backdoor

--- a/tests/neg-custom-args/captures/unsound-reach-6.check
+++ b/tests/neg-custom-args/captures/unsound-reach-6.check
@@ -11,7 +11,7 @@
    |                      ^
    |                      Found:    (x : () ->{io} Unit)
    |                      Required: () -> Unit
-   |                      Note that capability (io : IO^) is not included in capture set {}.
+   |                      Note that capability io is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/unsound-reach-6.scala:7:13 ----------------------------------------------------

--- a/tests/neg-custom-args/captures/unsound-reach.check
+++ b/tests/neg-custom-args/captures/unsound-reach.check
@@ -15,7 +15,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/unsound-reach.scala:18:31 --------------------------------
 18 |    val backdoor: Foo[File^] = new Bar   // error (follow-on, since the parent Foo[File^] of bar is illegal).
    |                               ^^^^^^^
-   |                               Found:    Bar^?
+   |                               Found:    Bar^'s1
    |                               Required: Foo[File^]
    |
    |                               where:    ^ refers to a fresh root capability in the type of value backdoor

--- a/tests/neg-custom-args/captures/use-capset.check
+++ b/tests/neg-custom-args/captures/use-capset.check
@@ -3,15 +3,15 @@
    |                      ^
    |                      Found:    (h : () ->{io} Unit)
    |                      Required: () -> Unit
-   |                      Note that capability (io : Object^) is not included in capture set {}.
+   |                      Note that capability io is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:13:50 -----------------------------------
 13 |  val _: () -> List[Object^{io}] -> Object^{io} = h2 // error, should be ->{io}
    |                                                  ^^
-   |                                          Found:    (h2 : () ->{} List[Object^{io}]^{} ->{io} Object^{io})
-   |                                          Required: () -> List[Object^{io}] -> Object^{io}
-   |                                          Note that capability (io : Object^) is not included in capture set {}.
+   |                                                Found:    (h2 : () ->{} List[Object^{io}]^{} ->{io} Object^{io})
+   |                                                Required: () -> List[Object^{io}] -> Object^{io}
+   |                                                Note that capability io is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/use-capset.scala:5:49 ---------------------------------------------------------

--- a/tests/neg-custom-args/captures/uses.check
+++ b/tests/neg-custom-args/captures/uses.check
@@ -3,7 +3,7 @@
   |                 ^
   |                 Found:    (d : D^{x, y})
   |                 Required: D^{y}
-  |                 Note that capability (x : C^) is not included in capture set {y}.
+  |                 Note that capability x is not included in capture set {y}.
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/uses.scala:9:13 ------------------------------------------
@@ -11,7 +11,7 @@
   |             ^
   |             Found:    (d : D^{x, y})
   |             Required: D
-  |             Note that capability (x : C^) is not included in capture set {}.
+  |             Note that capability x is not included in capture set {}.
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/uses.scala:18:34 -----------------------------------------
@@ -19,7 +19,7 @@
    |                                  ^
    |                                  Found:    () ->{x, y} () ->{y} Unit
    |                                  Required: () ->{x} () ->{y} Unit
-   |                                  Note that capability (y : C^) is not included in capture set {x}.
+   |                                  Note that capability y is not included in capture set {x}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/uses.scala:19:28 -----------------------------------------
@@ -27,6 +27,6 @@
    |                            ^
    |                            Found:    () ->{x, y} () ->{y} Unit
    |                            Required: () -> () -> Unit
-   |                            Note that capability (x : C^) is not included in capture set {}.
+   |                            Note that capability x is not included in capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -1,48 +1,48 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/usingLogFile.scala:22:27 ---------------------------------
 22 |  val later = usingLogFile { f => () => f.write(0) } // error
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (f: java.io.FileOutputStream^?) ->? () ->{f} Unit
-   |Required: java.io.FileOutputStream^ => () ->? Unit
+   |Found:    (f: java.io.FileOutputStream^'s1) ->'s2 () ->{f} Unit
+   |Required: java.io.FileOutputStream^ => () ->'s3 Unit
    |
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability f cannot be included in outer capture set ?.
+   |Note that capability f cannot be included in outer capture set 's3.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/usingLogFile.scala:27:36 ---------------------------------
 27 |  private val later2 = usingLogFile { f => Cell(() => f.write(0)) } // error
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (f: java.io.FileOutputStream^?) ->? Test2.Cell[() ->{f} Unit]^?
-   |Required: java.io.FileOutputStream^ => Test2.Cell[() ->? Unit]^?
+   |Found:    (f: java.io.FileOutputStream^'s4) ->'s5 Test2.Cell[() ->{f} Unit]^'s6
+   |Required: java.io.FileOutputStream^ => Test2.Cell[() ->'s7 Unit]^'s8
    |
    |where:    => refers to a fresh root capability created in value later2 when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability f cannot be included in outer capture set ?.
+   |Note that capability f cannot be included in outer capture set 's7.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/usingLogFile.scala:43:33 ---------------------------------
 43 |    val later = usingFile("out", f => (y: Int) => xs.foreach(x => f.write(x + y))) // error
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (f: java.io.OutputStream^?) ->? Int ->{f} Unit
-   |Required: java.io.OutputStream^ => Int ->? Unit
+   |Found:    (f: java.io.OutputStream^'s9) ->'s10 Int ->{f} Unit
+   |Required: java.io.OutputStream^ => Int ->'s11 Unit
    |
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability f cannot be included in outer capture set ?.
+   |Note that capability f cannot be included in outer capture set 's11.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/usingLogFile.scala:52:6 ----------------------------------
 52 |      usingLogger(_, l => () => l.log("test")))  // error after checking mapping scheme
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |Found:    (_$1: java.io.OutputStream^?) ->? () ->{_$1} Unit
-   |Required: java.io.OutputStream^ => () ->? Unit
+   |Found:    (_$1: java.io.OutputStream^'s12) ->'s13 () ->{_$1} Unit
+   |Required: java.io.OutputStream^ => () ->'s14 Unit
    |
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability _$1 cannot be included in outer capture set ?.
+   |Note that capability _$1 cannot be included in outer capture set 's14.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -7,8 +7,7 @@
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability f.type
-   |cannot be included in outer capture set ?.
+   |Note that capability f cannot be included in outer capture set ?.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/usingLogFile.scala:27:36 ---------------------------------
@@ -20,8 +19,7 @@
    |where:    => refers to a fresh root capability created in value later2 when checking argument to parameter op of method usingLogFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability f.type
-   |cannot be included in outer capture set ?.
+   |Note that capability f cannot be included in outer capture set ?.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/usingLogFile.scala:43:33 ---------------------------------
@@ -33,8 +31,7 @@
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability f.type
-   |cannot be included in outer capture set ?.
+   |Note that capability f cannot be included in outer capture set ?.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/usingLogFile.scala:52:6 ----------------------------------
@@ -46,7 +43,6 @@
    |where:    => refers to a fresh root capability created in value later when checking argument to parameter op of method usingFile
    |          ^  refers to the universal root capability
    |
-   |Note that capability _$1.type
-   |cannot be included in outer capture set ?.
+   |Note that capability _$1 cannot be included in outer capture set ?.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/vars-simple.check
+++ b/tests/neg-custom-args/captures/vars-simple.check
@@ -14,7 +14,7 @@
    |        ^
    |        Found:    (x: String) ->{cap3} String
    |        Required: String ->{cap1, cap2} String
-   |        Note that capability (cap3 : CC^) is not included in capture set {cap1, cap2}.
+   |        Note that capability cap3 is not included in capture set {cap1, cap2}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/vars-simple.scala:17:12 ----------------------------------
@@ -22,6 +22,6 @@
    |        ^^^^^^^
    |        Found:    List[String ->{cap3} String]
    |        Required: List[String ->{cap1, cap2} String]
-   |        Note that capability (cap3 : CC^) is not included in capture set {cap1, cap2}.
+   |        Note that capability cap3 is not included in capture set {cap1, cap2}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/vars.check
+++ b/tests/neg-custom-args/captures/vars.check
@@ -3,7 +3,7 @@
    |        ^^^^^^^^^
    |        Found:    (x: String) ->{cap3} String
    |        Required: String ->{cap1} String
-   |        Note that capability (cap3 : CC^), defined in method scope
+   |        Note that capability cap3, defined in method scope
    |        cannot be included in outer capture set {cap1} of variable a.
    |
    | longer explanation available when compiling with `-explain`
@@ -12,7 +12,7 @@
    |        ^
    |        Found:    (x: String) ->{cap3} String
    |        Required: String ->{cap1} String
-   |        Note that capability (cap3 : CC^), defined in method scope
+   |        Note that capability cap3, defined in method scope
    |        cannot be included in outer capture set {cap1} of variable a.
    |
    | longer explanation available when compiling with `-explain`
@@ -21,7 +21,7 @@
    |        ^^^^^^^
    |        Found:    List[String ->{cap3} String]
    |        Required: List[String ->{cap1, cap2} String]
-   |        Note that capability (cap3 : CC^) is not included in capture set {cap1, cap2}.
+   |        Note that capability cap3 is not included in capture set {cap1, cap2}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/vars.scala:36:8 ------------------------------------------
@@ -34,8 +34,7 @@
    |          =>² refers to a fresh root capability created in method test of parameter parameter cap3² of method $anonfun
    |          ^   refers to the universal root capability
    |
-   |Note that capability <cap of (cap3: CC^): String => String>
-   |cannot be included in outer capture set {cap}.
+   |      Note that capability <cap of (cap3: CC^): String => String> cannot be included in outer capture set {cap}.
 37 |    def g(x: String): String = if cap3 == cap3 then "" else "a"
 38 |    g
 39 |  }

--- a/tests/neg-custom-args/captures/vars.check
+++ b/tests/neg-custom-args/captures/vars.check
@@ -27,8 +27,8 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/vars.scala:36:8 ------------------------------------------
 36 |  local { cap3 => // error
    |        ^
-   |Found:    (cap3: CC^) ->? String => String
-   |Required: CC^ -> String =>² String
+   |      Found:    (cap3: CC^) ->'s1 String => String
+   |      Required: CC^ -> String =>² String
    |
    |where:    =>  refers to a root capability associated with the result type of (cap3: CC^): String => String
    |          =>² refers to a fresh root capability created in method test of parameter parameter cap3² of method $anonfun

--- a/tests/neg-custom-args/captures/vars.check
+++ b/tests/neg-custom-args/captures/vars.check
@@ -27,14 +27,14 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/vars.scala:36:8 ------------------------------------------
 36 |  local { cap3 => // error
    |        ^
-   |      Found:    (cap3: CC^) ->'s1 String => String
-   |      Required: CC^ -> String =>² String
+   |Found:    (cap3: CC^) ->'s1 String => String
+   |Required: CC^ -> String =>² String
    |
    |where:    =>  refers to a root capability associated with the result type of (cap3: CC^): String => String
    |          =>² refers to a fresh root capability created in method test of parameter parameter cap3² of method $anonfun
    |          ^   refers to the universal root capability
    |
-   |      Note that capability <cap of (cap3: CC^): String => String> cannot be included in outer capture set {cap}.
+   |Note that capability <cap of (cap3: CC^): String => String> cannot be included in outer capture set {cap}.
 37 |    def g(x: String): String = if cap3 == cap3 then "" else "a"
 38 |    g
 39 |  }

--- a/tests/neg-custom-args/captures/widen-reach.check
+++ b/tests/neg-custom-args/captures/widen-reach.check
@@ -8,7 +8,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/widen-reach.scala:9:24 -----------------------------------
 9 |  val foo: IO^ -> IO^ = x => x // error
   |                        ^^^^^^
-  |                        Found:    (x: IO^) ->? IO^²
+  |                        Found:    (x: IO^) ->'s1 IO^²
   |                        Required: IO^ -> IO^³
   |
   |                        where:    ^  refers to the universal root capability

--- a/tests/neg/i16842.check
+++ b/tests/neg/i16842.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i16842.scala:24:7 ----------------------------------------------------------------------------------
 24 |  Liter(SemanticArray[SemanticInt.type], x) // error
    |       ^
-   |       invalid new prefix (dim: Int): SemanticArray[SemanticInt.type] cannot replace ty.type in type ty.T
+   |invalid new prefix (dim: Int): SemanticArray[SemanticInt.type] cannot replace (ty : SemanticArray[SemanticType]) in type ty.T

--- a/tests/neg/i18058.check
+++ b/tests/neg/i18058.check
@@ -1,4 +1,4 @@
 -- Error: tests/neg/i18058.scala:4:21 ----------------------------------------------------------------------------------
 4 |type G = (f: ? <: F) => f.A // error
   |                     ^
-  |                     invalid new prefix  <: F cannot replace f.type in type f.A
+  |                     invalid new prefix  <: F cannot replace (f :  <: F) in type f.A

--- a/tests/neg/lambda-rename.check
+++ b/tests/neg/lambda-rename.check
@@ -1,8 +1,8 @@
 -- [E007] Type Mismatch Error: tests/neg/lambda-rename.scala:4:33 ------------------------------------------------------
 4 |val a: (x: Int) => Bar[x.type] = ??? : ((x: Int) => Foo[x.type]) // error
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |                                 Found:    (x: Int) => Foo[x.type]
-  |                                 Required: (x: Int) => Bar[x.type]
+  |                                 Found:    (x: Int) => Foo[(x : Int)]
+  |                                 Required: (x: Int) => Bar[(x : Int)]
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg/lambda-rename.scala:7:33 ------------------------------------------------------

--- a/tests/neg/polymorphic-functions1.check
+++ b/tests/neg/polymorphic-functions1.check
@@ -1,8 +1,8 @@
 -- [E007] Type Mismatch Error: tests/neg/polymorphic-functions1.scala:1:33 ---------------------------------------------
 1 |val f: [T] => (x: T) => x.type = [T] => (x: Int) => x // error
   |                                 ^^^^^^^^^^^^^^^^^^^^
-  |                                 Found:    [T] => (x: Int) => x.type
-  |                                 Required: [T] => (x²: T) => x².type
+  |                                 Found:    [T] => (x: Int) => (x : Int)
+  |                                 Required: [T] => (x²: T) => (x² : T)
   |
   |                                 where:    x  is a reference to a value parameter
   |                                           x² is a reference to a value parameter


### PR DESCRIPTION
 - Special case in some situations so that we only print the name,
   not the underlying type.
 - Print TermParamRefs like other singleton types
 - Use unique names to print empty capture set variables
 

