### PR TITLE
Backport "Use more context for implicit search only if no default argument" to 3.7.3

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5116,17 +5116,11 @@ object Types extends TypeUtils {
      */
     private def currentEntry(using Context): Type = ctx.typerState.constraint.entry(origin)
 
-    /** For uninstantiated type variables: the lower bound */
-    def lowerBound(using Context): Type = currentEntry.loBound
-
-    /** For uninstantiated type variables: the upper bound */
-    def upperBound(using Context): Type = currentEntry.hiBound
-
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
-    def hasLowerBound(using Context): Boolean = !lowerBound.isExactlyNothing
+    def hasLowerBound(using Context): Boolean = !currentEntry.loBound.isExactlyNothing
 
     /** For uninstantiated type variables: Is the upper bound different from Any? */
-    def hasUpperBound(using Context): Boolean = !upperBound.isTopOfSomeKind
+    def hasUpperBound(using Context): Boolean = !currentEntry.hiBound.isTopOfSomeKind
 
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5116,11 +5116,17 @@ object Types extends TypeUtils {
      */
     private def currentEntry(using Context): Type = ctx.typerState.constraint.entry(origin)
 
+    /** For uninstantiated type variables: the lower bound */
+    def lowerBound(using Context): Type = currentEntry.loBound
+
+    /** For uninstantiated type variables: the upper bound */
+    def upperBound(using Context): Type = currentEntry.hiBound
+
     /** For uninstantiated type variables: Is the lower bound different from Nothing? */
-    def hasLowerBound(using Context): Boolean = !currentEntry.loBound.isExactlyNothing
+    def hasLowerBound(using Context): Boolean = !lowerBound.isExactlyNothing
 
     /** For uninstantiated type variables: Is the upper bound different from Any? */
-    def hasUpperBound(using Context): Boolean = !currentEntry.hiBound.isTopOfSomeKind
+    def hasUpperBound(using Context): Boolean = !upperBound.isTopOfSomeKind
 
     /** Unwrap to instance (if instantiated) or origin (if not), until result
      *  is no longer a TypeVar

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4362,11 +4362,17 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
 
             val arg = inferImplicitArg(formal, tree.span.endPos)
 
+            lazy val defaultArg = findDefaultArgument(argIndex)
+              .showing(i"default argument: for $formal, $tree, $argIndex = $result", typr)
+            def argHasDefault = hasDefaultParams && !defaultArg.isEmpty
+
             def canProfitFromMoreConstraints =
               arg.tpe.isInstanceOf[AmbiguousImplicits]
-                    // ambiguity could be decided by more constraints
-              || !isFullyDefined(formal, ForceDegree.none)
-                    // more context might constrain type variables which could make implicit scope larger
+                    // Ambiguity could be decided by more constraints
+              || !isFullyDefined(formal, ForceDegree.none) && !argHasDefault
+                    // More context might constrain type variables which could make implicit scope larger.
+                    // But in this case we should search with additional arguments typed only if there
+                    // is no default argument.
 
             arg.tpe match
               case failed: SearchFailureType if canProfitFromMoreConstraints =>
@@ -4379,15 +4385,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               case failed: AmbiguousImplicits =>
                 arg :: implicitArgs(formals1, argIndex + 1, pt)
               case failed: SearchFailureType =>
-                lazy val defaultArg = findDefaultArgument(argIndex)
-                  .showing(i"default argument: for $formal, $tree, $argIndex = $result", typr)
-                if !hasDefaultParams || defaultArg.isEmpty then
-                  // no need to search further, the adapt fails in any case
-                  // the reason why we continue inferring arguments in case of an AmbiguousImplicits
-                  // is that we need to know whether there are further errors.
-                  // If there are none, we have to propagate the ambiguity to the caller.
-                  arg :: formals1.map(dummyArg)
-                else
+                if argHasDefault then
                   // This is tricky. On the one hand, we need the defaultArg to
                   // correctly type subsequent formal parameters in the same using
                   // clause in case there are parameter dependencies. On the other hand,
@@ -4398,6 +4396,12 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                   // `if propFail.exists` where we re-type the whole using clause with named
                   // arguments for all implicits that were found.
                   arg :: inferArgsAfter(defaultArg)
+                else
+                  // no need to search further, the adapt fails in any case
+                  // the reason why we continue inferring arguments in case of an AmbiguousImplicits
+                  // is that we need to know whether there are further errors.
+                  // If there are none, we have to propagate the ambiguity to the caller.
+                  arg :: formals1.map(dummyArg)
               case _ =>
                 arg :: inferArgsAfter(arg)
         end implicitArgs


### PR DESCRIPTION
Backports #23664 to the 3.7.3-RC2.

PR submitted by the release tooling.
[skip ci]