### PR TITLE
Backport "Check for mismatched argument type length in PatternMatcher due to Named Tuple :* syntax" to 3.7.3

### DIFF
--- a/tests/neg/i23155a.scala
+++ b/tests/neg/i23155a.scala
@@ -1,0 +1,7 @@
+import scala.NamedTuple
+object Unpack_NT {
+  (1, 2) match {
+    case Unpack_NT(first, _) => first // error
+  }
+  def unapply(e: (Int, Int)): Some[NamedTuple.NamedTuple["x" *: "y" *: EmptyTuple, Int *: Int *: EmptyTuple]] = ???
+}

--- a/tests/neg/i23155b.scala
+++ b/tests/neg/i23155b.scala
@@ -1,0 +1,6 @@
+object Unpack_T {
+  (1, 2) match {
+    case Unpack_T(first, _) => first // error
+  }
+  def unapply(e: (Int, Int)): Some[Int *: Int *: EmptyTuple] = ???
+}


### PR DESCRIPTION
Backports #23602 to the 3.7.3-RC1.

PR submitted by the release tooling.
[skip ci]