### PR TITLE
chore: port Scala.js to the new build

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -242,6 +242,26 @@ jobs:
       - name: Compile `scala-library` for Scala.js
         run: ./project/scripts/sbt scala-library-sjs/compile
 
+  scala3-library-sjs:
+    runs-on: ubuntu-latest
+    ## Add when we add support for caching here
+    ##needs: [scala-library-sjs]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-staging`
+        run: ./project/scripts/sbt scala3-staging-new/compile
+      - name: Compile `scala3-library` for Scala.js
+        run: ./project/scripts/sbt scala3-library-sjs/compile
+
   #################################################################################################
   ########################################### TEST JOBS ###########################################
   #################################################################################################

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -219,6 +219,29 @@ jobs:
       - name: Compile `scala3-tasty-inspector`
         run: ./project/scripts/sbt scala3-tasty-inspector-new/compile
 
+  scala-library-sjs:
+    runs-on: ubuntu-latest
+    ## Add when we add support for caching here
+    ##needs: [scala3-library-nonbootstrapped,
+    ##        tasty-core-nonbootstrapped,
+    ##        scala3-compiler-nonbootstrapped,
+    ##        scala3-sbt-bridge-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Compile `scala3-staging`
+        run: ./project/scripts/sbt scala3-staging-new/compile
+      - name: Compile `scala-library` for Scala.js
+        run: ./project/scripts/sbt scala-library-sjs/compile
+
   #################################################################################################
   ########################################### TEST JOBS ###########################################
   #################################################################################################

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val `scala3-compiler-nonbootstrapped` = Build.`scala3-compiler-nonbootstrapped`
 val `scala3-compiler-bootstrapped-new` = Build.`scala3-compiler-bootstrapped-new`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
 val `scala-library-sjs` = Build.`scala-library-sjs`
+val `scala3-library-sjs` = Build.`scala3-library-sjs`
 val `scala-library-nonbootstrapped` = Build.`scala-library-nonbootstrapped`
 val `scala3-library-nonbootstrapped` = Build.`scala3-library-nonbootstrapped`
 val `scala-library-bootstrapped` = Build.`scala-library-bootstrapped`

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val `scala3-compiler` = Build.`scala3-compiler`
 val `scala3-compiler-nonbootstrapped` = Build.`scala3-compiler-nonbootstrapped`
 val `scala3-compiler-bootstrapped-new` = Build.`scala3-compiler-bootstrapped-new`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
+val `scala-library-sjs` = Build.`scala-library-sjs`
 val `scala-library-nonbootstrapped` = Build.`scala-library-nonbootstrapped`
 val `scala3-library-nonbootstrapped` = Build.`scala3-library-nonbootstrapped`
 val `scala-library-bootstrapped` = Build.`scala-library-bootstrapped`

--- a/library-js/src/scala/Array.scala
+++ b/library-js/src/scala/Array.scala
@@ -68,7 +68,7 @@ object Array {
   /**
    * Returns a new [[scala.collection.mutable.ArrayBuilder]].
    */
-  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](t)
+  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   def from[A : ClassTag](it: IterableOnce[A]): Array[A] = {
     val n = it.knownSize

--- a/library-js/src/scala/Console.scala
+++ b/library-js/src/scala/Console.scala
@@ -280,5 +280,5 @@ object Console extends AnsiColor {
    *  @throws java.lang.IllegalArgumentException if there was a problem with the format string or arguments
    *  @group console-output
    */
-  def printf(text: String, args: Any*): Unit = { out.print(text format (args : _*)) }
+  def printf(text: String, args: Any*): Unit = { out.print(text.format(args*)) }
 }

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -966,7 +966,7 @@ final class StringOps(private val s: String) extends AnyVal {
     else new WrappedString(s).toArray[B]
 
   private[this] def unwrapArg(arg: Any): AnyRef = arg match {
-    case x: ScalaNumber => x.underlying
+    case x: ScalaNumber => x.underlying()
     case x              => x.asInstanceOf[AnyRef]
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1885,6 +1885,14 @@ object Build {
             .exists(overwrittenSources.contains))
 
       },
+      // Drop all the tasty files and the classfiles when packaging bu the scalajs exclusive classes
+      // More info here: https://github.com/scala-js/scala-js/issues/5217
+      Compile / packageBin / mappings := {
+        (Compile / packageBin / mappings).value.filter(file =>
+          file._2.endsWith(".sjsir")
+          || file._2.endsWith("UnitOps.tasty")         || file._2.endsWith("UnitOps.class") || file._2.endsWith("UnitOps$.class")
+          || file._2.endsWith("AnonFunctionXXL.tasty") || file._2.endsWith("AnonFunctionXXL.class"))
+      },
       libraryDependencies += ("org.scala-js" %% "scalajs-library" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
       libraryDependencies += ("org.scala-js" % "scalajs-javalib" % scalaJSVersion),
       // Project specific target folder. sbt doesn't like having two projects using the same target folder


### PR DESCRIPTION
Port the implementation of Scala.js scalalib to the new build
NOTE: We still need to overwrite the `.sjsir` of specialized classes (as we do when we overwrite `.class`files)

Related to: https://github.com/scala-js/scala-js/issues/5217