### PR TITLE
Use the new stdlib when generating scaladoc

### DIFF
--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: Compile and test
         run: |
           ./project/scripts/sbt scaladoc/test
+          ./project/scripts/sbt dist/Universal/stage
           ./project/scripts/cmdScaladocTests
 
       - name: Locally publish self

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
@@ -135,7 +135,7 @@ case class ScaladocTastyInspector()(using ctx: DocContext) extends Inspector:
   def mergeAnyRefAliasAndObject(parser: TastyParser) =
     import parser.qctx.reflect._
     val javaLangObjectDef = defn.ObjectClass.tree.asInstanceOf[ClassDef]
-    val objectMembers = parser.extractPatchedMembers(javaLangObjectDef)
+    val objectMembers = javaLangObjectDef.extractMembers
     val aM = parser.parseTypeDef(
       defn.AnyRefClass.tree.asInstanceOf[TypeDef],
       defn.AnyClass.tree.asInstanceOf[ClassDef],


### PR DESCRIPTION
In this PR, we use the new stdlib project to generate the scaladoc and website of scala 3.
The previous build used `scala2-library-bootstrapped` to fetch have tasty files available. We change this by now using the real, and to be, TASTy files for the stdlib.
This changes will already take effect in the first run after the merge of this PR.