### PR TITLE
chore: mark `scala-library` and `scalajs-scalalib_2.13` as `always` instead of `semver-spec`

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1661,7 +1661,12 @@ object Build {
       name          := "scala-library-nonbootstrapped",
       moduleName    := "scala-library",
       version       := dottyNonBootstrappedVersion,
-      versionScheme := Some("semver-spec"),
+      // We mark the current library as "always" instead of "semver-spec" so that buildtools can
+      // assume binary compatibility between 2.13.x and 3.x.y. If not set, build tools will, at least sbt,
+      // will error by claiming that scala-library:2.13.x and 3.x.y are potentially binary incompatible.
+      // Situation where we have 2.13.x and 3.x.y in the same dependency tree happens
+      // because we allow cross-compilation.
+      versionScheme := Some("always"),
       scalaVersion  := referenceVersion, // nonbootstrapped artifacts are compiled with the reference compiler (already officially published)
       crossPaths    := false, // org.scala-lang:scala-library doesn't have a crosspath
       autoScalaLibrary := false, // do not add a dependency to stdlib
@@ -1736,7 +1741,12 @@ object Build {
       name          := "scala-library-bootstrapped",
       moduleName    := "scala-library",
       version       := dottyVersion,
-      versionScheme := Some("semver-spec"),
+      // We mark the current library as "always" instead of "semver-spec" so that buildtools can
+      // assume binary compatibility between 2.13.x and 3.x.y. If not set, build tools will, at least sbt,
+      // will error by claiming that scala-library:2.13.x and 3.x.y are potentially binary incompatible.
+      // Situation where we have 2.13.x and 3.x.y in the same dependency tree happens
+      // because we allow cross-compilation.
+      versionScheme := Some("always"),
       // sbt defaults to scala 2.12.x and metals will report issues as it doesn't consider the project a scala 3 project
       // (not the actual version we use to compile the project)
       scalaVersion  := referenceVersion,
@@ -1851,7 +1861,12 @@ object Build {
       // Yes, I know, this is weird and feels wrong.
       moduleName    := "scalajs-scalalib_2.13",
       version       := dottyVersion,
-      versionScheme := Some("semver-spec"),
+      // We mark the current library as "always" instead of "semver-spec" so that buildtools can
+      // assume binary compatibility between 2.13.x and 3.x.y. If not set, build tools will, at least sbt,
+      // will error by claiming that scalajs-scalalib_2.13:2.13.x and 3.x.y are potentially binary incompatible.
+      // Situation where we have 2.13.x and 3.x.y in the same dependency tree happens
+      // because we allow cross-compilation.
+      versionScheme := Some("always"),
       crossPaths    := false,
       // sbt defaults to scala 2.12.x and metals will report issues as it doesn't consider the project a scala 3 project
       // (not the actual version we use to compile the project)


### PR DESCRIPTION
In some scenarios, specifically in cross compilation projects, sbt will complain that `scala-library:2.13.x` and `scala-library:3.x.y` might be imcompatible, as they are both declared `semver-spec`. See en example here:
```scala
[error] (update) found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.scala-lang:scala-library:3.8.0-RC1-bin-SNAPSHOT (semver-spec) is selected over 2.13.0
[error] 	    +- org.scala-lang:scala3-library_3:3.8.0-RC1-bin-SNAPSHOT (depends on 3.8.0-RC1-bin-SNAPSHOT)
[error] 	    +- org.scala-lang.modules:scala-xml_2.13:1.2.0        (depends on 2.13.0)
```

In this PR, we change the version scheme of both `scala-library` and `scalajs-scalalib_2.13` to `always` so that the transition between the old stdlib structure and the new one stay invisible to the users.
In the future, when we break binary compatibility (meaning Scala 4), we can revert this PR and have artifacts labeled with `semver-spec` as it will be exactly that scheme.

[skip ci]