### PR TITLE
Scaladoc cc: don't eagerly drop caps on parameters

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -535,6 +535,7 @@ trait TypesSupport:
   private def isCapturedInContext(using Quotes)(ref: reflect.TypeRepr)(using elideThis: reflect.ClassDef): Boolean =
     import reflect._
     ref match
+      case t if t.isCaptureRoot  => true
       case ReachCapability(c)    => isCapturedInContext(c)
       case ReadOnlyCapability(c) => isCapturedInContext(c)
       case ThisType(tr)          => !elideThis.symbol.typeRef.isPureClass(elideThis) /* is the current class pure? */


### PR DESCRIPTION
If parameters have caps.cap as the only capture set, we would previously eagerly drop them, as caps.cap.type is thought of as being a pure class :/
