### PR TITLE
chore: do not render `consume update` in `scaladoc`

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -25,9 +25,10 @@ trait ClassLikeSupport:
     def getExtraModifiers(): Seq[Modifier] =
       var mods = SymOps.getExtraModifiers(symbol)()
       if ccEnabled && symbol.flags.is(Flags.Mutable) then
-        mods :+= Modifier.Update
-      if ccEnabled && symbol.hasAnnotation(cc.CaptureDefs.ConsumeAnnot) then
-        mods :+= Modifier.Consume
+        if symbol.hasAnnotation(cc.CaptureDefs.ConsumeAnnot) then
+          mods :+= Modifier.Consume
+        else
+          mods :+= Modifier.Update
       mods
   }
 


### PR DESCRIPTION
In #23755, a `consume` method now implies an `update` method.
This PR changes the rendering in scaladoc to avoid printing `consume update def` and rather print `consume def`.
Note that at the moment, in #23755, writing `consume update def` or `consume def` has the same effect.
An error or a warning might be added in the feature to highlight that `update` in `consume update def` is a redundant modifier.

[skip ci]