### PR TITLE
chore: allow access to secrets to the nightly release workflow

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -17,3 +17,4 @@ jobs:
     uses: ./.github/workflows/release-maven-artifacts.yml
     with:
       environment: release-nightly
+    secrets: inherit


### PR DESCRIPTION
The workflow test failed because the environment didn't grant access to the secrets to the reusable workflow.
In this PR, we do grant access. This was validated by a run of the workflow on my personal fork of `scala/scala3` (https://github.com/hamzaremmal/scala3/actions/runs/17009629759/job/48223892571).

[skip ci]