### PR TITLE
Add test for i23739

### DIFF
--- a/tests/init-global/pos/i23739.scala
+++ b/tests/init-global/pos/i23739.scala
@@ -1,0 +1,3 @@
+enum E {
+  case A extends E
+}


### PR DESCRIPTION
Adds test for i23739, which should not crash since version 3.7.2