### PR TITLE
fix(patmat): Add subtype-based fallback in inferPrefixMap and recalculate constraints after application

### DIFF
--- a/tests/warn/i23369.scala
+++ b/tests/warn/i23369.scala
@@ -1,0 +1,26 @@
+class Module {
+  type BarTy
+  sealed trait Adt[A]
+  case class Foo() extends Adt[String]
+  case class Bar[A <: BarTy](x: BarTy) extends Adt[A]
+}
+
+object Basic extends Module {
+  type BarTy = String
+}
+
+def test(a: Basic.Adt[String]) = {
+  a match { // warn: match may not be exhaustive
+    case Basic.Foo() =>
+  }
+}
+
+object Basic2 extends Module {
+  type BarTy = Int
+}
+
+def test2(a: Basic2.Adt[String]) = {
+  a match {
+    case Basic2.Foo() =>
+  }
+}


### PR DESCRIPTION
fix https://github.com/scala/scala3/issues/23369

1. Add fallback logic in inferPrefixMap that uses subtype relationships to find a singleton when an exact match cannot be found
2. Ensure that constraints are calculated after applying inferPrefixMap