### PR TITLE
Check conformance to caps.Pure upper bound only under cc

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -706,9 +706,29 @@ object TypeOps:
     def loop(args: List[Tree], boundss: List[TypeBounds]): Unit = args match
       case arg :: args1 => boundss match
         case bounds :: boundss1 =>
+
+          // Drop caps.Pure from a bound (1) at the top-level, (2) in an `&`, (3) under a type lambda.
+          def dropPure(tp: Type): Option[Type] = tp match
+            case tp @ AndType(tp1, tp2) =>
+              for tp1o <- dropPure(tp1); tp2o <- dropPure(tp2) yield
+                tp.derivedAndType(tp1o, tp2o)
+            case tp: HKTypeLambda =>
+              for rt <- dropPure(tp.resType) yield
+                tp.derivedLambdaType(resType = rt)
+            case _ =>
+              if tp.typeSymbol == defn.PureClass then None
+              else Some(tp)
+
+          val relevantBounds =
+            if Feature.ccEnabled then bounds
+            else
+              // Drop caps.Pure from bound, it should be checked only when capture checking is enabled
+              dropPure(bounds.hi).match
+                case Some(hi1) => bounds.derivedTypeBounds(bounds.lo, hi1)
+                case None => TypeBounds(bounds.lo, defn.AnyKindType)
           arg.tpe match
-            case TypeBounds(lo, hi) => checkOverlapsBounds(lo, hi, arg, bounds)
-            case tp => checkOverlapsBounds(tp, tp, arg, bounds)
+            case TypeBounds(lo, hi) => checkOverlapsBounds(lo, hi, arg, relevantBounds)
+            case tp => checkOverlapsBounds(tp, tp, arg, relevantBounds)
           loop(args1, boundss1)
         case _ =>
       case _ =>

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -710,8 +710,13 @@ object TypeOps:
           // Drop caps.Pure from a bound (1) at the top-level, (2) in an `&`, (3) under a type lambda.
           def dropPure(tp: Type): Option[Type] = tp match
             case tp @ AndType(tp1, tp2) =>
-              for tp1o <- dropPure(tp1); tp2o <- dropPure(tp2) yield
-                tp.derivedAndType(tp1o, tp2o)
+              dropPure(tp1) match
+                case Some(tp1o) =>
+                  dropPure(tp2) match
+                    case Some(tp2o) => Some(tp.derivedAndType(tp1o, tp2o))
+                    case None => Some(tp1o)
+                case None =>
+                  dropPure(tp2)
             case tp: HKTypeLambda =>
               for rt <- dropPure(tp.resType) yield
                 tp.derivedLambdaType(resType = rt)

--- a/library/src/scala/caps/Pure.scala
+++ b/library/src/scala/caps/Pure.scala
@@ -6,6 +6,15 @@ import language.experimental.captureChecking
 /** A marker trait that declares that all inheriting classes are "pure" in the
  *  sense that their values retain no capabilities including capabilities needed
  *  to perform effects. This has formal meaning only under capture checking.
+ *
+ *  NOTE: If an upper bound is Pure, we check that an argument conforms to it only
+ *  in sources where capture checking is enabled. For instance,
+ *
+ *    def f[C <: Pure]()
+ *    f[Object]()
+ *
+ *  would give an error only under capture checking. Pure is also dropped in
+ *  upper bounds if it forms part of an &-type, or is under a type lambda.
  */
 trait Pure:
   this: Pure =>

--- a/tests/neg-custom-args/captures/puretest.scala
+++ b/tests/neg-custom-args/captures/puretest.scala
@@ -1,0 +1,10 @@
+import caps.Pure
+def foo[C <: Pure]() = ()
+def bar[T, C <: Iterable[T] & Pure]() = ()
+def baz[CC[_] <: Pure]() = ()
+def bam[CC[A] <: Pure & Iterable[A]]() = ()
+def test =
+  foo[Int]()  // error
+  bar[Int, List[Int]]() // error
+  baz[Seq]() // error
+  bam[Seq]() // error

--- a/tests/neg-custom-args/captures/puretest.scala
+++ b/tests/neg-custom-args/captures/puretest.scala
@@ -1,4 +1,5 @@
 import caps.Pure
+class P extends Pure
 def foo[C <: Pure]() = ()
 def bar[T, C <: Iterable[T] & Pure]() = ()
 def baz[CC[_] <: Pure]() = ()
@@ -8,3 +9,4 @@ def test =
   bar[Int, List[Int]]() // error
   baz[Seq]() // error
   bam[Seq]() // error
+  foo[P]() // OK

--- a/tests/neg/puretest.scala
+++ b/tests/neg/puretest.scala
@@ -1,0 +1,12 @@
+import caps.Pure
+def foo[C <: Pure]() = ()
+def bar[T, C <: Iterable[T] & Pure]() = ()
+def baz[CC[_] <: Pure]() = ()
+def bam[CC[A] <: Pure & Iterable[A]]() = ()
+def test =
+  foo[Int]()
+  bar[Int, List[Int]]()
+  bar[Int, Iterator[Int]]() // error
+  baz[Seq]()
+  bam[Seq]()
+  bam[Iterator]() // error

--- a/tests/pos/puretest.scala
+++ b/tests/pos/puretest.scala
@@ -1,0 +1,10 @@
+import caps.Pure
+def foo[C <: Pure]() = ()
+def bar[T, C <: Iterable[T] & Pure]() = ()
+def baz[CC[_] <: Pure]() = ()
+def bam[CC[A] <: Pure & Iterable[A]]() = ()
+def test =
+  foo[Int]()
+  bar[Int, List[Int]]()
+  baz[Seq]()
+  bam[Seq]()


### PR DESCRIPTION
This is necessary to ensure source compatibility of the capture checked stdlib.