### PR TITLE
Error tree on outdent is zero extent

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -409,7 +409,9 @@ object Parsers {
       false
     }
 
-    def errorTermTree(start: Offset): Tree = atSpan(Span(start, in.offset)) { unimplementedExpr }
+    def errorTermTree(start: Offset): Tree =
+      val end = if in.token == OUTDENT then start else in.offset
+      atSpan(Span(start, end)) { unimplementedExpr }
 
     private var inFunReturnType = false
     private def fromWithinReturnType[T](body: => T): T = {

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -307,7 +307,7 @@ object Scanners {
         println(s"\nSTART SKIP AT ${sourcePos().line + 1}, $this in $currentRegion")
       var noProgress = 0
         // Defensive measure to ensure we always get out of the following while loop
-        // even if source file is weirly formatted (i.e. we never reach EOF)
+        // even if source file is weirdly formatted (i.e. we never reach EOF)
       var prevOffset = offset
       while !atStop && noProgress < 3 do
         nextToken()

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1339,7 +1339,7 @@ trait Checking {
     typr.println(i"check no double declarations $cls")
 
     def checkDecl(decl: Symbol): Unit = {
-      for (other <- seen(decl.name) if !decl.isAbsent() && !other.isAbsent()) {
+      for other <- seen(decl.name) if decl.name != nme.ERROR && !decl.isAbsent() && !other.isAbsent() do
         typr.println(i"conflict? $decl $other")
         def javaFieldMethodPair =
           decl.is(JavaDefined) && other.is(JavaDefined) &&
@@ -1356,7 +1356,6 @@ trait Checking {
         if decl.hasDefaultParams && other.hasDefaultParams then
           report.error(em"two or more overloaded variants of $decl have default arguments", decl.srcPos)
           decl.resetFlag(HasDefaultParams)
-      }
       if (!excludeFromDoubleDeclCheck(decl))
         seen(decl.name) = decl :: seen(decl.name)
     }

--- a/tests/neg/i23729.scala
+++ b/tests/neg/i23729.scala
@@ -1,0 +1,19 @@
+
+trait Collection[Self, Element]:
+  type Index
+  extension (self: Self)
+    def start: Index
+
+sealed trait Tree[+T]
+object Tree:
+  case object Empty extends Tree[Nothing]
+  case class Node[+T](value: T, lhs: Tree[T], rhs: Tree[T]) extends Tree[T]
+
+enum Direction:
+  case Left, Right, Here
+given [T]: Collection[Tree[T], T] with
+  type Index = List[Direction]
+  extension (self: Tree[T])
+    def start: List[Direction] = match self // error syntax
+      case Empty => Nil // error poor recovery
+      case Node(_, l, _) => l.start :+ Left // error poor recovery


### PR DESCRIPTION
Recovery on syntax error may consume remaining input, with an OUTDENT at EOF, so that the parent tree does not actually extend to EOF.

Do not report spurious `def <error>` as ambiguous.

Fixes #23729 