### PR TITLE
Fix false unreachable case warning

### DIFF
--- a/tests/pos/i20225.scala
+++ b/tests/pos/i20225.scala
@@ -1,0 +1,12 @@
+sealed abstract class Parent
+class A extends Parent
+class B extends Parent
+
+inline def matchAs[T <: Parent](p: Parent): Unit = p match
+  case _: T => ()
+  case _    => ()
+
+object Test:
+  def main(args: Array[String]): Unit =
+    matchAs[A](new B)
+

--- a/tests/pos/i20395.scala
+++ b/tests/pos/i20395.scala
@@ -1,0 +1,13 @@
+sealed trait NodeId
+case object Hi extends NodeId
+case object Hello extends NodeId
+
+extension (value: NodeId)
+  inline def parse[T <: NodeId] = value match
+    case _: T => ()
+    case _    => ()
+
+object Test:
+  def main(args: Array[String]): Unit =
+    Hi.parse[Hello.type]
+

--- a/tests/run/i20225.check
+++ b/tests/run/i20225.check
@@ -1,0 +1,1 @@
+unreachable case reached

--- a/tests/run/i20225.scala
+++ b/tests/run/i20225.scala
@@ -1,0 +1,12 @@
+sealed abstract class Parent
+class A extends Parent
+class B extends Parent
+
+inline def matchAs[T <: Parent](p: Parent): Unit = p match
+  case _: T => ()
+  case _    => println("unreachable case reached")
+
+object Test:
+  def main(args: Array[String]): Unit =
+    matchAs[A](new B)
+

--- a/tests/run/i20395.check
+++ b/tests/run/i20395.check
@@ -1,0 +1,1 @@
+not match

--- a/tests/run/i20395.scala
+++ b/tests/run/i20395.scala
@@ -1,0 +1,13 @@
+sealed trait NodeId
+case object Hi extends NodeId
+case object Hello extends NodeId
+
+extension (value: NodeId)
+  inline def parse[T <: NodeId]: Unit = value match
+    case _: T => println("match")
+    case _    => println("not match")
+
+object Test:
+  def main(args: Array[String]): Unit =
+    Hi.parse[Hello.type]
+


### PR DESCRIPTION
We want to allow decomposition only on the right-hand side of a pattern if the type is not a type parameter, a type parameter reference, or a deferred type reference. This is because decomposition on the right-hand side of a pattern can lead to false positive warnings.

Fixes https://github.com/scala/scala3/issues/20395 
Fixes https://github.com/scala/scala3/issues/20225