### PR TITLE
Add support for unqualified selectors

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3291,7 +3291,7 @@ object Parsers {
      *                    |  SimplePattern1 [TypeArgs] [ArgumentPatterns]
      *                    |  ‘given’ RefinedType
      *  SimplePattern1   ::= SimpleRef
-     *                    |  SimplePattern1 `.' id
+     *                    |  [SimplePattern1] `.' id
      *  PatVar           ::= id
      *                    |  `_'
      */
@@ -3308,6 +3308,9 @@ object Parsers {
         simpleExpr(Location.InPattern)
       case XMLSTART =>
         xmlLiteralPattern()
+      case DOT =>
+        accept(DOT)
+        simplePatternRest(selector(EmptyTree))
       case GIVEN =>
         atSpan(in.offset) {
           val givenMod = atSpan(in.skipToken())(Mod.Given())

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1269,9 +1269,7 @@ object Parsers {
 
     /** Accept identifier or match clause acting as a selector on given tree `t` */
     def selectorOrMatch(t: Tree): Tree =
-      atSpan(startOffset(t), in.offset) {
-        if in.token == MATCH then matchClause(t) else Select(t, ident())
-      }
+      if in.token == MATCH then matchClause(t) else selector(t)
 
     def selector(t: Tree): Tree =
       atSpan(startOffset(t), in.offset) { Select(t, ident()) }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2368,6 +2368,7 @@ object Parsers {
      *                      |  `try' Expr [`finally' Expr]
      *                      |  `throw' Expr
      *                      |  `return' [Expr]
+     *                      |  `.` id
      *                      |  ForExpr
      *                      |  [SimpleExpr `.'] id `=' Expr
      *                      |  PrefixOperator SimpleExpr `=' Expr
@@ -2756,6 +2757,7 @@ object Parsers {
      *  SimpleExpr1   ::= literal
      *                 |  xmlLiteral
      *                 |  SimpleRef
+     *                 |  `.` id
      *                 |  `(` [ExprsInParens] `)`
      *                 |  SimpleExpr `.` id
      *                 |  SimpleExpr `.` MatchClause
@@ -2800,6 +2802,9 @@ object Parsers {
         case MACRO =>
           val start = in.skipToken()
           MacroTree(simpleExpr(Location.ElseWhere))
+        case DOT =>
+          accept(DOT)
+          selector(EmptyTree)
         case _ =>
           if isLiteral then
             literal()

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -227,7 +227,7 @@ object Tokens extends TokensCommon {
     | BitSet(QUOTE, NEW)
 
   final val canStartExprTokens3: TokenSet =
-    canStartInfixExprTokens | BitSet(INDENT, IF, WHILE, FOR, TRY, THROW)
+    canStartInfixExprTokens | BitSet(INDENT, IF, WHILE, FOR, TRY, THROW, DOT)
 
   final val canStartExprTokens2: TokenSet = canStartExprTokens3 | BitSet(DO)
 

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1096,10 +1096,15 @@ trait Applications extends Compatibility {
           if tpt.isType && typedAheadType(tpt).tpe.typeSymbol.typeParams.isEmpty then
             IgnoredProto(pt)
           else
-            pt // Don't ignore expected value types of `new` expressions with parameterized type.
-                // If we have a `new C()` with expected type `C[T]` we want to use the type to
-                // instantiate `C` immediately. This is necessary since `C` might _also_ have using
-                // clauses that we want to instantiate with the best available type. See i15664.scala.
+            // Don't ignore expected value types of `new` expressions with parameterized type.
+            // If we have a `new C()` with expected type `C[T]` we want to use the type to
+            // instantiate `C` immediately. This is necessary since `C` might _also_ have using
+            // clauses that we want to instantiate with the best available type. See i15664.scala.
+            pt
+        // When typing the selector of an `Apply` node, and if the selector is `unqualifed` (e.g. `.some(10)`)
+        // We preserve the prototype `pt` and keep it in the prototype passed to type the selector.
+        // Unqualified selectors relies on the expected type to resolve the qualifier of the selection.
+        case Select(EmptyTree, name) => pt
         case _ => IgnoredProto(pt)
           // Do ignore other expected result types, since there might be an implicit conversion
           // on the result. We could drop this if we disallow unrestricted implicit conversions.

--- a/tests/pos/unqualified-selector-enum.scala
+++ b/tests/pos/unqualified-selector-enum.scala
@@ -2,6 +2,11 @@ enum Opt[+T]:
   case none extends Opt[Nothing]
   case some[T](value: T) extends Opt[T]
 
+  def map[U](f: T => U): Opt[U] = this match
+    case .none => .none
+    case Opt.some(v) => .some(f(v)) // TODO: This should be `case .some(v) => .some(f(v))`
+  end map
+
 object Proxy:
   def opt(o: Opt[Int]): Opt[Int] = o
 

--- a/tests/pos/unqualified-selector-enum.scala
+++ b/tests/pos/unqualified-selector-enum.scala
@@ -1,0 +1,12 @@
+enum Opt[+T]:
+  case none extends Opt[Nothing]
+  case some[T](value: T) extends Opt[T]
+
+object Proxy:
+  def opt(o: Opt[Int]): Opt[Int] = o
+
+val _: Opt[Int] = .some(10)
+val _: Opt[Any] = .none
+
+val _ = Proxy.opt(.some(10))
+val _ = Proxy.opt(.none)

--- a/tests/pos/unqualified-selector-object.scala
+++ b/tests/pos/unqualified-selector-object.scala
@@ -1,0 +1,8 @@
+class Opt[+T](v: T)
+
+object Opt:
+  def some[T](b: T): Opt[T] = Opt(b)
+  val none: Opt[Nothing] = ???
+
+val _: Opt[Int] = .some(10)
+val _: Opt[Int] = .none


### PR DESCRIPTION
TODO:
- [ ] This will require a SIP to get to the language
- [ ] Add support for `case .some(v) => ???`, `case _:  .InnerClass`, ...
- [ ] Add error message when the expected type cannot derive the qualifier
- [ ] Specify the qualifier resolution (which should answer any question we might have)