### PR TITLE
Widen type parameters before box adaptation

### DIFF
--- a/tests/neg-custom-args/captures/i23746.check
+++ b/tests/neg-custom-args/captures/i23746.check
@@ -1,0 +1,21 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23746.scala:5:2 -----------------------------------------
+5 |  () => op.run()  // error
+  |  ^^^^^^^^^^^^^^
+  |  Found:    () => Unit
+  |  Required: () -> Unit
+  |
+  |  Note that capability cap is not included in capture set {}.
+  |
+  |  where:    =>  refers to a fresh root capability in the type of type X
+  |            cap is a fresh root capability in the type of type X
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i23746.scala:10:4 ----------------------------------------
+10 |    () => op.run()  // error
+   |    ^^^^^^^^^^^^^^
+   |    Found:    () ->{a} Unit
+   |    Required: () -> Unit
+   |
+   |    Note that capability a is not included in capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i23746.scala
+++ b/tests/neg-custom-args/captures/i23746.scala
@@ -1,0 +1,10 @@
+import language.experimental.captureChecking
+trait Op:
+  def run(): Unit
+def helper[X <: Op^](op: X): () -> Unit =
+  () => op.run()  // error
+def test1(a: Op^): Unit =
+  def foo[X <: Op^{a}](op: X): () ->{a} Unit =
+    () => op.run()  // ok
+  def bar[X <: Op^{a}](op: X): () ->{} Unit =
+    () => op.run()  // error

--- a/tests/pos-custom-args/captures/i19076.scala
+++ b/tests/pos-custom-args/captures/i19076.scala
@@ -1,0 +1,4 @@
+import language.experimental.captureChecking
+trait IO
+def main(a: IO^): Unit =
+  def foo[X <: IO^{a}](x: X): IO^{a} = x  // now ok


### PR DESCRIPTION
Fixes #23746 and #19076.

Widen type parameters to their upper bounds in certain cases before box adaptation. This helps revealing a boxed type inside the upper bound of a type parameter.