### PR TITLE
Explain no expansion of ContextFunction0

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3749,12 +3749,18 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val ifpt = defn.asContextFunctionType(pt)
           val result =
             if ifpt.exists
-              && defn.functionArity(ifpt) > 0 // ContextFunction0 is only used after ElimByName
+              && !ctx.isAfterTyper
+              && {
+                // ContextFunction0 is only used after ElimByName
+                val arity = defn.functionArity(ifpt)
+                if arity == 0 then
+                  report.error(em"context function types require at least one parameter", xtree.srcPos)
+                arity > 0
+              }
               && xtree.isTerm
               && !untpd.isContextualClosure(xtree)
               && !ctx.mode.is(Mode.Pattern)
               && !xtree.isInstanceOf[SplicePattern]
-              && !ctx.isAfterTyper
               && !ctx.isInlineContext
             then
               makeContextualFunction(xtree, ifpt)

--- a/tests/neg/i21321.check
+++ b/tests/neg/i21321.check
@@ -1,0 +1,19 @@
+-- Error: tests/neg/i21321.scala:3:42 ----------------------------------------------------------------------------------
+3 |val v1b: scala.ContextFunction0[String] = () ?=> "x" // error
+  |                                          ^^
+  |                                          context function literals require at least one formal parameter
+-- Error: tests/neg/i21321.scala:4:8 -----------------------------------------------------------------------------------
+4 |val v2: () ?=> String = "y" // error // error in parser
+  |        ^^
+  |        context function types require at least one parameter
+-- Error: tests/neg/i21321.scala:2:41 ----------------------------------------------------------------------------------
+2 |val v1: scala.ContextFunction0[String] = "x" // error
+  |                                         ^^^
+  |                                         context function types require at least one parameter
+-- [E007] Type Mismatch Error: tests/neg/i21321.scala:4:24 -------------------------------------------------------------
+4 |val v2: () ?=> String = "y" // error // error in parser
+  |                        ^^^
+  |                        Found:    ("y" : String)
+  |                        Required: () => String
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i21321.scala
+++ b/tests/neg/i21321.scala
@@ -1,0 +1,4 @@
+
+val v1: scala.ContextFunction0[String] = "x" // error
+val v1b: scala.ContextFunction0[String] = () ?=> "x" // error
+val v2: () ?=> String = "y" // error // error in parser


### PR DESCRIPTION
Fixes #21321 

Just an edge case.

I tried emitting `TypeMismatch` with addenda, but it didn't render, so that was too much hassle just to add a string.

This is the existing notice; it doesn't indicate why it doesn't work.
```
2 |val v1: scala.ContextFunction0[String] = "x" // error
  |                                         ^^^
  |                                         Found:    ("x" : String)
  |                                         Required: () ?=> String
```