### PR TITLE
Closes #7532: Parameter hints not working for functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -379,7 +379,7 @@ object Signatures {
     case other => other.stripAnnots
 
   /**
-   * Checks if tree is valid for signatureHelp. Skipped trees are either tuple or function applies
+   * Checks if tree is valid for signatureHelp. Skips tuple apply trees
    *
    * @param tree tree to validate
    */
@@ -389,12 +389,7 @@ object Signatures {
         && tree.symbol.exists
         && ctx.definitions.isTupleClass(tree.symbol.owner.companionClass)
 
-    val isFunctionNApply =
-      tree.symbol.name == nme.apply
-        && tree.symbol.exists
-        && ctx.definitions.isFunctionSymbol(tree.symbol.owner)
-
-    !isTupleApply && !isFunctionNApply
+    !isTupleApply
 
   /**
    * Get unapply method result type omiting unknown types and another method calls.

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpSuite.scala
@@ -1610,3 +1610,39 @@ class SignatureHelpSuite extends BaseSignatureHelpSuite:
       |            ^^^^^^
       """.stripMargin
     )
+
+  @Test def `proper-function-signature` =
+    check(
+      """
+        |object OOO {
+        |
+        |val function: (x: Int, y: String) => Unit =
+        |(_, _) =>
+        | ()
+        |
+        |function(@@, "one")
+        |}
+      """.stripMargin,
+      """|apply(v1: Int, v2: String): Unit
+         |      ^^^^^^^
+         |""".stripMargin
+    )
+
+  @Test def `proper-function-signature-with-explicit-apply` =
+    check(
+      """
+        |object OOO {
+        |
+        |val function: (x: Int, y: String) => Unit =
+        |(_, _) =>
+        | ()
+        |
+        |function.apply(@@, "one")
+        |}
+      """.stripMargin,
+      """|apply(v1: Int, v2: String): Unit
+         |      ^^^^^^^
+         |""".stripMargin
+    )
+
+


### PR DESCRIPTION
- Treat function `apply` calls as valid for signatureHelp; stop excluding FunctionN `apply`.

- Add tests for implicit/explicit apply; keep skipping tuple applies.

This work was done during the Scala Tooling Spree session with the help of @tgodzik ! 