### PR TITLE
Modelling assigning to null in the global object initialization checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -905,7 +905,7 @@ class Objects(using Context @constructorOnly):
             // the typer might mistakenly set the receiver to be a package instead of package object.
             // See pos/packageObjectStringInterpolator.scala
             if packageModuleClass == klass || (klass.denot.isPackageObject && klass.owner == packageModuleClass) then a else Bottom
-          case v: SafeValue => if v.typeSymbol.asClass.isSubClass(klass) then a else Bottom
+          case v: SafeValue => if v.typeSymbol.asClass.isSubClass(klass) && v.typeSymbol.asClass != defn.NullClass then a else Bottom
           case ref: Ref => if ref.klass.isSubClass(klass) then ref else Bottom
           case ValueSet(values) => values.map(v => v.filterClass(klass)).join
           case fun: Fun =>

--- a/tests/init-global/pos/assignment-to-null.scala
+++ b/tests/init-global/pos/assignment-to-null.scala
@@ -1,0 +1,9 @@
+class C {
+  var f: Int = 1
+}
+
+object O {
+  var c: C = null
+  c = new C
+  c.f = 2
+}


### PR DESCRIPTION
This PR adds support in the global object initialization order to assign to a value set that contains null. Avoid throwing internal error in this case