### PR TITLE
Fix global init checker unexpected by name

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1360,7 +1360,7 @@ class Objects(using Context @constructorOnly):
           case env: Env.EnvRef => Env.ofByName(sym, thisV, Env.EnvSet(Set(env)))
         }
         given Scope = byNameEnv
-        eval(code, thisV, klass)
+        eval(code, thisV, klass, cacheResult = true)
       case UnknownValue =>
         reportWarningForUnknownValue("Calling on unknown value. " + Trace.show, Trace.position)
       case Bottom => Bottom

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1364,9 +1364,9 @@ class Objects(using Context @constructorOnly):
       case UnknownValue =>
         reportWarningForUnknownValue("Calling on unknown value. " + Trace.show, Trace.position)
       case Bottom => Bottom
-      case ValueSet(values) if values.size == 1 =>
-        evalByNameParam(values.head)
-      case _: ValueSet | _: Ref | _: ArrayRef | _: Package | SafeValue(_) =>
+      case ValueSet(values) =>
+        values.map(evalByNameParam(_)).join
+      case _: Ref | _: ArrayRef | _: Package | SafeValue(_) =>
         report.warning("[Internal error] Unexpected by-name value " + value.show  + ". " + Trace.show, Trace.position)
         Bottom
     end evalByNameParam

--- a/tests/init-global/pos/i18628_2.scala
+++ b/tests/init-global/pos/i18628_2.scala
@@ -2,6 +2,6 @@ object Test:
   class Box(val x: Int)
 
   def recur(a: => Box, b: Box): Int =
-    a.x + recur(a, b) + b.x // warn
+    a.x + recur(a, b) + b.x
 
   recur(Box(1), Box(2))

--- a/tests/init-global/pos/i18628_3.scala
+++ b/tests/init-global/pos/i18628_3.scala
@@ -6,6 +6,6 @@ object Test:
   class Box(val x: Int)
 
   def recur(a: => Box, b: => Box): Int =
-    a.x + recur(a: @widen(5), b: @widen(5)) + b.x // warn // warn
+    a.x + recur(a: @widen(5), b: @widen(5)) + b.x
 
   recur(Box(1), Box(2))

--- a/tests/init-global/pos/i18628_4.scala
+++ b/tests/init-global/pos/i18628_4.scala
@@ -2,6 +2,6 @@ object Test:
   class Box(val x: Int)
 
   def recur(a: => Box, b: => Box): Int =
-    a.x + recur(a, b) + b.x // warn // warn
+    a.x + recur(a, b) + b.x
 
   recur(Box(1), Box(2))

--- a/tests/init-global/pos/multiple-by-name.scala
+++ b/tests/init-global/pos/multiple-by-name.scala
@@ -1,0 +1,15 @@
+class X {
+  def bar(): Int = 5
+}
+class Y extends X {
+  override def bar(): Int = 6
+}
+
+object O {
+  def foo(p: => X) = {
+    p.bar()
+  }
+
+  val a = foo(new X)
+  val b = foo(new Y)
+}


### PR DESCRIPTION
This PR fixes the issue of throwing unexpected by name error in the global object initialization error when the by-name value is a modelled by set of `Fun`. Each element in the value set is recursively evaluated