### PR TITLE
Fix selection on safe value in the global object initialization checker

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/init/Util.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Util.scala
@@ -62,6 +62,10 @@ object Util:
       case ref: RefTree if ref.symbol.is(Flags.Method) =>
         Some((ref, Nil))
 
+      case ref: RefTree if ref.tpe.widenSingleton.isInstanceOf[MethodicType] =>
+        // for polymorphic method with no `apply` symbol; see tests/init/pos/interleaving-overload.scala
+        Some((ref, Nil))
+
       case _ => None
 
   object NewExpr:

--- a/compiler/src/dotty/tools/dotc/transform/init/Util.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Util.scala
@@ -59,7 +59,7 @@ object Util:
       case TypeApply(fn, targs) =>
         unapply(fn)
 
-      case ref: RefTree if ref.tpe.widenSingleton.isInstanceOf[MethodicType] =>
+      case ref: RefTree if ref.symbol.is(Flags.Method) =>
         Some((ref, Nil))
 
       case _ => None

--- a/tests/init-global/pos-tasty/test-safe-value.scala
+++ b/tests/init-global/pos-tasty/test-safe-value.scala
@@ -1,0 +1,7 @@
+package scala.collection.immutable
+
+object A { // These are a safe values, so no warning should be emitted
+    Node.HashCodeLength
+    Node.BitPartitionSize
+    Node.MaxDepth
+}


### PR DESCRIPTION
This PR fixes the internal error of selection on safe value thrown by the global object initialization checker, which is caused by Tasty annotating the return type of methods like `toDouble` as ConstantType