### PR TITLE
Backport "[chore] Update scala-cli to 1.9.0 (was 1.8.5)" to 3.7.3

### DIFF
--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v6
-      - uses: VirtusLab/scala-cli-setup@v1.8.5
+      - uses: VirtusLab/scala-cli-setup@v1.9.0
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ secrets.GRAPHQL_API_TOKEN }}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -137,7 +137,7 @@ object Build {
   val mimaPreviousLTSDottyVersion = "3.3.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.8.5"
+  val scalaCliLauncherVersion = "1.9.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.24"
 


### PR DESCRIPTION
Backports #23856 to the 3.7.3-RC3.

PR submitted by the release tooling.