### PR TITLE
Support zinc invalidation for type arguments in macro calls 

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -125,6 +125,12 @@ private class ExtractDependenciesCollector(rec: DependencyRecorder) extends Abst
   override def traverse(tree: Tree)(using Context): Unit =
     try
       recordTree(tree)
+
+      tree match
+        case TypeApply(fun, args) if fun.symbol.is(Inline) =>
+          addMacroDependency(args)
+        case _ =>
+        
       tree match
         case tree: Inlined if !tree.inlinedFromOuterScope =>
           // The inlined call is normally ignored by TreeTraverser but we need to
@@ -181,6 +187,30 @@ trait AbstractExtractDependenciesCollector(rec: DependencyRecorder) extends tpd.
       for parent <- tree.parents do
         rec.addClassDependency(parent.tpe.classSymbol, depContext)
     }
+
+  // Only reference DependencyByMacroExpansion if it an be found on the classpath,
+  // as it was added later to the zinc.apiinfo DependencyContext enum
+  // e.g. pre 1.10.x sbt would throw java.lang.NoSuchFieldError errors here
+  lazy val allowsDependencyByMacroExpansion =
+    classOf[DependencyContext].getFields().exists(_.getName() == "DependencyByMacroExpansion")
+
+  private def addMacroDependency(sym: Symbol)(using Context): Unit =
+    if (allowsDependencyByMacroExpansion) {
+      if (!ignoreDependency(sym)) {
+        if (!sym.is(Package)) {
+          val enclOrModuleClass = if (sym.is(ModuleVal)) sym.moduleClass else sym.enclosingClass
+          assert(enclOrModuleClass.isClass, s"$enclOrModuleClass, $sym")
+
+          rec.addClassDependency(enclOrModuleClass, DependencyByMacroExpansion)
+        }
+      }
+    }
+
+  private def addMacroDependency(trees: List[Tree])(using Context): Unit =
+    val traverser = new TypeDependencyTraverser {
+      def addDependency(symbol: Symbol) = addMacroDependency(symbol)
+    }
+    trees.foreach(tree => traverser.traverse(tree.tpe))
 
   private def depContextOf(cls: Symbol)(using Context): DependencyContext =
     if cls.isLocal then LocalDependencyByInheritance

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -126,10 +126,7 @@ private class ExtractDependenciesCollector(rec: DependencyRecorder) extends Abst
     try
       recordTree(tree)
 
-      tree match
-        case TypeApply(fun, args) if fun.symbol.is(Inline) =>
-          addMacroDependency(args)
-        case _ =>
+      recordInlineCallArgs(tree)
         
       tree match
         case tree: Inlined if !tree.inlinedFromOuterScope =>
@@ -223,6 +220,12 @@ trait AbstractExtractDependenciesCollector(rec: DependencyRecorder) extends tpd.
     catch case ex: StaleSymbol =>
       // can happen for constructor proxies. Test case is pos-macros/i13532.
       true
+
+  protected def recordInlineCallArgs(tree: Tree)(using Context) =
+    tree match
+      case TypeApply(fun, args) if fun.symbol.is(Inline) =>
+        addMacroDependency(args)
+      case _ =>
 
   protected def recordTree(tree: Tree)(using Context): Unit =
     tree match

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -194,23 +194,19 @@ trait AbstractExtractDependenciesCollector(rec: DependencyRecorder) extends tpd.
   lazy val allowsDependencyByMacroExpansion =
     classOf[DependencyContext].getFields().exists(_.getName() == "DependencyByMacroExpansion")
 
-  private def addMacroDependency(sym: Symbol)(using Context): Unit =
-    if (allowsDependencyByMacroExpansion) {
-      if (!ignoreDependency(sym)) {
-        if (!sym.is(Package)) {
-          val enclOrModuleClass = if (sym.is(ModuleVal)) sym.moduleClass else sym.enclosingClass
-          assert(enclOrModuleClass.isClass, s"$enclOrModuleClass, $sym")
-
-          rec.addClassDependency(enclOrModuleClass, DependencyByMacroExpansion)
-        }
-      }
-    }
-
   private def addMacroDependency(trees: List[Tree])(using Context): Unit =
-    val traverser = new TypeDependencyTraverser {
-      def addDependency(symbol: Symbol) = addMacroDependency(symbol)
+    if (allowsDependencyByMacroExpansion) {
+      val traverser = new TypeDependencyTraverser {
+        def addDependency(symbol: Symbol) =
+          if (!ignoreDependency(symbol)) {
+            val enclOrModuleClass = if (symbol.is(ModuleVal)) symbol.moduleClass else symbol.enclosingClass
+            assert(enclOrModuleClass.isClass, s"$enclOrModuleClass, $symbol")
+
+            rec.addClassDependency(enclOrModuleClass, DependencyByMacroExpansion)
+          }
+      }
+      trees.foreach(tree => traverser.traverse(tree.tpe))
     }
-    trees.foreach(tree => traverser.traverse(tree.tpe))
 
   private def depContextOf(cls: Symbol)(using Context): DependencyContext =
     if cls.isLocal then LocalDependencyByInheritance

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -795,7 +795,7 @@ object Build {
       libraryDependencies ++= Seq(
         ("org.scala-sbt" %% "zinc-apiinfo" % "1.12.0" % Test).cross(CrossVersion.for3Use2_13),
         "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-        ),
+      ),
       // Exclude the transitive dependencies from `zinc-apiinfo` that causes issues at the moment
       excludeDependencies ++= Seq(
         "org.scala-lang" % "scala-reflect",

--- a/sbt-test/macros/i23852/Components.scala
+++ b/sbt-test/macros/i23852/Components.scala
@@ -1,0 +1,9 @@
+object Components extends App {
+  try {
+    wire[Dep]
+  } catch {
+    case e: Throwable =>
+      e.printStackTrace()
+      sys.exit(-1)
+  }
+}

--- a/sbt-test/macros/i23852/Dep.scala
+++ b/sbt-test/macros/i23852/Dep.scala
@@ -1,0 +1,1 @@
+class Dep()

--- a/sbt-test/macros/i23852/Dep.scala-added
+++ b/sbt-test/macros/i23852/Dep.scala-added
@@ -1,0 +1,1 @@
+class Dep(int: Int)

--- a/sbt-test/macros/i23852/macro.scala
+++ b/sbt-test/macros/i23852/macro.scala
@@ -1,0 +1,16 @@
+import scala.quoted.*
+
+inline def wire[T]: T = ${ wireImpl[T] }
+def wireImpl[T: Type](using q: Quotes): Expr[T] = {
+  import q.reflect.*
+
+  lazy val targetType = TypeRepr.of[T]
+  val constructorValue = targetType.typeSymbol.primaryConstructor
+  val constructionMethodTree: Term = {
+    val ctor = Select(New(TypeIdent(targetType.typeSymbol)), constructorValue)
+    if (targetType.typeArgs.isEmpty) ctor else ctor.appliedToTypes(targetType.typeArgs)
+  }
+  val constructorArgsValue = List(Nil)
+  val code: Tree = constructorArgsValue.foldLeft(constructionMethodTree)((acc: Term, args: List[Term]) => Apply(acc, args))
+  code.asExprOf[T]
+}

--- a/sbt-test/macros/i23852/project/DottyInjectedPlugin.scala
+++ b/sbt-test/macros/i23852/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/macros/i23852/test
+++ b/sbt-test/macros/i23852/test
@@ -1,0 +1,3 @@
+> run
+$ copy-file Dep.scala-added Dep.scala
+-> compile

--- a/sbt-test/macros/macro-type-change-2/A/A.scala
+++ b/sbt-test/macros/macro-type-change-2/A/A.scala
@@ -1,0 +1,2 @@
+package A
+class A

--- a/sbt-test/macros/macro-type-change-2/app/App.scala
+++ b/sbt-test/macros/macro-type-change-2/app/App.scala
@@ -1,0 +1,11 @@
+package app
+
+import Macros.*
+import A.A
+
+object App {
+  @main def hasFields(expected: Boolean): Unit = {
+    val actual = Macros.hasAnyField[A]
+    assert(expected == actual, s"Expected $expected, obtained $actual")
+  }
+}

--- a/sbt-test/macros/macro-type-change-2/build.sbt
+++ b/sbt-test/macros/macro-type-change-2/build.sbt
@@ -1,0 +1,27 @@
+// {
+//   "projects": [
+//     {
+//       "name": "app",
+//       "dependsOn": [
+//         "macros",
+//         "A"
+//       ],
+//       "scalaVersion": "2.13.12"
+//     },
+//     {
+//       "name": "macros",
+//       "scalaVersion": "2.13.12"
+//     },
+//     {
+//       "name": "A",
+//       "scalaVersion": "2.13.12"
+//     }
+//   ]
+// }
+
+lazy val app = project.in(file("app"))
+  .dependsOn(macros, A)
+
+lazy val macros = project.in(file("macros"))
+
+lazy val A = project.in(file("A"))

--- a/sbt-test/macros/macro-type-change-2/changes/A1.scala
+++ b/sbt-test/macros/macro-type-change-2/changes/A1.scala
@@ -1,0 +1,4 @@
+package A
+class A {
+  val hello: String = ""
+}

--- a/sbt-test/macros/macro-type-change-2/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change-2/macros/Macros.scala
@@ -8,7 +8,7 @@ object Macros {
   def hasAnyFieldImpl[T: Type](using Quotes): Expr[Boolean] = {
     import quotes.reflect.*
 
-    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+    val hasField = TypeRepr.of[T].typeSymbol.fieldMembers.nonEmpty
 
     Expr(hasField)
   }

--- a/sbt-test/macros/macro-type-change-2/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change-2/macros/Macros.scala
@@ -1,0 +1,15 @@
+package Macros
+
+import scala.quoted.*
+
+object Macros {
+  inline def hasAnyField[T]: Boolean = ${ hasAnyFieldImpl[T] }
+
+  def hasAnyFieldImpl[T: Type](using Quotes): Expr[Boolean] = {
+    import quotes.reflect.*
+
+    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+
+    Expr(hasField)
+  }
+}

--- a/sbt-test/macros/macro-type-change-2/project/DottyInjectedPlugin.scala
+++ b/sbt-test/macros/macro-type-change-2/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/macros/macro-type-change-2/test
+++ b/sbt-test/macros/macro-type-change-2/test
@@ -1,0 +1,4 @@
+# adapted from https://github.com/sbt/zinc/blob/1e422e5525c698aa71cc35b30c275c8c1c3135b2/zinc/src/sbt-test/macros/macro-type-change-2/test
+> app/run false
+$ copy-file changes/A1.scala A/A.scala
+> app/run true

--- a/sbt-test/macros/macro-type-change-3/A/A.scala
+++ b/sbt-test/macros/macro-type-change-3/A/A.scala
@@ -1,0 +1,2 @@
+package A
+class A

--- a/sbt-test/macros/macro-type-change-3/A/B.scala
+++ b/sbt-test/macros/macro-type-change-3/A/B.scala
@@ -1,0 +1,2 @@
+package A
+class B extends A

--- a/sbt-test/macros/macro-type-change-3/app/App.scala
+++ b/sbt-test/macros/macro-type-change-3/app/App.scala
@@ -1,0 +1,11 @@
+package app
+
+import Macros.*
+import A.B
+
+object App {
+  @main def hasFields(expected: Boolean): Unit = {
+    val actual = Macros.hasAnyField[B]
+    assert(expected == actual, s"Expected $expected, obtained $actual")
+  }
+}

--- a/sbt-test/macros/macro-type-change-3/build.sbt
+++ b/sbt-test/macros/macro-type-change-3/build.sbt
@@ -1,0 +1,27 @@
+// {
+//   "projects": [
+//     {
+//       "name": "app",
+//       "dependsOn": [
+//         "macros",
+//         "A"
+//       ],
+//       "scalaVersion": "2.13.12"
+//     },
+//     {
+//       "name": "macros",
+//       "scalaVersion": "2.13.12"
+//     },
+//     {
+//       "name": "A",
+//       "scalaVersion": "2.13.12"
+//     }
+//   ]
+// }
+
+lazy val app = project.in(file("app"))
+  .dependsOn(macros, A)
+
+lazy val macros = project.in(file("macros"))
+
+lazy val A = project.in(file("A"))

--- a/sbt-test/macros/macro-type-change-3/changes/A1.scala
+++ b/sbt-test/macros/macro-type-change-3/changes/A1.scala
@@ -1,0 +1,4 @@
+package A
+class A {
+  val hello: String = ""
+}

--- a/sbt-test/macros/macro-type-change-3/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change-3/macros/Macros.scala
@@ -8,7 +8,7 @@ object Macros {
   def hasAnyFieldImpl[T: Type](using Quotes): Expr[Boolean] = {
     import quotes.reflect.*
 
-    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+    val hasField = TypeRepr.of[T].typeSymbol.fieldMembers.nonEmpty
 
     Expr(hasField)
   }

--- a/sbt-test/macros/macro-type-change-3/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change-3/macros/Macros.scala
@@ -1,0 +1,15 @@
+package Macros
+
+import scala.quoted.*
+
+object Macros {
+  inline def hasAnyField[T]: Boolean = ${ hasAnyFieldImpl[T] }
+
+  def hasAnyFieldImpl[T: Type](using Quotes): Expr[Boolean] = {
+    import quotes.reflect.*
+
+    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+
+    Expr(hasField)
+  }
+}

--- a/sbt-test/macros/macro-type-change-3/project/DottyInjectedPlugin.scala
+++ b/sbt-test/macros/macro-type-change-3/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/macros/macro-type-change-3/test
+++ b/sbt-test/macros/macro-type-change-3/test
@@ -1,0 +1,4 @@
+# adapted from https://github.com/sbt/zinc/blob/1e422e5525c698aa71cc35b30c275c8c1c3135b2/zinc/src/sbt-test/macros/macro-type-change-3/test
+> app/run false
+$ copy-file changes/A1.scala A/A.scala
+> app/run true

--- a/sbt-test/macros/macro-type-change-4/A/A.scala
+++ b/sbt-test/macros/macro-type-change-4/A/A.scala
@@ -1,0 +1,2 @@
+package A
+class A

--- a/sbt-test/macros/macro-type-change-4/app/App.scala
+++ b/sbt-test/macros/macro-type-change-4/app/App.scala
@@ -1,0 +1,11 @@
+package app
+
+import Macros.*
+import A.A
+
+object App {
+  @main def hasFields(expected: Boolean): Unit = {
+    val actual = Macros.hasAnyField[A](true)
+    assert(expected == actual, s"Expected $expected, obtained $actual")
+  }
+}

--- a/sbt-test/macros/macro-type-change-4/build.sbt
+++ b/sbt-test/macros/macro-type-change-4/build.sbt
@@ -1,0 +1,27 @@
+// {
+//   "projects": [
+//     {
+//       "name": "app",
+//       "dependsOn": [
+//         "macros",
+//         "A"
+//       ],
+//       "scalaVersion": "2.13.12"
+//     },
+//     {
+//       "name": "macros",
+//       "scalaVersion": "2.13.12"
+//     },
+//     {
+//       "name": "A",
+//       "scalaVersion": "2.13.12"
+//     }
+//   ]
+// }
+
+lazy val app = project.in(file("app"))
+  .dependsOn(macros, A)
+
+lazy val macros = project.in(file("macros"))
+
+lazy val A = project.in(file("A"))

--- a/sbt-test/macros/macro-type-change-4/changes/A1.scala
+++ b/sbt-test/macros/macro-type-change-4/changes/A1.scala
@@ -1,0 +1,4 @@
+package A
+class A {
+  val hello: String = ""
+}

--- a/sbt-test/macros/macro-type-change-4/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change-4/macros/Macros.scala
@@ -1,0 +1,15 @@
+package Macros
+
+import scala.quoted.*
+
+object Macros {
+  inline def hasAnyField[T](placeholder: Boolean): Boolean = ${ hasAnyFieldImpl[T]('placeholder) }
+
+  def hasAnyFieldImpl[T: Type](placeholder: Expr[Boolean])(using Quotes): Expr[Boolean] = {
+    import quotes.reflect.*
+
+    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+
+    Expr(hasField)
+  }
+}

--- a/sbt-test/macros/macro-type-change-4/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change-4/macros/Macros.scala
@@ -8,7 +8,7 @@ object Macros {
   def hasAnyFieldImpl[T: Type](placeholder: Expr[Boolean])(using Quotes): Expr[Boolean] = {
     import quotes.reflect.*
 
-    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+    val hasField = TypeRepr.of[T].typeSymbol.fieldMembers.nonEmpty
 
     Expr(hasField)
   }

--- a/sbt-test/macros/macro-type-change-4/project/DottyInjectedPlugin.scala
+++ b/sbt-test/macros/macro-type-change-4/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/macros/macro-type-change-4/test
+++ b/sbt-test/macros/macro-type-change-4/test
@@ -1,0 +1,4 @@
+# adapted from https://github.com/sbt/zinc/blob/1e422e5525c698aa71cc35b30c275c8c1c3135b2/zinc/src/sbt-test/macros/macro-type-change-4/test
+> app/run false
+$ copy-file changes/A1.scala A/A.scala
+> app/run true

--- a/sbt-test/macros/macro-type-change/app/A.scala
+++ b/sbt-test/macros/macro-type-change/app/A.scala
@@ -1,0 +1,2 @@
+package app
+class A

--- a/sbt-test/macros/macro-type-change/app/App.scala
+++ b/sbt-test/macros/macro-type-change/app/App.scala
@@ -1,0 +1,10 @@
+package app
+
+import Macros.*
+
+object App {
+  @main def hasFields(expected: Boolean): Unit = {
+    val actual = Macros.hasAnyField[A]
+    assert(expected == actual, s"Expected $expected, obtained $actual")
+  }
+}

--- a/sbt-test/macros/macro-type-change/build.sbt
+++ b/sbt-test/macros/macro-type-change/build.sbt
@@ -1,0 +1,20 @@
+// {
+//   "projects": [
+//     {
+//       "name": "app",
+//       "dependsOn": [
+//         "macros"
+//       ],
+//       "scalaVersion": "2.13.12"
+//     },
+//     {
+//       "name": "macros",
+//       "scalaVersion": "2.13.12"
+//     }
+//   ]
+// }
+
+lazy val app = project.in(file("app"))
+  .dependsOn(macros)
+
+lazy val macros = project.in(file("macros"))

--- a/sbt-test/macros/macro-type-change/changes/A1.scala
+++ b/sbt-test/macros/macro-type-change/changes/A1.scala
@@ -1,0 +1,4 @@
+package app
+class A {
+  val hello: String = ""
+}

--- a/sbt-test/macros/macro-type-change/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change/macros/Macros.scala
@@ -8,7 +8,7 @@ object Macros {
   def hasAnyFieldImpl[T: Type](using Quotes): Expr[Boolean] = {
     import quotes.reflect.*
 
-    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+    val hasField = TypeRepr.of[T].typeSymbol.fieldMembers.nonEmpty
 
     Expr(hasField)
   }

--- a/sbt-test/macros/macro-type-change/macros/Macros.scala
+++ b/sbt-test/macros/macro-type-change/macros/Macros.scala
@@ -1,0 +1,15 @@
+package Macros
+
+import scala.quoted.*
+
+object Macros {
+  inline def hasAnyField[T]: Boolean = ${ hasAnyFieldImpl[T] }
+
+  def hasAnyFieldImpl[T: Type](using Quotes): Expr[Boolean] = {
+    import quotes.reflect.*
+
+    val hasField = TypeRepr.of[T].typeSymbol.declaredFields.nonEmpty
+
+    Expr(hasField)
+  }
+}

--- a/sbt-test/macros/macro-type-change/project/DottyInjectedPlugin.scala
+++ b/sbt-test/macros/macro-type-change/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/macros/macro-type-change/test
+++ b/sbt-test/macros/macro-type-change/test
@@ -1,0 +1,4 @@
+# adapted from https://github.com/sbt/zinc/blob/1e422e5525c698aa71cc35b30c275c8c1c3135b2/zinc/src/sbt-test/macros/macro-type-change/test
+> app/run false
+$ copy-file changes/A1.scala app/A.scala
+> app/run true


### PR DESCRIPTION
Fixes #23852 
Closes #19426 

Around a year ago a new `DependencyContext` value was added to the zinc api: `DependencyByMacroExpansion`.
It causes the recorded dependency to trigger recompilation if there is any API change in the recorded type, not just if the feudal/method member that was explicitly referenced was changed. So now, for every inline call:
`macroCall[T1, T2, ...]`, in file `call.scala`, if anything changes in a TN definition, `call.scala` is recompiled.

Since `DependencyByMacroExpansion` was added later to the API, referencing it in older versions (e.g. any sbt < `1.10.0`), would cause crashes. to avoid that, we use reflection to check if that field exists.

These changes do not seem to affect #23783, likely the way annotations are handled needs to be changed in zinc itself, as the APIInfo phase does successfully record the change in the annotation argument.

Related discussion: https://github.com/sbt/zinc/pull/1316 (a PR adding the functionality to zinc and scala-2 plugin).