### PR TITLE
chore: make `scala.caps.Pure` transparent

### DIFF
--- a/library/src/scala/caps/Pure.scala
+++ b/library/src/scala/caps/Pure.scala
@@ -16,5 +16,5 @@ import language.experimental.captureChecking
  *  would give an error only under capture checking. Pure is also dropped in
  *  upper bounds if it forms part of an &-type, or is under a type lambda.
  */
-trait Pure extends Any:
+transparent trait Pure extends Any:
   this: Pure =>


### PR DESCRIPTION
It makes more sense to have `scala.caps.Pure` a `transparent` trait.
For the same reason `scala.Matchable` is `transparent` or `scala.Product` too.