### PR TITLE
When unpickling, do not incorrectly set PureInterface flags

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -813,7 +813,7 @@ class TreeUnpickler(reader: TastyReader,
             if (sym.isTerm && !sym.isOneOf(DeferredOrLazyOrMethod))
               initsFlags = EmptyFlags
             else if (sym.isClass ||
-              sym.is(Method, butNot = Deferred) && !sym.isConstructor)
+              sym.isOneOf(Method | Lazy, butNot = Deferred) && !sym.isConstructor)
               initsFlags &= NoInits
           case IMPORT | EXPORT =>
             skipTree()

--- a/tests/run/i23863-a/BaseTest_1.scala
+++ b/tests/run/i23863-a/BaseTest_1.scala
@@ -1,0 +1,13 @@
+abstract class BaseTest {
+  def genName(): String = "outerAccess"
+  trait Fixture {
+    lazy val service: Service = new Service {
+      val a = genName()
+      def doIt(a: String): Int = 0
+    }
+  }
+}
+
+trait Service {
+  def doIt(a: String): Int
+}

--- a/tests/run/i23863-a/Test_2.scala
+++ b/tests/run/i23863-a/Test_2.scala
@@ -1,0 +1,4 @@
+object Test extends BaseTest {
+  def main(args: Array[String]): Unit =
+    new Fixture { service.doIt("test") }
+}

--- a/tests/run/i23863-b/NestedObject_1.scala
+++ b/tests/run/i23863-b/NestedObject_1.scala
@@ -1,0 +1,3 @@
+trait NestedObject {
+  case class A()
+}

--- a/tests/run/i23863-b/Test_2.scala
+++ b/tests/run/i23863-b/Test_2.scala
@@ -1,0 +1,3 @@
+object Test extends NestedObject {
+  def main(args: Array[String]): Unit = ()
+}


### PR DESCRIPTION
Previously, the behavior for setting `NoInits` and `PureInterface` flags for class symbols in `TreeInfo.defKind` (when compiling from a source) and in `TreeUnpickler` (when reading Tasty) was inconsistent. This was problematic, as the `PureInterface` flag dictated whether outer accessors were generated in `ExplicitOuter` phase (in the `needsOuterIfReferenced` method), so in the issue minimization, the inherited trait would have the outer accessors defined, and the inheriting object would then not implement them. This lead to runtime `MethodNotFound` errors.
The problem was specifically with lazy vals, which were treated as if they did not have an rhs.

Fixes #23863

I've added an additional test case also testing the same adjusted method in the TreeUnpickler, as I've run into an issue with nested objects when testing a previous incorrect fix on the original linked minimisation with external dependencies (and no compiler tests would fail).