### PR TITLE
update `BackendUtils.classfileVersionMap`

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BackendUtils.scala
@@ -169,15 +169,6 @@ class BackendUtils(val postProcessor: PostProcessor) {
 
 object BackendUtils {
   lazy val classfileVersionMap: Map[Int, Int] = Map(
-    8 -> asm.Opcodes.V1_8,
-    9 -> asm.Opcodes.V9,
-    10 -> asm.Opcodes.V10,
-    11 -> asm.Opcodes.V11,
-    12 -> asm.Opcodes.V12,
-    13 -> asm.Opcodes.V13,
-    14 -> asm.Opcodes.V14,
-    15 -> asm.Opcodes.V15,
-    16 -> asm.Opcodes.V16,
     17 -> asm.Opcodes.V17,
     18 -> asm.Opcodes.V18,
     19 -> asm.Opcodes.V19,

--- a/compiler/src/dotty/tools/backend/jvm/PostProcessorFrontendAccess.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessorFrontendAccess.scala
@@ -118,7 +118,7 @@ object PostProcessorFrontendAccess {
           case (Some(release), Some(_)) =>
             report.warning(s"The value of ${s.XuncheckedJavaOutputVersion.name} was overridden by ${ctx.settings.javaOutputVersion.name}")
             release
-          case (None, None) => "8" // least supported version by default
+          case (None, None) => "17" // least supported version by default
 
       override val debug: Boolean = ctx.debug
       override val dumpClassesDirectory: Option[String] = s.Xdumpclasses.valueSetByUser


### PR DESCRIPTION
delete old versions

https://www.scala-lang.org/news/next-scala-lts-jdk.html