### PR TITLE
chore: enable back the develocity build cache

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -287,8 +287,8 @@ object Build {
         })
         .withBuildCache(
           buildCache
-            .withLocal(buildCache.local.withEnabled(false).withStoreEnabled(false))
-            .withRemote(buildCache.remote.withEnabled(false).withStoreEnabled(false))
+            .withLocal(buildCache.local.withEnabled(true).withStoreEnabled(true))
+            .withRemote(buildCache.remote.withEnabled(true).withStoreEnabled(isInsideCI))
             .withRequireClean(!isInsideCI)
         )
         .withTestRetry(
@@ -1478,6 +1478,9 @@ object Build {
       scalaCompilerBridgeBinaryJar := {
         Some((`scala3-sbt-bridge-nonbootstrapped` / Compile / packageBin).value)
       },
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   /* Configuration of the org.scala-lang:scala3-staging:*.**.**-bootstrapped project */
@@ -1536,6 +1539,9 @@ object Build {
       scalaCompilerBridgeBinaryJar := {
         Some((`scala3-sbt-bridge-nonbootstrapped` / Compile / packageBin).value)
       },
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   /* Configuration of the org.scala-lang:scala3-tasty-inspector:*.**.**-bootstrapped project */
@@ -1594,6 +1600,9 @@ object Build {
       scalaCompilerBridgeBinaryJar := {
         Some((`scala3-sbt-bridge-nonbootstrapped` / Compile / packageBin).value)
       },
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   // ==============================================================================================
@@ -1771,6 +1780,9 @@ object Build {
       mimaForwardIssueFilters := MiMaFilters.Scala3Library.ForwardsBreakingChanges,
       mimaBackwardIssueFilters := MiMaFilters.Scala3Library.BackwardsBreakingChanges,
       customMimaReportBinaryIssues("MiMaFilters.Scala3Library"),
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   /* Configuration of the org.scala-lang:scala3-library_3:*.**.**-bootstrapped project */
@@ -1812,6 +1824,9 @@ object Build {
       publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library-bootstrapped",
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   /* Configuration of the org.scala-js:scalajs-scalalib_2.13:*.**.**-bootstrapped project */
@@ -1925,6 +1940,9 @@ object Build {
         }
       }).transform(node).head
       },
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   /* Configuration of the org.scala-lang:scala3-library_sjs1_3:*.**.**-bootstrapped project */
@@ -1966,6 +1984,9 @@ object Build {
       publish / skip := false,
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala3-library",
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   // ==============================================================================================
@@ -2104,6 +2125,9 @@ object Build {
       mimaForwardIssueFilters := MiMaFilters.TastyCore.ForwardsBreakingChanges,
       mimaBackwardIssueFilters := MiMaFilters.TastyCore.BackwardsBreakingChanges,
       customMimaReportBinaryIssues("MiMaFilters.TastyCore"),
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   // ==============================================================================================
@@ -2453,6 +2477,9 @@ object Build {
           s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
         )
       },
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   // ==============================================================================================
@@ -2534,6 +2561,9 @@ object Build {
       scalaCompilerBridgeBinaryJar := {
         Some((`scala3-sbt-bridge-nonbootstrapped` / Compile / packageBin).value)
       },
+      // Force recomplilation when bootstrapped compiler changes
+      Compile / extraDevelocityCacheInputFiles ++=
+        (`scala3-compiler-nonbootstrapped` / Compile / fullClasspathAsJars).value.map(_.data.toPath)
     )
 
   def dottyLibrary(implicit mode: Mode): Project = mode match {


### PR DESCRIPTION
In this Pr, we fix the make sure that all the bootstrapped projects are updated when their reference compiler (aka non-bootstrapped compiler changes).