### PR TITLE
deprecate `scala.runtime.SymbolLiteral`

### DIFF
--- a/library/src/scala/runtime/SymbolLiteral.java
+++ b/library/src/scala/runtime/SymbolLiteral.java
@@ -14,6 +14,7 @@ package scala.runtime;
 
 import java.lang.invoke.*;
 
+@Deprecated
 public final class SymbolLiteral {
     private SymbolLiteral() {
     }


### PR DESCRIPTION
- https://github.com/scala/scala/pull/4896

Scala 2 use `scala.runtime.SymbolLiteral` but Scala 3 not because `scala.Symbol` literal is no longer supported.