### PR TITLE
Backport "Fix LiftToAnchors for higher-kinded type applications" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -844,6 +844,10 @@ trait ImplicitRunInfo:
             case t: TypeVar => apply(t.underlying)
             case t: ParamRef => applyToUnderlying(t)
             case t: ConstantType => apply(t.underlying)
+            case t @ AppliedType(tycon, args) if !tycon.typeSymbol.isClass =>
+              // To prevent arguments to be reduced away when re-applying the tycon bounds,
+              // we collect all parts as elements of a tuple. See i21951.scala for a test case.
+              apply(defn.tupleType(tycon :: args))
             case t => mapOver(t)
         end liftToAnchors
         val liftedTp = liftToAnchors(tp)

--- a/tests/pos/i21951.scala
+++ b/tests/pos/i21951.scala
@@ -1,0 +1,33 @@
+class A
+object A:
+  given g[F[_]]: F[A] = ???
+
+object Test:
+  summon[List[A]] // ok
+  def foo[F[_]] =
+    summon[F[A]] // error
+
+final case class X(val i: Int)
+object X {
+  implicit final class XOps[F[_]](xs: F[X]) {
+    def unpack(implicit ev: F[X] <:< Iterable[X]): Iterable[Int] = xs.map(_.i)
+  }
+}
+
+object App extends App {
+  // good
+  val ys: List[X] = List(X(1))
+  println(ys.unpack)
+
+  // bad
+  def printPolymorphic[F[_]](xs: F[X])(implicit ev: F[X] <:< Iterable[X]) = {
+    locally {
+      // implicit XOps is correct
+      import X.XOps
+      println(xs.unpack) // found
+    }
+    // but it's not being searched for in the companion object of X
+    println(xs.unpack) // error: unpack is not a member of F[X]
+  }
+  printPolymorphic[List](ys)
+}


### PR DESCRIPTION
Backports #23672 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]