### PR TITLE
Backport "Bump actions/download-artifact from 4 to 5" to 3.7.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -824,7 +824,7 @@ jobs:
           prepareSDK "-x86_64-pc-win32"      "dist-win-x86_64"    "./dist/win-x86_64/"
 
       - name: Download MSI package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: scala.msi
           path: .

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Fetch the Chocolatey package from GitHub
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: scala.nupkg
       - name: Publish the package to Chocolatey

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -35,7 +35,7 @@ jobs:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
       - name: Download the 'nupkg' from GitHub Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: scala.nupkg
           path: ${{ env.CHOCOLATEY-REPOSITORY }}

--- a/.github/workflows/test-msi.yml
+++ b/.github/workflows/test-msi.yml
@@ -29,7 +29,7 @@ jobs:
           distribution: temurin
           java-version: ${{ inputs.java-version }}
       - name: Download MSI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: scala.msi
           path: .


### PR DESCRIPTION
Backports #23711 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]