### PR TITLE
Backport "Fix #23737: Update superCallContext to include dummy capture parameters in scope" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -402,8 +402,8 @@ object Contexts {
      *
      *  - as owner: The primary constructor of the class
      *  - as outer context: The context enclosing the class context
-     *  - as scope: type parameters, the parameter accessors, and
-     *    the context bound companions in the class context,
+     *  - as scope: type parameters, the parameter accessors,
+     *    the dummy capture parameters and the context bound companions in the class context,
      *
      *  The reasons for this peculiar choice of attributes are as follows:
      *
@@ -420,7 +420,7 @@ object Contexts {
     def superCallContext: Context =
       val locals = owner.typeParams
           ++ owner.asClass.unforcedDecls.filter: sym =>
-              sym.is(ParamAccessor) || sym.isContextBoundCompanion
+              sym.is(ParamAccessor) || sym.isContextBoundCompanion || sym.isDummyCaptureParam
       superOrThisCallContext(owner.primaryConstructor, newScopeWith(locals*))
 
     /** The context for the arguments of a this(...) constructor call.

--- a/compiler/src/dotty/tools/dotc/core/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymUtils.scala
@@ -91,7 +91,7 @@ class SymUtils:
       self.is(Synthetic) && self.infoOrCompleter.typeSymbol == defn.CBCompanion
 
     def isDummyCaptureParam(using Context): Boolean =
-      self.isAllOf(CaptureParam) && !(self.isClass || self.is(Method))
+      self.is(PhantomSymbol) && self.infoOrCompleter.typeSymbol != defn.CBCompanion
 
     /** Is this a case class for which a product mirror is generated?
     *  Excluded are value classes, abstract classes and case classes with more than one

--- a/tests/pos-custom-args/captures/i23737.scala
+++ b/tests/pos-custom-args/captures/i23737.scala
@@ -1,0 +1,10 @@
+import language.experimental.captureChecking
+
+class C
+
+trait A[T]
+
+trait B[CC^] extends A[C^{CC}] // error: CC not found
+
+trait D[CC^]:
+  val x: Object^{CC} = ???

--- a/tests/pos-custom-args/captures/i23737.scala
+++ b/tests/pos-custom-args/captures/i23737.scala
@@ -8,3 +8,7 @@ trait B[CC^] extends A[C^{CC}] // error: CC not found
 
 trait D[CC^]:
   val x: Object^{CC} = ???
+
+def f(c: C^) =
+  val b = new B[{c}] {}
+  val a: A[C^{c}] = b


### PR DESCRIPTION
Backports #23740 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]