### PR TITLE
Backport "Scaladoc cc: don't eagerly drop caps on parameters" to 3.7.4

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -533,6 +533,7 @@ trait TypesSupport:
   private def isCapturedInContext(using Quotes)(ref: reflect.TypeRepr)(using elideThis: reflect.ClassDef): Boolean =
     import reflect._
     ref match
+      case t if t.isCaptureRoot  => true
       case ReachCapability(c)    => isCapturedInContext(c)
       case ReadOnlyCapability(c) => isCapturedInContext(c)
       case ThisType(tr)          => !elideThis.symbol.typeRef.isPureClass(elideThis) /* is the current class pure? */


### PR DESCRIPTION
Backports #23759 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]