### PR TITLE
Backport "chore: do not render `consume update` in `scaladoc`" to 3.7.4

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ClassLikeSupport.scala
@@ -25,9 +25,10 @@ trait ClassLikeSupport:
     def getExtraModifiers(): Seq[Modifier] =
       var mods = SymOps.getExtraModifiers(symbol)()
       if ccEnabled && symbol.flags.is(Flags.Mutable) then
-        mods :+= Modifier.Update
-      if ccEnabled && symbol.hasAnnotation(cc.CaptureDefs.ConsumeAnnot) then
-        mods :+= Modifier.Consume
+        if symbol.hasAnnotation(cc.CaptureDefs.ConsumeAnnot) then
+          mods :+= Modifier.Consume
+        else
+          mods :+= Modifier.Update
       mods
   }
 


### PR DESCRIPTION
Backports #23760 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]