### PR TITLE
Backport "chore(deps): bump sdkman/sdkman-release-action from 2800d4359ae097a99afea7e0370f0c6e726182a4 to c70225d437d17182d19476702b671513dc8bf048" to 3.7.4

### DIFF
--- a/.github/workflows/publish-sdkman.yml
+++ b/.github/workflows/publish-sdkman.yml
@@ -46,7 +46,7 @@ jobs:
           - platform: WINDOWS_64
             archive : 'scala3-${{ inputs.version }}-x86_64-pc-win32.zip'
     steps:
-      - uses: sdkman/sdkman-release-action@2800d4359ae097a99afea7e0370f0c6e726182a4
+      - uses: sdkman/sdkman-release-action@c70225d437d17182d19476702b671513dc8bf048
         with:
           CONSUMER-KEY   : ${{ secrets.CONSUMER-KEY }}
           CONSUMER-TOKEN : ${{ secrets.CONSUMER-TOKEN }}


### PR DESCRIPTION
Backports #23813 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]