### PR TITLE
Backport "Fix implicit scope liftToAnchors for parameter lower bounds" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -832,7 +832,7 @@ trait ImplicitRunInfo:
               WildcardType
             else
               seen += t
-              t.superType match
+              t.underlying match
                 case TypeBounds(lo, hi) =>
                   if lo.isBottomTypeAfterErasure then apply(hi)
                   else AndType.make(apply(lo), apply(hi))

--- a/tests/pos/i21951b.scala
+++ b/tests/pos/i21951b.scala
@@ -1,0 +1,12 @@
+
+class A
+object A:
+  given A = ???
+
+class B[X]
+object B:
+  given g[T]: B[T] = ???
+
+object Test:
+  def foo[X >: A] = summon[X] // was error
+  def bar[F[T] >: B[T]] = summon[F[Int]] // was error


### PR DESCRIPTION
Backports #23679 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]