### PR TITLE
Backport "fix: do not transform `Ident` to `This` in PostTyper anymore" to 3.7.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -391,11 +391,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             checkNotPackage(tree)
           else
             registerNeedsInlining(tree)
-            val tree1 = checkUsableAsValue(tree)
-            tree1.tpe match {
-              case tpe: ThisType => This(tpe.cls).withSpan(tree.span)
-              case _ => tree1
-            }
+            checkUsableAsValue(tree)
         case tree @ Select(qual, name) =>
           registerNeedsInlining(tree)
           if name.isTypeName then

--- a/tests/run/i23875.check
+++ b/tests/run/i23875.check
@@ -1,0 +1,3 @@
+true
+false
+false

--- a/tests/run/i23875.scala
+++ b/tests/run/i23875.scala
@@ -1,0 +1,11 @@
+object Foo {
+  override def equals(that : Any) = that match {
+    case _: this.type => true
+    case _            => false
+  }
+}
+
+@main def Test =
+  println(Foo.equals(Foo))
+  println(Foo.equals(new AnyRef {}))
+  println(Foo.equals(0))


### PR DESCRIPTION
Backports #23899 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]