### PR TITLE
Backport "Fix separation checking for function results" to 3.7.4

### DIFF
--- a/tests/neg-custom-args/captures/i23726.check
+++ b/tests/neg-custom-args/captures/i23726.check
@@ -1,0 +1,51 @@
+-- Error: tests/neg-custom-args/captures/i23726.scala:10:5 -------------------------------------------------------------
+10 |  f1(a)  // error, as expected
+   |     ^
+   |Separation failure: argument of type  (a : Ref^)
+   |to a function of type (x: Ref^) -> List[() ->{a, x} Unit]
+   |corresponds to capture-polymorphic formal parameter x of type  Ref^²
+   |and hides capabilities  {a}.
+   |Some of these overlap with the captures of the function result with type  List[() ->{a} Unit].
+   |
+   |  Hidden set of current argument        : {a}
+   |  Hidden footprint of current argument  : {a}
+   |  Capture set of function result        : {a}
+   |  Footprint set of function result      : {a}
+   |  The two sets overlap at               : {a}
+   |
+   |where:    ^  refers to a fresh root capability classified as Mutable created in value a when constructing mutable Ref
+   |          ^² refers to a fresh root capability classified as Mutable created in method test1 when checking argument to parameter x of method apply
+-- Error: tests/neg-custom-args/captures/i23726.scala:15:5 -------------------------------------------------------------
+15 |  f3(b)  // error
+   |     ^
+   |Separation failure: argument of type  (b : Ref^)
+   |to a function of type (x: Ref^) -> (op: () ->{b} Unit) -> List[() ->{op} Unit]
+   |corresponds to capture-polymorphic formal parameter x of type  Ref^²
+   |and hides capabilities  {b}.
+   |Some of these overlap with the captures of the function result with type  (op: () ->{b} Unit) -> List[() ->{op} Unit].
+   |
+   |  Hidden set of current argument        : {b}
+   |  Hidden footprint of current argument  : {b}
+   |  Capture set of function result        : {op}
+   |  Footprint set of function result      : {op, b}
+   |  The two sets overlap at               : {b}
+   |
+   |where:    ^  refers to a fresh root capability classified as Mutable created in value b when constructing mutable Ref
+   |          ^² refers to a fresh root capability classified as Mutable created in method test1 when checking argument to parameter x of method apply
+-- Error: tests/neg-custom-args/captures/i23726.scala:23:5 -------------------------------------------------------------
+23 |  f7(a)  // error
+   |     ^
+   |Separation failure: argument of type  (a : Ref^)
+   |to a function of type (x: Ref^) ->{a, b} (y: List[Ref^{a, b}]) ->{a, b} Unit
+   |corresponds to capture-polymorphic formal parameter x of type  Ref^²
+   |and hides capabilities  {a}.
+   |Some of these overlap with the captures of the function prefix.
+   |
+   |  Hidden set of current argument        : {a}
+   |  Hidden footprint of current argument  : {a}
+   |  Capture set of function prefix        : {f7*}
+   |  Footprint set of function prefix      : {f7*, a, b}
+   |  The two sets overlap at               : {a}
+   |
+   |where:    ^  refers to a fresh root capability classified as Mutable created in value a when constructing mutable Ref
+   |          ^² refers to a fresh root capability classified as Mutable created in method test1 when checking argument to parameter x of method apply

--- a/tests/neg-custom-args/captures/i23726.scala
+++ b/tests/neg-custom-args/captures/i23726.scala
@@ -1,0 +1,23 @@
+import language.experimental.captureChecking
+import language.experimental.separationChecking
+import caps.*
+class Ref extends Mutable
+def swap(a: Ref^, b: Ref^): Unit = ()
+def test1(): Unit =
+  val a = Ref()
+  val b = Ref()
+  val f1: (x: Ref^) -> List[() ->{a,x} Unit] = ???
+  f1(a)  // error, as expected
+  val f2: (x: Ref^) -> List[() ->{x} Unit] = ???
+  f2(a)  // ok, as expected
+  val f3: (x: Ref^) -> (op: () ->{b} Unit) -> List[() ->{op} Unit] = ???
+  f3(a)  // ok
+  f3(b)  // error
+  val f4: (x: Ref^) -> (y: Ref^{x}) ->{x} Unit = ???
+  f4(a)  // ok
+  val f5: (x: Ref^) -> (y: List[Ref^{a}]) ->{} Unit = ???
+  f5(a)  // ok
+  val f6: (x: Ref^) -> (y: List[Ref^{a, b}]) ->{} Unit = ???
+  f6(b)  // ok
+  val f7: (x: Ref^) ->{a, b} (y: List[Ref^{a, b}]) ->{a, b} Unit = ???
+  f7(a)  // error


### PR DESCRIPTION
Backports #23927 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]