### PR TITLE
Backport "[build] Increment default thread stack size from to 2MB (was 1MB)" to 3.7.4

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,4 @@
--Xss1m
+-Xss2m
 -Xms1024m
 -Xmx8192m
 -XX:MaxInlineLevel=35


### PR DESCRIPTION
Backports #23638 to the 3.7.4.

PR submitted by the release tooling.
[skip ci]