### PR TITLE
Backport "pc: completions - do not add `[]` for `... derives TC@@`" to 3.7.4

### DIFF
--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -2285,3 +2285,11 @@ class CompletionSuite extends BaseCompletionSuite:
         |""".stripMargin,
       "asTerm: Term"
     )
+  
+  @Test def `derives-no-square-brackets` =
+    check(
+      """
+        |case class Miau(y: Int) derives Ordering, CanEqu@@
+        |""".stripMargin,
+      "CanEqual scala"
+    )


### PR DESCRIPTION
Backports #23811 to the 3.7.4.

PR submitted by the release tooling.