### PR TITLE
sync the history from `scala/scala` to `scala/scala3`

### DIFF
--- a/library/src/scala/AnyVal.scala
+++ b/library/src/scala/AnyVal.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/AnyVal.scala
+++ b/library/src/scala/AnyVal.scala
@@ -29,9 +29,8 @@ package scala
  *   - The ''integer types'' include the subrange types as well as [[scala.Int]] and [[scala.Long]].
  *   - The ''floating point types'' are [[scala.Float]] and [[scala.Double]].
  *
- * Prior to Scala 2.10, `AnyVal` was a sealed trait. Beginning with Scala 2.10,
- * however, it is possible to define a subclass of `AnyVal` called a ''user-defined value class''
- * which is treated specially by the compiler. Properly-defined user value classes provide a way
+ * A subclass of `AnyVal` is called a ''user-defined value class''
+ * and is treated specially by the compiler. Properly-defined user value classes provide a way
  * to improve performance on user-defined types by avoiding object allocation at runtime, and by
  * replacing virtual method invocations with static method invocations.
  *

--- a/library/src/scala/AnyValCompanion.scala
+++ b/library/src/scala/AnyValCompanion.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/App.scala
+++ b/library/src/scala/App.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -106,7 +106,9 @@ object Array {
    */
   def copy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int): Unit = {
     val srcClass = src.getClass
-    if (srcClass.isArray && dest.getClass.isAssignableFrom(srcClass))
+    val destClass = dest.getClass
+    if (srcClass.isArray && ((destClass eq srcClass) ||
+        (destClass.isArray && !srcClass.getComponentType.isPrimitive && !destClass.getComponentType.isPrimitive)))
       java.lang.System.arraycopy(src, srcPos, dest, destPos, length)
     else
       slowcopy(src, srcPos, dest, destPos, length)

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -124,16 +124,16 @@ object Array {
     * @see `java.util.Arrays#copyOf`
     */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
-    case x: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
-    case x: Array[AnyRef]     => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Int]        => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Double]     => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Long]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Float]      => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Char]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Byte]       => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Short]      => java.util.Arrays.copyOf(x, newLength)
-    case x: Array[Boolean]    => java.util.Arrays.copyOf(x, newLength)
+    case original: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
+    case original: Array[AnyRef]     => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Int]        => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Double]     => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Long]       => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Float]      => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Char]       => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Byte]       => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Short]      => java.util.Arrays.copyOf(original, newLength)
+    case original: Array[Boolean]    => java.util.Arrays.copyOf(original, newLength)
   }).asInstanceOf[Array[A]]
 
   /** Copy one array to another, truncating or padding with default values (if

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -54,7 +54,7 @@ object Array {
   /**
    * Returns a new [[scala.collection.mutable.ArrayBuilder]].
    */
-  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](t)
+  def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   /** Build an array from the iterable collection.
    *

--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/DelayedInit.scala
+++ b/library/src/scala/DelayedInit.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/DummyImplicit.scala
+++ b/library/src/scala/DummyImplicit.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Dynamic.scala
+++ b/library/src/scala/Dynamic.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Dynamic.scala
+++ b/library/src/scala/Dynamic.scala
@@ -30,7 +30,7 @@ package scala
  *  foo.arr(10)         ~~> foo.applyDynamic("arr")(10)
  *  }}}
  *
- *  As of Scala 2.10, defining direct or indirect subclasses of this trait
+ *  Defining direct or indirect subclasses of this trait
  *  is only possible if the language feature `dynamics` is enabled.
  */
 trait Dynamic extends Any

--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Equals.scala
+++ b/library/src/scala/Equals.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function0.scala
+++ b/library/src/scala/Function0.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function1.scala
+++ b/library/src/scala/Function1.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function10.scala
+++ b/library/src/scala/Function10.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function11.scala
+++ b/library/src/scala/Function11.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function12.scala
+++ b/library/src/scala/Function12.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function13.scala
+++ b/library/src/scala/Function13.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function14.scala
+++ b/library/src/scala/Function14.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function15.scala
+++ b/library/src/scala/Function15.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function16.scala
+++ b/library/src/scala/Function16.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function17.scala
+++ b/library/src/scala/Function17.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function18.scala
+++ b/library/src/scala/Function18.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function19.scala
+++ b/library/src/scala/Function19.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function2.scala
+++ b/library/src/scala/Function2.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function20.scala
+++ b/library/src/scala/Function20.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function21.scala
+++ b/library/src/scala/Function21.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function22.scala
+++ b/library/src/scala/Function22.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function3.scala
+++ b/library/src/scala/Function3.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function4.scala
+++ b/library/src/scala/Function4.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function5.scala
+++ b/library/src/scala/Function5.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function6.scala
+++ b/library/src/scala/Function6.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function7.scala
+++ b/library/src/scala/Function7.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function8.scala
+++ b/library/src/scala/Function8.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Function9.scala
+++ b/library/src/scala/Function9.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/MatchError.scala
+++ b/library/src/scala/MatchError.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/NotImplementedError.scala
+++ b/library/src/scala/NotImplementedError.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -55,18 +55,18 @@ object Option {
  *  `foreach`:
  *
  *  {{{
- *  val name: Option[String] = request getParameter "name"
- *  val upper = name map { _.trim } filter { _.length != 0 } map { _.toUpperCase }
- *  println(upper getOrElse "")
+ *  val name: Option[String] = request.getParameter("name")
+ *  val upper = name.map(_.trim).filter(_.length != 0).map(_.toUpperCase)
+ *  println(upper.getOrElse(""))
  *  }}}
  *
  *  Note that this is equivalent to {{{
  *  val upper = for {
- *    name <- request getParameter "name"
+ *    name <- request.getParameter("name")
  *    trimmed <- Some(name.trim)
  *    upper <- Some(trimmed.toUpperCase) if trimmed.length != 0
  *  } yield upper
- *  println(upper getOrElse "")
+ *  println(upper.getOrElse(""))
  *  }}}
  *
  *  Because of how for comprehension works, if $none is returned
@@ -254,7 +254,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    * }}}
    * This is also equivalent to:
    * {{{
-   * option map f getOrElse ifEmpty
+   * option.map(f).getOrElse(ifEmpty)
    * }}}
    *  @param  ifEmpty the expression to evaluate if empty.
    *  @param  f       the function to apply if nonempty.

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -99,7 +99,7 @@ object Option {
  *  - [[toList]] — Unary list of optional value, otherwise the empty list
  *
  *  A less-idiomatic way to use $option values is via pattern matching: {{{
- *  val nameMaybe = request getParameter "name"
+ *  val nameMaybe = request.getParameter("name")
  *  nameMaybe match {
  *    case Some(name) =>
  *      println(name.trim.toUppercase)

--- a/library/src/scala/PartialFunction.scala
+++ b/library/src/scala/PartialFunction.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product.scala
+++ b/library/src/scala/Product.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product1.scala
+++ b/library/src/scala/Product1.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product10.scala
+++ b/library/src/scala/Product10.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product11.scala
+++ b/library/src/scala/Product11.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product12.scala
+++ b/library/src/scala/Product12.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product13.scala
+++ b/library/src/scala/Product13.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product14.scala
+++ b/library/src/scala/Product14.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product15.scala
+++ b/library/src/scala/Product15.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product16.scala
+++ b/library/src/scala/Product16.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product17.scala
+++ b/library/src/scala/Product17.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product18.scala
+++ b/library/src/scala/Product18.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product19.scala
+++ b/library/src/scala/Product19.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product2.scala
+++ b/library/src/scala/Product2.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product20.scala
+++ b/library/src/scala/Product20.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product21.scala
+++ b/library/src/scala/Product21.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product22.scala
+++ b/library/src/scala/Product22.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product3.scala
+++ b/library/src/scala/Product3.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product4.scala
+++ b/library/src/scala/Product4.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product5.scala
+++ b/library/src/scala/Product5.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product6.scala
+++ b/library/src/scala/Product6.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product7.scala
+++ b/library/src/scala/Product7.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product8.scala
+++ b/library/src/scala/Product8.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Product9.scala
+++ b/library/src/scala/Product9.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Proxy.scala
+++ b/library/src/scala/Proxy.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/SerialVersionUID.scala
+++ b/library/src/scala/SerialVersionUID.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Specializable.scala
+++ b/library/src/scala/Specializable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Symbol.scala
+++ b/library/src/scala/Symbol.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple1.scala
+++ b/library/src/scala/Tuple1.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple10.scala
+++ b/library/src/scala/Tuple10.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple11.scala
+++ b/library/src/scala/Tuple11.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple12.scala
+++ b/library/src/scala/Tuple12.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple13.scala
+++ b/library/src/scala/Tuple13.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple14.scala
+++ b/library/src/scala/Tuple14.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple15.scala
+++ b/library/src/scala/Tuple15.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple16.scala
+++ b/library/src/scala/Tuple16.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple17.scala
+++ b/library/src/scala/Tuple17.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple18.scala
+++ b/library/src/scala/Tuple18.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple19.scala
+++ b/library/src/scala/Tuple19.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple2.scala
+++ b/library/src/scala/Tuple2.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple20.scala
+++ b/library/src/scala/Tuple20.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple21.scala
+++ b/library/src/scala/Tuple21.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple22.scala
+++ b/library/src/scala/Tuple22.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple3.scala
+++ b/library/src/scala/Tuple3.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple4.scala
+++ b/library/src/scala/Tuple4.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple5.scala
+++ b/library/src/scala/Tuple5.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple6.scala
+++ b/library/src/scala/Tuple6.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple7.scala
+++ b/library/src/scala/Tuple7.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple8.scala
+++ b/library/src/scala/Tuple8.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Tuple9.scala
+++ b/library/src/scala/Tuple9.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/UninitializedError.scala
+++ b/library/src/scala/UninitializedError.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/UninitializedFieldError.scala
+++ b/library/src/scala/UninitializedFieldError.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/Unit.scala
+++ b/library/src/scala/Unit.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/ValueOf.scala
+++ b/library/src/scala/ValueOf.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/Annotation.scala
+++ b/library/src/scala/annotation/Annotation.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/ClassfileAnnotation.scala
+++ b/library/src/scala/annotation/ClassfileAnnotation.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/ConstantAnnotation.scala
+++ b/library/src/scala/annotation/ConstantAnnotation.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/StaticAnnotation.scala
+++ b/library/src/scala/annotation/StaticAnnotation.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/TypeConstraint.scala
+++ b/library/src/scala/annotation/TypeConstraint.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/compileTimeOnly.scala
+++ b/library/src/scala/annotation/compileTimeOnly.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/elidable.scala
+++ b/library/src/scala/annotation/elidable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/implicitAmbiguous.scala
+++ b/library/src/scala/annotation/implicitAmbiguous.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/implicitNotFound.scala
+++ b/library/src/scala/annotation/implicitNotFound.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/beanGetter.scala
+++ b/library/src/scala/annotation/meta/beanGetter.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/beanSetter.scala
+++ b/library/src/scala/annotation/meta/beanSetter.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/companionClass.scala
+++ b/library/src/scala/annotation/meta/companionClass.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/companionMethod.scala
+++ b/library/src/scala/annotation/meta/companionMethod.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/companionObject.scala
+++ b/library/src/scala/annotation/meta/companionObject.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/defaultArg.scala
+++ b/library/src/scala/annotation/meta/defaultArg.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc. dba Akka
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+package meta
+
+/**
+ * This internal meta annotation is used by the compiler to support default annotation arguments.
+ *
+ * For an annotation definition `class ann(x: Int = defaultExpr) extends Annotation`, the compiler adds
+ * `@defaultArg(defaultExpr)` to the parameter `x`. This causes the syntax tree of `defaultExpr` to be
+ * stored in the classfile.
+ *
+ * When using a default annotation argument, the compiler can recover the syntax tree and insert it in the
+ * `AnnotationInfo`.
+ *
+ * For details, see `scala.reflect.internal.AnnotationInfos.AnnotationInfo`.
+ */
+@meta.param class defaultArg(arg: Any) extends StaticAnnotation {
+  def this() = this(null)
+}

--- a/library/src/scala/annotation/meta/field.scala
+++ b/library/src/scala/annotation/meta/field.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/getter.scala
+++ b/library/src/scala/annotation/meta/getter.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/languageFeature.scala
+++ b/library/src/scala/annotation/meta/languageFeature.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/package.scala
+++ b/library/src/scala/annotation/meta/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/param.scala
+++ b/library/src/scala/annotation/meta/param.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/setter.scala
+++ b/library/src/scala/annotation/meta/setter.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/meta/superArg.scala
+++ b/library/src/scala/annotation/meta/superArg.scala
@@ -1,0 +1,34 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc. dba Akka
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.annotation
+package meta
+
+/**
+ * This internal annotation encodes arguments passed to annotation superclasses. Example:
+ *
+ * {{{
+ *   class a(x: Int) extends Annotation
+ *   class b extends a(42) // the compiler adds `@superArg("x", 42)` to class b
+ * }}}
+ */
+class superArg(p: String, v: Any) extends StaticAnnotation
+
+/**
+ * This internal annotation encodes arguments passed to annotation superclasses. Example:
+ *
+ * {{{
+ *   class a(x: Int) extends Annotation
+ *   class b(y: Int) extends a(y) // the compiler adds `@superFwdArg("x", "y")` to class b
+ * }}}
+ */
+class superFwdArg(p: String, n: String) extends StaticAnnotation

--- a/library/src/scala/annotation/migration.scala
+++ b/library/src/scala/annotation/migration.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/nowarn.scala
+++ b/library/src/scala/annotation/nowarn.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/nowarn.scala
+++ b/library/src/scala/annotation/nowarn.scala
@@ -14,14 +14,20 @@ package scala.annotation
 
 /** An annotation for local warning suppression.
   *
-  * The optional `value` parameter allows selectively silencing messages, see `scalac -Wconf:help`
-  * for help. Examples:
+  * The optional `value` parameter allows selectively silencing messages. See `-Wconf:help` for help
+  * writing a message filter expression, or use `@nowarn("verbose")` / `@nowarn("v")` to display message
+  * filters applicable to a specific warning.
+  *
+  * Examples:
   *
   * {{{
   *   def f = {
   *     1: @nowarn // don't warn "a pure expression does nothing in statement position"
   *     2
   *   }
+  *
+  *   // show the warning, plus the applicable @nowarn / Wconf filters ("cat=other-pure-statement", ...)
+  *   @nowarn("v") def f = { 1; 2 }
   *
   *   @nowarn def f = { 1; deprecated() } // don't warn
   *

--- a/library/src/scala/annotation/showAsInfix.scala
+++ b/library/src/scala/annotation/showAsInfix.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/strictfp.scala
+++ b/library/src/scala/annotation/strictfp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/switch.scala
+++ b/library/src/scala/annotation/switch.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/tailrec.scala
+++ b/library/src/scala/annotation/tailrec.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/unchecked/uncheckedStable.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedStable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/unchecked/uncheckedVariance.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedVariance.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/unspecialized.scala
+++ b/library/src/scala/annotation/unspecialized.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/unused.scala
+++ b/library/src/scala/annotation/unused.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/annotation/varargs.scala
+++ b/library/src/scala/annotation/varargs.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/beans/BeanProperty.scala
+++ b/library/src/scala/beans/BeanProperty.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/beans/BeanProperty.scala
+++ b/library/src/scala/beans/BeanProperty.scala
@@ -27,6 +27,11 @@ import scala.annotation.meta.{beanGetter, beanSetter, field}
  *  }}}
  *  For fields of type `Boolean`, if you need a getter named `isStatus`,
  *  use the `scala.beans.BooleanBeanProperty` annotation instead.
+ *
+ *  In Scala 2, the added methods are visible from both Scala and Java.
+ *
+ *  In Scala 3, that has changed. The added methods are only visible from
+ *  Java (including via Java reflection).
  */
 @field @beanGetter @beanSetter
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")

--- a/library/src/scala/beans/BooleanBeanProperty.scala
+++ b/library/src/scala/beans/BooleanBeanProperty.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -44,6 +44,7 @@ import scala.Predef.{ // unimport all array-related implicit conversions to avoi
   _
 }
 import scala.collection.Stepper.EfficientSplit
+import scala.collection.generic.CommonErrors
 import scala.collection.immutable.Range
 import scala.collection.mutable.ArrayBuilder
 import scala.math.Ordering
@@ -1545,7 +1546,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     *  @throws IndexOutOfBoundsException if `index` does not satisfy `0 <= index < length`.
     */
   def updated[B >: A : ClassTag](index: Int, elem: B): Array[B] = {
-    if(index < 0 || index >= xs.length) throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${xs.length-1})")
+    if(index < 0 || index >= xs.length)
+      throw CommonErrors.indexOutOfBounds(index = index, max = xs.length-1)
     val dest = toArray[B]
     dest(index) = elem
     dest

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -589,7 +589,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     val len = xs.length
     def boxed = if(len < ArrayOps.MaxStableSortLength) {
       val a = xs.clone()
-      Sorting.stableSort(a)(ord.asInstanceOf[Ordering[A]])
+      Sorting.stableSort(a)(using ord.asInstanceOf[Ordering[A]])
       a
     } else {
       val a = Array.copyAs[AnyRef](xs, len)(ClassTag.AnyRef)
@@ -1299,7 +1299,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     val bb = new ArrayBuilder.ofRef[Array[B]]()(ClassTag[Array[B]](aClass))
     if (xs.length == 0) bb.result()
     else {
-      def mkRowBuilder() = ArrayBuilder.make[B](ClassTag[B](aClass.getComponentType))
+      def mkRowBuilder() = ArrayBuilder.make[B](using ClassTag[B](aClass.getComponentType))
       val bs = new ArrayOps(asArray(xs(0))).map((x: B) => mkRowBuilder())
       for (xs <- this) {
         var i = 0

--- a/library/src/scala/collection/BitSet.scala
+++ b/library/src/scala/collection/BitSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/BufferedIterator.scala
+++ b/library/src/scala/collection/BufferedIterator.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/BuildFrom.scala
+++ b/library/src/scala/collection/BuildFrom.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/DefaultMap.scala
+++ b/library/src/scala/collection/DefaultMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -667,16 +667,16 @@ object ClassTagIterableFactory {
     * sound depending on the use of the `ClassTag` by the collection implementation. */
   @SerialVersionUID(3L)
   class AnyIterableDelegate[CC[_]](delegate: ClassTagIterableFactory[CC]) extends IterableFactory[CC] {
-    def empty[A]: CC[A] = delegate.empty(ClassTag.Any).asInstanceOf[CC[A]]
-    def from[A](it: IterableOnce[A]): CC[A] = delegate.from[Any](it)(ClassTag.Any).asInstanceOf[CC[A]]
-    def newBuilder[A]: Builder[A, CC[A]] = delegate.newBuilder(ClassTag.Any).asInstanceOf[Builder[A, CC[A]]]
-    override def apply[A](elems: A*): CC[A] = delegate.apply[Any](elems: _*)(ClassTag.Any).asInstanceOf[CC[A]]
-    override def iterate[A](start: A, len: Int)(f: A => A): CC[A] = delegate.iterate[A](start, len)(f)(ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A] = delegate.unfold[A, S](init)(f)(ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def range[A](start: A, end: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end)(i, ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def range[A](start: A, end: A, step: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end, step)(i, ClassTag.Any.asInstanceOf[ClassTag[A]])
-    override def fill[A](n: Int)(elem: => A): CC[A] = delegate.fill[Any](n)(elem)(ClassTag.Any).asInstanceOf[CC[A]]
-    override def tabulate[A](n: Int)(f: Int => A): CC[A] = delegate.tabulate[Any](n)(f)(ClassTag.Any).asInstanceOf[CC[A]]
+    def empty[A]: CC[A] = delegate.empty(using ClassTag.Any).asInstanceOf[CC[A]]
+    def from[A](it: IterableOnce[A]): CC[A] = delegate.from[Any](it)(using ClassTag.Any).asInstanceOf[CC[A]]
+    def newBuilder[A]: Builder[A, CC[A]] = delegate.newBuilder(using ClassTag.Any).asInstanceOf[Builder[A, CC[A]]]
+    override def apply[A](elems: A*): CC[A] = delegate.apply[Any](elems: _*)(using ClassTag.Any).asInstanceOf[CC[A]]
+    override def iterate[A](start: A, len: Int)(f: A => A): CC[A] = delegate.iterate[A](start, len)(f)(using ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def unfold[A, S](init: S)(f: S => Option[(A, S)]): CC[A] = delegate.unfold[A, S](init)(f)(using ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def range[A](start: A, end: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end)(using i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def range[A](start: A, end: A, step: A)(implicit i: Integral[A]): CC[A] = delegate.range[A](start, end, step)(using i, ClassTag.Any.asInstanceOf[ClassTag[A]])
+    override def fill[A](n: Int)(elem: => A): CC[A] = delegate.fill[Any](n)(elem)(using ClassTag.Any).asInstanceOf[CC[A]]
+    override def tabulate[A](n: Int)(f: Int => A): CC[A] = delegate.tabulate[Any](n)(f)(using ClassTag.Any).asInstanceOf[CC[A]]
   }
 }
 

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -90,7 +90,7 @@ trait IterableFactory[+CC[_]] extends Serializable {
     */
   def from[A](source: IterableOnce[A]): CC[A]
 
-  /** An empty collection
+  /** An empty $coll
     * @tparam A      the type of the ${coll}'s elements
     */
   def empty[A]: CC[A]

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -146,10 +146,10 @@ trait IterableFactory[+CC[_]] extends Serializable {
   def newBuilder[A]: Builder[A, CC[A]]
 
   /** Produces a $coll containing the results of some element computation a number of times.
-    *  @param   n  the number of elements contained in the $coll.
-    *  @param   elem the element computation
-    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
-    */
+   *  @param   n  the number of elements contained in the $coll.
+   *  @param   elem the element computation
+   *  @return  A $coll that contains the results of `n` evaluations of `elem`.
+   */
   def fill[A](n: Int)(elem: => A): CC[A] = from(new View.Fill(n)(elem))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.

--- a/library/src/scala/collection/Hashing.scala
+++ b/library/src/scala/collection/Hashing.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/IndexedSeq.scala
+++ b/library/src/scala/collection/IndexedSeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/IndexedSeqView.scala
+++ b/library/src/scala/collection/IndexedSeqView.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -725,10 +725,12 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
    *  @return       a new $coll which contains all elements
    *                of this $coll followed by all elements of `suffix`.
    */
-  def concat[B >: A](suffix: IterableOnce[B]): CC[B] = iterableFactory.from(suffix match {
-    case xs: Iterable[B] => new View.Concat(this, xs)
-    case xs => iterator ++ suffix.iterator
-  })
+  def concat[B >: A](suffix: IterableOnce[B]): CC[B] = iterableFactory.from {
+    suffix match {
+      case suffix: Iterable[B] => new View.Concat(this, suffix)
+      case suffix => iterator ++ suffix.iterator
+    }
+  }
 
   /** Alias for `concat` */
   @inline final def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -127,7 +127,7 @@ trait Iterable[+A] extends IterableOnce[A]
   * @define willNotTerminateInf
   *
   *    Note: will not terminate for infinite-sized collections.
-  *  @define undefinedorder
+  * @define undefinedorder
   *  The order in which operations are performed on elements is unspecified
   *  and may be nondeterministic.
   */
@@ -140,9 +140,9 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   def toIterable: Iterable[A]
 
   /** Converts this $coll to an unspecified Iterable.  Will return
-    *  the same collection if this instance is already Iterable.
-    *  @return An Iterable containing all elements of this $coll.
-    */
+   *  the same collection if this instance is already Iterable.
+   *  @return An Iterable containing all elements of this $coll.
+   */
   @deprecated("toTraversable is internal and will be made protected; its name is similar to `toList` or `toSeq`, but it doesn't copy non-immutable collections", "2.13.0")
   final def toTraversable: Traversable[A] = toIterable
 
@@ -208,24 +208,24 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     */
   protected def newSpecificBuilder: Builder[A @uncheckedVariance, C]
 
-  /** The empty iterable of the same type as this iterable.
+  /** The empty $coll.
     *
-    * @return an empty iterable of type `C`.
+    * @return an empty iterable of type $Coll.
     */
   def empty: C = fromSpecific(Nil)
 
   /** Selects the first element of this $coll.
-    *  $orderDependent
-    *  @return  the first element of this $coll.
-    *  @throws NoSuchElementException if the $coll is empty.
-    */
+   *  $orderDependent
+   *  @return  the first element of this $coll.
+   *  @throws NoSuchElementException if the $coll is empty.
+   */
   def head: A = iterator.next()
 
   /** Optionally selects the first element.
-    *  $orderDependent
-    *  @return  the first element of this $coll if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *  $orderDependent
+   *  @return  the first element of this $coll if it is nonempty,
+   *           `None` if it is empty.
+   */
   def headOption: Option[A] = {
     val it = iterator
     if (it.hasNext) Some(it.next()) else None
@@ -244,32 +244,32 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   }
 
   /** Optionally selects the last element.
-    *  $orderDependent
-    *  @return  the last element of this $coll$ if it is nonempty,
-    *           `None` if it is empty.
-    */
+   *  $orderDependent
+   *  @return  the last element of this $coll if it is nonempty,
+   *           `None` if it is empty.
+   */
   def lastOption: Option[A] = if (isEmpty) None else Some(last)
 
   /** A view over the elements of this collection. */
   def view: View[A] = View.fromIteratorProvider(() => iterator)
 
   /** Compares the size of this $coll to a test value.
-    *
-    *   @param   otherSize the test value that gets compared with the size.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.size <  otherSize
-    *        x == 0       if this.size == otherSize
-    *        x >  0       if this.size >  otherSize
-    *   }}}
-    *
-    *  The method as implemented here does not call `size` directly; its running time
-    *  is `O(size min otherSize)` instead of `O(size)`. The method should be overridden
-    *  if computing `size` is cheap and `knownSize` returns `-1`.
-    *
-    *  @see [[sizeIs]]
-    */
-  def sizeCompare(otherSize: Int): Int = {
+   *
+   *  @param   otherSize the test value that gets compared with the size.
+   *  @return  A value `x` where
+   *  {{{
+   *       x <  0       if this.size <  otherSize
+   *       x == 0       if this.size == otherSize
+   *       x >  0       if this.size >  otherSize
+   *  }}}
+   *
+   *  The method as implemented here does not call `size` directly; its running time
+   *  is `O(size min otherSize)` instead of `O(size)`. The method should be overridden
+   *  if computing `size` is cheap and `knownSize` returns `-1`.
+   *
+   *  @see [[sizeIs]]
+   */
+  def sizeCompare(otherSize: Int): Int =
     if (otherSize < 0) 1
     else {
       val known = knownSize
@@ -285,7 +285,6 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
         i - otherSize
       }
     }
-  }
 
   /** Returns a value class containing operations for comparing the size of this $coll to a test value.
     *
@@ -304,19 +303,19 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   @inline final def sizeIs: IterableOps.SizeCompareOps = new IterableOps.SizeCompareOps(this)
 
   /** Compares the size of this $coll to the size of another `Iterable`.
-    *
-    *   @param   that the `Iterable` whose size is compared with this $coll's size.
-    *   @return  A value `x` where
-    *   {{{
-    *        x <  0       if this.size <  that.size
-    *        x == 0       if this.size == that.size
-    *        x >  0       if this.size >  that.size
-    *   }}}
-    *
-    *  The method as implemented here does not call `size` directly; its running time
-    *  is `O(this.size min that.size)` instead of `O(this.size + that.size)`.
-    *  The method should be overridden if computing `size` is cheap and `knownSize` returns `-1`.
-    */
+   *
+   *  @param   that the `Iterable` whose size is compared with this $coll's size.
+   *  @return  A value `x` where
+   *  {{{
+   *       x <  0       if this.size <  that.size
+   *       x == 0       if this.size == that.size
+   *       x >  0       if this.size >  that.size
+   *  }}}
+   *
+   *  The method as implemented here does not call `size` directly; its running time
+   *  is `O(this.size min that.size)` instead of `O(this.size + that.size)`.
+   *  The method should be overridden if computing `size` is cheap and `knownSize` returns `-1`.
+   */
   def sizeCompare(that: Iterable[_]): Int = {
     val thatKnownSize = that.knownSize
 
@@ -345,39 +344,39 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
   def view(from: Int, until: Int): View[A] = view.slice(from, until)
 
   /** Transposes this $coll of iterable collections into
-    *  a $coll of ${coll}s.
-    *
-    *    The resulting collection's type will be guided by the
-    *    static type of $coll. For example:
-    *
-    *    {{{
-    *    val xs = List(
-    *               Set(1, 2, 3),
-    *               Set(4, 5, 6)).transpose
-    *    // xs == List(
-    *    //         List(1, 4),
-    *    //         List(2, 5),
-    *    //         List(3, 6))
-    *
-    *    val ys = Vector(
-    *               List(1, 2, 3),
-    *               List(4, 5, 6)).transpose
-    *    // ys == Vector(
-    *    //         Vector(1, 4),
-    *    //         Vector(2, 5),
-    *    //         Vector(3, 6))
-    *    }}}
-    *
-    *  $willForceEvaluation
-    *
-    *  @tparam B the type of the elements of each iterable collection.
-    *  @param  asIterable an implicit conversion which asserts that the
-    *          element type of this $coll is an `Iterable`.
-    *  @return a two-dimensional $coll of ${coll}s which has as ''n''th row
-    *          the ''n''th column of this $coll.
-    *  @throws IllegalArgumentException if all collections in this $coll
-    *          are not of the same size.
-    */
+   *  a $coll of ${coll}s.
+   *
+   *  The resulting collection's type will be guided by the
+   *  static type of $coll. For example:
+   *
+   *  {{{
+   *  val xs = List(
+   *             Set(1, 2, 3),
+   *             Set(4, 5, 6)).transpose
+   *  // xs == List(
+   *  //         List(1, 4),
+   *  //         List(2, 5),
+   *  //         List(3, 6))
+   *
+   *  val ys = Vector(
+   *             List(1, 2, 3),
+   *             List(4, 5, 6)).transpose
+   *  // ys == Vector(
+   *  //         Vector(1, 4),
+   *  //         Vector(2, 5),
+   *  //         Vector(3, 6))
+   *  }}}
+   *
+   *  $willForceEvaluation
+   *
+   *  @tparam B the type of the elements of each iterable collection.
+   *  @param  asIterable an implicit conversion which asserts that the
+   *          element type of this $coll is an `Iterable`.
+   *  @return a two-dimensional $coll of ${coll}s which has as ''n''th row
+   *          the ''n''th column of this $coll.
+   *  @throws IllegalArgumentException if all collections in this $coll
+   *          are not of the same size.
+   */
   def transpose[B](implicit asIterable: A => /*<:<!!!*/ Iterable[B]): CC[CC[B] @uncheckedVariance] = {
     if (isEmpty)
       return iterableFactory.empty[CC[B]]
@@ -717,32 +716,32 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     (iterableFactory.from(left), iterableFactory.from(right))
   }
 
-  /** Returns a new $coll containing the elements from the left hand operand followed by the elements from the
-    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
-    *  the element types of the two operands.
-    *
-    *  @param suffix   the iterable to append.
-    *  @tparam B     the element type of the returned collection.
-    *  @return       a new $coll which contains all elements
-    *                of this $coll followed by all elements of `suffix`.
-    */
+  /** Returns a new $ccoll containing the elements from the left hand operand followed by the elements from the
+   *  right hand operand. The element type of the $ccoll is the most specific superclass encompassing
+   *  the element types of the two operands.
+   *
+   *  @param suffix   the iterable to append.
+   *  @tparam B     the element type of the returned collection.
+   *  @return       a new $coll which contains all elements
+   *                of this $coll followed by all elements of `suffix`.
+   */
   def concat[B >: A](suffix: IterableOnce[B]): CC[B] = iterableFactory.from(suffix match {
     case xs: Iterable[B] => new View.Concat(this, xs)
     case xs => iterator ++ suffix.iterator
   })
 
   /** Alias for `concat` */
-  @`inline` final def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)
+  @inline final def ++ [B >: A](suffix: IterableOnce[B]): CC[B] = concat(suffix)
 
-  /** Returns a $coll formed from this $coll and another iterable collection
-    *  by combining corresponding elements in pairs.
-    *  If one of the two collections is longer than the other, its remaining elements are ignored.
-    *
-    *  @param   that  The iterable providing the second half of each result pair
-    *  @tparam  B     the type of the second half of the returned pairs
-    *  @return        a new $coll containing pairs consisting of corresponding elements of this $coll and `that`.
-    *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
-    */
+  /** Returns a $ccoll formed from this $coll and another iterable collection
+   *  by combining corresponding elements in pairs.
+   *  If one of the two collections is longer than the other, its remaining elements are ignored.
+   *
+   *  @param   that  The iterable providing the second half of each result pair
+   *  @tparam  B     the type of the second half of the returned pairs
+   *  @return        a new $ccoll containing pairs consisting of corresponding elements of this $coll and `that`.
+   *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
+   */
   def zip[B](that: IterableOnce[B]): CC[(A @uncheckedVariance, B)] = iterableFactory.from(that match { // sound bcs of VarianceNote
     case that: Iterable[B] => new View.Zip(this, that)
     case _ => iterator.zip(that)
@@ -862,7 +861,7 @@ object IterableOps {
   /** Operations for comparing the size of a collection to a test value.
     *
     * These operations are implemented in terms of
-    * [[scala.collection.IterableOps.sizeCompare(Int) `sizeCompare(Int)`]].
+    * [[scala.collection.IterableOps!.sizeCompare(Int):Int* `sizeCompare(Int)`]]
     */
   final class SizeCompareOps private[collection](val it: IterableOps[_, AnyConstr, _]) extends AnyVal {
     /** Tests if the size of the collection is less than some value. */

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -518,7 +518,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *          element (which may be the only element) will be smaller
     *          if there are fewer than `size` elements remaining to be grouped.
     *  @example `List(1, 2, 3, 4, 5).sliding(2, 2) = Iterator(List(1, 2), List(3, 4), List(5))`
-    *  @example `List(1, 2, 3, 4, 5, 6).sliding(2, 3) = Iterator(List(1, 2), List(4, 5))` 
+    *  @example `List(1, 2, 3, 4, 5, 6).sliding(2, 3) = Iterator(List(1, 2), List(4, 5))`
     */
   def sliding(size: Int, step: Int): Iterator[C] =
     iterator.sliding(size, step).map(fromSpecific)
@@ -708,7 +708,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *  @tparam A2  the element type of the second resulting collection
     *  @param f    the 'split function' mapping the elements of this $coll to an [[scala.util.Either]]
     *
-    *  @return     a pair of ${coll}s: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]], 
+    *  @return     a pair of ${coll}s: the first one made of those values returned by `f` that were wrapped in [[scala.util.Left]],
     *              and the second one made of those wrapped in [[scala.util.Right]].
     */
   def partitionMap[A1, A2](f: A => Either[A1, A2]): (CC[A1], CC[A2]) = {
@@ -982,9 +982,9 @@ trait SortedSetFactoryDefaults[+A,
     +WithFilterCC[x] <: IterableOps[x, WithFilterCC, WithFilterCC[x]] with Set[x]] extends SortedSetOps[A @uncheckedVariance, CC, CC[A @uncheckedVariance]] {
   self: IterableOps[A, WithFilterCC, _] =>
 
-  override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)(ordering)
-  override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A](ordering)
-  override def empty: CC[A @uncheckedVariance] = sortedIterableFactory.empty(ordering)
+  override protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]): CC[A @uncheckedVariance]    = sortedIterableFactory.from(coll)(using ordering)
+  override protected def newSpecificBuilder: mutable.Builder[A @uncheckedVariance, CC[A @uncheckedVariance]] = sortedIterableFactory.newBuilder[A](using ordering)
+  override def empty: CC[A @uncheckedVariance] = sortedIterableFactory.empty(using ordering)
 
   override def withFilter(p: A => Boolean): SortedSetOps.WithFilter[A, WithFilterCC, CC] =
     new SortedSetOps.WithFilter[A, WithFilterCC, CC](this, p)
@@ -1036,9 +1036,9 @@ trait SortedMapFactoryDefaults[K, +V,
     +UnsortedCC[x, y] <: Map[x, y]] extends SortedMapOps[K, V, CC, CC[K, V @uncheckedVariance]] with MapOps[K, V, UnsortedCC, CC[K, V @uncheckedVariance]] {
   self: IterableOps[(K, V), WithFilterCC, _] =>
 
-  override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty(ordering)
-  override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)(ordering)
-  override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = sortedMapFactory.newBuilder[K, V](ordering)
+  override def empty: CC[K, V @uncheckedVariance] = sortedMapFactory.empty(using ordering)
+  override protected def fromSpecific(coll: IterableOnce[(K, V @uncheckedVariance)]): CC[K, V @uncheckedVariance] = sortedMapFactory.from(coll)(using ordering)
+  override protected def newSpecificBuilder: mutable.Builder[(K, V @uncheckedVariance), CC[K, V @uncheckedVariance]] = sortedMapFactory.newBuilder[K, V](using ordering)
 
   override def withFilter(p: ((K, V)) => Boolean): collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC] =
     new collection.SortedMapOps.WithFilter[K, V, WithFilterCC, UnsortedCC, CC](this, p)

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -758,7 +758,7 @@ trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] with Iterable
     *  @param that     the iterable providing the second half of each result pair
     *  @param thisElem the element to be used to fill up the result if this $coll is shorter than `that`.
     *  @param thatElem the element to be used to fill up the result if `that` is shorter than this $coll.
-    *  @return        a new collection of type `That` containing pairs consisting of
+    *  @return        a new $coll containing pairs consisting of
     *                 corresponding elements of this $coll and `that`. The length
     *                 of the returned collection is the maximum of the lengths of this $coll and `that`.
     *                 If this $coll is shorter than `that`, `thisElem` values are used to pad the result.

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -40,6 +40,7 @@ import scala.runtime.{AbstractFunction1, AbstractFunction2}
   * without inheriting unwanted implementations.
   *
   * @define coll collection
+  * @define ccoll $coll
   */
 trait IterableOnce[+A] extends Any {
 
@@ -318,8 +319,6 @@ object IterableOnce {
   *              The order of applications of the operator is unspecified and may be nondeterministic.
   * @define exactlyOnce
   *              Each element appears exactly once in the computation.
-  * @define coll collection
-  *
   */
 trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
   /////////////////////////////////////////////////////////////// Abstract methods that must be implemented
@@ -439,51 +438,50 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    */
   def slice(from: Int, until: Int): C
 
-  /** Builds a new $coll by applying a function to all elements of this $coll.
+  /** Builds a new $ccoll by applying a function to all elements of this $coll.
    *
    *  @param f      the function to apply to each element.
-   *  @tparam B     the element type of the returned $coll.
-   *  @return       a new $coll resulting from applying the given function
+   *  @tparam B     the element type of the returned $ccoll.
+   *  @return       a new $ccoll resulting from applying the given function
    *                `f` to each element of this $coll and collecting the results.
    */
   def map[B](f: A => B): CC[B]
 
-  /** Builds a new $coll by applying a function to all elements of this $coll
+  /** Builds a new $ccoll by applying a function to all elements of this $coll
    *  and using the elements of the resulting collections.
    *
    *    For example:
    *
    *    {{{
-   *      def getWords(lines: Seq[String]): Seq[String] = lines flatMap (line => line split "\\W+")
+   *      def getWords(lines: Seq[String]): Seq[String] = lines.flatMap(line => line.split("\\W+"))
    *    }}}
    *
-   *    The type of the resulting collection is guided by the static type of $coll. This might
+   *    The type of the resulting collection is guided by the static type of this $coll. This might
    *    cause unexpected results sometimes. For example:
    *
    *    {{{
    *      // lettersOf will return a Seq[Char] of likely repeated letters, instead of a Set
-   *      def lettersOf(words: Seq[String]) = words flatMap (word => word.toSet)
+   *      def lettersOf(words: Seq[String]) = words.flatMap(word => word.toSet)
    *
    *      // lettersOf will return a Set[Char], not a Seq
-   *      def lettersOf(words: Seq[String]) = words.toSet flatMap ((word: String) => word.toSeq)
+   *      def lettersOf(words: Seq[String]) = words.toSet.flatMap(word => word.toSeq)
    *
    *      // xs will be an Iterable[Int]
-   *      val xs = Map("a" -> List(11,111), "b" -> List(22,222)).flatMap(_._2)
+   *      val xs = Map("a" -> List(11, 111), "b" -> List(22, 222)).flatMap(_._2)
    *
    *      // ys will be a Map[Int, Int]
-   *      val ys = Map("a" -> List(1 -> 11,1 -> 111), "b" -> List(2 -> 22,2 -> 222)).flatMap(_._2)
+   *      val ys = Map("a" -> List(1 -> 11, 1 -> 111), "b" -> List(2 -> 22, 2 -> 222)).flatMap(_._2)
    *    }}}
    *
    *  @param f      the function to apply to each element.
    *  @tparam B     the element type of the returned collection.
-   *  @return       a new $coll resulting from applying the given collection-valued function
+   *  @return       a new $ccoll resulting from applying the given collection-valued function
    *                `f` to each element of this $coll and concatenating the results.
    */
   def flatMap[B](f: A => IterableOnce[B]): CC[B]
 
-  /** Converts this $coll of iterable collections into
-   *  a $coll formed by the elements of these iterable
-   *  collections.
+  /** Given that the elements of this collection are themselves iterable collections,
+   *  converts this $coll into a $ccoll comprising the elements of these iterable collections.
    *
    *    The resulting collection's type will be guided by the
    *    type of $coll. For example:
@@ -505,16 +503,16 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @tparam B the type of the elements of each iterable collection.
    *  @param asIterable an implicit conversion which asserts that the element
    *          type of this $coll is an `Iterable`.
-   *  @return a new $coll resulting from concatenating all element ${coll}s.
+   *  @return a new $ccoll resulting from concatenating all element collections.
    */
   def flatten[B](implicit asIterable: A => IterableOnce[B]): CC[B]
 
-  /** Builds a new $coll by applying a partial function to all elements of this $coll
+  /** Builds a new $ccoll by applying a partial function to all elements of this $coll
    *  on which the function is defined.
    *
    *  @param pf     the partial function which filters and maps the $coll.
    *  @tparam B     the element type of the returned $coll.
-   *  @return       a new $coll resulting from applying the given partial function
+   *  @return       a new $ccoll resulting from applying the given partial function
    *                `pf` to each element on which it is defined and collecting the results.
    *                The order of the elements is preserved.
    */
@@ -522,7 +520,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
 
   /** Zips this $coll with its indices.
    *
-   *  @return        A new $coll containing pairs consisting of all elements of this $coll paired with their index.
+   *  @return        A new $ccoll containing pairs consisting of all elements of this $coll paired with their index.
    *                 Indices start at `0`.
    *  @example
    *    `List("a", "b", "c").zipWithIndex == List(("a", 0), ("b", 1), ("c", 2))`
@@ -533,7 +531,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *
    *  Note: `c span p`  is equivalent to (but possibly more efficient than)
    *  `(c takeWhile p, c dropWhile p)`, provided the evaluation of the
-   *  predicate `p` does not cause any side-effects.
+   *  predicate `p` does not cause any side effects.
    *  $orderDependent
    *
    *  @param p the test predicate

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -1372,7 +1372,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
     if (it.hasNext) {
       jsb.append(it.next())
       while (it.hasNext) {
-        jsb.append(sep)
+        if (sep.length != 0) jsb.append(sep)
         jsb.append(it.next())
       }
     }

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -435,6 +435,8 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @return  a $coll containing the elements greater than or equal to
    *           index `from` extending up to (but not including) index `until`
    *           of this $coll.
+   *  @example
+   *    `List('a', 'b', 'c', 'd', 'e').slice(1, 3) == List('b', 'c')`
    */
   def slice(from: Int, until: Int): C
 
@@ -1241,7 +1243,7 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @param pf   the partial function
    *  @return     an option value containing pf applied to the first
    *              value for which it is defined, or `None` if none exists.
-   *  @example    `Seq("a", 1, 5L).collectFirst({ case x: Int => x*10 }) = Some(10)`
+   *  @example    `Seq("a", 1, 5L).collectFirst { case x: Int => x*10 } = Some(10)`
    */
   def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = {
     // Presumably the fastest way to get in and out of a partial function is for a sentinel function to return itself

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -21,6 +21,8 @@ import scala.math.{Numeric, Ordering}
 import scala.reflect.ClassTag
 import scala.runtime.{AbstractFunction1, AbstractFunction2}
 
+import IterableOnce.elemsToCopyToArray
+
 /**
   * A template trait for collections which can be traversed either once only
   * or one or more times.
@@ -264,16 +266,25 @@ object IterableOnce {
   @inline implicit def iterableOnceExtensionMethods[A](it: IterableOnce[A]): IterableOnceExtensionMethods[A] =
     new IterableOnceExtensionMethods[A](it)
 
-  /** Computes the number of elements to copy to an array from a source IterableOnce
-    *
-    * @param srcLen the length of the source collection
-    * @param destLen the length of the destination array
-    * @param start the index in the destination array at which to start copying elements to
-    * @param len the requested number of elements to copy (we may only be able to copy less than this)
-    * @return the number of elements that will be copied to the destination array
-    */
-  @inline private[collection] def elemsToCopyToArray(srcLen: Int, destLen: Int, start: Int, len: Int): Int =
-    math.max(math.min(math.min(len, srcLen), destLen - start), 0)
+  /** Computes the number of elements to copy to an array from a source IterableOnce.
+   *
+   *  If `start` is less than zero, it is taken as zero.
+   *  If any of the length inputs is less than zero, the computed result is zero.
+   *
+   *  The result is the smaller of the remaining capacity in the destination and the requested count.
+   *
+   *  @param srcLen the length of the source collection
+   *  @param destLen the length of the destination array
+   *  @param start the index in the destination array at which to start copying elements
+   *  @param len the requested number of elements to copy (we may only be able to copy less than this)
+   *  @return the number of elements that will be copied to the destination array
+   */
+  @inline private[collection] def elemsToCopyToArray(srcLen: Int, destLen: Int, start: Int, len: Int): Int = {
+    val limit = math.min(len, srcLen)
+    val capacity = if (start < 0) destLen else destLen - start
+    val total = math.min(capacity, limit)
+    math.max(0, total)
+  }
 
   /** Calls `copyToArray` on the given collection, regardless of whether or not it is an `Iterable`. */
   @inline private[collection] def copyElemsToArray[A, B >: A](elems: IterableOnce[A],
@@ -986,28 +997,29 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
 
   /** Copies elements to an array, returning the number of elements written.
    *
-   *  Fills the given array `xs` starting at index `start` with values of this $coll.
+   *  Fills the given array `dest` starting at index `start` with values of this $coll.
    *
    *  Copying will stop once either all the elements of this $coll have been copied,
    *  or the end of the array is reached.
    *
-   *  @param  xs     the array to fill.
+   *  @param  dest   the array to fill.
    *  @tparam B      the type of the elements of the array.
    *  @return        the number of elements written to the array
    *
    *  @note    Reuse: $consumesIterator
    */
   @deprecatedOverriding("This should always forward to the 3-arg version of this method", since = "2.13.4")
-  def copyToArray[B >: A](xs: Array[B]): Int = copyToArray(xs, 0, Int.MaxValue)
+  def copyToArray[B >: A](@deprecatedName("xs", since="2.13.17") dest: Array[B]): Int =
+    copyToArray(dest, start = 0, n = Int.MaxValue)
 
   /** Copies elements to an array, returning the number of elements written.
    *
-   *  Fills the given array `xs` starting at index `start` with values of this $coll.
+   *  Fills the given array `dest` starting at index `start` with values of this $coll.
    *
    *  Copying will stop once either all the elements of this $coll have been copied,
    *  or the end of the array is reached.
    *
-   *  @param  xs     the array to fill.
+   *  @param  dest   the array to fill.
    *  @param  start  the starting index of xs.
    *  @tparam B      the type of the elements of the array.
    *  @return        the number of elements written to the array
@@ -1015,29 +1027,40 @@ trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A] =>
    *  @note    Reuse: $consumesIterator
    */
   @deprecatedOverriding("This should always forward to the 3-arg version of this method", since = "2.13.4")
-  def copyToArray[B >: A](xs: Array[B], start: Int): Int = copyToArray(xs, start, Int.MaxValue)
+  def copyToArray[B >: A](@deprecatedName("xs", since="2.13.17") dest: Array[B], start: Int): Int =
+    copyToArray(dest, start = start, n = Int.MaxValue)
 
-  /** Copy elements to an array, returning the number of elements written.
+  /** Copies elements to an array and returns the number of elements written.
    *
-   *  Fills the given array `xs` starting at index `start` with at most `len` elements of this $coll.
+   *  Fills the given array `dest` starting at index `start` with at most `n` elements of this $coll.
    *
    *  Copying will stop once either all the elements of this $coll have been copied,
-   *  or the end of the array is reached, or `len` elements have been copied.
+   *  or the end of the array is reached, or `n` elements have been copied.
    *
-   *  @param  xs     the array to fill.
+   *  If `start` is less than zero, it is taken as zero.
+   *
+   *  @param  dest   the array to fill.
    *  @param  start  the starting index of xs.
-   *  @param  len    the maximal number of elements to copy.
+   *  @param  n      the maximal number of elements to copy.
    *  @tparam B      the type of the elements of the array.
    *  @return        the number of elements written to the array
    *
    *  @note    Reuse: $consumesIterator
    */
-  def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = {
+  def copyToArray[B >: A](
+    @deprecatedName("xs", since="2.13.17") dest: Array[B],
+    start: Int,
+    @deprecatedName("len", since="2.13.17") n: Int
+  ): Int = {
     val it = iterator
     var i = start
-    val end = start + math.min(len, xs.length - start)
+    val srclen = knownSize match {
+      case -1 => dest.length
+      case  k => k
+    }
+    val end = start + elemsToCopyToArray(srclen, dest.length, start, n)
     while (i < end && it.hasNext) {
-      xs(i) = it.next()
+      dest(i) = it.next()
       i += 1
     }
     i - start

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -413,7 +413,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
 
   @deprecated("Call scanRight on an Iterable instead.", "2.13.0")
   def scanRight[B](z: B)(op: (A, B) => B): Iterator[B] = ArrayBuffer.from(this).scanRight(z)(op).iterator
-
+ 
+  /** Finds index of the first element satisfying some predicate after or at some start index.
+    *
+    *  $mayNotTerminateInf
+    *
+    *  @param  p     the predicate used to test elements.
+    *  @param  from   the start index
+    *  @return the index `>= from` of the first element of this $coll that satisfies the predicate `p`,
+    *           or `-1`, if none exists.
+    *  @note   Reuse: $consumesIterator
+    */
   def indexWhere(p: A => Boolean, from: Int = 0): Int = {
     var i = math.max(from, 0)
     val dropped = drop(from)

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -1257,12 +1257,15 @@ object Iterator extends IterableFactory[Iterator] {
         else if (until <= lo) 0               // empty
         else if (unbounded) until - lo        // now finite
         else adjustedBound min (until - lo)   // keep lesser bound
+      val sum = dropping + lo
       if (rest == 0) empty
+      else if (sum < 0) {
+        dropping = Int.MaxValue
+        remaining = 0
+        this.concat(new SliceIterator(underlying, start = sum - Int.MaxValue, limit = rest))
+      }
       else {
-        dropping = {
-          val sum = dropping + lo
-          if (sum < 0) Int.MaxValue else sum
-        }
+        dropping = sum
         remaining = rest
         this
       }

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -844,17 +844,14 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *  @param that  the collection to compare
    *  @tparam B    the type of the elements of collection `that`.
    *  @return `true` if both collections contain equal elements in the same order, `false` otherwise.
-   *
-   *    @inheritdoc
    */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     val those = that.iterator
-    while (hasNext && those.hasNext)
-      if (next() != those.next())
-        return false
-    // At that point we know that *at least one* iterator has no next element
-    // If *both* of them have no elements then the collections are the same
-    hasNext == those.hasNext
+    while (hasNext) {
+      if (!those.hasNext) return false
+      if (next() != those.next()) return false
+    }
+    !those.hasNext
   }
 
   /** Creates two new iterators that both iterate over the same elements

--- a/library/src/scala/collection/JavaConverters.scala
+++ b/library/src/scala/collection/JavaConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/LazyZipOps.scala
+++ b/library/src/scala/collection/LazyZipOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/MapView.scala
+++ b/library/src/scala/collection/MapView.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Searching.scala
+++ b/library/src/scala/collection/Searching.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -180,11 +180,11 @@ trait SeqOps[+A, +CC[_], +C] extends Any
   def appendedAll[B >: A](suffix: IterableOnce[B]): CC[B] = super.concat(suffix)
 
   /** Alias for `appendedAll`. */
-  @`inline` final def :++ [B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+  @inline final def :++ [B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
   // Make `concat` an alias for `appendedAll` so that it benefits from performance
   // overrides of this method
-  @`inline` final override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
+  @inline final override def concat[B >: A](suffix: IterableOnce[B]): CC[B] = appendedAll(suffix)
 
  /** Produces a new sequence which contains all elements of this $coll and also all elements of
    *  a given sequence. `xs union ys`  is equivalent to `xs ++ ys`.
@@ -286,7 +286,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
    *  @param   len   the target length
    *  @param   elem  the padding value
    *  @tparam B      the element type of the returned $coll.
-   *  @return a new $coll consisting of
+   *  @return a new $ccoll consisting of
    *          all elements of this $coll followed by the minimal number of occurrences of `elem` so
    *          that the resulting collection has a length of at least `len`.
    */
@@ -843,16 +843,23 @@ trait SeqOps[+A, +CC[_], +C] extends Any
 
   override def isEmpty: Boolean = lengthCompare(0) == 0
 
-  /** Tests whether the elements of this collection are the same (and in the same order)
-    * as those of `that`.
-    */
+  /** Checks whether corresponding elements of the given iterable collection
+   *  compare equal (with respect to `==`) to elements of this $coll.
+   *
+   *  @param that  the collection to compare
+   *  @tparam B    the type of the elements of collection `that`.
+   *  @return `true` if both collections contain equal elements in the same order, `false` otherwise.
+   */
   def sameElements[B >: A](that: IterableOnce[B]): Boolean = {
     val thisKnownSize = knownSize
-    val knownSizeDifference = thisKnownSize != -1 && {
+    if (thisKnownSize != -1) {
       val thatKnownSize = that.knownSize
-      thatKnownSize != -1 && thisKnownSize != thatKnownSize
+      if (thatKnownSize != -1) {
+        if (thisKnownSize != thatKnownSize) return false
+        if (thisKnownSize == 0) return true
+      }
     }
-    !knownSizeDifference && iterator.sameElements(that)
+    iterator.sameElements(that)
   }
 
   /** Tests whether every element of this $coll relates to the

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -878,7 +878,7 @@ trait SeqOps[+A, +CC[_], +C] extends Any
     *
     *  @param that   the sequence of elements to remove
     *  @return       a new $coll which contains all elements of this $coll
-    *                except some of occurrences of elements that also appear in `that`.
+    *                except some of the occurrences of elements that also appear in `that`.
     *                If an element value `x` appears
     *                ''n'' times in `that`, then the first ''n'' occurrences of `x` will not form
     *                part of the result, but any following occurrences will.

--- a/library/src/scala/collection/SeqMap.scala
+++ b/library/src/scala/collection/SeqMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/SeqView.scala
+++ b/library/src/scala/collection/SeqView.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/SeqView.scala
+++ b/library/src/scala/collection/SeqView.scala
@@ -14,6 +14,7 @@ package scala
 package collection
 
 import scala.annotation.nowarn
+import scala.collection.generic.CommonErrors
 
 
 trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
@@ -95,7 +96,10 @@ object SeqView {
     def apply(idx: Int): A = if (idx < n) {
       underlying(idx)
     } else {
-      throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${if (underlying.knownSize >= 0) knownSize - 1 else "unknown"})")
+      throw (
+        if (underlying.knownSize >= 0) CommonErrors.indexOutOfBounds(index = idx, max = knownSize - 1)
+        else CommonErrors.indexOutOfBounds(index = idx)
+      )
     }
     def length: Int = underlying.length min normN
   }

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -210,9 +210,7 @@ trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @deprecated("Use &- with an explicit collection argument instead of - with varargs", "2.13.0")
   def - (elem1: A, elem2: A, elems: A*): C = diff(elems.toSet + elem1 + elem2)
 
-  /** Creates a new $coll by adding all elements contained in another collection to this $coll, omitting duplicates.
-    *
-    * This method takes a collection of elements and adds all elements, omitting duplicates, into $coll.
+  /** Creates a new $ccoll by adding all elements contained in another collection to this $coll, omitting duplicates.
     *
     * Example:
     *  {{{

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -179,16 +179,16 @@ trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOps[X, Y, CC, _],
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]): CC[K, V2] = sortedMapFactory.from(suffix match {
     case it: Iterable[(K, V2)] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
-  })(ordering)
+  })(using ordering)
 
   /** Alias for `concat` */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]): CC[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
-  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(this, kv))(ordering)
+  override def + [V1 >: V](kv: (K, V1)): CC[K, V1] = sortedMapFactory.from(new View.Appended(this, kv))(using ordering)
 
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
-  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))(ordering)
+  override def + [V1 >: V](elem1: (K, V1), elem2: (K, V1), elems: (K, V1)*): CC[K, V1] = sortedMapFactory.from(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))(using ordering)
 }
 
 object SortedMapOps {

--- a/library/src/scala/collection/SortedOps.scala
+++ b/library/src/scala/collection/SortedOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -57,6 +57,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
     */
   def sortedIterableFactory: SortedIterableFactory[CC]
 
+  /** Widens the type of this set to its unsorted counterpart. */
   def unsorted: Set[A]
 
   /**

--- a/library/src/scala/collection/Stepper.scala
+++ b/library/src/scala/collection/Stepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StepperShape.scala
+++ b/library/src/scala/collection/StepperShape.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StrictOptimizedIterableOps.scala
+++ b/library/src/scala/collection/StrictOptimizedIterableOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StrictOptimizedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedMapOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSeqOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StrictOptimizedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSetOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedMapOps.scala
@@ -33,7 +33,7 @@ trait StrictOptimizedSortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] with SortedMapOp
     strictOptimizedFlatMap(sortedMapFactory.newBuilder, f)
 
   override def concat[V2 >: V](xs: IterableOnce[(K, V2)]): CC[K, V2] =
-    strictOptimizedConcat(xs, sortedMapFactory.newBuilder(ordering))
+    strictOptimizedConcat(xs, sortedMapFactory.newBuilder(using ordering))
 
   override def collect[K2, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit @implicitNotFound(SortedMapOps.ordMsg) ordering: Ordering[K2]): CC[K2, V2] =
     strictOptimizedCollect(sortedMapFactory.newBuilder, pf)

--- a/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSortedSetOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -26,9 +26,7 @@ import scala.util.matching.Regex
 object StringOps {
   // just statics for companion class.
   private final val LF = 0x0A
-  private final val FF = 0x0C
   private final val CR = 0x0D
-  private final val SU = 0x1A
 
   private class StringIterator(private[this] val s: String) extends AbstractIterator[Char] {
     private[this] var pos = 0
@@ -180,14 +178,14 @@ object StringOps {
 final class StringOps(private val s: String) extends AnyVal {
   import StringOps._
 
-  @`inline` def view: StringView = new StringView(s)
+  @inline def view: StringView = new StringView(s)
 
-  @`inline` def size: Int = s.length
+  @inline def size: Int = s.length
 
-  @`inline` def knownSize: Int = s.length
+  @inline def knownSize: Int = s.length
 
   /** Get the char at the specified index. */
-  @`inline` def apply(i: Int): Char = s.charAt(i)
+  @inline def apply(i: Int): Char = s.charAt(i)
 
   def sizeCompare(otherSize: Int): Int = Integer.compare(s.length, otherSize)
 
@@ -344,13 +342,13 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @return       a new string which contains all chars
     *                of this string followed by all chars of `suffix`.
     */
-  @`inline` def concat(suffix: String): String = s + suffix
+  @inline def concat(suffix: String): String = s + suffix
 
   /** Alias for `concat` */
-  @`inline` def ++[B >: Char](suffix: Iterable[B]): immutable.IndexedSeq[B] = concat(suffix)
+  @inline def ++[B >: Char](suffix: Iterable[B]): immutable.IndexedSeq[B] = concat(suffix)
 
   /** Alias for `concat` */
-  @`inline` def ++(suffix: IterableOnce[Char]): String = concat(suffix)
+  @inline def ++(suffix: IterableOnce[Char]): String = concat(suffix)
 
   /** Alias for `concat` */
   def ++(xs: String): String = concat(xs)
@@ -412,14 +410,14 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Alias for `prepended` */
-  @`inline` def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
+  @inline def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
 
   /** A copy of the string with an char prepended */
   def prepended(c: Char): String =
     new JStringBuilder(s.length + 1).append(c).append(s).toString
 
   /** Alias for `prepended` */
-  @`inline` def +: (c: Char): String = prepended(c)
+  @inline def +: (c: Char): String = prepended(c)
 
   /** A copy of the string with all elements from a collection prepended */
   def prependedAll[B >: Char](prefix: IterableOnce[B]): immutable.IndexedSeq[B] = {
@@ -432,13 +430,13 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Alias for `prependedAll` */
-  @`inline` def ++: [B >: Char] (prefix: IterableOnce[B]): immutable.IndexedSeq[B] = prependedAll(prefix)
+  @inline def ++: [B >: Char] (prefix: IterableOnce[B]): immutable.IndexedSeq[B] = prependedAll(prefix)
 
   /** A copy of the string with another string prepended */
   def prependedAll(prefix: String): String = prefix + s
 
   /** Alias for `prependedAll` */
-  @`inline` def ++: (prefix: String): String = prependedAll(prefix)
+  @inline def ++: (prefix: String): String = prependedAll(prefix)
 
   /** A copy of the string with an element appended */
   def appended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
@@ -450,28 +448,28 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Alias for `appended` */
-  @`inline` def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
+  @inline def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
 
   /** A copy of the string with an element appended */
   def appended(c: Char): String =
     new JStringBuilder(s.length + 1).append(s).append(c).toString
 
   /** Alias for `appended` */
-  @`inline` def :+ (c: Char): String = appended(c)
+  @inline def :+ (c: Char): String = appended(c)
 
   /** A copy of the string with all elements from a collection appended */
-  @`inline` def appendedAll[B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
+  @inline def appendedAll[B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
     concat(suffix)
 
   /** Alias for `appendedAll` */
-  @`inline` def :++ [B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
+  @inline def :++ [B >: Char](suffix: IterableOnce[B]): immutable.IndexedSeq[B] =
     concat(suffix)
 
   /** A copy of the string with another string appended */
-  @`inline` def appendedAll(suffix: String): String = s + suffix
+  @inline def appendedAll(suffix: String): String = s + suffix
 
   /** Alias for `appendedAll` */
-  @`inline` def :++ (suffix: String): String = s + suffix
+  @inline def :++ (suffix: String): String = s + suffix
 
   /** Produces a new collection where a slice of characters in this string is replaced by another collection.
     *
@@ -488,7 +486,7 @@ final class StringOps(private val s: String) extends AnyVal {
     */
   def patch[B >: Char](from: Int, other: IterableOnce[B], replaced: Int): immutable.IndexedSeq[B] = {
     val len = s.length
-    @`inline` def slc(off: Int, length: Int): WrappedString =
+    @inline def slc(off: Int, length: Int): WrappedString =
       new WrappedString(s.substring(off, off+length))
     val b = immutable.IndexedSeq.newBuilder[B]
     val k = other.knownSize
@@ -645,8 +643,8 @@ final class StringOps(private val s: String) extends AnyVal {
 
   // Note: String.repeat is added in JDK 11.
   /** Return the current string concatenated `n` times.
-    */
-  def *(n: Int): String = {
+   */
+  def *(n: Int): String =
     if (n <= 0) {
       ""
     } else {
@@ -658,10 +656,9 @@ final class StringOps(private val s: String) extends AnyVal {
       }
       sb.toString
     }
-  }
 
-  @`inline` private[this] def isLineBreak(c: Char) = c == CR || c == LF
-  @`inline` private[this] def isLineBreak2(c0: Char, c: Char) = c0 == CR && c == LF
+  @inline private def isLineBreak(c: Char) = c == CR || c == LF
+  @inline private def isLineBreak2(c0: Char, c: Char) = c0 == CR && c == LF
 
   /** Strip the trailing line separator from this string if there is one.
    *  The line separator is taken as `"\n"`, `"\r"`, or `"\r\n"`.
@@ -698,7 +695,7 @@ final class StringOps(private val s: String) extends AnyVal {
 
     private[this] val len = s.length
     private[this] var index = 0
-    @`inline` private def done = index >= len
+    @inline private def done = index >= len
     private def advance(): String = {
       val start = index
       while (!done && !isLineBreak(apply(index))) index += 1
@@ -1118,7 +1115,7 @@ final class StringOps(private val s: String) extends AnyVal {
    *   @return        The result of applying `op` to `z` and all chars in this string,
    *                  going left to right. Returns `z` if this string is empty.
    */
-  @`inline` def fold[A1 >: Char](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
+  @inline def fold[A1 >: Char](z: A1)(op: (A1, A1) => A1): A1 = foldLeft(z)(op)
 
   /** Selects the first char of this string.
     *  @return  the first char of this string.
@@ -1158,19 +1155,19 @@ final class StringOps(private val s: String) extends AnyVal {
   /** Stepper can be used with Java 8 Streams. This method is equivalent to a call to
     * [[charStepper]]. See also [[codePointStepper]].
     */
-  @`inline` def stepper: IntStepper with EfficientSplit = charStepper
+  @inline def stepper: IntStepper with EfficientSplit = charStepper
 
   /** Steps over characters in this string. Values are packed in `Int` for efficiency
     * and compatibility with Java 8 Streams which have an efficient specialization for `Int`.
     */
-  @`inline` def charStepper: IntStepper with EfficientSplit = new CharStringStepper(s, 0, s.length)
+  @inline def charStepper: IntStepper with EfficientSplit = new CharStringStepper(s, 0, s.length)
 
   /** Steps over code points in this string.
     */
-  @`inline` def codePointStepper: IntStepper with EfficientSplit = new CodePointStringStepper(s, 0, s.length)
+  @inline def codePointStepper: IntStepper with EfficientSplit = new CodePointStringStepper(s, 0, s.length)
 
   /** Tests whether the string is not empty. */
-  @`inline` def nonEmpty: Boolean = !s.isEmpty
+  @inline def nonEmpty: Boolean = !s.isEmpty
 
   /** Returns new sequence with elements in reversed order.
     * @note $unicodeunaware
@@ -1268,7 +1265,7 @@ final class StringOps(private val s: String) extends AnyVal {
   }
 
   /** Selects all chars of this string which do not satisfy a predicate. */
-  @`inline` def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
+  @inline def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
 
   /** Copy chars of this string to an array.
     * Fills the given array `xs` starting at index 0.
@@ -1277,7 +1274,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *
     *  @param  xs     the array to fill.
     */
-  @`inline` def copyToArray(xs: Array[Char]): Int =
+  @inline def copyToArray(xs: Array[Char]): Int =
     copyToArray(xs, 0, Int.MaxValue)
 
   /** Copy chars of this string to an array.
@@ -1288,7 +1285,7 @@ final class StringOps(private val s: String) extends AnyVal {
     *  @param  xs     the array to fill.
     *  @param  start  the starting index.
     */
-  @`inline` def copyToArray(xs: Array[Char], start: Int): Int =
+  @inline def copyToArray(xs: Array[Char], start: Int): Int =
     copyToArray(xs, start, Int.MaxValue)
 
   /** Copy chars of this string to an array.

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -1201,14 +1201,16 @@ final class StringOps(private val s: String) extends AnyVal {
   def withFilter(p: Char => Boolean): StringOps.WithFilter = new StringOps.WithFilter(p, s)
 
   /** The rest of the string without its first char.
-    * @note $unicodeunaware
-    */
-  def tail: String = slice(1, s.length)
+   *  @throws UnsupportedOperationException if the string is empty.
+   *  @note $unicodeunaware
+   */
+  def tail: String = if(s.isEmpty) throw new UnsupportedOperationException("tail of empty String") else slice(1, s.length)
 
   /** The initial part of the string without its last char.
-    * @note $unicodeunaware
-    */
-  def init: String = slice(0, s.length-1)
+   *  @throws UnsupportedOperationException if the string is empty.
+   * @note $unicodeunaware
+   */
+  def init: String = if(s.isEmpty) throw new UnsupportedOperationException("init of empty String") else slice(0, s.length-1)
 
   /** A string containing the first `n` chars of this string.
     * @note $unicodeunaware

--- a/library/src/scala/collection/StringParsers.scala
+++ b/library/src/scala/collection/StringParsers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/View.scala
+++ b/library/src/scala/collection/View.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/WithFilter.scala
+++ b/library/src/scala/collection/WithFilter.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/concurrent/BasicNode.java
+++ b/library/src/scala/collection/concurrent/BasicNode.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/concurrent/CNodeBase.java
+++ b/library/src/scala/collection/concurrent/CNodeBase.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/concurrent/Gen.java
+++ b/library/src/scala/collection/concurrent/Gen.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/concurrent/INodeBase.java
+++ b/library/src/scala/collection/concurrent/INodeBase.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/concurrent/MainNode.java
+++ b/library/src/scala/collection/concurrent/MainNode.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/concurrent/Map.scala
+++ b/library/src/scala/collection/concurrent/Map.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/concurrent/TrieMap.scala
+++ b/library/src/scala/collection/concurrent/TrieMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/AsJavaConverters.scala
+++ b/library/src/scala/collection/convert/AsJavaConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/AsJavaExtensions.scala
+++ b/library/src/scala/collection/convert/AsJavaExtensions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/AsScalaConverters.scala
+++ b/library/src/scala/collection/convert/AsScalaConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/AsScalaExtensions.scala
+++ b/library/src/scala/collection/convert/AsScalaExtensions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/ImplicitConversions.scala
+++ b/library/src/scala/collection/convert/ImplicitConversions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/library/src/scala/collection/convert/JavaCollectionWrappers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/StreamExtensions.scala
+++ b/library/src/scala/collection/convert/StreamExtensions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/ArrayStepper.scala
+++ b/library/src/scala/collection/convert/impl/ArrayStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
+++ b/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/BitSetStepper.scala
+++ b/library/src/scala/collection/convert/impl/BitSetStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/ChampStepper.scala
+++ b/library/src/scala/collection/convert/impl/ChampStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/IndexedSeqStepper.scala
+++ b/library/src/scala/collection/convert/impl/IndexedSeqStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/IteratorStepper.scala
+++ b/library/src/scala/collection/convert/impl/IteratorStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/NumericRangeStepper.scala
+++ b/library/src/scala/collection/convert/impl/NumericRangeStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/RangeStepper.scala
+++ b/library/src/scala/collection/convert/impl/RangeStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/StringStepper.scala
+++ b/library/src/scala/collection/convert/impl/StringStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/TableStepper.scala
+++ b/library/src/scala/collection/convert/impl/TableStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/convert/impl/VectorStepper.scala
+++ b/library/src/scala/collection/convert/impl/VectorStepper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/BitOperations.scala
+++ b/library/src/scala/collection/generic/BitOperations.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/CommonErrors.scala
+++ b/library/src/scala/collection/generic/CommonErrors.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/CommonErrors.scala
+++ b/library/src/scala/collection/generic/CommonErrors.scala
@@ -1,0 +1,29 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection
+package generic
+
+
+/** Some precomputed common errors to reduce the generated code size.
+  */
+private[collection] object CommonErrors {
+  /** IndexOutOfBounds exception with a known max index */
+  @noinline
+  def indexOutOfBounds(index: Int, max: Int): IndexOutOfBoundsException = 
+    new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${max})")
+
+  /** IndexOutOfBounds exception with an unknown max index. */
+  @noinline
+  def indexOutOfBounds(index: Int): IndexOutOfBoundsException = 
+    new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max unknown)")
+}

--- a/library/src/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/library/src/scala/collection/generic/DefaultSerializationProxy.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/library/src/scala/collection/generic/DefaultSerializationProxy.scala
@@ -77,9 +77,9 @@ private[collection] case object SerializeEnd
 trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[_] =>
   protected[this] def writeReplace(): AnyRef = {
     val f: Factory[Any, Any] = this match {
-      case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]
+      case it: scala.collection.SortedMap[_, _] => it.sortedMapFactory.sortedMapFactory[Any, Any](using it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]
       case it: scala.collection.Map[_, _] => it.mapFactory.mapFactory[Any, Any].asInstanceOf[Factory[Any, Any]]
-      case it: scala.collection.SortedSet[_] => it.sortedIterableFactory.evidenceIterableFactory[Any](it.ordering.asInstanceOf[Ordering[Any]])
+      case it: scala.collection.SortedSet[_] => it.sortedIterableFactory.evidenceIterableFactory[Any](using it.ordering.asInstanceOf[Ordering[Any]])
       case it => it.iterableFactory.iterableFactory
     }
     new DefaultSerializationProxy(f, this)

--- a/library/src/scala/collection/generic/IsIterable.scala
+++ b/library/src/scala/collection/generic/IsIterable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/IsIterableOnce.scala
+++ b/library/src/scala/collection/generic/IsIterableOnce.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -75,6 +75,7 @@ object IsMap {
     }
 
   // AnyRefMap has stricter bounds than the ones used by the mapOpsIsMap definition
+  @deprecated("AnyRefMap is deprecated", "2.13.16")
   implicit def anyRefMapIsMap[K0 <: AnyRef, V0]: IsMap[mutable.AnyRefMap[K0, V0]] { type K = K0; type V = V0; type C = mutable.AnyRefMap[K0, V0] } =
     new IsMap[mutable.AnyRefMap[K0, V0]] {
       type K = K0

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/IsSeq.scala
+++ b/library/src/scala/collection/generic/IsSeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/Subtractable.scala
+++ b/library/src/scala/collection/generic/Subtractable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/generic/package.scala
+++ b/library/src/scala/collection/generic/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -575,7 +575,14 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def apply(i: Int): Float = unsafeArray(i)
     override def hashCode = MurmurHash3.arraySeqHash(unsafeArray)
     override def equals(that: Any) = that match {
-      case that: ofFloat => Arrays.equals(unsafeArray, that.unsafeArray)
+      case that: ofFloat =>
+        val array = unsafeArray
+        val thatArray = that.unsafeArray
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Float] = new ArrayOps.ArrayIterator[Float](unsafeArray)
@@ -610,7 +617,14 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def apply(i: Int): Double = unsafeArray(i)
     override def hashCode = MurmurHash3.arraySeqHash(unsafeArray)
     override def equals(that: Any) = that match {
-      case that: ofDouble => Arrays.equals(unsafeArray, that.unsafeArray)
+      case that: ofDouble =>
+        val array = unsafeArray
+        val thatArray = that.unsafeArray
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Double] = new ArrayOps.ArrayIterator[Double](unsafeArray)

--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/ChampCommon.scala
+++ b/library/src/scala/collection/immutable/ChampCommon.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -1310,7 +1310,7 @@ private final class BitmapIndexedMapNode[K, +V](
         }
       }
     case _: HashCollisionMapNode[_, _] =>
-      throw new Exception("Cannot merge BitmapIndexedMapNode with HashCollisionMapNode")
+      throw new RuntimeException("Cannot merge BitmapIndexedMapNode with HashCollisionMapNode")
   }
 
   override def equals(that: Any): Boolean =
@@ -2061,7 +2061,7 @@ private final class HashCollisionMapNode[K, +V ](
         i += 1
       }
     case _: BitmapIndexedMapNode[K, V1] =>
-      throw new Exception("Cannot merge HashCollisionMapNode with BitmapIndexedMapNode")
+      throw new RuntimeException("Cannot merge HashCollisionMapNode with BitmapIndexedMapNode")
 
   }
 

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -144,7 +144,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
     rootNode.getOrElse(key, keyUnimprovedHash, keyHash, 0, default)
   }
 
-  @`inline` private[this] def newHashMapOrThis[V1 >: V](newRootNode: BitmapIndexedMapNode[K, V1]): HashMap[K, V1] =
+  @inline private[this] def newHashMapOrThis[V1 >: V](newRootNode: BitmapIndexedMapNode[K, V1]): HashMap[K, V1] =
     if (newRootNode eq rootNode) this else new HashMap(newRootNode)
 
   def updated[V1 >: V](key: K, value: V1): HashMap[K, V1] = {
@@ -167,7 +167,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
       else {
         val newNode = rootNode.concat(hm.rootNode, 0)
         if (newNode eq hm.rootNode) hm
-        else newHashMapOrThis(rootNode.concat(hm.rootNode, 0))
+        else newHashMapOrThis(newNode)
       }
     case hm: mutable.HashMap[K @unchecked, V @unchecked] =>
       val iter = hm.nodeIterator
@@ -271,7 +271,7 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
   override def foreachEntry[U](f: (K, V) => U): Unit = rootNode.foreachEntry(f)
 
   /** Applies a function to each key, value, and **original** hash value in this Map */
-  @`inline` private[collection] def foreachWithHash(f: (K, V, Int) => Unit): Unit = rootNode.foreachWithHash(f)
+  @inline private[collection] def foreachWithHash(f: (K, V, Int) => Unit): Unit = rootNode.foreachWithHash(f)
 
   override def equals(that: Any): Boolean =
     that match {
@@ -1326,7 +1326,7 @@ private final class BitmapIndexedMapNode[K, +V](
       case _ => false
     }
 
-  @`inline` private def deepContentEquality(a1: Array[Any], a2: Array[Any], length: Int): Boolean = {
+  @inline private def deepContentEquality(a1: Array[Any], a2: Array[Any], length: Int): Boolean = {
     if (a1 eq a2)
       true
     else {

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -1345,6 +1345,8 @@ private final class BitmapIndexedMapNode[K, +V](
   override def hashCode(): Int =
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
 
+  override def toString = s"${getClass.getName}@${Integer.toHexString(System.identityHashCode(this))}"
+
   override def concat[V1 >: V](that: MapNode[K, V1], shift: Int): BitmapIndexedMapNode[K, V1] = that match {
     case bm: BitmapIndexedMapNode[K, V] @unchecked =>
       if (size == 0) return bm
@@ -2089,6 +2091,8 @@ private final class HashCollisionMapNode[K, +V ](
 
   override def hashCode(): Int =
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
+
+  override def toString = s"${getClass.getName}@${Integer.toHexString(System.identityHashCode(this))}"
 
   override def cachedJavaKeySetHashCode: Int = size * hash
 

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Iterable.scala
+++ b/library/src/scala/collection/immutable/Iterable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/LazyList.scala
+++ b/library/src/scala/collection/immutable/LazyList.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -21,60 +21,60 @@ import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.Statics.releaseFence
 
 /** A class for immutable linked lists representing ordered collections
-  *  of elements of type `A`.
-  *
-  *  This class comes with two implementing case classes `scala.Nil`
-  *  and `scala.::` that implement the abstract members `isEmpty`,
-  *  `head` and `tail`.
-  *
-  *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
-  *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
-  *
-  *  ==Performance==
-  *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
-  *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
-  *
-  *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
-  *  zero- or constant-memory cost.
-  *  {{{
-  *  val mainList = List(3, 2, 1)
-  *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
-  *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
-  *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
-  *  }}}
-  *
-  *  @example {{{
-  *  // Make a list via the companion object factory
-  *  val days = List("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
-  *
-  *  // Make a list element-by-element
-  *  val when = "AM" :: "PM" :: Nil
-  *
-  *  // Pattern match
-  *  days match {
-  *    case firstDay :: otherDays =>
-  *      println("The first day of the week is: " + firstDay)
-  *    case Nil =>
-  *      println("There don't seem to be any week days.")
-  *  }
-  *  }}}
-  *
-  *  @note The functional list is characterized by persistence and structural sharing, thus offering considerable
-  *        performance and space consumption benefits in some scenarios if used correctly.
-  *        However, note that objects having multiple references into the same functional list (that is,
-  *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
-  *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
-  *
-  *  @see  [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
-  *  section on `Lists` for more information.
-  *
-  *  @define coll list
-  *  @define Coll `List`
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  of elements of type `A`.
+ *
+ *  This class comes with two implementing case classes `scala.Nil`
+ *  and `scala.::` that implement the abstract members `isEmpty`,
+ *  `head` and `tail`.
+ *
+ *  This class is optimal for last-in-first-out (LIFO), stack-like access patterns. If you need another access
+ *  pattern, for example, random access or FIFO, consider using a collection more suited to this than `List`.
+ *
+ *  ==Performance==
+ *  '''Time:''' `List` has `O(1)` prepend and head/tail access. Most other operations are `O(n)` on the number of elements in the list.
+ *  This includes the index-based lookup of elements, `length`, `append` and `reverse`.
+ *
+ *  '''Space:''' `List` implements '''structural sharing''' of the tail list. This means that many operations are either
+ *  zero- or constant-memory cost.
+ *  {{{
+ *  val mainList = List(3, 2, 1)
+ *  val with4 =    4 :: mainList  // re-uses mainList, costs one :: instance
+ *  val with42 =   42 :: mainList // also re-uses mainList, cost one :: instance
+ *  val shorter =  mainList.tail  // costs nothing as it uses the same 2::1::Nil instances as mainList
+ *  }}}
+ *
+ *  @example {{{
+ *  // Make a list via the companion object factory
+ *  val days = List("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday")
+ *
+ *  // Make a list element-by-element
+ *  val when = "AM" :: "PM" :: Nil
+ *
+ *  // Pattern match
+ *  days match {
+ *    case firstDay :: otherDays =>
+ *      println("The first day of the week is: " + firstDay)
+ *    case Nil =>
+ *      println("There don't seem to be any week days.")
+ *  }
+ *  }}}
+ *
+ *  @note The functional list is characterized by persistence and structural sharing, thus offering considerable
+ *        performance and space consumption benefits in some scenarios if used correctly.
+ *        However, note that objects having multiple references into the same functional list (that is,
+ *        objects that rely on structural sharing), will be serialized and deserialized with multiple lists, one for
+ *        each reference to it. I.e. structural sharing is lost after serialization/deserialization.
+ *
+ *  @see  [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-immutable-collection-classes.html#lists "Scala's Collection Library overview"]]
+ *  section on `Lists` for more information.
+ *
+ *  @define coll list
+ *  @define Coll `List`
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(3L)
 sealed abstract class List[+A]
   extends AbstractSeq[A]

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -17,7 +17,7 @@ package immutable
 import scala.annotation.unchecked.uncheckedVariance
 import scala.annotation.tailrec
 import mutable.{Builder, ListBuffer}
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.Statics.releaseFence
 
 /** A class for immutable linked lists representing ordered collections
@@ -238,7 +238,7 @@ sealed abstract class List[+A]
     if (i == index && current.nonEmpty) {
       prefix.prependToList(elem :: current.tail)
     } else {
-      throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${length-1})")
+      throw CommonErrors.indexOutOfBounds(index = index, max = length - 1)
     }
   }
 

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -186,17 +186,6 @@ sealed abstract class List[+A]
     h
   }
 
-  /** @inheritdoc
-    *
-    *  @example {{{
-    *  // Given a list
-    *  val letters = List('a','b','c','d','e')
-    *
-    *  // `slice` returns all elements beginning at index `from` and afterwards,
-    *  // up until index `until` (excluding index `until`.)
-    *  letters.slice(1,3) // Returns List('b','c')
-    *  }}}
-    */
   override def slice(from: Int, until: Int): List[A] = {
     val lo = scala.math.max(from, 0)
     if (until <= lo || isEmpty) Nil

--- a/library/src/scala/collection/immutable/ListMap.scala
+++ b/library/src/scala/collection/immutable/ListMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/ListSet.scala
+++ b/library/src/scala/collection/immutable/ListSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -14,6 +14,7 @@ package scala.collection.immutable
 
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, Iterator, Stepper, StepperShape}
+import scala.collection.generic.CommonErrors
 
 /** `NumericRange` is a more generic version of the
   *  `Range` class which works with arbitrary types.
@@ -104,7 +105,8 @@ sealed class NumericRange[T](
 
   @throws[IndexOutOfBoundsException]
   def apply(idx: Int): T = {
-    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${length - 1})")
+    if (idx < 0 || idx >= length)
+      throw CommonErrors.indexOutOfBounds(index = idx, max = length - 1)
     else locationAfterN(idx)
   }
 

--- a/library/src/scala/collection/immutable/Queue.scala
+++ b/library/src/scala/collection/immutable/Queue.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -15,6 +15,7 @@ package collection.immutable
 
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.convert.impl.RangeStepper
+import scala.collection.generic.CommonErrors
 import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, Iterator, Stepper, StepperShape}
 import scala.util.hashing.MurmurHash3
 
@@ -177,7 +178,8 @@ sealed abstract class Range(
   @throws[IndexOutOfBoundsException]
   final def apply(idx: Int): Int = {
     validateMaxLength()
-    if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${numRangeElements-1})")
+    if (idx < 0 || idx >= numRangeElements)
+      throw CommonErrors.indexOutOfBounds(index = idx, max = numRangeElements - 1)
     else start + (step * idx)
   }
 

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -20,42 +20,43 @@ import scala.collection.{AbstractIterator, AnyStepper, IterableFactoryDefaults, 
 import scala.util.hashing.MurmurHash3
 
 /** The `Range` class represents integer values in range
-  *  ''[start;end)'' with non-zero step value `step`.
-  *  It's a special case of an indexed sequence.
-  *  For example:
-  *
-  *  {{{
-  *     val r1 = 0 until 10
-  *     val r2 = r1.start until r1.end by r1.step + 1
-  *     println(r2.length) // = 5
-  *  }}}
-  *
-  *  Ranges that contain more than `Int.MaxValue` elements can be created, but
-  *  these overfull ranges have only limited capabilities. Any method that
-  *  could require a collection of over `Int.MaxValue` length to be created, or
-  *  could be asked to index beyond `Int.MaxValue` elements will throw an
-  *  exception. Overfull ranges can safely be reduced in size by changing
-  *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
-  *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
-  *  `init`) are also permitted on overfull ranges.
-  *
-  *  @param start       the start of this range.
-  *  @param end         the end of the range.  For exclusive ranges, e.g.
-  *                     `Range(0,3)` or `(0 until 3)`, this is one
-  *                     step past the last one in the range.  For inclusive
-  *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
-  *                     it may be in the range if it is not skipped by the step size.
-  *                     To find the last element inside a non-empty range,
-  *                     use `last` instead.
-  *  @param step        the step for the range.
-  *
-  *  @define coll range
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  *  @define doesNotUseBuilders
-  *    '''Note:''' this method does not use builders to construct a new range,
-  *         and its complexity is O(1).
-  */
+ *  ''[start;end)'' with non-zero step value `step`.
+ *  It's a special case of an indexed sequence.
+ *  For example:
+ *
+ *  {{{
+ *     val r1 = 0 until 10
+ *     val r2 = r1.start until r1.end by r1.step + 1
+ *     println(r2.length) // = 5
+ *  }}}
+ *
+ *  Ranges that contain more than `Int.MaxValue` elements can be created, but
+ *  these overfull ranges have only limited capabilities. Any method that
+ *  could require a collection of over `Int.MaxValue` length to be created, or
+ *  could be asked to index beyond `Int.MaxValue` elements will throw an
+ *  exception. Overfull ranges can safely be reduced in size by changing
+ *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
+ *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
+ *  `init`) are also permitted on overfull ranges.
+ *
+ *  @param start       the start of this range.
+ *  @param end         the end of the range.  For exclusive ranges, e.g.
+ *                     `Range(0,3)` or `(0 until 3)`, this is one
+ *                     step past the last one in the range.  For inclusive
+ *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
+ *                     it may be in the range if it is not skipped by the step size.
+ *                     To find the last element inside a non-empty range,
+ *                     use `last` instead.
+ *  @param step        the step for the range.
+ *
+ *  @define coll range
+ *  @define ccoll indexed sequence
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define doesNotUseBuilders
+ *    '''Note:''' this method does not use builders to construct a new range,
+ *         and its complexity is O(1).
+ */
 @SerialVersionUID(3L)
 sealed abstract class Range(
   val start: Int,
@@ -522,11 +523,7 @@ sealed abstract class Range(
     }
 }
 
-/**
-  * Companion object for ranges.
-  *  @define Coll `Range`
-  *  @define coll range
-  */
+/** Companion object for ranges. */
 object Range {
 
   /** Counts the number of range elements.

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -91,10 +91,11 @@ sealed abstract class Range(
   def isInclusive: Boolean
 
   final override val isEmpty: Boolean = (
-    (start > end && step > 0)
-      || (start < end && step < 0)
-      || (start == end && !isInclusive)
-    )
+    if (isInclusive)
+      (if (step >= 0) start > end else start < end)
+    else
+      (if (step >= 0) start >= end else start <= end)
+  )
 
   private[this] val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -57,7 +57,7 @@ import scala.util.hashing.MurmurHash3
  *    '''Note:''' this method does not use builders to construct a new range,
  *         and its complexity is O(1).
  */
-@SerialVersionUID(3L)
+@SerialVersionUID(4L)
 sealed abstract class Range(
   val start: Int,
   val end: Int,
@@ -83,11 +83,6 @@ sealed abstract class Range(
     r.asInstanceOf[S with EfficientSplit]
   }
 
-  private[this] def gap           = end.toLong - start.toLong
-  private[this] def isExact       = gap % step == 0
-  private[this] def hasStub       = isInclusive || !isExact
-  private[this] def longLength    = gap / step + ( if (hasStub) 1 else 0 )
-
   def isInclusive: Boolean
 
   final override val isEmpty: Boolean = (
@@ -97,27 +92,90 @@ sealed abstract class Range(
       (if (step >= 0) start >= end else start <= end)
   )
 
+  if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
+
+  /** Number of elements in this range, if it is non-empty.
+   *
+   *  If the range is empty, `numRangeElements` does not have a meaningful value.
+   *
+   *  Otherwise, `numRangeElements` is interpreted in the range [1, 2^32],
+   *  respecting modular arithmetics wrt. the unsigned interpretation.
+   *  In other words, it is 0 if the mathematical value should be 2^32, and the
+   *  standard unsigned int encoding of the mathematical value otherwise.
+   *
+   *  This interpretation allows to represent all values with the correct
+   *  modular arithmetics, which streamlines the usage sites.
+   */
   private[this] val numRangeElements: Int = {
-    if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
-    else if (isEmpty) 0
-    else {
-      val len = longLength
-      if (len > scala.Int.MaxValue) -1
-      else len.toInt
-    }
+    val stepSign = step >> 31 // if (step >= 0) 0 else -1
+    val gap = ((end - start) ^ stepSign) - stepSign // if (step >= 0) (end - start) else -(end - start)
+    val absStep = (step ^ stepSign) - stepSign // if (step >= 0) step else -step
+
+    /* If `absStep` is a constant 1, `div` collapses to being an alias of
+     * `gap`. Then `absStep * div` also collapses to `gap` and therefore
+     * `absStep * div != gap` constant-folds to `false`.
+     *
+     * Since most ranges are exclusive, that makes `numRangeElements` an alias
+     * of `gap`. Moreover, for exclusive ranges with step 1 and start 0 (which
+     * are the common case), it makes it an alias of `end` and the entire
+     * computation goes away.
+     */
+    val div = Integer.divideUnsigned(gap, absStep)
+    if (isInclusive || (absStep * div != gap)) div + 1 else div
   }
 
-  final def length = if (numRangeElements < 0) fail() else numRangeElements
+  final def length: Int =
+    if (isEmpty) 0
+    else if (numRangeElements > 0) numRangeElements
+    else fail()
 
-  // This field has a sensible value only for non-empty ranges
-  private[this] val lastElement = step match {
-    case 1  => if (isInclusive) end else end-1
-    case -1 => if (isInclusive) end else end+1
-    case _  =>
-      val remainder = (gap % step).toInt
-      if (remainder != 0) end - remainder
-      else if (isInclusive) end
-      else end - step
+  /** Computes the element of this range after `n` steps from `start`.
+   *
+   *  `n` is interpreted as an unsigned integer.
+   *
+   *  If the mathematical result is not within this Range, the result won't
+   *  make sense, but won't error out.
+   */
+  @inline
+  private[this] def locationAfterN(n: Int): Int = {
+    /* If `step >= 0`, we interpret `step * n` as an unsigned multiplication,
+     * and the addition as a mixed `(signed, unsigned) -> signed` operation.
+     * With those interpretation, they do not overflow, assuming the
+     * mathematical result is within this Range.
+     *
+     * If `step < 0`, we should compute `start - (-step * n)`, with the
+     * multiplication also interpreted as unsigned, and the subtraction as
+     * mixed. Again, using those interpretations, they do not overflow.
+     * But then modular arithmetics allow us to cancel out the two `-` signs,
+     * so we end up with the same formula.
+     */
+    start + (step * n)
+  }
+
+  /** Last element of this non-empty range.
+   *
+   *  For empty ranges, this value is nonsensical.
+   */
+  private[this] val lastElement: Int = {
+    /* Since we can assume the range is non-empty, `(numRangeElements - 1)`
+     * is a valid unsigned value in the full int range. The general formula is
+     * therefore `locationAfterN(numRangeElements - 1)`.
+     *
+     * We special-case 1 and -1 so that, in the happy path where `step` is a
+     * constant 1 or -1, and we only use `foreach`, `numRangeElements` is dead
+     * code.
+     *
+     * When `step` is not constant, it is probably 1 or -1 anyway, so the
+     * single branch should be predictably true.
+     *
+     * `step == 1 || step == -1`
+     *   equiv `(step + 1 == 2) || (step + 1 == 0)`
+     *   equiv `((step + 1) & ~2) == 0`
+     */
+    if (((step + 1) & ~2) == 0)
+      (if (isInclusive) end else end - step)
+    else
+      locationAfterN(numRangeElements - 1)
   }
 
   /** The last element of this range.  This method will return the correct value
@@ -171,7 +229,7 @@ sealed abstract class Range(
   // which means it will not fail fast for those cases where failing was
   // correct.
   private[this] def validateMaxLength(): Unit = {
-    if (numRangeElements < 0)
+    if (numRangeElements <= 0 && !isEmpty)
       fail()
   }
   private[this] def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
@@ -179,10 +237,14 @@ sealed abstract class Range(
 
   @throws[IndexOutOfBoundsException]
   final def apply(idx: Int): Int = {
-    validateMaxLength()
-    if (idx < 0 || idx >= numRangeElements)
-      throw CommonErrors.indexOutOfBounds(index = idx, max = numRangeElements - 1)
-    else start + (step * idx)
+    /* If length is not valid, numRangeElements <= 0, so the condition is always true.
+     * We push validateMaxLength() inside the then branch, out of the happy path.
+     */
+    if (idx < 0 || idx >= numRangeElements || isEmpty) {
+      validateMaxLength()
+      val max = if (isEmpty) -1 else numRangeElements - 1
+      throw CommonErrors.indexOutOfBounds(index = idx, max = max)
+    } else locationAfterN(idx)
   }
 
   /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
@@ -230,6 +292,14 @@ sealed abstract class Range(
     case _ => super.sameElements(that)
   }
 
+  /** Is the non-negative value `n` greater or equal to the number of elements
+   *  in this non-empty range?
+   *
+   *  This method returns nonsensical results if `n < 0` or if `this.isEmpty`.
+   */
+  @inline private[this] def greaterEqualNumRangeElements(n: Int): Boolean =
+    (n ^ Int.MinValue) > ((numRangeElements - 1) ^ Int.MinValue) // unsigned comparison
+
   /** Creates a new range containing the first `n` elements of this range.
     *
     *  @param n  the number of elements to take.
@@ -237,12 +307,8 @@ sealed abstract class Range(
     */
   final override def take(n: Int): Range =
     if (n <= 0 || isEmpty) newEmptyRange(start)
-    else if (n >= numRangeElements && numRangeElements >= 0) this
-    else {
-      // May have more than Int.MaxValue elements in range (numRangeElements < 0)
-      // but the logic is the same either way: take the first n
-      new Range.Inclusive(start, locationAfterN(n - 1), step)
-    }
+    else if (greaterEqualNumRangeElements(n)) this
+    else new Range.Inclusive(start, locationAfterN(n - 1), step)
 
   /** Creates a new range containing all the elements of this range except the first `n` elements.
     *
@@ -251,27 +317,17 @@ sealed abstract class Range(
     */
   final override def drop(n: Int): Range =
     if (n <= 0 || isEmpty) this
-    else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
-    else {
-      // May have more than Int.MaxValue elements (numRangeElements < 0)
-      // but the logic is the same either way: go forwards n steps, keep the rest
-      copy(locationAfterN(n), end, step)
-    }
+    else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
+    else copy(locationAfterN(n), end, step)
 
   /** Creates a new range consisting of the last `n` elements of the range.
     *
     *  $doesNotUseBuilders
     */
   final override def takeRight(n: Int): Range = {
-    if (n <= 0) newEmptyRange(start)
-    else if (numRangeElements >= 0) drop(numRangeElements - n)
-    else {
-      // Need to handle over-full range separately
-      val y = last
-      val x = y - step.toLong*(n-1)
-      if ((step > 0 && x < start) || (step < 0 && x > start)) this
-      else Range.inclusive(x.toInt, y, step)
-    }
+    if (n <= 0 || isEmpty) newEmptyRange(start)
+    else if (greaterEqualNumRangeElements(n)) this
+    else copy(locationAfterN(numRangeElements - n), end, step)
   }
 
   /** Creates a new range consisting of the initial `length - n` elements of the range.
@@ -279,14 +335,9 @@ sealed abstract class Range(
     *  $doesNotUseBuilders
     */
   final override def dropRight(n: Int): Range = {
-    if (n <= 0) this
-    else if (numRangeElements >= 0) take(numRangeElements - n)
-    else {
-      // Need to handle over-full range separately
-      val y = last - step.toInt*n
-      if ((step > 0 && y < start) || (step < 0 && y > start)) newEmptyRange(start)
-      else Range.inclusive(start, y.toInt, step)
-    }
+    if (n <= 0 || isEmpty) this
+    else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
+    else Range.inclusive(start, locationAfterN(numRangeElements - 1 - n), step)
   }
 
   // Advance from the start while we meet the given test
@@ -340,8 +391,9 @@ sealed abstract class Range(
     *  @return   a new range consisting of a contiguous interval of values in the old range
     */
   final override def slice(from: Int, until: Int): Range =
-    if (from <= 0) take(until)
-    else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
+    if (isEmpty) this
+    else if (from <= 0) take(until)
+    else if (greaterEqualNumRangeElements(until) && until >= 0) drop(from)
     else {
       val fromValue = locationAfterN(from)
       if (from >= until) newEmptyRange(fromValue)
@@ -350,10 +402,6 @@ sealed abstract class Range(
 
   // Overridden only to refine the return type
   final override def splitAt(n: Int): (Range, Range) = (take(n), drop(n))
-
-  // Methods like apply throw exceptions on invalid n, but methods like take/drop
-  // are forgiving: therefore the checks are with the methods.
-  private[this] def locationAfterN(n: Int) = start + (step * n)
 
   // When one drops everything.  Can't ever have unchecked operations
   // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
@@ -374,13 +422,13 @@ sealed abstract class Range(
     else new Range.Inclusive(start, end, step)
 
   final def contains(x: Int): Boolean = {
-    if (x == end && !isInclusive) false
+    if (isEmpty) false
     else if (step > 0) {
-      if (x < start || x > end) false
+      if (x < start || x > lastElement) false
       else (step == 1) || (Integer.remainderUnsigned(x - start, step) == 0)
     }
     else {
-      if (x < end || x > start) false
+      if (x > start || x < lastElement) false
       else (step == -1) || (Integer.remainderUnsigned(start - x, -step) == 0)
     }
   }
@@ -483,7 +531,12 @@ sealed abstract class Range(
   final override def toString: String = {
     val preposition = if (isInclusive) "to" else "until"
     val stepped = if (step == 1) "" else s" by $step"
-    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+
+    def isInexact =
+      if (isInclusive) lastElement != end
+      else (lastElement + step) != end
+
+    val prefix = if (isEmpty) "empty " else if (isInexact) "inexact " else ""
     s"${prefix}Range $start $preposition $end$stepped"
   }
 
@@ -543,16 +596,19 @@ object Range {
 
     if (isEmpty) 0
     else {
-      // Counts with Longs so we can recognize too-large ranges.
-      val gap: Long    = end.toLong - start.toLong
-      val jumps: Long  = gap / step
-      // Whether the size of this range is one larger than the
-      // number of full-sized jumps.
-      val hasStub      = isInclusive || (gap % step != 0)
-      val result: Long = jumps + ( if (hasStub) 1 else 0 )
+      val stepSign = step >> 31 // if (step >= 0) 0 else -1
+      val gap = ((end - start) ^ stepSign) - stepSign // if (step >= 0) (end - start) else -(end - start)
+      val absStep = (step ^ stepSign) - stepSign // if (step >= 0) step else -step
 
-      if (result > scala.Int.MaxValue) -1
-      else result.toInt
+      val div = Integer.divideUnsigned(gap, absStep)
+      if (isInclusive) {
+        if (div == -1) // max unsigned int
+          -1 // corner case: there are 2^32 elements, which would overflow to 0
+        else
+          div + 1
+      } else {
+        if (absStep * div != gap) div + 1 else div
+      }
     }
   }
   def count(start: Int, end: Int, step: Int): Int =
@@ -576,12 +632,12 @@ object Range {
     */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
-  @SerialVersionUID(3L)
+  @SerialVersionUID(4L)
   final class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
     def isInclusive: Boolean = true
   }
 
-  @SerialVersionUID(3L)
+  @SerialVersionUID(4L)
   final class Exclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
     def isInclusive: Boolean = false
   }
@@ -635,7 +691,7 @@ object Range {
   * @param lastElement The last element included in the Range
   * @param initiallyEmpty Whether the Range was initially empty or not
   */
-@SerialVersionUID(3L)
+@SerialVersionUID(4L)
 private class RangeIterator(
   start: Int,
   step: Int,

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -1236,7 +1236,7 @@ private[collection] object RedBlackTree {
     if((t1 eq null) || (t2 eq null)) t1
     else if (t1 eq t2) null
     else {
-      val (l1, _, r1, k1) = split(t1, t2.key)
+      val (l1, _, r1, _) = split(t1, t2.key)
       val tl = _difference(l1, t2.left)
       val tr = _difference(r1, t2.right)
       join2(tl, tr)

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -19,12 +19,12 @@ import scala.annotation.tailrec
 import scala.runtime.Statics.releaseFence
 
 /** An object containing the RedBlack tree implementation used by for `TreeMaps` and `TreeSets`.
-  *
-  *  Implementation note: since efficiency is important for data structures this implementation
-  *  uses `null` to represent empty trees. This also means pattern matching cannot
-  *  easily be used. The API represented by the RedBlackTree object tries to hide these
-  *  optimizations behind a reasonably clean API.
-  */
+ *
+ *  Implementation note: since efficiency is important for data structures this implementation
+ *  uses `null` to represent empty trees. This also means pattern matching cannot
+ *  easily be used. The API represented by the RedBlackTree object tries to hide these
+ *  optimizations behind a reasonably clean API.
+ */
 private[collection] object RedBlackTree {
   def validate[A](tree: Tree[A, _])(implicit ordering: Ordering[A]): tree.type = {
     def impl(tree: Tree[A, _], keyProp: A => Boolean): Int = {

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/SeqMap.scala
+++ b/library/src/scala/collection/immutable/SeqMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/SortedMap.scala
+++ b/library/src/scala/collection/immutable/SortedMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/SortedSet.scala
+++ b/library/src/scala/collection/immutable/SortedSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -14,6 +14,8 @@ package scala
 package collection
 package immutable
 
+import scala.collection.generic.CommonErrors
+
 /** Trait that overrides operations to take advantage of strict builders.
  */
 trait StrictOptimizedSeqOps[+A, +CC[_], +C]
@@ -38,7 +40,11 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
   }
 
   override def updated[B >: A](index: Int, elem: B): CC[B] = {
-    if (index < 0) throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${if (knownSize>=0) knownSize else "unknown"})")
+    if (index < 0)
+      throw (
+        if (knownSize >= 0) CommonErrors.indexOutOfBounds(index = index, max = knownSize)
+        else CommonErrors.indexOutOfBounds(index = index)
+      )
     val b = iterableFactory.newBuilder[B]
     b.sizeHint(this)
     var i = 0
@@ -47,7 +53,8 @@ trait StrictOptimizedSeqOps[+A, +CC[_], +C]
       b += it.next()
       i += 1
     }
-    if (!it.hasNext) throw new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${i-1})")
+    if (!it.hasNext)
+      throw CommonErrors.indexOutOfBounds(index = index, max = i - 1)
     b += elem
     it.next()
     while (it.hasNext) b += it.next()

--- a/library/src/scala/collection/immutable/TreeMap.scala
+++ b/library/src/scala/collection/immutable/TreeMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/TreeMap.scala
+++ b/library/src/scala/collection/immutable/TreeMap.scala
@@ -132,6 +132,16 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V])(implicit va
     else resultOrNull.value
   }
 
+  // override for performance -- no Some allocation
+  override def apply(key: K): V = {
+    val resultOrNull = RB.lookup(tree, key)
+    if (resultOrNull eq null) default(key)
+    else resultOrNull.value
+  }
+
+  // override for performance -- no Some allocation
+  override def contains(key: K): Boolean = RB.contains(tree, key)
+
   def removed(key: K): TreeMap[K,V] =
     newMapOrSelf(RB.delete(tree, key))
 

--- a/library/src/scala/collection/immutable/TreeSeqMap.scala
+++ b/library/src/scala/collection/immutable/TreeSeqMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/TreeSeqMap.scala
+++ b/library/src/scala/collection/immutable/TreeSeqMap.scala
@@ -392,10 +392,11 @@ object TreeSeqMap extends MapFactory[TreeSeqMap] {
 
       if (it != Zero) push(it)
 
-      def hasNext = index != 0
+      def hasNext = index > 0
       @tailrec
       def next(): V =
-        pop match {
+        if (!hasNext) scala.collection.Iterator.empty.next()
+        else pop match {
           case Bin(_,_, Tip(_, v), right) =>
             push(right)
             v

--- a/library/src/scala/collection/immutable/TreeSet.scala
+++ b/library/src/scala/collection/immutable/TreeSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -20,7 +20,7 @@ import java.util.{Arrays, Spliterator}
 import scala.annotation.switch
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.Stepper.EfficientSplit
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.collection.immutable.VectorInline._
 import scala.collection.immutable.VectorStatics._
 import scala.collection.mutable.ReusableBuilder
@@ -283,7 +283,7 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   }
 
   protected[this] def ioob(index: Int): IndexOutOfBoundsException =
-    new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${length-1})")
+    CommonErrors.indexOutOfBounds(index = index, max = length - 1)
 
   override final def head: A =
     if (prefix1.length == 0) throw new NoSuchElementException("empty.head")

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -81,8 +81,9 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
   }
 
   private val defaultApplyPreferredMaxLength: Int =
-    try System.getProperty("scala.collection.immutable.Vector.defaultApplyPreferredMaxLength",
-      "250").toInt
+    // explicit StringOps to avoid initialization cycle with Predef (scala/bug#13009)
+    try new StringOps(System.getProperty("scala.collection.immutable.Vector.defaultApplyPreferredMaxLength",
+      "250")).toInt
     catch {
       case _: SecurityException => 250
     }

--- a/library/src/scala/collection/immutable/VectorMap.scala
+++ b/library/src/scala/collection/immutable/VectorMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/WrappedString.scala
+++ b/library/src/scala/collection/immutable/WrappedString.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/immutable/package.scala
+++ b/library/src/scala/collection/immutable/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/AnyRefMap.scala
+++ b/library/src/scala/collection/mutable/AnyRefMap.scala
@@ -14,6 +14,7 @@ package scala
 package collection
 package mutable
 
+import scala.annotation.meta.companionClass
 import scala.annotation.nowarn
 import scala.collection.generic.DefaultSerializationProxy
 import scala.language.implicitConversions
@@ -41,6 +42,7 @@ import scala.language.implicitConversions
  *  rapidly as 2^30^ is approached.
  *
  */
+@(deprecated @companionClass)("Use `scala.collection.mutable.HashMap` instead for better performance.", since = "2.13.16")
 class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initialBufferSize: Int, initBlank: Boolean)
   extends AbstractMap[K, V]
     with MapOps[K, V, Map, AnyRefMap[K, V]]
@@ -521,6 +523,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K => V, initi
   override protected[this] def stringPrefix = "AnyRefMap"
 }
 
+@deprecated("Use `scala.collection.mutable.HashMap` instead for better performance.", since = "2.13.16")
 object AnyRefMap {
   private final val IndexMask  = 0x3FFFFFFF
   private final val MissingBit = 0x80000000

--- a/library/src/scala/collection/mutable/AnyRefMap.scala
+++ b/library/src/scala/collection/mutable/AnyRefMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -317,9 +317,9 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
    *   - Throws an exception if `targetLen` exceeds `VM_MaxArraySize` or is negative (overflow).
    */
   private[mutable] def resizeUp(arrayLen: Int, targetLen: Int): Int =
-    if (targetLen < 0) throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
+    if (targetLen < 0) throw new RuntimeException(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
     else if (targetLen <= arrayLen) -1
-    else if (targetLen > VM_MaxArraySize) throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
+    else if (targetLen > VM_MaxArraySize) throw new RuntimeException(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
     else if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
     else math.max(targetLen, math.max(arrayLen * 2, DefaultInitialSize))
 

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -269,9 +269,16 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override def foldRight[B](z: B)(op: (A, B) => B): B = foldr(0, length, z, op)
 
-  override def reduceLeft[B >: A](op: (B, A) => B): B = if (length > 0) foldl(1, length, array(0).asInstanceOf[B], op) else super.reduceLeft(op)
+  override def reduceLeft[B >: A](op: (B, A) => B): B =
+    if (length > 0) foldl(1, length, array(0).asInstanceOf[B], op)
+    else super.reduceLeft(op)
 
-  override def reduceRight[B >: A](op: (A, B) => B): B = if (length > 0) foldr(0, length - 1, array(length - 1).asInstanceOf[B], op) else super.reduceRight(op)
+  override def reduceRight[B >: A](op: (A, B) => B): B =
+    if (length > 0) foldr(0, length - 1, array(length - 1).asInstanceOf[B], op)
+    else super.reduceRight(op)
+
+  override def sliding(size: Int, step: Int): Iterator[ArrayBuffer[A]] =
+    new MutationTracker.CheckedIterator(super.sliding(size = size, step = step), mutationCount)
 }
 
 /**

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -17,7 +17,7 @@ package mutable
 import java.util.Arrays
 import scala.annotation.{nowarn, tailrec}
 import scala.collection.Stepper.EfficientSplit
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.PStatics.VM_MaxArraySize
 
 /** An implementation of the `Buffer` class using an array to
@@ -99,8 +99,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
     array = ArrayBuffer.downsize(array, requiredLength)
 
   @inline private def checkWithinBounds(lo: Int, hi: Int) = {
-    if (lo < 0) throw new IndexOutOfBoundsException(s"$lo is out of bounds (min 0, max ${size0 - 1})")
-    if (hi > size0) throw new IndexOutOfBoundsException(s"${hi - 1} is out of bounds (min 0, max ${size0 - 1})")
+    if (lo < 0) throw CommonErrors.indexOutOfBounds(index = lo, max = size0 - 1)
+    if (hi > size0) throw CommonErrors.indexOutOfBounds(index = hi - 1, max = size0 - 1)
   }
 
   def apply(n: Int): A = {

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -21,23 +21,22 @@ import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.runtime.PStatics.VM_MaxArraySize
 
 /** An implementation of the `Buffer` class using an array to
-  *  represent the assembled sequence internally. Append, update and random
-  *  access take constant time (amortized time). Prepends and removes are
-  *  linear in the buffer size.
-  *
-  *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
-  *  section on `Array Buffers` for more information.
-
-  *
-  *  @tparam A    the type of this arraybuffer's elements.
-  *
-  *  @define Coll `mutable.ArrayBuffer`
-  *  @define coll array buffer
-  *  @define orderDependent
-  *  @define orderDependentFold
-  *  @define mayNotTerminateInf
-  *  @define willNotTerminateInf
-  */
+ *  represent the assembled sequence internally. Append, update and random
+ *  access take constant time (amortized time). Prepends and removes are
+ *  linear in the buffer size.
+ *
+ *  @see [[https://docs.scala-lang.org/overviews/collections-2.13/concrete-mutable-collection-classes.html#array-buffers "Scala's Collection Library overview"]]
+ *  section on `Array Buffers` for more information.
+ *
+ *  @tparam A    the type of this arraybuffer's elements.
+ *
+ *  @define Coll `mutable.ArrayBuffer`
+ *  @define coll array buffer
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
 @SerialVersionUID(-1582447879429021880L)
 class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   extends AbstractBuffer[A]

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -140,9 +140,9 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   def addOne(elem: A): this.type = {
     mutationCount += 1
     val newSize = size0 + 1
-    ensureSize(newSize)
+    if(array.length <= newSize - 1) ensureSize(newSize)
     size0 = newSize
-    this(size0 - 1) = elem
+    array(newSize - 1) = elem.asInstanceOf[AnyRef]
     this
   }
 

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -192,7 +192,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
           //     the previous line
           //   - `copyElemsToArray` will call `System.arraycopy`
           //   - `System.arraycopy` will effectively "read" all the values before
-          //     overwriting any of them when two arrays are the the same reference
+          //     overwriting any of them when two arrays are the same reference
           val actual = IterableOnce.copyElemsToArray(elems, array.asInstanceOf[Array[Any]], index, elemsLength)
           if (actual != elemsLength) throw new IllegalStateException(s"Copied $actual of $elemsLength")
           size0 = len + elemsLength // update size AFTER the copy, in case we're inserting a proxy

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -316,20 +316,12 @@ object ArrayBuffer extends StrictOptimizedSeqFactory[ArrayBuffer] {
    *   - `max(targetLen, arrayLen * 2, DefaultInitialSize)`.
    *   - Throws an exception if `targetLen` exceeds `VM_MaxArraySize` or is negative (overflow).
    */
-  private[mutable] def resizeUp(arrayLen: Int, targetLen: Int): Int = {
-    def checkArrayLengthLimit(): Unit =
-      if (targetLen > VM_MaxArraySize)
-        throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
-      else if (targetLen < 0)
-        throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
-
-    if (targetLen > 0 && targetLen <= arrayLen) -1
-    else {
-      checkArrayLengthLimit()
-      if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
-      else math.max(targetLen, math.max(arrayLen * 2, DefaultInitialSize))
-    }
-  }
+  private[mutable] def resizeUp(arrayLen: Int, targetLen: Int): Int =
+    if (targetLen < 0) throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
+    else if (targetLen <= arrayLen) -1
+    else if (targetLen > VM_MaxArraySize) throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
+    else if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
+    else math.max(targetLen, math.max(arrayLen * 2, DefaultInitialSize))
 
   // if necessary, copy (curSize elements of) the array to a new array of capacity n.
   // Should use Array.copyOf(array, resizeEnsuring(array.length))?

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -46,7 +46,7 @@ sealed abstract class ArrayBuilder[T]
   protected[this] def resize(size: Int): Unit
 
   /** Add all elements of an array. */
-  def addAll(xs: Array[_ <: T]): this.type = doAddAll(xs, 0, xs.length)
+  def addAll(xs: Array[_ <: T]): this.type = addAll(xs, 0, xs.length)
 
   /** Add a slice of an array. */
   def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -16,7 +16,7 @@ package mutable
 
 import scala.annotation.nowarn
 import scala.collection.Stepper.EfficientSplit
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.reflect.ClassTag
 
 /** An implementation of a double-ended queue that internally uses a resizable circular buffer.
@@ -580,7 +580,8 @@ trait ArrayDequeOps[A, +CC[_], +C <: AnyRef] extends StrictOptimizedSeqOps[A, CC
   protected def start_+(idx: Int): Int
 
   @inline protected final def requireBounds(idx: Int, until: Int = length): Unit =
-    if (idx < 0 || idx >= until) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${until-1})")
+    if (idx < 0 || idx >= until)
+      throw CommonErrors.indexOutOfBounds(index = idx, max = until - 1)
 
   /**
     * This is a more general version of copyToArray - this also accepts a srcStart unlike copyToArray

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -633,16 +633,8 @@ trait ArrayDequeOps[A, +CC[_], +C <: AnyRef] extends StrictOptimizedSeqOps[A, CC
     }
   }
 
-  override def sliding(window: Int, step: Int): Iterator[C] = {
-    require(window > 0 && step > 0, s"window=$window and step=$step, but both must be positive")
-    length match {
-      case 0 => Iterator.empty
-      case n if n <= window => Iterator.single(slice(0, length))
-      case n =>
-        val lag = if (window > step) window - step else 0
-        Iterator.range(start = 0, end = n - lag, step = step).map(i => slice(i, i + window))
-    }
-  }
+  override def sliding(@deprecatedName("window") size: Int, step: Int): Iterator[C] =
+    super.sliding(size = size, step = step)
 
   override def grouped(n: Int): Iterator[C] = sliding(n, n)
 }

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -42,13 +42,13 @@ sealed abstract class ArraySeq[T]
   override def iterableFactory: scala.collection.SeqFactory[ArraySeq] = ArraySeq.untagged
 
   override protected def fromSpecific(coll: scala.collection.IterableOnce[T]): ArraySeq[T] = {
-    val b = ArrayBuilder.make(elemTag).asInstanceOf[ArrayBuilder[T]]
+    val b = ArrayBuilder.make(using elemTag).asInstanceOf[ArrayBuilder[T]]
     b.sizeHint(coll, delta = 0)
     b ++= coll
     ArraySeq.make(b.result())
   }
-  override protected def newSpecificBuilder: Builder[T, ArraySeq[T]] = ArraySeq.newBuilder(elemTag).asInstanceOf[Builder[T, ArraySeq[T]]]
-  override def empty: ArraySeq[T] = ArraySeq.empty(elemTag.asInstanceOf[ClassTag[T]])
+  override protected def newSpecificBuilder: Builder[T, ArraySeq[T]] = ArraySeq.newBuilder(using elemTag).asInstanceOf[Builder[T, ArraySeq[T]]]
+  override def empty: ArraySeq[T] = ArraySeq.empty(using elemTag.asInstanceOf[ClassTag[T]])
 
   /** The tag of the element type. This does not have to be equal to the element type of this ArraySeq. A primitive
     * ArraySeq can be backed by an array of boxed values and a reference ArraySeq can be backed by an array of a supertype

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -286,7 +286,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def update(index: Int, elem: Float): Unit = { array(index) = elem }
     override def hashCode = MurmurHash3.arraySeqHash(array)
     override def equals(that: Any) = that match {
-      case that: ofFloat => Arrays.equals(array, that.array)
+      case that: ofFloat =>
+        val thatArray = that.array
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Float] = new ArrayOps.ArrayIterator[Float](array)
@@ -306,7 +312,13 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
     def update(index: Int, elem: Double): Unit = { array(index) = elem }
     override def hashCode = MurmurHash3.arraySeqHash(array)
     override def equals(that: Any) = that match {
-      case that: ofDouble => Arrays.equals(array, that.array)
+      case that: ofDouble =>
+        val thatArray = that.array
+        (array eq thatArray) || array.length == thatArray.length && {
+          var i = 0
+          while (i < array.length && array(i) == thatArray(i)) i += 1
+          i >= array.length
+        }
       case _ => super.equals(that)
     }
     override def iterator: Iterator[Double] = new ArrayOps.ArrayIterator[Double](array)

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Buffer.scala
+++ b/library/src/scala/collection/mutable/Buffer.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Buffer.scala
+++ b/library/src/scala/collection/mutable/Buffer.scala
@@ -16,7 +16,11 @@ package mutable
 import scala.annotation.nowarn
 
 
-/** A `Buffer` is a growable and shrinkable `Seq`. */
+/** A `Buffer` is a growable and shrinkable `Seq`.
+ *
+ *  @define coll buffer
+ *  @define Coll `Buffer`
+ */
 trait Buffer[A]
   extends Seq[A]
     with SeqOps[A, Buffer, Buffer[A]]

--- a/library/src/scala/collection/mutable/Builder.scala
+++ b/library/src/scala/collection/mutable/Builder.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Builder.scala
+++ b/library/src/scala/collection/mutable/Builder.scala
@@ -91,7 +91,7 @@ trait Builder[-A, +To] extends Growable[A] { self =>
     }
   }
 
-  /** A builder resulting from this builder my mapping the result using `f`. */
+  /** A builder resulting from this builder by mapping the result using `f`. */
   def mapResult[NewTo](f: To => NewTo): Builder[A, NewTo] = new Builder[A, NewTo] {
     def addOne(x: A): this.type = { self += x; this }
     def clear(): Unit = self.clear()

--- a/library/src/scala/collection/mutable/CheckedIndexedSeqView.scala
+++ b/library/src/scala/collection/mutable/CheckedIndexedSeqView.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Cloneable.scala
+++ b/library/src/scala/collection/mutable/Cloneable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -766,7 +766,7 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
   @SerialVersionUID(3L)
   private final class DeserializationFactory[K, V](val tableLength: Int, val loadFactor: Double, val ordering: Ordering[K]) extends Factory[(K, V), CollisionProofHashMap[K, V]] with Serializable {
     def fromSpecific(it: IterableOnce[(K, V)]): CollisionProofHashMap[K, V] = new CollisionProofHashMap[K, V](tableLength, loadFactor)(ordering) ++= it
-    def newBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] = CollisionProofHashMap.newBuilder(tableLength, loadFactor)(ordering)
+    def newBuilder: Builder[(K, V), CollisionProofHashMap[K, V]] = CollisionProofHashMap.newBuilder(tableLength, loadFactor)(using ordering)
   }
 
   @unused @`inline` private def compare[K, V](key: K, hash: Int, node: LLNode[K, V])(implicit ord: Ordering[K]): Int = {

--- a/library/src/scala/collection/mutable/Growable.scala
+++ b/library/src/scala/collection/mutable/Growable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/GrowableBuilder.scala
+++ b/library/src/scala/collection/mutable/GrowableBuilder.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/HashMap.scala
+++ b/library/src/scala/collection/mutable/HashMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/HashTable.scala
+++ b/library/src/scala/collection/mutable/HashTable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ImmutableBuilder.scala
+++ b/library/src/scala/collection/mutable/ImmutableBuilder.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Iterable.scala
+++ b/library/src/scala/collection/mutable/Iterable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/LinkedHashMap.scala
+++ b/library/src/scala/collection/mutable/LinkedHashMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/LinkedHashSet.scala
+++ b/library/src/scala/collection/mutable/LinkedHashSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -14,6 +14,7 @@ package scala.collection
 package mutable
 
 import scala.annotation.{nowarn, tailrec}
+import scala.collection.generic.CommonErrors
 import scala.collection.immutable.{::, List, Nil}
 import java.lang.{IllegalArgumentException, IndexOutOfBoundsException}
 
@@ -203,7 +204,7 @@ class ListBuffer[A]
 
   def update(idx: Int, elem: A): Unit = {
     ensureUnaliased()
-    if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx >= len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     if (idx == 0) {
       val newElem = new :: (elem, first.tail)
       if (last0 eq first) {
@@ -223,7 +224,7 @@ class ListBuffer[A]
 
   def insert(idx: Int, elem: A): Unit = {
     ensureUnaliased()
-    if (idx < 0 || idx > len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx > len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     if (idx == len) addOne(elem)
     else {
       val p = locate(idx)
@@ -250,7 +251,7 @@ class ListBuffer[A]
   }
 
   def insertAll(idx: Int, elems: IterableOnce[A]): Unit = {
-    if (idx < 0 || idx > len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx > len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     val it = elems.iterator
     if (it.hasNext) {
       if (idx == len) addAll(it)
@@ -264,7 +265,7 @@ class ListBuffer[A]
 
   def remove(idx: Int): A = {
     ensureUnaliased()
-    if (idx < 0 || idx >= len) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${len-1})")
+    if (idx < 0 || idx >= len) throw CommonErrors.indexOutOfBounds(index = idx, max = len - 1)
     val p = locate(idx)
     val nx = getNext(p)
     if(p eq null) {
@@ -281,7 +282,7 @@ class ListBuffer[A]
   def remove(idx: Int, count: Int): Unit =
     if (count > 0) {
       ensureUnaliased()
-      if (idx < 0 || idx + count > len) throw new IndexOutOfBoundsException(s"$idx to ${idx + count} is out of bounds (min 0, max ${len-1})")
+      if (idx < 0 || idx + count > len) throw new IndexOutOfBoundsException(s"$idx to ${idx + count} is out of bounds (min 0, max ${len - 1})")
       removeAfter(locate(idx), count)
     } else if (count < 0) {
       throw new IllegalArgumentException("removing negative number of elements: " + count)

--- a/library/src/scala/collection/mutable/ListMap.scala
+++ b/library/src/scala/collection/mutable/ListMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -128,11 +128,11 @@ trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, _], +C <: MapOps[K, V, CC, C]]
 
   /** If given key is already in this map, returns associated value.
    *
-   *  Otherwise, computes value from given expression `op`, stores with key
+   *  Otherwise, computes value from given expression `defaultValue`, stores with key
    *  in map and returns that value.
    *
-   *  Concurrent map implementations may evaluate the expression `op`
-   *  multiple times, or may evaluate `op` without inserting the result.
+   *  Concurrent map implementations may evaluate the expression `defaultValue`
+   *  multiple times, or may evaluate `defaultValue` without inserting the result.
    *
    *  @param  key the key to test
    *  @param  defaultValue  the computation yielding the value to associate with `key`, if

--- a/library/src/scala/collection/mutable/MultiMap.scala
+++ b/library/src/scala/collection/mutable/MultiMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/MutationTracker.scala
+++ b/library/src/scala/collection/mutable/MutationTracker.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/OpenHashMap.scala
+++ b/library/src/scala/collection/mutable/OpenHashMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/PriorityQueue.scala
+++ b/library/src/scala/collection/mutable/PriorityQueue.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Queue.scala
+++ b/library/src/scala/collection/mutable/Queue.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/RedBlackTree.scala
+++ b/library/src/scala/collection/mutable/RedBlackTree.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/ReusableBuilder.scala
+++ b/library/src/scala/collection/mutable/ReusableBuilder.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Seq.scala
+++ b/library/src/scala/collection/mutable/Seq.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/SeqMap.scala
+++ b/library/src/scala/collection/mutable/SeqMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Shrinkable.scala
+++ b/library/src/scala/collection/mutable/Shrinkable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/Shrinkable.scala
+++ b/library/src/scala/collection/mutable/Shrinkable.scala
@@ -16,30 +16,30 @@ package collection.mutable
 import scala.annotation.tailrec
 
 /** This trait forms part of collections that can be reduced
-  *  using a `-=` operator.
-  *
-  *  @define coll shrinkable collection
-  *  @define Coll `Shrinkable`
-  */
+ *  using a `-=` operator.
+ *
+ *  @define coll shrinkable collection
+ *  @define Coll `Shrinkable`
+ */
 trait Shrinkable[-A] {
 
   /** Removes a single element from this $coll.
-    *
-    *  @param elem  the element to remove.
-    *  @return the $coll itself
-    */
+   *
+   *  @param elem  the element to remove.
+   *  @return the $coll itself
+   */
   def subtractOne(elem: A): this.type
 
   /** Alias for `subtractOne` */
   @`inline` final def -= (elem: A): this.type = subtractOne(elem)
 
   /** Removes two or more elements from this $coll.
-    *
-    *  @param elem1 the first element to remove.
-    *  @param elem2 the second element to remove.
-    *  @param elems the remaining elements to remove.
-    *  @return the $coll itself
-    */
+   *
+   *  @param elem1 the first element to remove.
+   *  @param elem2 the second element to remove.
+   *  @param elems the remaining elements to remove.
+   *  @return the $coll itself
+   */
   @deprecated("Use `--=` aka `subtractAll` instead of varargs `-=`; infix operations with an operand of multiple args will be deprecated", "2.13.3")
   def -= (elem1: A, elem2: A, elems: A*): this.type = {
     this -= elem1
@@ -48,10 +48,10 @@ trait Shrinkable[-A] {
   }
 
   /** Removes all elements produced by an iterator from this $coll.
-    *
-    *  @param xs   the iterator producing the elements to remove.
-    *  @return the $coll itself
-    */
+   *
+   *  @param xs   the iterator producing the elements to remove.
+   *  @return the $coll itself
+   */
   def subtractAll(xs: collection.IterableOnce[A]): this.type = {
     @tailrec def loop(xs: collection.LinearSeq[A]): Unit = {
       if (xs.nonEmpty) {

--- a/library/src/scala/collection/mutable/SortedMap.scala
+++ b/library/src/scala/collection/mutable/SortedMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -14,9 +14,8 @@ package scala
 package collection
 package mutable
 
-/**
-  * Base type for mutable sorted set collections
-  */
+/** Base type for mutable sorted set collections
+ */
 trait SortedSet[A]
   extends Set[A]
     with collection.SortedSet[A]
@@ -30,7 +29,7 @@ trait SortedSet[A]
 
 /**
   * @define coll mutable sorted set
-  * @define Coll `mutable.Sortedset`
+  * @define Coll `mutable.SortedSet`
   */
 trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]
@@ -40,9 +39,7 @@ trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
 }
 
 /**
-  * $factoryInfo
-  * @define coll mutable sorted set
-  * @define Coll `mutable.Sortedset`
-  */
+ *  $factoryInfo
+ */
 @SerialVersionUID(3L)
 object SortedSet extends SortedIterableFactory.Delegate[SortedSet](TreeSet)

--- a/library/src/scala/collection/mutable/Stack.scala
+++ b/library/src/scala/collection/mutable/Stack.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/TreeMap.scala
+++ b/library/src/scala/collection/mutable/TreeMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/TreeSet.scala
+++ b/library/src/scala/collection/mutable/TreeSet.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -14,7 +14,7 @@ package scala.collection
 package mutable
 
 import scala.annotation.tailrec
-import scala.collection.generic.DefaultSerializable
+import scala.collection.generic.{CommonErrors, DefaultSerializable}
 import scala.reflect.ClassTag
 import scala.collection.immutable.Nil
 
@@ -158,11 +158,11 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
 
   def apply(idx: Int) =
     if (idx >= 0 && idx < sz) headptr(idx)
-    else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   def update(idx: Int, newelem: T) =
     if (idx >= 0 && idx < sz) headptr(idx) = newelem
-    else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   /** Replace the contents of this $coll with the mapped result.
    *
@@ -178,7 +178,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
     if (idx >= 0 && idx < sz) {
       sz -= 1
       headptr.remove(idx, this)
-    } else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    } else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   @tailrec final def remove(idx: Int, count: Int): Unit =
     if (count > 0) {
@@ -198,7 +198,7 @@ sealed class UnrolledBuffer[T](implicit val tag: ClassTag[T])
   def insertAll(idx: Int, elems: IterableOnce[T]): Unit =
     if (idx >= 0 && idx <= sz) {
       sz += headptr.insertAll(idx, elems, this)
-    } else throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${sz-1})")
+    } else throw CommonErrors.indexOutOfBounds(index = idx, max = sz - 1)
 
   override def subtractOne(elem: T): this.type = {
     if (headptr.subtractOne(elem, this)) {

--- a/library/src/scala/collection/mutable/WeakHashMap.scala
+++ b/library/src/scala/collection/mutable/WeakHashMap.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/mutable/package.scala
+++ b/library/src/scala/collection/mutable/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/collection/package.scala
+++ b/library/src/scala/collection/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/compat/Platform.scala
+++ b/library/src/scala/compat/Platform.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/Awaitable.scala
+++ b/library/src/scala/concurrent/Awaitable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/BatchingExecutor.scala
+++ b/library/src/scala/concurrent/BatchingExecutor.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/BlockContext.scala
+++ b/library/src/scala/concurrent/BlockContext.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/Channel.scala
+++ b/library/src/scala/concurrent/Channel.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/DelayedLazyVal.scala
+++ b/library/src/scala/concurrent/DelayedLazyVal.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/ExecutionContext.scala
+++ b/library/src/scala/concurrent/ExecutionContext.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/Future.scala
+++ b/library/src/scala/concurrent/Future.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/JavaConversions.scala
+++ b/library/src/scala/concurrent/JavaConversions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/Promise.scala
+++ b/library/src/scala/concurrent/Promise.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/SyncChannel.scala
+++ b/library/src/scala/concurrent/SyncChannel.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/SyncVar.scala
+++ b/library/src/scala/concurrent/SyncVar.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/duration/Deadline.scala
+++ b/library/src/scala/concurrent/duration/Deadline.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/duration/Duration.scala
+++ b/library/src/scala/concurrent/duration/Duration.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/duration/DurationConversions.scala
+++ b/library/src/scala/concurrent/duration/DurationConversions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/duration/package.scala
+++ b/library/src/scala/concurrent/duration/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/library/src/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/impl/FutureConvertersImpl.scala
+++ b/library/src/scala/concurrent/impl/FutureConvertersImpl.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/impl/Promise.scala
+++ b/library/src/scala/concurrent/impl/Promise.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/impl/Promise.scala
+++ b/library/src/scala/concurrent/impl/Promise.scala
@@ -255,9 +255,9 @@ private[concurrent] object Promise {
               l.result
             }
           if (r ne null) r
-          else throw new TimeoutException("Future timed out after [" + atMost + "]")
+          else Future.timeoutError(atMost)
         }
-      } else throw new IllegalArgumentException("Cannot wait for Undefined duration of time")
+      } else Future.waitUndefinedError()
 
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])

--- a/library/src/scala/concurrent/package.scala
+++ b/library/src/scala/concurrent/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/concurrent/package.scala
+++ b/library/src/scala/concurrent/package.scala
@@ -12,8 +12,9 @@
 
 package scala
 
-import scala.concurrent.duration.Duration
 import scala.annotation.implicitNotFound
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 /** This package object contains primitives for concurrent and parallel programming.
  *
@@ -170,8 +171,11 @@ package concurrent {
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
     final def ready[T](awaitable: Awaitable[T], atMost: Duration): awaitable.type = awaitable match {
-      case f: Future[T] if f.isCompleted => awaitable.ready(atMost)(AwaitPermission)
-      case _ => blocking(awaitable.ready(atMost)(AwaitPermission))
+      case f: Future[T] if f.isCompleted =>
+        if (atMost eq Duration.Undefined) Future.waitUndefinedError() // preserve semantics, see scala/scala#10972
+        else awaitable
+      case _ =>
+        blocking(awaitable.ready(atMost)(AwaitPermission))
     }
 
     /**
@@ -197,8 +201,18 @@ package concurrent {
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
     final def result[T](awaitable: Awaitable[T], atMost: Duration): T = awaitable match {
-      case f: Future[T] if f.isCompleted => f.result(atMost)(AwaitPermission)
-      case _ => blocking(awaitable.result(atMost)(AwaitPermission))
+      case FutureValue(v) =>
+        if (atMost eq Duration.Undefined) Future.waitUndefinedError() // preserve semantics, see scala/scala#10972
+        else v.get
+      case _ =>
+        blocking(awaitable.result(atMost)(AwaitPermission))
+    }
+
+    private object FutureValue {
+      def unapply[T](a: Awaitable[T]): Option[Try[T]] = a match {
+        case f: Future[T] => f.value
+        case _ => None
+      }
     }
   }
 }

--- a/library/src/scala/deprecated.scala
+++ b/library/src/scala/deprecated.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/deprecatedInheritance.scala
+++ b/library/src/scala/deprecatedInheritance.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/deprecatedName.scala
+++ b/library/src/scala/deprecatedName.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/deprecatedOverriding.scala
+++ b/library/src/scala/deprecatedOverriding.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/inline.scala
+++ b/library/src/scala/inline.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/io/AnsiColor.scala
+++ b/library/src/scala/io/AnsiColor.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/io/BufferedSource.scala
+++ b/library/src/scala/io/BufferedSource.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/io/Codec.scala
+++ b/library/src/scala/io/Codec.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/io/Position.scala
+++ b/library/src/scala/io/Position.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/io/StdIn.scala
+++ b/library/src/scala/io/StdIn.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/Accumulator.scala
+++ b/library/src/scala/jdk/Accumulator.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/AnyAccumulator.scala
+++ b/library/src/scala/jdk/AnyAccumulator.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/CollectionConverters.scala
+++ b/library/src/scala/jdk/CollectionConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/CollectionConverters.scala
+++ b/library/src/scala/jdk/CollectionConverters.scala
@@ -28,7 +28,7 @@ import scala.collection.convert.{AsJavaExtensions, AsScalaExtensions}
   * }}}
   *
   * The conversions return adapters for the corresponding API, i.e., the collections are wrapped,
-  * not converted. Changes to the original collection are reflected in the view, and vice versa:
+  * not copied. Changes to the original collection are reflected in the view, and vice versa:
   *
   * {{{
   *   scala> import scala.jdk.CollectionConverters._

--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -17,6 +17,7 @@ import java.util.Spliterator
 import java.util.function.{Consumer, DoubleConsumer}
 import java.{lang => jl}
 
+import scala.annotation._
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, DoubleStepper, Factory, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
@@ -236,6 +237,7 @@ final class DoubleAccumulator
   }
 
   /** Copies the elements in this `DoubleAccumulator` into an `Array[Double]` */
+  @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Double] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
     val a = new Array[Double](totalSize.toInt)

--- a/library/src/scala/jdk/DurationConverters.scala
+++ b/library/src/scala/jdk/DurationConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/FunctionConverters.scala
+++ b/library/src/scala/jdk/FunctionConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/FunctionExtensions.scala
+++ b/library/src/scala/jdk/FunctionExtensions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/FunctionWrappers.scala
+++ b/library/src/scala/jdk/FunctionWrappers.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/FutureConverters.scala
+++ b/library/src/scala/jdk/FutureConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -17,6 +17,7 @@ import java.util.Spliterator
 import java.util.function.{Consumer, IntConsumer}
 import java.{lang => jl}
 
+import scala.annotation._
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, IntStepper, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
@@ -241,6 +242,7 @@ final class IntAccumulator
   }
 
   /** Copies the elements in this `IntAccumulator` into an `Array[Int]` */
+  @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Int] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
     val a = new Array[Int](totalSize.toInt)

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -17,6 +17,7 @@ import java.util.Spliterator
 import java.util.function.{Consumer, LongConsumer}
 import java.{lang => jl}
 
+import scala.annotation._
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{AnyStepper, Factory, LongStepper, SeqFactory, Stepper, StepperShape, mutable}
 import scala.language.implicitConversions
@@ -236,6 +237,7 @@ final class LongAccumulator
   }
 
   /** Copies the elements in this `LongAccumulator` into an `Array[Long]` */
+  @nowarn // cat=lint-overload see toArray[B: ClassTag]
   def toArray: Array[Long] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
     val a = new Array[Long](totalSize.toInt)

--- a/library/src/scala/jdk/OptionConverters.scala
+++ b/library/src/scala/jdk/OptionConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/OptionShape.scala
+++ b/library/src/scala/jdk/OptionShape.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/StreamConverters.scala
+++ b/library/src/scala/jdk/StreamConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/javaapi/CollectionConverters.scala
+++ b/library/src/scala/jdk/javaapi/CollectionConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/javaapi/CollectionConverters.scala
+++ b/library/src/scala/jdk/javaapi/CollectionConverters.scala
@@ -34,7 +34,7 @@ import scala.collection.convert.{AsJavaConverters, AsScalaConverters}
   * }}}
   *
   * The conversions return adapters for the corresponding API, i.e., the collections are wrapped,
-  * not converted. Changes to the original collection are reflected in the view, and vice versa.
+  * not copied. Changes to the original collection are reflected in the view, and vice versa.
   *
   * The following conversions are supported via `asScala` and `asJava`:
   *

--- a/library/src/scala/jdk/javaapi/DurationConverters.scala
+++ b/library/src/scala/jdk/javaapi/DurationConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/javaapi/FunctionConverters.scala
+++ b/library/src/scala/jdk/javaapi/FunctionConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/javaapi/FutureConverters.scala
+++ b/library/src/scala/jdk/javaapi/FutureConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/javaapi/OptionConverters.scala
+++ b/library/src/scala/jdk/javaapi/OptionConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/javaapi/StreamConverters.scala
+++ b/library/src/scala/jdk/javaapi/StreamConverters.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/jdk/package.scala
+++ b/library/src/scala/jdk/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/languageFeature.scala
+++ b/library/src/scala/languageFeature.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -379,7 +379,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
       else if (_long < 0) BigInt(-1)
       else BigInt(0) // for _long >= 0
     } else BigInt(this.bigInteger.shiftRight(n))
-  
+
   /** Bitwise and of BigInts
    */
   def &(that: BigInt): BigInt =
@@ -501,7 +501,7 @@ final class BigInt private (private var _bigInteger: BigInteger, private val _lo
         (_long & (1L << n)) != 0
       else
         _long < 0 // give the sign bit
-    } else _bigInteger.testBit(n)
+    } else this.bigInteger.testBit(n)
 
   /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set.
    */

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/Fractional.scala
+++ b/library/src/scala/math/Fractional.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/Integral.scala
+++ b/library/src/scala/math/Integral.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -382,8 +382,15 @@ object Ordering extends LowPriorityOrderingImplicits {
 
   /** `Ordering`s for `Float`s.
     *
-    * The behavior of the comparison operations provided by the default (implicit)
-    * ordering on `Float` changed in 2.10.0 and 2.13.0.
+    * The default extends `Ordering.Float.TotalOrdering`.
+    *
+    * `Ordering.Float.TotalOrdering` uses the `java.lang.Float.compare` semantics for all operations.
+    * Scala also provides the `Ordering.Float.IeeeOrdering` semantics. Which uses the IEEE 754 semantics
+    * for float ordering.
+    *
+    * Historically: `IeeeOrdering` was used in Scala from 2.10.x through 2.12.x. This changed in 2.13.0
+    * to `TotalOrdering`.
+    *
     * Prior to Scala 2.10.0, the `Ordering` instance used semantics
     * consistent with `java.lang.Float.compare`.
     *
@@ -394,11 +401,6 @@ object Ordering extends LowPriorityOrderingImplicits {
     * `false` thus `0.0F < Float.NaN`, `0.0F > Float.NaN`, and
     * `Float.NaN == Float.NaN` all yield `false`, analogous `None` in `flatMap`.
     *
-    * Recognizing the limitation of the IEEE 754 semantics in terms of ordering,
-    * Scala 2.13.0 created two instances: `Ordering.Float.IeeeOrdering`, which retains
-    * the IEEE 754 semantics from Scala 2.12.x, and `Ordering.Float.TotalOrdering`,
-    * which brings back the `java.lang.Float.compare` semantics for all operations.
-    * The default extends `TotalOrdering`.
     *
     *  {{{
     *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).sorted      // List(-Infinity, 0.0, 1.0, NaN)

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -69,7 +69,6 @@ import scala.annotation.migration
   *
   * @see [[scala.math.Ordered]], [[scala.util.Sorting]], [[scala.math.Ordering.Implicits]]
   */
-@annotation.implicitNotFound(msg = "No implicit Ordering defined for ${T}.")
 trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable {
   outer =>
 

--- a/library/src/scala/math/PartialOrdering.scala
+++ b/library/src/scala/math/PartialOrdering.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/PartiallyOrdered.scala
+++ b/library/src/scala/math/PartiallyOrdered.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/ScalaNumber.java
+++ b/library/src/scala/math/ScalaNumber.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/ScalaNumericConversions.scala
+++ b/library/src/scala/math/ScalaNumericConversions.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/math/package.scala
+++ b/library/src/scala/math/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/native.scala
+++ b/library/src/scala/native.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/noinline.scala
+++ b/library/src/scala/noinline.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/package.scala
+++ b/library/src/scala/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/ref/PhantomReference.scala
+++ b/library/src/scala/ref/PhantomReference.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/ref/ReferenceQueue.scala
+++ b/library/src/scala/ref/ReferenceQueue.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/ref/ReferenceWrapper.scala
+++ b/library/src/scala/ref/ReferenceWrapper.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/Manifest.scala
+++ b/library/src/scala/reflect/Manifest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/NameTransformer.scala
+++ b/library/src/scala/reflect/NameTransformer.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/NoManifest.scala
+++ b/library/src/scala/reflect/NoManifest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/OptManifest.scala
+++ b/library/src/scala/reflect/OptManifest.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/ScalaLongSignature.java
+++ b/library/src/scala/reflect/ScalaLongSignature.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/ScalaSignature.java
+++ b/library/src/scala/reflect/ScalaSignature.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/macros/internal/macroImpl.scala
+++ b/library/src/scala/reflect/macros/internal/macroImpl.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/reflect/package.scala
+++ b/library/src/scala/reflect/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction0.scala
+++ b/library/src/scala/runtime/AbstractFunction0.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction1.scala
+++ b/library/src/scala/runtime/AbstractFunction1.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction10.scala
+++ b/library/src/scala/runtime/AbstractFunction10.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction11.scala
+++ b/library/src/scala/runtime/AbstractFunction11.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction12.scala
+++ b/library/src/scala/runtime/AbstractFunction12.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction13.scala
+++ b/library/src/scala/runtime/AbstractFunction13.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction14.scala
+++ b/library/src/scala/runtime/AbstractFunction14.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction15.scala
+++ b/library/src/scala/runtime/AbstractFunction15.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction16.scala
+++ b/library/src/scala/runtime/AbstractFunction16.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction17.scala
+++ b/library/src/scala/runtime/AbstractFunction17.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction18.scala
+++ b/library/src/scala/runtime/AbstractFunction18.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction19.scala
+++ b/library/src/scala/runtime/AbstractFunction19.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction2.scala
+++ b/library/src/scala/runtime/AbstractFunction2.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction20.scala
+++ b/library/src/scala/runtime/AbstractFunction20.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction21.scala
+++ b/library/src/scala/runtime/AbstractFunction21.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction22.scala
+++ b/library/src/scala/runtime/AbstractFunction22.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction3.scala
+++ b/library/src/scala/runtime/AbstractFunction3.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction4.scala
+++ b/library/src/scala/runtime/AbstractFunction4.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction5.scala
+++ b/library/src/scala/runtime/AbstractFunction5.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction6.scala
+++ b/library/src/scala/runtime/AbstractFunction6.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction7.scala
+++ b/library/src/scala/runtime/AbstractFunction7.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction8.scala
+++ b/library/src/scala/runtime/AbstractFunction8.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractFunction9.scala
+++ b/library/src/scala/runtime/AbstractFunction9.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/AbstractPartialFunction.scala
+++ b/library/src/scala/runtime/AbstractPartialFunction.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ArrayCharSequence.scala
+++ b/library/src/scala/runtime/ArrayCharSequence.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/BooleanRef.java
+++ b/library/src/scala/runtime/BooleanRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/BoxedUnit.java
+++ b/library/src/scala/runtime/BoxedUnit.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/BoxesRunTime.java
+++ b/library/src/scala/runtime/BoxesRunTime.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ByteRef.java
+++ b/library/src/scala/runtime/ByteRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/CharRef.java
+++ b/library/src/scala/runtime/CharRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ClassValueCompat.scala
+++ b/library/src/scala/runtime/ClassValueCompat.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/DoubleRef.java
+++ b/library/src/scala/runtime/DoubleRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/FloatRef.java
+++ b/library/src/scala/runtime/FloatRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/IntRef.java
+++ b/library/src/scala/runtime/IntRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/LambdaDeserialize.scala
+++ b/library/src/scala/runtime/LambdaDeserialize.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/LazyRef.scala
+++ b/library/src/scala/runtime/LazyRef.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/LongRef.java
+++ b/library/src/scala/runtime/LongRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/MethodCache.scala
+++ b/library/src/scala/runtime/MethodCache.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/MethodHandleConstants.java
+++ b/library/src/scala/runtime/MethodHandleConstants.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ModuleSerializationProxy.scala
+++ b/library/src/scala/runtime/ModuleSerializationProxy.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ModuleSerializationProxy.scala
+++ b/library/src/scala/runtime/ModuleSerializationProxy.scala
@@ -18,7 +18,7 @@ import java.security.PrivilegedExceptionAction
 import scala.annotation.nowarn
 
 private[runtime] object ModuleSerializationProxy {
-  private val instances = new ClassValueCompat[Object] {
+  private val instances: ClassValueCompat[Object] = new ClassValueCompat[Object] {
     @nowarn("cat=deprecation") // AccessController is deprecated on JDK 17
     def getModule(cls: Class[_]): Object =
       java.security.AccessController.doPrivileged(

--- a/library/src/scala/runtime/NonLocalReturnControl.scala
+++ b/library/src/scala/runtime/NonLocalReturnControl.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/Nothing$.scala
+++ b/library/src/scala/runtime/Nothing$.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/Null$.scala
+++ b/library/src/scala/runtime/Null$.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ObjectRef.java
+++ b/library/src/scala/runtime/ObjectRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/PStatics.scala
+++ b/library/src/scala/runtime/PStatics.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichBoolean.scala
+++ b/library/src/scala/runtime/RichBoolean.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichByte.scala
+++ b/library/src/scala/runtime/RichByte.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichChar.scala
+++ b/library/src/scala/runtime/RichChar.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichDouble.scala
+++ b/library/src/scala/runtime/RichDouble.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichFloat.scala
+++ b/library/src/scala/runtime/RichFloat.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichLong.scala
+++ b/library/src/scala/runtime/RichLong.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/RichShort.scala
+++ b/library/src/scala/runtime/RichShort.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ScalaNumberProxy.scala
+++ b/library/src/scala/runtime/ScalaNumberProxy.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -274,22 +274,20 @@ object ScalaRunTime {
       case s => s + "\n"
     }
 
-  // Convert arrays to immutable.ArraySeq for use with Java varargs:
-  def genericWrapArray[T](xs: Array[T]): ArraySeq[T] =
-    if (xs eq null) null
-    else ArraySeq.unsafeWrapArray(xs)
-  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T] = {
-    if (xs eq null) null
-    else if (xs.length == 0) ArraySeq.empty[AnyRef].asInstanceOf[ArraySeq[T]]
-    else new ArraySeq.ofRef[T](xs)
-  }
-  def wrapIntArray(xs: Array[Int]): ArraySeq[Int] = if (xs ne null) new ArraySeq.ofInt(xs) else null
-  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double] = if (xs ne null) new ArraySeq.ofDouble(xs) else null
-  def wrapLongArray(xs: Array[Long]): ArraySeq[Long] = if (xs ne null) new ArraySeq.ofLong(xs) else null
-  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float] = if (xs ne null) new ArraySeq.ofFloat(xs) else null
-  def wrapCharArray(xs: Array[Char]): ArraySeq[Char] = if (xs ne null) new ArraySeq.ofChar(xs) else null
-  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte] = if (xs ne null) new ArraySeq.ofByte(xs) else null
-  def wrapShortArray(xs: Array[Short]): ArraySeq[Short] = if (xs ne null) new ArraySeq.ofShort(xs) else null
-  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = if (xs ne null) new ArraySeq.ofBoolean(xs) else null
-  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit] = if (xs ne null) new ArraySeq.ofUnit(xs) else null
+  // Convert arrays to immutable.ArraySeq for use with Scala varargs.
+  // By construction, calls to these methods always receive a fresh (and non-null), non-empty array.
+  // In cases where an empty array would appear, the compiler uses a direct reference to Nil instead.
+  // Synthetic Java varargs forwarders (@annotation.varargs or varargs bridges when overriding) may pass
+  // `null` to these methods; but returning `null` or `ArraySeq(null)` makes little difference in practice.
+  def genericWrapArray[T](xs: Array[T]): ArraySeq[T] = ArraySeq.unsafeWrapArray(xs)
+  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T] = new ArraySeq.ofRef[T](xs)
+  def wrapIntArray(xs: Array[Int]): ArraySeq[Int] = new ArraySeq.ofInt(xs)
+  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double] = new ArraySeq.ofDouble(xs)
+  def wrapLongArray(xs: Array[Long]): ArraySeq[Long] = new ArraySeq.ofLong(xs)
+  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float] = new ArraySeq.ofFloat(xs)
+  def wrapCharArray(xs: Array[Char]): ArraySeq[Char] = new ArraySeq.ofChar(xs)
+  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte] = new ArraySeq.ofByte(xs)
+  def wrapShortArray(xs: Array[Short]): ArraySeq[Short] = new ArraySeq.ofShort(xs)
+  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = new ArraySeq.ofBoolean(xs)
+  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit] = new ArraySeq.ofUnit(xs)
 }

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -152,10 +152,16 @@ object ScalaRunTime {
   // More background at ticket #2318.
   def ensureAccessible(m: JMethod): JMethod = scala.reflect.ensureAccessible(m)
 
+  // This is called by the synthetic case class `toString` method.
+  // It originally had a `CaseClass` parameter type which was changed to `Product`.
   def _toString(x: Product): String =
     x.productIterator.mkString(x.productPrefix + "(", ",", ")")
 
-  def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.productHash(x)
+  // This method is called by case classes compiled by older Scala 2.13 / Scala 3 versions, so it needs to stay.
+  // In newer versions, the synthetic case class `hashCode` has either the calculation inlined or calls
+  // `MurmurHash3.productHash`.
+  // There used to be an `_equals` method as well which was removed in 5e7e81ab2a.
+  def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.caseClassHash(x)
 
   /** A helper for case classes. */
   def typedProductIterator[T](x: Product): Iterator[T] = {

--- a/library/src/scala/runtime/ShortRef.java
+++ b/library/src/scala/runtime/ShortRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/Static.java
+++ b/library/src/scala/runtime/Static.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/Statics.java
+++ b/library/src/scala/runtime/Statics.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/StructuralCallSite.scala
+++ b/library/src/scala/runtime/StructuralCallSite.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/SymbolLiteral.java
+++ b/library/src/scala/runtime/SymbolLiteral.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/Tuple2Zipped.scala
+++ b/library/src/scala/runtime/Tuple2Zipped.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/Tuple3Zipped.scala
+++ b/library/src/scala/runtime/Tuple3Zipped.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileBooleanRef.java
+++ b/library/src/scala/runtime/VolatileBooleanRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileByteRef.java
+++ b/library/src/scala/runtime/VolatileByteRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileCharRef.java
+++ b/library/src/scala/runtime/VolatileCharRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileDoubleRef.java
+++ b/library/src/scala/runtime/VolatileDoubleRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileFloatRef.java
+++ b/library/src/scala/runtime/VolatileFloatRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileIntRef.java
+++ b/library/src/scala/runtime/VolatileIntRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileLongRef.java
+++ b/library/src/scala/runtime/VolatileLongRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileObjectRef.java
+++ b/library/src/scala/runtime/VolatileObjectRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/VolatileShortRef.java
+++ b/library/src/scala/runtime/VolatileShortRef.java
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcB$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcB$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcC$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcC$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcF$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcS$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcS$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcV$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcV$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction0$mcZ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcZ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcDF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDF$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcFD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcFF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFF$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcFI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcFJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcID$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcIF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcIF$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcII$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcIJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcJF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJF$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcVD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcVF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVF$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcVI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcVJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcZD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcZF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZF$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcZI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction1$mcZJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDDD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDDI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDDJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDID$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDII$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDIJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDJD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDJI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcDJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDJJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFDD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFDI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFDJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFID$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFII$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFIJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFJD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFJI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcFJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFJJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIDD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIDI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIDJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIID$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIII$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIIJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIJD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIJI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcIJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIJJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJDD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJDI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJDJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJID$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJII$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJIJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJJD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJJI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcJJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJJJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVDD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVDI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVDJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVID$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVII$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVIJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVJD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVJI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcVJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVJJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZDD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZDI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZDJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZID$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZII$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZIJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZJD$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZJI$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/runtime/java8/JFunction2$mcZJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZJJ$sp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/specialized.scala
+++ b/library/src/scala/specialized.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/BooleanProp.scala
+++ b/library/src/scala/sys/BooleanProp.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/Prop.scala
+++ b/library/src/scala/sys/Prop.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/ShutdownHookThread.scala
+++ b/library/src/scala/sys/ShutdownHookThread.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/SystemProperties.scala
+++ b/library/src/scala/sys/SystemProperties.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/package.scala
+++ b/library/src/scala/sys/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/BasicIO.scala
+++ b/library/src/scala/sys/process/BasicIO.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/Parser.scala
+++ b/library/src/scala/sys/process/Parser.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/Process.scala
+++ b/library/src/scala/sys/process/Process.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/ProcessBuilder.scala
+++ b/library/src/scala/sys/process/ProcessBuilder.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/ProcessBuilderImpl.scala
+++ b/library/src/scala/sys/process/ProcessBuilderImpl.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/ProcessIO.scala
+++ b/library/src/scala/sys/process/ProcessIO.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/ProcessImpl.scala
+++ b/library/src/scala/sys/process/ProcessImpl.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/ProcessLogger.scala
+++ b/library/src/scala/sys/process/ProcessLogger.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/sys/process/package.scala
+++ b/library/src/scala/sys/process/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/throws.scala
+++ b/library/src/scala/throws.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/transient.scala
+++ b/library/src/scala/transient.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/typeConstraints.scala
+++ b/library/src/scala/typeConstraints.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/unchecked.scala
+++ b/library/src/scala/unchecked.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/ChainingOps.scala
+++ b/library/src/scala/util/ChainingOps.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/Either.scala
+++ b/library/src/scala/util/Either.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).
@@ -92,7 +92,7 @@ private[scala] trait PropertiesTrait {
   /** A verbose alternative to [[versionNumberString]].
    */
   val versionString         = s"version ${scalaPropOrElse("version.number", "(unknown)")}"
-  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2024, LAMP/EPFL and Lightbend, Inc.")
+  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2024, LAMP/EPFL and Lightbend, Inc. dba Akka")
 
   /** This is the encoding to use reading in source files, overridden with -encoding.
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -142,7 +142,7 @@ private[scala] trait PropertiesTrait {
   private[scala] lazy val isAvian = javaVmName.contains("Avian")
 
   private[scala] def coloredOutputEnabled: Boolean = propOrElse("scala.color", "auto") match {
-    case "auto" => !isWin && consoleIsTerminal
+    case "auto" => consoleIsTerminal
     case s      => "" == s || "true".equalsIgnoreCase(s)
   }
 

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -92,7 +92,7 @@ private[scala] trait PropertiesTrait {
   /** A verbose alternative to [[versionNumberString]].
    */
   val versionString         = s"version ${scalaPropOrElse("version.number", "(unknown)")}"
-  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2024, LAMP/EPFL and Lightbend, Inc. dba Akka")
+  val copyrightString       = scalaPropOrElse("copyright.string", "Copyright 2002-2025, LAMP/EPFL and Lightbend, Inc. dba Akka")
 
   /** This is the encoding to use reading in source files, overridden with -encoding.
    *  Note that it uses "prop" i.e. looks in the scala jar, not the system properties.

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -148,9 +148,10 @@ private[scala] trait PropertiesTrait {
 
   /** System.console.isTerminal, or just check for null console on JDK < 22 */
   private[scala] lazy val consoleIsTerminal: Boolean = {
+    import language.reflectiveCalls
     val console = System.console
     def isTerminal: Boolean =
-      try classOf[java.io.Console].getMethod("isTerminal", null).invoke(console).asInstanceOf[Boolean]
+      try console.asInstanceOf[{ def isTerminal(): Boolean }].isTerminal()
       catch { case _: NoSuchMethodException => false }
     console != null && (!isJavaAtLeast("22") || isTerminal)
   }

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -130,16 +130,16 @@ private[scala] trait PropertiesTrait {
 
   /* Some derived values. */
   /** Returns `true` iff the underlying operating system is a version of Microsoft Windows. */
-  def isWin                 = osName startsWith "Windows"
+  lazy val isWin            = osName.startsWith("Windows")
   // See https://mail.openjdk.java.net/pipermail/macosx-port-dev/2012-November/005148.html for
   // the reason why we don't follow developer.apple.com/library/mac/#technotes/tn2002/tn2110.
   /** Returns `true` iff the underlying operating system is a version of Apple Mac OSX.  */
-  def isMac                 = osName startsWith "Mac OS X"
+  lazy val isMac            = osName.startsWith("Mac OS X")
   /** Returns `true` iff the underlying operating system is a Linux distribution. */
-  def isLinux               = osName startsWith "Linux"
+  lazy val isLinux          = osName.startsWith("Linux")
 
   /* Some runtime values. */
-  private[scala] def isAvian = javaVmName contains "Avian"
+  private[scala] lazy val isAvian = javaVmName.contains("Avian")
 
   private[scala] def coloredOutputEnabled: Boolean = propOrElse("scala.color", "auto") match {
     case "auto" => System.console() != null && !isWin

--- a/library/src/scala/util/Random.scala
+++ b/library/src/scala/util/Random.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/Try.scala
+++ b/library/src/scala/util/Try.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/Try.scala
+++ b/library/src/scala/util/Try.scala
@@ -217,7 +217,7 @@ object Try {
       val r1 = r
       Success(r1)
     } catch {
-      case NonFatal(e) => return Failure(e)
+      case NonFatal(e) => Failure(e)
     }
 }
 

--- a/library/src/scala/util/Using.scala
+++ b/library/src/scala/util/Using.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/Using.scala
+++ b/library/src/scala/util/Using.scala
@@ -125,8 +125,8 @@ import scala.util.control.{ControlThrowable, NonFatal}
   *   - `java.lang.LinkageError`
   *   - `java.lang.InterruptedException` and `java.lang.ThreadDeath`
   *   - [[scala.util.control.NonFatal fatal exceptions]], excluding `scala.util.control.ControlThrowable`
+  *   - all other exceptions, excluding `scala.util.control.ControlThrowable`
   *   - `scala.util.control.ControlThrowable`
-  *   - all other exceptions
   *
   * When more than two exceptions are thrown, the first two are combined and
   * re-thrown as described above, and each successive exception thrown is combined
@@ -265,9 +265,9 @@ object Using {
       case _: VirtualMachineError                   => 4
       case _: LinkageError                          => 3
       case _: InterruptedException | _: ThreadDeath => 2
-      case _: ControlThrowable                      => 0
+      case _: ControlThrowable                      => -1 // below everything
       case e if !NonFatal(e)                        => 1 // in case this method gets out of sync with NonFatal
-      case _                                        => -1
+      case _                                        => 0
     }
     @inline def suppress(t: Throwable, suppressed: Throwable): Throwable = { t.addSuppressed(suppressed); t }
 

--- a/library/src/scala/util/control/Breaks.scala
+++ b/library/src/scala/util/control/Breaks.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/control/ControlThrowable.scala
+++ b/library/src/scala/util/control/ControlThrowable.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/control/NoStackTrace.scala
+++ b/library/src/scala/util/control/NoStackTrace.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/control/TailCalls.scala
+++ b/library/src/scala/util/control/TailCalls.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/control/TailCalls.scala
+++ b/library/src/scala/util/control/TailCalls.scala
@@ -10,14 +10,17 @@
  * additional information regarding copyright ownership.
  */
 
-package scala
-package util.control
+package scala.util.control
+
+import annotation.tailrec
 
 /** Methods exported by this object implement tail calls via trampolining.
- *  Tail calling methods have to return their result using `done` or call the
- *  next method using `tailcall`. Both return a `TailRec` object. The result
- *  of evaluating a tailcalling function can be retrieved from a `Tailrec`
+ *
+ *  Tail calling methods must either return their result using `done` or call the
+ *  next method using `tailcall`. Both return an instance of `TailRec`. The result
+ *  of evaluating a tailcalling function can be retrieved from a `TailRec`
  *  value using method `result`.
+ *
  *  Implemented as described in "Stackless Scala with Free Monads"
  *  [[https://blog.higher-order.com/assets/trampolines.pdf]]
  *
@@ -44,67 +47,65 @@ package util.control
  */
 object TailCalls {
 
-  /** This class represents a tailcalling computation
+  /** This class represents a tailcalling computation.
    */
   sealed abstract class TailRec[+A] {
 
     /** Continue the computation with `f`. */
-    final def map[B](f: A => B): TailRec[B] =
-      flatMap(a => Call(() => Done(f(a))))
+    final def map[B](f: A => B): TailRec[B] = flatMap(a => Call(() => Done(f(a))))
 
     /** Continue the computation with `f` and merge the trampolining
-      * of this computation with that of `f`. */
-    final def flatMap[B](f: A => TailRec[B]): TailRec[B] =
-      this match {
-        case Done(a) => Call(() => f(a))
-        case c @ Call(_) => Cont(c, f)
-        // Take advantage of the monad associative law to optimize the size of the required stack
-        case c: Cont[a1, b1] => Cont(c.a, (x: a1) => c.f(x) flatMap f)
-      }
+     *  of this computation with that of `f`. */
+    final def flatMap[B](f: A => TailRec[B]): TailRec[B] = this match {
+      case Done(a)         => Call(() => f(a))
+      case Call(_)         => Cont(this, f)
+      // Take advantage of the monad associative law to optimize the size of the required stack
+      case c: Cont[a1, b1] => Cont(c.a, (x: a1) => c.f(x).flatMap(f))
+    }
 
     /** Returns either the next step of the tailcalling computation,
       * or the result if there are no more steps. */
-    @annotation.tailrec final def resume: Either[() => TailRec[A], A] = this match {
-      case Done(a) => Right(a)
-      case Call(k) => Left(k)
+    @tailrec final def resume: Either[() => TailRec[A], A] = this match {
+      case Done(a)    => Right(a)
+      case Call(k)    => Left(k)
       case Cont(a, f) => a match {
-        case Done(v) => f(v).resume
-        case Call(k) => Left(() => k().flatMap(f))
-        case Cont(b, g) => b.flatMap(x => g(x) flatMap f).resume
+        case Done(v)    => f(v).resume
+        case Call(k)    => Left(() => k().flatMap(f))
+        case Cont(b, g) => b.flatMap(x => g(x).flatMap(f)).resume
       }
     }
 
     /** Returns the result of the tailcalling computation.
      */
-    @annotation.tailrec final def result: A = this match {
-      case Done(a) => a
-      case Call(t) => t().result
+    @tailrec final def result: A = this match {
+      case Done(a)    => a
+      case Call(t)    => t().result
       case Cont(a, f) => a match {
-        case Done(v) => f(v).result
-        case Call(t) => t().flatMap(f).result
-        case Cont(b, g) => b.flatMap(x => g(x) flatMap f).result
+        case Done(v)    => f(v).result
+        case Call(t)    => t().flatMap(f).result
+        case Cont(b, g) => b.flatMap(x => g(x).flatMap(f)).result
       }
     }
   }
 
-  /** Internal class representing a tailcall */
+  /** Internal class representing a tailcall. */
   protected case class Call[A](rest: () => TailRec[A]) extends TailRec[A]
 
   /** Internal class representing the final result returned from a tailcalling
-    * computation */
+   *  computation. */
   protected case class Done[A](value: A) extends TailRec[A]
 
   /** Internal class representing a continuation with function A => TailRec[B].
-    * It is needed for the flatMap to be implemented. */
+   *  It is needed for the flatMap to be implemented. */
   protected case class Cont[A, B](a: TailRec[A], f: A => TailRec[B]) extends TailRec[B]
 
-  /** Performs a tailcall
+  /** Perform a tailcall.
    *  @param rest  the expression to be evaluated in the tailcall
    *  @return a `TailRec` object representing the expression `rest`
    */
   def tailcall[A](rest: => TailRec[A]): TailRec[A] = Call(() => rest)
 
-  /** Used to return final result from tailcalling computation
+  /** Return the final result from a tailcalling computation.
    *  @param  `result` the result value
    *  @return a `TailRec` object representing a computation which immediately
    *          returns `result`

--- a/library/src/scala/util/hashing/ByteswapHashing.scala
+++ b/library/src/scala/util/hashing/ByteswapHashing.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/hashing/Hashing.scala
+++ b/library/src/scala/util/hashing/Hashing.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/hashing/MurmurHash3.scala
+++ b/library/src/scala/util/hashing/MurmurHash3.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/hashing/MurmurHash3.scala
+++ b/library/src/scala/util/hashing/MurmurHash3.scala
@@ -136,7 +136,7 @@ private[hashing] class MurmurHash3 {
     while (it.hasNext) {
       h = mix(h, prev)
       val hash = it.next().##
-      if(rangeDiff != hash - prev) {
+      if(rangeDiff != hash - prev || rangeDiff == 0) {
         h = mix(h, hash)
         i += 1
         while (it.hasNext) {
@@ -173,7 +173,7 @@ private[hashing] class MurmurHash3 {
         while (i < l) {
           h = mix(h, prev)
           val hash = a(i).##
-          if(rangeDiff != hash - prev) {
+          if(rangeDiff != hash - prev || rangeDiff == 0) {
             h = mix(h, hash)
             i += 1
             while (i < l) {
@@ -252,7 +252,7 @@ private[hashing] class MurmurHash3 {
         while (i < l) {
           h = mix(h, prev)
           val hash = a(i).##
-          if(rangeDiff != hash - prev) {
+          if(rangeDiff != hash - prev || rangeDiff == 0) {
             h = mix(h, hash)
             i += 1
             while (i < l) {
@@ -292,7 +292,7 @@ private[hashing] class MurmurHash3 {
           rangeDiff = hash - prev
           rangeState = 2
         case 2 =>
-          if(rangeDiff != hash - prev) rangeState = 3
+          if(rangeDiff != hash - prev || rangeDiff == 0) rangeState = 3
         case _ =>
       }
       prev = hash

--- a/library/src/scala/util/hashing/package.scala
+++ b/library/src/scala/util/hashing/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/matching/Regex.scala
+++ b/library/src/scala/util/matching/Regex.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/util/package.scala
+++ b/library/src/scala/util/package.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).

--- a/library/src/scala/volatile.scala
+++ b/library/src/scala/volatile.scala
@@ -1,7 +1,7 @@
 /*
  * Scala (https://www.scala-lang.org)
  *
- * Copyright EPFL and Lightbend, Inc.
+ * Copyright EPFL and Lightbend, Inc. dba Akka
  *
  * Licensed under Apache License 2.0
  * (http://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
This is the first sync between the stdlib of scala 2 and scala 3 after merging the histories.
The steps to reproduce this:
```shell
git clone git@github.com:scala/scala.git --single-branch --no-tags --branch 2.13.x embed
cd embed
git filter-repo --path src/library --path-rename src/library:library/src
git filter-repo --message-callback 'return re.sub(rb"(?<!\w)#(\d+)", rb"scala/scala#\1", message)'
git remote add scala3 git@github.com:scala/scala3.git
git fetch scala3 main
git replace --graft b594c22eac364ca2449a2700506b4f6b3f571b86 2308509d2651ee78e1122b5d61b798c984c96c4d
git filter-repo --proceed
git checkout -b sync-stdlib
git push scala3
```

This was done manually, when I have some free time, I will make a workflow to automatically do this.