### PR TITLE
Fix captureWildcards with FlexibleType

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Inferencing.scala
@@ -626,11 +626,13 @@ object Inferencing {
     case tp: RecType => tp.derivedRecType(captureWildcards(tp.parent))
     case tp: LazyRef => captureWildcards(tp.ref)
     case tp: AnnotatedType => tp.derivedAnnotatedType(captureWildcards(tp.parent), tp.annot)
+    case tp: FlexibleType => tp.derivedFlexibleType(captureWildcards(tp.hi))
     case _ => tp
   }
 
   def hasCaptureConversionArg(tp: Type)(using Context): Boolean = tp match
     case tp: AppliedType => tp.args.exists(_.typeSymbol == defn.TypeBox_CAP)
+    case tp: FlexibleType => hasCaptureConversionArg(tp.hi)
     case _ => false
 }
 

--- a/tests/explicit-nulls/pos/java-collectors.scala
+++ b/tests/explicit-nulls/pos/java-collectors.scala
@@ -1,0 +1,6 @@
+import java.util.stream._
+
+def test =
+  val seqStream: Stream[String] = ???
+  val shouldNotNPE = seqStream.collect(Collectors.toList())
+  val shouldNotNPE2 = seqStream.collect(Collectors.toList[String]())


### PR DESCRIPTION
Apply `captureWildcards` inside `FlexibleType` as well

```scala
import java.util.stream._

val seqStream: Stream[String] = ???
val shouldNotNPE = seqStream.collect(Collectors.toList())
```

cc @HarrisL2 