### PR TITLE
Tweak tryParameterless to use readapt

### DIFF
--- a/tests/neg/i21207.scala
+++ b/tests/neg/i21207.scala
@@ -1,0 +1,32 @@
+
+abstract class P {
+  def foo1(): Int = 1
+  def foo2(x: Int): Int = 22
+  def g4(s: String): String = s * 4
+}
+
+class C extends P {
+  def foo1(x: Int): Int = 11
+  def foo2(): Int = 2
+
+  def foo3(): Int = 3
+  def foo3(x: Int): Int = 33
+
+  def g4(): Int = 4
+}
+
+object Test extends App {
+  val c = new C
+  println(c.foo1) // error was omitted because of nullary fallback during ambiguous overload resolution
+  println(c.foo2) // error, add parens
+  println(c.foo3) // error
+  println(c.g4) // error
+  val s: String = c.g4 // error missing arg, expected type picks method
+  println(s)
+}
+
+/* Scala 2 warns for all three selections:
+warning: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method foo1,
+or remove the empty argument list from its definition (Java-defined methods are exempt).
+In Scala 3, an unapplied method like this will be eta-expanded into a function. [quickfixable]
+*/

--- a/tests/warn/i21207/Over.java
+++ b/tests/warn/i21207/Over.java
@@ -1,0 +1,8 @@
+
+interface I {
+    default int f() { return 42; }
+}
+
+public class Over implements I {
+    public int f(int i) { return 42 + i; }
+}

--- a/tests/warn/i21207/usage.scala
+++ b/tests/warn/i21207/usage.scala
@@ -1,0 +1,17 @@
+//> using options -source:3.0-migration
+
+// Hope to see a migration warning! with quickfix.
+
+class P {
+  def g(): Int = 42
+}
+class C extends P {
+  def g(i: Int): Int = 42 + i
+}
+
+object Test extends App {
+  val over = Over()
+  println(over.f) // nowarn Java
+  val c = C()
+  println(c.g) // warn migration
+}


### PR DESCRIPTION
Readapt will autoapply if permitted and also warn on migration.

Fixes #21207 

### Why was the ticket worth tackling?

I started to look at tickets about overloading, so this is a first step on the journey of understanding the parts involved.

It happens that I backported `tryParameterless` to Scala 2.

### How I fixed it

There are just two places where it adds parens.

My first attempt was more direct, since I want only a possible warning and parens:
```
alt.info match
case wtp: MethodType => adaptNoArgsUnappliedMethod(wtp, functionExpected = false, arity = -1)
```
but the tree has an overloaded type.

### Why is this PR worth reviewing?

It's a one-line change, so now I'm on pace for 1 LOC/day, which is net zero.

### What's the worse that could happen?

The fix is a bit indirect, so it's easy to imagine it breaking under strain.