### PR TITLE
Changes to Fresh and Separation Checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -12,7 +12,7 @@ import CCState.*
 import Periods.{NoRunId, RunWidth}
 import compiletime.uninitialized
 import StdNames.nme
-import CaptureSet.VarState
+import CaptureSet.{Refs, emptyRefs, VarState}
 import Annotations.Annotation
 import Flags.*
 import config.Printers.capt
@@ -546,6 +546,17 @@ object Capabilities:
           myCaptureSet = computed
           captureSetValid = currentId
         computed
+
+    /** The elements hidden by this capability, if this is a FreshCap
+     *  or a derived version of one. Read-only status is transferred from
+     *  the capability to its hidden set. TODO Should classifiers also be
+     *  transferred?
+     */
+    def hiddenElems(using Context): Refs = this.stripRestricted.stripReadOnly match
+      case self: FreshCap =>
+        val hidden = self.hiddenSet.elems
+        if isReadOnly then hidden.map(_.readOnly) else hidden
+      case _ => emptyRefs
 
     /** The transitive classifiers of this capability. */
     def transClassifiers(using Context): Classifiers =

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -769,6 +769,7 @@ object Capabilities:
      *   x covers x
      *   x covers y  ==>  x covers y.f
      *   x covers y  ==>  x* covers y*, x? covers y?
+     *   x covers y  ==>  x.only[C] covers y, x covers y.only[C]
      *   TODO what other clauses from subsumes do we need to port here?
      */
     final def covers(y: Capability)(using Context): Boolean =
@@ -784,10 +785,13 @@ object Capabilities:
             this match
               case Maybe(x1) => x1.covers(y1)
               case _ => false
-          case y: FreshCap =>
-            y.hiddenSet.superCaps.exists(this.covers(_))
+          case Restricted(y1, _) =>
+            this.covers(y1)
           case _ =>
             false
+      || this.match
+          case Restricted(x1, _) => x1.covers(y)
+          case _ => false
 
     def assumedContainsOf(x: TypeRef)(using Context): SimpleIdentitySet[Capability] =
       CaptureSet.assumedContains.getOrElse(x, SimpleIdentitySet.empty)

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -147,7 +147,7 @@ object Capabilities:
    *  @param origin  an indication where and why the FreshCap was created, used
    *                 for diagnostics
    */
-  case class FreshCap private (owner: Symbol, origin: Origin)(using @constructorOnly ctx: Context) extends RootCapability:
+  case class FreshCap (owner: Symbol, origin: Origin)(using @constructorOnly ctx: Context) extends RootCapability:
     val hiddenSet = CaptureSet.HiddenSet(owner, this: @unchecked)
       // fails initialization check without the @unchecked
 

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -548,14 +548,19 @@ object Capabilities:
         computed
 
     /** The elements hidden by this capability, if this is a FreshCap
-     *  or a derived version of one. Read-only status is transferred from
-     *  the capability to its hidden set. TODO Should classifiers also be
-     *  transferred?
+     *  or a derived version of one. Read-only status and restrictions
+     *  are transferred from the capability to its hidden set.
      */
-    def hiddenElems(using Context): Refs = this.stripRestricted.stripReadOnly match
-      case self: FreshCap =>
-        val hidden = self.hiddenSet.elems
-        if isReadOnly then hidden.map(_.readOnly) else hidden
+    def hiddenSet(using Context): Refs = computeHiddenSet(identity)
+
+    /** Compute hidden set of this capability.
+     *  Restrictions and read-only status transfer from the capability to its
+     *  hidden set.
+     */
+    def computeHiddenSet(f: Refs => Refs)(using Context): Refs = this match
+      case self: FreshCap => f(self.hiddenSet.elems)
+      case Restricted(elem1, cls) => elem1.computeHiddenSet(f).map(_.restrict(cls))
+      case ReadOnly(elem1) => elem1.computeHiddenSet(f).map(_.readOnly)
       case _ => emptyRefs
 
     /** The transitive classifiers of this capability. */

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -553,9 +553,10 @@ object Capabilities:
      */
     def hiddenSet(using Context): Refs = computeHiddenSet(identity)
 
-    /** Compute hidden set of this capability.
+    /** Compute result based on hidden set of this capability.
      *  Restrictions and read-only status transfer from the capability to its
      *  hidden set.
+     *  @param  f   a function that gets applied to all detected hidden sets
      */
     def computeHiddenSet(f: Refs => Refs)(using Context): Refs = this match
       case self: FreshCap => f(self.hiddenSet.elems)

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -770,9 +770,14 @@ object Capabilities:
      *   x covers x
      *   x covers y  ==>  x covers y.f
      *   x covers y  ==>  x* covers y*, x? covers y?
-     *   x covers y  ==>  x.only[C] covers y, x covers y.only[C]
      *   x covers y  ==>  <fresh hiding x> covers y
+     *   x covers y  ==>  x.only[C] covers y, x covers y.only[C]
+     *
      *   TODO what other clauses from subsumes do we need to port here?
+     *   The last clause is a conservative over-approximation: basically, we can't achieve
+     *   separation by having different classifiers for now. It would be good to
+     *   have a test that would expect such separation, then we can try to refine
+     *   the clause to make the test pass.
      */
     final def covers(y: Capability)(using Context): Boolean =
       val seen: util.EqHashSet[FreshCap] = new util.EqHashSet

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -950,8 +950,6 @@ object CaptureSet:
     override def toString = s"Var$id$elems"
   end Var
 
-  inline val strictFreshLevels = true
-
   /** Variables created in types of inferred type trees */
   class ProperVar(override val owner: Symbol, initialElems: Refs = emptyRefs, nestedOK: Boolean = true, isRefining: Boolean)(using /*@constructorOnly*/ ictx: Context)
   extends Var(owner, initialElems, nestedOK):
@@ -971,7 +969,7 @@ object CaptureSet:
         def fail = i"attempting to add $elem to $this"
         def hideIn(fc: FreshCap): Unit =
           assert(elem.tryClassifyAs(fc.hiddenSet.classifier), fail)
-          if strictFreshLevels && !isRefining then
+          if !isRefining then
             // If a variable is added by addCaptureRefinements in a synthetic
             // refinement of a class type, don't do level checking. The problem is
             // that the variable might be matched against a type that does not have
@@ -1560,7 +1558,7 @@ object CaptureSet:
   /** The capture set of the type underlying the capability `c` */
   def ofInfo(c: Capability)(using Context): CaptureSet = c match
     case Reach(c1) =>
-      c1.widen.deepCaptureSet(includeTypevars = true)
+      c1.widen.computeDeepCaptureSet(includeTypevars = true)
         .showing(i"Deep capture set of $c: ${c1.widen} = ${result}", capt)
     case Restricted(c1, cls) =>
       if cls == defn.NothingClass then CaptureSet.empty

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -954,6 +954,10 @@ object CaptureSet:
   class RefiningVar(owner: Symbol)(using Context) extends Var(owner):
     override def disallowBadRoots(upto: Symbol)(handler: () => Context ?=> Unit)(using Context) = this
 
+  /** Variables created in types of inferred type trees */
+  class ProperVar(override val owner: Symbol, initialElems: Refs, nestedOK: Boolean)(using /*@constructorOnly*/ ictx: Context)
+  extends Var(owner, initialElems, nestedOK)
+  
   /** A variable that is derived from some other variable via a map or filter. */
   abstract class DerivedVar(owner: Symbol, initialElems: Refs)(using @constructorOnly ctx: Context)
   extends Var(owner, initialElems):

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1376,7 +1376,10 @@ class CheckCaptures extends Recheck, SymTransformer:
      *  where local capture roots are instantiated to root variables.
      */
     override def checkConformsExpr(actual: Type, expected: Type, tree: Tree, addenda: Addenda)(using Context): Type =
-      testAdapted(actual, expected, tree, addenda)(err.typeMismatch)
+      try testAdapted(actual, expected, tree, addenda)(err.typeMismatch)
+      catch case ex: AssertionError =>
+        println(i"error while checking $tree: $actual against $expected")
+        throw ex
 
     @annotation.tailrec
     private def findImpureUpperBound(tp: Type)(using Context): Type = tp match

--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -118,9 +118,9 @@ object SepCheck:
 
     def clashing(ref: Capability)(using Context): SrcPos | Null =
       val refPeaks = ref.directPeaks
-      if !directPeaks .sharedPeaks(refPeaks).isEmpty then
+      if !directPeaks.sharedPeaks(refPeaks).isEmpty then
         var i = 0
-        while i < size && refs(i).directPeaks .sharedPeaks(refPeaks).isEmpty do
+        while i < size && refs(i).directPeaks.sharedPeaks(refPeaks).isEmpty do
           i += 1
         assert(i < size)
         locs(i)
@@ -232,13 +232,12 @@ object SepCheck:
      *  such that one of the following is true:
      *   1.
      *      - one of the sets contains `r`
-     *      - the other contains a capability `s` or `s.rd` where `s` _covers_ `r`
+     *      - the other contains a capability `s` or `s.rd` where `s` covers `r`
      *   2.
      *      - one of the sets contains `r.rd`
-     *      - the other contains a capability `s` where `s` _covers_ `r`
+     *      - the other contains a capability `s` where `s` covers `r`
      *
-     *  A capability `s` covers `r` if `r` can be seen as a path extension of `s`. E.g.
-     *  if `s = x.a` and `r = x.a.b.c` then `s` covers `a`.
+     *  @see covers in Capability
      */
     private def overlapWith(other: Refs)(using Context): Refs =
       val refs1 = refs
@@ -343,11 +342,11 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
   private def formalCaptures(arg: Tree)(using Context): Refs =
     arg.formalType.orElse(arg.nuType).spanCaptureSet.elems
 
-   /** The span capture set if the type of `tree` */
+   /** The span capture set of the type of `tree` */
   private def spanCaptures(tree: Tree)(using Context): Refs =
    tree.nuType.spanCaptureSet.elems
 
-   /** The deep capture set if the type of `tree` */
+   /** The deep capture set of the type of `tree` */
   private def deepCaptures(tree: Tree)(using Context): Refs =
    tree.nuType.deepCaptureSet.elems
 
@@ -588,7 +587,7 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
       for ref <- used do
         val pos = consumed.clashing(ref)
         if pos != null then
-          // println(i"consumed so far ${consumed.refs.toList} with peaks ${consumed.directPeaks .toList}, used = $used, exposed = ${ref.directPeaks }")
+          // println(i"consumed so far ${consumed.refs.toList} with peaks ${consumed.directPeaks.toList}, used = $used, exposed = ${ref.directPeaks }")
           consumeError(ref, pos, tree.srcPos)
   end checkUse
 

--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -175,15 +175,18 @@ object SepCheck:
      *   2. if `f in F` then the footprint of `f`'s info is also in `F`.
      */
     private def oldFootprint(using Context): Refs =
-      def retain(ref: Capability) = !ref.isTerminalCapability
-      def recur(elems: Refs, newElems: List[Capability]): Refs = newElems match
-        case newElem :: newElems1 =>
-          val superElems = newElem.captureSetOfInfo.elems.filter: superElem =>
-            retain(superElem) && !elems.contains(superElem)
-          recur(elems ++ superElems, newElems1 ++ superElems.toList)
-        case Nil => elems
-      val elems: Refs = refs.filter(retain)
-      recur(elems, elems.toList)
+      if ccConfig.newScheme then
+        directFootprint.nonPeaks
+      else
+        def retain(ref: Capability) = !ref.isTerminalCapability
+        def recur(elems: Refs, newElems: List[Capability]): Refs = newElems match
+          case newElem :: newElems1 =>
+            val superElems = newElem.captureSetOfInfo.elems.filter: superElem =>
+              retain(superElem) && !elems.contains(superElem)
+            recur(elems ++ superElems, newElems1 ++ superElems.toList)
+          case Nil => elems
+        val elems: Refs = refs.filter(retain)
+        recur(elems, elems.toList)
 
     /** The footprint of a set of capabilities `refs` is the closure
      *  of `refs` under `_.captureSetOfInfo`, dropping any shared terminal

--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -203,7 +203,7 @@ object SepCheck:
             case _ if newElem.isTerminalCapability =>
               recur(seen + newElem, acc, newElems1)
             case _ =>
-              recur(seen + newElem, acc, newElem.captureSetOfInfo.dropEmpties().elems.toList ++ newElems1)
+              recur(seen + newElem, acc + newElem, newElem.captureSetOfInfo.dropEmpties().elems.toList ++ newElems1)
         case Nil => acc
       recur(emptyRefs, emptyRefs, refs.toList)
 

--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -312,8 +312,12 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
   private def formalCaptures(arg: Tree)(using Context): Refs =
     arg.formalType.orElse(arg.nuType).deepCaptureSet.elems
 
-   /** The deep capture set if the type of `tree` */
+   /** The span capture set if the type of `tree` */
   private def captures(tree: Tree)(using Context): Refs =
+   tree.nuType.spanCaptureSet.elems
+
+   /** The deep capture set if the type of `tree` */
+  private def deepCaptures(tree: Tree)(using Context): Refs =
    tree.nuType.deepCaptureSet.elems
 
   // ---- Error reporting TODO Once these are stabilized, move to messages -----" +
@@ -376,7 +380,7 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
       if clashIdx == 0 && !isShowableMethod then "" // we already mentioned the type in `funStr`
       else i" with type  ${clashing.nuType}"
     val hiddenSet = formalCaptures(polyArg).hiddenSet
-    val clashSet = captures(clashing)
+    val clashSet = deepCaptures(clashing)
     report.error(
       em"""Separation failure: argument of type  ${polyArg.nuType}
           |to $funStr

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -252,7 +252,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     *  Polytype bounds are only cleaned using step 1, but not otherwise transformed.
     */
   private def transformInferredType(tp: Type)(using Context): Type =
-    def mapInferred(refine: Boolean): TypeMap = new TypeMap with SetupTypeMap:
+    def mapInferred(inCaptureRefinement: Boolean): TypeMap = new TypeMap with SetupTypeMap:
       override def toString = "map inferred"
 
       var refiningNames: Set[Name] = Set()
@@ -262,23 +262,23 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
        *  where CV_1, ..., CV_n are fresh capture set variables.
        */
       def addCaptureRefinements(tp: Type): Type = tp match
-        case _: TypeRef | _: AppliedType if refine && tp.typeParams.isEmpty =>
+        case _: TypeRef | _: AppliedType if !inCaptureRefinement && tp.typeParams.isEmpty =>
           tp.typeSymbol match
             case cls: ClassSymbol
             if !defn.isFunctionClass(cls) && cls.is(CaptureChecked) =>
-              cls.paramGetters.foldLeft(tp) { (core, getter) =>
+              cls.paramGetters.foldLeft(tp): (core, getter) =>
                 if atPhase(thisPhase.next)(getter.hasTrackedParts)
                     && getter.isRefiningParamAccessor
                     && !refiningNames.contains(getter.name) // Don't add a refinement if we have already an explicit one for the same name
                 then
                   val getterType =
-                    mapInferred(refine = false)(tp.memberInfo(getter)).strippedDealias
+                    mapInferred(inCaptureRefinement = true)(tp.memberInfo(getter)).strippedDealias
                   RefinedType(core, getter.name,
-                      CapturingType(getterType, new CaptureSet.RefiningVar(ctx.owner)))
+                      CapturingType(getterType,
+                        CaptureSet.ProperVar(ctx.owner, isRefining = true)))
                     .showing(i"add capture refinement $tp --> $result", capt)
                 else
                   core
-              }
             case _ => tp
         case _ => tp
 
@@ -302,11 +302,12 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             mapFollowingAliases(tp)
         addVar(
           addCaptureRefinements(normalizeCaptures(normalizeFunctions(tp1, tp))),
-          ctx.owner)
+          ctx.owner,
+          isRefining = inCaptureRefinement)
     end mapInferred
 
     try
-      val tp1 = mapInferred(refine = true)(tp)
+      val tp1 = mapInferred(inCaptureRefinement = false)(tp)
       val tp2 = toResultInResults(NoSymbol, _ => assert(false))(tp1)
       if tp2 ne tp then capt.println(i"expanded inferred in ${ctx.owner}: $tp  -->  $tp1  -->  $tp2")
       tp2
@@ -685,7 +686,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
                 // Infer the self type for the rest, which is all classes without explicit
                 // self types (to which we also add nested module classes), provided they are
                 // neither pure, nor are publicily extensible with an unconstrained self type.
-                val cs = CaptureSet.ProperVar(cls, CaptureSet.emptyRefs, nestedOK = false)
+                val cs = CaptureSet.ProperVar(cls, CaptureSet.emptyRefs, nestedOK = false, isRefining = false)
                 if cls.derivesFrom(defn.Caps_Capability) then
                   // If cls is a capability class, we need to add a fresh readonly capability to
                   // ensure we cannot treat the class as pure.
@@ -851,8 +852,8 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       else maybeAdd(tp, tp)
 
   /** Add a capture set variable to `tp` if necessary. */
-  private def addVar(tp: Type, owner: Symbol)(using Context): Type =
-    decorate(tp, CaptureSet.ProperVar(owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner)))
+  private def addVar(tp: Type, owner: Symbol, isRefining: Boolean)(using Context): Type =
+    decorate(tp, CaptureSet.ProperVar(owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner), isRefining))
 
   /** A map that adds <fluid> capture sets at all contra- and invariant positions
    *  in a type where a capture set would be needed. This is used to make types

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -685,7 +685,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
                 // Infer the self type for the rest, which is all classes without explicit
                 // self types (to which we also add nested module classes), provided they are
                 // neither pure, nor are publicily extensible with an unconstrained self type.
-                val cs = CaptureSet.Var(cls)
+                val cs = CaptureSet.ProperVar(cls, CaptureSet.emptyRefs, nestedOK = false)
                 if cls.derivesFrom(defn.Caps_Capability) then
                   // If cls is a capability class, we need to add a fresh readonly capability to
                   // ensure we cannot treat the class as pure.
@@ -852,7 +852,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
   /** Add a capture set variable to `tp` if necessary. */
   private def addVar(tp: Type, owner: Symbol)(using Context): Type =
-    decorate(tp, CaptureSet.Var(owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner)))
+    decorate(tp, CaptureSet.ProperVar(owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner)))
 
   /** A map that adds <fluid> capture sets at all contra- and invariant positions
    *  in a type where a capture set would be needed. This is used to make types

--- a/tests/neg-custom-args/captures/cc-poly-varargs.check
+++ b/tests/neg-custom-args/captures/cc-poly-varargs.check
@@ -1,0 +1,34 @@
+-- Error: tests/neg-custom-args/captures/cc-poly-varargs.scala:11:13 ---------------------------------------------------
+11 |  val left = src1.transformValuesWith(Left(_))    // error
+   |             ^^^^
+   |Separation failure: argument of type  (src1 : Source[T1, scala.caps.CapSet^{Cap}]^{Cap})
+   |to method transformValuesWith: [T, Cap >: scala.caps.CapSet <: scala.caps.CapSet^]
+   |  (src: Source[T, scala.caps.CapSet^{Cap}]^)[U](f: T ->{Cap} U): Source[U, scala.caps.CapSet^{Cap}]^{src, f}
+   |corresponds to capture-polymorphic formal parameter src of type  Source[T1^'s3, scala.caps.CapSet^{Cap}]^
+   |and hides capabilities  {src1}.
+   |Some of these overlap with the captures of the function result with type  Source[Left[T1^'s1, Nothing]^'s2, scala.caps.CapSet^{Cap}]^{src1}.
+   |
+   |  Hidden set of current argument        : {src1}
+   |  Hidden footprint of current argument  : {src1, Cap}
+   |  Capture set of function result        : {src1, Cap}
+   |  Footprint set of function result      : {src1, Cap}
+   |  The two sets overlap at               : {src1, Cap}
+   |
+   |where:    ^ refers to a fresh root capability created in value left when checking argument to parameter src of method transformValuesWith
+-- Error: tests/neg-custom-args/captures/cc-poly-varargs.scala:12:14 ---------------------------------------------------
+12 |  val right = src2.transformValuesWith(Right(_))  // error
+   |              ^^^^
+   |Separation failure: argument of type  (src2 : Source[T2, scala.caps.CapSet^{Cap}]^{Cap})
+   |to method transformValuesWith: [T, Cap >: scala.caps.CapSet <: scala.caps.CapSet^]
+   |  (src: Source[T, scala.caps.CapSet^{Cap}]^)[U](f: T ->{Cap} U): Source[U, scala.caps.CapSet^{Cap}]^{src, f}
+   |corresponds to capture-polymorphic formal parameter src of type  Source[T2^'s6, scala.caps.CapSet^{Cap}]^
+   |and hides capabilities  {src2}.
+   |Some of these overlap with the captures of the function result with type  Source[Right[Nothing, T2^'s4]^'s5, scala.caps.CapSet^{Cap}]^{src2}.
+   |
+   |  Hidden set of current argument        : {src2}
+   |  Hidden footprint of current argument  : {src2, Cap}
+   |  Capture set of function result        : {src2, Cap}
+   |  Footprint set of function result      : {src2, Cap}
+   |  The two sets overlap at               : {src2, Cap}
+   |
+   |where:    ^ refers to a fresh root capability created in value right when checking argument to parameter src of method transformValuesWith

--- a/tests/neg-custom-args/captures/cc-poly-varargs.scala
+++ b/tests/neg-custom-args/captures/cc-poly-varargs.scala
@@ -8,6 +8,6 @@ def race[T, Cap^](sources: Source[T, {Cap}]^{Cap}*): Source[T, {Cap}]^{Cap} = ??
 def either[T1, T2, Cap^](
     src1: Source[T1, {Cap}]^{Cap},
     src2: Source[T2, {Cap}]^{Cap}): Source[Either[T1, T2], {Cap}]^{Cap} =
-  val left = src1.transformValuesWith(Left(_))
-  val right = src2.transformValuesWith(Right(_))
+  val left = src1.transformValuesWith(Left(_))    // error
+  val right = src2.transformValuesWith(Right(_))  // error
   race(left, right)

--- a/tests/neg-custom-args/captures/cc-this5.check
+++ b/tests/neg-custom-args/captures/cc-this5.check
@@ -1,8 +1,3 @@
--- Error: tests/neg-custom-args/captures/cc-this5.scala:16:20 ----------------------------------------------------------
-16 |    def f = println(c)  // error
-   |                    ^
-   |                    reference (c : Cap) is not included in the allowed capture set {}
-   |                    of the enclosing class A
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/cc-this5.scala:21:15 -------------------------------------
 21 |    val x: A = this // error
    |               ^^^^

--- a/tests/neg-custom-args/captures/cc-this5.scala
+++ b/tests/neg-custom-args/captures/cc-this5.scala
@@ -13,7 +13,7 @@ def foo(c: Cap) =
 def test(c: Cap) =
   class A:
     val x: A = this
-    def f = println(c)  // error
+    def f = println(c)
 
 def test2(c: Cap) =
   class A:

--- a/tests/neg-custom-args/captures/i23726.check
+++ b/tests/neg-custom-args/captures/i23726.check
@@ -13,7 +13,7 @@
    |  Footprint set of function result      : {a}
    |  The two sets overlap at               : {a}
    |
-   |where:    ^  refers to a fresh root capability classified as Mutable created in value a when constructing mutable Ref
+   |where:    ^  refers to a fresh root capability classified as Mutable in the type of value a
    |          ^² refers to a fresh root capability classified as Mutable created in method test1 when checking argument to parameter x of method apply
 -- Error: tests/neg-custom-args/captures/i23726.scala:15:5 -------------------------------------------------------------
 15 |  f3(b)  // error
@@ -30,7 +30,7 @@
    |  Footprint set of function result      : {op, b}
    |  The two sets overlap at               : {b}
    |
-   |where:    ^  refers to a fresh root capability classified as Mutable created in value b when constructing mutable Ref
+   |where:    ^  refers to a fresh root capability classified as Mutable in the type of value b
    |          ^² refers to a fresh root capability classified as Mutable created in method test1 when checking argument to parameter x of method apply
 -- Error: tests/neg-custom-args/captures/i23726.scala:23:5 -------------------------------------------------------------
 23 |  f7(a)  // error
@@ -47,5 +47,5 @@
    |  Footprint set of function prefix      : {f7*, a, b}
    |  The two sets overlap at               : {a}
    |
-   |where:    ^  refers to a fresh root capability classified as Mutable created in value a when constructing mutable Ref
+   |where:    ^  refers to a fresh root capability classified as Mutable in the type of value a
    |          ^² refers to a fresh root capability classified as Mutable created in method test1 when checking argument to parameter x of method apply

--- a/tests/neg-custom-args/captures/lazyref.check
+++ b/tests/neg-custom-args/captures/lazyref.check
@@ -54,7 +54,7 @@
    |  Hidden set of current argument        : {cap2}
    |  Hidden footprint of current argument  : {cap2}
    |  Capture set of function prefix        : {ref1, ref2, ref2*}
-   |  Footprint set of function prefix      : {ref1, ref2, ref2*, cap1, cap2}
+   |  Footprint set of function prefix      : {ref1, cap1, ref2, cap2, ref2*}
    |  The two sets overlap at               : {cap2}
    |
    |where:    => refers to a fresh root capability created in value ref4 when checking argument to parameter f of method map

--- a/tests/neg-custom-args/captures/reference-cc.check
+++ b/tests/neg-custom-args/captures/reference-cc.check
@@ -1,8 +1,3 @@
--- Error: tests/neg-custom-args/captures/reference-cc.scala:42:20 ------------------------------------------------------
-42 |    def f = println(c)  // error
-   |                    ^
-   |                    reference (c : Cap) is not included in the allowed capture set {}
-   |                    of the enclosing class A
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reference-cc.scala:44:29 ---------------------------------
 44 |  val later = usingLogFile { file => () => file.write(0) } // error
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/neg-custom-args/captures/reference-cc.scala
+++ b/tests/neg-custom-args/captures/reference-cc.scala
@@ -39,7 +39,7 @@ class Cap extends caps.SharedCapability
 def test(c: Cap) =
   class A:
     val x: A = this
-    def f = println(c)  // error
+    def f = println(c)
 
   val later = usingLogFile { file => () => file.write(0) } // error
   later() // crash

--- a/tests/neg-custom-args/captures/scope-extrude-mut.check
+++ b/tests/neg-custom-args/captures/scope-extrude-mut.check
@@ -1,15 +1,15 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scope-extrude-mut.scala:9:8 ------------------------------
 9 |    a = a1  // error
   |        ^^
-  |Found:    (a1 : A^)
-  |Required: A^²
+  |        Found:    (a1 : A^)
+  |        Required: A^²
   |
-  |Note that capability cap is not included in capture set {cap²}
-  |because cap in method b is not visible from cap² in variable a.
+  |        Note that capability cap is not included in capture set {cap²}
+  |        because cap in method b is not visible from cap² in variable a.
   |
-  |where:    ^    refers to a fresh root capability classified as Mutable created in value a1 when constructing mutable A
-  |          ^²   refers to a fresh root capability classified as Mutable in the type of variable a
-  |          cap  is a fresh root capability classified as Mutable created in value a1 when constructing mutable A
-  |          cap² is a fresh root capability classified as Mutable in the type of variable a
+  |        where:    ^    refers to a fresh root capability classified as Mutable in the type of value a1
+  |                  ^²   refers to a fresh root capability classified as Mutable in the type of variable a
+  |                  cap  is a fresh root capability classified as Mutable in the type of value a1
+  |                  cap² is a fresh root capability classified as Mutable in the type of variable a
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/sep-counter.check
+++ b/tests/neg-custom-args/captures/sep-counter.check
@@ -3,7 +3,7 @@
    |                   ^^^^^^^^^^^^^^^^
    |Separation failure in method mkCounter's result type Pair[Ref^, Ref^²].
    |One part,  Ref^, hides capabilities  {c, cap, cap²}.
-   |Another part,  Ref^²,  captures capabilities  {c, cap, cap²}.
+   |Another part,  Ref^²,  captures capabilities  {c}.
    |The two sets overlap at  {c}.
    |
    |where:    ^    refers to a fresh root capability classified as Mutable in the result type of method mkCounter

--- a/tests/neg-custom-args/captures/sep-counter.check
+++ b/tests/neg-custom-args/captures/sep-counter.check
@@ -1,11 +1,12 @@
 -- Error: tests/neg-custom-args/captures/sep-counter.scala:12:19 -------------------------------------------------------
 12 |  def mkCounter(): Pair[Ref^, Ref^] =  // error
    |                   ^^^^^^^^^^^^^^^^
-   | Separation failure in method mkCounter's result type Pair[Ref^, Ref^²].
-   | One part,  Ref^, hides capabilities  {c, cap}.
-   | Another part,  Ref^²,  captures capabilities  {c, cap}.
-   | The two sets overlap at  {c}.
+   |Separation failure in method mkCounter's result type Pair[Ref^, Ref^²].
+   |One part,  Ref^, hides capabilities  {c, cap, cap²}.
+   |Another part,  Ref^²,  captures capabilities  {c, cap, cap²}.
+   |The two sets overlap at  {c}.
    |
-   | where:    ^   refers to a fresh root capability classified as Mutable in the result type of method mkCounter
-   |           ^²  refers to a fresh root capability classified as Mutable in the result type of method mkCounter
-   |           cap is a fresh root capability classified as Mutable created in value c when constructing mutable Ref
+   |where:    ^    refers to a fresh root capability classified as Mutable in the result type of method mkCounter
+   |          ^²   refers to a fresh root capability classified as Mutable in the result type of method mkCounter
+   |          cap  is a fresh root capability classified as Mutable in the type of value c
+   |          cap² is a fresh root capability classified as Mutable created in value c when constructing mutable Ref

--- a/tests/neg-custom-args/captures/sep-pairs.check
+++ b/tests/neg-custom-args/captures/sep-pairs.check
@@ -13,7 +13,7 @@
    |         ^^^^^^^^^^^^^^^^
    |         Separation failure in method bad's result type Pair[Ref^, Ref^²].
    |         One part,  Ref^, hides capabilities  {r1*, cap, cap², r0}.
-   |         Another part,  Ref^²,  captures capabilities  {r1*, cap, cap², r0}.
+   |         Another part,  Ref^²,  captures capabilities  {r1*, r0}.
    |         The two sets overlap at  {r1*, r0}.
    |
    |         where:    ^    refers to a fresh root capability classified as Mutable in the result type of method bad
@@ -25,7 +25,7 @@
    |                  ^^^^^^^^^^^^^^^^
    |            Separation failure in value sameToPair's type Pair[Ref^, Ref^²].
    |            One part,  Ref^, hides capabilities  {fstSame}.
-   |            Another part,  Ref^²,  captures capabilities  {sndSame}.
+   |            Another part,  Ref^²,  captures capabilities  {sndSame, same.snd*}.
    |            The two sets overlap at  cap of value same.
    |
    |            where:    ^  refers to a fresh root capability classified as Mutable in the type of value sameToPair

--- a/tests/neg-custom-args/captures/sepchecks2.check
+++ b/tests/neg-custom-args/captures/sepchecks2.check
@@ -1,11 +1,3 @@
--- Error: tests/neg-custom-args/captures/sepchecks2.scala:10:10 --------------------------------------------------------
-10 |  println(c) // error
-   |          ^
-   |          Separation failure: Illegal access to {c} which is hidden by the previous definition
-   |          of value xs with type List[() => Unit].
-   |          This type hides capabilities  {c}
-   |
-   |          where:    => refers to a fresh root capability in the type of value xs
 -- Error: tests/neg-custom-args/captures/sepchecks2.scala:13:7 ---------------------------------------------------------
 13 |  foo((() => println(c)) :: Nil, c) // error
    |       ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/neg-custom-args/captures/sepchecks2.check
+++ b/tests/neg-custom-args/captures/sepchecks2.check
@@ -1,19 +1,3 @@
--- Error: tests/neg-custom-args/captures/sepchecks2.scala:13:7 ---------------------------------------------------------
-13 |  foo((() => println(c)) :: Nil, c) // error
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^
-   |Separation failure: argument of type  List[() ->{c} Unit]
-   |to method foo: (xs: List[() => Unit], y: Object^): Nothing
-   |corresponds to capture-polymorphic formal parameter xs of type  List[() => Unit]
-   |and hides capabilities  {c}.
-   |Some of these overlap with the captures of the second argument with type  (c : Object^).
-   |
-   |  Hidden set of current argument        : {c}
-   |  Hidden footprint of current argument  : {c}
-   |  Capture set of second argument        : {c}
-   |  Footprint set of second argument      : {c}
-   |  The two sets overlap at               : {c}
-   |
-   |where:    => refers to a fresh root capability created in method Test2 when checking argument to parameter xs of method foo
 -- Error: tests/neg-custom-args/captures/sepchecks2.scala:14:10 --------------------------------------------------------
 14 |  val x1: (Object^, Object^) = (c, c) // error
    |          ^^^^^^^^^^^^^^^^^^

--- a/tests/neg-custom-args/captures/sepchecks2.scala
+++ b/tests/neg-custom-args/captures/sepchecks2.scala
@@ -10,7 +10,7 @@ def Test(consume c: Object^) =
   println(c)
 
 def Test2(c: Object^, d: Object^): Unit =
-  foo((() => println(c)) :: Nil, c) // error
+  foo((() => println(c)) :: Nil, c) // ok
   val x1: (Object^, Object^) = (c, c) // error
   val x2: (Object^, Object^{d}) = (d, d) // error
 

--- a/tests/neg-custom-args/captures/sepchecks2.scala
+++ b/tests/neg-custom-args/captures/sepchecks2.scala
@@ -7,7 +7,7 @@ def bar(x: (Object^, Object^)): Unit = ???
 
 def Test(consume c: Object^) =
   val xs: List[() => Unit] = (() => println(c)) :: Nil
-  println(c) // error
+  println(c)
 
 def Test2(c: Object^, d: Object^): Unit =
   foo((() => println(c)) :: Nil, c) // error

--- a/tests/neg-custom-args/captures/unsound-reach-6.check
+++ b/tests/neg-custom-args/captures/unsound-reach-6.check
@@ -26,7 +26,3 @@
    |              ^^
    |              Local reach capability ys* leaks into capture scope of method test.
    |              You could try to abstract the capabilities referred to by ys* in a capset variable.
--- Error: tests/neg-custom-args/captures/unsound-reach-6.scala:19:14 ---------------------------------------------------
-19 |    val z = f(ys)  // error consume failure
-   |              ^^
-   |Separation failure: argument to consume parameter with type List[() ->{io} Unit] refers to non-local parameter io

--- a/tests/neg-custom-args/captures/unsound-reach-6.scala
+++ b/tests/neg-custom-args/captures/unsound-reach-6.scala
@@ -16,7 +16,7 @@ def test(io: IO^)(ys: List[() ->{io} Unit]) =
 def test(io: IO^) =
   def ys: List[() ->{io} Unit] = ???
   val x = () =>
-    val z = f(ys)  // error consume failure
+    val z = f(ys)  // ok, was error consume failure
     z()
   val _: () -> Unit = x // error
   ()

--- a/tests/new/test.scala
+++ b/tests/new/test.scala
@@ -1,9 +1,1 @@
-object e:
-  def foldRL(f: Int => Int)(g: String => Int) = ???
-
-
-val xs = e.foldRL
-  : i => i + 1
-  : s => s.length
-
-
+object Test

--- a/tests/pos-custom-args/captures/drop-refinement.scala
+++ b/tests/pos-custom-args/captures/drop-refinement.scala
@@ -1,0 +1,18 @@
+import scala.annotation.unchecked.uncheckedVariance
+
+private final class ConcatIterator[+A](val from: Iterator[A @uncheckedVariance]^) {
+  self: ConcatIterator[A]^ =>
+  def hasNext: Boolean = ???
+  def next(): A = ???
+
+  def concat[B >: A](that: => IterableOnce[B]^): ConcatIterator[B]^{this, that} = {
+    val c = new ConcatIteratorCell[B](that, null).asInstanceOf[ConcatIteratorCell[A]]
+      // crashes without special exemption for isRefining in CaptureSet.ProperVar$includeElem.
+    this
+  }
+}
+
+private final class ConcatIteratorCell[A](head: => IterableOnce[A]^, var tail: ConcatIteratorCell[A]^) {
+  def headIterator: Iterator[A]^{this} = head.iterator
+}
+

--- a/tests/run-custom-args/captures/colltest5/CollectionStrawManCC5_1.scala
+++ b/tests/run-custom-args/captures/colltest5/CollectionStrawManCC5_1.scala
@@ -532,7 +532,7 @@ object CollectionStrawMan5 {
       }
       -1
     }
-    def filter(p: A => Boolean): Iterator[A]^{this, p} = new Iterator[A] {
+    def filter(p: A ->{cap, this} Boolean): Iterator[A]^{this, p} = new Iterator[A] {
       private var hd: A = compiletime.uninitialized
       private var hdDefined: Boolean = false
 


### PR DESCRIPTION
In this PR, I originally only wanted to change the scheme handling fresh caps: Capture sets in the type of a val or the result type of a def should only have a single fresh that had the val or def as its origin. Any other fresh caps that were inferred before in those sets should instead be hidden by the unique fresh. 

But doing this disturbed the system sufficiently to cause new problems in separation checking. These problems were caused by incorrect algorithms that had to be fixed first. The current status of the separation checker is "improved relative to the state before, but still a way to go".


