### PR TITLE
Consider rendering prefix when pretty printing values in the REPL

### DIFF
--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -119,7 +119,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
           val prefix = s"$dcl = "
           // Prefix can have multiple lines, only consider the last one
           // when determining the initial column offset for pretty-printing
-          val prefixLength = prefix.linesIterator.toSeq.lastOption.getOrElse("")
+          val prefixLength = prefix.linesIterator.toSeq.lastOption.getOrElse("").length
           valueOf(d.symbol, prefixLength).map(value => msg(s"$prefix$value"))
         }
       )

--- a/compiler/src/dotty/tools/repl/Rendering.scala
+++ b/compiler/src/dotty/tools/repl/Rendering.scala
@@ -53,16 +53,23 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
     else str.substring(0, str.offsetByCodePoints(0, maxPrintCharacters - 1))
 
   /** Return a String representation of a value we got from `classLoader()`. */
-  private[repl] def replStringOf(sym: Symbol, value: Object)(using Context): String = {
+  private[repl] def replStringOf(value: Object, prefixLength: Int)(using Context): String = {
     // pretty-print things with 100 cols 50 rows by default,
-    dotty.shaded.pprint.PPrinter.BlackWhite.apply(value, width = 100, height = 50).plainText
+    dotty.shaded.pprint.PPrinter.BlackWhite
+      .apply(
+        value,
+        width = 100,
+        height = 50,
+        initialOffset = prefixLength
+      )
+      .plainText
   }
 
   /** Load the value of the symbol using reflection.
    *
    *  Calling this method evaluates the expression using reflection
    */
-  private def valueOf(sym: Symbol)(using Context): Option[String] =
+  private def valueOf(sym: Symbol, prefixLength: Int)(using Context): Option[String] =
     val objectName = sym.owner.fullName.encode.toString.stripSuffix("$")
     val resObj: Class[?] = Class.forName(objectName, true, classLoader())
     val symValue = resObj
@@ -71,7 +78,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       .flatMap(result => rewrapValueClass(sym.info.classSymbol, result.invoke(null)))
     symValue
       .filter(_ => sym.is(Flags.Method) || sym.info != defn.UnitType)
-      .map(value => stripReplPrefix(replStringOf(sym, value)))
+      .map(value => stripReplPrefix(replStringOf(value, prefixLength)))
 
   private def stripReplPrefix(s: String): String =
     if (s.startsWith(REPL_WRAPPER_NAME_PREFIX))
@@ -108,7 +115,13 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
     try
       Right(
         if d.symbol.is(Flags.Lazy) then Some(msg(dcl))
-        else valueOf(d.symbol).map(value => msg(s"$dcl = $value"))
+        else {
+          val prefix = s"$dcl = "
+          // Prefix can have multiple lines, only consider the last one
+          // when determining the initial column offset for pretty-printing
+          val prefixLength = prefix.linesIterator.toSeq.lastOption.getOrElse("")
+          valueOf(d.symbol, prefixLength).map(value => msg(s"$prefix$value"))
+        }
       )
     catch case e: ReflectiveOperationException => Left(e)
   end renderVal


### PR DESCRIPTION
Previously the initial `val res0: Seq[Int] =` was not considered, so the pretty-printed value when appended to it could over-run the 100-column limit of the REPL. This PR properly takes the last line of the prefix (which can have multiple lines) and passes it to `PPrinter.apply`'s `initialOffset` so the first line considers the prefix and wraps earlier as necessary

Tested manually with `Seq.tabulate(22)(identity)`. The single-line output (below) is 104 characters, exceeding the 100 char default limit. With this PR, it properly wraps, while without this PR it doesn't, and you instead need to go all the way up to `Seq.tabulate(27)(identity)` for it to wrap

```scala
val res0: Seq[Int] = List(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
```
