### PR TITLE
improvement: Additional way of defining ENABLE_BSP_ALL_PROJECTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ docs/_spec/.jekyll-metadata
 
 # scaladoc related
 scaladoc/output/
+
+# only used in local development
+.enable_bsp_all_projects

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -459,7 +459,10 @@ object Build {
     ) ++ extMap
   }
 
-  val enableBspAllProjects = sys.env.get("ENABLE_BSP_ALL_PROJECTS").map(_.toBoolean).getOrElse(false)
+  val enableBspAllProjects = sys.env.get("ENABLE_BSP_ALL_PROJECTS").map(_.toBoolean).getOrElse{
+    val enableBspAllProjectsFile = file(".enable_bsp_all_projects")
+    enableBspAllProjectsFile.exists()
+  }
 
   // Settings used when compiling dotty with a non-bootstrapped dotty
   lazy val commonBootstrappedSettings = commonDottySettings ++ Seq(


### PR DESCRIPTION
Seems that the environment variables are not always picked up, so instead a more reliable solution would be to create file for yourself that can track it instead.