### PR TITLE
Fix compiler crash with `-Ymagic-offset-header`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -55,11 +55,11 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
   def sourcePos(using Context): SourcePosition =
     val info = WrappedSourceFile.locateMagicHeader(source)
     info match
-      case HasHeader(offset, originalFile) =>
-        if span.start >= offset then  // This span is in user code
+      // This span is in user code
+      case HasHeader(offset, originalFile)
+        if span != NoSpan && span.start >= offset =>
           originalFile.atSpan(span.shift(-offset))
-        else  // Otherwise, return the source position in the wrapper code
-          source.atSpan(span)
+      // Otherwise, return the source position in the wrapper code
       case _ => source.atSpan(span)
 
   /** This positioned item, widened to `SrcPos`. Used to make clear we only need the

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -57,7 +57,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
     info match
       // This span is in user code
       case HasHeader(offset, originalFile)
-        if span != NoSpan && span.start >= offset =>
+        if span.exists && span.start >= offset =>
           originalFile.atSpan(span.shift(-offset))
       // Otherwise, return the source position in the wrapper code
       case _ => source.atSpan(span)


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/24091

Since `span.start` is only valid when `span.exists`, we just check that first before calling `span.start` and otherwise fall back to the default code path