### PR TITLE
Trap Ctrl-C in the REPL: if no command is running clear the prompt, if some command is running ask for confirmation before exiting

### DIFF
--- a/compiler/src/dotty/tools/repl/JLineTerminal.scala
+++ b/compiler/src/dotty/tools/repl/JLineTerminal.scala
@@ -82,6 +82,10 @@ class JLineTerminal extends java.io.Closeable {
 
   def close(): Unit = terminal.close()
 
+  /** Register a signal handler and return the previous handler */
+  def handle(signal: org.jline.terminal.Terminal.Signal, handler: org.jline.terminal.Terminal.SignalHandler): org.jline.terminal.Terminal.SignalHandler =
+    terminal.handle(signal, handler)
+
   /** Provide syntax highlighting */
   private class Highlighter(using Context) extends reader.Highlighter {
     def highlight(reader: LineReader, buffer: String): AttributedString = {


### PR DESCRIPTION
This ports over one of the other Ammonite features to the Scala 3 REPL, making it behave much more similarly to other prompt environment (Bash, Python, etc.): 

- If there is no code running, `Ctrl-C` just resets the prompt without exiting
- If there is code running, `Ctrl-C` first interrupts the thread to try and force a gentle exit. A second `Ctrl-C` would then terminate the process.

We will no longer be able to terminate the thread forcefully, as `Thread.stop` is busted Java >20 (see https://github.com/com-lihaoyi/Ammonite/issues/1379), so using `Thread.interrupt` and `sys.exit` is the best we have

Tested manually using `bin/scala`