### PR TITLE
Add unsafe RawPresentationCompiler implementation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -181,7 +181,7 @@ object Contexts {
       val local = incCallback
       local != null && local.enabled || forceRun
 
-    /** The Zinc compile progress callback implementation if we are run from Zinc, null otherwise */
+    /** The Zinc compile progress callback implementation if we are run from Zinc or used by presentation compiler, null otherwise */
     def progressCallback: ProgressCallback | Null = store(progressCallbackLoc)
 
     /** Run `op` if there exists a Zinc progress callback */

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -14,6 +14,7 @@ import java.util.zip.*
 import scala.collection.*
 import scala.io.Codec
 
+import dotty.tools.dotc.sbt.interfaces.ProgressCallback
 import dotty.tools.io.AbstractFile
 
 import ast.{Trees, tpd}
@@ -29,6 +30,9 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
   import tpd.*
 
   override def sourcesRequired: Boolean = false
+
+  private var myProgressCallback: ProgressCallback = new ProgressCallback:
+    override def isCancelled(): Boolean = Thread.interrupted()
 
   private val myInitCtx: Context = {
     val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions).addMode(Mode.Interactive)
@@ -151,7 +155,7 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
       val reporter =
         new StoreReporter(null) with UniqueMessagePositions with HideNonSensicalMessages
 
-      val run = compiler.newRun(using myInitCtx.fresh.setReporter(reporter))
+      val run = compiler.newRun(using myInitCtx.fresh.setReporter(reporter).setProgressCallback(myProgressCallback))
       myCtx = run.runContext.withRootImports
 
       given Context = myCtx
@@ -169,8 +173,7 @@ class InteractiveDriver(val settings: List[String]) extends Driver {
       myCtx = myCtx.fresh.setPhase(myInitCtx.base.typerPhase)
 
       reporter.removeBufferedMessages
-    }
-    catch {
+    } catch {
       case ex: FatalError  =>
         myCtx = previousCtx
         close(uri)

--- a/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
@@ -1,0 +1,65 @@
+package dotty.tools.pc
+
+import org.eclipse.lsp4j
+import org.eclipse.lsp4j.DiagnosticSeverity
+import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.interfaces.Diagnostic as DiagnosticInterfaces
+import dotty.tools.dotc.reporting.Diagnostic
+import dotty.tools.pc.utils.InteractiveEnrichments.toLsp
+
+import scala.meta.pc.VirtualFileParams
+import ch.epfl.scala.bsp4j
+import dotty.tools.dotc.reporting.CodeAction
+import dotty.tools.dotc.rewrites.Rewrites.ActionPatch
+import scala.jdk.CollectionConverters.*
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.reporting.ErrorMessageID
+import org.eclipse.lsp4j.DiagnosticTag
+
+class DiagnosticProvider(driver: InteractiveDriver, params: VirtualFileParams):
+
+  def diagnostics(): List[lsp4j.Diagnostic] =
+    val diags = driver.run(params.uri().nn, params.text().nn)
+    given Context = driver.currentCtx
+    diags.flatMap(toLsp)
+
+  private def toLsp(diag: Diagnostic)(using Context): Option[lsp4j.Diagnostic] =
+    Option.when(diag.pos.exists):
+      val lspDiag = lsp4j.Diagnostic(
+        diag.pos.toLsp,
+        diag.msg.message,
+        toDiagnosticSeverity(diag.level),
+        "presentation compiler",
+      )
+      lspDiag.setCode(diag.msg.errorId.errorNumber)
+
+      val scalaDiagnostic = new bsp4j.ScalaDiagnostic()
+      val actions = diag.msg.actions.map(toBspScalaAction).asJava
+      scalaDiagnostic.setActions(actions)
+      // lspDiag.setRelatedInformation(???) Currently not emitted by the compiler
+      lspDiag.setData(scalaDiagnostic)
+      if diag.msg.errorId == ErrorMessageID.UnusedSymbolID then
+        lspDiag.setTags(List(DiagnosticTag.Unnecessary).asJava)
+
+      lspDiag
+
+  private def toBspScalaAction(action: CodeAction): bsp4j.ScalaAction =
+    val bspAction = bsp4j.ScalaAction(action.title)
+    action.description.foreach(bspAction.setDescription)
+    val workspaceEdit = bsp4j.ScalaWorkspaceEdit(action.patches.map(toBspTextEdit).asJava)
+    bspAction.setEdit(workspaceEdit)
+    bspAction
+
+  private def toBspTextEdit(actionPatch: ActionPatch): bsp4j.ScalaTextEdit =
+    val startPos = bsp4j.Position(actionPatch.srcPos.startLine, actionPatch.srcPos.startColumn)
+    val endPos   = bsp4j.Position(actionPatch.srcPos.endLine, actionPatch.srcPos.endColumn)
+    val range = bsp4j.Range(startPos, endPos)
+    bsp4j.ScalaTextEdit(range, actionPatch.replacement)
+
+
+  private def toDiagnosticSeverity(severity: Int): DiagnosticSeverity =
+    severity match
+      case DiagnosticInterfaces.ERROR   => DiagnosticSeverity.Error
+      case DiagnosticInterfaces.WARNING => DiagnosticSeverity.Warning
+      case DiagnosticInterfaces.INFO    => DiagnosticSeverity.Information
+      case _                            => DiagnosticSeverity.Information

--- a/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
@@ -1,0 +1,340 @@
+package dotty.tools.pc
+
+import java.io.File
+import java.net.URI
+import java.nio.file.Path
+import java.util.Optional
+import java.util as ju
+
+import scala.jdk.CollectionConverters._
+import scala.language.unsafeNulls
+import scala.meta.internal.metals.CompilerVirtualFileParams
+import scala.meta.pc.reports.EmptyReportContext
+import scala.meta.internal.metals.PcQueryContext
+import scala.meta.pc.reports.ReportContext
+import scala.meta.internal.metals.ReportLevel
+import scala.meta.internal.mtags.CommonMtagsEnrichments.*
+import scala.meta.internal.pc.EmptySymbolSearch
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.*
+import scala.meta.pc.{PcSymbolInformation as IPcSymbolInformation}
+
+import dotty.tools.pc.completions.CompletionProvider
+import dotty.tools.pc.InferExpectedType
+import dotty.tools.pc.completions.OverrideCompletions
+import dotty.tools.pc.buildinfo.BuildInfo
+import dotty.tools.pc.SymbolInformationProvider
+import dotty.tools.dotc.interactive.InteractiveDriver
+
+import org.eclipse.lsp4j.DocumentHighlight
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j as l
+
+
+case class RawScalaPresentationCompiler(
+    buildTargetIdentifier: String = "",
+    buildTargetName: Option[String] = None,
+    classpath: Seq[Path] = Nil,
+    options: List[String] = Nil,
+    search: SymbolSearch = EmptySymbolSearch,
+    config: PresentationCompilerConfig = PresentationCompilerConfigImpl(),
+    folderPath: Option[Path] = None,
+    reportsLevel: ReportLevel = ReportLevel.Info,
+    completionItemPriority: CompletionItemPriority = (_: String) => 0,
+    reportContext: ReportContext = EmptyReportContext()
+) extends RawPresentationCompiler:
+
+  def this() = this("uninitialized-presentation-compiler")
+
+  given ReportContext = reportContext
+
+  override def supportedCodeActions(): ju.List[String] = List(
+     CodeActionId.ConvertToNamedArguments,
+     CodeActionId.ImplementAbstractMembers,
+     CodeActionId.ExtractMethod,
+     CodeActionId.InlineValue,
+     CodeActionId.InsertInferredType,
+     CodeActionId.InsertInferredMethod,
+     PcConvertToNamedLambdaParameters.codeActionId
+   ).asJava
+
+  override val scalaVersion = BuildInfo.scalaVersion
+
+  private val forbiddenOptions = Set("-print-lines", "-print-tasty")
+  private val forbiddenDoubleOptions = Set.empty[String]
+
+  val driverSettings =
+    val implicitSuggestionTimeout = List("-Ximport-suggestion-timeout", "0")
+    val defaultFlags = List("-color:never")
+    val filteredOptions = removeDoubleOptions(options.filterNot(forbiddenOptions))
+
+    filteredOptions ::: defaultFlags ::: implicitSuggestionTimeout ::: "-classpath" :: classpath
+      .mkString(File.pathSeparator) :: Nil
+
+  lazy val driver: InteractiveDriver = CachingDriver(driverSettings)
+
+  override def codeAction[T](
+    params: OffsetParams,
+    codeActionId: String,
+    codeActionPayload: Optional[T]
+   ): ju.List[TextEdit] =
+     (codeActionId, codeActionPayload.asScala) match
+        case (
+              CodeActionId.ConvertToNamedArguments,
+              Some(argIndices: ju.List[_])
+            ) =>
+          val payload = argIndices.asScala.collect { case i: Integer => i.toInt }.toSet
+          convertToNamedArguments(params, payload)
+        case (CodeActionId.ImplementAbstractMembers, _) =>
+          implementAbstractMembers(params)
+        case (CodeActionId.InsertInferredType, _) =>
+          insertInferredType(params)
+        case (CodeActionId.InsertInferredMethod, _) =>
+          insertInferredMethod(params)
+        case (CodeActionId.InlineValue, _) =>
+          inlineValue(params)
+        case (CodeActionId.ExtractMethod, Some(extractionPos: OffsetParams)) =>
+          params match {
+            case range: RangeParams =>
+              extractMethod(range, extractionPos)
+            case _ => throw new IllegalArgumentException(s"Expected range parameters")
+          }
+        case (PcConvertToNamedLambdaParameters.codeActionId, _) =>
+          PcConvertToNamedLambdaParameters(driver, params).convertToNamedLambdaParameters
+        case (id, _) => throw new IllegalArgumentException(s"Unsupported action id $id")
+
+  override def withCompletionItemPriority(
+    priority: CompletionItemPriority
+  ): RawPresentationCompiler =
+    copy(completionItemPriority = priority)
+
+  override def withBuildTargetName(buildTargetName: String): RawPresentationCompiler =
+    copy(buildTargetName = Some(buildTargetName))
+
+  override def withReportsLoggerLevel(level: String): RawPresentationCompiler =
+    copy(reportsLevel = ReportLevel.fromString(level))
+
+  private def removeDoubleOptions(options: List[String]): List[String] =
+    options match
+      case head :: _ :: tail if forbiddenDoubleOptions(head) =>
+        removeDoubleOptions(tail)
+      case head :: tail => head :: removeDoubleOptions(tail)
+      case Nil => options
+
+  override def semanticTokens(
+      params: VirtualFileParams
+  ): ju.List[Node] =
+    PcSemanticTokensProvider(driver, params).provide().asJava
+
+  override def inlayHints(
+      params: InlayHintsParams
+  ): ju.List[l.InlayHint] =
+    PcInlayHintsProvider(driver, params, search)
+      .provide()
+      .asJava
+
+  override def getTasty(
+      targetUri: URI,
+      isHttpEnabled: Boolean
+  ): String =
+    TastyUtils.getTasty(targetUri, isHttpEnabled)
+
+  override def complete(params: OffsetParams, completionTriggerKind: l.CompletionTriggerKind): l.CompletionList =
+    CompletionProvider(
+      search,
+      driver,
+      () => InteractiveDriver(driverSettings),
+      params,
+      config,
+      buildTargetIdentifier,
+      folderPath,
+      completionItemPriority
+    ).completions()
+
+  def definition(params: OffsetParams): DefinitionResult =
+    PcDefinitionProvider(driver, params, search).definitions()
+
+  override def typeDefinition(
+      params: OffsetParams
+  ): DefinitionResult =
+    PcDefinitionProvider(driver, params, search).typeDefinitions()
+
+  override def documentHighlight(
+      params: OffsetParams
+  ): ju.List[DocumentHighlight] =
+    PcDocumentHighlightProvider(driver, params).highlights.asJava
+
+  override def references(
+      params: ReferencesRequest
+  ): ju.List[ReferencesResult] =
+    PcReferencesProvider(driver, params)
+      .references()
+      .asJava
+
+  def inferExpectedType(params: OffsetParams): ju.Optional[String] =
+    InferExpectedType(search, driver, params).infer().asJava
+
+  override def info(
+      symbol: String
+  ): Optional[IPcSymbolInformation] =
+    SymbolInformationProvider(using driver.currentCtx)
+      .info(symbol)
+      .map(_.asJava)
+      .asJava
+
+  override def semanticdbTextDocument(
+      filename: URI,
+      code: String
+  ): Array[Byte] =
+    val provider = SemanticdbTextDocumentProvider(driver, folderPath)
+    provider.textDocument(filename, code)
+
+  override def completionItemResolve(
+      item: l.CompletionItem,
+      symbol: String
+  ): l.CompletionItem =
+    CompletionItemResolver.resolve(item, symbol, search, config)(using driver.currentCtx) // FIX ME
+
+  override def autoImports(
+      name: String,
+      params: scala.meta.pc.OffsetParams,
+      isExtension: java.lang.Boolean
+  ): ju.List[scala.meta.pc.AutoImportsResult] =
+    AutoImportsProvider(
+      search,
+      driver,
+      name,
+      params,
+      config,
+      buildTargetIdentifier
+    )
+      .autoImports(isExtension)
+      .asJava
+
+  override def implementAbstractMembers(
+      params: OffsetParams
+  ): ju.List[l.TextEdit] =
+    OverrideCompletions.implementAllAt(
+      params,
+      driver,
+      search,
+      config
+    )
+
+  override def insertInferredType(
+      params: OffsetParams
+  ): ju.List[l.TextEdit] =
+    InferredTypeProvider(params, driver, config, search)
+      .inferredTypeEdits()
+      .asJava
+
+  private def insertInferredMethod(
+      params: OffsetParams
+  ): ju.List[l.TextEdit] =
+    InferredMethodProvider(params, driver, config, search)
+      .inferredMethodEdits()
+      .asJava
+
+  override def inlineValue(
+      params: OffsetParams
+  ): ju.List[l.TextEdit] =
+    PcInlineValueProvider(driver, params).getInlineTextEdits() match
+      case Right(edits: List[TextEdit]) => edits.asJava
+      case Left(error: String) => throw new DisplayableException(error)
+
+  override def extractMethod(
+      range: RangeParams,
+      extractionPos: OffsetParams
+  ): ju.List[l.TextEdit] =
+    ExtractMethodProvider(
+      range,
+      extractionPos,
+      driver,
+      search,
+      options.contains("-no-indent"),
+    )
+      .extractMethod()
+      .asJava
+
+  override def convertToNamedArguments(
+      params: OffsetParams,
+      argIndices: ju.List[Integer]
+  ): ju.List[l.TextEdit] =
+    convertToNamedArguments(params, argIndices.asScala.toSet.map(_.toInt))
+
+  def convertToNamedArguments(
+      params: OffsetParams,
+      argIndices: Set[Int]
+  ): ju.List[l.TextEdit] =
+    ConvertToNamedArgumentsProvider(
+      driver,
+      params,
+      argIndices
+    ).convertToNamedArguments match
+      case Left(error: String) => throw new DisplayableException(error)
+      case Right(edits: List[l.TextEdit]) => edits.asJava
+
+  override def selectionRange(
+      params: ju.List[OffsetParams]
+  ): ju.List[l.SelectionRange] =
+    SelectionRangeProvider(
+      driver,
+      params,
+    ).selectionRange().asJava
+
+  override def hover(
+      params: OffsetParams
+  ): ju.Optional[HoverSignature] =
+    HoverProvider.hover(params, driver, search, config.hoverContentType())
+
+  override def prepareRename(
+      params: OffsetParams
+  ): ju.Optional[l.Range] =
+    PcRenameProvider(driver, params, None).prepareRename().asJava
+
+  override def rename(
+      params: OffsetParams,
+      name: String
+  ): ju.List[l.TextEdit] =
+    PcRenameProvider(driver, params, Some(name)).rename().asJava
+
+  override def newInstance(
+      buildTargetIdentifier: String,
+      classpath: ju.List[Path],
+      options: ju.List[String]
+  ): RawPresentationCompiler =
+    copy(
+      buildTargetIdentifier = buildTargetIdentifier,
+      classpath = classpath.asScala.toSeq,
+      options = options.asScala.toList
+    )
+
+  override def signatureHelp(params: OffsetParams): l.SignatureHelp =
+    SignatureHelpProvider.signatureHelp(driver, params, search)
+
+  override def didChange(params: VirtualFileParams): ju.List[l.Diagnostic] =
+    DiagnosticProvider(driver, params).diagnostics().asJava
+
+  override def didClose(uri: URI): Unit =
+    driver.close(uri)
+
+  override def semanticdbTextDocument(params: VirtualFileParams): Array[Byte] =
+    semanticdbTextDocument(params.uri, params.text)
+
+  override def buildTargetId(): String = buildTargetIdentifier
+
+  override def withConfiguration(
+      config: PresentationCompilerConfig
+  ): RawPresentationCompiler =
+    copy(config = config)
+
+  override def withSearch(search: SymbolSearch): RawPresentationCompiler =
+    copy(search = search)
+
+  override def withReportContext(reportContext: ReportContext): RawPresentationCompiler =
+    copy(reportContext = reportContext)
+
+  override def withWorkspace(workspace: Path): RawPresentationCompiler =
+    copy(folderPath = Some(workspace))
+
+end RawScalaPresentationCompiler

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseInlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseInlayHintsSuite.scala
@@ -38,7 +38,8 @@ class BaseInlayHintsSuite extends BasePCSuite {
       byNameParameters = true,
       implicitConversions = true,
       namedParameters = true,
-      hintsInPatternMatch = hintsInPatternMatch
+      hintsInPatternMatch = hintsInPatternMatch,
+      closingLabels = false
     )
 
     val inlayHints = presentationCompiler

--- a/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticProviderSuite.scala
@@ -1,0 +1,60 @@
+package dotty.tools.pc.tests
+
+import java.net.URI
+import scala.meta.internal.jdk.CollectionConverters.*
+import scala.meta.internal.metals.CompilerVirtualFileParams
+import scala.meta.internal.metals.EmptyCancelToken
+
+import org.junit.Test
+import org.eclipse.lsp4j.DiagnosticSeverity
+import dotty.tools.pc.utils.TestExtensions.getOffset
+import dotty.tools.pc.base.TestResources
+import java.nio.file.Path
+import dotty.tools.pc.RawScalaPresentationCompiler
+import dotty.tools.pc.utils.PcAssertions
+
+class DiagnosticProviderSuite extends PcAssertions {
+  case class TestDiagnostic(startIndex: Int, endIndex: Int, msg: String, severity: DiagnosticSeverity)
+
+  val pc = RawScalaPresentationCompiler().newInstance("", TestResources.classpath.asJava, Nil.asJava)
+
+  def check(
+    text: String,
+    expected: List[TestDiagnostic]
+  ): Unit =
+    val diagnostics = pc
+      .didChange(CompilerVirtualFileParams(URI.create("file:/Diagnostic.scala"), text, EmptyCancelToken))
+      .asScala
+
+    val actual = diagnostics.map(d => TestDiagnostic(d.getRange().getStart().getOffset(text), d.getRange().getEnd().getOffset(text), d.getMessage(), d.getSeverity()))
+    // NOTE IF those tests turn out to be flaky, consider just checking the beginning of the message
+    assertEquals(expected, actual, s"Expected [${expected.mkString(", ")}] but got [${actual.mkString(", ")}]")
+
+  @Test def error =
+    check(
+      """|class Bar(i: It)
+         |""".stripMargin,
+      List(TestDiagnostic(13, 15, "Not found: type It - did you mean Int? or perhaps Int.type?", DiagnosticSeverity.Error))
+    )
+
+  @Test def warning =
+    check(
+      """|object M:
+         |  1 + 1
+         |""".stripMargin,
+      List(TestDiagnostic(12, 17, "A pure expression does nothing in statement position", DiagnosticSeverity.Warning))
+    )
+
+  @Test def mixed =
+    check(
+      """|class Bar(i: It)
+         |object M:
+         |  1 + 1
+         |""".stripMargin,
+      List(
+        TestDiagnostic(13 ,15, "Not found: type It - did you mean Int? or perhaps Int.type?", DiagnosticSeverity.Error),
+        TestDiagnostic(29, 34, "A pure expression does nothing in statement position", DiagnosticSeverity.Warning)
+      )
+    )
+
+}

--- a/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsSuite.scala
@@ -1069,7 +1069,7 @@ class InlayHintsSuite extends BaseInlayHintsSuite {
       """|def hello/*: (path : String<<java/lang/String#>>, num : Int<<scala/Int#>>)*/ = (path = ".", num = 5)/*[(String<<java/lang/String#>>, Int<<scala/Int#>>)]*/
          |
          |def test/*: (path : String<<java/lang/String#>>, num : Int<<scala/Int#>>, line : Int<<scala/Int#>>)*/ =
-         |  hello ++/*[Tuple1<<scala/Tuple1#>>["line"], Tuple1<<scala/Tuple1#>>[Int<<scala/Int#>>]]*/ (line = 1)/*(using refl<<scala/`<:<`.refl().>>)*//*[Tuple1<<scala/Tuple1#>>[Int<<scala/Int#>>]]*/
+         |  hello ++/*[Tuple1<<scala/Tuple1#>>["line"], Tuple1<<scala/Tuple1#>>[Int<<scala/Int#>>]]*/ (line = 1)/*[Tuple1<<scala/Tuple1#>>[Int<<scala/Int#>>]]*//*(using refl<<scala/`<:<`.refl().>>)*/
          |
          |@main def bla/*: Unit<<scala/Unit#>>*/ =
          |   val x: (path: String, num: Int, line: Int) = test

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2826,15 +2826,17 @@ object Build {
       BuildInfoPlugin.buildInfoDefaultSettings
 
   lazy val presentationCompilerSettings = {
-    val mtagsVersion = "1.6.2"
+    val mtagsVersion = "1.6.2+105-e665821a-SNAPSHOT"
     Seq(
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",
         "io.get-coursier" % "interface" % "1.0.18",
         "org.scalameta" % "mtags-interfaces" % mtagsVersion,
         "com.google.guava" % "guava" % "33.2.1-jre",
+        "ch.epfl.scala" % "bsp4j" % "2.1.1",
       ),
       libraryDependencies += ("org.scalameta" % "mtags-shared_2.13.16" % mtagsVersion % SourceDeps),
+      resolvers += Resolver.sonatypeCentralSnapshots,
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       scalacOptions ++= Seq("-source", "3.3"), // To avoid fatal migration warnings


### PR DESCRIPTION
`RawPresentationCompiler` is a direct, unsafe way to access presentation compiler interface provided in
https://github.com/scalameta/metals/pull/7841

It is up to the consumer to guarantee thread safety and sequential request processing.
This solves many issues with the current `PresentationCompiler` interface but most important are:
- We now have control where and how each presentation compiler method is run. Before it was always run on a `SingleThreadExecutor` created by the `PresentationCompiler`. The original behavior will stay with the standard `ScalaPresentationCompiler` interface. (There is another PR that refactors that part),
- If there was bug in scheduler all versions were affected,

On top of that this PR implements all things that will work out of the box:
- Diagnostic provider - trivial implementation, previously not possible to LIFO task used by `Scala3CompilerAccess`. Will be super useful e.g for Scastie which will become a consumer of this new raw API.
- `InteractiveDriver` compilation cancellation by checking Thread.interrupted(). Future changes are required to make it work with safe `ScalaPresentationCompiler` and `CancelTokens`. Here we can omit the cancel token support for now, because we would check for `Thread.interrupted()` along the `cancelToken.isCancelled` anyway, and we can now easily interrupt it from e.g `IO.interruptible` 

Those changes were adapted from my other PR's that required adjustment of `Scala3CompilerAccess` but I don't think it is ready / I'm not happy with current state of that refactor.

In the future we should think of replacing the implementation of `ScalaPresentationCompiler` to use `RawPresentationCompiler` as underlying impl and just call it in safe way.
 
The implementation was tested on the actual LSP server and it works fine.