### PR TITLE
module classes can sometimes extend `scala.runtime.AbstractFuntionN` in Scala 2

### DIFF
--- a/library/src/scala/UninitializedFieldError.scala
+++ b/library/src/scala/UninitializedFieldError.scala
@@ -23,3 +23,6 @@ import scala.language.`2.13`
 final case class UninitializedFieldError(msg: String) extends RuntimeException(msg) {
   def this(obj: Any) = this("" + obj)
 }
+
+object UninitializedFieldError extends scala.runtime.AbstractFunction1[String, UninitializedFieldError]:
+  override def toString: String = "UninitializedFieldError"

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -1651,3 +1651,6 @@ final case class StringView(s: String) extends AbstractIndexedSeqView[Char] {
   def apply(n: Int) = s.charAt(n)
   override def toString: String = s"StringView($s)"
 }
+
+object StringView extends scala.runtime.AbstractFunction1[String, StringView]:
+  override def toString: String = "StringView"

--- a/library/src/scala/reflect/package.scala
+++ b/library/src/scala/reflect/package.scala
@@ -76,3 +76,6 @@ package object reflect {
 
 /** An exception that indicates an error during Scala reflection */
 case class ScalaReflectionException(msg: String) extends Exception(msg)
+
+object ScalaReflectionException extends scala.runtime.AbstractFunction1[String, ScalaReflectionException]:
+  override def toString: String = "ScalaReflectionException"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1522,7 +1522,7 @@ object Build {
         val wrappedArgs = if (printTasty) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
         val fullArgs = main :: (defaultOutputDirectory ::: wrappedArgs).map("\""+ _ + "\"").map(_.replace("\\", "\\\\"))
 
-        (Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
+        (`scala3-compiler-bootstrapped-new` / Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
       }.evaluated,
       testCompilation := Def.inputTaskDyn {
         val args = spaceDelimited("<arg>").parsed

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -548,17 +548,6 @@ object MiMaFilters {
           ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Tuple3Zipped.coll2$extension"),
           ProblemFilters.exclude[DirectMissingMethodProblem]("scala.runtime.Tuple3Zipped.coll3$extension"),
 
-          // singleton case classes modules inherit AbstractFunction1??
-          ProblemFilters.exclude[MissingTypesProblem]("scala.ScalaReflectionException$"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("scala.ScalaReflectionException.compose"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("scala.ScalaReflectionException.andThen"),
-          ProblemFilters.exclude[MissingTypesProblem]("scala.UninitializedFieldError$"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("scala.UninitializedFieldError.compose"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("scala.UninitializedFieldError.andThen"),
-          ProblemFilters.exclude[MissingTypesProblem]("scala.collection.StringView$"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.StringView.compose"),
-          ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.StringView.andThen"),
-
           // TO INVESTIGATE: This constructor changed, but it is private... why complaining?
           ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.collection.immutable.LazyList.this"),
           // This one should be fine, public class inside private object


### PR DESCRIPTION
Ported from: https://github.com/scala/scala/blob/6ecf74bfb4e914391fda1df5288ebaad6e4699b8/src/compiler/scala/tools/nsc/typechecker/Unapplies.scala#L122

This is supposed to follow [this part of the spec](https://scala-lang.org/files/archive/spec/2.13/05-classes-and-objects.html#case-classes) but the implementation is somehow different...