### PR TITLE
Warn dubious negative literal syntax

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -224,9 +224,8 @@ object Parsers {
       isIdent(nme.erased) && in.erasedEnabled && in.isSoftModifierInParamModifierPosition
     def isConsume =
       isIdent(nme.consume) && ccEnabled //\&& in.isSoftModifierInParamModifierPosition
-    def isSimpleLiteral =
-      simpleLiteralTokens.contains(in.token)
-      || isIdent(nme.raw.MINUS) && numericLitTokens.contains(in.lookahead.token)
+    def isNegatedNumber = isIdent(nme.raw.MINUS) && numericLitTokens.contains(in.lookahead.token)
+    def isSimpleLiteral = simpleLiteralTokens.contains(in.token) || isNegatedNumber
     def isLiteral = literalTokens contains in.token
     def isNumericLit = numericLitTokens contains in.token
     def isTemplateIntro = templateIntroTokens contains in.token
@@ -1406,9 +1405,7 @@ object Parsers {
      */
     def simpleLiteral(): Tree =
       if isIdent(nme.raw.MINUS) then
-        val start = in.offset
-        in.nextToken()
-        literal(negOffset = start, inTypeOrSingleton = true)
+        literal(start = in.skipToken(), inTypeOrSingleton = true)
       else
         literal(inTypeOrSingleton = true)
 
@@ -1417,15 +1414,18 @@ object Parsers {
      *                      |  symbolLiteral
      *                      |  ‘null’
      *
-     *  @param negOffset   The offset of a preceding `-' sign, if any.
-     *                     If the literal is not negated, negOffset == in.offset.
+     *  @param start   The offset of a preceding `-' sign, if any.
+     *                 If the literal is not negated, start == in.offset.
      */
-    def literal(negOffset: Int = in.offset, inPattern: Boolean = false, inTypeOrSingleton: Boolean = false, inStringInterpolation: Boolean = false): Tree = {
+    def literal(start: Int = in.offset, inPattern: Boolean = false, inTypeOrSingleton: Boolean = false, inStringInterpolation: Boolean = false): Tree = {
       def literalOf(token: Token): Tree = {
-        val isNegated = negOffset < in.offset
+        val isNegated = start < in.offset
         def digits0 = in.removeNumberSeparators(in.strVal.nn)
-        def digits = if (isNegated) "-" + digits0 else digits0
+        def digits = if isNegated then "-" + digits0 else digits0
         if !inTypeOrSingleton then
+          if isNegated && start < in.offset - 1 then
+            warning(IllegalLiteral(), start)
+            patch(Span(start, in.offset + in.strVal.nn.length), "-" + in.strVal.nn.trim)
           token match {
             case INTLIT  => return Number(digits, NumberKind.Whole(in.base))
             case DECILIT => return Number(digits, NumberKind.Decimal)
@@ -1460,15 +1460,15 @@ object Parsers {
         val t = in.token match {
           case STRINGLIT | STRINGPART =>
             val value = in.strVal.nn
-            atSpan(negOffset, negOffset, negOffset + value.length) { Literal(Constant(value)) }
+            atSpan(start, start, start + value.length) { Literal(Constant(value)) }
           case _ =>
             syntaxErrorOrIncomplete(IllegalLiteral())
-            atSpan(negOffset) { Literal(Constant(null)) }
+            atSpan(start) { Literal(Constant(null)) }
         }
         in.nextToken()
         t
       }
-      else atSpan(negOffset) {
+      else atSpan(start) {
         if (in.token == QUOTEID)
           val inName = in.name.nn
           if ((staged & StageKind.Spliced) != 0 && Chars.isIdentifierStart(inName(0))) {
@@ -1542,7 +1542,7 @@ object Parsers {
         nextSegment(in.offset + offsetCorrection)
         offsetCorrection = 0
       if (in.token == STRINGLIT)
-        segmentBuf += literal(inPattern = inPattern, negOffset = in.offset + offsetCorrection, inStringInterpolation = true)
+        segmentBuf += literal(in.offset + offsetCorrection, inPattern = inPattern, inStringInterpolation = true)
 
       InterpolatedString(interpolator.nn, segmentBuf.toList)
     }
@@ -2832,14 +2832,15 @@ object Parsers {
      */
     val prefixExpr: Location => Tree = location =>
       if in.token == IDENTIFIER && nme.raw.isUnary(in.name)
-         && in.canStartExprTokens.contains(in.lookahead.token)
+        && {
+          val lookahead = in.lookahead
+          in.canStartExprTokens.contains(lookahead.token) && lookahead.lineOffset < 0
+        }
       then
-        val start = in.offset
-        val op = termIdent()
-        if (op.name == nme.raw.MINUS && isNumericLit)
-          simpleExprRest(literal(start), location, canApply = true)
+        if isNegatedNumber then
+          simpleExprRest(literal(start = in.skipToken()), location, canApply = true)
         else
-          atSpan(start) { PrefixOp(op, simpleExpr(location)) }
+          atSpan(in.offset) { PrefixOp(termIdent(), simpleExpr(location)) }
       else simpleExpr(location)
 
     /** SimpleExpr    ::= ‘new’ ConstrApp {`with` ConstrApp} [TemplateBody]
@@ -2917,6 +2918,14 @@ object Parsers {
       if (canApply) argumentStart()
       in.token match
         case DOT =>
+          t match
+            case Number(n, _) if n(0) == '-' =>
+              val start = t.span.start
+              val span = Span(start, in.lastOffset)
+              warning(IllegalLiteral(), start)
+              unpatch(ctx.compilationUnit.source, span)
+              patch(span, s"($n)")
+            case _ =>
           in.nextToken()
           simpleExprRest(selectorOrMatch(t), location, canApply = true)
         case LBRACKET =>
@@ -3432,9 +3441,8 @@ object Parsers {
      */
     def simplePattern(): Tree = in.token match {
       case IDENTIFIER | BACKQUOTED_IDENT | THIS | SUPER =>
-        simpleRef() match
-          case id @ Ident(nme.raw.MINUS) if isNumericLit => literal(startOffset(id))
-          case t => simplePatternRest(t)
+        if isNegatedNumber then literal(start = in.skipToken())
+        else simplePatternRest(simpleRef())
       case USCORE =>
         wildcardIdent()
       case LPAREN =>

--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -161,9 +161,9 @@ object Scanners {
       strVal = litBuf.toString
       litBuf.clear()
 
-    @inline def isNumberSeparator(c: Char): Boolean = c == '_'
+    inline def isNumberSeparator(c: Char): Boolean = c == '_'
 
-    @inline def removeNumberSeparators(s: String): String = if (s.indexOf('_') == -1) s else s.replace("_", "")
+    def removeNumberSeparators(s: String): String = if (s.indexOf('_') == -1) s else s.replace("_", "")
 
     // disallow trailing numeric separator char, but continue lexing
     def checkNoTrailingSeparator(): Unit =
@@ -917,21 +917,7 @@ object Scanners {
             putChar('/')
             getOperatorRest()
           }
-        case '0' =>
-          def fetchLeadingZero(): Unit = {
-            nextChar()
-            ch match {
-              case 'x' | 'X' => base = 16 ; nextChar()
-              case 'b' | 'B' => base = 2  ; nextChar()
-              case _         => base = 10 ; putChar('0')
-            }
-            if (base != 10 && !isNumberSeparator(ch) && digit2int(ch, base) < 0)
-              error(em"invalid literal number")
-          }
-          fetchLeadingZero()
-          getNumber()
-        case '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
-          base = 10
+        case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
           getNumber()
         case '`' =>
           getBackquotedIdent()
@@ -1504,9 +1490,21 @@ object Scanners {
       if (isIdentifierPart(ch) && ch >= ' ')
         error(em"Invalid literal number")
 
-    /** Read a number into strVal and set base
-    */
-    protected def getNumber(): Unit = {
+    /** Read a number into strVal and set base and token.
+     */
+    def getNumber(): Unit = {
+      def checkNumberChar() =
+        if !isNumberSeparator(ch) && digit2int(ch, base) < 0 then
+          error(em"invalid literal number")
+      if ch == '0' then
+        nextChar()
+        ch match
+          case 'x' | 'X' => base = 16; nextChar(); checkNumberChar()
+          case 'b' | 'B' => base =  2; nextChar(); checkNumberChar()
+          case _         => base = 10; putChar('0')
+      else
+        base = 10
+
       while (isNumberSeparator(ch) || digit2int(ch, base) >= 0) {
         putChar(ch)
         nextChar()
@@ -1529,9 +1527,7 @@ object Scanners {
           token = LONGLIT
         case _ =>
       }
-
       checkNoTrailingSeparator()
-
       setStrVal()
     }
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -86,6 +86,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i24103b.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i24213.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i18234.scala", defaultOptions.and("-rewrite", "-source:3.8-migration")),
+      compileFile("tests/rewrites/unary-minus.scala", defaultOptions.and("-rewrite")),
     )).checkRewrites()
   }
 

--- a/tests/neg/i24162.scala
+++ b/tests/neg/i24162.scala
@@ -1,0 +1,5 @@
+
+def test(x: Int) =
+  x match
+  case `-`42 => true // error => expected
+  case _ => false // error unindent expected, case found

--- a/tests/pos/i7910.scala
+++ b/tests/pos/i7910.scala
@@ -1,0 +1,13 @@
+
+class C {
+  def k = {
+    object + extends Function1[Int, Int] { def apply(i: Int): Int = i + 1 }
+    val g: Int => Int = +
+    g(1)
+  }
+  def ok = {
+    val i = 42
+    val n = +i
+    n
+  }
+}

--- a/tests/rewrites/unary-minus.check
+++ b/tests/rewrites/unary-minus.check
@@ -1,0 +1,8 @@
+
+import util.chaining.*
+
+def f = -42
+def g = (-42).abs
+def h = (-42).abs
+def i = (-42)
+  .pipe(_.abs)

--- a/tests/rewrites/unary-minus.scala
+++ b/tests/rewrites/unary-minus.scala
@@ -1,0 +1,8 @@
+
+import util.chaining.*
+
+def f = - 42
+def g = -42.abs
+def h = - 42.abs
+def i = - 42
+  .pipe(_.abs)

--- a/tests/warn/unary-minus.scala
+++ b/tests/warn/unary-minus.scala
@@ -1,0 +1,13 @@
+//> using options -Wnonunit-statement
+
+class C {
+  def f1 = -2.abs // warn funky precedence
+  def f2 = - 2.abs // warn meaningless space
+  def f3 = - 2 // warn meaningless space
+  def f4 = 42
+    -2.abs // warn precedence // hides warn unused expression
+  def f5 = 42
+    - 2.abs // nowarn infix
+  def f6 = (-2).abs // nowarn explicit precedence
+  def f7 = -3.14 // nowarn decimal point
+}


### PR DESCRIPTION
Warns about `- 42` (the misconception that space is significant);
and `-42.abs` (the misconception that it parses the same as `-x.abs`, i.e. `-(42.abs)`).

Patches are emitted for `-rewrite`.

Tweak `prefixExpr` to exclude subsequent expression on the next line.

Tweak `simplePattern` to exclude backquoted hyphen as unary minus.

Fixes #7910 
Fixes #24162 