### PR TITLE
feat: introduce `scala.annotation.meta.exportable`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -126,6 +126,9 @@ object Annotations {
     /** Operations for hash-consing, can be overridden */
     def hash: Int = System.identityHashCode(this)
     def eql(that: Annotation) = this eq that
+
+    final def isExportable(using Context): Boolean =
+      symbol.hasAnnotation(defn.ExportableAnnotation)
   }
 
   case class ConcreteAnnotation(t: Tree) extends Annotation:

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1128,6 +1128,7 @@ class Definitions {
   @tu lazy val GetterMetaAnnot: ClassSymbol = requiredClass("scala.annotation.meta.getter")
   @tu lazy val ParamMetaAnnot: ClassSymbol = requiredClass("scala.annotation.meta.param")
   @tu lazy val SetterMetaAnnot: ClassSymbol = requiredClass("scala.annotation.meta.setter")
+  @tu lazy val ExportableAnnotation: ClassSymbol = requiredClass("scala.annotation.meta.exportable")
   @tu lazy val CompanionClassMetaAnnot: ClassSymbol = requiredClass("scala.annotation.meta.companionClass")
   @tu lazy val CompanionMethodMetaAnnot: ClassSymbol = requiredClass("scala.annotation.meta.companionMethod")
   @tu lazy val ShowAsInfixAnnot: ClassSymbol = requiredClass("scala.annotation.showAsInfix")

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1399,12 +1399,7 @@ class Namer { typer: Typer =>
           forwarder.info = avoidPrivateLeaks(forwarder)
 
           // Add annotations at the member level
-          forwarder.addAnnotations(sym.annotations.filterConserve { annot =>
-            annot.symbol != defn.BodyAnnot
-            && annot.symbol != defn.TailrecAnnot
-            && annot.symbol != defn.MainAnnot
-            && !annot.symbol.derivesFrom(defn.MacroAnnotationClass)
-          })
+          forwarder.addAnnotations(sym.annotations.filterConserve(_.isExportable))
 
           if forwarder.isType then
             buf += tpd.TypeDef(forwarder.asType).withSpan(span)

--- a/library/src/scala/annotation/experimental.scala
+++ b/library/src/scala/annotation/experimental.scala
@@ -1,11 +1,13 @@
 package scala.annotation
 
 import language.experimental.captureChecking
+import meta.exportable
 
 /** An annotation that can be used to mark a definition as experimental.
  *
  *  @see [[https://nightly.scala-lang.org/docs/reference/other-new-features/experimental-defs]]
  *  @syntax markdown
  */
+@exportable
 final class experimental(message: String) extends StaticAnnotation:
   def this() = this("")

--- a/library/src/scala/annotation/meta/exportable.scala
+++ b/library/src/scala/annotation/meta/exportable.scala
@@ -1,0 +1,3 @@
+package scala.annotation.meta
+
+final class exportable extends scala.annotation.StaticAnnotation

--- a/library/src/scala/annotation/targetName.scala
+++ b/library/src/scala/annotation/targetName.scala
@@ -1,10 +1,12 @@
 package scala.annotation
 
 import language.experimental.captureChecking
+import meta.exportable
 
 /** An annotation that defines an external name for a definition.
  *  If an `targetName(extname)` annotation is given for a method or some other
  *  definition, its implementation will use the name `extname` instead of
  *  the regular name.
  */
+@exportable
 final class targetName(name: String) extends StaticAnnotation

--- a/library/src/scala/deprecated.scala
+++ b/library/src/scala/deprecated.scala
@@ -60,6 +60,7 @@ import scala.annotation.meta._
  *  @see    [[scala.deprecatedOverriding]]
  *  @see    [[scala.deprecatedName]]
  */
+@exportable
 @getter @setter @beanGetter @beanSetter @field
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
 class deprecated(message: String = "", since: String = "") extends scala.annotation.ConstantAnnotation

--- a/library/src/scala/throws.scala
+++ b/library/src/scala/throws.scala
@@ -13,6 +13,7 @@
 package scala
 
 import scala.language.`2.13`
+import scala.annotation.meta.exportable
 
 /** Annotation for specifying the exceptions thrown by a method.
  *  For example:
@@ -24,6 +25,7 @@ import scala.language.`2.13`
  *  }
  *  ```
  */
+@exportable
 final class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {
   def this(clazz: Class[T]) = this("")
 }


### PR DESCRIPTION
This is a WIP. It still requires documentation and a test suite.

This annotation should also be annotated with `@documented` from #23770. `@documented` should probably be annotated with `@exportable` too?

Closes #19516