### PR TITLE
Refine the type of inline vals with literal rhs

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -647,4 +647,32 @@ object Inlines:
           inlined
     end expand
   end InlineCall
+
+  /** An inline val is refinable if it has an explicit type that is not a
+   *  singleton type.
+   */
+  def mightRefineInlineVal(mdef: untpd.ValOrDefDef, sym: Symbol)(using Context): Boolean =
+    sym.isInlineVal && !sym.is(Final)
+    && !mdef.tpt.isEmpty && !mdef.tpt.isInstanceOf[untpd.SingletonTypeTree]
+
+  /** Refine the type of an inline val to a constant type if its right hand
+   *  side is a literal. See tests/pos/i24321.scala and tests/printing/i24321.scala.
+   */
+  def refineInlineVal(mdef: untpd.ValOrDefDef, sym: Symbol, tp: Type)(using Context): Type =
+    if !Inlines.mightRefineInlineVal(mdef, sym) then
+      return tp
+
+    // Only refine if the explicit type is a primitive value types and String.
+    // We don't include opaque types. See tests/neg/i13851b.scala.
+    val tpSym = tp.dealiasKeepOpaques.typeSymbol
+    if !tpSym.isPrimitiveValueClass && tpSym != defn.StringClass then
+      return tp
+
+    untpd.stripBlock(mdef.rhs) match
+      case rhs: (untpd.Literal | untpd.Number) =>
+        ctx.typer.typedAheadExpr(rhs, tp) match
+          case tpd.ConstantValue(c) => ConstantType(Constant(c))
+          case _ => tp
+      case _ => tp
+
 end Inlines

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -662,7 +662,7 @@ object Inlines:
     if !Inlines.mightRefineInlineVal(mdef, sym) then
       return tp
 
-    // Only refine if the explicit type is a primitive value types and String.
+    // Only refine if the explicit type is a primitive value type or String.
     // We don't include opaque types. See tests/neg/i13851b.scala.
     val tpSym = tp.dealiasKeepOpaques.typeSymbol
     if !tpSym.isPrimitiveValueClass && tpSym != defn.StringClass then

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1985,7 +1985,10 @@ class Namer { typer: Typer =>
           sym.setFlag(Deferred | HasDefault)
         case _ =>
 
-    val mbrTpe = paramFn(checkSimpleKinded(typedAheadType(mdef.tpt, tptProto)).tpe)
+    val mbrTpe0 = checkSimpleKinded(typedAheadType(mdef.tpt, tptProto)).tpe
+    val mbrTpe1 = Inlines.refineInlineVal(mdef, sym, mbrTpe0)
+    val mbrTpe = paramFn(mbrTpe1)
+
     // Add an erased to the using clause generated from a `: Singleton` context bound
     mdef.tpt match
       case tpt: untpd.ContextBoundTypeTree if mbrTpe.typeSymbol == defn.SingletonClass =>

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3082,7 +3082,14 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         sym.resetFlag(Lazy)
       checkErasedOK(sym)
       sym.setFlag(Erased)
-    val tpt1 = checkSimpleKinded(typedType(tpt))
+
+    val isRefinedInlineVal =
+      Inlines.mightRefineInlineVal(vdef, sym)
+      && sym.info.isInstanceOf[ConstantType]
+
+    val tpt0 = checkSimpleKinded(typedType(tpt))
+    val tpt1 = if isRefinedInlineVal then TypeTree(sym.info) else tpt0
+
     val rhs1 = vdef.rhs match
       case rhs @ Ident(nme.WILDCARD) =>
         rhs.withType(tpt1.tpe)

--- a/tests/neg/i8841.check
+++ b/tests/neg/i8841.check
@@ -1,7 +1,3 @@
--- Error: tests/neg/i8841.scala:2:20 -----------------------------------------------------------------------------------
-2 |  inline val log1 : Boolean = false // error
-  |                    ^^^^^^^
-  |                    inline value must have a literal constant type
 -- Error: tests/neg/i8841.scala:3:20 -----------------------------------------------------------------------------------
 3 |  inline val log2 = true: Boolean // error
   |                    ^^^^^^^^^^^^^

--- a/tests/neg/i8841.scala
+++ b/tests/neg/i8841.scala
@@ -1,5 +1,5 @@
 object Foo {
-  inline val log1 : Boolean = false // error
+  inline val log1 : Boolean = false // ok
   inline val log2 = true: Boolean // error
   inline val log3: false  = { println(); false } // error
 }

--- a/tests/neg/inline-tracked-val.scala
+++ b/tests/neg/inline-tracked-val.scala
@@ -1,0 +1,50 @@
+import language.experimental.modularity
+
+inline val v1 = 3
+inline val v2: Short = 3
+inline val v3: Int = 3
+inline val v4 = 3: Short
+inline val v5 = 3: Int
+inline val v6: Short = 3: Short
+inline val v7: Short = 3: Int // error
+inline val v8: Int = 3: Short
+inline val v9: Int = 3: Int
+
+// The same tests with `tracked` should behave the same way
+
+tracked inline val v1t = 3
+tracked inline val v2t: Short = 3
+tracked inline val v3t: Int = 3
+tracked inline val v4t = 3: Short
+tracked inline val v5t = 3: Int
+tracked inline val v6t: Short = 3: Short
+tracked inline val v7t: Short = 3: Int // error
+tracked inline val v8t: Int = 3: Short
+tracked inline val v9t: Int = 3: Int
+
+@main def Test() =
+  summon[v1.type =:= 3]
+  summon[v2.type <:< Short]
+  summon[v3.type =:= 3]
+  summon[v4.type <:< Short]
+  summon[v5.type <:< Int]
+  summon[v5.type <:< 3] // error
+  summon[v6.type <:< Short]
+  summon[v7.type <:< Short]
+  summon[v8.type <:< Int]
+  summon[v8.type <:< 3] // error
+  summon[v9.type <:< Int]
+  summon[v9.type <:< 3] // error
+
+  summon[v1t.type =:= 3]
+  summon[v2t.type <:< Short]
+  summon[v3t.type =:= 3]
+  summon[v4t.type <:< Short]
+  summon[v5t.type <:< Int]
+  summon[v5t.type <:< 3] // error
+  summon[v6t.type <:< Short]
+  summon[v7t.type <:< Short]
+  summon[v8t.type <:< Int]
+  summon[v8t.type <:< 3] // error
+  summon[v9t.type <:< Int]
+  summon[v9t.type <:< 3] // error

--- a/tests/neg/inline-val-out-of-bounds.check
+++ b/tests/neg/inline-val-out-of-bounds.check
@@ -1,0 +1,11 @@
+-- [E007] Type Mismatch Error: tests/neg/inline-val-out-of-bounds.scala:1:21 -------------------------------------------
+1 |inline val a: Byte = 500 // error
+  |                     ^^^
+  |                     Found:    (500 : Int)
+  |                     Required: Byte
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/inline-val-out-of-bounds.scala:2:20 ----------------------------------------------------------------
+2 |inline val b: Int = 8589934592 // error
+  |                    ^^^^^^^^^^
+  |                    number too large

--- a/tests/neg/inline-val-out-of-bounds.scala
+++ b/tests/neg/inline-val-out-of-bounds.scala
@@ -1,0 +1,2 @@
+inline val a: Byte = 500 // error
+inline val b: Int = 8589934592 // error

--- a/tests/neg/inline-val.scala
+++ b/tests/neg/inline-val.scala
@@ -1,4 +1,4 @@
 
 inline val a = 1 : Int // error
-inline val b: Int = 1 // error
-inline val c = b // error
+inline val b: Int = 1 // ok
+inline val c = b // ok

--- a/tests/pos/i24321.scala
+++ b/tests/pos/i24321.scala
@@ -1,0 +1,4 @@
+object Bar:
+  inline val MAX: Byte = 10
+
+val y = Bar.MAX to Bar.MAX

--- a/tests/printing/i24321.check
+++ b/tests/printing/i24321.check
@@ -1,0 +1,15 @@
+[[syntax trees at end of                     typer]] // tests/printing/i24321.scala
+package <empty> {
+  final lazy module val i24321$package: i24321$package = new i24321$package()
+  final module class i24321$package() extends Object() {
+    this: i24321$package.type =>
+    inline val BOOL_CONST: (true : Boolean) = true
+    inline val CHAR_CONST: ('A' : Char) = 'A'
+    inline val INT_CONST: (100000 : Int) = 100000
+    inline val LONG_CONST: (100000L : Long) = 100000L
+    inline val FLOAT_CONST: (3.14f : Float) = 3.14f
+    inline val DOUBLE_CONST: (3.14159d : Double) = 3.14159d
+    inline val STRING_CONST: ("Hello, Scala 3!" : String) = "Hello, Scala 3!"
+  }
+}
+

--- a/tests/printing/i24321.scala
+++ b/tests/printing/i24321.scala
@@ -1,0 +1,7 @@
+inline val BOOL_CONST: Boolean = true
+inline val CHAR_CONST: Char = 'A'
+inline val INT_CONST: Int = 100000
+inline val LONG_CONST: Long = 100000L
+inline val FLOAT_CONST: Float = 3.14f
+inline val DOUBLE_CONST: Double = 3.14159
+inline val STRING_CONST: String = "Hello, Scala 3!"


### PR DESCRIPTION
Closes #24321.

This PR changes the type of `inline val`s to be the exact type of the right-hand side if it is a literal, such that in following snippet, `x` would have type `(4: Int)`:

```scala
inline val x: Int = 4
```

```scala
> scalac -Xprint:typer test.scala
...
[[syntax trees at end of                     typer]] // test.scala
...
    inline val x: (4 : Int) = 4
...
```

Previously, it would not compile:

```scala
$ scala -S 3.7.3 test.scala
Compiling project (Scala 3.7.3, JVM (17))
[error] ./test.scala:1:15
[error] inline value must have a literal constant type
[error] inline val x: Int = 4
[error]               ^^^
Error compiling project (Scala 3.7.3, JVM (17))
Compilation failed
```