### PR TITLE
VarArgsBuilder specialized classes, adapt posttyper

### DIFF
--- a/library/src/scala/runtime/VarArgsBuilder.scala
+++ b/library/src/scala/runtime/VarArgsBuilder.scala
@@ -11,210 +11,210 @@ sealed abstract class VarArgsBuilder[T]:
 
 object VarArgsBuilder:
 
-  def generic[T](n: Int): VarArgsBuilder[T] = new VarArgsBuilder[T]:
+  class generic[T](n: Int) extends VarArgsBuilder[T]:
     private val xs = new Array[AnyRef](n)
-    def result() = ArraySeq.ofRef(xs).asInstanceOf[ArraySeq[T]]
+    override def result(): Seq[T] = ArraySeq.ofRef(xs).asInstanceOf[ArraySeq[T]]
     private var i = 0
-    def add(elem: T): this.type =
+    override def add(elem: T): this.type =
       xs(i) = elem.asInstanceOf[AnyRef]
       i += 1
       this
-    def addSeq(elems: Seq[T]): this.type =
+    override def addSeq(elems: Seq[T]): this.type =
       for elem <- elems do
         xs(i) = elem.asInstanceOf[AnyRef]
         i += 1
       this
-    def addArray(elems: Array[T]): this.type =
+    override def addArray(elems: Array[T]): this.type =
       for elem <- elems do
         xs(i) = elem.asInstanceOf[AnyRef]
         i += 1
       this
 
-  def ofRef[T <: AnyRef](n: Int): VarArgsBuilder[T] = new VarArgsBuilder[T]:
+  class ofRef[T <: AnyRef](n: Int) extends VarArgsBuilder[T]:
     private val xs = new Array[AnyRef](n)
-    def result() = ArraySeq.ofRef(xs).asInstanceOf[ArraySeq[T]]
+    override def result(): Seq[T] = ArraySeq.ofRef(xs).asInstanceOf[ArraySeq[T]]
     private var i = 0
-    def add(elem: T): this.type =
+    override def add(elem: T): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[T]): this.type =
+    override def addSeq(elems: Seq[T]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[T]): this.type =
+    override def addArray(elems: Array[T]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofByte(n: Int): VarArgsBuilder[Byte] = new VarArgsBuilder[Byte]:
+  class ofByte(n: Int) extends VarArgsBuilder[Byte]:
     private val xs = new Array[Byte](n)
-    def result() = ArraySeq.ofByte(xs)
+    override def result(): Seq[Byte] = ArraySeq.ofByte(xs)
     private var i = 0
-    def add(elem: Byte): this.type =
+    override def add(elem: Byte): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Byte]): this.type =
+    override def addSeq(elems: Seq[Byte]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Byte]): this.type =
+    override def addArray(elems: Array[Byte]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofShort(n: Int): VarArgsBuilder[Short] = new VarArgsBuilder[Short]:
+  class ofShort(n: Int) extends VarArgsBuilder[Short]:
     private val xs = new Array[Short](n)
-    def result() = ArraySeq.ofShort(xs)
+    override def result(): Seq[Short] = ArraySeq.ofShort(xs)
     private var i = 0
-    def add(elem: Short): this.type =
+    override def add(elem: Short): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Short]): this.type =
+    override def addSeq(elems: Seq[Short]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Short]): this.type =
+    override def addArray(elems: Array[Short]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofChar(n: Int): VarArgsBuilder[Char] = new VarArgsBuilder[Char]:
+  class ofChar(n: Int) extends VarArgsBuilder[Char]:
     private val xs = new Array[Char](n)
-    def result() = ArraySeq.ofChar(xs)
+    override def result(): Seq[Char] = ArraySeq.ofChar(xs)
     private var i = 0
-    def add(elem: Char): this.type =
+    override def add(elem: Char): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Char]): this.type =
+    override def addSeq(elems: Seq[Char]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Char]): this.type =
+    override def addArray(elems: Array[Char]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofInt(n: Int): VarArgsBuilder[Int] = new VarArgsBuilder[Int]:
+  class ofInt(n: Int) extends VarArgsBuilder[Int]:
     private val xs = new Array[Int](n)
-    def result() = ArraySeq.ofInt(xs)
+    override def result(): Seq[Int] = ArraySeq.ofInt(xs)
     private var i = 0
-    def add(elem: Int): this.type =
+    override def add(elem: Int): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Int]): this.type =
+    override def addSeq(elems: Seq[Int]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Int]): this.type =
+    override def addArray(elems: Array[Int]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofLong(n: Int): VarArgsBuilder[Long] = new VarArgsBuilder[Long]:
+  class ofLong(n: Int) extends VarArgsBuilder[Long]:
     private val xs = new Array[Long](n)
-    def result() = ArraySeq.ofLong(xs)
+    override def result(): Seq[Long] = ArraySeq.ofLong(xs)
     private var i = 0
-    def add(elem: Long): this.type =
+    override def add(elem: Long): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Long]): this.type =
+    override def addSeq(elems: Seq[Long]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Long]): this.type =
+    override def addArray(elems: Array[Long]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofFloat(n: Int): VarArgsBuilder[Float] = new VarArgsBuilder[Float]:
+  class ofFloat(n: Int) extends VarArgsBuilder[Float]:
     private val xs = new Array[Float](n)
-    def result() = ArraySeq.ofFloat(xs)
+    override def result(): Seq[Float] = ArraySeq.ofFloat(xs)
     private var i = 0
-    def add(elem: Float): this.type =
+    override def add(elem: Float): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Float]): this.type =
+    override def addSeq(elems: Seq[Float]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Float]): this.type =
+    override def addArray(elems: Array[Float]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofDouble(n: Int): VarArgsBuilder[Double] = new VarArgsBuilder[Double]:
+  class ofDouble(n: Int) extends VarArgsBuilder[Double]:
     private val xs = new Array[Double](n)
-    def result() = ArraySeq.ofDouble(xs)
+    override def result(): Seq[Double] = ArraySeq.ofDouble(xs)
     private var i = 0
-    def add(elem: Double): this.type =
+    override def add(elem: Double): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Double]): this.type =
+    override def addSeq(elems: Seq[Double]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Double]): this.type =
+    override def addArray(elems: Array[Double]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofBoolean(n: Int): VarArgsBuilder[Boolean] = new VarArgsBuilder[Boolean]:
+  class ofBoolean(n: Int) extends VarArgsBuilder[Boolean]:
     private val xs = new Array[Boolean](n)
-    def result() = ArraySeq.ofBoolean(xs)
+    override def result(): Seq[Boolean] = ArraySeq.ofBoolean(xs)
     private var i = 0
-    def add(elem: Boolean): this.type =
+    override def add(elem: Boolean): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Boolean]): this.type =
+    override def addSeq(elems: Seq[Boolean]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Boolean]): this.type =
+    override def addArray(elems: Array[Boolean]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
 
-  def ofUnit(n: Int): VarArgsBuilder[Unit] = new VarArgsBuilder[Unit]:
+  class ofUnit(n: Int) extends VarArgsBuilder[Unit]:
     private val xs = new Array[Unit](n)
-    def result() = ArraySeq.ofUnit(xs)
+    override def result(): Seq[Unit] = ArraySeq.ofUnit(xs)
     private var i = 0
-    def add(elem: Unit): this.type =
+    override def add(elem: Unit): this.type =
       xs(i) = elem
       i += 1
       this
-    def addSeq(elems: Seq[Unit]): this.type =
+    override def addSeq(elems: Seq[Unit]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1
       this
-    def addArray(elems: Array[Unit]): this.type =
+    override def addArray(elems: Array[Unit]): this.type =
       for elem <- elems do
         xs(i) = elem
         i += 1


### PR DESCRIPTION
Returning anonymous classes mean that virtual calls are always made, with specialised type the specialised method is immediately selected.

fixes https://github.com/scala/scala3/issues/24501