### PR TITLE
drop: remove access to `Predef.any2stringadd`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1732,7 +1732,7 @@ class Definitions {
     RootRef(() => ScalaPackageVal.termRef)
 
   private val PredefImportFns: RootRef =
-    RootRef(() => ScalaPredefModule.termRef, isPredef=true)
+    RootRef(() => ScalaPredefModule.termRef)
 
   @tu private lazy val YimportsImportFns: List[RootRef] = ctx.settings.Yimports.value.map { name =>
     val denot =

--- a/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportInfo.scala
@@ -16,7 +16,7 @@ import scala.compiletime.uninitialized
 
 object ImportInfo {
 
-  case class RootRef(refFn: () => TermRef, isPredef: Boolean = false)
+  case class RootRef(refFn: () => TermRef)
 
   /** The import info for a root import */
   def rootImport(ref: RootRef)(using Context): ImportInfo =
@@ -24,9 +24,6 @@ object ImportInfo {
       untpd.ImportSelector(untpd.Ident(nme.WILDCARD))  // import all normal members...
       :: untpd.ImportSelector(untpd.Ident(nme.EMPTY))  // ... and also all given members
       :: Nil
-    if ref.isPredef then                               // do not import any2stringadd
-      selectors = untpd.ImportSelector(untpd.Ident(nme.any2stringadd), untpd.Ident(nme.WILDCARD))
-        :: selectors
 
     def sym(using Context) =
       val expr = tpd.Ident(ref.refFn()) // refFn must be called in the context of ImportInfo.sym

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -443,9 +443,11 @@ object Predef extends LowPriorityImplicits {
   @(deprecated @companionMethod)("Implicit injection of + is deprecated. Convert to String to call +", "2.13.0")
   @(deprecated @companionClass)("Implicit injection of + is deprecated. Convert to String to call +", "2.13.0") // for Scaladoc
   // scala/bug#8229 retaining the pre 2.11 name for source compatibility in shadowing this implicit
-  implicit final class any2stringadd[A](private val self: A) extends AnyVal {
+  private[scala] final class any2stringadd[A](private val self: A) extends AnyVal {
     def +(other: String): String = String.valueOf(self) + other
   }
+  @deprecated
+  private[scala] def any2stringadd[A](self: A): any2stringadd[A] = new any2stringadd[A](self)
 
   /**
    *  @group char-sequence-wrappers

--- a/tests/neg/i7137.scala
+++ b/tests/neg/i7137.scala
@@ -3,5 +3,5 @@ object App {
   val any: Any = 3
   val str: String = any + "a" // error
   val str2: String = any2stringadd(any) + "a" // error
-  val str3: String = Predef.any2stringadd(any) + "a"
+  val str3: String = Predef.any2stringadd(any) + "a" // error
 }


### PR DESCRIPTION
Disclaimer: This PR might be controversial and we will probably have to debate it and set precedence on how to handle such changes.

In this PR, we break source compatibility (but not backwards binary compatibility) by removing access to the `Predef.any2stringadd` implicit class. It was deprecated in Scala 2.13, not imported by default in Scala 3 (behaviour that was documented nowhere). As such, and as part of cleaning up the stdlib, we drop access to it while keeping it public in the bytecode. I have also removed the implicit keyword since I've undone the logic in the compiler that removes it from the root import and it might be available `scala` package and sub-packages (which goes against the point).

Closes #8830