### PR TITLE
chore: remove old support for `getClass` in `scala.AnyVal`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -795,17 +795,7 @@ object desugar {
         case PatDef(_, ids: List[Ident] @ unchecked, _, _) => ids
       }
 
-      val stats0 = impl.body.map(expandConstructor)
-      val stats =
-        if (ctx.owner eq defn.ScalaPackageClass) && defn.hasProblematicGetClass(className) then
-          stats0.filterConserve {
-            case ddef: DefDef =>
-              ddef.name ne nme.getClass_
-            case _ =>
-              true
-          }
-        else
-          stats0
+      val stats = impl.body.map(expandConstructor)
 
       if (isEnum) {
         val (enumCases, enumStats) = stats.partition(DesugarEnums.isEnumCase)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -2024,27 +2024,6 @@ class Definitions {
     if (isBoxedUnitClass(cls)) parents.filter(_.typeSymbol != JavaSerializableClass)
     else parents
 
-  private val HasProblematicGetClass: Set[Name] = Set(
-    tpnme.AnyVal, tpnme.Byte, tpnme.Short, tpnme.Char, tpnme.Int, tpnme.Long, tpnme.Float, tpnme.Double,
-    tpnme.Unit, tpnme.Boolean)
-
-  /** When typing a primitive value class or AnyVal, we ignore the `getClass`
-   *  member: it's supposed to be an override of the `getClass` defined on `Any`,
-   *  but in dotty `Any#getClass` is polymorphic so it ends up being an overload.
-   *  This is especially problematic because it means that when writing:
-   *
-   *    1.asInstanceOf[Int & AnyRef].getClass
-   *
-   *  the `getClass` that returns `Class[Int]` defined in Int can be selected,
-   *  but this call is specified to return `classOf[Integer]`, see
-   *  tests/run/t5568.scala.
-   *
-   *  FIXME: remove all the `getClass` methods defined in the standard library
-   *  so we don't have to hot-patch it like this.
-   */
-  def hasProblematicGetClass(className: Name): Boolean =
-    HasProblematicGetClass.contains(className)
-
   @tu lazy val assumedTransparentNames: Map[Name, Set[Symbol]] =
     // we should do a more through sweep through it then.
     val strs = Map(

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -447,11 +447,9 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
 
     var flags = unpickleScalaFlags(readLongNat(), name.isTypeName)
 
-    if (name eq nme.getClass_) && defn.hasProblematicGetClass(owner.name)
-       // Scala 2 sometimes pickle the same type parameter symbol multiple times
-       // (see i11173 for an example), but we should only unpickle it once.
-       || tag == TYPEsym && flags.is(TypeParam) && symScope(owner).lookup(name.asTypeName).exists
-    then
+    // Scala 2 sometimes pickle the same type parameter symbol multiple times
+    // (see i11173 for an example), but we should only unpickle it once.
+    if tag == TYPEsym && flags.is(TypeParam) && symScope(owner).lookup(name.asTypeName).exists then
       // skip this member
       return NoSymbol
 

--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1059,14 +1059,7 @@ object RefChecks {
           case Nil =>
             report.error(OverridesNothing(member), member.srcPos)
           case ms =>
-            // getClass in primitive value classes is defined in the standard library as:
-            //     override def getClass(): Class[Int] = ???
-            // However, it's not actually an override in Dotty because our Any#getClass
-            // is polymorphic (see `Definitions#Any_getClass`), so since we can't change
-            // the standard library, we need to drop the override flag without reporting
-            // an error.
-            if (!(member.name == nme.getClass_ && clazz.isPrimitiveValueClass))
-              report.error(OverridesNothingButNameExists(member, ms), member.srcPos)
+            report.error(OverridesNothingButNameExists(member, ms), member.srcPos)
         }
         member.resetFlag(Override)
         member.resetFlag(AbsOverride)

--- a/library/src/scala/AnyVal.scala
+++ b/library/src/scala/AnyVal.scala
@@ -55,6 +55,4 @@ import scala.language.`2.13`
  * still must allocate a value class instance at runtime. These limitations and circumstances are
  * explained in greater detail in the [Value Classes and Universal Traits](https://docs.scala-lang.org/overviews/core/value-classes.html).
  */
-transparent abstract class AnyVal extends Any, Matchable {
-  def getClass(): Class[? <: AnyVal] = null.asInstanceOf[Class[? <: AnyVal]]
-}
+transparent abstract class AnyVal extends Any, Matchable

--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -118,8 +118,6 @@ final abstract class Boolean private extends AnyVal {
    */
   def ^(x: Boolean): Boolean
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Boolean] = ???
 }
 
 object Boolean extends AnyValCompanion {

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -607,8 +607,6 @@ final abstract class Byte private extends AnyVal {
    */
   def %(x: Double): Double
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Byte] = ???
 }
 
 object Byte extends AnyValCompanion {

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -607,8 +607,6 @@ final abstract class Char private extends AnyVal {
    */
   def %(x: Double): Double
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Char] = ???
 }
 
 object Char extends AnyValCompanion {

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -350,8 +350,6 @@ final abstract class Double private extends AnyVal {
    */
   def %(x: Double): Double
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Double] = ???
 }
 
 object Double extends AnyValCompanion {

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -350,8 +350,6 @@ final abstract class Float private extends AnyVal {
    */
   def %(x: Double): Double
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Float] = ???
 }
 
 object Float extends AnyValCompanion {

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -607,8 +607,6 @@ final abstract class Int private extends AnyVal {
    */
   def %(x: Double): Double
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Int] = ???
 }
 
 object Int extends AnyValCompanion {

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -610,8 +610,6 @@ final abstract class Long private extends AnyVal {
    */
   def %(x: Double): Double
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Long] = ???
 }
 
 object Long extends AnyValCompanion {

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -607,8 +607,6 @@ final abstract class Short private extends AnyVal {
    */
   def %(x: Double): Double
 
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Short] = ???
 }
 
 object Short extends AnyValCompanion {

--- a/library/src/scala/Unit.scala
+++ b/library/src/scala/Unit.scala
@@ -19,10 +19,7 @@ import scala.language.`2.13`
  *  runtime system. A method with return type `Unit` is analogous to a Java
  *  method which is declared `void`.
  */
-final abstract class Unit private extends AnyVal {
-  // Provide a more specific return type for Scaladoc
-  override def getClass(): Class[Unit] = ???
-}
+final abstract class Unit private extends AnyVal
 
 @scala.annotation.compileTimeOnly("`Unit` companion object is not allowed in source; instead, use `()` for the unit value")
 object Unit extends AnyValCompanion {


### PR DESCRIPTION
Before, we have some special management for `getClass` in all value classes. In this PR, we remove this old behavior and cleanup the value classes files.