### PR TITLE
Warn about dollars in names of definitions unless backticked

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
@@ -34,6 +34,7 @@ enum MigrationVersion(val warnFrom: SourceVersion, val errorFrom: SourceVersion)
   case GivenSyntax extends MigrationVersion(future, future)
   case ImplicitParamsWithoutUsing extends MigrationVersion(`3.7`, future)
   case Scala2Implicits extends MigrationVersion(future, future)
+  case IdentifierDollars extends MigrationVersion(`3.8`, never)
 
   require(warnFrom.ordinal <= errorFrom.ordinal)
 

--- a/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/MigrationVersion.scala
@@ -34,7 +34,7 @@ enum MigrationVersion(val warnFrom: SourceVersion, val errorFrom: SourceVersion)
   case GivenSyntax extends MigrationVersion(future, future)
   case ImplicitParamsWithoutUsing extends MigrationVersion(`3.7`, future)
   case Scala2Implicits extends MigrationVersion(future, future)
-  case IdentifierDollars extends MigrationVersion(`3.8`, never)
+  case IdentifierDollars extends MigrationVersion(`3.9`, never)
 
   require(warnFrom.ordinal <= errorFrom.ordinal)
 

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -407,6 +407,7 @@ object NameKinds {
   val AdaptedClosureName: SuffixNameKind = new SuffixNameKind(ADAPTEDCLOSURE, "$adapted") { override def definesNewName = true }
   val SyntheticSetterName: SuffixNameKind = new SuffixNameKind(SETTER, "_$eq")
   val LazyVarHandleName: SuffixNameKind = new SuffixNameKind(LAZYVALVARHANDLE, "$lzyHandle")
+  val ReplAssignName: SuffixNameKind = new SuffixNameKind(REPL_ASSIGN, str.REPL_ASSIGN_SUFFIX)
 
   /** A name together with a signature. Used in Tasty trees. */
   object SignedName extends NameKind(SIGNED) {

--- a/compiler/src/dotty/tools/dotc/core/NameTags.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameTags.scala
@@ -30,7 +30,7 @@ object NameTags extends TastyFormat.NameTags {
 
   inline val PARAMACC = 33       // Used for a private parameter alias
 
-  inline val SETTER = 34         // A synthesized += suffix.
+  inline val SETTER = 34         // A synthesized _= suffix.
 
   // Name of type variables created by `ConstraintHandling#LevelAvoidMap`.
   final val AVOIDUPPER = 35
@@ -41,6 +41,8 @@ object NameTags extends TastyFormat.NameTags {
                                  // with a regular field of the underlying name
 
   inline val LAZYVALVARHANDLE = 39 // A field containing a VarHandle generated for lazy vals
+
+  inline val REPL_ASSIGN = 40 // Alias of an assigned term in REPL
 
   def nameTagToString(tag: Int): String = tag match {
     case UTF8 => "UTF8"

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileTastyUUIDParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileTastyUUIDParser.scala
@@ -105,6 +105,6 @@ class ClassfileTastyUUIDParser(classfile: AbstractFile)(ictx: Context) {
   class ConstantPool(using in: DataReader) extends ClassfileParser.AbstractConstantPool {
     def getClassOrArrayType(index: Int)(using ctx: Context, in: DataReader): Type = throw new UnsupportedOperationException
     def getClassSymbol(index: Int)(using ctx: Context, in: DataReader): Symbol = throw new UnsupportedOperationException
-    def getType(index: Int, isVarargs: Boolean)(using x$3: Context, x$4: DataReader): Type = throw new UnsupportedOperationException
+    def getType(index: Int, isVarargs: Boolean)(using Context, DataReader): Type = throw new UnsupportedOperationException
   }
 }

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -4476,7 +4476,7 @@ object Parsers {
       val mods1 = checkEnumModifiers(mods, " case") | EnumCase
       accept(CASE)
 
-      atSpan(start, nameStart):
+      atSpan(start, nameStart) {
         val id = termIdent()
         if (in.token == COMMA) {
           in.nextToken()
@@ -4502,6 +4502,7 @@ object Parsers {
               ModuleDef(id.name.toTermName, caseTemplate(emptyConstructor))
           finalizeDef(caseDef, mods1, start)
         }
+      }
     }
 
     /** [`extends' ConstrApps] */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -6,7 +6,7 @@ import scala.annotation.tailrec
 import scala.annotation.threadUnsafe as tu
 import scala.collection.mutable.ListBuffer
 import scala.collection.immutable.BitSet
-import util.{ SourceFile, SourcePosition, NoSourcePosition }
+import util.{SourceFile, SourcePosition, NoSourcePosition, SrcPos}
 import Tokens.*
 import Scanners.*
 import xml.MarkupParsers.MarkupParser
@@ -135,6 +135,13 @@ object Parsers {
 
     def atSpan[T <: Positioned](start: Offset)(t: T): T =
       atSpan(start, start)(t)
+
+    inline def atNameSpan[T <: NameTree](start: Offset)(inline tree: => T): T =
+      val backquoted = in.token == BACKQUOTED_IDENT
+      atSpan(start, if backquoted then in.offset + 1 else in.offset):
+        tree.tap: t =>
+          if backquoted then
+            t.pushAttachment(Backquoted, ())
 
     def startOffset(t: Positioned): Int =
       if (t.span.exists) t.span.start else in.offset
@@ -1291,9 +1298,7 @@ object Parsers {
       if (isIdent) {
         val name = in.name.nn
         if name == nme.CONSTRUCTOR || name == nme.STATIC_CONSTRUCTOR then
-          report.error(
-            em"""Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden""",
-            in.sourcePos())
+          report.error(IllegalIdentifier(name), in.sourcePos())
         in.nextToken()
         name
       }
@@ -1301,6 +1306,13 @@ object Parsers {
         syntaxErrorOrIncomplete(ExpectedTokenButFound(IDENTIFIER, in.token))
         nme.ERROR
       }
+
+    extension (nameTree: NameTree)
+      inline def checkPatternName: nameTree.type =
+        if !isBackquoted(nameTree) && nameTree.name.toSimpleName.contains('$') then
+          report.errorOrMigrationWarning(
+            IllegalIdentifier(nameTree.name), nameTree.srcPos, MigrationVersion.IdentifierDollars)
+        nameTree
 
     /** Accept identifier and return Ident with its name as a term name. */
     def termIdent(): Ident =
@@ -1314,7 +1326,7 @@ object Parsers {
       val tree = Ident(name)
       if (tok == BACKQUOTED_IDENT) tree.pushAttachment(Backquoted, ())
 
-      // Make sure that even trees with parsing errors have a offset that is within the offset
+      // Make sure that even trees with parsing errors have an offset that is within the offset
       val errorOffset = offset min (in.lastOffset - 1)
       if (tree.name == nme.ERROR && tree.span == NoSpan) tree.withSpan(Span(errorOffset, errorOffset))
       else atSpan(offset)(tree)
@@ -3458,7 +3470,9 @@ object Parsers {
           p = atSpan(startOffset(t), in.offset) { TypeApply(p, typeArgs(namedOK = false, wildOK = false)) }
         if (in.token == LPAREN)
           p = atSpan(startOffset(t), in.offset) { Apply(p, argumentPatterns()) }
-        p
+        p match
+        case nt: NameTree if isVarPattern(nt) => nt.checkPatternName
+        case p => p
 
     /** Patterns          ::=  Pattern [`,' Pattern]
      *                      |  NamedPattern {‘,’ NamedPattern}
@@ -3796,7 +3810,7 @@ object Parsers {
           if in.isColon then
             syntaxErrorOrIncomplete(ExpectedTokenButFoundSoftKeyword(IDENTIFIER, COLONop, nme.using, paramModAdvice))
 
-      def param(): ValDef = {
+      def param(): ValDef =
         val start = in.offset
         var mods = impliedMods.withAnnotations(annotations())
         if isConsume || isErased then
@@ -3820,7 +3834,7 @@ object Parsers {
             mods = addModifier(mods)
           mods |= Param
         }
-        atSpan(start, nameStart) {
+        atNameSpan(start):
           val name = ident() match
             case nme.using if !in.isColon =>
               val msg = ExpectedTokenButFoundSoftKeyword(expected = COLONop, found = in.token, nme.using, paramModAdvice)
@@ -3845,8 +3859,6 @@ object Parsers {
           if (impliedMods.mods.nonEmpty)
             impliedMods = impliedMods.withMods(Nil) // keep only flags, so that parameter positions don't overlap
           ValDef(name, tpt, default).withMods(mods)
-        }
-      }
 
       def checkVarArgsRules(vparams: List[ValDef]): Unit = vparams match {
         case Nil =>
@@ -4173,8 +4185,12 @@ object Parsers {
         else EmptyTree
       lhs match {
         case IdPattern(id, t) :: Nil if t.isEmpty =>
-          val vdef = ValDef(id.name.asTermName, tpt, rhs)
-          if (isBackquoted(id)) vdef.pushAttachment(Backquoted, ())
+          val vdef =
+            if isBackquoted(id) then
+              ValDef(id.name.asTermName, tpt, rhs)
+              .tap(_.pushAttachment(Backquoted, ()))
+            else
+              ValDef(id.name.asTermName, tpt, rhs)
           finalizeDef(vdef, mods, start)
         case _ =>
           def isAllIds = lhs.forall {
@@ -4397,7 +4413,7 @@ object Parsers {
     /** ClassDef ::= id ClassConstr TemplateOpt
      */
     def classDef(start: Offset, mods: Modifiers): TypeDef =
-      val td = atSpan(start, nameStart):
+      val td = atNameSpan(start):
         val name = ident().toTypeName
         val constr = classConstr(if mods.is(Case) then ParamOwner.CaseClass else ParamOwner.Class)
         val templ = templateOpt(constr)
@@ -4421,7 +4437,7 @@ object Parsers {
     /** ObjectDef       ::= id TemplateOpt
      */
     def objectDef(start: Offset, mods: Modifiers): ModuleDef =
-      val md = atSpan(start, nameStart):
+      val md = atNameSpan(start):
         val nameIdent = termIdent()
         val templ = templateOpt(emptyConstructor)
         ModuleDef(nameIdent.name.asTermName, templ)
@@ -4445,14 +4461,13 @@ object Parsers {
 
     /**  EnumDef ::=  id ClassConstr InheritClauses EnumBody
      */
-    def enumDef(start: Offset, mods: Modifiers): TypeDef = atSpan(start, nameStart) {
+    def enumDef(start: Offset, mods: Modifiers): TypeDef = atNameSpan(start):
       val mods1 = checkEnumModifiers(mods, "")
       val modulName = ident()
       val clsName = modulName.toTypeName
       val constr = classConstr(ParamOwner.Class)
       val templ = template(constr, isEnum = true)
       finalizeDef(TypeDef(clsName, templ), mods1, start)
-    }
 
     /** EnumCase = `case' (id ClassConstr [`extends' ConstrApps] | ids)
      */
@@ -4460,7 +4475,7 @@ object Parsers {
       val mods1 = checkEnumModifiers(mods, " case") | EnumCase
       accept(CASE)
 
-      atSpan(start, nameStart) {
+      atSpan(start, nameStart):
         val id = termIdent()
         if (in.token == COMMA) {
           in.nextToken()
@@ -4486,7 +4501,6 @@ object Parsers {
               ModuleDef(id.name.toTermName, caseTemplate(emptyConstructor))
           finalizeDef(caseDef, mods1, start)
         }
-      }
     }
 
     /** [`extends' ConstrApps] */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3834,7 +3834,7 @@ object Parsers {
             mods = addModifier(mods)
           mods |= Param
         }
-        atNameSpan(start):
+        atNameSpan(start) {
           val name = ident() match
             case nme.using if !in.isColon =>
               val msg = ExpectedTokenButFoundSoftKeyword(expected = COLONop, found = in.token, nme.using, paramModAdvice)
@@ -3859,6 +3859,7 @@ object Parsers {
           if (impliedMods.mods.nonEmpty)
             impliedMods = impliedMods.withMods(Nil) // keep only flags, so that parameter positions don't overlap
           ValDef(name, tpt, default).withMods(mods)
+        }
       }
 
       def checkVarArgsRules(vparams: List[ValDef]): Unit = vparams match {
@@ -4186,12 +4187,8 @@ object Parsers {
         else EmptyTree
       lhs match {
         case IdPattern(id, t) :: Nil if t.isEmpty =>
-          val vdef =
-            if isBackquoted(id) then
-              ValDef(id.name.asTermName, tpt, rhs)
-                .tap(_.pushAttachment(Backquoted, ()))
-            else
-              ValDef(id.name.asTermName, tpt, rhs)
+          val vdef = ValDef(id.name.asTermName, tpt, rhs)
+          if (isBackquoted(id)) vdef.pushAttachment(Backquoted, ())
           finalizeDef(vdef, mods, start)
         case _ =>
           def isAllIds = lhs.forall {

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -140,7 +140,7 @@ object Parsers {
       val backquoted = in.token == BACKQUOTED_IDENT
       atSpan(start, if backquoted then in.offset + 1 else in.offset):
         tree.tap: t =>
-          if backquoted then
+          if backquoted && !t.hasAttachment(Backquoted) then
             t.pushAttachment(Backquoted, ())
 
     def startOffset(t: Positioned): Int =
@@ -4442,9 +4442,6 @@ object Parsers {
         val nameIdent = termIdent()
         val templ = templateOpt(emptyConstructor)
         ModuleDef(nameIdent.name.asTermName, templ)
-          .tap: md =>
-            if nameIdent.isBackquoted then
-              md.pushAttachment(Backquoted, ())
       finalizeDef(md, mods, start)
 
     // We allow `infix` and `into` on `enum` definitions.

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3471,8 +3471,8 @@ object Parsers {
         if (in.token == LPAREN)
           p = atSpan(startOffset(t), in.offset) { Apply(p, argumentPatterns()) }
         p match
-        case nt: NameTree if isVarPattern(nt) => nt.checkPatternName
-        case p => p
+          case nt: NameTree if isVarPattern(nt) => nt.checkPatternName
+          case p => p
 
     /** Patterns          ::=  Pattern [`,' Pattern]
      *                      |  NamedPattern {‘,’ NamedPattern}
@@ -3810,7 +3810,7 @@ object Parsers {
           if in.isColon then
             syntaxErrorOrIncomplete(ExpectedTokenButFoundSoftKeyword(IDENTIFIER, COLONop, nme.using, paramModAdvice))
 
-      def param(): ValDef =
+      def param(): ValDef = {
         val start = in.offset
         var mods = impliedMods.withAnnotations(annotations())
         if isConsume || isErased then
@@ -3859,6 +3859,7 @@ object Parsers {
           if (impliedMods.mods.nonEmpty)
             impliedMods = impliedMods.withMods(Nil) // keep only flags, so that parameter positions don't overlap
           ValDef(name, tpt, default).withMods(mods)
+      }
 
       def checkVarArgsRules(vparams: List[ValDef]): Unit = vparams match {
         case Nil =>
@@ -4188,7 +4189,7 @@ object Parsers {
           val vdef =
             if isBackquoted(id) then
               ValDef(id.name.asTermName, tpt, rhs)
-              .tap(_.pushAttachment(Backquoted, ()))
+                .tap(_.pushAttachment(Backquoted, ()))
             else
               ValDef(id.name.asTermName, tpt, rhs)
           finalizeDef(vdef, mods, start)

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -245,6 +245,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case PrivateShadowsTypeID // errorNumber: 227
   case AmbiguousTemplateNameID // errorNumber: 228
   case IndentationWarningID // errorNumber: 229
+  case IllegalIdentifierID // errorNumber: 230
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3884,14 +3884,12 @@ extends SyntaxMsg(IndentationWarningID):
     "Indentation that does not reflect syntactic nesting may be due to a typo such as missing punctuation."
 
 final class IllegalIdentifier(name: Name)(using Context) extends SyntaxMsg(IllegalIdentifierID):
-  override protected def msg(using Context): String =
-    name match
+  override protected def msg(using Context): String = name match
     case nme.CONSTRUCTOR | nme.STATIC_CONSTRUCTOR =>
       "Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden"
     case _ =>
       i"The identifier `$name` should not contain `$$`, which is reserved for internal compiler use."
-  override protected def explain(using Context): String =
-    name match
+  override protected def explain(using Context): String = name match
     case nme.CONSTRUCTOR | nme.STATIC_CONSTRUCTOR =>
       "Names can include unusual characters when enclosed in backquotes, but `<init>` and `<clinit>` are reserved."
     case _ =>

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3882,3 +3882,21 @@ extends SyntaxMsg(IndentationWarningID):
     }"
   override protected def explain(using Context): String =
     "Indentation that does not reflect syntactic nesting may be due to a typo such as missing punctuation."
+
+final class IllegalIdentifier(name: Name)(using Context) extends SyntaxMsg(IllegalIdentifierID):
+  override protected def msg(using Context): String =
+    name match
+    case nme.CONSTRUCTOR | nme.STATIC_CONSTRUCTOR =>
+      "Illegal backquoted identifier: `<init>` and `<clinit>` are forbidden"
+    case _ =>
+      i"The identifier `$name` should not contain `$$`, which is reserved for internal compiler use."
+  override protected def explain(using Context): String =
+    name match
+    case nme.CONSTRUCTOR | nme.STATIC_CONSTRUCTOR =>
+      "Names can include unusual characters when enclosed in backquotes, but `<init>` and `<clinit>` are reserved."
+    case _ =>
+      i"""User identifiers may be encoded with embedded `$$`, and other compiler artifacts
+         |may rely on using `$$` with specific meanings.
+         |
+         |The prohibition against explicit `$$` may be ignored by enclosing the identifier in backquotes
+         |at the definition site."""

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -7,7 +7,7 @@ import ast.*
 import Trees.*, StdNames.*, Scopes.*, Denotations.*, NamerOps.*, ContextOps.*
 import Contexts.*, Symbols.*, Types.*, SymDenotations.*, Names.*, NameOps.*, Flags.*
 import Decorators.*, Comments.{_, given}
-import NameKinds.DefaultGetterName
+import NameKinds.{DefaultGetterName, ModuleClassName}
 import ast.desugar, ast.desugar.*
 import ProtoTypes.*
 import util.Spans.*
@@ -15,7 +15,7 @@ import util.Property
 import collection.mutable, mutable.ListBuffer
 import tpd.tpes
 import Variances.alwaysInvariant
-import config.{Config, Feature}
+import config.{Config, Feature, MigrationVersion}
 import config.Printers.typr
 import inlines.{Inlines, PrepareInlineable}
 import parsing.JavaParsers.JavaParser
@@ -28,6 +28,7 @@ import TypeErasure.erasure
 import reporting.*
 import config.Feature.{sourceVersion, modularity}
 import config.SourceVersion.*
+import rewrites.Rewrites.patch
 
 import scala.compiletime.uninitialized
 
@@ -179,6 +180,20 @@ class Namer { typer: Typer =>
     if conflictsDetected then name.freshened else name
   end checkNoConflict
 
+  def checkDefName(name: Name, tree: Tree)(using Context): Unit =
+    val isModule = name.is(ModuleClassName)
+    if isModule || !name.toTermName.isInstanceOf[DerivedName] then
+      val simple = name.toSimpleName
+      val max = if isModule then simple.length - 1 else simple.length
+      val last = simple.lastIndexOf('$', start = max - 1)
+      if last >= 0 then
+        val start = tree.span.point
+        val errPos = tree.srcPos.sourcePos.withSpan(Span(start, start + max, start))
+        if MigrationVersion.IdentifierDollars.needsPatch then
+          patch(errPos.sourcePos.source, errPos.span.startPos, "`")
+          patch(errPos.sourcePos.source, errPos.span.endPos, "`")
+        report.errorOrMigrationWarning(IllegalIdentifier(name), errPos, MigrationVersion.IdentifierDollars)
+
   /** If this tree is a member def or an import, create a symbol of it
    *  and store in symOfTree map.
    */
@@ -252,6 +267,12 @@ class Namer { typer: Typer =>
         if Feature.shouldBehaveAsScala2 then
           flags |= Scala2x
         val name = checkNoConflict(tree.name, tree.span).asTypeName
+        if name == tree.name
+        && !isBackquoted(tree)
+        && !tree.span.isSynthetic
+        && !flags.is(Synthetic)
+        then
+          checkDefName(name, tree)
         val cls =
           createOrRefine[ClassSymbol](tree, name, flags, ctx.owner,
             cls => adjustIfModule(new ClassCompleter(cls, tree)(ctx), tree),
@@ -261,6 +282,15 @@ class Namer { typer: Typer =>
       case tree: MemberDef =>
         var flags = checkFlags(tree.mods.flags)
         val name = checkNoConflict(tree.name, tree.span)
+        if name == tree.name
+        && !isBackquoted(tree)
+        && !tree.span.isSynthetic
+        && !flags.is(Synthetic)
+        && !(flags.is(Param) && ctx.owner.is(Synthetic))
+        && !flags.is(Accessor)
+        && !flags.is(CaseAccessor) // check only the param
+        then
+          checkDefName(name, tree)
         tree match
           case tree: ValOrDefDef =>
             if tree.isInstanceOf[ValDef] && !flags.is(Param) && name.endsWith("_=") then
@@ -343,7 +373,10 @@ class Namer { typer: Typer =>
         report.error(PkgDuplicateSymbol(existingType), pid.srcPos)
         newCompletePackageSymbol(pkgOwner, (pid.name ++ "$_error_").toTermName).entered
       }
-      else newCompletePackageSymbol(pkgOwner, pid.name.asTermName).entered
+      else
+        val pname = pid.name.asTermName
+        checkDefName(pname, pid)
+        newCompletePackageSymbol(pkgOwner, pname).entered
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -180,9 +180,14 @@ class Namer { typer: Typer =>
     if conflictsDetected then name.freshened else name
   end checkNoConflict
 
-  def checkDefName(name: Name, tree: Tree)(using Context): Unit =
+  def checkDefName(name: Name, tree: Tree, flags: FlagSet)(using Context): Unit =
+    def exempt =
+         isBackquoted(tree)
+      || tree.span.isSynthetic
+      || flags.isOneOf(Synthetic | Accessor | CaseAccessor) // check the case param not the accessor
+      || flags.is(Param) && ctx.owner.is(Synthetic)
     val isModule = name.is(ModuleClassName)
-    if isModule || !name.toTermName.isInstanceOf[DerivedName] then
+    if !exempt && (isModule || !name.toTermName.isInstanceOf[DerivedName]) then
       val simple = name.toSimpleName
       val max = if isModule then simple.length - 1 else simple.length
       val last = simple.lastIndexOf('$', start = max - 1)
@@ -267,12 +272,8 @@ class Namer { typer: Typer =>
         if Feature.shouldBehaveAsScala2 then
           flags |= Scala2x
         val name = checkNoConflict(tree.name, tree.span).asTypeName
-        if name == tree.name
-        && !isBackquoted(tree)
-        && !tree.span.isSynthetic
-        && !flags.is(Synthetic)
-        then
-          checkDefName(name, tree)
+        if name == tree.name then
+          checkDefName(name, tree, flags)
         val cls =
           createOrRefine[ClassSymbol](tree, name, flags, ctx.owner,
             cls => adjustIfModule(new ClassCompleter(cls, tree)(ctx), tree),
@@ -282,15 +283,8 @@ class Namer { typer: Typer =>
       case tree: MemberDef =>
         var flags = checkFlags(tree.mods.flags)
         val name = checkNoConflict(tree.name, tree.span)
-        if name == tree.name
-        && !isBackquoted(tree)
-        && !tree.span.isSynthetic
-        && !flags.is(Synthetic)
-        && !(flags.is(Param) && ctx.owner.is(Synthetic))
-        && !flags.is(Accessor)
-        && !flags.is(CaseAccessor) // check only the param
-        then
-          checkDefName(name, tree)
+        if name == tree.name then
+          checkDefName(name, tree, flags)
         tree match
           case tree: ValOrDefDef =>
             if tree.isInstanceOf[ValDef] && !flags.is(Param) && name.endsWith("_=") then
@@ -375,7 +369,7 @@ class Namer { typer: Typer =>
       }
       else
         val pname = pid.name.asTermName
-        checkDefName(pname, pid)
+        checkDefName(pname, pid, EmptyFlags)
         newCompletePackageSymbol(pkgOwner, pname).entered
     }
   }

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -181,12 +181,25 @@ class Namer { typer: Typer =>
   end checkNoConflict
 
   def checkDefName(name: Name, tree: Tree, flags: FlagSet)(using Context): Unit =
+    val isModule = name.is(ModuleClassName)
+    // nme.raw.DOLLAR or $$, avoiding toString and toSimpleName but incurring toTermName
+    // also matches "a" since it cannot contain "$"
+    inline def isDollars =
+      name.toTermName.match {
+        case simple: SimpleName =>
+          simple.length == 1 || simple.length == 2 && simple.endsWith(str.EXPAND_SEPARATOR)
+        case _ =>
+          isModule && {
+            val simple = name.toSimpleName
+            simple.length == 2 && simple.endsWith(str.EXPAND_SEPARATOR)
+          }
+      }
     def exempt =
          isBackquoted(tree)
       || tree.span.isSynthetic
       || flags.isOneOf(Synthetic | Accessor | CaseAccessor) // check the case param not the accessor
       || flags.is(Param) && ctx.owner.is(Synthetic)
-    val isModule = name.is(ModuleClassName)
+      || isDollars
     if !exempt && (isModule || !name.toTermName.isInstanceOf[DerivedName]) then
       val simple = name.toSimpleName
       val max = if isModule then simple.length - 1 else simple.length

--- a/compiler/src/dotty/tools/dotc/util/Spans.scala
+++ b/compiler/src/dotty/tools/dotc/util/Spans.scala
@@ -101,7 +101,7 @@ object Spans {
     /** Is this a zero-extent span? */
     def isZeroExtent: Boolean = exists && start == end
 
-     /** A span where all components are shifted by a given `offset`
+    /** A span where all components are shifted by a given `offset`
      *  relative to this span.
      */
     def shift(offset: Int): Span =

--- a/compiler/test/dotc/neg-best-effort-unpickling.excludelist
+++ b/compiler/test/dotc/neg-best-effort-unpickling.excludelist
@@ -30,3 +30,6 @@ i23504.scala
 
 # owner of anon, where package object has funky name
 i20511-1.scala
+
+# NoDenotation.owner
+i18234.scala

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -84,6 +84,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i24103.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i24103b.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i24213.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
+      compileFile("tests/rewrites/i18234.scala", defaultOptions.and("-rewrite", "-source:3.8-migration")),
     )).checkRewrites()
   }
 

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -986,10 +986,12 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       lazy val actualErrors = reporters.foldLeft(0)(_ + _.errorCount)
       lazy val (expected, unexpected) = getMissingExpectedErrors(errorMap, reporters.iterator.flatMap(_.errors))
       def hasMissingAnnotations = expected.nonEmpty || unexpected.nonEmpty
+      def showLines(title: String, lines: Seq[String]) =
+        if lines.isEmpty then "" else lines.mkString(s"$title\n", "\n", "")
       def showErrors = "-> following the errors:\n" +
         reporters.flatMap(_.allErrors.sortBy(_.pos.line).map(e => s"${e.pos.line + 1}: ${e.message}")).mkString(" at ", "\n at ", "")
 
-      Option {
+      Option:
         if actualErrors == 0 then s"\nNo errors found when compiling neg test $testSource"
         else if expectedErrors == 0 then
           s"""|No expected errors marked in $testSource -- use // error or // nopos-error
@@ -1006,13 +1008,12 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
               |""".stripMargin.trim.linesIterator.mkString("\n", "\n", "")
         else if hasMissingAnnotations then
           s"""|Errors found on incorrect row numbers when compiling $testSource
+              |${showLines("Unfulfilled expectations:", expected)}
+              |${showLines("Unexpected errors:", unexpected)}
               |$showErrors
-              |${expected.mkString("Unfulfilled expectations:\n", "\n", "")}
-              |${unexpected.mkString("Unexpected errors:\n", "\n", "")}
               |""".stripMargin.trim.linesIterator.mkString("\n", "\n", "")
         else if !errorMap.isEmpty then s"\nExpected error(s) have {<error position>=<unreported error>}: $errorMap"
         else null
-      }
     end maybeFailureMessage
 
     override def onSuccess(testSource: TestSource, reporters: Seq[TestReporter], logger: LoggedRunnable): Unit =

--- a/docs/_docs/reference/error-codes/E230.md
+++ b/docs/_docs/reference/error-codes/E230.md
@@ -47,7 +47,8 @@ usually to preserve binary compatibility.
 
 That name can be wrapped in backquotes to suppress the warning:
 
-```
-@publicInBinary private[::] def `next$access$1` = next
+```scala sc:compile sc-opts:-Werror
+var next = 42
+def `next$access$1` = next
 ```
 

--- a/docs/_docs/reference/error-codes/E230.md
+++ b/docs/_docs/reference/error-codes/E230.md
@@ -1,0 +1,53 @@
+---
+title: E230: Illegal Identifier
+kind: Warning
+since: 3.9.0
+---
+# E228: Illegal Identifier
+
+Besides syntactic rules for identifiers, the language specification adds:
+
+The ‘$’ character is reserved for compiler-synthesized identifiers. User programs should not define identifiers that contain ‘$’ characters.
+
+A warning is emitted for definitions with a name that contains a ‘$’ character.
+
+No warning is emitted for usages of such a definition.
+
+---
+
+## Example
+
+```scala sc:fail sc-opts:-Werror
+var next = 42
+def next$access$1 = next // attempt to explicitly define a member for binary compatibility
+```
+
+### Error
+
+```scala sc:nocompile
+-- [E230] Syntax Warning: example.scala:2:4 ------------------------------------
+2 |def next$access$1 = next // attempt to explicitly define a member for binary compatibility
+  |    ^^^^^^^^^^^^^
+  |The identifier `next$access$1` should not contain `$`, which is reserved for internal compiler use.
+  |-----------------------------------------------------------------------------
+  | Explanation (enabled by `-explain`)
+  |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  | User identifiers may be encoded with embedded `$`, and other compiler artifacts
+  | may rely on using `$` with specific meanings.
+  |
+  | The prohibition against explicit `$` may be ignored by enclosing the identifier in backquotes
+  | at the definition site.
+   -----------------------------------------------------------------------------
+```
+
+### Solution
+
+Occasionally, it is necessary to introduce an identifier that breaks this rule,
+usually to preserve binary compatibility.
+
+That name can be wrapped in backquotes to suppress the warning:
+
+```
+@publicInBinary private[::] def `next$access$1` = next
+```
+

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -435,4 +435,5 @@ subsection:
       - page: reference/error-codes/E227.md
       - page: reference/error-codes/E228.md
       - page: reference/error-codes/E229.md
+      - page: reference/error-codes/E230.md
 

--- a/library/src/scala/annotation/internal/$into.scala
+++ b/library/src/scala/annotation/internal/$into.scala
@@ -8,4 +8,4 @@ package scala.annotation.internal
  *  underlying type in the types of local parameters.
  */
 @preview
-class $into extends annotation.StaticAnnotation
+class `$into` extends annotation.StaticAnnotation

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -656,7 +656,7 @@ final case class :: [+A](override val head: A, private[scala] var next: List[A @
   override def tail: List[A] = next
 
   @publicInBinary
-  private[::] def next$access$1 = next
+  private[::] def `next$access$1` = next
 
 }
 

--- a/library/src/scala/runtime/$throws.scala
+++ b/library/src/scala/runtime/$throws.scala
@@ -11,4 +11,4 @@ import annotation.experimental
  *  Used in desugar.throws.
  */
 @experimental
-infix type $throws[R, +E <: Exception] = CanThrow[E] ?=> R
+infix type `$throws`[R, +E <: Exception] = CanThrow[E] ?=> R

--- a/repl/src/dotty/tools/repl/ReplCompiler.scala
+++ b/repl/src/dotty/tools/repl/ReplCompiler.scala
@@ -9,6 +9,7 @@ import dotc.core.CompilationUnitInfo
 import dotc.core.Decorators.*
 import dotc.core.Flags.*
 import dotc.core.Names.*
+import dotc.core.NameKinds.ReplAssignName
 import dotc.core.Phases.Phase
 import dotc.core.StdNames.*
 import dotc.core.Symbols.*
@@ -304,7 +305,7 @@ class ReplPhase extends Phase:
       case expr @ Assign(id: Ident, _) =>
         // special case simple reassignment (e.g. x = 3)
         // in order to print the new value in the REPL
-        val assignName = (id.name ++ str.REPL_ASSIGN_SUFFIX).toTermName
+        val assignName = ReplAssignName(id.name.toTermName)
         val assign = ValDef(assignName, TypeTree(), id).withSpan(expr.span)
         defs += expr += assign
       case expr if expr.isTerm =>

--- a/repl/test-resources/type-printer/source-compatible
+++ b/repl/test-resources/type-printer/source-compatible
@@ -7,7 +7,7 @@ val m:
       def i_=(x$1: Int): Unit; type N = Int; val l: List[Int];
       def p[T](t: T): String
   } = Bag()
-scala> type t = Bag { val f: Int; def g: Int; def h(i: Int): Int; val i: Int; def i_=(x$1: Int): Unit; type N = Int; val l: List[Int]; val s: String @unchecked }
+scala> type t = Bag { val f: Int; def g: Int; def h(i: Int): Int; val i: Int; def i_=(`x$1`: Int): Unit; type N = Int; val l: List[Int]; val s: String @unchecked }
 // defined alias type t
    =
     Bag{

--- a/scaladoc/src/dotty/tools/scaladoc/site/LoadedTemplate.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/LoadedTemplate.scala
@@ -11,7 +11,7 @@ import scala.jdk.CollectionConverters._
 
 case class LazyEntry(getKey: String, value: () => String) extends JMapEntry[String, Object]:
   lazy val getValue: Object = value()
-  def setValue(x$0: Object): Object = ???
+  def setValue(`x$0`: Object): Object = ???
 
 case class LoadedTemplate(
   templateFile: TemplateFile,

--- a/tests/init/pos/i10549a.scala
+++ b/tests/init/pos/i10549a.scala
@@ -2,6 +2,6 @@ class Wrap {
   class E
   object E {
     final val A = new E {}
-    val $values = Array(A)
+    val `$values` = Array(A)
   }
 }

--- a/tests/init/pos/i9664.scala
+++ b/tests/init/pos/i9664.scala
@@ -2,7 +2,7 @@ object Wrap1 {
   class E
   object E {
     final val A = E()
-    val $values = Array(A)
+    val `$values` = Array(A)
   }
 }
 object Wrap2 {

--- a/tests/init/warn/java1.scala
+++ b/tests/init/warn/java1.scala
@@ -5,7 +5,7 @@ class A extends Spliterator.OfDouble:
   def characteristics() = 10
   def estimateSize() = 10
   def trySplit() = ???
-  def tryAdvance(x$0: java.util.function.DoubleConsumer): Boolean = false
+  def tryAdvance(`x$0`: java.util.function.DoubleConsumer): Boolean = false
 
   val m = n + 1
   val n = 10     // warn

--- a/tests/neg/i15381.scala
+++ b/tests/neg/i15381.scala
@@ -1,6 +1,6 @@
 //> using options -Vprint:parser
 
-case class $[A](value: A)
+case class `$`[A](value: A)
 
 def g: Int = $        // error
 

--- a/tests/neg/i18234.scala
+++ b/tests/neg/i18234.scala
@@ -1,0 +1,172 @@
+//> using options -Wconf:name=IllegalIdentifier&msg=reserved:e
+/* vals */
+val goodVal = 1
+val $startVal = 1 // error
+val mid$dleVal = 1 // error
+val endVal$ = 1 // error
+
+def testValUsage =
+  $startVal + endVal$ // ok, should only warn on declaration not on usage
+
+/* functions */
+def $funcStart() = 3 // error
+def func$Middle() = 3 // error
+def funcEnd$() = 3 // error
+
+def func1badArg(goodArg: Int, bad$Arg: Int) = 5 // error
+def func1badArgAndUsageDoesNotThrowWarning(goodArg: Int, bad$Arg: Int) = bad$Arg // error
+def func2badArgs(goodArg: Int, bad$Arg: Int, bad$arg2: String) = 5 // error // error
+def multilineFunc(
+  goodArg: Int,
+  badAr$g: Int // error
+) = 1
+
+def testFuncUsaage =
+  $funcStart() + func1badArg(1, 2) // ok, should only warn on declaration not on usage
+
+/* types */
+type GoodType = Int
+type $StartType = Int // error
+type Middle$Type = Int // error
+type EndType$ = Int // error
+
+val typedVal: Middle$Type = 2 // ok, should only warn on declaration not on usage
+def funcWithDollarTypes(foo: $StartType): Middle$Type = 2 // ok, should only warn on declaration not on usage
+
+class `Check$Me$Not`
+
+/* enums */
+enum GoodEnum:
+  case GoodCase
+  case $BadCaseStart // error
+  case BadCase$Middle // error
+  case BadCaseEnd$ // error
+
+enum $BadEnumStart: // error
+  case GoodCase
+  case $BadCase // error
+
+enum BadEnum$Middle: // error
+  case GoodCase
+  case Bad$Case // error
+
+enum BadEnumEnd$: // error
+  case GoodCase
+  case BadCase$ // error
+
+enum E$numWithEndKeyword: // error
+  case SomeCase
+end E$numWithEndKeyword // ok
+
+def TestEnumUsage(a: $BadEnumStart): Int = // ok, should only warn on declaration not on usage
+  a match
+    case $BadEnumStart.GoodCase => 1
+    case $BadEnumStart.$BadCase => 2 // ok, should only warn on declaration not on usage
+
+/* objects */
+object $ObjectStart: // error
+  val goodVal = 1
+  val $badVal = 2 // error
+
+object Object$Middle: // error
+  val goodVal = 1
+  val bad$Val = 2 // error
+
+object ObjectEnd$: // error
+  val goodVal = 1
+  val badVal$ = 2 // error
+
+object GoodObject:
+  val goodVal = 1
+  val b$adVal = 2 // error
+
+object Ob$jectWithEndKeyword: // error
+  val someVal = 1
+end Ob$jectWithEndKeyword // ok
+
+val testObjectUsage = ObjectEnd$.badVal$ // ok, should only warn on declaration not on usage
+
+/* case classes */
+case class $InlineCaseClassStart(someField: Int) // error
+case class InlineCaseClass$Middle(someField: Int) // error
+case class InlineCaseClassEnd$(someField: Int) // error
+
+case class InlineCaseClass(goodField: Int, badFiel$d: Int) // error
+
+case class $CaseClassStart( // error
+  somefield: Int,
+  b$adfield: Int // error
+)
+
+case class CaseClass$Middle( // error
+  somefield: Int,
+  bad$Field: Int // error
+)
+object CaseClass$Middle // error
+
+case class CaseClassEnd$( // error
+  somefield: Int,
+  badField$: Int // error
+)
+
+// companion oject
+object CaseClassEnd$: // error
+  val food = 1
+
+val testCaseClassUsage = CaseClass$Middle(somefield = 1, bad$Field = 2) // ok, should only warn on declaration not on usage
+
+/* classes */
+class GoodClass
+class $StartClass // error
+class Middle$Class // error
+class EndClass$ // error
+
+class Cla$$( // error
+   var goodMember: Int,
+   var badM$ember: Int // error
+):
+  def goodMethod(x: Int) = badM$ember // ok, only checking if the method name does not contain a dollar sign
+  def bad$Method(y: Int) = goodMember // error
+  def methodWithBadArgNames(b$ad$arg: Int) = goodMember // error
+  def method$WithEndKeyword() = // error
+    3
+  end method$WithEndKeyword
+end Cla$$ // ok
+
+def testUsage =
+  val instantiation = new Cla$$(goodMember = 1, badM$ember = 2) // ok, should only warn on declaration not on usage
+  instantiation.bad$Method(1) // ok, should only warn on declaration not on usage
+  instantiation.methodWithBadArgNames(2) // ok, should only warn on declaration not on usage
+
+
+/* traits */
+trait GoodTrait
+trait $BadTraitStart // error
+trait BadTrait$Middle // error
+trait BadTraitEnd$ // error
+
+class TestTraitUsage extends $BadTraitStart // ok, should only warn on declaration not on usage
+
+package GoodPackage:
+  val goodVal = 1
+  val b$adVal = 2 // error
+
+package $BadPackageStart: // error
+  val goodVal = 1
+  val $badVal = 2 // error
+
+package BadPackage$Middle: // error
+  val goodVal = 1
+  val bad$Val = 2 // error
+
+package BadPackageEnd$ : // error
+  val goodVal = 1
+  val badVal$ = 2 // error
+
+class BadConstructor:
+  def `<init>`() = () // error // error
+
+def patvar[A](x: Option[A]) =
+  x match
+  case Some(funky$thing) => true // error
+  case _ => false

--- a/tests/neg/i18234.scala
+++ b/tests/neg/i18234.scala
@@ -1,4 +1,4 @@
-//> using options -Wconf:name=IllegalIdentifier&msg=reserved:e
+//> using options -Wconf:name=IllegalIdentifier&msg=reserved:e -source:3.9
 /* vals */
 val goodVal = 1
 val $startVal = 1 // error

--- a/tests/neg/i4986c.scala
+++ b/tests/neg/i4986c.scala
@@ -14,7 +14,7 @@ class Outer[A] {
   }
 }
 
-trait X$Y
+trait `X$Y`
 
 @implicitNotFound(msg = "There's no U[${X}, ${Y}, ${Z}]")
 trait U[X, Y[_], Z[_, ZZ]] {

--- a/tests/pos/i18234.scala
+++ b/tests/pos/i18234.scala
@@ -1,0 +1,9 @@
+//> using options -Werror
+
+class `C$Z`:
+  override def toString = "C$Z"
+
+  def patvar[A](x: Option[A]) =
+    x match
+    case Some(`funky$thing` @ _) => true
+    case _ => false

--- a/tests/pos/i18234.scala
+++ b/tests/pos/i18234.scala
@@ -7,3 +7,6 @@ class `C$Z`:
     x match
     case Some(`funky$thing` @ _) => true
     case _ => false
+
+class $
+object $

--- a/tests/rewrites/i18234.check
+++ b/tests/rewrites/i18234.check
@@ -1,0 +1,165 @@
+/* vals */
+val goodVal = 1
+val `$startVal` = 1 // error
+val `mid$dleVal` = 1 // error
+val `endVal$` = 1 // error
+
+def testValUsage =
+  $startVal + endVal$ // ok, should only warn on declaration not on usage
+
+/* functions */
+def `$funcStart`() = 3 // error
+def `func$Middle`() = 3 // error
+def `funcEnd$`() = 3 // error
+
+def func1badArg(goodArg: Int, `bad$Arg`: Int) = 5 // error
+def func1badArgAndUsageDoesNotThrowWarning(goodArg: Int, `bad$Arg`: Int) = bad$Arg // error
+def func2badArgs(goodArg: Int, `bad$Arg`: Int, `bad$arg2`: String) = 5 // error // error
+def multilineFunc(
+  goodArg: Int,
+  `badAr$g`: Int // error
+) = 1
+
+def testFuncUsaage =
+  $funcStart() + func1badArg(1, 2) // ok, should only warn on declaration not on usage
+
+/* types */
+type GoodType = Int
+type `$StartType` = Int // error
+type `Middle$Type` = Int // error
+type `EndType$` = Int // error
+
+val typedVal: Middle$Type = 2 // ok, should only warn on declaration not on usage
+def funcWithDollarTypes(foo: $StartType): Middle$Type = 2 // ok, should only warn on declaration not on usage
+
+/* enums */
+enum GoodEnum:
+  case GoodCase
+  case `$BadCaseStart` // error
+  case `BadCase$Middle` // error
+  case `BadCaseEnd$` // error
+
+enum `$BadEnumStart`: // error
+  case GoodCase
+  case `$BadCase` // error
+
+enum `BadEnum$Middle`: // error
+  case GoodCase
+  case `Bad$Case` // error
+
+enum `BadEnumEnd$`: // error
+  case GoodCase
+  case `BadCase$` // error
+
+enum `E$numWithEndKeyword`: // error
+  case SomeCase
+end E$numWithEndKeyword // ok
+
+def TestEnumUsage(a: $BadEnumStart): Int = // ok, should only warn on declaration not on usage
+  a match
+    case $BadEnumStart.GoodCase => 1
+    case $BadEnumStart.$BadCase => 2 // ok, should only warn on declaration not on usage
+
+/* objects */
+object `$ObjectStart`: // error
+  val goodVal = 1
+  val `$badVal` = 2 // error
+
+object `Object$Middle`: // error
+  val goodVal = 1
+  val `bad$Val` = 2 // error
+
+object `ObjectEnd$`: // error
+  val goodVal = 1
+  val `badVal$` = 2 // error
+
+object GoodObject:
+  val goodVal = 1
+  val `b$adVal` = 2 // error
+
+object `Ob$jectWithEndKeyword`: // error
+  val someVal = 1
+end Ob$jectWithEndKeyword // ok
+
+val testObjectUsage = ObjectEnd$.badVal$ // ok, should only warn on declaration not on usage
+
+/* case classes */
+case class `$InlineCaseClassStart`(someField: Int) // error
+case class `InlineCaseClass$Middle`(someField: Int) // error
+case class `InlineCaseClassEnd$`(someField: Int) // error
+
+case class InlineCaseClass(goodField: Int, `badFiel$d`: Int) // error
+
+case class `$CaseClassStart`( // error
+  somefield: Int,
+  `b$adfield`: Int // error
+)
+
+case class `CaseClass$Middle`( // error
+  somefield: Int,
+  `bad$Field`: Int // error
+)
+
+case class `CaseClassEnd$`( // error
+  somefield: Int,
+  `badField$`: Int // error
+)
+
+// companion object
+object `CaseClassEnd$`: // error
+  val food = 1
+
+val testCaseClassUsage = CaseClass$Middle(somefield = 1, bad$Field = 2) // ok, should only warn on declaration not on usage
+
+/* classes */
+class GoodClass
+class `$StartClass` // error
+class `Middle$Class` // error
+class `EndClass$` // error
+
+class `Cla$$`( // error
+   var goodMember: Int,
+   var `badM$ember`: Int // error
+):
+  def goodMethod(x: Int) = badM$ember // ok, only checking if the method name does not contain a dollar sign
+  def `bad$Method`(y: Int) = goodMember // error
+  def methodWithBadArgNames(`b$ad$arg`: Int) = goodMember // error
+  def `method$WithEndKeyword`() = // error
+    3
+  end method$WithEndKeyword
+end Cla$$ // ok
+
+def testUsage =
+  val instantiation = new Cla$$(goodMember = 1, badM$ember = 2) // ok, should only warn on declaration not on usage
+  instantiation.bad$Method(1) // ok, should only warn on declaration not on usage
+  instantiation.methodWithBadArgNames(2) // ok, should only warn on declaration not on usage
+
+
+/* traits */
+trait GoodTrait
+trait `$BadTraitStart` // error
+trait `BadTrait$Middle` // error
+trait `BadTraitEnd$` // error
+
+class TestTraitUsage extends $BadTraitStart // ok, should only warn on declaration not on usage
+
+package GoodPackage:
+  val goodVal = 1
+  val `b$adVal` = 2 // error
+
+package `$BadPackageStart`: // error
+  val goodVal = 1
+  val `$badVal` = 2 // error
+
+package `BadPackage$Middle`: // error
+  val goodVal = 1
+  val `bad$Val` = 2 // error
+
+package `BadPackageEnd$` : // error
+  val goodVal = 1
+  val `badVal$` = 2 // error
+
+def patvar[A](x: Option[A]) =
+  x match
+  case Some(funky$thing) => true // error
+  case _ => false

--- a/tests/rewrites/i18234.check
+++ b/tests/rewrites/i18234.check
@@ -1,3 +1,4 @@
+//> using options -source:3.9-migration
 /* vals */
 val goodVal = 1
 val `$startVal` = 1 // error

--- a/tests/rewrites/i18234.scala
+++ b/tests/rewrites/i18234.scala
@@ -1,0 +1,165 @@
+/* vals */
+val goodVal = 1
+val $startVal = 1 // error
+val mid$dleVal = 1 // error
+val endVal$ = 1 // error
+
+def testValUsage =
+  $startVal + endVal$ // ok, should only warn on declaration not on usage
+
+/* functions */
+def $funcStart() = 3 // error
+def func$Middle() = 3 // error
+def funcEnd$() = 3 // error
+
+def func1badArg(goodArg: Int, bad$Arg: Int) = 5 // error
+def func1badArgAndUsageDoesNotThrowWarning(goodArg: Int, bad$Arg: Int) = bad$Arg // error
+def func2badArgs(goodArg: Int, bad$Arg: Int, bad$arg2: String) = 5 // error // error
+def multilineFunc(
+  goodArg: Int,
+  badAr$g: Int // error
+) = 1
+
+def testFuncUsaage =
+  $funcStart() + func1badArg(1, 2) // ok, should only warn on declaration not on usage
+
+/* types */
+type GoodType = Int
+type $StartType = Int // error
+type Middle$Type = Int // error
+type EndType$ = Int // error
+
+val typedVal: Middle$Type = 2 // ok, should only warn on declaration not on usage
+def funcWithDollarTypes(foo: $StartType): Middle$Type = 2 // ok, should only warn on declaration not on usage
+
+/* enums */
+enum GoodEnum:
+  case GoodCase
+  case $BadCaseStart // error
+  case BadCase$Middle // error
+  case BadCaseEnd$ // error
+
+enum $BadEnumStart: // error
+  case GoodCase
+  case $BadCase // error
+
+enum BadEnum$Middle: // error
+  case GoodCase
+  case Bad$Case // error
+
+enum BadEnumEnd$: // error
+  case GoodCase
+  case BadCase$ // error
+
+enum E$numWithEndKeyword: // error
+  case SomeCase
+end E$numWithEndKeyword // ok
+
+def TestEnumUsage(a: $BadEnumStart): Int = // ok, should only warn on declaration not on usage
+  a match
+    case $BadEnumStart.GoodCase => 1
+    case $BadEnumStart.$BadCase => 2 // ok, should only warn on declaration not on usage
+
+/* objects */
+object $ObjectStart: // error
+  val goodVal = 1
+  val $badVal = 2 // error
+
+object Object$Middle: // error
+  val goodVal = 1
+  val bad$Val = 2 // error
+
+object ObjectEnd$: // error
+  val goodVal = 1
+  val badVal$ = 2 // error
+
+object GoodObject:
+  val goodVal = 1
+  val b$adVal = 2 // error
+
+object Ob$jectWithEndKeyword: // error
+  val someVal = 1
+end Ob$jectWithEndKeyword // ok
+
+val testObjectUsage = ObjectEnd$.badVal$ // ok, should only warn on declaration not on usage
+
+/* case classes */
+case class $InlineCaseClassStart(someField: Int) // error
+case class InlineCaseClass$Middle(someField: Int) // error
+case class InlineCaseClassEnd$(someField: Int) // error
+
+case class InlineCaseClass(goodField: Int, badFiel$d: Int) // error
+
+case class $CaseClassStart( // error
+  somefield: Int,
+  b$adfield: Int // error
+)
+
+case class CaseClass$Middle( // error
+  somefield: Int,
+  bad$Field: Int // error
+)
+
+case class CaseClassEnd$( // error
+  somefield: Int,
+  badField$: Int // error
+)
+
+// companion object
+object CaseClassEnd$: // error
+  val food = 1
+
+val testCaseClassUsage = CaseClass$Middle(somefield = 1, bad$Field = 2) // ok, should only warn on declaration not on usage
+
+/* classes */
+class GoodClass
+class $StartClass // error
+class Middle$Class // error
+class EndClass$ // error
+
+class Cla$$( // error
+   var goodMember: Int,
+   var badM$ember: Int // error
+):
+  def goodMethod(x: Int) = badM$ember // ok, only checking if the method name does not contain a dollar sign
+  def bad$Method(y: Int) = goodMember // error
+  def methodWithBadArgNames(b$ad$arg: Int) = goodMember // error
+  def method$WithEndKeyword() = // error
+    3
+  end method$WithEndKeyword
+end Cla$$ // ok
+
+def testUsage =
+  val instantiation = new Cla$$(goodMember = 1, badM$ember = 2) // ok, should only warn on declaration not on usage
+  instantiation.bad$Method(1) // ok, should only warn on declaration not on usage
+  instantiation.methodWithBadArgNames(2) // ok, should only warn on declaration not on usage
+
+
+/* traits */
+trait GoodTrait
+trait $BadTraitStart // error
+trait BadTrait$Middle // error
+trait BadTraitEnd$ // error
+
+class TestTraitUsage extends $BadTraitStart // ok, should only warn on declaration not on usage
+
+package GoodPackage:
+  val goodVal = 1
+  val b$adVal = 2 // error
+
+package $BadPackageStart: // error
+  val goodVal = 1
+  val $badVal = 2 // error
+
+package BadPackage$Middle: // error
+  val goodVal = 1
+  val bad$Val = 2 // error
+
+package BadPackageEnd$ : // error
+  val goodVal = 1
+  val badVal$ = 2 // error
+
+def patvar[A](x: Option[A]) =
+  x match
+  case Some(funky$thing) => true // error
+  case _ => false

--- a/tests/rewrites/i18234.scala
+++ b/tests/rewrites/i18234.scala
@@ -1,3 +1,4 @@
+//> using options -source:3.9-migration
 /* vals */
 val goodVal = 1
 val $startVal = 1 // error

--- a/tests/warn/i18234.scala
+++ b/tests/warn/i18234.scala
@@ -1,0 +1,166 @@
+// using options -source:3.9
+/* vals */
+val goodVal = 1
+val $startVal = 1 // warn
+val mid$dleVal = 1 // warn
+val endVal$ = 1 // warn
+
+def testValUsage =
+  $startVal + endVal$ // ok, should only warn on declaration not on usage
+
+/* functions */
+def $funcStart() = 3 // warn
+def func$Middle() = 3 // warn
+def funcEnd$() = 3 // warn
+
+def func1badArg(goodArg: Int, bad$Arg: Int) = 5 // warn
+def func1badArgAndUsageDoesNotThrowWarning(goodArg: Int, bad$Arg: Int) = bad$Arg // warn
+def func2badArgs(goodArg: Int, bad$Arg: Int, bad$arg2: String) = 5 // warn // warn
+def multilineFunc(
+  goodArg: Int,
+  badAr$g: Int // warn
+) = 1
+
+def testFuncUsaage =
+  $funcStart() + func1badArg(1, 2) // ok, should only warn on declaration not on usage
+
+/* types */
+type GoodType = Int
+type $StartType = Int // warn
+type Middle$Type = Int // warn
+type EndType$ = Int // warn
+
+val typedVal: Middle$Type = 2 // ok, should only warn on declaration not on usage
+def funcWithDollarTypes(foo: $StartType): Middle$Type = 2 // ok, should only warn on declaration not on usage
+
+/* enums */
+enum GoodEnum:
+  case GoodCase
+  case $BadCaseStart // warn
+  case BadCase$Middle // warn
+  case BadCaseEnd$ // warn
+
+enum $BadEnumStart: // warn
+  case GoodCase
+  case $BadCase // warn
+
+enum BadEnum$Middle: // warn
+  case GoodCase
+  case Bad$Case // warn
+
+enum BadEnumEnd$: // warn
+  case GoodCase
+  case BadCase$ // warn
+
+enum E$numWithEndKeyword: // warn
+  case SomeCase
+end E$numWithEndKeyword // ok
+
+def TestEnumUsage(a: $BadEnumStart): Int = // ok, should only warn on declaration not on usage
+  a match
+    case $BadEnumStart.GoodCase => 1
+    case $BadEnumStart.$BadCase => 2 // ok, should only warn on declaration not on usage
+
+/* objects */
+object $ObjectStart: // warn
+  val goodVal = 1
+  val $badVal = 2 // warn
+
+object Object$Middle: // warn
+  val goodVal = 1
+  val bad$Val = 2 // warn
+
+object ObjectEnd$: // warn
+  val goodVal = 1
+  val badVal$ = 2 // warn
+
+object GoodObject:
+  val goodVal = 1
+  val b$adVal = 2 // warn
+
+object Ob$jectWithEndKeyword: // warn
+  val someVal = 1
+end Ob$jectWithEndKeyword // ok
+
+val testObjectUsage = ObjectEnd$.badVal$ // ok, should only warn on declaration not on usage
+
+/* case classes */
+case class $InlineCaseClassStart(someField: Int) // warn
+case class InlineCaseClass$Middle(someField: Int) // warn
+case class InlineCaseClassEnd$(someField: Int) // warn
+
+case class InlineCaseClass(goodField: Int, badFiel$d: Int) // warn
+
+case class $CaseClassStart( // warn
+  somefield: Int,
+  b$adfield: Int // warn
+)
+
+case class CaseClass$Middle( // warn
+  somefield: Int,
+  bad$Field: Int // warn
+)
+
+case class CaseClassEnd$( // warn
+  somefield: Int,
+  badField$: Int // warn
+)
+
+// companion oject
+object CaseClassEnd$: // warn
+  val food = 1
+
+val testCaseClassUsage = CaseClass$Middle(somefield = 1, bad$Field = 2) // ok, should only warn on declaration not on usage
+
+/* classes */
+class GoodClass
+class $StartClass // warn
+class Middle$Class // warn
+class EndClass$ // warn
+
+class Cla$$( // warn
+   var goodMember: Int,
+   var badM$ember: Int // warn
+):
+  def goodMethod(x: Int) = badM$ember // ok, only checking if the method name does not contain a dollar sign
+  def bad$Method(y: Int) = goodMember // warn
+  def methodWithBadArgNames(b$ad$arg: Int) = goodMember // warn
+  def method$WithEndKeyword() = // warn
+    3
+  end method$WithEndKeyword
+end Cla$$ // ok
+
+def testUsage =
+  val instantiation = new Cla$$(goodMember = 1, badM$ember = 2) // ok, should only warn on declaration not on usage
+  instantiation.bad$Method(1) // ok, should only warn on declaration not on usage
+  instantiation.methodWithBadArgNames(2) // ok, should only warn on declaration not on usage
+
+
+/* traits */
+trait GoodTrait
+trait $BadTraitStart // warn
+trait BadTrait$Middle // warn
+trait BadTraitEnd$ // warn
+
+class TestTraitUsage extends $BadTraitStart // ok, should only warn on declaration not on usage
+
+package GoodPackage:
+  val goodVal = 1
+  val b$adVal = 2 // warn
+
+package $BadPackageStart: // warn
+  val goodVal = 1
+  val $badVal = 2 // warn
+
+package BadPackage$Middle: // warn
+  val goodVal = 1
+  val bad$Val = 2 // warn
+
+package BadPackageEnd$ : // warn
+  val goodVal = 1
+  val badVal$ = 2 // warn
+
+def patvar[A](x: Option[A]) =
+  x match
+  case Some(funky$thing) => true // warn
+  case _ => false

--- a/tests/warn/i18234.scala
+++ b/tests/warn/i18234.scala
@@ -1,4 +1,4 @@
-// using options -source:3.9
+//> using options -source:3.9
 /* vals */
 val goodVal = 1
 val $startVal = 1 // warn

--- a/tests/warn/t11681.scala
+++ b/tests/warn/t11681.scala
@@ -106,4 +106,4 @@ object Answers {
   def answer: Int = 42
 }
 
-val a$1 = 2
+val `a$1` = 2


### PR DESCRIPTION
Warns on definitions named with embedded dollars, which can be written in backquotes to be accepted quietly.

Fixes #18234

Test from https://github.com/scala/scala3/pull/18563