### PR TITLE
JEP 401: Project Valhalla value classes

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1660,7 +1660,7 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
             case ZAND   => genZandOrZor(and = true)
             case ZOR    => genZandOrZor(and = false)
             case code   =>
-              if (ScalaPrimitivesOps.isUniversalEqualityOp(code) && tpeTK(lhs).isClass) {
+              if (ScalaPrimitivesOps.isUniversalEqualityOp(code) && tpeTK(lhs).isClass && !tpeTK(lhs).asClassBType.isDeepValhalla) {
                 // rewrite `==` to null tests and `equals`. not needed for arrays (`equals` is reference equality).
                 if (code == EQ) genEqEqPrimitive(lhs, rhs, success, failure, targetIfNoJump)
                 else            genEqEqPrimitive(lhs, rhs, failure, success, targetIfNoJump)

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1660,12 +1660,17 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
             case ZAND   => genZandOrZor(and = true)
             case ZOR    => genZandOrZor(and = false)
             case code   =>
-              if (ScalaPrimitivesOps.isUniversalEqualityOp(code) && tpeTK(lhs).isClass && !tpeTK(lhs).asClassBType.isDeepValhalla) {
+              if (ScalaPrimitivesOps.isUniversalEqualityOp(code) && tpeTK(lhs).isClass && tpeTK(rhs).isClass && !(tpeTK(lhs).asClassBType.isDeepValhalla || tpeTK(rhs).asClassBType.isDeepValhalla)) {
                 // rewrite `==` to null tests and `equals`. not needed for arrays (`equals` is reference equality).
                 if (code == EQ) genEqEqPrimitive(lhs, rhs, success, failure, targetIfNoJump)
                 else            genEqEqPrimitive(lhs, rhs, failure, success, targetIfNoJump)
               } else if (ScalaPrimitivesOps.isComparisonOp(code)) {
-                genComparisonOp(lhs, rhs, code)
+                if(tpeTK(lhs).isClass && tpeTK(rhs).isClass && !tpeTK(lhs).asClassBType.isDeepValhalla && tpeTK(rhs).asClassBType.isDeepValhalla){
+                  genComparisonOp(rhs, lhs, code)
+                }
+                else{
+                  genComparisonOp(lhs, rhs, code)
+                }
               } else
                 loadAndTestBoolean()
           }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -371,7 +371,6 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
           else genSig.toString
       }
     }
-
   } // end of trait BCJGenSigGen
 
   trait BCForwardersGen extends BCAnnotGen with BCJGenSigGen {

--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -687,7 +687,7 @@ object BCodeHelpers {
     asm.Opcodes.ACC_PUBLIC   | asm.Opcodes.ACC_PRIVATE   | asm.Opcodes.ACC_PROTECTED  |
       asm.Opcodes.ACC_STATIC   | asm.Opcodes.ACC_FINAL     | asm.Opcodes.ACC_INTERFACE  |
       asm.Opcodes.ACC_ABSTRACT | asm.Opcodes.ACC_SYNTHETIC | asm.Opcodes.ACC_ANNOTATION |
-      asm.Opcodes.ACC_ENUM
+      asm.Opcodes.ACC_ENUM  | asm.Opcodes.ACC_SUPER
   }
 
 }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -385,6 +385,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
         .addFlagIf(sym.hasAnnotation(defn.TransientAnnot), ACC_TRANSIENT)
         .addFlagIf(sym.hasAnnotation(defn.VolatileAnnot), ACC_VOLATILE)
         .addFlagIf(!sym.is(Mutable), ACC_FINAL)
+        .addFlagIf(sym.denot.owner.isValhallaValueClass, ACC_STRICT)
     }
 
     private def addClassField(f: Symbol)(using Context): Unit = {
@@ -404,6 +405,9 @@ trait BCodeSkelBuilder extends BCodeHelpers {
       )
       cnode.fields.add(jfield)
       emitAnnotations(jfield, f.annotations)
+
+      if(f.denot.info.isValhallaValueClassType)
+        cnode.visitLoadableDescriptors(jfield.desc)
     }
 
     private def addClassFields()(using Context): Unit =

--- a/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
@@ -511,7 +511,7 @@ object BCodeUtils {
       .addFlagIf(sym.isStaticMember && !sym.isClass, ACC_STATIC)
       .addFlagIf(sym.is(Bridge), ACC_BRIDGE | ACC_SYNTHETIC)
       .addFlagIf(sym.is(Artifact), ACC_SYNTHETIC)
-      .addFlagIf(sym.isClass && !sym.is(Trait), ACC_SUPER)
+      .addFlagIf(sym.isClass && !sym.is(Trait) && !sym.isValhallaValueClass, ACC_SUPER)
       .addFlagIf(sym.isAllOf(JavaEnum), ACC_ENUM)
       .addFlagIf(sym.is(JavaVarargs), ACC_VARARGS)
       .addFlagIf(sym.is(Synchronized), ACC_SYNCHRONIZED)

--- a/compiler/src/dotty/tools/backend/jvm/BTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypes.scala
@@ -12,7 +12,6 @@ import dotty.tools.dotc.core.Definitions
 import scala.collection.SortedMap
 import scala.tools.asm.Opcodes
 
-
 /**
  * The BTypes component defines The BType class hierarchy. BTypes encapsulates all type information
  * that is required after building the ASM nodes. This includes optimizations, generation of
@@ -763,6 +762,8 @@ final case class ClassBType private(internalName: String) extends RefBType {
     // (*) check if some interface of this class conforms to other.
     info.interfaces.exists(_.isSubtypeOf(other))
   }
+
+  def isDeepValhalla: Boolean = isSubtypeOf(ts.deepValhallaRef)
 
   /**
    * Finding the least upper bound in agreement with the bytecode verifier

--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -721,6 +721,10 @@ object desugar {
     def isEnumCase = mods.isEnumCase
     def isNonEnumCase = !isEnumCase && (isCaseClass || isCaseObject)
     val isValueClass = parents.nonEmpty && isAnyVal(parents.head)
+    val isValhallaVC = isValueClass && mods.annotations.exists{ annot => annot match
+      case Apply(Select(New(Ident(annotName)), _), _) => annotName eq tpnme.valhalla
+      case _ => false
+    }
       // This is not watertight, but `extends AnyVal` will be replaced by `inline` later.
     val caseClassInScala2Library = isCaseClass && Feature.shouldBehaveAsScala2
 
@@ -1038,7 +1042,7 @@ object desugar {
       }
       else if (companionMembers.nonEmpty || companionDerived.nonEmpty || isEnum)
         companionDefs(anyRef, companionMembers)
-      else if isValueClass && !isObject then
+      else if isValueClass && !isObject && !isValhallaVC then
         companionDefs(anyRef, Nil)
       else Nil
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -548,7 +548,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def wrapArrayMethodName(elemtp: Type)(using Context): TermName = {
     val elemCls = elemtp.classSymbol
     if (elemCls.isPrimitiveValueClass) nme.wrapXArray(elemCls.name)
-    else if (elemCls.derivesFrom(defn.ObjectClass) && !elemCls.isNotRuntimeClass) nme.wrapRefArray
+    else if ((elemCls.derivesFrom(defn.ObjectClass) || elemCls.isValhallaValueClass) && !elemCls.isNotRuntimeClass) nme.wrapRefArray
     else nme.genericWrapArray
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -582,6 +582,9 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def makeConsumeAnnot()(using Context): Tree =
     New(scalaCapsInternalDot(tpnme.consume), Nil :: Nil)
 
+  def makeValhallaAnnot()(using Context): Tree =
+    New(scalaAnnotationDot(tpnme.valhalla), Nil :: Nil)
+
   def makeConstructor(tparams: List[TypeDef], vparamss: List[List[ValDef]], rhs: Tree = EmptyTree)(using Context): DefDef =
     DefDef(nme.CONSTRUCTOR, joinParams(tparams, vparamss), TypeTree(), rhs)
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -572,6 +572,7 @@ private sealed trait YSettings:
   val YccLog: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycc-log", "Used in conjunction with captureChecking language import, print tracing and debug info")
   val YccVerbose: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycc-verbose", "Print root capabilities with more details")
   val YccPrintSetup: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycc-print-setup", "Used in conjunction with captureChecking language import, print trees after cc.Setup phase")
+  val YvalueClasses: Setting[Boolean] = BooleanSetting(ForkSetting, "Yvalue-classes", "value classes")
 
   /** Area-specific debug output */
   val YexplainLowlevel: Setting[Boolean] = BooleanSetting(ForkSetting, "Yexplain-lowlevel", "When explaining type errors, show types at a lower level.")

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -572,7 +572,7 @@ private sealed trait YSettings:
   val YccLog: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycc-log", "Used in conjunction with captureChecking language import, print tracing and debug info")
   val YccVerbose: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycc-verbose", "Print root capabilities with more details")
   val YccPrintSetup: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycc-print-setup", "Used in conjunction with captureChecking language import, print trees after cc.Setup phase")
-  val YvalueClasses: Setting[Boolean] = BooleanSetting(ForkSetting, "Yvalue-classes", "value classes")
+  val Yvalhalla: Setting[Boolean] = BooleanSetting(ForkSetting, "Yvalhalla", "Valhalla features like value classes and null-restricted types")
 
   /** Area-specific debug output */
   val YexplainLowlevel: Setting[Boolean] = BooleanSetting(ForkSetting, "Yexplain-lowlevel", "When explaining type errors, show types at a lower level.")

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -339,6 +339,8 @@ class Definitions {
   }
   def ObjectType: TypeRef = ObjectClass.typeRef
 
+  @tu lazy val DeepValhallaTrait: ClassSymbol = requiredClass("scala.DeepValhalla")
+
   /** A type alias of Object used to represent any reference to Object in a Java
    *  signature, the secret sauce is that subtype checking treats it specially:
    *
@@ -1148,6 +1150,7 @@ class Definitions {
   @tu lazy val StableNullAnnot: ClassSymbol = requiredClass("scala.annotation.stableNull")
   @tu lazy val InlineAnnot: ClassSymbol = requiredClass("scala.inline")
   @tu lazy val NoInlineAnnot: ClassSymbol = requiredClass("scala.noinline")
+  @tu lazy val ValhallaAnnot: ClassSymbol = requiredClass("scala.annotation.valhalla")
 
   @tu lazy val JavaRepeatableAnnot: ClassSymbol = requiredClass("java.lang.annotation.Repeatable")
 

--- a/compiler/src/dotty/tools/dotc/core/ImplicitNullInterop.scala
+++ b/compiler/src/dotty/tools/dotc/core/ImplicitNullInterop.scala
@@ -146,7 +146,7 @@ object ImplicitNullInterop:
         case tp: TypeRef =>
           // We don't modify value types because they're non-nullable even in Java.
           val isValueOrSpecialClass =
-            tp.symbol.isValueClass
+           (tp.symbol.isValueClass && !tp.symbol.isValhallaValueClass)
             || tp.isRef(defn.NullClass)
             || tp.isRef(defn.NothingClass)
             || tp.isRef(defn.UnitClass)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -666,6 +666,7 @@ object StdNames {
     val valueOf : N             = "valueOf"
     val fromOrdinal: N          = "fromOrdinal"
     val values: N               = "values"
+    val valhalla: N             = "valhalla"
     val view_ : N               = "view"
     val varargGetter : N        = "varargGetter"
     val wait_ : N               = "wait"

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -896,6 +896,9 @@ object SymDenotations {
     /** Is this symbol a class that extends `AnyVal`? Overridden in ClassDenotation */
     def isValueClass(using Context): Boolean = false
 
+    /** Is this symbol a class or trait that extends `AnyVal` and has the `valhalla` annotation? Overridden in ClassDenotation */
+    def isValhallaValueClass(using Context): Boolean = false
+
     /** Is this symbol a class of which `null` is a value? */
     final def isNullableClass(using Context): Boolean =
       if ctx.mode.is(Mode.SafeNulls) && !ctx.phase.erasedTypes
@@ -907,7 +910,7 @@ object SymDenotations {
      *  but it becomes nullable after erasure.
      */
     final def isNullableClassAfterErasure(using Context): Boolean =
-      isClass && !isValueClass && !is(ModuleClass) && symbol != defn.NothingClass
+      isClass && (!isValueClass || isValhallaValueClass) && !is(ModuleClass) && symbol != defn.NothingClass
 
     /** Is `pre` the same as C.this, where C is exactly the owner of this symbol,
      *  or, if this symbol is protected, a subclass of the owner?
@@ -2136,6 +2139,9 @@ object SymDenotations {
         // We call derivesFrom at the initial phase both because AnyVal does not exist
         // after Erasure and to avoid cyclic references caused by forcing denotations
         atPhase(di.validFor.firstPhaseId)(di.derivesFrom(anyVal))
+
+    final override def isValhallaValueClass(using Context): Boolean =
+      hasAnnotation(defn.ValhallaAnnot) && (symbol.isUniversalTrait || isValueClass)
 
     /** Enter a symbol in current scope, and future scopes of same denotation.
      *  Note: We require that this does not happen after the first time

--- a/compiler/src/dotty/tools/dotc/core/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymUtils.scala
@@ -84,8 +84,18 @@ class SymUtils:
       !d.isRefinementClass &&
       d.isValueClass &&
       (d.initial.symbol ne defn.AnyValClass) && // Compare the initial symbol because AnyVal does not exist after erasure
-      !d.isPrimitiveValueClass
+      !d.isPrimitiveValueClass &&
+      !d.isValhallaValueClass
     }
+
+    def isDeepValhallaOrPrimitive(using Context): Boolean =
+      self.isDeepValhalla || self.isPrimitiveValueClass
+
+    def isJavaInterface(using Context): Boolean =
+      self.is(Trait) && self.is(JavaDefined)
+
+    def isInScalaPackage(using Context): Boolean =
+      self.ownersIterator.contains(defn.ScalaPackageClass)
 
     def isContextBoundCompanion(using Context): Boolean =
       self.is(Synthetic) && self.infoOrCompleter.isContextBoundCompanion

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -220,6 +220,14 @@ object Symbols extends SymUtils {
     final def isStatic(using Context): Boolean =
       lastDenot.initial.isStatic
 
+    /** Overridden by ClassSymbol */
+    def isValhallaValueClass(using Context): Boolean =
+      false
+
+    /** Overridden by ClassSymbol */
+    def isDeepValhalla(using Context): Boolean =
+      false
+
     /** This symbol entered into owner's scope (owner must be a class). */
     final def entered(using Context): this.type = {
       if (this.owner.isClass) {
@@ -539,6 +547,12 @@ object Symbols extends SymUtils {
             }
       mySource
     }
+
+    override final def isValhallaValueClass(using Context): Boolean =
+      classDenot.isValhallaValueClass
+
+    override final def isDeepValhalla(using Context): Boolean =
+      classDenot.derivesFrom(defn.DeepValhallaTrait)
 
     final def classDenot(using Context): ClassDenotation =
       denot.asInstanceOf[ClassDenotation]

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -417,9 +417,9 @@ object TypeErasure:
   def erasedLub(tp1: Type, tp2: Type)(using Context): Type = {
     // We need to short-circuit the following 2 case because the regular lub logic in the else relies on
     // the class hierarchy, which doesn't properly capture `Nothing`/`Null` subtyping behaviour.
-    if tp1.isRef(defn.NothingClass) || (tp1.isRef(defn.NullClass) && tp2.derivesFrom(defn.ObjectClass)) then
+    if tp1.isRef(defn.NothingClass) || (tp1.isRef(defn.NullClass) && (tp2.derivesFrom(defn.ObjectClass) || tp2.isValhallaValueClassType)) then
       tp2 // After erasure, Nothing | T is just T and Null | C is just C, if C is a reference type.
-    else if tp2.isRef(defn.NothingClass) || (tp2.isRef(defn.NullClass) && tp1.derivesFrom(defn.ObjectClass)) then
+    else if tp2.isRef(defn.NothingClass) || (tp2.isRef(defn.NullClass) && (tp1.derivesFrom(defn.ObjectClass) || tp1.isValhallaValueClassType)) then
       tp1 // After erasure, T | Nothing is just T and C | Null is just C, if C is a reference type.
     else tp1 match {
       case JavaArrayType(elem1) =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -313,6 +313,14 @@ object Types extends TypeUtils {
       loop(this)
     }
 
+    def isValhallaValueClassType(using Context): Boolean =
+      this match
+        case tp: TypeRef =>
+          val sym = tp.symbol
+          if (sym.isClass) sym.isValhallaValueClass else false
+        case _ =>
+          false
+
     def isFromJavaObject(using Context): Boolean =
       isRef(defn.ObjectClass) && (typeSymbol eq defn.FromJavaObjectSymbol)
 
@@ -649,7 +657,7 @@ object Types extends TypeUtils {
           def tp2Null = tp.tp2.hasClassSymbol(defn.NullClass)
           if ctx.erasedTypes && (tp1Null || tp2Null) then
             val otherSide = if tp1Null then tp.tp2.classSymbol else tp.tp1.classSymbol
-            if otherSide.isValueClass then defn.AnyClass else otherSide
+            if (otherSide.isValueClass && !otherSide.isValhallaValueClass) then defn.AnyClass else otherSide
           else
             tp.join.classSymbol
       case _: JavaArrayType =>

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -248,6 +248,15 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case IllegalIdentifierID // errorNumber: 230
   case ConcreteClassHasUnimplementedMethodsID // errorNumber: 231
   case UseOfAnyMethodAsInterpolatorID // errorNumber: 232
+  case ValueClassCannotExtendIdentityClassID // errorNumber: 233
+  case ValueClassMustNotExtendTraitWithMutableFieldID // errorNumber: 234
+  case IncorrectValueClassDeclarationID // errorNumber: 235
+  case ValhallaTraitsMayNotHaveSelfTypesWithVarsID // errorNumber: 236
+  case AnyRefClassCantExtendDeepValhallaID // errorNumber: 237
+  case NonDeepValhallaFieldInClassThatExtendsDeepValhallaID // errorNumber: 238
+  case DeepValhallaFieldInstantiatedWithNonDeepValhallaTypeID // errorNumber: 239
+  case DeepValhallaClassExtendsNonDeepValhallaClassID // errorNumber: 240
+  case DeepValhallaClassMustNotExtendParentWithIdentityFieldID // errorNumber: 241
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3945,3 +3945,59 @@ class UseOfAnyMethodAsInterpolator(interpolator: Name)(using Context)
        |which can target methods declared by ${hl("Any")} such as ${hl(i"$interpolator")}.
        |This is unlikely to be what you intended."""
 }
+class ValueClassCannotExtendIdentityClass(valueClass: Symbol, parent: Symbol)(using Context)
+  extends SyntaxMsg(ValueClassCannotExtendIdentityClassID) {
+  def msg(using Context) = i"""A Valhalla value class cannot extend Identity Class ($parent)}"""
+  def explain(using Context) = ""
+}
+
+class ValueClassMustNotExtendTraitWithMutableField(parentClass: Symbol, field: Symbol)(using Context)
+  extends SyntaxMsg(ValueClassMustNotExtendTraitWithMutableFieldID) {
+  def msg(using Context) = i"""A Valhalla value class/trait cannot extend $parentClass with mutable field ($field)"""
+  def explain(using Context) = ""
+}
+
+class IncorrectValueClassDeclaration(isClass: Boolean)(using Context)
+  extends SyntaxMsg(IncorrectValueClassDeclarationID) {
+  def msg(using Context) = i"""Incorrect Valhalla value class declaration: Valhalla ${if isClass then "value classes" else "traits"} must extend ${if isClass then "AnyVal" else "Any"}."""
+  def explain(using Context) = "Valhalla Value Classes and Traits need to extend AnyVal or Any respectively."
+}
+
+class ValhallaTraitsMayNotHaveSelfTypesWithVars(selfTypeSym: Symbol, field: Symbol)(using Context)
+  extends SyntaxMsg(ValhallaTraitsMayNotHaveSelfTypesWithVarsID) {
+  def msg(using Context) = i"""A Valhalla trait may not have a self type ($selfTypeSym) with mutable field ($field)."""
+  def explain(using Context) = ""
+}
+
+class AnyRefClassCantExtendDeepValhalla(sym: Symbol)(using Context)
+  extends SyntaxMsg(AnyRefClassCantExtendDeepValhallaID) {
+  def msg(using Context) = i"""An AnyRef class ($sym) cannot extend DeepValhalla."""
+  def explain(using Context) = "Only Valhalla value classes should extend DeepValhalla, which indicates that all fields are either primitives or DeepValhalla classes."
+}
+
+class NonDeepValhallaFieldInClassThatExtendsDeepValhalla(valueClass: Symbol, field: Symbol)(using Context)
+  extends SyntaxMsg(NonDeepValhallaFieldInClassThatExtendsDeepValhallaID) {
+  def msg(using Context) = i"""Non-DeepValhalla field ($field) of type ${field.info} in a DeepValhalla class ($valueClass)."""
+  def explain(using Context) =
+    i"""A DeepValhalla alue class must only have fields which are DeepValhalla or primitive."""
+}
+
+class DeepValhallaFieldInstantiatedWithNonDeepValhallaType(valueClass: Symbol, instTypeSym: Symbol)(using Context)
+  extends SyntaxMsg(DeepValhallaFieldInstantiatedWithNonDeepValhallaTypeID) {
+  def msg(using Context) = i"""DeepValhalla class ($valueClass) is instantiated with non-DeepValhalla type ($instTypeSym)."""
+  def explain(using Context) =
+    i""""""
+}
+
+class DeepValhallaClassExtendsNonDeepValhallaClass(valueClass: Symbol, parentSym: Symbol)(using Context)
+  extends SyntaxMsg(DeepValhallaClassExtendsNonDeepValhallaClassID) {
+  def msg(using Context) = i"""DeepValhalla class ($valueClass) cannot extend non-DeepValhalla class ($parentSym)."""
+  def explain(using Context) =
+    i""""""
+}
+
+class DeepValhallaClassMustNotExtendParentWithIdentityField(parentClass: Symbol, field: Symbol)(using Context)
+  extends SyntaxMsg(DeepValhallaClassMustNotExtendParentWithIdentityFieldID) {
+  def msg(using Context) = i"""A DeepValhalla value class/trait cannot extend $parentClass with non-Identity field ($field)"""
+  def explain(using Context) = ""
+}

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -541,7 +541,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
         val builder =
           if defn.ScalaValueClasses().contains(elemCls) then
             makeBuilder(s"of${elemCls.name}")
-          else if elemCls.derivesFrom(defn.ObjectClass) then
+          else if elemCls.derivesFrom(defn.ObjectClass) || elemCls.isValhallaValueClass then
             makeBuilder("ofRef").appliedToType(elemType)
           else
             makeBuilder("generic").appliedToType(elemType)
@@ -614,6 +614,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
                 // which would not be reflected as `tree.tpe`
                 checkClassType(nu.tpe, stablePrefixReq = false)
               Checking.checkInstantiable(tree.tpe, nu.tpe, nu.srcPos)
+              Checking.checkDeepValhallaInstantiation(tree.tpe, nu.srcPos)
               withNoCheckNews(nu :: Nil)(app1)
             case _ =>
               app1
@@ -706,6 +707,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
                 val reference = ctx.settings.sourceroot.value
                 val relativePath = util.SourceFile.relativePath(ctx.compilationUnit.source, reference)
                 sym.addAnnotation(Annotation(defn.SourceFileAnnot, Literal(Constants.Constant(relativePath)), tree.span))
+            Checking.checkValhallaValueClass(tree, sym)
           else
             if !sym.is(Param) && !sym.owner.isOneOf(AbstractOrTrait) then
               Checking.checkGoodBounds(tree.symbol)

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -59,6 +59,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
 
   private var myValueSymbols: List[Symbol] = Nil
   private var myCaseSymbols: List[Symbol] = Nil
+  private var myValueCaseSymbols: List[Symbol] = Nil
   private var myCaseModuleSymbols: List[Symbol] = Nil
   private var myEnumValueSymbols: List[Symbol] = Nil
   private var myNonJavaEnumValueSymbols: List[Symbol] = Nil
@@ -67,6 +68,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     if (myValueSymbols.isEmpty) {
       myValueSymbols = List(defn.Any_hashCode, defn.Any_equals)
       myCaseSymbols = defn.caseClassSynthesized
+      myValueCaseSymbols = myCaseSymbols.filter(_ ne defn.Any_equals)
       myCaseModuleSymbols = myCaseSymbols.filter(_ ne defn.Any_equals)
       myEnumValueSymbols = List(defn.Product_productPrefix)
       myNonJavaEnumValueSymbols = myEnumValueSymbols :+ defn.Any_toString :+ defn.Enum_ordinal :+ defn.Any_hashCode
@@ -74,6 +76,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
 
   def valueSymbols(using Context): List[Symbol] = { initSymbols; myValueSymbols }
   def caseSymbols(using Context): List[Symbol] = { initSymbols; myCaseSymbols }
+  def valueCaseSymbols(using Context): List[Symbol] = { initSymbols; myValueCaseSymbols }
   def caseModuleSymbols(using Context): List[Symbol] = { initSymbols; myCaseModuleSymbols }
   def enumValueSymbols(using Context): List[Symbol] = { initSymbols; myEnumValueSymbols }
   def nonJavaEnumValueSymbols(using Context): List[Symbol] = { initSymbols; myNonJavaEnumValueSymbols }
@@ -108,6 +111,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     val symbolsToSynthesize: List[Symbol] =
       if clazz.is(Case) then
         if clazz.is(Module) then caseModuleSymbols
+        else if clazz.isDeepValhalla then valueCaseSymbols
         else caseSymbols
       else if isNonJavaEnumValue then nonJavaEnumValueSymbols
       else if isEnumValue then enumValueSymbols
@@ -309,7 +313,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       val matchingCase = CaseDef(pattern, EmptyTree, rhs) // case x$0 @ (_: C) => this.x == this$0.x && this.y == x$0.y
       val defaultCase = CaseDef(Underscore(defn.AnyType), EmptyTree, Literal(Constant(false))) // case _ => false
       val matchExpr = Match(that, List(matchingCase, defaultCase))
-      if (isDerivedValueClass(clazz)) matchExpr
+      if (isDerivedValueClass(clazz) || clazz.isValhallaValueClass) matchExpr
       else {
         val eqCompare = This(clazz).select(defn.Object_eq).appliedTo(that.cast(defn.ObjectType))
         eqCompare `or` matchExpr
@@ -436,7 +440,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
 
   private def hasWriteReplace(clazz: ClassSymbol)(using Context): Boolean =
     clazz.membersNamed(nme.writeReplace)
-      .filterWithPredicate(s => s.signature == Signature(defn.AnyRefType, sourceLanguage = SourceLanguage.Scala3))
+      .filterWithPredicate(s => s.signature == Signature(defn.AnyRefType, sourceLanguage = SourceLanguage.Scala3) || s.signature == Signature(defn.AnyType, sourceLanguage = SourceLanguage.Scala3))
       .exists
 
   private def hasReadResolve(clazz: ClassSymbol)(using Context): Boolean =
@@ -450,7 +454,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
 
   private def readResolveDef(clazz: ClassSymbol)(using Context): TermSymbol =
     newSymbol(clazz, nme.readResolve, PrivateMethod | Synthetic,
-        MethodType(Nil, defn.AnyRefType), coord = clazz.coord).entered.asTerm
+        MethodType(Nil, defn.AnyType), coord = clazz.coord).entered.asTerm
 
   /** If this is a static object `Foo`, add the method:
    *

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -29,6 +29,7 @@ import config.Printers.{typr, patmatch}
 import NameKinds.DefaultGetterName
 import NameOps.*
 import SymDenotations.{NoCompleter, NoDenotation}
+import Denotations.*
 import Applications.UnapplyArgs
 import Inferencing.isFullyDefined
 import transform.patmat.SpaceEngine.{isIrrefutable, isIrrefutableQuotePattern}
@@ -139,6 +140,25 @@ object Checking {
     def checkValidIfApply(using Context): Unit =
       checkWildcardApply(tycon.tpe.appliedTo(args.map(_.tpe)))
     withMode(Mode.AllowLambdaWildcardApply)(checkValidIfApply)
+    
+    if (tycon.symbol.isDeepValhalla)
+      def recur(argTypes: List[Type]): Unit = {
+        argTypes.foreach(argType => {
+          argType match {
+            case arg: TypeRef => 
+              val argSym = arg.classSymbol
+              if (!arg.symbol.isTypeParam && !argSym.isDeepValhallaOrPrimitive && !argSym.isInScalaPackage && !argSym.isJavaInterface)
+                report.error(DeepValhallaFieldInstantiatedWithNonDeepValhallaType(tycon.symbol, argSym), tree.srcPos)
+            case AppliedType(tycon1, args1) => 
+              val tycon1Sym = tycon1.classSymbol
+              if(!tycon1Sym.isDeepValhalla && !tycon1Sym.isInScalaPackage && !tycon1Sym.isJavaInterface)
+                report.error(DeepValhallaFieldInstantiatedWithNonDeepValhallaType(tycon.symbol, tycon1Sym), tree.srcPos)
+              recur(args1)
+            case _ =>
+          }
+        })
+      }
+      recur(args.map(_.tpe))      
   }
 
   /** Check all applied type trees in inferred type `tpt` for well-formedness */
@@ -218,6 +238,21 @@ object Checking {
           if selfType.exists && !(stp <:< selfType) then
             report.error(DoesNotConformToSelfTypeCantBeInstantiated(tp, selfType), pos)
       case _ =>
+
+  def checkDeepValhallaInstantiation(tp: Type, pos: SrcPos)(using Context): Unit =    
+    tp match {
+      case AppliedType(tycon, args) if tycon.classSymbol.isDeepValhalla => 
+        args.foreach(arg => {
+          arg match {
+            case arg: TypeRef => 
+              val argSym = arg.classSymbol
+              if (!arg.symbol.isTypeParam && !argSym.isDeepValhallaOrPrimitive)
+                report.error(DeepValhallaFieldInstantiatedWithNonDeepValhallaType(tycon.classSymbol, argSym), pos)
+            case _ =>
+          }
+        })
+      case _ =>
+    }
 
   /** Check that type `tp` is realizable. */
   def checkRealizable(tp: Type, pos: SrcPos, what: String = "path")(using Context): Unit = {
@@ -898,6 +933,53 @@ object Checking {
       }
       stats.foreach(checkValueClassMember)
     }
+  }
+
+  /** Verify classes and traits with the valhalla annotation meet the requirements */
+  def checkValhallaValueClass(cdef: TypeDef, clazz: Symbol)(using Context): Unit = {
+    val isAnyRef = clazz.asClass.parentSyms.contains(defn.ObjectClass)
+    val isDeepValhalla = clazz.isDeepValhalla
+
+    def checkValueClassMember(memberDenot: Denotation) =
+      val member = memberDenot.symbol
+      if(member.isField){
+        if !member.is(ParamAccessor) && member.owner == clazz then
+          report.error(ValueClassesMayNotDefineNonParameterField(clazz, member), member.srcPos)
+        if member.is(Mutable) then
+          report.error(ValueClassParameterMayNotBeAVar(clazz, member), cdef.srcPos)
+        if isDeepValhalla then
+          val fieldSym = member.info.classSymbol
+          val typeIsTypeVar = member.info.typeSymbol.is(Flags.TypeParam)
+          if !typeIsTypeVar && !fieldSym.isDeepValhallaOrPrimitive then
+            report.error(NonDeepValhallaFieldInClassThatExtendsDeepValhalla(clazz, member), cdef.srcPos)
+      }
+      else if(member.isConstructor){
+        report.error(ValueClassesMayNotDefineASecondaryConstructor(clazz, member), member.srcPos)
+      }
+
+    def checkParents(): Unit = {
+      clazz.asClass.baseClasses.foreach(c => {
+        val parentSym = if(c.isConstructor) then c.owner else c
+
+        if (parentSym.asClass.baseClasses.contains(defn.ObjectClass))
+          report.error(ValueClassCannotExtendIdentityClass(clazz, parentSym), cdef.srcPos)
+      })
+    }
+
+    inline def checkSelfType(): Unit = {
+      if(clazz.asClass.givenSelfType.exists)
+        val selfTypeSym = clazz.asClass.givenSelfType.classSymbol
+
+        if(selfTypeSym.exists && !selfTypeSym.isValhallaValueClass)
+          selfTypeSym.asClass.classInfo.decls.foreach(f => if f.isMutableVar then report.error(ValhallaTraitsMayNotHaveSelfTypesWithVars(selfTypeSym, f), cdef.srcPos))
+    }
+
+    if (isDeepValhalla && isAnyRef) report.error(AnyRefClassCantExtendDeepValhalla(clazz), cdef.srcPos)
+    if(clazz.hasAnnotation(defn.ValhallaAnnot))
+      if isAnyRef then report.error(IncorrectValueClassDeclaration(clazz.isClass), cdef.srcPos)
+      checkParents()
+      checkSelfType()
+      clazz.info.allMembers.foreach(checkValueClassMember)
   }
 
   /** Check the inline override methods only use inline parameters if they override an inline parameter. */

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -1838,7 +1838,7 @@ class Namer { typer: Typer =>
       tempInfo = null // The temporary info can now be garbage-collected
 
       Checking.checkWellFormed(cls)
-      if (isDerivedValueClass(cls)) cls.setFlag(Final)
+      if (isDerivedValueClass(cls) || (cls.isValhallaValueClass && !cls.is(Abstract) && !cls.is(Trait))) cls.setFlag(Final)
       cls.info = avoidPrivateLeaks(cls)
       cls.baseClasses.foreach(_.invalidateBaseTypeCache()) // we might have looked before and found nothing
       cls.invalidateMemberCaches() // we might have checked for a member when parents were not known yet.

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -204,9 +204,9 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
       else if cls2.isPrimitiveValueClass then
         cmpWithBoxed(cls2, cls1)
       else if cls1 == defn.NullClass then
-        cls1 == cls2 || cls2.derivesFrom(defn.ObjectClass)
+        cls1 == cls2 || cls2.derivesFrom(defn.ObjectClass) || cls2.isValhallaValueClass
       else if cls2 == defn.NullClass then
-        cls1.derivesFrom(defn.ObjectClass)
+        cls1.derivesFrom(defn.ObjectClass) || cls1.isValhallaValueClass
       else
         cls1 == defn.NothingClass || cls2 == defn.NothingClass
     end canComparePredefinedClasses

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3490,13 +3490,20 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     end implementDeferredGivens
 
     ensureCorrectSuperClass()
-    completeAnnotations(cdef, cls)
+    // completeAnnotations(cdef, cls)
     val constr1 = typed(constr).asInstanceOf[DefDef]
     val parents1 = parentTrees(
         cls.classInfo.declaredParents,
         parents.mapconserve(typedParent).filterConserve(!_.isEmpty))
     val firstParentTpe = parents1.head.tpe.dealias
     val firstParent = firstParentTpe.typeSymbol
+
+    if(firstParentTpe.classSymbol.isValhallaValueClass && !cls.hasAnnotation(defn.ValhallaAnnot))
+      val valhallaAnnot = untpd.makeValhallaAnnot().withSpan(cdef.span)
+      val typedValhallaAnnot = ConcreteAnnotation(typedAnnotation(valhallaAnnot))
+      cls.addAnnotation(typedValhallaAnnot)
+
+    completeAnnotations(cdef, cls)
 
     checkEnumParent(cls, firstParent)
 
@@ -3540,7 +3547,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         !Feature.dynamicsEnabled
       if (reportDynamicInheritance) {
         val isRequired = parents1.exists(_.tpe.isRef(defn.DynamicClass))
-        report.featureWarning(nme.dynamics.toString, "extension of type scala.Dynamic", cls, isRequired, cdef.srcPos)
+        report.featureWarning(nme.dynamics.toString, "extension of type scala.Dynamic", cls, isRequired, cdef1.srcPos)
       }
 
       checkNonCyclicInherited(cls.thisType, cls.info.parents, cls.info.decls, cdef.srcPos)
@@ -3552,6 +3559,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       if cls.is(ModuleClass)
          && effectiveOwner.is(Trait)
          && !effectiveOwner.derivesFrom(defn.ObjectClass)
+         && !effectiveOwner.isValhallaValueClass
       then
         report.error(em"$cls cannot be defined in universal $effectiveOwner", cdef.srcPos)
 
@@ -3587,6 +3595,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    *       extended by the superclass).
    */
   def ensureConstrCall(cls: ClassSymbol, parent: Tree, psym: Symbol)(using Context): Tree =
+    // println(s"cls $cls, parent $parent, psym $psym, parent.isType ${parent.isType}")
     if parent.isType && !cls.is(Trait) && !cls.is(JavaDefined) && psym.isClass && cls != defn.AnyValClass
         // Annotations are represented as traits with constructors, but should
         // never be called as such outside of annotation trees.
@@ -3855,6 +3864,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    */
   def typedUnadapted(initTree: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree = {
     record("typedUnadapted")
+    // println(s"0: initTree: ${initTree}, pt: $pt, locked: $locked")
     val xtree = expanded(initTree)
     xtree.removeAttachment(TypedAhead) match {
       case Some(ttree) => ttree
@@ -3984,7 +3994,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             else xtree match
               case xtree: untpd.NameTree => typedNamed(xtree, pt)
               case xtree => typedUnnamed(xtree)
-
+          // println(s"result: $result")
           val unsimplifiedType = result.tpe
           simplify(result, pt, locked)
           result.tpe.stripTypeVar match

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3490,7 +3490,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     end implementDeferredGivens
 
     ensureCorrectSuperClass()
-    // completeAnnotations(cdef, cls)
     val constr1 = typed(constr).asInstanceOf[DefDef]
     val parents1 = parentTrees(
         cls.classInfo.declaredParents,
@@ -3595,7 +3594,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    *       extended by the superclass).
    */
   def ensureConstrCall(cls: ClassSymbol, parent: Tree, psym: Symbol)(using Context): Tree =
-    // println(s"cls $cls, parent $parent, psym $psym, parent.isType ${parent.isType}")
     if parent.isType && !cls.is(Trait) && !cls.is(JavaDefined) && psym.isClass && cls != defn.AnyValClass
         // Annotations are represented as traits with constructors, but should
         // never be called as such outside of annotation trees.
@@ -3864,7 +3862,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    */
   def typedUnadapted(initTree: untpd.Tree, pt: Type, locked: TypeVars)(using Context): Tree = {
     record("typedUnadapted")
-    // println(s"0: initTree: ${initTree}, pt: $pt, locked: $locked")
     val xtree = expanded(initTree)
     xtree.removeAttachment(TypedAhead) match {
       case Some(ttree) => ttree
@@ -3994,7 +3991,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             else xtree match
               case xtree: untpd.NameTree => typedNamed(xtree, pt)
               case xtree => typedUnnamed(xtree)
-          // println(s"result: $result")
           val unsimplifiedType = result.tpe
           simplify(result, pt, locked)
           result.tpe.stripTypeVar match

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -456,27 +456,6 @@ class CompilationTests {
     compileFilesInDir("tests/valhalla/pos", valueClassOptions).checkCompile()
     compileFilesInDir("tests/valhalla/neg", valueClassOptions).checkExpectedErrors()
   }
-
-  @Test def valueClassesRun: Unit = {
-    implicit val testGroup: TestGroup = TestGroup("valueClassesRun")
-    
-    locally {
-      val caseClassesGroup = TestGroup("valueClassesRun/case-classes")
-      val caseClassOptions = valueClassOptions.and("-Yexplicit-nulls")
-
-      val valueOptionClass =  Paths.get(defaultOutputDir.getAbsolutePath, caseClassesGroup.name, "ValueOption", "valuelib", "ValueOption").toString
-      val valueOptionTest = withCoverage(compileFile("tests/valhalla/case-classes/valuelib/ValueOption.scala", caseClassOptions)(using caseClassesGroup).keepOutput)
-      runWithCoverageOrFallback[PosTestWithCoverage](valueOptionTest, "Pos")
-
-      val main = withCoverage(compileFile("tests/valhalla/case-classes/ValueOptionAnimals.scala", caseClassOptions.withClasspath(valueOptionClass))(using caseClassesGroup).keepOutput)
-      runWithCoverageOrFallback[PosTestWithCoverage](main, "Pos")
-      // runWithCoverageOrFallback[RunTestWithCoverage](main, "Run")
-      valueOptionTest.delete()
-      main.delete()
-    }
-    // val compilationTest = withCoverage(compileFilesInDir("tests/valhalla/case-classes", valueClassOptions))
-    // runWithCoverageOrFallback[RunTestWithCoverage](compilationTest, "Run")
-  }
 }
 
 object CompilationTests extends ParallelTesting with CoverageSupport {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -449,6 +449,34 @@ class CompilationTests {
     finally
       allTests.foreach(_.delete())
   }
+  
+  // Valhalla Value Classes tests
+  @Test def checkValhallaValueClasses: Unit = {
+    implicit val testGroup: TestGroup = TestGroup("checkValhallaVC")
+    compileFilesInDir("tests/valhalla/pos", valueClassOptions).checkCompile()
+    compileFilesInDir("tests/valhalla/neg", valueClassOptions).checkExpectedErrors()
+  }
+
+  @Test def valueClassesRun: Unit = {
+    implicit val testGroup: TestGroup = TestGroup("valueClassesRun")
+    
+    locally {
+      val caseClassesGroup = TestGroup("valueClassesRun/case-classes")
+      val caseClassOptions = valueClassOptions.and("-Yexplicit-nulls")
+
+      val valueOptionClass =  Paths.get(defaultOutputDir.getAbsolutePath, caseClassesGroup.name, "ValueOption", "valuelib", "ValueOption").toString
+      val valueOptionTest = withCoverage(compileFile("tests/valhalla/case-classes/valuelib/ValueOption.scala", caseClassOptions)(using caseClassesGroup).keepOutput)
+      runWithCoverageOrFallback[PosTestWithCoverage](valueOptionTest, "Pos")
+
+      val main = withCoverage(compileFile("tests/valhalla/case-classes/ValueOptionAnimals.scala", caseClassOptions.withClasspath(valueOptionClass))(using caseClassesGroup).keepOutput)
+      runWithCoverageOrFallback[PosTestWithCoverage](main, "Pos")
+      // runWithCoverageOrFallback[RunTestWithCoverage](main, "Run")
+      valueOptionTest.delete()
+      main.delete()
+    }
+    // val compilationTest = withCoverage(compileFilesInDir("tests/valhalla/case-classes", valueClassOptions))
+    // runWithCoverageOrFallback[RunTestWithCoverage](compilationTest, "Run")
+  }
 }
 
 object CompilationTests extends ParallelTesting with CoverageSupport {

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -96,6 +96,7 @@ object TestConfiguration {
   val oldSyntax = defaultOptions `and` "-old-syntax"
   val newSyntax = defaultOptions `and` "-new-syntax"
   val valueClassOptions = defaultOptions.and("-Yvalue-classes").and("-experimental")
+  val valueClassOptions = defaultOptions.and("-Yvalhalla").and("-experimental")
 
   /** Default target of the generated class files */
   private def defaultTarget: String = "17"

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -95,6 +95,7 @@ object TestConfiguration {
 
   val oldSyntax = defaultOptions `and` "-old-syntax"
   val newSyntax = defaultOptions `and` "-new-syntax"
+  val valueClassOptions = defaultOptions.and("-Yvalue-classes").and("-experimental")
 
   /** Default target of the generated class files */
   private def defaultTarget: String = "17"

--- a/docs/_docs/reference/experimental/valhalla.md
+++ b/docs/_docs/reference/experimental/valhalla.md
@@ -1,0 +1,58 @@
+---
+layout: doc-page
+title: "Valhalla Value Classes and Traits"
+nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/valhalla.html
+---
+
+## Valhalla Value Classes
+
+Valhalla value classes are the Scala equivalence of Java's Project Valhalla's value classes (see [JEP 401](https://openjdk.org/jeps/401)). When used with the Project Valhalla JVM, Valhalla value classes are optimized.
+
+Valhalla value classes extend AnyVal and have a `valhalla` annotation. Valhalla value classes cannot have non-parameter fields and cannot have auxilliary constructors.
+
+Valhalla value classes do not have object identity -- two valhalla value classes are equal when their fields are the same.
+
+```scala
+import scala.annotation.valhalla
+
+@valhalla class ValhallaValueClass(val x: Int, val y: Int) extends AnyVal
+```
+
+Valhalla value classes are implicitly final and cannot be extended unless it is abstract. Its fields are immutable and cannot be lazy.
+
+Valhalla value classes can extend `AnyVal`, universal traits, or abstract valhalla value classes.
+
+## Valhalla Traits
+
+Valhalla Traits are Universal Traits (traits that extend Any) with a `valhalla` annotation.
+
+Like Valhalla value classes, any Valhalla trait must have immutable fields only.
+
+Valhalla traits can extend `Any` or universal traits.
+
+```scala
+import scala.annotation.valhalla
+
+@valhalla trait ValhallaTrait(val x: Int, val y: Int) extends Any
+
+```
+
+## Using Explicit Self with Valhalla
+
+Valhalla traits can have self-type of any trait without mutable fields.
+
+## CanEqual with Valhalla
+
+Valhalla value classes can be null, so the CanEqual of `null` and a valhalla value class returns `true`.
+
+## Using Value Classes
+
+Use the `--Yvalue-classes` and `-experimental` compiler options when compiling value classes in the scala compiler.
+
+## Getting Started
+
+1. Install [Project Valhalla JVM](https://jdk.java.net/valhalla/) or alternatively clone the [source code](https://github.com/openjdk/valhalla). For the latter, follow the [build instructions](https://github.com/openjdk/jdk/blob/master/doc/building.md).
+
+2. Clone [scala-asm](https://github.com/lidaisy/scala-asm) and run `sbt publishLocal` to use it locally.
+
+3. Run `sbt scala-library-nonbootstrapped/publishLocal` in scala3 to use the local library that includes the value class annotation.

--- a/docs/_docs/reference/experimental/valhalla.md
+++ b/docs/_docs/reference/experimental/valhalla.md
@@ -47,7 +47,7 @@ Valhalla value classes can be null, so the CanEqual of `null` and a valhalla val
 
 ## Using Value Classes
 
-Use the `--Yvalue-classes` and `-experimental` compiler options when compiling value classes in the scala compiler.
+Use the `-Yvalhalla` and `-experimental` compiler options when compiling value classes in the scala compiler.
 
 ## Getting Started
 

--- a/java_interop.sh
+++ b/java_interop.sh
@@ -1,0 +1,3 @@
+./../../Thesis/valhalla/build/macosx-aarch64-server-release/images/jdk/bin/javac --enable-preview --release 27 -parameters -d tests/null-restricted/java_interop tests/null-restricted/java_interop/"$1".java
+cd tests/null-restricted/java_interop
+jar -cf myJar.jar Foo.class "$1".class

--- a/library/src/scala/DeepValhalla.scala
+++ b/library/src/scala/DeepValhalla.scala
@@ -1,0 +1,3 @@
+package scala
+
+trait DeepValhalla extends Any

--- a/library/src/scala/annotation/valhalla.scala
+++ b/library/src/scala/annotation/valhalla.scala
@@ -1,0 +1,14 @@
+package scala.annotation
+
+import scala.language.`2.13`
+
+/** A class annotation which verifies that the class will be a
+ * Project Valhalla value class.
+ *
+ * If it is present, the compiler will issue an error if the class
+ * does not satisfy the requirements of the Project Valhalla value
+ * class as specified in https://openjdk.org/jeps/401.
+ */
+
+@scala.annotation.experimental
+final class valhalla extends StaticAnnotation

--- a/library/src/scala/runtime/EnumValue.scala
+++ b/library/src/scala/runtime/EnumValue.scala
@@ -2,8 +2,20 @@ package scala.runtime
 
 import language.experimental.captureChecking
 
-transparent trait EnumValue extends Product, Serializable:
-  override def canEqual(that: Any) = this eq that.asInstanceOf[AnyRef]
+transparent trait EnumValue extends Any, Product, Serializable:
+  infix def veq(that: Any): Boolean = {
+    if(this.isInstanceOf[AnyRef] && that.isInstanceOf[AnyRef]){
+      this.asInstanceOf[AnyRef] eq that.asInstanceOf[AnyRef]
+    }
+    else if(this.isInstanceOf[AnyVal] && that.isInstanceOf[AnyVal]){
+      this == that
+    }
+    else{
+      false
+    }
+  }
+
+  override def canEqual(that: Any) = this veq that
   override def productArity: Int = 0
   override def productElement(n: Int): Any =
     throw IndexOutOfBoundsException(n.toString)

--- a/print_classfile.sh
+++ b/print_classfile.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "$#" -lt 1 ]; then
+    echo "Usage: $0 <class file name> <optional: output file>"
+    exit 1
+fi
+
+out="/dev/stdout"
+
+if [ "$#" -eq 2 ]; then
+    out="$2"
+fi
+
+./../../Thesis/valhalla/build/macosx-aarch64-server-release/images/jdk/bin/javap -c -v -p tests/valhalla/bin/"$1" > "$out"

--- a/run_and_clean.sh
+++ b/run_and_clean.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+run="false"
+clean="false"
+mainclass="Main"
+LIST_ARGS=()
+
+while getopts "rcm:p:" flag
+do
+    case "${flag}" in
+        r) run="true";;
+        c) clean="true";;
+        m) mainclass=$OPTARG;;
+        p) LIST_ARGS+=("$OPTARG")
+    esac
+done
+
+if [[ "$clean" == "true" ]]; then
+  cd tests/valhalla/bin
+  rm -rf *
+fi
+
+if [[ "$run" == "true" ]]; then
+  ./../../Thesis/valhalla/build/macosx-aarch64-server-release/images/jdk/bin/java -cp library/target/scala-library-nonbootstrapped/scala-library-3.8.5-RC1-bin-SNAPSHOT-nonbootstrapped.jar:tests/valhalla/bin --enable-preview "$mainclass" "$LIST_ARGS"
+fi

--- a/tests/valhalla/benchmark/Bench.scala
+++ b/tests/valhalla/benchmark/Bench.scala
@@ -1,0 +1,205 @@
+package benchmark
+
+// import org.openjdk.jmh.annotations.*
+
+import scala.collection.immutable.Seq
+import scala.util.Random
+
+// @State(Scope.Benchmark)
+// @Fork(value = 5)
+// @Warmup(iterations = 5)
+// @Measurement(iterations = 5)
+// @BenchmarkMode(Array(Mode.Throughput))
+//class Bench(val debug1 : Boolean, val ptCnt1 : Int, val k1: Int) {
+class Bench(){
+  val k = 32
+  val xRange = 100
+  val yRange = 200
+  val zRange = 500
+  val ptCnt = 50000
+  val debug = false
+  val tolerance = 0.0000001
+//  val k = k1
+//  val ptCnt = ptCnt1
+//  val debug = debug1
+  val identityPoints : Seq[IdentityPoint] = generatePoints(k, ptCnt)
+  val identityMeans : Seq[IdentityPoint] = initializeMeans(k, identityPoints)
+  val seqPoints: SeqPoints = new SeqPoints(identityPoints)
+  val seqMeans: SeqPoints = new SeqPoints(identityMeans)
+
+  val valhallaPoints : Seq[ValhallaPoint] = generateValhallaPoints(k, ptCnt)
+  val valhallaMeans : Seq[ValhallaPoint] = initializeMeans(k, valhallaPoints)
+
+  def generatePoints(k: Int, pointsCount: Int): Seq[IdentityPoint] = {
+    val randX = new Random(1)
+    val randY = new Random(3)
+    val randZ = new Random(5)
+    (0 until pointsCount).map({ i =>
+      val x = randX.nextDouble() * xRange
+      val y = randY.nextDouble() * yRange
+      val z = randZ.nextDouble() * zRange
+      new IdentityPoint(x, y, z)
+    })
+  }
+
+  def generateValhallaPoints(k: Int, pointsCount: Int): Seq[ValhallaPoint] = {
+    val randX = new Random(1)
+    val randY = new Random(3)
+    val randZ = new Random(5)
+    (0 until pointsCount).map({ i =>
+      val x = randX.nextDouble() * xRange
+      val y = randY.nextDouble() * yRange
+      val z = randZ.nextDouble() * zRange
+      new ValhallaPoint(x, y, z)
+    })
+  }
+
+  /** Randomly select k points as the initial centroids */
+  def initializeMeans[A](k: Int, points: Seq[A]): Seq[A] = {
+    val rand = new Random(37)
+    (0 until k)
+      .map(_ => points(rand.nextInt(points.length)))
+  }
+
+  // @Benchmark
+  def runKmeans: Seq[IdentityPoint] = kMeans(identityPoints, identityMeans)
+  // @Benchmark
+  def runKmeansSeqPts: Seq[IdentityPoint] = seqPtsKMeans(seqPoints, seqMeans)
+  // @Benchmark
+  def runKMeansValhalla: Seq[ValhallaPoint] = kMeansValhalla(valhallaPoints, valhallaMeans)
+
+  /** Given point p and the centroids, return the centroid the p is the closest to. */
+  def findClosest(p: IdentityPoint, centroids: Seq[IdentityPoint]): IdentityPoint = {
+    assert(centroids.nonEmpty)
+    var minDistance = p.squareDistance(centroids(0))
+    var closest = centroids(0)
+
+    for (mean <- centroids.tail) {
+      val distance = p.squareDistance(mean)
+      if (distance < minDistance) {
+        minDistance = distance
+        closest = mean
+      }
+    }
+    closest
+  }
+
+  def findClosestValhalla(p: ValhallaPoint, centroids: Seq[ValhallaPoint]): ValhallaPoint = {
+    assert(centroids.nonEmpty)
+    var minDistance = p.squareDistance(centroids(0))
+    var closest = centroids(0)
+
+    for (mean <- centroids.tail) {
+      val distance = p.squareDistance(mean)
+      if (distance < minDistance) {
+        minDistance = distance
+        closest = mean
+      }
+    }
+    closest
+  }
+
+  /** Given all points `points` in a cluster with mean `oldMean`, return the average of `points`. */
+  def findAverage(oldMean: IdentityPoint, points: Seq[IdentityPoint]): IdentityPoint = {
+    if (points.isEmpty) then
+      oldMean
+    else
+      var x = 0.0
+      var y = 0.0
+      var z = 0.0
+      points.foreach { p =>
+        x += p.x
+        y += p.y
+        z += p.z
+      }
+      new IdentityPoint(x / points.length, y / points.length, z / points.length)
+  }
+
+  def findAverageValhalla(oldMean: ValhallaPoint, points: Seq[ValhallaPoint]): ValhallaPoint = {
+    if (points.isEmpty) then
+      oldMean
+    else
+      var x = 0.0
+      var y = 0.0
+      var z = 0.0
+      points.foreach { p =>
+        x += p.x
+        y += p.y
+        z += p.z
+      }
+      new ValhallaPoint(x / points.length, y / points.length, z / points.length)
+  }
+
+  /** Assign each point to closest centroid */
+  def classify(points: Seq[IdentityPoint], centroids: Seq[IdentityPoint]): Map[IdentityPoint, Seq[IdentityPoint]] = {
+    val grouped = points.groupBy(p => findClosest(p, centroids))
+
+    centroids.foldLeft(grouped) {
+      (map, mean) => if (map.contains(mean)) map else map.updated(mean, Seq())
+    }
+  }
+
+  def classifyValhalla(points: Seq[ValhallaPoint], centroids: Seq[ValhallaPoint]): Map[ValhallaPoint, Seq[ValhallaPoint]] = {
+    val grouped = points.groupBy(p => findClosestValhalla(p, centroids))
+
+    centroids.foldLeft(grouped) {
+      (map, mean) => if (map.contains(mean)) map else map.updated(mean, Seq())
+    }
+  }
+  
+  /** Given the classify map and the oldMeans, update each cluster's average. */
+  def updateMeans(classified: Map[IdentityPoint, Seq[IdentityPoint]], oldMeans: Seq[IdentityPoint]): Seq[IdentityPoint] =
+    oldMeans.map(mean => findAverage(mean, classified(mean)))
+
+  def seqPtsUpdateMeans(classified: Map[IdentityPoint, Seq[IdentityPoint]], oldMeans: Seq[IdentityPoint]): Seq[IdentityPoint] =
+    SeqPoints(oldMeans.map(mean => findAverage(mean, classified(mean))))
+
+  def updateMeansValhalla(classified: Map[ValhallaPoint, Seq[ValhallaPoint]], oldMeans: Seq[ValhallaPoint]): Seq[ValhallaPoint] =
+    oldMeans.map(mean => findAverageValhalla(mean, classified(mean)))
+
+  /** Given oldMeans and newMeans, check if euclidean distance between the two is less than the tolerance.*/
+  def converged(oldMeans: Seq[IdentityPoint], newMeans: Seq[IdentityPoint]): Boolean =
+    (oldMeans zip newMeans).map({
+      (oldMean, newMean) => oldMean l1Distance newMean
+    }).forall(_ <= tolerance)
+
+  def convergedValhalla(oldMeans: Seq[ValhallaPoint], newMeans: Seq[ValhallaPoint]): Boolean =
+    (oldMeans zip newMeans).map({
+      (oldMean, newMean) => oldMean l1Distance newMean
+    }).forall(_ <= tolerance)
+
+  @annotation.tailrec
+  final def seqPtsKMeans(points: Seq[IdentityPoint], centroids: Seq[IdentityPoint]): Seq[IdentityPoint] = {
+    val classifiedPoints = classify(points, centroids)
+    val newMeans = seqPtsUpdateMeans(classifiedPoints, centroids)
+
+    if (converged(centroids, newMeans)) then
+      newMeans
+    else
+      seqPtsKMeans(points, newMeans)
+  }
+
+  @annotation.tailrec
+  final def kMeans(points: Seq[IdentityPoint], centroids: Seq[IdentityPoint]): Seq[IdentityPoint] = {
+    println("Entering kMeans.")
+    val classifiedPoints = classify(points, centroids)
+    val newMeans = updateMeans(classifiedPoints, centroids)
+
+    if (converged(centroids, newMeans)) then
+      newMeans
+    else
+      kMeans(points, newMeans)
+  }
+
+  @annotation.tailrec
+  final def kMeansValhalla(points: Seq[ValhallaPoint], centroids: Seq[ValhallaPoint]): Seq[ValhallaPoint] = {
+    println("Entering kMeansValhalla.")
+    val classifiedPoints = classifyValhalla(points, centroids)
+    val newMeans = updateMeansValhalla(classifiedPoints, centroids)
+
+    if (convergedValhalla(centroids, newMeans)) then
+      newMeans
+    else
+      kMeansValhalla(points, newMeans)
+  }
+}

--- a/tests/valhalla/benchmark/IdentityPoint.scala
+++ b/tests/valhalla/benchmark/IdentityPoint.scala
@@ -1,0 +1,14 @@
+package benchmark
+
+case class IdentityPoint(x: Double, y: Double, z: Double){
+  private def square(v: Double): Double = v * v
+  private def round(v: Double): Double = (v * 100).toInt / 100.0
+
+  infix def squareDistance(that: IdentityPoint): Double =
+    square(that.x - x) + square(that.y - y) + square(that.z - z)
+
+  infix def l1Distance(that: IdentityPoint): Double =
+    (that.x - x).abs + (that.y - y).abs + (that.z - z).abs
+    
+  override def toString = s"Point(${round(x)}, ${round(y)}, ${round(z)})"
+}

--- a/tests/valhalla/benchmark/SeqPoints.scala
+++ b/tests/valhalla/benchmark/SeqPoints.scala
@@ -1,0 +1,137 @@
+package benchmark
+
+import scala.collection.{IterableFactoryDefaults, IterableOps, mutable}
+import scala.collection.immutable.SeqOps
+import scala.collection.mutable.{ArrayBuffer, ReusableBuilder}
+
+class SeqPoints(pts: Seq[IdentityPoint]) extends Seq[IdentityPoint] with SeqOps[IdentityPoint,Seq,SeqPoints] with IterableOps[IdentityPoint,Seq,SeqPoints]{
+  protected var arr : Array[Double] =  pts.flatMap(p => Array(p.x, p.y, p.z)).toArray
+  final class SeqPtsBuilder extends mutable.ReusableBuilder[IdentityPoint, SeqPoints] {
+    protected var elems : Array[IdentityPoint] = new Array[IdentityPoint](0) //make this array of doubles
+    protected var capacity : Int = 0
+    protected var size : Int = 0 //current number of elements
+    private final val DefaultInitialSize = 16
+    final val VM_MaxArraySize = 2147483639
+
+    private def resize(size : Int) : Unit = {
+//        println("resize: making array with size:" + size)
+      elems = mkArray(size)
+//        println("resize: after resize, elems size:" + elems.length)
+      capacity = size
+      //Thread.sleep(2000)
+    }
+
+    private def ensureSize(size: Int) : Unit = {
+      def aux(arrayLen : Int, targetLen: Int): Int = {
+        if (targetLen < 0) throw new Exception(s"Overflow while resizing array of array-backed collection. Requested length: $targetLen; current length: $arrayLen; increase: ${targetLen - arrayLen}")
+        else if (targetLen <= arrayLen) -1
+        else if (targetLen > VM_MaxArraySize) throw new Exception(s"Array of array-backed collection exceeds VM length limit of $VM_MaxArraySize. Requested length: $targetLen; current length: $arrayLen")
+        else if (arrayLen > VM_MaxArraySize / 2) VM_MaxArraySize
+        else {
+          val ret = math.max(targetLen,
+            math.max(
+              arrayLen * 2,
+              DefaultInitialSize))
+//            println(ret)
+          ret
+        }
+
+      }
+      val newLen = aux(capacity, size)
+//        println("ensuresize: newLen: " + newLen)
+      if (newLen > 0) resize(newLen)
+    }
+
+    override def addOne(elem: IdentityPoint): SeqPtsBuilder.this.type = {
+//        println("addOne:adding" + elem + " to " + elems.mkString("Array(", ", ", ")"))
+      ensureSize(size + 1)
+//        println("addone: after ensureSize, size:" + size + ": " + elems.length)
+//        println("addone: after ensuresize elems:" + elems.mkString("Array(", ", ", ")"))
+      elems(size) = elem
+//        println("his")
+      size += 1
+      this
+    }
+
+    override def clear(): Unit = size = 0
+
+    private def mkArray(size: Int): Array[IdentityPoint] = {
+      val newelems = new Array[IdentityPoint](size)
+//        println("newelems init size:" + newelems.length)
+//        println("newelems:" + newelems.mkString("Array(", ", ", ")"))
+      if (this.size > 0) {
+        Array.copy(elems, 0, newelems, 0, this.size)
+      }
+//        println("in mkarray-else: newelems has size:" + size + "newelems:" + newelems.length)
+      newelems
+    }
+
+    override def result(): benchmark.SeqPoints = {
+      if (capacity != 0 && capacity == size){
+        capacity = 0
+        val ret = elems
+        elems = null
+        SeqPoints(ret.toSeq)
+      } else {
+        SeqPoints(mkArray(size).toSeq)
+      }
+    }
+  }
+
+  override def fromSpecific(coll: IterableOnce[IdentityPoint]): SeqPoints = {
+    val builder = newSpecificBuilder
+    builder.sizeHint(coll, delta = 0)
+    builder ++= coll
+    builder.result()
+  }
+
+//  def fromSpecific(it: IterableOnce[A]): Array[A] = {
+//    val b = newBuilder
+//    b.sizeHint(it, delta = 0)
+//    b ++= it
+//    b.result()
+//  }
+  override def newSpecificBuilder: mutable.Builder[IdentityPoint, SeqPoints] = new SeqPtsBuilder
+
+  override def empty: SeqPoints = new SeqPoints(Seq())
+
+  private def round(v: Double): Double = (v * 100).toInt / 100.0
+
+
+  override def apply(i: Int): IdentityPoint = {
+    //if debug then println("apply: new point ")
+    new IdentityPoint(arr(i * 3), arr(i * 3 + 1), arr(i * 3 + 2))
+  }
+
+  override def length: Int = {
+    //if debug then println("length!")
+    arr.length / 3
+  }
+  override def iterator: Iterator[IdentityPoint] = {
+    //if debug then println("iterator")
+    new SeqPtsIterator(arr, length)
+  }
+
+  override def toString(): String = {
+    def aux(array : List[Double]) : String = {
+      array match {
+        case x :: y :: z :: res => s", Point(${round(x)}, ${round(y)}, ${round(z)})" + aux(res)
+        case _ => ""
+      }
+    }
+    aux(arr.toList)
+  }
+  class SeqPtsIterator(a: Array[Double], private var arrLen : Int) extends Iterator[IdentityPoint] {
+    private var i = 0;
+    override def hasNext: Boolean = arrLen > i
+    def next(): IdentityPoint = {
+      if (i == arrLen) Iterator.empty.next()
+      val x = a(i * 3)
+      val y = a(i * 3 + 1)
+      val z = a(i * 3 + 2)
+      i+=1
+      IdentityPoint(x, y, z)
+    }
+  }
+}
+

--- a/tests/valhalla/benchmark/Test.scala
+++ b/tests/valhalla/benchmark/Test.scala
@@ -1,0 +1,34 @@
+package benchmark
+
+import scala.collection._
+
+// class Main {
+object Test extends App {
+  val m = new Bench()
+  val debug = false
+  val points = m.identityPoints
+  val valhallaPoints = m.valhallaPoints
+  val means = m.identityMeans
+  val valhallaMeans = m.valhallaMeans
+
+  val seqPts = m.seqPoints
+  val seqMeans = m.seqMeans
+
+  def testingKmeans(debug: Boolean = false, seqPt : Boolean = false) : Seq[IdentityPoint] = {
+    val ret =
+      if (!seqPt) m.kMeans(points, means)
+      else m.seqPtsKMeans(seqPts, seqMeans)
+    ret
+  }
+  def testingKmeansValhalla() : Seq[ValhallaPoint] = {
+    val ret = m.kMeansValhalla(valhallaPoints, valhallaMeans)
+    ret
+  }
+  @main def main() : Unit = {
+  // def main() : Unit = {
+    println("entering main")
+    testingKmeans(false, false)
+    testingKmeansValhalla()
+    // testingKmeans(false, true)
+  }
+}

--- a/tests/valhalla/benchmark/ValhallaPoint.scala
+++ b/tests/valhalla/benchmark/ValhallaPoint.scala
@@ -1,0 +1,16 @@
+package benchmark
+// import scala.annotation.valhalla
+
+// @valhalla
+case class ValhallaPoint(x: Double, y: Double, z: Double){//} extends AnyVal{
+  private def square(v: Double): Double = v * v
+  private def round(v: Double): Double = (v * 100).toInt / 100.0
+
+  infix def squareDistance(that: ValhallaPoint): Double =
+    square(that.x - x) + square(that.y - y) + square(that.z - z)
+
+  infix def l1Distance(that: ValhallaPoint): Double =
+    (that.x - x).abs + (that.y - y).abs + (that.z - z).abs
+    
+  override def toString = s"ValhallaPoint(${round(x)}, ${round(y)}, ${round(z)})"
+}

--- a/tests/valhalla/case-classes/ValueOptionAnimals.scala
+++ b/tests/valhalla/case-classes/ValueOptionAnimals.scala
@@ -1,0 +1,42 @@
+import valuelib.*
+import scala.annotation.valhalla
+
+@valhalla
+case class Horse(id: Int) extends AnyVal with DeepValhalla
+
+@valhalla
+class NonCaseClassPig(val id: Int, val luckyNumber: Int) extends AnyVal
+
+@valhalla
+case class PigWithSomeHorse(id: Int, luckyNumber: Int, favouriteHorse: Option[Horse]) extends AnyVal
+
+@valhalla
+case class PigWithValueSomeHorse(id: Int, luckyNumber: Int, favouriteHorse: ValueOption[Horse]) extends AnyVal with DeepValhalla
+
+class IdentityPig(val id: Int, val luckyNumber: Int)
+
+object Test:
+    def main(args: Array[String]): Unit = {
+        val clover = Horse(10)
+        val clover1 = Horse(10)
+        val notClover = Horse(11)
+
+        assert(clover == clover1 && clover != notClover) // deep valhalla case class should use acmp
+
+        val oldMajor = NonCaseClassPig(1, 2)
+        val oldMajor1 = NonCaseClassPig(1, 2)
+
+        assert(oldMajor == oldMajor1) // valhalla class uses .equals()
+
+        val napoleon = PigWithValueSomeHorse(1, 2, ValueSome(clover))
+        val napoleon1 = PigWithValueSomeHorse(1, 2, ValueSome(clover))
+        val napoleon2 = PigWithValueSomeHorse(1, 2, ValueSome(clover1))
+
+        assert(napoleon == napoleon1 && napoleon == napoleon2) // deep valhalla all the way down should use acmp
+
+        val snowball = PigWithSomeHorse(1, 2, Some(clover))
+        val snowball1 = PigWithSomeHorse(1, 2, Some(clover))
+        val snowball2 = PigWithSomeHorse(1, 2, Some(clover1))
+
+        assert(snowball == snowball1 && snowball == snowball2) // case class .equals()
+    }

--- a/tests/valhalla/case-classes/valuelib/ValueOption.scala
+++ b/tests/valhalla/case-classes/valuelib/ValueOption.scala
@@ -1,0 +1,635 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc. dba Akka
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package valuelib
+
+import scala.language.`2.13`
+import scala.annotation.valhalla
+
+object ValueOption {
+
+  import scala.language.implicitConversions
+
+  /** An implicit conversion that converts an option to an iterable value. */
+  implicit def option2Iterable[A](xo: ValueOption[A]): Iterable[A] =
+    if (xo.isEmpty) Iterable.empty else Iterable.single(xo.get)
+
+  /** An ValueOption factory which creates ValueSome(x) if the argument is not null,
+   *  and ValueNone if it is null.
+   *
+   *  @param  x the value
+   *  @return   ValueSome(value) if value != null, ValueNone if value == null
+   */
+  def apply[A](x: A | Null): ValueOption[A] = if (x == null) ValueNone else ValueSome(x)
+
+  /** An ValueOption factory which returns `ValueNone` in a manner consistent with
+   *  the collections hierarchy.
+   */
+  def empty[A] : ValueOption[A] = ValueNone
+
+  /** When a given condition is true, evaluates the `a` argument and returns
+   *  `ValueSome(a)`. When the condition is false, `a` is not evaluated and `ValueNone` is
+   *  returned.
+   */
+  def when[A](cond: Boolean)(a: => A): ValueOption[A] =
+    if (cond) ValueSome(a) else ValueNone
+
+  /** Unless a given condition is true, this will evaluate the `a` argument and
+   *  return `ValueSome(a)`. Otherwise, `a` is not evaluated and `ValueNone` is returned.
+   */
+  @inline def unless[A](cond: Boolean)(a: => A): ValueOption[A] =
+    when(!cond)(a)
+}
+
+/** Represents optional values. Instances of `ValueOption`
+ *  are either an instance of $some or the object $none.
+ *
+ *  The most idiomatic way to use an $option instance is to treat it
+ *  as a collection or monad and use `map`,`flatMap`, `filter`, or
+ *  `foreach`:
+ *
+ *  ```
+ *  val name: ValueOption[String] = request.getParameter("name")
+ *  val upper = name.map(_.trim).filter(_.length != 0).map(_.toUpperCase)
+ *  println(upper.getOrElse(""))
+ *  ```
+ *
+ *  Note that this is equivalent to ```
+ *  val upper = for {
+ *    name <- request.getParameter("name")
+ *    trimmed <- ValueSome(name.trim)
+ *    upper <- ValueSome(trimmed.toUpperCase) if trimmed.length != 0
+ *  } yield upper
+ *  println(upper.getOrElse(""))
+ *  ```
+ *
+ *  Because of how for comprehension works, if $none is returned
+ *  from `request.getParameter`, the entire expression results in
+ *  $none
+ *
+ *  This allows for sophisticated chaining of $option values without
+ *  having to check for the existence of a value.
+ *
+ *  These are useful methods that exist for both $some and $none.
+ *  - [[isDefined]] — True if not empty
+ *  - [[isEmpty]] — True if empty
+ *  - [[nonEmpty]] — True if not empty
+ *  - [[orElse]] — Evaluate and return alternate optional value if empty
+ *  - [[getOrElse]] — Evaluate and return alternate value if empty
+ *  - [[get]] — Return value, throw exception if empty
+ *  - [[fold]] —  Apply function on optional value, return default if empty
+ *  - [[map]] — Apply a function on the optional value
+ *  - [[flatMap]] — Same as map but function must return an optional value
+ *  - [[foreach]] — Apply a procedure on option value
+ *  - [[collect]] — Apply partial pattern match on optional value
+ *  - [[filter]] — An optional value satisfies predicate
+ *  - [[filterNot]] — An optional value doesn't satisfy predicate
+ *  - [[exists]] — Apply predicate on optional value, or false if empty
+ *  - [[forall]] — Apply predicate on optional value, or true if empty
+ *  - [[contains]] — Checks if value equals optional value, or false if empty
+ *  - [[zip]] — Combine two optional values to make a paired optional value
+ *  - [[unzip]] — Split an optional pair to two optional values
+ *  - [[unzip3]] — Split an optional triple to three optional values
+ *  - [[toList]] — Unary list of optional value, otherwise the empty list
+ *
+ *  A less-idiomatic way to use $option values is via pattern matching: ```
+ *  val nameMaybe = request.getParameter("name")
+ *  nameMaybe match {
+ *    case ValueSome(name) =>
+ *      println(name.trim.toUppercase)
+ *    case ValueNone =>
+ *      println("No name value")
+ *  }
+ *  ```
+ *
+ *  Interacting with code that can occasionally return null can be
+ *  safely wrapped in $option to become $none and $some otherwise. ```
+ *  val abc = new java.util.HashMap[Int, String]
+ *  abc.put(1, "A")
+ *  bMaybe = ValueOption(abc.get(2))
+ *  bMaybe match {
+ *   case ValueSome(b) =>
+ *     println(s"Found \$b")
+ *   case ValueNone =>
+ *     println("Not found")
+ *  }
+ *  ```
+ *
+ *  @note Many of the methods in here are duplicative with those
+ *  in the Iterable hierarchy, but they are duplicated for a reason:
+ *  the implicit conversion tends to leave one with an Iterable in
+ *  situations where one could have retained an ValueOption.
+ *
+ *  @define none `ValueNone`
+ *  @define some [[scala.ValueSome]]
+ *  @define option [[scala.ValueOption]]
+ *  @define p `p`
+ *  @define f `f`
+ *  @define coll option
+ *  @define Coll `ValueOption`
+ *  @define orderDependent
+ *  @define orderDependentFold
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define collectExample
+ *  @define undefinedorder
+ */
+@valhalla
+@SerialVersionUID(-114498752079829388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
+sealed abstract class ValueOption[+A] extends AnyVal with IterableOnce[A] with Product with Serializable with DeepValhalla {
+  self =>
+
+  /** Returns true if the option is $none, false otherwise.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(_) => false
+   *   case ValueNone    => true
+   *  }
+   *  ```
+   */
+  final def isEmpty: Boolean = this eq ValueNone
+
+  /** Returns true if the option is an instance of $some, false otherwise.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(_) => true
+   *   case ValueNone    => false
+   *  }
+   *  ```
+   */
+  final def isDefined: Boolean = !isEmpty
+
+  override final def knownSize: Int = if (isEmpty) 0 else 1
+
+  /** Returns the option's value.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => x
+   *   case ValueNone    => throw new Exception
+   *  }
+   *  ```
+   *  @note The option must be nonempty.
+   *  @throws NoSuchElementException if the option is empty.
+   */
+  def get: A
+
+  /** Returns the option's value if the option is nonempty, otherwise
+   *  return the result of evaluating `default`.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => x
+   *   case ValueNone    => default
+   *  }
+   *  ```
+   *
+   *  @param default  the default expression.
+   */
+  @inline final def getOrElse[B >: A](default: => B): B =
+    if (isEmpty) default else this.get
+
+  /** Returns the option's value if it is nonempty,
+   *  or `null` if it is empty.
+   *
+   *  Although the use of null is discouraged, code written to use
+   *  $option must often interface with code that expects and returns nulls.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => x
+   *   case ValueNone    => null
+   *  }
+   *  ```
+   *  @example ```
+   *  val initialText: ValueOption[String] = getInitialText
+   *  val textField = new JComponent(initialText.orNull,20)
+   *  ```
+   */
+  @inline final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
+
+  /** Returns a $some containing the result of applying $f to this $option's
+   *  value if this $option is nonempty.
+   *  Otherwise return $none.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => ValueSome(f(x))
+   *   case ValueNone    => ValueNone
+   *  }
+   *  ```
+   *  @note This is similar to `flatMap` except here,
+   *  $f does not need to wrap its result in an $option.
+   *
+   *  @param  f   the function to apply
+   *  @see flatMap
+   *  @see foreach
+   */
+  @inline final def map[B](f: A => B): ValueOption[B] =
+    if (isEmpty) ValueNone else ValueSome(f(this.get))
+
+  /** Returns the result of applying $f to this $option's
+   *  value if the $option is nonempty.  Otherwise, evaluates
+   *  expression `ifEmpty`.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => f(x)
+   *   case ValueNone    => ifEmpty
+   *  }
+   *  ```
+   *  This is also equivalent to:
+   *  ```
+   *  option.map(f).getOrElse(ifEmpty)
+   *  ```
+   *  @param  ifEmpty the expression to evaluate if empty.
+   *  @param  f       the function to apply if nonempty.
+   */
+  @inline final def fold[B](ifEmpty: => B)(f: A => B): B =
+    if (isEmpty) ifEmpty else f(this.get)
+
+  /** Returns the result of applying $f to this $option's value if
+   *  this $option is nonempty.
+   *  Returns $none if this $option is empty.
+   *  Slightly different from `map` in that $f is expected to
+   *  return an $option (which could be $none).
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => f(x)
+   *   case ValueNone    => ValueNone
+   *  }
+   *  ```
+   *  @param  f   the function to apply
+   *  @see map
+   *  @see foreach
+   */
+  @inline final def flatMap[B](f: A => ValueOption[B]): ValueOption[B] =
+    if (isEmpty) ValueNone else f(this.get)
+
+  /** Returns the nested $option value if it is nonempty.  Otherwise,
+   *  return $none.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(ValueSome(b)) => ValueSome(b)
+   *   case _             => ValueNone
+   *  }
+   *  ```
+   *  @example ```
+   *  ValueSome(ValueSome("something")).flatten
+   *  ```
+   *
+   *  @param ev an implicit conversion that asserts that the value is
+   *           also an $option.
+   *  @see flatMap
+   */
+  def flatten[B](implicit ev: A <:< ValueOption[B]): ValueOption[B] =
+    if (isEmpty) ValueNone else ev(this.get)
+
+  /** Returns this $option if it is nonempty **and** applying the predicate $p to
+   *  this $option's value returns true. Otherwise, return $none.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) if p(x) => ValueSome(x)
+   *   case _               => ValueNone
+   *  }
+   *  ```
+   *  @param  p   the predicate used for testing.
+   */
+  @inline final def filter(p: A => Boolean): ValueOption[A] =
+    if (isEmpty || p(this.get)) this else ValueNone
+
+  /** Returns this $option if it is nonempty **and** applying the predicate $p to
+   *  this $option's value returns false. Otherwise, return $none.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) if !p(x) => ValueSome(x)
+   *   case _                => ValueNone
+   *  }
+   *  ```
+   *  @param  p   the predicate used for testing.
+   */
+  @inline final def filterNot(p: A => Boolean): ValueOption[A] =
+    if (isEmpty || !p(this.get)) this else ValueNone
+
+  /** Returns false if the option is $none, true otherwise.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(_) => true
+   *   case ValueNone    => false
+   *  }
+   *  ```
+   *  @note   Implemented here to avoid the implicit conversion to Iterable.
+   */
+  final def nonEmpty: Boolean = isDefined
+
+  /** Necessary to keep $option from being implicitly converted to
+   *  [[scala.collection.Iterable]] in `for` comprehensions.
+   */
+  @inline final def withFilter(p: A => Boolean): WithFilter = new WithFilter(p)
+
+  /** We need a whole WithFilter class to honor the "doesn't create a new
+   *  collection" contract even though it seems unlikely to matter much in a
+   *  collection with max size 1.
+   */
+  class WithFilter(p: A => Boolean) {
+    def map[B](f: A => B): ValueOption[B] = self filter p map f
+    def flatMap[B](f: A => ValueOption[B]): ValueOption[B] = self filter p flatMap f
+    def foreach[U](f: A => U): Unit = self filter p foreach f
+    def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
+  }
+
+  /** Tests whether the option contains a given value as an element.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => x == elem
+   *   case ValueNone    => false
+   *  }
+   *  ```
+   *  @example ```
+   *  // Returns true because ValueSome instance contains string "something" which equals "something".
+   *  ValueSome("something") contains "something"
+   *
+   *  // Returns false because "something" != "anything".
+   *  ValueSome("something") contains "anything"
+   *
+   *  // Returns false when method called on ValueNone.
+   *  ValueNone contains "anything"
+   *  ```
+   *
+   *  @param elem the element to test.
+   *  @return `true` if the option has an element that is equal (as
+   *  determined by `==`) to `elem`, `false` otherwise.
+   */
+  final def contains[A1 >: A](elem: A1): Boolean =
+    !isEmpty && this.get == elem
+
+  /** Returns true if this option is nonempty **and** the predicate
+   *  $p returns true when applied to this $option's value.
+   *  Otherwise, returns false.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => p(x)
+   *   case ValueNone    => false
+   *  }
+   *  ```
+   *  @param  p   the predicate to test
+   */
+  @inline final def exists(p: A => Boolean): Boolean =
+    !isEmpty && p(this.get)
+
+  /** Returns true if this option is empty **or** the predicate
+   *  $p returns true when applied to this $option's value.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => p(x)
+   *   case ValueNone    => true
+   *  }
+   *  ```
+   *  @param  p   the predicate to test
+   */
+  @inline final def forall(p: A => Boolean): Boolean = isEmpty || p(this.get)
+
+  /** Applies the given procedure $f to the option's value,
+   *  if it is nonempty. Otherwise, do nothing.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => f(x)
+   *   case ValueNone    => ()
+   *  }
+   *  ```
+   *  @param  f   the procedure to apply.
+   *  @see map
+   *  @see flatMap
+   */
+  @inline final def foreach[U](f: A => U): Unit = {
+    if (!isEmpty) f(this.get)
+  }
+
+  /** Returns a $some containing the result of
+   *  applying `pf` to this $option's contained
+   *  value, **if** this option is
+   *  nonempty **and** `pf` is defined for that value.
+   *  Returns $none otherwise.
+   *
+   *  @example ```
+   *  // Returns ValueSome(HTTP) because the partial function covers the case.
+   *  ValueSome("http") collect {case "http" => "HTTP"}
+   *
+   *  // Returns ValueNone because the partial function doesn't cover the case.
+   *  ValueSome("ftp") collect {case "http" => "HTTP"}
+   *
+   *  // Returns ValueNone because the option is empty. There is no value to pass to the partial function.
+   *  ValueNone collect {case value => value}
+   *  ```
+   *
+   *  @param  pf   the partial function.
+   *  @return the result of applying `pf` to this $option's
+   *  value (if possible), or $none.
+   */
+  // @inline final def collect[B](pf: ValuePartialFunction[A, B]): ValueOption[B] =
+  //   if (!isEmpty) pf.lift(this.get) else ValueNone
+
+  @inline final def collect[B](pf: PartialFunction[A, B]): ValueOption[B] =
+    if (!isEmpty) pf.lift(this.get) match {case Some(x) => ValueSome(x)} else ValueNone
+
+  /** Returns this $option if it is nonempty,
+   *  otherwise return the result of evaluating `alternative`.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => ValueSome(x)
+   *   case ValueNone    => alternative
+   *  }
+   *  ```
+   *  @param alternative the alternative expression.
+   */
+  @inline final def orElse[B >: A](alternative: => ValueOption[B]): ValueOption[B] =
+    if (isEmpty) alternative else this
+
+  /** Returns a $some formed from this option and another option
+   *  by combining the corresponding elements in a pair.
+   *  If either of the two options is empty, $none is returned.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  (option1, option2) match {
+   *    case (ValueSome(x), ValueSome(y)) => ValueSome((x, y))
+   *    case _                  => ValueNone
+   *  }
+   *  ```
+   *  @example ```
+   *  // Returns ValueSome(("foo", "bar")) because both options are nonempty.
+   *  ValueSome("foo") zip ValueSome("bar")
+   *
+   *  // Returns ValueNone because `that` option is empty.
+   *  ValueSome("foo") zip ValueNone
+   *
+   *  // Returns ValueNone because `this` option is empty.
+   *  ValueNone zip ValueSome("bar")
+   *  ```
+   *
+   *  @param  that   the options which is going to be zipped
+   */
+  final def zip[A1 >: A, B](that: ValueOption[B]): ValueOption[(A1, B)] =
+    if (isEmpty || that.isEmpty) ValueNone else ValueSome((this.get, that.get))
+
+  /** Converts an ValueOption of a pair into an ValueOption of the first element and an ValueOption of the second element.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *    case ValueSome((x, y)) => (ValueSome(x), ValueSome(y))
+   *    case _            => (ValueNone,    ValueNone)
+   *  }
+   *  ```
+   *  @tparam A1    the type of the first half of the element pair
+   *  @tparam A2    the type of the second half of the element pair
+   *  @param asPair an implicit conversion which asserts that the element type
+   *                of this ValueOption is a pair.
+   *  @return       a pair of ValueOptions, containing, respectively, the first and second half
+   *                of the element pair of this ValueOption.
+   */
+  final def unzip[A1, A2](implicit asPair: A <:< (A1, A2)): (ValueOption[A1], ValueOption[A2]) = {
+    if (isEmpty)
+      (ValueNone, ValueNone)
+    else {
+      val e = asPair(this.get)
+      (ValueSome(e._1), ValueSome(e._2))
+    }
+  }
+
+  /** Converts an ValueOption of a triple into three ValueOptions, one containing the element from each position of the triple.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *    case ValueSome((x, y, z)) => (ValueSome(x), ValueSome(y), ValueSome(z))
+   *    case _               => (ValueNone,    ValueNone,    ValueNone)
+   *  }
+   *  ```
+   *  @tparam A1      the type of the first of three elements in the triple
+   *  @tparam A2      the type of the second of three elements in the triple
+   *  @tparam A3      the type of the third of three elements in the triple
+   *  @param asTriple an implicit conversion which asserts that the element type
+   *                  of this ValueOption is a triple.
+   *  @return         a triple of ValueOptions, containing, respectively, the first, second, and third
+   *                  elements from the element triple of this ValueOption.
+   */
+  final def unzip3[A1, A2, A3](implicit asTriple: A <:< (A1, A2, A3)): (ValueOption[A1], ValueOption[A2], ValueOption[A3]) = {
+    if (isEmpty)
+      (ValueNone, ValueNone, ValueNone)
+    else {
+      val e = asTriple(this.get)
+      (ValueSome(e._1), ValueSome(e._2), ValueSome(e._3))
+    }
+  }
+
+  /** Returns a singleton iterator returning the $option's value
+   *  if it is nonempty, or an empty iterator if the option is empty.
+   */
+  def iterator: Iterator[A] =
+    if (isEmpty) collection.Iterator.empty else collection.Iterator.single(this.get)
+
+  /** Returns a singleton list containing the $option's value
+   *  if it is nonempty, or the empty list if the $option is empty.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => List(x)
+   *   case ValueNone    => Nil
+   *  }
+   *  ```
+   */
+  def toList: List[A] =
+    if (isEmpty) List() else new ::(this.get, Nil)
+
+  /** Returns a [[scala.util.Left]] containing the given
+   *  argument `left` if this $option is empty, or
+   *  a [[scala.util.Right]] containing this $option's value if
+   *  this is nonempty.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => Right(x)
+   *   case ValueNone    => Left(left)
+   *  }
+   *  ```
+   *  @param left the expression to evaluate and return if this is empty
+   *  @see toLeft
+   */
+  @inline final def toRight[X](left: => X): Either[X, A] =
+    if (isEmpty) Left(left) else Right(this.get)
+
+  /** Returns a [[scala.util.Right]] containing the given
+   *  argument `right` if this is empty, or
+   *  a [[scala.util.Left]] containing this $option's value
+   *  if this $option is nonempty.
+   *
+   *  This is equivalent to:
+   *  ```
+   *  option match {
+   *   case ValueSome(x) => Left(x)
+   *   case ValueNone    => Right(right)
+   *  }
+   *  ```
+   *  @param right the expression to evaluate and return if this is empty
+   *  @see toRight
+   */
+  @inline final def toLeft[X](right: => X): Either[A, X] =
+    if (isEmpty) Right(right) else Left(this.get)
+}
+
+/** Class `ValueSome[A]` represents existing values of type
+ *  `A`.
+ */
+@valhalla
+@SerialVersionUID(1234815782226070388L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
+final case class ValueSome[+A](value: A) extends ValueOption[A] {
+  def get: A = value
+}
+
+@valhalla
+/** This case object represents non-existent values. */
+@SerialVersionUID(5066590221178148012L) // value computed by serialver for 2.11.2, annotation added in 2.11.4
+case object ValueNone extends ValueOption[Nothing] {
+  def get: Nothing = throw new NoSuchElementException("ValueNone.get")
+}

--- a/tests/valhalla/neg/DeepValhallaAnonymousClass.scala
+++ b/tests/valhalla/neg/DeepValhallaAnonymousClass.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+class Baz
+
+@valhalla
+abstract class Foo[A](value: A) extends AnyVal with DeepValhalla
+
+class Bar:
+    def foobar() = {
+        val x = new Foo(new Baz) { } // error
+    }

--- a/tests/valhalla/neg/DeepValhallaAnonymousClass2.scala
+++ b/tests/valhalla/neg/DeepValhallaAnonymousClass2.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+class Baz
+
+@valhalla
+abstract class Foo[A](value: A) extends AnyVal with DeepValhalla
+
+class Bar:
+    def foobar() = {
+        val y = new Foo(new Some(new Baz)) {} // error
+    }

--- a/tests/valhalla/neg/DeepValhallaCaseClass.scala
+++ b/tests/valhalla/neg/DeepValhallaCaseClass.scala
@@ -1,0 +1,16 @@
+import scala.annotation.valhalla
+
+class Baz
+
+@valhalla
+abstract class ValueOption[+A] extends AnyVal with DeepValhalla
+
+@valhalla
+case class ValueSome[+A](value: A) extends ValueOption[A] {
+    def get: A = value
+}
+
+class Bar:
+    def foobar() = {
+        val z = ValueSome(new Baz) // error
+    }

--- a/tests/valhalla/neg/DeepValhallaClassDeclaration.scala
+++ b/tests/valhalla/neg/DeepValhallaClassDeclaration.scala
@@ -1,0 +1,26 @@
+import scala.annotation.valhalla
+
+/*  
+
+a class extending DeepValhalla must extend AnyVal and have
+the valhalla annotation
+
+*/
+
+class A extends DeepValhalla // error
+
+
+/*  
+
+A DeepValhalla class must must have a non-DeepValhalla field 
+
+*/
+
+@valhalla
+class B extends AnyVal
+
+@valhalla class C(val b: B) extends AnyVal with DeepValhalla // error
+
+class D
+
+@valhalla class E(val d: D) extends AnyVal with DeepValhalla // error

--- a/tests/valhalla/neg/DeepValhallaClassDeclarationTypeParam.scala
+++ b/tests/valhalla/neg/DeepValhallaClassDeclarationTypeParam.scala
@@ -1,0 +1,23 @@
+import scala.annotation.valhalla
+
+class Baz
+
+@valhalla
+abstract class ValueOption[+A] extends AnyVal with DeepValhalla
+
+@valhalla
+class ValueSome[+A](value: A) extends ValueOption[A] {
+    def get: A = value
+}
+
+/*  
+
+A DeepValhalla class must not have a non-DeepValhalla field 
+
+*/
+
+@valhalla
+class Fred(f: ValueOption[Baz]) extends AnyVal with DeepValhalla // error
+
+@valhalla
+class Garply(value: Option[Int]) extends AnyVal with DeepValhalla // error

--- a/tests/valhalla/neg/DeepValhallaClassNew.scala
+++ b/tests/valhalla/neg/DeepValhallaClassNew.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+class Baz
+
+@valhalla
+class Grault[A](value: A) extends AnyVal with DeepValhalla
+
+class Bar:
+    def foobar() = {
+        val v = new Grault(new Baz) // error
+    }

--- a/tests/valhalla/neg/DeepValhallaClassNew2.scala
+++ b/tests/valhalla/neg/DeepValhallaClassNew2.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+class Baz
+
+@valhalla
+class Grault[A](value: A) extends AnyVal with DeepValhalla
+
+class Bar:
+    def foobar() = {
+        val w = new Grault(new Some(new Baz)) // error
+    }

--- a/tests/valhalla/neg/DeepValhallaClassNew3.scala
+++ b/tests/valhalla/neg/DeepValhallaClassNew3.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+class Baz
+
+@valhalla
+class Grault[A](value: A) extends AnyVal with DeepValhalla
+
+class Bar:
+    def foobar() = {
+        val u = new Grault(new Grault(new Baz)) // error
+    }

--- a/tests/valhalla/neg/ExplicitSelf.scala
+++ b/tests/valhalla/neg/ExplicitSelf.scala
@@ -1,0 +1,9 @@
+import scala.annotation.valhalla
+
+trait RecordLabel:
+  var name: String = "Sony"
+
+@valhalla trait SoundProduction extends Any { // error
+  this: RecordLabel =>
+    val prodName = "prod " + name
+}

--- a/tests/valhalla/neg/ExtendingConcreteVVC.scala
+++ b/tests/valhalla/neg/ExtendingConcreteVVC.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+@valhalla
+class ConcreteVVC extends AnyVal {
+  def addOne(x: Int): Int = x + 1
+}
+
+@valhalla
+class VVC extends ConcreteVVC // error
+
+class Ident extends ConcreteVVC // error

--- a/tests/valhalla/neg/ExtendsAnyRef.scala
+++ b/tests/valhalla/neg/ExtendsAnyRef.scala
@@ -1,0 +1,29 @@
+import scala.annotation.valhalla
+
+/**
+ * Valhalla Class Extends AnyRef Class
+ * */
+abstract class Abs {
+  def addOne(x : Int) : Int
+}
+
+@valhalla
+class ValhallaAnnotWithoutExtendingAnyVal extends Abs{ // error
+  def addOne(x : Int) : Int = x + 1
+}
+
+/**
+ * Valhalla Trait Extends AnyRef 2
+ * */
+@valhalla
+trait Uni extends Any
+
+@valhalla
+trait AnyRefTrait extends Uni // error
+
+trait Trait:
+  def add(x:Int, y:Int): Int
+
+@valhalla
+class VVC extends AnyVal with Trait: // error
+  def add(x:Int, y:Int): Int = x + y

--- a/tests/valhalla/neg/IncorrectDeclaration.scala
+++ b/tests/valhalla/neg/IncorrectDeclaration.scala
@@ -1,0 +1,7 @@
+import scala.annotation.valhalla
+
+@valhalla
+class A // error
+
+@valhalla
+trait T // error

--- a/tests/valhalla/neg/SecondaryCtor.scala
+++ b/tests/valhalla/neg/SecondaryCtor.scala
@@ -1,0 +1,5 @@
+class SecondaryCtor(val x: Int) extends AnyVal {
+  def this(a: Int, b: Int) = { // error
+    this(a + b)
+  }
+}

--- a/tests/valhalla/neg/VVCMutableParam.scala
+++ b/tests/valhalla/neg/VVCMutableParam.scala
@@ -1,0 +1,7 @@
+import scala.annotation.valhalla
+
+@valhalla
+class VVCMutableField(var a: Int) extends AnyVal // error
+
+@valhalla
+trait VTMutableField(var a: Int) extends Any // error

--- a/tests/valhalla/neg/ValhallaExtendsNonValhallaAnyTraitWithVar.scala
+++ b/tests/valhalla/neg/ValhallaExtendsNonValhallaAnyTraitWithVar.scala
@@ -1,0 +1,19 @@
+import scala.annotation.valhalla
+
+/**
+ * Valhalla classes and traits cannot extend non-Valhalla classes or traits
+ */
+
+trait AnyTrait extends Any:
+  var a : Int = 2
+  def add(x:Int, y:Int): Int
+
+
+@valhalla
+trait TraitExtendsAnyTrait extends Any with AnyTrait: // error
+  def addOne(x: Int): Int
+
+@valhalla
+class VVC extends AnyVal with AnyTrait: // error
+  def add(x:Int, y:Int): Int = x + y
+  def addOne(x: Int): Int = x + 1

--- a/tests/valhalla/neg/ValhallaMutableField.scala
+++ b/tests/valhalla/neg/ValhallaMutableField.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+@valhalla
+trait VTMutableField extends Any {
+  var a = 5 // error
+}
+
+@valhalla
+class VVCMutableField extends AnyVal {
+  var a = 5 // error
+}

--- a/tests/valhalla/neg/ValhallaWithField.scala
+++ b/tests/valhalla/neg/ValhallaWithField.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+@valhalla
+trait VTMutableField extends Any {
+  val a = 5 // error
+}
+
+@valhalla
+class VVCMutableField extends AnyVal {
+  val a = 5 // error
+}

--- a/tests/valhalla/pos/AbstractVVC.scala
+++ b/tests/valhalla/pos/AbstractVVC.scala
@@ -1,0 +1,6 @@
+import scala.annotation.valhalla
+
+@valhalla
+abstract class AbstractVVC(val a: Int, val b: Int) extends AnyVal {
+  def addOne(x: Int):Int = x
+}

--- a/tests/valhalla/pos/AnimalFarm.scala
+++ b/tests/valhalla/pos/AnimalFarm.scala
@@ -1,0 +1,31 @@
+import scala.annotation.valhalla
+
+@valhalla
+case class Pig(id: Int, luckyNumber: Int) extends AnyVal
+
+@valhalla
+case class Horse(id: Int) extends AnyVal
+
+@valhalla
+case class PigWithSomeHorse(id: Int, luckyNumber: Int, favouriteHorse: Option[Horse]) extends AnyVal
+
+class Main:
+    def main: Unit = {
+        val snowball = Pig(1, 2)
+        val snowball1 = Pig(1, 2)
+        val notSnowball = Pig(1, 3)
+
+        if(snowball == snowball1 && snowball != notSnowball){
+            println("Good job!")
+        }
+
+        val clover = Horse(10)
+        val unnamedHorse1 = Horse(10)
+        val napoleon = PigWithSomeHorse(1, 2, Some(clover))
+        val napoleon1 = PigWithSomeHorse(1, 2, Some(clover))
+        val napoleon2 = PigWithSomeHorse(1, 2, Some(unnamedHorse1))
+
+        if(napoleon == napoleon1 && napoleon == napoleon2){
+            println("Good job! We are using case class equals!")
+        }
+    }

--- a/tests/valhalla/pos/CanEqual.scala
+++ b/tests/valhalla/pos/CanEqual.scala
@@ -1,0 +1,16 @@
+import scala.language.strictEquality
+import scala.annotation.valhalla
+
+// Motivation:
+// val x = ... // of type T
+// val y = ... // of type S, but should be T
+// x == y      // typechecks, will always yield false
+
+@valhalla
+class T(val a: Int) extends AnyVal
+
+class Main:
+  def main = {
+    val t = new T(1)
+    t == null
+  }

--- a/tests/valhalla/pos/ConcreteVVC.scala
+++ b/tests/valhalla/pos/ConcreteVVC.scala
@@ -1,0 +1,6 @@
+import scala.annotation.valhalla
+
+@valhalla
+class ConcreteVVC(val a: Int, val b: Int) extends AnyVal {
+  def addOne(x: Int): Int = x + 1
+}

--- a/tests/valhalla/pos/DeepVal.scala
+++ b/tests/valhalla/pos/DeepVal.scala
@@ -1,0 +1,12 @@
+import scala.annotation.valhalla
+
+@valhalla
+class A extends AnyVal with DeepValhalla
+
+@valhalla
+trait B extends Any with DeepValhalla
+
+@valhalla
+case class C(c1: Int, c2: A) extends AnyVal with B
+
+@valhalla class D(val a: A, val b: Int, val c: C, val d: B) extends AnyVal with DeepValhalla

--- a/tests/valhalla/pos/Enum.scala
+++ b/tests/valhalla/pos/Enum.scala
@@ -1,0 +1,30 @@
+import scala.annotation.valhalla
+
+@valhalla
+enum Planet(mass: Double, radius: Double) extends AnyVal:
+  private final def G = 6.67300E-11
+  def surfaceGravity = G * mass / (radius * radius)
+  def surfaceWeight(otherMass: Double) = otherMass * surfaceGravity
+
+  case Mercury extends Planet(3.303e+23, 2.4397e6)
+  case Venus   extends Planet(4.869e+24, 6.0518e6)
+  case Earth   extends Planet(5.976e+24, 6.37814e6)
+  case Earth1   extends Planet(5.976e+24, 6.37814e6)
+  case Mars    extends Planet(6.421e+23, 3.3972e6)
+  case Jupiter extends Planet(1.9e+27,   7.1492e7)
+  case Saturn  extends Planet(5.688e+26, 6.0268e7)
+  case Uranus  extends Planet(8.686e+25, 2.5559e7)
+  case Neptune extends Planet(1.024e+26, 2.4746e7)
+end Planet
+
+class Main:
+  def main(args: Array[String]) =
+    val earthWeight = args(0).toDouble
+    val mass = earthWeight / Planet.Earth.surfaceGravity
+    for p <- Planet.values do
+      println(s"Your weight on $p is ${p.surfaceWeight(mass)}")
+
+    println(Planet.valueOf("Mercury"))
+    println(Planet.fromOrdinal(0))
+    println(Planet.Mercury.ordinal)
+    println(Planet.Earth == Planet.Earth)

--- a/tests/valhalla/pos/EnumDeepVal.scala
+++ b/tests/valhalla/pos/EnumDeepVal.scala
@@ -1,21 +1,14 @@
-// import scala.annotation.valhalla
+import scala.annotation.valhalla
 
-// @valhalla
-enum Planet(mass: Double, radius: Double): // extends AnyVal
+@valhalla
+enum Planet(mass: Double, radius: Double) extends AnyVal with DeepValhalla:
   private final def G = 6.67300E-11
   def surfaceGravity = G * mass / (radius * radius)
   def surfaceWeight(otherMass: Double) = otherMass * surfaceGravity
 
-  // override def equals(that: Any): Boolean = 
-  //   needs mass & radius to be public
-  //   if !that.isInstanceOf[Planet] then
-  //     return false
-  //   else
-  //     that.asInstanceOf[Planet].mass == mass && that.asInstanceOf[Planet].radius == radius
-
   case Mercury extends Planet(3.303e+23, 2.4397e6)
   case Venus   extends Planet(4.869e+24, 6.0518e6)
-  case Earth(x: Int)   extends Planet(5.976e+24, 6.37814e6)
+  case Earth   extends Planet(5.976e+24, 6.37814e6)
   case Earth1   extends Planet(5.976e+24, 6.37814e6)
   case Mars    extends Planet(6.421e+23, 3.3972e6)
   case Jupiter extends Planet(1.9e+27,   7.1492e7)
@@ -27,12 +20,11 @@ end Planet
 class Main:
   def main(args: Array[String]) =
     val earthWeight = args(0).toDouble
-    val mass = earthWeight / Planet.Earth(1).surfaceGravity
-    // for p <- Planet.values do
-    //   println(s"Your weight on $p is ${p.surfaceWeight(mass)}")
+    val mass = earthWeight / Planet.Earth.surfaceGravity
+    for p <- Planet.values do
+      println(s"Your weight on $p is ${p.surfaceWeight(mass)}")
 
-    // println(Planet.valueOf("Mercury"))
+    println(Planet.valueOf("Mercury"))
     println(Planet.fromOrdinal(0))
     println(Planet.Mercury.ordinal)
-    println(Planet.Earth(1) == Planet.Earth(1))
-    println(Planet.Earth(1) == Planet.Earth(2))
+    println(Planet.Earth == Planet.Earth1)

--- a/tests/valhalla/pos/EnumOption.scala
+++ b/tests/valhalla/pos/EnumOption.scala
@@ -1,0 +1,18 @@
+import scala.annotation.valhalla
+
+@valhalla
+enum Option[+T] extends AnyVal:
+  case Some(x: T)
+  case Some1(x: T)
+  case None
+
+@valhalla
+enum OptionDV[+T] extends AnyVal with DeepValhalla:
+  case Some(x: T)
+  case Some1(x: T)
+  case None
+
+class Main:
+    def main = {
+
+    }

--- a/tests/valhalla/pos/EqualityContract.scala
+++ b/tests/valhalla/pos/EqualityContract.scala
@@ -1,0 +1,19 @@
+import scala.annotation.valhalla
+
+@valhalla
+case class Pig(val id: Int, val luckyNumber: Int) extends AnyVal with DeepValhalla
+
+class Pig1(val id: Int, val luckyNumber: Int):
+    override def equals(that: Any): Boolean = {
+        that match {
+            case Pig(id1, luckyNumber1) => id == id1 && luckyNumber == luckyNumber1
+            case _ => false
+        }
+    }
+
+class Main:
+    def main(args: Array[String]): Unit = {
+        val pig1 = new Pig(1, 10)
+        val refPig = new Pig1(1, 10)
+        if(pig1 != refPig && refPig != pig1) then println("Symmetric!") else println("badbad!")
+    }

--- a/tests/valhalla/pos/ExplicitSelf.scala
+++ b/tests/valhalla/pos/ExplicitSelf.scala
@@ -1,0 +1,8 @@
+import scala.annotation.valhalla
+
+trait Animal(val cuteness: Int):
+  val happiness = 100
+  def speak: Unit
+
+@valhalla trait Mammal(val furColour: Tuple) extends Any:
+  this: Animal =>

--- a/tests/valhalla/pos/ExplicitSelf2.scala
+++ b/tests/valhalla/pos/ExplicitSelf2.scala
@@ -1,0 +1,7 @@
+import scala.annotation.valhalla
+
+@valhalla trait Animal(val cuteness: Int) extends Any:
+  def speak: Unit
+
+@valhalla trait Mammal(val furColour: Tuple) extends Any:
+  this: Animal =>

--- a/tests/valhalla/pos/IdentClassExtendsValhallaTrait.scala
+++ b/tests/valhalla/pos/IdentClassExtendsValhallaTrait.scala
@@ -1,0 +1,14 @@
+import scala.annotation.valhalla
+
+@valhalla
+trait ValhallaTrait extends Any:
+  def add(x:Int, y:Int): Int
+
+class IdentClass extends ValhallaTrait:
+  def add(x:Int, y:Int): Int = x + y
+
+// class Main:
+//   def main = {
+//     val ic = IdentClass()
+//     println(ic.add(2,3))
+//   }

--- a/tests/valhalla/pos/InnerClass.scala
+++ b/tests/valhalla/pos/InnerClass.scala
@@ -1,0 +1,14 @@
+class Foo:
+  def bar(x: Int) = {
+    // @valhalla
+    class Boo:// extends AnyVal: // Still runs but Error: Access Flags: Unmatched bit position 0x8 for location CLASS for class file format CURRENT_PREVIEW_FEATURES
+    // added a static java flag to this class.
+      def booAdd(x: Int, y: Int): Int = x + y + y
+
+    println(new Boo().booAdd(x, 2))
+  }
+ 
+class Main:
+    def main = {
+      new Foo().bar(123)
+    }

--- a/tests/valhalla/pos/Instantiation.scala
+++ b/tests/valhalla/pos/Instantiation.scala
@@ -1,0 +1,23 @@
+import scala.annotation.valhalla
+
+@valhalla
+abstract class Foo[A](value: A) extends AnyVal with DeepValhalla
+
+@valhalla
+class Grault extends AnyVal with DeepValhalla
+
+@valhalla
+trait Corge[A] extends Any with DeepValhalla
+
+@valhalla
+class Baz[A](value: A) extends AnyVal with Corge[A]
+
+class Qux
+
+class Bar:
+    def foobar() = {
+        val x = new Foo(5) { }
+        val w = new Foo(new Grault) { }
+        val z = new Baz(new Grault)
+    }
+

--- a/tests/valhalla/pos/NestedClasses.scala
+++ b/tests/valhalla/pos/NestedClasses.scala
@@ -1,0 +1,75 @@
+import scala.annotation.valhalla
+
+class Graph:
+  class Node:
+    var connectedNodes: List[Node] = Nil
+    def connectTo(node: Node): Unit =
+      if !connectedNodes.exists(node.equals) then
+        connectedNodes = node :: connectedNodes
+
+  var nodes: List[Node] = Nil
+  def newNode: Node =
+    val res = Node()
+    nodes = res :: nodes
+    res
+
+@valhalla
+class IntList(val list: List[Int], val size: Int) extends AnyVal:
+  class IntListIterator:
+    var nextIndex = 0;
+        
+    def hasNext(): Boolean = (nextIndex <= size - 1)
+
+    def next(): Int = {
+      val res = list(nextIndex)
+      nextIndex+=1
+      res
+    }
+
+  def appendFront(e: Int): IntList =
+    IntList(e :: list, size + 1)
+
+  def show(): Unit = {
+    val iterator = IntListIterator()
+
+    while (iterator.hasNext()) {
+      print(iterator.next() + " ");
+    }
+    println();
+  }
+
+class Book:
+  @valhalla class Chapter(val index: Int, val content: String, val lastEdited: Int) extends AnyVal:
+    def update(time: Int): Chapter =
+      Chapter(index, content, time)
+    def read: Unit =
+      println(s"Chapter ${index}\nLast edited on ${lastEdited}\n${content}")
+
+  var chapters: scala.collection.mutable.ListBuffer[Chapter] = scala.collection.mutable.ListBuffer.empty[Chapter]
+  var numChapters = 0
+
+  def newChapter(content: String, time: Int): Chapter =
+    numChapters+=1
+    val res = Chapter(numChapters, content, time)
+    chapters = chapters :+ res
+    res
+  def read: Unit =
+    for chapter <- chapters do chapter.read
+
+class Main:
+  def main = {
+    val graph = new Graph
+    for i <- 1 to 10 do graph.newNode
+
+    val intList = new IntList(Nil, 0)
+    val newlist1 = intList.appendFront(1)
+    val newlist2 = newlist1.appendFront(2)
+    val newlist3 = newlist2.appendFront(3)
+    newlist3.show()
+
+    val book = Book()
+    for time <- 1 to 10 do
+      book.newChapter("Oliver", time)
+    book.chapters(3) = book.chapters(3).update(11)
+    book.read
+  }

--- a/tests/valhalla/pos/RegularEnum.scala
+++ b/tests/valhalla/pos/RegularEnum.scala
@@ -1,0 +1,25 @@
+// import scala.annotation.valhalla
+
+enum Planet(mass: Double, radius: Double):
+  private final def G = 6.67300E-11
+  def surfaceGravity = G * mass / (radius * radius)
+  def surfaceWeight(otherMass: Double) = otherMass * surfaceGravity
+
+  case Mercury extends Planet(3.303e+23, 2.4397e6)
+  case Venus   extends Planet(4.869e+24, 6.0518e6)
+  case Earth   extends Planet(5.976e+24, 6.37814e6)
+  case Earth1   extends Planet(5.976e+24, 6.37814e6)
+  case Mars    extends Planet(6.421e+23, 3.3972e6)
+  case Jupiter extends Planet(1.9e+27,   7.1492e7)
+  case Saturn  extends Planet(5.688e+26, 6.0268e7)
+  case Uranus  extends Planet(8.686e+25, 2.5559e7)
+  case Neptune extends Planet(1.024e+26, 2.4746e7)
+end Planet
+
+class Main:
+  def main(args: Array[String]) =
+    val earthWeight = args(0).toDouble
+    val mass = earthWeight / Planet.Earth.surfaceGravity
+    for p <- Planet.values do
+      println(p) // s"Your weight on $p is" ${p.surfaceWeight(mass)}
+    println(Planet.Earth == Planet.Earth1)

--- a/tests/valhalla/pos/TraitExtendsAny.scala
+++ b/tests/valhalla/pos/TraitExtendsAny.scala
@@ -1,0 +1,4 @@
+import scala.annotation.valhalla
+
+@valhalla
+trait TraitExtendsAny extends Any

--- a/tests/valhalla/pos/VVCExtendsAbstractVVC.scala
+++ b/tests/valhalla/pos/VVCExtendsAbstractVVC.scala
@@ -1,0 +1,11 @@
+import scala.annotation.valhalla
+
+@valhalla
+abstract class AbstractVVC extends AnyVal {
+  def addOne(x: Int): Int
+}
+
+@valhalla
+class VVC extends AbstractVVC {
+  def addOne(x: Int): Int = x + 1
+}

--- a/tests/valhalla/pos/VVCExtendsValhallaTrait.scala
+++ b/tests/valhalla/pos/VVCExtendsValhallaTrait.scala
@@ -1,0 +1,9 @@
+import scala.annotation.valhalla
+
+@valhalla
+trait ValhallaTrait extends Any:
+  def add(x:Int, y:Int): Int
+
+@valhalla
+class VVC extends AnyVal with ValhallaTrait:
+  def add(x:Int, y:Int): Int = x + y

--- a/tests/valhalla/pos/ValhallaExtendsNonValhallaAnyTrait.scala
+++ b/tests/valhalla/pos/ValhallaExtendsNonValhallaAnyTrait.scala
@@ -1,0 +1,14 @@
+import scala.annotation.valhalla
+
+trait AnyTrait extends Any:
+  val a: Int = 2
+  def add(x:Int, y:Int): Int
+
+@valhalla
+trait TraitExtendsAnyTrait extends Any with AnyTrait:
+  def addOne(x: Int): Int
+
+@valhalla
+class VVC extends AnyVal with AnyTrait:
+  def add(x:Int, y:Int): Int = x + y
+  def addOne(x: Int): Int = x + 1


### PR DESCRIPTION
I implemented Project Valhalla's value classes. The documentations are in docs/_docs/reference/experimental/valhalla.md and I have copied it below as well.

As per [JEP 401](https://openjdk.org/jeps/401), there is a new attribute LoadableDescriptors in the class files. Thus, this PR depends on modifications in the scala-asm repo. [Here](https://github.com/lidaisy/scala-asm) is my fork of it for anyone who wants to try it out.

You should use the flag --Yvalue-classes to compile any value classes, since this changes the class file's major and minor version to be compatible with Project Valhalla's JVM.

# Documentation
## Valhalla Value Classes

Valhalla value classes are the Scala equivalence of Java's Project Valhalla's value classes (see [JEP 401](https://openjdk.org/jeps/401)). When used with the Project Valhalla JVM, Valhalla value classes are optimized.

Valhalla value classes extend AnyVal and have a `valhalla` annotation. Valhalla value classes cannot have non-parameter fields and cannot have auxilliary constructors.

Valhalla value classes do not have object identity -- two valhalla value classes are equal when their fields are the same.

```scala
import scala.annotation.valhalla

@valhalla class ValhallaValueClass(val x: Int, val y: Int) extends AnyVal
```

Valhalla value classes are implicitly final and cannot be extended unless it is abstract. Its fields are immutable and cannot be lazy.

Valhalla value classes can extend `AnyVal`, universal traits, or abstract valhalla value classes.

## Valhalla Traits

Valhalla Traits are Universal Traits (traits that extend Any) with a `valhalla` annotation.

Like Valhalla value classes, any Valhalla trait must have immutable fields only.

Valhalla traits can extend `Any` or universal traits.

```scala
import scala.annotation.valhalla

@valhalla trait(val x: Int, val y: Int) ValhallaTrait extends Any

```

## Using Explicit Self with Valhalla

Valhalla traits can have self-type of any trait without mutable fields.

## CanEqual with Valhalla

Valhalla value classes can be null, so the CanEqual of `null` and a valhalla value class returns `true`.