### PR TITLE
use `IndexOutOfBoundsException` constructor with `Int`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -674,6 +674,11 @@ class Definitions {
   @tu lazy val JavaCloneableClass: ClassSymbol        = requiredClass("java.lang.Cloneable")
   @tu lazy val NullPointerExceptionClass: ClassSymbol = requiredClass("java.lang.NullPointerException")
   @tu lazy val IndexOutOfBoundsException: ClassSymbol = requiredClass("java.lang.IndexOutOfBoundsException")
+  @tu lazy val IndexOutOfBoundsExceptionType: Type    = IndexOutOfBoundsException.typeRef
+    @tu lazy val IndexOutOfBoundsException_IntConstructor: TermSymbol  = IndexOutOfBoundsException.info.member(nme.CONSTRUCTOR).suchThat(_.info.firstParamTypes match {
+        case List(pt) => pt.isRef(IntClass)
+        case _ => false
+      }).symbol.asTerm
   @tu lazy val ClassClass: ClassSymbol                = requiredClass("java.lang.Class")
   @tu lazy val BoxedNumberClass: ClassSymbol          = requiredClass("java.lang.Number")
   @tu lazy val ClassCastExceptionClass: ClassSymbol   = requiredClass("java.lang.ClassCastException")

--- a/library/src/scala/runtime/Statics.java
+++ b/library/src/scala/runtime/Statics.java
@@ -125,10 +125,10 @@ public final class Statics {
   private static int anyHashNumber(Number x) {
     if (x instanceof java.lang.Long)
       return longHash(((java.lang.Long)x).longValue());
-  
+
     if (x instanceof java.lang.Double)
       return doubleHash(((java.lang.Double)x).doubleValue());
-  
+
     if (x instanceof java.lang.Float)
       return floatHash(((java.lang.Float)x).floatValue());
 
@@ -148,6 +148,7 @@ public final class Statics {
    * Used by the synthetic `productElement` and `productElementName` methods in case classes.
    * Delegating the exception-throwing to this function reduces the bytecode size of the case class.
    */
+  @Deprecated
   public static final <T> T ioobe(int n) throws IndexOutOfBoundsException {
     throw new IndexOutOfBoundsException(String.valueOf(n));
   }

--- a/tests/run/1938.scala
+++ b/tests/run/1938.scala
@@ -39,7 +39,8 @@ object Test {
       l.productElement(23)
       ???
     } catch {
-      case e: IndexOutOfBoundsException => assert(e.getMessage == "23")
+      case e: IndexOutOfBoundsException => assert(e.getMessage.contains("23"))
+      case _ => assert(false)
     }
   }
 }

--- a/tests/run/i2314.scala
+++ b/tests/run/i2314.scala
@@ -18,15 +18,15 @@ object Test {
       a.productElement(-1)
       ???
     } catch {
-      case e: IndexOutOfBoundsException =>
-        assert(e.getMessage == "-1")
+      case e: IndexOutOfBoundsException => assert(e.getMessage().contains("-1"))
+      case _ => assert(false)
     }
     try {
       a.productElement(2)
       ???
     } catch {
-      case e: IndexOutOfBoundsException =>
-        assert(e.getMessage == "2")
+      case e: IndexOutOfBoundsException => assert(e.getMessage().contains("2"))
+      case _ => assert(false)
     }
 
     val b = B(1, "s")


### PR DESCRIPTION
The idea of using `scala.runtime.Statics.ioobe` was to reduce the size of the generated bytecode.
In this PR, we instead use the JDK9+ constructor of `IndexOutOfBoundsException`.
In the generated code, `checkcast` mentioned in https://github.com/scala/scala/pull/7086#issue-351143908 is also not present making the generated code more efficient than what it looked like in Scala 2.

One question remains, should we deprecate `scala.runtime.Statics.ioobe`? ~I believe we should~ I did deprecate it.
https://github.com/scala/scala3/blob/7eba9a7db49e82141078a8633007b376692bafd6/library/src/scala/runtime/Statics.java#L151

Closes #23971