### PR TITLE
Update `-Wconf:src` to match Scala 2 behavior

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -244,7 +244,9 @@ private sealed trait WarningSettings:
          |    The message name is printed with the warning in verbose warning mode.
          |
          |  - Source location: src=regex
-         |    The regex is evaluated against the full source path.
+         |    The regex must match the canonical path relative to any path segment
+         |    (`b/.*Test.scala` matches `/a/b/XTest.scala` but not `/ab/Test.scala`).
+         |    Use unix-style paths, separated by `/`.
          |
          |  - Origin of warning: origin=regex
          |    The regex must match the full name (`package.Class.method`) of the deprecated entity.


### PR DESCRIPTION
Adds `^` and `$` anchors to the `-Wconf:src` regex to ensure it matches entire path segments by default. Mostly replicates the Scala 2 `src` filter anchoring logic except for the `rootDir` bit, which Scala 3 doesn't support:

- https://github.com/mbland/scala/blob/v2.13.18/src/compiler/scala/tools/nsc/Reporting.scala#L862-L875
- https://docs.scala-lang.org/scala3/guides/migration/options-lookup.html

Applies the new `anchored` function after parsing the `-Wconf:src` argument as a regex first. This guards against pathological cases of invalid patterns that may become valid after anchoring, such as `\` becoming `/\$`. (One of the existing test cases covers this specific invalid regex case.)

Adds new test cases, including cases to validate the existing behavior of normalizing paths without resolving symlinks. This is to help ensure that the Scala 2 issue from scala/bug#13145 (which scala/scala#11192 resolves) doesn't ever appear.

Also extracts the `diagnosticWarning`, `virtualFile`, and `plainFile` helper methods to reduce duplication between new and existing test cases.

Fixes #24771. Review by @lrytz.