### PR TITLE
Configurable caches for classpaths, files, sources, and file bytes

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -78,5 +78,5 @@ class JavaPlatform extends Platform {
     new ClassfileLoader(bin)
 
   def newTastyLoader(bin: AbstractFile)(using Context): SymbolLoader =
-    new TastyLoader(bin)
+    new TastyLoader(bin, ctx.cacheStore.tastyBytes)
 }

--- a/compiler/src/dotty/tools/dotc/core/CacheStores.scala
+++ b/compiler/src/dotty/tools/dotc/core/CacheStores.scala
@@ -18,6 +18,7 @@ object CacheStores:
     def files: Cache[TermName, AbstractFile]
     def sources: Cache[AbstractFile, SourceFile]
     def classBytes: Cache[AbstractFile, Array[Byte]]
+    def tastyBytes: Cache[AbstractFile, Array[Byte]]
 
     override def toString: String =
       s"""CacheStore(
@@ -25,6 +26,7 @@ object CacheStores:
          |  files = $files,
          |  sources = $sources
          |  classBytes = $classBytes
+         |  tastyBytes = $tastyBytes
          |)""".stripMargin
 
   /** Default, per-run cache store implementation. */
@@ -50,8 +52,8 @@ object CacheStores:
      */
     val sources = NoopCache()
 
-    /** By default, we do not cache class bytes across runs. */
+    /** By default, we do not cache class bytes. */
     val classBytes = NoopCache()
 
-    /** By default, we do not cache tasty loaders. */
-    val tastyLoaders = NoopCache()
+    /** By default, we do not cache tasty bytes. */
+    val tastyBytes = NoopCache()

--- a/compiler/src/dotty/tools/dotc/core/CacheStores.scala
+++ b/compiler/src/dotty/tools/dotc/core/CacheStores.scala
@@ -1,0 +1,49 @@
+package dotty.tools.dotc.core
+
+import dotty.tools.dotc.core.Caches.{Cache, FileBasedCache, NoopCache}
+import dotty.tools.dotc.core.Names.TermName
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.io.{AbstractFile, ClassPath}
+
+object CacheStores:
+
+  /** A store of caches used by the compiler.
+   *
+   *  These caches can be shared across different runs.
+   *
+   *  Set on a [[Context]] via `setCacheStore` and retrieved via `cacheStore`.
+   */
+  trait CacheStore:
+    def classPaths: Cache[AbstractFile, ClassPath]
+    def files: Cache[TermName, AbstractFile]
+    def sources: Cache[AbstractFile, SourceFile]
+
+    override def toString: String =
+      s"""CacheStore(
+         |  classPaths = $classPaths,
+         |  files = $files,
+         |  sources = $sources
+         |)""".stripMargin
+
+  /** Default, per-run cache store implementation. */
+  object DefaultCacheStore extends CacheStore:
+
+    /** A unique global cache for classpaths, shared across all runs.
+     *
+     *  This instance is thread-safe.
+     */
+    val classPaths = FileBasedCache()
+
+    /** By default, we do not cache files across runs.
+     *
+     *  Regardless, files are always cached within a single run via
+     *  `ContextBase.files`. See also `Context.getFile`.
+     */
+    val files = NoopCache()
+
+    /** By default, we do not cache source files across runs.
+     *
+     *  Regardless, source files are always cached within a single run via
+     *  `ContextBase.sources`. See also `Context.getSource`.
+     */
+    val sources = NoopCache()

--- a/compiler/src/dotty/tools/dotc/core/CacheStores.scala
+++ b/compiler/src/dotty/tools/dotc/core/CacheStores.scala
@@ -17,12 +17,14 @@ object CacheStores:
     def classPaths: Cache[AbstractFile, ClassPath]
     def files: Cache[TermName, AbstractFile]
     def sources: Cache[AbstractFile, SourceFile]
+    def classBytes: Cache[AbstractFile, Array[Byte]]
 
     override def toString: String =
       s"""CacheStore(
          |  classPaths = $classPaths,
          |  files = $files,
          |  sources = $sources
+         |  classBytes = $classBytes
          |)""".stripMargin
 
   /** Default, per-run cache store implementation. */
@@ -47,3 +49,9 @@ object CacheStores:
      *  `ContextBase.sources`. See also `Context.getSource`.
      */
     val sources = NoopCache()
+
+    /** By default, we do not cache class bytes across runs. */
+    val classBytes = NoopCache()
+
+    /** By default, we do not cache tasty loaders. */
+    val tastyLoaders = NoopCache()

--- a/compiler/src/dotty/tools/dotc/core/Caches.scala
+++ b/compiler/src/dotty/tools/dotc/core/Caches.scala
@@ -1,0 +1,149 @@
+package dotty.tools.dotc.core
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.{BasicFileAttributes, FileTime}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.LongAdder
+
+import scala.collection.mutable.Map
+
+import dotty.tools.io.AbstractFile
+
+object Caches:
+
+  /** Cache for values of type `V`, associated with keys of type `K`. */
+  trait Cache[K, V]:
+    def apply(key: K, value: => V): V
+    def stats(): CacheStats
+    override def toString: String =
+      s"${this.getClass.getSimpleName}(stats() = ${stats()})"
+
+  /** Statistics about a cache */
+  final class CacheStats(total: Long, misses: Long, uncached: Long):
+    val hits: Long = total - misses - uncached
+
+    override def toString: String =
+      s"(total = $total, hits = $hits, misses = $misses, uncached = $uncached)"
+
+  /** A no-op cache implementation that does not cache anything. */
+  final class NoopCache[K, V] extends Cache[K, V]:
+    private var total = 0L
+
+    def apply(key: K, value: => V): V =
+      total += 1
+      value
+
+    def stats(): CacheStats =
+      CacheStats(total, misses = 0, uncached = total)
+
+  /** A thread-unsafe cache implementation based on a mutable [[Map]].
+   *
+   *  Entries are not evicted.
+   *
+   *  @param getStamp
+   *    Function to obtain a stamp for a given key. If the function returns
+   *    `None`, no caching is performed for that key. If the function returns
+   *    `Some(stamp)`, the stamp is used to validate cached entries: cache
+   *    values are only reused if the stamp matches the cached stamp.
+   */
+  final class MapCache[K, S, V](getStamp: K => Option[S]) extends Cache[K, V]:
+    private val map = Map.empty[K, (S, V)]
+    private var total = 0L
+    private var misses = 0L
+    private var uncached = 0L
+
+    def apply(key: K, value: => V): V =
+      total += 1
+      getStamp(key) match
+        case None =>
+          uncached += 1
+          value
+        case Some(stamp) =>
+          map.get(key) match
+            case Some((cachedStamp, cachedValue)) if cachedStamp == stamp =>
+              cachedValue
+            case _ =>
+              misses += 1
+              val v = value
+              map.put(key, (stamp, v))
+              v
+
+    def stats(): CacheStats =
+      CacheStats(total, misses, uncached)
+
+  /** A thread-safe cache implementation based on a Java [[ConcurrentHashMap]].
+   *
+   *  Entries are not evicted.
+   */
+  final class SynchronizedMapCache[K, S, V](getStamp: K => Option[S]) extends Cache[K, V]:
+    private val map = ConcurrentHashMap[K, (S, V)]()
+    private val total = LongAdder()
+    private val misses = LongAdder()
+    private val uncached = LongAdder()
+
+    def apply(key: K, value: => V): V =
+      total.increment()
+      getStamp(key) match
+        case None =>
+          uncached.increment()
+          value
+        case Some(stamp) =>
+          map.compute(
+            key,
+            (_, cached) =>
+              if cached != null && cached._1 == stamp then
+                cached
+              else
+                misses.increment()
+                (stamp, value)
+          )._2
+
+    def stats(): CacheStats =
+      CacheStats(total.longValue(), misses.longValue(), uncached.longValue())
+
+  /** A cache where keys are [[AbstractFile]]s.
+   *
+   *  The cache uses file modification time and file key (inode) as stamp to
+   *  invalidate cached entries when the underlying file has changed.
+   *
+   *  For files with an underlying source (e.g. files inside a zip/jar), the
+   *  stamp is obtained from the underlying source file.
+   *
+   *  If the [[AbstractFile]] does not correspond to a physical file on disk, no
+   *  caching is performed.
+   *
+   *  See https://github.com/scala/bug/issues/10295 for discussion about the
+   *  invalidation strategy.
+   */
+  final class FileBasedCache[V]() extends Cache[AbstractFile, V]:
+    private case class FileStamp(lastModified: FileTime, fileKey: Object)
+
+    private def getFileStamp(abstractFile: AbstractFile): Option[FileStamp] =
+      abstractFile.underlyingSource match
+        case Some(underlyingSource) if underlyingSource ne abstractFile =>
+          getFileStamp(underlyingSource)
+        case _ =>
+          val javaFile = abstractFile.file
+          if javaFile == null then
+            None
+          else
+            val attrs = Files.readAttributes(javaFile.toPath, classOf[BasicFileAttributes])
+            val lastModified = attrs.lastModifiedTime()
+            // This can be `null` on some platforms, but that's okay, we just use
+            // the last modified timestamp as our stamp in that case.
+            val fileKey = attrs.fileKey()
+            Some(FileStamp(lastModified, fileKey))
+
+    private val underlying = SynchronizedMapCache[AbstractFile, FileStamp, V](getFileStamp)
+
+    def apply(key: AbstractFile, value: => V): V =
+      underlying(key, value)
+
+    def stats(): CacheStats =
+      underlying.stats()
+
+    override def toString: String =
+      s"FileBasedCache(${underlying.toString})"
+
+

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -17,6 +17,7 @@ import NameOps.*
 import StdNames.*
 import classfile.{ClassfileParser, ClassfileTastyUUIDParser}
 import Decorators.*
+import Caches.Cache
 
 import util.Stats
 import reporting.trace
@@ -471,10 +472,11 @@ class ClassfileLoader(val classfile: AbstractFile) extends SymbolLoader {
     classfileParser.run()
 }
 
-class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
-  val isBestEffortTasty = tastyFile.hasBetastyExtension
+class TastyLoader(val tastyFile: AbstractFile, tastyBytesCache: Cache[AbstractFile, Array[Byte]]) extends SymbolLoader {
+  private val isBestEffortTasty = tastyFile.hasBetastyExtension
 
-  lazy val tastyBytes = tastyFile.toByteArray
+  private lazy val tastyBytes: Array[Byte] =
+    tastyBytesCache(tastyFile, tastyFile.toByteArray)
 
   private lazy val unpickler: tasty.DottyUnpickler =
     handleUnpicklingExceptions:

--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -572,7 +572,8 @@ object TreeChecker {
         ctxOwner.isWeakOwner && ownerMatches(symOwner, ctxOwner.owner)
       assert(ownerMatches(tree.symbol.owner, ctx.owner),
         i"bad owner; ${tree.symbol} has owner ${tree.symbol.owner}, expected was ${ctx.owner}\n" +
-        i"owner chain = ${tree.symbol.ownersIterator.toList}%, %, ctxOwners = ${ctx.outersIterator.map(_.owner).toList}%, %")
+        i"owner chain = ${tree.symbol.ownersIterator.toList}%, %\n" +
+        i"ctx owners = ${ctx.owner.ownersIterator.toList}%, %")
     }
 
     private def checkParents(tree: untpd.TypeDef)(using Context): Unit = {

--- a/compiler/test/dotty/tools/TestCacheStore.scala
+++ b/compiler/test/dotty/tools/TestCacheStore.scala
@@ -27,7 +27,10 @@ object TestCacheStore extends CacheStore:
 
   /** Cache class bytes across runs, except for classes in the `out` directory.
    *
-   *  Classes in the `out` directory are generated during tests, so we do not
-   *  want to cache them.
+   *  Files in the `out` directory are generated during tests, so we do not want
+   *  to cache them.
    */
   val classBytes = FilteringCache(SynchronizedMapCache(), !_.canonicalPath.startsWith(outDir))
+
+  /** Cache tasty bytes across runs, except for those in the `out` directory. */
+  val tastyBytes = FilteringCache(SynchronizedMapCache(), !_.canonicalPath.startsWith(outDir))

--- a/compiler/test/dotty/tools/TestCacheStore.scala
+++ b/compiler/test/dotty/tools/TestCacheStore.scala
@@ -1,0 +1,22 @@
+package dotty.tools
+
+import dotty.tools.dotc.core.Caches.{FilteringCache, SynchronizedMapCache}
+import dotty.tools.dotc.core.CacheStores.{CacheStore, DefaultCacheStore}
+import dotty.tools.io.AbstractFile
+
+object TestCacheStore extends CacheStore:
+  /** Use the default global classpath cache. */
+  val classPaths = DefaultCacheStore.classPaths
+
+  private val stdLibDir = "library/src"
+
+  /** Cache files across runs, without invalidation. */
+  val files = FilteringCache(SynchronizedMapCache(), _.startsWith((stdLibDir)))
+
+  /** Cache source files across runs, without invalidation.
+   *
+   *  We use a [[SynchronizedMapCache]] and not a [[FileBasedCache]] here
+   *  because we assume that source files in `library/src` do not change during
+   *  a test run.
+   */
+  val sources = FilteringCache(SynchronizedMapCache(), _.canonicalPath.startsWith(stdLibDir))

--- a/compiler/test/dotty/tools/TestCacheStore.scala
+++ b/compiler/test/dotty/tools/TestCacheStore.scala
@@ -8,6 +8,7 @@ object TestCacheStore extends CacheStore:
   /** Use the default global classpath cache. */
   val classPaths = DefaultCacheStore.classPaths
 
+  /** Standard library sources directory */
   private val stdLibDir = "library/src"
 
   /** Cache files across runs, without invalidation. */
@@ -20,3 +21,13 @@ object TestCacheStore extends CacheStore:
    *  a test run.
    */
   val sources = FilteringCache(SynchronizedMapCache(), _.canonicalPath.startsWith(stdLibDir))
+
+  /** Test output directory */
+  private val outDir = "out"
+
+  /** Cache class bytes across runs, except for classes in the `out` directory.
+   *
+   *  Classes in the `out` directory are generated during tests, so we do not
+   *  want to cache them.
+   */
+  val classBytes = FilteringCache(SynchronizedMapCache(), !_.canonicalPath.startsWith(outDir))

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -19,6 +19,7 @@ import TestSources.sources
 import reporting.TestReporter
 import vulpix._
 import dotty.tools.dotc.config.ScalaSettings
+import dotty.tools.dotc.core.CacheStores.DefaultCacheStore
 
 class CompilationTests {
   import ParallelTesting._
@@ -406,6 +407,7 @@ object CompilationTests extends ParallelTesting {
 
   implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def tearDown(): Unit = {
+    println(s"Cache statistics: $TestCacheStore")
     super.cleanup()
     summaryReport.echoSummary()
   }

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -63,6 +63,14 @@ trait ParallelTesting extends RunnerOrchestration:
 
   protected def testPlatform: TestPlatform = TestPlatform.JVM
 
+  private def setupTestContext(initCtx: FreshContext): FreshContext =
+    initCtx.setCacheStore(TestCacheStore)
+    initCtx
+
+  private class TestDriver extends Driver:
+    override protected def initCtx =
+      setupTestContext(super.initCtx.fresh)
+
   /** A test source whose files or directory of files is to be compiled
    *  in a specific way defined by the `Test`
    */
@@ -533,8 +541,8 @@ trait ParallelTesting extends RunnerOrchestration:
       val reporter = mkReporter
 
       val driver =
-        if (times == 1) new Driver
-        else new Driver {
+        if (times == 1) TestDriver()
+        else new TestDriver() {
           private def ntimes(n: Int)(op: Int => Reporter): Reporter =
             (1 to n).foldLeft(emptyReporter) ((_, i) => op(i))
 
@@ -686,7 +694,7 @@ trait ParallelTesting extends RunnerOrchestration:
       val classes = flattenFiles(targetDir).filter(isBestEffortTastyFile).map(_.toString)
       val flags = flags0 `and` "-from-tasty" `and` "-Ywith-best-effort-tasty"
       val reporter = mkReporter
-      val driver = new Driver
+      val driver = TestDriver()
 
       driver.process(flags.all ++ classes, reporter = reporter)
 
@@ -698,7 +706,7 @@ trait ParallelTesting extends RunnerOrchestration:
         .and("-Ywith-best-effort-tasty")
         .and("-d", targetDir.getPath)
       val reporter = mkReporter
-      val driver = new Driver
+      val driver = TestDriver()
 
       val args = Array("-classpath", flags.defaultClassPath + JFile.pathSeparator + bestEffortDir.toString) ++ flags.options
 
@@ -716,7 +724,7 @@ trait ParallelTesting extends RunnerOrchestration:
 
       val reporter = mkReporter
 
-      val driver = new Driver
+      val driver = TestDriver()
 
       driver.process(flags.all ++ classes, reporter = reporter)
 

--- a/tests/neg-macros/wrong-owner.check
+++ b/tests/neg-macros/wrong-owner.check
@@ -16,6 +16,7 @@
   |
   |Error:
   |assertion failed: bad owner; method toString has owner class String, expected was class Foo
-  |owner chain = method toString, class String, package java.lang, package java, package <root>, ctxOwners = class Foo, class Foo, package <empty>, package <empty>, package <empty>, package <root>, package <root>, package <root>, package <root>, package <root>, package <root>, package <root>, <none>, <none>, <none>, <none>, <none>
+  |owner chain = method toString, class String, package java.lang, package java, package <root>
+  |ctx owners = class Foo, package <empty>, package <root>
   |
   |stacktrace available when compiling with `-Ydebug`


### PR DESCRIPTION
The main goal of this PR is to enable caching of file contents across compiler runs. Importantly, this PR is careful _not_ to change any of the existing caching strategies (except for compilation tests). It only enables users of the compiler to customize them.

This PR follows a series of experiments (#24630, #24644, #24737, #24777) in which I tried caching at different levels.

This PR addresses the problem by introducing two new concepts:

* `CacheStore`: a configurable set of caches that can potentially be shared across runs. A `CacheStore` is associated with each context.
* `Cache`: the interface for individual caches, together with a collection of composable implementations: thread-safe and thread-unsafe variants; a file-based implementation that invalidates entries when files on disk change (refactored from the existing `FileBasedCache`); and a filter cache that allows caching only a subset of keys.

This PR deliberately sidesteps the question of how these caches should be used by other tools, such as Zinc. Addressing that will require further work on API boundaries. However, the proposed changes are self-contained and already allow speeding up compilation tests (by ~11% on my machine), as well as running benchmarks without measuring I/O, which was the initial motivation.

Commits:

* f539802: Refactoring only. Introduces `CacheStore`, which provides caches for classpaths, abstract files (by name), and source files. The default `DefaultCacheStore` preserves the current behavior: a singleton global cache for `ClassPath` instances, and no-op caches for files and sources (which are still cached per run via `ContextBase`).
* 8823120: Uses a custom `CacheStore` for compilation tests that caches `SourceFile` and `AbstractFile` instances across runs, avoiding repeated reads of the standard library from disk.
* f17e93b: Fixes the output of the `wrong-owner` test to list context owners instead of all outer contexts. This is needed because `ctx.fresh` adds an outer context that would otherwise introduce an extra `<none>`.
* 254b87c: Adds a cache in `CacheStore` for class file bytes. The default is to not cache them. The test cache is updated to cache class bytes globally.
* 8d322fa: Adds a cache in `CacheStore` for TASTy file bytes, analogous to the class-file cache.