### PR TITLE
Restore testing in the CI and fix `scala3-staging` build

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -221,6 +221,8 @@ jobs:
       - uses: sbt/setup-sbt@v1
       - name: Compile `scala3-staging`
         run: ./project/scripts/sbt scala3-staging-new/compile
+      - name: Test `scala3-staging`
+        run: ./project/scripts/sbt scala3-staging-new/test
 
   scala3-tasty-inspector:
     runs-on: ubuntu-latest

--- a/compiler/src/dotty/tools/dotc/util/ClasspathFromClassloader.scala
+++ b/compiler/src/dotty/tools/dotc/util/ClasspathFromClassloader.scala
@@ -9,6 +9,13 @@ import dotty.tools.io.AbstractFileClassLoader
 
 object ClasspathFromClassloader {
 
+  // Class name of the REPL classloader.
+  // We can't import AbstractFileClassLoader directly because the REPL module
+  // depends on compiler, not vice-versa. The class name comparison is required
+  // anyway because the REPL classloader class is normally loaded with a different
+  // classloader (see the comment below at the usage site).
+  private final val ReplAbstractFileClassLoaderName = "dotty.tools.repl.AbstractFileClassLoader"
+
   /** Attempt to recreate a classpath from a classloader.
    *
    *  BEWARE: with exotic enough classloaders, this may not work at all or do
@@ -29,7 +36,8 @@ object ClasspathFromClassloader {
             classpathBuff ++=
               cl.getURLs.iterator.map(url => Paths.get(url.toURI).toAbsolutePath.toString)
           case _ =>
-            if cl.getClass.getName == classOf[AbstractFileClassLoader].getName then
+            if cl.getClass.getName == ReplAbstractFileClassLoaderName ||
+               cl.getClass.getName == classOf[AbstractFileClassLoader].getName then
               // HACK: We can't just collect the classpath from arbitrary parent
               // classloaders since the current classloader might intentionally
               // filter loading classes from its parent (for example

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -52,31 +52,31 @@ object Properties {
   val testsSafeMode: Boolean = sys.props.isDefinedAt("dotty.tests.safemode")
 
   /** Extra directory containing sources for the compiler */
-  def dottyCompilerManagedSources: Path = Paths.get(sys.props("dotty.tests.dottyCompilerManagedSources"))
+  def dottyCompilerManagedSources: Path = Paths.get(requireNonEmptyProperty("dotty.tests.dottyCompilerManagedSources"))
 
   /** dotty-interfaces jar */
-  def dottyInterfaces: String = sys.props("dotty.tests.classes.dottyInterfaces")
+  def dottyInterfaces: String = requireNonEmptyProperty("dotty.tests.classes.dottyInterfaces")
 
   /** dotty-compiler jar */
-  def dottyCompiler: String = sys.props("dotty.tests.classes.dottyCompiler")
+  def dottyCompiler: String = requireNonEmptyProperty("dotty.tests.classes.dottyCompiler")
 
   /** dotty-repl jar */
-  def dottyRepl: String = sys.props("dotty.tests.classes.dottyRepl")
+  def dottyRepl: String = requireNonEmptyProperty("dotty.tests.classes.dottyRepl")
 
   /** dotty-staging jar */
-  def dottyStaging: String = sys.props("dotty.tests.classes.dottyStaging")
+  def dottyStaging: String = requireNonEmptyProperty("dotty.tests.classes.dottyStaging")
 
   /** dotty-tasty-inspector jar */
-  def dottyTastyInspector: String = sys.props("dotty.tests.classes.dottyTastyInspector")
+  def dottyTastyInspector: String = requireNonEmptyProperty("dotty.tests.classes.dottyTastyInspector")
 
   /** tasty-core jar */
-  def tastyCore: String = sys.props("dotty.tests.classes.tastyCore")
+  def tastyCore: String = requireNonEmptyProperty("dotty.tests.classes.tastyCore")
 
   /** compiler-interface jar */
-  def compilerInterface: String = sys.props("dotty.tests.classes.compilerInterface")
+  def compilerInterface: String = requireNonEmptyProperty("dotty.tests.classes.compilerInterface")
 
   /** scala-library jar */
-  def scalaLibrary: String = sys.props("dotty.tests.classes.scalaLibrary")
+  def scalaLibrary: String = requireNonEmptyProperty("dotty.tests.classes.scalaLibrary")
 
   // TODO: Remove this once we migrate the test suite
   def usingScalaLibraryCCTasty: Boolean = true
@@ -85,20 +85,27 @@ object Properties {
   def usingScalaLibraryTasty: Boolean = true
 
   /** scala-asm jar */
-  def scalaAsm: String = sys.props("dotty.tests.classes.scalaAsm")
+  def scalaAsm: String = requireNonEmptyProperty("dotty.tests.classes.scalaAsm")
 
   /** jline-terminal jar */
-  def jlineTerminal: String = sys.props("dotty.tests.classes.jlineTerminal")
+  def jlineTerminal: String = requireNonEmptyProperty("dotty.tests.classes.jlineTerminal")
 
   /** jline-reader jar */
-  def jlineReader: String = sys.props("dotty.tests.classes.jlineReader")
+  def jlineReader: String = requireNonEmptyProperty("dotty.tests.classes.jlineReader")
 
   /** scalajs-javalib jar */
-  def scalaJSJavalib: String = sys.props("dotty.tests.classes.scalaJSJavalib")
+  def scalaJSJavalib: String = requireNonEmptyProperty("dotty.tests.classes.scalaJSJavalib")
 
   /** scalajs-scalalib jar */
-  def scalaJSScalalib: String = sys.props("dotty.tests.classes.scalaJSScalalib")
+  def scalaJSScalalib: String = requireNonEmptyProperty("dotty.tests.classes.scalaJSScalalib")
 
   /** scalajs-library jar */
-  def scalaJSLibrary: String = sys.props("dotty.tests.classes.scalaJSLibrary")
+  def scalaJSLibrary: String = requireNonEmptyProperty("dotty.tests.classes.scalaJSLibrary")
+
+  private def requireNonEmptyProperty(name: String): String = {
+    sys.props(name).ensuring(
+      value => value != null && value.nonEmpty,
+      s"Property $name is not set"
+    )
+  }
 }


### PR DESCRIPTION
Fixes #24799  

`scala3-staging` was not tested, at least not since scala3-repl seperation, it actually is currently broken when using from REPL: 

WIP - blocked by classpath issues 
A REPL-staging test currently fails, I believe it's the same underlying issue as with REPL classpath separation and might require a larger refactor 

```diff
[info] Test scala.quoted.staging.repl.StagingScriptedReplTests.replStagingTests started
  scala> import scala.quoted._
  scala> import quoted.staging.{Compiler => StagingCompiler, _}
  scala> implicit def compiler: StagingCompiler = StagingCompiler.make(getClass.getClassLoader)
  def compiler: scala.quoted.staging.Compiler
  scala> def v(using Quotes) = '{ (if true then Some(1) else None).map(v => v+1) }
  def v(using x$1: scala.quoted.Quotes): scala.quoted.Expr[Option[Int]]
  scala> scala.quoted.staging.withQuotes(v.show)
  val res0: String = "(if (true) scala.Some.apply[scala.Int](1) else scala.None).map[scala.Int](((v: scala.Int) => v.+(1)))"
  scala> scala.quoted.staging.run(v)
+ java.lang.IncompatibleClassChangeError: Class Generated$Code$From$Quoted$$Lambda/0x0000000800a50208 does not implement the requested interface scala.Function1
+   at scala.Option.map(Option.scala:244)
+   at Generated$Code$From$Quoted.apply(<quoted.Expr>:1)
+   at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
+   at java.lang.reflect.Method.invoke(Method.java:580)
+   at scala.quoted.staging.QuoteDriver.run(QuoteDriver.scala:70)
+   at scala.quoted.staging.Compiler$$anon$1.run(Compiler.scala:50)
+   at scala.quoted.staging.package$.run(staging.scala:19)
+   ... 75 elided
- val res1: Option[Int] = Some(2)
```