### PR TITLE
deprecate `scala.annotation.strictfp`

### DIFF
--- a/library/src/scala/annotation/strictfp.scala
+++ b/library/src/scala/annotation/strictfp.scala
@@ -18,5 +18,5 @@ import scala.language.`2.13`
  *  the strictfp flag will be emitted.
  */
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
-@deprecated("as of release JDK 17, all floating-point expressions are evaluated strictly and 'strictfp' is not required", "3.8.0")
+@deprecated("As of JDK 17, all floating-point expressions are evaluated strictly and 'strictfp' is not required", "3.8.0")
 class strictfp extends scala.annotation.StaticAnnotation

--- a/library/src/scala/annotation/strictfp.scala
+++ b/library/src/scala/annotation/strictfp.scala
@@ -18,4 +18,5 @@ import scala.language.`2.13`
  *  the strictfp flag will be emitted.
  */
 @deprecatedInheritance("Scheduled for being final in the future", "2.13.0")
+@deprecated("as of release JDK 17, all floating-point expressions are evaluated strictly and 'strictfp' is not required", "3.8.0")
 class strictfp extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
https://openjdk.org/jeps/306

```
$ cat A.java
public class A {
  strictfp double foo() {
    return 1.2;
  }
}
$ java --version
openjdk 17.0.17 2025-10-21 LTS
OpenJDK Runtime Environment Corretto-17.0.17.10.1 (build 17.0.17+10-LTS)
OpenJDK 64-Bit Server VM Corretto-17.0.17.10.1 (build 17.0.17+10-LTS, mixed mode, sharing)
$ javac A.java
A.java:2: warning: [strictfp] as of release 17, all floating-point expressions are evaluated strictly and 'strictfp' is not required
  strictfp double foo() {
                  ^
1 warning
```