### PR TITLE
Add CanEqual instance for NamedTuple

### DIFF
--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -3,6 +3,7 @@ import compiletime.ops.boolean.*
 import collection.immutable.{SeqMap, ListMap}
 
 import language.experimental.captureChecking
+import scala.annotation.experimental
 
 object NamedTuple:
 
@@ -15,6 +16,16 @@ object NamedTuple:
 
   /** A type which is a supertype of all named tuples. */
   opaque type AnyNamedTuple = Any
+
+  // This formulation fixes the name types, following the standard established in this file.
+  // Alternatively you could require additional evidence and compare `N1` and `N2` types.
+  // However if this is explored, you must not use `CanEqual[N1, N2]` because `CanEqual`
+  // for Strings widens singletons.
+  // Comparing different name types with `=:=` could also be possible.
+  @experimental
+  given namedTupleCanEqual: [N <: Tuple, V1 <: Tuple, V2 <: Tuple]
+    => (eq: CanEqual[V1, V2])
+    => CanEqual[NamedTuple[N, V1], NamedTuple[N, V2]] = CanEqual.derived
 
   def apply[N <: Tuple, V <: Tuple](x: V): NamedTuple[N, V] = x
 

--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -4,6 +4,7 @@ import collection.immutable.{SeqMap, ListMap}
 
 import language.experimental.captureChecking
 import scala.annotation.experimental
+import scala.annotation.unused
 
 object NamedTuple:
 
@@ -17,15 +18,13 @@ object NamedTuple:
   /** A type which is a supertype of all named tuples. */
   opaque type AnyNamedTuple = Any
 
-  // This formulation fixes the name types, following the standard established in this file.
-  // Alternatively you could require additional evidence and compare `N1` and `N2` types.
-  // However if this is explored, you must not use `CanEqual[N1, N2]` because `CanEqual`
-  // for Strings widens singletons.
-  // Comparing different name types with `=:=` could also be possible.
+  // Alternatively we could restrict `N` to be identical on both sides, but this provides less
+  // useful error messages
   @experimental
-  given namedTupleCanEqual: [N <: Tuple, V1 <: Tuple, V2 <: Tuple]
-    => (eq: CanEqual[V1, V2])
-    => CanEqual[NamedTuple[N, V1], NamedTuple[N, V2]] = CanEqual.derived
+  given namedTupleCanEqual: [N1 <: Tuple, N2 <: Tuple, V1 <: Tuple, V2 <: Tuple]
+    => (@unused eqN: N1 =:= N2)
+    => (@unused eqV: CanEqual[V1, V2])
+    => CanEqual[NamedTuple[N1, V1], NamedTuple[N2, V2]] = CanEqual.derived
 
   def apply[N <: Tuple, V <: Tuple](x: V): NamedTuple[N, V] = x
 

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -16,7 +16,9 @@ object MiMaFilters {
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.iterateUntilEmpty$extension"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.scala$collection$ArrayOps$$elemTag$extension"),
         ProblemFilters.exclude[MissingFieldProblem]("scala.language#experimental.safe"),
-        ProblemFilters.exclude[MissingClassProblem]("scala.language$experimental$safe$")
+        ProblemFilters.exclude[MissingClassProblem]("scala.language$experimental$safe$"),
+        // new feature: CanEqual support for NamedTuple
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.NamedTuple.namedTupleCanEqual"),
     ))
 
     val BackwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(

--- a/tests/neg/named-tuples-strictEquality.check
+++ b/tests/neg/named-tuples-strictEquality.check
@@ -1,0 +1,18 @@
+-- [E172] Type Error: tests/neg/named-tuples-strictEquality.scala:9:20 -------------------------------------------------
+9 |  val b2: Boolean = u == v // error
+  |                    ^^^^^^
+  |Values of types (name : String, age : Int) and (name : String, birthYear : Int) cannot be compared with == or !=.
+  |I found:
+  |
+  |    NamedTuple.namedTupleCanEqual[N, V1, V2]
+  |
+  |But given instance namedTupleCanEqual in object NamedTuple does not match type CanEqual[(name : String, age : Int), (name : String, birthYear : Int)].
+-- [E172] Type Error: tests/neg/named-tuples-strictEquality.scala:15:11 ------------------------------------------------
+15 |      case ScalaBook => true // error
+   |           ^^^^^^^^^
+   |Values of types (name : String, published : Int) and (name : String, age : Int) cannot be compared with == or !=.
+   |I found:
+   |
+   |    NamedTuple.namedTupleCanEqual[N, V1, V2]
+   |
+   |But given instance namedTupleCanEqual in object NamedTuple does not match type CanEqual[(name : String, published : Int), (name : String, age : Int)].

--- a/tests/neg/named-tuples-strictEquality.check
+++ b/tests/neg/named-tuples-strictEquality.check
@@ -4,15 +4,17 @@
   |Values of types (name : String, age : Int) and (name : String, birthYear : Int) cannot be compared with == or !=.
   |I found:
   |
-  |    NamedTuple.namedTupleCanEqual[N, V1, V2]
+  |    NamedTuple.namedTupleCanEqual[(("name" : String), ("age" : String)), (("name" : String), ("birthYear" : String)), V1, V2
+  |      ](/* missing */summon[(("name" : String), ("age" : String)) =:= (("name" : String), ("birthYear" : String))])
   |
-  |But given instance namedTupleCanEqual in object NamedTuple does not match type CanEqual[(name : String, age : Int), (name : String, birthYear : Int)].
+  |But no implicit values were found that match type (("name" : String), ("age" : String)) =:= (("name" : String), ("birthYear" : String)).
 -- [E172] Type Error: tests/neg/named-tuples-strictEquality.scala:15:11 ------------------------------------------------
 15 |      case ScalaBook => true // error
    |           ^^^^^^^^^
    |Values of types (name : String, published : Int) and (name : String, age : Int) cannot be compared with == or !=.
    |I found:
    |
-   |    NamedTuple.namedTupleCanEqual[N, V1, V2]
+   |    NamedTuple.namedTupleCanEqual[(("name" : String), ("published" : String)), (("name" : String), ("age" : String)), V1, V2
+   |      ](/* missing */summon[(("name" : String), ("published" : String)) =:= (("name" : String), ("age" : String))])
    |
-   |But given instance namedTupleCanEqual in object NamedTuple does not match type CanEqual[(name : String, published : Int), (name : String, age : Int)].
+   |But no implicit values were found that match type (("name" : String), ("published" : String)) =:= (("name" : String), ("age" : String)).

--- a/tests/neg/named-tuples-strictEquality.scala
+++ b/tests/neg/named-tuples-strictEquality.scala
@@ -1,0 +1,17 @@
+//> using options -language:strictEquality
+
+object Test:
+
+  val u: (name: String, age: Int) = (name = "Bob", age = 25)
+  val v: (name: String, birthYear: Int) = (name = "Charlie", birthYear = 1990)
+
+  val b1: Boolean = u.toTuple == v.toTuple // ok
+  val b2: Boolean = u == v // error
+
+  val ScalaBook = (name = "Programming in Scala, 5th edition", published = 2021)
+
+  def hasScalaBook(books: IterableOnce[(name: String, age: Int)]): Boolean =
+    books.exists {
+      case ScalaBook => true // error
+      case _         => false
+    }

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -105,6 +105,9 @@ val experimentalDefinitionInLibrary = Set(
 
   // New feature: Erased trait
   "scala.compiletime.Erased",
+
+  // New API: Multiversal equality for Named Tuples
+  "scala.NamedTuple$.namedTupleCanEqual",
 )
 
 

--- a/tests/run/named-tuples-strictEquality.scala
+++ b/tests/run/named-tuples-strictEquality.scala
@@ -1,0 +1,24 @@
+//> using options -language:strictEquality
+
+@main def Test =
+
+  val u: (name: String, age: Int) = (name = "Bob", age = 25)
+  val v: (name: String, birthYear: Int) = (name = "Charlie", birthYear = 1990)
+
+  val ScalaBook = (name = "Programming in Scala, 5th edition", published = 2021)
+  val books = Map(
+    ScalaBook,
+    (name = "Hands on Scala, 2nd edition", published = 2026),
+  )
+
+  assert(u.toTuple != v.toTuple)
+  assert(u == u)
+  assert(v == v)
+
+  def hasScalaBook(books: IterableOnce[(name: String, published: Int)]): Boolean =
+    books.exists {
+      case ScalaBook => true
+      case _         => false
+    }
+
+  assert(hasScalaBook(books))


### PR DESCRIPTION
Require same type for names. A possible other formulation could compare name types with `=:=` evidence, but this only benefits error messages with an explicit summon for CanEqual, and users would likely identify that the name fields dont match anyway.