### PR TITLE
Allow constraints be inferred when gadt bounds are exact

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -579,7 +579,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       case info2: TypeBounds =>
         def compareGADT: Boolean =
           tp2.symbol.onGadtBounds(gbounds2 =>
-            isSubTypeWhenFrozen(tp1, gbounds2.lo)
+            isSubType(tp1, gbounds2.lo, whenFrozen = gbounds2.lo ne gbounds2.hi)
             || tp1.match
                 case tp1: NamedType if ctx.gadt.contains(tp1.symbol) =>
                   // Note: since we approximate constrained types only with their non-param bounds,
@@ -964,7 +964,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           case info1 @ TypeBounds(lo1, hi1) =>
             def compareGADT =
               tp1.symbol.onGadtBounds(gbounds1 =>
-                isSubTypeWhenFrozen(gbounds1.hi, tp2)
+                isSubType(gbounds1.hi, tp2, whenFrozen = gbounds1.lo ne gbounds1.hi)
                 || narrowGADTBounds(tp1, tp2, approx, isUpper = true))
               && (tp2.isAny || GADTusage(tp1.symbol))
 

--- a/tests/pos/i23925.scala
+++ b/tests/pos/i23925.scala
@@ -1,0 +1,12 @@
+object test {
+  sealed trait A[T] 
+  case class O[T](e: A[T]) extends A[Option[T]]
+
+  def opt[U](v: Option[U], a: A[U]) = ???
+
+  def f[T](a: A[T], t: T) = {
+    a match {
+      case O(i) => opt(t, i)
+    }
+  }
+}


### PR DESCRIPTION
fixes #23925

In the new test case if the arguments to `def opt[U](v: Option[U], a: A[U]) = ???` is switched then the code compiles  fine. So to me that makes it seems like it it is okay to infer bounds based on the gadt bounds.  The patch relaxes when bounds are frozen when using gadt bounds to make the code from the ticket compile. Only relaxing when the bounds are tight was to be conservative with the change.

I don't understand the TypeComparer logic enough to be confident that the change is correct. After not finding anything useful in the git history on why the bounds should be frozen, I hoped CI would have showed me with a failing test. But it seems CI is happy with the change.