### PR TITLE
Fix "Since 3.8.0-RC1, inline match with inlined values sometimes does not compile as it erases values that it accesses"

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -175,9 +175,11 @@ class InlineReducer(inliner: Inliner)(using Context):
 
     val unusable: util.EqHashSet[Symbol] = util.EqHashSet()
 
-    // Check if a symbol is truly erased (not just a macro which happens to have the Erased flag).
-    // Macros like StringContext.s are marked Erased but are not truly erased values.
-    // See issue #24588.
+    /** Check if a symbol is truly erased.
+     *  Scala 2-based macro declarations like StringContext.s are marked Erased & Macro to reuse
+     *  flag bits (isScala2MacroInScala3 in SymDenotations) but are not truly erased values.
+     *  See issue #24588.
+     */
     def isTrulyErased(sym: Symbol): Boolean =
       sym.isErased && !sym.is(Macro)
 

--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -175,13 +175,19 @@ class InlineReducer(inliner: Inliner)(using Context):
 
     val unusable: util.EqHashSet[Symbol] = util.EqHashSet()
 
+    // Check if a symbol is truly erased (not just a macro which happens to have the Erased flag).
+    // Macros like StringContext.s are marked Erased but are not truly erased values.
+    // See issue #24588.
+    def isTrulyErased(sym: Symbol): Boolean =
+      sym.isErased && !sym.is(Macro)
+
     /** Adjust internaly generated value definitions;
      *   - If the RHS refers to an erased symbol, mark the val as erased
      *   - If the RHS refers to an unusable symbol, mark the val as unusable
      */
     def adjustErased(sym: TermSymbol, rhs: Tree): Unit =
       rhs.foreachSubTree:
-        case id: Ident if id.symbol.isErased =>
+        case id: Ident if isTrulyErased(id.symbol) =>
           sym.setFlag(Erased)
           if unusable.contains(id.symbol) then unusable += sym
         case _ =>
@@ -371,7 +377,7 @@ class InlineReducer(inliner: Inliner)(using Context):
         // to unusable symbols.
         // Note that compiletime.erasedValue is treated as erased but not pure, so scrutinees
         // containing references to it becomes unusable.
-        if scrutinee.existsSubTree(_.symbol.isErased) then
+        if scrutinee.existsSubTree(t => isTrulyErased(t.symbol)) then
           scrutineeSym.setFlag(Erased)
           if !tpd.isPureExpr(scrutinee) then unusable += scrutineeSym
         val binding = normalizeBinding(ValDef(scrutineeSym, scrutinee))

--- a/tests/pos/i24588.scala
+++ b/tests/pos/i24588.scala
@@ -1,0 +1,87 @@
+// Test for issue #24588: Inline match with string interpolation
+// The compiler incorrectly marked matched values as erased when using string interpolation
+// because StringContext.s is a macro marked with the Erased flag.
+
+object Test:
+  // Basic inline match with union type
+  inline def dispatch(inline v: Long | String): Unit =
+    inline v match
+      case str: String => printString(str)
+      case long: Long  => printLong(long)
+
+  def printString(s: String) = println(s)
+  def printLong(l: Long) = println(l)
+
+  // Test with regular strings (always worked)
+  def testRegularStrings(): Unit =
+    dispatch("hello")
+    dispatch(System.nanoTime().toString)
+
+  // Test with string interpolation (was broken)
+  def testStringInterpolation(): Unit =
+    dispatch(s"hello")
+    dispatch(s"${System.nanoTime()}")
+    dispatch(s"${System.nanoTime().toString}")
+    dispatch(s"time: ${System.nanoTime()}")
+    dispatch(s"${"nested"}")
+
+  // Test with f-interpolator
+  def testFInterpolation(): Unit =
+    dispatch(f"${3.14}%.2f")
+    dispatch(f"${42}%d")
+
+  // Test with raw interpolator
+  def testRawInterpolation(): Unit =
+    dispatch(raw"hello\nworld")
+
+  // More complex inline match
+  inline def complexDispatch(inline v: Int | Long | String | Double): String =
+    inline v match
+      case i: Int    => s"int: $i"
+      case l: Long   => s"long: $l"
+      case s: String => s"string: $s"
+      case d: Double => s"double: $d"
+
+  def testComplexDispatch(): Unit =
+    val r1: String = complexDispatch(42)
+    val r2: String = complexDispatch(42L)
+    val r3: String = complexDispatch("hello")
+    val r4: String = complexDispatch(3.14)
+    val r5: String = complexDispatch(s"interpolated")
+    val r6: String = complexDispatch(s"${System.nanoTime()}")
+
+  // Inline match returning the matched value
+  inline def identity(inline v: Long | String): Long | String =
+    inline v match
+      case str: String => str
+      case long: Long  => long
+
+  def testIdentity(): Unit =
+    val s1: Long | String = identity("hello")
+    val s2: Long | String = identity(s"interpolated")
+    val s3: Long | String = identity(s"${System.nanoTime()}")
+    val l1: Long | String = identity(42L)
+
+  // Nested inline matches
+  inline def nestedDispatch(inline v: Long | String): String =
+    inline v match
+      case str: String =>
+        inline str.length match
+          case 0 => "empty"
+          case _ => s"non-empty: $str"
+      case long: Long => s"long: $long"
+
+  def testNestedDispatch(): Unit =
+    val r1 = nestedDispatch("")
+    val r2 = nestedDispatch("hello")
+    val r3 = nestedDispatch(s"interpolated")
+    val r4 = nestedDispatch(42L)
+
+  def main(args: Array[String]): Unit =
+    testRegularStrings()
+    testStringInterpolation()
+    testFInterpolation()
+    testRawInterpolation()
+    testComplexDispatch()
+    testIdentity()
+    testNestedDispatch()


### PR DESCRIPTION
Attempts to fix https://github.com/scala/scala3/issues/24588, vibe coded

From claude
> Problem: Inline match with string interpolation failed because StringContext.s (and other interpolators) are macros marked with the Erased flag. The code checking for erased values in inline match scrutinees incorrectly treated macro calls as erased values.
>
> Root Cause: Commit 7f9b4beaa0 changed the check from specifically looking for compiletime.erasedValue to a general _.symbol.isErased check. This broader check caught macros which have the Erased flag but are not truly erased values.
>
> Fix: Added a helper function isTrulyErased that excludes macros:
> def isTrulyErased(sym: Symbol): Boolean =
>   sym.isErased && !sym.is(Macro)
>
> Files Changed:
> - compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala - Added isTrulyErased check
> - tests/pos/i24588.scala - Comprehensive test cases
>
> Verified:
> - New test i24588.scala passes (was failing before)
> - Existing test i23406.scala still correctly reports errors for compiletime.erasedValue usage
> - Bootstrapped compiler compiles successfully
>