### PR TITLE
Fix ""missing outer accessor" if the source file name is alphabetically is before O1.scala"

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -515,8 +515,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     ref(NamedType(simplifyThisTypePrefix(sym.owner.thisType), sym.name, sym.denot))
 
   private def followOuterLinks(t: Tree)(using Context) = t match {
-    case t: This if ctx.erasedTypes && !(t.symbol == ctx.owner.enclosingClass || t.symbol.isStaticOwner) =>
+    case t: This if ctx.erasedTypes && !(t.symbol == ctx.owner.enclosingClass || t.symbol.isStatic) =>
       // after erasure outer paths should be respected
+      // Use isStatic instead of isStaticOwner because a package-level class/trait
+      // (which is static but not a static owner) doesn't need an outer accessor
       ExplicitOuter.OuterOps(ctx).path(toCls = t.tpe.classSymbol)
     case t =>
       t

--- a/tests/pos/i24936/A1.scala
+++ b/tests/pos/i24936/A1.scala
@@ -1,0 +1,39 @@
+// Test for issue #24936: Compiler crash based on file name ordering
+// The crash occurred when a trait with a self-type referring to an object
+// was compiled before the object, due to incorrect outer accessor path computation.
+
+package example
+
+// Original failing case: trait with self-type to O1
+trait A1 { self: O1.type =>
+  import O2.someKey
+  def taskImpl: Unit = println(someKey)
+}
+
+// Test case: accessing nested object member directly
+trait A2 { self: O1.type =>
+  def accessNested: Int = O2.someKey
+}
+
+// Test case: accessing nested object method
+trait A3 { self: O1.type =>
+  def callNested: String = O2.getInfo
+}
+
+// Test case: multiple levels of nesting
+trait A4 { self: O1.type =>
+  def deepAccess: Boolean = O2.Nested.flag
+}
+
+// Test case: using type from nested object
+trait A5 { self: O1.type =>
+  def useType: O2.MyType = O2.myValue
+}
+
+// Test case: pattern matching on nested object
+trait A6 { self: O1.type =>
+  def patternMatch(x: Int): String = x match {
+    case O2.someKey => "matched"
+    case _ => "not matched"
+  }
+}

--- a/tests/pos/i24936/B1.scala
+++ b/tests/pos/i24936/B1.scala
@@ -1,0 +1,27 @@
+// Additional test cases for issue #24936
+
+package example2
+
+// Test case: abstract class with self-type
+abstract class B1 { self: P1.type =>
+  import Inner.value
+  def getValue: Int = value
+}
+
+// Test case: class referencing sibling object through self-type
+trait B2 { self: P1.type =>
+  def siblingAccess: String = P2.name
+}
+
+// Test case: generic trait with self-type
+trait B3[T] { self: P1.type =>
+  def genericAccess: T = Inner.genericValue.asInstanceOf[T]
+}
+
+object P1 extends B1 with B2 with B3[Int]:
+  object Inner:
+    val value: Int = 100
+    val genericValue: Any = 42
+
+object P2:
+  val name: String = "P2"

--- a/tests/pos/i24936/O1.scala
+++ b/tests/pos/i24936/O1.scala
@@ -1,0 +1,13 @@
+package example
+
+object O1 extends A1 with A2 with A3 with A4 with A5 with A6:
+  object O2:
+    val someKey: Int = 42
+    def getInfo: String = "info"
+
+    object Nested:
+      val flag: Boolean = true
+
+    type MyType = String
+    val myValue: MyType = "value"
+end O1


### PR DESCRIPTION
Attempts to fix https://github.com/scala/scala3/issues/24936. Largely vibe-coded

Claude's explanation of the attempted fix

>  Problem: The compiler crashed with assertion failed: missing outer accessor in package <root> when source files were compiled in a specific alphabetical order. This happened when a trait with a self-type referring to an object was compiled before the object.
>
>  Root Cause: In tpd.followOuterLinks (line 517-523), the condition used t.symbol.isStaticOwner to determine whether to compute an outer accessor path. However, isStaticOwner only returns true for module classes (objects) that are packages or are themselves static.
>
>  For a package-level trait:
>  - trait A1.isStaticOwner = false (traits are not module classes)
>  - trait A1.isStatic = true (its owner is a package, which is a static owner)
>
>  This meant the compiler incorrectly tried to compute an outer path from <root> to A1, which failed.
>
>  Fix: Changed t.symbol.isStaticOwner to t.symbol.isStatic in followOuterLinks:
>
>  // Before:
>  case t: This if ctx.erasedTypes && !(t.symbol == ctx.owner.enclosingClass || t.symbol.isStaticOwner) =>
>
>  // After:  
>  case t: This if ctx.erasedTypes && !(t.symbol == ctx.owner.enclosingClass || t.symbol.isStatic) =>
>
>  Test Cases Added: (tests/pos/i24936/)
>  - Original failing case: trait with self-type accessing nested object via import
>  - Direct access to nested object members
>  - Method calls on nested object
>  - Multiple levels of nesting
>  - Using types from nested objects
>  - Pattern matching on nested object values
>  - Abstract class with self-type
>  - Generic trait with self-type
>
>> why does the order of compilation matter? 
>
>● That's a great question. Looking at the debug output more carefully:
>
>  DEBUG followOuterLinks: t.symbol=trait A1, ctx.owner.enclosingClass=module class <root>, t.symbol.isStaticOwner=false
>
>  The key observation is that ctx.owner.enclosingClass is <root> (the root package), not A1. This is unusual - when generating code for trait A1's method body, you'd expect the enclosing class to be A1 itself.
>
>  I believe the order matters because of how the backend processes compilation units:
>
>  1. Compilation units are processed in file order - when files are listed alphabetically, A1.scala is processed before O1.scala
>  2. Context setup during code generation - when the backend generates code for a class, it sets up a context. The issue seems to be that when A1's unit is processed first (before O1), something about the context inheritance or setup results in ctx.owner.enclosingClass being <root> instead of A1
>  3. The check condition - the condition in followOuterLinks was:
>  t.symbol == ctx.owner.enclosingClass || t.symbol.isStaticOwner
>    - A1 == <root> → false
>    - A1.isStaticOwner → false (traits aren't module classes)
>    - So it tried to compute an outer path from <root> to A1, which fails
>
>  When O1.scala is processed first (because it's alphabetically after A1 with names like P1.scala), the context setup may differ, possibly because O1's processing somehow establishes a different owner chain.
>
>  The fix using isStatic is order-independent because it correctly identifies that A1 is at a static level (its owner is a package) regardless of how the context is set up during backend processing. This is the more fundamental property we should check - whether the class needs an outer accessor, not whether the current context happens to be set up correctly.
>
>