### PR TITLE
Fix "Spurious shadowing warning with -Wshadow:type-parameter-shadow"

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
@@ -277,7 +277,9 @@ object CheckShadowing:
       /** Looks after any type import symbol in the given import that matches this symbol */
       private def isAnImportedType(imp: tpd.Import)(using Context): Option[Symbol] =
         val tpd.Import(qual, sels) = imp
-        val simpleSelections = qual.tpe.member(sym.name).alternatives
+        // Only look up sym.name on qualifier if there's a wildcard import
+        val hasWildcard = sels.exists(_.isWildcard)
+        val simpleSelections = if hasWildcard then qual.tpe.member(sym.name).alternatives else Nil
         val typeSelections = sels.flatMap(n => qual.tpe.member(n.name.toTypeName).alternatives)
         sels
           .find(is => is.rename.toSimpleName == sym.name.toSimpleName).map(_.symbol)

--- a/tests/warn/i24582.scala
+++ b/tests/warn/i24582.scala
@@ -1,0 +1,40 @@
+// Test for issue #24582: Spurious shadowing warning for type parameters
+//> using options -Wshadow:type-parameter-shadow
+
+import scala.compiletime.ops.int.+
+
+// Should NOT warn - only + was imported, not S
+type Foo[S] = S
+
+// Various test cases for import shadowing behavior
+object TestImportShadowing:
+  object MyModule:
+    type A = Int
+    type B = String
+    val x = 1
+
+  // Should NOT warn - specific import of A only
+  import MyModule.A
+  type Test1[B] = B
+
+  // Should warn - A was explicitly imported and is being shadowed
+  type Test2[A] = A // warn
+
+  object WildcardTest:
+    import MyModule.*
+    // Should warn - wildcard import brings in B
+    type Test3[B] = B // warn
+
+  object RenamedTest:
+    import MyModule.{A => RenamedA}
+    // Should NOT warn - A is imported but renamed to RenamedA
+    type Test4[A] = A
+
+  object MultipleSelectorTest:
+    import MyModule.{A, x}
+    // Should warn - A was explicitly imported
+    type Test5[A] = A // warn
+    // Should NOT warn - B was not imported
+    type Test6[B] = B
+
+end TestImportShadowing

--- a/tests/warn/i24582.scala
+++ b/tests/warn/i24582.scala
@@ -37,4 +37,9 @@ object TestImportShadowing:
     // Should NOT warn - B was not imported
     type Test6[B] = B
 
+  object WildcardAndDiscardTest:
+    import MyModule.{A => _, *}
+    // Should NOT warn - A was explicitly discarded
+    type Test[A] = A
+
 end TestImportShadowing

--- a/tests/warn/i24582.scala
+++ b/tests/warn/i24582.scala
@@ -37,6 +37,11 @@ object TestImportShadowing:
     // Should NOT warn - B was not imported
     type Test6[B] = B
 
+  object WildcardGivenTest:
+    import MyModule.given
+    // Should NOT warn - no types imported
+    type Test[A] = A
+
   object WildcardAndDiscardTest:
     import MyModule.{A => _, *}
     // Should NOT warn - A was explicitly discarded


### PR DESCRIPTION
Attempts to fix https://github.com/scala/scala3/issues/24582. One-shot vibe coded

>  Root Cause: In CheckShadowing.scala, the isAnImportedType method had a bug at line 280:
>
>  val simpleSelections = qual.tpe.member(sym.name).alternatives
>
>  This looked up the type parameter's name (S) directly on the import qualifier (scala.compiletime.ops.int) regardless of what was actually imported. Even when only + was imported (import int.+), it would still find S in the int object and report it as shadowed.
>
>  Fix: Only perform this lookup when there's a wildcard import:
>
>  val hasWildcard = sels.exists(_.isWildcard)
>  val simpleSelections = if hasWildcard then qual.tpe.member(sym.name).alternatives else Nil
>
>  Test cases verify:
>  1. Specific import (import int.+) does NOT warn for unrelated type params - fixed
>  2. Wildcard import (import MyModule.*) DOES warn - still works
>  3. Explicit type import (import MyModule.A) DOES warn - still works
>  4. Renamed import (import MyModule.{A => RenamedA}) does NOT warn for original name - still works
>  5. Multiple selectors work correctly - still works