### PR TITLE
Support pattern match exhaustivity checks for quoted patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
@@ -302,6 +302,8 @@ object QuotePatterns:
         if (sel.symbol == defn.QuoteUnpickler_unpickleExprV2) sel.getAttachment(transform.PickleQuotes.OriginalTree).get
         else shape
       case List(Apply(Apply(Select(TypeApply(_, _), apply),List(shape)),_)) => shape
+      case List(TypeApply(Select(Apply(_, List(Apply(_,List(shape)))), _),_)) => shape
+      case List(shape @ Ident(_)) => shape
     fun match
       // <quotes>.asInstanceOf[QuoteMatching].{ExprMatch,TypeMatch}.unapply[<typeBindings>, <resTypes>]
       case TypeApply(Select(Select(TypeApply(Select(quotes, _), _), _), _), typeBindings :: resTypes :: Nil) =>
@@ -335,8 +337,6 @@ object QuotePatterns:
               if shapeBinding.hasAnnotation(defn.QuotedRuntimePatterns_fromAboveAnnot) then
                 binding.symbol.addAnnotation(defn.QuotedRuntimePatterns_fromAboveAnnot)
             val body1 = if stats.isEmpty then expr else cpy.Block(block)(stats, expr)
-            println("shapeBindingSyms " + shapeBindingSyms)
-            println("bindings.map(_.symbol) " + bindings.map(_.symbol))
             body1.subst(shapeBindingSyms, bindings.map(_.symbol))
           case body => body
         cpy.QuotePattern(tree)(bindings, body, quotes)

--- a/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
@@ -299,11 +299,20 @@ object QuotePatterns:
     val shape = (implicits: @unchecked) match
       case Apply(Select(Quote(shape, _), _), _) :: Nil => shape
       case List(Apply(sel @ TypeApply(_, shape :: Nil), _)) =>
-        if (sel.symbol == defn.QuoteUnpickler_unpickleExprV2) sel.getAttachment(transform.PickleQuotes.OriginalTree).get
+        if (sel.symbol == defn.QuoteUnpickler_unpickleExprV2 || sel.symbol == defn.QuoteUnpickler_unpickleTypeV2) then
+          sel.getAttachment(transform.PickleQuotes.OriginalTree).get
         else shape
-      case List(Apply(Apply(Select(TypeApply(_, _), apply),List(shape)),_)) => shape
-      case List(TypeApply(Select(Apply(_, List(Apply(_,List(shape)))), _),_)) => shape
-      case List(shape @ Ident(_)) => shape
+      // transforms/optimisations done to the code after quote pickling can change it into one of the below:
+      case List(Apply(Apply(Select(TypeApply(_, _), apply),List(shape)),_)) =>
+        // scala.quoted.ToExpr.IntToExpr[(0 : Int)].apply(0)(x$1)
+        shape
+      case List(TypeApply(Select(Apply(_, List(Apply(_,List(shape)))), _),_)) =>
+        // x$1.reflect.TypeReprMethods.asType(x$1.reflect.TypeRepr.typeConstructorOf(classOf[Int])).asInstanceOf[scala.quoted.Type[Int]]
+        shape
+      case List(ident: Ident) =>
+        // Ident(t), can show up when using '[t.Underlying]
+        ident.tpe.widen match
+          case AppliedType(cons, List(arg)) if cons.typeSymbol == defn.QuotedTypeClass => TypeTree(arg)
     fun match
       // <quotes>.asInstanceOf[QuoteMatching].{ExprMatch,TypeMatch}.unapply[<typeBindings>, <resTypes>]
       case TypeApply(Select(Select(TypeApply(Select(quotes, _), _), _), _), typeBindings :: resTypes :: Nil) =>
@@ -344,7 +353,10 @@ object QuotePatterns:
   private def unrollHkNestedPairsTypeTree(tree: Tree)(using Context): List[Tree] = tree match
     case AppliedTypeTree(tupleN, bindings) if defn.isTupleClass(tupleN.symbol) => bindings // TupleN, 1 <= N <= 22
     case AppliedTypeTree(_, head :: tail :: Nil) => head :: unrollHkNestedPairsTypeTree(tail) // KCons or *:
-    case tt: TypeTree => unrollHkNestedPairsTypeTreeFromType(tt.tpe).map(TypeTree(_))
+    case tt: TypeTree =>
+      // transforms/optimisations done to the code after quote pickling can change it into a TypeTree[_] form,
+      // where we have to convert it into Type to properly read it
+      unrollHkNestedPairsTypeTreeFromType(tt.tpe).map(TypeTree(_))
     case _ => Nil // KNil or EmptyTuple
 
   private def unrollHkNestedPairsTypeTreeFromType(tree: Type)(using Context): List[Type] = tree match

--- a/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/QuotePatterns.scala
@@ -300,6 +300,8 @@ object QuotePatterns:
       case Apply(Select(Quote(shape, _), _), _) :: Nil => shape
       case List(Apply(sel @ TypeApply(_, shape :: Nil), _)) =>
         if (sel.symbol == defn.QuoteUnpickler_unpickleExprV2 || sel.symbol == defn.QuoteUnpickler_unpickleTypeV2) then
+          // we can safely access the attachment as we know that the unapply tree
+          // was created in PickleQuotes during the same compilation run (and so was the attachment)
           sel.getAttachment(transform.PickleQuotes.OriginalTree).get
         else shape
       // transforms/optimisations done to the code after quote pickling can change it into one of the below:
@@ -311,8 +313,14 @@ object QuotePatterns:
         shape
       case List(ident: Ident) =>
         // Ident(t), can show up when using '[t.Underlying]
-        ident.tpe.widen match
-          case AppliedType(cons, List(arg)) if cons.typeSymbol == defn.QuotedTypeClass => TypeTree(arg)
+
+        // Returns the Arg from Type[Arg]
+        def getTypeArg(t: Type): Type = t match
+          case AndType(a, b) => getTypeArg(a) & getTypeArg(b)
+          case AppliedType(cons, List(arg)) if cons.typeSymbol == defn.QuotedTypeClass => arg
+          case _ => defn.AnyType
+
+        TypeTree(getTypeArg(ident.tpe.widen))
     fun match
       // <quotes>.asInstanceOf[QuoteMatching].{ExprMatch,TypeMatch}.unapply[<typeBindings>, <resTypes>]
       case TypeApply(Select(Select(TypeApply(Select(quotes, _), _), _), _), typeBindings :: resTypes :: Nil) =>

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -11,6 +11,7 @@ import Constants.*
 import ast.Trees.*
 import ast.untpd
 import ast.TreeTypeMap
+import util.Property
 
 import NameKinds.*
 import dotty.tools.dotc.ast.tpd
@@ -211,6 +212,11 @@ object PickleQuotes {
   val name: String = "pickleQuotes"
   val description: String = "turn quoted trees into explicit run-time data structures"
 
+  /** Attachment added to unpickleTypeV2/unpickleExprV2 Select node.
+   *  Points to the original tree from before serialization.
+  */
+  val OriginalTree = Property.StickyKey[tpd.Tree]
+
   def pickle(quote: Quote, quotes: Tree, holeContents: List[Tree])(using Context) = {
     val body = quote.body
     val bodyType = quote.bodyType
@@ -356,6 +362,7 @@ object PickleQuotes {
       quotes
         .asInstance(defn.QuoteUnpicklerClass.typeRef)
         .select(unpickleMeth).appliedToType(bodyType)
+        .withAttachment(OriginalTree, body)
         .appliedToArgs(unpickleArgs).withSpan(body.span)
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -944,6 +944,8 @@ object SpaceEngine {
       val classSym = tpw.classSymbol
       classSym.is(Sealed) && !tpw.isLargeGenericTuple || // exclude large generic tuples from exhaustivity
                                                          // requires an unknown number of changes to make work
+      sel.tpe.widen.isRef(defn.QuotedExprClass) ||
+      sel.tpe.widen.isRef(defn.QuotedTypeClass) ||
       tpw.isInstanceOf[OrType] ||
       (tpw.isInstanceOf[AndType] && {
         val and = tpw.asInstanceOf[AndType]

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -16,6 +16,7 @@ import util.*
 import scala.annotation.internal.sharable
 import scala.annotation.tailrec
 import scala.collection.mutable
+import quoted.QuotePatterns
 
 import SpaceEngine.*
 
@@ -341,8 +342,19 @@ object SpaceEngine {
    *  @param  pt The scrutinee body type
    */
   def isIrrefutableQuotePattern(pat: QuotePattern, pt: Type)(using Context): Boolean = {
-    if pat.body.isType then pat.bindings.isEmpty && pt =:= pat.tpe
-    else pat.body match
+    if pat.body.isType then
+      pat.bindings match
+        case Nil => pt =:= pat.tpe // constant type: '[T]
+        case binding +: Nil => // generic type variable: '[t]
+          def isTypeRefWithWildcardBounds(tree: Tree) =
+            val info = tree.symbol.info
+            info match
+              case TypeBounds(_, hi) => hi.isAny
+              case _ => false
+          isTypeRefWithWildcardBounds(binding) && isTypeRefWithWildcardBounds(pat.body)
+
+        case _ => false
+    else pat.body match // expr: '{$x: T}
       case _: SplicePattern | Typed(_: SplicePattern, _) => pat.bindings.isEmpty && pt <:< pat.tpe
       case _ => false
   }
@@ -391,7 +403,7 @@ object SpaceEngine {
     case SeqLiteral(pats, _) =>
       projectSeq(pats)
 
-    case UnApply(fun, _, pats) =>
+    case unapp @ UnApply(fun, _, pats) =>
       val fun1 = funPart(fun)
       val funRef = fun1.tpe.asInstanceOf[TermRef]
       if (fun.symbol.name == nme.unapplySeq)
@@ -410,7 +422,24 @@ object SpaceEngine {
             Prod(erase(pat.tpe.stripAnnots, isValue = false), funRef, pats.take(arity - 1).map(project) :+ projectSeq(pats.drop(arity - 1)))
         }
       else
-        Prod(erase(pat.tpe.stripAnnots, isValue = false), funRef, pats.map(project))
+        def unapplyProd() = Prod(erase(pat.tpe.stripAnnots, isValue = false), funRef, pats.map(project))
+
+        // Custom logic for '[...] and '{...} quoted patterns.
+        // Since their irrefutability has to be checked against a set Type,
+        // it's more practical to convert them here into `Typ(...)` (pointing
+        // to that Type) instead of `Prod(...)`.
+        if fun.symbol == defn.QuoteMatching_ExprMatch_unapply
+            || fun.symbol == defn.QuoteMatching_TypeMatch_unapply
+        then
+          val quotePattern = QuotePatterns.decode(unapp)
+          if (isIrrefutableQuotePattern(quotePattern, quotePattern.tpe)) then
+            if quotePattern.body.isType then
+              if(quotePattern.bindings.isEmpty) Typ(quotePattern.tpe, decomposed = false)
+              else Typ(defn.QuotedTypeClass.typeRef.appliedTo(WildcardType), decomposed = false)
+            else
+              Typ(quotePattern.tpe, decomposed = false)
+          else unapplyProd()
+        else unapplyProd()
 
     case Typed(pat @ UnApply(_, _, _), _) =>
       project(pat)

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -361,9 +361,10 @@ object SpaceEngine {
           case _ => false
       else false
     else pat.body match
-      case _: SplicePattern | Typed(_: SplicePattern, _) =>
+      case _: SplicePattern | Typed(_: SplicePattern, _) | Block(List(TypeDef(_, _: Hole)), _: SplicePattern) =>
         pat.bindings match
-          case Nil => pt <:< pat.tpe // expr: '{$x: T}
+          case Nil =>
+            pt <:< pat.tpe // expr: '{$x: T}
           case binding +: Nil => // expr with generic type variable: '{$x: t}
             isTypeRefWithWildcardBounds(binding) && (toExprType(getAppliedType(pt) & binding.tpe) <:< pat.tpe)
           case _ => false
@@ -448,6 +449,8 @@ object SpaceEngine {
             else tree match
               case AppliedType(cons, List(AndType(a, b))) if a == quotePattern.bindings.head.tpe => AppliedType(cons, List(b))
               case AppliedType(cons, List(AndType(a, b))) if b == quotePattern.bindings.head.tpe => AppliedType(cons, List(a))
+              case AppliedType(cons, List(arg)) if arg == quotePattern.bindings.head.tpe =>
+                AppliedType(cons, List(TypeBounds(defn.NothingType, defn.AnyType)))
               case _ => tree
 
           if (isIrrefutableQuotePattern(quotePattern, quotePattern.tpe)) then

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -342,20 +342,31 @@ object SpaceEngine {
    *  @param  pt The scrutinee body type
    */
   def isIrrefutableQuotePattern(pat: QuotePattern, pt: Type)(using Context): Boolean = {
-    if pat.body.isType then
-      pat.bindings match
-        case Nil => pt =:= pat.tpe // constant type: '[T]
-        case binding +: Nil => // generic type variable: '[t]
-          def isTypeRefWithWildcardBounds(tree: Tree) =
-            val info = tree.symbol.info
-            info match
-              case TypeBounds(_, hi) => hi.isAny
-              case _ => false
-          isTypeRefWithWildcardBounds(binding) && isTypeRefWithWildcardBounds(pat.body)
-
+    def isTypeRefWithWildcardBounds(tree: Tree) =
+      val info = tree.symbol.info
+      info match
+        case TypeBounds(_, hi) => hi.isAny
         case _ => false
-    else pat.body match // expr: '{$x: T}
-      case _: SplicePattern | Typed(_: SplicePattern, _) => pat.bindings.isEmpty && pt <:< pat.tpe
+    def getAppliedType(tree: Type) =
+      tree match
+        case AppliedType(_, actual +: Nil) => actual
+    def toExprType(tree: Type) =
+      AppliedType(defn.QuotedExprClass.typeRef, List(tree))
+    if pat.body.isType then
+      if (!getAppliedType(pt.widen).etaExpand.isInstanceOf[LambdaType])
+        pat.bindings match
+          case Nil => pt =:= pat.tpe // constant type: '[T]
+          case binding +: Nil => // generic type variable: '[t]
+            isTypeRefWithWildcardBounds(binding) && isTypeRefWithWildcardBounds(pat.body)
+          case _ => false
+      else false
+    else pat.body match
+      case _: SplicePattern | Typed(_: SplicePattern, _) =>
+        pat.bindings match
+          case Nil => pt <:< pat.tpe // expr: '{$x: T}
+          case binding +: Nil => // expr with generic type variable: '{$x: t}
+            isTypeRefWithWildcardBounds(binding) && (toExprType(getAppliedType(pt) & binding.tpe) <:< pat.tpe)
+          case _ => false
       case _ => false
   }
 
@@ -432,12 +443,19 @@ object SpaceEngine {
             || fun.symbol == defn.QuoteMatching_TypeMatch_unapply
         then
           val quotePattern = QuotePatterns.decode(unapp)
+          def removeTypeVar(tree: Type) =
+            if quotePattern.bindings.isEmpty then tree
+            else tree match
+              case AppliedType(cons, List(AndType(a, b))) if a == quotePattern.bindings.head.tpe => AppliedType(cons, List(b))
+              case AppliedType(cons, List(AndType(a, b))) if b == quotePattern.bindings.head.tpe => AppliedType(cons, List(a))
+              case _ => tree
+
           if (isIrrefutableQuotePattern(quotePattern, quotePattern.tpe)) then
             if quotePattern.body.isType then
               if(quotePattern.bindings.isEmpty) Typ(quotePattern.tpe, decomposed = false)
-              else Typ(defn.QuotedTypeClass.typeRef.appliedTo(WildcardType), decomposed = false)
+              else Typ(defn.QuotedTypeClass.typeRef.appliedTo(TypeBounds(defn.NothingType, defn.AnyType)), decomposed = false)
             else
-              Typ(quotePattern.tpe, decomposed = false)
+              Typ(removeTypeVar(quotePattern.tpe), decomposed = false)
           else unapplyProd()
         else unapplyProd()
 

--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -345,15 +345,16 @@ object SpaceEngine {
     def isTypeRefWithWildcardBounds(tree: Tree) =
       val info = tree.symbol.info
       info match
-        case TypeBounds(_, hi) => hi.isAny
+        case TypeBounds(lo, hi) => hi.isAny && lo.isNothingType
         case _ => false
     def getAppliedType(tree: Type) =
       tree match
         case AppliedType(_, actual +: Nil) => actual
     def toExprType(tree: Type) =
       AppliedType(defn.QuotedExprClass.typeRef, List(tree))
+
     if pat.body.isType then
-      if (!getAppliedType(pt.widen).etaExpand.isInstanceOf[LambdaType])
+      if !getAppliedType(pt.widen).etaExpand.isInstanceOf[LambdaType] then
         pat.bindings match
           case Nil => pt =:= pat.tpe // constant type: '[T]
           case binding +: Nil => // generic type variable: '[t]
@@ -437,13 +438,20 @@ object SpaceEngine {
         def unapplyProd() = Prod(erase(pat.tpe.stripAnnots, isValue = false), funRef, pats.map(project))
 
         // Custom logic for '[...] and '{...} quoted patterns.
-        // Since their irrefutability has to be checked against a set Type,
+        // Since their irrefutability has to be checked against a specific Type,
         // it's more practical to convert them here into `Typ(...)` (pointing
         // to that Type) instead of `Prod(...)`.
         if fun.symbol == defn.QuoteMatching_ExprMatch_unapply
             || fun.symbol == defn.QuoteMatching_TypeMatch_unapply
         then
           val quotePattern = QuotePatterns.decode(unapp)
+          // removes a type variable duplicated by typer
+          // eg. for
+          //   (expr1: Expr[Int]) match
+          //     case '{$expr2: t}
+          // quote pattern type might be retyped as Expr[Int & t]
+          // In that case, we return Expr[Int]
+          // For Expr[t], we would return Expr[_ :< Nothing :> Any]
           def removeTypeVar(tree: Type) =
             if quotePattern.bindings.isEmpty then tree
             else tree match
@@ -455,7 +463,7 @@ object SpaceEngine {
 
           if (isIrrefutableQuotePattern(quotePattern, quotePattern.tpe)) then
             if quotePattern.body.isType then
-              if(quotePattern.bindings.isEmpty) Typ(quotePattern.tpe, decomposed = false)
+              if quotePattern.bindings.isEmpty then Typ(quotePattern.tpe, decomposed = false)
               else Typ(defn.QuotedTypeClass.typeRef.appliedTo(TypeBounds(defn.NothingType, defn.AnyType)), decomposed = false)
             else
               Typ(removeTypeVar(quotePattern.tpe), decomposed = false)

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -282,7 +282,7 @@ object Expr {
 
   private def ofTupleFromSeqXXL(seq: Seq[Expr[Any]])(using Quotes): Expr[Tuple] =
     val tupleTpe = tupleTypeFromSeq(seq)
-    tupleTpe.asType match
+    tupleTpe.asType: @unchecked match
       case '[tpe] =>
         '{ Tuple.fromIArray(IArray(${Varargs(seq)}*)).asInstanceOf[tpe & Tuple] }
 

--- a/tests/neg-macros/i6432/Macro_1.scala
+++ b/tests/neg-macros/i6432/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
 
   def impl(sc: Expr[StringContext])(using Quotes) : Expr[Unit] = {
     import quotes.reflect.*
-    sc match {
+    (sc: @unchecked) match {
       case '{ StringContext(${Varargs(parts)}*) } =>
         for (case part @ Expr(s) <- parts)
           report.error(s, part.asTerm.pos)

--- a/tests/neg-macros/i6432b/Macro_1.scala
+++ b/tests/neg-macros/i6432b/Macro_1.scala
@@ -7,7 +7,7 @@ object Macro {
 
   def impl(sc: Expr[StringContext])(using Quotes) : Expr[Unit] = {
     import quotes.reflect.*
-    sc match {
+    (sc: @unchecked) match {
       case '{ StringContext(${Varargs(parts)}*) } =>
         for (case part @ Expr(s) <- parts)
           report.error(s, part.asTerm.pos)

--- a/tests/neg-macros/i9570.scala
+++ b/tests/neg-macros/i9570.scala
@@ -11,7 +11,7 @@ object Macros {
 
     private def sizeImpl(e: Expr[HList], n:Int)(using qctx:Quotes): Expr[Int] = {
       import quotes.reflect.*
-      e match {
+      (e: @unchecked) match {
         case '{HCons(_,$t)} => // warn (in .check file)
           sizeImpl(t,n+1)
         case '{HNil} => Expr(n)

--- a/tests/warn/i15503i.scala
+++ b/tests/warn/i15503i.scala
@@ -233,6 +233,7 @@ package foo.test.i16863c:
   def fn[A](expr: Expr[Any])(using Quotes) =
     val imp = expr match
       case '{ ${ _ }: a } => Expr.summon[Numeric[a]] // OK
+      case _ => '{}
     println(imp)
 
 package foo.test.i16863d:

--- a/tests/warn/i22981.scala
+++ b/tests/warn/i22981.scala
@@ -5,5 +5,8 @@ object test {
   import scala.concurrent.duration.FiniteDuration
 
   def applyImpl[A: Type](using Quotes): Expr[Unit] =
-    Type.of[A] match { case '[type d <: FiniteDuration; d] => '{ () } }
+    Type.of[A] match {
+      case '[type d <: FiniteDuration; d] => '{ () }
+      case _ => '{ () }
+    }
 }

--- a/tests/warn/i24034/circe.scala
+++ b/tests/warn/i24034/circe.scala
@@ -61,6 +61,7 @@ object ConfiguredCodec:
             derivation.summonEncoders[et & Tuple](false)(using $conf)
           )(using $conf)
         }
+      case _ => ???
     }
   }
 

--- a/tests/warn/quoted-patterns-exhaustivity.check
+++ b/tests/warn/quoted-patterns-exhaustivity.check
@@ -1,38 +1,38 @@
--- Warning: tests/warn/quoted-patterns-exhaustivity.scala:10:6 ---------------------------------------------------------
-10 |  val '{call(); $t2: tpe} = '{0} // warn
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:12:6 ---------------------------------------------------------
+12 |  val '{call(); $t3: tpe} = '{0} // warn
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |      pattern binding uses refutable extractor `'{...}`
    |
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- Warning: tests/warn/quoted-patterns-exhaustivity.scala:12:6 ---------------------------------------------------------
-12 |  val '[type t <: String; t] = x // warn
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:14:6 ---------------------------------------------------------
+14 |  val '[type t <: String; t] = x // warn
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |      pattern binding uses refutable extractor `'[...]`
    |
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- Warning: tests/warn/quoted-patterns-exhaustivity.scala:13:6 ---------------------------------------------------------
-13 |  val '[List[t]] = x // warn
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:15:6 ---------------------------------------------------------
+15 |  val '[List[t]] = x // warn
    |      ^^^^^^^^^^^^^^
    |      pattern binding uses refutable extractor `'[...]`
    |
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:22:2 -----------------------
-22 |  ('{1}, '{""}) match // warn
-   |  ^^^^^^^^^^^^^
-   |  match may not be exhaustive.
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:16:6 ---------------------------------------------------------
+16 |  val '[t] = hkt // warn
+   |      ^^^^^^^^^^
+   |      pattern binding uses refutable extractor `'[...]`
    |
-   |  It would fail on pattern case: (_, _)
-   |
-   | longer explanation available when compiling with `-explain`
+   |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
+   |      which may result in a MatchError at runtime.
+   |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
 -- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:25:2 -----------------------
-25 |  ('{0}, '{1}) match // warn
-   |  ^^^^^^^^^^^^
+25 |  ('{1}, '{""}) match // warn
+   |  ^^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
@@ -46,17 +46,9 @@
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:37:2 -----------------------
-37 |  (x, x) match // warn
-   |  ^^^^^^
-   |  match may not be exhaustive.
-   |
-   |  It would fail on pattern case: (_, _)
-   |
-   | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:40:2 -----------------------
-40 |  (x, x) match // warn
-   |  ^^^^^^
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:31:2 -----------------------
+31 |  ('{0}, '{1}) match // warn
+   |  ^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
@@ -70,52 +62,44 @@
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:53:2 -----------------------
-53 |  '{""} match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:46:2 -----------------------
+46 |  (x, x) match // warn
+   |  ^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:49:2 -----------------------
+49 |  (x, x) match // warn
+   |  ^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:62:2 -----------------------
+62 |  '{""} match // warn
    |  ^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Expr[String]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:56:2 -----------------------
-56 |  '{0} match // warn
-   |  ^^^
-   |  match may not be exhaustive.
-   |
-   |  It would fail on pattern case: _: scala.quoted.Expr[Int]
-   |
-   | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:59:2 -----------------------
-59 |  '{0} match // warn
-   |  ^^^
-   |  match may not be exhaustive.
-   |
-   |  It would fail on pattern case: _: scala.quoted.Expr[Int]
-   |
-   | longer explanation available when compiling with `-explain`
 -- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:65:2 -----------------------
-65 |  x match // warn
-   |  ^
+65 |  '{0} match // warn
+   |  ^^^
    |  match may not be exhaustive.
    |
-   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |  It would fail on pattern case: _: scala.quoted.Expr[Int]
    |
    | longer explanation available when compiling with `-explain`
 -- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:68:2 -----------------------
-68 |  x match // warn
-   |  ^
+68 |  '{0} match // warn
+   |  ^^^
    |  match may not be exhaustive.
    |
-   |  It would fail on pattern case: _: scala.quoted.Type[Int]
-   |
-   | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:71:2 -----------------------
-71 |  x match // warn
-   |  ^
-   |  match may not be exhaustive.
-   |
-   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |  It would fail on pattern case: _: scala.quoted.Expr[Int]
    |
    | longer explanation available when compiling with `-explain`
 -- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:74:2 -----------------------
@@ -124,5 +108,37 @@
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:77:2 -----------------------
+77 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:80:2 -----------------------
+80 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:83:2 -----------------------
+83 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:86:2 -----------------------
+86 |  hkt match // warn
+   |  ^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[List]
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/warn/quoted-patterns-exhaustivity.check
+++ b/tests/warn/quoted-patterns-exhaustivity.check
@@ -1,144 +1,152 @@
--- Warning: tests/warn/quoted-patterns-exhaustivity.scala:12:6 ---------------------------------------------------------
-12 |  val '{call(); $t3: tpe} = '{0} // warn
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:13:6 ---------------------------------------------------------
+13 |  val '{call(); $t3: tpe} = '{0} // warn
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |      pattern binding uses refutable extractor `'{...}`
    |
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- Warning: tests/warn/quoted-patterns-exhaustivity.scala:14:6 ---------------------------------------------------------
-14 |  val '[type t <: String; t] = x // warn
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:15:6 ---------------------------------------------------------
+15 |  val '[type t <: String; t] = x // warn
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |      pattern binding uses refutable extractor `'[...]`
    |
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- Warning: tests/warn/quoted-patterns-exhaustivity.scala:15:6 ---------------------------------------------------------
-15 |  val '[List[t]] = x // warn
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:16:6 ---------------------------------------------------------
+16 |  val '[List[t]] = x // warn
    |      ^^^^^^^^^^^^^^
    |      pattern binding uses refutable extractor `'[...]`
    |
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- Warning: tests/warn/quoted-patterns-exhaustivity.scala:16:6 ---------------------------------------------------------
-16 |  val '[t] = hkt // warn
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:17:6 ---------------------------------------------------------
+17 |  val '[t] = hkt // warn
    |      ^^^^^^^^^^
    |      pattern binding uses refutable extractor `'[...]`
    |
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:25:2 -----------------------
-25 |  ('{1}, '{""}) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:26:2 -----------------------
+26 |  ('{1}, '{""}) match // warn
    |  ^^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:28:2 -----------------------
-28 |  ('{0}, '{1}) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:29:2 -----------------------
+29 |  ('{0}, '{1}) match // warn
    |  ^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:31:2 -----------------------
-31 |  ('{0}, '{1}) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:32:2 -----------------------
+32 |  ('{0}, '{1}) match // warn
    |  ^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:43:2 -----------------------
-43 |  (x, x) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:44:2 -----------------------
+44 |  (x, x) match // warn
    |  ^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:46:2 -----------------------
-46 |  (x, x) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:47:2 -----------------------
+47 |  (x, x) match // warn
    |  ^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:49:2 -----------------------
-49 |  (x, x) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:50:2 -----------------------
+50 |  (x, x) match // warn
    |  ^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:62:2 -----------------------
-62 |  '{""} match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:63:2 -----------------------
+63 |  '{""} match // warn
    |  ^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Expr[String]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:65:2 -----------------------
-65 |  '{0} match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:66:2 -----------------------
+66 |  '{0} match // warn
    |  ^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Expr[Int]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:68:2 -----------------------
-68 |  '{0} match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:69:2 -----------------------
+69 |  '{0} match // warn
    |  ^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Expr[Int]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:74:2 -----------------------
-74 |  x match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:75:2 -----------------------
+75 |  x match // warn
    |  ^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Type[Int]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:77:2 -----------------------
-77 |  x match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:78:2 -----------------------
+78 |  x match // warn
    |  ^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Type[Int]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:80:2 -----------------------
-80 |  x match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:81:2 -----------------------
+81 |  x match // warn
    |  ^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Type[Int]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:83:2 -----------------------
-83 |  x match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:84:2 -----------------------
+84 |  x match // warn
    |  ^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Type[Int]
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:86:2 -----------------------
-86 |  hkt match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:87:2 -----------------------
+87 |  hkt match // warn
    |  ^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: _: scala.quoted.Type[List]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:93:2 -----------------------
+93 |  anyExpr match // warn
+   |  ^^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Expr[Any]
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/warn/quoted-patterns-exhaustivity.check
+++ b/tests/warn/quoted-patterns-exhaustivity.check
@@ -22,51 +22,107 @@
    |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
    |      which may result in a MatchError at runtime.
    |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:21:2 -----------------------
-21 |  ('{1}, '{""}) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:22:2 -----------------------
+22 |  ('{1}, '{""}) match // warn
    |  ^^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:24:2 -----------------------
-24 |  ('{0}, '{1}) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:25:2 -----------------------
+25 |  ('{0}, '{1}) match // warn
    |  ^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:27:2 -----------------------
-27 |  ('{0}, '{1}) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:28:2 -----------------------
+28 |  ('{0}, '{1}) match // warn
    |  ^^^^^^^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:36:2 -----------------------
-36 |  (x, x) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:37:2 -----------------------
+37 |  (x, x) match // warn
    |  ^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:39:2 -----------------------
-39 |  (x, x) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:40:2 -----------------------
+40 |  (x, x) match // warn
    |  ^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
    |
    | longer explanation available when compiling with `-explain`
--- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:42:2 -----------------------
-42 |  (x, x) match // warn
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:43:2 -----------------------
+43 |  (x, x) match // warn
    |  ^^^^^^
    |  match may not be exhaustive.
    |
    |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:53:2 -----------------------
+53 |  '{""} match // warn
+   |  ^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Expr[String]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:56:2 -----------------------
+56 |  '{0} match // warn
+   |  ^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Expr[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:59:2 -----------------------
+59 |  '{0} match // warn
+   |  ^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Expr[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:65:2 -----------------------
+65 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:68:2 -----------------------
+68 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:71:2 -----------------------
+71 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[Int]
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:74:2 -----------------------
+74 |  x match // warn
+   |  ^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: _: scala.quoted.Type[Int]
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/warn/quoted-patterns-exhaustivity.check
+++ b/tests/warn/quoted-patterns-exhaustivity.check
@@ -1,0 +1,72 @@
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:10:6 ---------------------------------------------------------
+10 |  val '{call(); $t2: tpe} = '{0} // warn
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      pattern binding uses refutable extractor `'{...}`
+   |
+   |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
+   |      which may result in a MatchError at runtime.
+   |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:12:6 ---------------------------------------------------------
+12 |  val '[type t <: String; t] = x // warn
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      pattern binding uses refutable extractor `'[...]`
+   |
+   |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
+   |      which may result in a MatchError at runtime.
+   |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
+-- Warning: tests/warn/quoted-patterns-exhaustivity.scala:13:6 ---------------------------------------------------------
+13 |  val '[List[t]] = x // warn
+   |      ^^^^^^^^^^^^^^
+   |      pattern binding uses refutable extractor `'[...]`
+   |
+   |      If this usage is intentional, this can be communicated by adding `.runtimeChecked` after the expression,
+   |      which may result in a MatchError at runtime.
+   |      This patch can be rewritten automatically under -rewrite -source 3.8-migration.
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:21:2 -----------------------
+21 |  ('{1}, '{""}) match // warn
+   |  ^^^^^^^^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:24:2 -----------------------
+24 |  ('{0}, '{1}) match // warn
+   |  ^^^^^^^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:27:2 -----------------------
+27 |  ('{0}, '{1}) match // warn
+   |  ^^^^^^^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:36:2 -----------------------
+36 |  (x, x) match // warn
+   |  ^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:39:2 -----------------------
+39 |  (x, x) match // warn
+   |  ^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:42:2 -----------------------
+42 |  (x, x) match // warn
+   |  ^^^^^^
+   |  match may not be exhaustive.
+   |
+   |  It would fail on pattern case: (_, _)
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/warn/quoted-patterns-exhaustivity.check
+++ b/tests/warn/quoted-patterns-exhaustivity.check
@@ -150,3 +150,27 @@
    |  It would fail on pattern case: _: scala.quoted.Expr[Any]
    |
    | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:124:10 ---------------------
+124 |  Type.of[Int] match // warn
+    |          ^^^^
+    |          match may not be exhaustive.
+    |
+    |          It would fail on pattern case: _: scala.quoted.Type[Int]
+    |
+    | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:137:10 ---------------------
+137 |  Type.of[List] match // warn
+    |          ^^^^
+    |          match may not be exhaustive.
+    |
+    |          It would fail on pattern case: _: scala.quoted.Type[List]
+    |
+    | longer explanation available when compiling with `-explain`
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/quoted-patterns-exhaustivity.scala:141:14 ---------------------
+141 |  typeReprTpe.asType match // warn
+    |  ^^^^^^^^^^^^^^^^^^
+    |  match may not be exhaustive.
+    |
+    |  It would fail on pattern case: _: scala.quoted.Type[? <: AnyKind]
+    |
+    | longer explanation available when compiling with `-explain`

--- a/tests/warn/quoted-patterns-exhaustivity.scala
+++ b/tests/warn/quoted-patterns-exhaustivity.scala
@@ -5,6 +5,7 @@ def foo(using Quotes) =
 
   val x: Type[Int] = ???
   val hkt: Type[List] = ???
+  val anyExpr: Expr[Any] = '{0}
 
   val '{$t0} = '{0} // ok
   val '{$t1: Int} = '{0} // ok
@@ -86,3 +87,13 @@ def foo(using Quotes) =
   hkt match // warn
     case '[t] => ()
 
+  anyExpr match // ok
+    case '{ $x: t } => ()
+
+  anyExpr match // warn
+    case '{ type t <: String; $x: t } => ()
+
+  // nested (causes a different shape of QuotePattern)
+  def f[A: Type](e: Expr[A]): Expr[A] =
+    e match // ok
+      case '{ $e2 } => e2

--- a/tests/warn/quoted-patterns-exhaustivity.scala
+++ b/tests/warn/quoted-patterns-exhaustivity.scala
@@ -4,13 +4,16 @@ def call() = 0
 def foo(using Quotes) =
 
   val x: Type[Int] = ???
+  val hkt: Type[List] = ???
 
   val '{$t0} = '{0} // ok
   val '{$t1: Int} = '{0} // ok
-  val '{call(); $t2: tpe} = '{0} // warn
+  val '{$t2: t} = '{0} // ok
+  val '{call(); $t3: tpe} = '{0} // warn
   val '[t] = x // ok
   val '[type t <: String; t] = x // warn
   val '[List[t]] = x // warn
+  val '[t] = hkt // warn
 
   // wrapped in other types
   ('{1}, '{0}) match // ok
@@ -31,6 +34,9 @@ def foo(using Quotes) =
   ('{1}, x) match // ok
     case ('{$y}, '[t]) => ()
 
+  ('{1}, x) match // ok
+    case ('{$y: t}, '[q]) => ()
+
   (x, x) match // ok
     case ('[t], '[q]) => ()
 
@@ -49,6 +55,9 @@ def foo(using Quotes) =
 
   '{1} match // ok
     case '{$y: Int} => ()
+
+  '{1} match // ok
+    case '{$y: t} => ()
 
   '{""} match // warn
     case '{$z: Int} => ()
@@ -73,3 +82,7 @@ def foo(using Quotes) =
 
   x match // warn
     case '[Int] => ()
+
+  hkt match // warn
+    case '[t] => ()
+

--- a/tests/warn/quoted-patterns-exhaustivity.scala
+++ b/tests/warn/quoted-patterns-exhaustivity.scala
@@ -12,6 +12,7 @@ def foo(using Quotes) =
   val '[type t <: String; t] = x // warn
   val '[List[t]] = x // warn
 
+  // wrapped in other types
   ('{1}, '{0}) match // ok
     case ('{$y}, '{$z}) => ()
 
@@ -41,3 +42,34 @@ def foo(using Quotes) =
 
   (x, x) match // warn
     case ('[List[String]], '[q]) => ()
+
+  // individual
+  '{1} match // ok
+    case '{$y} => ()
+
+  '{1} match // ok
+    case '{$y: Int} => ()
+
+  '{""} match // warn
+    case '{$z: Int} => ()
+
+  '{0} match // warn
+    case '{0} => ()
+
+  '{0} match // warn
+    case '{call(); $y} => ()
+
+  x match // ok
+    case '[t] => ()
+
+  x match // warn
+    case '[type t <: Number; t] => ()
+
+  x match // warn
+    case '[List[t]] => ()
+
+  x match // warn
+    case '[List[String]] => ()
+
+  x match // warn
+    case '[Int] => ()

--- a/tests/warn/quoted-patterns-exhaustivity.scala
+++ b/tests/warn/quoted-patterns-exhaustivity.scala
@@ -1,0 +1,43 @@
+import scala.quoted.*
+
+def call() = 0
+def foo(using Quotes) =
+
+  val x: Type[Int] = ???
+
+  val '{$t0} = '{0} // ok
+  val '{$t1: Int} = '{0} // ok
+  val '{call(); $t2: tpe} = '{0} // warn
+  val '[t] = x // ok
+  val '[type t <: String; t] = x // warn
+  val '[List[t]] = x // warn
+
+  ('{1}, '{0}) match // ok
+    case ('{$y}, '{$z}) => ()
+
+  ('{1}, '{0}) match // ok
+    case ('{$y: Int}, '{$z}) => ()
+
+  ('{1}, '{""}) match // warn
+    case ('{$y}, '{$z: Int}) => ()
+
+  ('{0}, '{1}) match // warn
+    case ('{0}, '{1}) => ()
+
+  ('{0}, '{1}) match // warn
+    case ('{call(); $y}, '{$z}) => ()
+
+  ('{1}, x) match // ok
+    case ('{$y}, '[t]) => ()
+
+  (x, x) match // ok
+    case ('[t], '[q]) => ()
+
+  (x, x) match // warn
+    case ('[type t <: Number; t], '[q]) => ()
+
+  (x, x) match // warn
+    case ('[List[t]], '[q]) => ()
+
+  (x, x) match // warn
+    case ('[List[String]], '[q]) => ()

--- a/tests/warn/quoted-patterns-exhaustivity.scala
+++ b/tests/warn/quoted-patterns-exhaustivity.scala
@@ -93,6 +93,10 @@ def foo(using Quotes) =
   anyExpr match // warn
     case '{ type t <: String; $x: t } => ()
 
+  val t = Type.of[Int]
+  Type.of[Int] match // ok
+    case '[t.Underlying] => ()
+
   // nested (causes a different shape of QuotePattern)
   def f[A: Type](e: Expr[A]): Expr[A] =
     e match // ok

--- a/tests/warn/quoted-patterns-exhaustivity.scala
+++ b/tests/warn/quoted-patterns-exhaustivity.scala
@@ -101,3 +101,43 @@ def foo(using Quotes) =
   def f[A: Type](e: Expr[A]): Expr[A] =
     e match // ok
       case '{ $e2 } => e2
+
+  // Intersection types
+  val tdx: Type[Int] & Serializable = ???
+  Type.of[Int] match // ok
+    case '[tdx.Underlying] => ()
+
+  val tdx2: Serializable & Type[Int] = ???
+  Type.of[Int] match // ok
+    case '[tdx2.Underlying] => ()
+
+  val tdx3: Type[Int] & Serializable & Cloneable = ???
+  Type.of[Int] match // ok
+    case '[tdx3.Underlying] => ()
+
+  val tdx4: Type[Int] & Type[String] = ??? // becomes TypeTree(Int & String) and Int & String <: Int
+  Type.of[Int] match // ok
+    case '[tdx4.Underlying] => ()
+
+  type AliasedType = Type[String] & Serializable
+  val tdx5: AliasedType = ???
+  Type.of[Int] match // warn
+    case '[tdx5.Underlying] => ()
+  
+  type AliasedType2 = Type[Int] & Serializable
+  val tdx6: AliasedType2 = ???
+  Type.of[Int] match // ok
+    case '[tdx6.Underlying] => ()
+
+  lazy val tlazy: Type[Int] & Serializable = ???
+  Type.of[Int] match // ok
+    case '[tlazy.Underlying] => ()
+
+  val tdxHkt: Type[List] & Serializable = ???
+  Type.of[List] match // warn
+    case '[tdxHkt.Underlying] => ()
+
+  val typeReprTpe = quotes.reflect.TypeRepr.of[Any] // impossible to know if TypeRepr is a hkt or not
+  typeReprTpe.asType match // warn
+    case '[tpe] => ()
+


### PR DESCRIPTION
Turns out they were not supported altogether, so they would always warn. This could be hidden by the fact that the checks would not trigger for quoted.Type and quoted.Expr (but they still would for any product types containing them). Also confusing was the fact that extraction (`val '{$t} = '{0}`) refutability checks would be called, and those are usually aligned with exhaustivity warnings. This is indeed what this PR tries to do. 

To support the exhaustivity warnings, we run the  refutability check against the type represented by the quote pattern. If it succeedes, we know that any subtype of the quote pattern will match, so instead of adding a `Prod` node, we transform the quote pattern into a `Typ` node, containing the type against which the refutability was checked.

To be able to achieve this, the ability to decode the encoded quote pattern back into QuotePattern tree node was extended to also work after the pickler phase - this is because the irrefutability check was already using QuotePatterns (since for `val '{$t} = '{0}`, it was run before pickler). To save time on unpicking the quoted pattern, we remember the tree from before pickling (handled via an attachment - this is safe to do, because the Space engine phase will only run for currently compiled pattern matches).

Closes #24196, #25005