### PR TITLE
Fix XML element span to include opening '<' character

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/xml/MarkupParsers.scala
@@ -277,7 +277,7 @@ object MarkupParsers {
      *                | xmlTag1 '/' '>'
      */
     def element: Tree = {
-      val start = curOffset // FIXME should be `curOffset - 1` (scalatest and tests/neg/i19100.scala must be updated)
+      val start = curOffset - 1 // Include the '<' character in the span
       val (qname, attrMap) = xTag(())
       if (ch == '/') { // empty element
         xToken("/>")
@@ -435,7 +435,7 @@ object MarkupParsers {
      *                  | Name [S] '/' '>'
      */
     def xPattern: Tree = {
-      var start = curOffset // FIXME should be `curOffset - 1` (scalatest and tests/neg/i19100.scala must be updated)
+      var start = curOffset - 1 // Include the '<' character in the span
       val qname = xName
       debugLastStartElement = (start, qname) :: debugLastStartElement
       xSpaceOpt()

--- a/tests/neg/i19100.check
+++ b/tests/neg/i19100.check
@@ -1,15 +1,15 @@
--- Error: tests/neg/i19100.scala:4:3 -----------------------------------------------------------------------------------
+-- Error: tests/neg/i19100.scala:4:2 -----------------------------------------------------------------------------------
 4 |  <foo/> match // error
-  |   ^^^^^
+  |  ^^^^^
   |   XML literals are no longer supported.
   |   See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
--- Error: tests/neg/i19100.scala:5:10 ----------------------------------------------------------------------------------
+-- Error: tests/neg/i19100.scala:5:9 ----------------------------------------------------------------------------------
 5 |    case <foo/> => 1 // error
-  |          ^^^^^
+  |         ^^^^^
   |          XML literals are no longer supported.
   |          See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html
--- Error: tests/neg/i19100.scala:6:3 -----------------------------------------------------------------------------------
+-- Error: tests/neg/i19100.scala:6:2 -----------------------------------------------------------------------------------
 6 |  <bar></bar> // error
-  |   ^^^^^^^^^^
+  |  ^^^^^^^^^^
   |   XML literals are no longer supported.
   |   See https://docs.scala-lang.org/scala3/reference/dropped-features/xml.html


### PR DESCRIPTION
Fix XML element span to include opening '<' character

- Change curOffset to curOffset - 1 in element() and xPattern()
- Update tests/neg/i19100.check with corrected error positions