### PR TITLE
Check for conflicting setter in getters

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1110,7 +1110,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     /** The translation of `tree = rhs`.
      *  This is either the tree as an assignment, or a setter call.
      */
-    def becomes(rhs: Tree)(using Context): Tree =
+    def becomes(rhs: Tree)(using Context): Tree = {
       val sym = tree.symbol
       if sym.is(Method) then
         val setter = sym.setter.orElse:
@@ -1118,6 +1118,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           sym
         setterAppliedTo(setter, rhs)
       else Assign(tree, rhs)
+    }
 
     def setterAppliedTo(setter: Symbol, rhs: Tree)(using Context): Tree =
       val qual = tree match

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1113,9 +1113,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     def becomes(rhs: Tree)(using Context): Tree = {
       val sym = tree.symbol
       if sym.is(Method) then
-        val setter = sym.setter.orElse:
+        val setter = sym.setter.orElse {
           assert(sym.name.isSetterName && sym.info.firstParamTypes.nonEmpty, sym)
           sym
+        }
         setterAppliedTo(setter, rhs)
       else Assign(tree, rhs)
     }

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1110,21 +1110,20 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     /** The translation of `tree = rhs`.
      *  This is either the tree as an assignment, or a setter call.
      */
-    def becomes(rhs: Tree)(using Context): Tree = {
+    def becomes(rhs: Tree)(using Context): Tree =
       val sym = tree.symbol
-      if (sym.is(Method)) {
-        val setter = sym.setter.orElse {
+      if sym.is(Method) then
+        val setter = sym.setter.orElse:
           assert(sym.name.isSetterName && sym.info.firstParamTypes.nonEmpty, sym)
           sym
-        }
-        val qual = tree match {
-          case id: Ident => desugarIdentPrefix(id)
-          case Select(qual, _) => qual
-        }
-        qual.select(setter).appliedTo(rhs)
-      }
+        setterAppliedTo(setter, rhs)
       else Assign(tree, rhs)
-    }
+
+    def setterAppliedTo(setter: Symbol, rhs: Tree)(using Context): Tree =
+      val qual = tree match
+        case id: Ident => desugarIdentPrefix(id)
+        case Select(qual, _) => qual
+      qual.select(setter).appliedTo(rhs)
 
     /** tree @annot
      *

--- a/compiler/src/dotty/tools/dotc/core/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymUtils.scala
@@ -277,8 +277,7 @@ class SymUtils:
       self.info.decls.filter(_.is(CaseAccessor))
 
     def getter(using Context): Symbol =
-      if self.isGetter then self
-      else accessorNamed(self.asTerm.name.getterName)
+      if (self.isGetter) self else accessorNamed(self.asTerm.name.getterName)
 
     def setter(using Context): Symbol =
       if (self.isSetter) self

--- a/compiler/src/dotty/tools/dotc/core/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymUtils.scala
@@ -277,7 +277,8 @@ class SymUtils:
       self.info.decls.filter(_.is(CaseAccessor))
 
     def getter(using Context): Symbol =
-      if (self.isGetter) self else accessorNamed(self.asTerm.name.getterName)
+      if self.isGetter then self
+      else accessorNamed(self.asTerm.name.getterName)
 
     def setter(using Context): Symbol =
       if (self.isSetter) self

--- a/compiler/src/dotty/tools/dotc/transform/Getters.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Getters.scala
@@ -98,23 +98,23 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
 
   private def ensureSetter(sym: TermSymbol)(using Context): Symbol =
     sym.setter match
-    case setter if setter.exists || newSetters.contains(setter) =>
-      setter
-    case _ =>
-      sym.copy(
-        name = sym.name.setterName,
-        info = MethodType(sym.info.widenExpr :: Nil, defn.UnitType)
-      )
-      .enteredAfter(thisPhase)
-      .tap: setter =>
-        newSetters += setter
-        if sym.is(Private) then
-          sym.owner.info.decls.toList.find: other =>
-            other != setter && other.name == setter.name && other.info =:= setter.info
-          .match
-          case Some(other) =>
-            report.error(DoubleDefinition(setter, other, sym.owner), sym.srcPos)
-          case _ =>
+      case setter if setter.exists || newSetters.contains(setter) =>
+        setter
+      case _ =>
+        sym.copy(
+          name = sym.name.setterName,
+          info = MethodType(sym.info.widenExpr :: Nil, defn.UnitType)
+        )
+        .enteredAfter(thisPhase)
+        .tap: setter =>
+          newSetters += setter
+          if sym.is(Private) then
+            sym.owner.info.decls.toList.find: other =>
+              other != setter && other.name == setter.name && other.info =:= setter.info
+            .match
+              case Some(other) =>
+                report.error(DoubleDefinition(setter, other, sym.owner), sym.srcPos)
+              case _ =>
 
   override def transformValDef(tree: ValDef)(using Context): Tree =
     val sym = tree.symbol
@@ -122,22 +122,22 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
     val getterDef = DefDef(sym.asTerm, tree.rhs).withSpan(tree.span).withAttachmentsFrom(tree)
     if !sym.is(Mutable) then return getterDef
     ensureSetter(sym.asTerm) match
-    case setter if newSetters.contains(setter) =>
-      val setterDef = DefDef(setter.asTerm, unitLiteral)
-      Thicket(getterDef, setterDef)
-    case _ =>
-      getterDef
+      case setter if newSetters.contains(setter) =>
+        val setterDef = DefDef(setter.asTerm, unitLiteral)
+        Thicket(getterDef, setterDef)
+      case _ =>
+        getterDef
 
   override def transformAssign(tree: Assign)(using Context): Tree =
     val lsym = tree.lhs.symbol.asTerm
     if lsym.is(Method) then
       ensureSetter(lsym) match
-      case setter if setter.exists => // setter == tree.lhs.symbol.setter or not
-        tree.lhs
-        .setterAppliedTo(setter, tree.rhs)
-        .withSpan(tree.span)
-      case _ =>
-        tree
+        case setter if setter.exists => // setter == tree.lhs.symbol.setter or not
+          tree.lhs
+          .setterAppliedTo(setter, tree.rhs)
+          .withSpan(tree.span)
+        case _ =>
+          tree
     else tree
 }
 

--- a/compiler/src/dotty/tools/dotc/transform/Getters.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Getters.scala
@@ -109,12 +109,9 @@ class Getters extends MiniPhase with SymTransformer { thisPhase =>
         .tap: setter =>
           newSetters += setter
           if sym.is(Private) then
-            sym.owner.info.decls.toList.find: other =>
-              other != setter && other.name == setter.name && other.info =:= setter.info
-            .match
-              case Some(other) =>
-                report.error(DoubleDefinition(setter, other, sym.owner), sym.srcPos)
-              case _ =>
+            sym.owner.info.decls.toList
+            .find(other => other != setter && other.name == setter.name && other.info =:= setter.info)
+            .foreach(other => report.error(DoubleDefinition(setter, other, sym.owner), sym.srcPos))
 
   override def transformValDef(tree: ValDef)(using Context): Tree =
     val sym = tree.symbol

--- a/tests/neg/i25183.check
+++ b/tests/neg/i25183.check
@@ -1,0 +1,8 @@
+-- [E120] Naming Error: tests/neg/i25183.scala:1:26 --------------------------------------------------------------------
+1 |class Counter(private var count: Int): // error
+  |                          ^
+  |                          Conflicting definitions:
+  |                          def count_=(newCount: Int): Unit in class Counter at line 2 and
+  |                          private var count_=(x$0: Int): Unit in class Counter
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/i25183.scala
+++ b/tests/neg/i25183.scala
@@ -1,0 +1,2 @@
+class Counter(private var count: Int): // error
+  def count_=(newCount: Int) = this.count = newCount

--- a/tests/pos/i25183.scala
+++ b/tests/pos/i25183.scala
@@ -1,0 +1,9 @@
+class CounterExample(private var count: Int):
+  def bump(): Unit =
+    count += 1
+
+class Accumulator:
+  private var h: Int = 0
+  def f =
+    val acc = Accumulator()
+    acc.h = h


### PR DESCRIPTION
Private vars arrive without a setter that would have been previously checked for a conflicting definition.

Don't create a setter if the set of newly created setters already has it.

Fixes #25183 