### PR TITLE
Avoid useless scrutinee proxy vals in inline match reduction

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/InlineReducer.scala
@@ -353,22 +353,29 @@ class InlineReducer(inliner: Inliner)(using Context):
       }
     }
 
-    /** The initial scrutinee binding: `val $scrutineeN = <scrutinee>` */
-    val scrutineeSym = newSym(InlineScrutineeName.fresh(), Synthetic, scrutType).asTerm
-    val scrutineeBinding = normalizeBinding(ValDef(scrutineeSym, scrutinee))
-
-    // If scrutinee has embedded references to `compiletime.erasedValue` or to
-    // other erased values, mark scrutineeSym as Erased. In addition, if scrutinee
-    // is not a pure expression, mark scrutineeSym as unusable. The reason is that
-    // scrutinee would then fail the tests in erasure that demand that the RHS of
-    // an erased val is a pure expression. At the end of the inline match reduction
-    // we throw out all unusable vals and check that the remaining code does not refer
-    // to unusable symbols.
-    // Note that compiletime.erasedValue is treated as erased but not pure, so scrutinees
-    // containing references to it becomes unusable.
-    if scrutinee.existsSubTree(_.symbol.isErased) then
-      scrutineeSym.setFlag(Erased)
-      if !tpd.isPureExpr(scrutinee) then unusable += scrutineeSym
+    // Reference to and binding of `val $scrutineeN = <scrutinee>`, or just
+    // `<scrutinee>` if it is pure and its type is already a bare local
+    // `TermRef` (no prefix). We restrict to `NoPrefix` to avoid duplicating
+    // pointer indirections from stable paths like `obj.field`.
+    val (scrutineeRef: TermRef, scrutineeBinding: Option[MemberDef]) = scrutinee.tpe match
+      case ref: TermRef if !isImplicit && ref.prefix == NoPrefix && tpd.isPureExpr(scrutinee) =>
+        (ref, None)
+      case _ =>
+        val scrutineeSym = newSym(InlineScrutineeName.fresh(), Synthetic, scrutType).asTerm
+        // If scrutinee has embedded references to `compiletime.erasedValue` or to
+        // other erased values, mark scrutineeSym as Erased. In addition, if scrutinee
+        // is not a pure expression, mark scrutineeSym as unusable. The reason is that
+        // scrutinee would then fail the tests in erasure that demand that the RHS of
+        // an erased val is a pure expression. At the end of the inline match reduction
+        // we throw out all unusable vals and check that the remaining code does not refer
+        // to unusable symbols.
+        // Note that compiletime.erasedValue is treated as erased but not pure, so scrutinees
+        // containing references to it becomes unusable.
+        if scrutinee.existsSubTree(_.symbol.isErased) then
+          scrutineeSym.setFlag(Erased)
+          if !tpd.isPureExpr(scrutinee) then unusable += scrutineeSym
+        val binding = normalizeBinding(ValDef(scrutineeSym, scrutinee))
+        (scrutineeSym.termRef, Some(binding))
 
     def reduceCase(cdef: CaseDef): MatchReduxWithGuard = {
       val caseBindingMap = new mutable.ListBuffer[(Symbol, MemberDef)]()
@@ -379,9 +386,9 @@ class InlineReducer(inliner: Inliner)(using Context):
         val substituted = bindings.map { case (sym, bnd) => bnd.subst(from, to) }
         (substituted, from, to)
 
-      if (!isImplicit) caseBindingMap += ((NoSymbol, scrutineeBinding))
+      for binding <- scrutineeBinding do caseBindingMap += ((NoSymbol, binding))
       val gadtCtx = ctx.fresh.setFreshGADTBounds.addMode(Mode.GadtConstraintInference)
-      if (reducePattern(caseBindingMap, scrutineeSym.termRef, cdef.pat)(using gadtCtx)) {
+      if (reducePattern(caseBindingMap, scrutineeRef, cdef.pat)(using gadtCtx)) {
         val (caseBindings, from, to) = substBindings(caseBindingMap.toList)
         val (guardOK, canReduceGuard) =
           if cdef.guard.isEmpty then (true, true)

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -81,4 +81,7 @@ class PrintingTest {
 
   @Test
   def getters: Unit = testIn("tests/printing/getters", "getters")
+
+  @Test
+  def inlining: Unit = testIn("tests/printing/inlining", "inlining")
 }

--- a/tests/printing/inlining/i24347.check
+++ b/tests/printing/inlining/i24347.check
@@ -20,8 +20,7 @@ package <empty> {
       {
         val b: Box = new Box(42)
         {
-          val $scrutinee1: (b : Box) = b
-          val b: Box = $scrutinee1
+          val b: Box = b
           b.value:Int
         }:Int
       }

--- a/tests/printing/inlining/i24347.check
+++ b/tests/printing/inlining/i24347.check
@@ -1,0 +1,44 @@
+[[syntax trees at end of                  inlining]] // tests/printing/inlining/i24347.scala
+package <empty> {
+  @SourceFile("tests/printing/inlining/i24347.scala") class Box(value: Int)
+     extends Object() {
+    val value: Int
+  }
+  final lazy module val i24347$package: i24347$package = new i24347$package()
+  @SourceFile("tests/printing/inlining/i24347.scala") final module class
+    i24347$package() extends Object() { this: i24347$package.type =>
+    private def writeReplace(): AnyRef =
+      new scala.runtime.ModuleSerializationProxy(classOf[i24347$package.type])
+    inline def unbox(b: Box): Int =
+      (inline b match
+        {
+          case b @ _:Box =>
+            b.value:Int
+        }
+      ):Int
+    @main def Test: Int =
+      {
+        val b: Box = new Box(42)
+        {
+          val $scrutinee1: (b : Box) = b
+          val b: Box = $scrutinee1
+          b.value:Int
+        }:Int
+      }
+  }
+  @SourceFile("tests/printing/inlining/i24347.scala") final class Test() extends
+     Object() {
+    <static> def main(args: Array[String]): Unit =
+      try
+        {
+          Test
+          ()
+        }
+       catch
+        {
+          case error @ _:scala.util.CommandLineParser.ParseError =>
+            scala.util.CommandLineParser.showError(error)
+        }
+  }
+}
+

--- a/tests/printing/inlining/i24347.scala
+++ b/tests/printing/inlining/i24347.scala
@@ -1,0 +1,9 @@
+class Box(val value: Int)
+
+inline def unbox(b: Box): Int =
+  inline b match
+    case b: Box => b.value
+
+@main def Test =
+  val b = Box(42)
+  unbox(b)


### PR DESCRIPTION
When the scrutinee of an inline match is already idempotent and has a `TermRef` type (e.g. a simple variable reference or stable path), reuse it directly instead of creating an intermediate `val $scrutineeN = <scrutinee>`. This follows the same logic as `evalOnce`.

Fixes #24347