### PR TITLE
Caution in following outer from flattened context

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -425,9 +425,11 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
         case DesugaredSelect(qualifier, _) =>
           val sym = tree.symbol
           generatedType = symInfoTK(sym)
-          val qualSafeToElide = tpd.isIdempotentExpr(qualifier)
 
-          def genLoadQualUnlessElidable(): Unit = { if (!qualSafeToElide) { genLoadQualifier(tree) } }
+          def genLoadQualUnlessElidable(): Unit = {
+            val qualSafeToElide = tpd.isIdempotentExpr(qualifier)
+            if !qualSafeToElide then genLoadQualifier(tree)
+          }
 
           // receiverClass is used in the bytecode to access the field. using sym.owner may lead to IllegalAccessError
           def receiverClass = qualifier.tpe.typeSymbol

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -472,7 +472,19 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     case _ => false
 
   /** A tree representing the same reference as the given type */
-  def ref(tp: NamedType, needLoad: Boolean = true)(using Context): Tree =
+  def ref(tp: NamedType, needLoad: Boolean = true)(using Context): Tree = {
+    def followOuterLinks(t: Tree) = t match {
+      case t: This
+        if ctx.erasedTypes
+        && ctx.owner != defn.RootClass
+        && t.symbol != ctx.owner.enclosingClass
+        && !t.symbol.isStaticOwner
+      =>
+        // after erasure outer paths should be respected
+        ExplicitOuter.OuterOps(ctx).path(toCls = t.tpe.classSymbol)
+      case t =>
+        t
+    }
     if tp.isType then TypeTree(tp)
     else if prefixIsElidable(tp) then Ident(tp)
     else if tp.symbol.is(Module) && ctx.owner.isContainedIn(tp.symbol.moduleClass) then
@@ -495,6 +507,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
         if needLoad && !res.symbol.isStatic then
           throw TypeError(em"cannot establish a reference to $res")
         res
+  }
 
   def ref(sym: Symbol)(using Context): Tree =
     ref(NamedType(sym.owner.thisType, sym.name, sym.denot))
@@ -513,19 +526,6 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
         case _ =>
           tpe
     ref(NamedType(simplifyThisTypePrefix(sym.owner.thisType), sym.name, sym.denot))
-
-  private def followOuterLinks(t: Tree)(using Context) = t match {
-    case t: This
-      if ctx.erasedTypes
-      && ctx.owner != defn.RootClass
-      && t.symbol != ctx.owner.enclosingClass
-      && !t.symbol.isStaticOwner
-    =>
-      // after erasure outer paths should be respected
-      ExplicitOuter.OuterOps(ctx).path(toCls = t.tpe.classSymbol)
-    case t =>
-      t
-  }
 
   def singleton(tp: Type, needLoad: Boolean = true)(using Context): Tree = tp.dealias match {
     case tp: TermRef => ref(tp, needLoad)

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -515,7 +515,12 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     ref(NamedType(simplifyThisTypePrefix(sym.owner.thisType), sym.name, sym.denot))
 
   private def followOuterLinks(t: Tree)(using Context) = t match {
-    case t: This if ctx.erasedTypes && !(t.symbol == ctx.owner.enclosingClass || t.symbol.isStaticOwner) =>
+    case t: This
+      if ctx.erasedTypes
+      && ctx.owner != defn.RootClass
+      && t.symbol != ctx.owner.enclosingClass
+      && !t.symbol.isStaticOwner
+    =>
       // after erasure outer paths should be respected
       ExplicitOuter.OuterOps(ctx).path(toCls = t.tpe.classSymbol)
     case t =>

--- a/tests/neg-macros/i19842-a.check
+++ b/tests/neg-macros/i19842-a.check
@@ -2,21 +2,17 @@
 9 |@main def Test = summon[Serializer[ValidationCls]] // error
   |                                                  ^
   |Exception occurred while executing macro expansion.
-  |java.lang.AssertionError: assertion failed: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
+  |java.lang.RuntimeException: assertion failed: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
   |
   |Parents in symbol: [class Object, trait Serializer]
   |Parents in tree: [trait Serializer]
   |
-  |	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:10)
-  |	at dotty.tools.dotc.transform.TreeChecker$.checkParents(TreeChecker.scala:208)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:284)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:283)
-  |	at Macros$.makeSerializer(Macro.scala:23)
+  |	at Macros$.makeSerializer(Macro.scala:32)
   |
   |---------------------------------------------------------------------------------------------------------------------
   |Inline stack trace
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from Test.scala:5
-5 |    implicit inline def implicitMakeSerializer[T]: Serializer[T] = ${ Macros.makeSerializer[T] }
-  |                                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+5 |  inline given [T] => Serializer[T] = ${ Macros.makeSerializer[T] }
+  |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i19842-a/Macro.scala
+++ b/tests/neg-macros/i19842-a/Macro.scala
@@ -12,7 +12,7 @@ object Macros {
     val modSym: Symbol = Symbol.newModule(
       Symbol.spliceOwner,
       name,
-      Flags.Implicit,
+      Flags.Given,
       Flags.EmptyFlags,
       _ => List(TypeRepr.of[Object], TypeRepr.of[Serializer[T]]),
       _ => Nil,
@@ -20,7 +20,18 @@ object Macros {
     )
 
     val (modValDef: ValDef, modClassDef: ClassDef) =
-      ClassDef.module(modSym, List(TypeTree.of[Serializer[T]]), Nil)
+      def bye: (ValDef, ClassDef) = ???
+      try {
+        ClassDef.module(modSym, List(TypeTree.of[Serializer[T]]), Nil)
+        assert(false, "Expected AssertionError")
+      }
+      catch {
+        case ae: AssertionError
+          if ae.getMessage.contains("Parents of class symbol differs from the parents in the tree")
+        =>
+          throw RuntimeException(ae.getMessage)
+      }
+      bye
 
     Block(List(modValDef, modClassDef), Ref(modSym)).asExprOf[Serializer[T]]
   }

--- a/tests/neg-macros/i19842-a/Test.scala
+++ b/tests/neg-macros/i19842-a/Test.scala
@@ -2,7 +2,7 @@
 trait Serializer[@specialized T]
 
 object Serializer:
-    implicit inline def implicitMakeSerializer[T]: Serializer[T] = ${ Macros.makeSerializer[T] }
+  inline given [T] => Serializer[T] = ${ Macros.makeSerializer[T] }
 
 case class ValidationCls(string: String)
 

--- a/tests/neg-macros/i19842-b.check
+++ b/tests/neg-macros/i19842-b.check
@@ -2,16 +2,12 @@
 9 |@main def Test = summon[Serializer[ValidationCls]] // error
   |                                                  ^
   |Exception occurred while executing macro expansion.
-  |java.lang.AssertionError: assertion failed: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
+  |java.lang.RuntimeException: assertion failed: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
   |
   |Parents in symbol: [class Object, trait Serializer]
   |Parents in tree: [class Object, trait Serializer, trait Foo]
   |
-  |	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:10)
-  |	at dotty.tools.dotc.transform.TreeChecker$.checkParents(TreeChecker.scala:208)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:284)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:283)
-  |	at Macros$.makeSerializer(Macro.scala:25)
+  |	at Macros$.makeSerializer(Macro.scala:34)
   |
   |---------------------------------------------------------------------------------------------------------------------
   |Inline stack trace

--- a/tests/neg-macros/i19842-b/Macro.scala
+++ b/tests/neg-macros/i19842-b/Macro.scala
@@ -22,7 +22,18 @@ object Macros {
     )
 
     val (modValDef: ValDef, modClassDef: ClassDef) =
-      ClassDef.module(modSym, List(TypeTree.of[Object], TypeTree.of[Serializer[T]], TypeTree.of[Foo]), Nil)
+      def bye: (ValDef, ClassDef) = ???
+      try {
+        ClassDef.module(modSym, List(TypeTree.of[Object], TypeTree.of[Serializer[T]], TypeTree.of[Foo]), Nil)
+        assert(false, "Expected AssertionError")
+      }
+      catch {
+        case ae: AssertionError
+          if ae.getMessage.contains("Parents of class symbol differs from the parents in the tree")
+        =>
+          throw RuntimeException(ae.getMessage)
+      }
+      bye
 
     Block(List(modValDef, modClassDef), Ref(modSym)).asExprOf[Serializer[T]]
   }

--- a/tests/pos/i24936/A1.scala
+++ b/tests/pos/i24936/A1.scala
@@ -1,0 +1,39 @@
+// Test for issue #24936: Compiler crash based on file name ordering
+// The crash occurred when a trait with a self-type referring to an object
+// was compiled before the object, due to incorrect outer accessor path computation.
+
+package example
+
+// Original failing case: trait with self-type to O1
+trait A1 { self: O1.type =>
+  import O2.someKey
+  def taskImpl: Unit = println(someKey)
+}
+
+// Test case: accessing nested object member directly
+trait A2 { self: O1.type =>
+  def accessNested: Int = O2.someKey
+}
+
+// Test case: accessing nested object method
+trait A3 { self: O1.type =>
+  def callNested: String = O2.getInfo
+}
+
+// Test case: multiple levels of nesting
+trait A4 { self: O1.type =>
+  def deepAccess: Boolean = O2.Nested.flag
+}
+
+// Test case: using type from nested object
+trait A5 { self: O1.type =>
+  def useType: O2.MyType = O2.myValue
+}
+
+// Test case: pattern matching on nested object
+trait A6 { self: O1.type =>
+  def patternMatch(x: Int): String = x match {
+    case O2.someKey => "matched"
+    case _ => "not matched"
+  }
+}

--- a/tests/pos/i24936/B1.scala
+++ b/tests/pos/i24936/B1.scala
@@ -1,0 +1,27 @@
+// Additional test cases for issue #24936
+
+package example2
+
+// Test case: abstract class with self-type
+abstract class B1 { self: P1.type =>
+  import Inner.value
+  def getValue: Int = value
+}
+
+// Test case: class referencing sibling object through self-type
+trait B2 { self: P1.type =>
+  def siblingAccess: String = P2.name
+}
+
+// Test case: generic trait with self-type
+trait B3[T] { self: P1.type =>
+  def genericAccess: T = Inner.genericValue.asInstanceOf[T]
+}
+
+object P1 extends B1 with B2 with B3[Int]:
+  object Inner:
+    val value: Int = 100
+    val genericValue: Any = 42
+
+object P2:
+  val name: String = "P2"

--- a/tests/pos/i24936/O1.scala
+++ b/tests/pos/i24936/O1.scala
@@ -1,0 +1,13 @@
+package example
+
+object O1 extends A1 with A2 with A3 with A4 with A5 with A6:
+  object O2:
+    val someKey: Int = 42
+    def getInfo: String = "info"
+
+    object Nested:
+      val flag: Boolean = true
+
+    type MyType = String
+    val myValue: MyType = "value"
+end O1

--- a/tests/run/i24936b/an-imported-term.scala
+++ b/tests/run/i24936b/an-imported-term.scala
@@ -1,0 +1,13 @@
+// this file must be first lexicographically because of order of operations
+trait T:
+  self: S.type =>
+  import X.m
+  def f = m // BCodeBodyBuilder desugars m to this.T.X.m, previously failed "missing outer accessor in <root>"
+            // previously failed "missing outer accessor in <root>"
+            // In other compilation order, BCodeSkelBuilder has set S.X to be JavaStatic,
+            // so prefix is elidable.
+
+// class vs trait doesn't matter. Selection X.m does not demonstrate the issue.
+class C:
+  self: D.type =>
+  def c = Y.n

--- a/tests/run/i24936b/concrete.scala
+++ b/tests/run/i24936b/concrete.scala
@@ -1,0 +1,11 @@
+object S extends T:
+  object X:
+    def m: Int = 42
+
+object D extends C:
+  object Y:
+    def n: Int = 27
+
+@main def Test =
+  assert(S.f == 42)
+  assert(D.c == 27)

--- a/tests/run/i24936c/concrete.scala
+++ b/tests/run/i24936c/concrete.scala
@@ -1,0 +1,6 @@
+object S extends T:
+  object X:
+    def m: Int = 42
+
+@main def Test =
+  assert(S.f == 42)

--- a/tests/run/i24936c/imported-term.scala
+++ b/tests/run/i24936c/imported-term.scala
@@ -1,0 +1,5 @@
+// this file must *not* be first lexicographically because of order of operations
+trait T:
+  self: S.type =>
+  import X.m
+  def f = m


### PR DESCRIPTION
Fixes #24936 

Follow-up to https://github.com/scala/scala3/pull/24937 but draws the opposite conclusion from Claude:

> The fix using isStatic is order-independent because it correctly identifies that A1 is at a static level (its owner is a package) regardless of how the context is set up during backend processing. This is the more fundamental property we should check - whether the class needs an outer accessor, not whether the current context happens to be set up correctly.

The context matters after `flatten`.

My previous comment on preferring `isStaticOwner`:

`isStaticOwner` is correct because it's dealing with the prefix of the type; that is also used in `prefixIsElidable`, which is used by `typedIdent` in `setType`.

The symptom is that in the backend, `genApply` of super calls uses `DesugaredSelect` to desugar `Ident` nodes to selects. `tpd.desugarIdent` is what tries & fails to construct the prefix path. `ref(prefix)` uses `prefixIsElidable`. 

It works if the two files are in reverse order because `BCodeSkelBuilder` makes the module prefix static, so that it is elidable for desugar of ident with that prefix. If module members were made static earlier, there would be no ordering dependency and it would just work.