### PR TITLE
Omit pkg receiver of inline accessor

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
@@ -184,6 +184,7 @@ object PrepareInlineable {
           def addQualType(tp: Type): Type = tp match {
             case tp: PolyType => tp.derivedLambdaType(tp.paramNames, tp.paramInfos, addQualType(tp.resultType))
             case tp: ExprType => addQualType(tp.resultType)
+            case tp if qualType.typeSymbol.is(Package) => MethodType(Nil, tp)
             case tp => MethodType(qualType.simplified :: Nil, tp)
           }
 
@@ -206,7 +207,8 @@ object PrepareInlineable {
           val (leadingTypeArgs, otherArgss) = splitArgs(argss)
           val argss1 = joinArgs(
             localRefs.map(TypeTree(_)) ++ leadingTypeArgs, // TODO: pass type parameters in two sections?
-            (qual :: Nil) :: otherArgss
+            if qualType.typeSymbol.is(Package) then Nil :: otherArgss
+            else (qual :: Nil) :: otherArgss
           )
           ref(accessor).appliedToArgss(argss1).withSpan(tree.span)
 

--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -43,11 +43,13 @@ abstract class AccessProxies {
         }
         val (targs, argss) = splitArgs(prefss)
         val (accessRef, forwardedTpts, forwardedArgss) =
-          if (passReceiverAsArg(accessor.name))
-            (argss.head.head.select(accessed), targs.takeRight(numTypeParams), argss.tail)
+          if passReceiverAsArg(accessor.name) then
+            if accessed.owner.is(Package) || accessed.owner.isPackageObject then
+              (ref(accessed), targs.takeRight(numTypeParams), argss.tail)
+            else
+              (argss.head.head.select(accessed), targs.takeRight(numTypeParams), argss.tail)
           else
-            (if (accessed.isStatic) ref(accessed) else ref(TermRef(accessor.owner.thisType, accessed)),
-             targs, argss)
+            (if (accessed.isStatic) ref(accessed) else ref(TermRef(accessor.owner.thisType, accessed)), targs, argss)
         val rhs =
           if (accessor.name.isSetterName &&
               forwardedArgss.nonEmpty && forwardedArgss.head.nonEmpty) // defensive conditions

--- a/tests/neg/inline-unstable-accessors.check
+++ b/tests/neg/inline-unstable-accessors.check
@@ -297,4 +297,27 @@
    | added to package I:
    |   @publicInBinary private[I] def inline$valBinaryAPI2: Int = foo.I.valBinaryAPI2
     --------------------------------------------------------------------------------------------------------------------
+-- [E192] Compatibility Warning: tests/neg/inline-unstable-accessors.scala:67:6 ----------------------------------------
+67 |    I.valBinaryAPI2 +
+   |    ^^^^^^^^^^^^^^^
+   |    Unstable inline accessor inline$valBinaryAPI2$i4 was generated in package J.
+   |--------------------------------------------------------------------------------------------------------------------
+   | Explanation (enabled by `-explain`)
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   | Access to non-public value valBinaryAPI2 causes the automatic generation of an accessor.
+   | This accessor is not stable, its name may change or it may disappear
+   | if not needed in a future version.
+   |
+   | To make sure that the inlined code is binary compatible you must make sure that
+   | value valBinaryAPI2 is public in the binary API.
+   |  * Option 1: Annotate value valBinaryAPI2 with @publicInBinary
+   |  * Option 2: Make value valBinaryAPI2 public
+   |
+   | This change may break binary compatibility if a previous version of this
+   | library was compiled with generated accessors. Binary compatibility should
+   | be checked using MiMa. If binary compatibility is broken, you should add the
+   | old accessor explicitly in the source code. The following code should be
+   | added to package J:
+   |   @publicInBinary private[J] def inline$valBinaryAPI2$i4(): Int = foo.I.valBinaryAPI2
+    --------------------------------------------------------------------------------------------------------------------
 No warnings can be incurred under -Werror

--- a/tests/neg/inline-unstable-accessors.scala
+++ b/tests/neg/inline-unstable-accessors.scala
@@ -64,7 +64,7 @@ package I:
       valBinaryAPI3
 package J:
   inline def inlined =
-    //  I.valBinaryAPI2 + // FIXME should error (now fails -Ycheck)
+    I.valBinaryAPI2 +
     I.valBinaryAPI3
 
 // nopos-error: No warnings can be incurred under -Werror (or -Xfatal-warnings)

--- a/tests/pos/i19237.scala
+++ b/tests/pos/i19237.scala
@@ -1,0 +1,30 @@
+package mono
+
+trait C
+object C {
+  given C = new C {}
+}
+private[mono] object Focus:
+  import internals.FocusImpl
+  class MkFocus[From]:
+    transparent inline def apply[To](inline f: C ?=> From => To): Any =
+      ${ FocusImpl('f) }
+
+package internals {
+  import scala.quoted.*
+
+  private[mono] object FocusImpl:
+    def apply[From: Type, To: Type](f: Expr[C ?=> From => To])(using Quotes): Expr[Any] =
+      f
+}
+
+/* did not actually fail to expand
+object Test {
+  def main() = {
+    val mk = new Focus.MkFocus[String]
+    mk.apply[Int] {
+      _ => 42
+    }
+  }
+}
+*/

--- a/tests/pos/i19572.scala
+++ b/tests/pos/i19572.scala
@@ -1,0 +1,6 @@
+//> using options -Ycheck:all
+package foo
+package object G:
+  private[foo] val valBinaryAPI2: Int = 1
+package object H:
+  inline def inlined = G.valBinaryAPI2 // was -Ycheck failure

--- a/tests/pos/i25350.scala
+++ b/tests/pos/i25350.scala
@@ -1,0 +1,13 @@
+//> using options -Ycheck:all
+package first
+
+private object Filter :
+  private[first] def pass(result: Boolean) = result
+
+class Worker :
+  import Filter.pass
+  def make(filter: Boolean): String = "done"
+  inline def call: String = make(pass(true))
+
+class Test :
+  def go = Worker().call


### PR DESCRIPTION
Fixes #25350 
Fixes #19237 
Fixes #19572 

## How much have your relied on LLM-based tools in this contribution?
```
Calculating extent of LLM-based tool usage...

=> 0%

Done.
```
## How was the solution tested?

One existing test and three ticket samples or corpora.

## Additional notes

Mostly jibe coded.

In `AccessProxies`, `passReceiverAsArg` is `true`, but nullified if owned by package or package object.
