### PR TITLE
Sys, concurrent, runtime (1): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library-js/src/scala/concurrent/ExecutionContext.scala
+++ b/library-js/src/scala/concurrent/ExecutionContext.scala
@@ -169,6 +169,8 @@ object ExecutionContext {
      *  The default `ExecutionContext` implementation is backed by a work-stealing thread pool. By default,
      *  the thread pool uses a target number of worker threads equal to the number of
      *  [available processors](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/Runtime.html#availableProcessors()).
+     *
+     *  @return the global `ExecutionContext`
      */
     implicit final def global: ExecutionContext = ExecutionContext.global
   }

--- a/library-js/src/scala/runtime/ScalaRunTime.scala
+++ b/library-js/src/scala/runtime/ScalaRunTime.scala
@@ -39,7 +39,11 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Returns the class object representing an array with element class `clazz`. */
+  /** Returns the class object representing an array with element class `clazz`.
+   *
+   *  @param clazz the element class for the resulting array type
+   *  @return the `Class` object representing `Array[clazz]`
+   */
   def arrayClass(clazz: jClass[_]): jClass[_] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
     if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
@@ -49,11 +53,20 @@ object ScalaRunTime {
   /** Returns the class object representing an unboxed value type,
    *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
    *  rewrites expressions like 5.getClass to come here.
+   *
+   *  @tparam T the primitive value type whose runtime class is to be retrieved
+   *  @param value the value instance (unused; the class is derived from the implicit `ClassTag`)
+   *  @return the runtime `Class` representing the unboxed type `T`
    */
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
-  /** Retrieves generic array element. */
+  /** Retrieves generic array element.
+   *
+   *  @param xs the array to access, typed as `AnyRef` to support both reference and primitive arrays
+   *  @param idx the zero-based index of the element to retrieve
+   *  @return the element at position `idx` in the array
+   */
   def array_apply(xs: AnyRef, idx: Int): Any = {
     xs match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
@@ -69,7 +82,12 @@ object ScalaRunTime {
     }
   }
 
-  /** Updates generic array element. */
+  /** Updates generic array element.
+   *
+   *  @param xs the array to update, typed as `AnyRef` to support both reference and primitive arrays
+   *  @param idx the zero-based index of the element to update
+   *  @param value the new value to store at the given index
+   */
   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
     xs match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
@@ -85,7 +103,11 @@ object ScalaRunTime {
     }
   }
 
-  /** Gets generic array length. */
+  /** Gets generic array length.
+   *
+   *  @param xs the array whose length is to be determined
+   *  @return the number of elements in the array
+   */
   @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
@@ -106,6 +128,9 @@ object ScalaRunTime {
   /** Converts an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
+   *
+   *  @param src the source array to convert, which may be a primitive array
+   *  @return an `Array[Object]` containing the (boxed) elements of `src`
    */
   def toObjectArray(src: AnyRef): Array[Object] = src match {
     case x: Array[AnyRef] => x
@@ -136,7 +161,12 @@ object ScalaRunTime {
 
   def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.productHash(x)
 
-  /** A helper for case classes. */
+  /** A helper for case classes.
+   *
+   *  @tparam T the target element type to which each product element is cast (unchecked)
+   *  @param x the product instance to iterate over
+   *  @return an iterator over the product's elements, cast to type `T`
+   */
   def typedProductIterator[T](x: Product): Iterator[T] = {
     new AbstractIterator[T] {
       private[this] var c: Int = 0
@@ -245,7 +275,12 @@ object ScalaRunTime {
     }
   }
 
-  /** stringOf formatted for use in a repl result. */
+  /** stringOf formatted for use in a repl result.
+   *
+   *  @param arg the value to convert to a string representation
+   *  @param maxElements the maximum number of collection elements to include in the output
+   *  @return a string representation of `arg`, formatted for REPL display
+   */
   def replStringOf(arg: Any, maxElements: Int): String =
     stringOf(arg, maxElements) match {
       case null => "null toString"

--- a/library/src/scala/concurrent/Awaitable.scala
+++ b/library/src/scala/concurrent/Awaitable.scala
@@ -24,6 +24,8 @@ import scala.concurrent.duration.Duration
  *  The [[Await]] object provides methods that allow accessing the result of an `Awaitable`
  *  by blocking the current thread until the `Awaitable` has been completed or a timeout has
  *  occurred.
+ *
+ *  @tparam T the type of the result value
  */
 trait Awaitable[+T] {
 

--- a/library/src/scala/concurrent/BatchingExecutor.scala
+++ b/library/src/scala/concurrent/BatchingExecutor.scala
@@ -221,16 +221,22 @@ private[concurrent] trait BatchingExecutor extends Executor {
   /** MUST throw a NullPointerException when `runnable` is null
    *  When implementing a sync BatchingExecutor, it is RECOMMENDED
    *  to implement this method as `runnable.run()`
+   *
+   *  @param runnable the `Runnable` to submit for execution; must not be null
    */
   protected def submitForExecution(runnable: Runnable): Unit
 
   /** Reports that an asynchronous computation failed.
    *  See `ExecutionContext.reportFailure(throwable: Throwable)`
+   *
+   *  @param throwable the `Throwable` that caused the computation to fail
    */
   protected def reportFailure(throwable: Throwable): Unit
 
   /** WARNING: Never use both `submitAsyncBatched` and `submitSyncBatched` in the same
    *  implementation of `BatchingExecutor`
+   *
+   *  @param runnable the `Runnable` to add to the current async batch, or to submit as a new batch if no batch is active
    */
   protected final def submitAsyncBatched(runnable: Runnable): Unit = {
     val b = _tasksLocal.get
@@ -240,6 +246,8 @@ private[concurrent] trait BatchingExecutor extends Executor {
 
   /** WARNING: Never use both `submitAsyncBatched` and `submitSyncBatched` in the same
    *  implementation of `BatchingExecutor`
+   *
+   *  @param runnable the `Runnable` to submit for synchronous execution, either directly or via a sync batch; must not be null
    */
   protected final def submitSyncBatched(runnable: Runnable): Unit = {
     Objects.requireNonNull(runnable, "runnable is null")

--- a/library/src/scala/concurrent/Future.scala
+++ b/library/src/scala/concurrent/Future.scala
@@ -103,6 +103,8 @@ import scala.concurrent.impl.Promise.DefaultPromise
  *  in a batch within a single `execute()` and it may run
  *  `execute()` either immediately or asynchronously.
  *  Completion of the `Future` must *happen-before* the invocation of the callback.
+ *
+ *  @tparam T the type of the value contained in this `Future`
  */
 trait Future[+T] extends Awaitable[T] {
 
@@ -122,6 +124,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U    only used to accept any return type of the given callback function
    *  @param f     the function to be executed when this `Future` completes
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @group Callbacks
    */
   def onComplete[U](f: Try[T] => U)(implicit executor: ExecutionContext): Unit
@@ -179,6 +182,7 @@ trait Future[+T] extends Awaitable[T] {
    *  @tparam U     only used to accept any return type of the given callback function
    *  @param f      the function which will be executed if this `Future` completes with a result,
    *               the return value of `f` will be discarded.
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @group Callbacks
    */
   def foreach[U](f: T => U)(implicit executor: ExecutionContext): Unit = onComplete { _ foreach f }
@@ -191,6 +195,7 @@ trait Future[+T] extends Awaitable[T] {
    *  @tparam S  the type of the returned `Future`
    *  @param  s  function that transforms a successful result of the receiver into a successful result of the returned future
    *  @param  f  function that transforms a failure of the receiver into a failure of the returned future
+   *  @param executor the `ExecutionContext` on which the transformation will be executed
    *  @return    a `Future` that will be completed with the transformed value
    *  @group Transformations
    */
@@ -207,6 +212,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param  f  function that transforms the result of this future
+   *  @param executor the `ExecutionContext` on which the transformation will be executed
    *  @return    a `Future` that will be completed with the transformed value
    *  @group Transformations
    */
@@ -218,6 +224,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param  f  function that transforms the result of this future
+   *  @param executor the `ExecutionContext` on which the transformation will be executed
    *  @return    a `Future` that will be completed with the transformed value
    *  @group Transformations
    */
@@ -242,6 +249,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param f   the function which will be applied to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the function will be executed
    *  @return    a `Future` which will be completed with the result of the application of the function
    *  @group Transformations
    */
@@ -256,6 +264,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S  the type of the returned `Future`
    *  @param f   the function which will be applied to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the function will be executed
    *  @return    a `Future` which will be completed with the result of the application of the function
    *  @group Transformations
    */
@@ -269,6 +278,7 @@ trait Future[+T] extends Awaitable[T] {
    *  to `flatMap(identity)`.
    *
    *  @tparam S  the type of the returned `Future`
+   *  @param ev evidence that `T` is itself a `Future[S]`
    *  @group Transformations
    */
   def flatten[S](implicit ev: T <:< Future[S]): Future[S] = flatMap(ev)(using parasitic)
@@ -290,6 +300,7 @@ trait Future[+T] extends Awaitable[T] {
    *  ```
    *
    *  @param p   the predicate to apply to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return    a `Future` which will hold the successful result of this `Future` if it matches the predicate or a `NoSuchElementException`
    *  @group Transformations
    */
@@ -304,6 +315,9 @@ trait Future[+T] extends Awaitable[T] {
 
   /** Used by for-comprehensions.
    *  @group Transformations
+   *
+   *  @param p the predicate to apply to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the predicate will be executed
    */
   final def withFilter(p: T => Boolean)(implicit executor: ExecutionContext): Future[T] = filter(p)(using executor)
 
@@ -329,6 +343,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam S    the type of the returned `Future`
    *  @param pf    the `PartialFunction` to apply to the successful result of this `Future`
+   *  @param executor the `ExecutionContext` on which the `PartialFunction` will be executed
    *  @return      a `Future` holding the result of application of the `PartialFunction` or a `NoSuchElementException`
    *  @group Transformations
    */
@@ -354,6 +369,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U    the type of the returned `Future`
    *  @param pf    the `PartialFunction` to apply if this `Future` fails
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return      a `Future` with the successful value of this `Future` or the result of the `PartialFunction`
    *  @group Transformations
    */
@@ -375,6 +391,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U    the type of the returned `Future`
    *  @param pf    the `PartialFunction` to apply if this `Future` fails
+   *  @param executor the `ExecutionContext` on which the `PartialFunction` will be executed
    *  @return      a `Future` with the successful value of this `Future` or the outcome of the `Future` returned by the `PartialFunction`
    *  @group Transformations
    */
@@ -505,6 +522,7 @@ trait Future[+T] extends Awaitable[T] {
    *
    *  @tparam U     only used to accept any return type of the given `PartialFunction`
    *  @param pf     a `PartialFunction` which will be conditionally applied to the outcome of this `Future`
+   *  @param executor the `ExecutionContext` on which the callback will be executed
    *  @return       a `Future` which will be completed with the exact same outcome as this `Future` but after the `PartialFunction` has been executed.
    *  @group Callbacks
    */
@@ -726,6 +744,7 @@ object Future {
    *
    *  @tparam T        the type of the value in the future
    *  @param futures   the `IterableOnce` of Futures in which to find the first completed
+   *  @param executor the `ExecutionContext` on which the futures' completion handlers will be executed
    *  @return          the `Future` holding the result of the future that is first to be completed
    */
   final def firstCompletedOf[T](futures: IterableOnce[Future[T]])(implicit executor: ExecutionContext): Future[T] = {
@@ -765,6 +784,7 @@ object Future {
    *  @tparam T        the type of the value in the future
    *  @param futures   the `scala.collection.immutable.Iterable` of Futures to search
    *  @param p         the predicate which indicates if it's a match
+   *  @param executor the `ExecutionContext` on which the futures' completion handlers will be executed
    *  @return          the `Future` holding the optional result of the search
    */
   final def find[T](futures: scala.collection.immutable.Iterable[Future[T]])(p: T => Boolean)(implicit executor: ExecutionContext): Future[Option[T]] = {

--- a/library/src/scala/concurrent/Promise.scala
+++ b/library/src/scala/concurrent/Promise.scala
@@ -33,6 +33,8 @@ import scala.util.{ Try, Success, Failure }
  *
  *  @define nonDeterministic
  *  Note: Using this method may result in non-deterministic concurrent programs.
+ *
+ *  @tparam T the type of the value held by this promise and its associated future
  */
 trait Promise[T] {
   /** Future containing the value of this promise. */
@@ -49,7 +51,8 @@ trait Promise[T] {
 
   /** Completes the promise with either an exception or a value.
    *
-   *  @param result     Either the value or the exception to complete the promise with.
+   *  @param result     either the value or the exception to complete the promise with
+   *  @return this promise
    *
    *  $promiseCompletion
    */
@@ -60,12 +63,14 @@ trait Promise[T] {
    *
    *  $nonDeterministic
    *
+   *  @param result either the value or the exception to complete the promise with
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
   def tryComplete(result: Try[T]): Boolean
 
   /** Completes this promise with the specified future, once that future is completed.
    *
+   *  @param other the future whose result will be used to complete this promise
    *  @return   This promise
    */
    def completeWith(other: Future[T]): this.type = {
@@ -84,7 +89,8 @@ trait Promise[T] {
 
   /** Completes the promise with a value.
    *
-   *  @param value The value to complete the promise with.
+   *  @param value the value to complete the promise with
+   *  @return this promise
    *
    *  $promiseCompletion
    */
@@ -94,13 +100,15 @@ trait Promise[T] {
    *
    *  $nonDeterministic
    *
+   *  @param value the value to complete the promise with
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
   def trySuccess(value: T): Boolean = tryComplete(Success(value))
 
   /** Completes the promise with an exception.
    *
-   *  @param cause    The throwable to complete the promise with.
+   *  @param cause    the throwable to complete the promise with
+   *  @return this promise
    *
    *  $allowedThrowables
    *
@@ -112,6 +120,7 @@ trait Promise[T] {
    *
    *  $nonDeterministic
    *
+   *  @param cause the throwable to complete the promise with
    *  @return    If the promise has already been completed returns `false`, or `true` otherwise.
    */
   def tryFailure(cause: Throwable): Boolean = tryComplete(Failure(cause))
@@ -128,6 +137,7 @@ object Promise {
   /** Creates an already completed Promise with the specified exception.
    *
    *  @tparam T       the type of the value in the promise
+   *  @param exception the throwable to fail the promise with
    *  @return         the newly created `Promise` instance
    */
   final def failed[T](exception: Throwable): Promise[T] = fromTry(Failure(exception))
@@ -135,6 +145,7 @@ object Promise {
   /** Creates an already completed Promise with the specified result.
    *
    *  @tparam T       the type of the value in the promise
+   *  @param result the successful value to complete the promise with
    *  @return         the newly created `Promise` instance
    */
   final def successful[T](result: T): Promise[T] = fromTry(Success(result))
@@ -142,6 +153,7 @@ object Promise {
   /** Creates an already completed Promise with the specified result or exception.
    *
    *  @tparam T       the type of the value in the promise
+   *  @param result the `Try` value (success or failure) to complete the promise with
    *  @return         the newly created `Promise` instance
    */
   final def fromTry[T](result: Try[T]): Promise[T] = new impl.Promise.DefaultPromise[T](result)

--- a/library/src/scala/concurrent/SyncVar.scala
+++ b/library/src/scala/concurrent/SyncVar.scala
@@ -37,6 +37,8 @@ class SyncVar[A] {
 
   /** Waits `timeout` millis. If `timeout <= 0` just returns 0.
    *  It never returns negative results.
+   *
+   *  @param timeout the maximum time to wait, in milliseconds
    */
   private def waitMeasuringElapsed(timeout: Long): Long = if (timeout <= 0) 0 else {
     val start = System.nanoTime()
@@ -80,8 +82,8 @@ class SyncVar[A] {
    *  to become defined and then gets the stored value, unsetting it
    *  as a side effect.
    *
-   *  @param timeout     the amount of milliseconds to wait
-   *  @return            the value or a throws an exception if the timeout occurs
+   *  @param timeout     the maximum time to wait, in milliseconds
+   *  @return            the value held in this `SyncVar`
    *  @throws NoSuchElementException on timeout
    */
   def take(timeout: Long): A = synchronized {
@@ -91,6 +93,8 @@ class SyncVar[A] {
 
   /** Place a value in the SyncVar. If the SyncVar already has a stored value,
    *  wait until another thread takes it. 
+   *
+   *  @param x the value to store in this `SyncVar`
    */
   def put(x: A): Unit = synchronized {
     while (isDefined) wait()

--- a/library/src/scala/concurrent/duration/Deadline.scala
+++ b/library/src/scala/concurrent/duration/Deadline.scala
@@ -29,31 +29,49 @@ import scala.language.`2.13`
  *  seconds).
  */
 case class Deadline private (time: FiniteDuration) extends Ordered[Deadline] {
-  /** Returns a deadline advanced (i.e., moved into the future) by the given duration. */
+  /** Returns a deadline advanced (i.e., moved into the future) by the given duration.
+   *
+   *  @param other the duration by which to advance this deadline
+   */
   def +(other: FiniteDuration): Deadline = copy(time = time + other)
-  /** Returns a deadline moved backwards (i.e., towards the past) by the given duration. */
+  /** Returns a deadline moved backwards (i.e., towards the past) by the given duration.
+   *
+   *  @param other the duration by which to move this deadline backwards
+   */
   def -(other: FiniteDuration): Deadline = copy(time = time - other)
-  /** Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative). */
+  /** Calculates time difference between this and the other deadline, where the result is directed (i.e., may be negative).
+   *
+   *  @param other the deadline to subtract from this deadline, yielding a directed duration
+   */
   def -(other: Deadline): FiniteDuration = time - other.time
   /** Calculates time difference between this duration and now; the result is negative if the deadline has passed.
    *
    *  ***Note that on some systems this operation is costly because it entails a system call.***
    *  Checks `System.nanoTime` for your platform.
+   *
+   *  @return the duration remaining until this deadline, negative if the deadline has passed
    */
   def timeLeft: FiniteDuration = this - Deadline.now
   /** Determine whether the deadline still lies in the future at the point where this method is called.
    *
    *  ***Note that on some systems this operation is costly because it entails a system call.***
    *  Checks `System.nanoTime` for your platform.
+   *
+   *  @return `true` if the deadline has not yet passed, `false` otherwise
    */
   def hasTimeLeft(): Boolean = !isOverdue()
   /** Determine whether the deadline lies in the past at the point where this method is called.
    *
    *  ***Note that on some systems this operation is costly because it entails a system call.***
    *  Checks `System.nanoTime` for your platform.
+   *
+   *  @return `true` if the deadline has passed, `false` otherwise
    */
   def isOverdue(): Boolean = (time.toNanos - System.nanoTime()) < 0
-  /** The natural ordering for deadline is determined by the natural order of the underlying (finite) duration. */
+  /** The natural ordering for deadline is determined by the natural order of the underlying (finite) duration.
+   *
+   *  @param other the deadline to compare against
+   */
   def compare(other: Deadline): Int = time compare other.time
 }
 

--- a/library/src/scala/concurrent/duration/Duration.scala
+++ b/library/src/scala/concurrent/duration/Duration.scala
@@ -25,12 +25,18 @@ object Duration {
    *
    *  Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
    *
+   *  @param length the duration length as a floating-point number
+   *  @param unit the time unit in which `length` is measured
+   *  @return a duration representing the given length in the given unit, possibly infinite or undefined
    *  @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
    */
   def apply(length: Double, unit: TimeUnit): Duration     = fromNanos(unit.toNanos(1) * length)
 
   /** Constructs a finite duration from the given length and time unit. The unit given is retained
    *  throughout calculations as long as possible, so that it can be retrieved later.
+   *
+   *  @param length the duration length as a whole number
+   *  @param unit the time unit in which `length` is measured
    */
   def apply(length: Long, unit: TimeUnit): FiniteDuration = new FiniteDuration(length, unit)
 
@@ -39,6 +45,10 @@ object Duration {
    *
    *  `d, day, h, hr, hour, m, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
    *  and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
+   *
+   *  @param length the duration length as a whole number
+   *  @param unit the string representation of the time unit (e.g. `"ms"`, `"second"`, `"days"`)
+   *  @return a finite duration of the given length with the resolved time unit
    */
   def apply(length: Long, unit: String): FiniteDuration   = new FiniteDuration(length,  Duration.timeUnit(unit))
 
@@ -50,6 +60,7 @@ object Duration {
    *  designated by `"Inf"`, `"PlusInf"`, `"+Inf"`, `"Duration.Inf"` and `"-Inf"`, `"MinusInf"` or `"Duration.MinusInf"`.
    *  Undefined is designated by `"Duration.Undefined"`.
    *
+   *  @param s the string to parse into a duration
    *  @throws NumberFormatException if format is not parsable
    */
   def apply(s: String): Duration = {
@@ -96,11 +107,16 @@ object Duration {
 
   /** Extracts length and time unit out of a string, where the format must match the description for [[Duration$.apply(s:String)* apply(String)]].
    *  The extractor will not match for malformed strings or non-finite durations.
+   *
+   *  @param s the string to parse and extract a length and time unit from
    */
   def unapply(s: String): Option[(Long, TimeUnit)] =
     ( try Some(apply(s)) catch { case _: RuntimeException => None } ) flatMap unapply
 
-  /** Extracts length and time unit out of a duration, if it is finite. */
+  /** Extracts length and time unit out of a duration, if it is finite.
+   *
+   *  @param d the duration to decompose into length and time unit
+   */
   def unapply(d: Duration): Option[(Long, TimeUnit)] =
     if (d.isFinite) Some((d.length, d.unit)) else None
 
@@ -114,6 +130,8 @@ object Duration {
    *  The semantics of the resulting Duration objects matches the semantics of their Double
    *  counterparts with respect to arithmetic operations.
    *
+   *  @param nanos the number of nanoseconds as a floating-point value, may be infinite or NaN
+   *  @return a duration corresponding to the given number of nanoseconds, possibly infinite or undefined
    *  @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
    */
   def fromNanos(nanos: Double): Duration = {
@@ -138,6 +156,7 @@ object Duration {
    *  result will have the coarsest possible time unit which can exactly express
    *  this duration.
    *
+   *  @param nanos the number of nanoseconds
    *  @throws IllegalArgumentException for `Long.MinValue` since that would lead to inconsistent behavior afterwards (cannot be negated)
    */
   def fromNanos(nanos: Long): FiniteDuration = {
@@ -251,6 +270,9 @@ object Duration {
 
   /** Constructs a finite duration from the given length and time unit. The unit given is retained
    *  throughout calculations as long as possible, so that it can be retrieved later.
+   *
+   *  @param length the duration length as a whole number
+   *  @param unit the time unit in which `length` is measured
    */
   def create(length: Long, unit: TimeUnit): FiniteDuration = apply(length, unit)
   /** Constructs a Duration from the given length and unit. Observe that nanosecond precision may be lost if
@@ -260,6 +282,9 @@ object Duration {
    *
    *  Infinite inputs (and NaN) are converted into [[Duration.Inf]], [[Duration.MinusInf]] and [[Duration.Undefined]], respectively.
    *
+   *  @param length the duration length as a floating-point number
+   *  @param unit the time unit in which `length` is measured
+   *  @return a duration representing the given length in the given unit, possibly infinite or undefined
    *  @throws IllegalArgumentException if the length was finite but the resulting duration cannot be expressed as a [[FiniteDuration]]
    */
   def create(length: Double, unit: TimeUnit): Duration     = apply(length, unit)
@@ -268,12 +293,17 @@ object Duration {
    *
    *  `d, day, h, hour, min, minute, s, sec, second, ms, milli, millisecond, µs, micro, microsecond, ns, nano, nanosecond`
    *  and their pluralized forms (for every but the first mentioned form of each unit, i.e. no "ds", but "days").
+   *
+   *  @param length the duration length as a whole number
+   *  @param unit the string representation of the time unit (e.g. `"ms"`, `"second"`, `"days"`)
+   *  @return a finite duration of the given length with the resolved time unit
    */
   def create(length: Long, unit: String): FiniteDuration   = apply(length, unit)
   /** Parses String into Duration.  Format is `"<length><unit>"`, where
    *  whitespace is allowed before, between and after the parts. Infinities are
    *  designated by `"Inf"`, `"PlusInf"`, `"+Inf"` and `"-Inf"` or `"MinusInf"`.
    *
+   *  @param s the string to parse into a duration
    *  @throws NumberFormatException if format is not parsable
    */
   def create(s: String): Duration                          = apply(s)
@@ -354,46 +384,64 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
   /** Obtains the length of this Duration measured in the unit obtained by the `unit` method.
    *
    *  $exc
+   *
+   *  @return the numeric length of this duration, measured in its associated `unit`
    */
   def length: Long
   /** Obtains the time unit in which the length of this duration is measured.
    *
    *  $exc
+   *
+   *  @return the time unit used to measure this duration
    */
   def unit: TimeUnit
   /** Returns the length of this duration measured in whole nanoseconds, rounding towards zero.
    *
    *  $exc
+   *
+   *  @return the length of this duration in nanoseconds
    */
   def toNanos: Long
   /** Returns the length of this duration measured in whole microseconds, rounding towards zero.
    *
    *  $exc
+   *
+   *  @return the length of this duration in microseconds
    */
   def toMicros: Long
   /** Returns the length of this duration measured in whole milliseconds, rounding towards zero.
    *
    *  $exc
+   *
+   *  @return the length of this duration in milliseconds
    */
   def toMillis: Long
   /** Returns the length of this duration measured in whole seconds, rounding towards zero.
    *
    *  $exc
+   *
+   *  @return the length of this duration in seconds
    */
   def toSeconds: Long
   /** Returns the length of this duration measured in whole minutes, rounding towards zero.
    *
    *  $exc
+   *
+   *  @return the length of this duration in minutes
    */
   def toMinutes: Long
   /** Returns the length of this duration measured in whole hours, rounding towards zero.
    *
    *  $exc
+   *
+   *  @return the length of this duration in hours
    */
   def toHours: Long
   /** Returns the length of this duration measured in whole days, rounding towards zero.
    *
    *  $exc
+   *
+   *  @return the length of this duration in days
    */
   def toDays: Long
   /** Returns the number of nanoseconds as floating point number, scaled down to the given unit.
@@ -402,6 +450,8 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    *  - [[Duration.Undefined]] is mapped to Double.NaN
    *  - [[Duration.Inf]] is mapped to Double.PositiveInfinity
    *  - [[Duration.MinusInf]] is mapped to Double.NegativeInfinity
+   *
+   *  @param unit the time unit to convert to
    */
   def toUnit(unit: TimeUnit): Double
 
@@ -409,28 +459,42 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param other the duration to add to this one
+   *  @return the sum of the two durations
    */
   def +(other: Duration): Duration
   /** Returns the difference of that duration and this. When involving non-finite summands the semantics match those
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param other the duration to subtract from this one
+   *  @return the difference of the two durations
    */
   def -(other: Duration): Duration
   /** Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param factor the scalar to multiply by
+   *  @return this duration scaled by the given factor
    */
   def *(factor: Double): Duration
   /** Returns this duration divided by the scalar factor. When involving non-finite factors the semantics match those
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param divisor the scalar to divide by
+   *  @return this duration divided by the given divisor
    */
   def /(divisor: Double): Duration
   /** Returns the quotient of this and that duration as floating-point number. The semantics are
    *  determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
+   *
+   *  @param divisor the duration to divide by
    */
   def /(divisor: Duration): Double
   /** Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]]. */
@@ -439,9 +503,15 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    *  `!isInfinite` for Double because this method also returns `false` for [[Duration.Undefined]].
    */
   def isFinite: Boolean
-  /** Returns the smaller of this and that duration as determined by the natural ordering. */
+  /** Returns the smaller of this and that duration as determined by the natural ordering.
+   *
+   *  @param other the duration to compare with
+   */
   def min(other: Duration): Duration = if (this < other) this else other
-  /** Returns the larger of this and that duration as determined by the natural ordering. */
+  /** Returns the larger of this and that duration as determined by the natural ordering.
+   *
+   *  @param other the duration to compare with
+   */
   def max(other: Duration): Duration = if (this > other) this else other
 
   // Java API
@@ -450,10 +520,15 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param divisor the scalar to divide by
+   *  @return this duration divided by the given divisor
    */
   def div(divisor: Double): Duration = this / divisor
   /** Returns the quotient of this and that duration as floating-point number. The semantics are
    *  determined by Double as if calculating the quotient of the nanosecond lengths of both factors.
+   *
+   *  @param other the duration to divide by
    */
   def div(other: Duration): Double   = this / other
   def gt(other: Duration): Boolean   = this > other
@@ -464,12 +539,18 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param other the duration to subtract from this one
+   *  @return the difference of the two durations
    */
   def minus(other: Duration): Duration = this - other
   /** Returns this duration multiplied by the scalar factor. When involving non-finite factors the semantics match those
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param factor the scalar to multiply by
+   *  @return this duration scaled by the given factor
    */
   def mul(factor: Double): Duration    = this * factor
   /** Negate this duration. The only two values which are mapped to themselves are [[Duration.Zero]] and [[Duration.Undefined]]. */
@@ -478,6 +559,9 @@ sealed abstract class Duration extends Serializable with Ordered[Duration] {
    *  of Double.
    *
    *  $ovf
+   *
+   *  @param other the duration to add to this one
+   *  @return the sum of the two durations
    */
   def plus(other: Duration): Duration  = this + other
   /** Returns duration which is equal to this duration but with a coarsest Unit, or self in case it is already the coarsest Unit
@@ -514,6 +598,9 @@ object FiniteDuration {
 
 /** This class represents a finite duration. Its addition and subtraction operators are overloaded to retain
  *  this guarantee statically. The range of this class is limited to `+-(2^63-1)`ns, which is roughly 292  years.
+ *
+ *  @param length the number of time units in this duration
+ *  @param unit the time unit in which `length` is measured
  */
 final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duration {
   import FiniteDuration._
@@ -606,12 +693,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
 
   /** Returns the quotient of this duration and the given integer factor.
    *
+   *  @param divisor the integer value to divide by
    *  @throws java.lang.ArithmeticException if the factor is 0
    */
   def /(divisor: Long): FiniteDuration = fromNanos(toNanos / divisor)
 
   /** Returns the product of this duration and the given integer factor.
    *
+   *  @param factor the integer value to multiply by
    *  @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
   def *(factor: Long): FiniteDuration  = new FiniteDuration(safeMul(length, factor), unit)
@@ -638,12 +727,14 @@ final class FiniteDuration(val length: Long, val unit: TimeUnit) extends Duratio
 
   /** Returns the quotient of this duration and the given integer factor.
    *
+   *  @param divisor the integer value to divide by
    *  @throws java.lang.ArithmeticException if the factor is 0
    */
   def div(divisor: Long): FiniteDuration = this / divisor
 
   /** Returns the product of this duration and the given integer factor.
    *
+   *  @param factor the integer value to multiply by
    *  @throws IllegalArgumentException if the result would overflow the range of FiniteDuration
    */
   def mul(factor: Long): FiniteDuration  = this * factor

--- a/library/src/scala/runtime/Arrays.scala
+++ b/library/src/scala/runtime/Arrays.scala
@@ -16,18 +16,36 @@ object Arrays {
 
   /** Creates an array of some element type determined by the given `ClassTag`
    *  argument. The erased type of applications of this method is `Object`.
+   *
+   *  @tparam T the element type of the array to create
+   *  @param length the number of elements in the new array
+   *  @param tag the `ClassTag` providing the runtime class information for `T`
+   *  @return the newly created array of type `T`
    */
   def newGenericArray[T](length: Int)(implicit tag: ClassTag[T]): Array[T] =
     tag.newArray(length)
 
-  /** Converts a sequence to a Java array with element type given by `clazz`. */
+  /** Converts a sequence to a Java array with element type given by `clazz`.
+   *
+   *  @tparam T the element type of the sequence and resulting array
+   *  @param xs the sequence to convert to an array
+   *  @param clazz the runtime `Class` of the element type `T`
+   *  @return a new array containing the elements of `xs`
+   */
   def seqToArray[T](xs: Seq[T], clazz: Class[?]): Array[T] = {
     val arr = java.lang.reflect.Array.newInstance(clazz, xs.length).asInstanceOf[Array[T]]
     xs.copyToArray(arr)
     arr
   }
 
-  /** Creates an array of a reference type T. */
+  /** Creates an array of a reference type T.
+   *
+   *  @tparam Arr the type of the resulting array, which may be multi-dimensional (e.g., `Array[Array[Int]]`)
+   *  @param componentType the runtime `Class` of the array's component type
+   *  @param returnType the `Class` representing the return type `Arr` (unused at runtime, provides type information for the compiler)
+   *  @param dimensions the sizes for each dimension of the new array
+   *  @return the newly created (possibly multi-dimensional) array
+   */
   def newArray[Arr](componentType: Class[?], @unused returnType: Class[Arr], dimensions: Array[Int]): Arr =
     jlr.Array.newInstance(componentType, dimensions*).asInstanceOf[Arr]
 }

--- a/library/src/scala/runtime/FunctionXXL.scala
+++ b/library/src/scala/runtime/FunctionXXL.scala
@@ -5,7 +5,10 @@ import language.experimental.captureChecking
 /** A function with all parameters grouped in an array. */
 trait FunctionXXL {
 
-  /** Applies all parameters grouped in xs to this function. */
+  /** Applies all parameters grouped in xs to this function.
+   *
+   *  @param xs the function arguments, packed into an immutable array of `Object`
+   */
   def apply(xs: IArray[Object]): Object
 
   override def toString() = "<functionXXL>"

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -39,7 +39,10 @@ object LambdaDeserializer {
    *  @param cache       A cache used to avoid spinning up a class for each deserialization of a given lambda. May be `null`
    *  @param serialized  The lambda to deserialize. Note that this is typically created by the `readResolve`
    *                    member of the anonymous class created by `LambdaMetaFactory`.
-   *  @return            An instance of the functional interface
+   *  @param targetMethodMap a mapping from lambda implementation method name and signature keys (as produced by
+   *                    `LambdaDeserialize.nameAndDescriptorKey`) to their `MethodHandle`s, used to look up the
+   *                    implementation method during deserialization. Must not be `null`
+   *  @return            an instance of the functional interface
    */
   def deserializeLambda(lookup: MethodHandles.Lookup, cache: java.util.Map[String, MethodHandle],
                         targetMethodMap: java.util.Map[String, MethodHandle], serialized: SerializedLambda): AnyRef = {

--- a/library/src/scala/runtime/MatchCase.scala
+++ b/library/src/scala/runtime/MatchCase.scala
@@ -2,5 +2,9 @@ package scala.runtime
 
 import language.experimental.captureChecking
 
-/** A type constructor for a case in a match type. */
+/** A type constructor for a case in a match type.
+ *
+ *  @tparam Pat the pattern type to match against the scrutinee of the match type
+ *  @tparam Body the result type produced when the scrutinee matches `Pat`
+ */
 final abstract class MatchCase[Pat, +Body]

--- a/library/src/scala/runtime/MethodCache.scala
+++ b/library/src/scala/runtime/MethodCache.scala
@@ -33,6 +33,8 @@ private[scala] sealed abstract class MethodCache {
    *  `null` is returned. If `null` is returned, find's caller should look-
    *  up the right method using whichever means it prefers, and add it to
    *  the cache for later use. 
+   *
+   *  @param forReceiver the runtime `Class` of the receiver object to look up in the cache
    */
   def find(forReceiver: JClass[?]): JMethod | Null
   def add(forReceiver: JClass[?], forMethod: JMethod): MethodCache
@@ -68,6 +70,8 @@ private[scala] final class PolyMethodCache(
 
   /** To achieve tail recursion this must be a separate method
    *  from `find`, because the type of next is not `PolyMethodCache`.
+   *
+   *  @param forReceiver the runtime `Class` of the receiver object to look up in the cache chain via tail recursion
    */
   @tailrec private def findInternal(forReceiver: JClass[?]): JMethod | Null =
     if (forReceiver eq receiver) method

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -56,33 +56,33 @@ final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] wit
   type ResultWithoutStep = Range
 
   /**
-   *  @param end The final bound of the range to make.
-   *  @return A [[scala.collection.immutable.Range]] from `this` up to but
-   *         not including `end`.
+   *  @param end the final bound of the range to make (exclusive)
+   *  @return a [[scala.collection.immutable.Range]] from `this` up to but
+   *         not including `end`
    */
   def until(end: Int): Range = Range(self, end)
 
   /**
-   *  @param end The final bound of the range to make.
-   *  @param step The number to increase by for each step of the range.
-   *  @return A [[scala.collection.immutable.Range]] from `this` up to but
-   *         not including `end`.
+   *  @param end the final bound of the range to make (exclusive)
+   *  @param step the increment value of the range
+   *  @return a [[scala.collection.immutable.Range]] from `this` up to but
+   *         not including `end`
    */
   def until(end: Int, step: Int): Range = Range(self, end, step)
 
-  /** Like `until`, but includes the last index. */
-  /**
-   *  @param end The final bound of the range to make.
-   *  @return A [[scala.collection.immutable.Range]] from `**this**` up to
-   *         and including `end`.
+  /** Like `until`, but includes the last index.
+   *
+   *  @param end the final bound of the range to make (inclusive)
+   *  @return a [[scala.collection.immutable.Range.Inclusive]] from `this` up to
+   *         and including `end`
    */
   def to(end: Int): Range.Inclusive = Range.inclusive(self, end)
 
   /**
-   *  @param end The final bound of the range to make.
-   *  @param step The number to increase by for each step of the range.
-   *  @return A [[scala.collection.immutable.Range]] from `**this**` up to
-   *         and including `end`.
+   *  @param end the final bound of the range to make (inclusive)
+   *  @param step the increment value of the range
+   *  @return a [[scala.collection.immutable.Range.Inclusive]] from `this` up to
+   *         and including `end`
    */
   def to(end: Int, step: Int): Range.Inclusive = Range.inclusive(self, end, step)
 }

--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -25,6 +25,8 @@ object Scala3RunTime:
   /** Called by the inline extension def `nn`.
    *
    *  Extracted to minimize the bytecode size at call site.
+   *
+   *  @throws NullPointerException always, indicating that a null value was encountered where non-null was expected
    */
   def nnFail(): Nothing =
     throw new NullPointerException("tried to cast away nullability, but value is null")

--- a/library/src/scala/runtime/ScalaNumberProxy.scala
+++ b/library/src/scala/runtime/ScalaNumberProxy.scala
@@ -33,9 +33,17 @@ trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Proxy
   def byteValue   = intValue.toByte
   def shortValue  = intValue.toShort
 
-  /** Returns `**this**` if `**this** < that` or `that` otherwise. */
+  /** Returns `**this**` if `**this** < that` or `that` otherwise.
+   *
+   *  @param that the value to compare against for finding the minimum
+   *  @return the smaller of `this` and `that`
+   */
   def min(that: T): T = num.min(self, that)
-  /** Returns `**this**` if `**this** > that` or `that` otherwise. */
+  /** Returns `**this**` if `**this** > that` or `that` otherwise.
+   *
+   *  @param that the value to compare against for finding the maximum
+   *  @return the larger of `this` and `that`
+   */
   def max(that: T): T = num.max(self, that)
   /** Returns the absolute value of `**this**`. */
   def abs             = num.abs(self)

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -38,7 +38,11 @@ object ScalaRunTime {
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
-  /** Returns the class object representing an array with element class `clazz`. */
+  /** Returns the class object representing an array with element class `clazz`.
+   *
+   *  @param clazz the element class of the desired array type
+   *  @return the `Class` object representing `Array[clazz]`
+   */
   def arrayClass(clazz: jClass[?]): jClass[?] = {
     // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
     if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
@@ -48,11 +52,20 @@ object ScalaRunTime {
   /** Returns the class object representing an unboxed value type,
    *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
    *  rewrites expressions like 5.getClass to come here.
+   *
+   *  @tparam T the value type whose runtime class is retrieved
+   *  @param value the boxed value whose unboxed class is returned
+   *  @return the runtime `Class` representing the unboxed type `T`
    */
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
-  /** Retrieves generic array element. */
+  /** Retrieves generic array element.
+   *
+   *  @param xs the array to read from (typed as `AnyRef` to support both reference and primitive arrays)
+   *  @param idx the index of the element to retrieve
+   *  @return the element at position `idx` in the array
+   */
   def array_apply(xs: AnyRef, idx: Int): Any = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
@@ -68,7 +81,12 @@ object ScalaRunTime {
     }
   }
 
-  /** Updates generic array element. */
+  /** Updates generic array element.
+   *
+   *  @param xs the array to update (typed as `AnyRef` to support both reference and primitive arrays)
+   *  @param idx the index of the element to set
+   *  @param value the value to store at the given index
+   */
   def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
@@ -84,7 +102,11 @@ object ScalaRunTime {
     }
   }
 
-  /** Gets generic array length. */
+  /** Gets generic array length.
+   *
+   *  @param xs the array to measure, as an `AnyRef`
+   *  @return the number of elements in the array
+   */
   @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
@@ -105,6 +127,9 @@ object ScalaRunTime {
   /** Converts an array to an object array.
    *  Needed to deal with vararg arguments of primitive types that are passed
    *  to a generic Java vararg parameter T ...
+   *
+   *  @param src the source array to convert, which may be a primitive array
+   *  @return an `Array[Object]` containing the (boxed) elements of `src`
    */
   def toObjectArray(src: AnyRef): Array[Object] = {
     def copy[@specialized T <: AnyVal](src: Array[T]): Array[Object] = {
@@ -163,7 +188,12 @@ object ScalaRunTime {
   // There used to be an `_equals` method as well which was removed in 5e7e81ab2a.
   def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.caseClassHash(x)
 
-  /** A helper for case classes. */
+  /** A helper for case classes.
+   *
+   *  @tparam T the expected element type; elements are cast to this type without checking
+   *  @param x the product whose elements are iterated over
+   *  @return an iterator over the product's elements, cast to type `T`
+   */
   def typedProductIterator[T](x: Product): Iterator[T] = {
     new AbstractIterator[T] {
       private var c: Int = 0
@@ -272,7 +302,12 @@ object ScalaRunTime {
     }
   }
 
-  /** stringOf formatted for use in a repl result. */
+  /** stringOf formatted for use in a repl result.
+   *
+   *  @param arg the value to convert to its string representation
+   *  @param maxElements the maximum number of collection elements to include
+   *  @return a string representation of `arg`, formatted for REPL display
+   */
   def replStringOf(arg: Any, maxElements: Int): String =
     (stringOf(arg, maxElements): String | Null) match {
       case null => "null toString"

--- a/library/src/scala/runtime/TupleMirror.scala
+++ b/library/src/scala/runtime/TupleMirror.scala
@@ -4,6 +4,8 @@ import language.experimental.captureChecking
 
 /** A concrete subclass of `scala.deriving.Mirror.Product`, enabling reduction of bytecode size.
  *  as we do not need to synthesize an anonymous Mirror class at every callsite.
+ *
+ *  @param arity the number of elements in the mirrored tuple type, must be non-negative
  */
 final class TupleMirror(arity: Int) extends scala.deriving.Mirror.Product with Serializable:
   assert(arity >= 0) // technically could be used for EmptyTuple also, but it has its own singleton mirror.

--- a/library/src/scala/runtime/TypeBox.scala
+++ b/library/src/scala/runtime/TypeBox.scala
@@ -7,6 +7,9 @@ import language.experimental.captureChecking
  *  is a tree `t` of type `C[_ >: L <: U]` and an expected type `C[X]` where `X` is an
  *  instantiatable type variable. To be able to instantiate `X`, we cast the tree to type
  *  `X[$n.CAP]` where `$n` is a fresh skolem type with underlying type `TypeBox[L, U]`.
+ *
+ *  @tparam L the lower bound of the wildcard type being captured
+ *  @tparam U the upper bound of the wildcard type being captured
  */
 final abstract class TypeBox[-L <: U, +U] {
   type CAP >: L <: U

--- a/library/src/scala/runtime/stdLibPatches/Predef.scala
+++ b/library/src/scala/runtime/stdLibPatches/Predef.scala
@@ -28,6 +28,9 @@ private[scala] object Predef:
    *  // bar is 23.type = 23
    *  ```
    *  @group utilities
+   *
+   *  @tparam T the singleton type whose unique value is to be retrieved
+   *  @return the unique inhabitant of type `T`
    */
   inline def valueOf[T]: T = summonFrom {
     case ev: ValueOf[T] => ev.value
@@ -36,7 +39,8 @@ private[scala] object Predef:
   /** Summon a given value of type `T`. Usually, the argument is not passed explicitly.
    *
    *  @tparam T the type of the value to be summoned
-   *  @return the given value typed: the provided type parameter
+   *  @param x the given instance of `T` to return
+   *  @return the summoned given instance of type `T`
    */
   transparent inline def summon[T](using x: T): x.type = x
 
@@ -51,6 +55,8 @@ private[scala] object Predef:
    *  val s3: String | Null = null
    *  val s4: String = s3.nn // throw NullPointerException
    *  ```
+   *
+   *  @return the value cast to its non-nullable type
    */
   extension [T](x: T | Null) inline def nn: x.type & T =
     if x.asInstanceOf[Any] == null then scala.runtime.Scala3RunTime.nnFail()
@@ -60,12 +66,16 @@ private[scala] object Predef:
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `eq` rather than only `==`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     *
+     *  @param y the reference to compare against for referential equality
      */
     inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `ne` rather than only `!=`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`. 
+     *
+     *  @param y the reference to compare against for referential inequality
      */
     inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)

--- a/library/src/scala/sys/BooleanProp.scala
+++ b/library/src/scala/sys/BooleanProp.scala
@@ -67,6 +67,8 @@ object BooleanProp {
    *  the value be equal to the String "true", case insensitively.  This method
    *  creates a BooleanProp instance which adheres to that definition.
    *
+   *  @tparam T unused type parameter, retained for API compatibility
+   *  @param key the name of the system property to look up
    *  @return   A BooleanProp which acts like java's Boolean.getBoolean
    */
   def valueIsTrue[T](key: String): BooleanProp = new BooleanPropImpl(key, _.toLowerCase == "true")
@@ -76,11 +78,17 @@ object BooleanProp {
    *  compared case-insensitively, or the empty string.  This way -Dmy.property
    *  results in a true-valued property, but -Dmy.property=false does not.
    *
+   *  @tparam T unused type parameter, retained for API compatibility
+   *  @param key the name of the system property to look up
    *  @return   A BooleanProp with a liberal truth policy
    */
   def keyExists[T](key: String): BooleanProp = new BooleanPropImpl(key, s => s == "" || s.equalsIgnoreCase("true"))
 
-  /** A constant true or false property which ignores all method calls. */
+  /** A constant true or false property which ignores all method calls.
+   *
+   *  @param key the name of the system property
+   *  @param isOn whether the constant property is true or false
+   */
   def constant(key: String, isOn: Boolean): BooleanProp = new ConstantImpl(key, isOn)
 
   implicit def booleanPropAsBoolean(b: BooleanProp): Boolean = b.value

--- a/library/src/scala/sys/Prop.scala
+++ b/library/src/scala/sys/Prop.scala
@@ -20,6 +20,8 @@ import scala.language.`2.13`
  *  is not a requirement.
  *
  *  See `scala.sys.SystemProperties` for an example usage.
+ *
+ *  @tparam T the type of the property value after conversion from string
  */
 trait Prop[+T] {
   /** The full name of the property, e.g., "java.awt.headless". */
@@ -45,7 +47,12 @@ trait Prop[+T] {
    */
   def set(newValue: String): String | Null
 
-  /** Sets the property with a value of the represented type. */
+  /** Sets the property with a value of the represented type.
+   *
+   *  @tparam T1 a supertype of `T`, used as the input type since `Prop` is covariant in `T`
+   *  @param value the value to set for this property
+   *  @return the previous value of this property
+   */
   def setValue[T1 >: T](value: T1): T
 
   /** Gets the current string value if any.  Will not return null: use
@@ -58,7 +65,11 @@ trait Prop[+T] {
   def option: Option[T]
 
   // Do not open until 2.12.
-  //** This value if the property is set, an alternative value otherwise. */
+  /** This value if the property is set, an alternative value otherwise.
+   *
+   *  @tparam T1 a supertype of `T`, the result type
+   *  @param alt the alternative value to use if the property is not set
+   */
   //def or[T1 >: T](alt: => T1): T1
 
   /** Removes the property from the underlying map. */
@@ -78,7 +89,10 @@ object Prop {
    */
   @annotation.implicitNotFound("No implicit property creator available for type ${T}.")
   trait Creator[+T] {
-    /** Creates a Prop[T] of this type based on the given key. */
+    /** Creates a Prop[T] of this type based on the given key.
+     *
+     *  @param key the property name used for lookup
+     */
     def apply(key: String): Prop[T]
   }
 

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -16,7 +16,12 @@ package sys
 import scala.language.`2.13`
 import scala.collection.mutable
 
-/** The internal implementation of scala.sys.Prop. */
+/** The internal implementation of scala.sys.Prop.
+ *
+ *  @tparam T the type of the property value after conversion from `String`
+ *  @param key the system property key used to look up the value
+ *  @param valueFn the function that converts the raw `String` property value to type `T`
+ */
 private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends Prop[T] {
   def value: T = if (isSet) valueFn(get) else zero
   def isSet    = underlying contains key

--- a/library/src/scala/sys/ShutdownHookThread.scala
+++ b/library/src/scala/sys/ShutdownHookThread.scala
@@ -30,6 +30,8 @@ object ShutdownHookThread {
   }
   /** Creates, names, and registers a shutdown hook to run the
    *  given code.
+   *
+   *  @param body the code to execute when the JVM shuts down
    */
   def apply(body: => Unit): ShutdownHookThread = {
     val t = new ShutdownHookThread(() => body, hookName())

--- a/library/src/scala/sys/SystemProperties.scala
+++ b/library/src/scala/sys/SystemProperties.scala
@@ -67,6 +67,9 @@ extends mutable.AbstractMap[String, String | Null] {
 object SystemProperties {
   /** An unenforceable, advisory only place to do some synchronization when
    *  mutating system properties.
+   *
+   *  @tparam T the return type of the body expression
+   *  @param body the code to execute while holding the lock
    */
   def exclusively[T](body: => T): T = this.synchronized:
     body

--- a/library/src/scala/sys/package.scala
+++ b/library/src/scala/sys/package.scala
@@ -23,19 +23,21 @@ import scala.jdk.CollectionConverters._
 package object sys {
   /** Throws a new RuntimeException with the supplied message.
    *
-   *  @return   Nothing.
+   *  @param message the detail message for the `RuntimeException`
+   *  @return   this method never returns normally (return type is `Nothing`)
    */
   def error(message: String): Nothing = throw new RuntimeException(message)
 
   /** Exits the JVM with the default status code.
    *
-   *  @return   Nothing.
+   *  @return   this method never returns normally (return type is `Nothing`)
    */
   def exit(): Nothing = exit(0)
 
   /** Exits the JVM with the given status code.
    *
-   *  @return   Nothing.
+   *  @param status the exit status code passed to `System.exit` (0 for success, non-zero for failure)
+   *  @return   this method never returns normally (return type is `Nothing`)
    */
   def exit(status: Int): Nothing = {
     java.lang.System.exit(status)
@@ -50,7 +52,7 @@ package object sys {
 
   /** A bidirectional, mutable Map representing the current system Properties.
    *
-   *  @return   a SystemProperties.
+   *  @return   a `SystemProperties` instance wrapping the current system properties
    *  @see      [[scala.sys.SystemProperties]]
    */
   def props: SystemProperties = new SystemProperties
@@ -79,7 +81,7 @@ package object sys {
    *  Note that shutdown hooks are NOT guaranteed to be run.
    *
    *  @param    body  the body of code to run at shutdown
-   *  @return   the   Thread which will run the shutdown hook.
+   *  @return   the `ShutdownHookThread` which will run the shutdown hook
    *  @see      [[scala.sys.ShutdownHookThread]]
    */
   def addShutdownHook(body: => Unit): ShutdownHookThread = ShutdownHookThread(body)

--- a/library/src/scala/sys/process/Parser.scala
+++ b/library/src/scala/sys/process/Parser.scala
@@ -23,7 +23,9 @@ private[scala] object Parser {
 
   /** Splits the line into tokens separated by whitespace or quotes.
    *
-   *  @return either an error message or reverse list of tokens
+   *  @param line the command line string to parse
+   *  @param errorFn the error handler invoked with a message when parsing fails (e.g., unmatched quote)
+   *  @return a list of parsed tokens in order of appearance, or `Nil` after invoking `errorFn` on failure
    */
   def tokenize(line: String, errorFn: String => Unit): List[String] = {
     import Character.isWhitespace

--- a/library/src/scala/sys/process/Process.scala
+++ b/library/src/scala/sys/process/Process.scala
@@ -57,6 +57,9 @@ trait ProcessCreation {
    *  ```
    *  apply("cat file.txt")
    *  ```
+   *
+   *  @param command the command string, including parameters separated by spaces
+   *  @return a new `ProcessBuilder` for the given command
    */
   def apply(command: String): ProcessBuilder                         = apply(command, None)
 
@@ -67,6 +70,9 @@ trait ProcessCreation {
    *  ```
    *  apply("cat" :: files)
    *  ```
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
+   *  @return a new `ProcessBuilder` for the given command
    */
   def apply(command: scala.collection.Seq[String]): ProcessBuilder   = apply(command, None)
 
@@ -77,6 +83,10 @@ trait ProcessCreation {
    *  ```
    *  apply("cat", files)
    *  ```
+   *
+   *  @param command the executable to run
+   *  @param arguments the arguments to pass to the command
+   *  @return a new `ProcessBuilder` for the given command and arguments
    */
   def apply(command: String, arguments: scala.collection.Seq[String]): ProcessBuilder = apply(command +: arguments, None)
 
@@ -87,6 +97,11 @@ trait ProcessCreation {
    *  ```
    *  apply("java", new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command the command string, including parameters separated by spaces
+   *  @param cwd the working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
+   *  @return a new `ProcessBuilder` for the given command with the specified working directory
    */
   def apply(command: String, cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv*)
@@ -98,6 +113,11 @@ trait ProcessCreation {
    *  ```
    *  apply("java" :: javaArgs, new java.io.File("/opt/app"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
+   *  @param cwd the working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
+   *  @return a new `ProcessBuilder` for the given command with the specified working directory
    */
   def apply(command: scala.collection.Seq[String], cwd: File, extraEnv: (String, String)*): ProcessBuilder =
     apply(command, Some(cwd), extraEnv*)
@@ -109,6 +129,11 @@ trait ProcessCreation {
    *  ```
    *  apply("java", params.get("cwd"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command the command string, including parameters separated by spaces
+   *  @param cwd an optional working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
+   *  @return a new `ProcessBuilder` for the given command
    */
   def apply(command: String, cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder =
     apply(Parser.tokenize(command), cwd, extraEnv*)
@@ -120,6 +145,11 @@ trait ProcessCreation {
    *  ```
    *  apply("java" :: javaArgs, params.get("cwd"), "CLASSPATH" -> "library.jar")
    *  ```
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
+   *  @param cwd an optional working directory for the process
+   *  @param extraEnv environment variable name-value pairs to add to the process environment
+   *  @return a new `ProcessBuilder` for the given command
    */
   def apply(command: scala.collection.Seq[String], cwd: Option[File], extraEnv: (String, String)*): ProcessBuilder = {
     val jpb = new JProcessBuilder(command.toArray*)
@@ -133,34 +163,55 @@ trait ProcessCreation {
    *  @example ```
    *  apply((new java.lang.ProcessBuilder("ls", "-l")) directory new java.io.File(System.getProperty("user.home")))
    *  ```
+   *
+   *  @param builder the `java.lang.ProcessBuilder` to wrap
+   *  @return a new `ProcessBuilder` wrapping the given Java process builder
    */
   def apply(builder: JProcessBuilder): ProcessBuilder = new Simple(builder)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.io.File`. This
    *  `ProcessBuilder` can then be used as a `Source` or a `Sink`, so one can
    *  pipe things from and to it.
+   *
+   *  @param file the file to use as a source or sink for the process
+   *  @return a `FileBuilder` wrapping the given file
    */
   def apply(file: File): FileBuilder                  = new FileImpl(file)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `java.net.URL`. This
    *  `ProcessBuilder` can then be used as a `Source`, so that one can pipe things
    *  from it.
+   *
+   *  @param url the URL to use as a source for the process
+   *  @return a `URLBuilder` wrapping the given URL
    */
   def apply(url: URL): URLBuilder                     = new URLImpl(url)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `Boolean`. This can be
    *  to force an exit value.
+   *
+   *  @param value if `true`, the process exits with code 0; if `false`, with code 1
+   *  @return a `ProcessBuilder` that immediately exits with the corresponding exit code
    */
   def apply(value: Boolean): ProcessBuilder           = apply(value.toString, if (value) 0 else 1)
 
   /** Creates a [[scala.sys.process.ProcessBuilder]] from a `String` name and a
    *  `Boolean`. This can be used to force an exit value, with the name being
    *  used for `toString`.
+   *
+   *  @param name the name used for the `toString` representation of this process
+   *  @param exitValue the exit code that this process will return (by-name, evaluated on each access)
+   *  @return a `ProcessBuilder` that immediately exits with the given exit code
    */
   def apply(name: String, exitValue: => Int): ProcessBuilder = new Dummy(name, exitValue)
 
   /** Creates a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence of
    *  something else for which there's an implicit conversion to `Source`.
+   *
+   *  @tparam T the type of the elements to be converted to `Source`
+   *  @param builders the sequence of elements to convert
+   *  @param convert the implicit conversion from `T` to `Source`
+   *  @return a sequence of `Source` instances converted from the input elements
    */
   def applySeq[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = builders.map(convert)
 
@@ -181,6 +232,10 @@ trait ProcessCreation {
    *  val build = new File("project/build.properties")
    *  cat(spde, dispatch, build) #| "grep -i scala" !
    *  ```
+   *
+   *  @param file the first `Source` to concatenate
+   *  @param files additional `Source` values to concatenate after the first
+   *  @return a `ProcessBuilder` whose output is the concatenation of all sources
    */
   def cat(file: Source, files: Source*): ProcessBuilder = cat(file +: files)
 
@@ -189,6 +244,9 @@ trait ProcessCreation {
    *  piped to something else.
    *
    *  This will concatenate the output of all sources.
+   *
+   *  @param files the non-empty sequence of sources to concatenate; throws `IllegalArgumentException` if empty
+   *  @return a `ProcessBuilder` whose output is the concatenation of all sources
    */
   def cat(files: scala.collection.Seq[Source]): ProcessBuilder = {
     require(files.nonEmpty)
@@ -206,10 +264,19 @@ trait ProcessImplicits {
 
   /** Returns a sequence of [[scala.sys.process.ProcessBuilder.Source]] from a sequence
    *  of values for which an implicit conversion to `Source` is available.
+   *
+   *  @tparam T the type of the elements to be converted to `Source`
+   *  @param builders the sequence of elements to convert
+   *  @param convert the implicit conversion from `T` to `Source`
+   *  @return a sequence of `Source` instances converted from the input elements
    */
   implicit def buildersToProcess[T](builders: scala.collection.Seq[T])(implicit convert: T => Source): scala.collection.Seq[Source] = applySeq(builders)
 
-  /** Implicitly convert a `java.lang.ProcessBuilder` into a Scala one. */
+  /** Implicitly convert a `java.lang.ProcessBuilder` into a Scala one.
+   *
+   *  @param builder the `java.lang.ProcessBuilder` to convert
+   *  @return a Scala `ProcessBuilder` wrapping the given Java process builder
+   */
   implicit def builderToProcess(builder: JProcessBuilder): ProcessBuilder = apply(builder)
 
   /** Implicitly convert a `java.io.File` into a
@@ -219,6 +286,9 @@ trait ProcessImplicits {
    *  import scala.sys.process._
    *  "ls" #> new java.io.File("dirContents.txt") !
    *  ```
+   *
+   *  @param file the file to convert into a `FileBuilder`
+   *  @return a `FileBuilder` wrapping the given file
    */
   implicit def fileToProcess(file: File): FileBuilder                     = apply(file)
 
@@ -229,16 +299,26 @@ trait ProcessImplicits {
    *  import scala.sys.process._
    *  Seq("xmllint", "--html", "-") #< new java.net.URL("https://www.scala-lang.org") #> new java.io.File("fixed.html") !
    *  ```
+   *
+   *  @param url the URL to convert into a `URLBuilder`
+   *  @return a `URLBuilder` wrapping the given URL
    */
   implicit def urlToProcess(url: URL): URLBuilder                         = apply(url)
 
-  /** Implicitly convert a `String` into a [[scala.sys.process.ProcessBuilder]]. */
+  /** Implicitly convert a `String` into a [[scala.sys.process.ProcessBuilder]].
+   *
+   *  @param command the command string to convert into a `ProcessBuilder`
+   *  @return a `ProcessBuilder` for the given command string
+   */
   implicit def stringToProcess(command: String): ProcessBuilder           = apply(command)
 
   /** Implicitly convert a sequence of `String` into a
    *  [[scala.sys.process.ProcessBuilder]]. The first argument will be taken to
    *  be the command to be executed, and the remaining will be its arguments.
    *  When using this, arguments may contain spaces.
+   *
+   *  @param command a sequence where the first element is the executable and the rest are arguments
+   *  @return a `ProcessBuilder` for the given command sequence
    */
   implicit def stringSeqToProcess(command: scala.collection.Seq[String]): ProcessBuilder = apply(command)
 }

--- a/library/src/scala/sys/process/ProcessBuilder.scala
+++ b/library/src/scala/sys/process/ProcessBuilder.scala
@@ -145,6 +145,8 @@ trait ProcessBuilder extends Source with Sink {
   /** Starts the process represented by this builder, blocks until it exits, and
    *  returns the output as a String.  Standard error is sent to the provided
    *  ProcessLogger.  If the exit code is non-zero, an exception is thrown.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def !!(log: ProcessLogger): String
 
@@ -159,6 +161,8 @@ trait ProcessBuilder extends Source with Sink {
    *  returns the output as a String.  Standard error is sent to the provided
    *  ProcessLogger.  If the exit code is non-zero, an exception is thrown.  The
    *  newly started process reads from standard input of the current process.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def !!<(log: ProcessLogger): String
 
@@ -178,6 +182,8 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the console.  If the process exits
    *  with a non-zero value, the `LazyList` will provide all lines up to termination
    *  and then throw an exception.
+   *
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines(capacity: Integer): LazyList[String]
 
@@ -186,6 +192,8 @@ trait ProcessBuilder extends Source with Sink {
    *  completed.  Standard error is sent to the provided `ProcessLogger`.  If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination and then throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def lazyLines(log: ProcessLogger): LazyList[String]
 
@@ -197,6 +205,9 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the provided `ProcessLogger`.  If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination and then throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines(log: ProcessLogger, capacity: Integer): LazyList[String]
 
@@ -216,6 +227,8 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the console. If the process exits
    *  with a non-zero value, the `LazyList` will provide all lines up to termination
    *  but will not throw an exception.
+   *
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines_!(capacity: Integer): LazyList[String]
 
@@ -224,6 +237,8 @@ trait ProcessBuilder extends Source with Sink {
    *  completed.  Standard error is sent to the provided `ProcessLogger`. If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination but will not throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
    */
   def lazyLines_!(log: ProcessLogger): LazyList[String]
 
@@ -235,6 +250,9 @@ trait ProcessBuilder extends Source with Sink {
    *  Standard error is sent to the provided `ProcessLogger`. If the
    *  process exits with a non-zero value, the `LazyList` will provide all lines up
    *  to termination but will not throw an exception.
+   *
+   *  @param log the `ProcessLogger` to receive standard error output
+   *  @param capacity the maximum number of lines to buffer before blocking the producer
    */
   def lazyLines_!(log: ProcessLogger, capacity: Integer): LazyList[String]
 
@@ -330,6 +348,8 @@ trait ProcessBuilder extends Source with Sink {
   /** Starts the process represented by this builder, blocks until it exits, and
    *  returns the exit code.  Standard output and error are sent to the given
    *  ProcessLogger.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
    */
   def !(log: ProcessLogger): Int
 
@@ -343,53 +363,82 @@ trait ProcessBuilder extends Source with Sink {
    *  returns the exit code.  Standard output and error are sent to the given
    *  ProcessLogger.  The newly started process reads from standard input of the
    *  current process.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
    */
   def !<(log: ProcessLogger): Int
 
   /** Starts the process represented by this builder.  Standard output and error
    *  are sent to the console.
+   *
+   *  @return the started `Process`
    */
   def run(): Process
 
   /** Starts the process represented by this builder.  Standard output and error
    *  are sent to the given ProcessLogger.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
+   *  @return the started `Process`
    */
   def run(log: ProcessLogger): Process
 
   /** Starts the process represented by this builder.  I/O is handled by the
    *  given ProcessIO instance.
+   *
+   *  @param io the `ProcessIO` that handles the process's standard input, output, and error streams
+   *  @return the started `Process`
    */
   def run(io: ProcessIO): Process
 
   /** Starts the process represented by this builder.  Standard output and error
    *  are sent to the console.  The newly started process reads from standard
    *  input of the current process if `connectInput` is true.
+   *
+   *  @param connectInput whether to connect the process's standard input to the current process's stdin
+   *  @return the started `Process`
    */
   def run(connectInput: Boolean): Process
 
   /** Starts the process represented by this builder.  Standard output and error
    *  are sent to the given ProcessLogger.  The newly started process reads from
    *  standard input of the current process if `connectInput` is true.
+   *
+   *  @param log the `ProcessLogger` to receive standard output and error
+   *  @param connectInput whether to connect the process's standard input to the current process's stdin
+   *  @return the started `Process`
    */
   def run(log: ProcessLogger, connectInput: Boolean): Process
 
   /** Constructs a command that runs this command first and then `other` if this
    *  command succeeds.
+   *
+   *  @param other the command to run if this one returns an exit code of zero
+   *  @return a new `ProcessBuilder` that sequences this and `other` conditionally
    */
   def #&& (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that runs this command first and then `other` if this
    *  command does not succeed.
+   *
+   *  @param other the command to run if this one returns a non-zero exit code
+   *  @return a new `ProcessBuilder` that sequences this and `other` conditionally
    */
   def #|| (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that will run this command and pipes the output to
    *  `other`.  `other` must be a simple command.
+   *
+   *  @param other the command to receive the output of this process as its input
+   *  @return a new `ProcessBuilder` that pipes output from this to `other`
    */
   def #| (other: ProcessBuilder): ProcessBuilder
 
   /** Constructs a command that will run this command and then `other`.  The
    *  exit code will be the exit code of `other`.
+   *
+   *  @param other the command to run after this one, regardless of exit code
+   *  @return a new `ProcessBuilder` that sequences this and `other` unconditionally
    */
   def ### (other: ProcessBuilder): ProcessBuilder
 
@@ -417,16 +466,32 @@ object ProcessBuilder extends ProcessBuilderImpl {
    *  [[scala.sys.process.ProcessBuilder.Sink]] from a file.
    */
   trait FileBuilder extends Sink with Source {
-    /** Appends the contents of a `java.io.File` to this file. */
+    /** Appends the contents of a `java.io.File` to this file.
+     *
+     *  @param f the file whose contents will be appended
+     *  @return a `ProcessBuilder` that appends `f` to this file when run
+     */
     def #<<(f: File): ProcessBuilder
 
-    /** Appends the contents from a `java.net.URL` to this file. */
+    /** Appends the contents from a `java.net.URL` to this file.
+     *
+     *  @param u the URL whose contents will be appended
+     *  @return a `ProcessBuilder` that appends `u` to this file when run
+     */
     def #<<(u: URL): ProcessBuilder
 
-    /** Appends the contents of a `java.io.InputStream` to this file. */
+    /** Appends the contents of a `java.io.InputStream` to this file.
+     *
+     *  @param i the input stream whose contents will be appended
+     *  @return a `ProcessBuilder` that appends `i` to this file when run
+     */
     def #<<(i: => InputStream): ProcessBuilder
 
-    /** Appends the contents of a [[scala.sys.process.ProcessBuilder]] to this file. */
+    /** Appends the contents of a [[scala.sys.process.ProcessBuilder]] to this file.
+     *
+     *  @param p the process builder whose output will be appended
+     *  @return a `ProcessBuilder` that appends `p`'s output to this file when run
+     */
     def #<<(p: ProcessBuilder): ProcessBuilder
   }
 
@@ -436,19 +501,34 @@ object ProcessBuilder extends ProcessBuilderImpl {
   trait Source {
     protected def toSource: ProcessBuilder
 
-    /** Writes the output stream of this process to the given file. */
+    /** Writes the output stream of this process to the given file.
+     *
+     *  @param f the file to write the output to
+     *  @return a `ProcessBuilder` that redirects output to `f`
+     */
     def #> (f: File): ProcessBuilder = toFile(f, append = false)
 
-    /** Appends the output stream of this process to the given file. */
+    /** Appends the output stream of this process to the given file.
+     *
+     *  @param f the file to append the output to
+     *  @return a `ProcessBuilder` that appends output to `f`
+     */
     def #>> (f: File): ProcessBuilder = toFile(f, append = true)
 
     /** Writes the output stream of this process to the given OutputStream. The
      *  argument is call-by-name, so the stream is recreated, written, and closed each
      *  time this process is executed.
+     *
+     *  @param out the output stream to write to, created anew for each execution
+     *  @return a `ProcessBuilder` that redirects output to `out`
      */
     def #>(out: => OutputStream): ProcessBuilder = #> (new OStreamBuilder(out, "<output stream>"))
 
-    /** Writes the output stream of this process to a [[scala.sys.process.ProcessBuilder]]. */
+    /** Writes the output stream of this process to a [[scala.sys.process.ProcessBuilder]].
+     *
+     *  @param b the process builder to receive this process's output as input
+     *  @return a `ProcessBuilder` that pipes output to `b`
+     */
     def #>(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(toSource, b, toError = false)
 
     /** Returns a [[scala.sys.process.ProcessBuilder]] representing this `Source`. */
@@ -462,19 +542,34 @@ object ProcessBuilder extends ProcessBuilderImpl {
   trait Sink {
     protected def toSink: ProcessBuilder
 
-    /** Reads the given file into the input stream of this process. */
+    /** Reads the given file into the input stream of this process.
+     *
+     *  @param f the file to read from as input
+     *  @return a `ProcessBuilder` that reads input from `f`
+     */
     def #< (f: File): ProcessBuilder = #< (new FileInput(f))
 
-    /** Reads the given URL into the input stream of this process. */
+    /** Reads the given URL into the input stream of this process.
+     *
+     *  @param f the `URL` to read from as input
+     *  @return a `ProcessBuilder` that reads input from `f`
+     */
     def #< (f: URL): ProcessBuilder = #< (new URLInput(f))
 
     /** Reads the given InputStream into the input stream of this process. The
      *  argument is call-by-name, so the stream is recreated, read, and closed each
      *  time this process is executed.
+     *
+     *  @param in the input stream to read from, created anew for each execution
+     *  @return a `ProcessBuilder` that reads input from `in`
      */
     def #<(in: => InputStream): ProcessBuilder = #< (new IStreamBuilder(in, "<input stream>"))
 
-    /** Reads the output of a [[scala.sys.process.ProcessBuilder]] into the input stream of this process. */
+    /** Reads the output of a [[scala.sys.process.ProcessBuilder]] into the input stream of this process.
+     *
+     *  @param b the process builder whose output will be used as input to this process
+     *  @return a `ProcessBuilder` that pipes `b`'s output to this process
+     */
     def #<(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(b, toSink, toError = false)
   }
 }

--- a/library/src/scala/sys/process/ProcessBuilderImpl.scala
+++ b/library/src/scala/sys/process/ProcessBuilderImpl.scala
@@ -86,7 +86,10 @@ private[process] trait ProcessBuilderImpl {
     }
   }
 
-  /** Represents a simple command without any redirection or combination. */
+  /** Represents a simple command without any redirection or combination.
+   *
+   *  @param p the underlying `java.lang.ProcessBuilder` used to start the external process
+   */
   private[process] class Simple(p: JProcessBuilder) extends AbstractBuilder {
     override def run(io: ProcessIO): Process = {
       import java.lang.ProcessBuilder.Redirect.{INHERIT => Inherit}
@@ -166,6 +169,8 @@ private[process] trait ProcessBuilderImpl {
      *
      *  Note: not in the public API because it's not fully baked, but I need the capability
      *  for fsc.
+     *
+     *  @return a new `ProcessBuilder` that runs this command with all I/O threads daemonized
      */
     def daemonized(): ProcessBuilder = new DaemonBuilder(this)
 

--- a/library/src/scala/sys/process/ProcessIO.scala
+++ b/library/src/scala/sys/process/ProcessIO.scala
@@ -59,15 +59,30 @@ final class ProcessIO(
 ) {
   def this(in: OutputStream => Unit, out: InputStream => Unit, err: InputStream => Unit) = this(in, out, err, daemonizeThreads = false)
 
-  /** Creates a new `ProcessIO` with a different handler for the process input. */
+  /** Creates a new `ProcessIO` with a different handler for the process input.
+   *
+   *  @param write the new function to handle the process input `OutputStream`
+   *  @return a new `ProcessIO` with the specified input handler
+   */
   def withInput(write: OutputStream => Unit): ProcessIO   = new ProcessIO(write, processOutput, processError, daemonizeThreads)
 
-  /** Creates a new `ProcessIO` with a different handler for the normal output. */
+  /** Creates a new `ProcessIO` with a different handler for the normal output.
+   *
+   *  @param process the new function to handle the process standard output `InputStream`
+   *  @return a new `ProcessIO` with the specified output handler
+   */
   def withOutput(process: InputStream => Unit): ProcessIO = new ProcessIO(writeInput, process, processError, daemonizeThreads)
 
-  /** Creates a new `ProcessIO` with a different handler for the error output. */
+  /** Creates a new `ProcessIO` with a different handler for the error output.
+   *
+   *  @param process the new function to handle the process error output `InputStream`
+   *  @return a new `ProcessIO` with the specified error handler
+   */
   def withError(process: InputStream => Unit): ProcessIO  = new ProcessIO(writeInput, processOutput, process, daemonizeThreads)
 
-  /** Creates a new `ProcessIO`, with `daemonizeThreads` true. */
+  /** Creates a new `ProcessIO`, with `daemonizeThreads` true.
+   *
+   *  @return a new `ProcessIO` that runs all I/O threads as daemon threads
+   */
   def daemonized(): ProcessIO = new ProcessIO(writeInput, processOutput, processError, daemonizeThreads = true)
 }

--- a/library/src/scala/sys/process/ProcessImpl.scala
+++ b/library/src/scala/sys/process/ProcessImpl.scala
@@ -242,6 +242,8 @@ private[process] trait ProcessImpl {
 
   /** A thin wrapper around a java.lang.Process.  `ioThreads` are the Threads created to do I/O.
    *  The implementation of `exitValue` waits until these threads die before returning.
+   *
+   *  @param action the by-name computation whose result will be used as the exit value
    */
   private[process] class DummyProcess(action: => Int) extends Process {
     private val (thread, value) = Future(action)
@@ -260,6 +262,10 @@ private[process] trait ProcessImpl {
    *
    *  The implementation of `exitValue` interrupts `inputThread`
    *  and then waits until all I/O threads die before returning.
+   *
+   *  @param p the underlying `java.lang.Process` being wrapped
+   *  @param inputThread the thread writing to the process's stdin, or null if stdin was inherited
+   *  @param outputThreads the threads reading from the process's stdout and stderr streams
    */
   private[process] class SimpleProcess(p: JProcess, inputThread: Thread | Null, outputThreads: List[Thread]) extends Process {
     override def isAlive() = p.isAlive()

--- a/library/src/scala/sys/process/ProcessLogger.scala
+++ b/library/src/scala/sys/process/ProcessLogger.scala
@@ -38,10 +38,16 @@ import java.io._
  *  @see [[scala.sys.process.ProcessBuilder]]
  */
 trait ProcessLogger {
-  /** Will be called with each line read from the process output stream. */
+  /** Will be called with each line read from the process output stream.
+   *
+   *  @param s a lazily-evaluated line from the process standard output
+   */
   def out(s: => String): Unit
 
-  /** Will be called with each line read from the process error stream. */
+  /** Will be called with each line read from the process error stream.
+   *
+   *  @param s a lazily-evaluated line from the process standard error
+   */
   def err(s: => String): Unit
 
   /** If a process is begun with one of these `ProcessBuilder` methods:
@@ -53,11 +59,17 @@ trait ProcessLogger {
    *  an opportunity to set up and tear down buffering.  At present the
    *  library implementations of `ProcessLogger` simply execute the body
    *  unbuffered.
+   *
+   *  @tparam T the return type of the buffered operation
+   *  @param f the code to execute with buffering, evaluated by name
    */
   def buffer[T](f: => T): T
 }
 
-/** A [[scala.sys.process.ProcessLogger]] that writes output to a file. */
+/** A [[scala.sys.process.ProcessLogger]] that writes output to a file.
+ *
+ *  @param file the file to which both standard and error output will be appended
+ */
 class FileProcessLogger(file: File) extends ProcessLogger with Closeable with Flushable {
   private val writer = (
     new PrintWriter(
@@ -80,20 +92,27 @@ class FileProcessLogger(file: File) extends ProcessLogger with Closeable with Fl
  *  when run.
  */
 object ProcessLogger {
-  /** Creates a [[scala.sys.process.ProcessLogger]] that redirects output to a `java.io.File`. */
+  /** Creates a [[scala.sys.process.ProcessLogger]] that redirects output to a `java.io.File`.
+   *
+   *  @param file the `java.io.File` to which output will be appended
+   *  @return a `FileProcessLogger` that writes to the given file
+   */
   def apply(file: File): FileProcessLogger = new FileProcessLogger(file)
 
   /** Creates a [[scala.sys.process.ProcessLogger]] that sends all output, standard and error,
    *  to the passed function.
+   *
+   *  @param fn the function to apply to each line of standard and error output
+   *  @return a `ProcessLogger` that passes all output to `fn`
    */
   def apply(fn: String => Unit): ProcessLogger = apply(fn, fn)
 
   /** Creates a [[scala.sys.process.ProcessLogger]] that sends all output to the corresponding
    *  function.
    *
-   *  @param fout  This function will receive standard output.
-   *
-   *  @param ferr  This function will receive standard error.
+   *  @param fout the function that will receive each line of standard output
+   *  @param ferr the function that will receive each line of standard error
+   *  @return a `ProcessLogger` that passes output to `fout` and errors to `ferr`
    */
   def apply(fout: String => Unit, ferr: String => Unit): ProcessLogger =
     new ProcessLogger {


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for sys, concurrent, runtime. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.