### PR TITLE
Collection mutable (2): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library-js/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library-js/src/scala/collection/mutable/ArrayBuilder.scala
@@ -54,10 +54,18 @@ sealed abstract class ArrayBuilder[T]
 
   protected[this] def resize(size: Int): Unit
 
-  /** Adds all elements of an array. */
+  /** Adds all elements of an array.
+   *
+   *  @param xs the array from which to add elements
+   */
   def addAll(xs: Array[_ <: T]): this.type = addAll(xs, 0, xs.length)
 
-  /** Adds a slice of an array. */
+  /** Adds a slice of an array.
+   *
+   *  @param xs the array from which to add a slice of elements
+   *  @param offset the starting index in `xs` from which to copy elements
+   *  @param length the number of elements to copy from `xs`
+   */
   def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
     ensureSize(this.size + length)
     Array.copy(xs, offset, elems.nn, this.size, length)
@@ -95,7 +103,10 @@ object ArrayBuilder {
     if (LinkingInfo.isWebAssembly) makeForWasm
     else makeForJS
 
-  /** Implementation of `make` for JS. */
+  /** Implementation of `make` for JS.
+   *
+   *  @tparam T the element type of the array builder, with a `ClassTag` context bound
+   */
   @inline
   private def makeForJS[T: ClassTag]: ArrayBuilder[T] =
     new ArrayBuilder.generic[T](implicitly[ClassTag[T]].runtimeClass)
@@ -103,6 +114,9 @@ object ArrayBuilder {
   /** Implementation of `make` for Wasm.
    *
    *  This is the original upstream implementation.
+   *
+   *  @tparam T the element type of the array builder, with a `ClassTag` context bound
+   *  @return a new array builder specialized for the runtime type of `T`
    */
   @inline
   private def makeForWasm[T: ClassTag]: ArrayBuilder[T] = {
@@ -146,7 +160,12 @@ object ArrayBuilder {
       this
     }
 
-    /** Adds a slice of an array. */
+    /** Adds a slice of an array.
+     *
+     *  @param xs the array from which to add a slice of elements
+     *  @param offset the starting index in `xs` from which to copy elements
+     *  @param length the number of elements to copy from `xs`
+     */
     override def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
       val end = offset + length
       var i = offset

--- a/library-js/src/scala/collection/mutable/Buffer.scala
+++ b/library-js/src/scala/collection/mutable/Buffer.scala
@@ -17,7 +17,10 @@ import scala.language.`2.13`
 
 import scala.scalajs.js
 
-/** A `Buffer` is a growable and shrinkable `Seq`. */
+/** A `Buffer` is a growable and shrinkable `Seq`.
+ *
+ *  @tparam A the type of elements contained in this buffer
+ */
 trait Buffer[A]
   extends Seq[A]
     with SeqOps[A, Buffer, Buffer[A]]

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -65,7 +65,10 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   override def knownSize: Int = super[IndexedSeqOps].knownSize
 
-  /** Ensures that the internal array has at least `n` cells. */
+  /** Ensures that the internal array has at least `n` cells.
+   *
+   *  @param n the minimum number of cells required in the internal array
+   */
   protected def ensureSize(n: Int): Unit = {
     array = ArrayBuffer.ensureSize(array, size0, n)
   }
@@ -77,7 +80,10 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   def sizeHint(size: Int): Unit =
     if(size > length && size >= 1) ensureSize(size)
 
-  /** Reduces length to `n`, nulling out all dropped elements. */
+  /** Reduces length to `n`, nulling out all dropped elements.
+   *
+   *  @param n the new size of the buffer, must be less than or equal to the current size
+   */
   private def reduceToSize(n: Int): Unit = {
     mutationCount += 1
     Arrays.fill(array, n, size0, null)
@@ -95,6 +101,8 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   /** Trims the `array` buffer size down to either a power of 2
    *  or Int.MaxValue while keeping first `requiredLength` elements.
+   *
+   *  @param requiredLength the number of elements to retain in the resized array
    */
   private def resize(requiredLength: Int): Unit =
     array = ArrayBuffer.downsize(array, requiredLength)
@@ -246,6 +254,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   /** Sorts this $coll in place according to an Ordering.
    *
    *  @see [[scala.collection.mutable.IndexedSeqOps.sortInPlace]]
+   *  @tparam B a supertype of the element type `A` for which an `Ordering` is available
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -47,10 +47,18 @@ sealed abstract class ArrayBuilder[T]
 
   protected def resize(size: Int): Unit
 
-  /** Adds all elements of an array. */
+  /** Adds all elements of an array.
+   *
+   *  @param xs the array of elements to add
+   */
   def addAll(xs: Array[? <: T]): this.type = addAll(xs, 0, xs.length)
 
-  /** Adds a slice of an array. */
+  /** Adds a slice of an array.
+   *
+   *  @param xs the array from which a slice of elements is added
+   *  @param offset the start index within `xs` from which to copy elements (clamped to 0 if negative)
+   *  @param length the maximum number of elements to copy from `xs` (clamped to 0 if negative, and to the number of available elements)
+   */
   def addAll(xs: Array[? <: T], offset: Int, length: Int): this.type = {
     val offset1 = offset.max(0)
     val length1 = length.max(0)

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -121,6 +121,10 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
    *  boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
    *  `ArraySeq.make(a.asInstanceOf[Array[Int]])` does not work, it throws a `ClassCastException`
    *  at runtime.
+   *
+   *  @tparam T the element type of the array
+   *  @param x the array to wrap
+   *  @return an `ArraySeq` wrapping the given array using the appropriate primitive specialization, or `null` if `x` is `null`
    */
   def make[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
     case null              => null

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -34,6 +34,8 @@ import scala.annotation.implicitNotFound
  *  @define orderDependentFold
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @param protected[collection] final var elems the underlying array of `Long` words storing the bits; used directly without copying, so external mutations will affect this bitset
  */
 class BitSet(protected[collection] final var elems: Array[Long])
   extends AbstractSet[Int]
@@ -368,7 +370,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   def newBuilder: Builder[Int, BitSet] = new GrowableBuilder(empty)
 
-  /** A bitset containing all the bits in an array. */
+  /** A bitset containing all the bits in an array.
+   *
+   *  @param elems the array of `Long` words representing the bits; a defensive copy is made
+   */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty
@@ -380,6 +385,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   /** A bitset containing all the bits in an array, wrapping the existing
    *  array without copying.
+   *
+   *  @param elems the array of `Long` words representing the bits, used directly without copying; the caller must not mutate the array afterward
    */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length

--- a/library/src/scala/collection/mutable/Buffer.scala
+++ b/library/src/scala/collection/mutable/Buffer.scala
@@ -22,6 +22,8 @@ import scala.annotation.nowarn
  *
  *  @define coll buffer
  *  @define Coll `Buffer`
+ *
+ *  @tparam A the element type of the buffer
  */
 trait Buffer[A]
   extends Seq[A]
@@ -311,5 +313,8 @@ object Buffer extends SeqFactory.Delegate[Buffer](ArrayBuffer)
 @SerialVersionUID(3L)
 object IndexedBuffer extends SeqFactory.Delegate[IndexedBuffer](ArrayBuffer)
 
-/** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the buffer
+ */
 abstract class AbstractBuffer[A] extends AbstractSeq[A] with Buffer[A]

--- a/library/src/scala/collection/mutable/Builder.scala
+++ b/library/src/scala/collection/mutable/Builder.scala
@@ -22,6 +22,9 @@ import language.experimental.captureChecking
  *  Builder, in which case `result()` simply returns `this`.
  *
  *  @see [[scala.collection.mutable.ReusableBuilder]] for Builders which can be reused after calling `result()`
+ *
+ *  @tparam A the type of elements that can be added to this builder
+ *  @tparam To the type of collection produced by this builder
  */
 trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
 
@@ -94,7 +97,11 @@ trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
     }
   }
 
-  /** A builder resulting from this builder by mapping the result using `f`. */
+  /** A builder resulting from this builder by mapping the result using `f`.
+   *
+   *  @tparam NewTo the type of collection produced by the returned builder
+   *  @param f the function to apply to this builder's result
+   */
   def mapResult[NewTo](f: To => NewTo): Builder[A, NewTo]^{this, f} = new Builder[A, NewTo] {
     def addOne(x: A): this.type = { self += x; this }
     def clear(): Unit = self.clear()

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -34,6 +34,11 @@ import scala.runtime.Statics
  *  @define coll mutable collision-proof hash map
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam K the type of the keys contained in this hash map
+ *  @tparam V the type of the values associated with the keys
+ *  @param initialCapacity the initial capacity of the internal hash table
+ *  @param loadFactor the load factor for the hash table, used to determine when to resize
  */
 final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double)(implicit ordering: Ordering[K])
   extends AbstractMap[K, V]
@@ -414,6 +419,8 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   /** Builds a new `CollisionProofHashMap` by applying a function to all elements of this $coll.
    *
+   *  @tparam K2 the key type of the returned collection
+   *  @tparam V2 the value type of the returned collection
    *  @param f      the function to apply to each element.
    *  @return       a new $coll resulting from applying the given function
    *                `f` to each element of this $coll and collecting the results.
@@ -425,6 +432,8 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   /** Builds a new `CollisionProofHashMap` by applying a function to all elements of this $coll
    *  and using the elements of the resulting collections.
    *
+   *  @tparam K2 the key type of the returned collection
+   *  @tparam V2 the value type of the returned collection
    *  @param f      the function to apply to each element.
    *  @return       a new $coll resulting from applying the given collection-valued function
    *                `f` to each element of this $coll and concatenating the results.
@@ -436,6 +445,8 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
    *  on which the function is defined.
    *
+   *  @tparam K2 the key type of the returned collection
+   *  @tparam V2 the value type of the returned collection
    *  @param pf     the partial function which filters and maps the $coll.
    *  @return       a new $coll resulting from applying the given partial function
    *                `pf` to each element on which it is defined and collecting the results.
@@ -450,7 +461,11 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     case _ => iterator.concat(suffix.iterator)
   })
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @tparam V2 the value type of the returned collection
+   *  @param xs the key-value pairs to append to this collection
+   */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]^): CollisionProofHashMap[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
@@ -695,6 +710,10 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
 
   /** Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
    *  parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
+   *
+   *  @param _root the root of the red-black tree
+   *  @param to the node to be replaced in the tree
+   *  @param from the node that replaces `to`
    */
   private def transplant(_root: RBNode, to: RBNode, from: RBNode): RBNode = {
     var root = _root
@@ -836,6 +855,10 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
 
   /** Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
    *  therefore, the last node), this method returns `null`.
+   *
+   *  @tparam A the key type of the tree nodes
+   *  @tparam B the value type of the tree nodes
+   *  @param node the node whose successor is to be found
    */
   private def successor[A, B](node: RBNode[A, B]): RBNode[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)

--- a/library/src/scala/collection/mutable/Growable.scala
+++ b/library/src/scala/collection/mutable/Growable.scala
@@ -25,6 +25,8 @@ import language.experimental.captureChecking
  *  @define Coll `Growable`
  *  @define add add
  *  @define Add Add
+ *
+ *  @tparam A the type of elements that can be added to this collection
  */
 trait Growable[-A] extends Clearable {
 

--- a/library/src/scala/collection/mutable/GrowableBuilder.scala
+++ b/library/src/scala/collection/mutable/GrowableBuilder.scala
@@ -23,6 +23,9 @@ import language.experimental.captureChecking
  *
  *  @define Coll `GrowingBuilder`
  *  @define coll growing builder
+ *
+ *  @tparam Elem the type of elements that can be added to the builder
+ *  @tparam To the type of the resulting growable collection, which must be a subtype of `Growable[Elem]`
  */
 class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
   extends Builder[Elem, To] {

--- a/library/src/scala/collection/mutable/HashMap.scala
+++ b/library/src/scala/collection/mutable/HashMap.scala
@@ -62,10 +62,16 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   override def size: Int = contentSize
 
-  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash. */
+  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
+   *
+   *  @param improvedHash the improved hash value to convert back to the original `any.##` hash
+   */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of an original (`any.##`) hash. */
+  /** Computes the improved hash of an original (`any.##`) hash.
+   *
+   *  @param originalHash the original hash code from `any.##`
+   */
   @`inline` private def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
@@ -77,7 +83,10 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     originalHash ^ (originalHash >>> 16)
   }
 
-  /** Computes the improved hash of this key. */
+  /** Computes the improved hash of this key.
+   *
+   *  @param o the key for which to compute the improved hash
+   */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -30,6 +30,10 @@ import scala.util.hashing.MurmurHash3
  *  @define coll mutable hash set
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam A the element type of the set
+ *  @param initialCapacity the initial capacity of the internal hash table
+ *  @param loadFactor the load factor for the hash table (ratio of size to capacity that triggers resizing)
  */
 final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   extends AbstractSet[A]
@@ -57,10 +61,16 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
 
   override def size: Int = contentSize
 
-  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash. */
+  /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
+   *
+   *  @param improvedHash the improved hash value to convert back to a standard hash index
+   */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of an original (`any.##`) hash. */
+  /** Computes the improved hash of an original (`any.##`) hash.
+   *
+   *  @param originalHash the original hash code obtained from `##`
+   */
   private def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
@@ -68,7 +78,10 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
     originalHash ^ (originalHash >>> 16)
   }
 
-  /** Computes the improved hash of this element. */
+  /** Computes the improved hash of this element.
+   *
+   *  @param o the element whose hash to compute
+   */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)

--- a/library/src/scala/collection/mutable/ImmutableBuilder.scala
+++ b/library/src/scala/collection/mutable/ImmutableBuilder.scala
@@ -17,7 +17,11 @@ package mutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Reusable builder for immutable collections */
+/** Reusable builder for immutable collections
+ *
+ *  @tparam A the element type of the collection being built
+ *  @tparam C the type of the immutable collection to build (must be a subtype of `IterableOnce[?]`)
+ */
 abstract class ImmutableBuilder[-A, C <: IterableOnce[?]](empty: C)
   extends ReusableBuilder[A, C] {
 

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -48,6 +48,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   /** Sorts this $coll in place according to an Ordering.
    *
    *  @see [[scala.collection.SeqOps.sorted]]
+   *  @tparam B a supertype of the element type `A` for which an `Ordering` is available
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */
@@ -73,6 +74,8 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   /** Sorts this $coll in place according to a comparison function.
    *
    *  @see [[scala.collection.SeqOps.sortWith]]
+   *
+   *  @param lt the less-than comparison function; should return `true` if the first argument strictly precedes the second in the desired ordering
    */
   def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
 
@@ -80,6 +83,10 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  an implicitly given Ordering with a transformation function.
    *
    *  @see [[scala.collection.SeqOps.sortBy]]
+   *
+   *  @tparam B the target type of the transformation function `f`, for which an `Ordering` must exist
+   *  @param f the transformation function that extracts a sort key of type `B` from each element
+   *  @param ord the implicit ordering on type `B` used to compare transformed elements
    */
   def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
 

--- a/library/src/scala/collection/mutable/Iterable.scala
+++ b/library/src/scala/collection/mutable/Iterable.scala
@@ -31,5 +31,8 @@ trait Iterable[A]
 @SerialVersionUID(3L)
 object Iterable extends IterableFactory.Delegate[Iterable](ArrayBuffer)
 
-/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the `Iterable`
+ */
 abstract class AbstractIterable[A] extends scala.collection.AbstractIterable[A] with Iterable[A]

--- a/library/src/scala/collection/mutable/LinkedHashMap.scala
+++ b/library/src/scala/collection/mutable/LinkedHashMap.scala
@@ -159,8 +159,8 @@ class LinkedHashMap[K, V]
   /** Removes a key from this map if it exists
    *
    *  @param elem the element to remove
-   *  @param hash the **improved** hashcode of `element` (see computeHash)
-   *  @return the node that contained element if it was present, otherwise null
+   *  @param hash the **improved** hash code of `elem` (see `computeHash`)
+   *  @return the entry that contained `elem` if it was present, otherwise `null`
    */
   private def removeEntry0(elem: K, hash: Int): Entry | Null = {
     val idx = index(hash)
@@ -190,13 +190,19 @@ class LinkedHashMap[K, V]
     }
   }
 
-  /** Computes the improved hash of an original (`any.##`) hash. */
+  /** Computes the improved hash of an original (`any.##`) hash.
+   *
+   *  @param originalHash the original hash code obtained from `any.##`
+   */
   @`inline` private def improveHash(originalHash: Int): Int = {
     originalHash ^ (originalHash >>> 16)
   }
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of this key. */
+  /** Computes the improved hash of this key.
+   *
+   *  @param o the key whose improved hash to compute
+   */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -365,7 +371,10 @@ class LinkedHashMap[K, V]
     e
   }
 
-  /** Deletes the entry from the LinkedHashMap, set the `earlier` and `later` pointers correctly. */
+  /** Deletes the entry from the `LinkedHashMap`, set the `earlier` and `later` pointers correctly.
+   *
+   *  @param e the entry to remove from the `LinkedHashMap`
+   */
   private def deleteEntry(e: Entry): Unit = {
     if (e.earlier eq null) firstEntry = e.later
     else e.earlier.nn.later = e.later
@@ -495,7 +504,14 @@ object LinkedHashMap extends MapFactory[LinkedHashMap] {
 
   def newBuilder[K, V]: GrowableBuilder[(K, V), LinkedHashMap[K, V]] = new GrowableBuilder(empty[K, V])
 
-  /** Class for the linked hash map entry, used internally. */
+  /** Class for the linked hash map entry, used internally.
+   *
+   *  @tparam K the type of key stored in this entry
+   *  @tparam V the type of value stored in this entry
+   *  @param key the key for this map entry
+   *  @param hash the improved hash code of `key` (see `improveHash`)
+   *  @param value the value associated with `key`
+   */
   private[mutable] final class LinkedEntry[K, V](val key: K, val hash: Int, var value: V) {
     var earlier: LinkedEntry[K, V] | Null = null
     var later: LinkedEntry[K, V] | Null = null

--- a/library/src/scala/collection/mutable/LinkedHashSet.scala
+++ b/library/src/scala/collection/mutable/LinkedHashSet.scala
@@ -152,7 +152,10 @@ class LinkedHashSet[A]
 
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
-  /** Computes the improved hash of this key. */
+  /** Computes the improved hash of this key.
+   *
+   *  @param o the key whose hash to compute
+   */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 
   @`inline` private def index(hash: Int) = hash & (table.length - 1)
@@ -180,7 +183,10 @@ class LinkedHashSet[A]
     e
   }
 
-  /** Deletes the entry from the LinkedHashSet, set the `earlier` and `later` pointers correctly. */
+  /** Deletes the entry from the `LinkedHashSet`, set the `earlier` and `later` pointers correctly.
+   *
+   *  @param e the entry to remove from the `LinkedHashSet`
+   */
   private def deleteEntry(e: Entry): Unit = {
     if (e.earlier eq null) firstEntry = e.later
     else e.earlier.later = e.later
@@ -329,7 +335,12 @@ object LinkedHashSet extends IterableFactory[LinkedHashSet] {
 
   def newBuilder[A]: GrowableBuilder[A, LinkedHashSet[A]] = new GrowableBuilder(empty[A])
 
-  /** Class for the linked hash set entry, used internally. */
+  /** Class for the linked hash set entry, used internally.
+   *
+   *  @tparam A the type of the elements contained in the linked hash set
+   *  @param key the element stored in this entry
+   *  @param hash the hash value of `key`
+   */
   private[mutable] final class Entry[A](val key: A, val hash: Int) {
     @annotation.stableNull var earlier: Entry[A] | Null = null
     @annotation.stableNull var later: Entry[A] | Null = null

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -182,6 +182,8 @@ class ListBuffer[A]
 
   /** Reduces the length of the buffer, and nulls out last0
    *  if this reduces the length to 0.
+   *
+   *  @param num the number of elements by which to reduce the length
    */
   private def reduceLengthBy(num: Int): Unit = {
     len -= num
@@ -393,7 +395,7 @@ class ListBuffer[A]
    *
    *  Runs in constant time.
    *
-   *  @return The last element of this $coll.
+   *  @return the last element of this $coll.
    *  @throws NoSuchElementException If the $coll is empty.
    */
   override def last: A = if (last0 eq null) throw new NoSuchElementException("last of empty ListBuffer") else last0.head
@@ -402,7 +404,7 @@ class ListBuffer[A]
    *
    *  Runs in constant time.
    *
-   *  @return the last element of this $coll$ if it is nonempty, `None` if it is empty.
+   *  @return the last element of this $coll if it is nonempty, `None` if it is empty.
    */
   override def lastOption: Option[A] = if (last0 eq null) None else Some(last0.head)
 

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -36,6 +36,8 @@ import scala.language.implicitConversions
  *  This map is not intended to contain more than 2<sup>29</sup> entries (approximately
  *  500 million).  The maximum capacity is 2<sup>30</sup>, but performance will degrade
  *  rapidly as 2<sup>30</sup> is approached.
+ *
+ *  @tparam V the type of the values stored in this map
  */
 final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBufferSize: Int, initBlank: Boolean)
   extends AbstractMap[Long, V]
@@ -56,17 +58,26 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   }
   override protected def newSpecificBuilder: Builder[(Long, V),LongMap[V]] = new GrowableBuilder(LongMap.empty[V])
 
-  /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping. */
+  /** Creates a new `LongMap` that returns default values according to a supplied key-value mapping.
+   *
+   *  @param defaultEntry the function mapping keys to default values
+   */
   def this(defaultEntry: Long -> V) = this(defaultEntry, 16, initBlank = true)
 
   /** Creates a new `LongMap` with an initial buffer of specified size.
    *
    *  A LongMap can typically contain half as many elements as its buffer size
    *  before it requires resizing.
+   *
+   *  @param initialBufferSize the initial size of the internal buffer; the map can hold about half this many elements before resizing
    */
   def this(initialBufferSize: Int) = this(LongMap.exceptionDefault, initialBufferSize, initBlank = true)
 
-  /** Creates a new `LongMap` with specified default values and initial buffer size. */
+  /** Creates a new `LongMap` with specified default values and initial buffer size.
+   *
+   *  @param defaultEntry the function mapping keys to default values
+   *  @param initialBufferSize the initial size of the internal buffer; the map can hold about half this many elements before resizing
+   */
   def this(defaultEntry: Long -> V,  initialBufferSize: Int) = this(defaultEntry,  initialBufferSize,  initBlank = true)
 
   private var mask = 0
@@ -220,6 +231,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *  Note: this is the fastest way to retrieve a value that may or
    *  may not exist, if the default null/zero is acceptable.  For key/value
    *  pairs that do exist,  `apply` (i.e. `map(key)`) is equally fast.
+   *
+   *  @param key the key to look up
+   *  @return the value associated with `key`, or `null` if not present
    */
   def getOrNull(key: Long): V | Null = {
     if (key == -key) {
@@ -236,6 +250,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   /** Retrieves the value associated with a key.
    *  If the key does not exist in the map, the `defaultEntry` for that key
    *  will be returned instead.
+   *
+   *  @param key the key to look up
    */
   override def apply(key: Long): V = {
     if (key == -key) {
@@ -251,6 +267,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
 
   /** The user-supplied default value for the key.  Throws an exception
    *  if no other default behavior was specified.
+   *
+   *  @param key the key whose default value is requested
    */
   override def default(key: Long) = defaultEntry(key)
 
@@ -321,6 +339,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   /** Updates the map to include a new key-value pair.
    *
    *  This is the fastest way to add an entry to a `LongMap`.
+   *
+   *  @param key the key of the entry to update
+   *  @param value the new value to associate with `key`
    */
   override def update(key: Long, value: V): Unit = {
     if (key == -key) {
@@ -354,7 +375,11 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   @deprecated("Use `addOne` or `update` instead; infix operations with an operand of multiple args will be deprecated", "2.13.3")
   def +=(key: Long, value: V): this.type = { update(key, value); this }
 
-  /** Adds a new key/value pair to this map and returns the map. */
+  /** Adds a new key/value pair to this map and returns the map.
+   *
+   *  @param key the key to add
+   *  @param value the value to associate with `key`
+   */
   @inline final def addOne(key: Long, value: V): this.type = { update(key, value); this }
 
   @inline override final def addOne(kv: (Long, V)): this.type = { update(kv._1, kv._2); this }
@@ -486,7 +511,11 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   override def updated[V1 >: V](key: Long, value: V1): LongMap[V1] =
     clone().asInstanceOf[LongMap[V1]].addOne(key, value)
 
-  /** Applies a function to all keys of this map. */
+  /** Applies a function to all keys of this map.
+   *
+   *  @tparam A the result type of the function
+   *  @param f the function to apply to each key
+   */
   def foreachKey[A](f: Long => A): Unit = {
     if ((extraKeys & 1) == 1) f(0L)
     if ((extraKeys & 2) == 2) f(Long.MinValue)
@@ -501,7 +530,11 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
     }
   }
 
-  /** Applies a function to all values of this map. */
+  /** Applies a function to all values of this map.
+   *
+   *  @tparam A the result type of the function
+   *  @param f the function to apply to each value
+   */
   def foreachValue[A](f: V => A): Unit = {
     if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V])
     if ((extraKeys & 2) == 2) f(minValue.asInstanceOf[V])
@@ -519,6 +552,9 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
   /** Creates a new `LongMap` with different values.
    *  Unlike `mapValues`, this method generates a new
    *  collection immediately.
+   *
+   *  @tparam V1 the type of the values in the resulting map
+   *  @param f the transformation function applied to each value
    */
   def mapValuesNow[V1](f: V => V1): LongMap[V1] = {
     val zv = if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null] else null
@@ -547,6 +583,8 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
 
   /** Applies a transformation function to all values stored in this map.
    *  Note: the default, if any,  is not transformed.
+   *
+   *  @param f the transformation function applied to each value
    */
   def transformValuesInPlace(f: V => V): this.type = {
     if ((extraKeys & 1) == 1) zeroValue = f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null]
@@ -565,19 +603,22 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
 
   /** An overload of `map` which produces a `LongMap`.
    *
+   *  @tparam V2 the value type of the resulting map
    *  @param f the mapping function
    */
   def map[V2](f: ((Long, V)) => (Long, V2)): LongMap[V2] = LongMap.from(new View.Map(coll, f))
 
   /** An overload of `flatMap` which produces a `LongMap`.
    *
+   *  @tparam V2 the value type of the resulting map
    *  @param f the mapping function
    */
   def flatMap[V2](f: ((Long, V)) => IterableOnce[(Long, V2)]^): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
 
   /** An overload of `collect` which produces a `LongMap`.
    *
-   *  @param pf the mapping function
+   *  @tparam V2 the value type of the resulting map
+   *  @param pf the partial function to apply to matching elements
    */
   def collect[V2](pf: PartialFunction[(Long, V), (Long, V2)]): LongMap[V2] =
     strictOptimizedCollect(LongMap.newBuilder[V2], pf)
@@ -598,6 +639,8 @@ object LongMap {
   /** A builder for instances of `LongMap`.
    *
    *  This builder can be reused to create multiple instances.
+   *
+   *  @tparam V the type of the values in the map being built
    */
   final class LongMapBuilder[V] extends ReusableBuilder[(Long, V), LongMap[V]] {
     private[collection] var elems: LongMap[V] = new LongMap[V]
@@ -610,7 +653,11 @@ object LongMap {
     override def knownSize: Int = elems.knownSize
   }
 
-  /** Creates a new `LongMap` with zero or more key/value pairs. */
+  /** Creates a new `LongMap` with zero or more key/value pairs.
+   *
+   *  @tparam V the type of the values
+   *  @param elems the key/value pairs to initialize the map with
+   */
   def apply[V](elems: (Long, V)*): LongMap[V] = buildFromIterableOnce(elems)
 
   private def buildFromIterableOnce[V](elems: IterableOnce[(Long, V)]^): LongMap[V] = {
@@ -622,18 +669,25 @@ object LongMap {
     lm
   }
 
-  /** Creates a new empty `LongMap`. */
+  /** Creates a new empty `LongMap`.
+   *
+   *  @tparam V the type of the values
+   */
   def empty[V]: LongMap[V] = new LongMap[V]
 
-  /** Creates a new empty `LongMap` with the supplied default. */
+  /** Creates a new empty `LongMap` with the supplied default.
+   *
+   *  @tparam V the type of the values
+   *  @param default the function mapping keys to default values
+   */
   def withDefault[V](default: Long -> V): LongMap[V] = new LongMap[V](default)
 
   /** Creates a new `LongMap` from an existing source collection. A source collection
    *  which is already a `LongMap` gets cloned.
    *
-   *  @tparam V the type of the collection’s elements
-   *  @param source Source collection
-   *  @return a new `LongMap` with the elements of `source`
+   *  @tparam V the type of the values
+   *  @param source the source collection to create the map from
+   *  @return a new `LongMap` with the elements of `source`; if `source` is already a `LongMap`, it is cloned
    */
   def from[V](source: IterableOnce[(Long, V)]^): LongMap[V] = source match {
     case source: LongMap[?] => source.clone().asInstanceOf[LongMap[V]]
@@ -644,6 +698,10 @@ object LongMap {
 
   /** Creates a new `LongMap` from arrays of keys and values.
    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+   *
+   *  @tparam V the type of the values
+   *  @param keys the array of `Long` keys
+   *  @param values the array of values corresponding to each key
    */
   def fromZip[V](keys: Array[Long], values: Array[V]): LongMap[V] = {
     val sz = math.min(keys.length, values.length)
@@ -656,6 +714,10 @@ object LongMap {
 
   /** Creates a new `LongMap` from keys and values.
    *  Equivalent to but more efficient than `LongMap((keys zip values): _*)`.
+   *
+   *  @tparam V the type of the values
+   *  @param keys the iterable of `Long` keys
+   *  @param values the iterable of values corresponding to each key
    */
   def fromZip[V](keys: scala.collection.Iterable[Long], values: scala.collection.Iterable[V]): LongMap[V] = {
     val sz = math.min(keys.size, values.size)

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -18,7 +18,11 @@ import language.experimental.captureChecking
 
 import scala.language.`2.13`
 
-/** Base type of mutable Maps. */
+/** Base type of mutable Maps.
+ *
+ *  @tparam K the type of keys in the map
+ *  @tparam V the type of values associated with keys
+ */
 trait Map[K, V]
   extends Iterable[(K, V)]
     with collection.Map[K, V]
@@ -65,6 +69,11 @@ trait Map[K, V]
 /**
  *  @define coll mutable map
  *  @define Coll `mutable.Map`
+ *
+ *  @tparam K the type of keys in the map
+ *  @tparam V the type of values associated with keys
+ *  @tparam CC the higher-kinded type constructor for map operations returning the same collection type
+ *  @tparam C the concrete type of the map collection
  */
 transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
@@ -267,5 +276,9 @@ object Map extends MapFactory.Delegate[Map](HashMap) {
 
 }
 
-/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses.
+ *
+ *  @tparam K the type of keys in the map
+ *  @tparam V the type of values associated with keys
+ */
 abstract class AbstractMap[K, V] extends scala.collection.AbstractMap[K, V] with Map[K, V]

--- a/library/src/scala/collection/mutable/OpenHashMap.scala
+++ b/library/src/scala/collection/mutable/OpenHashMap.scala
@@ -41,6 +41,12 @@ object OpenHashMap extends MapFactory[OpenHashMap] {
    *  deleted if and only if its `value` is `None`.
    *  If its `key` is not the default value of type `Key`, the entry is occupied.
    *  If the entry is occupied, `hash` contains the hash value of `key`.
+   *
+   *  @tparam Key the type of keys stored in this entry
+   *  @tparam Value the type of values stored in this entry
+   *  @param key the key associated with this entry
+   *  @param hash the cached hash code of `key`
+   *  @param value `Some(v)` if the entry is occupied, `None` if deleted
    */
   final private class OpenEntry[Key, Value](var key: Key,
                                             var hash: Int,
@@ -101,7 +107,10 @@ class OpenHashMap[Key, Value](initialSize : Int)
   override def knownSize: Int = size
   private def size_=(s : Int): Unit = _size = s
   override def isEmpty: Boolean = _size == 0
-  /** Returns a mangled hash code of the provided key. */
+  /** Returns a mangled hash code of the provided key.
+   *
+   *  @param key the key to compute the hash for
+   */
   protected def hashOf(key: Key) = {
     var h = key.##
     h ^= ((h >>> 20) ^ (h >>> 12))
@@ -126,7 +135,8 @@ class OpenHashMap[Key, Value](initialSize : Int)
   /** Returns the index of the first slot in the hash table (in probe order)
    *  that is, in order of preference, either occupied by the given key, deleted, or empty.
    *
-   *  @param hash hash value for `key`
+   *  @param hash the hash code of `key`
+   *  @param key the key to search for in the hash table
    */
   private def findIndex(key: Key, hash: Int): Int = {
     var index = hash & mask
@@ -186,7 +196,10 @@ class OpenHashMap[Key, Value](initialSize : Int)
     }
   }
 
-  /** Deletes the hash table slot contained in the given entry. */
+  /** Deletes the hash table slot contained in the given entry.
+   *
+   *  @param entry the hash table entry to mark as deleted
+   */
   @`inline`
   private def deleteSlot(entry: Entry) = {
     entry.key = null.asInstanceOf[Key]

--- a/library/src/scala/collection/mutable/PriorityQueue.scala
+++ b/library/src/scala/collection/mutable/PriorityQueue.scala
@@ -264,7 +264,10 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
     } else
       throw new NoSuchElementException("no element to remove from heap")
 
-  /** Dequeues all elements and returns them in a sequence, in priority order. */
+  /** Dequeues all elements and returns them in a sequence, in priority order.
+   *
+   *  @tparam A1 a supertype of the element type `A`, allowing the result to be typed more broadly
+   */
   def dequeueAll[A1 >: A]: immutable.Seq[A1] = {
     val b = ArrayBuilder.make[Any]
     b.sizeHint(size)
@@ -347,6 +350,8 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   /** Returns a regular queue containing the same elements.
    *
    *  Note: the order of elements is undefined.
+   *
+   *  @return a mutable `Queue` containing all elements of this priority queue
    */
   def toQueue: Queue[A] = new Queue[A] ++= this.iterator
 

--- a/library/src/scala/collection/mutable/Queue.scala
+++ b/library/src/scala/collection/mutable/Queue.scala
@@ -28,6 +28,8 @@ import scala.collection.generic.DefaultSerializable
  *  @define orderDependentFold
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam A the element type stored in this queue
  */
 class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
   extends ArrayDeque[A](array, start, end)
@@ -48,30 +50,32 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Adds elements to the end of this queue
    *
-   *  @param elem
-   *  @return this
+   *  @param elem the element to enqueue
+   *  @return the queue with the element enqueued
    */
   def enqueue(elem: A): this.type = this += elem
 
   /** Enqueue two or more elements at the end of the queue. The last element
    *  of the sequence will be on end of the queue.
    *
-   *  @param   elems      the element sequence.
-   *  @return this
+   *  @param elem1 the first element to enqueue
+   *  @param elem2 the second element to enqueue
+   *  @param elems the remaining elements to enqueue
+   *  @return the queue with the elements enqueued
    */
   def enqueue(elem1: A, elem2: A, elems: A*): this.type = enqueue(elem1).enqueue(elem2).enqueueAll(elems)
 
   /** Enqueues all elements in the given iterable object into the queue. The
-   *  last element in the iterable object will be on front of the new queue.
+   *  last element in the iterable object will be at the end of the queue.
    *
    *  @param elems the iterable object.
-   *  @return this
+   *  @return the queue with the elements enqueued
    */
   def enqueueAll(elems: scala.collection.IterableOnce[A]^): this.type = this ++= elems
 
   /** Removes the first element from this queue and returns it.
    *
-   *  @return
+   *  @return the first element of the queue
    *  @throws NoSuchElementException when queue is empty
    */
   def dequeue(): A = removeHead()
@@ -97,8 +101,8 @@ class Queue[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Returns and dequeues all elements from the queue which satisfy the given predicate.
    *
-   *  @param f   the predicate used for choosing elements
-   *  @return The removed elements
+   *  @param f   the predicate that must hold true for elements to be dequeued from the front
+   *  @return the removed elements, in order from front of the queue
    */
   def dequeueWhile(f: A => Boolean): scala.collection.Seq[A] = removeHeadWhile(f)
 

--- a/library/src/scala/collection/mutable/RedBlackTree.scala
+++ b/library/src/scala/collection/mutable/RedBlackTree.scala
@@ -128,6 +128,12 @@ private[collection] object RedBlackTree {
 
   /** Returns the first (lowest) map entry with a key equal or greater than `key`. Returns `None` if there is no such
    *  node.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to search
+   *  @param key the lower bound (inclusive) for the key lookup
+   *  @param ord the ordering used to compare keys
    */
   def minAfter[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     minNodeAfter(tree.root, key) match {
@@ -157,7 +163,14 @@ private[collection] object RedBlackTree {
     }
   }
 
-  /** Returns the last (highest) map entry with a key smaller than `key`. Returns `None` if there is no such node. */
+  /** Returns the last (highest) map entry with a key smaller than `key`. Returns `None` if there is no such entry.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to search
+   *  @param key the upper bound (exclusive) for the key lookup
+   *  @param ord the ordering used to compare keys
+   */
   def maxBefore[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     maxNodeBefore(tree.root, key) match {
       case null => None
@@ -360,6 +373,10 @@ private[collection] object RedBlackTree {
 
   /** Returns the node that follows `node` in an in-order tree traversal. If `node` has the maximum key (and is,
    *  therefore, the last node), this method returns `null`.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param node the node whose in-order successor is to be found
    */
   private def successor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)
@@ -376,6 +393,10 @@ private[collection] object RedBlackTree {
 
   /** Returns the node that precedes `node` in an in-order tree traversal. If `node` has the minimum key (and is,
    *  therefore, the first node), this method returns `null`.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param node the node whose in-order predecessor is to be found
    */
   private def predecessor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.left ne null) maxNodeNonNull(node.left)
@@ -424,6 +445,12 @@ private[collection] object RedBlackTree {
 
   /** Transplant the node `from` to the place of node `to`. This is done by setting `from` as a child of `to`'s previous
    *  parent and setting `from`'s parent to the `to`'s previous parent. The children of `from` are left unchanged.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree being modified
+   *  @param to the node to be replaced
+   *  @param from the node to put in `to`'s position, or `null` to leave the position empty
    */
   private def transplant[A, B](tree: Tree[A, B], to: Node[A, B], from: Node[A, B] | Null): Unit = {
     if (to.parent eq null) tree.root = from
@@ -542,11 +569,20 @@ private[collection] object RedBlackTree {
    *  - All red-black properties are satisfied;
    *  - All non-null nodes have their `parent` reference correct;
    *  - The size variable in `tree` corresponds to the actual size of the tree.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to validate
    */
   def isValid[A: Ordering, B](tree: Tree[A, B]): Boolean =
     isValidBST(tree.root) && hasProperParentRefs(tree) && isValidRedBlackTree(tree) && size(tree.root) == tree.size
 
-  /** Returns true if all non-null nodes have their `parent` reference correct. */
+  /** Returns true if all non-null nodes have their `parent` reference correct.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to check
+   */
   private def hasProperParentRefs[A, B](tree: Tree[A, B]): Boolean = {
 
     def hasProperParentRefs(node: Node[A, B] | Null): Boolean = {
@@ -562,7 +598,13 @@ private[collection] object RedBlackTree {
     else (tree.root.nn.parent eq null) && hasProperParentRefs(tree.root)
   }
 
-  /** Returns true if this node follows the properties of a binary search tree. */
+  /** Returns true if this node follows the properties of a binary search tree.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param node the root node of the subtree to validate
+   *  @param ord the ordering used to compare keys
+   */
   private def isValidBST[A, B](node: Node[A, B] | Null)(implicit ord: Ordering[A]): Boolean = {
     if (node eq null) true
     else {
@@ -574,6 +616,10 @@ private[collection] object RedBlackTree {
 
   /** Returns true if the tree has all the red-black tree properties: if the root node is black, if all children of red
    *  nodes are black and if the path from any node to any of its null children has the same number of black nodes.
+   *
+   *  @tparam A the key type of the tree entries
+   *  @tparam B the value type of the tree entries
+   *  @param tree the red-black tree to validate
    */
   private def isValidRedBlackTree[A, B](tree: Tree[A, B]): Boolean = {
 
@@ -600,7 +646,12 @@ private[collection] object RedBlackTree {
 
   // building
 
-  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys. */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys.
+   *
+   *  @tparam A the key type of the set entries
+   *  @param xs an iterator over keys in ascending order
+   *  @param size the number of keys in the iterator
+   */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, Null] | Null = size match {
@@ -619,7 +670,13 @@ private[collection] object RedBlackTree {
     new Tree(f(1, size), size)
   }
 
-  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs. */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs.
+   *
+   *  @tparam A the key type of the map entries
+   *  @tparam B the value type of the map entries
+   *  @param xs an iterator over key-value pairs in ascending key order
+   *  @param size the number of key-value pairs in the iterator
+   */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Node[A, B] | Null = size match {

--- a/library/src/scala/collection/mutable/Seq.scala
+++ b/library/src/scala/collection/mutable/Seq.scala
@@ -35,6 +35,10 @@ object Seq extends SeqFactory.Delegate[Seq](ArrayBuffer)
 /**
  *  @define coll mutable sequence
  *  @define Coll `mutable.Seq`
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the resulting collection
+ *  @tparam C the full sequence type
  */
 transparent trait SeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   extends collection.SeqOps[A, CC, C]
@@ -65,5 +69,8 @@ transparent trait SeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
   }
 }
 
-/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the sequence
+ */
 abstract class AbstractSeq[A] extends scala.collection.AbstractSeq[A] with Seq[A]

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -16,7 +16,10 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{IterableFactory, IterableFactoryDefaults, IterableOps}
 
-/** Base trait for mutable sets. */
+/** Base trait for mutable sets.
+ *
+ *  @tparam A the element type of the set
+ */
 trait Set[A]
   extends Iterable[A]
     with collection.Set[A]
@@ -29,6 +32,10 @@ trait Set[A]
 /**
  *  @define coll mutable set
  *  @define Coll `mutable.Set`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the collection (e.g., `Set`)
+ *  @tparam C the concrete collection type
  */
 transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C]
@@ -119,5 +126,8 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
 object Set extends IterableFactory.Delegate[Set](HashSet)
 
 
-/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the set
+ */
 abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]

--- a/library/src/scala/collection/mutable/Shrinkable.scala
+++ b/library/src/scala/collection/mutable/Shrinkable.scala
@@ -22,6 +22,8 @@ import scala.annotation.tailrec
  *
  *  @define coll shrinkable collection
  *  @define Coll `Shrinkable`
+ *
+ *  @tparam A the type of elements that can be removed from this collection
  */
 trait Shrinkable[-A] {
 

--- a/library/src/scala/collection/mutable/SortedMap.scala
+++ b/library/src/scala/collection/mutable/SortedMap.scala
@@ -17,7 +17,11 @@ import scala.language.`2.13`
 import language.experimental.captureChecking
 import scala.collection.{SortedMapFactory, SortedMapFactoryDefaults}
 
-/** Base type for mutable sorted map collections */
+/** Base type for mutable sorted map collections
+ *
+ *  @tparam K the type of the keys in this sorted map; an implicit `Ordering[K]` is required for most operations
+ *  @tparam V the type of the values associated with the keys
+ */
 trait SortedMap[K, V]
   extends collection.SortedMap[K, V]
     with Map[K, V]

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -17,7 +17,10 @@ package mutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base type for mutable sorted set collections */
+/** Base type for mutable sorted set collections
+ *
+ *  @tparam A the element type of the set, which must have an implicit `Ordering`
+ */
 trait SortedSet[A]
   extends Set[A]
     with collection.SortedSet[A]
@@ -32,6 +35,9 @@ trait SortedSet[A]
 /**
  *  @define coll mutable sorted set
  *  @define Coll `mutable.SortedSet`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the sorted set collection
  */
 transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]

--- a/library/src/scala/collection/mutable/Stack.scala
+++ b/library/src/scala/collection/mutable/Stack.scala
@@ -54,15 +54,17 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Adds elements to the top of this stack
    *
-   *  @param elem
-   *  @return
+   *  @param elem the element to push onto the stack
+   *  @return the stack with the new element on top
    */
   def push(elem: A): this.type = prepend(elem)
 
   /** Pushes two or more elements onto the stack. The last element
    *  of the sequence will be on top of the new stack.
    *
-   *  @param   elems      the element sequence.
+   *  @param elem1 the first element to push
+   *  @param elem2 the second element to push
+   *  @param elems the remaining elements to push
    *  @return the stack with the new elements on top.
    */
   def push(elem1: A, elem2: A, elems: A*): this.type = {
@@ -85,7 +87,7 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
 
   /** Removes the top element from this stack and returns it
    *
-   *  @return
+   *  @return the element removed from the top of the stack
    *  @throws NoSuchElementException when stack is empty
    */
   def pop(): A = removeHead()

--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -71,11 +71,16 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   /** Constructs a string builder with initial characters
    *  equal to characters of `str`.
+   *
+   *  @param str the initial string content of this builder
    */
   def this(str: String) = this(new java.lang.StringBuilder(str))
 
   /** Constructs a string builder initialized with string value `initValue`
    *  and with additional character capacity `initCapacity`.
+   *
+   *  @param initCapacity additional character capacity beyond the length of `initValue`
+   *  @param initValue the initial string content of this builder
    */
   def this(initCapacity: Int, initValue: String) =
     this(new java.lang.StringBuilder(initValue.length + initCapacity).append(initValue))
@@ -101,7 +106,10 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
 
   def clear(): Unit = underlying.setLength(0)
 
-  /** Overloaded version of `addAll` that takes a string. */
+  /** Overloaded version of `addAll` that takes a string.
+   *
+   *  @param s the string to append to this builder
+   */
   def addAll(s: String): this.type = { underlying.append(s); this }
 
   /** Alias for `addAll`. */
@@ -447,7 +455,11 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    */
   def substring(start: Int, end: Int): String = underlying.substring(start, end)
 
-  /** For implementing CharSequence. */
+  /** For implementing CharSequence.
+   *
+   *  @param start the beginning index, inclusive
+   *  @param end the ending index, exclusive
+   */
   def subSequence(start: Int, end: Int): java.lang.CharSequence =
     underlying.substring(start, end)
 

--- a/library/src/scala/collection/mutable/TreeMap.scala
+++ b/library/src/scala/collection/mutable/TreeMap.scala
@@ -128,6 +128,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
    *             bound.
    *  @param until the upper bound (exclusive) of this projection wrapped in a `Some`, or `None` if there is no upper
    *              bound.
+   *  @return a new `TreeMap` that is a ranged projection of this map, sharing the same underlying data
    */
   def rangeImpl(from: Option[K], until: Option[K]): TreeMap[K, V] = new TreeMapProjection(from, until)
 
@@ -165,21 +166,30 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
    */
   private final class TreeMapProjection(from: Option[K], until: Option[K]) extends TreeMap[K, V](tree) {
 
-    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum). */
+    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
+     *
+     *  @param newFrom a possible new lower bound wrapped in a `Some`, or `None` if unconstrained
+     */
     private def pickLowerBound(newFrom: Option[K]): Option[K] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
       case (None, _) => newFrom
       case _ => from
     }
 
-    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum). */
+    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
+     *
+     *  @param newUntil a possible new upper bound wrapped in a `Some`, or `None` if unconstrained
+     */
     private def pickUpperBound(newUntil: Option[K]): Option[K] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
       case (None, _) => newUntil
       case _ => until
     }
 
-    /** Returns true if the argument is inside the view bounds (between `from` and `until`). */
+    /** Returns true if the argument is inside the view bounds (between `from` and `until`).
+     *
+     *  @param key the key to check against the view bounds
+     */
     private def isInsideViewBounds(key: K): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0
       val beforeUntil = until.isEmpty || ordering.compare(key, until.get) < 0

--- a/library/src/scala/collection/mutable/TreeSet.scala
+++ b/library/src/scala/collection/mutable/TreeSet.scala
@@ -115,21 +115,30 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
   private final class TreeSetProjection(from: Option[A], until: Option[A]) extends TreeSet[A](tree) {
     self: TreeSetProjection^{} =>
 
-    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum). */
+    /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
+     *
+     *  @param newFrom a possible new lower bound wrapped in a `Some`, or `None` if unbounded
+     */
     private def pickLowerBound(newFrom: Option[A]): Option[A] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
       case (None, _) => newFrom
       case _ => from
     }
 
-    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum). */
+    /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
+     *
+     *  @param newUntil a possible new upper bound wrapped in a `Some`, or `None` if unbounded
+     */
     private def pickUpperBound(newUntil: Option[A]): Option[A] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
       case (None, _) => newUntil
       case _ => until
     }
 
-    /** Returns true if the argument is inside the view bounds (between `from` and `until`). */
+    /** Returns true if the argument is inside the view bounds (between `from` and `until`).
+     *
+     *  @param key the element to check against the view bounds
+     */
     private def isInsideViewBounds(key: A): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0
       val beforeUntil = until.isEmpty || ordering.compare(key, until.get) < 0

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -261,7 +261,10 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
 
   private[collection] val unrolledlength = 32
 
-  /** Unrolled buffer node. */
+  /** Unrolled buffer node.
+   *
+   *  @tparam T the element type stored in the node's array; requires an implicit `ClassTag` for array creation
+   */
   class Unrolled[T: ClassTag] private[collection] (var size: Int, var array: Array[T], var next: Unrolled[T] | Null, val buff: UnrolledBuffer[T] | Null = null) {
     this: Unrolled[T]^{} =>
     private[collection] def this() = this(0, new Array[T](unrolledlength), null, null)


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for collection mutable. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.