### PR TITLE
Collection immutable (3): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library-js/src/scala/collection/immutable/NumericRange.scala
+++ b/library-js/src/scala/collection/immutable/NumericRange.scala
@@ -95,11 +95,18 @@ sealed class NumericRange[T](
 
   /** Creates a new range with the start and end values of this range and
    *  a new `step`.
+   *
+   *  @param newStep the new step value for the resulting range
    */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Creates a copy of this range. */
+  /** Creates a copy of this range.
+   *
+   *  @param start the first value of the new range
+   *  @param end the upper bound of the new range (inclusive or exclusive, matching the original range)
+   *  @param step the step value between successive elements of the new range
+   */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
 
@@ -350,6 +357,13 @@ object NumericRange {
   /** Calculates the number of elements in a range given start, end, step, and
    *  whether or not it is inclusive.  Throws an exception if step == 0 or
    *  the number of elements exceeds the maximum Int.
+   *
+   *  @tparam T the numeric type of the range elements, which must have an `Integral` instance
+   *  @param start the first value in the range
+   *  @param end the end boundary of the range (exclusive or inclusive depending on `isInclusive`)
+   *  @param step the increment between successive elements
+   *  @param isInclusive whether `end` is included in the range
+   *  @param num the `Integral` instance used for arithmetic on `T`
    */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero

--- a/library-js/src/scala/collection/immutable/Range.scala
+++ b/library-js/src/scala/collection/immutable/Range.scala
@@ -160,6 +160,7 @@ sealed abstract class Range(
   /** Creates a new range with the `start` and `end` values of this range and
    *  a new `step`.
    *
+   *  @param step the new step value for the range; must be non-zero
    *  @return a new range with a different step
    */
   final def by(step: Int): Range = copy(start, end, step)
@@ -258,6 +259,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the last `n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to take from the end of this range
+   *  @return a new range consisting of the last `n` elements, or the entire range if `n` is greater than the range length
    */
   final override def takeRight(n: Int): Range = {
     if (n <= 0) newEmptyRange(start)
@@ -274,6 +278,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the initial `length - n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to drop from the end of this range
+   *  @return a new range consisting of all elements except the last `n`, or an empty range if `n` is greater than the range length
    */
   final override def dropRight(n: Int): Range = {
     if (n <= 0) this
@@ -536,6 +543,11 @@ object Range {
    *  precondition:  step != 0
    *  If the size of the range exceeds Int.MaxValue, the
    *  result will be negative.
+   *
+   *  @param start the first element of the range
+   *  @param end the end boundary of the range (inclusive or exclusive depending on `isInclusive`)
+   *  @param step the increment between successive elements; must be non-zero
+   *  @param isInclusive whether `end` is included in the range
    */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
@@ -565,18 +577,34 @@ object Range {
 
   /** Makes a range from `start` until `end` (exclusive) with given step value.
    *  @note step != 0
+   *
+   *  @param start the first element of the range
+   *  @param end the exclusive upper bound of the range
+   *  @param step the increment between successive elements; must be non-zero
    */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Makes a range from `start` until `end` (exclusive) with step value 1. */
+  /** Makes a range from `start` until `end` (exclusive) with step value 1.
+   *
+   *  @param start the first element of the range
+   *  @param end the exclusive upper bound of the range
+   */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
   /** Makes an inclusive range from `start` to `end` with given step value.
    *  @note step != 0
+   *
+   *  @param start the first element of the range
+   *  @param end the inclusive upper bound of the range
+   *  @param step the increment between successive elements; must be non-zero
    */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Makes an inclusive range from `start` to `end` with step value 1. */
+  /** Makes an inclusive range from `start` to `end` with step value 1.
+   *
+   *  @param start the first element of the range
+   *  @param end the inclusive upper bound of the range
+   */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
   @SerialVersionUID(3L)

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -33,6 +33,8 @@ import scala.util.hashing.MurmurHash3
  *
  *  @define coll immutable array
  *  @define Coll `ArraySeq`
+ *
+ *  @tparam A the element type of the immutable array
  */
 sealed abstract class ArraySeq[+A]
   extends AbstractSeq[A]
@@ -90,7 +92,9 @@ sealed abstract class ArraySeq[+A]
 
   /** Fast concatenation of two [[ArraySeq]]s.
    *
-   *  @return null if optimisation not possible.
+   *  @tparam B the element type of the resulting sequence, a supertype of `A`
+   *  @param that the `ArraySeq` to append to this sequence
+   *  @return the concatenated `ArraySeq`, or `null` if optimization is not possible
    */
   private def appendedAllArraySeq[B >: A](that: ArraySeq[B]): ArraySeq[B] | Null = {
     // Optimise concatenation of two ArraySeqs
@@ -310,6 +314,10 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
    *  boxed, the resulting instance is an [[ArraySeq.ofRef]]. Writing
    *  `ArraySeq.unsafeWrapArray(a.asInstanceOf[Array[Int]])` does not work, it throws a
    *  `ClassCastException` at runtime.
+   *
+   *  @tparam T the element type of the array to wrap
+   *  @param x the array to wrap, which must not be modified after wrapping
+   *  @return an `ArraySeq` backed by the given array, using the appropriate primitive specialization
    */
   def unsafeWrapArray[T](x: Array[T]): ArraySeq[T] = ((x: @unchecked) match {
     case null              => null

--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -65,7 +65,11 @@ sealed abstract class BitSet
     } else this
   }
 
-  /** Updates word at index `idx`; enlarges set if `idx` outside range of set. */
+  /** Updates word at index `idx`; enlarges set if `idx` outside range of set.
+   *
+   *  @param idx the index of the word to update
+   *  @param w the new value for the word at index `idx`
+   */
   protected def updateWord(idx: Int, w: Long): BitSet
 
   override def map(f: Int => Int): BitSet = strictOptimizedMap(newSpecificBuilder, f)
@@ -108,7 +112,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   private def createSmall(a: Long, b: Long): BitSet = if (b == 0L) new BitSet1(a) else new BitSet2(a, b)
 
-  /** A bitset containing all the bits in an array. */
+  /** A bitset containing all the bits in an array.
+   *
+   *  @param elems the array of `Long` words representing the bits; the array is defensively copied
+   */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
     if (len == 0) empty
@@ -122,6 +129,8 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
 
   /** A bitset containing all the bits in an array, wrapping the existing
    *  array without copying.
+   *
+   *  @param elems the array of `Long` words representing the bits; the caller must not modify the array after this call
    */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length

--- a/library/src/scala/collection/immutable/ChampCommon.scala
+++ b/library/src/scala/collection/immutable/ChampCommon.scala
@@ -105,6 +105,7 @@ private[collection] abstract class Node[T <: Node[T]] {
  *  node before traversing sub-nodes (left to right).
  *
  *  @tparam T the trie node type we are iterating over
+ *  @tparam A the element type produced by the iterator
  */
 private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 
@@ -191,6 +192,7 @@ private[immutable] abstract class ChampBaseIterator[A, T <: Node[T]] extends Abs
  *  iterator performs a depth-first post-order traversal, traversing sub-nodes (right to left).
  *
  *  @tparam T the trie node type we are iterating over
+ *  @tparam A the element type produced by the iterator
  */
 private[immutable] abstract class ChampBaseReverseIterator[A, T <: Node[T]] extends AbstractIterator[A] {
 

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -126,7 +126,10 @@ private[immutable] abstract class IntMapIterator[V, T](it: IntMap[V]) extends Ab
   }
   push(it)
 
-  /** What value do we assign to a tip? */
+  /** What value do we assign to a tip?
+   *
+   *  @param tip the leaf node to extract a value from
+   */
   def valueOf(tip: IntMap.Tip[V]): T
 
   def hasNext = index != 0
@@ -210,7 +213,11 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case _ => new IntMapEntryIterator(this)
   }
 
-  /** Loops over the key, value pairs of the map in unsigned order of the keys. */
+  /** Loops over the key, value pairs of the map in unsigned order of the keys.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function applied to each key-value pair in the map
+   */
   override final def foreach[U](f: ((Int, T)) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case IntMap.Tip(key, value) => f((key, value))
@@ -231,6 +238,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   /** Loop over the keys of the map. The same as `keys.foreach(f)`, but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachKey[U](f: Int => U): Unit = this match {
@@ -247,6 +255,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   /** Loop over the values of the map. The same as `values.foreach(f)`, but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachValue[U](f: T => U): Unit = this match {
@@ -340,7 +349,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *   }
    *  ```
    *
-   *  @tparam S     The supertype of values in this `LongMap`.
+   *  @tparam S     the supertype of values in this `IntMap`.
    *  @param key    The key to update
    *  @param value  The value to use if there is no conflict
    *  @param f      The function used to resolve conflicts.
@@ -372,7 +381,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *  for each `(key, value)` mapping in this map, if `f(key, value) == None`
    *  the map contains no mapping for key, and if `f(key, value)`.
    *
-   *  @tparam S  The type of the values in the resulting `LongMap`.
+   *  @tparam S  the type of the values in the resulting `IntMap`.
    *  @param f   The transforming function.
    *  @return    The modified map.
    */
@@ -427,7 +436,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *  values produced from the original mappings by combining them with `f`.
    *
    *  @tparam S      The type of values in `that`.
-   *  @tparam R      The type of values in the resulting `LongMap`.
+   *  @tparam R      the type of values in the resulting `IntMap`.
    *  @param that    The map to intersect with.
    *  @param f       The combining function.
    *  @return        Intersection of `this` and `that`, with values for identical keys produced by function `f`.

--- a/library/src/scala/collection/immutable/LazyListIterable.scala
+++ b/library/src/scala/collection/immutable/LazyListIterable.scala
@@ -426,6 +426,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** Applies the given function `f` to each element of this linear sequence
    *  (while respecting the order of the elements).
    *
+   *  @tparam U the return type of the function `f`
    *  @param f The treatment to apply to each element.
    *  @note  Overridden here as final to trigger tail-call optimization, which
    *  replaces 'this' with 'tail' at each iteration. This is absolutely
@@ -467,6 +468,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $appendStackSafety
    *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param suffix The collection that gets appended to this lazy list
    *  @return The lazy list containing elements of this lazy list and the iterable object.
    */
@@ -485,6 +487,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  $appendStackSafety
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param suffix the collection to append
+   *  @return a new lazy list containing elements of this lazy list followed by elements of `suffix`
    */
   override def appendedAll[B >: A](suffix: IterableOnce[B]^): LazyListIterable[B]^{this, suffix} =
     if (knownIsEmpty) LazyListIterable.from(suffix)
@@ -495,6 +501,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  $appendStackSafety
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param elem the element to append
+   *  @return a new lazy list containing all elements of this lazy list followed by `elem`
    */
   override def appended[B >: A](elem: B): LazyListIterable[B]^{this} =
     if (knownIsEmpty) eagerCons(elem, Empty)
@@ -503,6 +513,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the result type of the binary operator and the type of the initial value
+   *  @param z the initial value
+   *  @param op the binary operator applied to the intermediate result and the element
    */
   override def scanLeft[B](z: B)(op: (B, A) => B): LazyListIterable[B]^{this, op} =
     if (knownIsEmpty) eagerCons(z, Empty)
@@ -540,12 +554,18 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param p the predicate used to test elements
    */
   override def partition(p: A => Boolean): (LazyListIterable[A]^{this, p}, LazyListIterable[A]^{this, p}) = (filter(p), filterNot(p))
 
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the element type of the first resulting collection
+   *  @tparam A2 the element type of the second resulting collection
+   *  @param f the function applied to each element that returns `Left` or `Right`
    */
   override def partitionMap[A1, A2](f: A => Either[A1, A2]): (LazyListIterable[A1]^{this, f}, LazyListIterable[A2]^{this, f}) = {
     val p: (LazyListIterable[Either[A1, A2]]^{this, f}, LazyListIterable[Either[A1, A2]]^{this, f}) = map(f).partition(_.isLeft)
@@ -555,6 +575,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param pred the predicate used to test elements
    */
   override def filter(pred: A => Boolean): LazyListIterable[A]^{this, pred} =
     if (knownIsEmpty) Empty
@@ -563,6 +585,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param pred the predicate used to test elements
    */
   override def filterNot(pred: A => Boolean): LazyListIterable[A]^{this, pred} =
     if (knownIsEmpty) Empty
@@ -575,6 +599,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The `collection.WithFilter` returned by this method preserves laziness; elements are
    *  only evaluated individually as needed.
+   *
+   *  @param p the predicate used to test elements
+   *  @return an object of class `WithFilter`, which supports `map`, `flatMap`, `foreach`, and `withFilter` operations
    */
   override def withFilter(p: A => Boolean): collection.WithFilter[A, LazyListIterable]^{this, p} =
     new LazyListIterable.WithFilter(coll, p)
@@ -582,12 +609,18 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param elem the element to prepend
    */
   override def prepended[B >: A](elem: B): LazyListIterable[B]^{this} = eagerCons(elem, this)
 
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param prefix the collection to prepend
    */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]^): LazyListIterable[B]^{this, prefix} =
     if (knownIsEmpty) LazyListIterable.from(prefix)
@@ -597,6 +630,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list
+   *  @param f the function to apply to each element
    */
   override def map[B](f: A => B): LazyListIterable[B]^{this, f} =
     if (knownIsEmpty) Empty
@@ -605,6 +641,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam U the return type of the function `f`
+   *  @param f the function to apply to each element for its side effect
    */
   override def tapEach[U](f: A => U): LazyListIterable[A]^{this, f} = map { a => f(a); a }
 
@@ -617,6 +656,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list
+   *  @param pf the partial function which filters and maps elements
    */
   override def collect[B](pf: PartialFunction[A, B]^): LazyListIterable[B]^{this, pf} =
     if (knownIsEmpty) Empty
@@ -626,6 +668,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  This method does not evaluate any elements further than
    *  the first element for which the partial function is defined.
+   *
+   *  @tparam B the element type of the returned option
+   *  @param pf the partial function which filters and maps elements
    */
   @tailrec
   override def collectFirst[B](pf: PartialFunction[A, B]^): Option[B] =
@@ -640,6 +685,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  This method does not evaluate any elements further than
    *  the first element matching the predicate.
+   *
+   *  @param p the predicate used to test elements
    */
   @tailrec
   override def find(p: A => Boolean): Option[A] =
@@ -663,12 +710,18 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list
+   *  @param asIterable an implicit conversion which asserts that the element type of this lazy list is an `IterableOnce`
    */
   override def flatten[B](implicit asIterable: A -> IterableOnce[B]): LazyListIterable[B]^{this} = flatMap(asIterable)
 
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the second half of the returned pairs
+   *  @param that the iterable providing the second half of each result pair
    */
   override def zip[B](that: collection.IterableOnce[B]^): LazyListIterable[(A, B)]^{this, that} =
     if (knownIsEmpty || that.knownSize == 0) Empty
@@ -687,6 +740,12 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the type of the first half of the returned pairs, a supertype of `A`
+   *  @tparam B the type of the second half of the returned pairs
+   *  @param that the iterable providing the second half of each result pair
+   *  @param thisElem the element to use if this lazy list is shorter than `that`
+   *  @param thatElem the element to use if `that` is shorter than this lazy list
    */
   override def zipAll[A1 >: A, B](that: collection.Iterable[B]^, thisElem: A1, thatElem: B): LazyListIterable[(A1, B)]^{this, that} = {
     if (knownIsEmpty) {
@@ -715,6 +774,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The `collection.LazyZip2` returned by this method preserves laziness; elements are
    *  only evaluated individually as needed.
+   *
+   *  @tparam B the element type of the second collection
+   *  @param that the collection providing the second element of each pair
+   *  @return a `LazyZip2` decorator for lazy pairing with `that`
    */
   // just in case it can be meaningfully overridden at some point
   override def lazyZip[B](that: collection.Iterable[B]^): LazyZip2[A, B, this.type]^{this, that} =
@@ -723,6 +786,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the type of the first element in each pair
+   *  @tparam A2 the type of the second element in each pair
+   *  @param asPair an implicit conversion which asserts that the element type of this lazy list is a pair
    */
   override def unzip[A1, A2](implicit asPair: A -> (A1, A2)): (LazyListIterable[A1]^{this}, LazyListIterable[A2]^{this}) =
     (map(asPair(_)._1), map(asPair(_)._2))
@@ -730,6 +797,11 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam A1 the type of the first element in each triple
+   *  @tparam A2 the type of the second element in each triple
+   *  @tparam A3 the type of the third element in each triple
+   *  @param asTriple an implicit conversion which asserts that the element type of this lazy list is a triple
    */
   override def unzip3[A1, A2, A3](implicit asTriple: A -> (A1, A2, A3)): (LazyListIterable[A1]^{this}, LazyListIterable[A2]^{this}, LazyListIterable[A3]^{this}) =
     (map(asTriple(_)._1), map(asTriple(_)._2), map(asTriple(_)._3))
@@ -738,6 +810,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $initiallyLazy
    *  Additionally, it preserves laziness for all except the first `n` elements.
+   *
+   *  @param n the number of elements to drop from this lazy list
    */
   override def drop(n: Int): LazyListIterable[A]^{this} =
     if (n <= 0) this
@@ -748,6 +822,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $initiallyLazy
    *  Additionally, it preserves laziness for all elements after the predicate returns `false`.
+   *
+   *  @param p the predicate used to test elements
    */
   override def dropWhile(p: A => Boolean): LazyListIterable[A]^{this, p} =
     if (knownIsEmpty) Empty
@@ -756,6 +832,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $initiallyLazy
+   *
+   *  @param n the number of elements to drop from the right end
    */
   override def dropRight(n: Int): LazyListIterable[A]^{this} = {
     if (n <= 0) this
@@ -779,6 +857,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param n the number of elements to take from this lazy list
    */
   override def take(n: Int): LazyListIterable[A]^{this} =
     if (knownIsEmpty) Empty
@@ -795,6 +875,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @param p the predicate used to test elements
    */
   override def takeWhile(p: A => Boolean): LazyListIterable[A]^{this, p} =
     if (knownIsEmpty) Empty
@@ -809,6 +891,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $initiallyLazy
+   *
+   *  @param n the number of elements to take from the right end
    */
   override def takeRight(n: Int): LazyListIterable[A]^{this} =
     if (n <= 0 || knownIsEmpty) Empty
@@ -818,6 +902,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  $initiallyLazy
    *  Additionally, it preserves laziness for all but the first `from` elements.
+   *
+   *  @param from the index of the first element in the slice
+   *  @param until the index of the element following the slice
    */
   override def slice(from: Int, until: Int): LazyListIterable[A]^{this} = take(until).drop(from)
 
@@ -836,6 +923,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param that the sequence of elements to subtract (by multiplicity)
    */
   override def diff[B >: A](that: collection.Seq[B]): LazyListIterable[A]^{this}  =
     if (knownIsEmpty) Empty
@@ -844,6 +934,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param that the sequence of elements to intersect with
    */
   override def intersect[B >: A](that: collection.Seq[B]): LazyListIterable[A]^{this} =
     if (knownIsEmpty) Empty
@@ -859,6 +952,8 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The iterator returned by this method mostly preserves laziness;
    *  a single element ahead of the iterator is evaluated.
+   *
+   *  @param size the number of elements per group, must be positive
    */
   override def grouped(size: Int): Iterator[LazyListIterable[A]^{this}]^{this} = {
     require(size > 0, "size must be positive, but was " + size)
@@ -869,6 +964,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  The iterator returned by this method mostly preserves laziness;
    *  `size - step max 1` elements ahead of the iterator are evaluated.
+   *
+   *  @param size the number of elements per window, must be positive
+   *  @param step the number of elements to advance per window, must be positive
    */
   override def sliding(size: Int, step: Int): Iterator[LazyListIterable[A]^{this}]^{this} = {
     require(size > 0 && step > 0, s"size=$size and step=$step, but both must be positive")
@@ -884,6 +982,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param len the length to which this lazy list should be padded
+   *  @param elem the padding element
    */
   override def padTo[B >: A](len: Int, elem: B): LazyListIterable[B]^{this} =
     if (len <= 0) this
@@ -895,6 +997,11 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param from the index of the first replaced element
+   *  @param other the collection of replacement elements
+   *  @param replaced the number of elements to replace starting from index `from`
    */
   override def patch[B >: A](from: Int, other: IterableOnce[B]^, replaced: Int): LazyListIterable[B]^{this, other} =
     if (knownIsEmpty) LazyListIterable from other
@@ -910,6 +1017,9 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $evaluatesAllElements
+   *
+   *  @tparam B the element type of each nested iterable
+   *  @param asIterable an implicit conversion which asserts that the element type of this lazy list is an `Iterable`
    */
   // overridden just in case a lazy implementation is developed at some point
   override def transpose[B](implicit asIterable: A -> collection.Iterable[B]): LazyListIterable[LazyListIterable[B]^{this}]^{this} = super.transpose
@@ -917,6 +1027,10 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
   /** @inheritdoc
    *
    *  $preservesLaziness
+   *
+   *  @tparam B the element type of the returned lazy list, a supertype of `A`
+   *  @param index the zero-based index of the element to replace
+   *  @param elem the replacing element
    */
   override def updated[B >: A](index: Int, elem: B): LazyListIterable[B]^{this} =
     if (index < 0) throw new IndexOutOfBoundsException(s"$index")
@@ -1074,10 +1188,19 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   private val Empty: LazyListIterable[Nothing] = new LazyListIterable(EmptyMarker)
 
-  /** Creates a new LazyListIterable. */
+  /** Creates a new LazyListIterable.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param state the by-name expression that computes the lazy list state when forced
+   */
   @inline private def newLL[A](state: => LazyListIterable[A]^): LazyListIterable[A]^{state} = new LazyListIterable[A](() => state)
 
-  /** Creates a new LazyListIterable with evaluated `head` and `tail`. */
+  /** Creates a new LazyListIterable with evaluated `head` and `tail`.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param hd the head element of the cons cell
+   *  @param tl the tail lazy list of the cons cell
+   */
   @inline private def eagerCons[A](hd: A, tl: LazyListIterable[A]^): LazyListIterable[A]^{tl} = new LazyListIterable[A](hd, tl)
 
   private val anyToMarker: Any -> Any = _ => Statics.pfMarker
@@ -1211,12 +1334,18 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   /** An alternative way of building and matching lazy lists using LazyListIterable.cons(hd, tl). */
   object cons {
     /** A lazy list consisting of a given first element and remaining elements.
+     *
+     *  @tparam A the element type of the lazy list
      *  @param hd   The first element of the result lazy list
      *  @param tl   The remaining elements of the result lazy list
      */
     def apply[A](hd: => A, tl: => LazyListIterable[A]): LazyListIterable[A]^{hd, tl} = newLL(eagerCons(hd, newLL(tl)))
 
-    /** Maps a lazy list to its head and tail. */
+    /** Maps a lazy list to its head and tail.
+     *
+     *  @tparam A the element type of the lazy list
+     *  @param xs the lazy list to decompose
+     */
     def unapply[A](xs: LazyListIterable[A]^): Option[(A, LazyListIterable[A]^{xs})] = #::.unapply(xs)
   }
 
@@ -1248,12 +1377,20 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   /** Creates a LazyListIterable with the elements of an iterator followed by a LazyListIterable suffix.
    *  Eagerly evaluates the first element.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param it the iterator whose elements are prepended
+   *  @param suffix the lazy list to append after the iterator elements are exhausted
    */
   private def eagerHeadPrependIterator[A](it: Iterator[A]^)(suffix: => LazyListIterable[A]^): LazyListIterable[A]^{it, suffix} =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadPrependIterator(it)(suffix)))
     else suffix
 
-  /** Creates a LazyListIterable from an Iterator. Eagerly evaluates the first element. */
+  /** Creates a LazyListIterable from an Iterator. Eagerly evaluates the first element.
+   *
+   *  @tparam A the element type of the lazy list
+   *  @param it the iterator to convert into a lazy list
+   */
   private def eagerHeadFromIterator[A](it: Iterator[A]^): LazyListIterable[A]^{it} =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadFromIterator(it)))
     else Empty
@@ -1281,6 +1418,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
 
   /** An infinite LazyListIterable that repeatedly applies a given function to a start value.
    *
+   *  @tparam A the element type of the lazy list
    *  @param start the start value of the LazyListIterable
    *  @param f     the function that's repeatedly applied
    *  @return      the LazyListIterable returning the infinite sequence of values `start, f(start), f(f(start)), ...`
@@ -1311,6 +1449,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
   /** Creates an infinite LazyListIterable containing the given element expression (which
    *  is computed for each occurrence).
    *
+   *  @tparam A the element type of the lazy list
    *  @param elem the element composing the resulting LazyListIterable
    *  @return the LazyListIterable containing an infinite number of elem
    */

--- a/library/src/scala/collection/immutable/ListMap.scala
+++ b/library/src/scala/collection/immutable/ListMap.scala
@@ -128,7 +128,14 @@ sealed class ListMap[K, +V]
  */
 @SerialVersionUID(3L)
 object ListMap extends MapFactory[ListMap] {
-  /** Represents an entry in the `ListMap`. */
+  /** Represents an entry in the `ListMap`.
+   *
+   *  @tparam K the type of the keys in this map entry
+   *  @tparam V the type of the values in this map entry
+   *  @param private[immutable] val key the key for this map entry
+   *  @param private[immutable] var _value the value associated with the key
+   *  @param private[immutable] var _init the rest of the list map (tail), or `null` during construction
+   */
   private[immutable] final class Node[K, V](
     override private[immutable] val key: K,
     private[immutable] var _value: V,
@@ -271,6 +278,7 @@ object ListMap extends MapFactory[ListMap] {
    *
    *  @tparam K the map key type
    *  @tparam V the map value type
+   *  @return a new `ReusableBuilder` for creating `ListMap` instances
    */
   def newBuilder[K, V]: ReusableBuilder[(K, V), ListMap[K, V]] = new ListMapBuilder[K, V]
 
@@ -282,6 +290,9 @@ object ListMap extends MapFactory[ListMap] {
 
 /** Builder for ListMap.
  *  $multipleResults
+ *
+ *  @tparam K the type of the keys in the list map being built
+ *  @tparam V the type of the values in the list map being built
  */
 private[immutable] final class ListMapBuilder[K, V] extends mutable.ReusableBuilder[(K, V), ListMap[K, V]] {
   private var isAliased: Boolean = false

--- a/library/src/scala/collection/immutable/ListSet.scala
+++ b/library/src/scala/collection/immutable/ListSet.scala
@@ -71,7 +71,10 @@ sealed class ListSet[A]
 
   override def iterableFactory: IterableFactory[ListSet] = ListSet
 
-  /** Represents an entry in the `ListSet`. */
+  /** Represents an entry in the `ListSet`.
+   *
+   *  @param elem the element contained in this node of the list set
+   */
   protected class Node(override protected val elem: A) extends ListSet[A] {
 
     override def size = sizeInternal(this, 0)

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -123,7 +123,10 @@ private[immutable] abstract class LongMapIterator[V, T](it: LongMap[V]) extends 
   }
   push(it)
 
-  /** What value do we assign to a tip? */
+  /** What value do we assign to a tip?
+   *
+   *  @param tip the leaf node to extract a value from
+   */
   def valueOf(tip: LongMap.Tip[V]): T
 
   def hasNext = index != 0
@@ -204,7 +207,11 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
     case _ => new LongMapEntryIterator(this)
   }
 
-  /** Loops over the key, value pairs of the map in unsigned order of the keys. */
+  /** Loops over the key, value pairs of the map in unsigned order of the keys.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function applied to each key-value pair in the map
+   */
   override final def foreach[U](f: ((Long, T)) => U): Unit = this match {
     case LongMap.Bin(_, _, left, right) => { left.foreach(f); right.foreach(f) }
     case LongMap.Tip(key, value) => f((key, value))
@@ -225,6 +232,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   /** Loop over the keys of the map. The same as keys.foreach(f), but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachKey[U](f: Long => U): Unit = this match {
@@ -241,6 +249,7 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   /** Loop over the values of the map. The same as values.foreach(f), but may
    *  be more efficient.
    *
+   *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f The loop body
    */
   final def foreachValue[U](f: T => U): Unit = this match {

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -23,7 +23,11 @@ import scala.collection.immutable.Map.Map4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 import SeqMap.{SeqMap1, SeqMap2, SeqMap3, SeqMap4}
 
-/** Base type of immutable Maps. */
+/** Base type of immutable Maps.
+ *
+ *  @tparam K the type of the keys in this map
+ *  @tparam V the type of the values associated with the keys
+ */
 trait Map[K, +V]
   extends Iterable[(K, V)]
      with collection.Map[K, V]
@@ -40,6 +44,7 @@ trait Map[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the values returned by the default function, which must be a supertype of `V`
    *  @param d     the function mapping keys to values, used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
@@ -51,6 +56,7 @@ trait Map[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the default value, which must be a supertype of `V`
    *  @param d     default value used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
@@ -61,6 +67,10 @@ trait Map[K, +V]
  *
  *  @define coll immutable map
  *  @define Coll `immutable.Map`
+ *
+ *  @tparam K the type of the keys in this map
+ *  @tparam V the type of the values associated with the keys
+ *  @tparam CC the type constructor of the resulting map (e.g., `Map`, `HashMap`)
  */
 transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]
@@ -76,7 +86,10 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    */
   def removed(key: K): C
 
-  /** Alias for `removed`. */
+  /** Alias for `removed`.
+   *
+   *  @param key the key to remove from this map
+   */
   @`inline` final def - (key: K): C = removed(key)
 
   @deprecated("Use -- with an explicit collection", "2.13.0")
@@ -93,7 +106,10 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    */
   def removedAll(keys: IterableOnce[K]^): C = keys.iterator.foldLeft[C](coll)(_ - _)
 
-  /** Alias for `removedAll`. */
+  /** Alias for `removedAll`.
+   *
+   *  @param keys the collection of keys to remove from this map
+   */
   @`inline` final override def -- (keys: IterableOnce[K]^): C = removedAll(keys)
 
   /** Creates a new map obtained by updating this map with a given key/value pair.
@@ -111,6 +127,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
    *  If the remapping function returns `None`, the mapping is removed (or remains absent if initially absent).
    *  If the function itself throws an exception, the exception is rethrown, and the current mapping is left unchanged.
    *
+   *  @tparam V1 the type of the values in the returned map, which must be a supertype of `V`
    *  @param key the key value
    *  @param remappingFunction a function that receives current optionally mapped value and returns a new mapping
    *  @return A new map with the updated mapping with the key
@@ -136,6 +153,7 @@ transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[
   /** This function transforms all the values of mappings contained
    *  in this map with function `f`.
    *
+   *  @tparam W the type of the transformed values
    *  @param f A function over keys and values
    *  @return  the updated map
    */
@@ -664,7 +682,11 @@ object Map extends MapFactory[Map] {
   }
 }
 
-/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses.
+ *
+ *  @tparam K the type of the keys in this map
+ *  @tparam V the type of the values associated with the keys
+ */
 abstract class AbstractMap[K, +V] extends scala.collection.AbstractMap[K, V] with Map[K, V]
 
 private[immutable] final class MapBuilderImpl[K, V] extends ReusableBuilder[(K, V), Map[K, V]] {

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -98,11 +98,18 @@ sealed class NumericRange[T](
 
   /** Creates a new range with the start and end values of this range and
    *  a new `step`.
+   *
+   *  @param newStep the new step value for the range
    */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
 
-  /** Creates a copy of this range. */
+  /** Creates a copy of this range.
+   *
+   *  @param start the start value of the new range
+   *  @param end the end value of the new range
+   *  @param step the step value of the new range
+   */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
 
@@ -407,6 +414,13 @@ object NumericRange {
   /** Calculates the number of elements in a range given start, end, step, and
    *  whether or not it is inclusive.  Throws an exception if step == 0 or
    *  the number of elements exceeds the maximum Int.
+   *
+   *  @tparam T the numeric type of the range elements, which must have an `Integral` instance
+   *  @param start the first element of the range
+   *  @param end the exclusive or inclusive upper bound, depending on `isInclusive`
+   *  @param step the increment between successive elements, must not be zero
+   *  @param isInclusive whether `end` is included in the range
+   *  @param num the `Integral` instance used for arithmetic on `T`
    */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero

--- a/library/src/scala/collection/immutable/Queue.scala
+++ b/library/src/scala/collection/immutable/Queue.scala
@@ -37,6 +37,8 @@ import scala.collection.mutable.{Builder, ListBuffer}
  *  @define coll immutable queue
  *  @define mayNotTerminateInf
  *  @define willNotTerminateInf
+ *
+ *  @tparam A the type of elements contained in this queue
  */
 
 sealed class Queue[+A] protected(protected val in: List[A], protected val out: List[A])
@@ -139,6 +141,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
   /** Creates a new queue with element added at the end
    *  of the old queue.
    *
+   *  @tparam B the element type of the returned queue, a supertype of `A`
    *  @param  elem        the element to insert
    */
   def enqueue[B >: A](elem: B): Queue[B] = new Queue(elem :: in, out)
@@ -160,7 +163,9 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
    *  The elements are appended in the order they are given out by the
    *  iterator.
    *
+   *  @tparam B the element type of the returned queue, a supertype of `A`
    *  @param  iter        an iterable object
+   *  @return a new queue with all elements of `iter` appended at the end
    */
   def enqueueAll[B >: A](iter: scala.collection.Iterable[B]^): Queue[B] = appendedAll(iter)
 

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -138,6 +138,9 @@ sealed abstract class Range(
    *
    *  If the mathematical result is not within this Range, the result won't
    *  make sense, but won't error out.
+   *
+   *  @param n the number of steps from `start`, interpreted as an unsigned integer
+   *  @return the element at position `n` in this range, i.e., `start + step * n`
    */
   @inline
   private def locationAfterN(n: Int): Int = {
@@ -222,6 +225,7 @@ sealed abstract class Range(
   /** Creates a new range with the `start` and `end` values of this range and
    *  a new `step`.
    *
+   *  @param step the new step value for the range; must be non-zero
    *  @return a new range with a different step
    */
   final def by(step: Int): Range = copy(start, end, step)
@@ -299,6 +303,9 @@ sealed abstract class Range(
    *  in this non-empty range?
    *
    *  This method returns nonsensical results if `n < 0` or if `this.isEmpty`.
+   *
+   *  @param n the non-negative value to compare against the number of elements
+   *  @return `true` if `n` is greater than or equal to the number of elements in this range
    */
   @inline private def greaterEqualNumRangeElements(n: Int): Boolean =
     (n ^ Int.MinValue) > ((numRangeElements - 1) ^ Int.MinValue) // unsigned comparison
@@ -326,6 +333,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the last `n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to take from the right
+   *  @return a new range consisting of the last `n` elements, or an empty range if `n <= 0`, or the entire range if `n` is greater than its length
    */
   final override def takeRight(n: Int): Range = {
     if (n <= 0 || isEmpty) newEmptyRange(start)
@@ -336,6 +346,9 @@ sealed abstract class Range(
   /** Creates a new range consisting of the initial `length - n` elements of the range.
    *
    *  $doesNotUseBuilders
+   *
+   *  @param n the number of elements to drop from the right
+   *  @return a new range consisting of all elements except the last `n`, or this range unchanged if `n <= 0`, or an empty range if `n` is greater than its length
    */
   final override def dropRight(n: Int): Range = {
     if (n <= 0 || isEmpty) this
@@ -585,6 +598,11 @@ object Range {
    *  precondition:  step != 0
    *  If the size of the range exceeds Int.MaxValue, the
    *  result will be negative.
+   *
+   *  @param start the start value of the range
+   *  @param end the end value of the range (exclusive or inclusive depending on `isInclusive`)
+   *  @param step the step value between consecutive elements, must be non-zero
+   *  @param isInclusive whether `end` is included in the range
    */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
@@ -617,18 +635,34 @@ object Range {
 
   /** Makes a range from `start` until `end` (exclusive) with given step value.
    *  @note step != 0
+   *
+   *  @param start the start value of the range
+   *  @param end the exclusive end value of the range
+   *  @param step the step value between consecutive elements, must be non-zero
    */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
-  /** Makes a range from `start` until `end` (exclusive) with step value 1. */
+  /** Makes a range from `start` until `end` (exclusive) with step value 1.
+   *
+   *  @param start the start value of the range
+   *  @param end the exclusive end value of the range
+   */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
   /** Makes an inclusive range from `start` to `end` with given step value.
    *  @note step != 0
+   *
+   *  @param start the start value of the range
+   *  @param end the inclusive end value of the range
+   *  @param step the step value between consecutive elements, must be non-zero
    */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
-  /** Makes an inclusive range from `start` to `end` with step value 1. */
+  /** Makes an inclusive range from `start` to `end` with step value 1.
+   *
+   *  @param start the start value of the range
+   *  @param end the inclusive end value of the range
+   */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 
   @SerialVersionUID(4L)

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -71,6 +71,12 @@ private[collection] object RedBlackTree {
     }
     /** Creates a new balanced tree where `newLeft` replaces `tree.left`.
      *  tree and newLeft are never null 
+     *
+     *  @tparam A1 the key type of the tree
+     *  @tparam B the original value type of the tree
+     *  @tparam B1 the value type of the result, a supertype of `B`
+     *  @param tree the original tree whose left child is being replaced
+     *  @param newLeft the new left subtree to substitute in
      */
     protected final def mutableBalanceLeft[A1, B, B1 >: B](tree: Tree[A1, B], newLeft: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -115,6 +121,12 @@ private[collection] object RedBlackTree {
     }
     /** Creates a new balanced tree where `newRight` replaces `tree.right`.
      *  tree and newRight are never null 
+     *
+     *  @tparam A1 the key type of the tree
+     *  @tparam B the original value type of the tree
+     *  @tparam B1 the value type of the result, a supertype of `B`
+     *  @param tree the original tree whose right child is being replaced
+     *  @param newRight the new right subtree to substitute in
      */
     protected final def mutableBalanceRight[A1, B, B1 >: B](tree: Tree[A1, B], newRight: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -246,7 +258,14 @@ private[collection] object RedBlackTree {
     blacken(_init(tree))
   }
 
-  /** Returns the smallest node with a key larger than or equal to `x`. Returns `null` if there is no such node. */
+  /** Returns the smallest node with a key larger than or equal to `x`. Returns `null` if there is no such node.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param tree the red-black tree to search
+   *  @param x the inclusive lower bound key to search for
+   *  @param ordering the ordering used to compare keys
+   */
   def minAfter[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
     if (cmp == 0) tree
@@ -256,7 +275,14 @@ private[collection] object RedBlackTree {
     } else minAfter(tree.right, x)
   }
 
-  /** Returns the largest node with a key smaller than `x`. Returns `null` if there is no such node. */
+  /** Returns the largest node with a key smaller than `x`. Returns `null` if there is no such node.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param tree the red-black tree to search
+   *  @param x the exclusive upper bound key
+   *  @param ordering the ordering used to compare keys
+   */
   def maxBefore[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
     if (cmp <= 0) maxBefore(tree.left, x)
@@ -338,7 +364,13 @@ private[collection] object RedBlackTree {
     new Tree(key, value.asInstanceOf[AnyRef], left, right, sizeAndColour)
   }
 
-  /** Creates a new balanced tree where `newLeft` replaces `tree.left`. */
+  /** Creates a new balanced tree where `newLeft` replaces `tree.left`.
+   *
+   *  @tparam A the key type
+   *  @tparam B1 the value type
+   *  @param tree the original tree whose left child is being replaced
+   *  @param newLeft the new left subtree to substitute in
+   */
   private def balanceLeft[A, B1](tree: Tree[A, B1], newLeft: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree              |                   newLeft
@@ -379,7 +411,13 @@ private[collection] object RedBlackTree {
       }
     }
   }
-  /** Creates a new balanced tree where `newRight` replaces `tree.right`. */
+  /** Creates a new balanced tree where `newRight` replaces `tree.right`.
+   *
+   *  @tparam A the key type
+   *  @tparam B1 the value type
+   *  @param tree the original tree whose right child is being replaced
+   *  @param newRight the new right subtree to substitute in
+   */
   private def balanceRight[A, B1](tree: Tree[A, B1], newRight: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
     //            tree                |                             newRight
@@ -785,6 +823,13 @@ private[collection] object RedBlackTree {
 
   /** Creates a new immutable red tree.
    *  left and right may be null.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param key the key stored in this node
+   *  @param value the value associated with the key
+   *  @param left the left subtree, or `null` if absent
+   *  @param right the right subtree, or `null` if absent
    */
   private[immutable] def RedTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null): Tree[A, B] = {
     //assertNotMutable(left)
@@ -857,6 +902,8 @@ private[collection] object RedBlackTree {
      *  the leftmost subtree with the key that would be "next" after it according
      *  to the ordering. Along the way build up the iterator's path stack so that "next"
      *  functionality works.
+     *
+     *  @param key the key from which to start iteration
      */
     private def startFrom(key: A) : Tree[A,B] | Null = if (root eq null) null else {
       @tailrec def find(tree: Tree[A, B] | Null): Tree[A, B] | Null =
@@ -936,7 +983,12 @@ private[collection] object RedBlackTree {
     override def nextResult(tree: Tree[A, B]) = tree.value
   }
 
-  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys. */
+  /** Builds a Tree suitable for a TreeSet from an ordered sequence of keys.
+   *
+   *  @tparam A the key type
+   *  @param xs an iterator yielding keys in ascending order
+   *  @param size the number of keys to consume from the iterator
+   */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, Null] | Null = size match {
@@ -952,7 +1004,13 @@ private[collection] object RedBlackTree {
     f(1, size)
   }
 
-  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs. */
+  /** Builds a Tree suitable for a TreeMap from an ordered sequence of key/value pairs.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param xs an iterator yielding key-value pairs in ascending key order
+   *  @param size the number of entries to consume from the iterator
+   */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
     def f(level: Int, size: Int): Tree[A, B] | Null = size match {
@@ -1089,7 +1147,13 @@ private[collection] object RedBlackTree {
          tl.nn.right.nn.redWithLeftRight(balance(tl.nn, tl.nn.left.nn.red, tl.nn.right.nn.left), tree.blackWithLeftRight(tl.nn.right.nn.right, tr))
     else sys.error("Defect: invariance violation")
 
-  /** `append` is similar to `join2` but requires that both subtrees have the same black height. */
+  /** `append` is similar to `join2` but requires that both subtrees have the same black height.
+   *
+   *  @tparam A the key type
+   *  @tparam B the value type
+   *  @param tl the left subtree to append, or `null` if empty
+   *  @param tr the right subtree to append, or `null` if empty
+   */
   private def append[A, B](tl: Tree[A, B] | Null, tr: Tree[A, B] | Null): Tree[A, B] | Null = {
     if (tl eq null) tr
     else if (tr eq null) tl
@@ -1129,7 +1193,11 @@ private[collection] object RedBlackTree {
   def difference[A, B](t1: Tree[A, B] | Null, t2: Tree[A, ?] | Null)(implicit ordering: Ordering[A]): Tree[A, B] | Null =
     blacken(_difference(t1, t2.asInstanceOf[Tree[A, B]]))
 
-  /** Computes the rank from a tree and its black height. */
+  /** Computes the rank from a tree and its black height.
+   *
+   *  @param t the tree node, or `null` for an empty subtree
+   *  @param bh the black height of `t`
+   */
   @`inline` private def rank(t: Tree[?, ?] | Null, bh: Int): Int = {
     if(t eq null) 0
     else if(t.isBlack) 2*(bh-1)

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -30,6 +30,9 @@ trait Seq[+A] extends Iterable[A]
 /**
  *  @define coll immutable sequence
  *  @define Coll `immutable.Seq`
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the collection type, constrained to be pure
  */
 transparent trait SeqOps[+A, +CC[B] <: caps.Pure, +C] extends Any with collection.SeqOps[A, CC, C] with caps.Pure
 
@@ -45,7 +48,10 @@ object Seq extends SeqFactory.Delegate[Seq](List) {
   }
 }
 
-/** Base trait for immutable indexed sequences that have efficient `apply` and `length`. */
+/** Base trait for immutable indexed sequences that have efficient `apply` and `length`.
+ *
+ *  @tparam A the element type of the indexed sequence
+ */
 trait IndexedSeq[+A] extends Seq[A]
                         with collection.IndexedSeq[A]
                         with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
@@ -94,7 +100,7 @@ trait IndexedSeq[+A] extends Seq[A]
   /** a hint to the runtime when scanning values
    *  [[apply]] is preferred for scan with a max index less than this value
    *  [[iterator]] is preferred for scans above this range
-   *  @return a hint about when to use [[apply]] or [[iterator]]
+   *  @return the maximum length below which [[apply]] is preferred over [[iterator]] for element access
    */
   protected def applyPreferredMaxLength: Int = IndexedSeqDefaults.defaultApplyPreferredMaxLength
 
@@ -118,7 +124,11 @@ object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector) {
   }
 }
 
-/** Base trait for immutable indexed `Seq` operations. */
+/** Base trait for immutable indexed `Seq` operations.
+ *
+ *  @tparam A the element type of the indexed sequence
+ *  @tparam CC the type constructor for the collection type, constrained to be pure
+ */
 transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends SeqOps[A, CC, C]
     with collection.IndexedSeqOps[A, CC, C] {
@@ -131,7 +141,10 @@ transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
 
 }
 
-/** Base trait for immutable linear sequences that have efficient `head` and `tail`. */
+/** Base trait for immutable linear sequences that have efficient `head` and `tail`.
+ *
+ *  @tparam A the element type of the linear sequence
+ */
 trait LinearSeq[+A]
   extends Seq[A]
     with collection.LinearSeq[A]
@@ -153,5 +166,8 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
   extends Any with SeqOps[A, CC, C]
     with collection.LinearSeqOps[A, CC, C]
 
-/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the sequence
+ */
 abstract class AbstractSeq[+A] extends scala.collection.AbstractSeq[A] with Seq[A]

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -20,7 +20,10 @@ import language.experimental.captureChecking
 import scala.collection.immutable.Set.Set4
 import scala.collection.mutable.{Builder, ReusableBuilder}
 
-/** Base trait for immutable set collections. */
+/** Base trait for immutable set collections.
+ *
+ *  @tparam A the element type of the set
+ */
 trait Set[A] extends Iterable[A]
     with collection.Set[A]
     with SetOps[A, Set, Set[A]]
@@ -32,6 +35,9 @@ trait Set[A] extends Iterable[A]
  *
  *  @define coll immutable set
  *  @define Coll `immutable.Set`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the resulting set (e.g., `Set`)
  */
 transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C] {
@@ -45,7 +51,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
    */
   def incl(elem: A): C
 
-  /** Alias for `incl`. */
+  /** Alias for `incl`.
+   *
+   *  @param elem the element to add
+   */
   override final def + (elem: A): C = incl(elem) // like in collection.Set but not deprecated
 
   /** Creates a new set with a given element removed from this set.
@@ -56,7 +65,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
    */
   def excl(elem: A): C
 
-  /** Alias for `excl`. */
+  /** Alias for `excl`.
+   *
+   *  @param elem the element to remove
+   */
   @`inline` final override def - (elem: A): C = excl(elem)
 
   def diff(that: collection.Set[A]): C =
@@ -70,7 +82,10 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
    */
   def removedAll(that: IterableOnce[A]^): C = that.iterator.foldLeft[C](coll)(_ - _)
 
-  /** Alias for removedAll. */
+  /** Alias for removedAll.
+   *
+   *  @param that the collection of elements to remove
+   */
   override final def -- (that: IterableOnce[A]^): C = removedAll(that)
 }
 
@@ -355,11 +370,16 @@ object Set extends IterableFactory[Set] {
   }
 }
 
-/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the set
+ */
 abstract class AbstractSet[A] extends scala.collection.AbstractSet[A] with Set[A]
 
 /** Builder for Set.
  *  $multipleResults
+ *
+ *  @tparam A the element type of the set being built
  */
 private final class SetBuilderImpl[A] extends ReusableBuilder[A, Set[A]] {
   private var elems: Set[A] = Set.empty

--- a/library/src/scala/collection/immutable/SortedMap.scala
+++ b/library/src/scala/collection/immutable/SortedMap.scala
@@ -69,6 +69,7 @@ trait SortedMap[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of `V`
    *  @param d     the function mapping keys to values, used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
@@ -80,6 +81,7 @@ trait SortedMap[K, +V]
    *
    *  Invoking transformer methods (e.g. `map`) will not preserve the default value.
    *
+   *  @tparam V1 the type of the values in the resulting map, a supertype of `V`
    *  @param d     default value used for non-present keys
    *  @return      a wrapper of the map with a default value
    */

--- a/library/src/scala/collection/immutable/SortedSet.scala
+++ b/library/src/scala/collection/immutable/SortedSet.scala
@@ -17,7 +17,10 @@ package immutable
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base trait for sorted sets. */
+/** Base trait for sorted sets.
+ *
+ *  @tparam A the element type of the sorted set, which must have an implicit `Ordering`
+ */
 trait SortedSet[A]
   extends Set[A]
      with collection.SortedSet[A]
@@ -32,6 +35,10 @@ trait SortedSet[A]
 /**
  *  @define coll immutable sorted set
  *  @define Coll `immutable.SortedSet`
+ *
+ *  @tparam A the element type of the sorted set
+ *  @tparam CC the type constructor for the resulting sorted set (e.g., `SortedSet`)
+ *  @tparam C the type of the concrete sorted set
  */
 transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -52,6 +52,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   /** Applies the given function `f` to each element of this linear sequence
    *  (while respecting the order of the elements).
    *
+   *  @tparam U the result type of `f`, discarded by `foreach`
    *  @param f The treatment to apply to each element.
    *  @note  Overridden here as final to trigger tail-call optimization, which
    *  replaces 'this' with 'tail' at each iteration. This is absolutely
@@ -117,6 +118,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
 
   /** The stream resulting from the concatenation of this stream with the argument stream.
    *
+   *  @tparam B the element type of the returned stream, which must be a supertype of `A`
    *  @param suffix The collection that gets appended to this stream
    *  @return The stream containing elements of this stream and the iterable object.
    */
@@ -163,7 +165,10 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     else iterableFactory.empty
   }
 
-  /** A `collection.WithFilter` which allows GC of the head of stream during processing. */
+  /** A `collection.WithFilter` which allows GC of the head of stream during processing.
+   *
+   *  @param p the predicate used to test elements
+   */
   override final def withFilter(p: A => Boolean): collection.WithFilter[A, Stream] =
     Stream.withFilter(coll, p)
 
@@ -362,12 +367,18 @@ object Stream extends SeqFactory[Stream] {
   /** An alternative way of building and matching Streams using Stream.cons(hd, tl). */
   object cons {
     /** A stream consisting of a given first element and remaining elements.
+     *
+     *  @tparam A the element type of the stream
      *  @param hd   The first element of the result stream
      *  @param tl   The remaining elements of the result stream
      */
     def apply[A](hd: A, tl: => Stream[A]): Stream[A] = new Cons(hd, tl)
 
-    /** Maps a stream to its head and tail. */
+    /** Maps a stream to its head and tail.
+     *
+     *  @tparam A the element type of the stream
+     *  @param xs the stream to decompose
+     */
     def unapply[A](xs: Stream[A]): Option[(A, Stream[A])] = #::.unapply(xs)
   }
 
@@ -487,6 +498,7 @@ object Stream extends SeqFactory[Stream] {
 
   /** An infinite Stream that repeatedly applies a given function to a start value.
    *
+   *  @tparam A the element type of the stream
    *  @param start the start value of the Stream
    *  @param f     the function that's repeatedly applied
    *  @return      the Stream returning the infinite sequence of values `start, f(start), f(f(start)), ...`
@@ -515,6 +527,7 @@ object Stream extends SeqFactory[Stream] {
   /** Creates an infinite Stream containing the given element expression (which
    *  is computed for each occurrence).
    *
+   *  @tparam A the element type of the stream
    *  @param elem the element composing the resulting Stream
    *  @return the Stream containing an infinite number of elem
    */

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -19,7 +19,12 @@ import language.experimental.captureChecking
 
 import scala.collection.generic.CommonErrors
 
-/** Trait that overrides operations to take advantage of strict builders. */
+/** Trait that overrides operations to take advantage of strict builders.
+ *
+ *  @tparam A the element type of the collection
+ *  @tparam CC the type constructor of the collection (higher-kinded)
+ *  @tparam C the type of the collection itself
+ */
 transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends Any
     with SeqOps[A, CC, C]

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -72,6 +72,11 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
    *  Unlike `fill`, which takes a by-name argument for the value and can thereby
    *  compute different values for each index, this method guarantees that all
    *  elements are identical. This allows sparse allocation in O(log n) time and space.
+   *
+   *  @tparam A the element type of the vector
+   *  @param n the number of elements in the vector
+   *  @param elem the element to fill every position with
+   *  @return a new vector of size `n` with each element set to `elem`
    */
   private[collection] def fillSparse[A](n: Int)(elem: A): Vector[A] = {
     //TODO Make public; this method is private for now because it is not forward binary compatible
@@ -115,6 +120,8 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
  *
  *  In addition to the data slices (`prefix1`, `prefix2`, ..., `dataN`, ..., `suffix2`, `suffix1`) we store a running
  *  count of elements after each prefix for more efficient indexing without having to dereference all prefix arrays.
+ *
+ *  @tparam A the element type of the vector
  */
 sealed abstract class Vector[+A] private[immutable] (private[immutable] final val prefix1: Arr1)
   extends AbstractSeq[A]
@@ -259,14 +266,24 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   override def tail: Vector[A] = slice(1, length)
   override def init: Vector[A] = slice(0, length-1)
 
-  /** Like slice but parameters must be 0 <= lo < hi < length. */
+  /** Like slice but parameters must be `0 <= lo < hi <= length`.
+   *
+   *  @param lo the lowest index to include (inclusive), must satisfy `0 <= lo < hi`
+   *  @param hi the exclusive upper bound index, must satisfy `lo < hi <= length`
+   */
   protected def slice0(lo: Int, hi: Int): Vector[A]
 
   /** Number of slices. */
   protected[immutable] def vectorSliceCount: Int
-  /** Slices at index. */
+  /** Slices at index.
+   *
+   *  @param idx the zero-based slice index
+   */
   protected[immutable] def vectorSlice(idx: Int): Array[? <: AnyRef | Null]
-  /** Length of all slices up to and including index. */
+  /** Length of all slices up to and including index.
+   *
+   *  @param idx the zero-based slice index
+   */
   protected[immutable] def vectorSlicePrefixLength(idx: Int): Int
 
   override def copyToArray[B >: A](xs: Array[B], start: Int, len: Int): Int = iterator.copyToArray(xs, start, len)
@@ -317,7 +334,10 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
 }
 
 
-/** This class only exists because we cannot override `slice` in `Vector` in a binary-compatible way. */
+/** This class only exists because we cannot override `slice` in `Vector` in a binary-compatible way.
+ *
+ *  @tparam A the element type of the vector
+ */
 private sealed abstract class VectorImpl[+A](_prefix1: Arr1) extends Vector[A](_prefix1) {
 
   override final def slice(from: Int, until: Int): Vector[A] = {
@@ -330,7 +350,12 @@ private sealed abstract class VectorImpl[+A](_prefix1: Arr1) extends Vector[A](_
 }
 
 
-/** Vector with suffix and length fields; all Vector subclasses except Vector1 extend this. */
+/** Vector with suffix and length fields; all Vector subclasses except Vector1 extend this.
+ *
+ *  @tparam A the element type of the vector
+ *  @param suffix1 the last data array containing the rightmost elements
+ *  @param length0 the total number of elements in this vector
+ */
 private sealed abstract class BigVector[+A](_prefix1: Arr1, private[immutable] val suffix1: Arr1, private[immutable] val length0: Int) extends VectorImpl[A](_prefix1) {
 
   protected[immutable] final def foreachRest[U](f: A => U): Unit = {
@@ -385,7 +410,10 @@ private object Vector0 extends BigVector[Nothing](empty1, empty1, 0) {
     new IndexOutOfBoundsException(s"$index is out of bounds (empty vector)")
 }
 
-/** Flat ArraySeq-like structure. */
+/** Flat ArraySeq-like structure.
+ *
+ *  @tparam A the element type of the vector
+ */
 private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
 
   @inline def apply(index: Int): A = {
@@ -443,7 +471,12 @@ private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
 }
 
 
-/** 2-dimensional radix-balanced finger tree. */
+/** 2-dimensional radix-balanced finger tree.
+ *
+ *  @tparam A the element type of the vector
+ *  @param len1 the number of elements in `prefix1`
+ *  @param data2 the central 2-dimensional data array
+ */
 private final class Vector2[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val data2: Arr2,
                                  _suffix1: Arr1,
@@ -543,7 +576,15 @@ private final class Vector2[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 3-dimensional radix-balanced finger tree. */
+/** 3-dimensional radix-balanced finger tree.
+ *
+ *  @tparam A the element type of the vector
+ *  @param len1 the number of elements in `prefix1`
+ *  @param prefix2 the 2nd-level prefix data arrays
+ *  @param len12 the combined number of elements in `prefix1` and `prefix2`
+ *  @param data3 the central 3-dimensional data array
+ *  @param suffix2 the 2nd-level suffix data arrays
+ */
 private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val data3: Arr3,
@@ -666,7 +707,18 @@ private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 4-dimensional radix-balanced finger tree. */
+/** 4-dimensional radix-balanced finger tree.
+ *
+ *  @tparam A the element type of the vector
+ *  @param len1 the number of elements in `prefix1`
+ *  @param prefix2 the 2nd-level prefix data arrays
+ *  @param len12 the combined number of elements in `prefix1` and `prefix2`
+ *  @param prefix3 the 3rd-level prefix data arrays
+ *  @param len123 the combined number of elements in `prefix1` through `prefix3`
+ *  @param data4 the central 4-dimensional data array
+ *  @param suffix3 the 3rd-level suffix data arrays
+ *  @param suffix2 the 2nd-level suffix data arrays
+ */
 private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val prefix3: Arr3, private[immutable] val len123: Int,
@@ -810,7 +862,21 @@ private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 5-dimensional radix-balanced finger tree. */
+/** 5-dimensional radix-balanced finger tree.
+ *
+ *  @tparam A the element type of the vector
+ *  @param len1 the number of elements in `prefix1`
+ *  @param prefix2 the 2nd-level prefix data arrays
+ *  @param len12 the combined number of elements in `prefix1` and `prefix2`
+ *  @param prefix3 the 3rd-level prefix data arrays
+ *  @param len123 the combined number of elements in `prefix1` through `prefix3`
+ *  @param prefix4 the 4th-level prefix data arrays
+ *  @param len1234 the combined number of elements in `prefix1` through `prefix4`
+ *  @param data5 the central 5-dimensional data array
+ *  @param suffix4 the 4th-level suffix data arrays
+ *  @param suffix3 the 3rd-level suffix data arrays
+ *  @param suffix2 the 2nd-level suffix data arrays
+ */
 private final class Vector5[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val prefix3: Arr3, private[immutable] val len123: Int,
@@ -975,7 +1041,24 @@ private final class Vector5[+A](_prefix1: Arr1, private[immutable] val len1: Int
 }
 
 
-/** 6-dimensional radix-balanced finger tree. */
+/** 6-dimensional radix-balanced finger tree.
+ *
+ *  @tparam A the element type of the vector
+ *  @param len1 the number of elements in `prefix1`
+ *  @param prefix2 the 2nd-level prefix data arrays
+ *  @param len12 the combined number of elements in `prefix1` and `prefix2`
+ *  @param prefix3 the 3rd-level prefix data arrays
+ *  @param len123 the combined number of elements in `prefix1` through `prefix3`
+ *  @param prefix4 the 4th-level prefix data arrays
+ *  @param len1234 the combined number of elements in `prefix1` through `prefix4`
+ *  @param prefix5 the 5th-level prefix data arrays
+ *  @param len12345 the combined number of elements in `prefix1` through `prefix5`
+ *  @param data6 the central 6-dimensional data array
+ *  @param suffix5 the 5th-level suffix data arrays
+ *  @param suffix4 the 4th-level suffix data arrays
+ *  @param suffix3 the 3rd-level suffix data arrays
+ *  @param suffix2 the 2nd-level suffix data arrays
+ */
 private final class Vector6[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
                                  private[immutable] val prefix3: Arr3, private[immutable] val len123: Int,
@@ -1166,6 +1249,9 @@ private final class Vector6[+A](_prefix1: Arr1, private[immutable] val len1: Int
  *  of the originating vector is or where the cut is performed, this always results in a
  *  structure with the highest-dimensional data in the middle and fingers of decreasing dimension
  *  at both ends, which can be turned into a new vector with very little rebalancing.
+ *
+ *  @param lo the start index (inclusive) of the slice
+ *  @param hi the end index (exclusive) of the slice
  */
 private final class VectorSliceBuilder(lo: Int, hi: Int) {
   //println(s"***** VectorSliceBuilder($lo, $hi)")
@@ -1348,7 +1434,10 @@ private final class VectorSliceBuilder(lo: Int, hi: Int) {
     }
   }
 
-  /** Ensures prefix is not empty. */
+  /** Ensures prefix is not empty.
+   *
+   *  @param n the dimension level (1 through `maxDim`) at which to ensure the prefix is non-empty
+   */
   private def balancePrefix(n: Int): Unit = {
     if(slices(prefixIdx(n)) eq null) {
       if(n == maxDim) {
@@ -1369,7 +1458,10 @@ private final class VectorSliceBuilder(lo: Int, hi: Int) {
     }
   }
 
-  /** Ensures suffix is not empty. */
+  /** Ensures suffix is not empty.
+   *
+   *  @param n the dimension level (1 through `maxDim`) at which to ensure the suffix is non-empty
+   */
   private def balanceSuffix(n: Int): Unit = {
     if(slices(suffixIdx(n)) eq null) {
       if(n == maxDim) {
@@ -2015,7 +2107,11 @@ private[immutable] object VectorInline {
   type Arr5 = Array[Array[Array[Array[Array[AnyRef]]]]]
   type Arr6 = Array[Array[Array[Array[Array[Array[AnyRef]]]]]]
 
-  /** Dimension of the slice at index. */
+  /** Dimension of the slice at index.
+   *
+   *  @param count the total number of slices
+   *  @param idx the zero-based slice index
+   */
   @inline def vectorSliceDim(count: Int, idx: Int): Int = {
     val c = count/2
     c+1-abs(idx-c)


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for collection immutable. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.