### PR TITLE
Collection core (4): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -63,11 +63,19 @@ object ArrayOps {
     override def toString(): String = immutable.ArraySeq.unsafeWrapArray(xs).mkString("ArrayView(", ", ", ")")
   }
 
-  /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
+  /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called.
+   *
+   *  @tparam A the element type of the array
+   *  @param p the filter predicate applied to each element
+   *  @param xs the underlying array being filtered
+   */
   class WithFilter[A](p: A => Boolean, xs: Array[A]) {
 
     /** Applies `f` to each element for its side effects.
      *  Note: [U] parameter needed to help scalac's type inference.
+     *
+     *  @tparam U the return type of the function `f`, used only for side effects
+     *  @param f the function to apply to each element
      */
     def foreach[U](f: A => U): Unit = {
       val len = xs.length
@@ -119,7 +127,10 @@ object ArrayOps {
     def flatMap[BS, B](f: A => BS)(implicit asIterable: BS => Iterable[B], m: ClassTag[B]): Array[B] =
       flatMap[B](x => asIterable(f(x)))
 
-    /** Creates a new non-strict filter which combines this filter with the given predicate. */
+    /** Creates a new non-strict filter which combines this filter with the given predicate.
+     *
+     *  @param q the additional predicate to apply in conjunction with `p`
+     */
     def withFilter(q: A => Boolean): WithFilter[A]^{this, q} = new WithFilter[A](a => p(a) && q(a), xs)
   }
 
@@ -199,6 +210,7 @@ object ArrayOps {
  *  `filter` and `map` will yield an array, whereas an `ArraySeq` will remain an `ArraySeq`.
  *
  *  @tparam A   type of the elements contained in this array.
+ *  @param xs the underlying array being wrapped
  */
 final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
@@ -294,6 +306,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  this.sizeIs >= size    // this.sizeCompare(size) >= 0
    *  this.sizeIs > size     // this.sizeCompare(size) > 0
    *  ```
+   *
+   *  @return the number of elements in this array
    */
   def sizeIs: Int = xs.length
 
@@ -311,6 +325,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  this.lengthIs >= len    // this.lengthCompare(len) >= 0
    *  this.lengthIs > len     // this.lengthCompare(len) > 0
    *  ```
+   *
+   *  @return the number of elements in this array
    */
   def lengthIs: Int = xs.length
 
@@ -373,16 +389,28 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   private def iterateUntilEmpty(f: Array[A] => Array[A]): Iterator[Array[A]]^{f} =
     Iterator.iterate(xs)(f).takeWhile(x => x.length != 0) ++ Iterator.single(Array.empty[A])
 
-  /** An array containing the first `n` elements of this array. */
+  /** An array containing the first `n` elements of this array.
+   *
+   *  @param n the number of elements to take from this array
+   */
   def take(n: Int): Array[A] = slice(0, n)
 
-  /** The rest of the array without its `n` first elements. */
+  /** The rest of the array without its `n` first elements.
+   *
+   *  @param n the number of elements to drop from the front of this array
+   */
   def drop(n: Int): Array[A] = slice(n, xs.length)
 
-  /** An array containing the last `n` elements of this array. */
+  /** An array containing the last `n` elements of this array.
+   *
+   *  @param n the number of elements to take from the end of this array
+   */
   def takeRight(n: Int): Array[A] = drop(xs.length - max(n, 0))
 
-  /** The rest of the array without its `n` last elements. */
+  /** The rest of the array without its `n` last elements.
+   *
+   *  @param n the number of elements to drop from the end of this array
+   */
   def dropRight(n: Int): Array[A] = take(xs.length - max(n, 0))
 
   /** Takes longest prefix of elements that satisfy a predicate.
@@ -476,7 +504,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    */
   def splitAt(n: Int): (Array[A], Array[A]) = (take(n), drop(n))
 
-  /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not. */
+  /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not.
+   *
+   *  @param p the predicate used to partition the elements
+   */
   def partition(p: A => Boolean): (Array[A], Array[A]) = {
     val res1, res2 = ArrayBuilder.make[A]
     var i = 0
@@ -586,6 +617,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *
    *  @see [[scala.math.Ordering]]
    *
+   *  @tparam B the element type for the ordering, a supertype of `A`
    *  @param  ord the ordering to be used to compare elements.
    *  @return     an array consisting of the elements of this array
    *              sorted according to the ordering `ord`.
@@ -721,6 +753,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   /** Finds index of last element satisfying some predicate before or at given end index.
    *
    *  @param   p     the predicate used to test elements.
+   *  @param end the maximum index to search up to (inclusive), defaults to the last index
    *  @return  the index `<= end` of the last element of this array that satisfies the predicate `p`,
    *           or `-1`, if none exists.
    */
@@ -926,6 +959,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *
    *  @tparam B     the element type of the returned array.
    *  @param f      the function to apply to each element.
+   *  @param ct the class tag for the element type `B`, required to create the result array
    *  @return       a new array resulting from applying the given function
    *                `f` to each element of this array and collecting the results.
    */
@@ -984,6 +1018,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *
    *  @tparam B         Type of row elements.
    *  @param asIterable A function that converts elements of this array to rows - Iterables of type `B`.
+   *  @param m the class tag for the element type `B`, required to create the result array
    *  @return           An array obtained by concatenating rows of this array.
    */
   def flatten[B](implicit asIterable: A => IterableOnce[B]^, m: ClassTag[B]): Array[B] = {
@@ -1033,6 +1068,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   /** Finds the first element of the array for which the given partial function is defined, and applies the
    *  partial function to it.
+   *
+   *  @tparam B the result type of the partial function
    */
   def collectFirst[B](@deprecatedName("f","2.13.9") pf: PartialFunction[A, B]^): Option[B] = {
     val fallback: Any => Any = ArrayOps.fallback
@@ -1091,6 +1128,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  If one of the two collections is shorter than the other,
    *  placeholder elements are used to extend the shorter collection to the length of the longer.
    *
+   *  @tparam A1 the type of the first element of each pair in the result, a supertype of `A`
+   *  @tparam B the type of elements in `that` iterable
    *  @param that     the iterable providing the second half of each result pair
    *  @param thisElem the element to be used to fill up the result if this array is shorter than `that`.
    *  @param thatElem the element to be used to fill up the result if `that` is shorter than this array.
@@ -1135,7 +1174,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     b
   }
 
-  /** A copy of this array with an element appended. */
+  /** A copy of this array with an element appended.
+   *
+   *  @tparam B the element type of the returned array, a supertype of `A`
+   *  @param x the element to append
+   */
   def appended[B >: A : ClassTag](x: B): Array[B] = {
     val dest = Array.copyAs[B](xs, xs.length+1)
     dest(xs.length) = x
@@ -1144,7 +1187,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   @`inline` final def :+ [B >: A : ClassTag](x: B): Array[B] = appended(x)
 
-  /** A copy of this array with an element prepended. */
+  /** A copy of this array with an element prepended.
+   *
+   *  @tparam B the element type of the returned array, a supertype of `A`
+   *  @param x the element to prepend
+   */
   def prepended[B >: A : ClassTag](x: B): Array[B] = {
     val dest = new Array[B](xs.length + 1)
     dest(0) = x
@@ -1154,7 +1201,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   @`inline` final def +: [B >: A : ClassTag](x: B): Array[B] = prepended(x)
 
-  /** A copy of this array with all elements of a collection prepended. */
+  /** A copy of this array with all elements of a collection prepended.
+   *
+   *  @tparam B the element type of the returned array, a supertype of `A`
+   *  @param prefix the collection to prepend
+   */
   def prependedAll[B >: A : ClassTag](prefix: IterableOnce[B]^): Array[B] = {
     val b = ArrayBuilder.make[B]
     val k = prefix.knownSize
@@ -1165,7 +1216,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     b.result()
   }
 
-  /** A copy of this array with all elements of an array prepended. */
+  /** A copy of this array with all elements of an array prepended.
+   *
+   *  @tparam B the element type of the returned array, a supertype of `A`
+   *  @param prefix the array to prepend
+   */
   def prependedAll[B >: A : ClassTag](prefix: Array[? <: B]): Array[B] = {
     val dest = Array.copyAs[B](prefix, prefix.length+xs.length)
     Array.copy(xs, 0, dest, prefix.length, xs.length)
@@ -1176,7 +1231,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   @`inline` final def ++: [B >: A : ClassTag](prefix: Array[? <: B]): Array[B] = prependedAll(prefix)
 
-  /** A copy of this array with all elements of a collection appended. */
+  /** A copy of this array with all elements of a collection appended.
+   *
+   *  @tparam B the element type of the returned array, a supertype of `A`
+   *  @param suffix the collection to append
+   */
   def appendedAll[B >: A : ClassTag](suffix: IterableOnce[B]^): Array[B] = {
     val b = ArrayBuilder.make[B]
     b.sizeHint(suffix, delta = xs.length)
@@ -1185,7 +1244,11 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     b.result()
   }
 
-  /** A copy of this array with all elements of an array appended. */
+  /** A copy of this array with all elements of an array appended.
+   *
+   *  @tparam B the element type of the returned array, a supertype of `A`
+   *  @param suffix the array to append
+   */
   def appendedAll[B >: A : ClassTag](suffix: Array[? <: B]): Array[B] = {
     val dest = Array.copyAs[B](xs, xs.length+suffix.length)
     Array.copy(suffix, 0, dest, xs.length, suffix.length)
@@ -1217,6 +1280,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  Patching at indices at or larger than the length of the original array appends the patch to the end.
    *  If more values are replaced than actually exist, the excess is ignored.
    *
+   *  @tparam B the element type of the returned array, a supertype of `A`
    *  @param from       The start index from which to patch
    *  @param other      The patch values
    *  @param replaced   The number of values in the original array that are replaced by the patch.
@@ -1319,6 +1383,9 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   /** Applies `f` to each element for its side effects.
    *  Note: [U] parameter needed to help scalac's type inference.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function to apply to each element
    */
   def foreach[U](f: A => U): Unit = {
     val len = xs.length
@@ -1419,6 +1486,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @tparam B the type of values returned by the transformation function
    *  @param key the discriminator function
    *  @param f the element transformation function
+   *  @return a map associating each key `k` with an array of transformed elements for which `key` returns `k`
    */
   def groupMap[K, B : ClassTag](key: A => K)(f: A => B): immutable.Map[K, Array[B]] = {
     val m = mutable.Map.empty[K, ArrayBuilder[B]]
@@ -1478,7 +1546,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     copied
   }
 
-  /** Creates a copy of this array with the specified element type. */
+  /** Creates a copy of this array with the specified element type.
+   *
+   *  @tparam B the element type of the copy, a supertype of `A`
+   */
   def toArray[B >: A: ClassTag]: Array[B] = {
     val destination = new Array[B](xs.length)
     @annotation.unused val copied = copyToArray(destination, 0)
@@ -1486,7 +1557,10 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     destination
   }
 
-  /** Counts the number of elements in this array which satisfy a predicate. */
+  /** Counts the number of elements in this array which satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   def count(p: A => Boolean): Int = {
     var i, res = 0
     val len = xs.length
@@ -1498,11 +1572,16 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   // can't use a default arg because we already have another overload with a default arg
-  /** Tests whether this array starts with the given array. */
+  /** Tests whether this array starts with the given array.
+   *
+   *  @tparam B the element type of the prefix array, a supertype of `A`
+   *  @param that the array to test as a prefix
+   */
   @`inline` def startsWith[B >: A](that: Array[B]): Boolean = startsWith(that, 0)
 
   /** Tests whether this array contains the given array at a given index.
    *
+   *  @tparam B the element type of the prefix array, a supertype of `A`
    *  @param  that    the array to test
    *  @param  offset  the index where the array is searched.
    *  @return `true` if the array `that` is contained in this array at
@@ -1524,6 +1603,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   /** Tests whether this array ends with the given array.
    *
+   *  @tparam B the element type of the suffix array, a supertype of `A`
    *  @param  that    the array to test
    *  @return `true` if this array has `that` as a suffix, `false` otherwise.
    */
@@ -1542,6 +1622,8 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   }
 
   /** A copy of this array with one single replaced element.
+   *
+   *  @tparam B the element type of the returned array, a supertype of `A`
    *  @param  index  the position of the replacement
    *  @param  elem   the replacing element
    *  @return a new array which is a copy of this array with the element at position `index` replaced by `elem`.
@@ -1567,6 +1649,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   /** Computes the multiset difference between this array and another sequence.
    *
+   *  @tparam B the element type of the other sequence, a supertype of `A`
    *  @param that   the sequence of elements to remove
    *  @return       a new array which contains all elements of this array
    *                except some of occurrences of elements that also appear in `that`.
@@ -1578,6 +1661,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
 
   /** Computes the multiset intersection between this array and another sequence.
    *
+   *  @tparam B the element type of the other sequence, a supertype of `A`
    *  @param that   the sequence of elements to intersect with.
    *  @return       a new array which contains all elements of this array
    *                 which also appear in `that`.
@@ -1622,6 +1706,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  of the original sequence, but the order in which elements were selected, by "first index";
    *  the order of each `x` element is also arbitrary.
    *
+   *  @param n the number of elements in each combination
    *  @return   An Iterator which traverses the n-element combinations of this array
    *  @example ```scala sc:compile
    *    Array('a', 'b', 'b', 'b', 'c').combinations(2).map(runtime.ScalaRunTime.stringOf).foreach(println)
@@ -1651,6 +1736,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   // we have another overload here, so we need to duplicate this method
   /** Tests whether this array contains the given sequence at a given index.
    *
+   *  @tparam B the element type of the prefix sequence, a supertype of `A`
    *  @param  that    the sequence to test
    *  @param  offset  the index where the sequence is searched.
    *  @return `true` if the sequence `that` is contained in this array at
@@ -1661,6 +1747,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
   // we have another overload here, so we need to duplicate this method
   /** Tests whether this array ends with the given sequence.
    *
+   *  @tparam B the element type of the suffix sequence, a supertype of `A`
    *  @param  that    the sequence to test
    *  @return `true` if this array has `that` as a suffix, `false` otherwise.
    */

--- a/library/src/scala/collection/BitSet.scala
+++ b/library/src/scala/collection/BitSet.scala
@@ -84,7 +84,10 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   }
 }
 
-/** Base implementation type of bitsets. */
+/** Base implementation type of bitsets.
+ *
+ *  @tparam C the type of the bitset itself, used for return types of operations
+ */
 transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
   extends SortedSetOps[Int, SortedSet, C] { self =>
   import BitSetOps._
@@ -100,10 +103,15 @@ transparent trait BitSetOps[+C <: BitSet & BitSetOps[C]]
 
   /** The words at index `idx`, or 0L if outside the range of the set
    *  **Note:** requires `idx >= 0`
+   *
+   *  @param idx the index of the word to retrieve, must be non-negative
    */
   protected[collection] def word(idx: Int): Long
 
-  /** Creates a new set of this kind from an array of longs */
+  /** Creates a new set of this kind from an array of longs
+   *
+   *  @param elems the array of 64-bit words representing the bit mask for the new set
+   */
   protected[collection] def fromBitMaskNoCopy(elems: Array[Long]): C
 
   def contains(elem: Int): Boolean =

--- a/library/src/scala/collection/BufferedIterator.scala
+++ b/library/src/scala/collection/BufferedIterator.scala
@@ -17,6 +17,8 @@ import language.experimental.captureChecking
 
 /** Buffered iterators are iterators which provide a method `head`
  *  that inspects the next element without discarding it.
+ *
+ *  @tparam A the type of elements returned by this iterator
  */
 trait BufferedIterator[+A] extends Iterator[A] {
 

--- a/library/src/scala/collection/BuildFrom.scala
+++ b/library/src/scala/collection/BuildFrom.scala
@@ -33,13 +33,18 @@ trait BuildFrom[-From, -A, +C] extends Any { self =>
 
   /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
    *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. 
+   *
+   *  @param from the source collection providing the factory for creating the builder
    */
   def newBuilder(from: From): Builder[A, C]
 
   @deprecated("Use newBuilder() instead of apply()", "2.13.0")
   @`inline` def apply(from: From): Builder[A, C] = newBuilder(from)
 
-  /** Partially apply a BuildFrom to a Factory. */
+  /** Partially apply a BuildFrom to a Factory.
+   *
+   *  @param from the source collection to partially apply, producing a `Factory` bound to it
+   */
   def toFactory(from: From): Factory[A, C] = new Factory[A, C] {
     def fromSpecific(it: IterableOnce[A]^): C^{it} = self.fromSpecific(from)(it)
     def newBuilder: Builder[A, C] = self.newBuilder(from)
@@ -48,14 +53,20 @@ trait BuildFrom[-From, -A, +C] extends Any { self =>
 
 object BuildFrom extends BuildFromLowPriority1 {
 
-  /** Builds the source collection type from a MapOps. */
+  /** Builds the source collection type from a MapOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the map collection (e.g. `HashMap`)
+   */
   implicit def buildFromMapOps[CC[X, Y] <: Map[X, Y] & MapOps[X, Y, CC, ?], K0, V0, K, V]: BuildFrom[CC[K0, V0] & Map[K0, V0], (K, V), CC[K, V] & Map[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: MapOps[K0, V0, CC, ?]).mapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]^): CC[K, V] = (from: MapOps[K0, V0, CC, ?]).mapFactory.from(it)
   }
 
-  /** Builds the source collection type from a SortedMapOps. */
+  /** Builds the source collection type from a SortedMapOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the sorted map collection (e.g. `TreeMap`)
+   */
   implicit def buildFromSortedMapOps[CC[X, Y] <: SortedMap[X, Y] & SortedMapOps[X, Y, CC, ?], K0, V0, K : Ordering, V]: BuildFrom[CC[K0, V0] & SortedMap[K0, V0], (K, V), CC[K, V] & SortedMap[K, V]] = new BuildFrom[CC[K0, V0], (K, V), CC[K, V]] {
     def newBuilder(from: CC[K0, V0]): Builder[(K, V), CC[K, V]] = (from: SortedMapOps[K0, V0, CC, ?]).sortedMapFactory.newBuilder[K, V]
     def fromSpecific(from: CC[K0, V0])(it: IterableOnce[(K, V)]^): CC[K, V] = (from: SortedMapOps[K0, V0, CC, ?]).sortedMapFactory.from(it)
@@ -95,7 +106,10 @@ object BuildFrom extends BuildFromLowPriority1 {
 
 trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 
-  /** Builds the source collection type from an Iterable with SortedOps. */
+  /** Builds the source collection type from an Iterable with SortedOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the sorted set collection (e.g. `TreeSet`)
+   */
   // Restating the upper bound of CC in the result type seems redundant, but it serves to prune the
   // implicit search space for faster compilation and reduced change of divergence. See the compilation
   // test in test/junit/scala/collection/BuildFromTest.scala and discussion in https://github.com/scala/scala/pull/10209
@@ -112,7 +126,10 @@ trait BuildFromLowPriority1 extends BuildFromLowPriority2 {
 }
 
 trait BuildFromLowPriority2 {
-  /** Builds the source collection type from an IterableOps. */
+  /** Builds the source collection type from an IterableOps.
+   *
+   *  @tparam CC the higher-kinded type constructor of the iterable collection (e.g. `List`, `Vector`)
+   */
   implicit def buildFromIterableOps[CC[X] <: Iterable[X] & IterableOps[X, CC, ?], A0, A]: BuildFrom[CC[A0], A, CC[A]] = new BuildFrom[CC[A0], A, CC[A]] {
     //TODO: Reuse a prototype instance
     def newBuilder(from: CC[A0]): Builder[A, CC[A]] = (from: IterableOps[A0, CC, ?]).iterableFactory.newBuilder[A]

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -34,9 +34,8 @@ import scala.reflect.ClassTag
 trait Factory[-A, +C] extends Any { self =>
 
   /**
-   *  @param it Source collection
-   *  @return A collection of type `C` containing the same elements
-   *         as the source collection `it`.
+   *  @param it the source of elements to include in the collection
+   *  @return a collection of type `C` containing the elements from `it`
    */
   def fromSpecific(it: IterableOnce[A]^): C^{it}
 
@@ -107,6 +106,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /** Produces a $coll containing repeated applications of a function to a start value.
    *
+   *  @tparam A the element type of the $coll
    *  @param start the start value of the $coll
    *  @param len   the number of elements contained in the $coll
    *  @param f     the function that's repeatedly applied
@@ -128,6 +128,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /** Produces a $coll containing a sequence of increasing of integers.
    *
+   *  @tparam A the element type of the $coll, which must have an `Integral` instance
    *  @param start the first element of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @return  a $coll with values `start, start + 1, ..., end - 1`
@@ -135,6 +136,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def range[A : Integral](start: A, end: A): CC[A] = from(NumericRange(start, end, implicitly[Integral[A]].one))
 
   /** Produces a $coll containing equally spaced values in some integer interval.
+   *
+   *  @tparam A the element type of the $coll, which must have an `Integral` instance
    *  @param start the start value of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
@@ -144,11 +147,13 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /**
    *  @tparam A the type of the ${coll}’s elements
-   *  @return A builder for $Coll objects.
+   *  @return a builder for $Coll objects.
    */
   def newBuilder[A]: Builder[A, CC[A]]
 
   /** Produces a $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n  the number of elements contained in the $coll.
    *  @param   elem the element computation
    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
@@ -156,6 +161,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def fill[A](n: Int)(elem: => A): CC[A]^{elem} = from(new View.Fill(n)(elem))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -164,6 +171,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def fill[A](n1: Int, n2: Int)(elem: => A): CC[(CC[A]^{elem}) @uncheckedVariance]^{elem} = fill(n1)(fill(n2)(elem))
 
   /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -173,6 +182,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def fill[A](n1: Int, n2: Int, n3: Int)(elem: => A): CC[(CC[CC[A]^{elem}]^{elem}) @uncheckedVariance]^{elem} = fill(n1)(fill(n2, n3)(elem))
 
   /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -184,6 +195,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     fill(n1)(fill(n2, n3, n4)(elem))
 
   /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -196,6 +209,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     fill(n1)(fill(n2, n3, n4, n5)(elem))
 
   /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param  n   The number of elements in the $coll
    *  @param  f   The function computing element values
    *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
@@ -203,6 +218,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
   def tabulate[A](n: Int)(f: Int => A): CC[A]^{f} = from(new View.Tabulate(n)(f))
 
   /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -213,6 +230,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
 
   /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -224,6 +243,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
 
   /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -236,6 +257,8 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
 
   /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -250,6 +273,7 @@ trait IterableFactory[+CC[_]] extends Serializable, caps.Pure {
 
   /** Concatenates all argument collections into a single $coll.
    *
+   *  @tparam A the element type of the $coll
    *  @param xss the collections that are to be concatenated.
    *  @return the concatenation of all the collections.
    */
@@ -382,22 +406,46 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
  *
  *  @define coll collection
  *  @define Coll `Iterable`
+ *
+ *  @tparam CC Collection type constructor for the map (e.g. `Map`, `HashMap`)
  */
 trait MapFactory[+CC[_, _]] extends Serializable { self =>
 
-  /** An empty Map. */
+  /** An empty Map.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   */
   def empty[K, V]: CC[K, V]
 
-  /** A collection of type Map generated from given iterable object. */
+  /** A collection of type Map generated from given iterable object.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param it the source collection of key-value pairs
+   */
   def from[K, V](it: IterableOnce[(K, V)]^): CC[K, V]^{it}
 
-  /** A collection of type Map that contains given key/value bindings. */
+  /** A collection of type Map that contains given key/value bindings.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @param elems the key-value pairs to include in the map
+   */
   def apply[K, V](elems: (K, V)*): CC[K, V] = from(elems)
 
-  /** The default builder for Map objects. */
+  /** The default builder for Map objects.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   */
   def newBuilder[K, V]: Builder[(K, V), CC[K, V]]
 
-  /** The default Factory instance for maps. */
+  /** The default Factory instance for maps.
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   */
   implicit def mapFactory[K, V]: Factory[(K, V), CC[K, V]] = MapFactory.toFactory(this)
 }
 
@@ -454,6 +502,8 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
   def apply[A : Ev](xs: A*): CC[A] = from(xs)
 
   /** Produces a $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, for which an implicit `Ev` instance must exist
    *  @param   n  the number of elements contained in the $coll.
    *  @param   elem the element computation
    *  @return  A $coll that contains the results of `n` evaluations of `elem`.
@@ -461,6 +511,8 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
   def fill[A : Ev](n: Int)(elem: => A): CC[A] = from(new View.Fill(n)(elem))
 
   /** Produces a $coll containing values of a given function over a range of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, for which an implicit `Ev` instance must exist
    *  @param  n   The number of elements in the $coll
    *  @param  f   The function computing element values
    *  @return A $coll consisting of elements `f(0), ..., f(n -1)`
@@ -469,6 +521,7 @@ trait EvidenceIterableFactory[+CC[_], Ev[_]] extends Serializable, caps.Pure {
 
   /** Produces a $coll containing repeated applications of a function to a start value.
    *
+   *  @tparam A the element type of the $coll, for which an implicit `Ev` instance must exist
    *  @param start the start value of the $coll
    *  @param len   the number of elements contained in the $coll
    *  @param f     the function that's repeatedly applied
@@ -547,6 +600,7 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
 
   /** Produces a $coll containing a sequence of increasing of integers.
    *
+   *  @tparam A the element type of the $coll, which must have `Integral` and `ClassTag` instances
    *  @param start the first element of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @return  a $coll with values `start, start + 1, ..., end - 1`
@@ -554,6 +608,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def range[A : Integral : ClassTag](start: A, end: A): CC[A] = from(NumericRange(start, end, implicitly[Integral[A]].one))
 
   /** Produces a $coll containing equally spaced values in some integer interval.
+   *
+   *  @tparam A the element type of the $coll, which must have `Integral` and `ClassTag` instances
    *  @param start the start value of the $coll
    *  @param end   the end value of the $coll (the first value NOT contained)
    *  @param step  the difference between successive elements of the $coll (must be positive or negative)
@@ -562,6 +618,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def range[A : Integral : ClassTag](start: A, end: A, step: A): CC[A] = from(NumericRange(start, end, step))
 
   /** Produces a two-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -570,6 +628,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def fill[A : ClassTag](n1: Int, n2: Int)(elem: => A): CC[CC[A] @uncheckedVariance] = fill(n1)(fill(n2)(elem))
 
   /** Produces a three-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -579,6 +639,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
   def fill[A : ClassTag](n1: Int, n2: Int, n3: Int)(elem: => A): CC[CC[CC[A]] @uncheckedVariance] = fill(n1)(fill(n2, n3)(elem))
 
   /** Produces a four-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -590,6 +652,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     fill(n1)(fill(n2, n3, n4)(elem))
 
   /** Produces a five-dimensional $coll containing the results of some element computation a number of times.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -602,6 +666,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     fill(n1)(fill(n2, n3, n4, n5)(elem))
 
   /** Produces a two-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -612,6 +678,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
 
   /** Produces a three-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -623,6 +691,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
 
   /** Produces a four-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -635,6 +705,8 @@ trait ClassTagIterableFactory[+CC[_]] extends EvidenceIterableFactory[CC, ClassT
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
 
   /** Produces a five-dimensional $coll containing values of a given function over ranges of integer values starting from 0.
+   *
+   *  @tparam A the element type of the $coll, which must have a `ClassTag`
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -724,6 +796,8 @@ trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extend
  *
  *  @define coll collection
  *  @define Coll `Iterable`
+ *
+ *  @tparam CC Collection type constructor for the sorted map (e.g. `TreeMap`)
  */
 trait SortedMapFactory[+CC[_, _]] extends Serializable { this: SortedMapFactory[CC] =>
 

--- a/library/src/scala/collection/IndexedSeq.scala
+++ b/library/src/scala/collection/IndexedSeq.scala
@@ -21,7 +21,10 @@ import scala.collection.Searching.{Found, InsertionPoint, SearchResult}
 import scala.collection.Stepper.EfficientSplit
 import scala.math.Ordering
 
-/** Base trait for indexed sequences that have efficient `apply` and `length`. */
+/** Base trait for indexed sequences that have efficient `apply` and `length`.
+ *
+ *  @tparam A the element type of the indexed sequence
+ */
 trait IndexedSeq[+A] extends Seq[A]
   with IndexedSeqOps[A, IndexedSeq, IndexedSeq[A]]
   with IterableFactoryDefaults[A, IndexedSeq] {
@@ -34,7 +37,12 @@ trait IndexedSeq[+A] extends Seq[A]
 @SerialVersionUID(3L)
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](immutable.IndexedSeq)
 
-/** Base trait for indexed Seq operations. */
+/** Base trait for indexed Seq operations.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the resulting collection (e.g., `IndexedSeq`)
+ *  @tparam C the type of the concrete collection
+ */
 transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C] { self: IndexedSeqOps[A, CC, C]^ =>
 
   def iterator: Iterator[A]^{this} = view.iterator
@@ -155,7 +163,11 @@ transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C
   }
 }
 
-/** A fast sliding iterator for IndexedSeqs which uses the underlying `slice` operation. */
+/** A fast sliding iterator for IndexedSeqs which uses the underlying `slice` operation.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the resulting collection (e.g., `IndexedSeq`)
+ */
 private final class IndexedSeqSlidingIterator[A, CC[_], C](s: IndexedSeqOps[A, CC, C]^, size: Int, step: Int)
   extends AbstractIterator[C^{s}] {
   // CC note: seems like the compiler cannot figure out that this class <: Iterator[C^{s}],

--- a/library/src/scala/collection/IndexedSeqView.scala
+++ b/library/src/scala/collection/IndexedSeqView.scala
@@ -19,7 +19,10 @@ import language.experimental.captureChecking
 import scala.annotation.nowarn
 
 
-/** View defined in terms of indexing a range. */
+/** View defined in terms of indexing a range.
+ *
+ *  @tparam A the element type of the view
+ */
 trait IndexedSeqView[+A] extends IndexedSeqOps[A, View, View[A]] with SeqView[A] {
 
   override def view: IndexedSeqView[A]^{this} = this

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -66,6 +66,8 @@ trait Iterable[+A] extends IterableOnce[A]
    *  published, but provides the exclusive access needed by
    *  `scala.runtime.ScalaRunTime.stringOf` (and a few tests in
    *  the test suite).
+   *
+   *  @return the class name of this collection, as returned by `className`
    */
   private[scala] final def collectionClassName: String = className
 
@@ -113,6 +115,7 @@ trait Iterable[+A] extends IterableOnce[A]
  *            with a different type of element `B` (e.g. `map`) return a `CC[B]`.
  *  @tparam C  type of the collection (e.g. `List[Int]`, `String`, `BitSet`). Operations returning a collection
  *            with the same type of element (e.g. `drop`, `filter`) return a `C`.
+ *  @tparam A the element type of the collection
  *
  *  @define Coll Iterable
  *  @define coll iterable collection
@@ -175,6 +178,9 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *       might be unsound. However, as long as it is called with an
    *       `Iterable[A]` obtained from `this` collection (as it is the case in the
    *       implementations of operations where we use a `View[A]`), it is safe.
+   *
+   *  @param coll the source collection to convert
+   *  @return a new collection of type `C` containing the elements of `coll`
    */
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): C^{coll}
 
@@ -183,6 +189,8 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  @note When implementing a custom collection type and refining `CC` to the new type, this
    *       method needs to be overridden to return a factory for the new type (the compiler will
    *       issue an error otherwise).
+   *
+   *  @return the companion factory object for this collection type
    */
   def iterableFactory: IterableFactory[CC]
 
@@ -303,6 +311,8 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  this.sizeIs >= size    // this.sizeCompare(size) >= 0
    *  this.sizeIs > size     // this.sizeCompare(size) > 0
    *  ```
+   *
+   *  @return a wrapper that allows size comparisons using operators such as `<`, `<=`, `==`, `!=`, `>=`, and `>`
    */
   @inline final def sizeIs: IterableOps.SizeCompareOps^{this} = new IterableOps.SizeCompareOps(caps.unsafe.unsafeAssumePure(this) /* see comment in SizeCompareOps*/)
 
@@ -430,6 +440,9 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  The default implementation provided here needs to traverse the collection twice.
    *  Strict collections have an overridden version of `partition` in `StrictOptimizedIterableOps`,
    *  which requires only a single traversal.
+   *
+   *  @param p the predicate used to test elements
+   *  @return a pair of ${coll}s: the first containing all elements that satisfy `p`, the second containing those that do not
    */
   def partition(p: A => Boolean): (C^{this, p}, C^{this, p}) = {
     val first = new View.Filter(this, p, isFlipped = false)
@@ -592,6 +605,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  @tparam B the type of values returned by the transformation function
    *  @param key the discriminator function
    *  @param f the element transformation function
+   *  @return a map associating each key `k` produced by `key` with a $coll of values produced by applying `f` to elements that map to `k`
    */
   def groupMap[K, B](key: A => K)(f: A => B): immutable.Map[K, CC[B]] = {
     val m = mutable.Map.empty[K, Builder[B, CC[B]]]
@@ -622,6 +636,12 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  ```
    *
    *  $willForceEvaluation
+   *
+   *  @tparam K the type of keys returned by the discriminator function
+   *  @tparam B the type of values returned by the transformation function
+   *  @param key the discriminator function
+   *  @param f the element transformation function
+   *  @param reduce the reduction function used to combine values mapped to the same key
    */
   def groupMapReduce[K, B](key: A => K)(f: A => B)(reduce: (B, B) => B): immutable.Map[K, B] = {
     val m = mutable.Map.empty[K, B]
@@ -733,7 +753,11 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
     }
   }
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @tparam B the element type of the returned collection
+   *  @param suffix the iterable to append to this $coll
+   */
   @inline final def ++ [B >: A](suffix: IterableOnce[B]^): CC[B]^{this, suffix} = concat(suffix)
 
   /** Returns a $ccoll formed from this $coll and another iterable collection
@@ -757,6 +781,8 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *  If one of the two collections is shorter than the other,
    *  placeholder elements are used to extend the shorter collection to the length of the longer.
    *
+   *  @tparam A1 the type of the first element in each result pair (supertype of `A`)
+   *  @tparam B the type of the second element in each result pair
    *  @param that     the iterable providing the second half of each result pair
    *  @param thisElem the element to be used to fill up the result if this $coll is shorter than `that`.
    *  @param thatElem the element to be used to fill up the result if `that` is shorter than this $coll.
@@ -874,7 +900,10 @@ object IterableOps {
     // is pending/pos-custom-args/captures/SizeCompareOps-redux.scala.
     // Without the `^`s, the `sizeIs` method needs an unsafeAssumePure.
 
-    /** Tests if the size of the collection is less than some value. */
+    /** Tests if the size of the collection is less than some value.
+     *
+     *  @param size the value to compare the collection size against
+     */
     @inline def <(size: Int): Boolean = it.sizeCompare(size) < 0
     /** Tests if the size of the collection is less than or equal to some value. */
     @inline def <=(size: Int): Boolean = it.sizeCompare(size) <= 0
@@ -884,7 +913,10 @@ object IterableOps {
     @inline def !=(size: Int): Boolean = it.sizeCompare(size) != 0
     /** Tests if the size of the collection is greater than or equal to some value. */
     @inline def >=(size: Int): Boolean = it.sizeCompare(size) >= 0
-    /** Tests if the size of the collection is greater than some value. */
+    /** Tests if the size of the collection is greater than some value.
+     *
+     *  @param size the value to compare the collection size against
+     */
     @inline def >(size: Int): Boolean = it.sizeCompare(size) > 0
   }
 
@@ -940,7 +972,10 @@ object Iterable extends IterableFactory.Delegate[Iterable](immutable.Iterable) {
   }
 }
 
-/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Iterable` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the collection
+ */
 abstract class AbstractIterable[+A] extends Iterable[A]
 
 /** This trait provides default implementations for the factory methods `fromSpecific` and
@@ -949,6 +984,9 @@ abstract class AbstractIterable[+A] extends Iterable[A]
  *
  *  The default implementations in this trait can be used in the common case when `CC[A]` is the
  *  same as `C`.
+ *
+ *  @tparam A the element type of the collection
+ *  @tparam CC the type constructor of the collection
  */
 trait IterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]]] extends IterableOps[A, CC, CC[A @uncheckedVariance]] {
   protected def fromSpecific(coll: IterableOnce[A @uncheckedVariance]^): CC[A @uncheckedVariance]^{coll} = iterableFactory.from(coll)
@@ -965,6 +1003,9 @@ trait IterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]]] extends I
  *
  *  The default implementations in this trait can be used in the common case when `CC[A]` is the
  *  same as `C`.
+ *
+ *  @tparam A the element type of the collection
+ *  @tparam CC the type constructor of the collection
  */
 trait EvidenceIterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]], Ev[_]] extends IterableOps[A, CC, CC[A @uncheckedVariance]] {
   protected def evidenceIterableFactory: EvidenceIterableFactory[CC, Ev]
@@ -985,6 +1026,9 @@ trait EvidenceIterableFactoryDefaults[+A, +CC[x] <: IterableOps[x, CC, CC[x]], E
  *
  *  The default implementations in this trait can be used in the common case when `CC[A]` is the
  *  same as `C`.
+ *
+ *  @tparam A the element type of the sorted set
+ *  @tparam CC the type constructor of the sorted set
  */
 trait SortedSetFactoryDefaults[+A,
     +CC[X] <: SortedSet[X] & SortedSetOps[X, CC, CC[X]],
@@ -1011,6 +1055,10 @@ trait SortedSetFactoryDefaults[+A,
  *
  *  The default implementations in this trait can be used in the common case when `CC[A]` is the
  *  same as `C`.
+ *
+ *  @tparam K the type of keys in the map
+ *  @tparam V the type of values in the map
+ *  @tparam CC the type constructor of the map
  */
 trait MapFactoryDefaults[K, +V,
     +CC[x, y] <: IterableOps[(x, y), Iterable, Iterable[(x, y)]],
@@ -1039,6 +1087,10 @@ trait MapFactoryDefaults[K, +V,
  *
  *  The default implementations in this trait can be used in the common case when `CC[A]` is the
  *  same as `C`.
+ *
+ *  @tparam K the type of keys in the sorted map
+ *  @tparam V the type of values in the sorted map
+ *  @tparam CC the type constructor of the sorted map
  */
 trait SortedMapFactoryDefaults[K, +V,
     +CC[x, y] <:  Map[x, y] & SortedMapOps[x, y, CC, CC[x, y]] & UnsortedCC[x, y],

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -45,6 +45,8 @@ import IterableOnce.elemsToCopyToArray
  *
  *  @define coll collection
  *  @define ccoll $coll
+ *
+ *  @tparam A the element type of the collection
  */
 trait IterableOnce[+A] extends Any { this: IterableOnce[A]^ =>
 
@@ -53,6 +55,8 @@ trait IterableOnce[+A] extends Any { this: IterableOnce[A]^ =>
    *  If an `IterableOnce` object is in fact an [[scala.collection.Iterator]], this method always returns itself,
    *  in its current state, but if it is an [[scala.collection.Iterable]], this method always returns a new
    *  [[scala.collection.Iterator]].
+   *
+   *  @return an iterator over all elements of this $coll
    */
   def iterator: Iterator[A]^{this}
 
@@ -75,6 +79,8 @@ trait IterableOnce[+A] extends Any { this: IterableOnce[A]^ =>
    *  [[scala.collection.Stepper.EfficientSplit]], the converters in [[scala.jdk.StreamConverters]]
    *  allow creating parallel streams, whereas bare `Stepper`s can be converted only to sequential
    *  streams.
+   *
+   *  @tparam S the type of the returned `Stepper`, determined by the implicit `StepperShape`
    */
   def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S^{this} = {
     import convert.impl._
@@ -288,7 +294,11 @@ object IterableOnce {
     math.max(0, total)
   }
 
-  /** Calls `copyToArray` on the given collection, regardless of whether or not it is an `Iterable`. */
+  /** Calls `copyToArray` on the given collection, regardless of whether or not it is an `Iterable`.
+   *
+   *  @tparam A the element type of the source collection
+   *  @tparam B the element type of the destination array, a supertype of `A`
+   */
   @inline private[collection] def copyElemsToArray[A, B >: A](elems: IterableOnce[A]^,
                                                               xs: Array[B],
                                                               start: Int = 0,
@@ -332,6 +342,9 @@ object IterableOnce {
  *              The order of applications of the operator is unspecified and may be nondeterministic.
  *  @define exactlyOnce
  *              Each element appears exactly once in the computation.
+ *
+ *  @tparam A the element type of the collection
+ *  @tparam CC the type constructor for the collection's "same element type" results (e.g., `List` for `List[Int]`)
  */
 transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOnce[A]^ =>
   /////////////////////////////////////////////////////////////// Abstract methods that must be implemented
@@ -620,6 +633,9 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
 
   /** Applies `f` to each element for its side effects.
    *  Note: `U` parameter needed to help scalac's type inference.
+   *
+   *  @tparam U the return type of `f`; the value is discarded, but the type parameter aids type inference
+   *  @param f the function to apply to each element for its side effects
    */
   def foreach[U](f: A => U): Unit = {
     val it = iterator
@@ -1258,6 +1274,7 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
    *  $mayNotTerminateInf
    *  $orderDependent
    *
+   *  @tparam B the result type of the partial function
    *  @param pf   the partial function
    *  @return     an option value containing pf applied to the first
    *              value for which it is defined, or `None` if none exists.
@@ -1442,6 +1459,10 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
    *      xs.to(ArrayBuffer)
    *      xs.to(BitSet) // for xs: Iterable[Int]
    *  ```
+   *
+   *  @tparam C1 the target collection type
+   *  @param factory the factory for the target collection type
+   *  @return a new collection of type `C1` containing all elements of this $coll
    */
   def to[C1](factory: Factory[A, C1]): C1^{this} = factory.fromSpecific(this)
 
@@ -1464,7 +1485,7 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
    *
    *  @tparam K The key type for the resulting map.
    *  @tparam V The value type for the resulting map.
-   *  @param ev An implicit coercion from `A` to `[K, V]`.
+   *  @param ev an implicit evidence that `A` is a subtype of `(K, V)`
    *  @return This $coll as a `Map[K, V]`.
    */
   def toMap[K, V](implicit ev: A <:< (K, V)): immutable.Map[K, V] =

--- a/library/src/scala/collection/JavaConverters.scala
+++ b/library/src/scala/collection/JavaConverters.scala
@@ -144,78 +144,121 @@ object JavaConverters extends AsJavaConverters with AsScalaConverters {
 
   /** Adds an `asJava` method that implicitly converts a Scala `Iterator` to a Java `Iterator`.
    *  @see [[asJavaIterator]]
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Scala `Iterator` to be converted
    */
   implicit def asJavaIteratorConverter[A](i : Iterator[A]): AsJava[ju.Iterator[A]] =
     new AsJava(asJavaIterator(i))
 
   /** Adds an `asJavaEnumeration` method that implicitly converts a Scala `Iterator` to a Java `Enumeration`.
    *  @see [[asJavaEnumeration]]
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Scala `Iterator` to be converted
    */
   implicit def asJavaEnumerationConverter[A](i : Iterator[A]): AsJavaEnumeration[A] =
     new AsJavaEnumeration(i)
 
   /** Adds an `asJava` method that implicitly converts a Scala `Iterable` to a Java `Iterable`.
    *  @see [[asJavaIterable]]
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Scala `Iterable` to be converted
    */
   implicit def asJavaIterableConverter[A](i : Iterable[A]): AsJava[jl.Iterable[A]] =
     new AsJava(asJavaIterable(i))
 
   /** Adds an `asJavaCollection` method that implicitly converts a Scala `Iterable` to an immutable Java `Collection`.
    *  @see [[asJavaCollection]]
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Scala `Iterable` to be converted
    */
   implicit def asJavaCollectionConverter[A](i : Iterable[A]): AsJavaCollection[A] =
     new AsJavaCollection(i)
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Buffer` to a Java `List`.
    *  @see [[bufferAsJavaList]]
+   *
+   *  @tparam A the element type of the buffer
+   *  @param b the Scala mutable `Buffer` to be converted
    */
   implicit def bufferAsJavaListConverter[A](b : mutable.Buffer[A]): AsJava[ju.List[A]] =
     new AsJava(bufferAsJavaList(b))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Seq` to a Java `List`.
    *  @see [[mutableSeqAsJavaList]]
+   *
+   *  @tparam A the element type of the sequence
+   *  @param b the Scala mutable `Seq` to be converted
    */
   implicit def mutableSeqAsJavaListConverter[A](b : mutable.Seq[A]): AsJava[ju.List[A]] =
     new AsJava(mutableSeqAsJavaList(b))
 
   /** Adds an `asJava` method that implicitly converts a Scala `Seq` to a Java `List`.
    *  @see [[seqAsJavaList]]
+   *
+   *  @tparam A the element type of the sequence
+   *  @param b the Scala `Seq` to be converted
    */
   implicit def seqAsJavaListConverter[A](b : Seq[A]): AsJava[ju.List[A]] =
     new AsJava(seqAsJavaList(b))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Set` to a Java `Set`.
    *  @see [[mutableSetAsJavaSet]]
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Scala mutable `Set` to be converted
    */
   implicit def mutableSetAsJavaSetConverter[A](s : mutable.Set[A]): AsJava[ju.Set[A]] =
     new AsJava(mutableSetAsJavaSet(s))
 
   /** Adds an `asJava` method that implicitly converts a Scala `Set` to a Java `Set`.
    *  @see [[setAsJavaSet]]
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Scala `Set` to be converted
    */
   implicit def setAsJavaSetConverter[A](s : Set[A]): AsJava[ju.Set[A]] =
     new AsJava(setAsJavaSet(s))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `Map` to a Java `Map`.
    *  @see [[mutableMapAsJavaMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala mutable `Map` to be converted
    */
   implicit def mutableMapAsJavaMapConverter[K, V](m : mutable.Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mutableMapAsJavaMap(m))
 
   /** Adds an `asJavaDictionary` method that implicitly converts a Scala mutable `Map` to a Java `Dictionary`.
    *  @see [[asJavaDictionary]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala mutable `Map` to be converted
    */
   implicit def asJavaDictionaryConverter[K, V](m : mutable.Map[K, V]): AsJavaDictionary[K, V] =
     new AsJavaDictionary(m)
 
   /** Adds an `asJava` method that implicitly converts a Scala `Map` to a Java `Map`.
    *  @see [[mapAsJavaMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala `Map` to be converted
    */
   implicit def mapAsJavaMapConverter[K, V](m : Map[K, V]): AsJava[ju.Map[K, V]] =
     new AsJava(mapAsJavaMap(m))
 
   /** Adds an `asJava` method that implicitly converts a Scala mutable `concurrent.Map` to a Java `ConcurrentMap`.
    *  @see [[mapAsJavaConcurrentMap]].
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala `concurrent.Map` to be converted
    */
   implicit def mapAsJavaConcurrentMapConverter[K, V](m: concurrent.Map[K, V]): AsJava[juc.ConcurrentMap[K, V]] =
     new AsJava(mapAsJavaConcurrentMap(m))
@@ -223,90 +266,143 @@ object JavaConverters extends AsJavaConverters with AsScalaConverters {
 
   /** Adds an `asScala` method that implicitly converts a Java `Iterator` to a Scala `Iterator`.
    *  @see [[asScalaIterator]]
+   *
+   *  @tparam A the element type of the iterator
+   *  @param i the Java `Iterator` to be converted
    */
   implicit def asScalaIteratorConverter[A](i : ju.Iterator[A]): AsScala[Iterator[A]] =
     new AsScala(asScalaIterator(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `Enumeration` to a Scala `Iterator`.
    *  @see [[enumerationAsScalaIterator]]
+   *
+   *  @tparam A the element type of the enumeration
+   *  @param i the Java `Enumeration` to be converted
    */
   implicit def enumerationAsScalaIteratorConverter[A](i : ju.Enumeration[A]): AsScala[Iterator[A]] =
     new AsScala(enumerationAsScalaIterator(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `Iterable` to a Scala `Iterable`.
    *  @see [[iterableAsScalaIterable]]
+   *
+   *  @tparam A the element type of the iterable
+   *  @param i the Java `Iterable` to be converted
    */
   implicit def iterableAsScalaIterableConverter[A](i : jl.Iterable[A]): AsScala[Iterable[A]] =
     new AsScala(iterableAsScalaIterable(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `Collection` to an Scala `Iterable`.
    *  @see [[collectionAsScalaIterable]]
+   *
+   *  @tparam A the element type of the collection
+   *  @param i the Java `Collection` to be converted
    */
   implicit def collectionAsScalaIterableConverter[A](i : ju.Collection[A]): AsScala[Iterable[A]] =
     new AsScala(collectionAsScalaIterable(i))
 
   /** Adds an `asScala` method that implicitly converts a Java `List` to a Scala mutable `Buffer`.
    *  @see [[asScalaBuffer]]
+   *
+   *  @tparam A the element type of the list
+   *  @param l the Java `List` to be converted
    */
   implicit def asScalaBufferConverter[A](l : ju.List[A]): AsScala[mutable.Buffer[A]] =
     new AsScala(asScalaBuffer(l))
 
   /** Adds an `asScala` method that implicitly converts a Java `Set` to a Scala mutable `Set`.
    *  @see [[asScalaSet]]
+   *
+   *  @tparam A the element type of the set
+   *  @param s the Java `Set` to be converted
    */
   implicit def asScalaSetConverter[A](s : ju.Set[A]): AsScala[mutable.Set[A]] =
     new AsScala(asScalaSet(s))
 
   /** Adds an `asScala` method that implicitly converts a Java `Map` to a Scala mutable `Map`.
    *  @see [[mapAsScalaMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Java `Map` to be converted
    */
   implicit def mapAsScalaMapConverter[K, V](m : ju.Map[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(mapAsScalaMap(m))
 
   /** Adds an `asScala` method that implicitly converts a Java `ConcurrentMap` to a Scala mutable `concurrent.Map`.
    *  @see [[mapAsScalaConcurrentMap]]
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Java `ConcurrentMap` to be converted
    */
   implicit def mapAsScalaConcurrentMapConverter[K, V](m: juc.ConcurrentMap[K, V]): AsScala[concurrent.Map[K, V]] =
     new AsScala(mapAsScalaConcurrentMap(m))
 
   /** Adds an `asScala` method that implicitly converts a Java `Dictionary` to a Scala mutable `Map`.
    *  @see [[dictionaryAsScalaMap]]
+   *
+   *  @tparam K the type of the dictionary keys
+   *  @tparam V the type of the dictionary values
+   *  @param p the Java `Dictionary` to be converted
    */
   implicit def dictionaryAsScalaMapConverter[K, V](p: ju.Dictionary[K, V]): AsScala[mutable.Map[K, V]] =
     new AsScala(dictionaryAsScalaMap(p))
 
   /** Adds an `asScala` method that implicitly converts a Java `Properties` to a Scala mutable `Map[String, String]`.
    *  @see [[propertiesAsScalaMap]]
+   *
+   *  @param p the Java `Properties` to be converted
    */
   implicit def propertiesAsScalaMapConverter(p: ju.Properties): AsScala[mutable.Map[String, String]] =
     new AsScala(propertiesAsScalaMap(p))
 
 
-  /** Generic class containing the `asJava` converter method. */
+  /** Generic class containing the `asJava` converter method.
+   *
+   *  @tparam A the target type of the conversion result
+   *  @param op the conversion operation, evaluated lazily
+   */
   class AsJava[A](op: => A) {
     /** Converts a Scala collection to the corresponding Java collection. */
     def asJava: A = op
   }
 
-  /** Generic class containing the `asScala` converter method. */
+  /** Generic class containing the `asScala` converter method.
+   *
+   *  @tparam A the target type of the conversion result
+   *  @param op the conversion operation, evaluated lazily
+   */
   class AsScala[A](op: => A) {
     /** Converts a Java collection to the corresponding Scala collection. */
     def asScala: A = op
   }
 
-  /** Generic class containing the `asJavaCollection` converter method. */
+  /** Generic class containing the `asJavaCollection` converter method.
+   *
+   *  @tparam A the element type of the collection
+   *  @param i the Scala `Iterable` to be converted
+   */
   class AsJavaCollection[A](i: Iterable[A]) {
     /** Converts a Scala `Iterable` to a Java `Collection`. */
     def asJavaCollection: ju.Collection[A] = JavaConverters.asJavaCollection(i)
   }
 
-  /** Generic class containing the `asJavaEnumeration` converter method. */
+  /** Generic class containing the `asJavaEnumeration` converter method.
+   *
+   *  @tparam A the element type of the enumeration
+   *  @param i the Scala `Iterator` to be converted
+   */
   class AsJavaEnumeration[A](i: Iterator[A]) {
     /** Converts a Scala `Iterator` to a Java `Enumeration`. */
     def asJavaEnumeration: ju.Enumeration[A] = JavaConverters.asJavaEnumeration(i)
   }
 
-  /** Generic class containing the `asJavaDictionary` converter method. */
+  /** Generic class containing the `asJavaDictionary` converter method.
+   *
+   *  @tparam K the type of the map keys
+   *  @tparam V the type of the map values
+   *  @param m the Scala mutable `Map` to be converted
+   */
   class AsJavaDictionary[K, V](m : mutable.Map[K, V]) {
     /** Converts a Scala `Map` to a Java `Dictionary`. */
     def asJavaDictionary: ju.Dictionary[K, V] = JavaConverters.asJavaDictionary(m)

--- a/library/src/scala/collection/LazyZipOps.scala
+++ b/library/src/scala/collection/LazyZipOps.scala
@@ -22,6 +22,10 @@ import language.experimental.captureChecking
  *  @define willNotTerminateInf
  *
  *              Note: will not terminate for infinite-sized collections.
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam C1 the type of the source collection, used to determine the result type of strict operations
  */
 final class LazyZip2[+El1, +El2, C1] private[collection](src: C1, coll1: Iterable[El1]^, coll2: Iterable[El2]^) {
 
@@ -147,6 +151,11 @@ object LazyZip2 {
  *  @define willNotTerminateInf
  *
  *              Note: will not terminate for infinite-sized collections.
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam El3 the element type of the third collection
+ *  @tparam C1 the type of the source collection, used to determine the result type of strict operations
  */
 final class LazyZip3[+El1, +El2, +El3, C1] private[collection](src: C1,
                                                                coll1: Iterable[El1]^,
@@ -288,6 +297,12 @@ object LazyZip3 {
  *  @define willNotTerminateInf
  *
  *              Note: will not terminate for infinite-sized collections.
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam El3 the element type of the third collection
+ *  @tparam El4 the element type of the fourth collection
+ *  @tparam C1 the type of the source collection, used to determine the result type of strict operations
  */
 final class LazyZip4[+El1, +El2, +El3, +El4, C1] private[collection](src: C1,
                                                                      coll1: Iterable[El1]^,

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -21,6 +21,8 @@ import scala.annotation.{nowarn, tailrec}
 /** Base trait for linearly accessed sequences that have efficient `head` and
  *  `tail` operations.
  *  Known subclasses: List, LazyList
+ *
+ *  @tparam A the element type of the sequence
  */
 trait LinearSeq[+A] extends Seq[A]
   with LinearSeqOps[A, LinearSeq, LinearSeq[A]]
@@ -34,7 +36,12 @@ trait LinearSeq[+A] extends Seq[A]
 @SerialVersionUID(3L)
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](immutable.LinearSeq)
 
-/** Base trait for linear Seq operations. */
+/** Base trait for linear Seq operations.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor for the collection (e.g., `List`, `LazyList`)
+ *  @tparam C the concrete collection type
+ */
 transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & LinearSeqOps[A, CC, C]] extends Any with SeqOps[A, CC, C] with caps.Pure { self =>
 
   /** @inheritdoc
@@ -288,6 +295,9 @@ transparent trait StrictOptimizedLinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: 
 
 /** A specialized Iterator for LinearSeqs that is lazy enough for Stream and LazyList. This is accomplished by not
  *  evaluating the tail after returning the current head.
+ *
+ *  @tparam A the element type of the linear sequence being iterated
+ *  @param coll the linear sequence to iterate over
  */
 private[collection] final class LinearSeqIterator[A](coll: LinearSeqOps[A, LinearSeq, LinearSeq[A]]) extends AbstractIterator[A] {
   // A call-by-need cell

--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -21,7 +21,11 @@ import scala.collection.generic.DefaultSerializable
 import scala.collection.mutable.StringBuilder
 import scala.util.hashing.MurmurHash3
 
-/** Base Map type. */
+/** Base Map type.
+ *
+ *  @tparam K the type of keys in this map
+ *  @tparam V the type of values associated with keys in this map
+ */
 trait Map[K, +V]
   extends Iterable[(K, V)]
     with MapOps[K, V, Map, Map[K, V]]
@@ -55,8 +59,8 @@ trait Map[K, +V]
    *   val result2 = HashMap("a" -> 1) == TreeMap("A" -> 1)(using ord) // true
    *  ```
    *
-   *  @param o The map to which this map is compared
-   *  @return `true` if the two maps are equal according to the description
+   *  @param o the object to compare this map with for equality
+   *  @return `true` if `o` is a `Map` with the same size and identical key-value mappings
    */
   override def equals(o: Any): Boolean =
     (this eq o.asInstanceOf[AnyRef]) || (o match {
@@ -102,7 +106,10 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
   override def view: MapView[K, V]^{this} = new MapView.Id(this)
 
-  /** Returns a [[Stepper]] for the keys of this map. See method [[stepper]]. */
+  /** Returns a [[Stepper]] for the keys of this map. See method [[stepper]].
+   *
+   *  @tparam S the type of `Stepper` to use, determined by the implicit `StepperShape`
+   */
   def keyStepper[S <: Stepper[?]](implicit shape: StepperShape[K, S]): S = {
     import convert.impl._
     val s = shape.shape match {
@@ -114,7 +121,10 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
     s.asInstanceOf[S]
   }
 
-  /** Returns a [[Stepper]] for the values of this map. See method [[stepper]]. */
+  /** Returns a [[Stepper]] for the values of this map. See method [[stepper]].
+   *
+   *  @tparam S the type of `Stepper` to use, determined by the implicit `StepperShape`
+   */
   def valueStepper[S <: Stepper[?]](implicit shape: StepperShape[V, S]): S = {
     import convert.impl._
     val s = shape.shape match {
@@ -128,6 +138,10 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
   /** Similar to `fromIterable`, but returns a Map collection type.
    *  Note that the return type is now `CC[K2, V2]`.
+   *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
+   *  @param it the iterable of key-value pairs to convert into a map
    */
   @`inline` protected final def mapFromIterable[K2, V2](it: Iterable[(K2, V2)]^): CC[K2, V2]^{it} = mapFactory.from(it)
 
@@ -136,6 +150,8 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
    *  @note When implementing a custom collection type and refining `CC` to the new type, this
    *       method needs to be overridden to return a factory for the new type (the compiler will
    *       issue an error otherwise).
+   *
+   *  @return the `MapFactory` companion object for this map type
    */
   def mapFactory: MapFactory[CC]
 
@@ -266,6 +282,9 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
   /** Applies `f` to each key/value pair for its side effects
    *  Note: [U] parameter needed to help scalac's type inference.
+   *
+   *  @tparam U the result type of the function `f`; not used in the method result but aids type inference
+   *  @param f the function to apply to each key-value pair
    */
   def foreachEntry[U](f: (K, V) => U): Unit = {
     val it = iterator
@@ -298,6 +317,7 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
    *  but it may be overridden by subclasses.
    *
    *  @param key the given key value for which a binding is missing.
+   *  @return the value associated with the given key when it is not found in the map
    *  @throws NoSuchElementException if no default value is defined
    */
   @throws[NoSuchElementException]
@@ -326,6 +346,8 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
   /** Builds a new map by applying a function to all elements of this $coll.
    *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
    *  @param f      the function to apply to each element.
    *  @return       a new $coll resulting from applying the given function
    *                `f` to each element of this $coll and collecting the results.
@@ -348,6 +370,8 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   /** Builds a new map by applying a function to all elements of this $coll
    *  and using the elements of the resulting collections.
    *
+   *  @tparam K2 the key type of the returned map
+   *  @tparam V2 the value type of the returned map
    *  @param f      the function to apply to each element.
    *  @return       a new $coll resulting from applying the given collection-valued function
    *                `f` to each element of this $coll and concatenating the results.
@@ -358,6 +382,7 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
    *  right hand operand. The element type of the $coll is the most specific superclass encompassing
    *  the element types of the two operands.
    *
+   *  @tparam V2 the value type of the returned map, a supertype of `V`
    *  @param suffix   the iterable to append.
    *  @return       a new $coll which contains all elements
    *                of this $coll followed by all elements of `suffix`.
@@ -369,7 +394,11 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
 
   // Not final because subclasses refine the result type, e.g. in SortedMap, the result type is
   // SortedMap's CC, while Map's CC is fixed to Map
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @tparam V2 the value type of the returned map, a supertype of `V`
+   *  @param xs the key-value pairs to append
+   */
   /*@`inline` final*/ def ++ [V2 >: V](xs: collection.IterableOnce[(K, V2)]^): CC[K, V2]^{this, xs} = concat(xs)
 
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =
@@ -423,7 +452,12 @@ object MapOps {
   }
 
 
-  /** The implementation class of the set returned by `keySet`, for pure maps. */
+  /** The implementation class of the set returned by `keySet`, for pure maps.
+   *
+   *  @tparam K the key type of the underlying map
+   *  @tparam V the value type of the underlying map
+   *  @tparam CC the type constructor of the underlying map
+   */
   private[collection] class LazyKeySet[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C](mp: MapOps[K, V, CC, C]) extends AbstractSet[K] with DefaultSerializable {
     def iterator: Iterator[K] = mp.keysIterator
     def diff(that: Set[K]): Set[K] = LazyKeySet.this.fromSpecific(this.view.filterNot(that))
@@ -433,7 +467,12 @@ object MapOps {
     override def isEmpty: Boolean = mp.isEmpty
   }
 
-  /** The implementation class of the set returned by `keySet`, for impure maps (i.e. views). */
+  /** The implementation class of the set returned by `keySet`, for impure maps (i.e. views).
+   *
+   *  @tparam K the key type of the underlying map
+   *  @tparam V the value type of the underlying map
+   *  @tparam CC the type constructor of the underlying map
+   */
   private[collection] class StrictKeySet[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C](@annotation.constructorOnly mp: MapOps[K, V, CC, C]^) extends AbstractSet[K] with DefaultSerializable {
     val allKeys = mp.keysIterator.to(mutable.LinkedHashSet)
     def iterator: Iterator[K] = allKeys.iterator
@@ -455,5 +494,9 @@ object Map extends MapFactory.Delegate[Map](immutable.Map) {
   private val DefaultSentinelFn: () -> AnyRef = () => DefaultSentinel
 }
 
-/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Map` trait to reduce class file size in subclasses.
+ *
+ *  @tparam K the type of keys in this map
+ *  @tparam V the type of values associated with keys in this map
+ */
 abstract class AbstractMap[K, +V] extends AbstractIterable[(K, V)] with Map[K, V]

--- a/library/src/scala/collection/MapView.scala
+++ b/library/src/scala/collection/MapView.scala
@@ -48,6 +48,8 @@ trait MapView[K, +V]
   override def filterKeys(p: K => Boolean): MapView[K, V]^{this, p} = new MapView.FilterKeys(this, p)
 
   /** Transforms this map by applying a function to every retrieved value.
+   *
+   *  @tparam W the type of the transformed values
    *  @param  f   the function used to transform values of this map.
    *  @return a map view which maps every key of this map
    *          to `f(this(key))`. The resulting map wraps the original map without copying any elements.

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -84,6 +84,8 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Gets the element at the specified index. This operation is provided for convenience in `Seq`. It should
    *  not be assumed to be efficient unless you have an `IndexedSeq`.
+   *
+   *  @param i the index of the element to retrieve, zero-based
    */
   @throws[IndexOutOfBoundsException]
   def apply(i: Int): A
@@ -105,7 +107,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @tparam B      the element type of the returned $coll.
    *  @param  elem   the prepended element
    *
-   *  @return a new $coll consisting of `value` followed
+   *  @return a new $coll consisting of `elem` followed
    *            by all elements of this $coll.
    */
   def prepended[B >: A](elem: B): CC[B]^{this} = iterableFactory.from(new View.Prepended(elem, this))
@@ -114,6 +116,8 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  Note that :-ending operators are right associative (see example).
    *  A mnemonic for `+:` vs. `:+` is: the COLon goes on the COLlection side.
+   *
+   *  @return a new $coll consisting of `elem` followed by all elements of this $coll
    */
   @`inline` final def +: [B >: A](elem: B): CC[B]^{this} = prepended(elem)
 
@@ -130,7 +134,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @tparam B      the element type of the returned $coll.
    *  @param  elem   the appended element
    *  @return a new $coll consisting of
-   *         all elements of this $coll followed by `value`.
+   *         all elements of this $coll followed by `elem`.
    */
   def appended[B >: A](elem: B): CC[B]^{this} = iterableFactory.from(new View.Appended(this, elem))
 
@@ -231,6 +235,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  **Note**: If the both the receiver object `this` and the argument
    *  `that` are infinite sequences this method may not terminate.
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @param  offset  the index where the sequence is searched.
    *  @return `true` if the sequence `that` is contained in this $coll at
@@ -248,6 +253,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Tests whether this $coll ends with the given sequence.
    *  $willNotTerminateInf
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @return `true` if this $coll has `that` as a suffix, `false` otherwise.
    */
@@ -384,6 +390,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  $willNotTerminateInf
    *
    *  @param   p     the predicate used to test elements.
+   *  @param end the maximum index to consider (inclusive)
    *  @return  the index `<= end` of the last element of this $coll that satisfies the predicate `p`,
    *           or `-1`, if none exists.
    */
@@ -412,6 +419,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Finds first index after or at a start index where this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @param  from    the start index
    *  @return  the first index `>= from` such that the elements of this $coll starting at this index
@@ -457,6 +465,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willNotTerminateInf
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @param  end     the end index
    *  @return  the last index `<= end` such that the elements of this $coll starting at this index
@@ -503,6 +512,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Tests whether this $coll contains a given sequence as a slice.
    *  $mayNotTerminateInf
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param  that    the sequence to test
    *  @return  `true` if this $coll contains a slice with the same elements
    *           as `that`, otherwise `false`.
@@ -512,6 +522,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
   /** Tests whether this $coll contains a given value as an element.
    *  $mayNotTerminateInf
    *
+   *  @tparam A1 the type of the element to test (a supertype of `A`)
    *  @param elem  the element to test.
    *  @return     `true` if this $coll has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
@@ -562,6 +573,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willForceEvaluation
    *
+   *  @param n the number of elements in each combination
    *  @return   An Iterator which traverses the n-element combinations of this $coll.
    *  @example ```scala sc:compile
    *    Seq('a', 'b', 'b', 'b', 'c').combinations(2).foreach(println)
@@ -705,6 +717,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *
    *  $willForceEvaluation
    *
+   *  @tparam B the element type used for ordering (a supertype of `A`)
    *  @param  ord the ordering to be used to compare elements.
    *  @return     a $coll consisting of the elements of this $coll
    *              sorted according to the ordering `ord`.
@@ -831,6 +844,8 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  this.lengthIs >= len    // this.lengthCompare(len) >= 0
    *  this.lengthIs > len     // this.lengthCompare(len) > 0
    *  ```
+   *
+   *  @return an object providing `<`, `<=`, `==`, `!=`, `>=`, and `>` operations for comparing the length
    */
   @inline final def lengthIs: IterableOps.SizeCompareOps^{this} = new IterableOps.SizeCompareOps(caps.unsafe.unsafeAssumePure(this) /* see comment in SizeCompareOps*/)
 
@@ -876,6 +891,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Computes the multiset difference between this $coll and another sequence.
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param that   the sequence of elements to remove
    *  @return       a new $coll which contains all elements of this $coll
    *                except some of the occurrences of elements that also appear in `that`.
@@ -901,6 +917,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
 
   /** Computes the multiset intersection between this $coll and another sequence.
    *
+   *  @tparam B the element type used for comparison (a supertype of `A`)
    *  @param that   the sequence of elements to intersect with.
    *  @return       a new $coll which contains all elements of this $coll
    *                which also appear in `that`.
@@ -976,9 +993,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @see [[scala.math.Ordering]]
    *  @see [[scala.collection.SeqOps]], method `sorted`
    *
+   *  @tparam B the element type used for searching and ordering (a supertype of `A`)
    *  @param elem the element to find.
-   *  @param ord  the ordering to be used to compare elements.
    *
+   *  @param ord  the ordering to be used to compare elements.
    *  @return a `Found` value containing the index corresponding to the element in the
    *         sequence, or the `InsertionPoint` where the element would be inserted if
    *         the element is not in the sequence.
@@ -997,11 +1015,12 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @see [[scala.math.Ordering]]
    *  @see [[scala.collection.SeqOps]], method `sorted`
    *
+   *  @tparam B the element type used for searching and ordering (a supertype of `A`)
    *  @param elem the element to find.
    *  @param from the index where the search starts.
    *  @param to   the index following where the search ends.
-   *  @param ord  the ordering to be used to compare elements.
    *
+   *  @param ord  the ordering to be used to compare elements.
    *  @return a `Found` value containing the index corresponding to the element in the
    *         sequence, or the `InsertionPoint` where the element would be inserted if
    *         the element is not in the sequence.
@@ -1033,6 +1052,7 @@ object SeqOps {
  /** A KMP implementation, based on the undoubtedly reliable wikipedia entry.
   *  Note: I made this private to keep it from entering the API.  That can be reviewed.
   *
+  *  @tparam B the element type of the sequences being searched
   *  @param  S       Sequence that may contain target
   *  @param  m0      First index of S to consider
   *  @param  m1      Last index of S to consider (exclusive)
@@ -1120,9 +1140,11 @@ object SeqOps {
 
   /** Makes sure a target sequence has fast, correctly-ordered indexing for KMP.
    *
+   *  @tparam B the element type of the target sequence
    *  @param  W    The target sequence
    *  @param  n0   The first element in the target sequence that we should use
    *  @param  n1   The far end of the target sequence that we should use (exclusive)
+   *  @param forward `true` to index in forward order, `false` to index in reverse order
    *  @return Target packed in an IndexedSeq (taken from iterator unless W already is an IndexedSeq)
    */
   private def kmpOptimizeWord[B](W: scala.collection.Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedSeqView[B] = W match {
@@ -1158,6 +1180,7 @@ object SeqOps {
 
  /** Makes a jump table for KMP search.
   *
+  *  @tparam B the element type of the target sequence
   *  @param  Wopt The target sequence
   *  @param  wlen Just in case we're only IndexedSeq and not IndexedSeqOptimized
   *  @return KMP jump table for target sequence
@@ -1186,5 +1209,8 @@ object SeqOps {
   }
 }
 
-/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Seq` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the collection
+ */
 abstract class AbstractSeq[+A] extends AbstractIterable[A] with Seq[A]

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -21,7 +21,10 @@ import java.lang.String
 
 import scala.annotation.nowarn
 
-/** Base trait for set collections. */
+/** Base trait for set collections.
+ *
+ *  @tparam A the element type of the set
+ */
 trait Set[A]
   extends Iterable[A]
     with SetOps[A, Set, Set[A]]
@@ -81,6 +84,9 @@ trait Set[A]
  *
  *  @define coll set
  *  @define Coll `Set`
+ *
+ *  @tparam A the element type of the set
+ *  @tparam CC the type constructor for the set's collection type
  */
 transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   extends IterableOps[A, CC, C]
@@ -144,6 +150,9 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    *  ListSet(1,2,3).subsets => {{1},{2},{3},{1,2},{1,3},{2,3},{1,2,3}}
    *
    *  $willForceEvaluation
+   *
+   *  @param elms the elements of the set as an indexed sequence
+   *  @param len the size of each subset to generate
    */
   private class SubsetsItr(elms: IndexedSeq[A], len: Int) extends AbstractIterator[C] {
     private val idxs = Array.range(0, len+1)
@@ -181,7 +190,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    */
   def intersect(that: Set[A]): C = this.filter(that)
 
-  /** Alias for `intersect`. */
+  /** Alias for `intersect`.
+   *
+   *  @param that the set to intersect with
+   */
   @`inline` final def & (that: Set[A]): C = intersect(that)
 
   /** Computes the difference of this set and another set.
@@ -192,7 +204,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    */
   def diff(that: Set[A]): C
 
-  /** Alias for `diff`. */
+  /** Alias for `diff`.
+   *
+   *  @param that the set of elements to exclude
+   */
   @`inline` final def &~ (that: Set[A]): C = this diff that
 
   @deprecated("Consider requiring an immutable Set", "2.13.0")
@@ -237,7 +252,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
   @deprecated("Use ++ with an explicit collection argument instead of + with varargs", "2.13.0")
   def + (elem1: A, elem2: A, elems: A*): C = fromSpecific(new View.Concat(new View.Appended(new View.Appended(this, elem1), elem2), elems))
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @param that the collection containing the elements to add
+   */
   @`inline` final def ++ (that: collection.IterableOnce[A]^): C = concat(that)
 
   /** Computes the union between of set and another set.
@@ -248,7 +266,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
    */
   @`inline` final def union(that: Set[A]): C = concat(that)
 
-  /** Alias for `union`. */
+  /** Alias for `union`.
+   *
+   *  @param that the set to form the union with
+   */
   @`inline` final def | (that: Set[A]): C = concat(that)
 }
 
@@ -259,5 +280,8 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
 @SerialVersionUID(3L)
 object Set extends IterableFactory.Delegate[Set](immutable.Set)
 
-/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses. */
+/** Explicit instantiation of the `Set` trait to reduce class file size in subclasses.
+ *
+ *  @tparam A the element type of the set
+ */
 abstract class AbstractSet[A] extends AbstractIterable[A] with Set[A]

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -18,7 +18,11 @@ import language.experimental.captureChecking
 
 import scala.annotation.{implicitNotFound, nowarn}
 
-/** A Map whose keys are sorted according to a [[scala.math.Ordering]]. */
+/** A Map whose keys are sorted according to a [[scala.math.Ordering]].
+ *
+ *  @tparam K the type of the keys contained in this sorted map
+ *  @tparam V the type of the values associated with the keys
+ */
 trait SortedMap[K, +V]
   extends Map[K, V]
     with SortedMapOps[K, V, SortedMap, SortedMap[K, V]]
@@ -60,11 +64,17 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    *  @note When implementing a custom collection type and refining `CC` to the new type, this
    *       method needs to be overridden to return a factory for the new type (the compiler will
    *       issue an error otherwise).
+   *
+   *  @return the factory for this sorted map type
    */
   def sortedMapFactory: SortedMapFactory[CC]
 
   /** Similar to `mapFromIterable`, but returns a SortedMap collection type.
    *  Note that the return type is now `CC[K2, V2]`.
+   *
+   *  @tparam K2 the type of the keys in the resulting sorted map
+   *  @tparam V2 the type of the values in the resulting sorted map
+   *  @param it the iterable of key-value pairs to convert into a sorted map
    */
   @`inline` protected final def sortedMapFromIterable[K2, V2](it: Iterable[(K2, V2)]^)(implicit ordering: Ordering[K2]): CC[K2, V2] = sortedMapFactory.from(it)
 
@@ -76,8 +86,9 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    *  this map. x.iteratorFrom(y) is equivalent
    *  to but often more efficient than x.from(y).iterator.
    *
-   *  @param start The lower bound (inclusive)
+   *  @param start the lower bound (inclusive)
    *  on the keys to be returned
+   *  @return an iterator over all key-value pairs with keys greater than or equal to `start`
    */
   def iteratorFrom(start: K): Iterator[(K, V)]
 
@@ -87,8 +98,9 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    *  is equivalent to but often more efficient than
    *  x.from(y).keysIterator.
    *
-   *  @param start The lower bound (inclusive)
+   *  @param start the lower bound (inclusive)
    *  on the keys to be returned
+   *  @return an iterator over all keys greater than or equal to `start`
    */
   def keysIteratorFrom(start: K): Iterator[K]
 
@@ -98,8 +110,9 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
    *  equivalent to but often more efficient than
    *  x.from(y).valuesIterator.
    *
-   *  @param start The lower bound (inclusive)
+   *  @param start the lower bound (inclusive)
    *  on the keys to be returned
+   *  @return an iterator over all values associated with keys greater than or equal to `start`
    */
   def valuesIteratorFrom(start: K): Iterator[V] = iteratorFrom(start).map(_._2)
 
@@ -163,7 +176,10 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
   // And finally, we add new overloads taking an ordering
   /** Builds a new sorted map by applying a function to all elements of this $coll.
    *
+   *  @tparam K2 the type of the keys in the returned sorted map
+   *  @tparam V2 the type of the values in the returned sorted map
    *  @param f      the function to apply to each element.
+   *  @param ordering the ordering to use for the keys of the returned sorted map
    *  @return       a new $coll resulting from applying the given function
    *                `f` to each element of this $coll and collecting the results.
    */
@@ -173,7 +189,10 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
   /** Builds a new sorted map by applying a function to all elements of this $coll
    *  and using the elements of the resulting collections.
    *
+   *  @tparam K2 the type of the keys in the returned sorted map
+   *  @tparam V2 the type of the values in the returned sorted map
    *  @param f      the function to apply to each element.
+   *  @param ordering the ordering to use for the keys of the returned sorted map
    *  @return       a new $coll resulting from applying the given collection-valued function
    *                `f` to each element of this $coll and concatenating the results.
    */
@@ -183,6 +202,8 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
   /** Builds a new sorted map by applying a partial function to all elements of this $coll
    *  on which the function is defined.
    *
+   *  @tparam K2 the type of the keys in the returned sorted map
+   *  @tparam V2 the type of the values in the returned sorted map
    *  @param pf     the partial function which filters and maps the $coll.
    *  @return       a new $coll resulting from applying the given partial function
    *                `pf` to each element on which it is defined and collecting the results.
@@ -196,7 +217,11 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
     case _ => iterator.concat(suffix.iterator)
   })(using ordering)
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @tparam V2 the value type of the returned sorted map, a supertype of `V`
+   *  @param xs the collection of key-value pairs to append
+   */
   @`inline` override final def ++ [V2 >: V](xs: IterableOnce[(K, V2)]^): CC[K, V2] = concat(xs)
 
   @deprecated("Consider requiring an immutable Map or fall back to Map.concat", "2.13.0")
@@ -212,6 +237,12 @@ object SortedMapOps {
   /** Specializes `MapWithFilter` for sorted Map collections
    *
    *  @define coll sorted map collection
+   *
+   *  @tparam K the type of the keys
+   *  @tparam V the type of the values
+   *  @tparam IterableCC the type constructor of the underlying iterable collection
+   *  @tparam MapCC the type constructor of the underlying map collection
+   *  @tparam CC the type constructor of the sorted map collection
    */
   class WithFilter[K, +V, +IterableCC[_], +MapCC[X, Y] <: Map[X, Y], +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y, CC, ?]](
     self: SortedMapOps[K, V, CC, ?] & MapOps[K, V, MapCC, ?] & IterableOps[(K, V), IterableCC, ?],

--- a/library/src/scala/collection/SortedOps.scala
+++ b/library/src/scala/collection/SortedOps.scala
@@ -15,7 +15,11 @@ package scala.collection
 import scala.language.`2.13`
 import language.experimental.captureChecking
 
-/** Base trait for sorted collections. */
+/** Base trait for sorted collections.
+ *
+ *  @tparam A the element type of this sorted collection
+ *  @tparam C the type of the sorted collection itself
+ */
 transparent trait SortedOps[A, +C] {
 
   def ordering: Ordering[A]
@@ -42,6 +46,7 @@ transparent trait SortedOps[A, +C] {
    *               `None` if there is no lower bound.
    *  @param until The upper-bound (exclusive) of the ranged projection.
    *               `None` if there is no upper bound.
+   *  @return a ranged projection of this collection containing only elements within the specified range
    */
   def rangeImpl(from: Option[A], until: Option[A]): C
 

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -18,7 +18,10 @@ import language.experimental.captureChecking
 import scala.annotation.{implicitNotFound, nowarn}
 import scala.annotation.unchecked.uncheckedVariance
 
-/** Base type of sorted sets. */
+/** Base type of sorted sets.
+ *
+ *  @tparam A the element type of the set
+ */
 trait SortedSet[A] extends Set[A]
     with SortedSetOps[A, SortedSet, SortedSet[A]]
     with SortedSetFactoryDefaults[A, SortedSet, Set] {
@@ -57,6 +60,8 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
    *  @note When implementing a custom collection type and refining `CC` to the new type, this
    *       method needs to be overridden to return a factory for the new type (the compiler will
    *       issue an error otherwise).
+   *
+   *  @return a factory for creating new sorted collections of the same type
    */
   def sortedIterableFactory: SortedIterableFactory[CC]
 
@@ -169,6 +174,9 @@ object SortedSetOps {
   /** Specialize `WithFilter` for sorted collections
    *
    *  @define coll sorted collection
+   *
+   *  @tparam A the element type of the sorted collection
+   *  @tparam IterableCC the type constructor for the unsorted collection type
    */
   class WithFilter[+A, +IterableCC[_], +CC[X] <: SortedSet[X]](
     self: SortedSetOps[A, CC, ?] & IterableOps[A, IterableCC, ?],

--- a/library/src/scala/collection/Stepper.scala
+++ b/library/src/scala/collection/Stepper.scala
@@ -53,6 +53,8 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
    *  May return `null`, in which case the current Stepper yields the same elements as before.
    *
    *  See method `trySplit` in [[java.util.Spliterator]].
+   *
+   *  @return a new `Stepper` containing a portion of the elements, or `null` if this stepper cannot be split
    */
   def trySplit(): Stepper[A]^{this} | Null
 
@@ -71,6 +73,9 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
    *  Note that the return type is `Spliterator[_]` instead of `Spliterator[A]` to allow returning
    *  a [[java.util.Spliterator.OfInt]] (which is a `Spliterator[Integer]`) in the subclass [[IntStepper]]
    *  (which is a `Stepper[Int]`).
+   *
+   *  @tparam B a supertype of the element type `A`
+   *  @return a `Spliterator` over the remaining elements of this stepper
    */
   def spliterator[B >: A]: Spliterator[?]^{this}
 
@@ -79,6 +84,9 @@ trait Stepper[@specialized(Double, Int, Long) +A] {
    *  Note that the return type is `Iterator[_]` instead of `Iterator[A]` to allow returning
    *  a [[java.util.PrimitiveIterator.OfInt]] (which is a `Iterator[Integer]`) in the subclass
    *  [[IntStepper]] (which is a `Stepper[Int]`).
+   *
+   *  @tparam B a supertype of the element type `A`
+   *  @return a Java `Iterator` over the remaining elements of this stepper
    */
   def javaIterator[B >: A]: JIterator[?]^{this}
 
@@ -184,7 +192,10 @@ object Stepper {
   }
 }
 
-/** A `Stepper` for arbitrary element types. See [[Stepper]]. */
+/** A `Stepper` for arbitrary element types. See [[Stepper]].
+ *
+ *  @tparam A the element type of the stepper
+ */
 trait AnyStepper[+A] extends Stepper[A] {
   def trySplit(): AnyStepper[A]^{this} | Null
 

--- a/library/src/scala/collection/StepperShape.scala
+++ b/library/src/scala/collection/StepperShape.scala
@@ -21,6 +21,9 @@ import scala.collection.Stepper.EfficientSplit
 
 /** An implicit StepperShape instance is used in the [[IterableOnce.stepper]] to return a possibly
  *  specialized Stepper `S` according to the element type `T`.
+ *
+ *  @tparam T the element type of the collection (may be a primitive or reference type)
+ *  @tparam S the type of `Stepper` to use, possibly specialized for primitive types
  */
 sealed trait StepperShape[-T, S <: Stepper[?]] { self =>
   /** Returns the Int constant (as defined in the `StepperShape` companion object) for this `StepperShape`. */
@@ -28,11 +31,15 @@ sealed trait StepperShape[-T, S <: Stepper[?]] { self =>
 
   /** Creates an unboxing primitive sequential Stepper from a boxed `AnyStepper`.
    *  This is an identity operation for reference shapes. 
+   *
+   *  @param st the boxed `AnyStepper` to convert into a possibly specialized stepper
    */
   def seqUnbox(st: AnyStepper[T]^): S^{st}
 
   /** Creates an unboxing primitive parallel (i.e. `with EfficientSplit`) Stepper from a boxed `AnyStepper`.
    *  This is an identity operation for reference shapes. 
+   *
+   *  @param st the boxed `AnyStepper` with `EfficientSplit` capability to convert into a possibly specialized stepper
    */
   def parUnbox(st: (AnyStepper[T] & EfficientSplit)^): (S & EfficientSplit)^{st}
 }

--- a/library/src/scala/collection/StrictOptimizedIterableOps.scala
+++ b/library/src/scala/collection/StrictOptimizedIterableOps.scala
@@ -254,6 +254,8 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
 
   /** A collection containing the last `n` elements of this collection.
    *  $willForceEvaluation
+   *
+   *  @param n the number of elements to take from the end of this collection
    */
   override def takeRight(n: Int): C = {
     val b = newSpecificBuilder
@@ -271,6 +273,8 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
   /** The rest of the collection without its `n` last elements. For
    *  linear, immutable collections this should avoid making a copy.
    *  $willForceEvaluation
+   *
+   *  @param n the number of elements to drop from the end of this collection
    */
   override def dropRight(n: Int): C = {
     val b = newSpecificBuilder

--- a/library/src/scala/collection/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/StrictOptimizedSeqOps.scala
@@ -17,6 +17,9 @@ import language.experimental.captureChecking
 
 /** Trait that overrides operations on sequences in order
  *  to take advantage of strict builders.
+ *
+ *  @tparam A the element type of the sequence
+ *  @tparam CC the type constructor of the collection
  */
 transparent trait StrictOptimizedSeqOps [+A, +CC[_] <: caps.Pure, +C]
   extends Any with SeqOps[A, CC, C] with StrictOptimizedIterableOps[A, CC, C] with caps.Pure {

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -64,11 +64,18 @@ object StringOps {
     }
   }
 
-  /** A lazy filtered string. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
+  /** A lazy filtered string. No filtering is applied until one of `foreach`, `map` or `flatMap` is called.
+   *
+   *  @param p the predicate used to filter characters
+   *  @param s the underlying string to filter
+   */
   class WithFilter(p: Char => Boolean, s: String) {
 
     /** Applies `f` to each element for its side effects.
      *  Note: [U] parameter needed to help scalac's type inference.
+     *
+     *  @tparam U the return type of the function `f`, used only for side effects
+     *  @param f the function to apply to each char
      */
     def foreach[U](f: Char => U): Unit = {
       val len = s.length
@@ -82,6 +89,7 @@ object StringOps {
 
     /** Builds a new collection by applying a function to all chars of this filtered string.
      *
+     *  @tparam B the element type of the returned collection
      *  @param f      the function to apply to each char.
      *  @return       a new collection resulting from applying the given function
      *                `f` to each char of this string and collecting the results.
@@ -120,6 +128,7 @@ object StringOps {
     /** Builds a new collection by applying a function to all chars of this filtered string
      *  and using the elements of the resulting collections.
      *
+     *  @tparam B the element type of the returned collection
      *  @param f      the function to apply to each char.
      *  @return       a new collection resulting from applying the given collection-valued function
      *                `f` to each char of this string and concatenating the results.
@@ -155,7 +164,10 @@ object StringOps {
       sb.toString
     }
 
-    /** Creates a new non-strict filter which combines this filter with the given predicate. */
+    /** Creates a new non-strict filter which combines this filter with the given predicate.
+     *
+     *  @param q the additional predicate to apply to each char
+     */
     def withFilter(q: Char => Boolean): WithFilter^{this, q} = new WithFilter(a => p(a) && q(a), s)
   }
 
@@ -177,6 +189,8 @@ object StringOps {
  *                        The user is responsible for making sure such cases
  *                        are handled correctly. Failing to do so may result in
  *                        an invalid Unicode string.
+ *
+ *  @param s the underlying string being wrapped
  */
 final class StringOps(private val s: String) extends AnyVal { self =>
   import StringOps._
@@ -187,7 +201,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   @inline def knownSize: Int = s.length
 
-  /** Gets the char at the specified index. */
+  /** Gets the char at the specified index.
+   *
+   *  @param i the zero-based index of the char to retrieve
+   */
   @inline def apply(i: Int): Char = s.charAt(i)
 
   def sizeCompare(otherSize: Int): Int = Integer.compare(s.length, otherSize)
@@ -200,6 +217,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Builds a new collection by applying a function to all chars of this string.
    *
+   *  @tparam B the element type of the returned collection
    *  @param f      the function to apply to each char.
    *  @return       a new collection resulting from applying the given function
    *                `f` to each char of this string and collecting the results.
@@ -235,6 +253,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Builds a new collection by applying a function to all chars of this string
    *  and using the elements of the resulting collections.
    *
+   *  @tparam B the element type of the returned collection
    *  @param f      the function to apply to each char.
    *  @return       a new collection resulting from applying the given collection-valued function
    *                `f` to each char of this string and concatenating the results.
@@ -310,6 +329,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Returns a new collection containing the chars from this string followed by the elements from the
    *  right hand operand.
    *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
    *  @param suffix the collection to append.
    *  @return       a new collection which contains all chars
    *                of this string followed by all elements of `suffix`.
@@ -347,17 +367,28 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    */
   @inline def concat(suffix: String): String = s + suffix
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param suffix the collection to append
+   */
   @inline def ++[B >: Char](suffix: Iterable[B]^): immutable.IndexedSeq[B] = concat(suffix)
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @param suffix the collection of chars to append
+   */
   @inline def ++(suffix: IterableOnce[Char]^): String = concat(suffix)
 
-  /** Alias for `concat`. */
+  /** Alias for `concat`.
+   *
+   *  @param xs the string to append
+   */
   def ++(xs: String): String = concat(xs)
 
   /** Returns a collection with an element appended until a given target length is reached.
    *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
    *  @param  len   the target length
    *  @param  elem  the padding value
    *  @return a collection consisting of
@@ -397,7 +428,11 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     }
   }
 
-  /** A copy of the string with an element prepended. */
+  /** A copy of the string with an element prepended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param elem the element to prepend
+   */
   def prepended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -409,14 +444,21 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Alias for `prepended`. */
   @inline def +: [B >: Char] (elem: B): immutable.IndexedSeq[B] = prepended(elem)
 
-  /** A copy of the string with an char prepended. */
+  /** A copy of the string with an char prepended.
+   *
+   *  @param c the char to prepend
+   */
   def prepended(c: Char): String =
     new JStringBuilder(s.length + 1).append(c).append(s).toString
 
   /** Alias for `prepended`. */
   @inline def +: (c: Char): String = prepended(c)
 
-  /** A copy of the string with all elements from a collection prepended. */
+  /** A copy of the string with all elements from a collection prepended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param prefix the collection to prepend
+   */
   def prependedAll[B >: Char](prefix: IterableOnce[B]^): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     val k = prefix.knownSize
@@ -429,13 +471,20 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Alias for `prependedAll`. */
   @inline def ++: [B >: Char] (prefix: IterableOnce[B]^): immutable.IndexedSeq[B] = prependedAll(prefix)
 
-  /** A copy of the string with another string prepended. */
+  /** A copy of the string with another string prepended.
+   *
+   *  @param prefix the string to prepend
+   */
   def prependedAll(prefix: String): String = prefix + s
 
   /** Alias for `prependedAll`. */
   @inline def ++: (prefix: String): String = prependedAll(prefix)
 
-  /** A copy of the string with an element appended. */
+  /** A copy of the string with an element appended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param elem the element to append
+   */
   def appended[B >: Char](elem: B): immutable.IndexedSeq[B] = {
     val b = immutable.IndexedSeq.newBuilder[B]
     b.sizeHint(s.length + 1)
@@ -447,14 +496,21 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Alias for `appended`. */
   @inline def :+ [B >: Char](elem: B): immutable.IndexedSeq[B] = appended(elem)
 
-  /** A copy of the string with an element appended. */
+  /** A copy of the string with an element appended.
+   *
+   *  @param c the char to append
+   */
   def appended(c: Char): String =
     new JStringBuilder(s.length + 1).append(s).append(c).toString
 
   /** Alias for `appended`. */
   @inline def :+ (c: Char): String = appended(c)
 
-  /** A copy of the string with all elements from a collection appended. */
+  /** A copy of the string with all elements from a collection appended.
+   *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
+   *  @param suffix the collection to append
+   */
   @inline def appendedAll[B >: Char](suffix: IterableOnce[B]^): immutable.IndexedSeq[B] =
     concat(suffix)
 
@@ -462,7 +518,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   @inline def :++ [B >: Char](suffix: IterableOnce[B]^): immutable.IndexedSeq[B] =
     concat(suffix)
 
-  /** A copy of the string with another string appended. */
+  /** A copy of the string with another string appended.
+   *
+   *  @param suffix the string to append
+   */
   @inline def appendedAll(suffix: String): String = s + suffix
 
   /** Alias for `appendedAll`. */
@@ -474,6 +533,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  Patching at indices at or larger than the length of the original string appends the patch to the end.
    *  If more values are replaced than actually exist, the excess is ignored.
    *
+   *  @tparam B the element type of the returned collection, a supertype of `Char`
    *  @param  from     the index of the first replaced char
    *  @param  other    the replacement collection
    *  @param  replaced the number of chars to drop in the original string
@@ -588,14 +648,27 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Returns this string. */
   @inline final def mkString: String = s
 
-  /** Appends this string to a string builder. */
+  /** Appends this string to a string builder.
+   *
+   *  @param b the string builder to append to
+   */
   @inline final def addString(b: StringBuilder): b.type = b.append(s)
 
-  /** Appends this string to a string builder using a separator string. */
+  /** Appends this string to a string builder using a separator string.
+   *
+   *  @param b the string builder to append to
+   *  @param sep the separator string inserted between chars
+   */
   @inline final def addString(b: StringBuilder, sep: String): b.type =
     addString(b, "", sep, "")
 
-  /** Appends this string to a string builder using start, end and separator strings. */
+  /** Appends this string to a string builder using start, end and separator strings.
+   *
+   *  @param b the string builder to append to
+   *  @param start the string to prepend before all chars
+   *  @param sep the separator string inserted between chars
+   *  @param end the string to append after all chars
+   */
   final def addString(b: StringBuilder, start: String, sep: String, end: String): b.type = {
     val jsb = b.underlying
     if (start.length != 0) jsb.append(start)
@@ -638,7 +711,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     else s.substring(start, end)
   }
 
-  /** Returns the current string concatenated `n` times. */
+  /** Returns the current string concatenated `n` times.
+   *
+   *  @param n the number of times to repeat this string
+   */
   def *(n: Int): String =
     if (n <= 0) {
       ""
@@ -668,6 +744,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  including trailing line separator characters.
    *
    *  The empty string yields an empty iterator.
+   *
+   *  @return an iterator over the lines in this string, including line separator characters
    */
   def linesWithSeparators: Iterator[String] = linesSeparated(stripped = false)
 
@@ -716,6 +794,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Returns this string with the given `prefix` stripped. If this string does not
    *  start with `prefix`, it is returned unchanged.
+   *
+   *  @param prefix the prefix to strip from this string
    */
   def stripPrefix(prefix: String): String =
     if (s.startsWith(prefix)) s.substring(prefix.length)
@@ -723,6 +803,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Returns this string with the given `suffix` stripped. If this string does not
    *  end with `suffix`, it is returned unchanged.
+   *
+   *  @param suffix the suffix to strip from this string
    */
   def stripSuffix(suffix: String): String =
     if (s.endsWith(suffix)) s.substring(0, s.length - suffix.length)
@@ -742,6 +824,9 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  Strip a leading prefix consisting of blanks or control characters
    *  followed by `marginChar` from the line.
+   *
+   *  @param marginChar the character used as a margin delimiter
+   *  @return the string with leading margin characters and preceding whitespace removed from each line
    */
   def stripMargin(marginChar: Char): String = {
     val sb = new JStringBuilder(s.length)
@@ -761,6 +846,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  Strip a leading prefix consisting of blanks or control characters
    *  followed by `|` from the line.
+   *
+   *  @return the string with leading `|` margin characters and preceding whitespace removed from each line
    */
   def stripMargin: String = stripMargin('|')
 
@@ -808,6 +895,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  bare.split(high) // Array("_", "_")
    *  ```
    *  @param separator the character used as a delimiter
+   *
+   *  @return an array of strings computed by splitting this string around occurrences of the separator character
    */
   def split(separator: Char): Array[String] = s.split(escape(separator))
 
@@ -824,6 +913,8 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  `"""(?<month>\d\d)-(?<day>\d\d)-(?<year>\d\d\d\d)""".r` matches dates
    *  and provides its subcomponents through groups named "month", "day" and
    *  "year".
+   *
+   *  @return a `Regex` with this string as the pattern
    */
   def r: Regex = new Regex(s)
 
@@ -948,6 +1039,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  checks the format string at compilation.
    *
    *  @param args the arguments used to instantiating the pattern.
+   *  @return the string with format placeholders replaced by the formatted arguments
    *  @throws java.util.IllegalFormatException if the format contains syntax or conversion errors
    */
   def format(args: Any*): String =
@@ -964,6 +1056,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  @param l    an instance of `java.util.Locale`
    *  @param args the arguments used to instantiating the pattern.
+   *  @return the string with format placeholders replaced by the formatted arguments using the given locale
    *  @throws java.util.IllegalFormatException if the format contains syntax or conversion errors
    */
   def formatLocal(l: java.util.Locale, args: Any*): String =
@@ -971,10 +1064,16 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   def compare(that: String): Int = s.compareTo(that)
 
-  /** Returns true if `this` is less than `that`. */
+  /** Returns true if `this` is less than `that`.
+   *
+   *  @param that the string to compare against
+   */
   def < (that: String): Boolean = compare(that) <  0
 
-  /** Returns true if `this` is greater than `that`. */
+  /** Returns true if `this` is greater than `that`.
+   *
+   *  @param that the string to compare against
+   */
   def > (that: String): Boolean = compare(that) >  0
 
   /** Returns true if `this` is less than or equal to `that`. */
@@ -983,7 +1082,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   /** Returns true if `this` is greater than or equal to `that`. */
   def >= (that: String): Boolean = compare(that) >= 0
 
-  /** Counts the number of chars in this string which satisfy a predicate. */
+  /** Counts the number of chars in this string which satisfy a predicate.
+   *
+   *  @param p the predicate used to test chars
+   */
   def count(p: (Char) => Boolean): Int = {
     var i, res = 0
     val len = s.length
@@ -996,6 +1098,9 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Applies `f` to each element for its side effects.
    *  Note: [U] parameter needed to help scalac's type inference.
+   *
+   *  @tparam U the return type of the function `f`, used only for side effects
+   *  @param f the function to apply to each char
    */
   def foreach[U](f: Char => U): Unit = {
     val len = s.length
@@ -1176,21 +1281,29 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** A string containing the first `n` chars of this string.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to take from the beginning of this string
    */
   def take(n: Int): String = slice(0, min(n, s.length))
 
   /** The rest of the string without its `n` first chars.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to drop from the beginning of this string
    */
   def drop(n: Int): String = slice(min(n, s.length), s.length)
 
   /** A string containing the last `n` chars of this string.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to take from the end of this string
    */
   def takeRight(n: Int): String = drop(s.length - max(n, 0))
 
   /** The rest of the string without its `n` last chars.
    *  @note $unicodeunaware
+   *
+   *  @param n the number of chars to drop from the end of this string
    */
   def dropRight(n: Int): String = take(s.length - max(n, 0))
 
@@ -1216,7 +1329,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
   private def iterateUntilEmpty(f: String => String): Iterator[String]^{f} =
     Iterator.iterate(s)(f).takeWhile(x => !x.isEmpty) ++ Iterator.single("")
 
-  /** Selects all chars of this string which satisfy a predicate. */
+  /** Selects all chars of this string which satisfy a predicate.
+   *
+   *  @param pred the predicate used to test chars
+   */
   def filter(pred: Char => Boolean): String = {
     val len = s.length
     val sb = new JStringBuilder(len)
@@ -1229,7 +1345,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     if(len == sb.length()) s else sb.toString
   }
 
-  /** Selects all chars of this string which do not satisfy a predicate. */
+  /** Selects all chars of this string which do not satisfy a predicate.
+   *
+   *  @param pred the predicate used to test chars
+   */
   @inline def filterNot(pred: Char => Boolean): String = filter(c => !pred(c))
 
   /** Copies chars of this string to an array.
@@ -1304,7 +1423,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     -1
   }
 
-  /** Tests whether a predicate holds for at least one char of this string. */
+  /** Tests whether a predicate holds for at least one char of this string.
+   *
+   *  @param p the predicate used to test chars
+   */
   def exists(p: Char => Boolean): Boolean = indexWhere(p) != -1
 
   /** Finds the first char of the string satisfying a predicate, if any.
@@ -1329,7 +1451,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
     case i => s.substring(i)
   }
 
-  /** Takes longest prefix of chars that satisfy a predicate. */
+  /** Takes longest prefix of chars that satisfy a predicate.
+   *
+   *  @param p the predicate used to test chars
+   */
   def takeWhile(p: Char => Boolean): String = indexWhere(c => !p(c)) match {
     case -1 => s
     case i => s.substring(0, i)
@@ -1370,7 +1495,10 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    */
   def grouped(size: Int): Iterator[String] = new StringOps.GroupedIterator(s, size)
 
-  /** A pair of, first, all chars that satisfy predicate `p` and, second, all chars that do not. */
+  /** A pair of, first, all chars that satisfy predicate `p` and, second, all chars that do not.
+   *
+   *  @param p the predicate used to partition chars
+   */
   def partition(p: Char => Boolean): (String, String) = {
     val res1, res2 = new JStringBuilder
     var i = 0
@@ -1443,6 +1571,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Computes the multiset difference between this string and another sequence.
    *
+   *  @tparam B the element type of the other sequence, a supertype of `Char`
    *  @param that   the sequence of chars to remove
    *  @return       a new string which contains all chars of this string
    *                except some of occurrences of elements that also appear in `that`.
@@ -1455,6 +1584,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
 
   /** Computes the multiset intersection between this string and another sequence.
    *
+   *  @tparam B the element type of the other sequence, a supertype of `Char`
    *  @param that   the sequence of chars to intersect with.
    *  @return       a new string which contains all chars of this string
    *                which also appear in `that`.
@@ -1488,6 +1618,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *
    *  @see [[scala.math.Ordering]]
    *
+   *  @tparam B the type over which the ordering is defined, a supertype of `Char`
    *  @param  ord the ordering to be used to compare elements.
    *  @return     a string consisting of the chars of this string
    *              sorted according to the ordering `ord`.
@@ -1578,6 +1709,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *  of the original sequence, but the order in which elements were selected, by "first index";
    *  the order of each `x` element is also arbitrary.
    *
+   *  @param n the number of elements per combination
    *  @return   An Iterator which traverses the n-element combinations of this string.
    *  @example ```
    *    "abbbc".combinations(2).foreach(println)

--- a/library/src/scala/collection/View.scala
+++ b/library/src/scala/collection/View.scala
@@ -26,6 +26,8 @@ import caps.unsafe.unsafeAssumePure
  *  or when the view is converted to a strict collection type (using the `to` operation).
  *  @define coll view
  *  @define Coll `View`
+ *
+ *  @tparam A the element type of the view
  */
 trait View[+A] extends Iterable[A] with IterableOps[A, View, View[A]] with IterableFactoryDefaults[A, View] with Serializable {
 

--- a/library/src/scala/collection/convert/AsJavaConverters.scala
+++ b/library/src/scala/collection/convert/AsJavaConverters.scala
@@ -41,6 +41,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterator` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Iterator` will be returned.
    *
+   *  @tparam A the element type of the iterator
    *  @param i The Scala `Iterator` to be converted.
    *  @return  A Java `Iterator` view of the argument.
    */
@@ -58,6 +59,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterator` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Enumeration` will be returned.
    *
+   *  @tparam A the element type of the iterator
    *  @param i The Scala `Iterator` to be converted.
    *  @return  A Java `Enumeration` view of the argument.
    */
@@ -75,6 +77,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterable` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Iterable` will be returned.
    *
+   *  @tparam A the element type of the iterable
    *  @param i The Scala `Iterable` to be converted.
    *  @return  A Java `Iterable` view of the argument.
    */
@@ -89,6 +92,7 @@ trait AsJavaConverters {
    *  If the Scala `Iterable` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Collection` will be returned.
    *
+   *  @tparam A the element type of the iterable
    *  @param i The Scala `Iterable` to be converted.
    *  @return  A Java `Collection` view of the argument.
    */
@@ -106,6 +110,7 @@ trait AsJavaConverters {
    *  If the Scala `Buffer` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `List` will be returned.
    *
+   *  @tparam A the element type of the buffer
    *  @param b The Scala `Buffer` to be converted.
    *  @return A Java `List` view of the argument.
    */
@@ -123,6 +128,7 @@ trait AsJavaConverters {
    *  If the Scala `Seq` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `List` will be returned.
    *
+   *  @tparam A the element type of the sequence
    *  @param s The Scala `Seq` to be converted.
    *  @return  A Java `List` view of the argument.
    */
@@ -140,6 +146,7 @@ trait AsJavaConverters {
    *  If the Scala `Seq` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `List` will be returned.
    *
+   *  @tparam A the element type of the sequence
    *  @param s The Scala `Seq` to be converted.
    *  @return  A Java `List` view of the argument.
    */
@@ -157,6 +164,7 @@ trait AsJavaConverters {
    *  If the Scala `Set` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Set` will be returned.
    *
+   *  @tparam A the element type of the set
    *  @param s The Scala mutable `Set` to be converted.
    *  @return  A Java `Set` view of the argument.
    */
@@ -174,6 +182,7 @@ trait AsJavaConverters {
    *  If the Scala `Set` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Set` will be returned.
    *
+   *  @tparam A the element type of the set
    *  @param s The Scala `Set` to be converted.
    *  @return  A Java `Set` view of the argument.
    */
@@ -191,6 +200,8 @@ trait AsJavaConverters {
    *  If the Scala `Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Map` will be returned.
    *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
    *  @param m The Scala mutable `Map` to be converted.
    *  @return  A Java `Map` view of the argument.
    */
@@ -209,7 +220,9 @@ trait AsJavaConverters {
    *  If the Scala `Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Dictionary` will be returned.
    *
-   *  @param m The Scala `Map` to be converted.
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m The Scala mutable `Map` to be converted.
    *  @return  A Java `Dictionary` view of the argument.
    */
   def asJavaDictionary[K, V](m: mutable.Map[K, V]): ju.Dictionary[K, V] = (m: mutable.Map[K, V] | Null) match {
@@ -226,6 +239,8 @@ trait AsJavaConverters {
    *  If the Scala `Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `Map` will be returned.
    *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
    *  @param m The Scala `Map` to be converted.
    *  @return  A Java `Map` view of the argument.
    */
@@ -244,6 +259,8 @@ trait AsJavaConverters {
    *  If the Scala `concurrent.Map` was previously obtained from an implicit or explicit call of
    *  `asScala` then the original Java `ConcurrentMap` will be returned.
    *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
    *  @param m The Scala `concurrent.Map` to be converted.
    *  @return  A Java `ConcurrentMap` view of the argument.
    */

--- a/library/src/scala/collection/convert/AsScalaConverters.scala
+++ b/library/src/scala/collection/convert/AsScalaConverters.scala
@@ -42,6 +42,7 @@ trait AsScalaConverters {
    *  If the Java `Iterator` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Iterator` will be returned.
    *
+   *  @tparam A the element type of the iterator
    *  @param i The Java `Iterator` to be converted.
    *  @return  A Scala `Iterator` view of the argument.
    */
@@ -59,6 +60,7 @@ trait AsScalaConverters {
    *  If the Java `Enumeration` was previously obtained from an implicit or explicit call of
    *  `asJavaEnumeration` then the original Scala `Iterator` will be returned.
    *
+   *  @tparam A the element type of the enumeration
    *  @param e The Java `Enumeration` to be converted.
    *  @return  A Scala `Iterator` view of the argument.
    */
@@ -76,6 +78,7 @@ trait AsScalaConverters {
    *  If the Java `Iterable` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Iterable` will be returned.
    *
+   *  @tparam A the element type of the iterable
    *  @param i The Java `Iterable` to be converted.
    *  @return  A Scala `Iterable` view of the argument.
    */
@@ -90,6 +93,7 @@ trait AsScalaConverters {
    *  If the Java `Collection` was previously obtained from an implicit or explicit call of
    *  `asJavaCollection` then the original Scala `Iterable` will be returned.
    *
+   *  @tparam A the element type of the collection
    *  @param c The Java `Collection` to be converted.
    *  @return  A Scala `Iterable` view of the argument.
    */
@@ -107,6 +111,7 @@ trait AsScalaConverters {
    *  If the Java `List` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Buffer` will be returned.
    *
+   *  @tparam A the element type of the list
    *  @param l The Java `List` to be converted.
    *  @return A Scala mutable `Buffer` view of the argument.
    */
@@ -124,6 +129,7 @@ trait AsScalaConverters {
    *  If the Java `Set` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `Set` will be returned.
    *
+   *  @tparam A the element type of the set
    *  @param s The Java `Set` to be converted.
    *  @return  A Scala mutable `Set` view of the argument.
    */
@@ -146,6 +152,8 @@ trait AsScalaConverters {
    *  This includes `get`, as `java.util.Map`'s API does not allow for an atomic `get` when `null`
    *  values may be present.
    *
+   *  @tparam K the type of keys in the map
+   *  @tparam V the type of values in the map
    *  @param m The Java `Map` to be converted.
    *  @return  A Scala mutable `Map` view of the argument.
    */
@@ -164,6 +172,8 @@ trait AsScalaConverters {
    *  If the Java `ConcurrentMap` was previously obtained from an implicit or explicit call of
    *  `asJava` then the original Scala `ConcurrentMap` will be returned.
    *
+   *  @tparam K the type of keys in the map
+   *  @tparam V the type of values in the map
    *  @param m The Java `ConcurrentMap` to be converted.
    *  @return  A Scala mutable `ConcurrentMap` view of the argument.
    */
@@ -181,6 +191,8 @@ trait AsScalaConverters {
    *  If the Java `Dictionary` was previously obtained from an implicit or explicit call of
    *  `asJavaDictionary` then the original Scala `Map` will be returned.
    *
+   *  @tparam K the type of keys in the dictionary
+   *  @tparam V the type of values in the dictionary
    *  @param d The Java `Dictionary` to be converted.
    *  @return  A Scala mutable `Map` view of the argument.
    */

--- a/library/src/scala/collection/convert/StreamExtensions.scala
+++ b/library/src/scala/collection/convert/StreamExtensions.scala
@@ -37,6 +37,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this collection. If the
      *  collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S =
       s.fromStepper(cc.stepper, par = false)
@@ -51,6 +53,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this collection. If the
      *  collection contains primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[A, S, St],
@@ -66,6 +70,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of this map. If
      *  the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the key type `K`
      */
     def asJavaSeqKeyStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[K, S, St], st: StepperShape[K, St]): S =
       s.fromStepper(cc.keyStepper, par = false)
@@ -73,6 +79,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of this map. If
      *  the values are primitives, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the value type `V`
      */
     def asJavaSeqValueStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[V, S, St], st: StepperShape[V, St]): S =
       s.fromStepper(cc.valueStepper, par = false)
@@ -80,6 +88,8 @@ trait StreamExtensions {
     // The asJavaSeqStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
      *  this map.
+     *
+     *  @tparam S the type of Java Stream to create, determined by the pair type `(K, V)`
      */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[(K, V), S, St], st: StepperShape[(K, V), St]): S =
       s.fromStepper(cc.stepper, par = false)
@@ -94,6 +104,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of this map. If
      *  the keys are primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the key type `K`
      */
     def asJavaParKeyStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[K, S, St],
@@ -105,6 +117,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of this map. If
      *  the values are primitives, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the value type `V`
      */
     def asJavaParValueStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[V, S, St],
@@ -116,6 +130,8 @@ trait StreamExtensions {
     // The asJavaParStream extension method for IterableOnce doesn't apply because its `CC` takes a single type parameter, whereas the one here takes two
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the `(key, value)` pairs of
      *  this map.
+     *
+     *  @tparam S the type of Java Stream to create, determined by the pair type `(K, V)`
      */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit
         s: StreamShape[(K, V), S, St],
@@ -131,6 +147,8 @@ trait StreamExtensions {
     /** Creates a sequential [[java.util.stream.Stream Java Stream]] for this stepper. If the
      *  stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = stepper match {
@@ -145,6 +163,8 @@ trait StreamExtensions {
     /** Creates a parallel [[java.util.stream.Stream Java Stream]] for this stepper. If the
      *  stepper yields primitive values, a corresponding specialized Stream is returned (e.g.,
      *  [[java.util.stream.IntStream `IntStream`]]).
+     *
+     *  @tparam S the type of Java Stream to create, determined by the element type `A`
      */
     def asJavaParStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = (stepper: @unchecked) match {
@@ -260,6 +280,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting the element type to a specialized `Accumulator`, or a generic fallback (resolved automatically)
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[A, C1])(implicit info: AccumulatorFactoryInfo[A, C1]): C1 = {
 
@@ -274,6 +299,9 @@ trait StreamExtensions {
 
     /** Converts a generic Java Stream wrapping a primitive type to a corresponding primitive
      *  Stream.
+     *
+     *  @tparam S the resulting primitive stream type (e.g., `IntStream`, `LongStream`, `DoubleStream`)
+     *  @param unboxer implicit conversion from boxed `Stream[A]` to primitive stream `S`
      */
     def asJavaPrimitiveStream[S](implicit unboxer: StreamUnboxer[A, S]): S = unboxer(stream)
   }
@@ -294,6 +322,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting `Int` to a specialized `IntAccumulator`, or a generic fallback
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[Int, C1])(implicit info: AccumulatorFactoryInfo[Int, C1]): C1 = {
       def intAcc = stream.collect(IntAccumulator.supplier, IntAccumulator.adder, IntAccumulator.merger)
@@ -320,6 +353,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting `Long` to a specialized `LongAccumulator`, or a generic fallback
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[Long, C1])(implicit info: AccumulatorFactoryInfo[Long, C1]): C1 = {
       def longAcc = stream.collect(LongAccumulator.supplier, LongAccumulator.adder, LongAccumulator.merger)
@@ -346,6 +384,11 @@ trait StreamExtensions {
      *
      *  Sequential streams are directly converted to the target collection. If the target collection
      *  is lazy, the conversion is lazy as well.
+     *
+     *  @tparam C1 the type of the target Scala collection
+     *  @param factory the factory used to build the target collection
+     *  @param info implicit evidence connecting `Double` to a specialized `DoubleAccumulator`, or a generic fallback
+     *  @return the elements of this stream collected into a Scala collection of type `C1`
      */
     def toScala[C1](factory: collection.Factory[Double, C1])(implicit info: AccumulatorFactoryInfo[Double, C1]): C1 = {
       def doubleAcc = stream.collect(DoubleAccumulator.supplier, DoubleAccumulator.adder, DoubleAccumulator.merger)
@@ -361,6 +404,10 @@ object StreamExtensions {
   /** An implicit StreamShape instance connects element types with the corresponding specialized
    *  Stream and Stepper types. This is used in `asJavaStream` extension methods to create
    *  generic or primitive streams according to the element type.
+   *
+   *  @tparam T the element type of the collection
+   *  @tparam S the type of Java Stream (e.g., `Stream[T]`, `IntStream`, `LongStream`, `DoubleStream`)
+   *  @tparam St the type of `Stepper` used to traverse elements
    */
   sealed trait StreamShape[T, S <: BaseStream[?, ?], St <: Stepper[?]] {
     final def fromStepper(st: St, par: Boolean): S = mkStream(st, par)
@@ -413,6 +460,9 @@ object StreamExtensions {
 
   /** Connects a stream element type `A` to the corresponding, potentially specialized, Stream type.
    *  Used in the `stream.asJavaPrimitiveStream` extension method.
+   *
+   *  @tparam A the boxed element type of the stream
+   *  @tparam S the target primitive stream type (e.g., `IntStream`, `LongStream`, `DoubleStream`)
    */
   sealed trait StreamUnboxer[A, S] {
     def apply(s: Stream[A]): S
@@ -442,6 +492,9 @@ object StreamExtensions {
    *
    *  When converting to a collection other than `Accumulator`, the generic
    *  `noAccumulatorFactoryInfo` is passed.
+   *
+   *  @tparam A the element type of the stream
+   *  @tparam C the target collection type, potentially a specialized `Accumulator`
    */
   trait AccumulatorFactoryInfo[A, C] {
     val companion: AnyRef | Null

--- a/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
+++ b/library/src/scala/collection/convert/impl/BinaryTreeStepper.scala
@@ -45,6 +45,11 @@ private[collection] object BinaryTreeStepper {
  *
  *  Subclasses should allow this class to do all the work of maintaining state; `next` should simply
  *  reduce `maxLength` by one, and consume `myCurrent` and set it to `null` if `hasNext` is true.
+ *
+ *  @tparam A the element type produced by this stepper
+ *  @tparam T the type of tree nodes being traversed, must be a reference type
+ *  @tparam Sub the public stepper type returned by `trySplit`
+ *  @tparam Semi the self type of the concrete stepper subclass, which must extend both `Sub` and `BinaryTreeStepperBase`
  */
 private[collection] abstract class BinaryTreeStepperBase[A, T <: AnyRef, Sub, Semi <: Sub & BinaryTreeStepperBase[A, T, ?, ?]](
   protected var maxLength: Int, protected var myCurrent: T | Null, protected var stack: Array[AnyRef | Null], protected var index: Int,
@@ -54,6 +59,8 @@ extends EfficientSplit {
   /** Unrolls a subtree onto the stack starting from a particular node, returning
    *  the last node found.  This final node is _not_ placed on the stack, and
    *  may have things to its right.
+   *
+   *  @param from the tree node from which to begin unrolling leftward
    */
   @tailrec protected final def unroll(from: T): T = {
     val l = left(from)
@@ -71,6 +78,8 @@ extends EfficientSplit {
    *  the subtree from the stack entirely (so it is ready to use).  It returns
    *  the node that is being detached. Note that the node must _not_ already be
    *  on the stack.
+   *
+   *  @param node the tree node to detach, whose left subtree has already been visited
    */
   protected final def detach(node: T): node.type = {
     val r = right(node)
@@ -88,6 +97,9 @@ extends EfficientSplit {
    *  tree is not already empty.
    *
    *  Right now overwrites everything so could allow reuse, but isn't used for it.
+   *
+   *  @param root the root node of the tree to traverse, or `null` for an empty tree
+   *  @param size the total number of elements in the tree
    */
   private[impl] final def initialize(root: T | Null, size: Int): Unit =
     if (root eq null) {
@@ -122,6 +134,8 @@ extends EfficientSplit {
    *  detaching the root, and leaving the right-hand side of the root unrolled.
    *
    *  If the tree is empty or only has one element left, it returns `null` instead of splitting.
+   *
+   *  @return a new stepper covering the left portion of the remaining elements, or `null` if the stepper cannot be split
    */
   def trySplit(): Sub | Null =
     if (!hasStep || index < 0) null

--- a/library/src/scala/collection/convert/impl/ChampStepper.scala
+++ b/library/src/scala/collection/convert/impl/ChampStepper.scala
@@ -21,6 +21,9 @@ import scala.collection.immutable.Node
 /** A stepper that is a slightly elaborated version of the ChampBaseIterator;
  *  the main difference is that it knows when it should stop instead of running
  *  to the end of all trees.
+ *
+ *  @tparam A the element type produced by this stepper
+ *  @tparam T the CHAMP trie node type, with recursive bound `T <: Node[T]`
  */
 private[collection] abstract class ChampStepperBase[
   A, T <: Node[T], Sub, Semi <: Sub & ChampStepperBase[A, T, ?, ?]

--- a/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/InOrderStepperBase.scala
@@ -22,6 +22,11 @@ import scala.collection.Stepper.EfficientSplit
  *  that has an indexable ordering but may have gaps.
  *
  *  For collections that are guaranteed to not have gaps, use `IndexedStepperBase` instead.
+ *
+ *  @tparam Sub the concrete stepper subtype, used as the self-type and return type of `trySplit`
+ *  @tparam Semi the concrete type of the split-off stepper half, constrained to be a subtype of `Sub`
+ *  @param i0 the starting index (inclusive) of the range to step over
+ *  @param iN the ending index (exclusive) of the range to step over
  */
 private[convert] abstract class InOrderStepperBase[Sub, Semi <: Sub](protected var i0: Int, protected var iN: Int)
 extends EfficientSplit {

--- a/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
+++ b/library/src/scala/collection/convert/impl/IndexedStepperBase.scala
@@ -18,7 +18,13 @@ import java.util.Spliterator
 
 import scala.collection.Stepper.EfficientSplit
 
-/** Abstracts all the generic operations of stepping over an indexable collection. */
+/** Abstracts all the generic operations of stepping over an indexable collection.
+ *
+ *  @tparam Sub the concrete stepper subtype
+ *  @tparam Semi the type returned by splitting, a subtype of `Sub`
+ *  @param i0 the starting index (inclusive) into the underlying collection
+ *  @param iN the ending index (exclusive) into the underlying collection
+ */
 private[convert] abstract class IndexedStepperBase[Sub, Semi <: Sub](protected var i0: Int, protected var iN: Int)
   extends EfficientSplit {
   protected def semiclone(half: Int): Semi

--- a/library/src/scala/collection/convert/impl/IteratorStepper.scala
+++ b/library/src/scala/collection/convert/impl/IteratorStepper.scala
@@ -119,7 +119,12 @@ private[collection] class LongIteratorStepper(_underlying: Iterator[Long] | Null
   }
 }
 
-/** Common functionality for Steppers that step through an Iterator, caching the results as needed when a split is requested. */
+/** Common functionality for Steppers that step through an Iterator, caching the results as needed when a split is requested.
+ *
+ *  @tparam A the element type of the iterator being stepped through
+ *  @tparam SP the specific `Stepper` subtype, bounded by `Stepper[A]`, used for proxied delegation and split results
+ *  @tparam Semi the concrete stepper subtype returned by `semiclone()`, must extend `SP`
+ */
 private[convert] abstract class IteratorStepperBase[A, SP <: Stepper[A], Semi <: SP](final protected val underlying: Iterator[A] | Null) {
   final protected var nextChunkSize = 16
   @annotation.stableNull

--- a/library/src/scala/collection/convert/impl/RangeStepper.scala
+++ b/library/src/scala/collection/convert/impl/RangeStepper.scala
@@ -19,6 +19,11 @@ import scala.collection.{IntStepper, Stepper}
 /** Implements Stepper on an integer Range.  You don't actually need the Range to do this,
  *  so only the relevant parts are included.  Because the arguments are protected, they are
  *  not error-checked; `Range` is required to provide valid arguments.
+ *
+ *  @param myNext the next integer value to be produced by this stepper
+ *  @param myStep the increment between consecutive elements of the range
+ *  @param _i0   the starting index (inclusive) into the logical element sequence
+ *  @param _iN   the ending index (exclusive) into the logical element sequence
  */
 private[collection] final class RangeStepper(protected var myNext: Int, myStep: Int, _i0: Int, _iN: Int)
 extends IndexedStepperBase[IntStepper, RangeStepper](_i0, _iN)

--- a/library/src/scala/collection/convert/impl/StringStepper.scala
+++ b/library/src/scala/collection/convert/impl/StringStepper.scala
@@ -20,7 +20,10 @@ import java.util.Spliterator
 import scala.collection.Stepper.EfficientSplit
 import scala.collection.{IntStepper, Stepper}
 
-/** Implements `Stepper` on a `String` where you step through chars packed into `Int`. */
+/** Implements `Stepper` on a `String` where you step through chars packed into `Int`.
+ *
+ *  @param underlying the `String` to step through
+ */
 private[collection] final class CharStringStepper(underlying: String, _i0: Int, _iN: Int)
 extends IndexedStepperBase[IntStepper, CharStringStepper](_i0, _iN)
 with IntStepper {
@@ -31,7 +34,12 @@ with IntStepper {
   def semiclone(half: Int): CharStringStepper = new CharStringStepper(underlying, i0, half)
 }
 
-/** Implements `Stepper` on a `String` where you step through code points. */
+/** Implements `Stepper` on a `String` where you step through code points.
+ *
+ *  @param underlying the `String` to step through by code point
+ *  @param i0 the starting char index (inclusive) into the string
+ *  @param iN the ending char index (exclusive) into the string
+ */
 private[collection] final class CodePointStringStepper(underlying: String, private var i0: Int, private var iN: Int)
 extends IntStepper with EfficientSplit {
   def characteristics: Int = Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED

--- a/library/src/scala/collection/generic/CommonErrors.scala
+++ b/library/src/scala/collection/generic/CommonErrors.scala
@@ -18,12 +18,19 @@ import language.experimental.captureChecking
 
 /** Some precomputed common errors to reduce the generated code size. */
 private[collection] object CommonErrors {
-  /** IndexOutOfBounds exception with a known max index. */
+  /** IndexOutOfBounds exception with a known max index.
+   *
+   *  @param index the index that was out of bounds
+   *  @param max the upper bound of the valid index range
+   */
   @noinline
   def indexOutOfBounds(index: Int, max: Int): IndexOutOfBoundsException = 
     new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${max})")
 
-  /** IndexOutOfBounds exception with an unknown max index. */
+  /** IndexOutOfBounds exception with an unknown max index.
+   *
+   *  @param index the index that was out of bounds
+   */
   @noinline
   def indexOutOfBounds(index: Int): IndexOutOfBoundsException = 
     new IndexOutOfBoundsException(s"$index is out of bounds (min 0, max unknown)")

--- a/library/src/scala/collection/generic/IsIterable.scala
+++ b/library/src/scala/collection/generic/IsIterable.scala
@@ -90,6 +90,11 @@ import caps.unsafe.untrackedCaptures
  *     def apply(coll: Range): IterableOps[Int, IndexedSeq, IndexedSeq[Int]] = coll
  *   }
  *  ```
+ *
+ *  @note In practice the `IsIterable[Range]` instance is already provided by
+ *        the standard library, and it is defined as an `IsSeq[Range]` instance.
+ *
+ *  @tparam Repr the representation type (e.g. `String`, `Array[Int]`) that can be converted to an `Iterable`
  */
 transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
 
@@ -105,7 +110,10 @@ transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
   @untrackedCaptures
   override val conversion: Repr => IterableOps[A, Iterable, C] = apply(_)
 
-  /** A conversion from the type `Repr` to `IterableOps[A, Iterable, C]`. */
+  /** A conversion from the type `Repr` to `IterableOps[A, Iterable, C]`.
+   *
+   *  @param coll the collection or value to convert to `IterableOps[A, Iterable, C]`
+   */
   def apply(coll: Repr): IterableOps[A, Iterable, C]
 
 }

--- a/library/src/scala/collection/generic/IsIterableOnce.scala
+++ b/library/src/scala/collection/generic/IsIterableOnce.scala
@@ -41,6 +41,8 @@ import caps.unsafe.untrackedCaptures
  *    List(1, 2, 3, 4, 5).filterMap(i => if(i % 2 == 0) Some(i) else None)
  *    // == List(2, 4)
  *  ```
+ *
+ *  @tparam Repr the collection representation type that can be converted to `IterableOnce`
  */
 transparent trait IsIterableOnce[Repr] {
 
@@ -51,7 +53,10 @@ transparent trait IsIterableOnce[Repr] {
   @untrackedCaptures
   val conversion: Repr => IterableOnce[A] = apply(_)
 
-  /** A conversion from the representation type `Repr` to a `IterableOnce[A]`. */
+  /** A conversion from the representation type `Repr` to an `IterableOnce[A]`.
+   *
+   *  @param coll the representation type instance to view as an `IterableOnce[A]`
+   */
   def apply(coll: Repr): IterableOnce[A]
 
 }

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -43,6 +43,9 @@ transparent trait IsMap[Repr] extends IsIterable[Repr] {
    *  @note The third type parameter of the returned `MapOps` value is
    *       still `Iterable` (and not `Map`) because `MapView[K, V]` only
    *       extends `MapOps[K, V, View, View[A]]`.
+   *
+   *  @param c the collection to convert to `MapOps`
+   *  @return a `MapOps[K, V, Iterable, C]` view of the collection
    */
   override def apply(c: Repr): MapOps[K, V, Tupled[Iterable]#Ap, C]
 

--- a/library/src/scala/collection/generic/IsSeq.scala
+++ b/library/src/scala/collection/generic/IsSeq.scala
@@ -28,6 +28,8 @@ import scala.reflect.ClassTag
  *  their implementation.
  *
  *  @see [[scala.collection.generic.IsIterable]]
+ *
+ *  @tparam Repr the collection representation type that is witnessed to have sequence-like operations
  */
 transparent trait IsSeq[Repr] extends IsIterable[Repr] {
 
@@ -40,6 +42,9 @@ transparent trait IsSeq[Repr] extends IsIterable[Repr] {
    *  @note The second type parameter of the returned `SeqOps` value is
    *       still `Iterable` (and not `Seq`) because `SeqView[A]` only
    *       extends `SeqOps[A, View, View[A]]`.
+   *
+   *  @param coll the collection to convert
+   *  @return a `SeqOps` instance that provides sequence operations on `coll`
    */
   def apply(coll: Repr): SeqOps[A, Iterable, C]
 }

--- a/library/src/scala/collection/package.scala
+++ b/library/src/scala/collection/package.scala
@@ -64,7 +64,10 @@ package object collection {
   /** An extractor used to head/tail deconstruct sequences. */
   object +: {
     /** Splits a sequence into head +: tail.
-     *  @return Some((head, tail)) if sequence is non-empty. None otherwise.
+     *
+     *  @tparam A the element type of the sequence
+     *  @tparam CC the type constructor of the sequence (e.g., `List`, `Vector`)
+     *  @return `Some((head, tail))` if the sequence is non-empty, `None` otherwise
      */
     def unapply[A, CC[_] <: Seq[?], C <: SeqOps[A, CC, C]](t: (C & SeqOps[A, CC, C])^): Option[(A, C^{t})] =
       if(t.isEmpty) None
@@ -74,7 +77,10 @@ package object collection {
   /** An extractor used to init/last deconstruct sequences. */
   object :+ {
     /** Splits a sequence into init :+ last.
-     *  @return Some((init, last)) if sequence is non-empty. None otherwise.
+     *
+     *  @tparam A the element type of the sequence
+     *  @tparam CC the type constructor of the sequence (e.g., `List`, `Vector`)
+     *  @return `Some((init, last))` if the sequence is non-empty, `None` otherwise
      */
     def unapply[A, CC[_] <: Seq[?], C <: SeqOps[A, CC, C]](t: (C & SeqOps[A, CC, C])^): Option[(C^{t}, A)] =
       if(t.isEmpty) None


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for collection core (root, convert, generic). I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.