### PR TITLE
Numeric types (5): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -57,6 +57,9 @@ final abstract class Boolean private extends AnyVal {
    *  @note This method uses 'short-circuit' evaluation and
    *       behaves as if it was declared as `def ||(x: => Boolean): Boolean`.
    *       If `a` evaluates to `true`, `true` is returned without evaluating `b`.
+   *
+   *  @param x the right-hand operand, only evaluated if `this` is `false`
+   *  @return `true` if at least one operand is `true`, `false` otherwise
    */
   def ||(x: Boolean): Boolean
 
@@ -68,6 +71,9 @@ final abstract class Boolean private extends AnyVal {
    *  @note This method uses 'short-circuit' evaluation and
    *       behaves as if it was declared as `def &&(x: => Boolean): Boolean`.
    *       If `a` evaluates to `false`, `false` is returned without evaluating `b`.
+   *
+   *  @param x the right-hand operand, only evaluated if `this` is `true`
+   *  @return `true` if both operands are `true`, `false` otherwise
    */
   def &&(x: Boolean): Boolean
 
@@ -83,6 +89,9 @@ final abstract class Boolean private extends AnyVal {
    *  - `a` and `b` are `true`.
    *
    *  @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
+   *
+   *  @param x the right-hand operand, always evaluated
+   *  @return `true` if at least one operand is `true`, `false` otherwise
    */
   def |(x: Boolean): Boolean
 
@@ -92,6 +101,9 @@ final abstract class Boolean private extends AnyVal {
    *  - `a` and `b` are `true`.
    *
    *  @note This method evaluates both `a` and `b`, even if the result is already determined after evaluating `a`.
+   *
+   *  @param x the right-hand operand, always evaluated
+   *  @return `true` if both operands are `true`, `false` otherwise
    */
   def &(x: Boolean): Boolean
 
@@ -100,6 +112,9 @@ final abstract class Boolean private extends AnyVal {
    *  `a ^ b` returns `true` if and only if
    *  - `a` is `true` and `b` is `false` or
    *  - `a` is `false` and `b` is `true`.
+   *
+   *  @param x the right-hand operand
+   *  @return `true` if the operands evaluate to different values, `false` otherwise
    */
   def ^(x: Boolean): Boolean
 

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -52,6 +52,8 @@ final abstract class Byte private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left (only the five lowest bits are used)
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -71,6 +73,8 @@ final abstract class Byte private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the five lowest bits are used)
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -92,6 +96,8 @@ final abstract class Byte private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the five lowest bits are used)
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -136,19 +142,40 @@ final abstract class Byte private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -166,19 +193,40 @@ final abstract class Byte private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -204,6 +252,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -214,6 +264,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -224,6 +276,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -234,6 +288,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -244,6 +300,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -255,6 +313,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -265,6 +325,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -275,6 +337,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -285,6 +349,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -295,6 +361,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -306,6 +374,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -316,6 +386,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -326,6 +398,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -336,6 +410,8 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -346,82 +422,189 @@ final abstract class Byte private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -458,7 +641,10 @@ object Byte extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Byte` companion object. */
   override def toString() = "object scala.Byte"
-  /** Language mandated coercions from `Byte` to "wider" types. */
+  /** Language mandated coercions from `Byte` to "wider" types.
+   *
+   *  @param x the `Byte` value to convert
+   */
   import scala.language.implicitConversions
   implicit def byte2short(x: Byte): Short = x.toShort
   implicit def byte2int(x: Byte): Int = x.toInt

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -501,73 +501,73 @@ final abstract class Byte private extends AnyVal {
 
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Byte): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Short): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Char): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Int): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Long): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Float): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Double): Double
 
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Byte): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Short): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Char): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Int): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Long): Long
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Float): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Double): Double
 

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -52,6 +52,8 @@ final abstract class Char private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -71,6 +73,8 @@ final abstract class Char private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -92,6 +96,8 @@ final abstract class Char private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -136,19 +142,40 @@ final abstract class Char private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -166,19 +193,40 @@ final abstract class Char private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -204,6 +252,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -214,6 +264,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -224,6 +276,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -234,6 +288,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -244,6 +300,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -255,6 +313,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -265,6 +325,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -275,6 +337,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -285,6 +349,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -295,6 +361,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -306,6 +374,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -316,6 +386,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -326,6 +398,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -336,6 +410,8 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -346,82 +422,189 @@ final abstract class Char private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -458,7 +641,10 @@ object Char extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Char` companion object. */
   override def toString() = "object scala.Char"
-  /** Language mandated coercions from `Char` to "wider" types. */
+  /** Language mandated coercions from `Char` to "wider" types.
+   *
+   *  @param x the `Char` value to convert
+   */
   import scala.language.implicitConversions
   implicit def char2int(x: Char): Int = x.toInt
   implicit def char2long(x: Char): Long = x.toLong

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -501,37 +501,37 @@ final abstract class Char private extends AnyVal {
 
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Byte): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Short): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Char): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Int): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Long): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Float): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Double): Double
 

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -172,145 +172,145 @@ final abstract class Double private extends AnyVal {
 
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add to this one
+   *  @param x the value to add to this value
    */
   def +(x: Byte): Double
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add to this one
+   *  @param x the value to add to this value
    */
   def +(x: Short): Double
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add to this one
+   *  @param x the value to add to this value
    */
   def +(x: Char): Double
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add to this one
+   *  @param x the value to add to this value
    */
   def +(x: Int): Double
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add to this one
+   *  @param x the value to add to this value
    */
   def +(x: Long): Double
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add to this one
+   *  @param x the value to add to this value
    */
   def +(x: Float): Double
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add to this one
+   *  @param x the value to add to this value
    */
   def +(x: Double): Double
 
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract from this one
+   *  @param x the value to subtract from this value
    */
   def -(x: Byte): Double
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract from this one
+   *  @param x the value to subtract from this value
    */
   def -(x: Short): Double
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract from this one
+   *  @param x the value to subtract from this value
    */
   def -(x: Char): Double
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract from this one
+   *  @param x the value to subtract from this value
    */
   def -(x: Int): Double
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract from this one
+   *  @param x the value to subtract from this value
    */
   def -(x: Long): Double
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract from this one
+   *  @param x the value to subtract from this value
    */
   def -(x: Float): Double
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract from this one
+   *  @param x the value to subtract from this value
    */
   def -(x: Double): Double
 
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this one
+   *  @param x the value to multiply this value by
    */
   def *(x: Byte): Double
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this one
+   *  @param x the value to multiply this value by
    */
   def *(x: Short): Double
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this one
+   *  @param x the value to multiply this value by
    */
   def *(x: Char): Double
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this one
+   *  @param x the value to multiply this value by
    */
   def *(x: Int): Double
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this one
+   *  @param x the value to multiply this value by
    */
   def *(x: Long): Double
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this one
+   *  @param x the value to multiply this value by
    */
   def *(x: Float): Double
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this one
+   *  @param x the value to multiply this value by
    */
   def *(x: Double): Double
 
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the value to divide this one by
+   *  @param x the value to divide this value by
    */
   def /(x: Byte): Double
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the value to divide this one by
+   *  @param x the value to divide this value by
    */
   def /(x: Short): Double
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the value to divide this one by
+   *  @param x the value to divide this value by
    */
   def /(x: Char): Double
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the value to divide this one by
+   *  @param x the value to divide this value by
    */
   def /(x: Int): Double
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the value to divide this one by
+   *  @param x the value to divide this value by
    */
   def /(x: Long): Double
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the value to divide this one by
+   *  @param x the value to divide this value by
    */
   def /(x: Float): Double
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the value to divide this one by
+   *  @param x the value to divide this value by
    */
   def /(x: Double): Double
 

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -68,19 +68,40 @@ final abstract class Double private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -98,19 +119,40 @@ final abstract class Double private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against this one
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -128,79 +170,184 @@ final abstract class Double private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Byte): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Short): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Char): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Int): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Long): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Float): Double
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this one
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Byte): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Short): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Char): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Int): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Long): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Float): Double
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this one
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Byte): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Short): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Char): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Int): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Long): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Float): Double
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this one
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Byte): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Short): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Char): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Int): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Long): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Float): Double
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this one by
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Double
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -68,19 +68,40 @@ final abstract class Float private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -98,19 +119,40 @@ final abstract class Float private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -128,79 +170,184 @@ final abstract class Float private extends AnyVal {
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
   def >=(x: Double): Boolean
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Byte): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Short): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Char): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Int): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Long): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Byte): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Short): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Char): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Int): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Long): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Byte): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Short): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Char): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Int): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Long): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the other factor
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -249,7 +396,10 @@ object Float extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Float` companion object. */
   override def toString() = "object scala.Float"
-  /** Language mandated coercions from `Float` to "wider" types. */
+  /** Language mandated coercions from `Float` to "wider" types.
+   *
+   *  @param x the `Float` value to convert
+   */
   import scala.language.implicitConversions
   implicit def float2double(x: Float): Double = x.toDouble
 }

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -172,145 +172,145 @@ final abstract class Float private extends AnyVal {
 
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add
+   *  @param x the value to add to this value
    */
   def +(x: Byte): Float
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add
+   *  @param x the value to add to this value
    */
   def +(x: Short): Float
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add
+   *  @param x the value to add to this value
    */
   def +(x: Char): Float
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add
+   *  @param x the value to add to this value
    */
   def +(x: Int): Float
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add
+   *  @param x the value to add to this value
    */
   def +(x: Long): Float
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add
+   *  @param x the value to add to this value
    */
   def +(x: Float): Float
   /** Returns the sum of this value and `x`.
    *
-   *  @param x the value to add
+   *  @param x the value to add to this value
    */
   def +(x: Double): Double
 
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract
+   *  @param x the value to subtract from this value
    */
   def -(x: Byte): Float
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract
+   *  @param x the value to subtract from this value
    */
   def -(x: Short): Float
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract
+   *  @param x the value to subtract from this value
    */
   def -(x: Char): Float
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract
+   *  @param x the value to subtract from this value
    */
   def -(x: Int): Float
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract
+   *  @param x the value to subtract from this value
    */
   def -(x: Long): Float
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract
+   *  @param x the value to subtract from this value
    */
   def -(x: Float): Float
   /** Returns the difference of this value and `x`.
    *
-   *  @param x the value to subtract
+   *  @param x the value to subtract from this value
    */
   def -(x: Double): Double
 
   /** Returns the product of this value and `x`.
    *
-   *  @param x the other factor
+   *  @param x the value to multiply this value by
    */
   def *(x: Byte): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the other factor
+   *  @param x the value to multiply this value by
    */
   def *(x: Short): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the other factor
+   *  @param x the value to multiply this value by
    */
   def *(x: Char): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the other factor
+   *  @param x the value to multiply this value by
    */
   def *(x: Int): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the other factor
+   *  @param x the value to multiply this value by
    */
   def *(x: Long): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the other factor
+   *  @param x the value to multiply this value by
    */
   def *(x: Float): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the other factor
+   *  @param x the value to multiply this value by
    */
   def *(x: Double): Double
 
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Byte): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Short): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Char): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Int): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Long): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Float): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Double): Double
 

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -501,73 +501,73 @@ final abstract class Int private extends AnyVal {
 
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Byte): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Short): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Char): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Int): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Long): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Float): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Double): Double
 
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Byte): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Short): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Char): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Int): Int
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Long): Long
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Float): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Double): Double
 

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -52,6 +52,8 @@ final abstract class Int private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left (only the 5 lowest-order bits are used)
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -71,6 +73,8 @@ final abstract class Int private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the 5 lowest-order bits are used)
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -92,6 +96,8 @@ final abstract class Int private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right (only the 5 lowest-order bits are used)
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -136,19 +142,40 @@ final abstract class Int private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -166,19 +193,40 @@ final abstract class Int private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -204,6 +252,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -214,6 +264,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -224,6 +276,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -234,6 +288,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -244,6 +300,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -255,6 +313,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -265,6 +325,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -275,6 +337,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -285,6 +349,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -295,6 +361,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -306,6 +374,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -316,6 +386,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -326,6 +398,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -336,6 +410,8 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -346,82 +422,189 @@ final abstract class Int private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -52,6 +52,8 @@ final abstract class Long private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Int): Long
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -60,6 +62,8 @@ final abstract class Long private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Long): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -70,6 +74,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Int): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -80,6 +86,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Long): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -90,6 +98,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Int): Long
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -100,6 +110,8 @@ final abstract class Long private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Long): Long
 
@@ -133,19 +145,40 @@ final abstract class Long private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -163,19 +196,40 @@ final abstract class Long private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -201,6 +255,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -211,6 +267,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -221,6 +279,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -231,6 +291,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Long
   /** Returns the bitwise OR of this value and `x`.
@@ -241,6 +303,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -252,6 +316,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -262,6 +328,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -272,6 +340,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -282,6 +352,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Long
   /** Returns the bitwise AND of this value and `x`.
@@ -292,6 +364,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -303,6 +377,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -313,6 +389,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -323,6 +401,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -333,6 +413,8 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Long
   /** Returns the bitwise XOR of this value and `x`.
@@ -343,82 +425,189 @@ final abstract class Long private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Byte): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Short): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Char): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Int): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply by
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Byte): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Short): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Char): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Int): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the divisor
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -504,73 +504,73 @@ final abstract class Long private extends AnyVal {
 
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Byte): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Short): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Char): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Int): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Long): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Float): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply by
+   *  @param x the value to multiply this value by
    */
   def *(x: Double): Double
 
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Byte): Long
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Short): Long
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Char): Long
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Int): Long
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Long): Long
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Float): Float
   /** Returns the quotient of this value and `x`.
    *
-   *  @param x the divisor
+   *  @param x the value to divide this value by
    */
   def /(x: Double): Double
 

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -52,6 +52,8 @@ final abstract class Short private extends AnyVal {
    *  ```
    *  6 << 3 == 48 // in binary: 0110 << 3 == 0110000
    *  ```
+   *
+   *  @param x the number of bits to shift left
    */
   def <<(x: Int): Int
   /** Returns this value bit-shifted left by the specified number of bits,
@@ -71,6 +73,8 @@ final abstract class Short private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >>> 3 ==
    *  //            00011111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -92,6 +96,8 @@ final abstract class Short private extends AnyVal {
    *  // in binary: 11111111 11111111 11111111 11101011 >> 3 ==
    *  //            11111111 11111111 11111111 11111101
    *  ```
+   *
+   *  @param x the number of bits to shift right
    */
   def >>(x: Int): Int
   /** Returns this value bit-shifted right by the specified number of bits,
@@ -136,19 +142,40 @@ final abstract class Short private extends AnyVal {
   /** Returns `true` if this value is not equal to x, `false` otherwise. */
   def !=(x: Double): Boolean
 
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Byte): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Short): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Char): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Int): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Long): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Float): Boolean
-  /** Returns `true` if this value is less than x, `false` otherwise. */
+  /** Returns `true` if this value is less than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def <(x: Double): Boolean
 
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
@@ -166,19 +193,40 @@ final abstract class Short private extends AnyVal {
   /** Returns `true` if this value is less than or equal to x, `false` otherwise. */
   def <=(x: Double): Boolean
 
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Byte): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Short): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Char): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Int): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Long): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Float): Boolean
-  /** Returns `true` if this value is greater than x, `false` otherwise. */
+  /** Returns `true` if this value is greater than x, `false` otherwise.
+   *
+   *  @param x the value to compare against
+   */
   def >(x: Double): Boolean
 
   /** Returns `true` if this value is greater than or equal to x, `false` otherwise. */
@@ -204,6 +252,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Byte): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -214,6 +264,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Short): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -224,6 +276,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Char): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -234,6 +288,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Int): Int
   /** Returns the bitwise OR of this value and `x`.
@@ -244,6 +300,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              11111010
    *  ```
+   *
+   *  @param x the value to OR with this value
    */
   def |(x: Long): Long
 
@@ -255,6 +313,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Byte): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -265,6 +325,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Short): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -275,6 +337,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Char): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -285,6 +349,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Int): Int
   /** Returns the bitwise AND of this value and `x`.
@@ -295,6 +361,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              10100000
    *  ```
+   *
+   *  @param x the value to AND with this value
    */
   def &(x: Long): Long
 
@@ -306,6 +374,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Byte): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -316,6 +386,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Short): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -326,6 +398,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Char): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -336,6 +410,8 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Int): Int
   /** Returns the bitwise XOR of this value and `x`.
@@ -346,82 +422,189 @@ final abstract class Short private extends AnyVal {
    *  //              --------
    *  //              01011010
    *  ```
+   *
+   *  @param x the value to XOR with this value
    */
   def ^(x: Long): Long
 
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Byte): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Short): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Char): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Int): Int
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Long): Long
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Float): Float
-  /** Returns the sum of this value and `x`. */
+  /** Returns the sum of this value and `x`.
+   *
+   *  @param x the value to add to this value
+   */
   def +(x: Double): Double
 
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Byte): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Short): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Char): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Int): Int
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Long): Long
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Float): Float
-  /** Returns the difference of this value and `x`. */
+  /** Returns the difference of this value and `x`.
+   *
+   *  @param x the value to subtract from this value
+   */
   def -(x: Double): Double
 
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Byte): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Short): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Char): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Int): Int
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Long): Long
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Float): Float
-  /** Returns the product of this value and `x`. */
+  /** Returns the product of this value and `x`.
+   *
+   *  @param x the value to multiply with this value
+   */
   def *(x: Double): Double
 
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Byte): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Short): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Char): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Int): Int
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Long): Long
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Float): Float
-  /** Returns the quotient of this value and `x`. */
+  /** Returns the quotient of this value and `x`.
+   *
+   *  @param x the value to divide this value by
+   */
   def /(x: Double): Double
 
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Byte): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Short): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Char): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Int): Int
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Long): Long
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Float): Float
-  /** Returns the remainder of the division of this value by `x`. */
+  /** Returns the remainder of the division of this value by `x`.
+   *
+   *  @param x the divisor
+   */
   def %(x: Double): Double
 
   // Provide a more specific return type for Scaladoc
@@ -458,7 +641,10 @@ object Short extends AnyValCompanion {
 
   /** The `String` representation of the `scala.Short` companion object. */
   override def toString() = "object scala.Short"
-  /** Language mandated coercions from `Short` to "wider" types. */
+  /** Language mandated coercions from `Short` to "wider" types.
+   *
+   *  @param x the `Short` value to be implicitly converted
+   */
   import scala.language.implicitConversions
   implicit def short2int(x: Short): Int = x.toInt
   implicit def short2long(x: Short): Long = x.toLong

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -501,37 +501,37 @@ final abstract class Short private extends AnyVal {
 
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Byte): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Short): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Char): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Int): Int
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Long): Long
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Float): Float
   /** Returns the product of this value and `x`.
    *
-   *  @param x the value to multiply with this value
+   *  @param x the value to multiply this value by
    */
   def *(x: Double): Double
 


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for numeric types (Byte, Short, Int, Long, Float, Double, Char, Boolean). I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.