### PR TITLE
Array, IArray, Predef, Option (6): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library-js/src/scala/Array.scala
+++ b/library-js/src/scala/Array.scala
@@ -61,7 +61,11 @@ object Array {
     val emptyObjectArray  = new Array[Object](0)
   }
 
-  /** Provides an implicit conversion from the Array object to a collection Factory. */
+  /** Provides an implicit conversion from the Array object to a collection Factory.
+   *
+   *  @tparam A the element type of the array, must have a `ClassTag`
+   *  @param dummy the `Array` companion object, used to trigger the implicit conversion
+   */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
@@ -69,7 +73,11 @@ object Array {
     def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
 
-  /** Returns a new [[scala.collection.mutable.ArrayBuilder]]. */
+  /** Returns a new [[scala.collection.mutable.ArrayBuilder]].
+   *
+   *  @tparam T the element type of the array to build
+   *  @param t the `ClassTag` for the element type, used to create the correct array type at runtime
+   */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   def from[A: ClassTag](it: IterableOnce[A]^): Array[A] = {
@@ -138,6 +146,11 @@ object Array {
    *  except that this works for primitive and object arrays in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @return a copy of the original array, truncated or padded with default values to obtain the specified length
    */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = (original match {
     case x: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
@@ -164,6 +177,12 @@ object Array {
    *  in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the destination array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @param ct the `ClassTag` for the target element type, used to create the correct array type at runtime
+   *  @return a copy of the original array, converted to type `Array[A]`, truncated or padded with default values to obtain the specified length
    */
   def copyAs[A](original: Array[_], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
     val runtimeClass = ct.runtimeClass
@@ -190,7 +209,10 @@ object Array {
     result
   }
 
-  /** Returns an array of length 0. */
+  /** Returns an array of length 0.
+   *
+   *  @tparam T the element type of the empty array
+   */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
   /** Creates an array with given elements.
@@ -210,7 +232,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Boolean` objects. */
+  /** Creates an array of `Boolean` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
@@ -223,7 +249,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Byte` objects. */
+  /** Creates an array of `Byte` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
@@ -236,7 +266,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Short` objects. */
+  /** Creates an array of `Short` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
@@ -249,7 +283,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Char` objects. */
+  /** Creates an array of `Char` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
@@ -262,7 +300,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Int` objects. */
+  /** Creates an array of `Int` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
@@ -275,7 +317,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Long` objects. */
+  /** Creates an array of `Long` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
@@ -288,7 +334,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Float` objects. */
+  /** Creates an array of `Float` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
@@ -301,7 +351,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Double` objects. */
+  /** Creates an array of `Double` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
@@ -314,7 +368,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Unit` objects. */
+  /** Creates an array of `Unit` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
@@ -326,28 +384,59 @@ object Array {
     array
   }
 
-  /** Creates array with given dimensions. */
+  /** Creates array with given dimensions.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
-  /** Creates a 2-dimensional array. */
+  /** Creates a 2-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
     for (i <- 0 until n1) arr(i) = new Array[T](n2)
     arr
     // tabulate(n1)(_ => ofDim[T](n2))
   }
-  /** Creates a 3-dimensional array. */
+  /** Creates a 3-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
-  /** Creates a 4-dimensional array. */
+  /** Creates a 4-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
-  /** Creates a 5-dimensional array. */
+  /** Creates a 5-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   *  @param n5 the number of elements in the 5th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
   /** Concatenates all arrays into a single array.
    *
+   *  @tparam T the element type of the arrays
    *  @param xss the given arrays
    *  @return   the array created from concatenating `xss`
    */
@@ -367,6 +456,7 @@ object Array {
    *  res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
    *  ```
    *
+   *  @tparam T the element type of the array
    *  @param   n  the number of elements desired
    *  @param   elem the element computation
    *  @return an Array of size n, where each element contains the result of computing
@@ -389,6 +479,7 @@ object Array {
   /** Returns a two-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -399,6 +490,7 @@ object Array {
   /** Returns a three-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -410,6 +502,7 @@ object Array {
   /** Returns a four-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -422,6 +515,7 @@ object Array {
   /** Returns a five-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -435,9 +529,10 @@ object Array {
   /** Returns an array containing values of a given function over a range of integer
    *  values starting from 0.
    *
+   *  @tparam T the element type of the array
    *  @param  n   The number of elements in the array
    *  @param  f   The function computing element values
-   *  @return A traversable consisting of elements `f(0),f(1), ..., f(n - 1)`
+   *  @return an array consisting of elements `f(0), f(1), ..., f(n - 1)`
    */
   def tabulate[T: ClassTag](n: Int)(f: Int => T): Array[T] = {
     if (n <= 0) {
@@ -456,6 +551,7 @@ object Array {
   /** Returns a two-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -466,6 +562,7 @@ object Array {
   /** Returns a three-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -477,6 +574,7 @@ object Array {
   /** Returns a four-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -489,6 +587,7 @@ object Array {
   /** Returns a five-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -531,6 +630,7 @@ object Array {
 
   /** Returns an array containing repeated applications of a function to a start value.
    *
+   *  @tparam T the element type of the array
    *  @param start the start value of the array
    *  @param len   the number of elements returned by the array
    *  @param f     the function that is repeatedly applied
@@ -572,8 +672,9 @@ object Array {
 
   /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
    *
+   *  @tparam T the element type of the array
    *  @param x the selector value
-   *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
+   *  @return  a [[UnapplySeqWrapper]] wrapping the array for pattern matching extraction
    */
   def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
 
@@ -657,6 +758,8 @@ object Array {
  *  @define willNotTerminateInf
  *  @define collectExample
  *  @define undefinedorder
+ *
+ *  @tparam T the type of the elements in the array
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self =>
 
@@ -687,7 +790,7 @@ final class Array[T](_length: Int) extends java.io.Serializable with java.lang.C
 
   /** Clones the Array.
    *
-   *  @return A clone of the Array.
+   *  @return a clone of the array
    */
   override def clone(): Array[T] = throw new Error()
 }

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -46,7 +46,11 @@ object Array {
   val emptyShortArray   = new Array[Short](0)
   val emptyObjectArray  = new Array[Object](0)
 
-  /** Provides an implicit conversion from the Array object to a collection Factory. */
+  /** Provides an implicit conversion from the Array object to a collection Factory.
+   *
+   *  @tparam A the element type of the array to be created
+   *  @param dummy the `Array` companion object used to trigger the implicit conversion
+   */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
   private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
@@ -54,7 +58,11 @@ object Array {
     def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
 
-  /** Returns a new [[scala.collection.mutable.ArrayBuilder]]. */
+  /** Returns a new [[scala.collection.mutable.ArrayBuilder]].
+   *
+   *  @tparam T the element type of the array to be built
+   *  @param t the `ClassTag` providing runtime type information for `T`
+   */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
   /** Builds an array from the iterable collection.
@@ -67,6 +75,7 @@ object Array {
    *  val b: Array[Int] = Array(1, 2, 3, 4)
    *  ```
    *
+   *  @tparam A the element type of the array
    *  @param  it the iterable collection
    *  @return    an array consisting of elements of the iterable collection
    */
@@ -123,6 +132,11 @@ object Array {
    *  except that this works for primitive and object arrays in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @return a copy of the original array, truncated or padded with default values to obtain the specified length
    */
   def copyOf[A](original: Array[A], newLength: Int): Array[A] = ((original: @unchecked) match {
     case original: Array[BoxedUnit]  => newUnitArray(newLength).asInstanceOf[Array[A]]
@@ -149,6 +163,12 @@ object Array {
    *  in a single method.
    *
    *  @see `java.util.Arrays#copyOf`
+   *
+   *  @tparam A the element type of the target array
+   *  @param original the array to be copied
+   *  @param newLength the length of the copy to be returned
+   *  @param ct the `ClassTag` providing runtime type information for the target element type `A`
+   *  @return a copy of the original array, with elements converted to type `A`, truncated or padded to the specified length
    */
   def copyAs[A](original: Array[?], newLength: Int)(implicit ct: ClassTag[A]): Array[A] = {
     val runtimeClass = ct.runtimeClass
@@ -175,7 +195,10 @@ object Array {
     result
   }
 
-  /** Returns an array of length 0. */
+  /** Returns an array of length 0.
+   *
+   *  @tparam T the element type of the array
+   */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
   /** Creates an array with given elements.
@@ -205,7 +228,11 @@ object Array {
     }
   }
 
-  /** Creates an array of `Boolean` objects. */
+  /** Creates an array of `Boolean` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
@@ -218,7 +245,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Byte` objects. */
+  /** Creates an array of `Byte` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
@@ -231,7 +262,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Short` objects. */
+  /** Creates an array of `Short` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
@@ -244,7 +279,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Char` objects. */
+  /** Creates an array of `Char` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
@@ -257,7 +296,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Int` objects. */
+  /** Creates an array of `Int` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
@@ -270,7 +313,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Long` objects. */
+  /** Creates an array of `Long` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
@@ -283,7 +330,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Float` objects. */
+  /** Creates an array of `Float` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
@@ -296,7 +347,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Double` objects. */
+  /** Creates an array of `Double` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
@@ -309,7 +364,11 @@ object Array {
     array
   }
 
-  /** Creates an array of `Unit` objects. */
+  /** Creates an array of `Unit` objects.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
@@ -321,28 +380,59 @@ object Array {
     array
   }
 
-  /** Creates array with given dimensions. */
+  /** Creates array with given dimensions.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
-  /** Creates a 2-dimensional array. */
+  /** Creates a 2-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
     for (i <- 0 until n1) arr(i) = new Array[T](n2)
     arr
     // tabulate(n1)(_ => ofDim[T](n2))
   }
-  /** Creates a 3-dimensional array. */
+  /** Creates a 3-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
-  /** Creates a 4-dimensional array. */
+  /** Creates a 4-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
-  /** Creates a 5-dimensional array. */
+  /** Creates a 5-dimensional array.
+   *
+   *  @tparam T the element type of the array
+   *  @param n1 the number of elements in the 1st dimension
+   *  @param n2 the number of elements in the 2nd dimension
+   *  @param n3 the number of elements in the 3rd dimension
+   *  @param n4 the number of elements in the 4th dimension
+   *  @param n5 the number of elements in the 5th dimension
+   */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
 
   /** Concatenates all arrays into a single array.
    *
+   *  @tparam T the element type of the arrays
    *  @param xss the given arrays
    *  @return   the array created from concatenating `xss`
    */
@@ -362,6 +452,7 @@ object Array {
    *  res3: Array[Double] = Array(0.365461167592537, 1.550395944913685E-4, 0.7907242137333306)
    *  ```
    *
+   *  @tparam T the element type of the array
    *  @param   n  the number of elements desired
    *  @param   elem the element computation
    *  @return an Array of size n, where each element contains the result of computing
@@ -384,6 +475,7 @@ object Array {
   /** Returns a two-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -394,6 +486,7 @@ object Array {
   /** Returns a three-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -405,6 +498,7 @@ object Array {
   /** Returns a four-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -417,6 +511,7 @@ object Array {
   /** Returns a five-dimensional array that contains the results of some element
    *  computation a number of times.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -430,6 +525,7 @@ object Array {
   /** Returns an array containing values of a given function over a range of integer
    *  values starting from 0.
    *
+   *  @tparam T the element type of the array
    *  @param  n   The number of elements in the array
    *  @param  f   The function computing element values
    *  @return An `Array` consisting of elements `f(0),f(1), ..., f(n - 1)`
@@ -451,6 +547,7 @@ object Array {
   /** Returns a two-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -461,6 +558,7 @@ object Array {
   /** Returns a three-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -472,6 +570,7 @@ object Array {
   /** Returns a four-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -484,6 +583,7 @@ object Array {
   /** Returns a five-dimensional array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -525,6 +625,7 @@ object Array {
 
   /** Returns an array containing repeated applications of a function to a start value.
    *
+   *  @tparam T the element type of the array
    *  @param start the start value of the array
    *  @param len   the number of elements returned by the array
    *  @param f     the function that is repeatedly applied
@@ -573,8 +674,9 @@ object Array {
 
   /** Called in a pattern match like `{ case Array(x,y,z) => println('3 elements')}`.
    *
+   *  @tparam T the element type of the array
    *  @param x the selector value
-   *  @return  sequence wrapped in a [[scala.Some]], if `x` is an Array, otherwise `None`
+   *  @return  a [[UnapplySeqWrapper]] that provides sequence-like access to the array elements
    */
   def unapplySeq[T](x: Array[T]): UnapplySeqWrapper[T] = new UnapplySeqWrapper(x)
 
@@ -656,6 +758,8 @@ object Array {
  *  @define willNotTerminateInf
  *  @define collectExample
  *  @define undefinedorder
+ *
+ *  @tparam T the element type of the array
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
 

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -44,87 +44,155 @@ object IArray:
   extension [T](arr: IArray[T]) def length: Int = arr.asInstanceOf[Array[T]].length
 
 
-  /** Tests whether this array contains a given value as an element. */
+  /** Tests whether this array contains a given value as an element.
+   *
+   *  @param elem the value to test for membership
+   */
   extension [T](arr: IArray[T]) def contains(elem: T): Boolean =
     genericArrayOps(arr).contains(elem.asInstanceOf)
 
-  /** Copies elements of this array to another array. */
+  /** Copies elements of this array to another array.
+   *
+   *  @tparam U the element type of the destination array, a supertype of `T`
+   *  @param xs the destination array to copy to
+   */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U]): Int =
     genericArrayOps(arr).copyToArray(xs)
 
-  /** Copies elements of this array to another array. */
+  /** Copies elements of this array to another array.
+   *
+   *  @tparam U the element type of the destination array, a supertype of `T`
+   *  @param xs the destination array to copy to
+   *  @param start the index in `xs` at which to start copying
+   */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start)
 
-  /** Copies elements of this array to another array. */
+  /** Copies elements of this array to another array.
+   *
+   *  @tparam U the element type of the destination array, a supertype of `T`
+   *  @param xs the destination array to copy to
+   *  @param start the index in `xs` at which to start copying
+   *  @param len the maximum number of elements to copy
+   */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start, len)
 
-  /** Counts the number of elements in this array which satisfy a predicate. */
+  /** Counts the number of elements in this array which satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def count(p: T => Boolean): Int =
     genericArrayOps(arr).count(p)
 
-  /** The rest of the array without its `n` first elements. */
+  /** The rest of the array without its `n` first elements.
+   *
+   *  @param n the number of elements to drop from the front
+   */
   extension [T](arr: IArray[T]) def drop(n: Int): IArray[T] =
     genericArrayOps(arr).drop(n)
 
-  /** The rest of the array without its `n` last elements. */
+  /** The rest of the array without its `n` last elements.
+   *
+   *  @param n the number of elements to drop from the end
+   */
   extension [T](arr: IArray[T]) def dropRight(n: Int): IArray[T] =
     genericArrayOps(arr).dropRight(n)
 
-  /** Drops longest prefix of elements that satisfy a predicate. */
+  /** Drops longest prefix of elements that satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def dropWhile(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).dropWhile(p)
 
-  /** Tests whether a predicate holds for at least one element of this array. */
+  /** Tests whether a predicate holds for at least one element of this array.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def exists(p: T => Boolean): Boolean =
     genericArrayOps(arr).exists(p)
 
-  /** Selects all elements of this array which satisfy a predicate. */
+  /** Selects all elements of this array which satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def filter(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).filter(p)
 
-  /** Selects all elements of this array which do not satisfy a predicate. */
+  /** Selects all elements of this array which do not satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def filterNot(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).filterNot(p)
 
-  /** Finds the first element of the array satisfying a predicate, if any. */
+  /** Finds the first element of the array satisfying a predicate, if any.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def find(p: T => Boolean): Option[T] =
     genericArrayOps(arr).find(p)
 
   /** Builds a new array by applying a function to all elements of this array
    *  and using the elements of the resulting collections. 
+   *
+   *  @tparam U the element type of the returned array
+   *  @param f the function to apply to each element, returning a collection of results
    */
   extension [T](arr: IArray[T]) def flatMap[U: ClassTag](f: T => IterableOnce[U]^): IArray[U] =
     genericArrayOps(arr).flatMap(f)
 
   /** Flattens a two-dimensional array by concatenating all its rows
    *  into a single array. 
+   *
+   *  @tparam U the element type of the resulting array after flattening
+   *  @param asIterable the implicit evidence that `T` can be viewed as `Iterable[U]`
    */
   extension [T](arr: IArray[T]) def flatten[U](using asIterable: T => Iterable[U]^, ct: ClassTag[U]): IArray[U] =
     genericArrayOps(arr).flatten
 
-  /** Folds the elements of this array using the specified associative binary operator. */
+  /** Folds the elements of this array using the specified associative binary operator.
+   *
+   *  @tparam U the result type of the binary operator, a supertype of `T`
+   *  @param z the start value
+   *  @param op the associative binary operator
+   */
   extension [T](arr: IArray[T]) def fold[U >: T](z: U)(op: (U, U) => U): U =
     genericArrayOps(arr).fold(z)(op)
 
   /** Applies a binary operator to a start value and all elements of this array,
    *  going left to right. 
+   *
+   *  @tparam U the result type of the binary operator
+   *  @param z the start value
+   *  @param op the binary operator applied from left to right
    */
   extension [T](arr: IArray[T]) def foldLeft[U](z: U)(op: (U, T) => U): U =
     genericArrayOps(arr).foldLeft(z)(op)
 
   /** Applies a binary operator to all elements of this array and a start value,
    *  going right to left. 
+   *
+   *  @tparam U the result type of the binary operator
+   *  @param z the start value
+   *  @param op the binary operator applied from right to left
    */
   extension [T](arr: IArray[T]) def foldRight[U](z: U)(op: (T, U) => U): U =
     genericArrayOps(arr).foldRight(z)(op)
 
-  /** Tests whether a predicate holds for all elements of this array. */
+  /** Tests whether a predicate holds for all elements of this array.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def forall(p: T => Boolean): Boolean =
     genericArrayOps(arr).forall(p)
 
-  /** Applies `f` to each element for its side effects. */
+  /** Applies `f` to each element for its side effects.
+   *
+   *  @tparam U the return type of `f`, discarded
+   *  @param f the function to apply to each element
+   */
   extension [T](arr: IArray[T]) def foreach[U](f: T => U): Unit =
     genericArrayOps(arr).foreach(f)
 
@@ -136,14 +204,22 @@ object IArray:
   extension [T](arr: IArray[T]) def headOption: Option[T] =
     genericArrayOps(arr).headOption
 
-  /** Finds index of first occurrence of some value in this array after or at some start index. */
+  /** Finds index of first occurrence of some value in this array after or at some start index.
+   *
+   *  @param elem the value to search for
+   *  @param from the start index where the search begins
+   */
   extension [T](arr: IArray[T]) def indexOf(elem: T, from: Int = 0): Int =
     // `asInstanceOf` needed because `elem` does not have type `arr.T`
     // We could use `arr.iterator.indexOf(elem, from)` or `arr.indexWhere(_ == elem, from)`
     // but these would incur some overhead.
     genericArrayOps(arr).indexOf(elem.asInstanceOf, from)
 
-  /** Finds index of the first element satisfying some predicate after or at some start index. */
+  /** Finds index of the first element satisfying some predicate after or at some start index.
+   *
+   *  @param p the predicate used to test elements
+   *  @param from the start index where the search begins
+   */
   extension [T](arr: IArray[T]) def indexWhere(p: T => Boolean, from: Int = 0): Int =
     genericArrayOps(arr).indexWhere(p, from)
 
@@ -171,16 +247,28 @@ object IArray:
   extension [T](arr: IArray[T]) def lastOption: Option[T] =
     genericArrayOps(arr).lastOption
 
-  /** Finds index of last occurrence of some value in this array before or at a given end index. */
+  /** Finds index of last occurrence of some value in this array before or at a given end index.
+   *
+   *  @param elem the value to search for
+   *  @param end the end index (inclusive) where the search ends
+   */
   extension [T](arr: IArray[T]) def lastIndexOf(elem: T, end: Int = arr.length - 1): Int =
     // see: same issue in `indexOf`
     genericArrayOps(arr).lastIndexOf(elem.asInstanceOf, end)
 
-  /** Finds index of last element satisfying some predicate before or at given end index. */
+  /** Finds index of last element satisfying some predicate before or at given end index.
+   *
+   *  @param p the predicate used to test elements
+   *  @param end the end index (inclusive) where the search ends
+   */
   extension [T](arr: IArray[T]) def lastIndexWhere(p: T => Boolean, end: Int = arr.length - 1): Int =
     genericArrayOps(arr).lastIndexWhere(p, end)
 
-  /** Builds a new array by applying a function to all elements of this array. */
+  /** Builds a new array by applying a function to all elements of this array.
+   *
+   *  @tparam U the element type of the returned array
+   *  @param f the function to apply to each element
+   */
   extension [T](arr: IArray[T]) def map[U: ClassTag](f: T => U): IArray[U] =
     genericArrayOps(arr).map(f)
 
@@ -188,7 +276,10 @@ object IArray:
   extension [T](arr: IArray[T]) def nonEmpty: Boolean =
     genericArrayOps(arr).nonEmpty
 
-  /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not. */
+  /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not.
+   *
+   *  @param p the predicate used to partition elements
+   */
   extension [T](arr: IArray[T]) def partition(p: T => Boolean): (IArray[T], IArray[T]) =
     genericArrayOps(arr).partition(p)
 
@@ -196,18 +287,31 @@ object IArray:
   extension [T](arr: IArray[T]) def reverse: IArray[T] =
     genericArrayOps(arr).reverse
 
-  /** Computes a prefix scan of the elements of the array. */
+  /** Computes a prefix scan of the elements of the array.
+   *
+   *  @tparam U the element type of the returned array, a supertype of `T`
+   *  @param z the initial value for the scan
+   *  @param op the associative binary operator
+   */
   extension [T](arr: IArray[T]) def scan[U >: T: ClassTag](z: U)(op: (U, U) => U): IArray[U] =
     genericArrayOps(arr).scan(z)(op)
 
   /** Produces an array containing cumulative results of applying the binary
    *  operator going left to right. 
+   *
+   *  @tparam U the element type of the returned array
+   *  @param z the initial value for the scan
+   *  @param op the binary operator applied from left to right
    */
   extension [T](arr: IArray[T]) def scanLeft[U: ClassTag](z: U)(op: (U, T) => U): IArray[U] =
     genericArrayOps(arr).scanLeft(z)(op)
 
   /** Produces an array containing cumulative results of applying the binary
    *  operator going right to left. 
+   *
+   *  @tparam U the element type of the returned array
+   *  @param z the initial value for the scan
+   *  @param op the binary operator applied from right to left
    */
   extension [T](arr: IArray[T]) def scanRight[U: ClassTag](z: U)(op: (T, U) => U): IArray[U] =
     genericArrayOps(arr).scanRight(z)(op)
@@ -216,29 +320,47 @@ object IArray:
   extension [T](arr: IArray[T]) def size: Int =
     arr.length
 
-  /** Selects the interval of elements between the given indices. */
+  /** Selects the interval of elements between the given indices.
+   *
+   *  @param from the index of the first included element
+   *  @param until the index of the first excluded element
+   */
   extension [T](arr: IArray[T]) def slice(from: Int, until: Int): IArray[T] =
     genericArrayOps(arr).slice(from, until)
 
   /** Sorts this array according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function. 
-   */
+   *
+   *  @tparam U the target type of the transformation function, which has an `Ordering`
+   *  @param f the transformation function mapping elements to their sort keys
+     */
   extension [T](arr: IArray[T]) def sortBy[U](f: T => U)(using math.Ordering[U]): IArray[T] =
     genericArrayOps(arr).sortBy(f)
 
-  /** Sorts this array according to a comparison function. */
+  /** Sorts this array according to a comparison function.
+   *
+   *  @param f the comparison function returning true if its first argument should come first
+   */
   extension [T](arr: IArray[T]) def sortWith(f: (T, T) => Boolean): IArray[T] =
     genericArrayOps(arr).sortWith(f)
 
-  /** Sorts this array according to an Ordering. */
+  /** Sorts this array according to an Ordering.
+   *
+     */
   extension [T](arr: IArray[T]) def sorted(using math.Ordering[T]^): IArray[T] =
     genericArrayOps(arr).sorted
 
-  /** Splits this array into a prefix/suffix pair according to a predicate. */
+  /** Splits this array into a prefix/suffix pair according to a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def span(p: T => Boolean): (IArray[T], IArray[T]) =
     genericArrayOps(arr).span(p)
 
-  /** Splits this array into two at a given position. */
+  /** Splits this array into two at a given position.
+   *
+   *  @param n the position at which to split
+   */
   extension [T](arr: IArray[T]) def splitAt(n: Int): (IArray[T], IArray[T]) =
     genericArrayOps(arr).splitAt(n)
 
@@ -246,15 +368,24 @@ object IArray:
   extension [T](arr: IArray[T]) def tail: IArray[T] =
     genericArrayOps(arr).tail
 
-  /** An array containing the first `n` elements of this array. */
+  /** An array containing the first `n` elements of this array.
+   *
+   *  @param n the number of elements to take from the front
+   */
   extension [T](arr: IArray[T]) def take(n: Int): IArray[T] =
     genericArrayOps(arr).take(n)
 
-  /** An array containing the last `n` elements of this array. */
+  /** An array containing the last `n` elements of this array.
+   *
+   *  @param n the number of elements to take from the end
+   */
   extension [T](arr: IArray[T]) def takeRight(n: Int): IArray[T] =
     genericArrayOps(arr).takeRight(n)
 
-  /** Takes longest prefix of elements that satisfy a predicate. */
+  /** Takes longest prefix of elements that satisfy a predicate.
+   *
+   *  @param p the predicate used to test elements
+   */
   extension [T](arr: IArray[T]) def takeWhile(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).takeWhile(p)
 
@@ -348,11 +479,19 @@ object IArray:
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @tparam T the element type of the array
+   *  @param arr the immutable array to wrap
+   */
   implicit def genericWrapArray[T](arr: IArray[T]): ArraySeq[T] =
     mapNull(arr, ArraySeq.unsafeWrapArray(arr))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @tparam T the element type of the array, a reference type
+   *  @param arr the immutable array to wrap
+   */
   implicit def wrapRefArray[T <: AnyRef | Null](arr: IArray[T]): ArraySeq.ofRef[T] =
     // Since the JVM thinks arrays are covariant, one 0-length Array[AnyRef | Null]
     // is as good as another for all T <: AnyRef | Null.  Instead of creating 100,000,000
@@ -362,49 +501,82 @@ object IArray:
       else ArraySeq.ofRef(arr.asInstanceOf[Array[T]])
     )
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Int` array to wrap
+   */
   implicit def wrapIntArray(arr: IArray[Int]): ArraySeq.ofInt =
     mapNull(arr, new ArraySeq.ofInt(arr.asInstanceOf[Array[Int]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Double` array to wrap
+   */
   implicit def wrapDoubleIArray(arr: IArray[Double]): ArraySeq.ofDouble =
     mapNull(arr, new ArraySeq.ofDouble(arr.asInstanceOf[Array[Double]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Long` array to wrap
+   */
   implicit def wrapLongIArray(arr: IArray[Long]): ArraySeq.ofLong =
     mapNull(arr, new ArraySeq.ofLong(arr.asInstanceOf[Array[Long]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Float` array to wrap
+   */
   implicit def wrapFloatIArray(arr: IArray[Float]): ArraySeq.ofFloat =
     mapNull(arr, new ArraySeq.ofFloat(arr.asInstanceOf[Array[Float]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Char` array to wrap
+   */
   implicit def wrapCharIArray(arr: IArray[Char]): ArraySeq.ofChar =
     mapNull(arr, new ArraySeq.ofChar(arr.asInstanceOf[Array[Char]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Byte` array to wrap
+   */
   implicit def wrapByteIArray(arr: IArray[Byte]): ArraySeq.ofByte =
     mapNull(arr, new ArraySeq.ofByte(arr.asInstanceOf[Array[Byte]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Short` array to wrap
+   */
   implicit def wrapShortIArray(arr: IArray[Short]): ArraySeq.ofShort =
     mapNull(arr, new ArraySeq.ofShort(arr.asInstanceOf[Array[Short]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Boolean` array to wrap
+   */
   implicit def wrapBooleanIArray(arr: IArray[Boolean]): ArraySeq.ofBoolean =
     mapNull(arr, new ArraySeq.ofBoolean(arr.asInstanceOf[Array[Boolean]]))
 
-  /** Conversion from IArray to immutable.ArraySeq. */
+  /** Conversion from IArray to immutable.ArraySeq.
+   *
+   *  @param arr the immutable `Unit` array to wrap
+   */
   implicit def wrapUnitIArray(arr: IArray[Unit]): ArraySeq.ofUnit =
     mapNull(arr, new ArraySeq.ofUnit(arr.asInstanceOf[Array[Unit]]))
 
   /** Converts an array into an immutable array without copying, the original array
    *   must _not_ be mutated after this or the guaranteed immutablity of IArray will
    *   be violated.
+   *
+   *  @tparam T the element type of the array
+   *  @param s the mutable array to treat as immutable (must not be mutated afterward)
    */
   def unsafeFromArray[T](s: Array[T]): IArray[T] = s
 
-  /** An immutable array of length 0. */
+  /** An immutable array of length 0.
+   *
+   *  @tparam T the element type of the empty array
+   */
   def empty[T: ClassTag]: IArray[T] = new Array[T](0)
 
   /** An immutable boolean array of length 0. */
@@ -426,25 +598,65 @@ object IArray:
   /** An immutable object array of length 0. */
   def emptyObjectIArray: IArray[Object]  = Array.emptyObjectArray
 
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @tparam T the element type of the array
+   *  @param xs the elements to include in the array
+   */
   def apply[T](xs: T*)(using ct: ClassTag[T]): IArray[T] = Array(xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Boolean, xs: Boolean*): IArray[Boolean] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Byte, xs: Byte*): IArray[Byte] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Short, xs: Short*): IArray[Short] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Char, xs: Char*): IArray[Char] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Int, xs: Int*): IArray[Int] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Long, xs: Long*): IArray[Long] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Float, xs: Float*): IArray[Float] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Double, xs: Double*): IArray[Double] = Array(x, xs*)
-  /** An immutable array with given elements. */
+  /** An immutable array with given elements.
+   *
+   *  @param x the first element
+   *  @param xs the remaining elements
+   */
   def apply(x: Unit, xs: Unit*): IArray[Unit] = Array(x, xs*)
 
   /** Builds an array from the iterable collection.
@@ -457,6 +669,7 @@ object IArray:
    *  val b: IArray[Int] = IArray(1, 2, 3, 4)
    *  ```
    *
+   *  @tparam A the element type of the array
    *  @param  it the iterable collection
    *  @return    an array consisting of elements of the iterable collection
    */
@@ -468,6 +681,7 @@ object IArray:
 
   /** Concatenates all arrays into a single immutable array.
    *
+   *  @tparam T the element type of the arrays
    *  @param xss the given immutable arrays
    *  @return   the array created from concatenating `xss`
    */
@@ -480,6 +694,7 @@ object IArray:
   /** Returns an immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n  the number of elements in the array
    *  @param   elem the element computation
    */
@@ -489,6 +704,7 @@ object IArray:
   /** Returns a two-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
@@ -499,9 +715,10 @@ object IArray:
   /** Returns a three-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
-   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
    *  @param   elem the element computation
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): IArray[IArray[IArray[T]]] =
@@ -510,9 +727,10 @@ object IArray:
   /** Returns a four-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
-   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   elem the element computation
    */
@@ -522,9 +740,10 @@ object IArray:
   /** Returns a five-dimensional immutable array that contains the results of some element computation a number
    *  of times. Each element is determined by a separate computation.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
-   *  @param   n3  the number of elements in the 3nd dimension
+   *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   elem the element computation
@@ -535,6 +754,7 @@ object IArray:
   /** Returns an immutable array containing values of a given function over a range of integer
    *  values starting from 0.
    *
+   *  @tparam T the element type of the array
    *  @param  n   The number of elements in the array
    *  @param  f   The function computing element values
    */
@@ -544,6 +764,7 @@ object IArray:
   /** Returns a two-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
@@ -554,6 +775,7 @@ object IArray:
   /** Returns a three-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -565,6 +787,7 @@ object IArray:
   /** Returns a four-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -577,6 +800,7 @@ object IArray:
   /** Returns a five-dimensional immutable array containing values of a given function
    *  over ranges of integer values starting from `0`.
    *
+   *  @tparam T the element type of the array
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
@@ -607,6 +831,7 @@ object IArray:
 
   /** Returns an immutable array containing repeated applications of a function to a start value.
    *
+   *  @tparam T the element type of the array
    *  @param start the start value of the array
    *  @param len   the number of elements returned by the array
    *  @param f     the function that is repeatedly applied
@@ -628,17 +853,26 @@ object IArray:
   /** Returns a decomposition of the array into a sequence. This supports
    *  a pattern match like `{ case IArray(x,y,z) => println('3 elements')}`.
    *
+   *  @tparam T the element type of the array
    *  @param x the selector value
    *  @return  sequence wrapped in a [[scala.Some]], if `x` is a Seq, otherwise `None`
    */
   def unapplySeq[T](x: IArray[T]): Array.UnapplySeqWrapper[? <: T] =
     Array.unapplySeq(x)
 
-  /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called. */
+  /** A lazy filtered array. No filtering is applied until one of `foreach`, `map` or `flatMap` is called.
+   *
+   *  @tparam T the element type of the array
+   *  @param p the filter predicate
+   *  @param xs the underlying immutable array
+   */
   class WithFilter[T](p: T => Boolean, xs: IArray[T]):
 
     /** Applies `f` to each element for its side effects.
      *  Note: [U] parameter needed to help scalac's type inference.
+     *
+     *  @tparam U the return type of `f`, discarded
+     *  @param f the function to apply to each element
      */
     def foreach[U](f: T => U): Unit = {
       val len = xs.length
@@ -690,7 +924,10 @@ object IArray:
     def flatMap[BS, U](f: T => BS)(using asIterable: BS => Iterable[U]^, m: ClassTag[U]): IArray[U] =
       flatMap[U](x => asIterable(f(x)))
 
-    /** Creates a new non-strict filter which combines this filter with the given predicate. */
+    /** Creates a new non-strict filter which combines this filter with the given predicate.
+     *
+     *  @param q the additional predicate to apply
+     */
     def withFilter(q: T => Boolean): WithFilter[T]^{p, q} = new WithFilter[T](a => p(a) && q(a), xs)
 
   end WithFilter

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -119,6 +119,8 @@ object Predef extends LowPriorityImplicits {
    *
    *  @return The runtime [[Class]] representation of type `T`.
    *  @group utilities
+   *
+   *  @tparam T the type whose runtime class representation is returned
    */
   def classOf[T]: Class[T] = null.asInstanceOf[Class[T]] // This is a stub method. The actual implementation is filled in by the compiler.
 
@@ -133,6 +135,10 @@ object Predef extends LowPriorityImplicits {
    *  // bar is 23.type = 23
    *  ```
    *  @group utilities
+   *
+   *  @tparam T the singleton type whose unique value is retrieved
+   *  @param vt the implicit `ValueOf` instance that provides the value
+   *  @return the unique inhabitant of type `T`
    */
   @inline def valueOf[T](implicit vt: ValueOf[T]): T = vt.value
 
@@ -147,6 +153,9 @@ object Predef extends LowPriorityImplicits {
    *  // bar is 23.type = 23
    *  ```
    *  @group utilities
+   *
+   *  @tparam T the singleton type whose unique value is retrieved
+   *  @return the unique inhabitant of type `T`
    */
   inline def valueOf[T]: T = summonFrom {
     case ev: ValueOf[T] => ev.value
@@ -217,9 +226,9 @@ object Predef extends LowPriorityImplicits {
   // Minor variations on identity functions
 
   /** A method that returns its input value.
-   *  @tparam A type of the input value x.
-   *  @param x the value of type `A` to be returned.
-   *  @return the value `x`.
+   *  @tparam A the type of the input value `x`
+   *  @param x the value of type `A` to be returned
+   *  @return the value `x`
    *  @group utilities
    */
   @inline def identity[A](x: A): A = x // see `$conforms` for the implicit version
@@ -227,6 +236,7 @@ object Predef extends LowPriorityImplicits {
   /** Summon an implicit value of type `T`. Usually, the argument is not passed explicitly.
    *
    *  @tparam T the type of the value to be summoned
+   *  @param e the implicit value of type `T`
    *  @return the implicit value of type `T`
    *  @group utilities
    */
@@ -235,7 +245,8 @@ object Predef extends LowPriorityImplicits {
   /** Summon a given value of type `T`. Usually, the argument is not passed explicitly.
    *
    *  @tparam T the type of the value to be summoned
-   *  @return the given value typed: the provided type parameter
+   *  @param x the given value of type `T`
+   *  @return the given value with its singleton type preserved
    */
   transparent inline def summon[T](using x: T): x.type = x
 
@@ -267,6 +278,8 @@ object Predef extends LowPriorityImplicits {
    *             // locally guards the block and helps communicate intent
    *           ```
    *  @group utilities
+   *
+   *  @tparam T the type of the expression being guarded
    */
   @inline def locally[T](@deprecatedName("x") x: T): T = x
 
@@ -384,14 +397,24 @@ object Predef extends LowPriorityImplicits {
 
   // implicit classes -----------------------------------------------------
 
-  /** @group implicit-classes-any */
+  /**
+   *  @group implicit-classes-any
+   *
+   *  @tparam A the type of the left-hand side of the arrow association
+   *  @param self the value to use as the first element of the resulting tuple
+   */
   implicit final class ArrowAssoc[A](private val self: A) extends AnyVal {
     @inline def -> [B](y: B): (A, B) = (self, y)
     @deprecated("Use `->` instead. If you still wish to display it as one character, consider using a font with programming ligatures such as Fira Code.", "2.13.0")
     def →[B](y: B): (A, B) = ->(y)
   }
 
-  /** @group implicit-classes-any */
+  /**
+   *  @group implicit-classes-any
+   *
+   *  @tparam A the type of the value being checked with `ensuring`
+   *  @param self the value to check postconditions against
+   */
   implicit final class Ensuring[A](private val self: A) extends AnyVal {
     def ensuring(cond: Boolean): A = { assert(cond); self }
     def ensuring(cond: Boolean, msg: => Any): A = { assert(cond, msg); self }
@@ -399,7 +422,12 @@ object Predef extends LowPriorityImplicits {
     def ensuring(cond: A => Boolean, msg: => Any): A = { assert(cond(self), msg); self }
   }
 
-  /** @group implicit-classes-any */
+  /**
+   *  @group implicit-classes-any
+   *
+   *  @tparam A the type of the value to be formatted as a string
+   *  @param self the value to format
+   */
   implicit final class StringFormat[A](private val self: A) extends AnyVal {
     /** Returns string formatted according to given `format` string.
      *  Format strings are as for `String.format`
@@ -419,7 +447,11 @@ object Predef extends LowPriorityImplicits {
     def +(other: String): String = String.valueOf(self) + other
   }
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param sequenceOfChars the indexed sequence of characters to wrap as a `CharSequence`
+   */
   final class SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]) extends CharSequence {
     def length: Int                                     = sequenceOfChars.length
     def charAt(index: Int): Char                        = sequenceOfChars(index)
@@ -427,10 +459,18 @@ object Predef extends LowPriorityImplicits {
     override def toString()                             = sequenceOfChars.mkString
   }
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param sequenceOfChars the indexed sequence of characters to wrap as a `CharSequence`
+   */
   def SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]): SeqCharSequence = new SeqCharSequence(sequenceOfChars)
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param arrayOfChars the array of characters to wrap as a `CharSequence`
+   */
   final class ArrayCharSequence(arrayOfChars: Array[Char]) extends CharSequence {
     def length: Int                                     = arrayOfChars.length
     def charAt(index: Int): Char                        = arrayOfChars(index)
@@ -438,10 +478,18 @@ object Predef extends LowPriorityImplicits {
     override def toString()                             = arrayOfChars.mkString
   }
 
-  /** @group char-sequence-wrappers */
+  /**
+   *  @group char-sequence-wrappers
+   *
+   *  @param arrayOfChars the array of characters to wrap as a `CharSequence`
+   */
   def ArrayCharSequence(arrayOfChars: Array[Char]): ArrayCharSequence = new ArrayCharSequence(arrayOfChars)
 
-  /** @group conversions-string */
+  /**
+   *  @group conversions-string
+   *
+   *  @param x the string to enrich with `StringOps` methods
+   */
   @inline implicit def augmentString(x: String): StringOps = new StringOps(x)
 
   // printing -----------------------------------------------------------
@@ -508,38 +556,102 @@ object Predef extends LowPriorityImplicits {
 
   // "Autoboxing" and "Autounboxing" ---------------------------------------------------
 
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Byte` value to convert
+   */
   implicit def byte2Byte(x: Byte): java.lang.Byte             = x.asInstanceOf[java.lang.Byte]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Short` value to convert
+   */
   implicit def short2Short(x: Short): java.lang.Short         = x.asInstanceOf[java.lang.Short]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Char` value to convert
+   */
   implicit def char2Character(x: Char): java.lang.Character   = x.asInstanceOf[java.lang.Character]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Int` value to convert
+   */
   implicit def int2Integer(x: Int): java.lang.Integer         = x.asInstanceOf[java.lang.Integer]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Long` value to convert
+   */
   implicit def long2Long(x: Long): java.lang.Long             = x.asInstanceOf[java.lang.Long]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Float` value to convert
+   */
   implicit def float2Float(x: Float): java.lang.Float         = x.asInstanceOf[java.lang.Float]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Double` value to convert
+   */
   implicit def double2Double(x: Double): java.lang.Double     = x.asInstanceOf[java.lang.Double]
-  /** @group conversions-anyval-to-java */
+  /**
+   *  @group conversions-anyval-to-java
+   *
+   *  @param x the Scala `Boolean` value to convert
+   */
   implicit def boolean2Boolean(x: Boolean): java.lang.Boolean = x.asInstanceOf[java.lang.Boolean]
 
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Byte` value to convert
+   */
   implicit def Byte2byte(x: java.lang.Byte): Byte             = x.asInstanceOf[Byte]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Short` value to convert
+   */
   implicit def Short2short(x: java.lang.Short): Short         = x.asInstanceOf[Short]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Character` value to convert
+   */
   implicit def Character2char(x: java.lang.Character): Char   = x.asInstanceOf[Char]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Integer` value to convert
+   */
   implicit def Integer2int(x: java.lang.Integer): Int         = x.asInstanceOf[Int]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Long` value to convert
+   */
   implicit def Long2long(x: java.lang.Long): Long             = x.asInstanceOf[Long]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Float` value to convert
+   */
   implicit def Float2float(x: java.lang.Float): Float         = x.asInstanceOf[Float]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Double` value to convert
+   */
   implicit def Double2double(x: java.lang.Double): Double     = x.asInstanceOf[Double]
-  /** @group conversions-java-to-anyval */
+  /**
+   *  @group conversions-java-to-anyval
+   *
+   *  @param x the `java.lang.Boolean` value to convert
+   */
   implicit def Boolean2boolean(x: java.lang.Boolean): Boolean = x.asInstanceOf[Boolean]
 
   /** An implicit of type `A => A` is available for all `A` because it can always
@@ -561,6 +673,8 @@ object Predef extends LowPriorityImplicits {
    *  val s3: String | Null = null
    *  val s4: String = s3.nn // throw NullPointerException
    *  ```
+   *
+   *  @return the value cast to its non-nullable type `x.type & T`
    */
   extension [T](x: T | Null) inline def nn: x.type & T =
     if x.asInstanceOf[Any] == null then scala.runtime.Scala3RunTime.nnFail()
@@ -570,12 +684,16 @@ object Predef extends LowPriorityImplicits {
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `eq` rather than only `==`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`.
+     *
+     *  @param y the reference to compare against for reference equality
      */
     inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
     /** Enables an expression of type `T|Null`, where `T` is a subtype of `AnyRef`, to be checked for `null`
      *  using `ne` rather than only `!=`. This is needed because `Null` no longer has
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`.
+     *
+     *  @param y the reference to compare against for reference non-equality
      */
     inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
@@ -629,6 +747,9 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
    *  the call to xxxWrapper is not eliminated even though it does nothing.
    *  Even inlined, every call site does a no-op retrieval of Predef's MODULE$
    *  because maybe loading Predef has side effects!
+   *
+   *  @param x the primitive value to wrap
+   *  @return a rich wrapper providing additional methods on the primitive value
    */
   @inline implicit def byteWrapper(x: Byte): runtime.RichByte          = new runtime.RichByte(x)
   @inline implicit def shortWrapper(x: Short): runtime.RichShort       = new runtime.RichShort(x)
@@ -639,39 +760,89 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
   @inline implicit def doubleWrapper(x: Double): runtime.RichDouble    = new runtime.RichDouble(x)
   @inline implicit def booleanWrapper(x: Boolean): runtime.RichBoolean = new runtime.RichBoolean(x)
 
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @tparam T the element type of the array
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def genericWrapArray[T](xs: Array[T]): ArraySeq[T] =
     mapNull(xs, ArraySeq.make(xs))
 
   // Since the JVM thinks arrays are covariant, one 0-length Array[AnyRef]
   // is as good as another for all T <: AnyRef.  Instead of creating 100,000,000
   // unique ones by way of this implicit, let's share one.
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @tparam T the element type of the array, must be a reference type
+   *  @param xs the array of reference-typed elements to wrap as an `ArraySeq`
+   */
   implicit def wrapRefArray[T <: AnyRef | Null](xs: Array[T]): ArraySeq.ofRef[T] =
     mapNull(xs,
       if (xs.length == 0) ArraySeq.empty[AnyRef].asInstanceOf[ArraySeq.ofRef[T]]
       else new ArraySeq.ofRef[T](xs))
 
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapIntArray(xs: Array[Int]): ArraySeq.ofInt = mapNull(xs, new ArraySeq.ofInt(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapDoubleArray(xs: Array[Double]): ArraySeq.ofDouble = mapNull(xs, new ArraySeq.ofDouble(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapLongArray(xs: Array[Long]): ArraySeq.ofLong = mapNull(xs, new ArraySeq.ofLong(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapFloatArray(xs: Array[Float]): ArraySeq.ofFloat = mapNull(xs, new ArraySeq.ofFloat(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapCharArray(xs: Array[Char]): ArraySeq.ofChar = mapNull(xs, new ArraySeq.ofChar(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapByteArray(xs: Array[Byte]): ArraySeq.ofByte = mapNull(xs, new ArraySeq.ofByte(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapShortArray(xs: Array[Short]): ArraySeq.ofShort = mapNull(xs, new ArraySeq.ofShort(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapBooleanArray(xs: Array[Boolean]): ArraySeq.ofBoolean = mapNull(xs, new ArraySeq.ofBoolean(xs))
-  /** @group conversions-array-to-wrapped-array */
+  /**
+   *  @group conversions-array-to-wrapped-array
+   *
+   *  @param xs the array to wrap as an `ArraySeq`
+   */
   implicit def wrapUnitArray(xs: Array[Unit]): ArraySeq.ofUnit = mapNull(xs, new ArraySeq.ofUnit(xs))
 
-  /** @group conversions-string */
+  /**
+   *  @group conversions-string
+   *
+   *  @param s the string to wrap as a `WrappedString`
+   */
   implicit def wrapString(s: String): WrappedString = mapNull(s, new WrappedString(s))
 }
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpDocSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/signaturehelp/SignatureHelpDocSuite.scala
@@ -262,5 +262,6 @@ class SignatureHelpDocSuite extends BaseSignatureHelpSuite:
       """|Found documentation for scala/Some#
          |Some[A](value: A)
          |        ^^^^^^^^
+         |  @param value the contained value
          |""".stripMargin
     )

--- a/tests/neg-macros/annot-crash.check
+++ b/tests/neg-macros/annot-crash.check
@@ -3,5 +3,5 @@
   |^^^^^^
   |Failed to evaluate macro annotation '@crash'.
   |  Caused by class scala.NotImplementedError: an implementation is missing
-  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:383)
+  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:396)
   |    crash.transform(Macro_1.scala:7)

--- a/tests/neg/i24460.check
+++ b/tests/neg/i24460.check
@@ -6,13 +6,13 @@
     |-------------------------------------------------------------------------------------------------------------------
     |Inline stack trace
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    |This location contains code that was inlined from Predef.scala:151
-151 |  inline def valueOf[T]: T = summonFrom {
+    |This location contains code that was inlined from Predef.scala:160
+160 |  inline def valueOf[T]: T = summonFrom {
     |                             ^
-152 |    case ev: ValueOf[T] => ev.value
-153 |  }
+161 |    case ev: ValueOf[T] => ev.value
+162 |  }
     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    |This location contains code that was inlined from Predef.scala:151
+    |This location contains code that was inlined from Predef.scala:160
   7 |      case _: (h *: t) => valueOf[`h` & T] +: singletons[T, t]
     |                          ^^^^^^^^^^^^^^^^
      -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing `@param`, `@tparam`, and `@return` tags for Array, IArray, Predef, Option. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.