### PR TITLE
Math (7): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -48,16 +48,26 @@ object BigDecimal {
     val UNNECESSARY = Value(JRM.UNNECESSARY.ordinal)
   }
 
-  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`, rounding if necessary. */
+  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`, rounding if necessary.
+   *
+   *  @param d the `Double` value to convert to a `BigDecimal`
+   *  @param mc the precision and rounding mode for the conversion
+   */
   def decimal(d: Double, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(java.lang.Double.toString(d), mc), mc)
 
-  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`. */
+  /** Constructs a `BigDecimal` using the decimal text representation of `Double` value `d`.
+   *
+   *  @param d the `Double` value to convert to a `BigDecimal`
+   */
   def decimal(d: Double): BigDecimal = decimal(d, defaultMathContext)
 
   /** Constructs a `BigDecimal` using the decimal text representation of `Float` value `f`, rounding if necessary.
    *  Note that `BigDecimal.decimal(0.1f) != 0.1f` since equality agrees with the `Double` representation, and
    *  `0.1 != 0.1f`.
+   *
+   *  @param f the `Float` value to convert to a `BigDecimal`
+   *  @param mc the precision and rounding mode for the conversion
    */
   def decimal(f: Float, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(java.lang.Float.toString(f), mc), mc)
@@ -65,18 +75,31 @@ object BigDecimal {
   /** Constructs a `BigDecimal` using the decimal text representation of `Float` value `f`.
    *  Note that `BigDecimal.decimal(0.1f) != 0.1f` since equality agrees with the `Double` representation, and
    *  `0.1 != 0.1f`.
+   *
+   *  @param f the `Float` value to convert to a `BigDecimal`
    */
   def decimal(f: Float): BigDecimal = decimal(f, defaultMathContext)
 
   // This exists solely to avoid conversion from Int/Long to Float, screwing everything up.
-  /** Constructs a `BigDecimal` from a `Long`, rounding if necessary.  This is identical to `BigDecimal(l, mc)`. */
+  /** Constructs a `BigDecimal` from a `Long`, rounding if necessary.  This is identical to `BigDecimal(l, mc)`.
+   *
+   *  @param l the `Long` value to convert to a `BigDecimal`
+   *  @param mc the precision and rounding mode for the conversion
+   */
   def decimal(l: Long, mc: MathContext): BigDecimal = apply(l, mc)
 
   // This exists solely to avoid conversion from Int/Long to Float, screwing everything up.
-  /** Constructs a `BigDecimal` from a `Long`.  This is identical to `BigDecimal(l)`. */
+  /** Constructs a `BigDecimal` from a `Long`.  This is identical to `BigDecimal(l)`.
+   *
+   *  @param l the `Long` value to convert to a `BigDecimal`
+   */
   def decimal(l: Long): BigDecimal = apply(l)
 
-  /** Constructs a `BigDecimal` using a `java.math.BigDecimal`, rounding if necessary. */
+  /** Constructs a `BigDecimal` using a `java.math.BigDecimal`, rounding if necessary.
+   *
+   *  @param bd the `java.math.BigDecimal` to convert
+   *  @param mc the precision and rounding mode for the conversion
+   */
   def decimal(bd: BigDec, mc: MathContext): BigDecimal = new BigDecimal(bd.round(mc), mc)
 
   /** Constructs a `BigDecimal` by expanding the binary fraction
@@ -84,18 +107,25 @@ object BigDecimal {
    *  rounding if necessary.  When a `Float` is converted to a
    *  `Double`, the binary fraction is preserved, so this method
    *  also works for converted `Float`s.
+   *
+   *  @param d the `Double` value whose binary fraction is expanded
+   *  @param mc the precision and rounding mode for the conversion
    */
   def binary(d: Double, mc: MathContext): BigDecimal = new BigDecimal(new BigDec(d, mc), mc)
 
   /** Constructs a `BigDecimal` by expanding the binary fraction
    *  contained by `Double` value `d` into a decimal representation.
    *  Note: this also works correctly on converted `Float`s.
+   *
+   *  @param d the `Double` value whose binary fraction is expanded
    */
   def binary(d: Double): BigDecimal = binary(d, defaultMathContext)
 
   /** Constructs a `BigDecimal` from a `java.math.BigDecimal`.  The
    *  precision is the default for `BigDecimal` or enough to represent
    *  the `java.math.BigDecimal` exactly, whichever is greater.
+   *
+   *  @param repr the `java.math.BigDecimal` to represent exactly
    */
   def exact(repr: BigDec): BigDecimal = {
     val mc =
@@ -107,25 +137,36 @@ object BigDecimal {
   /** Constructs a `BigDecimal` by fully expanding the binary fraction
    *  contained by `Double` value `d`, adjusting the precision as
    *  necessary.  Note: this works correctly on converted `Float`s also.
+   *
+   *  @param d the `Double` value whose binary fraction is fully expanded
    */
   def exact(d: Double): BigDecimal = exact(new BigDec(d))
 
-  /** Constructs a `BigDecimal` that exactly represents a `BigInt`. */
+  /** Constructs a `BigDecimal` that exactly represents a `BigInt`.
+   *
+   *  @param bi the `BigInt` value to represent exactly
+   */
   def exact(bi: BigInt): BigDecimal = exact(new BigDec(bi.bigInteger))
 
   /** Constructs a `BigDecimal` that exactly represents a `Long`.  Note that
    *  all creation methods for `BigDecimal` that do not take a `MathContext`
    *  represent a `Long`; this is equivalent to `apply`, `valueOf`, etc..
+   *
+   *  @param l the `Long` value to represent exactly
    */
   def exact(l: Long): BigDecimal = apply(l)
 
   /** Constructs a `BigDecimal` that exactly represents the number
    *  specified in a `String`.
+   *
+   *  @param s the string representation of the number
    */
   def exact(s: String): BigDecimal = exact(new BigDec(s))
 
   /** Constructs a `BigDecimal` that exactly represents the number
    *  specified in base 10 in a character array.
+   *
+   *  @param cs the character array containing the decimal representation
    */
   def exact(cs: Array[Char]): BigDecimal = exact(new BigDec(cs))
 
@@ -233,22 +274,32 @@ object BigDecimal {
 
   /** Translates a character array representation of a `BigDecimal`
    *  into a `BigDecimal`.
+   *
+   *  @param x the character array containing the decimal representation
    */
   def apply(x: Array[Char]): BigDecimal = exact(x)
 
   /** Translates a character array representation of a `BigDecimal`
    *  into a `BigDecimal`, rounding if necessary.
+   *
+   *  @param x the character array containing the decimal representation
+   *  @param mc the precision and rounding mode for creation of this value and future operations on it
    */
   def apply(x: Array[Char], mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(x, mc), mc)
 
   /** Translates the decimal String representation of a `BigDecimal`
    *  into a `BigDecimal`.
+   *
+   *  @param x the string representation of the decimal value
    */
   def apply(x: String): BigDecimal = exact(x)
 
   /** Translates the decimal String representation of a `BigDecimal`
    *  into a `BigDecimal`, rounding if necessary.
+   *
+   *  @param x the string representation of the decimal value
+   *  @param mc the precision and rounding mode for creation of this value and future operations on it
    */
   def apply(x: String, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(x, mc), mc)
@@ -292,16 +343,28 @@ object BigDecimal {
   def apply(unscaledVal: BigInt, scale: Int, mc: MathContext): BigDecimal =
     new BigDecimal(new BigDec(unscaledVal.bigInteger, scale, mc), mc)
 
-  /** Constructs a `BigDecimal` from a `java.math.BigDecimal`. */
+  /** Constructs a `BigDecimal` from a `java.math.BigDecimal`.
+   *
+   *  @param bd the `java.math.BigDecimal` to convert
+   */
   def apply(bd: BigDec): BigDecimal = new BigDecimal(bd, defaultMathContext)
 
-  /** Implicit conversion from `Int` to `BigDecimal`. */
+  /** Implicit conversion from `Int` to `BigDecimal`.
+   *
+   *  @param i the `Int` value to convert
+   */
   implicit def int2bigDecimal(i: Int): BigDecimal = apply(i)
 
-  /** Implicit conversion from `Long` to `BigDecimal`. */
+  /** Implicit conversion from `Long` to `BigDecimal`.
+   *
+   *  @param l the `Long` value to convert
+   */
   implicit def long2bigDecimal(l: Long): BigDecimal = apply(l)
 
-  /** Implicit conversion from `Double` to `BigDecimal`. */
+  /** Implicit conversion from `Double` to `BigDecimal`.
+   *
+   *  @param d the `Double` value to convert
+   */
   implicit def double2bigDecimal(d: Double): BigDecimal = decimal(d)
 
   // For the following function, both the parameter and the return type are non-nullable.
@@ -309,7 +372,10 @@ object BigDecimal {
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Implicit conversion from `java.math.BigDecimal` to `scala.BigDecimal`. */
+  /** Implicit conversion from `java.math.BigDecimal` to `scala.BigDecimal`.
+   *
+   *  @param x the `java.math.BigDecimal` to convert
+   */
   implicit def javaBigDecimal2bigDecimal(x: BigDec): BigDecimal = mapNull(x, apply(x))
 }
 
@@ -358,6 +424,9 @@ object BigDecimal {
  *  and powers.  The left-hand argument's `MathContext` always determines the
  *  degree of rounding, if any, and is the one propagated through arithmetic
  *  operations that do not apply rounding themselves.
+ *
+ *  @param bigDecimal the underlying `java.math.BigDecimal`
+ *  @param mc the `MathContext` specifying the precision and rounding mode for operations
  */
 final class BigDecimal(val bigDecimal: BigDec, val mc: MathContext)
 extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[BigDecimal] {
@@ -403,6 +472,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Compares this BigDecimal with the specified value for equality.  Where `Float` and `Double`
    *  disagree, `BigDecimal` will agree with the `Double` value
+   *
+   *  @param that the value to compare with this `BigDecimal`
    */
   override def equals (that: Any): Boolean = that match {
     case that: BigDecimal     => this equals that
@@ -474,55 +545,93 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   def underlying: java.math.BigDecimal = bigDecimal
 
 
-  /** Compares this BigDecimal with the specified BigDecimal for equality. */
+  /** Compares this BigDecimal with the specified BigDecimal for equality.
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def equals (that: BigDecimal): Boolean = compare(that) == 0
 
-  /** Compares this BigDecimal with the specified BigDecimal */
+  /** Compares this BigDecimal with the specified BigDecimal
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def compare (that: BigDecimal): Int = this.bigDecimal.compareTo(that.bigDecimal)
 
-  /** Addition of BigDecimals */
+  /** Addition of BigDecimals
+   *
+   *  @param that the `BigDecimal` to add to this value
+   */
   def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.add(that.bigDecimal, mc), mc)
 
-  /** Subtraction of BigDecimals */
+  /** Subtraction of BigDecimals
+   *
+   *  @param that the `BigDecimal` to subtract from this value
+   */
   def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.subtract(that.bigDecimal, mc), mc)
 
-  /** Multiplication of BigDecimals */
+  /** Multiplication of BigDecimals
+   *
+   *  @param that the `BigDecimal` to multiply with this value
+   */
   def *  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.multiply(that.bigDecimal, mc), mc)
 
-  /** Division of BigDecimals */
+  /** Division of BigDecimals
+   *
+   *  @param that the `BigDecimal` to divide this value by
+   */
   def /  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.divide(that.bigDecimal, mc), mc)
 
   /** Division and Remainder - returns tuple containing the result of
    *  divideToIntegralValue and the remainder.  The computation is exact: no rounding is applied.
+   *
+   *  @param that the `BigDecimal` divisor
    */
   def /% (that: BigDecimal): (BigDecimal, BigDecimal) = {
     val qr = this.bigDecimal.divideAndRemainder(that.bigDecimal, mc)
     (new BigDecimal(qr(0), mc), new BigDecimal(qr(1), mc))
   }
 
-  /** Divide to Integral value. */
+  /** Divide to Integral value.
+   *
+   *  @param that the `BigDecimal` divisor
+   */
   def quot (that: BigDecimal): BigDecimal =
     new BigDecimal(this.bigDecimal.divideToIntegralValue(that.bigDecimal, mc), mc)
 
-  /** Returns the minimum of this and that, or this if the two are equal */
+  /** Returns the minimum of this and that, or this if the two are equal
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def min (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x <= 0 => this
     case _           => that
   }
 
-  /** Returns the maximum of this and that, or this if the two are equal */
+  /** Returns the maximum of this and that, or this if the two are equal
+   *
+   *  @param that the `BigDecimal` to compare with
+   */
   def max (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x >= 0 => this
     case _           => that
   }
 
-  /** Remainder after dividing this by that. */
+  /** Remainder after dividing this by that.
+   *
+   *  @param that the `BigDecimal` divisor
+   */
   def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.remainder(that.bigDecimal, mc), mc)
 
-  /** Remainder after dividing this by that. */
+  /** Remainder after dividing this by that.
+   *
+   *  @param that the `BigDecimal` divisor
+   */
   def % (that: BigDecimal): BigDecimal = this.remainder(that)
 
-  /** Returns a BigDecimal whose value is this ** n. */
+  /** Returns a BigDecimal whose value is this ** n.
+   *
+   *  @param n the exponent to raise this `BigDecimal` to
+   */
   def pow (n: Int): BigDecimal = new BigDecimal(this.bigDecimal.pow(n, mc), mc)
 
   /** Returns a BigDecimal whose value is the negation of this BigDecimal */
@@ -550,6 +659,8 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
 
   /** Returns a BigDecimal rounded according to the supplied MathContext settings, but
    *  preserving its own MathContext for future operations.
+   *
+   *  @param mc the `MathContext` specifying the precision and rounding mode
    */
   def round(mc: MathContext): BigDecimal = {
     val r = this.bigDecimal.round(mc)
@@ -568,11 +679,16 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   /** Returns the size of an ulp, a unit in the last place, of this BigDecimal. */
   def ulp: BigDecimal = new BigDecimal(this.bigDecimal.ulp, mc)
 
-  /** Returns a new BigDecimal based on the supplied MathContext, rounded as needed. */
+  /** Returns a new BigDecimal based on the supplied MathContext, rounded as needed.
+   *
+   *  @param mc the new `MathContext` for precision and rounding
+   */
   def apply(mc: MathContext): BigDecimal = new BigDecimal(this.bigDecimal.round(mc), mc)
 
   /** Returns a `BigDecimal` whose scale is the specified value, and whose value is
    *  numerically equal to this BigDecimal's.
+   *
+   *  @param scale the scale to set for this `BigDecimal`
    */
   def setScale(scale: Int): BigDecimal =
     if (this.scale == scale) this
@@ -677,14 +793,25 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   def until(end: BigDecimal): Range.Partial[BigDecimal, NumericRange.Exclusive[BigDecimal]] =
     new Range.Partial(until(end, _))
 
-  /** Same as the one-argument `until`, but creates the range immediately. */
+  /** Same as the one-argument `until`, but creates the range immediately.
+   *
+   *  @param end the end value of the range (exclusive)
+   *  @param step the increment between successive values in the range
+   */
   def until(end: BigDecimal, step: BigDecimal): NumericRange.Exclusive[BigDecimal] = Range.BigDecimal(this, end, step)
 
-  /** Like `until`, but inclusive of the end value. */
+  /** Like `until`, but inclusive of the end value.
+   *
+   *  @param end the end value of the range (inclusive)
+   */
   def to(end: BigDecimal): Range.Partial[BigDecimal, NumericRange.Inclusive[BigDecimal]] =
     new Range.Partial(to(end, _))
 
-  /** Like `until`, but inclusive of the end value. */
+  /** Like `until`, but inclusive of the end value.
+   *
+   *  @param end the end value of the range (inclusive)
+   *  @param step the increment between successive values in the range
+   */
   def to(end: BigDecimal, step: BigDecimal) = Range.BigDecimal.inclusive(this, end, step)
 
   /** Converts this `BigDecimal` to a scala.BigInt. */

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -64,6 +64,8 @@ object BigInt {
 
   /** Translates a byte array containing the two's-complement binary
    *  representation of a BigInt into a BigInt.
+   *
+   *  @param x the two's-complement big-endian binary representation of a `BigInt`
    */
   def apply(x: Array[Byte]): BigInt =
     apply(new BigInteger(x))
@@ -74,33 +76,50 @@ object BigInt {
    *                   for positive).
    *  @param  magnitude big-endian binary representation of the magnitude of
    *                   the number.
+   *  @return the `BigInt` with the specified sign and magnitude
    */
   def apply(signum: Int, magnitude: Array[Byte]): BigInt =
     apply(new BigInteger(signum, magnitude))
 
   /** Constructs a randomly generated positive BigInt that is probably prime,
    *  with the specified bitLength.
+   *
+   *  @param bitlength the bit length of the generated probable prime `BigInt`
+   *  @param certainty a measure of the uncertainty that the caller is willing to tolerate: the probability of primality exceeds `(1 - 1/2 ^ certainty)`
+   *  @param rnd the source of randomness used to generate the candidate
    */
   def apply(bitlength: Int, certainty: Int, rnd: scala.util.Random): BigInt =
     apply(new BigInteger(bitlength, certainty, rnd.self))
 
   /** Constructs a randomly generated BigInt, uniformly distributed over the
    *  range `0` to `(2 ^ numBits - 1)`, inclusive.
+   *
+   *  @param numbits the number of random bits used to generate the `BigInt`
+   *  @param rnd the source of randomness used for the generation
    */
   def apply(numbits: Int, rnd: scala.util.Random): BigInt =
     apply(new BigInteger(numbits, rnd.self))
 
-  /** Translates the decimal String representation of a BigInt into a BigInt. */
+  /** Translates the decimal String representation of a BigInt into a BigInt.
+   *
+   *  @param x the decimal string representation of the `BigInt`
+   */
   def apply(x: String): BigInt =
     apply(new BigInteger(x))
 
   /** Translates the string representation of a `BigInt` in the
    *  specified `radix` into a BigInt.
+   *
+   *  @param x the string representation of the `BigInt` in the specified radix
+   *  @param radix the radix to use when parsing `x`
    */
   def apply(x: String, radix: Int): BigInt =
     apply(new BigInteger(x, radix))
 
-  /** Translates a `java.math.BigInteger` into a BigInt. */
+  /** Translates a `java.math.BigInteger` into a BigInt.
+   *
+   *  @param x the `java.math.BigInteger` value to convert
+   */
   def apply(x: BigInteger): BigInt = {
     if (x.bitLength <= 63) {
       val l = x.longValue
@@ -108,14 +127,24 @@ object BigInt {
     } else new BigInt(x, Long.MinValue)
   }
 
-  /** Returns a positive BigInt that is probably prime, with the specified bitLength. */
+  /** Returns a positive BigInt that is probably prime, with the specified bitLength.
+   *
+   *  @param bitLength the bit length of the returned probable prime `BigInt`
+   *  @param rnd the source of randomness used to generate the candidate
+   */
   def probablePrime(bitLength: Int, rnd: scala.util.Random): BigInt =
     apply(BigInteger.probablePrime(bitLength, rnd.self))
 
-  /** Implicit conversion from `Int` to `BigInt`. */
+  /** Implicit conversion from `Int` to `BigInt`.
+   *
+   *  @param i the `Int` value to convert
+   */
   implicit def int2bigInt(i: Int): BigInt = apply(i)
 
-  /** Implicit conversion from `Long` to `BigInt`. */
+  /** Implicit conversion from `Long` to `BigInt`.
+   *
+   *  @param l the `Long` value to convert
+   */
   implicit def long2bigInt(l: Long): BigInt = apply(l)
 
   // For the following function, both the parameter and the return type are non-nullable.
@@ -123,7 +152,10 @@ object BigInt {
   // We intentionally keep this signature to discourage passing nulls implicitly while
   // preserving the previous behavior for backward compatibility.
 
-  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`. */
+  /** Implicit conversion from `java.math.BigInteger` to `scala.BigInt`.
+   *
+   *  @param x the `java.math.BigInteger` value to convert
+   */
   implicit def javaBigInteger2bigInt(x: BigInteger): BigInt = mapNull(x, apply(x))
 
   // this method is adapted from Google Guava's version at
@@ -132,7 +164,11 @@ object BigInt {
   //   * Copyright (C) 2011 The Guava Authors
   //   *
   //   * Licensed under the Apache License, Version 2.0 (the "License")
-  /** Returns the greatest common divisor of a and b. Returns 0 if a == 0 && b == 0. */
+  /** Returns the greatest common divisor of a and b. Returns 0 if a == 0 && b == 0.
+   *
+   *  @param a the first non-negative operand
+   *  @param b the second non-negative operand
+   */
   private def longGcd(a: Long, b: Long): Long = {
     // both a and b must be >= 0
     if (a == 0) { // 0 % b == 0, so b divides a, but the converse doesn't hold.
@@ -201,7 +237,10 @@ final class BigInt private (
   //
   // Additionally, we know that if this.isValidLong is true, then _long is the encoded value.
 
-  /** Public constructor present for compatibility. Use the BigInt.apply companion object method instead. */
+  /** Public constructor present for compatibility. Use the BigInt.apply companion object method instead.
+   *
+   *  @param bigInteger the `java.math.BigInteger` value to wrap
+   */
   def this(bigInteger: BigInteger) = this(
     bigInteger, // even if it is a short BigInteger, we cache the instance
     if (bigInteger.bitLength <= 63)
@@ -282,14 +321,20 @@ final class BigInt private (
   def isWhole: Boolean = true
   def underlying: BigInteger = bigInteger
 
-  /** Compares this BigInt with the specified BigInt for equality. */
+  /** Compares this BigInt with the specified BigInt for equality.
+   *
+   *  @param that the `BigInt` to compare against
+   */
   def equals(that: BigInt): Boolean =
     if (this.longEncoding)
       that.longEncoding && (this._long == that._long)
     else
       !that.longEncoding && (this._bigInteger == that._bigInteger)
 
-  /** Compares this BigInt with the specified BigInt */
+  /** Compares this BigInt with the specified BigInt
+   *
+   *  @param that the `BigInt` to compare against
+   */
   def compare(that: BigInt): Int =
     if (this.longEncoding) {
       if (that.longEncoding) java.lang.Long.compare(this._long, that._long) else -that._bigInteger.nn.signum()
@@ -297,7 +342,10 @@ final class BigInt private (
       if (that.longEncoding) _bigInteger.nn.signum() else this._bigInteger.nn.compareTo(that._bigInteger)
     }
 
-  /** Addition of BigInts */
+  /** Addition of BigInts
+   *
+   *  @param that the value to add to this `BigInt`
+   */
   def +(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -308,7 +356,10 @@ final class BigInt private (
     BigInt(this.bigInteger.add(that.bigInteger))
   }
 
-  /** Subtraction of BigInts */
+  /** Subtraction of BigInts
+   *
+   *  @param that the value to subtract from this `BigInt`
+   */
   def -(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -319,7 +370,10 @@ final class BigInt private (
     BigInt(this.bigInteger.subtract(that.bigInteger))
   }
 
-  /** Multiplication of BigInts */
+  /** Multiplication of BigInts
+   *
+   *  @param that the value to multiply with this `BigInt`
+   */
   def *(that: BigInt): BigInt = {
     if (this.longEncoding && that.longEncoding) { // fast path
       val x = this._long
@@ -332,7 +386,10 @@ final class BigInt private (
     BigInt(this.bigInteger.multiply(that.bigInteger))
   }
 
-  /** Division of BigInts */
+  /** Division of BigInts
+   *
+   *  @param that the divisor
+   */
   def /(that: BigInt): BigInt =
   // in the fast path, note that the original code avoided storing -Long.MinValue in a long:
   //    if (this._long != Long.MinValue || that._long != -1) return BigInt(this._long / that._long)
@@ -340,13 +397,19 @@ final class BigInt private (
     if (this.longEncoding && that.longEncoding) BigInt(this._long / that._long)
     else BigInt(this.bigInteger.divide(that.bigInteger))
 
-  /** Remainder of BigInts */
+  /** Remainder of BigInts
+   *
+   *  @param that the divisor
+   */
   def %(that: BigInt): BigInt =
   // see / for the original logic regarding Long.MinValue
     if (this.longEncoding && that.longEncoding) BigInt(this._long % that._long)
     else BigInt(this.bigInteger.remainder(that.bigInteger))
 
-  /** Returns a pair of two BigInts containing (this / that) and (this % that). */
+  /** Returns a pair of two BigInts containing (this / that) and (this % that).
+   *
+   *  @param that the divisor
+   */
   def /%(that: BigInt): (BigInt, BigInt) =
     if (this.longEncoding && that.longEncoding) {
       val x = this._long
@@ -358,11 +421,17 @@ final class BigInt private (
       (BigInt(dr(0)), BigInt(dr(1)))
     }
 
-  /** Leftshift of BigInt */
+  /** Leftshift of BigInt
+   *
+   *  @param n the number of bits to shift left
+   */
   def <<(n: Int): BigInt =
     if (longEncoding && n <= 0) (this >> (-n)) else BigInt(this.bigInteger.shiftLeft(n))
 
-  /** (Signed) rightshift of BigInt */
+  /** (Signed) rightshift of BigInt
+   *
+   *  @param n the number of bits to shift right
+   */
   def >>(n: Int): BigInt =
     if (longEncoding && n >= 0) {
       if (n < 64) BigInt(_long >> n)
@@ -370,31 +439,46 @@ final class BigInt private (
       else BigInt(0) // for _long >= 0
     } else BigInt(this.bigInteger.shiftRight(n))
 
-  /** Bitwise and of BigInts */
+  /** Bitwise and of BigInts
+   *
+   *  @param that the value to AND with this `BigInt`
+   */
   def &(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long & that._long)
     else BigInt(this.bigInteger.and(that.bigInteger))
 
-  /** Bitwise or of BigInts */
+  /** Bitwise or of BigInts
+   *
+   *  @param that the value to OR with this `BigInt`
+   */
   def |(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long | that._long)
     else BigInt(this.bigInteger.or(that.bigInteger))
 
-  /** Bitwise exclusive-or of BigInts */
+  /** Bitwise exclusive-or of BigInts
+   *
+   *  @param that the value to XOR with this `BigInt`
+   */
   def ^(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long ^ that._long)
     else BigInt(this.bigInteger.xor(that.bigInteger))
 
-  /** Bitwise and-not of BigInts. Returns a BigInt whose value is (this & ~that). */
+  /** Bitwise and-not of BigInts. Returns a BigInt whose value is (this & ~that).
+   *
+   *  @param that the value whose complement is ANDed with this `BigInt`
+   */
   def &~(that: BigInt): BigInt =
     if (this.longEncoding && that.longEncoding)
       BigInt(this._long & ~that._long)
     else BigInt(this.bigInteger.andNot(that.bigInteger))
 
-  /** Returns the greatest common divisor of abs(this) and abs(that) */
+  /** Returns the greatest common divisor of abs(this) and abs(that)
+   *
+   *  @param that the other value for computing the greatest common divisor
+   */
   def gcd(that: BigInt): BigInt =
     if (this.longEncoding) {
       if (this._long == 0) return that.abs
@@ -427,23 +511,38 @@ final class BigInt private (
       if (res >= 0) BigInt(res) else BigInt(res + that._long)
     } else BigInt(this.bigInteger.mod(that.bigInteger))
 
-  /** Returns the minimum of this and that */
+  /** Returns the minimum of this and that
+   *
+   *  @param that the value to compare with this `BigInt`
+   */
   def min(that: BigInt): BigInt =
     if (this <= that) this else that
 
-  /** Returns the maximum of this and that */
+  /** Returns the maximum of this and that
+   *
+   *  @param that the value to compare with this `BigInt`
+   */
   def max(that: BigInt): BigInt =
     if (this >= that) this else that
 
-  /** Returns a BigInt whose value is (<tt>this</tt> raised to the power of <tt>exp</tt>). */
+  /** Returns a BigInt whose value is (<tt>this</tt> raised to the power of <tt>exp</tt>).
+   *
+   *  @param exp the exponent, must be non-negative
+   */
   def pow(exp: Int): BigInt = BigInt(this.bigInteger.pow(exp))
 
   /** Returns a BigInt whose value is
    *  (<tt>this</tt> raised to the power of <tt>exp</tt> modulo <tt>m</tt>).
+   *
+   *  @param exp the exponent
+   *  @param m the modulus, must be positive
    */
   def modPow(exp: BigInt, m: BigInt): BigInt = BigInt(this.bigInteger.modPow(exp.bigInteger, m.bigInteger))
 
-  /** Returns a BigInt whose value is (the inverse of <tt>this</tt> modulo <tt>m</tt>). */
+  /** Returns a BigInt whose value is (the inverse of <tt>this</tt> modulo <tt>m</tt>).
+   *
+   *  @param m the modulus, must be positive
+   */
   def modInverse(m: BigInt): BigInt = BigInt(this.bigInteger.modInverse(m.bigInteger))
 
   /** Returns a BigInt whose value is the negation of this BigInt */
@@ -471,7 +570,10 @@ final class BigInt private (
     // it is equal to -(this + 1)
     if (longEncoding && _long != Long.MaxValue) BigInt(-(_long + 1)) else BigInt(this.bigInteger.not())
 
-  /** Returns true if and only if the designated bit is set. */
+  /** Returns true if and only if the designated bit is set.
+   *
+   *  @param n the zero-based index of the bit to test
+   */
   def testBit(n: Int): Boolean =
     if (longEncoding && n >= 0) {
       if (n <= 63)
@@ -480,15 +582,24 @@ final class BigInt private (
         _long < 0 // give the sign bit
     } else this.bigInteger.testBit(n)
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set. */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit set.
+   *
+   *  @param n the zero-based index of the bit to set
+   */
   def setBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long | (1L << n)) else BigInt(this.bigInteger.setBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared. */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit cleared.
+   *
+   *  @param n the zero-based index of the bit to clear
+   */
   def clearBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long & ~(1L << n)) else BigInt(this.bigInteger.clearBit(n))
 
-  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped. */
+  /** Returns a BigInt whose value is equivalent to this BigInt with the designated bit flipped.
+   *
+   *  @param n the zero-based index of the bit to flip
+   */
   def flipBit(n: Int): BigInt  = // note that we do not operate on the Long sign bit #63
     if (longEncoding && n <= 62 && n >= 0) BigInt(_long ^ (1L << n)) else BigInt(this.bigInteger.flipBit(n))
 
@@ -586,17 +697,24 @@ final class BigInt private (
    *
    *  @param end    the end value of the range (exclusive)
    *  @param step   the distance between elements (defaults to 1)
-   *  @return       the range
+   *  @return       the exclusive `NumericRange` from this to `end`
    */
   def until(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Exclusive[BigInt] = Range.BigInt(this, end, step)
 
-  /** Like until, but inclusive of the end value. */
+  /** Like until, but inclusive of the end value.
+   *
+   *  @param end the end value of the range (inclusive)
+   *  @param step the distance between elements (defaults to 1)
+   */
   def to(end: BigInt, step: BigInt = BigInt(1)): NumericRange.Inclusive[BigInt] = Range.BigInt.inclusive(this, end, step)
 
   /** Returns the decimal String representation of this BigInt. */
   override def toString(): String = if (longEncoding) _long.toString() else _bigInteger.toString()
 
-  /** Returns the String representation in the specified radix of this BigInt. */
+  /** Returns the String representation in the specified radix of this BigInt.
+   *
+   *  @param radix the radix to use in the string representation
+   */
   def toString(radix: Int): String = this.bigInteger.toString(radix)
 
   /** Returns a byte array containing the two's-complement representation of

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -30,10 +30,16 @@ import scala.annotation.migration
  *    1. symmetric: `equiv(x, y) == equiv(y, x)` for any `x` and `y` of type `T`.
  *    1. transitive: if `equiv(x, y) == true` and `equiv(y, z) == true`, then
  *       `equiv(x, z) == true` for any `x`, `y`, and `z` of type `T`.
+ *
+ *  @tparam T the type of values being compared for equivalence
  */
 
 trait Equiv[T] extends Any with Serializable {
-  /** Returns `true` iff `x` is equivalent to `y`. */
+  /** Returns `true` iff `x` is equivalent to `y`.
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def equiv(x: T, y: T): Boolean
 }
 
@@ -95,10 +101,16 @@ object Equiv extends LowPriorityEquiv {
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:
      *  For instance `implicitly[Equiv[Any]]` diverges in its presence.
+     *
+     *  @tparam CC the collection type constructor, a subtype of `Seq` (e.g., `List`, `Vector`)
+     *  @tparam T the element type of the collection
      */
     implicit def seqEquiv[CC[X] <: scala.collection.Seq[X], T](implicit eqv: Equiv[T]): Equiv[CC[T]] =
       new IterableEquiv[CC, T](eqv)
 
+    /** @tparam CC the collection type constructor, a subtype of `SortedSet`
+     *  @tparam T the element type of the collection
+     */
     implicit def sortedSetEquiv[CC[X] <: scala.collection.SortedSet[X], T](implicit eqv: Equiv[T]): Equiv[CC[T]] =
       new IterableEquiv[CC, T](eqv)
   }

--- a/library/src/scala/math/Integral.scala
+++ b/library/src/scala/math/Integral.scala
@@ -35,6 +35,10 @@ object Integral {
     /** The regrettable design of Numeric/Integral/Fractional has them all
      *  bumping into one another when searching for this implicit, so they
      *  are exiled into their own companions.
+     *
+     *  @tparam T the numeric type for which an `Integral` instance exists
+     *  @param x the value to wrap with integral operator syntax (`/`, `%`, `/%`)
+     *  @param num the implicit `Integral` instance for type `T`
      */
     implicit def infixIntegralOps[T](x: T)(implicit num: Integral[T]): Integral[T]#IntegralOps = new num.IntegralOps(x)
   }

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -28,6 +28,10 @@ object Numeric {
      *  ```
      *  def plus[T: Numeric](x: T, y: T) = x + y
      *  ```
+     *
+     *  @tparam T the numeric type for which a `Numeric` instance exists
+     *  @param x the value to wrap with numeric infix operations
+     *  @param num the implicit `Numeric` instance that provides the arithmetic operations
      */
     implicit def infixNumericOps[T](x: T)(implicit num: Numeric[T]): Numeric[T]#NumericOps = new num.NumericOps(x)
   }

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -56,6 +56,8 @@ import scala.language.implicitConversions
  *  provide it yourself either when inheriting or instantiating.
  *
  *  @see [[scala.math.Ordering]], [[scala.math.PartiallyOrdered]]
+ *
+ *  @tparam A the type of the objects that this object can be compared to
  */
 trait Ordered[A] extends Any with java.lang.Comparable[A] {
 
@@ -70,13 +72,22 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
    *   - `x == 0` when `this == that`
    *
    *   - `x > 0` when  `this > that`
+   *
+   *  @param that the instance to compare against
+   *  @return an integer whose sign indicates the ordering relation between `this` and `that`
    */
   def compare(that: A): Int
 
-  /** Returns true if `this` is less than `that` */
+  /** Returns true if `this` is less than `that`
+   *
+   *  @param that the instance to compare against
+   */
   def <  (that: A): Boolean = (this compare that) <  0
 
-  /** Returns true if `this` is greater than `that`. */
+  /** Returns true if `this` is greater than `that`.
+   *
+   *  @param that the instance to compare against
+   */
   def >  (that: A): Boolean = (this compare that) >  0
 
   /** Returns true if `this` is less than or equal to `that`. */
@@ -85,12 +96,20 @@ trait Ordered[A] extends Any with java.lang.Comparable[A] {
   /** Returns true if `this` is greater than or equal to `that`. */
   def >= (that: A): Boolean = (this compare that) >= 0
 
-  /** Result of comparing `this` with operand `that`. */
+  /** Result of comparing `this` with operand `that`.
+   *
+   *  @param that the instance to compare against
+   */
   def compareTo(that: A): Int = compare(that)
 }
 
 object Ordered {
-  /** Lens from `Ordering[T]` to `Ordered[T]`. */
+  /** Lens from `Ordering[T]` to `Ordered[T]`.
+   *
+   *  @tparam T the type of the value to be wrapped as `Ordered`
+   *  @param x the value to be converted to an `Ordered` instance
+   *  @param ord the implicit `Ordering` instance used to perform comparisons
+   */
   implicit def orderingToOrdered[T](x: T)(implicit ord: Ordering[T]): Ordered[T] =
     new Ordered[T] { def compare(that: T): Int = ord.compare(x, that) }
 }

--- a/library/src/scala/math/PartialOrdering.scala
+++ b/library/src/scala/math/PartialOrdering.scala
@@ -38,6 +38,8 @@ import scala.language.`2.13`
  *  `lteq(x, y) && lteq(y, x) == **true**`. This equivalence relation is
  *  exposed as the `equiv` method, inherited from the
  *  [[scala.math.Equiv Equiv]] trait.
+ *
+ *  @tparam T the type of elements being ordered
  */
 
 trait PartialOrdering[T] extends Equiv[T] {
@@ -49,26 +51,47 @@ trait PartialOrdering[T] extends Equiv[T] {
    *  - `r < 0`    iff    `x < y`
    *  - `r == 0`   iff    `x == y`
    *  - `r > 0`    iff    `x > y`
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
    */
   def tryCompare(x: T, y: T): Option[Int]
 
-  /** Returns `**true**` iff `x` comes before `y` in the ordering. */
+  /** Returns `**true**` iff `x` comes before `y` in the ordering.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
+   */
   def lteq(x: T, y: T): Boolean
 
-  /** Returns `**true**` iff `y` comes before `x` in the ordering. */
+  /** Returns `**true**` iff `y` comes before `x` in the ordering.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
+   */
   def gteq(x: T, y: T): Boolean = lteq(y, x)
 
   /** Returns `**true**` iff `x` comes before `y` in the ordering
    *  and is not the same as `y`.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
    */
   def lt(x: T, y: T): Boolean = lteq(x, y) && !equiv(x, y)
 
   /** Returns `**true**` iff `y` comes before `x` in the ordering
    *  and is not the same as `x`.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
    */
   def gt(x: T, y: T): Boolean = gteq(x, y) && !equiv(x, y)
 
-  /** Returns `**true**` iff `x` is equivalent to `y` in the ordering. */
+  /** Returns `**true**` iff `x` is equivalent to `y` in the ordering.
+   *
+   *  @param x the first element to compare
+   *  @param y the second element to compare
+   */
   def equiv(x: T, y: T): Boolean = lteq(x,y) && lteq(y,x)
 
   def reverse : PartialOrdering[T] = new PartialOrdering[T] {

--- a/library/src/scala/math/PartiallyOrdered.scala
+++ b/library/src/scala/math/PartiallyOrdered.scala
@@ -15,7 +15,10 @@ package math
 
 import scala.language.`2.13`
 
-/** A class for partially ordered data. */
+/** A class for partially ordered data.
+ *
+ *  @tparam A the type of the elements being ordered
+ */
 trait PartiallyOrdered[+A] extends Any {
 
   type AsPartiallyOrdered[B] = B => PartiallyOrdered[B]
@@ -26,6 +29,9 @@ trait PartiallyOrdered[+A] extends Any {
    *  - `x < 0`    iff   `**this** &lt; that`
    *  - `x == 0`   iff   `**this** == that`
    *  - `x > 0`    iff   `**this** &gt; that`
+   *
+   *  @tparam B a supertype of `A` for which an implicit conversion to `PartiallyOrdered[B]` exists
+   *  @param that the value to compare against
    */
   def tryCompareTo [B >: A: AsPartiallyOrdered](that: B): Option[Int]
 

--- a/library/src/scala/math/ScalaNumericConversions.scala
+++ b/library/src/scala/math/ScalaNumericConversions.scala
@@ -27,7 +27,7 @@ trait ScalaNumericConversions extends ScalaNumber with ScalaNumericAnyConversion
  */
 trait ScalaNumericAnyConversions extends Any {
   /**
-   *  @return `**true**` if this number has no decimal component, `**false**` otherwise.
+   *  @return `true` if this number has no decimal component, `false` otherwise.
    */
   def isWhole: Boolean
 
@@ -112,6 +112,8 @@ trait ScalaNumericAnyConversions extends Any {
    *  in its lower 64 bits.  Or a BigDecimal with more precision
    *  than Double can hold: same thing.  There's no way given the
    *  interface available here to prevent this error.
+   *
+   *  @param x the value to compare against this numeric value for primitive equality
    */
   protected def unifiedPrimitiveEquals(x: Any) = x match {
     case x: Char    => isValidChar && (toInt == x.toInt)

--- a/library/src/scala/math/package.scala
+++ b/library/src/scala/math/package.scala
@@ -105,17 +105,41 @@ package object math {
    */
   def random(): Double = java.lang.Math.random()
 
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the angle, in radians
+   */
   def sin(x: Double): Double = java.lang.Math.sin(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the angle, in radians
+   */
   def cos(x: Double): Double = java.lang.Math.cos(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the angle, in radians
+   */
   def tan(x: Double): Double = java.lang.Math.tan(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the value whose arc sine is to be returned
+   */
   def asin(x: Double): Double = java.lang.Math.asin(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the value whose arc cosine is to be returned
+   */
   def acos(x: Double): Double = java.lang.Math.acos(x)
-  /**  @group trig */
+  /**
+   *  @group trig
+   *
+   *  @param x the value whose arc tangent is to be returned
+   */
   def atan(x: Double): Double = java.lang.Math.atan(x)
 
   /** Converts an angle measured in degrees to an approximately equivalent
@@ -138,8 +162,8 @@ package object math {
 
   /** Converts rectangular coordinates `(x, y)` to polar `(r, theta)`.
    *
-   *  @param  x the ordinate coordinate
-   *  @param  y the abscissa coordinate
+   *  @param  y the ordinate coordinate
+   *  @param  x the abscissa coordinate
    *  @return the *theta* component of the point `(r, theta)` in polar
    *          coordinates that corresponds to the point `(x, y)` in
    *          Cartesian coordinates.
@@ -154,6 +178,10 @@ package object math {
    *  coordinates that corresponds to the point `(x, y)` in
    *  Cartesian coordinates.
    *  @group polar-coords
+   *
+   *  @param x the x coordinate value
+   *  @param y the y coordinate value
+   *  @return sqrt(`x`² + `y`²) without intermediate overflow or underflow
    */
   def hypot(x: Double, y: Double): Double = java.lang.Math.hypot(x, y)
 
@@ -161,9 +189,17 @@ package object math {
   // rounding functions
   // -----------------------------------------------------------------------
 
-  /** @group rounding */
+  /**
+   *  @group rounding
+   *
+   *  @param x the value to be rounded up
+   */
   def ceil(x: Double): Double  = java.lang.Math.ceil(x)
-  /** @group rounding */
+  /**
+   *  @group rounding
+   *
+   *  @param x the value to be rounded down
+   */
   def floor(x: Double): Double = java.lang.Math.floor(x)
 
   /** Returns the `Double` value that is closest in value to the
@@ -195,93 +231,227 @@ package object math {
   /** Returns the closest `Long` to the argument.
    *
    *  @param  x a floating-point value to be rounded to a `Long`.
-   *  @return the value of the argument rounded to the nearest`long` value.
+   *  @return the value of the argument rounded to the nearest `Long` value.
    *  @group rounding
    */
   def round(x: Double): Long = java.lang.Math.round(x)
 
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Int): Int       = java.lang.Math.abs(x)
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Long): Long     = java.lang.Math.abs(x)
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Float): Float   = java.lang.Math.abs(x)
-  /** @group abs */
+  /**
+   *  @group abs
+   *
+   *  @param x the value whose absolute value is to be determined
+   */
   def abs(x: Double): Double = java.lang.Math.abs(x)
 
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Int, y: Int): Int          = java.lang.Math.max(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Long, y: Long): Long       = java.lang.Math.max(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Float, y: Float): Float    = java.lang.Math.max(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def max(x: Double, y: Double): Double = java.lang.Math.max(x, y)
 
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Int, y: Int): Int          = java.lang.Math.min(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Long, y: Long): Long       = java.lang.Math.min(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Float, y: Float): Float    = java.lang.Math.min(x, y)
-  /** @group minmax */
+  /**
+   *  @group minmax
+   *
+   *  @param x the first value to compare
+   *  @param y the second value to compare
+   */
   def min(x: Double, y: Double): Double = java.lang.Math.min(x, y)
 
   /**
    *  @group signs
    *  @note Forwards to [[java.lang.Integer]]
+   *
+   *  @param x the value whose signum is to be computed
    */
   def signum(x: Int): Int       = java.lang.Integer.signum(x)
   /**
    *  @group signs
    *  @note Forwards to [[java.lang.Long]]
+   *
+   *  @param x the value whose signum is to be computed
    */
   def signum(x: Long): Long     = java.lang.Long.signum(x)
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param x the value whose signum is to be computed
+   */
   def signum(x: Float): Float   = java.lang.Math.signum(x)
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param x the value whose signum is to be computed
+   */
   def signum(x: Double): Double = java.lang.Math.signum(x)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorDiv(x: Int, y: Int): Int = java.lang.Math.floorDiv(x, y)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorDiv(x: Long, y: Long): Long = java.lang.Math.floorDiv(x, y)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorMod(x: Int, y: Int): Int = java.lang.Math.floorMod(x, y)
 
-  /** @group modquo */
+  /**
+   *  @group modquo
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def floorMod(x: Long, y: Long): Long = java.lang.Math.floorMod(x, y)
 
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param magnitude the value providing the magnitude of the result
+   *  @param sign the value providing the sign of the result
+   */
   def copySign(magnitude: Double, sign: Double): Double = java.lang.Math.copySign(magnitude, sign)
 
-  /** @group signs */
+  /**
+   *  @group signs
+   *
+   *  @param magnitude the value providing the magnitude of the result
+   *  @param sign the value providing the sign of the result
+   */
   def copySign(magnitude: Float, sign: Float): Float = java.lang.Math.copySign(magnitude, sign)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param start the starting floating-point value
+   *  @param direction the value indicating which of `start`'s neighbors should be returned
+   */
   def nextAfter(start: Double, direction: Double): Double = java.lang.Math.nextAfter(start, direction)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param start the starting floating-point value
+   *  @param direction the value indicating which of `start`'s neighbors should be returned
+   */
   def nextAfter(start: Float, direction: Double): Float = java.lang.Math.nextAfter(start, direction)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param d the starting floating-point value
+   */
   def nextUp(d: Double): Double = java.lang.Math.nextUp(d)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param f the starting floating-point value
+   */
   def nextUp(f: Float): Float = java.lang.Math.nextUp(f)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param d the starting floating-point value
+   */
   def nextDown(d: Double): Double = java.lang.Math.nextDown(d)
 
-  /** @group adjacent-float */
+  /**
+   *  @group adjacent-float
+   *
+   *  @param f the starting floating-point value
+   */
   def nextDown(f: Float): Float = java.lang.Math.nextDown(f)
 
-  /** @group scaling */
+  /**
+   *  @group scaling
+   *
+   *  @param d the value to be scaled by a power of two
+   *  @param scaleFactor the power of 2 used to scale `d`
+   */
   def scalb(d: Double, scaleFactor: Int): Double = java.lang.Math.scalb(d, scaleFactor)
 
-  /** @group scaling */
+  /**
+   *  @group scaling
+   *
+   *  @param f the value to be scaled by a power of two
+   *  @param scaleFactor the power of 2 used to scale `f`
+   */
   def scalb(f: Float, scaleFactor: Int): Float = java.lang.Math.scalb(f, scaleFactor)
 
   // -----------------------------------------------------------------------
@@ -321,7 +491,7 @@ package object math {
   /** Returns Euler's number `e` raised to the power of a `Double` value.
    *
    *  @param  x the exponent to raise `e` to.
-   *  @return the value `e^a^`, where `e` is the base of the natural
+   *  @return the value `e^x^`, where `e` is the base of the natural
    *          logarithms.
    *  @group explog
    */
@@ -329,13 +499,23 @@ package object math {
 
   /** Returns `exp(x) - 1`.
    *  @group explog
+   *
+   *  @param x the exponent to raise `e` to in the computation of `e`^`x`^ - 1
    */
   def expm1(x: Double): Double = java.lang.Math.expm1(x)
 
-  /** @group explog */
+  /**
+   *  @group explog
+   *
+   *  @param f the `Float` value whose unbiased exponent is to be extracted
+   */
   def getExponent(f: Float): Int = java.lang.Math.getExponent(f)
 
-  /** @group explog */
+  /**
+   *  @group explog
+   *
+   *  @param d the `Double` value whose unbiased exponent is to be extracted
+   */
   def getExponent(d: Double): Int = java.lang.Math.getExponent(d)
 
   // -----------------------------------------------------------------------
@@ -345,18 +525,22 @@ package object math {
   /** Returns the natural logarithm of a `Double` value.
    *
    *  @param  x the number to take the natural logarithm of
-   *  @return the value `logₑ(x)` where `e` is Eulers number
+   *  @return the value `logₑ(x)` where `e` is Euler's number
    *  @group explog
    */
   def log(x: Double): Double = java.lang.Math.log(x)
 
   /** Returns the natural logarithm of the sum of the given `Double` value and 1.
    *  @group explog
+   *
+   *  @param x the value for which to compute `ln(1 + x)`
    */
   def log1p(x: Double): Double = java.lang.Math.log1p(x)
 
   /** Returns the base 10 logarithm of the given `Double` value.
    *  @group explog
+   *
+   *  @param x the value whose base 10 logarithm is to be computed
    */
   def log10(x: Double): Double = java.lang.Math.log10(x)
 
@@ -366,16 +550,22 @@ package object math {
 
   /** Returns the hyperbolic sine of the given `Double` value.
    *  @group hyperbolic
+   *
+   *  @param x the value whose hyperbolic sine is to be returned
    */
   def sinh(x: Double): Double = java.lang.Math.sinh(x)
 
   /** Returns the hyperbolic cosine of the given `Double` value.
    *  @group hyperbolic
+   *
+   *  @param x the value whose hyperbolic cosine is to be returned
    */
   def cosh(x: Double): Double = java.lang.Math.cosh(x)
 
   /** Returns the hyperbolic tangent of the given `Double` value.
    *  @group hyperbolic
+   *
+   *  @param x the value whose hyperbolic tangent is to be returned
    */
   def tanh(x: Double):Double = java.lang.Math.tanh(x)
 
@@ -385,58 +575,125 @@ package object math {
 
   /** Returns the size of an ulp of the given `Double` value.
    *  @group ulp
+   *
+   *  @param x the `Double` value whose ulp is to be returned
    */
   def ulp(x: Double): Double = java.lang.Math.ulp(x)
 
   /** Returns the size of an ulp of the given `Float` value.
    *  @group ulp
+   *
+   *  @param x the `Float` value whose ulp is to be returned
    */
   def ulp(x: Float): Float = java.lang.Math.ulp(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the dividend value
+   *  @param y the divisor value
+   */
   def IEEEremainder(x: Double, y: Double): Double = java.lang.Math.IEEEremainder(x, y)
 
   // -----------------------------------------------------------------------
   // exact functions
   // -----------------------------------------------------------------------
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first addend
+   *  @param y the second addend
+   */
   def addExact(x: Int, y: Int): Int = java.lang.Math.addExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first addend
+   *  @param y the second addend
+   */
   def addExact(x: Long, y: Long): Long = java.lang.Math.addExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the minuend
+   *  @param y the subtrahend
+   */
   def subtractExact(x: Int, y: Int): Int = java.lang.Math.subtractExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the minuend
+   *  @param y the subtrahend
+   */
   def subtractExact(x: Long, y: Long): Long = java.lang.Math.subtractExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first factor
+   *  @param y the second factor
+   */
   def multiplyExact(x: Int, y: Int): Int = java.lang.Math.multiplyExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the first factor
+   *  @param y the second factor
+   */
   def multiplyExact(x: Long, y: Long): Long = java.lang.Math.multiplyExact(x, y)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be incremented
+   */
   def incrementExact(x: Int): Int = java.lang.Math.incrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be incremented
+   */
   def incrementExact(x: Long) =  java.lang.Math.incrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be decremented
+   */
   def decrementExact(x: Int) =  java.lang.Math.decrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be decremented
+   */
   def decrementExact(x: Long) =  java.lang.Math.decrementExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be negated
+   */
   def negateExact(x: Int) =  java.lang.Math.negateExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the value to be negated
+   */
   def negateExact(x: Long) =  java.lang.Math.negateExact(x)
 
-  /** @group exact */
+  /**
+   *  @group exact
+   *
+   *  @param x the `Long` value to convert to an `Int`
+   */
   def toIntExact(x: Long): Int = java.lang.Math.toIntExact(x)
 
 }


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for math. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.