### PR TITLE
Jdk (9): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -62,7 +62,10 @@ final class DoubleAccumulator
     else history = java.util.Arrays.copyOf(history, history.length << 1)
   }
 
-  /** Appends an element to this `DoubleAccumulator`. */
+  /** Appends an element to this `DoubleAccumulator`.
+   *
+   *  @param a the `Double` value to append
+   */
   def addOne(a: Double): this.type = {
     totalSize += 1
     if (index+1 >= current.length) expand()
@@ -74,7 +77,10 @@ final class DoubleAccumulator
   /** Result collection consisting of all elements appended so far. */
   override def result(): DoubleAccumulator = this
 
-  /** Removes all elements from `that` and appends them to this `DoubleAccumulator`. */
+  /** Removes all elements from `that` and appends them to this `DoubleAccumulator`.
+   *
+   *  @param that the `DoubleAccumulator` to drain elements from; it will be empty after this operation
+   */
   def drain(that: DoubleAccumulator): Unit = {
     var h = 0
     var prev = 0L
@@ -137,7 +143,10 @@ final class DoubleAccumulator
     history = DoubleAccumulator.emptyDoubleArrayArray
   }
 
-  /** Retrieves the `ix`th element. */
+  /** Retrieves the `ix`th element.
+   *
+   *  @param ix the zero-based index of the element to retrieve
+   */
   def apply(ix: Long): Double = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
     else {
@@ -146,7 +155,10 @@ final class DoubleAccumulator
     }
   }
 
-  /** Retrieves the `ix`th element, using an `Int` index. */
+  /** Retrieves the `ix`th element, using an `Int` index.
+   *
+   *  @param i the zero-based index of the element to retrieve (converted to `Long` internally)
+   */
   def apply(i: Int): Double = apply(i.toLong)
 
   def update(idx: Long, elem: Double): Unit = {
@@ -283,6 +295,9 @@ final class DoubleAccumulator
   /** Copies the elements in this `DoubleAccumulator` to a specified collection.
    *  Note that the target collection is not specialized.
    *  Usage example: `acc.to(Vector)`
+   *
+   *  @tparam C1 the result type of the target collection (e.g., `Vector[Double]`)
+   *  @param factory the factory for creating the target collection from elements
    */
   override def to[C1](factory: Factory[Double, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -65,7 +65,10 @@ final class IntAccumulator
     else history = java.util.Arrays.copyOf(history, history.length << 1)
   }
 
-  /** Appends an element to this `IntAccumulator`. */
+  /** Appends an element to this `IntAccumulator`.
+   *
+   *  @param a the `Int` value to append
+   */
   def addOne(a: Int): this.type = {
     totalSize += 1
     if (index+2 >= current.length) expand()
@@ -77,7 +80,10 @@ final class IntAccumulator
   /** Result collection consisting of all elements appended so far. */
   override def result(): IntAccumulator = this
 
-  /** Removes all elements from `that` and appends them to this `IntAccumulator`. */
+  /** Removes all elements from `that` and appends them to this `IntAccumulator`.
+   *
+   *  @param that the `IntAccumulator` to drain elements from; it will be empty after this operation
+   */
   def drain(that: IntAccumulator): Unit = {
     var h = 0
     var prev = 0L
@@ -143,7 +149,10 @@ final class IntAccumulator
     history = IntAccumulator.emptyIntArrayArray
   }
 
-  /** Retrieves the `ix`th element. */
+  /** Retrieves the `ix`th element.
+   *
+   *  @param ix the zero-based index of the element to retrieve, as a `Long`
+   */
   def apply(ix: Long): Int = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
     else {
@@ -152,7 +161,10 @@ final class IntAccumulator
     }
   }
 
-  /** Retrieves the `ix`th element, using an `Int` index. */
+  /** Retrieves the `ix`th element, using an `Int` index.
+   *
+   *  @param i the zero-based index of the element to retrieve
+   */
   def apply(i: Int): Int = apply(i.toLong)
 
   def update(idx: Long, elem: Int): Unit = {
@@ -289,6 +301,9 @@ final class IntAccumulator
   /** Copies the elements in this `IntAccumulator` to a specified collection.
    *  Note that the target collection is not specialized.
    *  Usage example: `acc.to(Vector)`
+   *
+   *  @tparam C1 the type of the target collection
+   *  @param factory the factory for building the target collection from `Int` elements
    */
   override def to[C1](factory: Factory[Int, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -63,7 +63,10 @@ final class LongAccumulator
     else history = java.util.Arrays.copyOf(history, history.length << 1)
   }
 
-  /** Appends an element to this `LongAccumulator`. */
+  /** Appends an element to this `LongAccumulator`.
+   *
+   *  @param a the `Long` value to append
+   */
   def addOne(a: Long): this.type = {
     totalSize += 1
     if (index+1 >= current.length) expand()
@@ -75,7 +78,10 @@ final class LongAccumulator
   /** Result collection consisting of all elements appended so far. */
   override def result(): LongAccumulator = this
 
-  /** Removes all elements from `that` and appends them to this `LongAccumulator`. */
+  /** Removes all elements from `that` and appends them to this `LongAccumulator`.
+   *
+   *  @param that the `LongAccumulator` to drain elements from; it will be empty after this operation
+   */
   def drain(that: LongAccumulator): Unit = {
     var h = 0
     var prev = 0L
@@ -138,7 +144,10 @@ final class LongAccumulator
     history = LongAccumulator.emptyLongArrayArray
   }
 
-  /** Retrieves the `ix`th element. */
+  /** Retrieves the `ix`th element.
+   *
+   *  @param ix the zero-based index of the element to retrieve
+   */
   def apply(ix: Long): Long = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
     else {
@@ -147,7 +156,10 @@ final class LongAccumulator
     }
   }
 
-  /** Retrieves the `ix`th element, using an `Int` index. */
+  /** Retrieves the `ix`th element, using an `Int` index.
+   *
+   *  @param i the zero-based index of the element to retrieve
+   */
   def apply(i: Int): Long = apply(i.toLong)
 
   def update(idx: Long, elem: Long): Unit = {
@@ -284,6 +296,9 @@ final class LongAccumulator
   /** Copies the elements in this `LongAccumulator` to a specified collection.
    *  Note that the target collection is not specialized.
    *  Usage example: `acc.to(Vector)`
+   *
+   *  @tparam C1 the result type of the target collection
+   *  @param factory the factory for the target collection type
    */
   override def to[C1](factory: Factory[Long, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/OptionConverters.scala
+++ b/library/src/scala/jdk/OptionConverters.scala
@@ -45,7 +45,11 @@ import java.util.{Optional, OptionalDouble, OptionalInt, OptionalLong}
  *  ```
  */
 object OptionConverters {
-  /** Provides conversions from Java `Optional` to Scala `Option` and specialized `Optional` types. */
+  /** Provides conversions from Java `Optional` to Scala `Option` and specialized `Optional` types.
+   *
+   *  @tparam A the type of the value contained in the `Optional`
+   *  @param o the Java `Optional` to convert
+   */
   implicit class RichOptional[A](private val o: java.util.Optional[A]) extends AnyVal {
     /** Converts a Java `Optional` to a Scala `Option`. */
     def toScala: Option[A] = if (o.isPresent) Some(o.get) else None
@@ -54,11 +58,19 @@ object OptionConverters {
     @deprecated("Use `toScala` instead", "2.13.0")
     def asScala: Option[A] = if (o.isPresent) Some(o.get) else None
 
-    /** Converts a generic Java `Optional` to a specialized variant. */
+    /** Converts a generic Java `Optional` to a specialized variant.
+     *
+     *  @tparam O the target specialized Java `Optional` type, inferred from the available `OptionShape` instance (e.g., `OptionalInt`, `OptionalDouble`, `OptionalLong`)
+     *  @param shape implicit evidence that defines how to convert between `Optional[A]` and the specialized type `O`
+     */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromJava(o)
   }
 
-  /** Provides conversions from Scala `Option` to Java `Optional` types. */
+  /** Provides conversions from Scala `Option` to Java `Optional` types.
+   *
+   *  @tparam A the type of the value contained in the `Option`
+   *  @param o the Scala `Option` to convert
+   */
   implicit class RichOption[A](private val o: Option[A]) extends AnyVal {
     /** Converts a Scala `Option` to a generic Java `Optional`. */
     def toJava: Optional[A] = o match { case Some(a) => Optional.ofNullable(a); case _ => Optional.empty[A] }
@@ -67,11 +79,18 @@ object OptionConverters {
     @deprecated("Use `toJava` instead", "2.13.0")
     def asJava: Optional[A] = o match { case Some(a) => Optional.ofNullable(a); case _ => Optional.empty[A] }
 
-    /** Converts a Scala `Option` to a specialized Java `Optional`. */
+    /** Converts a Scala `Option` to a specialized Java `Optional`.
+     *
+     *  @tparam O the specialized Java `Optional` type (e.g., `OptionalInt`, `OptionalDouble`, `OptionalLong`)
+     *  @param shape implicit evidence that defines how to convert between `Option[A]` and the specialized type `O`
+     */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromScala(o)
   }
 
-  /** Provides conversions from `OptionalDouble` to Scala `Option` and the generic `Optional`. */
+  /** Provides conversions from `OptionalDouble` to Scala `Option` and the generic `Optional`.
+   *
+   *  @param o the Java `OptionalDouble` to convert
+   */
   implicit class RichOptionalDouble(private val o: OptionalDouble) extends AnyVal {
     /** Converts a Java `OptionalDouble` to a Scala `Option`. */
     def toScala: Option[Double] = if (o.isPresent) Some(o.getAsDouble) else None
@@ -84,7 +103,10 @@ object OptionConverters {
     def toJavaGeneric: Optional[Double] = if (o.isPresent) Optional.of(o.getAsDouble) else Optional.empty[Double]
   }
 
-  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional`. */
+  /** Provides conversions from `OptionalInt` to Scala `Option` and the generic `Optional`.
+   *
+   *  @param o the Java `OptionalInt` to convert
+   */
   implicit class RichOptionalInt(private val o: OptionalInt) extends AnyVal {
     /** Converts a Java `OptionalInt` to a Scala `Option`. */
     def toScala: Option[Int] = if (o.isPresent) Some(o.getAsInt) else None
@@ -97,7 +119,10 @@ object OptionConverters {
     def toJavaGeneric: Optional[Int] = if (o.isPresent) Optional.of(o.getAsInt) else Optional.empty[Int]
   }
 
-  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional`. */
+  /** Provides conversions from `OptionalLong` to Scala `Option` and the generic `Optional`.
+   *
+   *  @param o the Java `OptionalLong` to convert
+   */
   implicit class RichOptionalLong(private val o: OptionalLong) extends AnyVal {
     /** Converts a Java `OptionalLong` to a Scala `Option`. */
     def toScala: Option[Long] = if (o.isPresent) Some(o.getAsLong) else None

--- a/library/src/scala/jdk/OptionShape.scala
+++ b/library/src/scala/jdk/OptionShape.scala
@@ -26,9 +26,15 @@ import scala.annotation.implicitNotFound
  */
 @implicitNotFound("No specialized Optional type exists for elements of type ${A}")
 sealed abstract class OptionShape[A, O] {
-  /** Converts from `Optional` to the specialized variant `O`. */
+  /** Converts from `Optional` to the specialized variant `O`.
+   *
+   *  @param o the generic `Optional` to convert to the specialized variant
+   */
   def fromJava(o: Optional[A]): O
-  /** Converts from `Option` to the specialized variant `O`. */
+  /** Converts from `Option` to the specialized variant `O`.
+   *
+   *  @param o the Scala `Option` to convert to the specialized Java variant
+   */
   def fromScala(o: Option[A]): O
 }
 

--- a/library/src/scala/jdk/javaapi/DurationConverters.scala
+++ b/library/src/scala/jdk/javaapi/DurationConverters.scala
@@ -29,6 +29,8 @@ object  DurationConverters {
    *  zero, the returned duration will have a time unit of seconds. If there is a nanoseconds part,
    *  the Scala duration will have a time unit of nanoseconds.
    *
+   *  @param duration the Java `java.time.Duration` to convert
+   *  @return a Scala `FiniteDuration` with the same length, using seconds or nanoseconds as the time unit
    *  @throws IllegalArgumentException If the given Java Duration is out of bounds of what can be
    *                                  expressed by [[scala.concurrent.duration.FiniteDuration]].
    */
@@ -58,6 +60,9 @@ object  DurationConverters {
   /** Converts a Scala `FiniteDuration` to a Java duration. Note that the Scala duration keeps the
    *  time unit it was created with, while a Java duration always is a pair of seconds and nanos,
    *  so the unit it lost.
+   *
+   *  @param duration the Scala `FiniteDuration` to convert
+   *  @return a Java `java.time.Duration` representing the same length of time
    */
   def toJava(duration: FiniteDuration): JDuration = {
     if (duration.length == 0) JDuration.ZERO

--- a/library/src/scala/jdk/javaapi/FunctionConverters.scala
+++ b/library/src/scala/jdk/javaapi/FunctionConverters.scala
@@ -32,6 +32,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param jf the Java `BiConsumer` to convert
    */
   @inline def asScalaFromBiConsumer[T, U](jf: java.util.function.BiConsumer[T, U]): scala.Function2[T, U, scala.runtime.BoxedUnit] = jf match {
     case AsJavaBiConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, U, scala.runtime.BoxedUnit]]
@@ -43,18 +47,32 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param sf the Scala `Function2` to convert to a Java `BiConsumer`
    */
   @inline def asJavaBiConsumer[T, U](sf: scala.Function2[T, U, scala.runtime.BoxedUnit]): java.util.function.BiConsumer[T, U] = ((sf): AnyRef) match {
     case FromJavaBiConsumer((f @ _)) => f.asInstanceOf[java.util.function.BiConsumer[T, U]]
     case _ => new AsJavaBiConsumer[T, U](sf.asInstanceOf[scala.Function2[T, U, Unit]])
   }
   
-  
+
+  /** @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param jf the Java `BiFunction` to convert
+   */
   @inline def asScalaFromBiFunction[T, U, R](jf: java.util.function.BiFunction[T, U, R]): scala.Function2[T, U, R] = jf match {
     case AsJavaBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, R]]
     case _ => new FromJavaBiFunction[T, U, R](jf).asInstanceOf[scala.Function2[T, U, R]]
   }
   
+  /** @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param sf the Scala `Function2` to convert to a Java `BiFunction`
+   */
   @inline def asJavaBiFunction[T, U, R](sf: scala.Function2[T, U, R]): java.util.function.BiFunction[T, U, R] = ((sf): AnyRef) match {
     case FromJavaBiFunction((f @ _)) => f.asInstanceOf[java.util.function.BiFunction[T, U, R]]
     case _ => new AsJavaBiFunction[T, U, R](sf.asInstanceOf[scala.Function2[T, U, R]])
@@ -66,6 +84,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param jf the Java `BiPredicate` to convert
    */
   @inline def asScalaFromBiPredicate[T, U](jf: java.util.function.BiPredicate[T, U]): scala.Function2[T, U, java.lang.Boolean] = jf match {
     case AsJavaBiPredicate((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Boolean]]
@@ -77,6 +99,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param sf the Scala `Function2` to convert to a Java `BiPredicate`
    */
   @inline def asJavaBiPredicate[T, U](sf: scala.Function2[T, U, java.lang.Boolean]): java.util.function.BiPredicate[T, U] = ((sf): AnyRef) match {
     case FromJavaBiPredicate((f @ _)) => f.asInstanceOf[java.util.function.BiPredicate[T, U]]
@@ -84,11 +110,17 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the input and output type of the binary operator
+   *  @param jf the Java `BinaryOperator` to convert
+   */
   @inline def asScalaFromBinaryOperator[T](jf: java.util.function.BinaryOperator[T]): scala.Function2[T, T, T] = jf match {
     case AsJavaBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[T, T, T]]
     case _ => new FromJavaBinaryOperator[T](jf).asInstanceOf[scala.Function2[T, T, T]]
   }
   
+  /** @tparam T the input and output type of the binary operator
+   *  @param sf the Scala `Function2` to convert to a Java `BinaryOperator`
+   */
   @inline def asJavaBinaryOperator[T](sf: scala.Function2[T, T, T]): java.util.function.BinaryOperator[T] = ((sf): AnyRef) match {
     case FromJavaBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.BinaryOperator[T]]
     case _ => new AsJavaBinaryOperator[T](sf.asInstanceOf[scala.Function2[T, T, T]])
@@ -100,6 +132,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `BooleanSupplier` to convert
    */
   @inline def asScalaFromBooleanSupplier(jf: java.util.function.BooleanSupplier): scala.Function0[java.lang.Boolean] = jf match {
     case AsJavaBooleanSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Boolean]]
@@ -111,6 +145,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `BooleanSupplier`
    */
   @inline def asJavaBooleanSupplier(sf: scala.Function0[java.lang.Boolean]): java.util.function.BooleanSupplier = ((sf): AnyRef) match {
     case FromJavaBooleanSupplier((f @ _)) => f.asInstanceOf[java.util.function.BooleanSupplier]
@@ -123,6 +159,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param jf the Java `Consumer` to convert
    */
   @inline def asScalaFromConsumer[T](jf: java.util.function.Consumer[T]): scala.Function1[T, scala.runtime.BoxedUnit] = jf match {
     case AsJavaConsumer((f @ _)) => f.asInstanceOf[scala.Function1[T, scala.runtime.BoxedUnit]]
@@ -134,6 +173,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param sf the Scala `Function1` to convert to a Java `Consumer`
    */
   @inline def asJavaConsumer[T](sf: scala.Function1[T, scala.runtime.BoxedUnit]): java.util.function.Consumer[T] = ((sf): AnyRef) match {
     case FromJavaConsumer((f @ _)) => f.asInstanceOf[java.util.function.Consumer[T]]
@@ -146,6 +188,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleBinaryOperator` to convert
    */
   @inline def asScalaFromDoubleBinaryOperator(jf: java.util.function.DoubleBinaryOperator): scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]]
@@ -157,6 +201,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function2` to convert to a Java `DoubleBinaryOperator`
    */
   @inline def asJavaDoubleBinaryOperator(sf: scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]): java.util.function.DoubleBinaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleBinaryOperator]
@@ -169,6 +215,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleConsumer` to convert
    */
   @inline def asScalaFromDoubleConsumer(jf: java.util.function.DoubleConsumer): scala.Function1[java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]]
@@ -180,6 +228,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleConsumer`
    */
   @inline def asJavaDoubleConsumer(sf: scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.DoubleConsumer = ((sf): AnyRef) match {
     case FromJavaDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.DoubleConsumer]
@@ -192,6 +242,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `DoubleFunction` to convert
    */
   @inline def asScalaFromDoubleFunction[R](jf: java.util.function.DoubleFunction[R]): scala.Function1[java.lang.Double, R] = jf match {
     case AsJavaDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, R]]
@@ -203,6 +256,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleFunction`
    */
   @inline def asJavaDoubleFunction[R](sf: scala.Function1[java.lang.Double, R]): java.util.function.DoubleFunction[R] = ((sf): AnyRef) match {
     case FromJavaDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleFunction[R]]
@@ -215,6 +271,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoublePredicate` to convert
    */
   @inline def asScalaFromDoublePredicate(jf: java.util.function.DoublePredicate): scala.Function1[java.lang.Double, java.lang.Boolean] = jf match {
     case AsJavaDoublePredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Boolean]]
@@ -226,6 +284,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoublePredicate`
    */
   @inline def asJavaDoublePredicate(sf: scala.Function1[java.lang.Double, java.lang.Boolean]): java.util.function.DoublePredicate = ((sf): AnyRef) match {
     case FromJavaDoublePredicate((f @ _)) => f.asInstanceOf[java.util.function.DoublePredicate]
@@ -238,6 +298,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleSupplier` to convert
    */
   @inline def asScalaFromDoubleSupplier(jf: java.util.function.DoubleSupplier): scala.Function0[java.lang.Double] = jf match {
     case AsJavaDoubleSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Double]]
@@ -249,6 +311,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `DoubleSupplier`
    */
   @inline def asJavaDoubleSupplier(sf: scala.Function0[java.lang.Double]): java.util.function.DoubleSupplier = ((sf): AnyRef) match {
     case FromJavaDoubleSupplier((f @ _)) => f.asInstanceOf[java.util.function.DoubleSupplier]
@@ -261,6 +325,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleToIntFunction` to convert
    */
   @inline def asScalaFromDoubleToIntFunction(jf: java.util.function.DoubleToIntFunction): scala.Function1[java.lang.Double, java.lang.Integer] = jf match {
     case AsJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Integer]]
@@ -272,6 +338,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleToIntFunction`
    */
   @inline def asJavaDoubleToIntFunction(sf: scala.Function1[java.lang.Double, java.lang.Integer]): java.util.function.DoubleToIntFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToIntFunction]
@@ -284,6 +352,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleToLongFunction` to convert
    */
   @inline def asScalaFromDoubleToLongFunction(jf: java.util.function.DoubleToLongFunction): scala.Function1[java.lang.Double, java.lang.Long] = jf match {
     case AsJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Long]]
@@ -295,6 +365,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleToLongFunction`
    */
   @inline def asJavaDoubleToLongFunction(sf: scala.Function1[java.lang.Double, java.lang.Long]): java.util.function.DoubleToLongFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToLongFunction]
@@ -307,6 +379,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `DoubleUnaryOperator` to convert
    */
   @inline def asScalaFromDoubleUnaryOperator(jf: java.util.function.DoubleUnaryOperator): scala.Function1[java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Double]]
@@ -318,6 +392,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `DoubleUnaryOperator`
    */
   @inline def asJavaDoubleUnaryOperator(sf: scala.Function1[java.lang.Double, java.lang.Double]): java.util.function.DoubleUnaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleUnaryOperator]
@@ -325,11 +401,19 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param jf the Java `Function` to convert
+   */
   @inline def asScalaFromFunction[T, R](jf: java.util.function.Function[T, R]): scala.Function1[T, R] = jf match {
     case AsJavaFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, R]]
     case _ => new FromJavaFunction[T, R](jf).asInstanceOf[scala.Function1[T, R]]
   }
   
+  /** @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `Function`
+   */
   @inline def asJavaFunction[T, R](sf: scala.Function1[T, R]): java.util.function.Function[T, R] = ((sf): AnyRef) match {
     case FromJavaFunction((f @ _)) => f.asInstanceOf[java.util.function.Function[T, R]]
     case _ => new AsJavaFunction[T, R](sf.asInstanceOf[scala.Function1[T, R]])
@@ -341,6 +425,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntBinaryOperator` to convert
    */
   @inline def asScalaFromIntBinaryOperator(jf: java.util.function.IntBinaryOperator): scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]]
@@ -352,6 +438,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function2` to convert to a Java `IntBinaryOperator`
    */
   @inline def asJavaIntBinaryOperator(sf: scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]): java.util.function.IntBinaryOperator = ((sf): AnyRef) match {
     case FromJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntBinaryOperator]
@@ -364,6 +452,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntConsumer` to convert
    */
   @inline def asScalaFromIntConsumer(jf: java.util.function.IntConsumer): scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaIntConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]]
@@ -375,6 +465,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntConsumer`
    */
   @inline def asJavaIntConsumer(sf: scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.IntConsumer = ((sf): AnyRef) match {
     case FromJavaIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.IntConsumer]
@@ -387,6 +479,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `IntFunction` to convert
    */
   @inline def asScalaFromIntFunction[R](jf: java.util.function.IntFunction[R]): scala.Function1[java.lang.Integer, R] = jf match {
     case AsJavaIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, R]]
@@ -398,6 +493,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `IntFunction`
    */
   @inline def asJavaIntFunction[R](sf: scala.Function1[java.lang.Integer, R]): java.util.function.IntFunction[R] = ((sf): AnyRef) match {
     case FromJavaIntFunction((f @ _)) => f.asInstanceOf[java.util.function.IntFunction[R]]
@@ -410,6 +508,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntPredicate` to convert
    */
   @inline def asScalaFromIntPredicate(jf: java.util.function.IntPredicate): scala.Function1[java.lang.Integer, java.lang.Boolean] = jf match {
     case AsJavaIntPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Boolean]]
@@ -421,6 +521,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntPredicate`
    */
   @inline def asJavaIntPredicate(sf: scala.Function1[java.lang.Integer, java.lang.Boolean]): java.util.function.IntPredicate = ((sf): AnyRef) match {
     case FromJavaIntPredicate((f @ _)) => f.asInstanceOf[java.util.function.IntPredicate]
@@ -433,6 +535,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntSupplier` to convert
    */
   @inline def asScalaFromIntSupplier(jf: java.util.function.IntSupplier): scala.Function0[java.lang.Integer] = jf match {
     case AsJavaIntSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Integer]]
@@ -444,6 +548,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `IntSupplier`
    */
   @inline def asJavaIntSupplier(sf: scala.Function0[java.lang.Integer]): java.util.function.IntSupplier = ((sf): AnyRef) match {
     case FromJavaIntSupplier((f @ _)) => f.asInstanceOf[java.util.function.IntSupplier]
@@ -456,6 +562,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntToDoubleFunction` to convert
    */
   @inline def asScalaFromIntToDoubleFunction(jf: java.util.function.IntToDoubleFunction): scala.Function1[java.lang.Integer, java.lang.Double] = jf match {
     case AsJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Double]]
@@ -467,6 +575,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntToDoubleFunction`
    */
   @inline def asJavaIntToDoubleFunction(sf: scala.Function1[java.lang.Integer, java.lang.Double]): java.util.function.IntToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToDoubleFunction]
@@ -479,6 +589,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntToLongFunction` to convert
    */
   @inline def asScalaFromIntToLongFunction(jf: java.util.function.IntToLongFunction): scala.Function1[java.lang.Integer, java.lang.Long] = jf match {
     case AsJavaIntToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Long]]
@@ -490,6 +602,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntToLongFunction`
    */
   @inline def asJavaIntToLongFunction(sf: scala.Function1[java.lang.Integer, java.lang.Long]): java.util.function.IntToLongFunction = ((sf): AnyRef) match {
     case FromJavaIntToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToLongFunction]
@@ -502,6 +616,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `IntUnaryOperator` to convert
    */
   @inline def asScalaFromIntUnaryOperator(jf: java.util.function.IntUnaryOperator): scala.Function1[java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Integer]]
@@ -513,6 +629,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `IntUnaryOperator`
    */
   @inline def asJavaIntUnaryOperator(sf: scala.Function1[java.lang.Integer, java.lang.Integer]): java.util.function.IntUnaryOperator = ((sf): AnyRef) match {
     case FromJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntUnaryOperator]
@@ -525,6 +643,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongBinaryOperator` to convert
    */
   @inline def asScalaFromLongBinaryOperator(jf: java.util.function.LongBinaryOperator): scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]]
@@ -536,6 +656,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function2` to convert to a Java `LongBinaryOperator`
    */
   @inline def asJavaLongBinaryOperator(sf: scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]): java.util.function.LongBinaryOperator = ((sf): AnyRef) match {
     case FromJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongBinaryOperator]
@@ -548,6 +670,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongConsumer` to convert
    */
   @inline def asScalaFromLongConsumer(jf: java.util.function.LongConsumer): scala.Function1[java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaLongConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]]
@@ -559,6 +683,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongConsumer`
    */
   @inline def asJavaLongConsumer(sf: scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.LongConsumer = ((sf): AnyRef) match {
     case FromJavaLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.LongConsumer]
@@ -571,6 +697,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `LongFunction` to convert
    */
   @inline def asScalaFromLongFunction[R](jf: java.util.function.LongFunction[R]): scala.Function1[java.lang.Long, R] = jf match {
     case AsJavaLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, R]]
@@ -582,6 +711,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `LongFunction`
    */
   @inline def asJavaLongFunction[R](sf: scala.Function1[java.lang.Long, R]): java.util.function.LongFunction[R] = ((sf): AnyRef) match {
     case FromJavaLongFunction((f @ _)) => f.asInstanceOf[java.util.function.LongFunction[R]]
@@ -594,6 +726,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongPredicate` to convert
    */
   @inline def asScalaFromLongPredicate(jf: java.util.function.LongPredicate): scala.Function1[java.lang.Long, java.lang.Boolean] = jf match {
     case AsJavaLongPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Boolean]]
@@ -605,6 +739,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongPredicate`
    */
   @inline def asJavaLongPredicate(sf: scala.Function1[java.lang.Long, java.lang.Boolean]): java.util.function.LongPredicate = ((sf): AnyRef) match {
     case FromJavaLongPredicate((f @ _)) => f.asInstanceOf[java.util.function.LongPredicate]
@@ -617,6 +753,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongSupplier` to convert
    */
   @inline def asScalaFromLongSupplier(jf: java.util.function.LongSupplier): scala.Function0[java.lang.Long] = jf match {
     case AsJavaLongSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Long]]
@@ -628,6 +766,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function0` to convert to a Java `LongSupplier`
    */
   @inline def asJavaLongSupplier(sf: scala.Function0[java.lang.Long]): java.util.function.LongSupplier = ((sf): AnyRef) match {
     case FromJavaLongSupplier((f @ _)) => f.asInstanceOf[java.util.function.LongSupplier]
@@ -640,6 +780,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongToDoubleFunction` to convert
    */
   @inline def asScalaFromLongToDoubleFunction(jf: java.util.function.LongToDoubleFunction): scala.Function1[java.lang.Long, java.lang.Double] = jf match {
     case AsJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Double]]
@@ -651,6 +793,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongToDoubleFunction`
    */
   @inline def asJavaLongToDoubleFunction(sf: scala.Function1[java.lang.Long, java.lang.Double]): java.util.function.LongToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToDoubleFunction]
@@ -663,6 +807,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongToIntFunction` to convert
    */
   @inline def asScalaFromLongToIntFunction(jf: java.util.function.LongToIntFunction): scala.Function1[java.lang.Long, java.lang.Integer] = jf match {
     case AsJavaLongToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Integer]]
@@ -674,6 +820,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongToIntFunction`
    */
   @inline def asJavaLongToIntFunction(sf: scala.Function1[java.lang.Long, java.lang.Integer]): java.util.function.LongToIntFunction = ((sf): AnyRef) match {
     case FromJavaLongToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToIntFunction]
@@ -686,6 +834,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param jf the Java `LongUnaryOperator` to convert
    */
   @inline def asScalaFromLongUnaryOperator(jf: java.util.function.LongUnaryOperator): scala.Function1[java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Long]]
@@ -697,6 +847,8 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @param sf the Scala `Function1` to convert to a Java `LongUnaryOperator`
    */
   @inline def asJavaLongUnaryOperator(sf: scala.Function1[java.lang.Long, java.lang.Long]): java.util.function.LongUnaryOperator = ((sf): AnyRef) match {
     case FromJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongUnaryOperator]
@@ -709,6 +861,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param jf the Java `ObjDoubleConsumer` to convert
    */
   @inline def asScalaFromObjDoubleConsumer[T](jf: java.util.function.ObjDoubleConsumer[T]): scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]]
@@ -720,6 +875,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param sf the Scala `Function2` to convert to a Java `ObjDoubleConsumer`
    */
   @inline def asJavaObjDoubleConsumer[T](sf: scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.ObjDoubleConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjDoubleConsumer[T]]
@@ -732,6 +890,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param jf the Java `ObjIntConsumer` to convert
    */
   @inline def asScalaFromObjIntConsumer[T](jf: java.util.function.ObjIntConsumer[T]): scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjIntConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]]
@@ -743,6 +904,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param sf the Scala `Function2` to convert to a Java `ObjIntConsumer`
    */
   @inline def asJavaObjIntConsumer[T](sf: scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.ObjIntConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjIntConsumer[T]]
@@ -755,6 +919,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param jf the Java `ObjLongConsumer` to convert
    */
   @inline def asScalaFromObjLongConsumer[T](jf: java.util.function.ObjLongConsumer[T]): scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjLongConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]]
@@ -766,6 +933,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer
+   *  @param sf the Scala `Function2` to convert to a Java `ObjLongConsumer`
    */
   @inline def asJavaObjLongConsumer[T](sf: scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.ObjLongConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjLongConsumer[T]]
@@ -778,6 +948,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param jf the Java `Predicate` to convert
    */
   @inline def asScalaFromPredicate[T](jf: java.util.function.Predicate[T]): scala.Function1[T, java.lang.Boolean] = jf match {
     case AsJavaPredicate((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Boolean]]
@@ -789,6 +962,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param sf the Scala `Function1` to convert to a Java `Predicate`
    */
   @inline def asJavaPredicate[T](sf: scala.Function1[T, java.lang.Boolean]): java.util.function.Predicate[T] = ((sf): AnyRef) match {
     case FromJavaPredicate((f @ _)) => f.asInstanceOf[java.util.function.Predicate[T]]
@@ -796,11 +972,17 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the return type of the supplier
+   *  @param jf the Java `Supplier` to convert
+   */
   @inline def asScalaFromSupplier[T](jf: java.util.function.Supplier[T]): scala.Function0[T] = jf match {
     case AsJavaSupplier((f @ _)) => f.asInstanceOf[scala.Function0[T]]
     case _ => new FromJavaSupplier[T](jf).asInstanceOf[scala.Function0[T]]
   }
   
+  /** @tparam T the return type of the supplier
+   *  @param sf the Scala `Function0` to convert to a Java `Supplier`
+   */
   @inline def asJavaSupplier[T](sf: scala.Function0[T]): java.util.function.Supplier[T] = ((sf): AnyRef) match {
     case FromJavaSupplier((f @ _)) => f.asInstanceOf[java.util.function.Supplier[T]]
     case _ => new AsJavaSupplier[T](sf.asInstanceOf[scala.Function0[T]])
@@ -812,6 +994,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToDoubleBiFunction` to convert
    */
   @inline def asScalaFromToDoubleBiFunction[T, U](jf: java.util.function.ToDoubleBiFunction[T, U]): scala.Function2[T, U, java.lang.Double] = jf match {
     case AsJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Double]]
@@ -823,6 +1009,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to convert to a Java `ToDoubleBiFunction`
    */
   @inline def asJavaToDoubleBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Double]): java.util.function.ToDoubleBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleBiFunction[T, U]]
@@ -835,6 +1025,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToDoubleFunction` to convert
    */
   @inline def asScalaFromToDoubleFunction[T](jf: java.util.function.ToDoubleFunction[T]): scala.Function1[T, java.lang.Double] = jf match {
     case AsJavaToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Double]]
@@ -846,6 +1039,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `ToDoubleFunction`
    */
   @inline def asJavaToDoubleFunction[T](sf: scala.Function1[T, java.lang.Double]): java.util.function.ToDoubleFunction[T] = ((sf): AnyRef) match {
     case FromJavaToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleFunction[T]]
@@ -858,6 +1054,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToIntBiFunction` to convert
    */
   @inline def asScalaFromToIntBiFunction[T, U](jf: java.util.function.ToIntBiFunction[T, U]): scala.Function2[T, U, java.lang.Integer] = jf match {
     case AsJavaToIntBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Integer]]
@@ -869,6 +1069,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to convert to a Java `ToIntBiFunction`
    */
   @inline def asJavaToIntBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Integer]): java.util.function.ToIntBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToIntBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntBiFunction[T, U]]
@@ -881,6 +1085,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToIntFunction` to convert
    */
   @inline def asScalaFromToIntFunction[T](jf: java.util.function.ToIntFunction[T]): scala.Function1[T, java.lang.Integer] = jf match {
     case AsJavaToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Integer]]
@@ -892,6 +1099,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `ToIntFunction`
    */
   @inline def asJavaToIntFunction[T](sf: scala.Function1[T, java.lang.Integer]): java.util.function.ToIntFunction[T] = ((sf): AnyRef) match {
     case FromJavaToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntFunction[T]]
@@ -904,6 +1114,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToLongBiFunction` to convert
    */
   @inline def asScalaFromToLongBiFunction[T, U](jf: java.util.function.ToLongBiFunction[T, U]): scala.Function2[T, U, java.lang.Long] = jf match {
     case AsJavaToLongBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Long]]
@@ -915,6 +1129,10 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to convert to a Java `ToLongBiFunction`
    */
   @inline def asJavaToLongBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Long]): java.util.function.ToLongBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToLongBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongBiFunction[T, U]]
@@ -927,6 +1145,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToLongFunction` to convert
    */
   @inline def asScalaFromToLongFunction[T](jf: java.util.function.ToLongFunction[T]): scala.Function1[T, java.lang.Long] = jf match {
     case AsJavaToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Long]]
@@ -938,6 +1159,9 @@ object FunctionConverters {
    *  Scala compiler emits `C[Int]` as `C[Object]` in bytecode due to
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to convert to a Java `ToLongFunction`
    */
   @inline def asJavaToLongFunction[T](sf: scala.Function1[T, java.lang.Long]): java.util.function.ToLongFunction[T] = ((sf): AnyRef) match {
     case FromJavaToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongFunction[T]]
@@ -945,11 +1169,17 @@ object FunctionConverters {
   }
   
   
+  /** @tparam T the input and output type of the unary operator
+   *  @param jf the Java `UnaryOperator` to convert
+   */
   @inline def asScalaFromUnaryOperator[T](jf: java.util.function.UnaryOperator[T]): scala.Function1[T, T] = jf match {
     case AsJavaUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[T, T]]
     case _ => new FromJavaUnaryOperator[T](jf).asInstanceOf[scala.Function1[T, T]]
   }
   
+  /** @tparam T the input and output type of the unary operator
+   *  @param sf the Scala `Function1` to convert to a Java `UnaryOperator`
+   */
   @inline def asJavaUnaryOperator[T](sf: scala.Function1[T, T]): java.util.function.UnaryOperator[T] = ((sf): AnyRef) match {
     case FromJavaUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.UnaryOperator[T]]
     case _ => new AsJavaUnaryOperator[T](sf.asInstanceOf[scala.Function1[T, T]])

--- a/library/src/scala/jdk/javaapi/FutureConverters.scala
+++ b/library/src/scala/jdk/javaapi/FutureConverters.scala
@@ -40,6 +40,7 @@ object FutureConverters {
    *  therefore the returned CompletionStage routes all calls to synchronous transformations to
    *  their asynchronous counterparts, i.e., `thenRun` will internally call `thenRunAsync`.
    *
+   *  @tparam T the result type of the Future and CompletionStage
    *  @param f The Scala Future which may eventually supply the completion for the returned
    *          CompletionStage
    *  @return a CompletionStage that runs all callbacks asynchronously and does not support the
@@ -62,6 +63,7 @@ object FutureConverters {
    *  executed asynchronously as specified by the ExecutionContext that is given to the combinator
    *  methods.
    *
+   *  @tparam T the result type of the CompletionStage and Future
    *  @param cs The CompletionStage which may eventually supply the completion for the returned
    *           Scala Future
    *  @return a Scala Future that represents the CompletionStage's completion

--- a/library/src/scala/jdk/javaapi/OptionConverters.scala
+++ b/library/src/scala/jdk/javaapi/OptionConverters.scala
@@ -29,7 +29,12 @@ import java.{lang => jl}
  *                       extension methods instead.
  */
 object OptionConverters {
-  /** Converts a Scala `Option` to a Java `Optional`. */
+  /** Converts a Scala `Option` to a Java `Optional`.
+   *
+   *  @tparam A the element type of the `Option` and the resulting `Optional`
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `Optional` containing the value, or empty if `o` is `None`
+   */
   def toJava[A](o: Option[A]): Optional[A] = o match {
     case Some(a) => Optional.ofNullable(a)
     case _ => Optional.empty[A]
@@ -38,6 +43,9 @@ object OptionConverters {
   /** Converts a Scala `Option[java.lang.Double]` to a Java `OptionalDouble`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `OptionalDouble` containing the value, or empty if `o` is `None`
    */
   def toJavaOptionalDouble(o: Option[jl.Double]): OptionalDouble = o match {
     case Some(a) => OptionalDouble.of(a)
@@ -47,6 +55,9 @@ object OptionConverters {
   /** Converts a Scala `Option[java.lang.Integer]` to a Java `OptionalInt`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `OptionalInt` containing the value, or empty if `o` is `None`
    */
   def toJavaOptionalInt(o: Option[jl.Integer]): OptionalInt = o match {
     case Some(a) => OptionalInt.of(a)
@@ -56,30 +67,47 @@ object OptionConverters {
   /** Converts a Scala `Option[java.lang.Long]` to a Java `OptionalLong`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Scala `Option` to convert
+   *  @return a Java `OptionalLong` containing the value, or empty if `o` is `None`
    */
   def toJavaOptionalLong(o: Option[jl.Long]): OptionalLong = o match {
     case Some(a) => OptionalLong.of(a)
     case _ => OptionalLong.empty
   }
 
-  /** Converts a Java `Optional` to a Scala `Option`. */
+  /** Converts a Java `Optional` to a Scala `Option`.
+   *
+   *  @tparam A the element type of the `Optional`
+   *  @param o the Java `Optional` to convert
+   *  @return a Scala `Option` containing the value, or `None` if the `Optional` is empty
+   */
   def toScala[A](o: Optional[A]): Option[A] = if (o.isPresent) Some(o.get) else None
 
   /** Converts a Java `OptionalDouble` to a Scala `Option[java.lang.Double]`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Java `OptionalDouble` to convert
+   *  @return a Scala `Option` containing the value as a boxed `java.lang.Double`, or `None` if empty
    */
   def toScala(o: OptionalDouble): Option[jl.Double] = if (o.isPresent) Some(o.getAsDouble) else None
 
   /** Converts a Java `OptionalInt` to a Scala `Option[java.lang.Integer]`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Java `OptionalInt` to convert
+   *  @return a Scala `Option` containing the value as a boxed `java.lang.Integer`, or `None` if empty
    */
   def toScala(o: OptionalInt): Option[jl.Integer] = if (o.isPresent) Some(o.getAsInt) else None
 
   /** Converts a Java `OptionalLong` to a Scala `Option[java.lang.Long]`.
    *
    *  $primitiveNote
+   *
+   *  @param o the Java `OptionalLong` to convert
+   *  @return a Scala `Option` containing the value as a boxed `java.lang.Long`, or `None` if empty
    */
   def toScala(o: OptionalLong): Option[jl.Long] = if (o.isPresent) Some(o.getAsLong) else None
 }

--- a/library/src/scala/jdk/javaapi/StreamConverters.scala
+++ b/library/src/scala/jdk/javaapi/StreamConverters.scala
@@ -45,130 +45,224 @@ object StreamConverters {
   // sequential streams for collections
   /////////////////////////////////////
 
-  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for a Scala collection. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for a Scala collection.
+   *
+   *  @tparam A the element type of the collection
+   *  @param cc the Scala collection to convert to a Java Stream
+   *  @return a sequential `Stream` for the collection
+   */
   def asJavaSeqStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of integers to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of bytes to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of shorts to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of characters to convert
+   *  @return a sequential `IntStream` for the collection
    */
   def asJavaSeqIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of doubles to convert
+   *  @return a sequential `DoubleStream` for the collection
    */
   def asJavaSeqDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of floats to convert
+   *  @return a sequential `DoubleStream` for the collection
    */
   def asJavaSeqDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for a Scala collection.
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of longs to convert
+   *  @return a sequential `LongStream` for the collection
    */
   def asJavaSeqLongStream(cc: IterableOnce[jl.Long]): LongStream = StreamSupport.longStream(cc.stepper.spliterator, false)
 
   // Map Key Streams
 
-  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `Stream` for the map's keys
+   */
   def asJavaSeqKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `IntStream` for the map's keys
    */
   def asJavaSeqKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `DoubleStream` for the map's keys
    */
   def asJavaSeqKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
   /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `DoubleStream` for the map's keys
    */
   def asJavaSeqKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, false)
 
   /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the keys of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a sequential `LongStream` for the map's keys
    */
   def asJavaSeqKeyLongStream[V](m: collection.Map[jl.Long, V]): LongStream = StreamSupport.longStream(m.keyStepper.spliterator, false)
 
   // Map Value Streams
 
-  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of a Scala Map. */
+  /** Creates a sequential [[java.util.stream.Stream Java Stream]] for the values of a Scala Map.
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `Stream` for the map's values
+   */
   def asJavaSeqValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, false)
 
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `IntStream` for the map's values
    */
   def asJavaSeqValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, false)
 
-  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `DoubleStream` for the map's values
    */
   def asJavaSeqValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
-  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `DoubleStream` for the map's values
    */
   def asJavaSeqValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, false)
 
-  /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the values of a
+  /** Creates a sequential [[java.util.stream.LongStream Java LongStream]] for the values of a Scala Map.
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a sequential `LongStream` for the map's values
    */
   def asJavaSeqValueLongStream[K](m: collection.Map[K, jl.Long]): LongStream = StreamSupport.longStream(m.valueStepper.spliterator, false)
 
@@ -179,6 +273,10 @@ object StreamConverters {
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for a Scala collection.
    *
    *  $parNote
+   *
+   *  @tparam A the element type of the collection
+   *  @param cc the Scala collection to convert to a parallel Java Stream
+   *  @return a parallel `Stream` for the collection
    */
   def asJavaParStream[A](cc: IterableOnce[A]): Stream[A] = StreamSupport.stream(cc.stepper.spliterator, true)
 
@@ -187,6 +285,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of integers to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStream         (cc: IterableOnce[jl.Integer]):   IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
@@ -194,6 +295,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of bytes to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStreamFromByte (cc: IterableOnce[jl.Byte]):      IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
@@ -201,6 +305,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of shorts to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStreamFromShort(cc: IterableOnce[jl.Short]):     IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for a Scala collection.
@@ -208,6 +315,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of characters to convert
+   *  @return a parallel `IntStream` for the collection
    */
   def asJavaParIntStreamFromChar (cc: IterableOnce[jl.Character]): IntStream = StreamSupport.intStream(cc.stepper.spliterator, true)
 
@@ -216,6 +326,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of doubles to convert
+   *  @return a parallel `DoubleStream` for the collection
    */
   def asJavaParDoubleStream         (cc: IterableOnce[jl.Double]): DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for a Scala collection.
@@ -223,6 +336,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of floats to convert
+   *  @return a parallel `DoubleStream` for the collection
    */
   def asJavaParDoubleStreamFromFloat(cc: IterableOnce[jl.Float]):  DoubleStream = StreamSupport.doubleStream(cc.stepper.spliterator, true)
 
@@ -231,6 +347,9 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @param cc the Scala collection of longs to convert
+   *  @return a parallel `LongStream` for the collection
    */
   def asJavaParLongStream(cc: IterableOnce[jl.Long]): LongStream = StreamSupport.longStream(cc.stepper.spliterator, true)
 
@@ -240,6 +359,11 @@ object StreamConverters {
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the keys of a Scala Map.
    *
    *  $parNote
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `Stream` for the map's keys
    */
   def asJavaParKeyStream[K, V](m: collection.Map[K, V]): Stream[K] = StreamSupport.stream(m.keyStepper.spliterator, true)
 
@@ -248,6 +372,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStream         [V](m: collection.Map[jl.Integer, V]):   IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
@@ -255,6 +383,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStreamFromByte [V](m: collection.Map[jl.Byte, V]):      IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
@@ -262,6 +394,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStreamFromShort[V](m: collection.Map[jl.Short, V]):     IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the keys of a Scala Map.
@@ -269,6 +405,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `IntStream` for the map's keys
    */
   def asJavaParKeyIntStreamFromChar [V](m: collection.Map[jl.Character, V]): IntStream = StreamSupport.intStream(m.keyStepper.spliterator, true)
 
@@ -277,6 +417,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `DoubleStream` for the map's keys
    */
   def asJavaParKeyDoubleStream         [V](m: collection.Map[jl.Double, V]): DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the keys of a Scala Map.
@@ -284,6 +428,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `DoubleStream` for the map's keys
    */
   def asJavaParKeyDoubleStreamFromFloat[V](m: collection.Map[jl.Float, V]):  DoubleStream = StreamSupport.doubleStream(m.keyStepper.spliterator, true)
 
@@ -292,6 +440,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose keys to stream over
+   *  @return a parallel `LongStream` for the map's keys
    */
   def asJavaParKeyLongStream[V](m: collection.Map[jl.Long, V]): LongStream = StreamSupport.longStream(m.keyStepper.spliterator, true)
 
@@ -300,6 +452,11 @@ object StreamConverters {
   /** Creates a parallel [[java.util.stream.Stream Java Stream]] for the values of a Scala Map.
    *
    *  $parNote
+   *
+   *  @tparam K the key type of the map
+   *  @tparam V the value type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `Stream` for the map's values
    */
   def asJavaParValueStream[K, V](m: collection.Map[K, V]): Stream[V] = StreamSupport.stream(m.valueStepper.spliterator, true)
 
@@ -308,6 +465,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStream         [K](m: collection.Map[K, jl.Integer]):   IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
@@ -315,6 +476,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStreamFromByte [K](m: collection.Map[K, jl.Byte]):      IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
@@ -322,6 +487,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStreamFromShort[K](m: collection.Map[K, jl.Short]):     IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.IntStream Java IntStream]] for the values of a Scala Map.
@@ -329,6 +498,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `IntStream` for the map's values
    */
   def asJavaParValueIntStreamFromChar [K](m: collection.Map[K, jl.Character]): IntStream = StreamSupport.intStream(m.valueStepper.spliterator, true)
 
@@ -337,6 +510,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `DoubleStream` for the map's values
    */
   def asJavaParValueDoubleStream         [K](m: collection.Map[K, jl.Double]): DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
   /** Creates a parallel [[java.util.stream.DoubleStream Java DoubleStream]] for the values of a Scala Map.
@@ -344,6 +521,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `DoubleStream` for the map's values
    */
   def asJavaParValueDoubleStreamFromFloat[K](m: collection.Map[K, jl.Float]):  DoubleStream = StreamSupport.doubleStream(m.valueStepper.spliterator, true)
 
@@ -352,6 +533,10 @@ object StreamConverters {
    *  $parNote
    *
    *  $primitiveNote
+   *
+   *  @tparam K the key type of the map
+   *  @param m the Scala Map whose values to stream over
+   *  @return a parallel `LongStream` for the map's values
    */
   def asJavaParValueLongStream[K](m: collection.Map[K, jl.Long]): LongStream = StreamSupport.longStream(m.valueStepper.spliterator, true)
 }


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for jdk. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.
