### PR TITLE
Util, io, ref (10): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library-js/src/scala/util/DynamicVariable.scala
+++ b/library-js/src/scala/util/DynamicVariable.scala
@@ -42,6 +42,9 @@ import java.lang.InheritableThreadLocal
  *
  *  @author  Lex Spoon
  *  @since   2.6
+ *
+ *  @tparam T the type of the dynamic variable's value
+ *  @param init the initial value of the variable
  */
 class DynamicVariable[T](init: T) {
   /* Scala.js: replaced InheritableThreadLocal by a simple var.
@@ -56,6 +59,7 @@ class DynamicVariable[T](init: T) {
   /** Sets the value of the variable while executing the specified
    *  thunk.
    *
+   *  @tparam S the result type of the thunk, also the return type of this method
    *  @param newval The value to which to set the variable
    *  @param thunk The code to evaluate under the new setting
    */

--- a/library/src/scala/io/BufferedSource.scala
+++ b/library/src/scala/io/BufferedSource.scala
@@ -20,6 +20,9 @@ import scala.collection.mutable.StringBuilder
 
 /** This object provides convenience methods to create an iterable
  *  representation of a source file.
+ *
+ *  @param inputStream the underlying input stream to read characters from
+ *  @param bufferSize the size of the internal buffer used for reading
  */
 class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val codec: Codec) extends Source {
   def this(inputStream: InputStream)(implicit codec: Codec) = this(inputStream, DefaultBufSize)(using codec)
@@ -91,6 +94,12 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
    *
    *  Note: This function may temporarily load the entire buffer into
    *  memory.
+   *
+   *  @param sb the string builder to append to
+   *  @param start the string to prepend before the first character
+   *  @param sep the separator string inserted between elements
+   *  @param end the string to append after the last element
+   *  @return the string builder `sb` with all elements appended
    */
   override def addString(sb: StringBuilder, start: String, sep: String, end: String): sb.type =
     if (sep.isEmpty) {

--- a/library/src/scala/io/Codec.scala
+++ b/library/src/scala/io/Codec.scala
@@ -30,7 +30,10 @@ import scala.language.implicitConversions
 // MacRoman vs. UTF-8: see https://groups.google.com/d/msg/jruby-developers/-qtwRhoE1WM/whSPVpTNV28J
 // -Dfile.encoding: see https://bugs.java.com/view_bug.do?bug_id=4375816
 
-/** A class for character encoding/decoding preferences. */
+/** A class for character encoding/decoding preferences.
+ *
+ *  @param charSet the character set used for encoding and decoding operations
+ */
 class Codec(val charSet: Charset) {
   type Configure[T] = (T => T, Boolean)
   type Handler      = CharacterCodingException => Int

--- a/library/src/scala/io/Position.scala
+++ b/library/src/scala/io/Position.scala
@@ -41,7 +41,11 @@ import annotation.nowarn
  */
 @deprecated("this class will be removed", "2.10.0")
 private[scala] abstract class Position {
-  /** Definable behavior for overflow conditions. */
+  /** Definable behavior for overflow conditions.
+   *
+   *  @param line the 1-based line number to validate (0 for undefined, negative values throw)
+   *  @param column the 1-based column number to validate (must be 0 when `line` is 0, negative values throw)
+   */
   def checkInput(line: Int, column: Int): Unit
 
   /** Number of bits used to encode the line number. */
@@ -53,7 +57,11 @@ private[scala] abstract class Position {
   /** Mask to decode the column number. */
   final val COLUMN_MASK = (1 << COLUMN_BITS) - 1
 
-  /** Encodes a position into a single integer. */
+  /** Encodes a position into a single integer.
+   *
+   *  @param line the 1-based line number, or 0 for undefined; values at or above `LINE_MASK` are clamped and the column is set to 0
+   *  @param column the 1-based column number, or 0 for undefined; clamped to `COLUMN_MASK`, ignored when `line` >= `LINE_MASK`
+   */
   final def encode(line: Int, column: Int): Int = {
     checkInput(line, column)
 
@@ -63,13 +71,22 @@ private[scala] abstract class Position {
       (line << COLUMN_BITS) | scala.math.min(COLUMN_MASK, column)
   }
 
-  /** Returns the line number of the encoded position. */
+  /** Returns the line number of the encoded position.
+   *
+   *  @param pos the encoded position as returned by `encode`
+   */
   final def line(pos: Int): Int = (pos >> COLUMN_BITS) & LINE_MASK
 
-  /** Returns the column number of the encoded position. */
+  /** Returns the column number of the encoded position.
+   *
+   *  @param pos the encoded position as returned by `encode`
+   */
   final def column(pos: Int): Int = pos & COLUMN_MASK
 
-  /** Returns a string representation of the encoded position. */
+  /** Returns a string representation of the encoded position.
+   *
+   *  @param pos the encoded position as returned by `encode`
+   */
   def toString(pos: Int): String = line(pos) + ":" + column(pos)
 }
 

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -38,42 +38,72 @@ object Source {
     val iter = iterable.iterator
   } withReset(() => fromIterable(iterable))
 
-  /** Creates a Source instance from a single character. */
+  /** Creates a Source instance from a single character.
+   *
+   *  @param c the character to use as the source content
+   */
   def fromChar(c: Char): Source = fromIterable(Array(c))
 
-  /** creates Source from array of characters, with empty description. */
+  /** Creates Source from array of characters, with empty description.
+   *
+   *  @param chars the array of characters to use as the source content
+   */
   def fromChars(chars: Array[Char]): Source = fromIterable(chars)
 
-  /** creates Source from a String, with no description. */
+  /** Creates Source from a String, with no description.
+   *
+   *  @param s the string to use as the source content
+   */
   def fromString(s: String): Source = fromIterable(s)
 
-  /** creates Source from file with given name, setting its description to
+  /** Creates Source from file with given name, setting its description to
    *  filename.
+   *
+   *  @param name the name of the file to read
+   *  @param codec the implicit codec used for character encoding
    */
   def fromFile(name: String)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(name))(using codec)
 
-  /** creates Source from file with given name, using given encoding, setting
+  /** Creates Source from file with given name, using given encoding, setting
    *  its description to filename.
+   *
+   *  @param name the name of the file to read
+   *  @param enc the name of the character encoding to use
    */
   def fromFile(name: String, enc: String): BufferedSource =
     fromFile(name)(using Codec(enc))
 
-  /** creates `source` from file with given file `URI`. */
+  /** Creates `source` from file with given file `URI`.
+   *
+   *  @param uri the file URI to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromFile(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
 
-  /** creates Source from file with given file: URI */
+  /** Creates Source from file with given file: URI
+   *
+   *  @param uri the file URI to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromFile(uri: URI, enc: String): BufferedSource =
     fromFile(uri)(using Codec(enc))
 
-  /** creates Source from file, using default character encoding, setting its
+  /** Creates Source from file, using default character encoding, setting its
    *  description to filename.
+   *
+   *  @param file the file to read from
+   *  @param codec the implicit codec used for character encoding
    */
   def fromFile(file: JFile)(implicit codec: Codec): BufferedSource =
     fromFile(file, Source.DefaultBufSize)(using codec)
 
-  /** same as fromFile(file, enc, Source.DefaultBufSize) */
+  /** same as fromFile(file, enc, Source.DefaultBufSize)
+   *
+   *  @param file the file to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromFile(file: JFile, enc: String): BufferedSource =
     fromFile(file)(using Codec(enc))
 
@@ -83,6 +113,10 @@ object Source {
   /** Creates Source from `file`, using given character encoding, setting
    *  its description to filename. Input is buffered in a buffer of size
    *  `bufferSize`.
+   *
+   *  @param file the file to read from
+   *  @param bufferSize the size of the input buffer, in characters
+   *  @param codec the implicit codec used for character encoding
    */
   def fromFile(file: JFile, bufferSize: Int)(implicit codec: Codec): BufferedSource = {
     val inputStream = new FileInputStream(file)
@@ -98,6 +132,8 @@ object Source {
   /** Creates a `Source` from array of bytes, decoding
    *  the bytes according to codec.
    *
+   *  @param bytes the array of bytes to decode into characters
+   *  @param codec the implicit codec used for character encoding
    *  @return      the created `Source` instance.
    */
   def fromBytes(bytes: Array[Byte])(implicit codec: Codec): Source =
@@ -113,23 +149,43 @@ object Source {
   def fromRawBytes(bytes: Array[Byte]): Source =
     fromString(new String(bytes, Codec.ISO8859.charSet))
 
-  /** creates `Source` from file with given file: URI */
+  /** creates `Source` from file with given file: URI
+   *
+   *  @param uri the file URI to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromURI(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
 
-  /** same as fromURL(new URL(s))(Codec(enc)) */
+  /** Same as fromURL(new URL(s))(Codec(enc))
+   *
+   *  @param s the URL string to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromURL(s: String, enc: String): BufferedSource =
     fromURL(s)(using Codec(enc))
 
-  /** same as fromURL(new URL(s)) */
+  /** Same as fromURL(new URL(s))
+   *
+   *  @param s the URL string to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromURL(s: String)(implicit codec: Codec): BufferedSource =
     fromURL(new URI(s).toURL)(using codec)
 
-  /** same as fromInputStream(url.openStream())(Codec(enc)) */
+  /** Same as fromInputStream(url.openStream())(Codec(enc))
+   *
+   *  @param url the URL to read from
+   *  @param enc the name of the character encoding to use
+   */
   def fromURL(url: URL, enc: String): BufferedSource =
     fromURL(url)(using Codec(enc))
 
-  /** same as fromInputStream(url.openStream())(codec) */
+  /** Same as fromInputStream(url.openStream())(codec)
+   *
+   *  @param url the URL to read from
+   *  @param codec the implicit codec used for character encoding
+   */
   def fromURL(url: URL)(implicit codec: Codec): BufferedSource =
     fromInputStream(url.openStream())(using codec)
 
@@ -347,7 +403,10 @@ abstract class Source extends Iterator[Char] with Closeable {
     descr = text
     this
   }
-  /** Change or disable the positioner. */
+  /** Change or disable the positioner.
+   *
+   *  @param on whether to enable (`true`) or disable (`false`) position tracking
+   */
   def withPositioning(on: Boolean): this.type = {
     positioner = if (on) RelaxedPositioner else NoPositioner
     this

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -16,6 +16,8 @@ import scala.language.`2.13`
 
 /**
  *  @see `java.lang.ref.Reference`
+ *
+ *  @tparam T the type of the referenced object, constrained to `AnyRef` (i.e., non-primitive types)
  */
 trait Reference[+T <: AnyRef] extends Function0[T] {
   /** Returns the underlying value. */

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -24,10 +24,18 @@ class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T] | Null) e
 /** A companion object that implements an extractor for `SoftReference` values */
 object SoftReference {
 
-  /** Creates a `SoftReference` pointing to `value`. */
+  /** Creates a `SoftReference` pointing to `value`.
+   *
+   *  @tparam T the type of the referenced object, must be a reference type
+   *  @param value the object to be softly referenced; may be reclaimed by the garbage collector when memory is low
+   */
   def apply[T <: AnyRef](value: T): SoftReference[T] = new SoftReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists. */
+  /** Optionally returns the referenced value, or `None` if that value no longer exists.
+   *
+   *  @tparam T the type of the referenced object, must be a reference type
+   *  @param sr the `SoftReference` to extract the value from
+   */
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
 }
 

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -17,6 +17,10 @@ import scala.language.`2.13`
 /** A wrapper class for java.lang.ref.WeakReference
  *  The new functionality is (1) results are Option values, instead of using null.
  *  (2) There is an extractor that maps the weak reference itself into an option.
+ *
+ *  @tparam T the covariant type of the weakly referenced object, must be a subtype of `AnyRef`
+ *  @param value the object to be weakly referenced
+ *  @param queue an optional reference queue to which the reference will be enqueued when the referent becomes weakly reachable, or `null` for no queue
  */
 class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T] | Null) extends ReferenceWrapper[T] {
   def this(value: T) = this(value, null)
@@ -27,10 +31,18 @@ class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T] | Null) ext
 /** An extractor for weak reference values. */
 object WeakReference {
 
-  /** Creates a weak reference pointing to `value`. */
+  /** Creates a weak reference pointing to `value`.
+   *
+   *  @tparam T the type of the value to wrap in a weak reference
+   *  @param value the object to be weakly referenced
+   */
   def apply[T <: AnyRef](value: T): WeakReference[T] = new WeakReference(value)
 
-  /** Optionally returns the referenced value, or `None` if that value no longer exists. */
+  /** Optionally returns the referenced value, or `None` if that value no longer exists.
+   *
+   *  @tparam T the type of the value to extract from the weak reference
+   *  @param wr the weak reference to extract a value from
+   */
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)
 }
 

--- a/library/src/scala/util/ChainingOps.scala
+++ b/library/src/scala/util/ChainingOps.scala
@@ -21,7 +21,11 @@ trait ChainingSyntax {
   @inline implicit final def scalaUtilChainingOps[A](a: A): ChainingOps[A] = new ChainingOps(a)
 }
 
-/** Adds chaining methods `tap` and `pipe` to every type. */
+/** Adds chaining methods `tap` and `pipe` to every type.
+ *
+ *  @tparam A the type of the wrapped value
+ *  @param self the value to enrich with chaining operations
+ */
 final class ChainingOps[A](private val self: A) extends AnyVal {
   /** Applies `f` to the value for its side effects, and returns the original value.
    *

--- a/library/src/scala/util/CommandLineParser.scala
+++ b/library/src/scala/util/CommandLineParser.scala
@@ -12,6 +12,11 @@ object CommandLineParser {
   class ParseError(val idx: Int, val msg: String) extends Exception
 
   /** Parses command line argument `s`, which has index `n`, as a value of type `T`.
+   *
+   *  @tparam T the target type to parse the string into
+   *  @param str the command line argument string to parse
+   *  @param n the zero-based index of the argument, used for error reporting
+   *  @param fs the type class instance (usually provided implicitly) that converts a string to type `T`
    *  @throws ParseError if argument cannot be converted to type `T`.
    */
   def parseString[T](str: String, n: Int)(using fs: FromString[T]^): T = {
@@ -22,6 +27,11 @@ object CommandLineParser {
   }
 
   /** Parses `n`'th argument in `args` (counting from 0) as a value of type `T`.
+   *
+   *  @tparam T the target type to parse the argument into
+   *  @param args the command line arguments array
+   *  @param n the zero-based index of the argument to parse
+   *  @param fs the type class instance that converts a string to type `T`
    *  @throws ParseError if argument does not exist or cannot be converted to type `T`.
    */
   def parseArgument[T](args: Array[String], n: Int)(using fs: FromString[T]^): T =
@@ -29,13 +39,21 @@ object CommandLineParser {
     else throw ParseError(n, "more arguments expected")
 
   /** Parses all arguments from `n`'th one (counting from 0) as a list of values of type `T`.
+   *
+   *  @tparam T the target type to parse each argument into
+   *  @param args the command line arguments array
+   *  @param n the zero-based index of the first remaining argument to parse
+   *  @param fs the type class instance that converts a string to type `T`
    *  @throws ParseError if some of the arguments cannot be converted to type `T`.
    */
   def parseRemainingArguments[T](args: Array[String], n: Int)(using fs: FromString[T]^): List[T] =
     if n < args.length then parseString(args(n), n) :: parseRemainingArguments(args, n + 1)
     else Nil
 
-  /** Prints error message explaining given ParserError. */
+  /** Prints error message explaining given ParserError.
+   *
+   *  @param err the parse error to display
+   */
   def showError(err: ParseError): Unit = {
     val where =
       if err.idx == 0 then ""
@@ -45,7 +63,10 @@ object CommandLineParser {
   }
 
   trait FromString[T] {
-    /** Can throw java.lang.IllegalArgumentException. */
+    /** Can throw java.lang.IllegalArgumentException.
+     *
+     *  @param s the string to convert to type `T`
+     */
     def fromString(s: String): T
 
     def fromStringOption(s: String): Option[T] =

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -38,6 +38,9 @@ import java.lang.InheritableThreadLocal
  *  of the stack of bindings from the parent thread, and
  *  from then on the bindings for the new thread
  *  are independent of those for the original thread.
+ *
+ *  @tparam T the type of the dynamic variable's value
+ *  @param init the initial value of the variable, inherited by new threads
  */
 class DynamicVariable[T](init: T) {
   private val tl = new InheritableThreadLocal[T] {
@@ -50,8 +53,9 @@ class DynamicVariable[T](init: T) {
   /** Sets the value of the variable while executing the specified
    *  thunk.
    *
-   *  @param newval The value to which to set the variable
-   *  @param thunk The code to evaluate under the new setting
+   *  @tparam S the result type of the thunk
+   *  @param newval the value to which to set the variable
+   *  @param thunk the code to evaluate under the new setting
    */
   def withValue[S](newval: T)(thunk: => S): S = {
     val oldval = value

--- a/library/src/scala/util/Either.scala
+++ b/library/src/scala/util/Either.scala
@@ -127,6 +127,9 @@ import language.experimental.captureChecking
  *  } yield x + y + z
  *  // Left(42.0), but unexpectedly a `Either[Double,String]`
  *  ```
+ *
+ *  @tparam A the type of the `Left` value
+ *  @tparam B the type of the `Right` value
  */
 sealed abstract class Either[+A, +B] extends Product with Serializable {
   /** Projects this `Either` as a `Left`.
@@ -192,9 +195,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  )
    *  ```
    *
-   *  @param fa the function to apply if this is a `Left`
-   *  @param fb the function to apply if this is a `Right`
-   *  @return the results of applying the function
+   *  @param fa the function to apply to the `Left` value
+   *  @param fb the function to apply to the `Right` value
+   *  @return the result of applying `fa` or `fb` to the contained value
+   *
+   *  @tparam C the result type of the fold
    */
   def fold[C](fa: A => C, fb: B => C): C = this match {
     case Right(b) => fb(b)
@@ -215,6 +220,8 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *    r2 <- left.swap
    *  } yield r1 * r2 // Right(6)
    *  ```
+   *
+   *  @return an `Either` with the left and right values swapped
    */
   def swap: Either[B, A] = this match {
     case Left(a)  => Right(a)
@@ -238,6 +245,12 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  ```
    *
    *  This method, and `joinLeft`, are analogous to `Option#flatten`
+   *
+   *  @tparam A1 the supertype of `A` used to widen the left type
+   *  @tparam B1 the supertype of `B`, evidenced to be an `Either[A1, C]`
+   *  @tparam C the right type of the inner `Either`
+   *  @param ev evidence that `B1` is a subtype of `Either[A1, C]`
+   *  @return the inner `Either` if this is a `Right`, otherwise this `Left` value
    */
   def joinRight[A1 >: A, B1 >: B, C](implicit ev: B1 <:< Either[A1, C]): Either[A1, C] = this match {
     case Right(b) => b
@@ -261,6 +274,12 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  ```
    *
    *  This method, and `joinRight`, are analogous to `Option#flatten`.
+   *
+   *  @tparam A1 the supertype of `A` constrained to be an `Either[C, B1]`
+   *  @tparam B1 the supertype of `B` used to widen the right type
+   *  @tparam C the left type of the inner `Either`
+   *  @param ev evidence that `A1` is a subtype of `Either[C, B1]`
+   *  @return the inner `Either` if this is a `Left`, otherwise this `Right` value
    */
   def joinLeft[A1 >: A, B1 >: B, C](implicit ev: A1 <:< Either[C, B1]): Either[C, B1] = this match {
     case Left(a) => a
@@ -273,7 +292,8 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(12).foreach(println) // prints "12"
    *  Left(12).foreach(println)  // doesn't print
    *  ```
-   *  @param f The side-effecting function to execute.
+   *  @tparam U the return type of the side-effecting function (discarded)
+   *  @param f the side-effecting function to execute
    */
   def foreach[U](f: B => U): Unit = this match {
     case Right(b) => f(b)
@@ -286,6 +306,10 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(12).getOrElse(17) // 12
    *  Left(12).getOrElse(17)  // 17
    *  ```
+   *
+   *  @tparam B1 the supertype of `B` used to widen the return type
+   *  @param or the default value to return if this is a `Left`, evaluated lazily
+   *  @return the `Right` value if present, otherwise `or`
    */
   def getOrElse[B1 >: B](or: => B1): B1 = this match {
     case Right(b) => b
@@ -299,6 +323,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Left(1) orElse Left(2)  // Left(2)
    *  Left(1) orElse Left(2) orElse Right(3) // Right(3)
    *  ```
+   *
+   *  @tparam A1 the supertype of `A` used to widen the left type
+   *  @tparam B1 the supertype of `B` used to widen the right type
+   *  @param or the alternative `Either` to return if this is a `Left`, evaluated lazily
+   *  @return this `Either` if it is a `Right`, otherwise `or`
    */
   def orElse[A1 >: A, B1 >: B](or: => Either[A1, B1]): Either[A1, B1] = this match {
     case Right(_) => this
@@ -319,6 +348,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Left("something") contains "something"
    *  ```
    *
+   *  @tparam B1 the supertype of `B` used to widen the comparison type
    *  @param elem    the element to test.
    *  @return `true` if this is a `Right` value equal to `elem`.
    */
@@ -335,6 +365,9 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(7).forall(_ > 10)     // false
    *  Left(12).forall(_ => false) // true
    *  ```
+   *
+   *  @param f the predicate to apply to the `Right` value
+   *  @return `true` if this is a `Left` or the predicate holds for the `Right` value
    */
   def forall(f: B => Boolean): Boolean = this match {
     case Right(b) => f(b)
@@ -349,6 +382,9 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(7).exists(_ > 10)    // false
    *  Left(12).exists(_ => true) // false
    *  ```
+   *
+   *  @param p the predicate to apply to the `Right` value
+   *  @return `true` if this is a `Right` and the predicate holds for its value
    */
   def exists(p: B => Boolean): Boolean = this match {
     case Right(b) => p(b)
@@ -357,7 +393,9 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
 
   /** Binds the given function across `Right`.
    *
-   *  @param f The function to bind across `Right`.
+   *  @tparam A1 the supertype of `A` used to widen the left type
+   *  @tparam B1 the right type of the resulting `Either`
+   *  @param f the function to bind across `Right`
    */
   def flatMap[A1 >: A, B1](f: B => Either[A1, B1]): Either[A1, B1] = this match {
     case Right(b) => f(b)
@@ -379,6 +417,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  ```
    *
    *  Equivalent to `flatMap(id => id)`
+   *
+   *  @tparam A1 the supertype of `A` used to widen the left type
+   *  @tparam B1 the right type of the inner `Either`
+   *  @param ev evidence that `B` is a subtype of `Either[A1, B1]`
+   *  @return the inner `Either` if this is a `Right`, otherwise the outer `Left`
    */
   def flatten[A1 >: A, B1](implicit ev: B <:< Either[A1, B1]): Either[A1, B1] = flatMap(ev)
 
@@ -388,6 +431,10 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(12).map(x => "flower") // Result: Right("flower")
    *  Left(12).map(x => "flower")  // Result: Left(12)
    *  ```
+   *
+   *  @tparam B1 the result type of the mapping function
+   *  @param f the function to apply to the `Right` value
+   *  @return a new `Either` with the function applied if this is a `Right`, otherwise the unchanged `Left`
    */
   def map[B1](f: B => B1): Either[A, B1] = this match {
     case Right(b) => Right(f(b))
@@ -404,6 +451,11 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(7).filterOrElse(_ > 10, -1)    // Left(-1)
    *  Left(7).filterOrElse(_ => false, -1) // Left(7)
    *  ```
+   *
+   *  @tparam A1 the supertype of `A` used to widen the left type
+   *  @param p the predicate to test the `Right` value against
+   *  @param zero the value to use as `Left` if the predicate does not hold, evaluated lazily
+   *  @return this `Either` if it is a `Left` or the predicate holds, otherwise `Left(zero)`
    */
   def filterOrElse[A1 >: A](p: B => Boolean, zero: => A1): Either[A1, B] = this match {
     case Right(b) if !p(b) => Left(zero)
@@ -417,6 +469,8 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(12).toSeq // Seq(12)
    *  Left(12).toSeq  // Seq()
    *  ```
+   *
+   *  @return a `Seq` containing the `Right` value, or an empty `Seq` if this is a `Left`
    */
   def toSeq: collection.immutable.Seq[B] = this match {
     case Right(b) => collection.immutable.Seq(b)
@@ -430,6 +484,8 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Right(12).toOption // Some(12)
    *  Left(12).toOption  // None
    *  ```
+   *
+   *  @return a `Some` containing the `Right` value, or `None` if this is a `Left`
    */
   def toOption: Option[B] = this match {
     case Right(b) => Some(b)
@@ -447,6 +503,8 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Left("tulip").isLeft // true
    *  Right("venus fly-trap").isLeft // false
    *  ```
+   *
+   *  @return `true` if this is a `Left`, `false` otherwise
    */
   def isLeft: Boolean
 
@@ -456,11 +514,18 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  Left("tulip").isRight // false
    *  Right("venus fly-trap").isRight // true
    *  ```
+   *
+   *  @return `true` if this is a `Right`, `false` otherwise
    */
   def isRight: Boolean
 }
 
-/** The left side of the disjoint union, as opposed to the [[scala.util.Right]] side. */
+/** The left side of the disjoint union, as opposed to the [[scala.util.Right]] side.
+ *
+ *  @tparam A the type of the value contained in this `Left`
+ *  @tparam B the type of the `Right` alternative
+ *  @param value the value wrapped in this `Left`
+ */
 final case class Left[+A, +B](value: A) extends Either[A, B] {
   def isLeft  = true
   def isRight = false
@@ -470,12 +535,19 @@ final case class Left[+A, +B](value: A) extends Either[A, B] {
    *   Left(1)                   // Either[Int, Nothing]
    *   Left(1).withRight[String] // Either[Int, String]
    *  ```
+   *
+   *  @tparam B1 the target right type to widen to
    */
   def withRight[B1 >: B]: Either[A, B1] = this
 
 }
 
-/** The right side of the disjoint union, as opposed to the [[scala.util.Left]] side. */
+/** The right side of the disjoint union, as opposed to the [[scala.util.Left]] side.
+ *
+ *  @tparam A the type of the `Left` alternative
+ *  @tparam B the type of the value contained in this `Right`
+ *  @param value the value wrapped in this `Right`
+ */
 final case class Right[+A, +B](value: B) extends Either[A, B] {
   def isLeft  = false
   def isRight = true
@@ -485,6 +557,8 @@ final case class Right[+A, +B](value: B) extends Either[A, B] {
    *   Right("x")               // Either[Nothing, String]
    *   Right("x").withLeft[Int] // Either[Int, String]
    *  ```
+   *
+   *  @tparam A1 the target left type to widen to
    */
   def withLeft[A1 >: A]: Either[A1, B] = this
 
@@ -502,6 +576,13 @@ object Either {
    *    PhoneNumber(userInput),
    *    s"The input (\$userInput) does not look like a phone number"
    *  ```
+   *
+   *  @tparam A the `Left` type
+   *  @tparam B the `Right` type
+   *  @param test the condition to evaluate
+   *  @param right the `Right` value to use if `test` is `true`, evaluated lazily
+   *  @param left the `Left` value to use if `test` is `false`, evaluated lazily
+   *  @return `Right(right)` if `test` is `true`, `Left(left)` otherwise
    */
   def cond[A, B](test: Boolean, right: => B, left: => A): Either[A, B] =
     if (test) Right(right) else Left(left)
@@ -515,6 +596,9 @@ object Either {
    *  l.merge: Seq[Int] // List(1)
    *  r.merge: Seq[Int] // Vector(1)
    *  ```
+   *
+   *  @tparam A the common type of both sides of the `Either`
+   *  @param x the `Either` instance whose left and right types are the same
    */
   implicit class MergeableEither[A](private val x: Either[A, A]) extends AnyVal {
     def merge: A = x match {
@@ -526,6 +610,10 @@ object Either {
   /** Projects an `Either` into a `Left`.
    *
    *  @see [[scala.util.Either#left]]
+   *
+   *  @tparam A the type of the `Left` value
+   *  @tparam B the type of the `Right` value
+   *  @param e the `Either` value to project
    */
   final case class LeftProjection[+A, +B](e: Either[A, B]) {
     /** Returns the value from this `Left` or throws `NoSuchElementException`
@@ -550,7 +638,8 @@ object Either {
      *  Left(12).left.foreach(x => println(x))  // prints "12"
      *  Right(12).left.foreach(x => println(x)) // doesn't print
      *  ```
-     *  @param f The side-effecting function to execute.
+     *  @tparam U the return type of the side-effecting function (discarded)
+     *  @param f the side-effecting function to execute
      */
     def foreach[U](f: A => U): Unit = e match {
       case Left(a) => f(a)
@@ -563,6 +652,10 @@ object Either {
      *  Left(12).left.getOrElse(17)  // 12
      *  Right(12).left.getOrElse(17) // 17
      *  ```
+     *
+     *  @tparam A1 the supertype of `A` used to widen the return type
+     *  @param or the default value to return if this is a `Right`, evaluated lazily
+     *  @return the `Left` value if present, otherwise `or`
      */
     def getOrElse[A1 >: A](or: => A1): A1 = e match {
       case Left(a) => a
@@ -577,6 +670,9 @@ object Either {
      *  Left(7).left.forall(_ > 10)   // false
      *  Right(12).left.forall(_ > 10) // true
      *  ```
+     *
+     *  @param p the predicate to apply to the `Left` value
+     *  @return `true` if this is a `Right` or the predicate holds for the `Left` value
      */
     def forall(p: A => Boolean): Boolean = e match {
       case Left(a) => p(a)
@@ -591,6 +687,9 @@ object Either {
      *  Left(7).left.exists(_ > 10)   // false
      *  Right(12).left.exists(_ > 10) // false
      *  ```
+     *
+     *  @param p the predicate to apply to the `Left` value
+     *  @return `true` if this is a `Left` and the predicate holds for its value
      */
     def exists(p: A => Boolean): Boolean = e match {
       case Left(a) => p(a)
@@ -603,7 +702,10 @@ object Either {
      *  Left(12).left.flatMap(x => Left("scala")) // Left("scala")
      *  Right(12).left.flatMap(x => Left("scala")) // Right(12)
      *  ```
-     *  @param f The function to bind across `Left`.
+     *  @tparam A1 the left type of the resulting `Either`
+     *  @tparam B1 the supertype of `B` used to widen the right type
+     *  @param f the function to bind across `Left`
+     *  @return the result of applying `f` if this is a `Left`, otherwise the unchanged `Right`
      */
     def flatMap[A1, B1 >: B](f: A => Either[A1, B1]): Either[A1, B1] = e match {
       case Left(a) => f(a)
@@ -616,6 +718,10 @@ object Either {
      *  Left(12).left.map(_ + 2) // Left(14)
      *  Right[Int, Int](12).left.map(_ + 2) // Right(12)
      *  ```
+     *
+     *  @tparam A1 the result type of the mapping function
+     *  @param f the function to apply to the `Left` value
+     *  @return a new `Either` with the function applied if this is a `Left`, otherwise the unchanged `Right`
      */
     def map[A1](f: A => A1): Either[A1, B] = e match {
       case Left(a) => Left(f(a))
@@ -645,6 +751,10 @@ object Either {
      *  Left(7).left.filterToOption(_ > 10)   // None
      *  Right(12).left.filterToOption(_ > 10) // None
      *  ```
+     *
+     *  @tparam B1 the right type of the resulting `Either`
+     *  @param p the predicate to apply to the `Left` value
+     *  @return `Some(Left(value))` if this is a `Left` and the predicate holds, `None` otherwise
      */
     def filterToOption[B1](p: A => Boolean): Option[Either[A, B1]] = e match {
       case x @ Left(a) if p(a) => Some(x.asInstanceOf[Either[A, B1]])
@@ -658,6 +768,8 @@ object Either {
      *  Left(12).left.toSeq // Seq(12)
      *  Right(12).left.toSeq // Seq()
      *  ```
+     *
+     *  @return a `Seq` containing the `Left` value, or an empty `Seq` if this is a `Right`
      */
     def toSeq: Seq[A] = e match {
       case Left(a) => Seq(a)
@@ -671,6 +783,8 @@ object Either {
      *  Left(12).left.toOption // Some(12)
      *  Right(12).left.toOption // None
      *  ```
+     *
+     *  @return a `Some` containing the `Left` value, or `None` if this is a `Right`
      */
     def toOption: Option[A] = e match {
       case Left(a) => Some(a)
@@ -709,7 +823,8 @@ object Either {
      *  Right(12).right.foreach(x => println(x)) // prints "12"
      *  Left(12).right.foreach(x => println(x))  // doesn't print
      *  ```
-     *  @param f The side-effecting function to execute.
+     *  @tparam U the return type of the side-effecting function (discarded)
+     *  @param f the side-effecting function to execute
      */
     def foreach[U](f: B => U): Unit = e match {
       case Right(b) => f(b)
@@ -722,6 +837,10 @@ object Either {
      *  Right(12).right.getOrElse(17) // 12
      *  Left(12).right.getOrElse(17)  // 17
      *  ```
+     *
+     *  @tparam B1 the supertype of `B` used to widen the return type
+     *  @param or the default value to return if this is a `Left`, evaluated lazily
+     *  @return the `Right` value if present, otherwise `or`
      */
     def getOrElse[B1 >: B](or: => B1): B1 = e match {
       case Right(b) => b
@@ -736,6 +855,9 @@ object Either {
      *  Right(7).right.forall(_ > 10)  // false
      *  Left(12).right.forall(_ > 10)  // true
      *  ```
+     *
+     *  @param f the predicate to apply to the `Right` value
+     *  @return `true` if this is a `Left` or the predicate holds for the `Right` value
      */
     def forall(f: B => Boolean): Boolean = e match {
       case Right(b) => f(b)
@@ -750,6 +872,9 @@ object Either {
      *  Right(7).right.exists(_ > 10)   // false
      *  Left(12).right.exists(_ > 10)   // false
      *  ```
+     *
+     *  @param p the predicate to apply to the `Right` value
+     *  @return `true` if this is a `Right` and the predicate holds for its value
      */
     def exists(p: B => Boolean): Boolean = e match {
       case Right(b) => p(b)
@@ -758,7 +883,9 @@ object Either {
 
     /** Binds the given function across `Right`.
      *
-     *  @param f The function to bind across `Right`.
+     *  @tparam A1 the supertype of `A` used to widen the left type
+     *  @tparam B1 the right type of the resulting `Either`
+     *  @param f the function to bind across `Right`
      */
     def flatMap[A1 >: A, B1](f: B => Either[A1, B1]): Either[A1, B1] = e match {
       case Right(b) => f(b)
@@ -771,6 +898,10 @@ object Either {
      *  Right(12).right.map(x => "flower") // Result: Right("flower")
      *  Left(12).right.map(x => "flower")  // Result: Left(12)
      *  ```
+     *
+     *  @tparam B1 the result type of the mapping function
+     *  @param f the function to apply to the `Right` value
+     *  @return a new `Either` with the function applied if this is a `Right`, otherwise the unchanged `Left`
      */
     def map[B1](f: B => B1): Either[A, B1] = e match {
       case Right(b) => Right(f(b))
@@ -802,6 +933,10 @@ object Either {
      *  Right(7).right.filterToOption(_ > 10)  // None
      *  Left(12).right.filterToOption(_ > 10)  // None
      *  ```
+     *
+     *  @tparam A1 the left type of the resulting `Either`
+     *  @param p the predicate to apply to the `Right` value
+     *  @return `Some(Right(value))` if this is a `Right` and the predicate holds, `None` otherwise
      */
     def filterToOption[A1](p: B => Boolean): Option[Either[A1, B]] = e match {
       case r @ Right(b) if p(b) => Some(r.asInstanceOf[Either[A1, B]])
@@ -815,6 +950,8 @@ object Either {
      *  Right(12).right.toSeq // Seq(12)
      *  Left(12).right.toSeq // Seq()
      *  ```
+     *
+     *  @return a `Seq` containing the `Right` value, or an empty `Seq` if this is a `Left`
      */
     def toSeq: Seq[B] = e match {
       case Right(b) => Seq(b)
@@ -828,6 +965,8 @@ object Either {
      *  Right(12).right.toOption // Some(12)
      *  Left(12).right.toOption // None
      *  ```
+     *
+     *  @return a `Some` containing the `Right` value, or `None` if this is a `Left`
      */
     def toOption: Option[B] = e match {
       case Right(b) => Some(b)

--- a/library/src/scala/util/NotGiven.scala
+++ b/library/src/scala/util/NotGiven.scala
@@ -23,6 +23,8 @@ import language.experimental.captureChecking
  *
  *  In Dotty, ambiguity is a global error, and therefore cannot be used to implement negation.
  *  Instead, `NotGiven` is treated natively in implicit search.
+ *
+ *  @tparam T the type for which no implicit instance should be available
  */
 final class NotGiven[+T] private ()
 

--- a/library/src/scala/util/Random.scala
+++ b/library/src/scala/util/Random.scala
@@ -22,10 +22,16 @@ import scala.language.implicitConversions
 import language.experimental.captureChecking
 
 class Random(val self: java.util.Random^) extends AnyRef with Serializable {
-  /** Creates a new random number generator using a single long seed. */
+  /** Creates a new random number generator using a single long seed.
+   *
+   *  @param seed the initial seed for the random number generator
+   */
   def this(seed: Long) = this(new java.util.Random(seed))
 
-  /** Creates a new random number generator using a single integer seed. */
+  /** Creates a new random number generator using a single integer seed.
+   *
+   *  @param seed the initial seed for the random number generator
+   */
   def this(seed: Int) = this(seed.toLong)
 
   /** Creates a new random number generator. */
@@ -38,10 +44,15 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
 
   /** Generates random bytes and places them into a user-supplied byte
    *  array.
+   *
+   *  @param bytes the byte array to fill with random bytes
    */
   def nextBytes(bytes: Array[Byte]): Unit = { self.nextBytes(bytes) }
 
-  /** Generates `n` random bytes and returns them in a new array. */
+  /** Generates `n` random bytes and returns them in a new array.
+   *
+   *  @param n the number of random bytes to generate
+   */
   def nextBytes(n: Int): Array[Byte] = {
     val bytes = new Array[Byte](0 max n)
     self.nextBytes(bytes)
@@ -55,6 +66,9 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
 
   /** Returns the next pseudorandom, uniformly distributed double value
    *  between min (inclusive) and max (exclusive) from this random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Double, maxExclusive: Double): Double = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -71,6 +85,9 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
 
   /** Returns the next pseudorandom, uniformly distributed float value
    *  between min (inclusive) and max (exclusive) from this random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Float, maxExclusive: Float): Float = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -94,12 +111,17 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
   /** Returns a pseudorandom, uniformly distributed int value between 0
    *  (inclusive) and the specified value (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param n the exclusive upper bound for the returned value (0 is the inclusive lower bound), must be positive
    */
   def nextInt(n: Int): Int = self.nextInt(n)
 
   /** Returns a pseudorandom, uniformly distributed int value between min
    *  (inclusive) and the specified value max (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Int, maxExclusive: Int): Int = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -129,6 +151,8 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
   /** Returns a pseudorandom, uniformly distributed long value between 0
    *  (inclusive) and the specified value (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param n the exclusive upper bound for the returned value (0 is the inclusive lower bound), must be positive
    */
   def nextLong(n: Long): Long = {
     require(n > 0, "n must be positive")
@@ -160,6 +184,9 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
   /** Returns a pseudorandom, uniformly distributed long value between min
    *  (inclusive) and the specified value max (exclusive), drawn from this
    *  random number generator's sequence.
+   *
+   *  @param minInclusive the lower bound (inclusive) of the range
+   *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
    */
   def between(minInclusive: Long, maxExclusive: Long): Long = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -187,8 +214,8 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *  so please don't use this for anything important.  It's primarily
    *  intended for generating test data.
    *
-   *  @param  length    the desired length of the String
-   *  @return           the String
+   *  @param  length    the desired length of the `String`
+   *  @return           a randomly generated `String` of the specified length
    */
   def nextString(length: Int): String = {
     def safeChar(): Char = {
@@ -222,6 +249,10 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
 
   /** Returns a new collection of the same type in a randomly chosen order.
    *
+   *  @tparam T the element type of the collection
+   *  @tparam C the type of the collection returned, determined by the implicit `BuildFrom`
+   *  @param xs the collection to shuffle
+   *  @param bf the implicit `BuildFrom` instance used to build the result collection
    *  @return         the shuffled collection
    */
   def shuffle[T, C](xs: IterableOnce[T])(implicit bf: BuildFrom[xs.type, T, C]): C = {

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -38,13 +38,22 @@ import language.experimental.captureChecking
  *  other libraries that cover this use case.
  */
 object Sorting {
-  /** Sorts an array of Doubles using `java.util.Arrays.sort`. */
+  /** Sorts an array of Doubles using `java.util.Arrays.sort`.
+   *
+   *  @param a the array of `Double`s to sort in place
+   */
   def quickSort(a: Array[Double]^): Unit = java.util.Arrays.sort(a)
 
-  /** Sorts an array of Ints using `java.util.Arrays.sort`. */
+  /** Sorts an array of Ints using `java.util.Arrays.sort`.
+   *
+   *  @param a the array of `Int`s to sort in place
+   */
   def quickSort(a: Array[Int]^): Unit    = java.util.Arrays.sort(a)
 
-  /** Sorts an array of Floats using `java.util.Arrays.sort`. */
+  /** Sorts an array of Floats using `java.util.Arrays.sort`.
+   *
+   *  @param a the array of `Float`s to sort in place
+   */
   def quickSort(a: Array[Float]^): Unit  = java.util.Arrays.sort(a)
 
   private final val qsortThreshold = 16
@@ -52,6 +61,9 @@ object Sorting {
   /** Sorts array `a` with quicksort, using the Ordering on its elements.
    *  This algorithm sorts in place, so no additional memory is used aside from
    *  what might be required to box individual elements during comparison.
+   *
+   *  @tparam K the element type of the array, which must have an `Ordering`
+   *  @param a the array to sort in place
    */
   def quickSort[K: Ordering](a: Array[K]^): Unit = {
     // Must have iN >= i0 or math will fail.  Also, i0 >= 0.
@@ -254,20 +266,28 @@ object Sorting {
 
   /** Sorts array `a` using the Ordering on its elements, preserving the original ordering where possible.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, 0, a.length)`.
+   *
+   *  @tparam K the element type of the array, which must have an `Ordering`
+   *  @param a the array to sort in place
    */
   @`inline` def stableSort[K: Ordering](a: Array[K]^): Unit = stableSort(a, 0, a.length)
 
   /** Sorts array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
    *
-   *  @param a The array to sort
-   *  @param from The first index in the array to sort
-   *  @param until The last index (exclusive) in the array to sort
+   *  @tparam K the element type of the array, which must have an `Ordering`
+   *  @param a the array to sort in place
+   *  @param from the first index in the array to sort
+   *  @param until the last index (exclusive) in the array to sort
    */
   def stableSort[K: Ordering](a: Array[K]^, from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
 
   /** Sorts array `a` using function `f` that computes the less-than relation for each element.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`.
+   *
+   *  @tparam K the element type of the array
+   *  @param a the array to sort in place
+   *  @param f a function that returns `true` if its first argument is less than its second
    */
   @`inline` def stableSort[K](a: Array[K]^, f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
 
@@ -275,14 +295,19 @@ object Sorting {
   /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
    *
-   *  @param a The array to sort
-   *  @param f A function that computes the less-than relation for each element
-   *  @param from The first index in the array to sort
-   *  @param until The last index (exclusive) in the array to sort
+   *  @tparam K the element type of the array
+   *  @param a the array to sort in place
+   *  @param f a function that returns `true` if its first argument is less than its second
+   *  @param from the first index in the array to sort
+   *  @param until the last index (exclusive) in the array to sort
    */
   def stableSort[K](a: Array[K]^, f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
-  /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @tparam K the element type, which must have a `ClassTag` and an `Ordering`
+   *  @param a the sequence of elements to sort
+   */
   def stableSort[K: ClassTag: Ordering](a: scala.collection.Seq[K]): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[K])
@@ -290,14 +315,25 @@ object Sorting {
   }
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
-  /** A sorted Array, given a function `f` that computes the less-than relation for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted Array, given a function `f` that computes the less-than relation for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @tparam K the element type, which must have a `ClassTag`
+   *  @param a the sequence of elements to sort
+   *  @param f a function that returns `true` if its first argument is less than its second
+   */
   def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) => Boolean): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering fromLessThan f)
     ret
   }
 
-  /** A sorted Array, given an extraction function `f` that returns an ordered key for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type. */
+  /** A sorted Array, given an extraction function `f` that returns an ordered key for each item in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
+   *
+   *  @tparam K the element type, which must have a `ClassTag`
+   *  @tparam M the key type returned by the extraction function, which must have an `Ordering`
+   *  @param a the sequence of elements to sort
+   *  @param f a function that extracts a comparable key from each element
+   */
   def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K => M): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[M] on f)

--- a/library/src/scala/util/Try.scala
+++ b/library/src/scala/util/Try.scala
@@ -63,6 +63,8 @@ import caps.Control
  *  Serious system errors, on the other hand, will be thrown.
  *
  *  *Note:*: all Try combinators will catch exceptions and return failure unless otherwise specified in the documentation.
+ *
+ *  @tparam T the type of the value computed by the `Try`
  */
 sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ =>
 
@@ -75,10 +77,18 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
   /** Returns the value from this `Success` or the given `default` argument if this is a `Failure`.
    *
    *  *Note:*: This will throw an exception if it is not a success and default throws an exception.
+   *
+   *  @tparam U the type of the returned value, a supertype of `T`
+   *  @param default the default value to return if this is a `Failure`
+   *  @return the value if this is a `Success`, otherwise `default`
    */
   def getOrElse[U >: T](default: => U): U
 
-  /** Returns this `Try` if it's a `Success` or the given `default` argument if this is a `Failure`. */
+  /** Returns this `Try` if it's a `Success` or the given `default` argument if this is a `Failure`.
+   *
+   *  @tparam U the type of the value in the returned `Try`, a supertype of `T`
+   *  @param default the fallback `Try` to return if this is a `Failure` (evaluated lazily)
+   */
   def orElse[U >: T](default: => Try[U]^): Try[U]^{default}
 
   /** Returns the value from this `Success` or throws the exception if this is a `Failure`. */
@@ -87,19 +97,37 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
   /** Applies the given function `f` if this is a `Success`, otherwise returns `Unit` if this is a `Failure`.
    *
    *  *Note:* If `f` throws, then this method may throw an exception.
+   *
+   *  @tparam U the (discarded) result type of the function `f`
+   *  @param f the function to apply to the value if this is a `Success`
    */
   def foreach[U](f: T => U): Unit
 
-  /** Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`. */
+  /** Returns the given function applied to the value from this `Success` or returns this if this is a `Failure`.
+   *
+   *  @tparam U the type of the value in the resulting `Try`
+   *  @param f the function to apply to the value if this is a `Success`
+   */
   def flatMap[U](f: T => Try[U]^): Try[U]^{this, f}
 
-  /** Maps the given function to the value from this `Success` or returns this if this is a `Failure`. */
+  /** Maps the given function to the value from this `Success` or returns this if this is a `Failure`.
+   *
+   *  @tparam U the type of the mapped value
+   *  @param f the function to apply to the value if this is a `Success`
+   */
   def map[U](f: T => U): Try[U]^{this, f.only[Control]}
 
-  /** Applies the given partial function to the value from this `Success` or returns this if this is a `Failure`. */
+  /** Applies the given partial function to the value from this `Success` or returns this if this is a `Failure`.
+   *
+   *  @tparam U the type of the value returned by the partial function
+   *  @param pf the partial function to apply to the value if this is a `Success`
+   */
   def collect[U](pf: PartialFunction[T, U]^): Try[U]^{this, pf.only[Control]}
 
-  /** Converts this to a `Failure` if the predicate is not satisfied. */
+  /** Converts this to a `Failure` if the predicate is not satisfied.
+   *
+   *  @param p the predicate to test the value against
+   */
   def filter(p: T => Boolean): Try[T]^{this, p.only[Control]}
 
   /** Creates a non-strict filter, which eventually converts this to a `Failure`
@@ -123,6 +151,8 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
   /** We need a whole WithFilter class to honor the "doesn't create a new
    *  collection" contract even though it seems unlikely to matter much in a
    *  collection with max size 1.
+   *
+   *  @param p the predicate used to test elements
    */
   final class WithFilter(p: T => Boolean) uses Try.this {
     def map[U](f:     T => U): Try[U]^{Try.this, p.only[Control], f.only[Control]} = Try.this.filter(p).map(f)
@@ -134,11 +164,17 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
 
   /** Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
    *  This is like `flatMap` for the exception.
+   *
+   *  @tparam U the type of the value in the resulting `Try`, a supertype of `T`
+   *  @param pf the partial function to apply if this is a `Failure`
    */
   def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]^]^): Try[U]^{this, pf}
 
   /** Applies the given function `f` if this is a `Failure`, otherwise returns this if this is a `Success`.
    *  This is like map for the exception.
+   *
+   *  @tparam U the type of the value in the resulting `Try`, a supertype of `T`
+   *  @param pf the partial function to apply if this is a `Failure`
    */
   def recover[U >: T](pf: PartialFunction[Throwable, U]^): Try[U]^{this, pf.only[Control]}
 
@@ -147,6 +183,9 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
 
   /** Transforms a nested `Try`, ie, a `Try` of type `Try[Try[T]]`,
    *  into an un-nested `Try`, ie, a `Try` of type `Try[T]`.
+   *
+   *  @tparam U the type of the value in the inner `Try`
+   *  @param ev evidence that `T` is itself a `Try[U]`
    */
   def flatten[U](implicit ev: T <:< Try[U]): Try[U]^{this}
 
@@ -157,6 +196,10 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
 
   /** Completes this `Try` by applying the function `f` to this if this is of type `Failure`, or conversely, by applying
    *  `s` if this is a `Success`.
+   *
+   *  @tparam U the type of the value in the resulting `Try`
+   *  @param s the function to apply if this is a `Success`
+   *  @param f the function to apply if this is a `Failure`
    */
   def transform[U](s: T => Try[U]^, f: Throwable => Try[U]^): Try[U]^{s, f}
 
@@ -178,6 +221,8 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *  @param fa the function to apply if this is a `Failure`
    *  @param fb the function to apply if this is a `Success`
    *  @return the results of applying the function
+   *
+   *  @tparam U the type of the result
    */
   def fold[U](fa: Throwable => U, fb: T => U): U
 
@@ -191,6 +236,7 @@ object Try {
    *  Any non-fatal exception is caught and results in a `Failure`
    *  that holds the exception.
    *
+   *  @tparam T the type of the value to be computed
    *  @param r the result value to compute
    *  @return the result of evaluating the value, as a `Success` or `Failure`
    */

--- a/library/src/scala/util/Using.scala
+++ b/library/src/scala/util/Using.scala
@@ -143,6 +143,10 @@ object Using {
    *
    *  $suppressionBehavior
    *
+   *  @tparam R the type of the resource
+   *  @tparam A the return type of the operation
+   *  @param resource the resource to be used and then released
+   *  @param f the operation to perform using the resource
    *  @return a [[Try]] containing an exception if one or more were thrown,
    *         or the result of the operation if no exceptions were thrown
    */
@@ -183,6 +187,9 @@ object Using {
     /** Registers the specified resource with this manager, so that
      *  the resource is released when the manager is closed, and then
      *  returns the (unmodified) resource.
+     *
+     *  @tparam R the type of the resource, which must have a `Releasable` instance
+     *  @param resource the resource to register with this manager
      */
     def apply[R: Releasable](resource: R): resource.type = {
       acquire(resource)
@@ -191,6 +198,9 @@ object Using {
 
     /** Registers the specified resource with this manager, so that
      *  the resource is released when the manager is closed.
+     *
+     *  @tparam R the type of the resource, which must have a `Releasable` instance
+     *  @param resource the resource to register, must be non-null
      */
     def acquire[R: Releasable](resource: R): Unit = {
       if (resource == null) throw new NullPointerException("null resource")
@@ -285,8 +295,9 @@ object Using {
    *
    *  @tparam R the type of the resource
    *  @tparam A the return type of the operation
-   *  @param resource the resource
+   *  @param resource the resource to be used and then released
    *  @param body     the operation to perform with the resource
+   *  @param releasable the implicit `Releasable` instance used to release the resource
    *  @return the result of the operation, if neither the operation nor
    *         releasing the resource throws
    */
@@ -319,8 +330,8 @@ object Using {
    *  @tparam R1 the type of the first resource
    *  @tparam R2 the type of the second resource
    *  @tparam A  the return type of the operation
-   *  @param resource1 the first resource
-   *  @param resource2 the second resource
+   *  @param resource1 the first resource (eagerly evaluated)
+   *  @param resource2 the second resource (by-name, evaluated after the first is acquired)
    *  @param body      the operation to perform using the resources
    *  @return the result of the operation, if neither the operation nor
    *         releasing the resources throws
@@ -418,7 +429,10 @@ object Using {
    *  @tparam R the type of the resource
    */
   trait Releasable[-R] {
-    /** Releases the specified resource. */
+    /** Releases the specified resource.
+     *
+     *  @param resource the resource to release
+     */
     def release(resource: R): Unit
   }
 

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -35,11 +35,16 @@ object boundary:
    *
    *  Note that it is **capability unsafe** to access `label` from a `Break`.
    *  This field will be marked private in a future release.
+   *
+   *  @tparam T the type of the value carried by this `Break` exception
    */
   final class Break[T] private[boundary](val label: Label[T]^{}, val value: T)
   extends RuntimeException(
     /*message*/ null, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false):
-    /** Compares the given [[Label]] to the one this [[Break]] was constructed with. */
+    /** Compares the given [[Label]] to the one this [[Break]] was constructed with.
+     *
+     *  @param other the `Label` to compare against this `Break`'s label
+     */
     def isSameLabelAs(other: Label[T]) = label eq other
 
   object Break:
@@ -54,12 +59,18 @@ object boundary:
 
   /** Abort current computation and instead return `value` as the value of
    *  the enclosing `boundary` call that created `label`.
+   *
+   *  @tparam T the type of the value to return from the enclosing `boundary`
+   *  @param value the value to return from the enclosing `boundary` call
+   *  @param label the label identifying the target `boundary` to exit
    */
   def break[T](value: T)(using label: Label[T]): Nothing =
     throw Break(label, value)
 
   /** Abort current computation and instead continue after the `boundary` call that
    *  created `label`.
+   *
+   *  @param label the label identifying the target `boundary` to exit
    */
   def break()(using label: Label[Unit]): Nothing =
     throw Break(label, ())
@@ -67,6 +78,9 @@ object boundary:
   /** Run `body` with freshly generated label as implicit argument. Catch any
    *  breaks associated with that label and return their results instead of
    *  `body`'s result.
+   *
+   *  @tparam T the result type of the boundary block
+   *  @param body the computation to execute, which receives a fresh `Label[T]` as a context parameter
    */
   inline def apply[T](inline body: Label[T] ?=> T): T =
     val local = Label[T]()

--- a/library/src/scala/util/control/Breaks.scala
+++ b/library/src/scala/util/control/Breaks.scala
@@ -74,6 +74,8 @@ class Breaks {
   /** A block from which one can exit with a `break`. The `break` may be
    *  executed further down in the call stack provided that it is called on the
    *  exact same instance of `Breaks`.
+   *
+   *  @param op the computation to execute, which may call `break` to exit early
    */
   def breakable(op: => Unit): Unit =
     try op catch { case ex: BreakControl if ex eq breakException => }
@@ -92,6 +94,10 @@ class Breaks {
    *   Vector.empty
    *  }
    *  ```
+   *
+   *  @tparam T the result type of the computation
+   *  @param op the computation to evaluate, which may call `break` to abort
+   *  @return a `TryBlock` whose `catchBreak` method provides the fallback value if `break` is invoked
    */
   def tryBreakable[T](op: => T): TryBlock[T] =
     new TryBlock[T] {

--- a/library/src/scala/util/control/ControlThrowable.scala
+++ b/library/src/scala/util/control/ControlThrowable.scala
@@ -41,6 +41,8 @@ import scala.language.`2.13`
  *
  *  Instances of `ControlThrowable` should not normally have a cause.
  *  Legacy subclasses may set a cause using `initCause`.
+ *
+ *  @param message the detail message for this control throwable, or `null` if none
  */
 abstract class ControlThrowable(message: String | Null) extends Throwable(
   message, /*cause*/ null, /*enableSuppression=*/ false, /*writableStackTrace*/ false) {

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -170,7 +170,8 @@ object Exception {
 
   /** !!! Not at all sure of every factor which goes into this,
    *  and/or whether we need multiple standard variations.
-   *  @return true if `x` is $protectedExceptions otherwise false.
+   *  @param x the throwable to check
+   *  @return true if `x` is a $protectedExceptions, otherwise `false`.
    */
   def shouldRethrow(x: Throwable): Boolean = x match {
     case _: ControlThrowable      => true
@@ -205,10 +206,10 @@ object Exception {
    *  Pass a different value for rethrow if you want to probably
    *  unwisely allow catching control exceptions and other throwables
    *  which the rest of the world may expect to get through.
-   *  @tparam T result type of bodies used in try and catch blocks
-   *  @param pf Partial function used when applying catch logic to determine result value
-   *  @param fin Finally logic which if defined will be invoked after catch logic
-   *  @param rethrow Predicate on throwables determining when to rethrow a caught [[Throwable]]
+   *  @tparam T result type produced by the catch logic
+   *  @param pf partial function used when applying catch logic to determine result value
+   *  @param fin finally logic which, if defined, will be invoked after catch logic
+   *  @param rethrow predicate on throwables determining when to rethrow a caught [[Throwable]]
    *  @group logic-container
    */
   class Catch[+T](
@@ -219,11 +220,19 @@ object Exception {
 
     protected val name = "Catch"
 
-    /** Creates a new Catch with additional exception handling logic. */
+    /** Creates a new Catch with additional exception handling logic.
+     *
+     *  @tparam U the result type of the combined catch logic, a supertype of `T`
+     *  @param pf2 the additional exception handler to combine with the existing one
+     */
     def or[U >: T](pf2: Catcher[U]): Catch[U] = new Catch(pf orElse pf2, fin, rethrow)
     def or[U >: T](other: Catch[U]): Catch[U] = or(other.pf)
 
-    /** Applies this catch logic to the supplied body. */
+    /** Applies this catch logic to the supplied body.
+     *
+     *  @tparam U the result type of the body, a supertype of `T`
+     *  @param body the code block to execute with exception handling
+     */
     def apply[U >: T](body: => U): U =
       try body
       catch {
@@ -233,7 +242,7 @@ object Exception {
       finally fin foreach (_.invoke())
 
     /** Creates a new Catch container from this object and the supplied finally body.
-     *  @param body The additional logic to apply after all existing finally bodies
+     *  @param body the additional logic to apply after all existing finally bodies
      */
     def andFinally(body: => Unit): Catch[T] = {
       val appendedFin = fin map(_ and body) getOrElse new Finally(body)
@@ -242,22 +251,34 @@ object Exception {
 
     /** Applies this catch logic to the supplied body, mapping the result
      *  into `Option[T]` - `None` if any exception was caught, `Some(T)` otherwise.
+     *
+     *  @tparam U the result type of the body, a supertype of `T`
+     *  @param body the code block to execute, whose result is wrapped in `Some` on success
      */
     def opt[U >: T](body: => U): Option[U] = toOption(Some(body))
 
     /** Applies this catch logic to the supplied body, mapping the result
      *  into `Either[Throwable, T]` - `Left(exception)` if an exception was caught,
      *  `Right(T)` otherwise.
+     *
+     *  @tparam U the result type of the body, a supertype of `T`
+     *  @param body the code block to execute, whose result is wrapped in `Right` on success
      */
     def either[U >: T](body: => U): Either[Throwable, U] = toEither(Right(body))
 
     /** Applies this catch logic to the supplied body, mapping the result
      *  into `Try[T]` - `Failure` if an exception was caught, `Success(T)` otherwise.
+     *
+     *  @tparam U the result type of the body, a supertype of `T`
+     *  @param body the code block to execute, whose result is wrapped in `Success` on success
      */
     def withTry[U >: T](body: => U): scala.util.Try[U] = toTry(Success(body))
 
     /** Creates a `Catch` object with the same `isDefinedAt` logic as this one,
      *  but with the supplied `apply` method replacing the current one. 
+     *
+     *  @tparam U the result type of the new exception handler
+     *  @param f the function to apply to caught exceptions instead of the current handler
      */
     def withApply[U](f: Throwable => U): Catch[U] = {
       val pf2 = new Catcher[U] {
@@ -284,11 +305,15 @@ object Exception {
 
   /** A `Catch` object which catches everything.
    *  @group canned-behavior
+   *
+   *  @tparam T the result type of the `Catch` body
    */
   final def allCatch[T]: Catch[T] = new Catch(allCatcher[T]) withDesc "<everything>"
 
   /** A `Catch` object which catches non-fatal exceptions.
    *  @group canned-behavior
+   *
+   *  @tparam T the result type of the `Catch` body
    */
   final def nonFatalCatch[T]: Catch[T] = new Catch(nonFatalCatcher[T]) withDesc "<non-fatal>"
 
@@ -301,6 +326,10 @@ object Exception {
    *  which should only be caught in exceptional circumstances.  If you really want
    *  to catch exactly what you specify, use `catchingPromiscuously` instead.
    *  @group composition-catch
+   *
+   *  @tparam T the result type of the `Catch` body
+   *  @param exceptions the exception classes to catch
+   *  @return a `Catch` object that will catch the specified exceptions
    */
   def catching[T](exceptions: Class[?]*): Catch[T] =
     new Catch(pfFromExceptions(exceptions*)) withDesc (exceptions map (_.getName) mkString ", ")
@@ -311,24 +340,36 @@ object Exception {
    *  Unlike "catching" which filters out those in shouldRethrow, this one will
    *  catch whatever you ask of it including $protectedExceptions.
    *  @group composition-catch-promiscuously
+   *
+   *  @tparam T the result type of the `Catch` body
+   *  @param exceptions the exception classes to catch, including $protectedExceptions
    */
   def catchingPromiscuously[T](exceptions: Class[?]*): Catch[T] = catchingPromiscuously(pfFromExceptions(exceptions*))
   def catchingPromiscuously[T](c: Catcher[T]): Catch[T]         = new Catch(c, None, _ => false)
 
   /** Creates a `Catch` object which catches and ignores any of the supplied exceptions.
    *  @group composition-catch
+   *
+   *  @param exceptions the exception classes to catch and ignore
    */
   def ignoring(exceptions: Class[?]*): Catch[Unit] =
     catching(exceptions*) withApply (_ => ())
 
   /** Creates a `Catch` object which maps all the supplied exceptions to `None`.
    *  @group composition-catch
+   *
+   *  @tparam T the value type of the resulting `Option`
+   *  @param exceptions the exception classes to catch, mapping them to `None`
    */
   def failing[T](exceptions: Class[?]*): Catch[Option[T]] =
     catching(exceptions*) withApply (_ => None)
 
   /** Creates a `Catch` object which maps all the supplied exceptions to the given value.
    *  @group composition-catch
+   *
+   *  @tparam T the result type of the `Catch` body and the default value
+   *  @param exceptions the exception classes to catch
+   *  @param value the default value to return when one of the specified exceptions is caught
    */
   def failAsValue[T](exceptions: Class[?]*)(value: => T): Catch[T] =
     catching(exceptions*) withApply (_ => value)
@@ -344,6 +385,9 @@ object Exception {
    *   handling(classOf[MalformedURLException], classOf[NullPointerException]) by (_.printStackTrace)
    *  ```
    *  @group dsl
+   *
+   *  @tparam T the result type of the handler function passed to `by`
+   *  @param exceptions the exception classes to catch
    */
   def handling[T](exceptions: Class[?]*): By[Throwable => T, Catch[T]] = {
     def fun(f: Throwable => T): Catch[T] = catching(exceptions*) withApply f
@@ -352,11 +396,17 @@ object Exception {
 
   /** Returns a `Catch` object with no catch logic and the argument as the finally logic.
    *  @group composition-finally
+   *
+   *  @tparam T the result type of the `Catch` body
+   *  @param body the finally logic to execute after the `Catch` body completes
    */
   def ultimately[T](body: => Unit): Catch[T] = noCatch andFinally body
 
   /** Creates a `Catch` object which unwraps any of the supplied exceptions.
    *  @group composition-catch
+   *
+   *  @tparam T the result type of the `Catch` body
+   *  @param exceptions the wrapper exception classes to unwrap before rethrowing
    */
   def unwrapping[T](exceptions: Class[?]*): Catch[T] = {
     @tailrec
@@ -367,7 +417,11 @@ object Exception {
     catching(exceptions*) withApply (x => throw unwrap(x))
   }
 
-  /** Private. */
+  /** Private.
+   *
+   *  @param x the throwable to test against `classes`
+   *  @param classes the exception classes to match against
+   */
   private def wouldMatch(x: Throwable, classes: scala.collection.Seq[Class[?]]): Boolean =
     classes exists (_.isAssignableFrom(x.getClass))
 

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -41,6 +41,9 @@ object NonFatal {
     case _: VirtualMachineError | _: ThreadDeath | _: InterruptedException | _: LinkageError | _: ControlThrowable => false
     case _ => true
   }
-  /** Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None` */
+  /** Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None`
+   *
+   *  @param t the `Throwable` to test for being non-fatal
+   */
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 }

--- a/library/src/scala/util/control/TailCalls.scala
+++ b/library/src/scala/util/control/TailCalls.scala
@@ -48,14 +48,24 @@ import annotation.tailrec
  */
 object TailCalls {
 
-  /** This class represents a tailcalling computation. */
+  /** This class represents a tailcalling computation.
+   *
+   *  @tparam A the result type of the computation
+   */
   sealed abstract class TailRec[+A] {
 
-    /** Continue the computation with `f`. */
+    /** Continue the computation with `f`.
+     *
+     *  @tparam B the result type of the mapped computation
+     *  @param f the function to apply to the result, transforming `A` to `B`
+     */
     final def map[B](f: A => B): TailRec[B] = flatMap(a => Call(() => Done(f(a))))
 
     /** Continue the computation with `f` and merge the trampolining
      *  of this computation with that of `f`. 
+     *
+     *  @tparam B the result type of the continuation
+     *  @param f the function to apply to the result, returning a new tailcalling computation
      */
     final def flatMap[B](f: A => TailRec[B]): TailRec[B] = this match {
       case Done(a)         => Call(() => f(a))
@@ -89,27 +99,43 @@ object TailCalls {
     }
   }
 
-  /** Internal class representing a tailcall. */
+  /** Internal class representing a tailcall.
+   *
+   *  @tparam A the result type of the computation
+   *  @param rest a thunk that computes the next step of the tailcalling computation
+   */
   protected case class Call[A](rest: () => TailRec[A]) extends TailRec[A]
 
   /** Internal class representing the final result returned from a tailcalling
    *  computation. 
+   *
+   *  @tparam A the result type of the computation
+   *  @param value the final result of the tailcalling computation
    */
   protected case class Done[A](value: A) extends TailRec[A]
 
   /** Internal class representing a continuation with function A => TailRec[B].
    *  It is needed for the flatMap to be implemented. 
+   *
+   *  @tparam A the intermediate result type
+   *  @tparam B the final result type of the continuation
+   *  @param a the first computation to evaluate
+   *  @param f the continuation function to apply to the result of `a`
    */
   protected case class Cont[A, B](a: TailRec[A], f: A => TailRec[B]) extends TailRec[B]
 
   /** Perform a tailcall.
+   *
+   *  @tparam A the result type of the tailcalling computation
    *  @param rest  the expression to be evaluated in the tailcall
    *  @return a `TailRec` object representing the expression `rest`
    */
   def tailcall[A](rest: => TailRec[A]): TailRec[A] = Call(() => rest)
 
   /** Returns the final result from a tailcalling computation.
-   *  @param  `result` the result value
+   *
+   *  @tparam A the result type of the computation
+   *  @param result the value to wrap as a completed computation
    *  @return a `TailRec` object representing a computation which immediately
    *          returns `result`
    */

--- a/library/src/scala/util/hashing/ByteswapHashing.scala
+++ b/library/src/scala/util/hashing/ByteswapHashing.scala
@@ -15,7 +15,10 @@ package util.hashing
 
 import scala.language.`2.13`
 
-/** A fast multiplicative hash by Phil Bagwell. */
+/** A fast multiplicative hash by Phil Bagwell.
+ *
+ *  @tparam T the type of values to be hashed
+ */
 final class ByteswapHashing[T] extends Hashing[T] {
 
   def hash(v: T) = byteswap32(v.##)
@@ -29,7 +32,11 @@ object ByteswapHashing {
     def hash(v: T) = byteswap32(h.hash(v))
   }
 
-  /** Composes another `Hashing` with the Byteswap hash. */
+  /** Composes another `Hashing` with the Byteswap hash.
+   *
+   *  @tparam T the type of values to be hashed
+   *  @param h the hashing instance whose result is passed through byteswap hashing
+   */
   def chain[T](h: Hashing[T]): Hashing[T] = new Chained(h)
 
 }

--- a/library/src/scala/util/hashing/package.scala
+++ b/library/src/scala/util/hashing/package.scala
@@ -17,7 +17,10 @@ import scala.language.`2.13`
 
 package object hashing {
 
-  /** Fast multiplicative hash with a nice distribution. */
+  /** Fast multiplicative hash with a nice distribution.
+   *
+   *  @param v the 32-bit `Int` value to hash
+   */
   def byteswap32(v: Int): Int = {
     var hc = v * 0x9e3775cd
     hc = java.lang.Integer.reverseBytes(hc)
@@ -26,6 +29,8 @@ package object hashing {
 
   /** Fast multiplicative hash with a nice distribution
    *  for 64-bit values.
+   *
+   *  @param v the 64-bit `Long` value to hash
    */
   def byteswap64(v: Long): Long = {
     var hc = v * 0x9e3775cd9e3775cdL

--- a/library/src/scala/util/matching/Regex.scala
+++ b/library/src/scala/util/matching/Regex.scala
@@ -335,6 +335,9 @@ class Regex private[matching](val pattern: Pattern, groupNames: String*) extends
    *
    *  Otherwise, this Regex is applied to the previously matched input,
    *  and the result of that match is used.
+   *
+   *  @param m the `Match` to extract groups from
+   *  @return the matched groups, or `None` if the match was unsuccessful
    */
   def unapplySeq(m: Match): Option[List[String | Null]] =
     if (m.matched == null) None
@@ -655,6 +658,8 @@ object Regex {
 
     /** The index of the first matched character in group `i`,
      *  or -1 if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def start(i: Int): Int
 
@@ -663,6 +668,8 @@ object Regex {
 
     /** The index following the last matched character in group `i`,
      *  or -1 if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def end(i: Int): Int
 
@@ -673,6 +680,8 @@ object Regex {
 
     /** The matched string in group `i`,
      *  or `null` if nothing was matched.
+     *
+     *  @param i the index of the capturing group
      */
     def group(i: Int): String | Null =
       if (start(i) >= 0) source.subSequence(start(i), end(i)).toString
@@ -690,6 +699,8 @@ object Regex {
 
     /** The char sequence before first character of match in group `i`,
      *  or `null` if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def before(i: Int): CharSequence | Null =
       if (start(i) >= 0) source.subSequence(0, start(i))
@@ -704,6 +715,8 @@ object Regex {
 
     /** The char sequence after last character of match in group `i`,
      *  or `null` if nothing was matched for that group.
+     *
+     *  @param i the index of the capturing group
      */
     def after(i: Int): CharSequence | Null =
       if (end(i) >= 0) source.subSequence(end(i), source.length)
@@ -739,7 +752,11 @@ object Regex {
     override def toString(): String = matched.nn
   }
 
-  /** Provides information about a successful match. */
+  /** Provides information about a successful match.
+   *
+   *  @param source the source character sequence that was matched against
+   *  @param matcher the underlying `Matcher` that performed the match
+   */
   class Match(val source: CharSequence,
               protected[matching] val matcher: Matcher,
               _groupNames: Seq[String]) extends MatchData {
@@ -761,10 +778,16 @@ object Regex {
     private lazy val ends: Array[Int] =
       Array.tabulate(groupCount + 1) { matcher.end }
 
-    /** The index of the first matched character in group `i`. */
+    /** The index of the first matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def start(i: Int): Int = starts(i)
 
-    /** The index following the last matched character in group `i`. */
+    /** The index following the last matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def end(i: Int): Int = ends(i)
 
     /** The match itself with matcher-dependent lazy vals forced,
@@ -818,6 +841,10 @@ object Regex {
    *  [[java.lang.IllegalStateException]].
    *
    *  @see [[java.util.regex.Matcher]]
+   *
+   *  @param source the character sequence being matched against
+   *  @param regex the `Regex` whose pattern is used for matching
+   *  @param _groupNames the names of the capturing groups, if any
    */
   class MatchIterator(val source: CharSequence, val regex: Regex, private[Regex] val _groupNames: Seq[String])
   extends AbstractIterator[String] with MatchData { self =>
@@ -871,13 +898,19 @@ object Regex {
     /** The index of the first matched character. */
     def start: Int = { ensure() ; matcher.start }
 
-    /** The index of the first matched character in group `i`. */
+    /** The index of the first matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def start(i: Int): Int = { ensure() ; matcher.start(i) }
 
     /** The index of the last matched character. */
     def end: Int = { ensure() ; matcher.end }
 
-    /** The index following the last matched character in group `i`. */
+    /** The index following the last matched character in group `i`.
+     *
+     *  @param i the index of the capturing group
+     */
     def end(i: Int): Int = { ensure() ; matcher.end(i) }
 
     /** The number of subgroups. */
@@ -921,6 +954,9 @@ object Regex {
    *  ```
    *  List("US\$", "CAN\$").map(Regex.quote).mkString("|").r
    *  ```
+   *
+   *  @param text the string to quote as a literal pattern
+   *  @return a regex pattern string that matches `text` literally
    */
   def quote(text: String): String = Pattern.quote(text)
 

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -18,8 +18,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:72
-72 |    val local = Label[T]()
+   |This location contains code that was inlined from boundary.scala:86
+86 |    val local = Label[T]()
    |                ^^^^^^^^^^
     --------------------------------------------------------------------------------------------------------------------
    |
@@ -58,8 +58,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:74
-74 |    catch case ex: Break[T] @unchecked =>
+   |This location contains code that was inlined from boundary.scala:88
+88 |    catch case ex: Break[T] @unchecked =>
    |                   ^
     --------------------------------------------------------------------------------------------------------------------
    |

--- a/tests/neg-custom-args/captures/try-boundary.check
+++ b/tests/neg-custom-args/captures/try-boundary.check
@@ -16,12 +16,12 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:71
-71 |  inline def apply[T](inline body: Label[T] ?=> T): T =
+   |This location contains code that was inlined from boundary.scala:85
+85 |  inline def apply[T](inline body: Label[T] ?=> T): T =
    |                                                    ^
-72 |    val local = Label[T]()
-73 |...
-76 |      else throw ex
+86 |    val local = Label[T]()
+87 |...
+90 |      else throw ex
     --------------------------------------------------------------------------------------------------------------------
    |
    | longer explanation available when compiling with `-explain`


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for util, io, ref. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.