### PR TITLE
Annotation, reflect, misc (11): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library-js/src/scala/Console.scala
+++ b/library-js/src/scala/Console.scala
@@ -163,6 +163,8 @@ object Console extends AnsiColor {
    *  @return the results of `thunk`
    *  @see `withOut[T](out:OutputStream)(thunk: => T)`
    *  @group io-redefinition
+   *
+   *  @tparam T the return type of `thunk`
    */
   def withOut[T](out: PrintStream)(thunk: =>T): T =
     outVar.withValue(out)(thunk)
@@ -170,6 +172,7 @@ object Console extends AnsiColor {
   /** Sets the default output stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param out the new output stream.
    *  @param thunk the code to execute with
    *               the new output stream active
@@ -192,6 +195,8 @@ object Console extends AnsiColor {
    *  @return the results of `thunk`
    *  @see `withErr[T](err:OutputStream)(thunk: =>T)`
    *  @group io-redefinition
+   *
+   *  @tparam T the return type of `thunk`
    */
   def withErr[T](err: PrintStream)(thunk: =>T): T =
     errVar.withValue(err)(thunk)
@@ -199,6 +204,7 @@ object Console extends AnsiColor {
   /** Sets the default error stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param err the new error stream.
    *  @param thunk the code to execute with
    *               the new error stream active
@@ -226,6 +232,9 @@ object Console extends AnsiColor {
    *  @return the results of `thunk`
    *  @see `withIn[T](in:InputStream)(thunk: =>T)`
    *  @group io-redefinition
+   *
+   *  @tparam T the return type of `thunk`
+   *  @param reader the new input reader
    */
   def withIn[T](reader: Reader)(thunk: =>T): T =
     inVar.withValue(new BufferedReader(reader))(thunk)
@@ -233,6 +242,7 @@ object Console extends AnsiColor {
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param in the new input stream.
    *  @param thunk the code to execute with
    *               the new input stream active

--- a/library-js/src/scala/Enumeration.scala
+++ b/library-js/src/scala/Enumeration.scala
@@ -148,7 +148,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
    */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x` */
+  /** The value of this enumeration with given id `x`
+   *
+   *  @param x the integer id of the desired value
+   */
   final def apply(x: Int): Value = vmap(x)
 
   /** Returns a `Value` from this `Enumeration` whose name matches
@@ -224,7 +227,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     override def hashCode: Int = id.##
 
-    /** Creates a ValueSet which contains this value and another one. */
+    /** Creates a ValueSet which contains this value and another one.
+     *
+     *  @param v the other value to include in the set
+     */
     def + (v: Value) = ValueSet(this, v)
   }
 
@@ -321,6 +327,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     val empty = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
      *  corresponding to the bits in an array. 
+     *
+     *  @param elems an array of `Long` values encoding the bit mask of value ids
      */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
     /** A builder object for value sets. */

--- a/library-js/src/scala/reflect/ClassTag.scala
+++ b/library-js/src/scala/reflect/ClassTag.scala
@@ -61,7 +61,10 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]`. */
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
-  /** Produces a new array with element type `T` and length `len`. */
+  /** Produces a new array with element type `T` and length `len`.
+   *
+   *  @param len the length of the new array
+   */
   def newArray(len: Int): Array[T] =
     java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 
@@ -72,6 +75,9 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
    *  Type tests necessary before calling other extractors are treated similarly.
    *  `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    *  is uncheckable, but we have an instance of `ClassTag[T]`.
+   *
+   *  @param x the value to match against the runtime class of `T`
+   *  @return `Some(x)` if `x` is an instance of `T`, `None` otherwise
    */
   def unapply(x: Any): Option[T] =
     if (runtimeClass.isInstance(x)) Some(x.asInstanceOf[T])

--- a/library/src/scala/CanEqual.scala
+++ b/library/src/scala/CanEqual.scala
@@ -21,6 +21,9 @@ object CanEqual {
    *  Even though this method is not declared as given, the compiler will
    *  synthesize implicit arguments as solutions to `CanEqual[T, U]` queries if
    *  the rules of multiversal equality require it.
+   *
+   *  @tparam L the left-hand comparison type
+   *  @tparam R the right-hand comparison type
    */
   def canEqualAny[L, R]: CanEqual[L, R] = derived
 

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -154,6 +154,7 @@ object Console extends AnsiColor {
    *  withOut(Console.err) { println("This goes to default _error_") }
    *  ```
    *
+   *  @tparam T the return type of `thunk`
    *  @param out the new output stream.
    *  @param thunk the code to execute with
    *               the new output stream active
@@ -167,6 +168,7 @@ object Console extends AnsiColor {
   /** Sets the default output stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param out the new output stream.
    *  @param thunk the code to execute with
    *               the new output stream active
@@ -183,6 +185,7 @@ object Console extends AnsiColor {
    *  withErr(Console.out) { err.println("This goes to default _out_") }
    *  ```
    *
+   *  @tparam T the return type of `thunk`
    *  @param err the new error stream.
    *  @param thunk the code to execute with
    *               the new error stream active
@@ -196,6 +199,7 @@ object Console extends AnsiColor {
   /** Sets the default error stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param err the new error stream.
    *  @param thunk the code to execute with
    *               the new error stream active
@@ -217,9 +221,10 @@ object Console extends AnsiColor {
    *  }
    *  ```
    *
+   *  @tparam T the return type of `thunk`
+   *  @param reader the new input reader to use as the default input source
    *  @param thunk the code to execute with
    *               the new input stream active
-   *
    *  @return the results of `thunk`
    *  @see `withIn[T](in:InputStream)(thunk: => T)`
    *  @group io-redefinition
@@ -230,6 +235,7 @@ object Console extends AnsiColor {
   /** Sets the default input stream for the duration
    *  of execution of one thunk.
    *
+   *  @tparam T the return type of `thunk`
    *  @param in the new input stream.
    *  @param thunk the code to execute with
    *               the new input stream active

--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -23,10 +23,16 @@ import annotation.internal.preview
  *
  *  The `Conversion` class can also be used to convert explicitly, using
  *  the `convert` extension method.
+ *
+ *  @tparam T the input type of the conversion (contravariant)
+ *  @tparam U the output type of the conversion (covariant)
  */
 @java.lang.FunctionalInterface
 abstract class Conversion[-T, +U] extends Function1[T, U]:
-    /** Converts value `x` of type `T` to type `U`. */
+    /** Converts value `x` of type `T` to type `U`.
+     *
+     *  @param x the value of type `T` to convert to type `U`
+     */
     def apply(x: T): U
 
     extension (x: T)

--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -152,7 +152,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
    */
   final def maxId = topId
 
-  /** The value of this enumeration with given id `x`. */
+  /** The value of this enumeration with given id `x`.
+   *
+   *  @param x the integer id of the desired value; throws `NoSuchElementException` if no value with this id exists
+   */
   final def apply(x: Int): Value = vmap(x)
 
   /** Returns a `Value` from this `Enumeration` whose name matches
@@ -245,7 +248,10 @@ abstract class Enumeration (initial: Int) extends Serializable {
     }
     override def hashCode(): Int = id.##
 
-    /** Creates a ValueSet which contains this value and another one. */
+    /** Creates a ValueSet which contains this value and another one.
+     *
+     *  @param v the other value to include in the set
+     */
     def + (v: Value): ValueSet = ValueSet(this, v)
   }
 
@@ -345,6 +351,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     val empty: ValueSet = new ValueSet(immutable.BitSet.empty)
     /** A value set containing all the values for the zero-adjusted ids
      *  corresponding to the bits in an array 
+     *
+     *  @param elems an array of `Long` values encoding the bit mask of zero-adjusted value ids
      */
     def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
     /** A builder object for value sets. */

--- a/library/src/scala/Equals.scala
+++ b/library/src/scala/Equals.scala
@@ -32,6 +32,8 @@ trait Equals extends Any {
 
   /** Checks whether this instance is equal to `that`.
    *  This universal equality method is defined in `AnyRef`.
+   *
+   *  @param that the object to compare for equality with this instance
    */
   def equals(that: Any): Boolean
 }

--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -22,6 +22,8 @@ object NamedTuple:
 
   /** A named tuple expression will desugar to a call to `build`. For instance,
    *  `(name = "Lyra", age = 23)` will desugar to `build[("name", "age")]()(("Lyra", 23))`.
+   *
+   *  @tparam N the tuple of literal string types representing the field names
    */
   inline def build[N <: Tuple]()[V <: Tuple](x: V): NamedTuple[N, V] = x
 
@@ -141,7 +143,10 @@ end NamedTuple
 object NamedTupleDecomposition:
   import NamedTuple.*
   extension [N <: Tuple, V <: Tuple](x: NamedTuple[N, V])
-      /** The value (without the name) at index `n` of this tuple. */
+    /** The value (without the name) at index `n` of this tuple.
+     *
+     *  @param n the zero-based index of the element to retrieve
+     */
     inline def apply(n: Int): Elem[NamedTuple[N, V], n.type] =
       x.toTuple.apply(n).asInstanceOf[Elem[NamedTuple[N, V], n.type]]
 
@@ -163,19 +168,30 @@ object NamedTupleDecomposition:
 
     /** The tuple consisting of the first `n` elements of this tuple, or all
      *  elements if `n` exceeds `size`.
+     *
+     *  @param n the number of elements to take from this tuple
      */
     inline def take(n: Int): Take[NamedTuple[N, V], n.type] = x.toTuple.take(n)
 
     /** The tuple consisting of all elements of this tuple except the first `n` ones,
      *  or no elements if `n` exceeds `size`.
+     *
+     *  @param n the number of elements to drop from the beginning of this tuple
      */
     inline def drop(n: Int): Drop[NamedTuple[N, V], n.type] = x.toTuple.drop(n)
 
-    /** The tuple `(x.take(n), x.drop(n))`. */
+    /** The tuple `(x.take(n), x.drop(n))`.
+     *
+     *  @param n the index at which to split this tuple
+     */
     inline def splitAt(n: Int): Split[NamedTuple[N, V], n.type] = x.toTuple.splitAt(n)
 
     /** The tuple consisting of all elements of this tuple followed by all elements
      *  of tuple `that`. The names of the two tuples must be disjoint.
+     *
+     *  @tparam N2 the tuple of name types of the other named tuple
+     *  @tparam V2 the tuple of value types of the other named tuple
+     *  @param that the named tuple to append to this one
      */
     inline def ++ [N2 <: Tuple, V2 <: Tuple](that: NamedTuple[N2, V2])(using Tuple.Disjoint[N, N2] =:= true)
       : Concat[NamedTuple[N, V], NamedTuple[N2, V2]]
@@ -184,6 +200,8 @@ object NamedTupleDecomposition:
     /** The named tuple consisting of all element values of this tuple mapped by
      *  the polymorphic mapping function `f`. The names of elements are preserved.
      *  If `x = (n1 = v1, ..., ni = vi)` then `x.map(f) = `(n1 = f(v1), ..., ni = f(vi))`.
+     *
+     *  @tparam F the type constructor applied to each element value type
      */
     inline def map[F[_]](f: [t] => t => F[t]): Map[NamedTuple[N, V], F] =
       x.toTuple.map[F](f)
@@ -197,6 +215,9 @@ object NamedTupleDecomposition:
      *  the extra elements of the larger tuple will be disregarded.
      *  The names of `x` and `that` at the same index must be the same.
      *  The result tuple keeps the same names as the operand tuples.
+     *
+     *  @tparam V2 the tuple of value types of the other named tuple
+     *  @param that the named tuple to zip with this one
      */
     inline def zip[V2 <: Tuple](that: NamedTuple[N, V2]): Zip[NamedTuple[N, V], NamedTuple[N, V2]] =
       x.toTuple.zip(that.toTuple)

--- a/library/src/scala/NotImplementedError.scala
+++ b/library/src/scala/NotImplementedError.scala
@@ -17,6 +17,8 @@ import scala.language.`2.13`
 /** Throwing this exception can be a temporary replacement for a method
  *  body that remains to be implemented. For instance, the exception is thrown by
  *  `Predef.???`.
+ *
+ *  @param msg the error message describing which implementation is missing
  */
 final class NotImplementedError(msg: String) extends Error(msg) {
   def this() = this("an implementation is missing")

--- a/library/src/scala/ScalaReflectionException.scala
+++ b/library/src/scala/ScalaReflectionException.scala
@@ -2,7 +2,10 @@ package scala
 
 import scala.language.`2.13`
 
-/** An exception that indicates an error during Scala reflection. */
+/** An exception that indicates an error during Scala reflection.
+ *
+ *  @param msg the detail message describing the reflection error
+ */
 case class ScalaReflectionException(msg: String) extends Exception(msg)
 
 object ScalaReflectionException extends scala.runtime.AbstractFunction1[String, ScalaReflectionException]:

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -81,7 +81,8 @@ case class StringContext(parts: String*) {
    *  ```
    *  will print the string `1 + 1 = 2`.
    *
-   *  @param `args` The arguments to be inserted into the resulting string.
+   *  @param args the values to be interpolated into the string
+   *  @return the interpolated string with arguments converted via `toString` and escape sequences expanded
    *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
@@ -127,6 +128,9 @@ case class StringContext(parts: String*) {
      *
      *  Here, we use the `TimeSplitter` regex within the `s` matcher, further splitting the
      *  matched string "10.50" into its constituent parts
+     *
+     *  @param s the string to match against the pattern
+     *  @return `Some` containing the sequence of matched substrings, or `None` if the input does not match
      */
     def unapplySeq(s: String): Option[Seq[String]] = glob(parts.map(processEscapes), s)
   }
@@ -147,7 +151,8 @@ case class StringContext(parts: String*) {
    *    res0: String = #
    *  ```
    *
-   *  @param `args` The arguments to be inserted into the resulting string.
+   *  @param args the values to be interpolated into the string
+   *  @return the interpolated string without expanding escape sequences
    *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
@@ -175,7 +180,9 @@ case class StringContext(parts: String*) {
    *    println(f"\$name%s is \$height%2.2f meters tall")  // James is 1.90 meters tall
    *  ```
    *
-   *  @param `args` The arguments to be inserted into the resulting string.
+   *  @tparam A the type of the arguments (effectively unconstrained; the lower bound `>: Any` ensures `A` resolves to `Any`)
+   *  @param args the values to be formatted and interpolated into the string
+   *  @return the interpolated and formatted string
    *  @throws IllegalArgumentException
    *          if the number of `parts` in the enclosing `StringContext` does not exceed
    *          the number of arguments `arg` by exactly 1.
@@ -421,6 +428,10 @@ object StringContext {
    *  backwards compatibility is also retained.
    *  Otherwise, the backslash is not taken to introduce an escape and the
    *  backslash is taken to be literal
+   *
+   *  @param str the string potentially containing Unicode escape sequences
+   *  @param backslash the index of the first `\\u` escape sequence in `str`
+   *  @return the string with Unicode escape sequences replaced by their corresponding characters
    */
   private def replaceU(str: String, backslash: Int): String = {
     val len = str.length()
@@ -466,6 +477,8 @@ object StringContext {
   /** Checks that the length of the given argument `args` is one less than the number
    *  of `parts` supplied to the `StringContext`.
    *
+   *  @param args the interpolated argument values
+   *  @param parts the literal parts of the interpolated string
    *  @throws IllegalArgumentException  if this is not the case.
    */
   def checkLengths(args: scala.collection.Seq[Any], parts: Seq[String]): Unit =

--- a/library/src/scala/Symbol.scala
+++ b/library/src/scala/Symbol.scala
@@ -35,6 +35,9 @@ object Symbol extends UniquenessCache[String, Symbol] {
 
 /** This is private so it won't appear in the library API, but
  *  abstracted to offer some hope of reusability.  
+ *
+ *  @tparam K the type of keys used for cache lookup, held via weak references
+ *  @tparam V the type of cached values, weakly referenced and constructed from keys via `valueFromKey`
  */
 private[scala] abstract class UniquenessCache[K, V] {
   import java.lang.ref.WeakReference

--- a/library/src/scala/UninitializedFieldError.scala
+++ b/library/src/scala/UninitializedFieldError.scala
@@ -19,6 +19,8 @@ import scala.language.`2.13`
  *
  *  Such runtime checks are not emitted by default.
  *  They can be enabled by the `-Xcheckinit` compiler option.
+ *
+ *  @param msg the error message describing which field was accessed before initialization
  */
 final case class UninitializedFieldError(msg: String) extends RuntimeException(msg) {
   def this(obj: Any) = this("" + obj)

--- a/library/src/scala/annotation/MacroAnnotation.scala
+++ b/library/src/scala/annotation/MacroAnnotation.scala
@@ -213,9 +213,10 @@ trait MacroAnnotation extends StaticAnnotation:
    *    override def hashCode(): Int = hash$macro$1
    *  ```
    *
-   *  @param Quotes     Implicit instance of Quotes used for tree reflection
-   *  @param definition Tree that will be transformed
-   *  @param companion  Tree for the companion class or module if the definition is respectively a module or a class
+   *  @param Quotes     the implicit `Quotes` context providing access to the reflection API
+   *  @param definition the annotated definition to be transformed
+   *  @param companion  the companion object definition if `definition` is a class, or the companion class definition if `definition` is an object; `None` if no companion exists
+   *  @return a non-empty list of definitions: the transformed `definition` (which must reuse the original symbol) followed by any additional new definitions
    *
    *  @syntax markdown
    */

--- a/library/src/scala/annotation/experimental.scala
+++ b/library/src/scala/annotation/experimental.scala
@@ -6,6 +6,8 @@ import language.experimental.captureChecking
  *
  *  @see [[https://nightly.scala-lang.org/docs/reference/other-new-features/experimental-defs]]
  *  @syntax markdown
+ *
+ *  @param message a description explaining the experimental status, or an empty string if no message is needed
  */
 final class experimental(message: String) extends StaticAnnotation:
   def this() = this("")

--- a/library/src/scala/annotation/implicitAmbiguous.scala
+++ b/library/src/scala/annotation/implicitAmbiguous.scala
@@ -38,6 +38,8 @@ import scala.language.`2.13`
  *
  *  implicitly[Int =!= Int]
  *  ```
+ *
+ *  @param msg the error message template, with `\${Xi}` placeholders for type parameters
  */
 @meta.getter
 final class implicitAmbiguous(msg: String) extends scala.annotation.ConstantAnnotation

--- a/library/src/scala/annotation/implicitNotFound.scala
+++ b/library/src/scala/annotation/implicitNotFound.scala
@@ -53,5 +53,7 @@ import scala.language.`2.13`
  *   k.n[String]
  *      ^
  *  </pre>
+ *
+ *  @param msg the error message template, with `\${Xi}` placeholders for type parameters
  */
 final class implicitNotFound(msg: String) extends scala.annotation.ConstantAnnotation

--- a/library/src/scala/annotation/init.scala
+++ b/library/src/scala/annotation/init.scala
@@ -29,6 +29,8 @@ object init:
    *  `C(a = Cold)` for the argument `c` of the method `build`. Consequently,
    *  the checker will issue a warning for the method call `c.a.square()` because
    *  it is forbidden to call methods or access fields on cold values.
+   *
+   *  @param height the maximum height (depth of the abstract object tree) to which the argument value is widened
    */
   @experimental
   final class widen(height: Int) extends StaticAnnotation
@@ -55,6 +57,10 @@ object init:
    *  Therefore, the field `box1.value` and `box2.value` points to both instances of `C` and `D`. Consequently,
    *  the method call `box1.value.foo()` will be invalid, because it reaches `A.m`, which is not yet initialized.
    *  The explicit context annotation solves the problem.
+   *
+   *  @tparam T the type of the value computed within the region
+   *  @param v the expression to evaluate within a fresh region context
+   *  @return the value `v` unchanged at runtime; at the checker level, mutable fields within this region receive distinct abstract representations
    */
   @experimental
   def region[T](v: T): T = v

--- a/library/src/scala/annotation/internal/Child.scala
+++ b/library/src/scala/annotation/internal/Child.scala
@@ -19,5 +19,7 @@ import language.experimental.captureChecking
  *  appears before the one for `B`.
  *
  *  TODO: This should be `Child[T <: AnyKind]`
+ *
+ *  @tparam T a reference to the child class or object that extends the annotated sealed class, typically a `TypeRef` to the child's class symbol
  */
 class Child[T] extends Annotation

--- a/library/src/scala/annotation/internal/ContextResultCount.scala
+++ b/library/src/scala/annotation/internal/ContextResultCount.scala
@@ -7,5 +7,7 @@ import language.experimental.captureChecking
  *  that have one or more nested context closures as their right hand side.
  *  The parameter `n` is an Int Literal that tells how many nested closures
  *  there are.
+ *
+ *  @param n the number of nested context closures in the method's right-hand side
  */
 class ContextResultCount(n: Int) extends StaticAnnotation

--- a/library/src/scala/annotation/internal/SourceFile.scala
+++ b/library/src/scala/annotation/internal/SourceFile.scala
@@ -4,8 +4,9 @@ import language.experimental.captureChecking
 
 import scala.annotation.Annotation
 
-/** An annotation to record a Scala2 pickled alias.
- *  @param aliased  A TermRef pointing to the aliased field.
+/** An annotation to record the source file path of a definition.
+ *
+ *  @param path the path of the source file in which the annotated definition appears
  */
 class SourceFile(path: String) extends Annotation {
 

--- a/library/src/scala/annotation/internal/WitnessNames.scala
+++ b/library/src/scala/annotation/internal/WitnessNames.scala
@@ -49,6 +49,8 @@ import language.experimental.captureChecking
  *  select the `map` method of `Functor`.
  *
  *  4. At PostTyper, issue an error when encountering any reference to a CB companion.
+ *
+ *  @param names the string names (n_1, ..., n_k) of the witness values generated for the context bounds of the annotated type
  */
 @experimental
 class WitnessNames(names: String*) extends StaticAnnotation

--- a/library/src/scala/annotation/internal/onlyCapability.scala
+++ b/library/src/scala/annotation/internal/onlyCapability.scala
@@ -3,6 +3,8 @@ package internal
 
 /** An annotation that represents a capability  `c.only[T]`,
  *  encoded as `x.type @onlyCapability[T]`
+ *
+ *  @tparam T the capability type that `c` is restricted to via `c.only[T]`
  */
 class onlyCapability[T] extends StaticAnnotation
 

--- a/library/src/scala/annotation/internal/preview.scala
+++ b/library/src/scala/annotation/internal/preview.scala
@@ -7,6 +7,8 @@ import language.experimental.captureChecking
  *
  *  @see [[https://nightly.scala-lang.org/docs/reference/other-new-features/preview-defs]]
  *  @syntax markdown
+ *
+ *  @param message an explanation of the preview status or migration guidance
  */
 private[scala] final class preview(message: String) extends StaticAnnotation:
   def this() = this("")

--- a/library/src/scala/annotation/internal/requiresCapability.scala
+++ b/library/src/scala/annotation/internal/requiresCapability.scala
@@ -3,6 +3,9 @@ import annotation.StaticAnnotation
 
 import language.experimental.captureChecking
 
-/** An annotation to record a required capaility in the type of a throws */
+/** An annotation to record a required capaility in the type of a throws
+ *
+ *  @param capability the capture checking capability required by the annotated throws type
+ */
 class requiresCapability(capability: Any) extends StaticAnnotation
 

--- a/library/src/scala/annotation/meta/defaultArg.scala
+++ b/library/src/scala/annotation/meta/defaultArg.scala
@@ -25,6 +25,8 @@ import scala.language.`2.13`
  *  `AnnotationInfo`.
  *
  *  For details, see `scala.reflect.internal.AnnotationInfos.AnnotationInfo`.
+ *
+ *  @param arg the default expression for the annotation parameter, stored as a syntax tree in the classfile
  */
 @meta.param class defaultArg(arg: Any) extends StaticAnnotation {
   def this() = this(null)

--- a/library/src/scala/annotation/meta/languageFeature.scala
+++ b/library/src/scala/annotation/meta/languageFeature.scala
@@ -14,5 +14,9 @@ package scala.annotation.meta
 
 import scala.language.`2.13`
 
-/** An annotation giving particulars for a language feature in object `scala.language`. */
+/** An annotation giving particulars for a language feature in object `scala.language`.
+ *
+ *  @param feature the name of the language feature being described
+ *  @param enableRequired whether an explicit import of the feature is required to suppress the compiler warning about its usage
+ */
 final class languageFeature(feature: String, enableRequired: Boolean) extends scala.annotation.StaticAnnotation

--- a/library/src/scala/annotation/meta/superArg.scala
+++ b/library/src/scala/annotation/meta/superArg.scala
@@ -24,6 +24,9 @@ import scala.language.`2.13`
  * class a(x: Int) extends Annotation
  * class b extends a(42) // the compiler adds `@superArg("x", 42)` to class b
  * ```
+ *
+ *  @param p the name of the parameter in the superclass annotation
+ *  @param v the value passed to the superclass annotation parameter
  */
 class superArg(p: String, v: Any) extends StaticAnnotation
 
@@ -36,5 +39,8 @@ class superArg(p: String, v: Any) extends StaticAnnotation
  * class a(x: Int) extends Annotation
  * class b(y: Int) extends a(y) // the compiler adds `@superFwdArg("x", "y")` to class b
  * ```
+ *
+ *  @param p the name of the parameter in the superclass annotation
+ *  @param n the name of the subclass parameter whose value is forwarded
  */
 class superFwdArg(p: String, n: String) extends StaticAnnotation

--- a/library/src/scala/annotation/nowarn.scala
+++ b/library/src/scala/annotation/nowarn.scala
@@ -40,5 +40,7 @@ import scala.language.`2.13`
  *  To ensure that a `@nowarn` annotation actually suppresses a warning, enable `-Xlint:unused` or `-Wunused:nowarn`.
  *  The unused annotation warning is emitted in category `unused-nowarn` and can be selectively managed
  *  using `-Wconf:cat=unused-nowarn:s`.
+ *
+ *  @param value a message filter expression for selectively suppressing warnings, or `""` to suppress all warnings
  */
 class nowarn(value: String = "") extends ConstantAnnotation

--- a/library/src/scala/annotation/retains.scala
+++ b/library/src/scala/annotation/retains.scala
@@ -12,6 +12,8 @@ import language.experimental.captureChecking
  *
  *  The annotation can also be written explicitly if one wants to avoid the
  *  non-standard capturing type syntax.
+ *
+ *  @tparam Elems a union of singleton `.type` references representing the captured capabilities (e.g., `x.type | y.type | z.type`)
  */
 @experimental
 class retains[Elems] extends annotation.StaticAnnotation

--- a/library/src/scala/annotation/retainsByName.scala
+++ b/library/src/scala/annotation/retainsByName.scala
@@ -2,6 +2,9 @@ package scala.annotation
 
 import language.experimental.captureChecking
 
-/** An annotation that indicates capture of an enclosing by-name type */
+/** An annotation that indicates capture of an enclosing by-name type
+ *
+ *  @tparam Elems the capture set elements retained by the enclosing by-name type
+ */
 @experimental class retainsByName[Elems] extends annotation.StaticAnnotation
 

--- a/library/src/scala/annotation/targetName.scala
+++ b/library/src/scala/annotation/targetName.scala
@@ -6,5 +6,7 @@ import language.experimental.captureChecking
  *  If an `targetName(extname)` annotation is given for a method or some other
  *  definition, its implementation will use the name `extname` instead of
  *  the regular name.
+ *
+ *  @param name the external name to use for the annotated definition
  */
 final class targetName(name: String) extends StaticAnnotation

--- a/library/src/scala/annotation/unused.scala
+++ b/library/src/scala/annotation/unused.scala
@@ -21,6 +21,8 @@ import scala.language.`2.13`
  *  For example, a method parameter may be marked `@unused`
  *  because the method is designed to be overridden by
  *  an implementation that does use the parameter.
+ *
+ *  @param message a description of why the element is unused
  */
 @meta.getter @meta.setter
 class unused(message: String) extends StaticAnnotation {

--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -117,6 +117,9 @@ trait CapSet extends Any
 
 /** A type constraint expressing that the capture set `C` needs to contain
  *  the capability `R`
+ *
+ *  @tparam C the capture set that must contain the capability `R`
+ *  @tparam R the singleton type of the capability that must be present in `C`
  */
 @experimental
 sealed trait Contains[+C >: CapSet <: CapSet @retainsCap, R <: Singleton]
@@ -205,10 +208,15 @@ object internal:
    *  user-accessible compiletime.erasedValue, this version is assumed
    *  to be a pure expression, hence capability safe. The compiler generates this
    *  version only where it is known that a value can be generated.
+   *
+   *  @tparam T the type of the erased value to produce
    */
   def erasedValue[T]: T = ???
 
-  /** A trait for capabilities representing usage of mutable vars in capture sets. */
+  /** A trait for capabilities representing usage of mutable vars in capture sets.
+   *
+   *  @tparam T the type of the mutable variable's value
+   */
   trait Var[T] extends Mutable:
     def get: T
     update def set(x: T): Unit
@@ -260,16 +268,24 @@ object unsafe:
      */
     def unsafeAssumePure: T = x
 
-  /** A wrapper around code for which separation checks are suppressed. */
+  /** A wrapper around code for which separation checks are suppressed.
+   *
+   *  @param op the code block to execute without separation checking; returned as-is
+   */
   def unsafeAssumeSeparate(op: Any): op.type = op
 
-  /** A wrapper around code for which uses go unrecorded. */
+  /** A wrapper around code for which uses go unrecorded.
+   *
+   *  @param op the code block to execute without recording capability uses; returned as-is
+   */
   def unsafeDiscardUses(op: Any): op.type = op
 
   /** An unsafe variant of erasedValue that can be used as an escape hatch. Unlike the
    *  user-accessible compiletime.erasedValue, this version is assumed
    *  to be a pure expression, hence capability safe. But there is no proof
    *  of realizability, hence it is unsafe.
+   *
+   *  @tparam T the type of the erased value to produce (no realizability guarantee, hence unsafe)
    */
   def unsafeErasedValue[T]: T = ???
 

--- a/library/src/scala/deriving/Mirror.scala
+++ b/library/src/scala/deriving/Mirror.scala
@@ -19,14 +19,20 @@ object Mirror {
 
   /** The `Mirror` for a sum type. */
   trait Sum extends Mirror { self =>
-    /** The ordinal number of the case class of `x`. For enums, `ordinal(x) == x.ordinal`. */
+    /** The ordinal number of the case class of `x`. For enums, `ordinal(x) == x.ordinal`.
+     *
+     *  @param x the instance of the sum type whose ordinal is returned
+     */
     def ordinal(x: MirroredMonoType): Int
   }
 
   /** The `Mirror` for a product type. */
   trait Product extends Mirror { self =>
 
-    /** Creates a new instance of type `T` with elements taken from product `p`. */
+    /** Creates a new instance of type `T` with elements taken from product `p`.
+     *
+     *  @param p the product whose elements are used to create the new instance
+     */
     def fromProduct(p: scala.Product): MirroredMonoType
   }
 
@@ -38,7 +44,10 @@ object Mirror {
     def fromProduct(p: scala.Product): MirroredMonoType = this
   }
 
-  /** A proxy for Scala 2 singletons, which do not inherit `Singleton` directly. */
+  /** A proxy for Scala 2 singletons, which do not inherit `Singleton` directly.
+   *
+   *  @param value the Scala 2 singleton instance being proxied
+   */
   class SingletonProxy(val value: AnyRef) extends Product {
     type MirroredMonoType = value.type
     type MirroredType = value.type
@@ -52,11 +61,20 @@ object Mirror {
   type SumOf[T] = Mirror.Sum { type MirroredType = T; type MirroredMonoType = T; type MirroredElemTypes <: Tuple }
 
   extension [T](p: ProductOf[T])
-    /** Creates a new instance of type `T` with elements taken from product `a`. */
+    /** Creates a new instance of type `T` with elements taken from product `a`.
+     *
+     *  @tparam A the product type whose elements are used as input
+     *  @tparam Elems the tuple type representing `A`'s elements, constrained to be a subtype of `T`'s `MirroredElemTypes`
+     *  @param a the product instance whose elements are copied into the new `T`
+
+     */
     def fromProductTyped[A <: scala.Product, Elems <: p.MirroredElemTypes](a: A)(using ProductOf[A] { type MirroredElemTypes = Elems }): T =
       p.fromProduct(a)
 
-    /** Creates a new instance of type `T` with elements taken from tuple `t`. */
+    /** Creates a new instance of type `T` with elements taken from tuple `t`.
+     *
+     *  @param t the tuple containing the elements for the new `T` instance
+     */
     def fromTuple(t: p.MirroredElemTypes): T =
       p.fromProduct(t)
 }

--- a/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -191,18 +191,31 @@ object ClassManifestFactory {
    *       it's called from ScalaRunTime.boxArray itself. If we
    *       pass varargs as arrays into this, we get an infinitely recursive call
    *       to boxArray. (Besides, having a separate case is more efficient)
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param clazz the runtime `Class` object for the type `T`
    */
   def classType[T](clazz: jClass[?]): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
   /** ClassManifest for the class type `clazz[args]`, where `clazz` is
    *  a top-level or static class and `args` are its type arguments 
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param clazz the runtime `Class` object for the type `T`
+   *  @param arg1 the manifest for the first type argument of `clazz`, ensuring at least one type argument is provided
+   *  @param args the manifests for the remaining type arguments of `clazz`
    */
   def classType[T](clazz: jClass[?], arg1: OptManifest[?], args: OptManifest[?]*): ClassManifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
   /** ClassManifest for the class type `clazz[args]`, where `clazz` is
    *  a class with non-package prefix type `prefix` and type arguments `args`.
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param prefix the manifest for the non-package prefix type of `clazz`
+   *  @param clazz the runtime `Class` object for the type `T`
+   *  @param args the manifests for the type arguments of `clazz`
    */
   def classType[T](prefix: OptManifest[?], clazz: jClass[?], args: OptManifest[?]*): ClassManifest[T] =
     new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
@@ -222,6 +235,12 @@ object ClassManifestFactory {
   /** ClassManifest for the abstract type `prefix # name`. `upperBound` is not
    *  strictly necessary as it could be obtained by reflection. It was
    *  added so that erasure can be calculated without reflection. 
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param prefix the manifest for the prefix type of the abstract type
+   *  @param name the name of the abstract type
+   *  @param clazz the runtime `Class` for the upper bound of the abstract type, used for erasure
+   *  @param args the manifests for the type arguments of the abstract type (note: currently unused in the implementation)
    */
   def abstractType[T](prefix: OptManifest[?], name: String, clazz: jClass[?], args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, clazz)
@@ -230,6 +249,12 @@ object ClassManifestFactory {
    *  strictly necessary as it could be obtained by reflection. It was
    *  added so that erasure can be calculated without reflection.
    *  todo: remove after next bootstrap
+   *
+   *  @tparam T the type represented by the manifest
+   *  @param prefix the manifest for the prefix type of the abstract type
+   *  @param name the name of the abstract type
+   *  @param upperbound the `ClassManifest` for the upper bound, whose `runtimeClass` is used for erasure
+   *  @param args the manifests for the type arguments of the abstract type (note: currently unused in the implementation)
    */
   def abstractType[T](prefix: OptManifest[?], name: String, upperbound: ClassManifest[?], args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, upperbound.runtimeClass)

--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -55,7 +55,10 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
   /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]`. */
   def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
 
-  /** Produces a new array with element type `T` and length `len`. */
+  /** Produces a new array with element type `T` and length `len`.
+   *
+   *  @param len the length of the new array
+   */
   def newArray(len: Int): Array[T] =
     java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
 
@@ -66,6 +69,9 @@ trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serial
    *  Type tests necessary before calling other extractors are treated similarly.
    *  `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    *  is uncheckable, but we have an instance of `ClassTag[T]`.
+   *
+   *  @param x the value to match against the runtime class of `T`
+   *  @return `Some(x)` if `x` is an instance of `T`, `None` otherwise
    */
   def unapply(x: Any): Option[T] =
     if (runtimeClass.isInstance(x)) Some(x.asInstanceOf[T])

--- a/library/src/scala/reflect/Manifest.scala
+++ b/library/src/scala/reflect/Manifest.scala
@@ -60,6 +60,8 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
   }
   /** Note: testing for erasure here is important, as it is many times
    *  faster than <:< and rules out most comparisons.
+   *
+   *  @param that the object to compare for equality (only `Manifest` instances can be equal)
    */
   override def equals(that: Any): Boolean = that match {
     case m: Manifest[?] => (m canEqual this) && (this.runtimeClass == m.runtimeClass) && (this <:< m) && (m <:< this)
@@ -100,7 +102,11 @@ object Manifest {
   val Null: Manifest[scala.Null] = ManifestFactory.Null
   val Nothing: Manifest[scala.Nothing] = ManifestFactory.Nothing
 
-  /** Manifest for the singleton type `value.type`. */
+  /** Manifest for the singleton type `value.type`.
+   *
+   *  @tparam T the type to be represented, typically inferred as the singleton type of `value`
+   *  @param value the runtime object whose singleton type is represented
+   */
   def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
     ManifestFactory.singleType[T](value)
 
@@ -110,18 +116,31 @@ object Manifest {
    *       it's called from ScalaRunTime.boxArray itself. If we
    *       pass varargs as arrays into this, we get an infinitely recursive call
    *       to boxArray. (Besides, having a separate case is more efficient)
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param clazz the runtime `Class` for the type `T`
    */
   def classType[T](clazz: Predef.Class[?]): Manifest[T] =
     ManifestFactory.classType[T](clazz)
 
   /** Manifest for the class type `clazz`, where `clazz` is
    *  a top-level or static class and args are its type arguments.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param clazz the runtime `Class` for the type `T`
+   *  @param arg1 the manifest for the first type argument (required to ensure at least one type argument)
+   *  @param args the manifests for the remaining type arguments
    */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.classType[T](clazz, arg1, args*)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
    *  a class with non-package prefix type `prefix` and type arguments `args`.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param prefix the manifest for the non-package prefix type
+   *  @param clazz the runtime `Class` for the type `T`
+   *  @param args the manifests for the type arguments
    */
   def classType[T](prefix: Manifest[?], clazz: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.classType[T](prefix, clazz, args*)
@@ -132,15 +151,30 @@ object Manifest {
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
    *  strictly necessary as it could be obtained by reflection. It was
    *  added so that erasure can be calculated without reflection.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param prefix the manifest for the type containing this abstract type member
+   *  @param name the name of the abstract type member
+   *  @param upperBound the runtime `Class` of the upper bound, used to compute erasure without reflection
+   *  @param args the manifests for the type arguments
    */
   def abstractType[T](prefix: Manifest[?], name: String, upperBound: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.abstractType[T](prefix, name, upperBound, args*)
 
-  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
+  /** Manifest for the unknown type `_ >: L <: U` in an existential.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param lowerBound the manifest for the lower bound `L` of the wildcard
+   *  @param upperBound the manifest for the upper bound `U` of the wildcard
+   */
   def wildcardType[T](lowerBound: Manifest[?], upperBound: Manifest[?]): Manifest[T] =
     ManifestFactory.wildcardType[T](lowerBound, upperBound)
 
-  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  /** Manifest for the intersection type `parents_0 with ... with parents_n`.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param parents the manifests for each type in the intersection
+   */
   def intersectionType[T](parents: Manifest[?]*): Manifest[T] =
     ManifestFactory.intersectionType[T](parents*)
 
@@ -374,7 +408,11 @@ object ManifestFactory {
     override lazy val toString = value.toString + ".type"
   }
 
-  /** Manifest for the singleton type `value.type`. */
+  /** Manifest for the singleton type `value.type`.
+   *
+   *  @tparam T the type to be represented, typically inferred as the singleton type of `value`
+   *  @param value the runtime object whose singleton type is represented
+   */
   def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
     new SingletonTypeManifest[T](value)
 
@@ -384,18 +422,31 @@ object ManifestFactory {
    *       it's called from ScalaRunTime.boxArray itself. If we
    *       pass varargs as arrays into this, we get an infinitely recursive call
    *       to boxArray. (Besides, having a separate case is more efficient)
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param clazz the runtime `Class` for the type `T`
    */
   def classType[T](clazz: Predef.Class[?]): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, Nil)
 
   /** Manifest for the class type `clazz`, where `clazz` is
    *  a top-level or static class and args are its type arguments.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param clazz the runtime `Class` for the type `T`
+   *  @param arg1 the manifest for the first type argument (required to ensure at least one type argument)
+   *  @param args the manifests for the remaining type arguments
    */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[?], args: Manifest[?]*): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
    *  a class with non-package prefix type `prefix` and type arguments `args`.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param prefix the manifest for the non-package prefix type
+   *  @param clazz the runtime `Class` for the type `T`
+   *  @param args the manifests for the type arguments
    */
   def classType[T](prefix: Manifest[?], clazz: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
@@ -433,6 +484,12 @@ object ManifestFactory {
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
    *  strictly necessary as it could be obtained by reflection. It was
    *  added so that erasure can be calculated without reflection.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param prefix the manifest for the type containing this abstract type member
+   *  @param name the name of the abstract type member
+   *  @param upperBound the runtime `Class` of the upper bound, used to compute erasure without reflection
+   *  @param args the manifests for the type arguments
    */
   def abstractType[T](prefix: Manifest[?], name: String, upperBound: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     new AbstractTypeManifest[T](prefix, name, upperBound, args)
@@ -446,7 +503,12 @@ object ManifestFactory {
         (if (upperBound eq Nothing) "" else " <: "+upperBound)
   }
 
-  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
+  /** Manifest for the unknown type `_ >: L <: U` in an existential.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param lowerBound the manifest for the lower bound `L` of the wildcard
+   *  @param upperBound the manifest for the upper bound `U` of the wildcard
+   */
   def wildcardType[T](lowerBound: Manifest[?], upperBound: Manifest[?]): Manifest[T] =
     new WildcardManifest[T](lowerBound, upperBound)
 
@@ -458,7 +520,11 @@ object ManifestFactory {
     override def toString() = parents.mkString(" with ")
   }
 
-  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  /** Manifest for the intersection type `parents_0 with ... with parents_n`.
+   *
+   *  @tparam T the type represented by this manifest
+   *  @param parents the manifests for each type in the intersection
+   */
   def intersectionType[T](parents: Manifest[?]*): Manifest[T] =
     new IntersectionTypeManifest[T](parents.toArray)
 }

--- a/library/src/scala/reflect/Selectable.scala
+++ b/library/src/scala/reflect/Selectable.scala
@@ -19,7 +19,10 @@ trait Selectable extends scala.Selectable:
   protected def selectedValue: Any = this
 
   // The Scala.js codegen relies on this method being final for correctness
-  /** Selects member with given name. */
+  /** Selects member with given name.
+   *
+   *  @param name the name of the structural member (field or no-arg method) to select
+   */
   final def selectDynamic(name: String): Any =
     val rcls = selectedValue.getClass
     try
@@ -31,9 +34,9 @@ trait Selectable extends scala.Selectable:
 
   // The Scala.js codegen relies on this method being final for correctness
   /** Selects method and applies to arguments.
-   *  @param name       The name of the selected method
-   *  @param paramTypes The class tags of the selected method's formal parameter types
-   *  @param args       The arguments to pass to the selected method
+   *  @param name       the name of the selected method
+   *  @param paramTypes the `Class` instances representing the selected method's formal parameter types
+   *  @param args       the arguments to pass to the selected method
    */
   final def applyDynamic(name: String, paramTypes: Class[?]*)(args: Any*): Any =
     val rcls = selectedValue.getClass
@@ -45,6 +48,8 @@ object Selectable:
 
   /** An implicit conversion that turns a value into a Selectable
    *  such that structural selections are performed on that value.
+   *
+   *  @param x the value to wrap in a `Selectable` for reflection-based structural member access
    */
   implicit def reflectiveSelectable(x: Any): Selectable =
     new DefaultSelectable(x)

--- a/library/src/scala/reflect/TypeTest.scala
+++ b/library/src/scala/reflect/TypeTest.scala
@@ -22,10 +22,16 @@ trait TypeTest[-S, T] extends Serializable:
    *  Type tests necessary before calling other extractors are treated similarly.
    *  `SomeExtractor(...)` is turned into `tt(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
    *  is uncheckable, but we have an instance of `TypeTest[S, T]`.
+   *
+   *  @param x the value of type `S` to test for being an instance of `T`
+   *  @return an `Option` containing `x` refined to type `x.type & T` if `x` is an instance of `T`, or `None` otherwise
    */
   def unapply(x: S): Option[x.type & T]
 
 object TypeTest:
 
-  /** Trivial type test that always succeeds. */
+  /** Trivial type test that always succeeds.
+   *
+   *  @tparam T the type for both the input and output of the type test, ensuring the test always succeeds
+   */
   def identity[T]: TypeTest[T, T] = Some(_)

--- a/library/src/scala/reflect/macros/internal/macroImpl.scala
+++ b/library/src/scala/reflect/macros/internal/macroImpl.scala
@@ -28,5 +28,7 @@ import scala.language.`2.13`
  *
  *  To lessen the weirdness we define this annotation as `private[scala]`.
  *  It will not prevent pickling, but it will prevent application developers (and scaladocs) from seeing the annotation.
+ *
+ *  @param referenceToMacroImpl the typechecked reference to the macro implementation method, as produced by `typedMacroBody`. Typed as `Any` because the concrete tree type is not available in scala-library.
  */
 private[scala] final class macroImpl(val referenceToMacroImpl: Any) extends scala.annotation.StaticAnnotation

--- a/library/src/scala/reflect/package.scala
+++ b/library/src/scala/reflect/package.scala
@@ -55,6 +55,9 @@ package object reflect {
   /** Makes a java reflection object accessible, if it is not already
    *  and it is possible to do so. If a SecurityException is thrown in the
    *  attempt, it is caught and discarded.
+   *
+   *  @tparam T the concrete subtype of `java.lang.reflect.AccessibleObject` to make accessible
+   *  @param m the reflection object to make accessible
    */
   def ensureAccessible[T <: jAccessibleObject](m: T): T = {
     // This calls `setAccessible` unnecessarily, because `isAccessible` is only `true` if `setAccessible(true)`

--- a/library/src/scala/specialized.scala
+++ b/library/src/scala/specialized.scala
@@ -27,6 +27,8 @@ import Specializable._
  *  ```
  *    class MyList[@specialized(Int, Double, Boolean) T] ..
  *  ```
+ *
+ *  @param group the group of primitive types for which specialization should be performed (typically constructed implicitly via the varargs constructor)
  */
 // class tspecialized[T](group: Group[T]) extends scala.annotation.StaticAnnotation {
 

--- a/library/src/scala/throws.scala
+++ b/library/src/scala/throws.scala
@@ -23,6 +23,9 @@ import scala.language.`2.13`
  *   def read() = in.read()
  *  }
  *  ```
+ *
+ *  @tparam T the type of exception that the annotated method may throw
+ *  @param cause a description of the condition under which the exception is thrown
  */
 final class throws[T <: Throwable](cause: String = "") extends scala.annotation.StaticAnnotation {
   def this(clazz: Class[T]) = this("")


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for annotation, reflect, and misc root files. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.