### PR TITLE
Function, Tuple, Product (12): fill in missing @param, @tparam, and @return tags in Scaladoc comments

### DIFF
--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -19,11 +19,18 @@ object Function {
   /** Given a sequence of functions `f,,1,,`, ..., `f,,n,,`, return the
    *  function `f,,1,, andThen ... andThen f,,n,,`.
    *
-   *  @param fs The given sequence of functions
+   *  @tparam T the common input and output type of the functions in the chain
+   *  @param fs the given sequence of functions
    */
   def chain[T](fs: scala.collection.Seq[T => T]): T => T = { x => fs.foldLeft(x)((x, f) => f(x)) }
 
-  /** The constant function. */
+  /** The constant function.
+   *
+   *  @tparam T the return type
+   *  @tparam U the type of the argument to ignore
+   *  @param x the constant value to return
+   *  @param y the argument that is ignored
+   */
   def const[T, U](x: T)(y: U): T = x
 
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.
@@ -34,6 +41,8 @@ object Function {
    *  function and examine the return value.
    *  See also [[scala.PartialFunction]], method `applyOrElse`.
    *
+   *  @tparam T the input type of the function
+   *  @tparam R the result type
    *  @param   f    a function `T => Option[R]`
    *  @return       a partial function defined for those inputs where
    *                f returns `Some(_)` and undefined where `f` returns `None`.
@@ -43,22 +52,51 @@ object Function {
 
   /** Uncurrying for functions of arity 2. This transforms a unary function
    *  returning another unary function into a function of arity 2.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
    */
   def uncurried[T1, T2, R](f: T1 => T2 => R): (T1, T2) => R = {
     (x1, x2) => f(x1)(x2)
   }
 
-  /** Uncurrying for functions of arity 3. */
+  /** Uncurrying for functions of arity 3.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam T3 the type of the 3rd argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
+   */
   def uncurried[T1, T2, T3, R](f: T1 => T2 => T3 => R): (T1, T2, T3) => R = {
     (x1, x2, x3) => f(x1)(x2)(x3)
   }
 
-  /** Uncurrying for functions of arity 4. */
+  /** Uncurrying for functions of arity 4.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam T3 the type of the 3rd argument
+   *  @tparam T4 the type of the 4th argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
+   */
   def uncurried[T1, T2, T3, T4, R](f: T1 => T2 => T3 => T4 => R): (T1, T2, T3, T4) => R = {
     (x1, x2, x3, x4) => f(x1)(x2)(x3)(x4)
   }
 
-  /** Uncurrying for functions of arity 5. */
+  /** Uncurrying for functions of arity 5.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam T3 the type of the 3rd argument
+   *  @tparam T4 the type of the 4th argument
+   *  @tparam T5 the type of the 5th argument
+   *  @tparam R the result type
+   *  @param f the curried function to uncurry
+   */
   def uncurried[T1, T2, T3, T4, T5, R](f: T1 => T2 => T3 => T4 => T5 => R): (T1, T2, T3, T4, T5) => R  =  {
     (x1, x2, x3, x4, x5) => f(x1)(x2)(x3)(x4)(x5)
   }
@@ -100,6 +138,11 @@ object Function {
 
   /** Un-tupling for functions of arity 2. This transforms a function taking
    *  a pair of arguments into a binary function which takes each argument separately.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, R](f: ((T1, T2)) => R): (T1, T2) => R = {
     (x1, x2) => f((x1, x2))
@@ -107,6 +150,12 @@ object Function {
 
   /** Un-tupling for functions of arity 3. This transforms a function taking
    *  a triple of arguments into a ternary function which takes each argument separately.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam T3 the type of the 3rd argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, T3, R](f: ((T1, T2, T3)) => R): (T1, T2, T3) => R = {
     (x1, x2, x3) => f((x1, x2, x3))
@@ -114,6 +163,13 @@ object Function {
 
   /** Un-tupling for functions of arity 4. This transforms a function taking
    *  a 4-tuple of arguments into a function of arity 4 which takes each argument separately.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam T3 the type of the 3rd argument
+   *  @tparam T4 the type of the 4th argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, T3, T4, R](f: ((T1, T2, T3, T4)) => R): (T1, T2, T3, T4) => R = {
     (x1, x2, x3, x4) => f((x1, x2, x3, x4))
@@ -121,6 +177,14 @@ object Function {
 
   /** Un-tupling for functions of arity 5. This transforms a function taking
    *  a 5-tuple of arguments into a function of arity 5 which takes each argument separately.
+   *
+   *  @tparam T1 the type of the 1st argument
+   *  @tparam T2 the type of the 2nd argument
+   *  @tparam T3 the type of the 3rd argument
+   *  @tparam T4 the type of the 4th argument
+   *  @tparam T5 the type of the 5th argument
+   *  @tparam R the result type
+   *  @param f the tupled function to untuple
    */
   def untupled[T1, T2, T3, T4, T5, R](f: ((T1, T2, T3, T4, T5)) => R): (T1, T2, T3, T4, T5) => R = {
     (x1, x2, x3, x4, x5) => f((x1, x2, x3, x4, x5))

--- a/library/src/scala/Function1.scala
+++ b/library/src/scala/Function1.scala
@@ -38,6 +38,8 @@ object Function1 {
      *              println("Not matched")
      *          }
      *          ```
+     *
+     *  @return a `PartialFunction` that is defined where `f` returns `Some` and undefined where `f` returns `None`
      */
     def unlift: PartialFunction[A, B] = Function.unlift(f)
   }
@@ -65,6 +67,8 @@ object Function1 {
 @annotation.implicitNotFound(msg = "No implicit view available from ${T1} => ${R}.")
 trait Function1[@specialized(Specializable.Arg) -T1, @specialized(Specializable.Return) +R] extends AnyRef {
   /** Applies the body of this function to the argument.
+   *
+   *  @param v1 the function argument
    *  @return   the result of function application.
    */
   def apply(v1: T1): R

--- a/library/src/scala/Function10.scala
+++ b/library/src/scala/Function10.scala
@@ -16,9 +16,33 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 10 parameters. */
+/** A function of 10 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam R the return type of this function
+ */
 trait Function10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
+   *  @param v4 the 4th argument
+   *  @param v5 the 5th argument
+   *  @param v6 the 6th argument
+   *  @param v7 the 7th argument
+   *  @param v8 the 8th argument
+   *  @param v9 the 9th argument
+   *  @param v10 the 10th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10): R

--- a/library/src/scala/Function11.scala
+++ b/library/src/scala/Function11.scala
@@ -16,9 +16,35 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 11 parameters. */
+/** A function of 11 parameters.
+ *
+ *  @tparam T1 the type of the 1st parameter of this function
+ *  @tparam T2 the type of the 2nd parameter of this function
+ *  @tparam T3 the type of the 3rd parameter of this function
+ *  @tparam T4 the type of the 4th parameter of this function
+ *  @tparam T5 the type of the 5th parameter of this function
+ *  @tparam T6 the type of the 6th parameter of this function
+ *  @tparam T7 the type of the 7th parameter of this function
+ *  @tparam T8 the type of the 8th parameter of this function
+ *  @tparam T9 the type of the 9th parameter of this function
+ *  @tparam T10 the type of the 10th parameter of this function
+ *  @tparam T11 the type of the 11th parameter of this function
+ *  @tparam R the return type of this function
+ */
 trait Function11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st parameter
+   *  @param v2 the value of the 2nd parameter
+   *  @param v3 the value of the 3rd parameter
+   *  @param v4 the value of the 4th parameter
+   *  @param v5 the value of the 5th parameter
+   *  @param v6 the value of the 6th parameter
+   *  @param v7 the value of the 7th parameter
+   *  @param v8 the value of the 8th parameter
+   *  @param v9 the value of the 9th parameter
+   *  @param v10 the value of the 10th parameter
+   *  @param v11 the value of the 11th parameter
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11): R

--- a/library/src/scala/Function12.scala
+++ b/library/src/scala/Function12.scala
@@ -16,9 +16,37 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 12 parameters. */
+/** A function of 12 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam R the return type of this function
+ */
 trait Function12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12): R

--- a/library/src/scala/Function13.scala
+++ b/library/src/scala/Function13.scala
@@ -16,9 +16,39 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 13 parameters. */
+/** A function of 13 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam R the return type of the function
+ */
 trait Function13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13): R

--- a/library/src/scala/Function14.scala
+++ b/library/src/scala/Function14.scala
@@ -16,9 +16,41 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 14 parameters. */
+/** A function of 14 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam R the type of the result
+ */
 trait Function14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14): R

--- a/library/src/scala/Function15.scala
+++ b/library/src/scala/Function15.scala
@@ -16,9 +16,43 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 15 parameters. */
+/** A function of 15 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam R the return type of the function
+ */
 trait Function15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15): R

--- a/library/src/scala/Function16.scala
+++ b/library/src/scala/Function16.scala
@@ -16,9 +16,45 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 16 parameters. */
+/** A function of 16 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam R the result type of the function
+ */
 trait Function16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
+   *  @param v16 the value of the 16th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16): R

--- a/library/src/scala/Function17.scala
+++ b/library/src/scala/Function17.scala
@@ -16,9 +16,47 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 17 parameters. */
+/** A function of 17 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam T17 the type of the 17th argument
+ *  @tparam R the type of the result
+ */
 trait Function17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
+   *  @param v16 the value of the 16th argument
+   *  @param v17 the value of the 17th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17): R

--- a/library/src/scala/Function18.scala
+++ b/library/src/scala/Function18.scala
@@ -16,9 +16,49 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 18 parameters. */
+/** A function of 18 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam T17 the type of the 17th argument
+ *  @tparam T18 the type of the 18th argument
+ *  @tparam R the return type of the function
+ */
 trait Function18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
+   *  @param v16 the value of the 16th argument
+   *  @param v17 the value of the 17th argument
+   *  @param v18 the value of the 18th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18): R

--- a/library/src/scala/Function19.scala
+++ b/library/src/scala/Function19.scala
@@ -16,9 +16,51 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 19 parameters. */
+/** A function of 19 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam T17 the type of the 17th argument
+ *  @tparam T18 the type of the 18th argument
+ *  @tparam T19 the type of the 19th argument
+ *  @tparam R the result type of the function
+ */
 trait Function19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
+   *  @param v16 the value of the 16th argument
+   *  @param v17 the value of the 17th argument
+   *  @param v18 the value of the 18th argument
+   *  @param v19 the value of the 19th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19): R

--- a/library/src/scala/Function2.scala
+++ b/library/src/scala/Function2.scala
@@ -34,6 +34,9 @@ import scala.language.`2.13`
  */
 trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable.Args) -T2, @specialized(Specializable.Return) +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument of type `T1`
+   *  @param v2 the 2nd argument of type `T2`
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2): R

--- a/library/src/scala/Function20.scala
+++ b/library/src/scala/Function20.scala
@@ -16,9 +16,53 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 20 parameters. */
+/** A function of 20 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam T17 the type of the 17th argument
+ *  @tparam T18 the type of the 18th argument
+ *  @tparam T19 the type of the 19th argument
+ *  @tparam T20 the type of the 20th argument
+ *  @tparam R the result type of the function
+ */
 trait Function20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the value of the 1st argument
+   *  @param v2 the value of the 2nd argument
+   *  @param v3 the value of the 3rd argument
+   *  @param v4 the value of the 4th argument
+   *  @param v5 the value of the 5th argument
+   *  @param v6 the value of the 6th argument
+   *  @param v7 the value of the 7th argument
+   *  @param v8 the value of the 8th argument
+   *  @param v9 the value of the 9th argument
+   *  @param v10 the value of the 10th argument
+   *  @param v11 the value of the 11th argument
+   *  @param v12 the value of the 12th argument
+   *  @param v13 the value of the 13th argument
+   *  @param v14 the value of the 14th argument
+   *  @param v15 the value of the 15th argument
+   *  @param v16 the value of the 16th argument
+   *  @param v17 the value of the 17th argument
+   *  @param v18 the value of the 18th argument
+   *  @param v19 the value of the 19th argument
+   *  @param v20 the value of the 20th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20): R

--- a/library/src/scala/Function21.scala
+++ b/library/src/scala/Function21.scala
@@ -16,9 +16,55 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 21 parameters. */
+/** A function of 21 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam T17 the type of the 17th argument
+ *  @tparam T18 the type of the 18th argument
+ *  @tparam T19 the type of the 19th argument
+ *  @tparam T20 the type of the 20th argument
+ *  @tparam T21 the type of the 21st argument
+ *  @tparam R the result type of the function
+ */
 trait Function21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument of type `T1`
+   *  @param v2 the 2nd argument of type `T2`
+   *  @param v3 the 3rd argument of type `T3`
+   *  @param v4 the 4th argument of type `T4`
+   *  @param v5 the 5th argument of type `T5`
+   *  @param v6 the 6th argument of type `T6`
+   *  @param v7 the 7th argument of type `T7`
+   *  @param v8 the 8th argument of type `T8`
+   *  @param v9 the 9th argument of type `T9`
+   *  @param v10 the 10th argument of type `T10`
+   *  @param v11 the 11th argument of type `T11`
+   *  @param v12 the 12th argument of type `T12`
+   *  @param v13 the 13th argument of type `T13`
+   *  @param v14 the 14th argument of type `T14`
+   *  @param v15 the 15th argument of type `T15`
+   *  @param v16 the 16th argument of type `T16`
+   *  @param v17 the 17th argument of type `T17`
+   *  @param v18 the 18th argument of type `T18`
+   *  @param v19 the 19th argument of type `T19`
+   *  @param v20 the 20th argument of type `T20`
+   *  @param v21 the 21st argument of type `T21`
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21): R

--- a/library/src/scala/Function22.scala
+++ b/library/src/scala/Function22.scala
@@ -16,9 +16,57 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 22 parameters. */
+/** A function of 22 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam T10 the type of the 10th argument
+ *  @tparam T11 the type of the 11th argument
+ *  @tparam T12 the type of the 12th argument
+ *  @tparam T13 the type of the 13th argument
+ *  @tparam T14 the type of the 14th argument
+ *  @tparam T15 the type of the 15th argument
+ *  @tparam T16 the type of the 16th argument
+ *  @tparam T17 the type of the 17th argument
+ *  @tparam T18 the type of the 18th argument
+ *  @tparam T19 the type of the 19th argument
+ *  @tparam T20 the type of the 20th argument
+ *  @tparam T21 the type of the 21st argument
+ *  @tparam T22 the type of the 22nd argument
+ *  @tparam R the result type of the function
+ */
 trait Function22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument of type `T1`
+   *  @param v2 the 2nd argument of type `T2`
+   *  @param v3 the 3rd argument of type `T3`
+   *  @param v4 the 4th argument of type `T4`
+   *  @param v5 the 5th argument of type `T5`
+   *  @param v6 the 6th argument of type `T6`
+   *  @param v7 the 7th argument of type `T7`
+   *  @param v8 the 8th argument of type `T8`
+   *  @param v9 the 9th argument of type `T9`
+   *  @param v10 the 10th argument of type `T10`
+   *  @param v11 the 11th argument of type `T11`
+   *  @param v12 the 12th argument of type `T12`
+   *  @param v13 the 13th argument of type `T13`
+   *  @param v14 the 14th argument of type `T14`
+   *  @param v15 the 15th argument of type `T15`
+   *  @param v16 the 16th argument of type `T16`
+   *  @param v17 the 17th argument of type `T17`
+   *  @param v18 the 18th argument of type `T18`
+   *  @param v19 the 19th argument of type `T19`
+   *  @param v20 the 20th argument of type `T20`
+   *  @param v21 the 21st argument of type `T21`
+   *  @param v22 the 22nd argument of type `T22`
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21, v22: T22): R

--- a/library/src/scala/Function3.scala
+++ b/library/src/scala/Function3.scala
@@ -16,9 +16,19 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 3 parameters. */
+/** A function of 3 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam R the return type of the function
+ */
 trait Function3[-T1, -T2, -T3, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3): R

--- a/library/src/scala/Function4.scala
+++ b/library/src/scala/Function4.scala
@@ -16,9 +16,21 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 4 parameters. */
+/** A function of 4 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam R the return type of the function
+ */
 trait Function4[-T1, -T2, -T3, -T4, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
+   *  @param v4 the 4th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4): R

--- a/library/src/scala/Function5.scala
+++ b/library/src/scala/Function5.scala
@@ -16,9 +16,23 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 5 parameters. */
+/** A function of 5 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam R the return type of this function
+ */
 trait Function5[-T1, -T2, -T3, -T4, -T5, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
+   *  @param v4 the 4th argument
+   *  @param v5 the 5th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): R

--- a/library/src/scala/Function6.scala
+++ b/library/src/scala/Function6.scala
@@ -16,9 +16,25 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 6 parameters. */
+/** A function of 6 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam R the return type of the function
+ */
 trait Function6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
+   *  @param v4 the 4th argument
+   *  @param v5 the 5th argument
+   *  @param v6 the 6th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): R

--- a/library/src/scala/Function7.scala
+++ b/library/src/scala/Function7.scala
@@ -16,9 +16,27 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 7 parameters. */
+/** A function of 7 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam R the return type of the function
+ */
 trait Function7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
+   *  @param v4 the 4th argument
+   *  @param v5 the 5th argument
+   *  @param v6 the 6th argument
+   *  @param v7 the 7th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): R

--- a/library/src/scala/Function8.scala
+++ b/library/src/scala/Function8.scala
@@ -16,9 +16,29 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 8 parameters. */
+/** A function of 8 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam R the return type of the function
+ */
 trait Function8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
+   *  @param v4 the 4th argument
+   *  @param v5 the 5th argument
+   *  @param v6 the 6th argument
+   *  @param v7 the 7th argument
+   *  @param v8 the 8th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8): R

--- a/library/src/scala/Function9.scala
+++ b/library/src/scala/Function9.scala
@@ -16,9 +16,31 @@ package scala
 
 import scala.language.`2.13`
 
-/** A function of 9 parameters. */
+/** A function of 9 parameters.
+ *
+ *  @tparam T1 the type of the 1st argument
+ *  @tparam T2 the type of the 2nd argument
+ *  @tparam T3 the type of the 3rd argument
+ *  @tparam T4 the type of the 4th argument
+ *  @tparam T5 the type of the 5th argument
+ *  @tparam T6 the type of the 6th argument
+ *  @tparam T7 the type of the 7th argument
+ *  @tparam T8 the type of the 8th argument
+ *  @tparam T9 the type of the 9th argument
+ *  @tparam R the return type of this function
+ */
 trait Function9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends AnyRef {
   /** Applies the body of this function to the arguments.
+   *
+   *  @param v1 the 1st argument
+   *  @param v2 the 2nd argument
+   *  @param v3 the 3rd argument
+   *  @param v4 the 4th argument
+   *  @param v5 the 5th argument
+   *  @param v6 the 6th argument
+   *  @param v7 the 7th argument
+   *  @param v8 the 8th argument
+   *  @param v9 the 9th argument
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9): R

--- a/library/src/scala/Product10.scala
+++ b/library/src/scala/Product10.scala
@@ -21,7 +21,19 @@ object Product10 {
     Some(x)
 }
 
-/** Product10 is a Cartesian product of 10 components. */
+/** Product10 is a Cartesian product of 10 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ */
 trait Product10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10] extends Any with Product {
   /** The arity of this product.
    *  @return 10

--- a/library/src/scala/Product11.scala
+++ b/library/src/scala/Product11.scala
@@ -21,7 +21,20 @@ object Product11 {
     Some(x)
 }
 
-/** Product11 is a Cartesian product of 11 components. */
+/** Product11 is a Cartesian product of 11 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ */
 trait Product11[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11] extends Any with Product {
   /** The arity of this product.
    *  @return 11

--- a/library/src/scala/Product12.scala
+++ b/library/src/scala/Product12.scala
@@ -21,7 +21,21 @@ object Product12 {
     Some(x)
 }
 
-/** Product12 is a Cartesian product of 12 components. */
+/** Product12 is a Cartesian product of 12 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ */
 trait Product12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12] extends Any with Product {
   /** The arity of this product.
    *  @return 12
@@ -32,8 +46,8 @@ trait Product12[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12] e
   /** Returns the n-th projection of this product if 0 <= n < productArity,
    *  otherwise throws an `IndexOutOfBoundsException`.
    *
-   *  @param n number of the projection to be returned
-   *  @return  same as `._(n+1)`, for example `productElement(0)` is the same as `._1`.
+   *  @param n the zero-based index of the projection to be returned
+   *  @return  the element at the given zero-based index, equivalent to `._(n+1)` (e.g., `productElement(0)` returns `._1`)
    *  @throws  IndexOutOfBoundsException if the `n` is out of range(n < 0 || n >= 12).
    */
 

--- a/library/src/scala/Product13.scala
+++ b/library/src/scala/Product13.scala
@@ -21,7 +21,22 @@ object Product13 {
     Some(x)
 }
 
-/** Product13 is a Cartesian product of 13 components. */
+/** Product13 is a Cartesian product of 13 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ */
 trait Product13[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13] extends Any with Product {
   /** The arity of this product.
    *  @return 13

--- a/library/src/scala/Product14.scala
+++ b/library/src/scala/Product14.scala
@@ -21,7 +21,23 @@ object Product14 {
     Some(x)
 }
 
-/** Product14 is a Cartesian product of 14 components. */
+/** Product14 is a Cartesian product of 14 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ */
 trait Product14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14] extends Any with Product {
   /** The arity of this product.
    *  @return 14

--- a/library/src/scala/Product15.scala
+++ b/library/src/scala/Product15.scala
@@ -21,7 +21,24 @@ object Product15 {
     Some(x)
 }
 
-/** Product15 is a Cartesian product of 15 components. */
+/** Product15 is a Cartesian product of 15 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ */
 trait Product15[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15] extends Any with Product {
   /** The arity of this product.
    *  @return 15

--- a/library/src/scala/Product16.scala
+++ b/library/src/scala/Product16.scala
@@ -21,7 +21,25 @@ object Product16 {
     Some(x)
 }
 
-/** Product16 is a Cartesian product of 16 components. */
+/** Product16 is a Cartesian product of 16 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ */
 trait Product16[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16] extends Any with Product {
   /** The arity of this product.
    *  @return 16

--- a/library/src/scala/Product17.scala
+++ b/library/src/scala/Product17.scala
@@ -21,7 +21,26 @@ object Product17 {
     Some(x)
 }
 
-/** Product17 is a Cartesian product of 17 components. */
+/** Product17 is a Cartesian product of 17 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ */
 trait Product17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17] extends Any with Product {
   /** The arity of this product.
    *  @return 17

--- a/library/src/scala/Product18.scala
+++ b/library/src/scala/Product18.scala
@@ -21,7 +21,27 @@ object Product18 {
     Some(x)
 }
 
-/** Product18 is a Cartesian product of 18 components. */
+/** Product18 is a Cartesian product of 18 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ */
 trait Product18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18] extends Any with Product {
   /** The arity of this product.
    *  @return 18

--- a/library/src/scala/Product19.scala
+++ b/library/src/scala/Product19.scala
@@ -21,7 +21,28 @@ object Product19 {
     Some(x)
 }
 
-/** Product19 is a Cartesian product of 19 components. */
+/** Product19 is a Cartesian product of 19 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ */
 trait Product19[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19] extends Any with Product {
   /** The arity of this product.
    *  @return 19

--- a/library/src/scala/Product20.scala
+++ b/library/src/scala/Product20.scala
@@ -21,7 +21,29 @@ object Product20 {
     Some(x)
 }
 
-/** Product20 is a Cartesian product of 20 components. */
+/** Product20 is a Cartesian product of 20 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ */
 trait Product20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20] extends Any with Product {
   /** The arity of this product.
    *  @return 20

--- a/library/src/scala/Product21.scala
+++ b/library/src/scala/Product21.scala
@@ -21,7 +21,30 @@ object Product21 {
     Some(x)
 }
 
-/** Product21 is a Cartesian product of 21 components. */
+/** Product21 is a Cartesian product of 21 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
+ */
 trait Product21[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21] extends Any with Product {
   /** The arity of this product.
    *  @return 21

--- a/library/src/scala/Product22.scala
+++ b/library/src/scala/Product22.scala
@@ -21,7 +21,31 @@ object Product22 {
     Some(x)
 }
 
-/** Product22 is a Cartesian product of 22 components. */
+/** Product22 is a Cartesian product of 22 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
+ *  @tparam T22 the type of the 22nd element
+ */
 trait Product22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21, +T22] extends Any with Product {
   /** The arity of this product.
    *  @return 22

--- a/library/src/scala/Product3.scala
+++ b/library/src/scala/Product3.scala
@@ -21,7 +21,12 @@ object Product3 {
     Some(x)
 }
 
-/** Product3 is a Cartesian product of 3 components. */
+/** Product3 is a Cartesian product of 3 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ */
 trait Product3[+T1, +T2, +T3] extends Any with Product {
   /** The arity of this product.
    *  @return 3

--- a/library/src/scala/Product4.scala
+++ b/library/src/scala/Product4.scala
@@ -21,7 +21,13 @@ object Product4 {
     Some(x)
 }
 
-/** Product4 is a Cartesian product of 4 components. */
+/** Product4 is a Cartesian product of 4 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ */
 trait Product4[+T1, +T2, +T3, +T4] extends Any with Product {
   /** The arity of this product.
    *  @return 4

--- a/library/src/scala/Product5.scala
+++ b/library/src/scala/Product5.scala
@@ -21,7 +21,14 @@ object Product5 {
     Some(x)
 }
 
-/** Product5 is a Cartesian product of 5 components. */
+/** Product5 is a Cartesian product of 5 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ */
 trait Product5[+T1, +T2, +T3, +T4, +T5] extends Any with Product {
   /** The arity of this product.
    *  @return 5

--- a/library/src/scala/Product6.scala
+++ b/library/src/scala/Product6.scala
@@ -21,7 +21,15 @@ object Product6 {
     Some(x)
 }
 
-/** Product6 is a Cartesian product of 6 components. */
+/** Product6 is a Cartesian product of 6 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ */
 trait Product6[+T1, +T2, +T3, +T4, +T5, +T6] extends Any with Product {
   /** The arity of this product.
    *  @return 6

--- a/library/src/scala/Product7.scala
+++ b/library/src/scala/Product7.scala
@@ -21,7 +21,16 @@ object Product7 {
     Some(x)
 }
 
-/** Product7 is a Cartesian product of 7 components. */
+/** Product7 is a Cartesian product of 7 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ */
 trait Product7[+T1, +T2, +T3, +T4, +T5, +T6, +T7] extends Any with Product {
   /** The arity of this product.
    *  @return 7

--- a/library/src/scala/Product8.scala
+++ b/library/src/scala/Product8.scala
@@ -21,7 +21,17 @@ object Product8 {
     Some(x)
 }
 
-/** Product8 is a Cartesian product of 8 components. */
+/** Product8 is a Cartesian product of 8 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ */
 trait Product8[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8] extends Any with Product {
   /** The arity of this product.
    *  @return 8

--- a/library/src/scala/Product9.scala
+++ b/library/src/scala/Product9.scala
@@ -21,7 +21,18 @@ object Product9 {
     Some(x)
 }
 
-/** Product9 is a Cartesian product of 9 components. */
+/** Product9 is a Cartesian product of 9 components.
+ *
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ */
 trait Product9[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9] extends Any with Product {
   /** The arity of this product.
    *  @return 9

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -34,35 +34,55 @@ sealed trait Tuple extends Product {
 
   /** Gets the i-th element of this tuple.
    *  Equivalent to productElement but with a precise return type.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the zero-based index of the element to retrieve
    */
   inline def apply[This >: this.type <: Tuple](n: Int): Elem[This, n.type] =
     runtime.Tuples.apply(this, n).asInstanceOf[Elem[This, n.type]]
 
-  /** Gets the head of this tuple. */
+  /** Gets the head of this tuple.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def head[This >: this.type <: Tuple]: Head[This] =
     runtime.Tuples.apply(this, 0).asInstanceOf[Head[This]]
 
-  /** Gets the initial part of the tuple without its last element. */
+  /** Gets the initial part of the tuple without its last element.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def init[This >: this.type <: Tuple]: Init[This] =
     runtime.Tuples.init(this).asInstanceOf[Init[This]]
 
-  /** Gets the last of this tuple. */
+  /** Gets the last of this tuple.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def last[This >: this.type <: Tuple]: Last[This] =
     runtime.Tuples.last(this).asInstanceOf[Last[This]]
 
   /** Gets the tail of this tuple.
    *  This operation is O(this.size)
+   *
+   *  @tparam This the exact type of this tuple
    */
   inline def tail[This >: this.type <: Tuple]: Tail[This] =
     runtime.Tuples.tail(this).asInstanceOf[Tail[This]]
 
   /** Returns a new tuple by concatenating `this` tuple with `that` tuple.
    *  This operation is O(this.size + that.size)
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param that the tuple to append to this tuple
    */
   inline def ++ [This >: this.type <: Tuple](that: Tuple): This ++ that.type =
     runtime.Tuples.concat(this, that).asInstanceOf[This ++ that.type]
 
-  /** Returns the size (or arity) of the tuple. */
+  /** Returns the size (or arity) of the tuple.
+   *
+   *  @tparam This the exact type of this tuple
+   */
   inline def size[This >: this.type <: Tuple]: Size[This] =
     runtime.Tuples.size(this).asInstanceOf[Size[This]]
 
@@ -72,6 +92,10 @@ sealed trait Tuple extends Product {
    *  The result is typed as `((A1, B1), ..., (An, Bn))` if at least one of the
    *  tuple types has a `EmptyTuple` tail. Otherwise the result type is
    *  `(A1, B1) *: ... *: (Ai, Bi) *: Tuple`
+   *
+   *  @tparam This the exact type of this tuple
+   *  @tparam T2 the type of the other tuple to zip with
+   *  @param t2 the tuple to zip with this tuple
    */
   inline def zip[This >: this.type <: Tuple, T2 <: Tuple](t2: T2): Zip[This, T2] =
     runtime.Tuples.zip(this, t2).asInstanceOf[Zip[This, T2]]
@@ -80,12 +104,17 @@ sealed trait Tuple extends Product {
    *  The result is typed as `(F[A1], ..., F[An])` if the tuple type is fully known.
    *  If the tuple is of the form `a1 *: ... *: Tuple` (that is, the tail is not known
    *  to be the cons type.
+   *
+   *  @tparam F the type constructor applied to each element type
    */
   inline def map[F[_]](f: [t] => t => F[t]): Map[this.type, F] =
     runtime.Tuples.map(this, f).asInstanceOf[Map[this.type, F]]
 
   /** Given a tuple `(a1, ..., am)`, returns the tuple `(a1, ..., an)` consisting
    *  of its first n elements.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the number of elements to take from the beginning
    */
   inline def take[This >: this.type <: Tuple](n: Int): Take[This, n.type] =
     runtime.Tuples.take(this, n).asInstanceOf[Take[This, n.type]]
@@ -93,6 +122,9 @@ sealed trait Tuple extends Product {
 
   /** Given a tuple `(a1, ..., am)`, returns the tuple `(an+1, ..., am)` consisting
    *  all its elements except the first n ones.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the number of elements to drop from the beginning
    */
   inline def drop[This >: this.type <: Tuple](n: Int): Drop[This, n.type] =
     runtime.Tuples.drop(this, n).asInstanceOf[Drop[This, n.type]]
@@ -100,12 +132,17 @@ sealed trait Tuple extends Product {
   /** Given a tuple `(a1, ..., am)`, returns a pair of the tuple `(a1, ..., an)`
    *  consisting of the first n elements, and the tuple `(an+1, ..., am)` consisting
    *  of the remaining elements.
+   *
+   *  @tparam This the exact type of this tuple
+   *  @param n the number of elements in the first part of the split
    */
   inline def splitAt[This >: this.type <: Tuple](n: Int): Split[This, n.type] =
     runtime.Tuples.splitAt(this, n).asInstanceOf[Split[This, n.type]]
 
   /** Given a tuple `(a1, ..., am)`, returns the reversed tuple `(am, ..., a1)`
    *  consisting all its elements.
+   *
+   *  @tparam This the exact type of this tuple
    */
   inline def reverse[This >: this.type <: Tuple]: Reverse[This] =
     runtime.Tuples.reverse(this).asInstanceOf[Reverse[This]]
@@ -285,13 +322,24 @@ object Tuple {
   /** Empty tuple. */
   def apply(): EmptyTuple = EmptyTuple
 
-  /** Tuple with one element. */
+  /** Tuple with one element.
+   *
+   *  @tparam T the type of the element
+   *  @param x the single element of the tuple
+   */
   def apply[T](x: T): T *: EmptyTuple = Tuple1(x)
 
-  /** Matches an empty tuple. */
+  /** Matches an empty tuple.
+   *
+   *  @param x the empty tuple to match
+   */
   def unapply(x: EmptyTuple): true = true
 
-  /** Converts an array into a tuple of unknown arity and types. */
+  /** Converts an array into a tuple of unknown arity and types.
+   *
+   *  @tparam T the element type of the array
+   *  @param xs the array to convert into a tuple
+   */
   def fromArray[T](xs: Array[T]): Tuple = {
     val xs2 = xs match {
       case xs: Array[Object] => xs
@@ -300,7 +348,11 @@ object Tuple {
     runtime.Tuples.fromArray(xs2)
   }
 
-  /** Converts an immutable array into a tuple of unknown arity and types. */
+  /** Converts an immutable array into a tuple of unknown arity and types.
+   *
+   *  @tparam T the element type of the immutable array
+   *  @param xs the immutable array to convert into a tuple
+   */
   def fromIArray[T](xs: IArray[T]): Tuple = {
     val xs2: IArray[Object] = xs match {
       case xs: IArray[Object] @unchecked => xs
@@ -310,7 +362,10 @@ object Tuple {
     runtime.Tuples.fromIArray(xs2)
   }
 
-  /** Converts a Product into a tuple of unknown arity and types. */
+  /** Converts a Product into a tuple of unknown arity and types.
+   *
+   *  @param product the product to convert into a tuple
+   */
   def fromProduct(product: Product): Tuple =
     runtime.Tuples.fromProduct(product)
 

--- a/library/src/scala/Tuple10.scala
+++ b/library/src/scala/Tuple10.scala
@@ -19,16 +19,26 @@ import scala.language.`2.13`
 /** A tuple of 10 elements; the canonical representation of a [[scala.Product10]].
  *
  *  @constructor  Create a new tuple with 10 elements. Note that it is more idiomatic to create a Tuple10 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)`
- *  @param  _1   Element 1 of this Tuple10
- *  @param  _2   Element 2 of this Tuple10
- *  @param  _3   Element 3 of this Tuple10
- *  @param  _4   Element 4 of this Tuple10
- *  @param  _5   Element 5 of this Tuple10
- *  @param  _6   Element 6 of this Tuple10
- *  @param  _7   Element 7 of this Tuple10
- *  @param  _8   Element 8 of this Tuple10
- *  @param  _9   Element 9 of this Tuple10
- *  @param  _10   Element 10 of this Tuple10
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @param  _1   element 1 of this Tuple10
+ *  @param  _2   element 2 of this Tuple10
+ *  @param  _3   element 3 of this Tuple10
+ *  @param  _4   element 4 of this Tuple10
+ *  @param  _5   element 5 of this Tuple10
+ *  @param  _6   element 6 of this Tuple10
+ *  @param  _7   element 7 of this Tuple10
+ *  @param  _8   element 8 of this Tuple10
+ *  @param  _9   element 9 of this Tuple10
+ *  @param  _10   element 10 of this Tuple10
  */
 final case class Tuple10[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10)
   extends Product10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]

--- a/library/src/scala/Tuple11.scala
+++ b/library/src/scala/Tuple11.scala
@@ -19,6 +19,17 @@ import scala.language.`2.13`
 /** A tuple of 11 elements; the canonical representation of a [[scala.Product11]].
  *
  *  @constructor  Create a new tuple with 11 elements. Note that it is more idiomatic to create a Tuple11 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
  *  @param  _1   Element 1 of this Tuple11
  *  @param  _2   Element 2 of this Tuple11
  *  @param  _3   Element 3 of this Tuple11

--- a/library/src/scala/Tuple12.scala
+++ b/library/src/scala/Tuple12.scala
@@ -19,6 +19,18 @@ import scala.language.`2.13`
 /** A tuple of 12 elements; the canonical representation of a [[scala.Product12]].
  *
  *  @constructor  Create a new tuple with 12 elements. Note that it is more idiomatic to create a Tuple12 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
  *  @param  _1   Element 1 of this Tuple12
  *  @param  _2   Element 2 of this Tuple12
  *  @param  _3   Element 3 of this Tuple12

--- a/library/src/scala/Tuple13.scala
+++ b/library/src/scala/Tuple13.scala
@@ -19,6 +19,19 @@ import scala.language.`2.13`
 /** A tuple of 13 elements; the canonical representation of a [[scala.Product13]].
  *
  *  @constructor  Create a new tuple with 13 elements. Note that it is more idiomatic to create a Tuple13 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
  *  @param  _1   Element 1 of this Tuple13
  *  @param  _2   Element 2 of this Tuple13
  *  @param  _3   Element 3 of this Tuple13

--- a/library/src/scala/Tuple14.scala
+++ b/library/src/scala/Tuple14.scala
@@ -19,20 +19,34 @@ import scala.language.`2.13`
 /** A tuple of 14 elements; the canonical representation of a [[scala.Product14]].
  *
  *  @constructor  Create a new tuple with 14 elements. Note that it is more idiomatic to create a Tuple14 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)`
- *  @param  _1   Element 1 of this Tuple14
- *  @param  _2   Element 2 of this Tuple14
- *  @param  _3   Element 3 of this Tuple14
- *  @param  _4   Element 4 of this Tuple14
- *  @param  _5   Element 5 of this Tuple14
- *  @param  _6   Element 6 of this Tuple14
- *  @param  _7   Element 7 of this Tuple14
- *  @param  _8   Element 8 of this Tuple14
- *  @param  _9   Element 9 of this Tuple14
- *  @param  _10   Element 10 of this Tuple14
- *  @param  _11   Element 11 of this Tuple14
- *  @param  _12   Element 12 of this Tuple14
- *  @param  _13   Element 13 of this Tuple14
- *  @param  _14   Element 14 of this Tuple14
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @param  _1   element 1 of this Tuple14
+ *  @param  _2   element 2 of this Tuple14
+ *  @param  _3   element 3 of this Tuple14
+ *  @param  _4   element 4 of this Tuple14
+ *  @param  _5   element 5 of this Tuple14
+ *  @param  _6   element 6 of this Tuple14
+ *  @param  _7   element 7 of this Tuple14
+ *  @param  _8   element 8 of this Tuple14
+ *  @param  _9   element 9 of this Tuple14
+ *  @param  _10   element 10 of this Tuple14
+ *  @param  _11   element 11 of this Tuple14
+ *  @param  _12   element 12 of this Tuple14
+ *  @param  _13   element 13 of this Tuple14
+ *  @param  _14   element 14 of this Tuple14
  */
 final case class Tuple14[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14)
   extends Product14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]

--- a/library/src/scala/Tuple15.scala
+++ b/library/src/scala/Tuple15.scala
@@ -19,6 +19,21 @@ import scala.language.`2.13`
 /** A tuple of 15 elements; the canonical representation of a [[scala.Product15]].
  *
  *  @constructor  Create a new tuple with 15 elements. Note that it is more idiomatic to create a Tuple15 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
  *  @param  _1   Element 1 of this Tuple15
  *  @param  _2   Element 2 of this Tuple15
  *  @param  _3   Element 3 of this Tuple15

--- a/library/src/scala/Tuple16.scala
+++ b/library/src/scala/Tuple16.scala
@@ -19,6 +19,22 @@ import scala.language.`2.13`
 /** A tuple of 16 elements; the canonical representation of a [[scala.Product16]].
  *
  *  @constructor  Create a new tuple with 16 elements. Note that it is more idiomatic to create a Tuple16 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
  *  @param  _1   Element 1 of this Tuple16
  *  @param  _2   Element 2 of this Tuple16
  *  @param  _3   Element 3 of this Tuple16

--- a/library/src/scala/Tuple17.scala
+++ b/library/src/scala/Tuple17.scala
@@ -19,23 +19,40 @@ import scala.language.`2.13`
 /** A tuple of 17 elements; the canonical representation of a [[scala.Product17]].
  *
  *  @constructor  Create a new tuple with 17 elements. Note that it is more idiomatic to create a Tuple17 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17)`
- *  @param  _1   Element 1 of this Tuple17
- *  @param  _2   Element 2 of this Tuple17
- *  @param  _3   Element 3 of this Tuple17
- *  @param  _4   Element 4 of this Tuple17
- *  @param  _5   Element 5 of this Tuple17
- *  @param  _6   Element 6 of this Tuple17
- *  @param  _7   Element 7 of this Tuple17
- *  @param  _8   Element 8 of this Tuple17
- *  @param  _9   Element 9 of this Tuple17
- *  @param  _10   Element 10 of this Tuple17
- *  @param  _11   Element 11 of this Tuple17
- *  @param  _12   Element 12 of this Tuple17
- *  @param  _13   Element 13 of this Tuple17
- *  @param  _14   Element 14 of this Tuple17
- *  @param  _15   Element 15 of this Tuple17
- *  @param  _16   Element 16 of this Tuple17
- *  @param  _17   Element 17 of this Tuple17
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @param  _1   element 1 of this Tuple17
+ *  @param  _2   element 2 of this Tuple17
+ *  @param  _3   element 3 of this Tuple17
+ *  @param  _4   element 4 of this Tuple17
+ *  @param  _5   element 5 of this Tuple17
+ *  @param  _6   element 6 of this Tuple17
+ *  @param  _7   element 7 of this Tuple17
+ *  @param  _8   element 8 of this Tuple17
+ *  @param  _9   element 9 of this Tuple17
+ *  @param  _10   element 10 of this Tuple17
+ *  @param  _11   element 11 of this Tuple17
+ *  @param  _12   element 12 of this Tuple17
+ *  @param  _13   element 13 of this Tuple17
+ *  @param  _14   element 14 of this Tuple17
+ *  @param  _15   element 15 of this Tuple17
+ *  @param  _16   element 16 of this Tuple17
+ *  @param  _17   element 17 of this Tuple17
  */
 final case class Tuple17[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17)
   extends Product17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]

--- a/library/src/scala/Tuple18.scala
+++ b/library/src/scala/Tuple18.scala
@@ -19,24 +19,42 @@ import scala.language.`2.13`
 /** A tuple of 18 elements; the canonical representation of a [[scala.Product18]].
  *
  *  @constructor  Create a new tuple with 18 elements. Note that it is more idiomatic to create a Tuple18 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18)`
- *  @param  _1   Element 1 of this Tuple18
- *  @param  _2   Element 2 of this Tuple18
- *  @param  _3   Element 3 of this Tuple18
- *  @param  _4   Element 4 of this Tuple18
- *  @param  _5   Element 5 of this Tuple18
- *  @param  _6   Element 6 of this Tuple18
- *  @param  _7   Element 7 of this Tuple18
- *  @param  _8   Element 8 of this Tuple18
- *  @param  _9   Element 9 of this Tuple18
- *  @param  _10   Element 10 of this Tuple18
- *  @param  _11   Element 11 of this Tuple18
- *  @param  _12   Element 12 of this Tuple18
- *  @param  _13   Element 13 of this Tuple18
- *  @param  _14   Element 14 of this Tuple18
- *  @param  _15   Element 15 of this Tuple18
- *  @param  _16   Element 16 of this Tuple18
- *  @param  _17   Element 17 of this Tuple18
- *  @param  _18   Element 18 of this Tuple18
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @param  _1   element 1 of this Tuple18
+ *  @param  _2   element 2 of this Tuple18
+ *  @param  _3   element 3 of this Tuple18
+ *  @param  _4   element 4 of this Tuple18
+ *  @param  _5   element 5 of this Tuple18
+ *  @param  _6   element 6 of this Tuple18
+ *  @param  _7   element 7 of this Tuple18
+ *  @param  _8   element 8 of this Tuple18
+ *  @param  _9   element 9 of this Tuple18
+ *  @param  _10   element 10 of this Tuple18
+ *  @param  _11   element 11 of this Tuple18
+ *  @param  _12   element 12 of this Tuple18
+ *  @param  _13   element 13 of this Tuple18
+ *  @param  _14   element 14 of this Tuple18
+ *  @param  _15   element 15 of this Tuple18
+ *  @param  _16   element 16 of this Tuple18
+ *  @param  _17   element 17 of this Tuple18
+ *  @param  _18   element 18 of this Tuple18
  */
 final case class Tuple18[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18)
   extends Product18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]

--- a/library/src/scala/Tuple19.scala
+++ b/library/src/scala/Tuple19.scala
@@ -19,6 +19,25 @@ import scala.language.`2.13`
 /** A tuple of 19 elements; the canonical representation of a [[scala.Product19]].
  *
  *  @constructor  Create a new tuple with 19 elements. Note that it is more idiomatic to create a Tuple19 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
  *  @param  _1   Element 1 of this Tuple19
  *  @param  _2   Element 2 of this Tuple19
  *  @param  _3   Element 3 of this Tuple19

--- a/library/src/scala/Tuple20.scala
+++ b/library/src/scala/Tuple20.scala
@@ -19,26 +19,46 @@ import scala.language.`2.13`
 /** A tuple of 20 elements; the canonical representation of a [[scala.Product20]].
  *
  *  @constructor  Create a new tuple with 20 elements. Note that it is more idiomatic to create a Tuple20 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20)`
- *  @param  _1   Element 1 of this Tuple20
- *  @param  _2   Element 2 of this Tuple20
- *  @param  _3   Element 3 of this Tuple20
- *  @param  _4   Element 4 of this Tuple20
- *  @param  _5   Element 5 of this Tuple20
- *  @param  _6   Element 6 of this Tuple20
- *  @param  _7   Element 7 of this Tuple20
- *  @param  _8   Element 8 of this Tuple20
- *  @param  _9   Element 9 of this Tuple20
- *  @param  _10   Element 10 of this Tuple20
- *  @param  _11   Element 11 of this Tuple20
- *  @param  _12   Element 12 of this Tuple20
- *  @param  _13   Element 13 of this Tuple20
- *  @param  _14   Element 14 of this Tuple20
- *  @param  _15   Element 15 of this Tuple20
- *  @param  _16   Element 16 of this Tuple20
- *  @param  _17   Element 17 of this Tuple20
- *  @param  _18   Element 18 of this Tuple20
- *  @param  _19   Element 19 of this Tuple20
- *  @param  _20   Element 20 of this Tuple20
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @param  _1   the 1st element of this Tuple20
+ *  @param  _2   the 2nd element of this Tuple20
+ *  @param  _3   the 3rd element of this Tuple20
+ *  @param  _4   the 4th element of this Tuple20
+ *  @param  _5   the 5th element of this Tuple20
+ *  @param  _6   the 6th element of this Tuple20
+ *  @param  _7   the 7th element of this Tuple20
+ *  @param  _8   the 8th element of this Tuple20
+ *  @param  _9   the 9th element of this Tuple20
+ *  @param  _10   the 10th element of this Tuple20
+ *  @param  _11   the 11th element of this Tuple20
+ *  @param  _12   the 12th element of this Tuple20
+ *  @param  _13   the 13th element of this Tuple20
+ *  @param  _14   the 14th element of this Tuple20
+ *  @param  _15   the 15th element of this Tuple20
+ *  @param  _16   the 16th element of this Tuple20
+ *  @param  _17   the 17th element of this Tuple20
+ *  @param  _18   the 18th element of this Tuple20
+ *  @param  _19   the 19th element of this Tuple20
+ *  @param  _20   the 20th element of this Tuple20
  */
 final case class Tuple20[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19, _20: T20)
   extends Product20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]

--- a/library/src/scala/Tuple21.scala
+++ b/library/src/scala/Tuple21.scala
@@ -19,6 +19,27 @@ import scala.language.`2.13`
 /** A tuple of 21 elements; the canonical representation of a [[scala.Product21]].
  *
  *  @constructor  Create a new tuple with 21 elements. Note that it is more idiomatic to create a Tuple21 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
  *  @param  _1   Element 1 of this Tuple21
  *  @param  _2   Element 2 of this Tuple21
  *  @param  _3   Element 3 of this Tuple21

--- a/library/src/scala/Tuple22.scala
+++ b/library/src/scala/Tuple22.scala
@@ -19,28 +19,50 @@ import scala.language.`2.13`
 /** A tuple of 22 elements; the canonical representation of a [[scala.Product22]].
  *
  *  @constructor  Create a new tuple with 22 elements. Note that it is more idiomatic to create a Tuple22 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, t22)`
- *  @param  _1   Element 1 of this Tuple22
- *  @param  _2   Element 2 of this Tuple22
- *  @param  _3   Element 3 of this Tuple22
- *  @param  _4   Element 4 of this Tuple22
- *  @param  _5   Element 5 of this Tuple22
- *  @param  _6   Element 6 of this Tuple22
- *  @param  _7   Element 7 of this Tuple22
- *  @param  _8   Element 8 of this Tuple22
- *  @param  _9   Element 9 of this Tuple22
- *  @param  _10   Element 10 of this Tuple22
- *  @param  _11   Element 11 of this Tuple22
- *  @param  _12   Element 12 of this Tuple22
- *  @param  _13   Element 13 of this Tuple22
- *  @param  _14   Element 14 of this Tuple22
- *  @param  _15   Element 15 of this Tuple22
- *  @param  _16   Element 16 of this Tuple22
- *  @param  _17   Element 17 of this Tuple22
- *  @param  _18   Element 18 of this Tuple22
- *  @param  _19   Element 19 of this Tuple22
- *  @param  _20   Element 20 of this Tuple22
- *  @param  _21   Element 21 of this Tuple22
- *  @param  _22   Element 22 of this Tuple22
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
+ *  @tparam T10 the type of the 10th element
+ *  @tparam T11 the type of the 11th element
+ *  @tparam T12 the type of the 12th element
+ *  @tparam T13 the type of the 13th element
+ *  @tparam T14 the type of the 14th element
+ *  @tparam T15 the type of the 15th element
+ *  @tparam T16 the type of the 16th element
+ *  @tparam T17 the type of the 17th element
+ *  @tparam T18 the type of the 18th element
+ *  @tparam T19 the type of the 19th element
+ *  @tparam T20 the type of the 20th element
+ *  @tparam T21 the type of the 21st element
+ *  @tparam T22 the type of the 22nd element
+ *  @param  _1   the 1st element of this Tuple22
+ *  @param  _2   the 2nd element of this Tuple22
+ *  @param  _3   the 3rd element of this Tuple22
+ *  @param  _4   the 4th element of this Tuple22
+ *  @param  _5   the 5th element of this Tuple22
+ *  @param  _6   the 6th element of this Tuple22
+ *  @param  _7   the 7th element of this Tuple22
+ *  @param  _8   the 8th element of this Tuple22
+ *  @param  _9   the 9th element of this Tuple22
+ *  @param  _10   the 10th element of this Tuple22
+ *  @param  _11   the 11th element of this Tuple22
+ *  @param  _12   the 12th element of this Tuple22
+ *  @param  _13   the 13th element of this Tuple22
+ *  @param  _14   the 14th element of this Tuple22
+ *  @param  _15   the 15th element of this Tuple22
+ *  @param  _16   the 16th element of this Tuple22
+ *  @param  _17   the 17th element of this Tuple22
+ *  @param  _18   the 18th element of this Tuple22
+ *  @param  _19   the 19th element of this Tuple22
+ *  @param  _20   the 20th element of this Tuple22
+ *  @param  _21   the 21st element of this Tuple22
+ *  @param  _22   the 22nd element of this Tuple22
  */
 final case class Tuple22[+T1, +T2, +T3, +T4, +T5, +T6, +T7, +T8, +T9, +T10, +T11, +T12, +T13, +T14, +T15, +T16, +T17, +T18, +T19, +T20, +T21, +T22](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7, _8: T8, _9: T9, _10: T10, _11: T11, _12: T12, _13: T13, _14: T14, _15: T15, _16: T16, _17: T17, _18: T18, _19: T19, _20: T20, _21: T21, _22: T22)
   extends Product22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]

--- a/library/src/scala/Tuple3.scala
+++ b/library/src/scala/Tuple3.scala
@@ -19,6 +19,9 @@ import scala.language.`2.13`
 /** A tuple of 3 elements; the canonical representation of a [[scala.Product3]].
  *
  *  @constructor  Create a new tuple with 3 elements. Note that it is more idiomatic to create a Tuple3 via `(t1, t2, t3)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
  *  @param  _1   Element 1 of this Tuple3
  *  @param  _2   Element 2 of this Tuple3
  *  @param  _3   Element 3 of this Tuple3

--- a/library/src/scala/Tuple4.scala
+++ b/library/src/scala/Tuple4.scala
@@ -19,10 +19,14 @@ import scala.language.`2.13`
 /** A tuple of 4 elements; the canonical representation of a [[scala.Product4]].
  *
  *  @constructor  Create a new tuple with 4 elements. Note that it is more idiomatic to create a Tuple4 via `(t1, t2, t3, t4)`
- *  @param  _1   Element 1 of this Tuple4
- *  @param  _2   Element 2 of this Tuple4
- *  @param  _3   Element 3 of this Tuple4
- *  @param  _4   Element 4 of this Tuple4
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @param  _1   element 1 of this Tuple4
+ *  @param  _2   element 2 of this Tuple4
+ *  @param  _3   element 3 of this Tuple4
+ *  @param  _4   element 4 of this Tuple4
  */
 final case class Tuple4[+T1, +T2, +T3, +T4](_1: T1, _2: T2, _3: T3, _4: T4)
   extends Product4[T1, T2, T3, T4]

--- a/library/src/scala/Tuple5.scala
+++ b/library/src/scala/Tuple5.scala
@@ -19,11 +19,16 @@ import scala.language.`2.13`
 /** A tuple of 5 elements; the canonical representation of a [[scala.Product5]].
  *
  *  @constructor  Create a new tuple with 5 elements. Note that it is more idiomatic to create a Tuple5 via `(t1, t2, t3, t4, t5)`
- *  @param  _1   Element 1 of this Tuple5
- *  @param  _2   Element 2 of this Tuple5
- *  @param  _3   Element 3 of this Tuple5
- *  @param  _4   Element 4 of this Tuple5
- *  @param  _5   Element 5 of this Tuple5
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @param  _1   the 1st element of this Tuple5
+ *  @param  _2   the 2nd element of this Tuple5
+ *  @param  _3   the 3rd element of this Tuple5
+ *  @param  _4   the 4th element of this Tuple5
+ *  @param  _5   the 5th element of this Tuple5
  */
 final case class Tuple5[+T1, +T2, +T3, +T4, +T5](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5)
   extends Product5[T1, T2, T3, T4, T5]

--- a/library/src/scala/Tuple6.scala
+++ b/library/src/scala/Tuple6.scala
@@ -19,12 +19,18 @@ import scala.language.`2.13`
 /** A tuple of 6 elements; the canonical representation of a [[scala.Product6]].
  *
  *  @constructor  Create a new tuple with 6 elements. Note that it is more idiomatic to create a Tuple6 via `(t1, t2, t3, t4, t5, t6)`
- *  @param  _1   Element 1 of this Tuple6
- *  @param  _2   Element 2 of this Tuple6
- *  @param  _3   Element 3 of this Tuple6
- *  @param  _4   Element 4 of this Tuple6
- *  @param  _5   Element 5 of this Tuple6
- *  @param  _6   Element 6 of this Tuple6
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @param  _1   the 1st element of this Tuple6
+ *  @param  _2   the 2nd element of this Tuple6
+ *  @param  _3   the 3rd element of this Tuple6
+ *  @param  _4   the 4th element of this Tuple6
+ *  @param  _5   the 5th element of this Tuple6
+ *  @param  _6   the 6th element of this Tuple6
  */
 final case class Tuple6[+T1, +T2, +T3, +T4, +T5, +T6](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6)
   extends Product6[T1, T2, T3, T4, T5, T6]

--- a/library/src/scala/Tuple7.scala
+++ b/library/src/scala/Tuple7.scala
@@ -19,13 +19,20 @@ import scala.language.`2.13`
 /** A tuple of 7 elements; the canonical representation of a [[scala.Product7]].
  *
  *  @constructor  Create a new tuple with 7 elements. Note that it is more idiomatic to create a Tuple7 via `(t1, t2, t3, t4, t5, t6, t7)`
- *  @param  _1   Element 1 of this Tuple7
- *  @param  _2   Element 2 of this Tuple7
- *  @param  _3   Element 3 of this Tuple7
- *  @param  _4   Element 4 of this Tuple7
- *  @param  _5   Element 5 of this Tuple7
- *  @param  _6   Element 6 of this Tuple7
- *  @param  _7   Element 7 of this Tuple7
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @param  _1   the 1st element of this Tuple7
+ *  @param  _2   the 2nd element of this Tuple7
+ *  @param  _3   the 3rd element of this Tuple7
+ *  @param  _4   the 4th element of this Tuple7
+ *  @param  _5   the 5th element of this Tuple7
+ *  @param  _6   the 6th element of this Tuple7
+ *  @param  _7   the 7th element of this Tuple7
  */
 final case class Tuple7[+T1, +T2, +T3, +T4, +T5, +T6, +T7](_1: T1, _2: T2, _3: T3, _4: T4, _5: T5, _6: T6, _7: T7)
   extends Product7[T1, T2, T3, T4, T5, T6, T7]

--- a/library/src/scala/Tuple8.scala
+++ b/library/src/scala/Tuple8.scala
@@ -19,6 +19,14 @@ import scala.language.`2.13`
 /** A tuple of 8 elements; the canonical representation of a [[scala.Product8]].
  *
  *  @constructor  Create a new tuple with 8 elements. Note that it is more idiomatic to create a Tuple8 via `(t1, t2, t3, t4, t5, t6, t7, t8)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
  *  @param  _1   Element 1 of this Tuple8
  *  @param  _2   Element 2 of this Tuple8
  *  @param  _3   Element 3 of this Tuple8

--- a/library/src/scala/Tuple9.scala
+++ b/library/src/scala/Tuple9.scala
@@ -19,6 +19,15 @@ import scala.language.`2.13`
 /** A tuple of 9 elements; the canonical representation of a [[scala.Product9]].
  *
  *  @constructor  Create a new tuple with 9 elements. Note that it is more idiomatic to create a Tuple9 via `(t1, t2, t3, t4, t5, t6, t7, t8, t9)`
+ *  @tparam T1 the type of the 1st element
+ *  @tparam T2 the type of the 2nd element
+ *  @tparam T3 the type of the 3rd element
+ *  @tparam T4 the type of the 4th element
+ *  @tparam T5 the type of the 5th element
+ *  @tparam T6 the type of the 6th element
+ *  @tparam T7 the type of the 7th element
+ *  @tparam T8 the type of the 8th element
+ *  @tparam T9 the type of the 9th element
  *  @param  _1   Element 1 of this Tuple9
  *  @param  _2   Element 2 of this Tuple9
  *  @param  _3   Element 3 of this Tuple9


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in missing @param, @tparam, and @return tags for Function*, Tuple*, Product*. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.