### PR TITLE
improvement: delete old compilation units from pc

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
@@ -31,6 +31,7 @@ class CachingDriver(override val settings: List[String]) extends InteractiveDriv
 
   private var lastCompiledURI: URI = uninitialized
   private var previousDiags = List.empty[Diagnostic]
+  private val compileUnitsCache = new CompileUnitsCache(5)
 
   private def alreadyCompiled(uri: URI, content: Array[Char]): Boolean =
     compilationUnits.get(uri) match
@@ -43,6 +44,10 @@ class CachingDriver(override val settings: List[String]) extends InteractiveDriv
   override def run(uri: URI, source: SourceFile): List[Diagnostic] =
     if !alreadyCompiled(uri, source.content) then previousDiags = super.run(uri, source)
     lastCompiledURI = uri
+    compileUnitsCache.didGetUnit(uri).foreach(s => close(URI.create(s)))
     previousDiags
+
+  def didChange(uri: URI): Unit =
+    compileUnitsCache.didChange(uri)
 
 end CachingDriver

--- a/presentation-compiler/src/main/dotty/tools/pc/CompileUnitsCache.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/CompileUnitsCache.scala
@@ -1,0 +1,51 @@
+package dotty.tools.pc
+
+import java.net.URI
+
+import scala.collection.mutable
+
+class CompileUnitsCache(keepLastCount: Short):
+  private val lastCompiled = new LastNElementsSet[String](keepLastCount)
+  private val lastModified = mutable.Set[String]()
+
+  def didGetUnit(uri: URI): Option[String] =
+    lastCompiled
+      .add(uri.toString)
+      .filterNot(lastModified(_))
+
+  def didChange(uri: URI): Unit =
+    lastModified.add(uri.toString())
+
+end CompileUnitsCache
+
+/** A set collection that keeps the last N elements.
+ *  @param keepLastCount the number of elements to keep
+ */
+class LastNElementsSet[T](keepLastCount: Short):
+  private val cache = new mutable.LinkedHashSet[T]()
+  private var last: Option[T] = None
+
+  /** Add an element to the set.
+   *  @param element the element to add
+   *  @return the optional oldest element, that was removed from the set
+   */
+  def add(element: T): Option[T] = this.synchronized:
+    if last.contains(element) then None
+    else
+      last = Some(element)
+      if cache.contains(element) then
+        cache.remove(element)
+        cache.add(element)
+        None
+      else if cache.size >= keepLastCount then
+        val oldest = cache.head
+        cache.remove(oldest)
+        cache.add(element)
+        Some(oldest)
+      else
+        cache.add(element)
+        None
+
+  def contains(element: T): Boolean = cache.contains(element)
+
+end LastNElementsSet

--- a/presentation-compiler/src/main/dotty/tools/pc/CompileUnitsCache.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/CompileUnitsCache.scala
@@ -45,7 +45,3 @@ class LastNElementsSet[T](keepLastCount: Short):
       else
         cache.add(element)
         None
-
-  def contains(element: T): Boolean = cache.contains(element)
-
-end LastNElementsSet

--- a/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
@@ -317,6 +317,9 @@ case class RawScalaPresentationCompiler(
     SignatureHelpProvider.signatureHelp(driver, params, search)
 
   override def didChange(params: VirtualFileParams): ju.List[l.Diagnostic] =
+    driver match
+      case cd: CachingDriver => cd.didChange(params.uri())
+      case _ =>
     DiagnosticProvider(driver, params).diagnostics().asJava
 
   override def didClose(uri: URI): Unit =

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -497,6 +497,9 @@ case class ScalaPresentationCompiler(
       EmptyCancelToken
     ) { access =>
       val driver = access.compiler()
+      driver match
+        case cd: CachingDriver => cd.didChange(params.uri())
+        case _ =>
       DiagnosticProvider(driver, params).diagnostics().asJava
     }(params.toQueryContext)
 


### PR DESCRIPTION
---
Port https://github.com/scalameta/metals/pull/7506.

---

## How much have your relied on LLM-based tools in this contribution?

Minimally

## How was the solution tested?

Tests added in `CompilerCachingSuite.scala`.
