### PR TITLE
Forward snippet compiler options to Scastie

### DIFF
--- a/scaladoc-js/common/src/code-snippets/CodeSnippets.scala
+++ b/scaladoc-js/common/src/code-snippets/CodeSnippets.scala
@@ -128,7 +128,16 @@ class CodeSnippets:
         document.body.appendChild(popup)
         document.body.addEventListener("click", handler)
 
-        scastie.Embedded(popup.querySelector("pre"), scastieConfig)
+        val config = Option(snippet.getAttribute("data-scalac-opts")).filter(_.nonEmpty) match
+          case Some(opts) =>
+            val scalacOpts = opts.split(",").map(o => s""""$o"""").mkString(", ")
+            js.Dynamic.literal(
+              sbtConfig = s"${scastieConfiguration}\nscalacOptions ++= Seq($scalacOpts)",
+              targetType = "scala3"
+            )
+          case None => scastieConfig
+
+        scastie.Embedded(popup.querySelector("pre"), config)
 
         popup.querySelector("li.btn.run-button").asInstanceOf[html.Element].click()
 

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
@@ -80,7 +80,7 @@ object FlexmarkSnippetProcessor:
 
         val fullSnippet = Seq(snippetImports, snippet).mkString("\n").stripPrefix("\n")
         val snippetCompilationResult = cf(fullSnippet, lineOffset, argOverride) match {
-          case Some(result @ SnippetCompilationResult(wrapped, _, _, messages)) =>
+          case Some(result: SnippetCompilationResult) =>
             node.setContentString(fullSnippet)
             Some(result)
           case result =>

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilationResult.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompilationResult.scala
@@ -12,7 +12,8 @@ case class SnippetCompilationResult(
   wrappedSnippet: WrappedSnippet,
   isSuccessful: Boolean,
   result: Option[AbstractFile],
-  messages: Seq[SnippetCompilerMessage]
+  messages: Seq[SnippetCompilerMessage],
+  scalacOptions: Seq[String] = Seq.empty
 ):
   def reportMessages()(using CompilerContext) = messages.foreach {
     case SnippetCompilerMessage(posOpt, msg, level) =>

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetCompiler.scala
@@ -124,5 +124,5 @@ class SnippetCompiler(
       additionalMessages(wrappedSnippet, arg, sourceFile, context)
 
     val t = Option.when(!context.reporter.hasErrors)(target)
-    SnippetCompilationResult(wrappedSnippet, isSuccessful(arg, context), t, messages)
+    SnippetCompilationResult(wrappedSnippet, isSuccessful(arg, context), t, messages, arg.scalacOptions)
   }

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/SnippetRenderer.scala
@@ -137,12 +137,13 @@ object SnippetRenderer:
     div(cls := "snippet-label")(name)
   ).toString
 
-  def renderSnippetWithMessages(snippetName: Option[String], codeLines: Seq[String], messages: Seq[SnippetCompilerMessage], success: Boolean): String =
+  def renderSnippetWithMessages(snippetName: Option[String], codeLines: Seq[String], messages: Seq[SnippetCompilerMessage], success: Boolean, scalacOptions: Seq[String] = Seq.empty): String =
     val transformedLines = wrapCodeLines.andThen(addCompileMessages(messages)).andThen(reindexLines).apply(codeLines).map(_.toHTML)
     val codeHTML = s"""<code class="language-scala">${transformedLines.mkString("")}</code>"""
     val isRunnable = success
     val attrs = Seq(
-      Option.when(isRunnable)(Attr("runnable") := "")
+      Option.when(isRunnable)(Attr("runnable") := ""),
+      Option.when(scalacOptions.nonEmpty)(Attr("data-scalac-opts") := scalacOptions.mkString(","))
     ).flatten
     div(cls := "snippet mono-small-block", Attr("scala-snippet") := "", attrs)(
       pre(
@@ -157,7 +158,8 @@ object SnippetRenderer:
       node.name,
       node.codeBlock.getContentChars.toString.split("\n").map(_ + "\n").toSeq,
       node.compilationResult.toSeq.flatMap(_.messages),
-      node.compilationResult.fold(false)(_.isSuccessful)
+      node.compilationResult.fold(false)(_.isSuccessful),
+      node.compilationResult.toSeq.flatMap(_.scalacOptions)
     )
 
   def renderSnippet(content: String, language: Option[String] = None): String =

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
@@ -18,13 +18,11 @@ class SnippetCompilerTest {
 
   def runTest(str: String) = compiler.compile(wrapFn(str), SnippetCompilerArg(SCFlags.Compile), dotty.tools.dotc.util.SourceFile.virtual("test", str))
 
-  private def assertSuccessfulCompilation(res: SnippetCompilationResult): Unit = res match {
-    case r @ SnippetCompilationResult(_, isSuccessful, _, messages) => assert(isSuccessful, r.messages.map(_.message).mkString("\n"))
-  }
+  private def assertSuccessfulCompilation(res: SnippetCompilationResult): Unit =
+    assert(res.isSuccessful, res.messages.map(_.message).mkString("\n"))
 
-  private def assertFailedCompilation(res: SnippetCompilationResult): Unit = res match {
-    case r @ SnippetCompilationResult(_, isSuccessful, _, messages) => assert(!isSuccessful, r.messages.map(_.message).mkString("\n"))
-  }
+  private def assertFailedCompilation(res: SnippetCompilationResult): Unit =
+    assert(!res.isSuccessful, res.messages.map(_.message).mkString("\n"))
 
   def assertSuccessfulCompilation(str: String): Unit = assertSuccessfulCompilation(runTest(str))
 
@@ -32,12 +30,11 @@ class SnippetCompilerTest {
 
   def assertMessageLevelPresent(str: String, level: MessageLevel): Unit = assertMessageLevelPresent(runTest(str), level)
 
-  def assertMessageLevelPresent(res: SnippetCompilationResult, level: MessageLevel): Unit = res match {
-    case r @ SnippetCompilationResult(_, isSuccessful, _, messages) => assertTrue(
-      s"Expected message with level: ${level.text}. Got result ${r.messages.map(_.message).mkString("\n")}",
-      messages.exists(_.level == level)
+  def assertMessageLevelPresent(res: SnippetCompilationResult, level: MessageLevel): Unit =
+    assertTrue(
+      s"Expected message with level: ${level.text}. Got result ${res.messages.map(_.message).mkString("\n")}",
+      res.messages.exists(_.level == level)
     )
-  }
 
 
   @Test


### PR DESCRIPTION
The scaladoc snippet compiler accepts per-directory scalac options (e.g. -language:experimental.captureChecking for capture checking docs), but these were discarded after compilation and never forwarded to the "Run in Scastie" button. This meant clicking "Run" would launch Scastie without the required compiler flags, causing the snippet to fail.

Thread scalacOptions through SnippetCompilationResult and SnippetRenderer, emit them as a `data-scalac-opts` HTML attribute, and read the attribute in the Scastie JS to build a per-snippet config with the appropriate scalacOptions.

## How much have your relied on LLM-based tools in this contribution?

I used Claude to understand which parts need to be adapted to pass through
the compiler options.

## How was the solution tested?

I manually verified that the snippet compiler options set in the scaladoc build for a particular subfolder in the language reference (capture checking in this case) reach Scastie.
