### PR TITLE
Change `typeOfArg` to take `TypedArg` instead of `Arg`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -576,7 +576,8 @@ trait Applications extends Compatibility {
      */
     protected def normalizedFun: Tree
 
-    protected def typeOfArg(arg: Arg): Type
+    /** The type of the given typed argument. */
+    protected def typeOfArg(arg: TypedArg): Type
 
     /** If constructing trees, pull out all parts of the function
      *  which are not idempotent into separate prefix definitions
@@ -832,14 +833,15 @@ trait Applications extends Compatibility {
            */
           def addTyped(arg: Arg): List[Type] =
             if !formal.isRepeatedParam then checkNoVarArg(arg)
-            addArg(typedArg(arg, formal), formal)
+            val argTyped = typedArg(arg, formal)
+            addArg(argTyped, formal)
             if methodType.looksParamDependent
                   // need to handle also false dependencies since we generate TypeTrees from
                   // formal parameters in makeVarArg. These are not de-aliased, so they might contain
                   // stray parameter references. Test case is i23266.scala.
-                && typeOfArg(arg).exists
+                && typeOfArg(argTyped).exists
                   // `typeOfArg(arg)` could be missing because the evaluation of `arg` produced type errors
-            then formals1.mapconserve(safeSubstParam(_, methodType.paramRefs(n), typeOfArg(arg)))
+            then formals1.mapconserve(safeSubstParam(_, methodType.paramRefs(n), typeOfArg(argTyped)))
             else formals1
 
           def missingArg(n: Int): Unit =
@@ -1110,6 +1112,8 @@ trait Applications extends Compatibility {
     private var myNormalizedFun: Tree = fun
     init()
 
+    def typeOfArg(arg: tpd.Tree): Type = arg.tpe
+
     def addArg(arg: Tree, formal: Type): Unit =
       val typedArg = adapt(arg, formal.widenExpr)
       typedArgBuf += typedArg
@@ -1263,7 +1267,6 @@ trait Applications extends Compatibility {
   extends TypedApply(app, fun, methRef, proto.args, resultType, proto.applyKind) {
     def typedArg(arg: untpd.Tree, formal: Type): TypedArg = proto.typedArg(arg, formal)
     def treeToArg(arg: Tree): untpd.Tree = untpd.TypedSplice(arg)
-    def typeOfArg(arg: untpd.Tree): Type = proto.typeOfArg(arg)
   }
 
   /** Subclass of Application for type checking an Apply node with typed arguments. */
@@ -1273,7 +1276,6 @@ trait Applications extends Compatibility {
   extends TypedApply(app, fun, methRef, args, resultType, applyKind) {
     def typedArg(arg: Tree, formal: Type): TypedArg = arg
     def treeToArg(arg: Tree): Tree = arg
-    def typeOfArg(arg: Tree): Type = arg.tpe
   }
 
   /** If `app` is a `this(...)` constructor call, the this-call argument context,

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -583,7 +583,7 @@ object ProtoTypes {
     /** The type of the argument `arg`, or `NoType` if `arg` has not been typed before
      *  or if `arg`'s typing produced a type error.
      */
-    def typeOfArg(arg: untpd.Tree)(using Context): Type = {
+    private[ProtoTypes] def typeOfArg(arg: untpd.Tree)(using Context): Type = {
       val t = state.typedArg(arg)
       if (t == null) NoType else t.tpe
     }

--- a/tests/neg/i16842.check
+++ b/tests/neg/i16842.check
@@ -1,4 +1,7 @@
--- Error: tests/neg/i16842.scala:24:7 ----------------------------------------------------------------------------------
+-- [E007] Type Mismatch Error: tests/neg/i16842.scala:24:8 -------------------------------------------------------------
 24 |  Liter(SemanticArray[SemanticInt.type], x) // error
-   |       ^
-   |invalid new prefix (dim: Int): SemanticArray[SemanticInt.type] cannot replace (ty : SemanticArray[SemanticType]) in type ty.T
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |        Found:    Int => SemanticArray[SemanticInt.type]
+   |        Required: SemanticArray[SemanticType]
+   |
+   | longer explanation available when compiling with `-explain`


### PR DESCRIPTION
Pass the typed argument to `typeOfArg` in `addTyped` so that overrides of `typedArg` can influence the type used for `safeSubstParam` substitution.

This is a pure refactoring with no behavioral change (except the improved error for i16842).

The motivation is to allow subclasses to preprocess arguments in `typedArg` (e.g. lifting unstable args to val defs) and have the resulting type flow into dependent parameter substitution.

## How much have your relied on LLM-based tools in this contribution?

I used Claude to generate a few other suboptimal solutions to this problem, none of which I ended up using 😄 It was still helpful for brainstorming. I also used it to proofread the description above.

## How was the solution tested?

`sbtn "testCompilation"` passes locally.