### PR TITLE
feature: Add logical package parsing for sourcepath

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -28,8 +28,8 @@ class ClassPathFactory {
   def sourcesInPath(path: String)(using Context): List[ClassPath] =
     // We also accept files in case of YlogicalPackageLoading
     if ctx.settings.sourcepath.value.nonEmpty && ctx.settings.YlogicalPackageLoading.value then
-      val rootPackage: LogicalPackage = new LogicalPackagesProvider(ctx.settings.sourcepath.value).root
-      List(new LogicalSourcePath(ctx.settings.sourcepath.value, rootPackage))
+      val rootPackage: LogicalPackage = new LogicalPackagesProvider(path).root
+      List(new LogicalSourcePath(path, rootPackage))
     else
       for
         file <- expandPath(path, expandStar = false)

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -7,6 +7,9 @@ import dotty.tools.io.{AbstractFile, VirtualDirectory}
 import FileUtils.*
 import dotty.tools.io.ClassPath
 import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.interactive.LogicalSourcePath
+import dotty.tools.dotc.interactive.LogicalPackagesProvider
+import dotty.tools.dotc.interactive.LogicalPackage
 import java.nio.file.Files
 
 /**
@@ -23,11 +26,15 @@ class ClassPathFactory {
     * Creators for sub classpaths which preserve this context.
     */
   def sourcesInPath(path: String)(using Context): List[ClassPath] =
-    for
-      file <- expandPath(path, expandStar = false)
-      dir <- Option(AbstractFile.getDirectory(file))
-    yield createSourcePath(dir)
-
+    // We also accept files in case of YlogicalPackageLoading
+    if ctx.settings.sourcepath.value.nonEmpty && ctx.settings.YlogicalPackageLoading.value then
+      val rootPackage: LogicalPackage = new LogicalPackagesProvider(ctx.settings.sourcepath.value).root
+      List(new LogicalSourcePath(ctx.settings.sourcepath.value, rootPackage))
+    else
+      for
+        file <- expandPath(path, expandStar = false)
+        dir <- Option(AbstractFile.getDirectory(file))
+      yield createSourcePath(dir)
 
   def expandPath(path: String, expandStar: Boolean = true): List[String] = dotty.tools.io.ClassPath.expandPath(path, expandStar)
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -358,7 +358,7 @@ private sealed trait OptimizerSettings:
   def optAllowSkipCoreModuleInit(using Context): Boolean = optEnabled("allow-skip-core-module-init")
   def optAssumeModulesNonNull(using Context): Boolean = optEnabled("assume-modules-non-null")
   def optAllowSkipClassLoading(using Context): Boolean = optEnabled("allow-skip-class-loading")
-  
+
   val inlineHelp =
     """Inlining requires a list of patterns defining where code can be inlined from: `-opt-inline:p1,p2`. (Use `-opt-inline:help` for more details)
       |
@@ -530,6 +530,7 @@ private sealed trait YSettings:
   val YstopAfter: Setting[List[String]] = PhasesSetting(ForkSetting, "Ystop-after", "Stop after", aliases = List("-stop")) // backward compat
   val YstopBefore: Setting[List[String]] = PhasesSetting(ForkSetting, "Ystop-before", "Stop before") // stop before erasure as long as we have not debugged it fully
   val YshowSuppressedErrors: Setting[Boolean] = BooleanSetting(ForkSetting, "Yshow-suppressed-errors", "Also show follow-on errors and warnings that are normally suppressed.")
+  val YlogicalPackageLoading: Setting[Boolean] = BooleanSetting(ForkSetting, "YlogicalPackageLoading", "Enable logical package loading. This will load the logical package structure by preparsing the source files to discover the package structure. To be used together with -sourcepath option.")
   val YdetailedStats: Setting[Boolean] = BooleanSetting(ForkSetting, "Ydetailed-stats", "Show detailed internal compiler stats (needs Stats.enabled to be set to true).")
   val YprintPos: Setting[Boolean] = BooleanSetting(ForkSetting, "Yprint-pos", "Show tree positions.")
   val YprintPosSyms: Setting[Boolean] = BooleanSetting(ForkSetting, "Yprint-pos-syms", "Show symbol definitions positions.")

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -530,7 +530,7 @@ private sealed trait YSettings:
   val YstopAfter: Setting[List[String]] = PhasesSetting(ForkSetting, "Ystop-after", "Stop after", aliases = List("-stop")) // backward compat
   val YstopBefore: Setting[List[String]] = PhasesSetting(ForkSetting, "Ystop-before", "Stop before") // stop before erasure as long as we have not debugged it fully
   val YshowSuppressedErrors: Setting[Boolean] = BooleanSetting(ForkSetting, "Yshow-suppressed-errors", "Also show follow-on errors and warnings that are normally suppressed.")
-  val YlogicalPackageLoading: Setting[Boolean] = BooleanSetting(ForkSetting, "YlogicalPackageLoading", "Enable logical package loading. This will load the logical package structure by preparsing the source files to discover the package structure. To be used together with -sourcepath option.")
+  val YlogicalPackageLoading: Setting[Boolean] = BooleanSetting(ForkSetting, "Ylogical-package-loading", "Enable logical package loading. This will load the logical package structure by preparsing the source files to discover the package structure. To be used together with -sourcepath option.")
   val YdetailedStats: Setting[Boolean] = BooleanSetting(ForkSetting, "Ydetailed-stats", "Show detailed internal compiler stats (needs Stats.enabled to be set to true).")
   val YprintPos: Setting[Boolean] = BooleanSetting(ForkSetting, "Yprint-pos", "Show tree positions.")
   val YprintPosSyms: Setting[Boolean] = BooleanSetting(ForkSetting, "Yprint-pos-syms", "Show symbol definitions positions.")

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalPackage.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalPackage.scala
@@ -16,7 +16,7 @@ trait LogicalPackage {
    * Return all sources contained by this package. Only direct members are returned, and there are no duplicates.
    *
    */
-  def sources: Seq[String]
+  def sources: Seq[AbstractFile]
 
   def getPackage(name: String): Option[LogicalPackage]
 
@@ -33,7 +33,7 @@ trait LogicalPackage {
     packages.sortBy(_.name).foreach(_.prettyPrintWith(indent + 4, sb))
     sources.foreach { s =>
       sb ++= (" " * (indent + 4))
-      sb ++= Option(AbstractFile.getFile(s)).map(_.name).getOrElse(s) + "\n"
+      sb ++= s.name + "\n"
     }
     sb
 

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalPackage.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalPackage.scala
@@ -1,0 +1,40 @@
+package dotty.tools.dotc.interactive
+
+import dotty.tools.io.AbstractFile
+
+/**
+ * A logical package representation. This is disconnected from the file system, and faithfully
+ * represents the nesting of packages and sources that contribute classes to those packages.
+ */
+trait LogicalPackage {
+
+  def name: String
+
+  def packages: Seq[LogicalPackage]
+
+  /**
+   * Return all sources contained by this package. Only direct members are returned, and there are no duplicates.
+   *
+   */
+  def sources: Seq[String]
+
+  def getPackage(name: String): Option[LogicalPackage]
+
+  def prettyPrint(): String = {
+    prettyPrintWith().toString().stripTrailing().stripIndent()
+  }
+
+  private def prettyPrintWith(
+      indent: Int = 0,
+      sb: StringBuilder = new StringBuilder
+  ): StringBuilder =
+    sb ++= " " * indent
+    sb ++= s"$name\n"
+    packages.sortBy(_.name).foreach(_.prettyPrintWith(indent + 4, sb))
+    sources.foreach { s =>
+      sb ++= (" " * (indent + 4))
+      sb ++= Option(AbstractFile.getFile(s)).map(_.name).getOrElse(s) + "\n"
+    }
+    sb
+
+}

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
@@ -1,0 +1,166 @@
+package dotty.tools.dotc.interactive
+
+import dotty.tools.dotc.ast.untpd
+import dotty.tools.dotc.core.Contexts.*
+import dotty.tools.dotc.core.StdNames.nme
+import dotty.tools.dotc.parsing.JavaParsers
+import dotty.tools.dotc.parsing.Parsers
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.io.AbstractFile
+import dotty.tools.io.ClassPath
+import dotty.tools.io.FileExtension
+import dotty.tools.io.Path
+
+import java.io.File
+import scala.collection.mutable
+import scala.language.unsafeNulls
+import scala.util.control.NonFatal
+
+/**
+ * A compiler component that adds support for parsing Scala and Java source files and finding out
+ * the logical package structure of the whole source path.
+ */
+class LogicalPackagesProvider(sourcePath: String)(using Context){
+
+  private lazy val sourceRoots: Seq[SourceFile] =
+    allSources(sourcePath).map(f => SourceFile(f, f.toCharArray))
+
+  lazy val root: LogicalPackage = parseSourcePath()
+
+  /**
+   * Parse all source files in the sourcepath and build the logical package structure.
+   */
+  def parseSourcePath(): LogicalPackage =
+    val pkg: ParsedLogicalPackage = newPackage()
+    for sourceFile <- sourceRoots do
+      try
+        parseSourceFile(sourceFile, pkg)
+      catch
+        case NonFatal(e) =>
+          // Silently ignore parsing errors
+    pkg
+
+  private def newPackage(): ParsedLogicalPackage =
+    new ParsedLogicalPackage("", None)
+
+  private def parseSourceFile(
+      sourceFile: SourceFile,
+      rootPackage: ParsedLogicalPackage
+  ): Unit =
+    val fileName = sourceFile.path
+    if fileName.endsWith(".scala") then
+      parseScalaSourceFile(sourceFile, fileName, rootPackage)
+    else if fileName.endsWith(".java") then
+      parseJavaSourceFile(sourceFile, fileName, rootPackage)
+
+  private def parseScalaSourceFile(
+      sourceFile: SourceFile,
+      fileName: String,
+      rootPackage: ParsedLogicalPackage
+  ): Unit =
+    try
+      // Use OutlineParser for fast parsing that skips method bodies
+      val parser = new Parsers.OutlineParser(sourceFile)
+      val tree = parser.parse()
+      val traverser = new SourceFileTraverser(fileName, rootPackage)
+      traverser.traverse(tree)
+    catch
+      case NonFatal(e) =>
+        // Silently ignore parsing errors
+
+  private def parseJavaSourceFile(
+      sourceFile: SourceFile,
+      fileName: String,
+      rootPackage: ParsedLogicalPackage
+  ): Unit =
+    try
+      // Use OutlineJavaParser for fast parsing
+      val parser = new JavaParsers.OutlineJavaParser(sourceFile)
+      val tree = parser.parse()
+
+      // Traverse the tree to extract package info
+      val traverser = new SourceFileTraverser(fileName, rootPackage)
+      traverser.traverse(tree)
+    catch
+      case NonFatal(e) =>
+        // Silently ignore parsing errors
+
+  /**
+   * Traverse an untyped AST to extract package and class definitions.
+   */
+  private class SourceFileTraverser(
+      fileName: String,
+      rootPackage: ParsedLogicalPackage
+  ) {
+    private var currentPackage = rootPackage
+
+    def traverse(tree: untpd.Tree): Unit = tree match
+      case untpd.Thicket(trees) =>
+        trees.foreach(traverse)
+      case pkg: untpd.PackageDef =>
+        traversePackageDef(pkg)
+      case _: untpd.MemberDef =>
+        // Top-level class or object in default package
+        currentPackage.enterSource(fileName)
+      case _ =>
+
+    private def traversePackageDef(pkg: untpd.PackageDef): Unit = {
+      // Navigate to the package
+      val pkgName = packageNameFromTree(pkg.pid)
+      val newCurrentPackage = {
+        var current = currentPackage
+        for (part <- pkgName.split('.') if part.nonEmpty) {
+          current = current.enterPackage(part)
+        }
+        current
+      }
+      // Traverse nested definitions
+      val oldPackage = currentPackage
+      currentPackage = newCurrentPackage
+      pkg.stats.foreach(traverse)
+      currentPackage = oldPackage
+    }
+
+    private def packageNameFromTree(tree: untpd.Tree): String = tree match {
+      case untpd.Ident(name) =>
+        if (name == nme.ROOT || name == nme.EMPTY_PACKAGE || name == nme.EMPTY) ""
+        else name.toString
+      case untpd.Select(qual, name) =>
+        val qualName = packageNameFromTree(qual)
+        if (qualName.isEmpty) name.toString
+        else s"$qualName.${name.toString}"
+      case _ =>
+        ""
+    }
+  }
+
+  /**
+   * Return all Scala and Java sources from the given sourcepath string.
+   */
+  private def allSources(srcPath: String): Seq[AbstractFile] = {
+    val entries =  ClassPath.split(srcPath).map(Path(_))
+    def isRelevantFile(path: Path) =
+      path.ext == FileExtension.Scala || path.ext == FileExtension.Java
+    // avoid using IO operation, assume standard extensions, Metals sends files so no sense chaking for directories eagerly
+    val rootDirs = entries.filter(f => !isRelevantFile(f))
+    val rootFiles = for {
+      e <- entries
+      if isRelevantFile(e)
+      f <- Option(AbstractFile.getFile(e))
+    } yield f
+    rootFiles ++ rootDirs.flatMap(dir => sourcesIn(AbstractFile.getDirectory(dir), "scala", "java"))
+  }
+
+  /**
+   * Recursively find all source files with given extensions in a directory.
+   */
+  private def sourcesIn(
+      dir: AbstractFile,
+      extensions: String*
+  ): Seq[AbstractFile] =
+    dir.iterator.toSeq.flatMap { file =>
+      if (file.isDirectory) sourcesIn(file, extensions*)
+      else if (extensions.exists(ext => file.name.endsWith(s".$ext"))) Seq(file)
+      else Seq.empty[AbstractFile]
+    }
+}

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
@@ -138,10 +138,10 @@ class LogicalPackagesProvider(sourcePath: String)(using Context){
    * Return all Scala and Java sources from the given sourcepath string.
    */
   private def allSources(srcPath: String): Seq[AbstractFile] = {
-    val entries =  ClassPath.split(srcPath).map(Path(_))
+    val entries = ClassPath.split(srcPath).map(Path(_))
     def isRelevantFile(path: Path) =
       path.ext == FileExtension.Scala || path.ext == FileExtension.Java
-    // avoid using IO operation, assume standard extensions, Metals sends files so no sense chaking for directories eagerly
+    // avoid using IO operation, assume standard extensions, Metals sends files so no sense checking for directories eagerly
     val rootDirs = entries.filter(f => !isRelevantFile(f))
     val rootFiles = for {
       e <- entries

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -1,0 +1,79 @@
+package dotty.tools.dotc.interactive
+
+import dotty.tools.dotc.classpath.BinaryFileEntry
+import dotty.tools.dotc.classpath.ClassPathEntries
+import dotty.tools.dotc.classpath.PackageEntry
+import dotty.tools.dotc.classpath.PackageEntryImpl
+import dotty.tools.dotc.classpath.PackageName
+import dotty.tools.dotc.classpath.SourceFileEntry
+import dotty.tools.io.AbstractFile
+import dotty.tools.io.ClassPath
+
+import java.io.File
+import java.net.URL
+import java.nio.file.Path
+import scala.collection.mutable
+
+/**
+ * A ClassPath implementation that can find sources regardless of the directory where they're declared.
+ */
+class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
+    extends ClassPath {
+
+  override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = None
+  override def findClassFile(className: String): Option[AbstractFile] = None
+  override def classes(inPackage: PackageName): Seq[BinaryFileEntry] = Seq.empty
+
+  override def hasPackage(inPackage: PackageName): Boolean = findPackage(
+    inPackage.dottedString
+  ).isDefined
+
+  /** Return all packages contained inside `inPackage`. Package entries contain the *full name* of the package. */
+  override def packages(inPackage: PackageName): Seq[PackageEntry] =
+    val rawPackage = inPackage.dottedString
+    findPackage(rawPackage) match
+      case Some(pkg) => packagesIn(pkg, rawPackage)
+      case None => Seq.empty[PackageEntry]
+
+
+  /** Return all sources contained directly inside `inPackage` */
+  override def sources(inPackage: PackageName): Seq[SourceFileEntry] =
+    val rawPackage = inPackage.dottedString
+    findPackage(rawPackage) match
+      case Some(pkg) =>
+        sourcesIn(pkg)
+      case None => Seq.empty[SourceFileEntry]
+
+  private def sourcesIn(pkg: LogicalPackage) =
+    pkg.sources.map(p => SourceFileEntry(AbstractFile.getFile(p)))
+
+  private def packagesIn(pkg: LogicalPackage, prefix: String) =
+    val pre = if (prefix.isEmpty) prefix else s"$prefix."
+    pkg.packages.map(p => PackageEntryImpl(pre + p.name))
+
+  override def list(inPackage: PackageName): ClassPathEntries =
+    val rawPackage = inPackage.dottedString
+    val res = findPackage(rawPackage) match
+      case Some(pkg) =>
+        ClassPathEntries(packagesIn(pkg, rawPackage), sourcesIn(pkg))
+      case None => ClassPathEntries(Seq(), Seq())
+    res
+
+  override def asURLs: Seq[URL] = sourcepath.split(File.pathSeparator).toIndexedSeq.map(new File(_)).map(_.toURI.toURL)
+
+  override def asClassPathStrings: Seq[String] = Seq()
+
+  override def asSourcePathString: String = sourcepath
+
+  /** Return the package for the given fullName, if any */
+  private def findPackage(fullName: String): Option[LogicalPackage] =
+    if fullName == "" then Option(rootPackage)
+    else
+      fullName.split('.').foldLeft(Option(rootPackage)) { (pkg, name) =>
+        pkg.flatMap(_.getPackage(name))
+      }
+
+  override def toString: String = rootPackage.prettyPrint()
+
+}
+

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -12,7 +12,6 @@ import dotty.tools.io.ClassPath
 import java.io.File
 import java.net.URL
 import java.nio.file.Path
-import scala.collection.mutable
 
 /**
  * A ClassPath implementation that can find sources regardless of the directory where they're declared.
@@ -45,7 +44,7 @@ class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
       case None => Seq.empty[SourceFileEntry]
 
   private def sourcesIn(pkg: LogicalPackage) =
-    pkg.sources.map(p => SourceFileEntry(AbstractFile.getFile(p)))
+    pkg.sources.map(p => SourceFileEntry(p))
 
   private def packagesIn(pkg: LogicalPackage, prefix: String) =
     val pre = if (prefix.isEmpty) prefix else s"$prefix."

--- a/compiler/src/dotty/tools/dotc/interactive/ParsedLogicalPackage.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/ParsedLogicalPackage.scala
@@ -1,0 +1,72 @@
+package dotty.tools.dotc.interactive
+
+import scala.collection.mutable
+
+/**
+ * Represent a package and its contents in a way that's close to the file system.
+ *
+ * A package contains any number of nested packages and source files. It is mutable in order to allow adding
+ * members at any level, as they are discovered by parsing source files.
+ *
+ * @param name simple name of the package
+ * @note This class is not thread safe
+ */
+class ParsedLogicalPackage(
+    val name: String,
+    val parent: Option[ParsedLogicalPackage]
+) extends LogicalPackage {
+  require(
+    (name.trim.isEmpty && parent.isEmpty) || (name.trim.nonEmpty && parent.nonEmpty),
+    s"Unexpected package name `$name` and parent `$parent`."
+  )
+
+  def this(name: String, parent: ParsedLogicalPackage) =
+    this(name, Some(parent))
+
+  private val subpackages =
+    mutable.LinkedHashMap.empty[String, ParsedLogicalPackage]
+  private val directSources = mutable.ListBuffer.empty[String]
+
+  def fullName: String =
+    if (parent.isEmpty || parent.get.name.isEmpty) name
+    else s"${parent.get.fullName}.$name"
+
+  def removeEmptyPackages(): Unit =
+    subpackages.values.foreach(_.removeEmptyPackages())
+    if subpackages.isEmpty && directSources.isEmpty then
+      parent.foreach(_.subpackages.remove(name))
+
+
+  /**
+   * Return the existing member package, or create a new one and add it to this package.
+   */
+  def enterPackage(name: String): ParsedLogicalPackage = synchronized{
+    subpackages.get(name) match {
+      case Some(p) => p
+      case None =>
+        val p = new ParsedLogicalPackage(name, this)
+        subpackages(name) = p
+        p
+    }
+  }
+
+  def getPackage(name: String): Option[ParsedLogicalPackage] =
+    subpackages.get(name)
+
+  def enterSource(fileName: String): this.type = synchronized:
+    directSources += fileName
+    this
+
+  /** Return all member packages. Only direct members are returned. */
+  def packages: Seq[ParsedLogicalPackage] = subpackages.values.toList
+
+  /**
+   * Return all sources contained by this package. Only direct members are returned, and there are no duplicates.
+   *
+   * The return type is a sequence and not a Set in order to have deterministic runs
+   */
+  def sources: Seq[String] = directSources.toSeq.distinct
+
+  override def toString(): String =
+    s"package $name(${packages.size} packages and ${sources.size} files)"
+}

--- a/compiler/src/dotty/tools/dotc/interactive/ParsedLogicalPackage.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/ParsedLogicalPackage.scala
@@ -1,6 +1,7 @@
 package dotty.tools.dotc.interactive
 
 import scala.collection.mutable
+import dotty.tools.io.AbstractFile
 
 /**
  * Represent a package and its contents in a way that's close to the file system.
@@ -65,7 +66,7 @@ class ParsedLogicalPackage(
    *
    * The return type is a sequence and not a Set in order to have deterministic runs
    */
-  def sources: Seq[String] = directSources.toSeq.distinct
+  def sources: Seq[AbstractFile] = directSources.toSeq.distinct.flatMap(name => Option(AbstractFile.getFile(name)))
 
   override def toString(): String =
     s"package $name(${packages.size} packages and ${sources.size} files)"

--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -1,6 +1,7 @@
 package dotty.tools.pc
 
 import java.nio.file.Paths
+import java.util.Optional
 
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -108,7 +109,8 @@ final class AutoImportsProvider(
         yield (
           AutoImportsResultImpl(
             sym.owner.showFullName,
-            edits.asJava
+            edits.asJava,
+            Optional.of(SemanticdbSymbols.symbolName(sym))
           ),
           sym
         )

--- a/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
@@ -77,7 +77,7 @@ case class RawScalaPresentationCompiler(
     val classpathFlags = List("-classpath", classpath.mkString(File.pathSeparator))
     val sourcePathFiles = sourcePath.get().asScala
     val sourcePathFlags = if sourcePathFiles.size > 0 && config.sourcePathMode() != SourcePathMode.DISABLED then
-      List("-YlogicalPackageLoading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
+      List("-Ylogical-package-loading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
     else Nil
     filteredOptions ++
       defaultFlags ++

--- a/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
@@ -46,7 +46,9 @@ case class RawScalaPresentationCompiler(
     folderPath: Option[Path] = None,
     reportsLevel: ReportLevel = ReportLevel.Info,
     completionItemPriority: CompletionItemPriority = (_: String) => 0,
-    reportContext: ReportContext = EmptyReportContext()
+    reportContext: ReportContext = EmptyReportContext(),
+    sourcePath: ju.function.Supplier[ju.List[Path]] = () => Nil.asJava,
+    semanticdbFileManager: SemanticdbFileManager = SemanticdbFileManager.EMPTY
 ) extends RawPresentationCompiler:
 
   def this() = this("uninitialized-presentation-compiler")
@@ -68,13 +70,20 @@ case class RawScalaPresentationCompiler(
   private val forbiddenOptions = Set("-print-tasty")
   private val forbiddenDoubleOptions = Set.empty[String]
 
-  val driverSettings =
+  val driverSettings: List[String] =
     val implicitSuggestionTimeout = List("-Ximport-suggestion-timeout", "0")
     val defaultFlags = List("-color:never")
     val filteredOptions = removeDoubleOptions(options.filterNot(forbiddenOptions))
-
-    filteredOptions ::: defaultFlags ::: implicitSuggestionTimeout ::: "-classpath" :: classpath
-      .mkString(File.pathSeparator) :: Nil
+    val classpathFlags = List("-classpath", classpath.mkString(File.pathSeparator))
+    val sourcePathFiles = sourcePath.get().asScala
+    val sourcePathFlags = if sourcePathFiles.size > 0 && config.sourcePathMode() != SourcePathMode.DISABLED then
+      List("-YlogicalPackageLoading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
+    else Nil
+    filteredOptions ++
+      defaultFlags ++
+      implicitSuggestionTimeout ++
+      classpathFlags ++
+      sourcePathFlags
 
   lazy val driver: InteractiveDriver = CachingDriver(driverSettings)
 
@@ -305,6 +314,20 @@ case class RawScalaPresentationCompiler(
   override def newInstance(
       buildTargetIdentifier: String,
       classpath: ju.List[Path],
+      options: ju.List[String],
+      sourcePath: ju.function.Supplier[ju.List[Path]]
+  ): RawPresentationCompiler = {
+    copy(
+      buildTargetIdentifier = buildTargetIdentifier,
+      classpath = classpath.asScala.toSeq,
+      options = options.asScala.toList,
+      sourcePath = sourcePath
+    )
+  }
+
+  override def newInstance(
+      buildTargetIdentifier: String,
+      classpath: ju.List[Path],
       options: ju.List[String]
   ): RawPresentationCompiler =
     copy(
@@ -340,5 +363,10 @@ case class RawScalaPresentationCompiler(
 
   override def withWorkspace(workspace: Path): RawPresentationCompiler =
     copy(folderPath = Some(workspace))
+
+  override def withSemanticdbFileManager(
+      semanticdbFileManager: SemanticdbFileManager
+  ): RawPresentationCompiler =
+    copy(semanticdbFileManager = semanticdbFileManager)
 
 end RawScalaPresentationCompiler

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -2,6 +2,7 @@ package dotty.tools.pc
 
 import java.io.File
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
@@ -52,7 +53,9 @@ case class ScalaPresentationCompiler(
     folderPath: Option[Path] = None,
     reportsLevel: ReportLevel = ReportLevel.Info,
     completionItemPriority: CompletionItemPriority = (_: String) => 0,
-    reportContext: ReportContext = EmptyReportContext()
+    reportContext: ReportContext = EmptyReportContext(),
+    sourcePath: ju.function.Supplier[ju.List[Path]] = () => Nil.asJava,
+    semanticdbFileManager: SemanticdbFileManager = SemanticdbFileManager.EMPTY
 ) extends PresentationCompiler:
 
   given ReportContext = reportContext
@@ -122,6 +125,11 @@ case class ScalaPresentationCompiler(
   override def withReportsLoggerLevel(level: String): PresentationCompiler =
     copy(reportsLevel = ReportLevel.fromString(level))
 
+  override def withSemanticdbFileManager(
+      semanticdbFileManager: SemanticdbFileManager
+  ): PresentationCompiler =
+    copy(semanticdbFileManager = semanticdbFileManager)
+
   val compilerAccess: CompilerAccess[StoreReporter, InteractiveDriver] =
     Scala3CompilerAccess(
       config,
@@ -129,13 +137,20 @@ case class ScalaPresentationCompiler(
       () => new Scala3CompilerWrapper(CachingDriver(driverSettings))
     )(using ec)
 
-  val driverSettings =
+  val driverSettings: List[String] =
     val implicitSuggestionTimeout = List("-Ximport-suggestion-timeout", "0")
     val defaultFlags = List("-color:never")
     val filteredOptions = removeDoubleOptions(options.filterNot(forbiddenOptions))
-
-    filteredOptions ::: defaultFlags ::: implicitSuggestionTimeout ::: "-classpath" :: classpath
-      .mkString(File.pathSeparator) :: Nil
+    val classpathFlags = List("-classpath", classpath.mkString(File.pathSeparator))
+    val sourcePathFiles = sourcePath.get().asScala
+    val sourcePathFlags = if sourcePathFiles.size > 0 && config.sourcePathMode() != SourcePathMode.DISABLED then
+      List("-YlogicalPackageLoading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
+    else Nil
+    filteredOptions ++
+      defaultFlags ++
+      implicitSuggestionTimeout ++
+      classpathFlags ++
+      sourcePathFlags
 
   private def removeDoubleOptions(options: List[String]): List[String] =
     options match
@@ -469,7 +484,21 @@ case class ScalaPresentationCompiler(
       PcRenameProvider(driver, params, Some(name)).rename().asJava
     }(params.toQueryContext)
 
-  def newInstance(
+  override def newInstance(
+      buildTargetIdentifier: String,
+      classpath: ju.List[Path],
+      options: ju.List[String],
+      sourcePath: ju.function.Supplier[ju.List[Path]]
+  ): PresentationCompiler = {
+    copy(
+      buildTargetIdentifier = buildTargetIdentifier,
+      classpath = classpath.asScala.toSeq,
+      options = options.asScala.toList,
+      sourcePath = sourcePath
+    )
+  }
+
+  override def newInstance(
       buildTargetIdentifier: String,
       classpath: ju.List[Path],
       options: ju.List[String]

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -2,7 +2,6 @@ package dotty.tools.pc
 
 import java.io.File
 import java.net.URI
-import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
@@ -144,7 +143,7 @@ case class ScalaPresentationCompiler(
     val classpathFlags = List("-classpath", classpath.mkString(File.pathSeparator))
     val sourcePathFiles = sourcePath.get().asScala
     val sourcePathFlags = if sourcePathFiles.size > 0 && config.sourcePathMode() != SourcePathMode.DISABLED then
-      List("-YlogicalPackageLoading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
+      List("-Ylogical-package-loading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
     else Nil
     filteredOptions ++
       defaultFlags ++

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseDiagnosticsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseDiagnosticsSuite.scala
@@ -36,6 +36,13 @@ class BaseDiagnosticsSuite extends PcAssertions:
     override def shouldReturnDiagnostics: Boolean = true
     override def token: CancelToken = EmptyCancelToken
 
+  def diagnosticMessageAsString(d: Diagnostic): String = {
+    val msg = d.getMessage()
+    if msg == null then ""
+    else if msg.isLeft then msg.getLeft
+    else msg.getRight.getValue
+  }
+
   def check(
       text: String,
       expected: List[TestDiagnostic],
@@ -51,7 +58,7 @@ class BaseDiagnosticsSuite extends PcAssertions:
       TestDiagnostic(
         d.getRange().getStart().getOffset(text),
         d.getRange().getEnd().getOffset(text),
-        d.getMessage(),
+        diagnosticMessageAsString(d),
         d.getSeverity()
       )
     )

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -40,6 +40,7 @@ abstract class BasePCSuite extends PcAssertions:
   val testingWorkspaceSearch = TestingWorkspaceSearch(
     TestResources.classpath.map(_.toString)
   )
+  protected val sourcePath: Seq[Path] = Nil
 
   lazy val presentationCompiler: PresentationCompiler =
     val myclasspath: Seq[Path] = TestResources.classpath ++ additionalClasspath
@@ -49,14 +50,13 @@ abstract class BasePCSuite extends PcAssertions:
       TestResources.classpathSearch,
       mockEntries
     )
-
     new ScalaPresentationCompiler()
       .withConfiguration(config)
       .withExecutorService(executorService)
       .withScheduledExecutorService(executorService)
       .withSearch(search)
       .withCompletionItemPriority(completionItemPriority)
-      .newInstance("", myclasspath.asJava, scalacOpts.asJava)
+      .newInstance("", myclasspath.asJava, scalacOpts.asJava, () => sourcePath.asJava)
 
   protected def config: PresentationCompilerConfigImpl =
     PresentationCompilerConfigImpl().copy(snippetAutoIndent = false, timeoutDelay = if isDebug then 3600 else 10)

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSourcepathSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSourcepathSuite.scala
@@ -1,0 +1,108 @@
+package dotty.tools.pc.tests.completion
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.collection.immutable
+import scala.language.unsafeNulls
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.SourcePathMode
+
+import dotty.tools.pc.base.BaseCompletionSuite
+
+import org.junit.Test
+
+class CompletionSourcepathSuite extends BaseCompletionSuite:
+  private val sourcepathDir: Path = Files.createDirectories(tmp.resolve("sourcepath"))
+  private val singleSourcepathDir: Path = Files.createDirectories(tmp.resolve("sourcepath2"))
+  private val singleSourcepathFile = singleSourcepathDir.resolve("Gamma.scala")
+
+  locally:
+    val pkg1Dir = Files.createDirectories(sourcepathDir.resolve("pkg1"))
+    Files.write(
+      pkg1Dir.resolve("Alpha.scala"),
+      """|package pkg1
+         |
+         |class Alpha:
+         |  def greetAlpha: String = ""
+         |  val countAlpha: Int = 0
+         |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+    )
+    val pkg2Dir = Files.createDirectories(sourcepathDir.resolve("pkg2"))
+    Files.write(
+      pkg2Dir.resolve("Beta.scala"),
+      """|package pkg2.pkg3.pkg4
+         |
+         |object Beta:
+         |  def greetBeta(name: String): String = s"Hello $name"
+         |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+    )
+    val pkg3Dir = Files.createDirectories(sourcepathDir.resolve("pkg3"))
+    Files.write(
+      pkg3Dir.resolve("toplevel.scala"),
+      """|package pkg3
+         |
+         |def greetFromToplevel(name: String): String = s"Hello $name"
+         |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+    )
+    Files.write(
+      singleSourcepathFile,
+      """|package pkg1
+         |package pkg2
+         |
+         |class Gamma:
+         |  def greetGamma: String = ""
+         |  val countAlpha: Int = 0
+         |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+    )
+
+  override protected def config: PresentationCompilerConfigImpl =
+    super.config.copy(sourcePathMode = SourcePathMode.FULL)
+  override protected val sourcePath: Seq[Path] = Seq(sourcepathDir, singleSourcepathFile)
+
+  override protected def scalacOptions(classpath: Seq[Path]): Seq[String] =
+    Seq("-YlogicalPackageLoading")
+
+  @Test def `class-from-sourcepath` =
+    check(
+      """|import pkg1.Alpha
+         |object Main:
+         |  val a = new Alpha
+         |  a.greetA@@
+         |""".stripMargin,
+      """|greetAlpha: String
+         |""".stripMargin
+    )
+
+  @Test def `object-from-different-package-in-sourcepath` =
+    check(
+      """|import pkg2.pkg3.pkg4.Beta
+         |object Main:
+         |  Beta.greetB@@
+         |""".stripMargin,
+      """|greetBeta(name: String): String
+         |""".stripMargin
+    )
+
+  @Test def `object-from-sourcefile` =
+    check(
+      """|import pkg1.pkg2.Gamma
+         |
+         |object ObjectFromSourceFile:
+         |  val gamma = new Gamma
+         |  gamma.greet@@
+         |""".stripMargin,
+      """|greetGamma: String
+         |""".stripMargin
+    )
+
+  @Test def `toplevel-from-sourcepath` =
+    check(
+      """|import pkg3.greetFromToplevel
+         |object Main:
+         |  greetFromToplevel@@
+         |""".stripMargin,
+      """|greetFromToplevel(name: String): String
+         |""".stripMargin
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSourcepathSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSourcepathSuite.scala
@@ -62,7 +62,7 @@ class CompletionSourcepathSuite extends BaseCompletionSuite:
   override protected val sourcePath: Seq[Path] = Seq(sourcepathDir, singleSourcepathFile)
 
   override protected def scalacOptions(classpath: Seq[Path]): Seq[String] =
-    Seq("-YlogicalPackageLoading")
+    Seq("-Ylogical-package-loading")
 
   @Test def `class-from-sourcepath` =
     check(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1227,7 +1227,6 @@ object Build {
       Compile / resourceGenerators += generateLibraryProperties.taskValue,
       bspEnabled := enableBspAllProjects,
       Compile / mainClass := None,
-
       Test / unmanagedSourceDirectories   := Seq(baseDirectory.value / "test"),
       Test / unmanagedResourceDirectories := Seq(baseDirectory.value / "test-resources"),
       libraryDependencies ++= Seq(
@@ -2125,7 +2124,7 @@ object Build {
       BuildInfoPlugin.buildInfoDefaultSettings
 
   lazy val presentationCompilerSettings = {
-    val mtagsVersion = "1.6.3"
+    val mtagsVersion = "1.6.7"
     Seq(
       libraryDependencies ++= Seq(
         "org.lz4" % "lz4-java" % "1.8.0",


### PR DESCRIPTION
The idea is that not all files follow the directory structure, which would make the current directory parsing (probably) inefficient. By creating the full package structure we also make sure that only relevant files are always loaded and no recalculation is needed.

I might be totally wrong here, so would love some feedback if it's even necessary. I've put it behind a flag just in case.

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->
 
## How much have your relied on LLM-based tools in this contribution?

Moderately -> LLM helped rewrite the code from the Scala 2 implementation.

## How was the solution tested?

Automatic test added to the presentation compiler tests

## Additional notes

I started porting changes that Julian Dragos did in Metals v2 and I realized that Scala 3 compiler is already quite efficient with loading symbols from source path, so I ported the other change used for determining package structure to use it efficiently in loading correct files from the source path


<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->


**EDIT** I also added the actual handling of sourcepath from Metals and run benchmarks on it.