### PR TITLE
Skip test of legacy compiler if not JDK 17

### DIFF
--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -28,10 +28,13 @@ i20053b.scala
 i2146.scala
 i23179.scala
 i23489.scala
+i25460.scala
 i5039.scala
 i8623.scala
 i8900a3.scala
 i9228.scala
+lazyVals_c3.0.0.scala
+lazyVals_c3.1.0.scala
 minicheck.scala
 minicheck-toplevel.scala
 mt-scrutinee-widen3.scala
@@ -41,4 +44,3 @@ skolems2.scala
 spurious-overload.scala
 tailrec.scala
 traitParams.scala
-i25460.scala

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -228,20 +228,23 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
   }
   object SeparateCompilationSource:
     val CompilerVersion = """c([\d\.]+)""".r
+    val HasCompilerVersion = """_c([\d\.]+)""".r.unanchored
     val GroupOrdinal = """(\d+)""".r
-    val usingCanonicalJava = javaSpecVersion.startsWith("17")
 
   /** Skip if there are no sources, such as in a spurious directory,
    *  or when compiling with a legacy compiler which may not run under this jdk.
    */
   protected def shouldSkipTestSource(testSource: TestSource): Boolean =
-    testSource.sourceFiles.length == 0
+    val files = testSource.sourceFiles
+    files.length == 0
     ||
-    testSource.match
-      case separate: SeparateCompilationSource =>
-        !SeparateCompilationSource.usingCanonicalJava
-        && separate.compilationGroups.exists((group, _) => group.compiler.nonEmpty)
-      case _ => false
+      !TestConfiguration.usingBaselineJava
+      &&
+      testSource.match
+        case separate: SeparateCompilationSource =>
+          separate.compilationGroups.exists((group, _) => group.compiler.nonEmpty)
+        case _ =>
+          files.exists(f => SeparateCompilationSource.HasCompilerVersion.matches(f.getName))
 
   protected def shouldReRun(testSource: TestSource): Boolean =
     failedTests.forall(rerun => testSource match {
@@ -262,7 +265,15 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       Try(testSource match {
         case testSource @ JointCompilationSource(name, files, flags, outDir, fromTasty, decompilation) =>
           val reporter = fromTasty match
-            case NotFromTasty => compile(testSource.sourceFiles, flags, outDir)
+            case NotFromTasty =>
+              if testSource.sourceFiles.length == 1 then
+                testSource.sourceFiles(0).getName match
+                  case SeparateCompilationSource.HasCompilerVersion(version) =>
+                    val compiler = version.stripSuffix(".")
+                    compileWithOtherCompiler(compiler, testSource.sourceFiles, flags, outDir)
+                  case _ => compile(testSource.sourceFiles, flags, outDir)
+              else
+                compile(testSource.sourceFiles, flags, outDir)
             case FromTasty => compileFromTasty(flags, outDir)
             case FromBestEffortTasty => compileFromBestEffortTasty(flags, outDir)
             case WithBestEffortTasty(bestEffortDir) => compileWithBestEffortTasty(testSource.sourceFiles, bestEffortDir, flags, outDir)
@@ -645,7 +656,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
         case Nil => Nil
       flags.copy(options = loop(flags.options.toList).toArray)
 
-    protected def compileWithOtherCompiler(compiler: String, files: Array[JFile], flags: TestFlags, targetDir: JFile): TestReporter =
+    protected def compileWithOtherCompiler(compiler: String, files: Array[JFile], flags: TestFlags, targetDir: JFile): TestReporter = {
       def artifactClasspath(organizationName: String, moduleName: String) =
         import coursier.*
         val dep = Dependency(
@@ -705,6 +716,8 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
         }
 
       reporter
+    }
+    end compileWithOtherCompiler
 
     protected def compileFromBestEffortTasty(flags0: TestFlags, targetDir: JFile): TestReporter = {
       val classes = flattenFiles(targetDir).filter(isBestEffortTastyFile).map(_.toString)
@@ -1572,8 +1585,14 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       !isPicklerTest || source.compilationGroups.length == 1
     }
     val targets =
-      files.map(f => JointCompilationSource(testGroup.name, Array(f), flags, createOutputDirsForFile(f, sourceDir, outDir))) ++
-      dirs.map { dir => SeparateCompilationSource(testGroup.name, dir, flags, createOutputDirsForDir(dir, sourceDir, outDir)) }.filter(picklerDirFilter)
+      files.map: f =>
+        val out = createOutputDirsForFile(f, sourceDir, outDir)
+        JointCompilationSource(testGroup.name, Array(f), flags, out)
+      ++
+      dirs.map: dir =>
+        val out = createOutputDirsForDir(dir, sourceDir, outDir)
+        SeparateCompilationSource(testGroup.name, dir, flags, out)
+      .filter(picklerDirFilter)
 
     // Create a CompilationTest and let the user decide whether to execute a pos or a neg test
     new CompilationTest(targets)

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -16,7 +16,9 @@ import scala.collection.mutable, mutable.ArrayBuffer, mutable.ListBuffer
 import scala.io.{Codec, Source}
 import scala.jdk.CollectionConverters.*
 import scala.util.{Random, Try, Using}
-import scala.collection.mutable.ListBuffer
+import scala.util.control.NonFatal
+import scala.util.matching.Regex
+import scala.util.Properties.{isJavaAtLeast, javaSpecVersion}
 
 import dotc.{Compiler, Driver}
 import dotty.tools.dotc.CoverageSupport
@@ -27,6 +29,7 @@ import dotc.reporting.{Reporter, TestReporter}
 import dotc.reporting.Diagnostic
 import dotc.util.{SourceFile, SourcePosition, Spans, NoSourcePosition}
 import io.AbstractFile
+import util.chaining.*
 
 /** A parallel testing suite whose goal is to integrate nicely with JUnit
  *
@@ -199,16 +202,15 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
     flags: TestFlags,
     outDir: JFile
   )(using val group: TestGroup) extends TestSource {
+    import SeparateCompilationSource.*
     case class Group(ordinal: Int, compiler: String)
 
-    lazy val compilationGroups: List[(Group, Array[JFile])] =
-      val Compiler = """c([\d\.]+)""".r
-      val Ordinal = """(\d+)""".r
+    lazy val compilationGroups: List[(Group, Array[JFile])] = {
       def groupFor(file: JFile): Group =
         val groupSuffix = file.getName.dropWhile(_ != '_').stripSuffix(".scala").stripSuffix(".java")
         val groupSuffixParts = groupSuffix.split("_")
-        val ordinal = groupSuffixParts.collectFirst { case Ordinal(n) => n.toInt }.getOrElse(Int.MinValue)
-        val compiler = groupSuffixParts.collectFirst { case Compiler(c) => c }.getOrElse("")
+        val ordinal = groupSuffixParts.collectFirst { case GroupOrdinal(n) => n.toInt }.getOrElse(Int.MinValue)
+        val compiler = groupSuffixParts.collectFirst { case CompilerVersion(c) => c }.getOrElse("")
         Group(ordinal, compiler)
 
       dir.listFiles
@@ -217,15 +219,29 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
         .toList
         .sortBy { (g, _) => (g.ordinal, g.compiler) }
         .map { (g, f) => (g, f.sorted) }
+    }
 
     def sourceFiles = compilationGroups.map(_._2).flatten.toArray
 
     def checkFileBasePathCandidates: Array[String] =
       Array(dir.getPath)
   }
+  object SeparateCompilationSource:
+    val CompilerVersion = """c([\d\.]+)""".r
+    val GroupOrdinal = """(\d+)""".r
+    val usingCanonicalJava = javaSpecVersion.startsWith("17")
 
+  /** Skip if there are no sources, such as in a spurious directory,
+   *  or when compiling with a legacy compiler which may not run under this jdk.
+   */
   protected def shouldSkipTestSource(testSource: TestSource): Boolean =
     testSource.sourceFiles.length == 0
+    ||
+    testSource.match
+      case separate: SeparateCompilationSource =>
+        !SeparateCompilationSource.usingCanonicalJava
+        && separate.compilationGroups.exists((group, _) => group.compiler.nonEmpty)
+      case _ => false
 
   protected def shouldReRun(testSource: TestSource): Boolean =
     failedTests.forall(rerun => testSource match {
@@ -487,7 +503,6 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
           throw e
 
     protected def compile(files0: Array[JFile], flags0: TestFlags, targetDir: JFile): TestReporter = {
-      import scala.util.Properties.*
 
       def flattenFiles(f: JFile): Array[JFile] =
         if (f.isDirectory) f.listFiles.flatMap(flattenFiles)
@@ -1532,6 +1547,8 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
    *    target all files are grouped according to the file suffix `_X` where `X`
    *    is a number. These groups are then ordered in ascending order based on
    *    the value of `X` and each group is compiled one after the other.
+   *    A file can request compilation by a legacy compiler via a version suffix:
+   *    `A_1_c3.2.0.scala` in group 1 is compiled by 3.2.0 under canonical JDK 17.
    *
    *  For this function to work as expected, we use the same convention for
    *  directory layout as the old partest. That is:

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1561,7 +1561,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
    *    is a number. These groups are then ordered in ascending order based on
    *    the value of `X` and each group is compiled one after the other.
    *    A file can request compilation by a legacy compiler via a version suffix:
-   *    `A_1_c3.2.0.scala` in group 1 is compiled by 3.2.0 under canonical JDK 17.
+   *    `A_1_c3.2.0.scala` in group 1 is compiled by 3.2.0 when testing under the minimum supported JDK.
    *
    *  For this function to work as expected, we use the same convention for
    *  directory layout as the old partest. That is:

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -3,10 +3,13 @@ package tools
 package vulpix
 
 import scala.language.unsafeNulls
+import scala.util.Properties.javaSpecVersion
 
 import java.io.File
 
 object TestConfiguration {
+
+  val usingBaselineJava = javaSpecVersion.startsWith("17")
 
   val pageWidth = 120
 

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -7,9 +7,11 @@ import scala.util.Properties.javaSpecVersion
 
 import java.io.File
 
+import dotc.config.ScalaSettingsProperties.supportedReleaseVersions
+
 object TestConfiguration {
 
-  val usingBaselineJava = javaSpecVersion.startsWith("17")
+  val usingBaselineJava = javaSpecVersion.startsWith(supportedReleaseVersions.headOption.getOrElse("17"))
 
   val pageWidth = 120
 

--- a/tests/run-tasty-inspector/tastyPaths.scala
+++ b/tests/run-tasty-inspector/tastyPaths.scala
@@ -1,7 +1,10 @@
 import scala.quoted.*
 import scala.tasty.inspector.*
 
-import java.io.File.separatorChar
+import java.io.File.{pathSeparator, separatorChar}
+
+import dotty.tools.dotc.util.ClasspathFromClassloader
+import dotty.tools.io.{FileExtension, Path}
 
 opaque type PhoneNumber = String
 
@@ -14,8 +17,12 @@ object Test {
   def main(args: Array[String]): Unit = {
     // Artefact of the current test infrastructure
     // TODO improve infrastructure to avoid needing this code on each test
-    val classpath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(_.contains("runWithCompiler")).get
-    val allTastyFiles = dotty.tools.io.Path(classpath).walkFilter(_.ext == dotty.tools.io.FileExtension.Tasty).map(_.toString).toList
+    val classpath =
+      ClasspathFromClassloader(getClass.getClassLoader)
+        .split(pathSeparator)
+        .find(_.contains("runWithCompiler"))
+        .get
+    val allTastyFiles = Path(classpath).walkFilter(_.ext == FileExtension.Tasty).map(_.toString).toList
     val tastyFiles = allTastyFiles.filter(_.contains("I8163"))
 
     TastyInspector.inspectTastyFiles(tastyFiles)(new TestInspector())

--- a/tests/run/lazyVals_c3.0.0.scala
+++ b/tests/run/lazyVals_c3.0.0.scala
@@ -1,3 +1,4 @@
+// scalajs: --skip
 // Compiled with 3.0.0 and run with current compiler
 class Foo:
   lazy val x =

--- a/tests/run/lazyVals_c3.1.0.scala
+++ b/tests/run/lazyVals_c3.1.0.scala
@@ -1,3 +1,4 @@
+// scalajs: --skip
 // Compiled with 3.1.0 and run with current compiler
 class Foo:
   lazy val x =


### PR DESCRIPTION
Fixes #23090 

## How much have your relied on LLM-based tools in this contribution?

LLM-free. 

That is reminiscent of [Ollie, ollie, in come free](https://www.appalachianhistory.net/2017/06/ollie-ollie-in-come-free.html), which is how we said it.

## How was the solution tested?

Manually tested locally under JDK 25, to show that
```
tests/run/backwardsCompat-implicitParens/A_1_c3.0.2.scala
```
causes that test to be skipped.

Single test files were not compiled correctly (with the legacy compiler), so also test that this fails without the fix and is skipped with the fix:
```
tests/run/lazyVals_c3.1.0.scala
```

## Additional notes

Left the unused import of `chaining` because lacking it results in a tangential rabbit hole:

https://github.com/scala/scala3/issues/25451
