### PR TITLE
Add sizeCompare overloaded methods to SizeCompareOps

### DIFF
--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -883,6 +883,19 @@ object IterableOps {
     @inline def >=(size: Int): Boolean = it.sizeCompare(size) >= 0
     /** Tests if the size of the collection is greater than some value. */
     @inline def >(size: Int): Boolean = it.sizeCompare(size) > 0
+
+    /** Tests if the size of the collection is less than the size of another `Iterable`. */
+    @inline def <(that: Iterable[?]^): Boolean = it.sizeCompare(that) < 0
+    /** Tests if the size of the collection is less than or equal to the size of another `Iterable`. */
+    @inline def <=(that: Iterable[?]^): Boolean = it.sizeCompare(that) <= 0
+    /** Tests if the size of the collection is equal to the size of another `Iterable`. */
+    @inline def ==(that: Iterable[?]^): Boolean = it.sizeCompare(that) == 0
+    /** Tests if the size of the collection is not equal to the size of another `Iterable`. */
+    @inline def !=(that: Iterable[?]^): Boolean = it.sizeCompare(that) != 0
+    /** Tests if the size of the collection is greater than or equal to the size of another `Iterable`. */
+    @inline def >=(that: Iterable[?]^): Boolean = it.sizeCompare(that) >= 0
+    /** Tests if the size of the collection is greater than the size of another `Iterable`. */
+    @inline def >(that: Iterable[?]^): Boolean = it.sizeCompare(that) > 0
   }
 
   /** A trait that contains just the `map`, `flatMap`, `foreach` and `withFilter` methods

--- a/library/test/scala/collection/IterableTest.scala
+++ b/library/test/scala/collection/IterableTest.scala
@@ -94,6 +94,80 @@ class IterableTest {
     check(unknown, unknown)
   }
 
+  @Test
+  def sizeIsInt(): Unit = {
+    val seq = Seq(1, 2, 3)
+
+    assertFalse(seq.sizeIs < 2)
+    assertFalse(seq.sizeIs < 3)
+    assert(seq.sizeIs < 4)
+
+    assertFalse(seq.sizeIs <= 2)
+    assert(seq.sizeIs <= 3)
+    assert(seq.sizeIs <= 4)
+
+    assertFalse(seq.sizeIs == 2)
+    assert(seq.sizeIs == 3)
+    assertFalse(seq.sizeIs == 4)
+
+    assert(seq.sizeIs != 2)
+    assertFalse(seq.sizeIs != 3)
+    assert(seq.sizeIs != 4)
+
+    assert(seq.sizeIs >= 2)
+    assert(seq.sizeIs >= 3)
+    assertFalse(seq.sizeIs >= 4)
+
+    assert(seq.sizeIs > 2)
+    assertFalse(seq.sizeIs > 3)
+    assertFalse(seq.sizeIs > 4)
+  }
+
+  @Test
+  def sizeIsIterable(): Unit = {
+    def check[I1[X] <: Iterable[X], I2[X] <: Iterable[X]]
+    (f1: IterableFactory[I1], f2: IterableFactory[I2]): Unit = {
+      val it = f1(1, 2, 3)
+
+      val t2 = f2(1, 2)
+      val t3 = f2(1, 2, 3)
+      val t4 = f2(1, 2, 3, 4)
+
+      assertFalse(it.sizeIs < t2)
+      assertFalse(it.sizeIs < t3)
+      assert(it.sizeIs < t4)
+
+      assertFalse(it.sizeIs <= t2)
+      assert(it.sizeIs <= t3)
+      assert(it.sizeIs <= t4)
+
+      assertFalse(it.sizeIs == t2)
+      assert(it.sizeIs == t3)
+      assertFalse(it.sizeIs == t4)
+
+      assert(it.sizeIs != t2)
+      assertFalse(it.sizeIs != t3)
+      assert(it.sizeIs != t4)
+
+      assert(it.sizeIs >= t2)
+      assert(it.sizeIs >= t3)
+      assertFalse(it.sizeIs >= t4)
+
+      assert(it.sizeIs > t2)
+      assertFalse(it.sizeIs > t3)
+      assertFalse(it.sizeIs > t4)
+    }
+
+    // factories for `Seq`s with known and unknown size
+    val known: IterableFactory[IndexedSeq] = Vector
+    val unknown: IterableFactory[LinearSeq] = List
+
+    check(known, known)
+    check(known, unknown)
+    check(unknown, known)
+    check(unknown, unknown)
+  }
+
   @Test def copyToArray(): Unit = {
     def check(a: Array[Int], copyToArray: Array[Int] => Int)(n: Int)(start: Int, end: Int) = {
 


### PR DESCRIPTION
`sizeCompare` has an overloaded version that `SizeCompareOps` does not support.

This PR adds the missing overloaded methods

## How much have your relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Automated tests are included

## Additional notes

Discussion: https://contributors.scala-lang.org/t/slc-add-sizecompare-overloaded-methods-to-sizecompareops/7410