### PR TITLE
More progress on CCfying stdlib

### DIFF
--- a/library/src/scala/AnyVal.scala
+++ b/library/src/scala/AnyVal.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `AnyVal` is the root class of all *value types*, which describe values

--- a/library/src/scala/AnyValCompanion.scala
+++ b/library/src/scala/AnyValCompanion.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A common supertype for companion classes of primitive types.

--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Boolean` (equivalent to Java's `boolean` primitive type) is a

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Byte`, a 8-bit signed integer (equivalent to Java's `byte` primitive type) is a

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Char`, a 16-bit unsigned integer (equivalent to Java's `char` primitive type) is a

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import java.io.{ BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream, Reader }

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Double`, a 64-bit IEEE-754 floating point number (equivalent to Java's `double` primitive type) is a

--- a/library/src/scala/DummyImplicit.scala
+++ b/library/src/scala/DummyImplicit.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A type for which there is always an implicit value. */

--- a/library/src/scala/Dynamic.scala
+++ b/library/src/scala/Dynamic.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A marker trait that enables dynamic invocations. Instances `x` of this

--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.collection.{SpecificIterableFactory, StrictOptimizedIterableOps, View, immutable, mutable}
@@ -87,7 +88,7 @@ import scala.util.matching.Regex
  *                 identifies values at run-time.
  */
 @SerialVersionUID(8476000850333817230L)
-abstract class Enumeration (initial: Int) extends Serializable {
+abstract class Enumeration (initial: Int) extends Serializable, caps.Pure {
   thisenum =>
 
   def this() = this(0)
@@ -232,7 +233,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
 
   /** The type of the enumerated values. */
   @SerialVersionUID(7091335633555234129L)
-  abstract class Value extends Ordered[Value] with Serializable {
+  abstract class Value extends Ordered[Value] with Serializable with caps.Pure {
     /** The id and bit location of this enumeration value. */
     def id: Int
     /** A marker so we can tell whose values belong to whom come reflective-naming time. */
@@ -322,7 +323,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
      */
     def toBitMask: Array[Long] = nnIds.toBitMask
 
-    override protected def fromSpecific(coll: IterableOnce[Value]): ValueSet = ValueSet.fromSpecific(coll)
+    override protected def fromSpecific(coll: IterableOnce[Value]^): ValueSet = ValueSet.fromSpecific(coll)
     override protected def newSpecificBuilder = ValueSet.newBuilder
 
     def map(f: Value => Value): ValueSet = fromSpecific(new View.Map(this, f))
@@ -331,11 +332,11 @@ abstract class Enumeration (initial: Int) extends Serializable {
     // necessary for disambiguation:
     override def map[B](f: Value => B)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
       super[SortedSet].map[B](f)
-    override def flatMap[B](f: Value => IterableOnce[B])(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
+    override def flatMap[B](f: Value => IterableOnce[B]^)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
       super[SortedSet].flatMap[B](f)
-    override def zip[B](that: IterableOnce[B])(implicit @implicitNotFound(ValueSet.zipOrdMsg) ev: Ordering[(Value, B)]): immutable.SortedSet[(Value, B)] =
+    override def zip[B](that: IterableOnce[B]^)(implicit @implicitNotFound(ValueSet.zipOrdMsg) ev: Ordering[(Value, B)]): immutable.SortedSet[(Value, B)] =
       super[SortedSet].zip[B](that)
-    override def collect[B](pf: PartialFunction[Value, B])(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
+    override def collect[B](pf: PartialFunction[Value, B]^)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
       super[SortedSet].collect[B](pf)
 
     @transient private[Enumeration] lazy val byName: Map[String, Value] = iterator.map( v => v.toString -> v).toMap
@@ -362,7 +363,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
       def clear() = b.clear()
       def result() = new ValueSet(b.toImmutable)
     }
-    def fromSpecific(it: IterableOnce[Value]): ValueSet =
+    def fromSpecific(it: IterableOnce[Value]^): ValueSet =
       newBuilder.addAll(it).result()
   }
 }

--- a/library/src/scala/Equals.scala
+++ b/library/src/scala/Equals.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An interface containing operations for equality.

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Float`, a 32-bit IEEE-754 floating point number (equivalent to Java's `float` primitive type) is a

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -368,7 +368,7 @@ object IArray:
    *  @param f the transformation function mapping elements to their sort keys
    *  @return a new array consisting of the elements of this array sorted by the value `f` produces for each
    */
-  extension [T](arr: IArray[T]) def sortBy[U](f: T => U)(using math.Ordering[U]): IArray[T] =
+  extension [T](arr: IArray[T]) def sortBy[U](f: T -> U)(using math.Ordering[U]): IArray[T] =
     genericArrayOps(arr).sortBy(f)
 
   /** Sorts this array according to a comparison function.
@@ -376,13 +376,13 @@ object IArray:
    *  @param f the comparison function returning true if its first argument should come first
    *  @return a new array consisting of the elements of this array sorted according to `f`
    */
-  extension [T](arr: IArray[T]) def sortWith(f: (T, T) => Boolean): IArray[T] =
+  extension [T](arr: IArray[T]) def sortWith(f: (T, T) -> Boolean): IArray[T] =
     genericArrayOps(arr).sortWith(f)
 
   /** Sorts this array according to an Ordering.
    *
      */
-  extension [T](arr: IArray[T]) def sorted(using math.Ordering[T]^): IArray[T] =
+  extension [T](arr: IArray[T]) def sorted(using math.Ordering[T]): IArray[T] =
     genericArrayOps(arr).sorted
 
   /** Splits this array into a prefix/suffix pair according to a predicate.

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Int`, a 32-bit signed integer (equivalent to Java's `int` primitive type) is a

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Long`, a 64-bit signed integer (equivalent to Java's `long` primitive type) is a

--- a/library/src/scala/MatchError.scala
+++ b/library/src/scala/MatchError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class implements errors which are thrown whenever an

--- a/library/src/scala/NotImplementedError.scala
+++ b/library/src/scala/NotImplementedError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Throwing this exception can be a temporary replacement for a method

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 object Option {
@@ -402,7 +403,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  @param p the predicate used to test elements
    *  @return a `WithFilter` that applies `p` to this option before subsequent `map`, `flatMap`, `foreach`, or `withFilter` operations
    */
-  @inline final def withFilter(p: A => Boolean): WithFilter = new WithFilter(p)
+  @inline final def withFilter(p: A -> Boolean): WithFilter = new WithFilter(p)
 
   /** We need a whole WithFilter class to honor the "doesn't create a new
    *  collection" contract even though it seems unlikely to matter much in a
@@ -414,7 +415,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     def map[B](f: A => B): Option[B] = self filter p map f
     def flatMap[B](f: A => Option[B]): Option[B] = self filter p flatMap f
     def foreach[U](f: A => U): Unit = self filter p foreach f
-    def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
+    def withFilter(q: A => Boolean): WithFilter^{this, q} = new WithFilter(x => p(x) && q(x))
   }
 
   /** Tests whether the option contains a given value as an element.
@@ -520,7 +521,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *
    *  @tparam B the result type of the partial function
    */
-  @inline final def collect[B](pf: PartialFunction[A, B]): Option[B] =
+  @inline final def collect[B](pf: PartialFunction[A, B]^): Option[B] =
     if (!isEmpty) pf.lift(this.get) else None
 
   /** Returns this $option if it is nonempty,

--- a/library/src/scala/Product.scala
+++ b/library/src/scala/Product.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Base trait for all products, which in the standard library include at
@@ -37,7 +38,7 @@ transparent trait Product extends Any with Equals {
   /** An iterator over all the elements of this product.
    *  @return     in the default implementation, an `Iterator[Any]`
    */
-  def productIterator: Iterator[Any] = new scala.collection.AbstractIterator[Any] {
+  def productIterator: Iterator[Any]^{this} = new scala.collection.AbstractIterator[Any] {
     private var c: Int = 0
     private val cmax = productArity
     def hasNext: Boolean = c < cmax
@@ -65,7 +66,7 @@ transparent trait Product extends Any with Equals {
 
   /** An iterator over the names of all the elements of this product.
    */
-  def productElementNames: Iterator[String] = new scala.collection.AbstractIterator[String] {
+  def productElementNames: Iterator[String]^{this} = new scala.collection.AbstractIterator[String] {
     private var c: Int = 0
     private val cmax = productArity
     def hasNext: Boolean = c < cmax

--- a/library/src/scala/Product1.scala
+++ b/library/src/scala/Product1.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 object Product1 {

--- a/library/src/scala/ScalaReflectionException.scala
+++ b/library/src/scala/ScalaReflectionException.scala
@@ -1,5 +1,6 @@
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An exception that indicates an error during Scala reflection.

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Short`, a 16-bit signed integer (equivalent to Java's `short` primitive type) is a

--- a/library/src/scala/Specializable.scala
+++ b/library/src/scala/Specializable.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A common supertype for companions of specializable types.

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.{ StringBuilder => JLSBuilder }
 import scala.annotation.tailrec

--- a/library/src/scala/Symbol.scala
+++ b/library/src/scala/Symbol.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class provides a simple way to get unique objects for equal strings.

--- a/library/src/scala/UninitializedError.scala
+++ b/library/src/scala/UninitializedError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class represents uninitialized variable/value errors.

--- a/library/src/scala/UninitializedFieldError.scala
+++ b/library/src/scala/UninitializedFieldError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class implements errors which are thrown whenever a

--- a/library/src/scala/Unit.scala
+++ b/library/src/scala/Unit.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Unit` is a subtype of [[scala.AnyVal]]. There is only one value of type

--- a/library/src/scala/ValueOf.scala
+++ b/library/src/scala/ValueOf.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/Annotation.scala
+++ b/library/src/scala/annotation/Annotation.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/ConstantAnnotation.scala
+++ b/library/src/scala/annotation/ConstantAnnotation.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/StaticAnnotation.scala
+++ b/library/src/scala/annotation/StaticAnnotation.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/TypeConstraint.scala
+++ b/library/src/scala/annotation/TypeConstraint.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A marker for annotations that, when applied to a type, should be treated

--- a/library/src/scala/annotation/compileTimeOnly.scala
+++ b/library/src/scala/annotation/compileTimeOnly.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/annotation/implicitAmbiguous.scala
+++ b/library/src/scala/annotation/implicitAmbiguous.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** To customize the error message that's emitted when an implicit search finds

--- a/library/src/scala/annotation/implicitNotFound.scala
+++ b/library/src/scala/annotation/implicitNotFound.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** To customize the error message that's emitted when an implicit of type

--- a/library/src/scala/annotation/internal/$into.scala
+++ b/library/src/scala/annotation/internal/$into.scala
@@ -1,5 +1,7 @@
 package scala.annotation.internal
 
+import language.experimental.captureChecking
+
 /** An internal annotation on (part of) a parameter type that serves as a marker where
  *  the original type was of the form `into[T]`. These annotated types are mapped back
  *  to `into[T]` types when forming a method types from the parameter types. The idea is

--- a/library/src/scala/annotation/internal/onlyCapability.scala
+++ b/library/src/scala/annotation/internal/onlyCapability.scala
@@ -1,6 +1,8 @@
 package scala.annotation
 package internal
 
+import language.experimental.captureChecking
+
 /** An annotation that represents a capability  `c.only[T]`,
  *  encoded as `x.type @onlyCapability[T]`
  *

--- a/library/src/scala/annotation/meta/beanGetter.scala
+++ b/library/src/scala/annotation/meta/beanGetter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/beanSetter.scala
+++ b/library/src/scala/annotation/meta/beanSetter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/companionClass.scala
+++ b/library/src/scala/annotation/meta/companionClass.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/companionMethod.scala
+++ b/library/src/scala/annotation/meta/companionMethod.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/companionObject.scala
+++ b/library/src/scala/annotation/meta/companionObject.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/defaultArg.scala
+++ b/library/src/scala/annotation/meta/defaultArg.scala
@@ -13,6 +13,7 @@
 package scala.annotation
 package meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This internal meta annotation is used by the compiler to support default annotation arguments.

--- a/library/src/scala/annotation/meta/field.scala
+++ b/library/src/scala/annotation/meta/field.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/getter.scala
+++ b/library/src/scala/annotation/meta/getter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/languageFeature.scala
+++ b/library/src/scala/annotation/meta/languageFeature.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation giving particulars for a language feature in object `scala.language`.

--- a/library/src/scala/annotation/meta/package.scala
+++ b/library/src/scala/annotation/meta/package.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/param.scala
+++ b/library/src/scala/annotation/meta/param.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/setter.scala
+++ b/library/src/scala/annotation/meta/setter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/superArg.scala
+++ b/library/src/scala/annotation/meta/superArg.scala
@@ -13,6 +13,7 @@
 package scala.annotation
 package meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This internal annotation encodes arguments passed to annotation superclasses. Example:

--- a/library/src/scala/annotation/migration.scala
+++ b/library/src/scala/annotation/migration.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/nowarn.scala
+++ b/library/src/scala/annotation/nowarn.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation for local warning suppression.

--- a/library/src/scala/annotation/showAsInfix.scala
+++ b/library/src/scala/annotation/showAsInfix.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/stableNull.scala
+++ b/library/src/scala/annotation/stableNull.scala
@@ -1,5 +1,7 @@
 package scala.annotation
 
+import language.experimental.captureChecking
+
 /** An annotation that can be used to mark a mutable field as trackable for nullability.
  *  With explicit nulls, a normal mutable field cannot be tracked for nullability by flow typing,
  *  since it can be updated to a null value at the same time.

--- a/library/src/scala/annotation/strictfp.scala
+++ b/library/src/scala/annotation/strictfp.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** If this annotation is present on a method or its enclosing class,

--- a/library/src/scala/annotation/switch.scala
+++ b/library/src/scala/annotation/switch.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation to be applied to a match expression.  If present,

--- a/library/src/scala/annotation/tailrec.scala
+++ b/library/src/scala/annotation/tailrec.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A method annotation which verifies that the method will be compiled

--- a/library/src/scala/annotation/unchecked/uncheckedOverride.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedOverride.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.unchecked
 
+import language.experimental.captureChecking
 import scala.annotation.StaticAnnotation
 import scala.language.`2.13`
 

--- a/library/src/scala/annotation/unchecked/uncheckedStable.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedStable.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.unchecked
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta.{field, getter}
 

--- a/library/src/scala/annotation/unchecked/uncheckedVariance.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedVariance.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.unchecked
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation for type arguments for which one wants to suppress variance checking.

--- a/library/src/scala/annotation/unspecialized.scala
+++ b/library/src/scala/annotation/unspecialized.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A method annotation which suppresses the creation of

--- a/library/src/scala/annotation/unused.scala
+++ b/library/src/scala/annotation/unused.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Mark an element unused for a given context.

--- a/library/src/scala/annotation/varargs.scala
+++ b/library/src/scala/annotation/varargs.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A method annotation which instructs the compiler to generate a

--- a/library/src/scala/beans/BeanProperty.scala
+++ b/library/src/scala/beans/BeanProperty.scala
@@ -12,6 +12,7 @@
 
 package scala.beans
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.annotation.meta.{beanGetter, beanSetter, field}

--- a/library/src/scala/beans/BooleanBeanProperty.scala
+++ b/library/src/scala/beans/BooleanBeanProperty.scala
@@ -12,6 +12,7 @@
 
 package scala.beans
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta.{beanGetter, beanSetter, field}
 

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -628,7 +628,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @return     an array consisting of the elements of this array
    *              sorted according to the ordering `ord`.
    */
-  def sorted[B >: A](implicit ord: Ordering[B]^): Array[A] = {
+  def sorted[B >: A](implicit ord: Ordering[B]): Array[A] = {
     val len = xs.length
     def boxed = if(len < ArrayOps.MaxStableSortLength) {
       val a = xs.clone()
@@ -676,7 +676,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @return     an array consisting of the elements of this array
    *              sorted according to the comparison function `lt`.
    */
-  def sortWith(lt: (A, A) => Boolean): Array[A] = sorted(using Ordering.fromLessThan(lt))
+  def sortWith(lt: (A, A) -> Boolean): Array[A] = sorted(using Ordering.fromLessThan(lt))
 
   /** Sorts this array according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -691,7 +691,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *           sorted according to the ordering where `x < y` if
    *           `ord.lt(f(x), f(y))`.
    */
-  def sortBy[B](f: A => B)(implicit ord: Ordering[B]): Array[A] = sorted(using ord.on(f))
+  def sortBy[B](f: A -> B)(implicit ord: Ordering[B]): Array[A] = sorted(using ord.on(f))
 
   /** Creates a non-strict filter of this array.
    *

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -723,7 +723,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @return     a $coll consisting of the elements of this $coll
    *              sorted according to the ordering `ord`.
    */
-  def sorted[B >: A](implicit ord: Ordering[B]): C^{this} = {
+  def sorted[B >: A](implicit ord: Ordering[B]^): C^{this, ord} = sortedImpl
+
+  // The actual sort implementation. `sorted` needs a more lenient capture set because of lazy seqs.
+  private[collection] def sortedImpl[B >: A](implicit ord: Ordering[B]^): C^{this} = {
     val len = this.length
     val b = newSpecificBuilder
     if (len == 1) b += head
@@ -760,7 +763,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *    // List("Bobby", "Bob", "John", "Steve", "Tom")
    *  ```
    */
-  def sortWith(lt: (A, A) => Boolean): C^{this} = sorted(using Ordering.fromLessThan(lt))
+  def sortWith(lt: (A, A) => Boolean): C^{this, lt} = sorted(using Ordering.fromLessThan(lt))
 
   /** Sorts this $coll according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -787,7 +790,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *    // sorted: Array[String] = Array(The, dog, fox, the, lazy, over, brown, quick, jumped)
    *  ```
    */
-  def sortBy[B](f: A => B)(implicit ord: Ordering[B]): C^{this} = sorted(using ord.on(f))
+  def sortBy[B](f: A => B)(implicit ord: Ordering[B]^): C^{this, f, ord} = sorted(using ord.on(f))
 
   /** Produces the range of all indices of this sequence.
    *  $willForceEvaluation

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -723,10 +723,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @return     a $coll consisting of the elements of this $coll
    *              sorted according to the ordering `ord`.
    */
-  def sorted[B >: A](implicit ord: Ordering[B]^): C^{this, ord} = sortedImpl
+  def sorted[B >: A](implicit ord: Ordering[B]): C^{this} = sortedImpl
 
   // The actual sort implementation. `sorted` needs a more lenient capture set because of lazy seqs.
-  private[collection] def sortedImpl[B >: A](implicit ord: Ordering[B]^): C^{this} = {
+  private[collection] def sortedImpl[B >: A](implicit ord: Ordering[B]): C^{this} = {
     val len = this.length
     val b = newSpecificBuilder
     if (len == 1) b += head
@@ -763,7 +763,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *    // List("Bobby", "Bob", "John", "Steve", "Tom")
    *  ```
    */
-  def sortWith(lt: (A, A) => Boolean): C^{this, lt} = sorted(using Ordering.fromLessThan(lt))
+  def sortWith(lt: (A, A) -> Boolean): C^{this} = sorted(using Ordering.fromLessThan(lt))
 
   /** Sorts this $coll according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -790,7 +790,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *    // sorted: Array[String] = Array(The, dog, fox, the, lazy, over, brown, quick, jumped)
    *  ```
    */
-  def sortBy[B](f: A => B)(implicit ord: Ordering[B]^): C^{this, f, ord} = sorted(using ord.on(f))
+  def sortBy[B](f: A -> B)(implicit ord: Ordering[B]): C^{this} = sorted(using ord.on(f))
 
   /** Produces the range of all indices of this sequence.
    *  $willForceEvaluation

--- a/library/src/scala/collection/SeqView.scala
+++ b/library/src/scala/collection/SeqView.scala
@@ -38,7 +38,7 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
   def appendedAll[B >: A](suffix: SeqView.SomeSeqOps[B]^): SeqView[B]^{this, suffix} = new SeqView.Concat(this, suffix)
   def prependedAll[B >: A](prefix: SeqView.SomeSeqOps[B]^): SeqView[B]^{this, prefix} = new SeqView.Concat(prefix, this)
 
-  override def sorted[B >: A](implicit ord: Ordering[B]): SeqView[A]^{this} = new SeqView.Sorted(this, ord)
+  override def sorted[B >: A](implicit ord: Ordering[B]^): SeqView[A]^{this, ord} = new SeqView.Sorted(this, ord)
 
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "SeqView"
@@ -135,7 +135,7 @@ object SeqView {
   @SerialVersionUID(3L)
   class Sorted[A, B >: A] private (underlying_ : SomeSeqOps[A]^,
                                    private val len: Int,
-                                   ord: Ordering[B])
+                                   ord: Ordering[B]^)
     extends SeqView[A] {
     outer: Sorted[A, B]^ =>
 
@@ -143,11 +143,12 @@ object SeqView {
 
     // force evaluation immediately by calling `length` so infinite collections
     // hang on `sorted`/`sortWith`/`sortBy` rather than on arbitrary method calls
-    def this(underlying: SomeSeqOps[A]^, ord: Ordering[B]) = this(underlying, underlying.length, ord)
+    def this(underlying: SomeSeqOps[A]^, ord: Ordering[B]^) = this(underlying, underlying.length, ord)
 
     @SerialVersionUID(3L)
-    private class ReverseSorted extends SeqView[A] {
+    private class ReverseSorted extends SeqView[A] uses Sorted.this uses_init Sorted.this {
       private lazy val _reversed = new SeqView.Reverse(_sorted)
+      private val original: Sorted[A, B]^{Sorted.this} = outer
 
       def apply(i: Int): A = _reversed.apply(i)
       def length: Int = len
@@ -158,10 +159,10 @@ object SeqView {
       override def reverse: SeqView[A]^{this} = outer
       override protected def reversed: Iterable[A]^{outer} = outer
 
-      override def sorted[B1 >: A](implicit ord1: Ordering[B1]): SeqView[A]^{this} =
-        if (ord1 == Sorted.this.ord) outer
+      override def sorted[B1 >: A](implicit ord1: Ordering[B1]^): SeqView[A]^{this, ord1} =
+        if (ord1 == Sorted.this.ord) original
         else if (ord1.isReverseOf(Sorted.this.ord)) this
-        else new Sorted(elems, len, ord1)
+        else new Sorted(original.elems, len, ord1)
     }
 
     @volatile private var evaluated = false
@@ -207,7 +208,7 @@ object SeqView {
     //  so this is acceptable for `reversed`
     override protected def reversed: Iterable[A]^{this} = new ReverseSorted
 
-    override def sorted[B1 >: A](implicit ord1: Ordering[B1]): SeqView[A]^{this} =
+    override def sorted[B1 >: A](implicit ord1: Ordering[B1]^): SeqView[A]^{this, ord1} =
       if (ord1 == this.ord) this
       else if (ord1.isReverseOf(this.ord)) reverse
       else new Sorted(elems, len, ord1)

--- a/library/src/scala/collection/SeqView.scala
+++ b/library/src/scala/collection/SeqView.scala
@@ -38,7 +38,7 @@ trait SeqView[+A] extends SeqOps[A, View, View[A]] with View[A] {
   def appendedAll[B >: A](suffix: SeqView.SomeSeqOps[B]^): SeqView[B]^{this, suffix} = new SeqView.Concat(this, suffix)
   def prependedAll[B >: A](prefix: SeqView.SomeSeqOps[B]^): SeqView[B]^{this, prefix} = new SeqView.Concat(prefix, this)
 
-  override def sorted[B >: A](implicit ord: Ordering[B]^): SeqView[A]^{this, ord} = new SeqView.Sorted(this, ord)
+  override def sorted[B >: A](implicit ord: Ordering[B]): SeqView[A]^{this} = new SeqView.Sorted(this, ord)
 
   @nowarn("""cat=deprecation&origin=scala\.collection\.Iterable\.stringPrefix""")
   override protected def stringPrefix: String = "SeqView"
@@ -135,7 +135,7 @@ object SeqView {
   @SerialVersionUID(3L)
   class Sorted[A, B >: A] private (underlying_ : SomeSeqOps[A]^,
                                    private val len: Int,
-                                   ord: Ordering[B]^)
+                                   ord: Ordering[B])
     extends SeqView[A] {
     outer: Sorted[A, B]^ =>
 
@@ -143,10 +143,10 @@ object SeqView {
 
     // force evaluation immediately by calling `length` so infinite collections
     // hang on `sorted`/`sortWith`/`sortBy` rather than on arbitrary method calls
-    def this(underlying: SomeSeqOps[A]^, ord: Ordering[B]^) = this(underlying, underlying.length, ord)
+    def this(underlying: SomeSeqOps[A]^, ord: Ordering[B]) = this(underlying, underlying.length, ord)
 
     @SerialVersionUID(3L)
-    private class ReverseSorted extends SeqView[A] uses Sorted.this uses_init Sorted.this {
+    private class ReverseSorted extends SeqView[A] uses Sorted.this initially, Sorted.this {
       private lazy val _reversed = new SeqView.Reverse(_sorted)
       private val original: Sorted[A, B]^{Sorted.this} = outer
 
@@ -159,7 +159,7 @@ object SeqView {
       override def reverse: SeqView[A]^{this} = outer
       override protected def reversed: Iterable[A]^{outer} = outer
 
-      override def sorted[B1 >: A](implicit ord1: Ordering[B1]^): SeqView[A]^{this, ord1} =
+      override def sorted[B1 >: A](implicit ord1: Ordering[B1]): SeqView[A]^{this} =
         if (ord1 == Sorted.this.ord) original
         else if (ord1.isReverseOf(Sorted.this.ord)) this
         else new Sorted(original.elems, len, ord1)
@@ -208,7 +208,7 @@ object SeqView {
     //  so this is acceptable for `reversed`
     override protected def reversed: Iterable[A]^{this} = new ReverseSorted
 
-    override def sorted[B1 >: A](implicit ord1: Ordering[B1]^): SeqView[A]^{this, ord1} =
+    override def sorted[B1 >: A](implicit ord1: Ordering[B1]): SeqView[A]^{this} =
       if (ord1 == this.ord) this
       else if (ord1.isReverseOf(this.ord)) reverse
       else new Sorted(elems, len, ord1)

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -1735,7 +1735,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *              sorted according to the comparison function `lt`.
    *  @note       $unicodeunaware
    */
-  def sortWith(lt: (Char, Char) => Boolean): String = new WrappedString(s).sortWith(lt).unwrap
+  def sortWith(lt: (Char, Char) -> Boolean): String = new WrappedString(s).sortWith(lt).unwrap
 
   /** Sorts this string according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -1754,7 +1754,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *           `ord.lt(f(x), f(y))`.
    *  @note    $unicodeunaware
    */
-  def sortBy[B](f: Char => B)(implicit ord: Ordering[B]): String = new WrappedString(s).sortBy(f)(using ord).unwrap
+  def sortBy[B](f: Char -> B)(implicit ord: Ordering[B]): String = new WrappedString(s).sortBy(f)(using ord).unwrap
 
   /** Partitions this string into a map of strings according to some discriminator function.
    *

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -263,7 +263,7 @@ sealed abstract class ArraySeq[+A]
 
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 
-  override def sorted[B >: A](implicit ord: Ordering[B]): ArraySeq[A] =
+  override def sorted[B >: A](implicit ord: Ordering[B]^): ArraySeq[A] =
     if(unsafeArray.length <= 1) this
     else {
       val a = Array.copyAs[AnyRef](unsafeArray, length)
@@ -347,7 +347,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
           that.unsafeArray.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
-    override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq.ofRef[T] = {
+    override def sorted[B >: T](implicit ord: Ordering[B]^): ArraySeq.ofRef[T] = {
       if(unsafeArray.length <= 1) this
       else {
         val a = unsafeArray.clone()
@@ -375,7 +375,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Byte](implicit ord: Ordering[B]): ArraySeq[Byte] =
+    override def sorted[B >: Byte](implicit ord: Ordering[B]^): ArraySeq[Byte] =
       if(length <= 1) this
       else if(ord eq Ordering.Byte) {
         val a = unsafeArray.clone()
@@ -417,7 +417,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Short](implicit ord: Ordering[B]): ArraySeq[Short] =
+    override def sorted[B >: Short](implicit ord: Ordering[B]^): ArraySeq[Short] =
       if(length <= 1) this
       else if(ord eq Ordering.Short) {
         val a = unsafeArray.clone()
@@ -459,7 +459,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Char](implicit ord: Ordering[B]): ArraySeq[Char] =
+    override def sorted[B >: Char](implicit ord: Ordering[B]^): ArraySeq[Char] =
       if(length <= 1) this
       else if(ord eq Ordering.Char) {
         val a = unsafeArray.clone()
@@ -504,7 +504,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Int](implicit ord: Ordering[B]): ArraySeq[Int] =
+    override def sorted[B >: Int](implicit ord: Ordering[B]^): ArraySeq[Int] =
       if(length <= 1) this
       else if(ord eq Ordering.Int) {
         val a = unsafeArray.clone()
@@ -546,7 +546,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Long](implicit ord: Ordering[B]): ArraySeq[Long] =
+    override def sorted[B >: Long](implicit ord: Ordering[B]^): ArraySeq[Long] =
       if(length <= 1) this
       else if(ord eq Ordering.Long) {
         val a = unsafeArray.clone()
@@ -672,7 +672,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Boolean](implicit ord: Ordering[B]): ArraySeq[Boolean] =
+    override def sorted[B >: Boolean](implicit ord: Ordering[B]^): ArraySeq[Boolean] =
       if(length <= 1) this
       else if(ord eq Ordering.Boolean) {
         val a = unsafeArray.clone()

--- a/library/src/scala/collection/immutable/ArraySeq.scala
+++ b/library/src/scala/collection/immutable/ArraySeq.scala
@@ -263,7 +263,7 @@ sealed abstract class ArraySeq[+A]
 
   override protected final def applyPreferredMaxLength: Int = Int.MaxValue
 
-  override def sorted[B >: A](implicit ord: Ordering[B]^): ArraySeq[A] =
+  override def sorted[B >: A](implicit ord: Ordering[B]): ArraySeq[A] =
     if(unsafeArray.length <= 1) this
     else {
       val a = Array.copyAs[AnyRef](unsafeArray, length)
@@ -347,7 +347,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
           that.unsafeArray.asInstanceOf[Array[AnyRef]])
       case _ => super.equals(that)
     }
-    override def sorted[B >: T](implicit ord: Ordering[B]^): ArraySeq.ofRef[T] = {
+    override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq.ofRef[T] = {
       if(unsafeArray.length <= 1) this
       else {
         val a = unsafeArray.clone()
@@ -375,7 +375,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofByte => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Byte](implicit ord: Ordering[B]^): ArraySeq[Byte] =
+    override def sorted[B >: Byte](implicit ord: Ordering[B]): ArraySeq[Byte] =
       if(length <= 1) this
       else if(ord eq Ordering.Byte) {
         val a = unsafeArray.clone()
@@ -417,7 +417,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofShort => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Short](implicit ord: Ordering[B]^): ArraySeq[Short] =
+    override def sorted[B >: Short](implicit ord: Ordering[B]): ArraySeq[Short] =
       if(length <= 1) this
       else if(ord eq Ordering.Short) {
         val a = unsafeArray.clone()
@@ -459,7 +459,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofChar => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Char](implicit ord: Ordering[B]^): ArraySeq[Char] =
+    override def sorted[B >: Char](implicit ord: Ordering[B]): ArraySeq[Char] =
       if(length <= 1) this
       else if(ord eq Ordering.Char) {
         val a = unsafeArray.clone()
@@ -504,7 +504,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofInt => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Int](implicit ord: Ordering[B]^): ArraySeq[Int] =
+    override def sorted[B >: Int](implicit ord: Ordering[B]): ArraySeq[Int] =
       if(length <= 1) this
       else if(ord eq Ordering.Int) {
         val a = unsafeArray.clone()
@@ -546,7 +546,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofLong => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Long](implicit ord: Ordering[B]^): ArraySeq[Long] =
+    override def sorted[B >: Long](implicit ord: Ordering[B]): ArraySeq[Long] =
       if(length <= 1) this
       else if(ord eq Ordering.Long) {
         val a = unsafeArray.clone()
@@ -672,7 +672,7 @@ object ArraySeq extends StrictOptimizedClassTagSeqFactory[ArraySeq] { self =>
       case that: ofBoolean => Arrays.equals(unsafeArray, that.unsafeArray)
       case _ => super.equals(that)
     }
-    override def sorted[B >: Boolean](implicit ord: Ordering[B]^): ArraySeq[Boolean] =
+    override def sorted[B >: Boolean](implicit ord: Ordering[B]): ArraySeq[Boolean] =
       if(length <= 1) this
       else if(ord eq Ordering.Boolean) {
         val a = unsafeArray.clone()

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -579,7 +579,7 @@ sealed abstract class Range(
     }
   }
 
-  override def sorted[B >: Int](implicit ord: Ordering[B]^): IndexedSeq[Int] =
+  override def sorted[B >: Int](implicit ord: Ordering[B]): IndexedSeq[Int] =
     if (ord eq Ordering.Int) {
       if (step > 0) {
         this

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -579,7 +579,7 @@ sealed abstract class Range(
     }
   }
 
-  override def sorted[B >: Int](implicit ord: Ordering[B]): IndexedSeq[Int] =
+  override def sorted[B >: Int](implicit ord: Ordering[B]^): IndexedSeq[Int] =
     if (ord eq Ordering.Int) {
       if (step > 0) {
         this

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -86,6 +86,6 @@ transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
     b.result()
   }
 
-  override def sorted[B >: A](implicit ord: Ordering[B]): C = super.sorted(using ord)
+  override def sorted[B >: A](implicit ord: Ordering[B]^): C = sortedImpl(using ord)
 
 }

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -86,6 +86,6 @@ transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
     b.result()
   }
 
-  override def sorted[B >: A](implicit ord: Ordering[B]^): C = sortedImpl(using ord)
+  override def sorted[B >: A](implicit ord: Ordering[B]): C = sortedImpl(using ord)
 
 }

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -267,7 +267,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */
-  override def sortInPlace[B >: A]()(implicit ord: Ordering[B]^): this.type = {
+  override def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
     if (length > 1) {
       mutationCount += 1
       scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]], 0, length)

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -267,7 +267,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */
-  override def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
+  override def sortInPlace[B >: A]()(implicit ord: Ordering[B]^): this.type = {
     if (length > 1) {
       mutationCount += 1
       scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]], 0, length)

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -93,10 +93,10 @@ sealed abstract class ArraySeq[T]
       super.equals(other)
   }
 
-  override def sorted[B >: T](implicit ord: Ordering[B]^): ArraySeq[T] =
+  override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq[T] =
     ArraySeq.make(array.sorted(using ord.asInstanceOf[Ordering[Any]])).asInstanceOf[ArraySeq[T]]
 
-  override def sortInPlace[B >: T]()(implicit ord: Ordering[B]^): this.type = {
+  override def sortInPlace[B >: T]()(implicit ord: Ordering[B]): this.type = {
     if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
     this
   }

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -93,10 +93,10 @@ sealed abstract class ArraySeq[T]
       super.equals(other)
   }
 
-  override def sorted[B >: T](implicit ord: Ordering[B]): ArraySeq[T] =
+  override def sorted[B >: T](implicit ord: Ordering[B]^): ArraySeq[T] =
     ArraySeq.make(array.sorted(using ord.asInstanceOf[Ordering[Any]])).asInstanceOf[ArraySeq[T]]
 
-  override def sortInPlace[B >: T]()(implicit ord: Ordering[B]): this.type = {
+  override def sortInPlace[B >: T]()(implicit ord: Ordering[B]^): this.type = {
     if (length > 1) scala.util.Sorting.stableSort(array.asInstanceOf[Array[B]])
     this
   }

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -52,7 +52,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */
-  def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
+  def sortInPlace[B >: A]()(implicit ord: Ordering[B]^): this.type = {
     val len = this.length
     if (len > 1) {
       val arr = new Array[AnyRef](len)
@@ -90,6 +90,6 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @param ord the implicit ordering on type `B` used to compare transformed elements
    *  @return this $coll sorted in place according to the ordering induced by applying `f` and comparing with `ord`
    */
-  def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
+  def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]^): this.type = sortInPlace()(using ord.on(f))
 
 }

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -52,7 +52,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @param  ord the ordering to be used to compare elements.
    *  @return modified input $coll sorted according to the ordering `ord`.
    */
-  def sortInPlace[B >: A]()(implicit ord: Ordering[B]^): this.type = {
+  def sortInPlace[B >: A]()(implicit ord: Ordering[B]): this.type = {
     val len = this.length
     if (len > 1) {
       val arr = new Array[AnyRef](len)
@@ -78,7 +78,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @param lt the less-than comparison function; should return `true` if the first argument strictly precedes the second in the desired ordering
    *  @return this $coll sorted in place according to the comparison function `lt`
    */
-  def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
+  def sortInPlaceWith(lt: (A, A) -> Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
 
   /** Sorts this $coll in place according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -90,6 +90,6 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @param ord the implicit ordering on type `B` used to compare transformed elements
    *  @return this $coll sorted in place according to the ordering induced by applying `f` and comparing with `ord`
    */
-  def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]^): this.type = sortInPlace()(using ord.on(f))
+  def sortInPlaceBy[B](f: A -> B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
 
 }

--- a/library/src/scala/compiletime/Erased.scala
+++ b/library/src/scala/compiletime/Erased.scala
@@ -1,6 +1,8 @@
 package scala.compiletime
 import annotation.experimental
 
+import language.experimental.captureChecking
+
 /** A marker trait for erased values. vals or parameters whose type extends
  *  `Erased` get an implicit `erased` modifier.
  */

--- a/library/src/scala/concurrent/Awaitable.scala
+++ b/library/src/scala/concurrent/Awaitable.scala
@@ -13,6 +13,7 @@
 package scala.concurrent
 
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.concurrent.duration.Duration
 

--- a/library/src/scala/deprecated.scala
+++ b/library/src/scala/deprecated.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/deprecatedInheritance.scala
+++ b/library/src/scala/deprecatedInheritance.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/deprecatedName.scala
+++ b/library/src/scala/deprecatedName.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/deprecatedOverriding.scala
+++ b/library/src/scala/deprecatedOverriding.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/inline.scala
+++ b/library/src/scala/inline.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/io/AnsiColor.scala
+++ b/library/src/scala/io/AnsiColor.scala
@@ -13,6 +13,7 @@
 package scala
 package io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** ANSI escape codes providing control over text formatting and color on supporting text terminals.

--- a/library/src/scala/io/BufferedSource.scala
+++ b/library/src/scala/io/BufferedSource.scala
@@ -12,6 +12,7 @@
 
 package scala.io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.io.{ InputStream, BufferedReader, InputStreamReader, PushbackReader }
 import Source.DefaultBufSize
@@ -41,7 +42,7 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
     bufferedReader()
   }
 
-  override val iter = (
+  override val iter: Iterator[Char]^{this} = (
     Iterator
     continually (codec wrap charReader.read())
     takeWhile (_ != -1)

--- a/library/src/scala/io/Codec.scala
+++ b/library/src/scala/io/Codec.scala
@@ -13,6 +13,7 @@
 package scala
 package io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.nio.charset.{CharacterCodingException, Charset, CharsetDecoder, CharsetEncoder, CodingErrorAction => Action}
 import java.nio.charset.StandardCharsets.{ISO_8859_1, UTF_8}
@@ -35,8 +36,8 @@ import scala.language.implicitConversions
  *  @param charSet the character set used for encoding and decoding operations
  */
 class Codec(val charSet: Charset) {
-  type Configure[T] = (T => T, Boolean)
-  type Handler      = CharacterCodingException => Int
+  type Configure[T] = (T -> T, Boolean)
+  type Handler      = CharacterCodingException -> Int
 
   // these variables allow configuring the Codec object, and then
   // all decoders and encoders retrieved from it will use these settings.

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -316,7 +316,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   def next(): Char = positioner.next()
 
   @nowarn("cat=deprecation")
-  class Positioner(encoder: Position) uses Source.this.iter uses_init Source.this {
+  class Positioner(encoder: Position) uses Source.this.iter, Source.this initially {
     def this() = this(RelaxedPosition)
     /** the last character returned by next. */
     var ch: Char = compiletime.uninitialized

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -17,6 +17,7 @@ import scala.collection.{AbstractIterator, BufferedIterator}
 import java.io.{Closeable, FileInputStream, FileNotFoundException, InputStream, PrintStream, File => JFile}
 import java.net.{URI, URL}
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.nowarn
 
@@ -217,8 +218,8 @@ object Source {
   def createBufferedSource(
     inputStream: InputStream,
     bufferSize: Int = DefaultBufSize,
-    reset: (() => Source) | Null = null,
-    close: (() => Unit) | Null = null
+    reset: (() -> Source) | Null = null,
+    close: (() -> Unit) | Null = null
   )(implicit codec: Codec): BufferedSource = {
     // workaround for default arguments being unable to refer to other parameters
     val resetFn = if (reset == null) () => createBufferedSource(inputStream, bufferSize, reset, close)(using codec) else reset
@@ -264,7 +265,7 @@ object Source {
  */
 abstract class Source extends Iterator[Char] with Closeable {
   /** The actual iterator. */
-  protected val iter: Iterator[Char]
+  protected val iter: Iterator[Char]^{this}
 
   // ------ public values
 
@@ -275,10 +276,10 @@ abstract class Source extends Iterator[Char] with Closeable {
 
   private def lineNum(line: Int): String = (getLines() drop (line - 1) take 1).mkString
 
-  class LineIterator extends AbstractIterator[String] with Iterator[String] {
+  class LineIterator extends AbstractIterator[String] with Iterator[String] uses Source.this.iter {
     private val sb = new StringBuilder
 
-    lazy val iter: BufferedIterator[Char] = Source.this.iter.buffered
+    lazy val iter: BufferedIterator[Char]^{Source.this.iter} = Source.this.iter.buffered
     def isNewline(ch: Char): Boolean = ch == '\r' || ch == '\n'
     def getc(): Boolean = iter.hasNext && {
       val ch = iter.next()
@@ -306,7 +307,7 @@ abstract class Source extends Iterator[Char] with Closeable {
    *  It will treat any of \r\n, \r, or \n as a line separator (longest match) - if
    *  you need more refined behavior you can subclass Source#LineIterator directly.
    */
-  def getLines(): Iterator[String] = new LineIterator()
+  def getLines(): Iterator[String]^{this} = new LineIterator()
 
   /** Returns `**true**` if this source has more characters. */
   def hasNext: Boolean = iter.hasNext
@@ -315,7 +316,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   def next(): Char = positioner.next()
 
   @nowarn("cat=deprecation")
-  class Positioner(encoder: Position) {
+  class Positioner(encoder: Position) uses Source.this.iter uses_init Source.this {
     def this() = this(RelaxedPosition)
     /** the last character returned by next. */
     var ch: Char = compiletime.uninitialized
@@ -352,8 +353,8 @@ abstract class Source extends Iterator[Char] with Closeable {
   object RelaxedPosition extends Position {
     def checkInput(line: Int, column: Int): Unit = ()
   }
-  object RelaxedPositioner extends Positioner(RelaxedPosition) { }
-  object NoPositioner extends Positioner(Position) {
+  object RelaxedPositioner extends Positioner(RelaxedPosition) uses Source.this { }
+  object NoPositioner extends Positioner(Position) uses Source.this {
     override def next(): Char = iter.next()
   }
   def ch: Char = positioner.ch
@@ -402,16 +403,16 @@ abstract class Source extends Iterator[Char] with Closeable {
   }
 
   @annotation.stableNull
-  private var resetFunction: (() => Source) | Null = null
+  private var resetFunction: (() -> Source) | Null = null
   @annotation.stableNull
-  private var closeFunction: (() => Unit) | Null = null
-  private var positioner: Positioner = RelaxedPositioner
+  private var closeFunction: (() -> Unit) | Null = null
+  private var positioner: Positioner^{this} = RelaxedPositioner
 
-  def withReset(f: (() => Source) | Null): this.type = {
+  def withReset(f: (() -> Source) | Null): this.type = {
     resetFunction = f
     this
   }
-  def withClose(f: (() => Unit) | Null): this.type = {
+  def withClose(f: (() -> Unit) | Null): this.type = {
     closeFunction = f
     this
   }

--- a/library/src/scala/io/StdIn.scala
+++ b/library/src/scala/io/StdIn.scala
@@ -13,6 +13,7 @@
 package scala
 package io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.text.MessageFormat
 

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.annotation.compileTimeOnly

--- a/library/src/scala/languageFeature.scala
+++ b/library/src/scala/languageFeature.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta
 

--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -15,6 +15,7 @@ package math
 
 import java.math.BigInteger
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.nowarn
 import scala.language.implicitConversions

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.util.Comparator
 import scala.annotation.migration
@@ -65,10 +66,10 @@ object Equiv extends LowPriorityEquiv {
   def fromComparator[T](cmp: Comparator[T]): Equiv[T] = {
     (x, y) => cmp.compare(x, y) == 0
   }
-  def fromFunction[T](cmp: (T, T) => Boolean): Equiv[T] = {
+  def fromFunction[T](cmp: (T, T) => Boolean): Equiv[T]^{cmp} = {
     (x, y) => cmp(x, y)
   }
-  def by[T, S: Equiv](f: T => S): Equiv[T] =
+  def by[T, S: Equiv](f: T => S): Equiv[T]^{f} =
     ((x, y) => implicitly[Equiv[S]].equiv(f(x), f(y)))
 
   @inline def apply[T: Equiv]: Equiv[T] = implicitly[Equiv[T]]
@@ -78,7 +79,7 @@ object Equiv extends LowPriorityEquiv {
   private final val optionSeed   = 43
   private final val iterableSeed = 47
 
-  private final class IterableEquiv[CC[X] <: Iterable[X], T](private val eqv: Equiv[T]) extends Equiv[CC[T]] {
+  private final class IterableEquiv[CC[X] <: Iterable[X], T](private val eqv: Equiv[T]^) extends Equiv[CC[T]] {
     def equiv(x: CC[T], y: CC[T]): Boolean = {
       val xe = x.iterator
       val ye = y.iterator
@@ -107,7 +108,7 @@ object Equiv extends LowPriorityEquiv {
      *  @param eqv the `Equiv` instance used to compare individual elements of type `T`
      *  @return an `Equiv` for sequences of type `CC[T]` that compares them element-by-element using `eqv`
      */
-    implicit def seqEquiv[CC[X] <: scala.collection.Seq[X], T](implicit eqv: Equiv[T]): Equiv[CC[T]] =
+    implicit def seqEquiv[CC[X] <: scala.collection.Seq[X], T](implicit eqv: Equiv[T]^): Equiv[CC[T]]^{eqv} =
       new IterableEquiv[CC, T](eqv)
 
     /**
@@ -116,7 +117,7 @@ object Equiv extends LowPriorityEquiv {
      *  @param eqv the `Equiv` instance used to compare individual elements of type `T`
      *  @return an `Equiv` for sorted sets of type `CC[T]` that compares them element-by-element in iteration order using `eqv`
      */
-    implicit def sortedSetEquiv[CC[X] <: scala.collection.SortedSet[X], T](implicit eqv: Equiv[T]): Equiv[CC[T]] =
+    implicit def sortedSetEquiv[CC[X] <: scala.collection.SortedSet[X], T](implicit eqv: Equiv[T]^): Equiv[CC[T]]^{eqv} =
       new IterableEquiv[CC, T](eqv)
   }
 
@@ -263,7 +264,7 @@ object Equiv extends LowPriorityEquiv {
   implicit def Option[T](implicit eqv: Equiv[T]): Equiv[Option[T]] =
     new OptionEquiv[T](eqv)
 
-  private final class OptionEquiv[T](private val eqv: Equiv[T]) extends Equiv[Option[T]] {
+  private final class OptionEquiv[T](private val eqv: Equiv[T]^) extends Equiv[Option[T]] {
     def equiv(x: Option[T], y: Option[T]): Boolean = (x, y) match {
       case (None, None)       => true
       case (Some(x), Some(y)) => eqv.equiv(x, y)
@@ -278,11 +279,11 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = eqv.hashCode() * optionSeed
   }
 
-  implicit def Tuple2[T1, T2](implicit eqv1: Equiv[T1], eqv2: Equiv[T2]): Equiv[(T1, T2)] =
+  implicit def Tuple2[T1, T2](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^): Equiv[(T1, T2)]^{eqv1, eqv2} =
     new Tuple2Equiv(eqv1, eqv2)
 
-  private final class Tuple2Equiv[T1, T2](private val eqv1: Equiv[T1],
-                                                private val eqv2: Equiv[T2]) extends Equiv[(T1, T2)] {
+  private final class Tuple2Equiv[T1, T2](private val eqv1: Equiv[T1]^,
+                                                private val eqv2: Equiv[T2]^) extends Equiv[(T1, T2)] {
     def equiv(x: (T1, T2), y: (T1, T2)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2)
@@ -297,12 +298,12 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = (eqv1, eqv2).hashCode()
   }
 
-  implicit def Tuple3[T1, T2, T3](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3]) : Equiv[(T1, T2, T3)] =
+  implicit def Tuple3[T1, T2, T3](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^, eqv3: Equiv[T3]^) : Equiv[(T1, T2, T3)]^{eqv1, eqv2, eqv3} =
     new Tuple3Equiv(eqv1, eqv2, eqv3)
 
-  private final class Tuple3Equiv[T1, T2, T3](private val eqv1: Equiv[T1],
-                                                    private val eqv2: Equiv[T2],
-                                                    private val eqv3: Equiv[T3]) extends Equiv[(T1, T2, T3)] {
+  private final class Tuple3Equiv[T1, T2, T3](private val eqv1: Equiv[T1]^,
+                                                    private val eqv2: Equiv[T2]^,
+                                                    private val eqv3: Equiv[T3]^) extends Equiv[(T1, T2, T3)] {
     def equiv(x: (T1, T2, T3), y: (T1, T2, T3)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
@@ -319,13 +320,13 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = (eqv1, eqv2, eqv3).hashCode()
   }
 
-  implicit def Tuple4[T1, T2, T3, T4](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4]) : Equiv[(T1, T2, T3, T4)] =
+  implicit def Tuple4[T1, T2, T3, T4](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^, eqv3: Equiv[T3]^, eqv4: Equiv[T4]^) : Equiv[(T1, T2, T3, T4)]^{eqv1,eqv2,eqv3,eqv4} =
     new Tuple4Equiv(eqv1, eqv2, eqv3, eqv4)
 
-  private final class Tuple4Equiv[T1, T2, T3, T4](private val eqv1: Equiv[T1],
-                                                        private val eqv2: Equiv[T2],
-                                                        private val eqv3: Equiv[T3],
-                                                        private val eqv4: Equiv[T4])
+  private final class Tuple4Equiv[T1, T2, T3, T4](private val eqv1: Equiv[T1]^,
+                                                        private val eqv2: Equiv[T2]^,
+                                                        private val eqv3: Equiv[T3]^,
+                                                        private val eqv4: Equiv[T4]^)
     extends Equiv[(T1, T2, T3, T4)] {
     def equiv(x: (T1, T2, T3, T4), y: (T1, T2, T3, T4)): Boolean =
       eqv1.equiv(x._1, y._1) &&
@@ -345,14 +346,14 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4).hashCode()
   }
 
-  implicit def Tuple5[T1, T2, T3, T4, T5](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5]): Equiv[(T1, T2, T3, T4, T5)] =
+  implicit def Tuple5[T1, T2, T3, T4, T5](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^, eqv3: Equiv[T3]^, eqv4: Equiv[T4]^, eqv5: Equiv[T5]^): Equiv[(T1, T2, T3, T4, T5)]^{eqv1,eqv2,eqv3,eqv4,eqv5} =
     new Tuple5Equiv(eqv1, eqv2, eqv3, eqv4, eqv5)
 
-  private final class Tuple5Equiv[T1, T2, T3, T4, T5](private val eqv1: Equiv[T1],
-                                                            private val eqv2: Equiv[T2],
-                                                            private val eqv3: Equiv[T3],
-                                                            private val eqv4: Equiv[T4],
-                                                            private val eqv5: Equiv[T5])
+  private final class Tuple5Equiv[T1, T2, T3, T4, T5](private val eqv1: Equiv[T1]^,
+                                                            private val eqv2: Equiv[T2]^,
+                                                            private val eqv3: Equiv[T3]^,
+                                                            private val eqv4: Equiv[T4]^,
+                                                            private val eqv5: Equiv[T5]^)
     extends Equiv[(T1, T2, T3, T4, T5)] {
     def equiv(x: (T1, T2, T3, T4, T5), y: (T1, T2, T3, T4, T5)): Boolean =
       eqv1.equiv(x._1, y._1) &&
@@ -374,15 +375,15 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5).hashCode()
   }
 
-  implicit def Tuple6[T1, T2, T3, T4, T5, T6](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6]): Equiv[(T1, T2, T3, T4, T5, T6)] =
+  implicit def Tuple6[T1, T2, T3, T4, T5, T6](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^, eqv3: Equiv[T3]^, eqv4: Equiv[T4]^, eqv5: Equiv[T5]^, eqv6: Equiv[T6]^): Equiv[(T1, T2, T3, T4, T5, T6)]^{eqv1,eqv2,eqv3,eqv4,eqv5,eqv6} =
     new Tuple6Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6)
 
-  private final class Tuple6Equiv[T1, T2, T3, T4, T5, T6](private val eqv1: Equiv[T1],
-                                                                private val eqv2: Equiv[T2],
-                                                                private val eqv3: Equiv[T3],
-                                                                private val eqv4: Equiv[T4],
-                                                                private val eqv5: Equiv[T5],
-                                                                private val eqv6: Equiv[T6])
+  private final class Tuple6Equiv[T1, T2, T3, T4, T5, T6](private val eqv1: Equiv[T1]^,
+                                                                private val eqv2: Equiv[T2]^,
+                                                                private val eqv3: Equiv[T3]^,
+                                                                private val eqv4: Equiv[T4]^,
+                                                                private val eqv5: Equiv[T5]^,
+                                                                private val eqv6: Equiv[T6]^)
     extends Equiv[(T1, T2, T3, T4, T5, T6)] {
     def equiv(x: (T1, T2, T3, T4, T5, T6), y: (T1, T2, T3, T4, T5, T6)): Boolean =
       eqv1.equiv(x._1, y._1) &&
@@ -406,16 +407,16 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5, eqv6).hashCode()
   }
 
-  implicit def Tuple7[T1, T2, T3, T4, T5, T6, T7](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6], eqv7: Equiv[T7]): Equiv[(T1, T2, T3, T4, T5, T6, T7)] =
+  implicit def Tuple7[T1, T2, T3, T4, T5, T6, T7](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^, eqv3: Equiv[T3]^, eqv4: Equiv[T4]^, eqv5: Equiv[T5]^, eqv6: Equiv[T6]^, eqv7: Equiv[T7]^): Equiv[(T1, T2, T3, T4, T5, T6, T7)]^{eqv1,eqv2,eqv3,eqv4,eqv5,eqv6,eqv7} =
     new Tuple7Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7)
 
-  private final class Tuple7Equiv[T1, T2, T3, T4, T5, T6, T7](private val eqv1: Equiv[T1],
-                                                                    private val eqv2: Equiv[T2],
-                                                                    private val eqv3: Equiv[T3],
-                                                                    private val eqv4: Equiv[T4],
-                                                                    private val eqv5: Equiv[T5],
-                                                                    private val eqv6: Equiv[T6],
-                                                                    private val eqv7: Equiv[T7])
+  private final class Tuple7Equiv[T1, T2, T3, T4, T5, T6, T7](private val eqv1: Equiv[T1]^,
+                                                                    private val eqv2: Equiv[T2]^,
+                                                                    private val eqv3: Equiv[T3]^,
+                                                                    private val eqv4: Equiv[T4]^,
+                                                                    private val eqv5: Equiv[T5]^,
+                                                                    private val eqv6: Equiv[T6]^,
+                                                                    private val eqv7: Equiv[T7]^)
     extends Equiv[(T1, T2, T3, T4, T5, T6, T7)] {
     def equiv(x: (T1, T2, T3, T4, T5, T6, T7), y: (T1, T2, T3, T4, T5, T6, T7)): Boolean =
       eqv1.equiv(x._1, y._1) &&
@@ -441,17 +442,17 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7).hashCode()
   }
 
-  implicit def Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6], eqv7: Equiv[T7], eqv8: Equiv[T8]): Equiv[(T1, T2, T3, T4, T5, T6, T7, T8)] =
+  implicit def Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^, eqv3: Equiv[T3]^, eqv4: Equiv[T4]^, eqv5: Equiv[T5]^, eqv6: Equiv[T6]^, eqv7: Equiv[T7]^, eqv8: Equiv[T8]^): Equiv[(T1, T2, T3, T4, T5, T6, T7, T8)]^{eqv1,eqv2,eqv3,eqv4,eqv5,eqv6,eqv7,eqv8} =
     new Tuple8Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7, eqv8)
 
-  private final class Tuple8Equiv[T1, T2, T3, T4, T5, T6, T7, T8](private val eqv1: Equiv[T1],
-                                                                        private val eqv2: Equiv[T2],
-                                                                        private val eqv3: Equiv[T3],
-                                                                        private val eqv4: Equiv[T4],
-                                                                        private val eqv5: Equiv[T5],
-                                                                        private val eqv6: Equiv[T6],
-                                                                        private val eqv7: Equiv[T7],
-                                                                        private val eqv8: Equiv[T8])
+  private final class Tuple8Equiv[T1, T2, T3, T4, T5, T6, T7, T8](private val eqv1: Equiv[T1]^,
+                                                                        private val eqv2: Equiv[T2]^,
+                                                                        private val eqv3: Equiv[T3]^,
+                                                                        private val eqv4: Equiv[T4]^,
+                                                                        private val eqv5: Equiv[T5]^,
+                                                                        private val eqv6: Equiv[T6]^,
+                                                                        private val eqv7: Equiv[T7]^,
+                                                                        private val eqv8: Equiv[T8]^)
     extends Equiv[(T1, T2, T3, T4, T5, T6, T7, T8)] {
     def equiv(x: (T1, T2, T3, T4, T5, T6, T7, T8), y: (T1, T2, T3, T4, T5, T6, T7, T8)): Boolean =
       eqv1.equiv(x._1, y._1) &&
@@ -479,18 +480,18 @@ object Equiv extends LowPriorityEquiv {
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7, eqv8).hashCode()
   }
 
-  implicit def Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6], eqv7: Equiv[T7], eqv8 : Equiv[T8], eqv9: Equiv[T9]): Equiv[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
+  implicit def Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit eqv1: Equiv[T1]^, eqv2: Equiv[T2]^, eqv3: Equiv[T3]^, eqv4: Equiv[T4]^, eqv5: Equiv[T5]^, eqv6: Equiv[T6]^, eqv7: Equiv[T7]^, eqv8 : Equiv[T8]^, eqv9: Equiv[T9]^): Equiv[(T1, T2, T3, T4, T5, T6, T7, T8, T9)]^{eqv1,eqv2,eqv3,eqv4,eqv5,eqv6,eqv7,eqv8,eqv9} =
     new Tuple9Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7, eqv8, eqv9)
 
-  private final class Tuple9Equiv[T1, T2, T3, T4, T5, T6, T7, T8, T9](private val eqv1: Equiv[T1],
-                                                                            private val eqv2: Equiv[T2],
-                                                                            private val eqv3: Equiv[T3],
-                                                                            private val eqv4: Equiv[T4],
-                                                                            private val eqv5: Equiv[T5],
-                                                                            private val eqv6: Equiv[T6],
-                                                                            private val eqv7: Equiv[T7],
-                                                                            private val eqv8: Equiv[T8],
-                                                                            private val eqv9: Equiv[T9])
+  private final class Tuple9Equiv[T1, T2, T3, T4, T5, T6, T7, T8, T9](private val eqv1: Equiv[T1]^,
+                                                                            private val eqv2: Equiv[T2]^,
+                                                                            private val eqv3: Equiv[T3]^,
+                                                                            private val eqv4: Equiv[T4]^,
+                                                                            private val eqv5: Equiv[T5]^,
+                                                                            private val eqv6: Equiv[T6]^,
+                                                                            private val eqv7: Equiv[T7]^,
+                                                                            private val eqv8: Equiv[T8]^,
+                                                                            private val eqv9: Equiv[T9]^)
     extends Equiv[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {
     def equiv(x: (T1, T2, T3, T4, T5, T6, T7, T8, T9), y: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Boolean =
       eqv1.equiv(x._1, y._1) &&

--- a/library/src/scala/math/Fractional.scala
+++ b/library/src/scala/math/Fractional.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/math/Integral.scala
+++ b/library/src/scala/math/Integral.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -13,13 +13,14 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.StringParsers
 import scala.language.implicitConversions
 import scala.util.Try
 
 object Numeric {
-  @inline def apply[T](implicit num: Numeric[T]): Numeric[T] = num
+  @inline def apply[T](implicit num: Numeric[T]^): Numeric[T]^{num} = num
 
   trait ExtraImplicits {
     /** These implicits create conversions from a value for which an implicit Numeric
@@ -252,7 +253,7 @@ trait Numeric[T] extends Ordering[T] {
     else if (gt(x, zero)) one
     else zero
 
-  class NumericOps(lhs: T) {
+  class NumericOps(lhs: T) uses Numeric.this {
     def +(rhs: T) = plus(lhs, rhs)
     def -(rhs: T) = minus(lhs, rhs)
     def *(rhs: T) = times(lhs, rhs)
@@ -265,5 +266,5 @@ trait Numeric[T] extends Ordering[T] {
     def toFloat: Float = Numeric.this.toFloat(lhs)
     def toDouble: Double = Numeric.this.toDouble(lhs)
   }
-  implicit def mkNumericOps(lhs: T): NumericOps = new NumericOps(lhs)
+  implicit def mkNumericOps(lhs: T): NumericOps^{this} = new NumericOps(lhs)
 }

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 
@@ -112,6 +113,6 @@ object Ordered {
    *  @param ord the implicit `Ordering` instance used to perform comparisons
    *  @return an `Ordered[T]` view of `x` that delegates comparisons to `ord`
    */
-  implicit def orderingToOrdered[T](x: T)(implicit ord: Ordering[T]): Ordered[T] =
+  implicit def orderingToOrdered[T](x: T)(implicit ord: Ordering[T]^): Ordered[T]^{ord} =
     new Ordered[T] { def compare(that: T): Int = ord.compare(x, that) }
 }

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.util.Comparator
 
@@ -81,7 +82,7 @@ import scala.annotation.unchecked.uncheckedOverride
  *  @tparam T the type of objects that this ordering can compare
  */
 trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable {
-  outer =>
+  outer: Ordering[T]^ =>
 
   /** Returns whether a comparison between `x` and `y` is defined, and if so
    *  the result of `compare(x, y)`.
@@ -165,7 +166,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *
    *  @return an `Ordering[T]` that compares elements in the reverse order of this ordering
    */
-  override def reverse: Ordering[T] = new Ordering.Reverse[T](this)
+  override def reverse: Ordering[T]^{this} = new Ordering.Reverse[T](this)
 
   /** Returns whether or not the other ordering is the opposite
    *  ordering of this one.
@@ -178,7 +179,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param other the ordering to check
    *  @return `true` if `other` is the reverse of this ordering, `false` otherwise
    */
-  def isReverseOf(other: Ordering[?]): Boolean = other match {
+  def isReverseOf(other: Ordering[?]^): Boolean = other match {
     case that: Ordering.Reverse[?] => that.outer == this
     case _ => false
   }
@@ -194,7 +195,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param f the function to extract a `T` value from a `U` value
    *  @return an `Ordering[U]` that orders values by applying `f` and comparing the results using this ordering
    */
-  def on[U](f: U => T): Ordering[U] = new Ordering[U] {
+  def on[U](f: U => T): Ordering[U]^{this, f} = new Ordering[U] {
     def compare(x: U, y: U) = outer.compare(f(x), f(y))
   }
 
@@ -213,7 +214,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param other an Ordering to use if this Ordering returns zero
    *  @return an `Ordering[T]` that uses this ordering first, falling back to `other` when values are equal
    */
-  def orElse(other: Ordering[T]): Ordering[T] = (x, y) => {
+  def orElse(other: Ordering[T]^): Ordering[T]^{this, other} = (x, y) => {
     val res1 = outer.compare(x, y)
     if (res1 != 0) res1 else other.compare(x, y)
   }
@@ -242,7 +243,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param ord the implicit ordering for the extracted key type `S`
    *  @return an `Ordering[T]` that uses this ordering first, falling back to comparing by `f` when values are equal
    */
-  def orElseBy[S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] = (x, y) => {
+  def orElseBy[S](f: T => S)(implicit ord: Ordering[S]^): Ordering[T]^{this, ord, f} = (x, y) => {
     val res1 = outer.compare(x, y)
     if (res1 != 0) res1 else ord.compare(f(x), f(y))
   }
@@ -254,7 +255,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *
    *  @param lhs the left-hand side value for infix comparison operations
    */
-  class OrderingOps(lhs: T) {
+  class OrderingOps(lhs: T) uses Ordering.this {
     def <(rhs: T): Boolean = lt(lhs, rhs)
     def <=(rhs: T): Boolean = lteq(lhs, rhs)
     def >(rhs: T): Boolean = gt(lhs, rhs)
@@ -270,7 +271,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param lhs the value to enrich with ordering operators
    *  @return an `OrderingOps` wrapping `lhs` and providing infix comparison operators
    */
-  implicit def mkOrderingOps(lhs: T): OrderingOps = new OrderingOps(lhs)
+  implicit def mkOrderingOps(lhs: T): OrderingOps^{this} = new OrderingOps(lhs)
 }
 
 trait LowPriorityOrderingImplicits {
@@ -287,7 +288,7 @@ trait LowPriorityOrderingImplicits {
    *  @param asComparable the implicit conversion from `A` to `Comparable[? >: A]`
    *  @return an `Ordering[A]` that compares values by delegating to their `Comparable.compareTo`
    */
-  implicit def ordered[A](implicit asComparable: AsComparable[A]): Ordering[A] = new Ordering[A] {
+  implicit def ordered[A](implicit asComparable: AsComparable[A]): Ordering[A]^{asComparable} = new Ordering[A] {
     def compare(x: A, y: A): Int = asComparable(x).compareTo(y)
   }
 
@@ -314,8 +315,8 @@ object Ordering extends LowPriorityOrderingImplicits {
    */
   sealed trait CachedReverse[T] extends Ordering[T] {
     private val _reverse = super.reverse
-    override final def reverse: Ordering[T] = _reverse
-    override final def isReverseOf(other: Ordering[?]): Boolean = other eq _reverse
+    override final def reverse: Ordering[T]^{this} = _reverse
+    override final def isReverseOf(other: Ordering[?]^): Boolean = other eq _reverse
   }
 
   /** A reverse ordering.
@@ -323,9 +324,10 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  @tparam T the type of objects that this ordering can compare
    *  @param outer the original ordering to be reversed
    */
-  private final class Reverse[T](private[Ordering] val outer: Ordering[T]) extends Ordering[T] {
-    override def reverse: Ordering[T]                   = outer
-    override def isReverseOf(other: Ordering[?]): Boolean = other == outer
+  /** A reverse ordering. */
+  private final class Reverse[T](private[Ordering] val outer: Ordering[T]^) extends Ordering[T] {
+    override def reverse: Ordering[T]^{this}               = outer
+    override def isReverseOf(other: Ordering[?]^): Boolean = other == outer
 
     def compare(x: T, y: T): Int            = outer.compare(y, x)
     override def lteq(x: T, y: T): Boolean  = outer.lteq(y, x)
@@ -345,7 +347,7 @@ object Ordering extends LowPriorityOrderingImplicits {
   }
 
   @SerialVersionUID(-2996748994664583574L)
-  private final class IterableOrdering[CC[X] <: Iterable[X], T](private val ord: Ordering[T]) extends Ordering[CC[T]] {
+  private final class IterableOrdering[CC[X] <: Iterable[X], T](private val ord: Ordering[T]^) extends Ordering[CC[T]] {
     def compare(x: CC[T], y: CC[T]): Int = {
       val xe = x.iterator
       val ye = y.iterator
@@ -407,7 +409,7 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  @param cmp a function that returns `true` if the first argument is less than the second
    *  @return an `Ordering[T]` whose comparison is derived from `cmp`
    */
-  def fromLessThan[T](cmp: (T, T) => Boolean): Ordering[T] = new Ordering[T] {
+  def fromLessThan[T](cmp: (T, T) => Boolean): Ordering[T]^{cmp} = new Ordering[T] {
     def compare(x: T, y: T) = if (cmp(x, y)) -1 else if (cmp(y, x)) 1 else 0
     // overrides to avoid multiple comparisons
     override def lt(x: T, y: T): Boolean = cmp(x, y)
@@ -432,7 +434,7 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  @param ord the implicit ordering for the extracted key type `S`
    *  @return an `Ordering[T]` that orders values by applying `f` and comparing the results
    */
-  def by[T, S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] = new Ordering[T] {
+  def by[T, S](f: T => S)(implicit ord: Ordering[S]^): Ordering[T]^{f, ord} = new Ordering[T] {
     def compare(x: T, y: T) = ord.compare(f(x), f(y))
     override def lt(x: T, y: T): Boolean = ord.lt(f(x), f(y))
     override def gt(x: T, y: T): Boolean = ord.gt(f(x), f(y))
@@ -732,15 +734,15 @@ object Ordering extends LowPriorityOrderingImplicits {
    */
   @deprecated("Iterables are not guaranteed to have a consistent order; if using a type with a " +
     "consistent order (e.g. Seq), use its Ordering (found in the Ordering.Implicits object)", since = "2.13.0")
-  implicit def Iterable[T](implicit ord: Ordering[T]): Ordering[Iterable[T]] =
+  implicit def Iterable[T](implicit ord: Ordering[T]^): Ordering[Iterable[T]]^{ord} =
     new IterableOrdering[Iterable, T](ord)
 
-  implicit def Tuple2[T1, T2](implicit ord1: Ordering[T1], ord2: Ordering[T2]): Ordering[(T1, T2)] =
+  implicit def Tuple2[T1, T2](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^): Ordering[(T1, T2)]^{ord1, ord2} =
     new Tuple2Ordering(ord1, ord2)
 
   @SerialVersionUID(4945084135299531202L)
-  private final class Tuple2Ordering[T1, T2](private val ord1: Ordering[T1],
-                                                   private val ord2: Ordering[T2]) extends Ordering[(T1, T2)] {
+  private final class Tuple2Ordering[T1, T2](private val ord1: Ordering[T1]^,
+                                                   private val ord2: Ordering[T2]^) extends Ordering[(T1, T2)] {
     def compare(x: (T1, T2), y: (T1, T2)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -757,13 +759,13 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def hashCode(): Int = (ord1, ord2).hashCode()
   }
 
-  implicit def Tuple3[T1, T2, T3](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3]) : Ordering[(T1, T2, T3)] =
+  implicit def Tuple3[T1, T2, T3](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^, ord3: Ordering[T3]^) : Ordering[(T1, T2, T3)]^{ord1,ord2,ord3} =
     new Tuple3Ordering(ord1, ord2, ord3)
 
   @SerialVersionUID(-5367223704121832335L)
-  private final class Tuple3Ordering[T1, T2, T3](private val ord1: Ordering[T1],
-                                                       private val ord2: Ordering[T2],
-                                                       private val ord3: Ordering[T3]) extends Ordering[(T1, T2, T3)] {
+  private final class Tuple3Ordering[T1, T2, T3](private val ord1: Ordering[T1]^,
+                                                       private val ord2: Ordering[T2]^,
+                                                       private val ord3: Ordering[T3]^) extends Ordering[(T1, T2, T3)] {
     def compare(x: (T1, T2, T3), y: (T1, T2, T3)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -783,14 +785,14 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def hashCode(): Int = (ord1, ord2, ord3).hashCode()
   }
 
-  implicit def Tuple4[T1, T2, T3, T4](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4]) : Ordering[(T1, T2, T3, T4)] =
+  implicit def Tuple4[T1, T2, T3, T4](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^, ord3: Ordering[T3]^, ord4: Ordering[T4]^) : Ordering[(T1, T2, T3, T4)]^{ord1,ord2,ord3,ord4} =
     new Tuple4Ordering(ord1, ord2, ord3, ord4)
 
   @SerialVersionUID(-6055313861145218178L)
-  private final class Tuple4Ordering[T1, T2, T3, T4](private val ord1: Ordering[T1],
-                                                           private val ord2: Ordering[T2],
-                                                           private val ord3: Ordering[T3],
-                                                           private val ord4: Ordering[T4])
+  private final class Tuple4Ordering[T1, T2, T3, T4](private val ord1: Ordering[T1]^,
+                                                           private val ord2: Ordering[T2]^,
+                                                           private val ord3: Ordering[T3]^,
+                                                           private val ord4: Ordering[T4]^)
     extends Ordering[(T1, T2, T3, T4)] {
     def compare(x: (T1, T2, T3, T4), y: (T1, T2, T3, T4)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
@@ -814,15 +816,15 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def hashCode(): Int = (ord1, ord2, ord3, ord4).hashCode()
   }
 
-  implicit def Tuple5[T1, T2, T3, T4, T5](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5]): Ordering[(T1, T2, T3, T4, T5)] =
+  implicit def Tuple5[T1, T2, T3, T4, T5](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^, ord3: Ordering[T3]^, ord4: Ordering[T4]^, ord5: Ordering[T5]^): Ordering[(T1, T2, T3, T4, T5)]^{ord1, ord2, ord3, ord4, ord5} =
     new Tuple5Ordering(ord1, ord2, ord3, ord4, ord5)
 
   @SerialVersionUID(-5517329921227646061L)
-  private final class Tuple5Ordering[T1, T2, T3, T4, T5](private val ord1: Ordering[T1],
-                                                               private val ord2: Ordering[T2],
-                                                               private val ord3: Ordering[T3],
-                                                               private val ord4: Ordering[T4],
-                                                               private val ord5: Ordering[T5])
+  private final class Tuple5Ordering[T1, T2, T3, T4, T5](private val ord1: Ordering[T1]^,
+                                                               private val ord2: Ordering[T2]^,
+                                                               private val ord3: Ordering[T3]^,
+                                                               private val ord4: Ordering[T4]^,
+                                                               private val ord5: Ordering[T5]^)
     extends Ordering[(T1, T2, T3, T4, T5)] {
     def compare(x: (T1, T2, T3, T4, T5), y: (T1, T2, T3, T4, T5)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
@@ -850,15 +852,15 @@ object Ordering extends LowPriorityOrderingImplicits {
   }
 
   @SerialVersionUID(3045467524192969060L)
-  implicit def Tuple6[T1, T2, T3, T4, T5, T6](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6]): Ordering[(T1, T2, T3, T4, T5, T6)] =
+  implicit def Tuple6[T1, T2, T3, T4, T5, T6](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^, ord3: Ordering[T3]^, ord4: Ordering[T4]^, ord5: Ordering[T5]^, ord6: Ordering[T6]^): Ordering[(T1, T2, T3, T4, T5, T6)]^{ord1, ord2, ord3, ord4, ord5, ord6} =
     new Tuple6Ordering(ord1, ord2, ord3, ord4, ord5, ord6)
 
-  private final class Tuple6Ordering[T1, T2, T3, T4, T5, T6](private val ord1: Ordering[T1],
-                                                                   private val ord2: Ordering[T2],
-                                                                   private val ord3: Ordering[T3],
-                                                                   private val ord4: Ordering[T4],
-                                                                   private val ord5: Ordering[T5],
-                                                                   private val ord6: Ordering[T6])
+  private final class Tuple6Ordering[T1, T2, T3, T4, T5, T6](private val ord1: Ordering[T1]^,
+                                                                   private val ord2: Ordering[T2]^,
+                                                                   private val ord3: Ordering[T3]^,
+                                                                   private val ord4: Ordering[T4]^,
+                                                                   private val ord5: Ordering[T5]^,
+                                                                   private val ord6: Ordering[T6]^)
     extends Ordering[(T1, T2, T3, T4, T5, T6)] {
     def compare(x: (T1, T2, T3, T4, T5, T6), y: (T1, T2, T3, T4, T5, T6)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
@@ -888,17 +890,17 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6).hashCode()
   }
 
-  implicit def Tuple7[T1, T2, T3, T4, T5, T6, T7](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7]): Ordering[(T1, T2, T3, T4, T5, T6, T7)] =
+  implicit def Tuple7[T1, T2, T3, T4, T5, T6, T7](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^, ord3: Ordering[T3]^, ord4: Ordering[T4]^, ord5: Ordering[T5]^, ord6: Ordering[T6]^, ord7: Ordering[T7]^): Ordering[(T1, T2, T3, T4, T5, T6, T7)]^{ord1, ord2, ord3, ord4, ord5, ord6, ord7} =
     new Tuple7Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7)
 
   @SerialVersionUID(1253188205893682451L)
-  private final class Tuple7Ordering[T1, T2, T3, T4, T5, T6, T7](private val ord1: Ordering[T1],
-                                                                       private val ord2: Ordering[T2],
-                                                                       private val ord3: Ordering[T3],
-                                                                       private val ord4: Ordering[T4],
-                                                                       private val ord5: Ordering[T5],
-                                                                       private val ord6: Ordering[T6],
-                                                                       private val ord7: Ordering[T7])
+  private final class Tuple7Ordering[T1, T2, T3, T4, T5, T6, T7](private val ord1: Ordering[T1]^,
+                                                                       private val ord2: Ordering[T2]^,
+                                                                       private val ord3: Ordering[T3]^,
+                                                                       private val ord4: Ordering[T4]^,
+                                                                       private val ord5: Ordering[T5]^,
+                                                                       private val ord6: Ordering[T6]^,
+                                                                       private val ord7: Ordering[T7]^)
     extends Ordering[(T1, T2, T3, T4, T5, T6, T7)] {
     def compare(x: (T1, T2, T3, T4, T5, T6, T7), y: (T1, T2, T3, T4, T5, T6, T7)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
@@ -932,17 +934,17 @@ object Ordering extends LowPriorityOrderingImplicits {
   }
 
   @SerialVersionUID(4003095353309354068L)
-  implicit def Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7], ord8: Ordering[T8]): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)] =
+  implicit def Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^, ord3: Ordering[T3]^, ord4: Ordering[T4]^, ord5: Ordering[T5]^, ord6: Ordering[T6]^, ord7: Ordering[T7]^, ord8: Ordering[T8]^): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)]^{ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8} =
     new Tuple8Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8)
 
-  private final class Tuple8Ordering[T1, T2, T3, T4, T5, T6, T7, T8](private val ord1: Ordering[T1],
-                                                                           private val ord2: Ordering[T2],
-                                                                           private val ord3: Ordering[T3],
-                                                                           private val ord4: Ordering[T4],
-                                                                           private val ord5: Ordering[T5],
-                                                                           private val ord6: Ordering[T6],
-                                                                           private val ord7: Ordering[T7],
-                                                                           private val ord8: Ordering[T8])
+  private final class Tuple8Ordering[T1, T2, T3, T4, T5, T6, T7, T8](private val ord1: Ordering[T1]^,
+                                                                           private val ord2: Ordering[T2]^,
+                                                                           private val ord3: Ordering[T3]^,
+                                                                           private val ord4: Ordering[T4]^,
+                                                                           private val ord5: Ordering[T5]^,
+                                                                           private val ord6: Ordering[T6]^,
+                                                                           private val ord7: Ordering[T7]^,
+                                                                           private val ord8: Ordering[T8]^)
     extends Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)] {
     def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8), y: (T1, T2, T3, T4, T5, T6, T7, T8)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
@@ -979,18 +981,18 @@ object Ordering extends LowPriorityOrderingImplicits {
   }
 
   @SerialVersionUID(8185342054829975001L)
-  implicit def Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7], ord8 : Ordering[T8], ord9: Ordering[T9]): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
+  implicit def Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit ord1: Ordering[T1]^, ord2: Ordering[T2]^, ord3: Ordering[T3]^, ord4: Ordering[T4]^, ord5: Ordering[T5]^, ord6: Ordering[T6]^, ord7: Ordering[T7]^, ord8 : Ordering[T8]^, ord9: Ordering[T9]^): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)]^{ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9} =
     new Tuple9Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9)
 
-  private final class Tuple9Ordering[T1, T2, T3, T4, T5, T6, T7, T8, T9](private val ord1: Ordering[T1],
-                                                                               private val ord2: Ordering[T2],
-                                                                               private val ord3: Ordering[T3],
-                                                                               private val ord4: Ordering[T4],
-                                                                               private val ord5: Ordering[T5],
-                                                                               private val ord6: Ordering[T6],
-                                                                               private val ord7: Ordering[T7],
-                                                                               private val ord8: Ordering[T8],
-                                                                               private val ord9: Ordering[T9])
+  private final class Tuple9Ordering[T1, T2, T3, T4, T5, T6, T7, T8, T9](private val ord1: Ordering[T1]^,
+                                                                               private val ord2: Ordering[T2]^,
+                                                                               private val ord3: Ordering[T3]^,
+                                                                               private val ord4: Ordering[T4]^,
+                                                                               private val ord5: Ordering[T5]^,
+                                                                               private val ord6: Ordering[T6]^,
+                                                                               private val ord7: Ordering[T7]^,
+                                                                               private val ord8: Ordering[T8]^,
+                                                                               private val ord9: Ordering[T9]^)
     extends Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {
     def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8, T9), y: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Int = {
       val compare1 = ord1.compare(x._1, y._1)

--- a/library/src/scala/math/PartialOrdering.scala
+++ b/library/src/scala/math/PartialOrdering.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A trait for representing partial orderings.  It is important to
@@ -43,7 +44,7 @@ import scala.language.`2.13`
  */
 
 trait PartialOrdering[T] extends Equiv[T] {
-  outer =>
+  outer: PartialOrdering[T]^ =>
 
   /** Result of comparing `x` with operand `y`.
    *  Returns `None` if operands are not comparable.
@@ -99,7 +100,7 @@ trait PartialOrdering[T] extends Equiv[T] {
    */
   def equiv(x: T, y: T): Boolean = lteq(x,y) && lteq(y,x)
 
-  def reverse : PartialOrdering[T] = new PartialOrdering[T] {
+  def reverse : PartialOrdering[T]^{this} = new PartialOrdering[T] {
     override def reverse = outer
     def tryCompare(x: T, y: T) = outer.tryCompare(y, x)
     def lteq(x: T, y: T) = outer.lteq(y, x)
@@ -111,5 +112,5 @@ trait PartialOrdering[T] extends Equiv[T] {
 }
 
 object PartialOrdering {
-  @inline def apply[T](implicit ev: PartialOrdering[T]): PartialOrdering[T] = ev
+  @inline def apply[T](implicit ev: PartialOrdering[T]^): PartialOrdering[T]^{ev} = ev
 }

--- a/library/src/scala/math/PartiallyOrdered.scala
+++ b/library/src/scala/math/PartiallyOrdered.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A class for partially ordered data.

--- a/library/src/scala/math/ScalaNumericConversions.scala
+++ b/library/src/scala/math/ScalaNumericConversions.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A slightly more specific conversion trait for classes which

--- a/library/src/scala/math/package.scala
+++ b/library/src/scala/math/package.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** The package object `scala.math` contains methods for performing basic

--- a/library/src/scala/native.scala
+++ b/library/src/scala/native.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Marker for native methods.

--- a/library/src/scala/noinline.scala
+++ b/library/src/scala/noinline.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/package.scala
+++ b/library/src/scala/package.scala
@@ -10,6 +10,7 @@
  * additional information regarding copyright ownership.
  */
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.migration
 

--- a/library/src/scala/ref/PhantomReference.scala
+++ b/library/src/scala/ref/PhantomReference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 class PhantomReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/ref/ReferenceQueue.scala
+++ b/library/src/scala/ref/ReferenceQueue.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 class ReferenceQueue[+T <: AnyRef] {

--- a/library/src/scala/ref/ReferenceWrapper.scala
+++ b/library/src/scala/ref/ReferenceWrapper.scala
@@ -12,11 +12,12 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.nowarn
 
 @nowarn("cat=deprecation")
-trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
+trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy with caps.Pure {
   val underlying: java.lang.ref.Reference[? <: T]
   override def get = Option(underlying.get)
   def apply() = {

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T] | Null) extends ReferenceWrapper[T] {

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A wrapper class for java.lang.ref.WeakReference

--- a/library/src/scala/runtime/ArrayCharSequence.scala
+++ b/library/src/scala/runtime/ArrayCharSequence.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 // Still need this one since the implicit class ArrayCharSequence only converts

--- a/library/src/scala/runtime/ClassValueCompat.scala
+++ b/library/src/scala/runtime/ClassValueCompat.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.runtime.ClassValueCompat._
 

--- a/library/src/scala/runtime/ClassValueCompat.scala
+++ b/library/src/scala/runtime/ClassValueCompat.scala
@@ -16,7 +16,7 @@ import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.runtime.ClassValueCompat._
 
-private[scala] abstract class ClassValueCompat[T] extends ClassValueInterface[T] { self =>
+private[scala] abstract class ClassValueCompat[T] extends ClassValueInterface[T] { self: ClassValueCompat[T] =>
   private val instance: ClassValueInterface[T] =
     if (classValueAvailable) new JavaClassValue()
     else new FallbackClassValue()

--- a/library/src/scala/runtime/LambdaDeserialize.scala
+++ b/library/src/scala/runtime/LambdaDeserialize.scala
@@ -18,6 +18,7 @@ import java.util
 import scala.annotation.varargs
 import scala.collection.immutable
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class LambdaDeserialize private (lookup: MethodHandles.Lookup, targetMethods: Array[MethodHandle]) {

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.invoke._
 

--- a/library/src/scala/runtime/LazyRef.scala
+++ b/library/src/scala/runtime/LazyRef.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Classes used as holders for lazy vals defined in methods. */

--- a/library/src/scala/runtime/MethodCache.scala
+++ b/library/src/scala/runtime/MethodCache.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.reflect.{ Method => JMethod }
 import java.lang.{ Class => JClass }

--- a/library/src/scala/runtime/ModuleSerializationProxy.scala
+++ b/library/src/scala/runtime/ModuleSerializationProxy.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.io.Serializable
 import java.security.PrivilegedActionException

--- a/library/src/scala/runtime/NonLocalReturnControl.scala
+++ b/library/src/scala/runtime/NonLocalReturnControl.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.util.control.ControlThrowable
 

--- a/library/src/scala/runtime/Nothing$.scala
+++ b/library/src/scala/runtime/Nothing$.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/runtime/Null$.scala
+++ b/library/src/scala/runtime/Null$.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/runtime/PStatics.scala
+++ b/library/src/scala/runtime/PStatics.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 // things that should be in `Statics`, but can't be yet for bincompat reasons

--- a/library/src/scala/runtime/RichBoolean.scala
+++ b/library/src/scala/runtime/RichBoolean.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class RichBoolean(val self: Boolean) extends AnyVal with OrderedProxy[Boolean] {

--- a/library/src/scala/runtime/RichByte.scala
+++ b/library/src/scala/runtime/RichByte.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class RichByte(val self: Byte) extends AnyVal with ScalaWholeNumberProxy[Byte] {

--- a/library/src/scala/runtime/RichChar.scala
+++ b/library/src/scala/runtime/RichChar.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class RichChar(val self: Char) extends AnyVal with IntegralProxy[Char] {

--- a/library/src/scala/runtime/RichDouble.scala
+++ b/library/src/scala/runtime/RichDouble.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Double] {

--- a/library/src/scala/runtime/RichFloat.scala
+++ b/library/src/scala/runtime/RichFloat.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float] {

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.immutable.Range
 

--- a/library/src/scala/runtime/RichLong.scala
+++ b/library/src/scala/runtime/RichLong.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {

--- a/library/src/scala/runtime/RichShort.scala
+++ b/library/src/scala/runtime/RichShort.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class RichShort(val self: Short) extends AnyVal with ScalaWholeNumberProxy[Short] {

--- a/library/src/scala/runtime/ScalaNumberProxy.scala
+++ b/library/src/scala/runtime/ScalaNumberProxy.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.immutable
 import scala.math.ScalaNumericAnyConversions
@@ -77,7 +78,7 @@ trait FractionalProxy[T] extends Any with ScalaNumberProxy[T] {
 
 @nowarn("cat=deprecation")
 trait OrderedProxy[T] extends Any with Ordered[T] with Proxy.Typed[T] {
-  protected def ord: Ordering[T]
+  protected def ord: Ordering[T]^
 
   def compare(y: T) = ord.compare(self, y)
 }

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.{AbstractIterator, AnyConstr, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View}
 import scala.collection.generic.IsIterable
@@ -66,7 +67,7 @@ object ScalaRunTime {
    *  @param idx the index of the element to retrieve
    *  @return the element at position `idx` in the array
    */
-  def array_apply(xs: AnyRef, idx: Int): Any = {
+  def array_apply(xs: AnyRef^, idx: Int): Any = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
       case x: Array[Int]     => x(idx).asInstanceOf[Any]
@@ -87,7 +88,7 @@ object ScalaRunTime {
    *  @param idx the index of the element to set
    *  @param value the value to store at the given index
    */
-  def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
+  def array_update(xs: AnyRef^, idx: Int, value: Any): Unit = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
       case x: Array[Int]     => x(idx) = value.asInstanceOf[Int]
@@ -107,11 +108,11 @@ object ScalaRunTime {
    *  @param xs the array to measure, as an `AnyRef`
    *  @return the number of elements in the array
    */
-  @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
+  @inline def array_length(xs: AnyRef^): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
   // the type switch. See Array_clone comment in BCodeBodyBuilder.
-  def array_clone(xs: AnyRef): AnyRef = (xs: @unchecked) match {
+  def array_clone(xs: AnyRef^): AnyRef = (xs: @unchecked) match {
     case x: Array[AnyRef]  => x.clone()
     case x: Array[Int]     => x.clone()
     case x: Array[Double]  => x.clone()
@@ -131,7 +132,7 @@ object ScalaRunTime {
    *  @param src the source array to convert, which may be a primitive array
    *  @return an `Array[Object]` containing the (boxed) elements of `src`
    */
-  def toObjectArray(src: AnyRef): Array[Object] = {
+  def toObjectArray(src: AnyRef^): Array[Object] = {
     def copy[@specialized T <: AnyVal](src: Array[T]): Array[Object] = {
       val length = src.length
       if (length == 0) Array.emptyObjectArray

--- a/library/src/scala/runtime/StructuralCallSite.scala
+++ b/library/src/scala/runtime/StructuralCallSite.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.invoke._
 import java.lang.ref.SoftReference

--- a/library/src/scala/runtime/VarArgsBuilder.scala
+++ b/library/src/scala/runtime/VarArgsBuilder.scala
@@ -1,5 +1,6 @@
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.collection.immutable.ArraySeq
 import scala.reflect.ClassTag
 

--- a/library/src/scala/specialized.scala
+++ b/library/src/scala/specialized.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import Specializable._

--- a/library/src/scala/sys/BooleanProp.scala
+++ b/library/src/scala/sys/BooleanProp.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/sys/Prop.scala
+++ b/library/src/scala/sys/Prop.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A lightweight interface wrapping a property contained in some
@@ -95,7 +96,7 @@ object Prop {
      *  @param key the property name used for lookup
      *  @return a new `Prop[T]` backed by the given key
      */
-    def apply(key: String): Prop[T]
+    def apply(key: String): Prop[T]^{this}
   }
 
   implicit object FileProp extends CreatorImpl[java.io.File](s => new java.io.File(s))

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.mutable
 
@@ -52,5 +53,5 @@ private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends P
 }
 
 private[sys] abstract class CreatorImpl[+T](f: String => T) extends Prop.Creator[T] {
-  def apply(key: String): Prop[T] = new PropImpl[T](key, f)
+  def apply(key: String): Prop[T]^{f} = new PropImpl[T](key, f)
 }

--- a/library/src/scala/sys/ShutdownHookThread.scala
+++ b/library/src/scala/sys/ShutdownHookThread.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A minimal Thread wrapper to enhance shutdown hooks.  It knows
@@ -34,7 +35,8 @@ object ShutdownHookThread {
    *  @param body the code to execute when the JVM shuts down
    *  @return the newly created and registered `ShutdownHookThread`
    */
-  def apply(body: => Unit): ShutdownHookThread = {
+  def apply(body: -> Unit): ShutdownHookThread = {
+    // CC note: shutdown hooks capture until the end of the program, so they have to be pure.
     val t = new ShutdownHookThread(() => body, hookName())
     Runtime.getRuntime.addShutdownHook(t)
     t

--- a/library/src/scala/sys/SystemProperties.scala
+++ b/library/src/scala/sys/SystemProperties.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.{mutable, Iterator}
 import scala.jdk.CollectionConverters._

--- a/library/src/scala/sys/package.scala
+++ b/library/src/scala/sys/package.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters._
@@ -73,6 +74,7 @@ package object sys {
     s
   }
 
+  // CC note: shutdown hooks capture until the end of the program, so they must be pure.
   /** Registers a shutdown hook to be run when the VM exits.
    *  The hook is automatically registered: the returned value can be ignored,
    *  but is available in case the Thread requires further modification.
@@ -84,7 +86,7 @@ package object sys {
    *  @return   the `ShutdownHookThread` which will run the shutdown hook
    *  @see      [[scala.sys.ShutdownHookThread]]
    */
-  def addShutdownHook(body: => Unit): ShutdownHookThread = ShutdownHookThread(body)
+  def addShutdownHook(body: -> Unit): ShutdownHookThread = ShutdownHookThread(body)
 
   /** Returns all active thread in the current thread's thread group and subgroups.
    *

--- a/library/src/scala/throws.scala
+++ b/library/src/scala/throws.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Annotation for specifying the exceptions thrown by a method.

--- a/library/src/scala/transient.scala
+++ b/library/src/scala/transient.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/typeConstraints.scala
+++ b/library/src/scala/typeConstraints.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.implicitNotFound
 
@@ -116,8 +117,8 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     substituteCo[Id](f)
   }
 
-  override def compose[C](r: C => From): C => To = {
-    type G[+T] = C => T
+  override def compose[C](r: C => From): C ->{r} To = {
+    type G[+T] = C ->{r} T
     substituteCo[G](r)
   }
   /** If `From <: To` and `C <: From`, then `C <: To` (subtyping is transitive).
@@ -129,8 +130,8 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     type G[+T] = C <:< T
     substituteCo[G](r)
   }
-  override def andThen[C](r: To => C): From => C = {
-    type G[-T] = T => C
+  override def andThen[C](r: To => C): From ->{r} C = {
+    type G[-T] = T ->{r} C
     substituteContra[G](r)
   }
   /** If `From <: To` and `To <: C`, then `From <: C` (subtyping is transitive).
@@ -169,10 +170,10 @@ object <:< {
     override def substituteContra[F[_]](ff: F[Any]) = ff
     override def apply(x: Any) = x
     override def flip: Any =:= Any = this
-    override def compose[C](r: C =>  Any) = r
+    override def compose[C](r: C =>  Any): C ->{r} Any = r
     override def compose[C](r: C <:< Any) = r
     override def compose[C](r: C =:= Any) = r
-    override def andThen[C](r: Any =>  C) = r
+    override def andThen[C](r: Any =>  C): Any ->{r} C = r
     override def andThen[C](r: Any <:< C) = r
     override def andThen[C](r: Any =:= C) = r
     override def liftCo    [F[_]] = asInstanceOf[F[Any] =:= F[Any]]

--- a/library/src/scala/unchecked.scala
+++ b/library/src/scala/unchecked.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation to designate that the annotated entity

--- a/library/src/scala/util/ChainingOps.scala
+++ b/library/src/scala/util/ChainingOps.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 import language.experimental.captureChecking

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.InheritableThreadLocal
 

--- a/library/src/scala/util/Either.scala
+++ b/library/src/scala/util/Either.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import language.experimental.captureChecking
 

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.io.{IOException, PrintWriter}
 import java.util.jar.Attributes.{Name => AttributeName}

--- a/library/src/scala/util/Random.scala
+++ b/library/src/scala/util/Random.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.{migration, tailrec}
 import scala.collection.mutable.ArrayBuffer
@@ -262,7 +263,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *  @param bf the implicit `BuildFrom` instance used to build the result collection
    *  @return         the shuffled collection
    */
-  def shuffle[T, C](xs: IterableOnce[T])(implicit bf: BuildFrom[xs.type, T, C]): C = {
+  def shuffle[T, C](xs: IterableOnce[T]^)(implicit bf: BuildFrom[xs.type, T, C]): C = {
     val buf = new ArrayBuffer[T] ++= xs
 
     def swap(i1: Int, i2: Int): Unit = {

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -13,6 +13,8 @@
 package scala
 package util
 
+// Context bounds cannot carry a capture set
+// import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.reflect.ClassTag
 import scala.math.Ordering

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -291,7 +291,7 @@ object Sorting {
    *  @param a the array to sort in place
    *  @param f a function that returns `true` if its first argument is less than its second
    */
-  @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
+  @`inline` def stableSort[K](a: Array[K], f: (K, K) -> Boolean): Unit = stableSort(a, f, 0, a.length)
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
   /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
@@ -303,7 +303,7 @@ object Sorting {
    *  @param from the first index in the array to sort
    *  @param until the last index (exclusive) in the array to sort
    */
-  def stableSort[K](a: Array[K], f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
+  def stableSort[K](a: Array[K], f: (K, K) -> Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
   /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
    *
@@ -325,7 +325,7 @@ object Sorting {
    *  @param f a function that returns `true` if its first argument is less than its second
    *  @return a new array containing the elements of `a` sorted according to the less-than relation `f`
    */
-  def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) => Boolean): Array[K] = {
+  def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) -> Boolean): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering fromLessThan f)
     ret
@@ -339,7 +339,7 @@ object Sorting {
    *  @param f a function that extracts a comparable key from each element
    *  @return a new array containing the elements of `a` sorted by comparing the keys produced by `f`
    */
-  def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K => M): Array[K] = {
+  def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K -> M): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[M] on f)
     ret

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -14,6 +14,7 @@ package scala
 package util
 package control
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.tailrec
 import scala.reflect.{ClassTag, classTag}
@@ -174,7 +175,7 @@ import scala.language.implicitConversions
 object Exception {
   type Catcher[+T] = PartialFunction[Throwable, T]
 
-  def mkCatcher[Ex <: Throwable: ClassTag, T](isDef: Ex => Boolean, f: Ex => T): PartialFunction[Throwable, T] = new Catcher[T] {
+  def mkCatcher[Ex <: Throwable: ClassTag, T](isDef: Ex => Boolean, f: Ex => T): PartialFunction[Throwable, T]^{isDef, f} = new Catcher[T] {
     private def downcast(x: Throwable): Option[Ex] =
       if (classTag[Ex].runtimeClass.isAssignableFrom(x.getClass)) Some(x.asInstanceOf[Ex])
       else None
@@ -183,9 +184,9 @@ object Exception {
     def apply(x: Throwable): T = f(downcast(x).get)
   }
 
-  def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T): PartialFunction[Throwable, T] = mkCatcher[Throwable, T](isDef, f)
+  def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T): PartialFunction[Throwable, T]^{isDef, f} = mkCatcher[Throwable, T](isDef, f)
 
-  implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]): Catcher[T] =
+  implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]^): Catcher[T]^{pf} =
     mkCatcher(pf.isDefinedAt, pf.apply)
 
   /** !!! Not at all sure of every factor which goes into this,
@@ -233,7 +234,7 @@ object Exception {
    *  @group logic-container
    */
   class Catch[+T](
-    val pf: Catcher[T],
+    val pf: Catcher[T]^,
     val fin: Option[Finally] = None,
     val rethrow: Throwable => Boolean = shouldRethrow)
   extends Described {
@@ -246,8 +247,8 @@ object Exception {
      *  @param pf2 the additional exception handler to combine with the existing one
      *  @return a new `Catch` that tries this catch's handler first, falling back to `pf2`
      */
-    def or[U >: T](pf2: Catcher[U]): Catch[U] = new Catch(pf orElse pf2, fin, rethrow)
-    def or[U >: T](other: Catch[U]): Catch[U] = or(other.pf)
+    def or[U >: T](pf2: Catcher[U]^): Catch[U]^{this, pf2} = new Catch(pf orElse pf2, fin, rethrow)
+    def or[U >: T](other: Catch[U]^): Catch[U]^{this, other} = or(other.pf)
 
     /** Applies this catch logic to the supplied body.
      *
@@ -268,7 +269,7 @@ object Exception {
      *  @param body the additional logic to apply after all existing finally bodies
      *  @return a new `Catch` with the same catch logic and `body` appended to the finally logic
      */
-    def andFinally(body: => Unit): Catch[T] = {
+    def andFinally(body: => Unit): Catch[T]^{this, body} = {
       val appendedFin = fin map(_ and body) getOrElse new Finally(body)
       new Catch(pf, Some(appendedFin), rethrow)
     }
@@ -308,7 +309,7 @@ object Exception {
      *  @param f the function to apply to caught exceptions instead of the current handler
      *  @return a new `Catch` that handles the same exceptions but produces results by applying `f`
      */
-    def withApply[U](f: Throwable => U): Catch[U] = {
+    def withApply[U](f: Throwable => U): Catch[U]^{this, f} = {
       val pf2 = new Catcher[U] {
         def isDefinedAt(x: Throwable): Boolean = pf isDefinedAt x
         def apply(x: Throwable): U = f(x)
@@ -317,9 +318,9 @@ object Exception {
     }
 
     /** Convenience methods. */
-    def toOption: Catch[Option[T]] = withApply(_ => None)
-    def toEither: Catch[Either[Throwable, T]] = withApply(Left(_))
-    def toTry: Catch[scala.util.Try[T]] = withApply(x => Failure(x))
+    def toOption: Catch[Option[T]]^{this} = withApply(_ => None)
+    def toEither: Catch[Either[Throwable, T]]^{this} = withApply(Left(_))
+    def toTry: Catch[scala.util.Try[T]]^{this} = withApply(x => Failure(x))
   }
 
   final val nothingCatcher: Catcher[Nothing]  = mkThrowableCatcher(_ => false, throw _)
@@ -405,7 +406,7 @@ object Exception {
    *  @param value the default value to return when one of the specified exceptions is caught
    *  @return a `Catch[T]` that returns `value` when any of the specified exceptions is caught
    */
-  def failAsValue[T](exceptions: Class[?]*)(value: => T): Catch[T] =
+  def failAsValue[T](exceptions: Class[?]*)(value: => T): Catch[T]^{value} =
     catching(exceptions*) withApply (_ => value)
 
   class By[T,R](f: T => R) {
@@ -428,9 +429,9 @@ object Exception {
    *
    *  @return a `By` builder whose `by` method takes a handler function and returns a configured `Catch[T]`
    */
-  def handling[T](exceptions: Class[?]*): By[Throwable => T, Catch[T]] = {
-    def fun(f: Throwable => T): Catch[T] = catching(exceptions*) withApply f
-    new By[Throwable => T, Catch[T]](fun)
+  def handling[T](exceptions: Class[?]*): By[Throwable -> T, Catch[T]] = { /* CC note: By is invariant. :( */
+    def fun(f: Throwable -> T): Catch[T] = catching(exceptions*) withApply f
+    new By[Throwable -> T, Catch[T]](fun)
   }
 
   /** Returns a `Catch` object with no catch logic and the argument as the finally logic.
@@ -439,7 +440,7 @@ object Exception {
    *  @tparam T the result type of the `Catch` body
    *  @param body the finally logic to execute after the `Catch` body completes
    */
-  def ultimately[T](body: => Unit): Catch[T] = noCatch andFinally body
+  def ultimately[T](body: => Unit): Catch[T]^{body} = noCatch andFinally body
 
   /** Creates a `Catch` object which unwraps any of the supplied exceptions.
    *  @group composition-catch

--- a/library/src/scala/util/control/NoStackTrace.scala
+++ b/library/src/scala/util/control/NoStackTrace.scala
@@ -13,6 +13,7 @@
 package scala
 package util.control
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A trait for exceptions which, for efficiency reasons, do not

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -13,6 +13,7 @@
 package scala
 package util.control
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`

--- a/library/src/scala/volatile.scala
+++ b/library/src/scala/volatile.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 


### PR DESCRIPTION
- [x] library/src/scala/AnyVal.scala
- [x] library/src/scala/AnyValCompanion.scala
- [ ] library/src/scala/App.scala DEPRECATED
- [x] library/src/scala/Boolean.scala
- [x] library/src/scala/Byte.scala
- [x] library/src/scala/Char.scala
- [x] library/src/scala/Console.scala
- [ ] library/src/scala/DelayedInit.scala DEPRECATED
- [x] library/src/scala/Double.scala
- [x] library/src/scala/DummyImplicit.scala
- [x] library/src/scala/Dynamic.scala
- [x] library/src/scala/Enumeration.scala
- [x] library/src/scala/Equals.scala
- [x] library/src/scala/Float.scala
- [ ] library/src/scala/Function.scala
- [ ] library/src/scala/Function0.scala GENERATED
- [ ] library/src/scala/Function1.scala GENERATED
- [ ] library/src/scala/Function10.scala GENERATED
- [ ] library/src/scala/Function11.scala GENERATED
- [ ] library/src/scala/Function12.scala GENERATED
- [ ] library/src/scala/Function13.scala GENERATED
- [ ] library/src/scala/Function14.scala GENERATED
- [ ] library/src/scala/Function15.scala GENERATED
- [ ] library/src/scala/Function16.scala GENERATED
- [ ] library/src/scala/Function17.scala GENERATED
- [ ] library/src/scala/Function18.scala GENERATED
- [ ] library/src/scala/Function19.scala GENERATED
- [ ] library/src/scala/Function2.scala GENERATED
- [ ] library/src/scala/Function20.scala GENERATED
- [ ] library/src/scala/Function21.scala GENERATED
- [ ] library/src/scala/Function22.scala GENERATED
- [ ] library/src/scala/Function3.scala GENERATED
- [ ] library/src/scala/Function4.scala GENERATED
- [ ] library/src/scala/Function5.scala GENERATED
- [ ] library/src/scala/Function6.scala GENERATED
- [ ] library/src/scala/Function7.scala GENERATED
- [ ] library/src/scala/Function8.scala GENERATED
- [ ] library/src/scala/Function9.scala GENERATED
- [x] library/src/scala/Int.scala
- [x] library/src/scala/Long.scala
- [x] library/src/scala/MatchError.scala
- [x] library/src/scala/NotImplementedError.scala
- [x] library/src/scala/Option.scala
- [x] library/src/scala/Product.scala
- [x] library/src/scala/Product1.scala
- [ ] library/src/scala/Product10.scala GENERATED
- [ ] library/src/scala/Product11.scala GENERATED
- [ ] library/src/scala/Product12.scala GENERATED
- [ ] library/src/scala/Product13.scala GENERATED
- [ ] library/src/scala/Product14.scala GENERATED
- [ ] library/src/scala/Product15.scala GENERATED
- [ ] library/src/scala/Product16.scala GENERATED
- [ ] library/src/scala/Product17.scala GENERATED
- [ ] library/src/scala/Product18.scala GENERATED
- [ ] library/src/scala/Product19.scala GENERATED
- [ ] library/src/scala/Product2.scala GENERATED
- [ ] library/src/scala/Product20.scala GENERATED
- [ ] library/src/scala/Product21.scala GENERATED
- [ ] library/src/scala/Product22.scala GENERATED
- [ ] library/src/scala/Product3.scala GENERATED
- [ ] library/src/scala/Product4.scala GENERATED
- [ ] library/src/scala/Product5.scala GENERATED
- [ ] library/src/scala/Product6.scala GENERATED
- [ ] library/src/scala/Product7.scala GENERATED
- [ ] library/src/scala/Product8.scala GENERATED
- [ ] library/src/scala/Product9.scala GENERATED
- [ ] library/src/scala/Proxy.scala DEPRECATED
- [x] library/src/scala/ScalaReflectionException.scala
- [ ] library/src/scala/SerialVersionUID.scala DEPRECATED
- [x] library/src/scala/Short.scala
- [x] library/src/scala/Specializable.scala
- [x] library/src/scala/StringContext.scala
- [x] library/src/scala/Symbol.scala
- [ ] library/src/scala/Tuple1.scala GENERATED
- [ ] library/src/scala/Tuple10.scala GENERATED
- [ ] library/src/scala/Tuple11.scala GENERATED
- [ ] library/src/scala/Tuple12.scala GENERATED
- [ ] library/src/scala/Tuple13.scala GENERATED
- [ ] library/src/scala/Tuple14.scala GENERATED
- [ ] library/src/scala/Tuple15.scala GENERATED
- [ ] library/src/scala/Tuple16.scala GENERATED
- [ ] library/src/scala/Tuple17.scala GENERATED
- [ ] library/src/scala/Tuple18.scala GENERATED
- [ ] library/src/scala/Tuple19.scala GENERATED
- [ ] library/src/scala/Tuple2.scala GENERATED
- [ ] library/src/scala/Tuple20.scala GENERATED
- [ ] library/src/scala/Tuple21.scala GENERATED
- [ ] library/src/scala/Tuple22.scala GENERATED
- [ ] library/src/scala/Tuple3.scala GENERATED
- [ ] library/src/scala/Tuple4.scala GENERATED
- [ ] library/src/scala/Tuple5.scala GENERATED
- [ ] library/src/scala/Tuple6.scala GENERATED
- [ ] library/src/scala/Tuple7.scala GENERATED
- [ ] library/src/scala/Tuple8.scala GENERATED
- [ ] library/src/scala/Tuple9.scala GENERATED
- [ ] library/src/scala/UninitializedError.scala DEPRECATED
- [x] library/src/scala/UninitializedFieldError.scala
- [x] library/src/scala/Unit.scala
- [x] library/src/scala/ValueOf.scala
- [x] library/src/scala/annotation/Annotation.scala
- [ ] library/src/scala/annotation/ClassfileAnnotation.scala DEPRECATED
- [x] library/src/scala/annotation/ConstantAnnotation.scala
- [x] library/src/scala/annotation/StaticAnnotation.scala
- [x] library/src/scala/annotation/TypeConstraint.scala
- [x] library/src/scala/annotation/compileTimeOnly.scala
- [ ] library/src/scala/annotation/elidable.scala DEPRECATED
- [x] library/src/scala/annotation/implicitAmbiguous.scala
- [x] library/src/scala/annotation/implicitNotFound.scala
- [x] library/src/scala/annotation/internal/$into.scala
- [x] library/src/scala/annotation/internal/onlyCapability.scala
- [x] library/src/scala/annotation/meta/beanGetter.scala
- [x] library/src/scala/annotation/meta/beanSetter.scala
- [x] library/src/scala/annotation/meta/companionClass.scala
- [x] library/src/scala/annotation/meta/companionMethod.scala
- [x] library/src/scala/annotation/meta/companionObject.scala
- [x] library/src/scala/annotation/meta/defaultArg.scala
- [x] library/src/scala/annotation/meta/field.scala
- [x] library/src/scala/annotation/meta/getter.scala
- [x] library/src/scala/annotation/meta/languageFeature.scala
- [x] library/src/scala/annotation/meta/package.scala
- [x] library/src/scala/annotation/meta/param.scala
- [x] library/src/scala/annotation/meta/setter.scala
- [x] library/src/scala/annotation/meta/superArg.scala
- [x] library/src/scala/annotation/migration.scala
- [x] library/src/scala/annotation/nowarn.scala
- [x] library/src/scala/annotation/showAsInfix.scala
- [x] library/src/scala/annotation/stableNull.scala
- [x] library/src/scala/annotation/strictfp.scala
- [x] library/src/scala/annotation/switch.scala
- [x] library/src/scala/annotation/tailrec.scala
- [x] library/src/scala/annotation/unchecked/uncheckedOverride.scala
- [x] library/src/scala/annotation/unchecked/uncheckedStable.scala
- [x] library/src/scala/annotation/unchecked/uncheckedVariance.scala
- [x] library/src/scala/annotation/unspecialized.scala
- [x] library/src/scala/annotation/unused.scala
- [x] library/src/scala/annotation/varargs.scala
- [x] library/src/scala/beans/BeanProperty.scala
- [x] library/src/scala/beans/BooleanBeanProperty.scala
- [ ] library/src/scala/collection/convert/impl/ArrayStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/BinaryTreeStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/BitSetStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/ChampStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/InOrderStepperBase.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/IndexedSeqStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/IndexedStepperBase.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/IteratorStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/NumericRangeStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/RangeStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/StringStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/TableStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/convert/impl/VectorStepper.scala JAVA_INTEROP
- [ ] library/src/scala/collection/immutable/LazyList.scala DEPRECATED
- [ ] library/src/scala/collection/immutable/Stream.scala DEPRECATED
- [ ] library/src/scala/compat/Platform.scala DEPRECATED
- [x] library/src/scala/compiletime/Erased.scala CONCURRENT
- [x] library/src/scala/concurrent/Awaitable.scala CONCURRENT
- [ ] library/src/scala/concurrent/BatchingExecutor.scala CONCURRENT
- [ ] library/src/scala/concurrent/BlockContext.scala CONCURRENT
- [ ] library/src/scala/concurrent/Channel.scala CONCURRENT
- [ ] library/src/scala/concurrent/DelayedLazyVal.scala CONCURRENT
- [ ] library/src/scala/concurrent/ExecutionContext.scala CONCURRENT
- [ ] library/src/scala/concurrent/Future.scala CONCURRENT
- [ ] library/src/scala/concurrent/JavaConversions.scala CONCURRENT
- [ ] library/src/scala/concurrent/Promise.scala CONCURRENT
- [ ] library/src/scala/concurrent/SyncChannel.scala CONCURRENT
- [ ] library/src/scala/concurrent/SyncVar.scala CONCURRENT
- [ ] library/src/scala/concurrent/duration/Deadline.scala CONCURRENT
- [ ] library/src/scala/concurrent/duration/Duration.scala CONCURRENT
- [ ] library/src/scala/concurrent/duration/DurationConversions.scala CONCURRENT
- [ ] library/src/scala/concurrent/duration/package.scala CONCURRENT
- [ ] library/src/scala/concurrent/impl/ExecutionContextImpl.scala CONCURRENT
- [ ] library/src/scala/concurrent/impl/FutureConvertersImpl.scala CONCURRENT
- [ ] library/src/scala/concurrent/impl/Promise.scala CONCURRENT
- [ ] library/src/scala/concurrent/package.scala CONCURRENT
- [x] library/src/scala/deprecated.scala
- [x] library/src/scala/deprecatedInheritance.scala
- [x] library/src/scala/deprecatedName.scala
- [x] library/src/scala/deprecatedOverriding.scala
- [ ] library/src/scala/deriving/Mirror.scala MIRRORS
- [x] library/src/scala/inline.scala
- [x] library/src/scala/io/AnsiColor.scala
- [x] library/src/scala/io/BufferedSource.scala
- [x] library/src/scala/io/Codec.scala
- [ ] library/src/scala/io/Position.scala DEPRECATED
- [x] library/src/scala/io/Source.scala
- [x] library/src/scala/io/StdIn.scala
- [ ] library/src/scala/jdk/Accumulator.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/AnyAccumulator.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/CollectionConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/DoubleAccumulator.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/DurationConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/FunctionConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/FunctionExtensions.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/FunctionWrappers.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/FutureConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/IntAccumulator.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/LongAccumulator.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/OptionConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/OptionShape.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/StreamConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/javaapi/CollectionConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/javaapi/DurationConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/javaapi/FunctionConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/javaapi/FutureConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/javaapi/OptionConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/javaapi/StreamConverters.scala JAVA_INTEROP
- [ ] library/src/scala/jdk/package.scala JAVA_INTEROP
- [x] library/src/scala/language.scala
- [x] library/src/scala/languageFeature.scala
- [x] library/src/scala/math/BigDecimal.scala
- [x] library/src/scala/math/BigInt.scala
- [x] library/src/scala/math/Equiv.scala
- [x] library/src/scala/math/Fractional.scala
- [x] library/src/scala/math/Integral.scala
- [x] library/src/scala/math/Numeric.scala
- [x] library/src/scala/math/Ordered.scala
- [x] library/src/scala/math/Ordering.scala
- [x] library/src/scala/math/PartialOrdering.scala
- [x] library/src/scala/math/PartiallyOrdered.scala
- [x] library/src/scala/math/ScalaNumericConversions.scala
- [x] library/src/scala/math/package.scala
- [x] library/src/scala/native.scala
- [x] library/src/scala/noinline.scala
- [x] library/src/scala/package.scala
- [x] library/src/scala/ref/PhantomReference.scala
- [x] library/src/scala/ref/Reference.scala
- [x] library/src/scala/ref/ReferenceQueue.scala
- [x] library/src/scala/ref/ReferenceWrapper.scala
- [x] library/src/scala/ref/SoftReference.scala
- [x] library/src/scala/ref/WeakReference.scala
- [ ] library/src/scala/reflect/ClassManifestDeprecatedApis.scala REFLECTION
- [ ] library/src/scala/reflect/ClassTag.scala REFLECTION
- [ ] library/src/scala/reflect/Manifest.scala REFLECTION
- [ ] library/src/scala/reflect/NameTransformer.scala REFLECTION
- [ ] library/src/scala/reflect/NoManifest.scala REFLECTION
- [ ] library/src/scala/reflect/OptManifest.scala REFLECTION
- [ ] library/src/scala/reflect/macros/internal/macroImpl.scala REFLECTION
- [ ] library/src/scala/reflect/package.scala REFLECTION
- [ ] library/src/scala/runtime/AbstractFunction0.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction1.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction10.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction11.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction12.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction13.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction14.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction15.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction16.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction17.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction18.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction19.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction2.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction20.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction21.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction22.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction3.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction4.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction5.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction6.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction7.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction8.scala GENERATED
- [ ] library/src/scala/runtime/AbstractFunction9.scala GENERATED
- [x] library/src/scala/runtime/ArrayCharSequence.scala
- [x] library/src/scala/runtime/ClassValueCompat.scala
- [x] library/src/scala/runtime/LambdaDeserialize.scala
- [x] library/src/scala/runtime/LambdaDeserializer.scala
- [x] library/src/scala/runtime/LazyRef.scala
- [x] library/src/scala/runtime/MethodCache.scala
- [x] library/src/scala/runtime/ModuleSerializationProxy.scala
- [x] library/src/scala/runtime/NonLocalReturnControl.scala
- [x] library/src/scala/runtime/Nothing$.scala
- [x] library/src/scala/runtime/Null$.scala
- [x] library/src/scala/runtime/PStatics.scala
- [x] library/src/scala/runtime/RichBoolean.scala
- [x] library/src/scala/runtime/RichByte.scala
- [x] library/src/scala/runtime/RichChar.scala
- [x] library/src/scala/runtime/RichDouble.scala
- [x] library/src/scala/runtime/RichFloat.scala
- [x] library/src/scala/runtime/RichInt.scala
- [x] library/src/scala/runtime/RichLong.scala
- [x] library/src/scala/runtime/RichShort.scala
- [x] library/src/scala/runtime/ScalaNumberProxy.scala
- [x] library/src/scala/runtime/ScalaRunTime.scala
- [x] library/src/scala/runtime/StructuralCallSite.scala
- [ ] library/src/scala/runtime/Tuple2Zipped.scala DEPRECATED
- [ ] library/src/scala/runtime/Tuple3Zipped.scala DEPRECATED
- [x] library/src/scala/runtime/VarArgsBuilder.scala
- [ ] library/src/scala/runtime/java8/JFunction0$mcB$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcC$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcF$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcS$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcV$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction0$mcZ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcDD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcDF$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcDI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcDJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcFD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcFF$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcFI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcFJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcID$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcIF$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcII$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcIJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcJD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcJF$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcJI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcJJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcVD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcVF$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcVI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcVJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcZD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcZF$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcZI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction1$mcZJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDDD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDDI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDDJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDID$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDII$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDIJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDJD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDJI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcDJJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFDD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFDI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFDJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFID$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFII$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFIJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFJD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFJI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcFJJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIDD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIDI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIDJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIID$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIII$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIIJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIJD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIJI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcIJJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJDD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJDI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJDJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJID$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJII$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJIJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJJD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJJI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcJJJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVDD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVDI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVDJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVID$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVII$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVIJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVJD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVJI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcVJJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZDD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZDI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZDJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZID$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZII$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZIJ$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZJD$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZJI$sp.scala JAVA_INTEROP
- [ ] library/src/scala/runtime/java8/JFunction2$mcZJJ$sp.scala JAVA_INTEROP
- [x] library/src/scala/specialized.scala
- [x] library/src/scala/sys/BooleanProp.scala
- [x] library/src/scala/sys/Prop.scala
- [x] library/src/scala/sys/PropImpl.scala
- [x] library/src/scala/sys/ShutdownHookThread.scala
- [x] library/src/scala/sys/SystemProperties.scala
- [x] library/src/scala/sys/package.scala
- [ ] library/src/scala/sys/process/BasicIO.scala TODO
- [ ] library/src/scala/sys/process/Parser.scala TODO
- [ ] library/src/scala/sys/process/Process.scala TODO
- [ ] library/src/scala/sys/process/ProcessBuilder.scala TODO
- [ ] library/src/scala/sys/process/ProcessBuilderImpl.scala TODO
- [ ] library/src/scala/sys/process/ProcessIO.scala TODO
- [ ] library/src/scala/sys/process/ProcessImpl.scala TODO
- [ ] library/src/scala/sys/process/ProcessLogger.scala TODO
- [ ] library/src/scala/sys/process/package.scala TODO
- [x] library/src/scala/throws.scala
- [x] library/src/scala/transient.scala
- [x] library/src/scala/typeConstraints.scala
- [x] library/src/scala/unchecked.scala
- [x] library/src/scala/util/ChainingOps.scala
- [x] library/src/scala/util/DynamicVariable.scala
- [x] library/src/scala/util/Either.scala
- [x] library/src/scala/util/Properties.scala
- [x] library/src/scala/util/Random.scala
- [ ] library/src/scala/util/Sorting.scala TODO
- [ ] library/src/scala/util/Try.scala PENDING
- [ ] library/src/scala/util/Using.scala PENDING
- [ ] library/src/scala/util/control/Breaks.scala SHOULD BE DEPRECATED
- [ ] library/src/scala/util/control/ControlThrowable.scala SHOULD BE DEPRECATED
- [x] library/src/scala/util/control/Exception.scala
- [x] library/src/scala/util/control/NoStackTrace.scala
- [x] library/src/scala/util/control/NonFatal.scala

Haven't attempted

- [ ] library/src/scala/util/control/TailCalls.scala 
- [ ] library/src/scala/util/hashing/ByteswapHashing.scala
- [ ] library/src/scala/util/hashing/Hashing.scala
- [ ] library/src/scala/util/hashing/MurmurHash3.scala
- [ ] library/src/scala/util/hashing/package.scala
- [ ] library/src/scala/util/matching/Regex.scala
- [ ] library/src/scala/util/package.scala
- [x] library/src/scala/volatile.scala

# TODO

- #25525
- Capture sets for context bounds

