### PR TITLE
Fix makePatDef regression with `@unchecked`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1554,7 +1554,7 @@ object desugar {
           // In this case too, `variables` may contain wildcard names.
           // Exception:
           // This optimization cannot be used in the presence of the `@unchecked` annotation,
-          // since given `a: List[A]` and `B <: A`, `val (x: List[B @unchecked], _) = (a, 1): @unchecked` is OK,
+          // since given `a: List[A]` and `B <: A`, `val (x: List[B @unchecked], _) = (a, 1)` is OK,
           // but `val x: List[B @unchecked] = a: @unchecked` is not.
           // So we cannot desugar the first one into `(a, 1) match { $1 @ (_: List[B @unchecked], _) => $1 }`
           // because that loses track of the unchecked-ness.
@@ -1568,6 +1568,7 @@ object desugar {
             // We want to include wildcards for the optimizations, so we can't use `IdPattern` which excludes them
             val allVariables = pats.map {
               case id: Ident => Some(id, TypeTree())
+              case Typed(id: Ident, Annotated(_, _)) => None
               case Typed(id: Ident, tpt) => Some((id, tpt))
               case _ => None
             }.flatten

--- a/tests/pos/tuple-unchecked-partition.scala
+++ b/tests/pos/tuple-unchecked-partition.scala
@@ -1,0 +1,13 @@
+import scala.unchecked
+
+sealed trait Tree
+final class DefDef extends Tree
+
+object Repro:
+  val trees: List[Tree] = Nil
+
+  val (allDefs: List[DefDef] @unchecked, allStepBlocks: List[Tree]) =
+    trees.partition {
+      case _: DefDef => true
+      case _ => false
+    }


### PR DESCRIPTION
Fixes #25544

Would be good if we had defined semantics for `@unchecked` somewhere...

## How much have your relied on LLM-based tools in this contribution?

not

## How was the solution tested?

regression test from the issue