### PR TITLE
Fix Java generic signatures for context functions

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -8,12 +8,15 @@ import core.Phases.*
 import core.Definitions
 import core.Flags.*
 import core.Names.Name
+import core.NameOps.isContextFunction
 import core.Symbols.*
 import core.TypeApplications.{EtaExpansion, TypeParamInfo}
 import core.TypeErasure.{erasedGlb, erasure, fullErasure, isGenericArrayElement, tupleArity}
 import core.Types.*
 import core.classfile.ClassfileConstants
 
+import config.Printers.transforms
+import reporting.trace
 import java.lang.StringBuilder
 
 import scala.annotation.tailrec
@@ -537,7 +540,14 @@ object GenericSignatures {
     @tailrec def recur(tpe: Type): Type = tpe match
       case mtd: MethodType =>
         vparams ++= mtd.paramInfos.filterNot(_.hasAnnotation(defn.ErasedParamAnnot))
-        recur(mtd.resType)
+        mtd.resType match
+          // Returned context functions are erased by putting their parameters into the method's parameters,
+          // so we must duplicate that logic here
+          case AppliedType(tycon, args) if tycon.typeSymbol.name.isContextFunction =>
+            vparams ++= args.take(args.length - 1)
+            recur(args.last)
+          case _ =>
+            recur(mtd.resType)
       case PolyType(tps, tpe) =>
         tparams ++= tps
         recur(tpe)

--- a/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/dotc/transform/GenericSignatures.scala
@@ -540,12 +540,15 @@ object GenericSignatures {
     @tailrec def recur(tpe: Type): Type = tpe match
       case mtd: MethodType =>
         vparams ++= mtd.paramInfos.filterNot(_.hasAnnotation(defn.ErasedParamAnnot))
-        mtd.resType match
+        mtd.resType.dealias match
           // Returned context functions are erased by putting their parameters into the method's parameters,
           // so we must duplicate that logic here
           case AppliedType(tycon, args) if tycon.typeSymbol.name.isContextFunction =>
             vparams ++= args.take(args.length - 1)
             recur(args.last)
+          // Handle erased types too
+          case defn.FunctionTypeOfMethod(mt: MethodType) if mt.isContextualMethod =>
+            recur(mt)
           case _ =>
             recur(mtd.resType)
       case PolyType(tps, tpe) =>

--- a/tests/run/returned-context-function-signature.check
+++ b/tests/run/returned-context-function-signature.check
@@ -1,6 +1,6 @@
 public void CtxFns$.puts(java.lang.Object,CtxFns$Context)
 class java.lang.Object,class CtxFns$Context -> void
-T -> scala.Function1<CtxFns$Context, scala.runtime.BoxedUnit>
+T,class CtxFns$Context -> void
 private java.lang.Object CtxFns$.writeReplace()
  -> class java.lang.Object
  -> class java.lang.Object

--- a/tests/run/returned-context-function-signature.check
+++ b/tests/run/returned-context-function-signature.check
@@ -1,0 +1,6 @@
+public void CtxFns$.puts(java.lang.Object,CtxFns$Context)
+class java.lang.Object,class CtxFns$Context -> void
+T -> scala.Function1<CtxFns$Context, scala.runtime.BoxedUnit>
+private java.lang.Object CtxFns$.writeReplace()
+ -> class java.lang.Object
+ -> class java.lang.Object

--- a/tests/run/returned-context-function-signature.check
+++ b/tests/run/returned-context-function-signature.check
@@ -1,3 +1,9 @@
+public java.lang.String CtxFns$.bar(int,CtxFns$Context)
+int,class CtxFns$Context -> class java.lang.String
+int,class CtxFns$Context -> class java.lang.String
+public java.lang.String CtxFns$.foo(int,CtxFns$Context)
+int,class CtxFns$Context -> class java.lang.String
+int,class CtxFns$Context -> class java.lang.String
 public void CtxFns$.puts(java.lang.Object,CtxFns$Context)
 class java.lang.Object,class CtxFns$Context -> void
 T,class CtxFns$Context -> void

--- a/tests/run/returned-context-function-signature.scala
+++ b/tests/run/returned-context-function-signature.scala
@@ -1,11 +1,20 @@
 // scalajs: --skip
 // (this is a JVM-only test)
 
+import language.experimental.erasedDefinitions
+
+class CanSerialize extends compiletime.Erased
+
 object CtxFns {
   abstract class Context:
     def puts[T](t: T): Unit
 
   def puts[T](t: T): Context ?=> Unit = summon[Context].puts(t)
+
+  def foo(x: Int): CanSerialize ?=> Context ?=> String = "foo"
+
+  type Handler = Context ?=> String
+  def bar(x: Int): Handler = "bar"
 }
 
 object Test:

--- a/tests/run/returned-context-function-signature.scala
+++ b/tests/run/returned-context-function-signature.scala
@@ -1,0 +1,17 @@
+// scalajs: --skip
+// (this is a JVM-only test)
+
+object CtxFns {
+  abstract class Context:
+    def puts[T](t: T): Unit
+
+  def puts[T](t: T): Context ?=> Unit = summon[Context].puts(t)
+}
+
+object Test:
+  def main(args: Array[String]): Unit =
+    classOf[CtxFns.type].getDeclaredMethods.sortBy(_.getName).foreach(m =>
+      println(m)
+      println(m.getParameterTypes().mkString(",") + " -> " + m.getReturnType.toString)
+      println(m.getGenericParameterTypes().mkString(",") + " -> " + m.getGenericReturnType.toString)
+    )


### PR DESCRIPTION
Fixes #10039

## How much have you relied on LLM-based tools in this contribution?

not

## How was the solution tested?

test from the issue turned into a fully automated one
