### PR TITLE
fix: #24765 SAM conversion for extension method from self-based types

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -398,8 +398,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           if !overridden.is(Deferred) then fwdMeth.setFlag(Override)
         DefDef(fwdMeth, ref(fn).appliedToArgss(_))
       }
-      termForwarders.map((name, sym) => forwarder(name, sym)) ++
-      typeMembers.map((name, info) => TypeDef(newSymbol(cls, name, Synthetic, info).entered))
+      val typeDefs = typeMembers.map((name, info) => TypeDef(newSymbol(cls, name, Synthetic, info).entered))
+      termForwarders.map((name, sym) => forwarder(name, sym)) ++ typeDefs
     }
   }
 

--- a/tests/pos/i24765.scala
+++ b/tests/pos/i24765.scala
@@ -1,0 +1,12 @@
+import language.experimental.modularity
+
+trait A[T]:
+  extension(t: T) def foo: T
+
+trait B:
+  type Self
+  extension(t: Self) def foo: Self
+
+given A[Int] = x => x // ok before
+
+given Int is B = x => x // was: "cannot override an extension method"


### PR DESCRIPTION
<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->
Fixes #24765
<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->
Enter type members into the anonymous class scope before creating term forwarders, so allOverriddenSymbols can resolve type aliases (like Self = Int) when matching method signatures.
<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have you relied on LLM-based tools in this contribution?

<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->
Claude helped me find the root cause.
<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

## How was the solution tested?
`i24765.scala` added
<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
