### PR TITLE
Preserve Java enum semantics for explicit java.lang.Enum inheritance

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1602,7 +1602,7 @@ trait Checking {
     if !isEnumAnonCls then
       if cdef.mods.isEnumCase then
         if isJavaEnum then
-          report.error(em"paramerized case is not allowed in an enum that extends java.lang.Enum", cdef.srcPos)
+          report.error(em"parameterized case is not allowed in an enum that extends java.lang.Enum", cdef.srcPos)
       else if cls.is(Case) || firstParent.is(Enum) then
         // Since enums are classes and Namer checks that classes don't extend multiple classes, we only check the class
         // parent.

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1575,6 +1575,19 @@ trait Checking {
           report.error(em"the ordinal method of enum $cls can not be defined by the user", decl.srcPos)
         else
           report.error(em"enum $cls can not inherit the concrete ordinal method of ${decl.owner}", cdef.srcPos)
+    def checkJavaEnumTypeArg(using Context) =
+      val javaEnumBase = cls.thisType.baseType(defn.JavaEnumClass)
+      if javaEnumBase.exists then
+        javaEnumBase.argInfos match
+          case typeArg :: Nil =>
+            val clsRef =
+              if cls.typeParams.isEmpty then cls.typeRef
+              else cls.typeRef.appliedTo(cls.typeParams.map(_.typeRef))
+            if typeArg.classSymbol != cls || !(clsRef <:< typeArg) then
+              report.error(
+                em"enum $cls extends ${javaEnumBase}, but $clsRef is not a subtype of $typeArg",
+                cdef.srcPos)
+          case _ =>
     def isEnumAnonCls =
       cls.isAnonymousClass
       && cls.owner.isTerm
@@ -1583,6 +1596,8 @@ trait Checking {
     val isJavaEnum = cls.derivesFrom(defn.JavaEnumClass)
     if isJavaEnum && cdef.mods.isEnumClass && !cls.isStatic then
       report.error(em"An enum extending java.lang.Enum must be declared in a static scope", cdef.srcPos)
+    if isJavaEnum && cdef.mods.isEnumClass then
+      checkJavaEnumTypeArg
     if !isEnumAnonCls then
       if cdef.mods.isEnumCase then
         if isJavaEnum then

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1584,7 +1584,7 @@ trait Checking {
           case typeArg :: Nil =>
             if cls.typeParams.nonEmpty then
               report.error(em"An enum extending java.lang.Enum cannot have type parameters", cdef.srcPos)
-            if !(typeArg =:= cls.typeRef) then
+            if typeArg.classSymbol ne cls then
               report.error(
                 em"enum $cls extends java.lang.Enum[$typeArg], but the type argument must be the enum class itself",
                 cdef.srcPos)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1563,6 +1563,8 @@ trait Checking {
    *  2. Check that parameterised `enum` cases do not extend java.lang.Enum.
    *  3. Check that only a static `enum` base class can extend java.lang.Enum.
    *  4. Check that user does not implement an `ordinal` method in the body of an enum class.
+   *  5. Check that an enum extending java.lang.Enum has no type parameters and
+   *     uses itself as the type argument to java.lang.Enum.
    */
   def checkEnum(cdef: untpd.TypeDef, cls: Symbol, firstParent: Symbol)(using Context): Unit = {
     def existingDef(sym: Symbol, clazz: ClassSymbol)(using Context): Symbol = // adapted from SyntheticMembers
@@ -1580,12 +1582,11 @@ trait Checking {
       if javaEnumBase.exists then
         javaEnumBase.argInfos match
           case typeArg :: Nil =>
-            val clsRef =
-              if cls.typeParams.isEmpty then cls.typeRef
-              else cls.typeRef.appliedTo(cls.typeParams.map(_.typeRef))
-            if !(typeArg =:= clsRef) then
+            if cls.typeParams.nonEmpty then
+              report.error(em"An enum extending java.lang.Enum cannot have type parameters", cdef.srcPos)
+            if !(typeArg =:= cls.typeRef) then
               report.error(
-                em"enum $cls extends ${javaEnumBase}, but the type argument $typeArg is not the same as $clsRef",
+                em"enum $cls extends java.lang.Enum[$typeArg], but the type argument must be the enum class itself",
                 cdef.srcPos)
           case _ =>
     def isEnumAnonCls =

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -1583,9 +1583,9 @@ trait Checking {
             val clsRef =
               if cls.typeParams.isEmpty then cls.typeRef
               else cls.typeRef.appliedTo(cls.typeParams.map(_.typeRef))
-            if typeArg.classSymbol != cls || !(clsRef <:< typeArg) then
+            if !(typeArg =:= clsRef) then
               report.error(
-                em"enum $cls extends ${javaEnumBase}, but $clsRef is not a subtype of $typeArg",
+                em"enum $cls extends ${javaEnumBase}, but the type argument $typeArg is not the same as $clsRef",
                 cdef.srcPos)
           case _ =>
     def isEnumAnonCls =

--- a/tests/neg-deep-subtype/i9325.scala
+++ b/tests/neg-deep-subtype/i9325.scala
@@ -1,2 +1,2 @@
-enum Foo[T] extends java.lang.Enum[Foo[T]] { case Red extends Foo[Int]; case Blue extends Foo[String] }
+enum Foo[T] extends java.lang.Enum[Foo[T]] { case Red extends Foo[Int]; case Blue extends Foo[String] } // error: An enum extending java.lang.Enum cannot have type parameters
 val res0 = (Foo.Red: Foo[?]) compareTo Foo.Blue // error: type mismatch Found (Foo.Blue : Foo[String]) Expected ?1.E

--- a/tests/neg/enum-constrs.scala
+++ b/tests/neg/enum-constrs.scala
@@ -3,3 +3,8 @@ enum E[+T] extends java.lang.Enum[E[_]] { // error: An enum extending java.lang.
   case S1, S2
   case C() extends E[Int]
 }
+
+enum E2 extends java.lang.Enum[E2] {
+  case S1, S2
+  case C() extends E2 // error: parameterized case is not allowed
+}

--- a/tests/neg/enum-constrs.scala
+++ b/tests/neg/enum-constrs.scala
@@ -1,5 +1,5 @@
 
-enum E[+T] extends java.lang.Enum[E[_]] {
+enum E[+T] extends java.lang.Enum[E[_]] { // error: An enum extending java.lang.Enum cannot have type parameters
   case S1, S2
-  case C() extends E[Int]  // error: parameterized case is not allowed
+  case C() extends E[Int]
 }

--- a/tests/neg/i11253.check
+++ b/tests/neg/i11253.check
@@ -1,0 +1,26 @@
+-- Error: tests/neg/i11253.scala:5:5 -----------------------------------------------------------------------------------
+5 |enum E1(val t: String) extends Enum[T], T { case X extends E1("xxx") } // error
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |enum class E1 extends Enum[T], but E1 is not a subtype of T
+-- Error: tests/neg/i11253.scala:9:5 -----------------------------------------------------------------------------------
+9 |enum E2 extends Enum[Nothing] { case X } // error
+  |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |enum class E2 extends Enum[Nothing], but E2 is not a subtype of Nothing
+-- Error: tests/neg/i11253.scala:11:5 ----------------------------------------------------------------------------------
+11 |enum E3[A](val inner: A) extends Enum[E3[Int]] { // error
+   |^
+   |enum class E3 extends Enum[E3[Int]], but E3[A] is not a subtype of E3[Int]
+   |
+12 |  case X extends E3[String]("hello")
+13 |}
+-- Error: tests/neg/i11253.scala:21:5 ----------------------------------------------------------------------------------
+21 |enum E7 extends UBad { case X } // error
+   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |enum class E7 extends Enum[UBad], but E7 is not a subtype of UBad
+-- [E134] Type Error: tests/neg/i11253.scala:23:5 ----------------------------------------------------------------------
+23 |enum E8 extends U[E7] { case X } // error
+   |     ^
+   |     None of the overloaded alternatives of constructor Enum in class Enum with types
+   |      [E <: Enum[E]](x$0: String, x$1: Int): Enum[E]
+   |      [E <: Enum[E]](): Enum[E]
+   |     match type arguments [E7] and arguments ()

--- a/tests/neg/i11253.check
+++ b/tests/neg/i11253.check
@@ -25,3 +25,11 @@
 27 |enum E7 extends UBad { case X } // error
    |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |enum class E7 extends java.lang.Enum[UBad], but the type argument must be the enum class itself
+-- Error: tests/neg/i11253.scala:31:5 ----------------------------------------------------------------------------------
+31 |enum E[+T] extends java.lang.Enum[E[_]] { // error
+   |^
+   |An enum extending java.lang.Enum cannot have type parameters
+   |
+32 |  case S1, S2
+33 |  case C extends E[Int]
+34 |}

--- a/tests/neg/i11253.check
+++ b/tests/neg/i11253.check
@@ -1,34 +1,27 @@
 -- Error: tests/neg/i11253.scala:5:5 -----------------------------------------------------------------------------------
 5 |enum E1(val t: String) extends Enum[T], T { case X extends E1("xxx") } // error
   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |enum class E1 extends Enum[T], but the type argument T is not the same as E1
+  |enum class E1 extends java.lang.Enum[T], but the type argument must be the enum class itself
 -- Error: tests/neg/i11253.scala:9:5 -----------------------------------------------------------------------------------
 9 |enum E2 extends Enum[Nothing] { case X } // error
   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |enum class E2 extends Enum[Nothing], but the type argument Nothing is not the same as E2
+  |enum class E2 extends java.lang.Enum[Nothing], but the type argument must be the enum class itself
 -- Error: tests/neg/i11253.scala:11:5 ----------------------------------------------------------------------------------
 11 |enum E3[A](val inner: A) extends Enum[E3[Int]] { // error
    |^
-   |enum class E3 extends Enum[E3[Int]], but the type argument E3[Int] is not the same as E3[A]
+   |An enum extending java.lang.Enum cannot have type parameters
    |
 12 |  case X extends E3[String]("hello")
 13 |}
 -- Error: tests/neg/i11253.scala:17:5 ----------------------------------------------------------------------------------
 17 |enum E5[+A] extends Enum[E5[?]] { case X extends E5[Nothing] } // error
    |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |enum class E5 extends Enum[E5[?]], but the type argument E5[?] is not the same as E5[A]
+   |An enum extending java.lang.Enum cannot have type parameters
 -- Error: tests/neg/i11253.scala:19:5 ----------------------------------------------------------------------------------
 19 |enum E6[A] extends Enum[E6[?]] { case X extends E6[Unit] } // error
    |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |enum class E6 extends Enum[E6[?]], but the type argument E6[?] is not the same as E6[A]
+   |An enum extending java.lang.Enum cannot have type parameters
 -- Error: tests/neg/i11253.scala:27:5 ----------------------------------------------------------------------------------
 27 |enum E7 extends UBad { case X } // error
    |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |enum class E7 extends Enum[UBad], but the type argument UBad is not the same as E7
--- [E134] Type Error: tests/neg/i11253.scala:29:5 ----------------------------------------------------------------------
-29 |enum E8 extends U[E7] { case X } // error
-   |     ^
-   |     None of the overloaded alternatives of constructor Enum in class Enum with types
-   |      [E <: Enum[E]](x$0: String, x$1: Int): Enum[E]
-   |      [E <: Enum[E]](): Enum[E]
-   |     match type arguments [E7] and arguments ()
+   |enum class E7 extends java.lang.Enum[UBad], but the type argument must be the enum class itself

--- a/tests/neg/i11253.check
+++ b/tests/neg/i11253.check
@@ -1,24 +1,32 @@
 -- Error: tests/neg/i11253.scala:5:5 -----------------------------------------------------------------------------------
 5 |enum E1(val t: String) extends Enum[T], T { case X extends E1("xxx") } // error
   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |enum class E1 extends Enum[T], but E1 is not a subtype of T
+  |enum class E1 extends Enum[T], but the type argument T is not the same as E1
 -- Error: tests/neg/i11253.scala:9:5 -----------------------------------------------------------------------------------
 9 |enum E2 extends Enum[Nothing] { case X } // error
   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |enum class E2 extends Enum[Nothing], but E2 is not a subtype of Nothing
+  |enum class E2 extends Enum[Nothing], but the type argument Nothing is not the same as E2
 -- Error: tests/neg/i11253.scala:11:5 ----------------------------------------------------------------------------------
 11 |enum E3[A](val inner: A) extends Enum[E3[Int]] { // error
    |^
-   |enum class E3 extends Enum[E3[Int]], but E3[A] is not a subtype of E3[Int]
+   |enum class E3 extends Enum[E3[Int]], but the type argument E3[Int] is not the same as E3[A]
    |
 12 |  case X extends E3[String]("hello")
 13 |}
--- Error: tests/neg/i11253.scala:21:5 ----------------------------------------------------------------------------------
-21 |enum E7 extends UBad { case X } // error
+-- Error: tests/neg/i11253.scala:17:5 ----------------------------------------------------------------------------------
+17 |enum E5[+A] extends Enum[E5[?]] { case X extends E5[Nothing] } // error
+   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |enum class E5 extends Enum[E5[?]], but the type argument E5[?] is not the same as E5[A]
+-- Error: tests/neg/i11253.scala:19:5 ----------------------------------------------------------------------------------
+19 |enum E6[A] extends Enum[E6[?]] { case X extends E6[Unit] } // error
+   |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |enum class E6 extends Enum[E6[?]], but the type argument E6[?] is not the same as E6[A]
+-- Error: tests/neg/i11253.scala:27:5 ----------------------------------------------------------------------------------
+27 |enum E7 extends UBad { case X } // error
    |^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |enum class E7 extends Enum[UBad], but E7 is not a subtype of UBad
--- [E134] Type Error: tests/neg/i11253.scala:23:5 ----------------------------------------------------------------------
-23 |enum E8 extends U[E7] { case X } // error
+   |enum class E7 extends Enum[UBad], but the type argument UBad is not the same as E7
+-- [E134] Type Error: tests/neg/i11253.scala:29:5 ----------------------------------------------------------------------
+29 |enum E8 extends U[E7] { case X } // error
    |     ^
    |     None of the overloaded alternatives of constructor Enum in class Enum with types
    |      [E <: Enum[E]](x$0: String, x$1: Int): Enum[E]

--- a/tests/neg/i11253.scala
+++ b/tests/neg/i11253.scala
@@ -12,6 +12,12 @@ enum E3[A](val inner: A) extends Enum[E3[Int]] { // error
   case X extends E3[String]("hello")
 }
 
+// --- Java enum behavior: generic enums with wildcard type args rejected ---
+
+enum E5[+A] extends Enum[E5[?]] { case X extends E5[Nothing] } // error
+
+enum E6[A] extends Enum[E6[?]] { case X extends E6[Unit] } // error
+
 // --- Cases from #9541 ---
 
 trait U[E <: Enum[E]] extends Enum[E]

--- a/tests/neg/i11253.scala
+++ b/tests/neg/i11253.scala
@@ -1,0 +1,23 @@
+// --- Cases from #11253 ---
+
+trait T extends Enum[T] { def t: String }
+
+enum E1(val t: String) extends Enum[T], T { case X extends E1("xxx") } // error
+
+// --- Cases from #11252 ---
+
+enum E2 extends Enum[Nothing] { case X } // error
+
+enum E3[A](val inner: A) extends Enum[E3[Int]] { // error
+  case X extends E3[String]("hello")
+}
+
+// --- Cases from #9541 ---
+
+trait U[E <: Enum[E]] extends Enum[E]
+
+trait UBad extends U[UBad]
+
+enum E7 extends UBad { case X } // error
+
+enum E8 extends U[E7] { case X } // error

--- a/tests/neg/i11253.scala
+++ b/tests/neg/i11253.scala
@@ -26,4 +26,10 @@ trait UBad extends U[UBad]
 
 enum E7 extends UBad { case X } // error
 
-enum E8 extends U[E7] { case X } // error
+// --- other cases ---
+
+enum E[+T] extends java.lang.Enum[E[_]] { // error
+  case S1, S2
+  case C extends E[Int]
+}
+

--- a/tests/neg/trait-java-enum.scala
+++ b/tests/neg/trait-java-enum.scala
@@ -1,5 +1,5 @@
 trait T[E <: java.lang.Enum[E]] extends java.lang.Enum[E]
 
-enum MyEnum extends T[MyEnum] {
+enum MyEnum extends T[MyEnum] { // error
   case A, B
 }

--- a/tests/neg/trait-java-enum.scala
+++ b/tests/neg/trait-java-enum.scala
@@ -1,5 +1,0 @@
-trait T[E <: java.lang.Enum[E]] extends java.lang.Enum[E]
-
-enum MyEnum extends T[MyEnum] { // error
-  case A, B
-}

--- a/tests/neg/trait-java-enum.scala
+++ b/tests/neg/trait-java-enum.scala
@@ -1,0 +1,5 @@
+trait T extends java.lang.Enum[T]
+
+enum MyEnum extends T { // error: enum class MyEnum extends java.lang.Enum[T], but the type argument must be the enum class itself
+  case A, B
+}

--- a/tests/pos/i11253.scala
+++ b/tests/pos/i11253.scala
@@ -5,10 +5,6 @@ trait TValid extends Enum[E9]
 
 enum E4 extends Enum[E4] { case X }
 
-enum E5[+A] extends Enum[E5[?]] { case X extends E5[Nothing] }
-
-enum E6[A] extends Enum[E6[?]] { case X extends E6[Unit] }
-
 enum E9 extends Enum[E9] with TValid { case X }
 
 enum E10 extends U[E10] { case X }

--- a/tests/pos/i11253.scala
+++ b/tests/pos/i11253.scala
@@ -1,0 +1,14 @@
+// --- Valid cases related to #11253/#9541 ---
+
+trait U[E <: Enum[E]] extends Enum[E]
+trait TValid extends Enum[E9]
+
+enum E4 extends Enum[E4] { case X }
+
+enum E5[+A] extends Enum[E5[?]] { case X extends E5[Nothing] }
+
+enum E6[A] extends Enum[E6[?]] { case X extends E6[Unit] }
+
+enum E9 extends Enum[E9] with TValid { case X }
+
+enum E10 extends U[E10] { case X }

--- a/tests/pos/trait-java-enum.scala
+++ b/tests/pos/trait-java-enum.scala
@@ -1,5 +1,5 @@
-trait T extends java.lang.Enum[T]
+trait T[E <: java.lang.Enum[E]] extends java.lang.Enum[E]
 
-enum MyEnum extends T {
+enum MyEnum extends T[MyEnum] {
   case A, B
 }

--- a/tests/run/enum-constrs.check
+++ b/tests/run/enum-constrs.check
@@ -1,3 +1,2 @@
 Red
-S1
 Car

--- a/tests/run/enum-constrs.scala
+++ b/tests/run/enum-constrs.scala
@@ -2,11 +2,6 @@ enum Color extends java.lang.Enum[Color] {
   case Red, Green, Blue
 }
 
-enum E[+T] extends java.lang.Enum[E[_]] {
-  case S1, S2
-  case C extends E[Int]
-}
-
 enum Vehicle(wheels: Int) extends java.lang.Enum[Vehicle] {
   case Bike extends Vehicle(2)
   case Car extends Vehicle(4)

--- a/tests/run/enum-constrs.scala
+++ b/tests/run/enum-constrs.scala
@@ -9,6 +9,5 @@ enum Vehicle(wheels: Int) extends java.lang.Enum[Vehicle] {
 
 object Test extends App {
   println(Color.Red)
-  println(E.S1)
   println(Vehicle.Car)
 }

--- a/tests/run/enum-custom-toString.scala
+++ b/tests/run/enum-custom-toString.scala
@@ -13,10 +13,6 @@ trait Mixin extends reflect.Enum:
 enum EM extends Mixin:
   case C
 
-enum ET[T] extends java.lang.Enum[ET[_]]:
-  case D extends ET[Unit]
-  override def toString: String = "overridden"
-
 enum EZ:
   case E(arg: Int)
   override def toString: String = "overridden"
@@ -53,8 +49,6 @@ object Tag:
   assert(EM.C.toString == "overridden",       s"EM.C.toString = ${EM.C.toString}")
   assert(EM.C.productPrefix == "noprefix",    s"EM.C.productPrefix = ${EM.C.productPrefix}")
   assert(EM.valueOf("C") == EM.C,             s"EM.valueOf(C) = ${EM.valueOf("C")}")
-  assert(ET.D.toString == "overridden",       s"ET.D.toString = ${ET.D.toString}")
-  assert(ET.D.productPrefix == "D",           s"ET.D.productPrefix = ${ET.D.productPrefix}")
   assert(EZ.E(0).toString == "overridden",    s"EZ.E(0).toString = ${EZ.E(0).toString}")
   assert(EZ.E(0).productPrefix == "E",        s"EZ.E(0).productPrefix = ${EZ.E(0).productPrefix}")
   assert(EC.F.toString == "F",                s"EC.F.toString = ${EC.F.toString}")

--- a/tests/run/enum-values-order.scala
+++ b/tests/run/enum-values-order.scala
@@ -3,8 +3,6 @@ enum LatinAlphabet { case A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, 
 
 enum LatinAlphabet2 extends java.lang.Enum[LatinAlphabet2] { case A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z }
 
-enum LatinAlphabet3[+T] extends java.lang.Enum[LatinAlphabet3[_]] { case A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z }
-
 object Color:
   trait Pretty
 enum Color extends java.lang.Enum[Color]:
@@ -35,14 +33,6 @@ enum Color extends java.lang.Enum[Color]:
       val ordered = Seq(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z)
 
       assert(ordered sameElements LatinAlphabet2.values)
-      assert(ordinals == ordered.map(_.ordinal))
-      assert(labels == ordered.map(_.name))
-
-    def testLatin3() =
-      import LatinAlphabet3.*
-      val ordered = Seq(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z)
-
-      assert(ordered sameElements LatinAlphabet3.values)
       assert(ordinals == ordered.map(_.ordinal))
       assert(labels == ordered.map(_.name))
 

--- a/tests/run/enum-values-order.scala
+++ b/tests/run/enum-values-order.scala
@@ -38,7 +38,6 @@ enum Color extends java.lang.Enum[Color]:
 
     testLatin1()
     testLatin2()
-    testLatin3()
 
   end testLatin
 


### PR DESCRIPTION
Scala currently accepts some explicit `java.lang.Enum[...]` usages that are not consistent with Java enum semantics. In particular, F-bound checking alone is not sufficient here: it can accept programs where the type argument satisfies `E <: Enum[E]`, but does not actually match the enum class.

This leads to problematic cases such as `enum E extends Enum[Nothing] { case X }` (`i11252`)

These cases may compile, but can break the expected Java enum behavior, especially around reflection and runtime consistency.

After discussion during the Scala Core meeting (01.04.2026), we decided that when code explicitly uses `extends java.lang.Enum[...]`, Scala should preserve Java enum semantics more strictly.

This means we require:
1. the `java.lang.Enum` type argument to refer to the enum class itself
2. the enum to have **no type parameters**

This rejects examples such as:
- `enum E extends Enum[Nothing]`
- generic enums like `enum E[A] extends Enum[E[?]]`

Fixes #11252
Fixes #11253


---
Typo in the error message has also been fixed (`paramerized` -> `parameterized`)