### PR TITLE
Regression test for #24824 - compiler crash in assertion from wildApprox from FunProtoTyped

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -1068,10 +1068,7 @@ object ProtoTypes {
           case tp => wildApprox(tp, theMap, seen, internal)
         arg.withType(argTp))
       val resTp = wildApprox(tp.resultType, theMap, seen, internal)
-      if (args eq tp.args) && (resTp eq tp.resultType) then
-        tp
-      else
-        FunProtoTyped(args, resTp)(ctx.typer, tp.applyKind)
+      FunProtoTyped(args, resTp)(ctx.typer, tp.applyKind)
     case tp: IgnoredProto =>
       WildcardType
     case  _: ThisType | _: BoundType => // default case, inlined for speed

--- a/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ProtoTypes.scala
@@ -657,29 +657,11 @@ object ProtoTypes {
    *  [](args): resultType, where args are known to be typed
    */
   class FunProtoTyped(args: List[tpd.Tree], resultType: Type)(typer: Typer, applyKind: ApplyKind)(using Context)
-    extends FunProto(args, resultType)(typer, applyKind) {
+  extends FunProto(args, resultType)(typer, applyKind):
     override def typedArgs(norm: (untpd.Tree, Int) => untpd.Tree)(using Context): List[tpd.Tree] = args
     override def typedArg(arg: untpd.Tree, formal: Type)(using Context): tpd.Tree = arg.asInstanceOf[tpd.Tree]
     override def allArgTypesAreCurrent()(using Context): Boolean = true
     override def withContext(ctx: Context): FunProtoTyped = this
-
-    override def map(tm: TypeMap)(using Context): FunProtoTyped =
-      derivedFunProtoTyped(args, tm(resultType), typer)
-
-    override def fold[T](x: T, ta: TypeAccumulator[T])(using Context): T =
-      ta(ta.foldOver(x, typedArgs().tpes), resultType)
-
-    def derivedFunProtoTyped(
-        args: List[tpd.Tree] = this.args,
-        resultType: Type = this.resultType,
-        typer: Typer = this.typer): FunProtoTyped =
-      if (args eq this.args)
-        && (resultType eq this.resultType)
-        && (typer eq this.typer)
-      then this
-      else FunProtoTyped(args, resultType)(typer, applyKind)
-  }
-
 
   /** A prototype for implicitly inferred views:
    *
@@ -1068,7 +1050,10 @@ object ProtoTypes {
           case tp => wildApprox(tp, theMap, seen, internal)
         arg.withType(argTp))
       val resTp = wildApprox(tp.resultType, theMap, seen, internal)
-      FunProtoTyped(args, resTp)(ctx.typer, tp.applyKind)
+      if (args eq tp.args) && (resTp eq tp.resultType) then
+        tp
+      else
+        FunProtoTyped(args, resTp)(ctx.typer, tp.applyKind)
     case tp: IgnoredProto =>
       WildcardType
     case  _: ThisType | _: BoundType => // default case, inlined for speed

--- a/tests/neg/i24824.scala
+++ b/tests/neg/i24824.scala
@@ -1,0 +1,14 @@
+trait TC[X]
+object TC {
+  given t2[T]: TC[T] = ???
+  given t1[T]: TC[T] = ???
+}
+class Seq2[T] {
+  def sorted(using TC[T]): Seq2[T] = ???
+}
+extension [T](s: Seq2[T])
+def f[G](c: Seq2[G]): Unit = ??? // error // Extension without extension methods
+object Crash {
+  val s: Seq2[Int] = ???
+  s.sorted.f(Seq2()) // error // ambiguous given instances: both given instance t2 in object TC and given instance t1 in object TC match type TC[Int] of parameter x$1 of method sorted in class Seq2
+}

--- a/tests/neg/i24824.scala
+++ b/tests/neg/i24824.scala
@@ -7,7 +7,7 @@ class Seq2[T] {
   def sorted(using TC[T]): Seq2[T] = ???
 }
 extension [T](s: Seq2[T])
-def f[G](c: Seq2[G]): Unit = ??? // error // Extension without extension methods
+  def f[G](c: Seq2[G]): Unit = ???
 object Crash {
   val s: Seq2[Int] = ???
   s.sorted.f(Seq2()) // error // ambiguous given instances: both given instance t2 in object TC and given instance t1 in object TC match type TC[Int] of parameter x$1 of method sorted in class Seq2


### PR DESCRIPTION
Reproduction case for #24824 as issue was solved by https://github.com/scala/scala3/pull/25367 (pass caller context - details: https://github.com/scala/scala3/issues/24824#issuecomment-5316292237).

~~Address #24824: preserve `FunProtoTyped` in `wildApprox` and `FunProtoTyped.map` to avoid assert from `collectParts` that leading to a crash~~

## How much have you relied on LLM-based tools in this contribution?

moderately: I feed LLM with relevant issues, PRs; reiterated over proposed solutions,
~then switched to work done by @Alex1005a as he had more mature solution~

## How was the solution tested?

Tested locally added reproduction case:

```shell
sbt --client "testCompilation 24824"
```
