### PR TITLE
Fix TastyPrinter's JAR-walking logic to include subdirectories

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -4,17 +4,18 @@ package tasty
 
 import dotty.tools.tasty.{TastyBuffer, TastyReader}
 import TastyBuffer.NameRef
-
-import Contexts.*, Decorators.*
+import Contexts.*
+import Decorators.*
 import Names.Name
 import TastyUnpickler.*
 import util.Spans.offsetToInt
-import dotty.tools.tasty.TastyFormat.{ASTsSection, PositionsSection, CommentsSection, AttributesSection}
-import java.nio.file.{Files, Paths}
-import dotty.tools.io.{JarArchive, Path}
-import dotty.tools.tasty.TastyFormat.header
-import scala.collection.immutable.BitSet
+import dotty.tools.tasty.TastyFormat.{ASTsSection, AttributesSection, CommentsSection, PositionsSection}
 
+import java.nio.file.{Files, Paths}
+import dotty.tools.io.{JarArchive, Path, PlainFile}
+import dotty.tools.tasty.TastyFormat.header
+
+import scala.collection.immutable.BitSet
 import scala.compiletime.uninitialized
 import dotty.tools.tasty.TastyBuffer.Addr
 import dotty.tools.dotc.core.Names.TermName
@@ -60,7 +61,7 @@ object TastyPrinter:
       else if arg.endsWith(".jar") then
         val jar = JarArchive.open(Path(arg), create = false)
         try
-          for file <- jar.iterator if file.hasTastyExtension do
+          for file <- jar.allFileNames().map(f => new PlainFile(Path(f))) if file.hasTastyExtension do
             printTasty(s"$arg ${file.path}", file.toByteArray, isBestEffortTasty = false)
         finally jar.close()
       else


### PR DESCRIPTION
Previously it only looked at tasty files at the root of the JAR. I'm not sure if anyone uses this code.

## How much have you relied on LLM-based tools in this contribution?

not

## How was the solution tested?

it wasn't