### PR TITLE
Simplify ProcessBuilderImpl

### DIFF
--- a/library/src/scala/sys/process/ProcessBuilder.scala
+++ b/library/src/scala/sys/process/ProcessBuilder.scala
@@ -446,7 +446,7 @@ object ProcessBuilder extends ProcessBuilderImpl {
      *  argument is call-by-name, so the stream is recreated, written, and closed each
      *  time this process is executed.
      */
-    def #>(out: => OutputStream): ProcessBuilder = #> (new OStreamBuilder(out, "<output stream>"))
+    def #>(out: => OutputStream): ProcessBuilder = #> (new StreamOutput(out, "<output stream>"))
 
     /** Writes the output stream of this process to a [[scala.sys.process.ProcessBuilder]]. */
     def #>(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(toSource, b, toError = false)
@@ -472,7 +472,7 @@ object ProcessBuilder extends ProcessBuilderImpl {
      *  argument is call-by-name, so the stream is recreated, read, and closed each
      *  time this process is executed.
      */
-    def #<(in: => InputStream): ProcessBuilder = #< (new IStreamBuilder(in, "<input stream>"))
+    def #<(in: => InputStream): ProcessBuilder = #< (new StreamInput(in, "<input stream>"))
 
     /** Reads the output of a [[scala.sys.process.ProcessBuilder]] into the input stream of this process. */
     def #<(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(b, toSink, toError = false)

--- a/library/src/scala/sys/process/ProcessBuilder.scala
+++ b/library/src/scala/sys/process/ProcessBuilder.scala
@@ -446,7 +446,7 @@ object ProcessBuilder extends ProcessBuilderImpl {
      *  argument is call-by-name, so the stream is recreated, written, and closed each
      *  time this process is executed.
      */
-    def #>(out: => OutputStream): ProcessBuilder = #> (new StreamOutput(out, "<output stream>"))
+    def #>(out: => OutputStream): ProcessBuilder = #> (new OStreamBuilder(out, "<output stream>"))
 
     /** Writes the output stream of this process to a [[scala.sys.process.ProcessBuilder]]. */
     def #>(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(toSource, b, toError = false)
@@ -472,7 +472,7 @@ object ProcessBuilder extends ProcessBuilderImpl {
      *  argument is call-by-name, so the stream is recreated, read, and closed each
      *  time this process is executed.
      */
-    def #<(in: => InputStream): ProcessBuilder = #< (new StreamInput(in, "<input stream>"))
+    def #<(in: => InputStream): ProcessBuilder = #< (new IStreamBuilder(in, "<input stream>"))
 
     /** Reads the output of a [[scala.sys.process.ProcessBuilder]] into the input stream of this process. */
     def #<(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(b, toSink, toError = false)

--- a/library/src/scala/sys/process/ProcessBuilderImpl.scala
+++ b/library/src/scala/sys/process/ProcessBuilderImpl.scala
@@ -28,37 +28,48 @@ import scala.util.control.NonFatal
 private[process] trait ProcessBuilderImpl {
   self: ProcessBuilder.type =>
 
-  private[process] class DaemonBuilder(underlying: ProcessBuilder) extends AbstractBuilder {
-    final def run(io: ProcessIO): Process = underlying.run(io.daemonized())
+  private[process] final class DaemonBuilder(underlying: ProcessBuilder) extends AbstractBuilder {
+    override def run(io: ProcessIO): Process = underlying.run(io.daemonized())
   }
 
-  private[process] class Dummy(override val toString: String, exitValue: => Int) extends AbstractBuilder {
+  private[process] final class Dummy(override val toString: String, exitValue: => Int) extends AbstractBuilder {
     override def run(io: ProcessIO): Process = new DummyProcess(exitValue)
     override def canPipeTo = true
   }
 
-  private[process] class URLInput(url: URL) extends IStreamBuilder(url.openStream(), url.toString)
-  private[process] class FileInput(file: File) extends IStreamBuilder(new FileInputStream(file), file.getAbsolutePath)
-  private[process] class FileOutput(file: File, append: Boolean) extends OStreamBuilder(new FileOutputStream(file, append), file.getAbsolutePath)
-
-  private[process] class OStreamBuilder(
-    stream: => OutputStream,
-    label: String
-  ) extends ThreadBuilder(label, _ writeInput protect(stream)) {
+  private[process] final class URLInput(url: URL) extends ThreadBuilder(url.toString) {
     override def hasExitValue = false
+    override def runImpl(io: ProcessIO): Unit = io.processOutput(protect(url.openStream()))
   }
 
-  private[process] class IStreamBuilder(
-    stream: => InputStream,
-    label: String
-  ) extends ThreadBuilder(label, _ processOutput protect(stream)) {
+  // Because the argument must be call-by-name to re-create the stream every time,
+  // this class should not be reused in a context where the call-by-name argument does something sensitive,
+  // like `url.openStream()`, since otherwise there is a hypothetical possibility of a Java deserialization gadget chain.
+  private[process] final class StreamInput(stream: => InputStream, label: String) extends ThreadBuilder(label) {
     override def hasExitValue = false
+    override def runImpl(io: ProcessIO): Unit = io.processOutput(protect(stream))
+  }
+
+  private[process] final class FileInput(file: File) extends ThreadBuilder(file.getAbsolutePath) {
+    override def hasExitValue = false
+    override def runImpl(io: ProcessIO): Unit = io.processOutput(protect(new FileInputStream(file)))
+  }
+
+  private[process] final class StreamOutput(stream: OutputStream, label: String) extends ThreadBuilder(label) {
+    override def hasExitValue = false
+    override def runImpl(io: ProcessIO): Unit = io.writeInput(protect(stream))
+  }
+
+  private[process] final class FileOutput(file: File, append: Boolean) extends ThreadBuilder(file.getAbsolutePath) {
+    override def hasExitValue = false
+    override def runImpl(io: ProcessIO): Unit = io.writeInput(protect(new FileOutputStream(file, append)))
   }
 
   private[process] abstract class ThreadBuilder(
-    override val toString: String,
-    runImpl: ProcessIO => Unit
+    override val toString: String
   ) extends AbstractBuilder {
+
+    def runImpl(io: ProcessIO): Unit
 
     override def run(io: ProcessIO): Process = {
       val success = new LinkedBlockingQueue[Boolean](1)
@@ -218,7 +229,7 @@ private[process] trait ProcessBuilderImpl {
 
     def #<<(f: File): ProcessBuilder           = #<<(new FileInput(f))
     def #<<(u: URL): ProcessBuilder            = #<<(new URLInput(u))
-    def #<<(s: => InputStream): ProcessBuilder = #<<(new IStreamBuilder(s, "<input stream>"))
+    def #<<(s: => InputStream): ProcessBuilder = #<<(new StreamInput(s, "<input stream>"))
     def #<<(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(b, new FileOutput(base, append = true), toError = false)
   }
 

--- a/library/src/scala/sys/process/ProcessBuilderImpl.scala
+++ b/library/src/scala/sys/process/ProcessBuilderImpl.scala
@@ -45,7 +45,7 @@ private[process] trait ProcessBuilderImpl {
   // Because the argument must be call-by-name to re-create the stream every time,
   // this class should not be reused in a context where the call-by-name argument does something sensitive,
   // like `url.openStream()`, since otherwise there is a hypothetical possibility of a Java deserialization gadget chain.
-  private[process] final class StreamInput(stream: => InputStream, label: String) extends ThreadBuilder(label) {
+  private[process] final class IStreamBuilder(stream: => InputStream, label: String) extends ThreadBuilder(label) {
     override def hasExitValue = false
     override def runImpl(io: ProcessIO): Unit = io.processOutput(protect(stream))
   }
@@ -55,7 +55,8 @@ private[process] trait ProcessBuilderImpl {
     override def runImpl(io: ProcessIO): Unit = io.processOutput(protect(new FileInputStream(file)))
   }
 
-  private[process] final class StreamOutput(stream: OutputStream, label: String) extends ThreadBuilder(label) {
+  // Same remark as IStreamBuilder
+  private[process] final class OStreamBuilder(stream: => OutputStream, label: String) extends ThreadBuilder(label) {
     override def hasExitValue = false
     override def runImpl(io: ProcessIO): Unit = io.writeInput(protect(stream))
   }
@@ -229,7 +230,7 @@ private[process] trait ProcessBuilderImpl {
 
     def #<<(f: File): ProcessBuilder           = #<<(new FileInput(f))
     def #<<(u: URL): ProcessBuilder            = #<<(new URLInput(u))
-    def #<<(s: => InputStream): ProcessBuilder = #<<(new StreamInput(s, "<input stream>"))
+    def #<<(s: => InputStream): ProcessBuilder = #<<(new IStreamBuilder(s, "<input stream>"))
     def #<<(b: ProcessBuilder): ProcessBuilder = new PipedBuilder(b, new FileOutput(base, append = true), toError = false)
   }
 

--- a/library/test/scala/sys/process/ProcessTest.scala
+++ b/library/test/scala/sys/process/ProcessTest.scala
@@ -58,11 +58,6 @@ class ProcessTest {
     val res = ("cat" #< new ByteArrayInputStream("lol".getBytes)).!!
     assertEquals("lol\n", res)
   }
-  // test non-hanging
-  //@Test def t10055(): Unit = noWin() {
-  //  val res = ("cat" #< ( () => -1 ) ).!
-  //  assertEquals(0, res)
-  //}
 
   @Test def t10953(): Unit =
     Using.resources(File.createTempFile("foo", "tmp"), File.createTempFile("bar", "tmp")) {


### PR DESCRIPTION
Remove a potential deserialization gadget due to the call-by-name generated functions immediately opening files/URLs

> [!WARNING]
> As usual, untrusted Java/Scala deserialization is a recipe for disaster. This is only a best-effort attempt at preventing potential problems.

## How much have you relied on LLM-based tools in this contribution?

not

## How was the solution tested?

existing tests
