### PR TITLE
Scoverage & CC interaction: exempt CC nested symbols from @experimental check

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -212,7 +212,8 @@ object Feature:
       report.error(experimentalUseSite(which) + note, srcPos)
 
   private def ccException(sym: Symbol)(using Context): Boolean =
-    ccEnabled && defn.ccExperimental.contains(sym)
+    ccEnabled && (defn.ccExperimental.contains(sym)
+      || sym.exists && defn.ccExperimental.contains(sym.owner))
 
   def checkExperimentalDef(sym: Symbol, srcPos: SrcPos)(using Context) =
     val experimentalSym =

--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -25,11 +25,9 @@ i18589
 i19955a.scala
 i19955b.scala
 i20053b.scala
-i21313.scala
 i2146.scala
 i23179.scala
 i23489.scala
-i24039.scala
 i5039.scala
 i8623.scala
 i8900a3.scala


### PR DESCRIPTION
Capture checking introduces some `experimental` symbols that are exempt from experimental checks with capture checking enabled. Currently, exemptions are only applied to the symbol itself, not its owner.

Coverage instrumentation introduces synthetic `ValDef`s which may expose capture checking symbols owned by experimental classes to experimental checks, bypassing the exemption.

This PR hardens the exemption to apply check the owner of the symbol as well.

## How much have you relied on LLM-based tools in this contribution?

Moderately.

## How was the solution tested?

- Reproduced the two failing tests individually with coverage before the fix
- Re-ran the same two tests with coverage after the fix and confirmed they pass
- Ran positive & coverage compilation suites with the fix introduced
