### PR TITLE
Improve sizeCompare doc

### DIFF
--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -264,9 +264,12 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *       x >  0       if this.size >  otherSize
    *  ```
    *
-   *  The method as implemented here does not call `size` directly; its running time
-   *  is `O(size min otherSize)` instead of `O(size)`. The method should be overridden
-   *  if computing `size` is cheap and `knownSize` returns `-1`.
+   *  The default implementation does not call `size`, which may be arbitrarily expensive.
+   *  It will use `knownSize` if nonnegative.
+   *  Otherwise, it will iterate to compute an element count,
+   *  with complexity `O(size min otherSize)`.
+   *  This method should be overridden if computing `size` is cheap and `knownSize` returns `-1`.
+   *  In that case, the custom implementation should just compare `size` and `otherSize` directly.
    *
    *  @see [[sizeIs]]
    */


### PR DESCRIPTION
Fixes scala/bug#11783

Not sure that collection implementers are confused, but the extant wording is confusing, per the ticket.

Not sure this attempt to improve the words is not tiresome.

The original uncertainty was: "Does it mean to say cheap or not cheap?"

An alternative fix would simply delete the confusing text. Curious folk may consult the open source code.