### PR TITLE
Include span of bad args if multiline

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4498,7 +4498,14 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         if isAcceptedSpuriousApply(tree, pt.args) then tree
         else
           tryInsertApplyOrImplicit(tree, pt, locked):
-            errorTree(tree, MethodDoesNotTakeParameters(tree))
+            val pos =
+              if pt.args.isEmpty then tree.srcPos
+              else
+                val union = tree.sourcePos.withSpan:
+                  tree.srcPos.span.union(pt.args.last.srcPos.span)
+                if union.startLine != union.endLine then union // if multiline, show more context
+                else tree.srcPos
+            errorTree(tree, MethodDoesNotTakeParameters(tree), pos)
     }
 
     def adaptNoArgsImplicitMethod(wtp: MethodType): Tree = {

--- a/tests/neg/19087.check
+++ b/tests/neg/19087.check
@@ -14,7 +14,9 @@
   |    Declaration of method foo not allowed here: only classes can have declared but undefined members
 -- [E050] Type Error: tests/neg/19087.scala:13:22 ----------------------------------------------------------------------
 13 |        foo(state.copy(x = 5): // Missing ")" // error: method copy in class State does not take more parameters
-   |            ^^^^^^^^^^^^^^^^^
+   |            ^
    |            method copy in class State does not take more parameters
+   |
+14 |          println("a")
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg/i9434.check
+++ b/tests/neg/i9434.check
@@ -1,0 +1,53 @@
+-- [E018] Syntax Error: tests/neg/i9434.scala:10:18 --------------------------------------------------------------------
+10 |      Vector(1) ++ // error
+   |                  ^
+   |                  expression expected but [31munindent[0m found
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E050] Type Error: tests/neg/i9434.scala:4:14 -----------------------------------------------------------------------
+4 |    val bar = foo // error
+  |              ^
+  |              value foo does not take parameters
+  |
+5 |      (1, 1)
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i9434.scala:6:3 ---------------------------------------------------------------
+6 |  } // error
+  |   ^
+  |   Found:    Unit
+  |   Required: (Int, Int)
+  |
+  |   Maybe the enclosing block is missing a final expression after the definition of `bar`?
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E050] Type Error: tests/neg/i9434.scala:26:29 ----------------------------------------------------------------------
+26 |  def f[A](as: List[A]) = as headOption // error
+   |                          ^
+   |                          method headOption in trait LinearSeqOps does not take parameters
+   |
+27 |    42
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E050] Type Error: tests/neg/i9434.scala:30:29 ----------------------------------------------------------------------
+30 |  def f[A](as: List[A]) = as headOption // error
+   |                          ^
+   |                          method headOption in trait LinearSeqOps does not take parameters
+   |
+31 |  42
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E050] Type Error: tests/neg/i9434.scala:35:10 ----------------------------------------------------------------------
+35 |  def f = g // error
+   |          ^
+   |          method g in object Y does not take parameters
+   |
+36 |    (42)
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E129] Potential Issue Warning: tests/neg/i9434.scala:41:2 ----------------------------------------------------------
+41 |  (42) // warn
+   |  ^^^^
+   |  A pure expression does nothing in statement position
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i9434.scala
+++ b/tests/neg/i9434.scala
@@ -1,0 +1,41 @@
+object Foo {
+  def bar1: (Int, Int) = {
+    val foo = 1.0
+    val bar = foo // error
+      (1, 1)
+  } // error
+
+  def bar2: Vector[Int] = {
+    val foo =
+      Vector(1) ++ // error
+    Vector(2) ++
+      Vector(3)
+    foo
+  }
+}
+/* Now the diagnostic is multiline, to show more context (the args), and only one caret for the point.
+-- [E050] Type Error: i9434.scala:5:14 ---------------------------------------------------------------------------------
+5 |    val bar = foo
+  |              ^^^
+  |              value foo does not take parameters
+  |
+  | longer explanation available when compiling with `-explain`
+*/
+
+object X:
+  def f[A](as: List[A]) = as headOption // error
+    42
+
+object X2:
+  def f[A](as: List[A]) = as headOption // error
+  42
+
+object Y:
+  def g = 42
+  def f = g // error
+    (42)
+
+object Z:
+  def g = 42
+  def f = g
+  (42) // warn


### PR DESCRIPTION
Fixes #9434 

The message position is tweaked only when the args are on a different line.

Then the source context includes the args; but only one caret for the point.

It would be nicer to request more context without changing the diagnostic position.