### PR TITLE
Refine isStatic test in SafeRefs.isSafe

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
@@ -158,25 +158,38 @@ object SafeRefs {
         sym.hasAnnotation(defn.AssumeSafeAnnot)
         || isSafe(if sym.is(ModuleVal) then sym.moduleClass else sym.owner)
 
-    val (sym, checkLater) = tree match
-      case tree: New =>
-        (tree.tpt.tpe.classSymbol, false)
-      case tree: RefTree =>
-        val checkLater =
-          !tree.symbol.is(Method)
-          && pt.match
-            case pt: PathSelectionProto => pt.selector.isStatic
-            case _: SelectionProto => true
-            case _ => false
-        (tree.symbol, checkLater)
+    val sym = tree match
+      case tree: New => tree.tpt.symbol
+      case tree: RefTree => tree.symbol
+
+    def checkLater =
+      sym.isTerm && !sym.is(Method) && pt.match
+        case pt: PathSelectionProto => pt.selector.isStatic
+        case _: SelectionProto => true
+        case _ => false
+
+    def isStatic = tree match
+      case tree: Ident =>
+        // Idents might refer to inherited symbols of static objects.
+        // in this case we need to check whether the prefix is static
+        // For Selects this is not an issue since we have already checked
+        // the qualifier for safety. safemode-pkg-inherit.scala is a test case.
+        tree.tpe match
+          case NamedType(prefix, _) =>
+            prefix.dealias match
+              case prefix: ThisType => prefix.cls.isStatic
+              case prefix: TermRef => prefix.symbol.isStatic
+              case _ => sym.isStatic
+          case _ => sym.isStatic
+      case _ => sym.isStatic
 
     if Feature.safeEnabled
         && sym.exists
+        && !sym.is(Package)
         && checkNotRejected(sym, tree.srcPos)
         && !checkLater
-        && sym.isStatic // if it's not static it is local, a parameter, or comes from another symbol,
-                        // which has been checked
-        && !sym.is(Package)
+        && isStatic // if it's not static it is local, a parameter, or comes from another symbol,
+                   // which has been checked
         && !isSafe(sym)
     then
       fail(sym, "it is neither compiled in safe mode nor tagged with @assumedSafe", tree.srcPos)

--- a/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SafeRefs.scala
@@ -159,7 +159,7 @@ object SafeRefs {
         || isSafe(if sym.is(ModuleVal) then sym.moduleClass else sym.owner)
 
     val sym = tree match
-      case tree: New => tree.tpt.symbol
+      case tree: New => tree.tpt.tpe.classSymbol
       case tree: RefTree => tree.symbol
 
     def checkLater =

--- a/tests/neg-custom-args/captures/safemode-pkg-inherit.check
+++ b/tests/neg-custom-args/captures/safemode-pkg-inherit.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg-custom-args/captures/safemode-pkg-inherit.scala:4:13 -----------------------------------------------
+4 |val result = Seq("sh", "-c", "echo 'oh no'").!! // error
+  |             ^
+  |Cannot refer to method stringSeqToProcess in trait ProcessImplicits from safe code since it is neither compiled in safe mode nor tagged with @assumedSafe

--- a/tests/neg-custom-args/captures/safemode-pkg-inherit.scala
+++ b/tests/neg-custom-args/captures/safemode-pkg-inherit.scala
@@ -1,0 +1,5 @@
+import scala.language.experimental.safe
+import scala.sys.process.*
+
+val result = Seq("sh", "-c", "echo 'oh no'").!! // error
+

--- a/tests/new/test.scala
+++ b/tests/new/test.scala
@@ -1,12 +1,14 @@
-package test
-
-object Console:
-  val out: java.io.PrintStream^ = System.out
-  def println(s: String) = out.println(s)
-
-
-object Test:// uses Console uses_init Console:
-  Console.println("hello")
-
-  def f() =
-    Console.println("hello")
+trait TC[X]
+object TC {
+  given t2[T]: TC[T] = ???
+  given t1[T]: TC[T] = ???
+}
+class Seq2[T] {
+  def sorted(using TC[T]): Seq2[T] = ???
+}
+extension [T](s: Seq2[T])
+  def f[G](c: Seq2[G]): Unit = ???
+object Crash {
+  val s: Seq2[Int] = ???
+  s.sorted.f(Seq2())
+}


### PR DESCRIPTION
If the tree is an Ident, we need to look into the type prefix of the symbol's reference.
