### PR TITLE
Go back to explicit @retains instead of uses_init in stdlib

### DIFF
--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -217,7 +217,7 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
    *  See [[MapOps.LazyKeySet]] for a version that lazily captures the map.
    */
   @deprecated("GenKeySet is not capture-safe, and so is deprecated and no longer used in .keySet implementations.", since = "3.8.0")
-  protected trait GenKeySet uses_init MapOps.this {
+  protected trait GenKeySet @retains[MapOps.this.type]() {
     this: Set[K] =>
     import caps.unsafe.{unsafeDiscardUses, unsafeAssumePure}
     def iterator: Iterator[K] = unsafeDiscardUses(MapOps.this).keysIterator.unsafeAssumePure


### PR DESCRIPTION
This prepares for a change in syntax for uses_init since stdlib has to be compilable in non-bootstrapped as well as bootstrapped settings.
