### PR TITLE
change lower bound of Option.orNull to nullable

### DIFF
--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -220,7 +220,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  val textField = new JComponent(initialText.orNull,20)
    *  ```
    */
-  @inline final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
+  @inline final def orNull[A1 >: A | Null](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
 
   /** Returns a $some containing the result of applying $f to this $option's
    *  value if this $option is nonempty.

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -220,7 +220,10 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  val textField = new JComponent(initialText.orNull,20)
    *  ```
    */
-  @inline final def orNull[A1 >: A | Null](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
+  @inline final def orNull: A | Null = this.getOrElse(null)
+  
+  // for binary and TASTy backwards compatibility 
+  @deprecated @inline protected final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
 
   /** Returns a $some containing the result of applying $f to this $option's
    *  value if this $option is nonempty.

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -52,6 +52,7 @@ object MiMaFilters {
         ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.:++"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.concat"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.sizeHint$default$2"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.None.orNull"),
       )
     )
   }

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -24,6 +24,7 @@ object MiMaFilters {
 
       // Breaking changes since last reference version
       Build.mimaPreviousDottyVersion -> Seq(
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.None.orNull"),
         ProblemFilters.exclude[MissingTypesProblem]("scala.util.control.NonLocalReturns$ReturnThrowable"),
         // THIS IS FINE, IT SHOULD HAVE BEEN THIS WAY
         ProblemFilters.exclude[MissingTypesProblem]("scala.Function1$"),
@@ -52,7 +53,6 @@ object MiMaFilters {
         ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.:++"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.concat"),
         ProblemFilters.exclude[FinalMethodProblem]("scala.jdk.Accumulator.sizeHint$default$2"),
-        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.None.orNull"),
       )
     )
   }

--- a/tests/explicit-nulls/pos/option-ornull.scala
+++ b/tests/explicit-nulls/pos/option-ornull.scala
@@ -1,0 +1,6 @@
+import java.util.Optional
+
+class CheckResult(result: Option[Unit]):
+  def foo =
+    val x: Optional[Unit] = Optional.ofNullable(result.orNull)
+    42


### PR DESCRIPTION
This PR changes the signature of `Option.orNull` from
```scala
  @inline final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
```
to
```scala
  @inline final def orNull: A | Null = this getOrElse ev(null)
```
Under `-Yexplicit-nulls`, type inference sometimes infers `A1` to be a non-null type, leading to a failure to find the implicit `ev`. The new result type is more straightforward for type inference.

Without `-Yexplicit-nulls`, `A | Null` is also correct. When `A` is a nullable type, `A | Null` is equivalent to `A`.

## How much have you relied on LLM-based tools in this contribution?

No.

## How was the solution tested?

Added test `option-ornull` minimized from akka-management.

## Additional notes

This may have to wait until a version when we can start making changes to standard library signatures.