### PR TITLE
Use precise type for `x` in `case x @ (_: A, _: B)`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1718,7 +1718,19 @@ trait Applications extends Compatibility {
   def typedUnApply(tree: untpd.Apply, selType0: Type)(using Context): Tree = {
     record("typedUnApply")
     val Apply(qual, unadaptedArgs) = tree
-    val selType = selType0.stripNamedTuple
+    // Use the types of the args if available, which can be more precise than the selector type,
+    // which is important if using `@unchecked`
+    val selType1 = selType0 match
+      case AppliedType(selCon, selArgs) if selArgs.size == unadaptedArgs.size =>
+        val newSelTypes = selArgs.zip(unadaptedArgs).map((sa, ua) => ua match
+          case Typed(_, tpt: AppliedTypeTree) =>
+            typed(tpt)
+            if tpt.hasType then tpt.tpe else sa
+          case _ => sa
+        )
+        AppliedType(selCon, newSelTypes)
+      case _ => selType0
+    val selType = selType1.stripNamedTuple
 
     def notAnExtractor(tree: Tree): Tree =
       // prefer inner errors
@@ -1954,21 +1966,6 @@ trait Applications extends Compatibility {
 
         val unapplyPatterns = UnapplyArgs(unapplyApp.tpe, unapplyFn, unadaptedArgs, tree.srcPos)
           .typedPatterns(qual, this)
-
-        // Use the types of the `unapply` arguments if available,
-        // so that in `match m { case x @ (_: A, _: B) => x }`, `x` is of type `(A, B)`, not the type of `m`.
-        // This matters for @unchecked
-        (newUnapplyFn, unapplyApp, ownType) match
-          case (newUnapplyFn1: TypeApply, unapplyApp1: Apply, ownType1: AppliedType) if newUnapplyFn1.args.size == unapplyPatterns.size =>
-            val newArgs = newUnapplyFn1.args.zip(unapplyPatterns).map((a, p) => p match
-              case Bind(_, Typed(_, tpt: AppliedTypeTree)) if tpt.tpe <:< a.tpe => tpt
-              case _ => a
-            )
-            newUnapplyFn = tpd.cpy.TypeApply(newUnapplyFn1)(newUnapplyFn1.fun, newArgs)
-            unapplyApp = tpd.cpy.Apply(unapplyApp1)(newUnapplyFn, unapplyApp1.args)
-            ownType = AppliedType(ownType1.tycon, newArgs.map(_.tpe))
-          case _ => ()
-
         val result = assignType(cpy.UnApply(tree)(newUnapplyFn, unapplyImplicits(dummyArg, unapplyApp), unapplyPatterns), ownType)
         if (ownType.stripped eq selType.stripped) || selType.isBottomType || ownType.isError then result
         else tryWithTypeTest(Typed(result, TypeTree(ownType)), selType)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1940,7 +1940,7 @@ trait Applications extends Compatibility {
       case mt: MethodType if mt.paramInfos.length == 1 =>
         val unapplyArgType = mt.paramInfos.head
         unapp.println(i"unapp arg tpe = $unapplyArgType, pt = $selType")
-        var ownType =
+        val ownType =
           if selType <:< unapplyArgType then
             unapp.println(i"case 1 $unapplyArgType ${ctx.typerState.constraint}")
             fullyDefinedType(unapplyArgType, "pattern selector", tree.srcPos)
@@ -1959,7 +1959,7 @@ trait Applications extends Compatibility {
             unapplyArgType
 
         val dummyArg = dummyTreeOfType(ownType)
-        var (newUnapplyFn, unapplyApp) =
+        val (newUnapplyFn, unapplyApp) =
           val unapplyAppCall =
             typedExpr(untpd.TypedSplice(Apply(unapplyFn, dummyArg :: Nil)))
           inlinedUnapplyFnAndApp(dummyArg, unapplyAppCall)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1928,7 +1928,7 @@ trait Applications extends Compatibility {
       case mt: MethodType if mt.paramInfos.length == 1 =>
         val unapplyArgType = mt.paramInfos.head
         unapp.println(i"unapp arg tpe = $unapplyArgType, pt = $selType")
-        val ownType =
+        var ownType =
           if selType <:< unapplyArgType then
             unapp.println(i"case 1 $unapplyArgType ${ctx.typerState.constraint}")
             fullyDefinedType(unapplyArgType, "pattern selector", tree.srcPos)
@@ -1947,13 +1947,28 @@ trait Applications extends Compatibility {
             unapplyArgType
 
         val dummyArg = dummyTreeOfType(ownType)
-        val (newUnapplyFn, unapplyApp) =
+        var (newUnapplyFn, unapplyApp) =
           val unapplyAppCall =
             typedExpr(untpd.TypedSplice(Apply(unapplyFn, dummyArg :: Nil)))
           inlinedUnapplyFnAndApp(dummyArg, unapplyAppCall)
 
         val unapplyPatterns = UnapplyArgs(unapplyApp.tpe, unapplyFn, unadaptedArgs, tree.srcPos)
           .typedPatterns(qual, this)
+
+        // Use the types of the `unapply` arguments if available,
+        // so that in `match m { case x @ (_: A, _: B) => x }`, `x` is of type `(A, B)`, not the type of `m`.
+        // This matters for @unchecked
+        (newUnapplyFn, unapplyApp, ownType) match
+          case (newUnapplyFn1: TypeApply, unapplyApp1: Apply, ownType1: AppliedType) if newUnapplyFn1.args.size == unapplyPatterns.size =>
+            val newArgs = newUnapplyFn1.args.zip(unapplyPatterns).map((a, p) => p match
+              case Bind(_, Typed(_, tpt: AppliedTypeTree)) if tpt.tpe <:< a.tpe => tpt
+              case _ => a
+            )
+            newUnapplyFn = tpd.cpy.TypeApply(newUnapplyFn1)(newUnapplyFn1.fun, newArgs)
+            unapplyApp = tpd.cpy.Apply(unapplyApp1)(newUnapplyFn, unapplyApp1.args)
+            ownType = AppliedType(ownType1.tycon, newArgs.map(_.tpe))
+          case _ => ()
+
         val result = assignType(cpy.UnApply(tree)(newUnapplyFn, unapplyImplicits(dummyArg, unapplyApp), unapplyPatterns), ownType)
         if (ownType.stripped eq selType.stripped) || selType.isBottomType || ownType.isError then result
         else tryWithTypeTest(Typed(result, TypeTree(ownType)), selType)

--- a/compiler/test/dotty/tools/dotc/Playground.scala
+++ b/compiler/test/dotty/tools/dotc/Playground.scala
@@ -15,7 +15,7 @@ import org.junit.Ignore
     // can add, e.g., .and("-some-option")
     val options = defaultOptions
     // can also use `compileDir` (single test as a dir), `compileFilesInDir` (all tests within a dir)
-    val test = compileFile("tests/pos/tuple-filter.scala", options)
+    val test = compileFile("tests/pos/match-precise-type-unchecked.scala", options)
     // or `RunTestWithCoverage` for "run" tests with output, or `WarnTestWithCoverage` for "warn" tests with warnings
     type TestKind = PosTestWithCoverage
     val compilationTest = withCoverage(aggregateTests(test))

--- a/compiler/test/dotty/tools/dotc/Playground.scala
+++ b/compiler/test/dotty/tools/dotc/Playground.scala
@@ -15,7 +15,7 @@ import org.junit.Ignore
     // can add, e.g., .and("-some-option")
     val options = defaultOptions
     // can also use `compileDir` (single test as a dir), `compileFilesInDir` (all tests within a dir)
-    val test = compileFile("tests/pos/match-precise-type-unchecked.scala", options)
+    val test = compileFile("tests/pos/tuple-filter.scala", options)
     // or `RunTestWithCoverage` for "run" tests with output, or `WarnTestWithCoverage` for "warn" tests with warnings
     type TestKind = PosTestWithCoverage
     val compilationTest = withCoverage(aggregateTests(test))

--- a/tests/pos/match-precise-type-unchecked.scala
+++ b/tests/pos/match-precise-type-unchecked.scala
@@ -1,0 +1,11 @@
+import scala.collection.*
+import scala.util.*
+
+val (ss: Seq[Success[Int] @unchecked], fs: Seq[Failure[Int] @unchecked]) =
+  Seq.empty[Try[Int]].partition(_.isSuccess)
+
+val (ss2: Seq[Success[Int]], fs2: Seq[Failure[Int]]) = Seq.empty[Try[Int]].partition(_.isSuccess) match
+  case (s: Seq[Success[Int] @unchecked], f: Seq[Failure[Int] @unchecked]) => (s, f)
+
+val (ss3: Seq[Success[Int]], fs3: Seq[Failure[Int]]) = Seq.empty[Try[Int]].partition(_.isSuccess) match
+  case x @ (s: Seq[Success[Int] @unchecked], f: Seq[Failure[Int] @unchecked]) => x

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -5059,8 +5059,8 @@ _empty_/Txn# => trait Txn [typeparam T  <: Txn[T]] extends Object { self: Txn[T]
 _empty_/Txn#[T] => typeparam T  <: Txn[T]
 _empty_/Txn#`<init>`(). => primary ctor <init> [typeparam T  <: Txn[T]](): Txn[T]
 local0 => val local out: Repr[Out]
-local1 => val local inObj: Obj[In] & Repr[In]
-local2 => val local outObj: Obj[Out] & Repr[Out]
+local1 => val local inObj: Obj[In]
+local2 => val local outObj: Obj[Out]
 
 Occurrences:
 [1:6..1:9): Txn <- _empty_/Txn#


### PR DESCRIPTION
Fixes #25544

I'm not a big fan of this, but it works, so it's a good first step in getting someone to tell me why it's actually bad and what should be done instead :)

## How much have you relied on LLM-based tools in this contribution?

as much as som-snytt does

## How was the solution tested?

issue regression test
