### PR TITLE
Don't pop outermost region when skipping

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -369,7 +369,7 @@ object Scanners {
         }
       case OUTDENT =>
         currentRegion match
-          case r: Indented => currentRegion = r.enclosing
+          case r: Indented if !r.isOutermost => currentRegion = r.enclosing
           case _ =>
       case STRINGLIT =>
         currentRegion match {

--- a/tests/neg/i25683.scala
+++ b/tests/neg/i25683.scala
@@ -1,0 +1,9 @@
+object OptionExample {
+  def f(x: Any) = ()
+  def example = {
+    f(
+      if (
+        false
+      )
+    ) // error
+    val someVal // error


### PR DESCRIPTION
Fixes #25683 

When skipping on error, tokens are consumed and current region is adjusted. But don't blow past the outermost region. There is an existing guard for RBRACE.

On outdent, skip will drop until indented. Normally, on subsequent outdent, one expects a corresponding indent region, but that may have been stripped on error recovery.

## How much have you relied on LLM-based tools in this contribution?

I forgot to again.

## How was the solution tested?

After diagnosis, simplified the ticket example. Recovery from the first error sets up the crash.

## Additional notes

I always wondered how regions worked.
