### PR TITLE
Preserve erased flags on synthetic context-function parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1348,26 +1348,29 @@ object desugar {
       case _ => body
     cpy.PolyFunction(tree)(tree.targs, stripped(tree.body)).asInstanceOf[PolyFunction]
 
+  /** Apply function-level parameter flags such as `given` and `erased` to term parameters. */
+  private def addFunctionParamFlags(params: List[ValDef], funFlags: FlagSet, erasedParams: List[Boolean])(using Context): List[ValDef] =
+    val commonFlags = funFlags.toTermFlags & GivenOrImplicit
+    params.zipWithConserve(erasedParams): (param, isErased) =>
+      val flags = commonFlags | (if isErased then Erased else EmptyFlags)
+      if flags.isEmpty then param else param.withAddedFlags(flags)
+
   /** Desugar [T_1, ..., T_M] => (P_1, ..., P_N) => R
    *  Into    scala.PolyFunction { def apply[T_1, ..., T_M](x$1: P_1, ..., x$N: P_N): R }
    */
   def makePolyFunctionType(tree: PolyFunction)(using Context): RefinedTypeTree = (tree: @unchecked) match
     case PolyFunction(tparams: List[untpd.TypeDef] @unchecked, fun @ untpd.Function(vparamTypes, res)) =>
-      val paramFlags = fun match
+      val vparams0 = vparamTypes.zipWithIndex.map {
+        case (p: ValDef, _) => p
+        case (p, n) => makeSyntheticParameter(n + 1, p)
+      }.toList
+      val vparams = fun match
         case fun: FunctionWithMods =>
           // TODO: make use of this in the desugaring when pureFuns is enabled.
           // val isImpure = funFlags.is(Impure)
-
-          // Function flags to be propagated to each parameter in the desugared method type.
-          val givenFlag = fun.mods.flags.toTermFlags & Given
-          fun.erasedParams.map(isErased => if isErased then givenFlag | Erased else givenFlag)
+          addFunctionParamFlags(vparams0, fun.mods.flags, fun.erasedParams)
         case _ =>
-          vparamTypes.map(_ => EmptyFlags)
-
-      val vparams = vparamTypes.lazyZip(paramFlags).zipWithIndex.map {
-        case ((p: ValDef, paramFlags), n) => p.withAddedFlags(paramFlags)
-        case ((p, paramFlags), n) => makeSyntheticParameter(n + 1, p).withAddedFlags(paramFlags)
-      }.toList
+          vparams0
 
       RefinedTypeTree(ref(defn.PolyFunctionType), List(
         DefDef(nme.apply, tparams :: vparams :: Nil, res, EmptyTree)
@@ -2076,8 +2079,9 @@ object desugar {
         if augmenting then paramNamesOrNil.map(ContextFunctionParamName.fresh(_))
         else paramNamesOrNil
       else List.fill(formals.length)(ContextFunctionParamName.fresh())
-    val params = for (tpt, pname) <- formals.zip(paramNames) yield
-      ValDef(pname, tpt, EmptyTree).withFlags(Given | Param)
+    val params0 = for (tpt, pname) <- formals.zip(paramNames) yield
+      ValDef(pname, tpt, EmptyTree).withFlags(Param)
+    val params = addFunctionParamFlags(params0, Given, erasedParams)
     FunctionWithMods(params, body, Modifiers(Given), erasedParams)
 
   private def derivedValDef(originalSpan: Span, named: NameTree, tpt: Tree, rhs: Tree, mods: Modifiers)(using Context) =

--- a/tests/run/i25725.check
+++ b/tests/run/i25725.check
@@ -1,0 +1,5 @@
+value: 99
+value: 99
+varA: 99
+varB: 99
+varC: 99 ok

--- a/tests/run/i25725.scala
+++ b/tests/run/i25725.scala
@@ -1,0 +1,33 @@
+//> using options -language:experimental.erasedDefinitions
+
+class Proof
+erased given Proof = Proof()
+
+class P1
+class P2
+erased given P1 = P1()
+erased given P2 = P2()
+
+def mixed: (erased Proof) ?=> Int ?=> String =
+  s"value: ${summon[Int]}"
+
+def reversed: Int ?=> (erased Proof) ?=> String =
+  s"value: ${summon[Int]}"
+
+def varA: (erased P1) ?=> (erased P2) ?=> Int ?=> String =
+  s"varA: ${summon[Int]}"
+
+def varB: (erased P1) ?=> Int ?=> (erased P2) ?=> String =
+  s"varB: ${summon[Int]}"
+
+def varC: Int ?=> (erased P1) ?=> String ?=> String =
+  s"varC: ${summon[Int]} ${summon[String]}"
+
+@main def Test(): Unit =
+  given Int = 99
+  given String = "ok"
+  println(mixed)
+  println(reversed)
+  println(varA)
+  println(varB)
+  println(varC)


### PR DESCRIPTION
fix #25725

**problem**
For normal parameters, erasure removes erased parameters from both the method type and the erased tree:

```scala
def direct(using erased p: Proof, x: Int): String =
  "value: " + x

// [[syntax trees at end of erasure]]
def direct(using x: Int): String =
  "value: " + Int.box(x)
```

However, parameters coming from a context-function result were not treated the same way. For example:

```scala
def mixed: (erased Proof) ?=> Int ?=> String =
  s"value: ${summon[Int]}"

// after typer: desugared
def mixed:
    PolyFunction {
      def apply(using erased x$1: Proof): (Int) ?=> String
    }
   = (using x$1: Proof) => (using contextual$1: Int) => ...

// erased to a tree that still kept the erased parameter:
def mixed(using x$1: Proof, contextual$1: Int): String =
  "value: " + Int.box(contextual$1)
```

This produced a mismatch between the symbol info and the erased tree.

On the type side, `TypeErasure` correctly drops erased parameters from the `MethodType`, so `mixed.symbol.info` becomes `(using Int)String`, and the backend emits the JVM descriptor `(I)Ljava/lang/String;`.

On the tree side, the erased `DefDef` still contains `x$1`, so the backend assigns local slots as if both parameters were present: 0 = this / 1 = x$1 / 2 = contextual$1
As a result, the body loads `contextual$1` with `iload_2`, even though the descriptor contains only one argument. That mismatch results in verifier error.

**Root cause**

The root cause is that erased flagfor synthetic context-function parameters was stored only in `FunctionWithMods.erasedParams`, but was not stored onto the synthetic parameter `ValDef`s themselves. `makeContextualFunction` created parameters with `Given | Param`, but not `Erased`. Later, `Erasure.skipContextClosures` decides whether to keep flattened context-result parameters by checking `param.symbol.is(Erased)`, so these parameters were incorrectly seen as non-erased and left in the tree.

**fix**

This commit fix by keep function-parameter metadata (erasedness) on synthetic parameters consistently. We introduce a shared helper in `Desugar` and use it from both `makeContextualFunction` so that parameter-level flags such as `given`/`implicit` and `erased` are applied to the generated `ValDef`s before they are turned into symbols.

With that change, synthetic context-function parameters carry `Erased` to the Erasure phase, the erased tree matches the erased method type, and the backend assigns locals consistently.

<!-- Fixes #XYZ (where XYZ is the issue number from the issue tracker) -->

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

<!--
  TODO first sign the CLA
  https://contribute.akka.io/cla/scala
-->

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have you relied on LLM-based tools in this contribution?

<!-- 
  State clearly in the pull request description, 
  whether LLM-based tools were used and to what extent 

  (extensively/moderately/minimally/not at all)
-->

<!--
  Refer to our [LLM usage policy](https://github.com/scala/scala3/blob/main/LLM_POLICY.md) for rules and guidelines
  regarding usage of LLM-based tools in contributions.
-->

moderately use Codex gpt-5.4

## How was the solution tested?

<!-- 
  If automated tests are included, mention it.
  If they are not, explain why and how the solution was tested.
-->

`testCompilation i25725`

## Additional notes

<!-- Placeholder for any extra context regarding this contribution. -->

<!--
  When in doubt, and for support regarding contributions to a particular component of the compiler, 
  refer to [our contribution guide](https://github.com/scala/scala3/blob/main/CONTRIBUTING.md),
  and feel free to tag the maintainers listed there for the area(s) you are modifying.
-->
