### PR TITLE
bugfix: Fix issue with empty name throwing exceptions

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -119,8 +119,10 @@ class Completions(
   end includeSymbol
 
   lazy val fuzzyMatcher: Name => Boolean = name =>
-    if completionMode.is(Mode.Member) then CompletionFuzzy.matchesSubCharacters(completionPos.query, name.toString)
-    else CompletionFuzzy.matches(completionPos.query, name.toString)
+    val nameString = name.toString
+    if nameString.isEmpty then false
+    else if completionMode.is(Mode.Member) then CompletionFuzzy.matchesSubCharacters(completionPos.query, nameString)
+    else CompletionFuzzy.matches(completionPos.query, nameString)
 
   def enrichedCompilerCompletions(
       qualType: Type,


### PR DESCRIPTION
I could reproduce it in the presentation compiler module, it would sometimes break when rapidly writing code.

<!-- if the PR is still a WIP, create it as a draft PR (or convert it into one) -->

## How much have you relied on LLM-based tools in this contribution?

None

## How was the solution tested?

Manually working on the compiler.

## Additional notes


