### PR TITLE
Use unchecked on some pattern matches

### DIFF
--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -71,7 +71,7 @@ object Array {
    *  @return    an array consisting of elements of the iterable collection
    */
   def from[A : ClassTag](it: IterableOnce[A]^): Array[A] = it match {
-    case it: Iterable[A] => it.toArray[A]
+    case it: Iterable[A @unchecked] => it.toArray[A]
     case _ => it.iterator.toArray[A]
   }
 

--- a/library/src/scala/PartialFunction.scala
+++ b/library/src/scala/PartialFunction.scala
@@ -162,7 +162,7 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
    *           arguments `x` to `k(this(x))`.
    */
   override def andThen[C](k: B => C): PartialFunction[A, C]^{this, k} = k match {
-    case pf: (PartialFunction[B, C]^{k}) => andThen(pf)
+    case pf: (PartialFunction[B @unchecked, C @unchecked]^{k}) => andThen(pf)
     case _                         => new AndThen[A, B, C](this, k)
   }
 

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -41,7 +41,7 @@ trait Factory[-A, +C] extends Any { self =>
   def fromSpecific(it: IterableOnce[A]^): C^{it}
 
   /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
-   *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. 
+   *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections.
    */
   def newBuilder: Builder[A, C]
 }
@@ -315,7 +315,7 @@ object SeqFactory {
     def lengthCompare(len: Int): Int = c.lengthCompare(len)
     def apply(i: Int): A = c(i)
     def drop(n: Int): scala.Seq[A] = c match {
-      case seq: scala.Seq[A] => seq.drop(n)
+      case seq: scala.Seq[A @unchecked] => seq.drop(n)
       case _                 => c.view.drop(n).toSeq
     }
     def toSeq: scala.Seq[A] = c.toSeq
@@ -654,7 +654,7 @@ object ClassTagIterableFactory {
     extends EvidenceIterableFactory.Delegate[CC, ClassTag](delegate) with ClassTagIterableFactory[CC]
 
   /** An IterableFactory that uses ClassTag.Any as the evidence for every element type. This may or may not be
-   *  sound depending on the use of the `ClassTag` by the collection implementation. 
+   *  sound depending on the use of the `ClassTag` by the collection implementation.
    */
   @SerialVersionUID(3L)
   class AnyIterableDelegate[CC[_]](delegate: ClassTagIterableFactory[CC]) extends IterableFactory[CC] {
@@ -685,7 +685,7 @@ object ClassTagSeqFactory {
     extends ClassTagIterableFactory.Delegate[CC](delegate) with ClassTagSeqFactory[CC]
 
   /** A SeqFactory that uses ClassTag.Any as the evidence for every element type. This may or may not be
-   *  sound depending on the use of the `ClassTag` by the collection implementation. 
+   *  sound depending on the use of the `ClassTag` by the collection implementation.
    */
   @SerialVersionUID(3L)
   class AnySeqDelegate[CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure](delegate: ClassTagSeqFactory[CC])

--- a/library/src/scala/collection/IndexedSeqView.scala
+++ b/library/src/scala/collection/IndexedSeqView.scala
@@ -162,7 +162,7 @@ object IndexedSeqView {
   @SerialVersionUID(3L)
   class Reverse[A](underlying: SomeIndexedSeqOps[A]^) extends SeqView.Reverse[A](underlying) with IndexedSeqView[A] {
     override def reverse: IndexedSeqView[A]^{this} = underlying match {
-      case x: IndexedSeqView[A] => x
+      case x: IndexedSeqView[A @unchecked] => x
       case _ => super.reverse
     }
   }

--- a/library/src/scala/collection/Iterable.scala
+++ b/library/src/scala/collection/Iterable.scala
@@ -725,7 +725,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    */
   def concat[B >: A](suffix: IterableOnce[B]^): CC[B]^{this, suffix} = iterableFactory.from {
     suffix match {
-      case suffix: Iterable[B] => new View.Concat(this, suffix)
+      case suffix: Iterable[B @unchecked] => new View.Concat(this, suffix)
       case suffix => iterator ++ suffix.iterator
     }
   }
@@ -743,7 +743,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
    *                 The length of the returned collection is the minimum of the lengths of this $coll and `that`.
    */
   def zip[B](that: IterableOnce[B]^): CC[(A @uncheckedVariance, B)]^{this, that} = iterableFactory.from(that match { // sound bcs of VarianceNote
-    case that: Iterable[B] => new View.Zip(this, that)
+    case that: Iterable[B @unchecked] => new View.Zip(this, that)
     case _ => iterator.zip(that)
   })
 
@@ -851,7 +851,7 @@ transparent trait IterableOps[+A, +CC[_], +C] extends Any with IterableOnce[A] w
 
   @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
   def ++:[B >: A](that: IterableOnce[B]^): CC[B]^{this, that} = iterableFactory.from(that match {
-    case xs: Iterable[B] => new View.Concat(xs, this)
+    case xs: Iterable[B @unchecked] => new View.Concat(xs, this)
     case _ => that.iterator ++ iterator
   })
 }

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -162,7 +162,7 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
 
   @deprecated("Use .iterator.foreach(...) instead", "2.13.0")
   @`inline` def foreach[U](f: A => U): Unit = it match {
-    case it: Iterable[A] => it.foreach(f)
+    case it: Iterable[A @unchecked] => it.foreach(f)
     case _ => it.iterator.foreach(f)
   }
 
@@ -174,7 +174,7 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
 
   @deprecated("Use .iterator.toArray", "2.13.0")
   def toArray[B >: A: ClassTag]: Array[B] = it match {
-    case it: Iterable[B] => it.toArray[B]
+    case it: Iterable[B @unchecked] => it.toArray[B]
     case _ => it.iterator.toArray[B]
   }
 
@@ -208,25 +208,25 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
 
   @deprecated("Use .iterator.isEmpty instead", "2.13.0")
   def isEmpty: Boolean = it match {
-    case it: Iterable[A] => it.isEmpty
+    case it: Iterable[A @unchecked] => it.isEmpty
     case _ => it.iterator.isEmpty
   }
 
   @deprecated("Use .iterator.mkString instead", "2.13.0")
   def mkString(start: String, sep: String, end: String): String = it match {
-    case it: Iterable[A] => it.mkString(start, sep, end)
+    case it: Iterable[A @unchecked] => it.mkString(start, sep, end)
     case _ => it.iterator.mkString(start, sep, end)
   }
 
   @deprecated("Use .iterator.mkString instead", "2.13.0")
   def mkString(sep: String): String = it match {
-    case it: Iterable[A] => it.mkString(sep)
+    case it: Iterable[A @unchecked] => it.mkString(sep)
     case _ => it.iterator.mkString(sep)
   }
 
   @deprecated("Use .iterator.mkString instead", "2.13.0")
   def mkString: String = it match {
-    case it: Iterable[A] => it.mkString
+    case it: Iterable[A @unchecked] => it.mkString
     case _ => it.iterator.mkString
   }
 
@@ -250,13 +250,13 @@ final class IterableOnceExtensionMethods[A](private val it: IterableOnce[A]) ext
 
   @deprecated("Use .iterator.map instead or consider requiring an Iterable", "2.13.0")
   def map[B](f: A => B): IterableOnce[B]^{f} = it match {
-    case it: Iterable[A]^{f} => it.map(f)
+    case it: Iterable[A @unchecked]^{f} => it.map(f)
     case _ => it.iterator.map(f)
   }
 
   @deprecated("Use .iterator.flatMap instead or consider requiring an Iterable", "2.13.0")
   def flatMap[B](f: A => IterableOnce[B]^): IterableOnce[B]^{f} = it match {
-    case it: Iterable[A] => it.flatMap(f)
+    case it: Iterable[A @unchecked] => it.flatMap(f)
     case _ => it.iterator.flatMap(f)
   }
 
@@ -294,7 +294,7 @@ object IterableOnce {
                                                               start: Int = 0,
                                                               len: Int = Int.MaxValue): Int =
     elems match {
-      case src: Iterable[A] => src.copyToArray[B](xs, start, len)
+      case src: Iterable[A @unchecked] => src.copyToArray[B](xs, start, len)
       case src              => src.iterator.copyToArray[B](xs, start, len)
     }
 }

--- a/library/src/scala/collection/LinearSeq.scala
+++ b/library/src/scala/collection/LinearSeq.scala
@@ -201,7 +201,7 @@ transparent trait LinearSeqOps[+A, +CC[X] <: LinearSeq[X], +C <: LinearSeq[A] & 
       }
 
     that match {
-      case that: LinearSeq[B] => linearSeqEq(coll, that)
+      case that: LinearSeq[B @unchecked] => linearSeqEq(coll, that)
       case _ => super.sameElements(that)
     }
   }

--- a/library/src/scala/collection/Map.scala
+++ b/library/src/scala/collection/Map.scala
@@ -368,7 +368,7 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
    *                of this $coll followed by all elements of `suffix`.
    */
   def concat[V2 >: V](suffix: collection.IterableOnce[(K, V2)]^): CC[K, V2]^{this, suffix} = mapFactory.from(suffix match {
-    case it: Iterable[(K, V2)] => new View.Concat(this, it)
+    case it: Iterable[(K, V2) @unchecked] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
   })
 
@@ -397,7 +397,7 @@ transparent trait MapOps[K, +V, +CC[_, _] <: IterableOps[?, AnyConstr, ?], +C]
   @deprecated("Use ++ instead of ++: for collections of type Iterable", "2.13.0")
   def ++: [V1 >: V](that: IterableOnce[(K,V1)]^): CC[K,V1]^{this, that} = {
     val thatIterable: Iterable[(K, V1)]^{that} = that match {
-      case that: Iterable[(K, V1)] => that
+      case that: Iterable[(K, V1) @unchecked] => that
       case that => View.from(that)
     }
     mapFactory.from(new View.Concat(thatIterable, this))

--- a/library/src/scala/collection/MapView.scala
+++ b/library/src/scala/collection/MapView.scala
@@ -167,7 +167,7 @@ object MapView extends MapViewFactory {
   override def from[K, V](it: IterableOnce[(K, V)]^): View[(K, V)]^{it} = View.from(it)
 
   override def from[K, V](it: SomeMapOps[K, V]): MapView[K, V] = it match {
-    case mv: MapView[K, V] => mv
+    case mv: MapView[K @unchecked, V @unchecked] => mv
     case other => new MapView.Id(other)
   }
 

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -165,7 +165,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *                  by all the elements of this $coll.
    */
   def prependedAll[B >: A](prefix: IterableOnce[B]^): CC[B]^{this, prefix} = iterableFactory.from(prefix match {
-    case prefix: Iterable[B] => new View.Concat(prefix, this)
+    case prefix: Iterable[B @unchecked] => new View.Concat(prefix, this)
     case _ => prefix.iterator ++ iterator
   })
 
@@ -1137,7 +1137,7 @@ object SeqOps {
    *  @return Target packed in an IndexedSeq (taken from iterator unless W already is an IndexedSeq)
    */
   private def kmpOptimizeWord[B](W: scala.collection.Seq[B], n0: Int, n1: Int, forward: Boolean): IndexedSeqView[B] = W match {
-    case iso: IndexedSeq[B] =>
+    case iso: IndexedSeq[B @unchecked] =>
       // Already optimized for indexing--use original (or custom view of original)
       if (forward && n0==0 && n1==W.length) iso.view
       else if (forward) new AbstractIndexedSeqView[B] {

--- a/library/src/scala/collection/Set.scala
+++ b/library/src/scala/collection/Set.scala
@@ -231,10 +231,10 @@ transparent trait SetOps[A, +CC[_], +C <: SetOps[A, CC, C]]
       while (it.hasNext) result = result + it.next()
       result.asInstanceOf[C]
     case _ => fromSpecific(that match {
-      case that: collection.Iterable[A] => new View.Concat(this, that)
+      case that: collection.Iterable[A @unchecked] => new View.Concat(this, that)
       case _ => iterator.concat(that.iterator)
     })
-  }    
+  }
 
   @deprecated("Consider requiring an immutable Set or fall back to Set.union", "2.13.0")
   def + (elem: A): C = fromSpecific(new View.Appended(this, elem))

--- a/library/src/scala/collection/SortedMap.scala
+++ b/library/src/scala/collection/SortedMap.scala
@@ -192,7 +192,7 @@ transparent trait SortedMapOps[K, +V, +CC[X, Y] <: Map[X, Y] & SortedMapOps[X, Y
     sortedMapFactory.from(new View.Collect(this, pf))
 
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]^): CC[K, V2] = sortedMapFactory.from(suffix match {
-    case it: Iterable[(K, V2)] => new View.Concat(this, it)
+    case it: Iterable[(K, V2) @unchecked] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
   })(using ordering)
 

--- a/library/src/scala/collection/SortedSet.scala
+++ b/library/src/scala/collection/SortedSet.scala
@@ -71,7 +71,7 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
    *  @param start The lower-bound (inclusive) of the iterator
    */
   def iteratorFrom(start: A): Iterator[A]
-  
+
   @deprecated("Use `iteratorFrom` instead.", "2.13.0")
   @`inline` def keysIteratorFrom(start: A): Iterator[A] = iteratorFrom(start)
 
@@ -145,7 +145,7 @@ transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, 
    */
   def zip[B](that: IterableOnce[B]^)(implicit @implicitNotFound(SortedSetOps.zipOrdMsg) ev: Ordering[(A @uncheckedVariance, B)]): CC[(A @uncheckedVariance, B)] = // sound bcs of VarianceNote
     sortedIterableFactory.from(that match {
-      case that: Iterable[B] => new View.Zip(this, that)
+      case that: Iterable[B @unchecked] => new View.Zip(this, that)
       case _ => iterator.zip(that)
     })
 

--- a/library/src/scala/collection/View.scala
+++ b/library/src/scala/collection/View.scala
@@ -73,8 +73,8 @@ object View extends IterableFactory[View] {
    *  @return A view iterating over the given `Iterable`
    */
   def from[E](it: IterableOnce[E]^): View[E]^{it} = it match {
-    case it: (View[E]^{it})     => it
-    case it: (Iterable[E]^{it}) => View.fromIteratorProvider(() => it.iterator)
+    case it: (View[E @unchecked]^{it})     => it
+    case it: (Iterable[E @unchecked]^{it}) => View.fromIteratorProvider(() => it.iterator)
     case _                      => LazyList.from(it).view
   }
 
@@ -415,7 +415,7 @@ object View extends IterableFactory[View] {
   private[collection] class Patched[A](underlying: SomeIterableOps[A]^, from: Int, other: IterableOnce[A]^, replaced: Int) extends AbstractView[A] {
     // we may be unable to traverse `other` more than once, so we need to cache it if that's the case
     private val _other: Iterable[A]^{other} = other match {
-      case other: Iterable[A] => other
+      case other: Iterable[A @unchecked] => other
       case other              => LazyList.from(other)
     }
 

--- a/library/src/scala/collection/convert/StreamExtensions.scala
+++ b/library/src/scala/collection/convert/StreamExtensions.scala
@@ -134,7 +134,7 @@ trait StreamExtensions {
      */
     def asJavaSeqStream[S <: BaseStream[?, ?], St <: Stepper[?]](implicit s: StreamShape[A, S, St], st: StepperShape[A, St]): S = {
       val sStepper = stepper match {
-        case as: AnyStepper[A] => st.seqUnbox(as)
+        case as: AnyStepper[A @unchecked] => st.seqUnbox(as)
         case _ => stepper.asInstanceOf[St]
       }
       s.fromStepper(sStepper, par = false)

--- a/library/src/scala/collection/immutable/Iterable.scala
+++ b/library/src/scala/collection/immutable/Iterable.scala
@@ -34,7 +34,7 @@ trait Iterable[+A] extends collection.Iterable[A]
 @SerialVersionUID(3L)
 object Iterable extends IterableFactory.Delegate[Iterable](List) {
   override def from[E](it: IterableOnce[E]^): Iterable[E]^{it} = it match {
-    case iterable: Iterable[E] => iterable
+    case iterable: Iterable[E @unchecked] => iterable
     case _ => super.from(it)
   }
 }

--- a/library/src/scala/collection/immutable/List.scala
+++ b/library/src/scala/collection/immutable/List.scala
@@ -424,7 +424,7 @@ sealed abstract class List[+A]
   }
 
   override def corresponds[B](that: collection.Seq[B])(p: (A, B) => Boolean): Boolean = that match {
-    case that: LinearSeq[B] =>
+    case that: LinearSeq[B @unchecked] =>
       var i = this
       var j = that
       while (!(i.isEmpty || j.isEmpty)) {

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -40,7 +40,7 @@ transparent trait SeqOps[+A, +CC[B] <: caps.Pure, +C] extends Any with collectio
 @SerialVersionUID(3L)
 object Seq extends SeqFactory.Delegate[Seq](List) {
   override def from[E](it: IterableOnce[E]^): Seq[E] = it match {
-    case s: Seq[E] => s
+    case s: Seq[E @unchecked] => s
     case _ => super.from(it)
   }
 }
@@ -113,7 +113,7 @@ object IndexedSeqDefaults {
 @SerialVersionUID(3L)
 object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector) {
   override def from[E](it: IterableOnce[E]^): IndexedSeq[E] = it match {
-    case is: IndexedSeq[E] => is
+    case is: IndexedSeq[E @unchecked] => is
     case _ => super.from(it)
   }
 }
@@ -144,7 +144,7 @@ trait LinearSeq[+A]
 @SerialVersionUID(3L)
 object LinearSeq extends SeqFactory.Delegate[LinearSeq](List) {
   override def from[E](it: IterableOnce[E]^): LinearSeq[E] = it match {
-    case ls: LinearSeq[E] => ls
+    case ls: LinearSeq[E @unchecked] => ls
     case _ => super.from(it)
   }
 }

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -213,7 +213,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
     if (this.isEmpty || that.isEmpty) iterableFactory.empty
     else {
       val thatIterable = that match {
-        case that: collection.Iterable[B] => that
+        case that: collection.Iterable[B @unchecked] => that
         case _ => LazyList.from(that)
       }
       Stream.cons[(A, B)]((this.head, thatIterable.head), this.tail.zip(thatIterable.tail))

--- a/library/src/scala/collection/immutable/TreeMap.scala
+++ b/library/src/scala/collection/immutable/TreeMap.scala
@@ -155,7 +155,7 @@ final class TreeMap[K, +V] private (private val tree: RB.Tree[K, V] | Null)(impl
     newMapOrSelf(that match {
       case tm: TreeMap[K, V] @unchecked if ordering == tm.ordering =>
         RB.union(tree, tm.tree)
-      case ls: LinearSeq[(K,V1)] =>
+      case ls: LinearSeq[(K,V1) @unchecked] =>
         if (ls.isEmpty) tree //to avoid the creation of the adder
         else {
           val adder = new Adder[V1]

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -48,7 +48,7 @@ object Vector extends StrictOptimizedSeqFactory[Vector] {
           val a1: Arr1 = it match {
             case as: ArraySeq.ofRef[?] if as.elemTag.runtimeClass == classOf[AnyRef] =>
               as.unsafeArray.asInstanceOf[Arr1]
-            case it: Iterable[E] =>
+            case it: Iterable[E @unchecked] =>
               val a1 = new Arr1(knownSize)
               @annotation.unused val copied = it.copyToArray(a1.asInstanceOf[Array[Any]])
               //assert(copied == knownSize)

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -179,7 +179,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   def insertAll(@deprecatedName("n", "2.13.0") index: Int, elems: IterableOnce[A]^): Unit = {
     checkWithinBounds(index, index)
     elems match {
-      case elems: collection.Iterable[A] =>
+      case elems: collection.Iterable[A @unchecked] =>
         val elemsLength = elems.size
         if (elemsLength > 0) {
           mutationCount += 1

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -215,7 +215,7 @@ class BitSet(protected[collection] final var elems: Array[Long])
       }
       this
 
-    case sorted: collection.SortedSet[Int] =>
+    case sorted: collection.SortedSet[Int @unchecked] =>
       // if `sorted` is using the regular Int ordering, ensure capacity for the largest
       // element up front to avoid multiple resizing allocations
       if (sorted.nonEmpty) {

--- a/library/src/scala/collection/mutable/CheckedIndexedSeqView.scala
+++ b/library/src/scala/collection/mutable/CheckedIndexedSeqView.scala
@@ -102,7 +102,7 @@ private[mutable] object CheckedIndexedSeqView {
   class Reverse[A](underlying: SomeIndexedSeqOps[A]^)(protected val mutationCount: () => Int)
     extends IndexedSeqView.Reverse[A](underlying) with CheckedIndexedSeqView[A] {
     override def reverse: IndexedSeqView[A]^{this} = underlying match {
-      case x: IndexedSeqView[A] => x
+      case x: IndexedSeqView[A @unchecked] => x
       case _ => super.reverse
     }
   }

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -446,7 +446,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     sortedMapFactory.from(new View.Collect(this, pf))
 
   override def concat[V2 >: V](suffix: IterableOnce[(K, V2)]^): CollisionProofHashMap[K, V2] = sortedMapFactory.from(suffix match {
-    case it: Iterable[(K, V2)] => new View.Concat(this, it)
+    case it: Iterable[(K, V2) @unchecked] => new View.Concat(this, it)
     case _ => iterator.concat(suffix.iterator)
   })
 
@@ -894,4 +894,3 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
     }
   }
 }
-

--- a/library/src/scala/collection/mutable/Shrinkable.scala
+++ b/library/src/scala/collection/mutable/Shrinkable.scala
@@ -68,7 +68,7 @@ trait Shrinkable[-A] {
       }
     } else {
       xs match {
-        case xs: collection.LinearSeq[A] => loop(xs)
+        case xs: collection.LinearSeq[A @unchecked] => loop(xs)
         case xs => xs.iterator.foreach(subtractOne)
       }
     }

--- a/library/src/scala/collection/mutable/Stack.scala
+++ b/library/src/scala/collection/mutable/Stack.scala
@@ -79,7 +79,7 @@ class Stack[A] protected (array: Array[AnyRef | Null], start: Int, end: Int)
    */
   def pushAll(elems: scala.collection.IterableOnce[A]^): this.type =
     prependAll(elems match {
-      case it: scala.collection.Seq[A] => it.view.reverse
+      case it: scala.collection.Seq[A @unchecked] => it.view.reverse
       case it => IndexedSeq.from(it).view.reverse
     })
 

--- a/library/src/scala/concurrent/package.scala
+++ b/library/src/scala/concurrent/package.scala
@@ -172,7 +172,7 @@ package concurrent {
     @throws(classOf[TimeoutException])
     @throws(classOf[InterruptedException])
     final def ready[T](awaitable: Awaitable[T], atMost: Duration): awaitable.type = awaitable match {
-      case f: Future[T] if f.isCompleted =>
+      case f: Future[T @unchecked] if f.isCompleted =>
         if (atMost eq Duration.Undefined) Future.waitUndefinedError() // preserve semantics, see scala/scala#10972
         else awaitable
       case _ =>
@@ -211,7 +211,7 @@ package concurrent {
 
     private object FutureValue {
       def unapply[T](a: Awaitable[T]): Option[Try[T]] = a match {
-        case f: Future[T] => f.value
+        case f: Future[T @unchecked] => f.value
         case _ => None
       }
     }


### PR DESCRIPTION
Note: In some of these cases the cause of the warning could actually be that the class matched on is too specific (in case of mutable collections where covariant type is trying to be unified with an invariant parameter) but it could theoretically change behavior to match a wider type that is still covariant.

<!-- TODO description of the change -->
<!-- Ideally should have a title like "Fix #XYZ: Short fix description" -->

## How much have you relied on LLM-based tools in this contribution?

I compiled the standard library myself, then asked LLM to analyse the compiler diagnostics and update type-test patterns that caused the unchecked type test warning by adding `@unchecked`, this makes it explicit in code but these are unlikely to be fixed in any other way.

## How was the solution tested?

run the compiler to verify warnings are no longer there.

## Additional notes
