### PR TITLE
improvement: improve perfomance of the presentation compiler

### DIFF
--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -52,9 +52,9 @@ object Completion:
 
   private val logger = Logger.getLogger(this.getClass.getName)
 
-  def scopeContext(pos: SourcePosition)(using Context): CompletionResult =
-    val tpdPath = Interactive.pathTo(ctx.compilationUnit.tpdTree, pos.span)
-    val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
+  def scopeContext(pos: SourcePosition, tpdPath: List[tpd.Tree], completionContext: Context)(using Context): CompletionResult =
+    // val tpdPath = Interactive.pathTo(ctx.compilationUnit.tpdTree, pos.span)
+    // val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
     inContext(completionContext):
       val untpdPath = Interactive.resolveTypedOrUntypedPath(tpdPath, pos)
       val rawPrefix = completionPrefix(untpdPath, pos)

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -66,14 +66,14 @@ object Completion:
    *
    *  @return offset and list of symbols for possible completions
    */
-  def completions(pos: SourcePosition)(using Context): (Int, List[Completion]) =
+  def completions(pos: SourcePosition, calculatedScopeContext: Option[CompletionResult] = None)(using Context): (Int, List[Completion]) =
     val tpdPath = Interactive.pathTo(ctx.compilationUnit.tpdTree, pos.span)
     val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
     inContext(completionContext):
       val untpdPath = Interactive.resolveTypedOrUntypedPath(tpdPath, pos)
       val mode = completionMode(untpdPath, pos)
       val rawPrefix = completionPrefix(untpdPath, pos)
-      val completions = rawCompletions(pos, mode, rawPrefix, tpdPath, untpdPath)
+      val completions = rawCompletions(pos, mode, rawPrefix, tpdPath, untpdPath, calculatedScopeContext = calculatedScopeContext)
       postProcessCompletions(untpdPath, completions, rawPrefix)
 
   /** Get possible completions from tree at `pos`
@@ -87,10 +87,11 @@ object Completion:
     rawPrefix: String,
     tpdPath: List[tpd.Tree],
     untpdPath: List[untpd.Tree],
-    customMatcher: Option[Name => Boolean] = None
+    customMatcher: Option[Name => Boolean] = None,
+    calculatedScopeContext: Option[CompletionResult]
   )(using Context): CompletionMap =
     val adjustedPath = typeCheckExtensionConstructPath(untpdPath, tpdPath, pos)
-    computeCompletions(pos, mode, rawPrefix, adjustedPath, untpdPath, customMatcher)
+    computeCompletions(pos, mode, rawPrefix, adjustedPath, untpdPath, customMatcher, calculatedScopeContext)
 
   /**
    * Inspect `path` to determine what kinds of symbols should be considered.
@@ -240,23 +241,38 @@ object Completion:
     rawPrefix: String,
     adjustedPath: List[tpd.Tree],
     untpdPath: List[untpd.Tree],
-    matches: Option[Name => Boolean]
-  )(using Context): CompletionMap =
+    matches: Option[Name => Boolean],
+    calculatedScopeContext: Option[CompletionResult]
+  )(using ctx: Context): CompletionMap =
     val hasBackTick = rawPrefix.headOption.contains('`')
     val prefix = if hasBackTick then rawPrefix.drop(1) else rawPrefix
     val matches0 = matches.getOrElse(_.startsWith(prefix))
-    val completer = new Completer(mode, pos, untpdPath, matches0)
+    lazy val completer = new Completer(mode, pos, untpdPath, matches0)
+    lazy val scopeContextNames = calculatedScopeContext match
+      case Some(scopeContext) =>
+        val isNew = isInNewContext(untpdPath)
+        scopeContext.names.flatMap {
+          case (name, CompletionDenotation(denots, site)) if matches0(name) =>
+            def isAccessible(denot: SingleDenotation): Boolean =
+              site.map(denot.symbol.isAccessibleFrom(_)).getOrElse(true)
+            val filtered = denots.filter(denot =>
+              isValidCompletionSymbol(denot.symbol, mode, isNew) && isAccessible(denot)
+            )
+            if filtered.nonEmpty then Some(name -> filtered) else None
+          case _ => None
+        }.toMap
+      case None => completer.scopeCompletions.names.map((name, denot) => name -> denot.denots)
 
     val result = adjustedPath match
       // Ignore synthetic select from `This` because in code it was `Ident`
       // See example in dotty.tools.languageserver.CompletionTest.syntheticThis
-      case tpd.Select(qual @ tpd.This(_), _) :: _ if qual.span.isSynthetic      => completer.scopeCompletions.names
+      case tpd.Select(qual @ tpd.This(_), _) :: _ if qual.span.isSynthetic      => scopeContextNames
       case StringContextApplication(qual) =>
-        completer.scopeCompletions.names ++ completer.selectionCompletions(qual)
+        scopeContextNames ++ completer.selectionCompletions(qual)
       case tpd.Select(qual, _) :: _                                             => completer.selectionCompletions(qual)
       case (tree: tpd.ImportOrExport) :: _                                      => completer.directMemberCompletions(tree.expr)
       case NamedTupleSelection(qual)                                            => completer.selectionCompletions(qual)
-      case _                                                                    => completer.scopeCompletions.names
+      case _                                                                    => scopeContextNames
 
     interactiv.println(i"""completion info with pos    = $pos,
                           |                     term   = ${completer.mode.is(Mode.Term)},
@@ -350,7 +366,7 @@ object Completion:
       // running sourceSymbol on ExportedTerm will force a lot of computation from collectSubTrees
     (sym.is(ExportedTerm) || sym.sourceSymbol.exists) &&
     (!sym.is(Package) || sym.is(ModuleClass)) &&
-    !sym.isAllOf(Mutable | Accessor) &&
+    !(sym.is(Mutable) && sym.is(Accessor)) &&
     !sym.isPackageObject &&
     !sym.is(Artifact) &&
     !(completionMode.is(Mode.Type) && sym.isAllOf(ConstructorProxyModule)) &&
@@ -401,10 +417,10 @@ object Completion:
       /** Temporary data structure representing denotations with the same name introduced in a given scope
        *  as a member of a type, by a local definition or by an import clause
        */
-      case class ScopedDenotations private (denots: Seq[SingleDenotation], ctx: Context)
+      case class ScopedDenotations private (denot: CompletionDenotation, ctx: Context)
       object ScopedDenotations:
-        def apply(denots: Seq[SingleDenotation], ctx: Context, includeFn: SingleDenotation => Boolean): ScopedDenotations =
-          ScopedDenotations(denots.filter(includeFn), ctx)
+        def apply(denot: CompletionDenotation, ctx: Context, includeFn: SingleDenotation => Boolean): ScopedDenotations =
+          ScopedDenotations(CompletionDenotation(denot.denots.filter(includeFn), denot.site), ctx)
 
       val mappings = collection.mutable.Map.empty[Name, List[ScopedDenotations]].withDefaultValue(List.empty)
       val renames = collection.mutable.Map.empty[Symbol, Name]
@@ -414,8 +430,8 @@ object Completion:
       ctx.outersIterator.foreach { case ctx @ given Context =>
         if ctx.isImportContext then
           val imported = importedCompletions
-          imported.names.foreach { (name, denots) =>
-            addMapping(name, ScopedDenotations(denots, ctx, include(_, name)))
+          imported.names.foreach { (name, denot) =>
+            addMapping(name, ScopedDenotations(denot, ctx, include(_, name)))
           }
           imported.renames.foreach { (name, newName) =>
             renames(name) = newName
@@ -423,17 +439,17 @@ object Completion:
         else if ctx.owner.isClass then
           accessibleMembers(ctx.owner.thisType)
             .groupByName.foreach { (name, denots) =>
-              addMapping(name, ScopedDenotations(denots, ctx, include(_, name)))
+              addMapping(name, ScopedDenotations(CompletionDenotation(denots, Some(ctx.owner.thisType)), ctx, include(_, name)))
             }
         else if ctx.scope ne EmptyScope then
           ctx.scope.toList.filter(symbol => include(symbol, symbol.name))
             .flatMap(_.alternatives)
             .groupByName.foreach { (name, denots) =>
-              addMapping(name, ScopedDenotations(denots, ctx, include(_, name)))
+              addMapping(name, ScopedDenotations(CompletionDenotation(denots, None), ctx, include(_, name)))
             }
       }
 
-      var resultMappings = Map.empty[Name, Seq[SingleDenotation]]
+      var resultMappings = Map.empty[Name, CompletionDenotation]
 
       mappings.foreach { (name, denotss) =>
         val first = denotss.head
@@ -445,7 +461,7 @@ object Completion:
         def isImportedInDifferentScope = first.ctx.scope ne denotss(1).ctx.scope
         // import a.C
         // import a.C
-        def isSameSymbolImportedDouble = denotss.forall(_.denots == first.denots)
+        def isSameSymbolImportedDouble = denotss.forall(_.denot.denots == first.denot.denots)
 
         // https://scala-lang.org/files/archive/spec/3.4/02-identifiers-names-and-scopes.html
         // import java.lang.*
@@ -457,16 +473,16 @@ object Completion:
         //   }
         // }
         def notConflictingWithDefaults = // is imported symbol
-          denotss.filterNot(_.denots.exists(denot => Interactive.isImportedByDefault(denot.symbol))).size <= 1
+          denotss.filterNot(_.denot.denots.exists(denot => Interactive.isImportedByDefault(denot.symbol))).size <= 1
 
         denotss.find(!_.ctx.isImportContext) match {
           // most deeply nested member or local definition if not shadowed by an import
           case Some(local) if local.ctx.scope == first.ctx.scope =>
-            resultMappings += name -> local.denots
+            resultMappings += name -> local.denot
           case None if isSingleImport || isImportedInDifferentScope || isSameSymbolImportedDouble =>
-            resultMappings += name -> first.denots
+            resultMappings += name -> first.denot
           case None if notConflictingWithDefaults =>
-            val ordered = denotss.map(_.denots).sorted
+            val ordered = denotss.map(_.denot).sortBy(_.denots)
             resultMappings += name -> ordered.head
           case _ =>
         }
@@ -553,7 +569,7 @@ object Completion:
             }.toSeq.groupByName
 
         val results = givenImports ++ wildcardMembers ++ explicitMembers
-        CompletionResult(results, renames.toMap)
+        CompletionResult(results.map((name, denots) => name -> CompletionDenotation(denots, Some(imp.site))), renames.toMap)
     end importedCompletions
 
     /** Completions from implicit conversions including old style extensions using implicit classes */
@@ -638,8 +654,8 @@ object Completion:
 
       // 1. The extension method is visible under a simple name, by being defined or inherited or imported in a scope enclosing the reference.
       val extMethodsInScope = scopeCompletions.names.toList.flatMap:
-        case (name, denots) =>
-          denots.collect:
+        case (name, denot) =>
+          denot.denots.collect:
             case d if d.isTerm && d.symbol.is(Extension) => (d.symbol.termRef, name.asTermName)
 
       // 2. The extension method is a member of some given instance that is visible at the point of the reference.
@@ -743,8 +759,9 @@ object Completion:
       def groupByName: CompletionMap = namedDenotations.groupMap((name, denot) => name)((name, denot) => denot)
 
   private type CompletionMap = Map[Name, Seq[SingleDenotation]]
-
-  case class CompletionResult(names: Map[Name, Seq[SingleDenotation]], renames: Map[Symbol, Name])
+  // A list of denotations together with site for checking accessibility
+  case class CompletionDenotation(denots: Seq[SingleDenotation], site: Option[Type])
+  case class CompletionResult(names: Map[Name, CompletionDenotation], renames: Map[Symbol, Name])
   /**
    * The completion mode: defines what kinds of symbols should be included in the completion
    * results.

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -53,8 +53,6 @@ object Completion:
   private val logger = Logger.getLogger(this.getClass.getName)
 
   def scopeContext(pos: SourcePosition, tpdPath: List[tpd.Tree], completionContext: Context)(using Context): CompletionResult =
-    // val tpdPath = Interactive.pathTo(ctx.compilationUnit.tpdTree, pos.span)
-    // val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
     inContext(completionContext):
       val untpdPath = Interactive.resolveTypedOrUntypedPath(tpdPath, pos)
       // Lazy mode is to avoid too many checks as it's mostly for printing types
@@ -65,14 +63,14 @@ object Completion:
    *
    *  @return offset and list of symbols for possible completions
    */
-  def completions(pos: SourcePosition, calculatedScopeContext: Option[CompletionResult] = None)(using Context): (Int, List[Completion]) =
+  def completions(pos: SourcePosition)(using Context): (Int, List[Completion]) =
     val tpdPath = Interactive.pathTo(ctx.compilationUnit.tpdTree, pos.span)
     val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
     inContext(completionContext):
       val untpdPath = Interactive.resolveTypedOrUntypedPath(tpdPath, pos)
       val mode = completionMode(untpdPath, pos)
       val rawPrefix = completionPrefix(untpdPath, pos)
-      val completions = rawCompletions(pos, mode, rawPrefix, tpdPath, untpdPath, calculatedScopeContext = calculatedScopeContext)
+      val completions = rawCompletions(pos, mode, rawPrefix, tpdPath, untpdPath)
       postProcessCompletions(untpdPath, completions, rawPrefix)
 
   /** Get possible completions from tree at `pos`
@@ -87,7 +85,7 @@ object Completion:
     tpdPath: List[tpd.Tree],
     untpdPath: List[untpd.Tree],
     customMatcher: Option[Name => Boolean] = None,
-    calculatedScopeContext: Option[CompletionResult]
+    calculatedScopeContext: Option[CompletionResult] = None
   )(using Context): CompletionMap =
     val adjustedPath = typeCheckExtensionConstructPath(untpdPath, tpdPath, pos)
     computeCompletions(pos, mode, rawPrefix, adjustedPath, untpdPath, customMatcher, calculatedScopeContext)

--- a/compiler/src/dotty/tools/dotc/interactive/Completion.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/Completion.scala
@@ -57,7 +57,6 @@ object Completion:
     // val completionContext = Interactive.contextOfPath(tpdPath).withPhase(Phases.typerPhase)
     inContext(completionContext):
       val untpdPath = Interactive.resolveTypedOrUntypedPath(tpdPath, pos)
-      val rawPrefix = completionPrefix(untpdPath, pos)
       // Lazy mode is to avoid too many checks as it's mostly for printing types
       val completer = new Completer(Mode.Lazy, pos, untpdPath, _ => true)
       completer.scopeCompletions
@@ -748,7 +747,7 @@ object Completion:
     /** Filter for names that should appear when looking for completions. */
     private object completionsFilter extends NameFilter:
       def apply(pre: Type, name: Name)(using Context): Boolean =
-        !name.isConstructorName && name.toTermName.info.kind == SimpleNameKind
+        !name.isConstructorName && name.toTermName.info.kind == SimpleNameKind && matches(name)
       def isStable = true
 
     extension (denotations: Seq[SingleDenotation])

--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -20,6 +20,8 @@ import dotty.tools.pc.completions.CompletionPos
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 
 import org.eclipse.lsp4j as l
+import dotty.tools.dotc.core.Phases
+import dotty.tools.dotc.core.Contexts.Context
 
 final class AutoImportsProvider(
     search: SymbolSearch,
@@ -44,10 +46,7 @@ final class AutoImportsProvider(
     val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
     val path =
       Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using newctx)
-
-    val indexedContext = IndexedContext(pos)(
-      using Interactive.contextOfPath(path)(using newctx)
-    )
+    val indexedContext = IndexedContext(pos, path, newctx)
     import indexedContext.ctx
 
     def correctInTreeContext(sym: Symbol) = path match

--- a/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/AutoImportsProvider.scala
@@ -20,8 +20,6 @@ import dotty.tools.pc.completions.CompletionPos
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 
 import org.eclipse.lsp4j as l
-import dotty.tools.dotc.core.Phases
-import dotty.tools.dotc.core.Contexts.Context
 
 final class AutoImportsProvider(
     search: SymbolSearch,

--- a/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ExtractMethodProvider.scala
@@ -48,12 +48,11 @@ final class ExtractMethodProvider(
     val pos = driver.sourcePosition(range).startPos
     val path =
       Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
-    given locatedCtx: Context =
-      val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
-      Interactive.contextOfPath(path)(using newctx)
-    val indexedCtx = IndexedContext(pos)(using locatedCtx)
+    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
+    val indexedContext = IndexedContext(pos, path, newctx)
+    import indexedContext.ctx
     val printer =
-      ShortenedTypePrinter(search, IncludeDefaultParam.Never)(using indexedCtx)
+      ShortenedTypePrinter(search, IncludeDefaultParam.Never)(using indexedContext)
     def prettyPrint(tpe: Type) =
       def prettyPrintReturnType(tpe: Type): String =
         tpe match
@@ -135,7 +134,7 @@ final class ExtractMethodProvider(
         val extractedPos = head.sourcePos.withEnd(expr.sourcePos.end)
         val exprType = prettyPrint(expr.typeOpt.widen)
         val name =
-          genName(indexedCtx.scopeSymbols.map(_.decodedName).toSet, "newMethod")
+          genName(indexedContext.scopeSymbols.map(_.decodedName).toSet, "newMethod")
         val (allMethodParams, typeParams) =
           localRefs(extracted, stat.sourcePos, extractedPos)
         val (methodParams, implicitParams) = allMethodParams.partition(!_.isOneOf(Flags.GivenOrImplicit))

--- a/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/HoverProvider.scala
@@ -50,7 +50,8 @@ object HoverProvider:
     val path = unit
       .map(unit => Interactive.pathTo(unit.tpdTree, pos.span))
       .getOrElse(Interactive.pathTo(driver.openedTrees(uri), pos))
-    val indexedContext = IndexedContext(pos)(using ctx)
+    val indexedContext = IndexedContext(pos, path, ctx)
+    import indexedContext.ctx
 
     def typeFromPath(path: List[Tree]) =
       if path.isEmpty then NoType else path.head.typeOpt
@@ -170,6 +171,10 @@ object HoverProvider:
     else
       val skipCheckOnName =
         !pos.isPoint // don't check isHoveringOnName for RangeHover
+
+      val printer = ShortenedTypePrinter(search, IncludeDefaultParam.Include)(
+        using indexedContext
+      )
       MetalsInteractive.enclosingSymbolsWithExpressionType(
         enclosing,
         pos,

--- a/presentation-compiler/src/main/dotty/tools/pc/IndexedContext.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/IndexedContext.scala
@@ -12,6 +12,7 @@ import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.Scopes.EmptyScope
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.interactive.Completion
 import dotty.tools.dotc.interactive.Interactive
 import dotty.tools.dotc.typer.ImportInfo
@@ -19,6 +20,7 @@ import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.pc.IndexedContext.Result
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 import dotty.tools.dotc.interactive.Completion.CompletionResult
+import dotty.tools.dotc.core.Phases
 
 sealed trait IndexedContext:
   given ctx: Context
@@ -76,10 +78,13 @@ end IndexedContext
 
 object IndexedContext:
 
-  def apply(pos: SourcePosition)(using Context): IndexedContext =
-    ctx match
+  def apply(pos: SourcePosition, tpdPath: List[tpd.Tree], driverCtx: Context): IndexedContext =
+    driverCtx match
       case NoContext => Empty
-      case _ => LazyWrapper(pos)(using ctx)
+      case _ =>
+        val typerCtx: Context = Interactive
+           .contextOfPath(tpdPath)(using driverCtx).withPhase(Phases.typerPhase(using driverCtx))
+        LazyWrapper(pos, tpdPath)(using typerCtx)
 
   case object Empty extends IndexedContext:
     given ctx: Context = NoContext
@@ -89,9 +94,9 @@ object IndexedContext:
     def scopeSymbols: List[Symbol] = List.empty
     def rename(sym: Symbol): Option[String] = None
 
-  class LazyWrapper(pos: SourcePosition)(using val ctx: Context) extends IndexedContext:
+  class LazyWrapper(pos: SourcePosition, tpdPath: List[tpd.Tree])(using val ctx: Context) extends IndexedContext:
 
-    val scopeContext: CompletionResult = Completion.scopeContext(pos)
+    val scopeContext: CompletionResult = Completion.scopeContext(pos, tpdPath, ctx)
     val names: Map[String, Seq[SingleDenotation]] = scopeContext.names.toList.groupBy(_._1.show).map {
       case (name, denotations) =>
         val denots = denotations.flatMap(_._2.denots)

--- a/presentation-compiler/src/main/dotty/tools/pc/IndexedContext.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/IndexedContext.scala
@@ -18,9 +18,11 @@ import dotty.tools.dotc.typer.ImportInfo
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.pc.IndexedContext.Result
 import dotty.tools.pc.utils.InteractiveEnrichments.*
+import dotty.tools.dotc.interactive.Completion.CompletionResult
 
 sealed trait IndexedContext:
   given ctx: Context
+  def scopeContext: CompletionResult
   def scopeSymbols: List[Symbol]
   def rename(sym: Symbol): Option[String]
   def findSymbol(name: Name, fromPrefix: Option[Type] = None): Option[List[Symbol]]
@@ -81,6 +83,7 @@ object IndexedContext:
 
   case object Empty extends IndexedContext:
     given ctx: Context = NoContext
+    def scopeContext: CompletionResult = CompletionResult(Map.empty, Map.empty)
     def findSymbol(name: Name, fromPrefix: Option[Type]): Option[List[Symbol]] = None
     def findSymbolInLocalScope(name: String): Option[List[Symbol]] = None
     def scopeSymbols: List[Symbol] = List.empty
@@ -88,10 +91,10 @@ object IndexedContext:
 
   class LazyWrapper(pos: SourcePosition)(using val ctx: Context) extends IndexedContext:
 
-    val completionContext = Completion.scopeContext(pos)
-    val names: Map[String, Seq[SingleDenotation]] = completionContext.names.toList.groupBy(_._1.show).map {
+    val scopeContext: CompletionResult = Completion.scopeContext(pos)
+    val names: Map[String, Seq[SingleDenotation]] = scopeContext.names.toList.groupBy(_._1.show).map {
       case (name, denotations) =>
-        val denots = denotations.flatMap(_._2)
+        val denots = denotations.flatMap(_._2.denots)
         val nonRoot = denots.filter(!_.symbol.owner.isRoot)
         val (importedByDefault, conflictingValue) =
           denots.partition(denot => Interactive.isImportedByDefault(denot.symbol))
@@ -100,7 +103,7 @@ object IndexedContext:
         else
           name.trim -> nonRoot
     }
-    val renames = completionContext.renames
+    val renames = scopeContext.renames
 
     def defaultScopes(name: Name): Option[List[Symbol]] =
       List(defn.ScalaPredefModuleClass, defn.ScalaPackageClass, defn.JavaLangPackageClass)

--- a/presentation-compiler/src/main/dotty/tools/pc/IndexedContext.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/IndexedContext.scala
@@ -1,26 +1,28 @@
 package dotty.tools.pc
 
 import scala.annotation.tailrec
+import scala.meta.pc.OffsetParams
 import scala.util.control.NonFatal
 
+import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Denotations.PreDenotation
 import dotty.tools.dotc.core.Denotations.SingleDenotation
 import dotty.tools.dotc.core.Flags.*
 import dotty.tools.dotc.core.NameOps.*
 import dotty.tools.dotc.core.Names.*
+import dotty.tools.dotc.core.Phases
 import dotty.tools.dotc.core.Scopes.EmptyScope
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.core.Types.*
-import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.interactive.Completion
+import dotty.tools.dotc.interactive.Completion.CompletionResult
 import dotty.tools.dotc.interactive.Interactive
+import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.typer.ImportInfo
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.pc.IndexedContext.Result
 import dotty.tools.pc.utils.InteractiveEnrichments.*
-import dotty.tools.dotc.interactive.Completion.CompletionResult
-import dotty.tools.dotc.core.Phases
 
 sealed trait IndexedContext:
   given ctx: Context
@@ -83,7 +85,7 @@ object IndexedContext:
       case NoContext => Empty
       case _ =>
         val typerCtx: Context = Interactive
-           .contextOfPath(tpdPath)(using driverCtx).withPhase(Phases.typerPhase(using driverCtx))
+          .contextOfPath(tpdPath)(using driverCtx).withPhase(Phases.typerPhase(using driverCtx))
         LazyWrapper(pos, tpdPath)(using typerCtx)
 
   case object Empty extends IndexedContext:

--- a/presentation-compiler/src/main/dotty/tools/pc/InferExpectedType.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferExpectedType.scala
@@ -40,14 +40,13 @@ class InferExpectedType(
       case Some(unit) =>
         val path =
           Interactive.pathTo(driver.openedTrees(uri), pos)(using ctx)
-        val newctx = ctx.fresh.setCompilationUnit(unit)
+        val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
         val tpdPath =
           Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using newctx)
-        val locatedCtx =
-          Interactive.contextOfPath(tpdPath)(using newctx)
-        val indexedCtx = IndexedContext(pos)(using locatedCtx)
+        val indexedContext = IndexedContext(pos, tpdPath, newctx)
+        import indexedContext.ctx
         val printer =
-          ShortenedTypePrinter(search, IncludeDefaultParam.ResolveLater)(using indexedCtx)
+          ShortenedTypePrinter(search, IncludeDefaultParam.ResolveLater)(using indexedContext)
         InferCompletionType.inferType(path)(using newctx).map {
           tpe => printer.tpe(tpe)
         }

--- a/presentation-compiler/src/main/dotty/tools/pc/InferredMethodProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredMethodProvider.scala
@@ -67,15 +67,16 @@ final class InferredMethodProvider(
     val path =
       Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
 
-    given locatedCtx: Context = driver.localContext(params)
-    val indexedCtx = IndexedContext(pos)(using locatedCtx)
+    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
+    val indexedContext = IndexedContext(pos, path, newctx)
+    import indexedContext.ctx
 
     val autoImportsGen = AutoImports.generator(
       pos,
       sourceText,
       unit.tpdTree,
       unit.comments,
-      indexedCtx,
+      indexedContext,
       config
     )
 
@@ -83,7 +84,7 @@ final class InferredMethodProvider(
       symbolSearch,
       includeDefaultParam = IncludeDefaultParam.ResolveLater,
       isTextEdit = true
-    )(using indexedCtx)
+    )(using indexedContext)
 
     def imports: List[TextEdit] =
       printer.imports(autoImportsGen)

--- a/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
@@ -74,8 +74,9 @@ final class InferredTypeProvider(
     val path =
       Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
 
-    given locatedCtx: Context = driver.localContext(params)
-    val indexedCtx = IndexedContext(pos)(using locatedCtx)
+    val locatedCtx: Context = driver.localContext(params)
+    val indexedCtx = IndexedContext(pos, path, locatedCtx)
+    import indexedCtx.ctx
     val autoImportsGen = AutoImports.generator(
       pos,
       sourceText,

--- a/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/InferredTypeProvider.scala
@@ -71,11 +71,10 @@ final class InferredTypeProvider(
     driver.run(uri, source)
     val unit = driver.currentCtx.run.nn.units.head
     val pos = driver.sourcePosition(params)
+    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
     val path =
-      Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
-
-    val locatedCtx: Context = driver.localContext(params)
-    val indexedCtx = IndexedContext(pos, path, locatedCtx)
+      Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using newctx)
+    val indexedCtx = IndexedContext(pos, path, newctx)
     import indexedCtx.ctx
     val autoImportsGen = AutoImports.generator(
       pos,

--- a/presentation-compiler/src/main/dotty/tools/pc/PcConvertToNamedLambdaParameters.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcConvertToNamedLambdaParameters.scala
@@ -36,12 +36,12 @@ final class PcConvertToNamedLambdaParameters(
       uri,
       SourceFile.virtual(filePath.toString, params.text)
     )
-    given newctx: Context = driver.localContext(params)
+    given ctx: Context = driver.currentCtx
     val pos = driver.sourcePosition(params)
     val trees = driver.openedTrees(uri)
     val treeList = Interactive.pathTo(trees, pos)
     // Extractor for a lambda function (needs context, so has to be defined here)
-    val LambdaExtractor = Lambda(using newctx)
+    val LambdaExtractor = Lambda(using ctx)
     // select the most inner wildcard lambda
     val firstLambda = treeList.collectFirst {
       case LambdaExtractor(params, rhsFn) if params.forall(isWildcardParam) =>

--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -50,8 +50,10 @@ class PcDefinitionProvider(
     val path =
       Interactive.pathTo(driver.openedTrees(uri), pos)(using driver.currentCtx)
 
-    given ctx: Context = driver.localContext(params)
-    val indexedContext = IndexedContext(pos)(using ctx)
+    val unit = driver.currentCtx.run.nn.units.head
+    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
+    val indexedContext = IndexedContext(pos, path, newctx)
+    import indexedContext.ctx
     val result =
       if findTypeDef then findTypeDefinitions(path, pos, indexedContext, uri)
       else findDefinitions(path, pos, indexedContext, uri)

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -190,8 +190,7 @@ class PcInlayHintsProvider(
       tpe: Type,
       pos: SourcePosition
   ): List[LabelPart] =
-    val tpdPath =
-      Interactive.pathTo(unit.tpdTree, pos.span)
+    val tpdPath = Interactive.pathTo(unit.tpdTree, pos.span)
     val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
     val indexedCtx = IndexedContext(pos, tpdPath, newctx)
     import indexedCtx.ctx
@@ -217,16 +216,10 @@ class PcInlayHintsProvider(
     val parts = partsFromType(dealiased, usedRenames)
     InlayHints.makeLabelParts(parts, tpeStr)
 
-  private val definitions = {
-    val tpdPath =
-      Interactive.pathTo(unit.tpdTree, pos.span)
-    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
-    IndexedContext(pos, tpdPath, newctx).ctx.definitions
-  }
   private def syntheticTupleApply(tree: Tree): Boolean =
     tree match
       case sel: Select =>
-        if definitions.isTupleNType(sel.symbol.info.finalResultType) then
+        if ctx.definitions.isTupleNType(sel.symbol.info.finalResultType) then
           sel match
             case Select(tupleClass: Ident, _)
                 if !tupleClass.span.isZeroExtent &&

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -192,8 +192,9 @@ class PcInlayHintsProvider(
   ): List[LabelPart] =
     val tpdPath =
       Interactive.pathTo(unit.tpdTree, pos.span)
-
-    val indexedCtx = IndexedContext(pos)(using Interactive.contextOfPath(tpdPath))
+    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
+    val indexedCtx = IndexedContext(pos, tpdPath, newctx)
+    import indexedCtx.ctx
     val printer = ShortenedTypePrinter(
       symbolSearch
     )(using indexedCtx)
@@ -217,7 +218,12 @@ class PcInlayHintsProvider(
     InlayHints.makeLabelParts(parts, tpeStr)
   end toLabelParts
 
-  private val definitions = IndexedContext(pos)(using ctx).ctx.definitions
+  private val definitions = {
+    val tpdPath =
+      Interactive.pathTo(unit.tpdTree, pos.span)
+    val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
+    IndexedContext(pos, tpdPath, newctx).ctx.definitions
+  }
   private def syntheticTupleApply(tree: Tree): Boolean =
     tree match
       case sel: Select =>

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -216,7 +216,6 @@ class PcInlayHintsProvider(
     val usedRenames = printer.getUsedRenames
     val parts = partsFromType(dealiased, usedRenames)
     InlayHints.makeLabelParts(parts, tpeStr)
-  end toLabelParts
 
   private val definitions = {
     val tpdPath =

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlineValueProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlineValueProvider.scala
@@ -113,7 +113,7 @@ final class PcInlineValueProvider(
         }
         .toRight(Errors.didNotFindDefinition)
       path = Interactive.pathTo(unit.tpdTree, definition.tree.rhs.span)(using newctx)
-      indexedContext = IndexedContext(definition.tree.namePos)(using Interactive.contextOfPath(path)(using newctx))
+      indexedContext = IndexedContext(definition.tree.namePos, path, newctx)
       symbols = symbolsUsedInDefn(definition.tree.rhs, indexedContext)
       references <- getReferencesToInline(definition, allOccurences, symbols)
     yield
@@ -268,9 +268,7 @@ final class PcInlineValueProvider(
     def buildRef(occurrence: Occurence): Either[String, Reference] =
       val path =
         Interactive.pathTo(unit.tpdTree, occurrence.pos.span)(using newctx)
-      val indexedContext = IndexedContext(pos)(
-        using Interactive.contextOfPath(path)(using newctx)
-      )
+      val indexedContext = IndexedContext(pos, path, newctx)
       import indexedContext.ctx
       val conflictingSymbols = symbols
         .withFilter {

--- a/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
@@ -37,12 +37,10 @@ object SignatureHelpProvider:
         val pos = driver.sourcePosition(params, isZeroExtent = false)
         val path = Interactive.pathTo(unit.tpdTree, pos.span)(using driver.currentCtx)
 
-        val localizedContext = Interactive.contextOfPath(path)(using driver.currentCtx)
-        val indexedContext = IndexedContext(pos)(using driver.currentCtx)
+        val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
+        val indexedContext = IndexedContext(pos, path, newctx)
 
-        given Context = localizedContext.fresh
-          .setCompilationUnit(unit)
-          .setPrinterFn(_ => ShortenedTypePrinter(search, IncludeDefaultParam.Never)(using indexedContext))
+        given Context = newctx.setPrinterFn(_ => ShortenedTypePrinter(search, IncludeDefaultParam.Never)(using indexedContext))
 
         val (paramN, callableN, alternatives) = Signatures.signatureHelp(path, pos.span)
 

--- a/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SignatureHelpProvider.scala
@@ -40,7 +40,8 @@ object SignatureHelpProvider:
         val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
         val indexedContext = IndexedContext(pos, path, newctx)
 
-        given Context = newctx.setPrinterFn(_ => ShortenedTypePrinter(search, IncludeDefaultParam.Never)(using indexedContext))
+        given Context =
+          newctx.setPrinterFn(_ => ShortenedTypePrinter(search, IncludeDefaultParam.Never)(using indexedContext))
 
         val (paramN, callableN, alternatives) = Signatures.signatureHelp(path, pos.span)
 

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/CompletionProvider.scala
@@ -116,10 +116,9 @@ class CompletionProvider(
               case _ => tpdPath0
           case _ => tpdPath0
 
-        val locatedCtx = Interactive.contextOfPath(tpdPath)(using newctx)
-        val indexedCtx = IndexedContext(pos)(using locatedCtx)
+        val indexedCtx = IndexedContext(pos, tpdPath, newctx)
 
-        val completionPos = CompletionPos.infer(pos, params, adjustedPath, wasCursorApplied)(using locatedCtx)
+        val completionPos = CompletionPos.infer(pos, params, adjustedPath, wasCursorApplied)(using indexedCtx.ctx)
 
         val autoImportsGen = AutoImports.generator(
           completionPos.toSourcePosition,
@@ -133,7 +132,7 @@ class CompletionProvider(
         val (completions, searchResult) =
           new Completions(
             text,
-            locatedCtx,
+            indexedCtx.ctx,
             search,
             buildTargetIdentifier,
             completionPos,
@@ -156,7 +155,7 @@ class CompletionProvider(
             completionPos,
             tpdPath,
             indexedCtx
-          )(using locatedCtx)
+          )(using indexedCtx.ctx)
         }
         val isIncomplete = searchResult match
           case SymbolSearch.Result.COMPLETE => false

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -140,7 +140,8 @@ class Completions(
         completionPos.query,
         fromPath,
         adjustedPath,
-        Some(fuzzyMatcher)
+        Some(fuzzyMatcher),
+        calculatedScopeContext = Some(indexedContext.scopeContext)
       )
 
     compilerCompletions
@@ -300,7 +301,7 @@ class Completions(
         symbol.info.member(nme.CONSTRUCTOR).allSymbols
       catch case NonFatal(_) => Nil
     val sym = denot.symbol
-    val hasNonSyntheticConstructor = sym.name.isTypeName && sym.isClass
+    def hasNonSyntheticConstructor = sym.name.isTypeName && sym.isClass
       && !sym.is(ModuleClass) && !sym.is(Trait) && !sym.is(Abstract) && !sym.is(Flags.JavaDefined)
 
     val (extraMethodDenots, skipOriginalDenot): (List[SingleDenotation], Boolean) =

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/OverrideCompletions.scala
@@ -189,7 +189,7 @@ object OverrideCompletions:
               template :: path
             case path => path
 
-        val indexedContext = IndexedContext(pos)(using Interactive.contextOfPath(path)(using newctx))
+        val indexedContext = IndexedContext(pos, path, newctx)
         import indexedContext.ctx
 
         lazy val autoImportsGen = AutoImports.generator(

--- a/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/utils/InteractiveEnrichments.scala
@@ -58,18 +58,6 @@ object InteractiveEnrichments extends CommonMtagsEnrichments:
 
       new SourcePosition(source, span)
 
-    def localContext(params: OffsetParams): Context =
-      if driver.currentCtx.run.nn.units.isEmpty then
-        throw new RuntimeException(
-          "No source files were passed to the Scala 3 presentation compiler"
-        )
-      val unit = driver.currentCtx.run.nn.units.head
-      val pos = driver.sourcePosition(params)
-      val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
-      val tpdPath =
-        Interactive.pathTo(newctx.compilationUnit.tpdTree, pos.span)(using newctx)
-      Interactive.contextOfPath(tpdPath)(using newctx)
-
   end extension
 
   extension (pos: SourcePosition)


### PR DESCRIPTION


## How much have you relied on LLM-based tools in this contribution?

Did some investigations using LLMs, but the code is mine.

## How was the solution tested?

The tests are the same and I also run some benchmarks in the Metals codebase.

## Additional notes

There are a few things that should improve performance:
- we used to calculate scope completions twice, now we do it in the IndexedContext and later check accessiblity when needed
- moved one name check into querying members instead of later
- stopped calculating typed path multiple times, just once and construct everything from it.


Performance seems mostly around the same as with Scala 2 except on empty completion. Need to investigate that later.