### PR TITLE
Several fixes to the handling of static objects and recheckIdent

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -532,6 +532,7 @@ object Capabilities:
     */
     final def pathOwner(using Context): Symbol = pathRoot match
       case tp1: ThisType => tp1.cls
+      case tp1: TermRef if tp1.symbol.is(Module) => tp1.symbol.moduleClass
       case tp1: NamedType => tp1.symbol.owner
       case _: GlobalCap => defn.CapsModule.moduleClass
       case tp1: LocalCap => tp1.ccOwner

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -779,6 +779,8 @@ object Capabilities:
               this.subsumes(hi)
             case _ =>
               y.captureSetOfInfo.elems.forall(this.subsumes)
+        case y: ThisType if y.cls.is(Module) =>
+          this.subsumes(y.cls.sourceModule.termRef)
         case _ => false
       || this.match
           case Reach(x1) => x1.subsumes(y.stripReach)
@@ -793,6 +795,8 @@ object Capabilities:
                 lo.subsumes(y)
               case _ =>
                 x.captureSetOfInfo.elems.exists(_.subsumes(y))
+          case x: ThisType if x.cls.is(Module) =>
+            x.cls.sourceModule.termRef.subsumes(y)
           case _ => false
       catch case ex: AssertionError =>
         println(i"error while subsumes $this >> $y")

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -516,6 +516,7 @@ object Capabilities:
         case tp1: (TermRef | TypeRef) => // can't use NamedType here since it is not a capability
           if tp1.symbol.maybeOwner.isClass && !tp1.symbol.is(TypeParam) then
             tp1.prefix match
+              case pre: ObjectCapability if pre.refersToPackage => tp1
               case pre: Capability => pre.pathRoot
               case _ => tp1
           else tp1

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -136,9 +136,7 @@ extension (tp: Type)
       false
 
   private def isPrefixOfTrackableRef(using Context): Boolean =
-    isTrackableRef || tp.match
-      case tp: TermRef => tp.symbol.is(Package)
-      case _ => false
+    isTrackableRef || tp.refersToPackage
 
   /** The capture set of a type. This is:
     *   - For object capabilities: The singleton capture set consisting of

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -803,8 +803,11 @@ extension (sym: Symbol) {
   def useSet(using Context): CaptureSet =
     ccState.useSetCache.getOrElseUpdate(sym,
       sym.getAnnotation(defn.RetainsAnnot) match
-        case Some(ann: RetainingAnnotation) =>
-          try ann.toCaptureSet
+        case Some(ann) =>
+          // If we read from Tasty, the annotation is not a RetainingAnnotation but is
+          // instead a regular annotation of type TreeUnpickler#DeferredSymAndTree.
+          // Map it to a RetainingAnnotation now.
+          try RetainingAnnotation.fromAnnotation(ann).toCaptureSet
           catch case ex: IllegalCaptureRef =>
             report.error(em"Illegal capture reference: ${ex.getMessage}", sym.srcPos)
             CaptureSet.empty

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -743,15 +743,20 @@ class CheckCaptures extends Recheck, SymTransformer:
         includeCallCaptures(sym, sym.info, tree)
 
       if sym.exists && !sym.is(Package)
-          && !sym.is(Method) // if it's a method the call captures already cover the use set
+          && !(sym.is(Method) && ctx.owner.isContainedIn(sym.owner.skipWeakOwner))
+            // if it's a method in some enclosing scope the call captures already cover the use set
+            // skipWeakOwner: Also exempt symbols in package objects of the source when referenced
+            // from classes in the same source.
       then
-        // Mark symbol as used, either as a path if it is a field of some tracked object
-        // or by itself.
+        // Mark symbol as used
+        //  - as a path if it is a member of some tracked object
+        //  - by itself if it is not a method
         tree.tpe.stripped match
           case TermRef(prefix: (TermRef | ThisType), _) if prefix.isTracked =>
             markPathFree(prefix, PathSelectionProto(sym, pt, tree), tree)
           case _ =>
-            markPathFree(sym.termRef, pt, tree)
+            if !sym.is(Method) then
+              markPathFree(sym.termRef, pt, tree)
 
       if sym.isMutableVar && sym.owner.isTerm && pt != LhsProto then
         // When we have `var x: A^{c} = ...` where `x` is a local variable then

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -742,13 +742,14 @@ class CheckCaptures extends Recheck, SymTransformer:
         // that uses captured references.
         includeCallCaptures(sym, sym.info, tree)
 
-      if sym.exists && !sym.is(Method) && !sym.is(Package) then
+      if sym.exists && !sym.is(Package)
+          && !sym.is(Method) // if it's a method the call captures already cover the use set
+      then
         // Mark symbol as used, either as a path if it is a field of some tracked object
         // or by itself.
-        sym.maybeOwner.thisType match
-          case ref: ThisType
-          if ref.isTracked && sym.isTerm =>
-            markPathFree(ref, PathSelectionProto(sym, pt, tree), tree)
+        tree.tpe.stripped match
+          case TermRef(prefix: (TermRef | ThisType), _) if prefix.isTracked =>
+            markPathFree(prefix, PathSelectionProto(sym, pt, tree), tree)
           case _ =>
             markPathFree(sym.termRef, pt, tree)
 

--- a/compiler/src/dotty/tools/dotc/cc/RetainingAnnotation.scala
+++ b/compiler/src/dotty/tools/dotc/cc/RetainingAnnotation.scala
@@ -5,13 +5,14 @@ package cc
 import core.*
 import Types.*, Symbols.*, Contexts.*
 import Annotations.{Annotation, CompactAnnotation, EmptyAnnotation}
+import ast.tpd.TypeTree
 import config.Feature
 
 /** A class for annotations @retains, @retainsByName and @retainsCap
  *  We make sure that all annotations with these classes are represented
  *  as RetainingAnnotations.
  */
-class RetainingAnnotation(tpe: Type) extends CompactAnnotation(tpe):
+class RetainingAnnotation(tpe: Type) extends CompactAnnotation(tpe) {
 
   def this(cls: ClassSymbol, args: Type*)(using Context) = this(cls.typeRef.appliedTo(args.toList))
 
@@ -48,5 +49,17 @@ class RetainingAnnotation(tpe: Type) extends CompactAnnotation(tpe):
     if myCaptureSet == null then
       myCaptureSet = CaptureSet(retainedType.retainedElements*)
     myCaptureSet.nn
+}
+object RetainingAnnotation {
 
-end RetainingAnnotation
+  /** Convert annotation with retains as symbol to a RetainingAnnotation */
+  def fromAnnotation(ann: Annotation)(using Context): RetainingAnnotation = ann match
+    case ann: RetainingAnnotation => ann
+    case _ =>
+      assert(ann.symbol.isRetains)
+      ann.tree match
+        case atree: TypeTree => // this is the case if sourceVersion.enablesCompactAnnotation
+          CompactAnnotation(atree.tpe).asInstanceOf[RetainingAnnotation]
+        case atree =>
+          CompactAnnotation(atree).asInstanceOf[RetainingAnnotation]
+}

--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -682,7 +682,7 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
         hiddenRef.pathRoot match
           case ref: TermRef if ref.symbol != role.dclSym =>
             val refSym = ref.symbol
-            if currentOwner.enclosingMethodOrClass.isProperlyContainedIn(refSym.maybeOwner.enclosingMethodOrClass) then
+            if currentOwner.enclosingMethodOrClassOrObject.isProperlyContainedIn(refSym.enclosingMethodOrClassOrObject) then
               report.error(em"""Separation failure: $descr non-local $refSym""", pos)
             else if refSym.is(TermParam)
               && !refSym.isConsumeParam
@@ -690,7 +690,7 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
             then
               badParams += refSym
           case ref: ThisType =>
-            val encl = currentOwner.enclosingMethodOrClass
+            val encl = currentOwner.enclosingMethodOrClassOrObject
             if encl.isProperlyContainedIn(ref.cls)
                 && !encl.is(Synthetic)
                 && !encl.hasAnnotation(defn.ConsumeAnnot)

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -162,8 +162,15 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           symd.info // don't transform symbols that will anyway be updated
         else
           val symCtx = if sym.isOneOf(TermParamOrAccessor) then ctx else ctx.withOwner(sym)
+          val oldInfo =
+            if sym.is(ModuleVal) then
+              sym.moduleClass.getAnnotation(defn.RetainsAnnot) match
+                case Some(ann) =>
+                  AnnotatedType(sym.info, RetainingAnnotation.fromAnnotation(ann))
+                case None => sym.info
+            else sym.info
           toResultInReturnType(sym, msg => throw TypeError(msg)):
-            transformExplicitType(symd.info, sym)(using symCtx)
+            transformExplicitType(oldInfo, sym)(using symCtx)
       if Synthetics.needsTransform(symd) then
         Synthetics.transform(symd, mappedInfo)
       else if sym.isClass && !sym.is(CaptureChecked) then

--- a/compiler/src/dotty/tools/dotc/core/SymUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymUtils.scala
@@ -252,6 +252,15 @@ class SymUtils:
       else if (self.exists) self.owner.enclosingMethodOrClass
       else NoSymbol
 
+    /** The closest enclosing method, class or object of this symbol.
+     *  Module references get mapped to their moduleClasses.
+     */
+    @tailrec final def enclosingMethodOrClassOrObject(using Context): Symbol =
+      if self.is(Method) || self.isClass then self
+      else if self.is(ModuleVal) then self.moduleClass
+      else if self.exists then self.owner.enclosingMethodOrClassOrObject
+      else NoSymbol
+
     /** Apply symbol/symbol substitution to this symbol */
     def subst(from: List[Symbol], to: List[Symbol]): Symbol = {
       @tailrec def loop(from: List[Symbol], to: List[Symbol]): Symbol =

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -231,7 +231,7 @@ class TypeUtils:
     /** If this type refers to a package, the class representing that package,
      *  otherwise NoSymbol.
      */
-    def packageClass(using Context): Symbol = self match
+    def packageClass(using Context): Symbol = self.stripped match
       case self: ThisType if self.cls.is(Package) => self.cls
       case self: TermRef if self.symbol.is(Package) => self.symbol.moduleClass
       case _ => NoSymbol

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -222,14 +222,21 @@ class TypeUtils:
           tpe
       self match
       case tpe: NamedType =>
-        if tpe.symbol.isRoot then
-          tpe
+        if tpe.prefix.refersToPackage then
+          tryInsert(tpe, tpe.prefix.packageClass)
         else
-          tpe.prefix match
-            case pre: ThisType if pre.cls.is(Package) => tryInsert(tpe, pre.cls)
-            case pre: TermRef if pre.symbol.is(Package) => tryInsert(tpe, pre.symbol.moduleClass)
-            case _ => tpe
+          tpe
       case tpe => tpe
+
+    /** If this type refers to a package, the class representing that package,
+     *  otherwise NoSymbol.
+     */
+    def packageClass(using Context): Symbol = self match
+      case self: ThisType if self.cls.is(Package) => self.cls
+      case self: TermRef if self.symbol.is(Package) => self.symbol.moduleClass
+      case _ => NoSymbol
+
+    def refersToPackage(using Context): Boolean = packageClass.exists
 
     /** Strip all outer refinements off this type */
     def stripRefinement: Type = self match

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -938,12 +938,17 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
   def pickleAnnotation(owner: Symbol, mdef: MemberDef, ann: Annotation)(using Context): Unit =
     if !isUnpicklable(owner, ann) then
       writeByte(ANNOTATION)
-      withLength { pickleType(ann.symbol.typeRef); pickleTree(ann.tree) }
+      val annotTree = ann match
+        case ann: CompactAnnotation =>
+          if sourceVersion.enablesCompactAnnotation then ann.tree else ann.oldTree
+        case _ =>
+          ann.tree
+      withLength { pickleType(ann.symbol.typeRef); pickleTree(annotTree) }
       var treeBuf = annotTrees.lookup(mdef)
       if treeBuf == null then
         treeBuf = new mutable.ListBuffer[Tree]
         annotTrees(mdef) = treeBuf
-      treeBuf += ann.tree
+      treeBuf += annotTree
 
 // ---- main entry points ---------------------------------------
 

--- a/tests/neg-custom-args/captures/i25758-in-package.check
+++ b/tests/neg-custom-args/captures/i25758-in-package.check
@@ -1,0 +1,16 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25758-in-package/B_2.scala:4:31 -------------------------
+4 |    val leak: String -> Unit = (secret: String) => // error
+  |                               ^
+  |                   Found:    (secret: String) ->{ttt.A} Unit
+  |                   Required: String -> Unit
+  |
+  |                   Note that capability `any` cannot flow into capture set {}.
+  |
+  |                   Note that capability `ttt.A` cannot flow into capture set {}.
+  |                   Note that object A is a capability because it uses capabilities {ttt.Console}
+  |
+  |                   where:    any is a root capability classified as SharedCapability in the type of object Console
+  |
+5 |      A.println(secret)
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25758-in-package/A_1.scala
+++ b/tests/neg-custom-args/captures/i25758-in-package/A_1.scala
@@ -1,0 +1,10 @@
+package ttt
+import caps.*
+class Text
+
+object Console extends SharedCapability:
+  def println(s: String): Unit = ()
+
+object A uses Console:
+  def println(s: String) = Console.println(s)
+

--- a/tests/neg-custom-args/captures/i25758-in-package/B_2.scala
+++ b/tests/neg-custom-args/captures/i25758-in-package/B_2.scala
@@ -1,0 +1,5 @@
+package ttt
+object Test uses A, Console:
+  def test =
+    val leak: String -> Unit = (secret: String) => // error
+      A.println(secret)

--- a/tests/neg-custom-args/captures/i25758.scala
+++ b/tests/neg-custom-args/captures/i25758.scala
@@ -1,0 +1,28 @@
+package test
+import caps.*
+object o extends SharedCapability:
+  class IO extends SharedCapability:
+    def println(msg: String): Unit = ()
+  val io: IO^ = new IO
+  def assertPure(op: () -> Unit): Unit = ()
+
+import o.*
+object Test uses test.o:
+  def test1(): Unit =
+    assertPure(() => io.println("hello"))  // error, as expected
+  def test(): Unit = io.println("hello")
+  def test2(): Unit =
+    val f = () => this.test()
+    assertPure(f) // error, as expected
+    assertPure: () =>  // error
+      this.test()
+    assertPure: () =>  // error
+      test()
+  def test3(): Unit =
+    def test(): Unit = io.println("hello")
+    val f = () => this.test()
+    assertPure(f) // error, as expected
+    assertPure: () =>  // error
+      this.test()
+    assertPure: () =>  // error
+      test()

--- a/tests/neg-custom-args/captures/i25758a.check
+++ b/tests/neg-custom-args/captures/i25758a.check
@@ -1,0 +1,20 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25758a/Test_2.scala:6:15 --------------------------------
+6 |    assertPure(() => IO.io.println("hello"))  // error, as expected
+  |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |               Found:    () ->{test.IO.io} Unit
+  |               Required: () -> Unit
+  |
+  |               Note that capability `test.IO.io` cannot flow into capture set {}.
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25758a/Test_2.scala:9:16 --------------------------------
+ 9 |    assertPure: () =>  // error
+   |                ^
+   |                Found:    () ->{test.IO.io} Unit
+   |                Required: () -> Unit
+   |
+   |                Note that capability `test.IO.io` cannot flow into capture set {}.
+   |
+10 |      test()
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25758a/IO_1.scala
+++ b/tests/neg-custom-args/captures/i25758a/IO_1.scala
@@ -1,0 +1,7 @@
+package test
+import caps.*
+class IO extends SharedCapability:
+  def println(msg: String): Unit = ()
+object IO extends SharedCapability:
+  val io: IO = new IO
+  def assertPure(op: () -> Unit): Unit = ()

--- a/tests/neg-custom-args/captures/i25758a/Test_2.scala
+++ b/tests/neg-custom-args/captures/i25758a/Test_2.scala
@@ -1,7 +1,7 @@
 package test
 import caps.*
 import IO.*
-object Test uses IO.io:
+object Test uses IO:
   def test1(): Unit =
     assertPure(() => IO.io.println("hello"))  // error, as expected
   def test2(): Unit =

--- a/tests/neg-custom-args/captures/i25758a/Test_2.scala
+++ b/tests/neg-custom-args/captures/i25758a/Test_2.scala
@@ -1,0 +1,10 @@
+package test
+import caps.*
+import IO.*
+object Test uses IO.io:
+  def test1(): Unit =
+    assertPure(() => IO.io.println("hello"))  // error, as expected
+  def test2(): Unit =
+    def test(): Unit = IO.io.println("hello")
+    assertPure: () =>  // error
+      test()

--- a/tests/neg-custom-args/captures/i25758b/IO_1.scala
+++ b/tests/neg-custom-args/captures/i25758b/IO_1.scala
@@ -1,0 +1,6 @@
+import caps.*
+class IO extends SharedCapability:
+  def println(msg: String): Unit = ()
+object IO extends SharedCapability:
+  val io: IO = new IO
+  def assertPure(op: () -> Unit): Unit = ()

--- a/tests/neg-custom-args/captures/i25758b/Test_2.scala
+++ b/tests/neg-custom-args/captures/i25758b/Test_2.scala
@@ -1,0 +1,8 @@
+import caps.*
+import IO.*
+def test1(): Unit =
+  assertPure(() => IO.io.println("hello"))  // error, as expected
+def test2(): Unit =
+  def test(): Unit = IO.io.println("hello")
+  assertPure: () =>  // error
+    test()

--- a/tests/neg-custom-args/captures/ident-inherited.check
+++ b/tests/neg-custom-args/captures/ident-inherited.check
@@ -1,0 +1,56 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ident-inherited/Test_2.scala:6:22 ------------------------
+6 |  val a: () -> Unit = () => this.println()    // error
+  |                      ^^^^^^^^^^^^^^^^^^^^
+  |                    Found:    () ->{test.Test} Unit
+  |                    Required: () -> Unit
+  |
+  |                    Note that capability `any` cannot flow into capture set {}.
+  |
+  |                    Note that capability `test.Test` cannot flow into capture set {}.
+  |                    Note that object Test is a capability because it uses capabilities {test.Consol}
+  |
+  |                    where:    any is a root capability classified as SharedCapability in the type of object Consol
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ident-inherited/Test_2.scala:7:22 ------------------------
+7 |  val b: () -> Unit = () => this.print    // error
+  |                      ^^^^^^^^^^^^^^^^
+  |                    Found:    () ->{test.Test} Unit
+  |                    Required: () -> Unit
+  |
+  |                    Note that capability `any` cannot flow into capture set {}.
+  |
+  |                    Note that capability `test.Test` cannot flow into capture set {}.
+  |                    Note that object Test is a capability because it uses capabilities {test.Consol}
+  |
+  |                    where:    any is a root capability classified as SharedCapability in the type of object Consol
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ident-inherited/Test_2.scala:8:22 ------------------------
+8 |  val c: () -> Unit = () => println()    // error
+  |                      ^^^^^^^^^^^^^^^
+  |                    Found:    () ->{test.Test} Unit
+  |                    Required: () -> Unit
+  |
+  |                    Note that capability `any` cannot flow into capture set {}.
+  |
+  |                    Note that capability `test.Test` cannot flow into capture set {}.
+  |                    Note that object Test is a capability because it uses capabilities {test.Consol}
+  |
+  |                    where:    any is a root capability classified as SharedCapability in the type of object Consol
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ident-inherited/Test_2.scala:9:22 ------------------------
+9 |  val d: () -> Unit = () => print    // error
+  |                      ^^^^^^^^^^^
+  |                    Found:    () ->{test.Test} Unit
+  |                    Required: () -> Unit
+  |
+  |                    Note that capability `any` cannot flow into capture set {}.
+  |
+  |                    Note that capability `test.Test` cannot flow into capture set {}.
+  |                    Note that object Test is a capability because it uses capabilities {test.Consol}
+  |
+  |                    where:    any is a root capability classified as SharedCapability in the type of object Consol
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/ident-inherited/A_1.scala
+++ b/tests/neg-custom-args/captures/ident-inherited/A_1.scala
@@ -1,0 +1,11 @@
+package test
+
+import caps.*
+
+object Consol extends SharedCapability:
+  def println(s: String) = ()
+
+trait A uses Consol:
+  def println(): Unit = Consol.println("hello")
+  def print: Unit = println()
+

--- a/tests/neg-custom-args/captures/ident-inherited/Test_2.scala
+++ b/tests/neg-custom-args/captures/ident-inherited/Test_2.scala
@@ -1,0 +1,9 @@
+package test
+
+import caps.*
+
+object Test extends A uses Consol:
+  val a: () -> Unit = () => this.println()    // error
+  val b: () -> Unit = () => this.print    // error
+  val c: () -> Unit = () => println()    // error
+  val d: () -> Unit = () => print    // error

--- a/tests/pos-custom-args/captures/caps-universal.scala
+++ b/tests/pos-custom-args/captures/caps-universal.scala
@@ -1,7 +1,8 @@
 import annotation.retains
 
-val foo: Int => Int = x => x
-val bar: (Int -> Int) @retains[caps.any.type] = foo
-val baz: Int => Int = bar
+def test =
+  val foo: Int => Int = x => x
+  val bar: (Int -> Int) @retains[caps.any.type] = foo
+  val baz: Int => Int = bar
 
 

--- a/tests/pos-custom-args/captures/i24901.scala
+++ b/tests/pos-custom-args/captures/i24901.scala
@@ -11,6 +11,10 @@ object Plan:
     test =>
       execute(test) // was error
 
+object PlanC:
+  def execute(test: Rand => Unit): Boolean =
+    true
+
   val err: (Rand => Unit) => Boolean =
     test =>
       execute(r => test(r)) // was error


### PR DESCRIPTION
See individual commit titles for details what got fixed.

Three main areas of fixes:

 - Infrastructure dealing with objects: subsumes rule, pickling/unpickling of use sets, refinements to pathRoot and pathOwner
 - Fixes to recheckIdent: Corrections to what is the proper prefix to check, also include methods that are not in some enclosing scope in checks.
 - Fixes to explicit checks: Don't exempt definitions in the empty package if they are compiled in safe mode or wrapped in an `@assumeSafe`. Merge the diverging definitions of isExemptFromExplicitChecks in CheckCaptures and CaptureOps. EDIT: These are now in #25795.

Fixes #25758 
