### PR TITLE
Fix `SubMatch` wrapped in `Typed` node by `ensureNoLocalRefs`

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1593,7 +1593,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         val newCases = cases.map: cdef =>
           val newBody = ascribeType(cdef.body, pt)
           cpy.CaseDef(cdef)(body = newBody).withType(newBody.tpe)
-        cpy.Match(m)(selector, newCases).withType(TypeComparer.lub(newCases.map(_.tpe)))
+        cpy.Match(m)(selector, newCases).withType(TypeComparer.lub(newCases.tpes))
       case _ =>
         val target = pt.simplified
         val targetTpt = TypeTree(target, inferred = true)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1589,6 +1589,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       case block @ Block(stats, expr) if !expr.isInstanceOf[Closure] =>
         val expr1 = ascribeType(expr, pt)
         cpy.Block(block)(stats, expr1).withType(expr1.tpe) // no assignType here because avoid is redundant
+      case m @ Match(selector, cases) if m.isSubMatch =>
+        val newCases = cases.map: cdef =>
+          val newBody = ascribeType(cdef.body, pt)
+          cpy.CaseDef(cdef)(body = newBody).withType(newBody.tpe)
+        cpy.Match(m)(selector, newCases).withType(TypeComparer.lub(newCases.map(_.tpe)))
       case _ =>
         val target = pt.simplified
         val targetTpt = TypeTree(target, inferred = true)

--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -84,3 +84,4 @@ tailrec.scala
 traitParams.scala
 i25460.scala
 matrix.scala
+i25746.scala

--- a/tests/pos/i25746.scala
+++ b/tests/pos/i25746.scala
@@ -1,0 +1,9 @@
+import scala.language.experimental.subCases
+
+@main def test =
+  val r1 = "^foo".r.unanchored
+  val r2 = "bar$".r.unanchored
+
+  val result1 = "foo bar" match
+    case s @ r1() if s match { case r2() => s }
+    case _ => "no"


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/25746

`ensureNoLocalRefs` in the typer wrapped `SubMatch` node in `Typed(SubMatch, String)`. This caused `PatternMatcher` to miss the `SubMatch` and emit it as a raw `ResultPlan`, which after a few steps crashed `BCodeBodyBuilder`.

## How much have you relied on LLM-based tools in this contribution?
To help me identify the error.

## How was the solution tested?
Tests are included.

## Additional notes
My first attempt was to handle `Typed(t: SubMatch, _)` in `caseDefPlan` in `PatternMatcher`, but I was afraid of silent errors by just stripping `Typed`.