### PR TITLE
Restore buildQuick sbt task for bin/scalacQ and bin/replQ

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -164,6 +164,8 @@ object Build {
   // Used to compile files similar to ./bin/scalac script
   val scalac = inputKey[Unit]("run the compiler using the correct classpath, or the user supplied classpath")
 
+  val buildQuick = taskKey[Unit]("compile the compiler and REPL, write classpath to bin/.cp for use by bin/scalacQ and bin/replQ")
+
   // Settings used to configure the test language server
   val ideTestsCompilerVersion = taskKey[String]("Compiler version to use in IDE tests")
   val ideTestsCompilerArguments = taskKey[Seq[String]]("Compiler arguments to use in IDE tests")
@@ -741,6 +743,14 @@ object Build {
 
         (`scala3-compiler-nonbootstrapped` / Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
       }.evaluated,
+      // TODO: scala3-repl depends on the bootstrapped compiler, making this slower
+      // than it needs to be. A non-bootstrapped REPL project would speed this up.
+      buildQuick := {
+        val _ = (`scala3-repl` / Compile / compile).value
+        val cp = (`scala3-repl` / Compile / fullClasspath).value.map(_.data.getAbsolutePath).mkString(File.pathSeparator)
+        IO.write(baseDirectory.value / "bin" / ".cp", cp)
+        streams.value.log.info(s"Wrote classpath to bin/.cp — use bin/scalacQ and bin/replQ")
+      },
       testCompilation := Def.inputTaskDyn {
         val args = spaceDelimited("<arg>").parsed
         if (args.contains("--help")) {

--- a/repl/src/dotty/tools/repl/Main.scala
+++ b/repl/src/dotty/tools/repl/Main.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package repl
 
 /** Main entry point to the REPL */
-// To test, run bin/scala
+// To test, run `sbt buildQuick` then `bin/replQ`
 object Main {
   def main(args: Array[String]): Unit =
     new ReplDriver(args, extraPredef = ReplDriver.pprintImport).tryRunning


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/24702

The `buildQuick` task was removed at some point but the `bin/scalacQ` and `bin/replQ` scripts still depend on it to populate `bin/.cp`.

Usage:
  * `sbt buildQuick`       compile and write classpath
  * `bin/replQ`             start REPL with jline support
  * `bin/scalacQ file.scala`  compile with non-bootstrapped compiler

## How much have you relied on LLM-based tools in this contribution?

not

## How was the solution tested?

- Manual tests described below (in enough detail that someone unfamiliar with this can still follow)

Using the commands above.

## Additional notes

Unlike https://github.com/scala/scala3/pull/19894, we use the `scala3-repl` project in `buildQuick`. `replQ` needs the REPL classes and jline which only exist in scala3-repl. That project depends on the compiler so its classpath includes everything. Both scripts will work.