### PR TITLE
bugfix: Don't add square braces in context bounds

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -80,15 +80,20 @@ class Completions(
         if appl.fun == funSel && sel == fun => false
     case _ => true
 
-  private lazy val isDerivingTemplate = adjustedPath match
+  private lazy val isDerivingOrContextBound = adjustedPath match
     /* In case of `class X derives TC@@` we shouldn't add `[]`
      */
     case Ident(_) :: (templ: untpd.DerivingTemplate) :: _ =>
       val pos = completionPos.toSourcePosition
       !templ.derived.exists(_.sourcePos.contains(pos))
+    /* In case of `def demo[F[_]: TC@@]` or `def demo[F[_]: {TC1, TC@@}]`
+     * we shouldn't add `[]` as we are in a context bound position.
+     */
+    case Ident(_) :: (_: untpd.ContextBounds) :: _ => false
+    case Ident(_) :: (_: untpd.ContextBoundTypeTree) :: _ => false
     case _ => true
 
-  private lazy val shouldAddSuffix = shouldAddSnippet && isContinuedApply && isDerivingTemplate
+  private lazy val shouldAddSuffix = shouldAddSnippet && isContinuedApply && isDerivingOrContextBound
 
   private lazy val isNew: Boolean = Completion.isInNewContext(adjustedPath)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSuite.scala
@@ -1940,8 +1940,8 @@ class CompletionSuite extends BaseCompletionSuite:
         |  extension [T: Orde@@]
         |}
         |""".stripMargin,
-      """Ordered[T] scala.math
-        |Ordering[T] scala.math
+      """Ordered scala.math
+        |Ordering scala.math
         |""".stripMargin,
       topLines = Some(2)
     )
@@ -1953,8 +1953,8 @@ class CompletionSuite extends BaseCompletionSuite:
         |  extension [T: Ordering: Orde@@]
         |}
         |""".stripMargin,
-      """Ordered[T] scala.math
-        |Ordering[T] scala.math
+      """Ordered scala.math
+        |Ordering scala.math
         |""".stripMargin,
       topLines = Some(2)
     )
@@ -2321,4 +2321,24 @@ class CompletionSuite extends BaseCompletionSuite:
         |case class Miau(y: Int) derives Ordering, CanEqu@@
         |""".stripMargin,
       "CanEqual scala"
+    )
+
+  @Test def `context-bound-no-square-brackets` =
+    check(
+      """|trait Applicative[F[_]]
+         |trait Monadic[F[_]]
+         |
+         |def demo[F[_]: Applicative: Mona@@]: Unit = ???
+         |""".stripMargin,
+      "Monadic test"
+    )
+
+  @Test def `context-bound-no-square-brackets-multi` =
+    check(
+      """|trait Applicative[F[_]]
+         |trait Monadic[F[_]]
+         |
+         |def demo[F[_]: {Applicative, Mona@@}]: Unit = ???
+         |""".stripMargin,
+      "Monadic test"
     )


### PR DESCRIPTION
Fixes https://github.com/scalameta/metals/issues/8311


## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, the fix was vibe coded, but it's mostly to save time. 

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests
