### PR TITLE
scaladoc: fix 'occured' -> 'occurred' typos in user-visible error strings

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ExternalDocLink.scala
@@ -22,7 +22,7 @@ object ExternalDocLink:
 
   private def tryParse[T](mapping: String, descr: String)(op: => T): Either[String, T] = Try(op) match {
     case Success(v) => Right(v)
-    case Failure(e) => fail(mapping, s"Unable to parse $descr. Exception $e occured")
+    case Failure(e) => fail(mapping, s"Unable to parse $descr. Exception $e occurred")
   }
 
   private def stripIndex(url: String): String = url.stripSuffix("index.html").stripSuffix("/") + "/"

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/HtmlRenderer.scala
@@ -92,7 +92,7 @@ class HtmlRenderer(rootPackage: Member, members: Map[DRI, Member])(using ctx: Do
               .map(from => Resource.File(resourceFile.toPath.relativize(from).toString, from))
           }.fold (
             { t =>
-              report.warn(s"Error occured while processing _assets file.", t)
+              report.warn(s"Error occurred while processing _assets file.", t)
               Seq.empty
             },
             identity

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/FlexmarkSnippetProcessor.scala
@@ -29,7 +29,7 @@ object FlexmarkSnippetProcessor:
             case Right(flags) => Some(flags)
             case Left(error) =>
               report.warning(
-                s"""|Error occured during parsing flags in snippet:
+                s"""|Error occurred during parsing flags in snippet:
                     |$error""".stripMargin
               )
               None
@@ -62,7 +62,7 @@ object FlexmarkSnippetProcessor:
             val snippet = snippetMap.get(id)
             if snippet.isEmpty then
               report.warning(
-                s"""|Error occured during parsing compile-with in snippet:
+                s"""|Error occurred during parsing compile-with in snippet:
                     |Snippet with id: $id not found.
                     |Remember that you cannot use forward reference to snippets""".stripMargin
               )


### PR DESCRIPTION
Fixes: N/A — documentation/user-visible string typo fix (no issue number).

## How much have you relied on LLM-based tools in this contribution?

Minimally, for drafting the PR description. The actual change is a two-word sed replacement.

## How was the solution tested?

Non-code change, no tests needed. The change is limited to user-visible string literals in scaladoc output — `occured` → `occurred`. No behavior, API, or logic change.

## What does this PR do?

Fix `occured` → `occurred` typos in scaladoc user-visible output strings. These strings appear verbatim in generated documentation so the typo is visible to every scaladoc reader.

## CLA

Signed the Akka CLA at https://contribute.akka.io/cla/scala.