### PR TITLE
Fix issue with flexifying unions from Java symbols under explicit-nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
+++ b/compiler/src/dotty/tools/dotc/core/OrderingConstraint.scala
@@ -760,6 +760,7 @@ class OrderingConstraint(private val boundsMap: ParamBounds,
     case tp: TypeVar if contains(tp.origin) => withHard(tp)
     case tp: TypeParamRef if contains(tp)   => hardenTypeVars(typeVarOfParam(tp))
     case tp: AndOrType                      => hardenTypeVars(tp.tp1).hardenTypeVars(tp.tp2)
+    case tp: FlexibleType                   => hardenTypeVars(tp.hi)
     case _                                  => this
 
   def remove(pt: TypeLambda)(using Context): This = {

--- a/tests/explicit-nulls/pos/lub/J.java
+++ b/tests/explicit-nulls/pos/lub/J.java
@@ -1,0 +1,9 @@
+// Minimized from https://scala3.westeurope.cloudapp.azure.com/dashboard/projects/greenfossil/thorium/builds/HarrisL2%2Fscala3%3Aunsafe-explicit-nulls%3A2026-04-01/logs
+
+import java.util.function.Function;
+public class J<T> {
+
+    public <U> U execute(Function<? super T,? extends U> function, T input) {
+        return function.apply(input);
+    }
+}

--- a/tests/explicit-nulls/pos/lub/S.scala
+++ b/tests/explicit-nulls/pos/lub/S.scala
@@ -1,0 +1,9 @@
+// Minimized from https://scala3.westeurope.cloudapp.azure.com/dashboard/projects/greenfossil/thorium/builds/HarrisL2%2Fscala3%3Aunsafe-explicit-nulls%3A2026-04-01/logs
+
+class A
+class B
+
+def foo(fn: A => A | B): A | B =
+  val v: J[A] = ???
+  val resp = v.execute(fn(_), ???)
+  resp


### PR DESCRIPTION
Fixes an issue with explicit nulls and flexifying unions from Java symbols.
Discovered from Open Community Build [here](https://scala3.westeurope.cloudapp.azure.com/dashboard/projects/greenfossil/thorium/builds/HarrisL2%2Fscala3%3Aunsafe-explicit-nulls%3A2026-04-01/logs)

In code where Java symbols return a union type and no upper bound is given, under explicit-nulls, the type was incorrectly inferred as (Object)? due to an interaction with flexible types.
```
class A
class B

def foo(fn: A => A | B): A | B =
  val v: J[A] = ???
  val resp = v.execute(fn(_), ???)
  resp
```
In this code, the type of resp is incorrectly inferred as (Object)?

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New tests in tests/explicit-nulls/pos/lub
