### PR TITLE
Context bound always has a span

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2327,16 +2327,19 @@ object Parsers {
 
     /** ContextBound      ::=  Type [`as` id] */
     def contextBound(pname: TypeName): Tree =
+      val start = in.offset
       val t = toplevelTyp(inContextBound = true)
       val ownName =
         if isIdent(nme.as) && sourceVersion.enablesNewGivens then
           in.nextToken()
           ident()
         else EmptyTermName
-      val res = ContextBoundTypeTree(t, pname, ownName)
-      if t.span.exists then
-        res.withSpan(Span(t.span.start, end = in.lastOffset, point = t.span.end))
-      else res
+      ContextBoundTypeTree(t, pname, ownName)
+        .withSpan:
+          if t.span.exists then
+            Span(t.span.start, end = in.lastOffset, point = t.span.end)
+          else
+            Span(start, end = in.lastOffset, point = start)
 
     /** ContextBounds     ::= ContextBound [`:` ContextBounds]
      *                      | `{` ContextBound {`,` ContextBound} `}`

--- a/tests/neg/i25456.check
+++ b/tests/neg/i25456.check
@@ -1,0 +1,22 @@
+-- [E040] Syntax Error: tests/neg/i25456.scala:6:41 --------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                         ^
+  |                                         ']' expected, but '[' found
+-- [E035] Syntax Error: tests/neg/i25456.scala:6:46 --------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                              ^
+  |                                              Unbound wildcard type
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E019] Syntax Error: tests/neg/i25456.scala:6:48 --------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                                ^
+  |                                                Missing return type
+  |
+  | longer explanation available when compiling with `-explain`
+-- Warning: tests/neg/i25456.scala:6:40 --------------------------------------------------------------------------------
+6 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+  |                                        ^
+  |                               `_` is deprecated for wildcard arguments of types: use `?` instead
+  |                               This construct can be rewritten automatically under -rewrite -source 3.4-migration.
+No warnings can be incurred under -Werror

--- a/tests/neg/i25456.scala
+++ b/tests/neg/i25456.scala
@@ -1,4 +1,12 @@
+//> using options -Werror
+
 trait ApplicativeError[F[_], E]
 
 object A:
-  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // error
+  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1 // error // error // error // nopos-error
+
+/* Previous spurious error
+4 |  def generate[F[_]: { ApplicativeError[_[?], ?] }]: Int = 1
+  |                                            ^
+  |                 Illegal context bound: Any does not take type parameters.
+*/

--- a/tests/neg/i25716.scala
+++ b/tests/neg/i25716.scala
@@ -1,0 +1,8 @@
+def g[@inline x: _](y: x): Unit = () // error: Unbound wildcard type
+
+trait F[A]
+trait G[A]
+def ok[A: {F, G}](a: A): Unit = () // pos is start of A | F
+def f0[A: {F, _}](a: A): Unit = () // error
+def f1[A: {_, G}](a: A): Unit = () // error
+def f2[A: {_, _}](a: A): Unit = () // error // error


### PR DESCRIPTION
Fixes #25716 

Follow-up https://github.com/scala/scala3/pull/25623

Supply a span at `ContextBound` (rather than defensively checking for a span up the stack).

## How much have you relied on LLM-based tools in this contribution?

Not at all

Solal did all the heavy lifting on the ticket. What is the Solal policy?

## How was the solution tested?

New automated tests (including the issue's excellently minimized reproducer, if applicable)
