### PR TITLE
Don't lookahead from interpolation

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3859,7 +3859,7 @@ object Parsers {
                 syntaxError(em"`using` expected")
               val (firstParamMod, paramsAreNamed) =
                 var mods = EmptyModifiers
-                if in.lookahead.isColon then
+                if in.token != INTERPOLATIONID && in.lookahead.isColon then
                   (mods, true)
                 else if isConsume then (mods, true)
                 else

--- a/tests/neg/i25717.scala
+++ b/tests/neg/i25717.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+object Crash {
+  def macroImpl(using Quotes)(q"a: String"): Expr[Boolean] = ??? // error
+
+  def f(s"a: String") = ??? // error
+
+  def softie(into q"a: String") = ??? // error
+}


### PR DESCRIPTION
Fixes #25717 

Verified manually that other usages of `lookahead` check the current `in.token` first.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
