### PR TITLE
Enable sc:compile for stdlib package scala.annotation

### DIFF
--- a/library/src/scala/annotation/MacroAnnotation.scala
+++ b/library/src/scala/annotation/MacroAnnotation.scala
@@ -42,10 +42,9 @@ trait MacroAnnotation extends StaticAnnotation:
    *
    *  #### Example 1
    *  This example shows how to modify a `def` and add a `val` next to it using a macro annotation.
-   *  ```scala
+   *  ```scala sc-hidden sc-name:memoize-context
    *  import scala.quoted.*
    *  import scala.collection.concurrent
-   *
    *  class memoize extends MacroAnnotation:
    *    def transform(using Quotes)(
    *      definition: quotes.reflect.Definition,
@@ -76,7 +75,7 @@ trait MacroAnnotation extends StaticAnnotation:
    *    end transform
    *  ```
    *  with this macro annotation a user can write
-   *  ```scala
+   *  ```scala sc:compile
    *  //{
    *  class memoize extends scala.annotation.StaticAnnotation
    *  //}
@@ -86,7 +85,7 @@ trait MacroAnnotation extends StaticAnnotation:
    *    if n <= 1 then n else fib(n - 1) + fib(n - 2)
    *  ```
    *  and the macro will modify the definition to create
-   *  ```scala
+   *  ```scala sc-compile-with:memoize-context
    *   val fibCache$macro$1 =
    *     scala.collection.concurrent.TrieMap.empty[Int, Int]
    *   def fib(n: Int): Int =
@@ -102,7 +101,7 @@ trait MacroAnnotation extends StaticAnnotation:
    *  #### Example 2
    *  This example shows how to modify a `class` using a macro annotation.
    *  It shows how to override inherited members and add new ones.
-   *  ```scala
+   *  ```scala sc:compile
    *  import scala.annotation.{experimental, MacroAnnotation}
    *  import scala.quoted.*
    *
@@ -193,14 +192,14 @@ trait MacroAnnotation extends StaticAnnotation:
    *      }
    *  ```
    *  with this macro annotation a user can write
-   *  ```scala
+   *  ```scala sc:compile
    *  //{
    *  class equals extends scala.annotation.StaticAnnotation
    *  //}
    *  @equals class User(val name: String, val id: Int)
    *  ```
    *  and the macro will modify the class definition to generate the following code
-   *  ```scala
+   *  ```scala sc:compile
    *  class User(val name: String, val id: Int):
    *    override def equals(that: Any): Boolean =
    *      that match

--- a/library/src/scala/annotation/meta/package.scala
+++ b/library/src/scala/annotation/meta/package.scala
@@ -21,8 +21,14 @@ import scala.language.`2.13`
  *
  * For instance in the following class definition
  *
+ * ```scala sc-hidden sc-name:bean-imports
+ * import scala.beans.BeanProperty
+ * import scala.annotation.Annotation
+ * import scala.annotation.meta.beanGetter
  * ```
- * class C(@myAnnot @BeanProperty var c: Int)
+ * ```scala sc-compile-with:bean-imports
+ * class myAnnotation extends Annotation
+ * class C(@myAnnotation @BeanProperty var c: Int)
  * ```
  *
  * there are six entities which can carry the annotation `@myAnnot`: the
@@ -41,12 +47,12 @@ import scala.language.`2.13`
  *
  * The target meta-annotations can be put on the annotation type when
  * instantiating the annotation. In the following example, the annotation
- * `@Id` will be added only to the bean getter `getX`.
+ * `@MyId` will be added only to the bean getter `getX`.
  *
- * ```
- * import javax.persistence.Id
+ * ```scala sc-compile-with:bean-imports
+ * class MyId extends Annotation
  * class A {
- *   @(Id @beanGetter) @BeanProperty val x = 0
+ *   @(MyId @beanGetter) @BeanProperty val x = 0
  * }
  * ```
  *
@@ -55,11 +61,12 @@ import scala.language.`2.13`
  *
  * The syntax can be improved using a type alias:
  *
- * ```
- * object ScalaJPA {
- *   type Id = javax.persistence.Id @beanGetter
+ * ```scala sc-compile-with:bean-imports
+ * class MyId extends Annotation
+ * object ScalaAnnotation {
+ *   type Id = MyId @beanGetter
  * }
- * import ScalaJPA.Id
+ * import ScalaAnnotation.Id
  * class A {
  *   @Id @BeanProperty val x = 0
  * }
@@ -70,7 +77,11 @@ import scala.language.`2.13`
  * For annotations defined in Scala, a default target can be specified
  * in the annotation class itself, for example
  *
+ * ```scala sc-hidden sc-name:getter-imports
+ * import scala.annotation.Annotation
+ * import scala.annotation.meta.getter
  * ```
+ * ```scala sc-compile-with:getter-imports
  * @getter
  * class myAnnotation extends Annotation
  * ```

--- a/library/src/scala/annotation/meta/superArg.scala
+++ b/library/src/scala/annotation/meta/superArg.scala
@@ -17,18 +17,24 @@ import scala.language.`2.13`
 
 /** This internal annotation encodes arguments passed to annotation superclasses. Example:
  *
- *  ```
- *   class a(x: Int) extends Annotation
- *   class b extends a(42) // the compiler adds `@superArg("x", 42)` to class b
- *  ```
+ * ```scala sc-hidden sc-name:superarg-imports
+ * import scala.annotation.Annotation
+ * ```
+ * ```scala sc-compile-with:superarg-imports
+ * class a(x: Int) extends Annotation
+ * class b extends a(42) // the compiler adds `@superArg("x", 42)` to class b
+ * ```
  */
 class superArg(p: String, v: Any) extends StaticAnnotation
 
 /** This internal annotation encodes arguments passed to annotation superclasses. Example:
  *
- *  ```
- *   class a(x: Int) extends Annotation
- *   class b(y: Int) extends a(y) // the compiler adds `@superFwdArg("x", "y")` to class b
- *  ```
+ * ```scala sc-hidden sc-name:superarg-imports
+ * import scala.annotation.Annotation
+ * ```
+ * ```scala sc-compile-with:superarg-imports
+ * class a(x: Int) extends Annotation
+ * class b(y: Int) extends a(y) // the compiler adds `@superFwdArg("x", "y")` to class b
+ * ```
  */
 class superFwdArg(p: String, n: String) extends StaticAnnotation


### PR DESCRIPTION
Added sc-compile to code snippets under scala.annotation package, used sc-name and sc-hidden for context code, and adjusted code snippets to make them compile.