### PR TITLE
enable strictEqualityPatternMatching behaviour for non-case objects

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1074,7 +1074,7 @@ trait Implicits:
     || locally:
       if strictEquality then
         strictEqualityPatternMatching &&
-          (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.isAllOf(Flags.Module | Flags.Case)) &&
+          (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
           ltp <:< lift(rtp)
       else
         ltp <:< lift(rtp) || rtp <:< lift(ltp)

--- a/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
+++ b/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
@@ -36,7 +36,7 @@ class SIP67Tests extends DottyTest:
       sealed trait Foo
 
       object Foo:
-        case object Bar extends Foo
+        object Bar extends Foo
 
       val _ =
         (??? : Foo) match


### PR DESCRIPTION
Hi,

after collecting feedback for strictEqualityPatternMatching ([SIP-67](https://github.com/scala/improvement-proposals/pull/97)), I've come to the conclusion that only enabling this behaviour for `case object`s isn't useful and it's better to enable it for all `object`s. Declaring ADTs without the `case` modifier for the relevant objects isn't that uncommon and there's no reason to not have it work in that case, too.
I've amended SIP-67 accordingly and I hope the SIP committee will approve the change soon.
