### PR TITLE
Iterate `where:` explanations to fixed point

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -221,18 +221,19 @@ object Message:
         case ref: Capability     => ref.isTerminalCapability
       }
 
-      val toExplain: List[(String, Recorded)] = seen.toList.flatMap { kvs =>
-        val res: List[(String, Recorded)] = kvs match {
-          case (key, entry :: Nil) =>
-            if (needsExplanation(entry)) (key.str, entry) :: Nil else Nil
-          case (key, entries) =>
-            for (alt <- entries) yield {
-              val tickedString = record(key.str, key.isType, alt)
-              (tickedString, alt)
-            }
-        }
-        res // help the inferencer out
-      }.sortBy(_._1)
+      def collectToExplain(): List[(String, Recorded)] =
+        seen.toList.flatMap { kvs =>
+          val res: List[(String, Recorded)] = kvs match {
+            case (key, entry :: Nil) =>
+              if (needsExplanation(entry)) (key.str, entry) :: Nil else Nil
+            case (key, entries) =>
+              for (alt <- entries) yield {
+                val tickedString = record(key.str, key.isType, alt)
+                (tickedString, alt)
+              }
+          }
+          res // help the inferencer out
+        }.sortBy(_._1)
 
       def columnar(parts: List[(String, String)]): List[String] =
         lazy val maxLen = parts.map(_._1.length).max
@@ -240,14 +241,19 @@ object Message:
           val variable = hl(leader)
           s"""$variable${" " * (maxLen - leader.length)} $trailer"""
 
-      // Group keys with the same Recorded entry together. We can't use groupBy here
-      // since we want to maintain the order in which entries first appear in the
-      //  original list.
-      val toExplainGrouped: List[(Recorded, List[String])] =
-        for entry <- toExplain.map(_._2).distinct
-        yield (entry, for (key, e) <- toExplain if e == entry yield key)
-      val explainParts = toExplainGrouped.map:
-        (entry, keys) => (keys.mkString(" and "), explanation(entry, keys))
+      // Rendering an explanation may record new entries (e.g. a type variable's
+      // constraint mentioning another type variable). Iterate to a fixed point.
+      val explained = collection.mutable.LinkedHashMap.empty[Recorded, (List[String], String)]
+      var prev = -1
+      while prev != explained.size do
+        prev = explained.size
+        val toExplain = collectToExplain()
+        for entry <- toExplain.map(_._2).distinct if !explained.contains(entry) do
+          val keys = for (key, e) <- toExplain if e == entry yield key
+          explained(entry) = (keys, explanation(entry, keys))
+
+      val explainParts = explained.values.toList.map:
+        (keys, expl) => (keys.mkString(" and "), expl)
       val explainLines = columnar(explainParts)
       if (explainLines.isEmpty) "" else i"where:    $explainLines%\n          %\n"
     end explanations

--- a/tests/neg-custom-args/captures/boundary-homebrew.check
+++ b/tests/neg-custom-args/captures/boundary-homebrew.check
@@ -8,5 +8,8 @@
    |
    |where:    ^   refers to a root capability created in method test
    |          any is a root capability created in anonymous function of type (using l1²: boundary.Label[boundary.Label[Int]^²]^²): boundary.Label[Int]^² of parameter parameter l1 of method $anonfun
+   |          ^²  refers to the root capability caps.any
+   |          l1  is a parameter in an anonymous function in method test
+   |          l1² is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -32,10 +32,12 @@
   |
   |Note that capability `any²` cannot flow into capture set {any}.
   |
-  |where:    ^    refers to the root capability caps.any
-  |          ^²   refers to a root capability classified as Control in the type of value local²
-  |          any  is a root capability classified as Control created in object test when checking argument to parameter label of method break
-  |          any² is a root capability classified as Control in the type of value local
+  |where:    ^      refers to the root capability caps.any
+  |          ^²     refers to a root capability classified as Control in the type of value local²
+  |          any    is a root capability classified as Control created in object test when checking argument to parameter label of method break
+  |          any²   is a root capability classified as Control in the type of value local
+  |          local  is a value locally defined in object test
+  |          local² is a value locally defined in object test
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/boundary.scala:5:4 ---------------------------------------

--- a/tests/neg-custom-args/captures/classifiers-secondclass.check
+++ b/tests/neg-custom-args/captures/classifiers-secondclass.check
@@ -5,6 +5,9 @@
    |of an enclosing function literal with expected type (Int, Int) ->{any.only[Read]} Int.
    |
    |where:    any is a root capability created in anonymous function of type (f²: Levels.File^): Unit when checking argument to parameter op of method parReduce
+   |          ^   refers to the root capability caps.any
+   |          f   is a parameter in an anonymous function in method test
+   |          f²  is a reference to a value parameter
 -- [E223] CaptureChecking Error: tests/neg-custom-args/captures/classifiers-secondclass.scala:54:12 --------------------
 54 |          f.write(42)         // error, the error stems from here
    |          ^^^^^^^
@@ -12,6 +15,7 @@
    |of an enclosing function literal with expected type (Int, Int) ->{any.only[Read]} Int.
    |
    |where:    any is a root capability created in anonymous function of type (g: Levels.File^): Unit when checking argument to parameter op of method parReduce
+   |          ^   refers to the root capability caps.any
 -- [E223] CaptureChecking Error: tests/neg-custom-args/captures/classifiers-secondclass.scala:57:12 --------------------
 57 |          g.write(42)         // error, the error stems from here
    |          ^^^^^^^
@@ -19,3 +23,6 @@
    |of an enclosing function literal with expected type (Int, Int) ->{any.only[Read]} Int.
    |
    |where:    any is a root capability created in anonymous function of type (g²: Levels.File^): Unit when checking argument to parameter op of method parReduce
+   |          ^   refers to the root capability caps.any
+   |          g   is a parameter in an anonymous function in method testMulti
+   |          g²  is a reference to a value parameter

--- a/tests/neg-custom-args/captures/freeze-boxes.check
+++ b/tests/neg-custom-args/captures/freeze-boxes.check
@@ -17,8 +17,9 @@
    |of value a with type Ref^.
    |This type hides capabilities  {any}
    |
-   |where:    ^   refers to a root capability classified as Unscoped in the type of value a
-   |          any is a root capability classified as Unscoped created in value a when instantiating method allocRef's type (): Ref^{fresh}
+   |where:    ^     refers to a root capability classified as Unscoped in the type of value a
+   |          any   is a root capability classified as Unscoped created in value a when instantiating method allocRef's type (): Ref^{fresh}
+   |          fresh is a root capability associated with the result type of (): Ref^{fresh}
 -- Error: tests/neg-custom-args/captures/freeze-boxes.scala:31:6 -------------------------------------------------------
 31 |  par(() => a.set(42), () => println(b.get))  // error
    |      ^^^^^^^^^^^^^^^

--- a/tests/neg-custom-args/captures/i15772.check
+++ b/tests/neg-custom-args/captures/i15772.check
@@ -21,15 +21,17 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i15772.scala:35:33 ---------------------------------------
 35 |  val boxed2 : Observe[C]^ = box2(c) // error
    |                             ^^^^^^^
-   |      Found:    (C{val arg: C^}^{any} => Unit) -> Unit
-   |      Required: (C => Unit) =>² Unit
+   |    Found:    (C{val arg: C^}^{any} => Unit) -> Unit
+   |    Required: (C => Unit) =>² Unit
    |
-   |      Note that capability `any` cannot flow into capture set {}.
+   |    Note that capability `any` cannot flow into capture set {}.
    |
-   |      where:    =>  refers to the root capability caps.any
-   |                =>² refers to a root capability in the type of value boxed2
-   |                ^   refers to a root capability in the type of value arg
-   |                any is a root capability created in value boxed2 when instantiating method c's type -> C^{fresh}
+   |    where:    =>    refers to the root capability caps.any
+   |              =>²   refers to a root capability in the type of value boxed2
+   |              ^     refers to a root capability in the type of value arg
+   |              any   is a root capability created in value boxed2 when instantiating method c's type -> C^{fresh}
+   |              fresh is a root capability associated with the result type of -> C^²
+   |              ^²    refers to a root capability in the result type of method c
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i15772.scala:46:2 ----------------------------------------

--- a/tests/neg-custom-args/captures/i15923.check
+++ b/tests/neg-custom-args/captures/i15923.check
@@ -7,6 +7,9 @@
    |Found:    Id[Cap^{any}]^'s2
    |Required: Id[Cap^'s1]^'s3
    |
-   |where:    any is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): Cap^{lcap} ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
+   |where:    any   is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): Cap^{lcap} ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
+   |          ^     refers to the root capability caps.any
+   |          lcap  is a reference to a value parameter
+   |          lcap² is a parameter in an anonymous function in method bar
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i16226.check
+++ b/tests/neg-custom-args/captures/i16226.check
@@ -7,8 +7,13 @@
    |Note that capability `f1` cannot flow into capture set {any}
    |because (f1 : A => B) in an enclosing function is not visible from any in method mapc.
    |
-   |where:    =>  refers to a root capability created in anonymous function of type (ref1²: LazyRef[A]^{io}, f1²: A => B): LazyRef[B]^ of parameter parameter f1 of method $anonfun
-   |          any is a root capability in the result type of method mapc
+   |where:    =>    refers to a root capability created in anonymous function of type (ref1²: LazyRef[A]^{io}, f1²: A => B): LazyRef[B]^ of parameter parameter f1 of method $anonfun
+   |          any   is a root capability in the result type of method mapc
+   |          ^     refers to the root capability caps.any
+   |          f1    is a parameter in an anonymous function in method mapc
+   |          f1²   is a reference to a value parameter
+   |          ref1  is a parameter in an anonymous function in method mapc
+   |          ref1² is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i16226.scala:15:27 ---------------------------------------
@@ -20,7 +25,12 @@
    |Note that capability `f1` cannot flow into capture set {any}
    |because (f1 : A => B) in an enclosing function is not visible from any in method mapd.
    |
-   |where:    =>  refers to a root capability created in anonymous function of type (ref1²: LazyRef[A]^{io}, f1²: A => B): LazyRef[B]^ of parameter parameter f1 of method $anonfun
-   |          any is a root capability in the result type of method mapd
+   |where:    =>    refers to a root capability created in anonymous function of type (ref1²: LazyRef[A]^{io}, f1²: A => B): LazyRef[B]^ of parameter parameter f1 of method $anonfun
+   |          any   is a root capability in the result type of method mapd
+   |          ^     refers to the root capability caps.any
+   |          f1    is a parameter in an anonymous function in method mapd
+   |          f1²   is a reference to a value parameter
+   |          ref1  is a parameter in an anonymous function in method mapd
+   |          ref1² is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i21401.check
+++ b/tests/neg-custom-args/captures/i21401.check
@@ -9,6 +9,9 @@
    |
    |where:    ^   refers to a root capability created in anonymous function of type (x²: IO^²): IO^² of parameter parameter x of method $anonfun
    |          any is a root capability created in value a
+   |          ^²  refers to the root capability caps.any
+   |          x   is a parameter in an anonymous function in method test2
+   |          x²  is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/i21401.scala:16:66 ------------------------------------------------------------

--- a/tests/neg-custom-args/captures/i21614.check
+++ b/tests/neg-custom-args/captures/i21614.check
@@ -8,6 +8,8 @@
    |
    |where:    any  is a root capability classified as SharedCapability created in anonymous function of type (f²: F): Logger when checking argument to parameter f of constructor Logger
    |          any² is a root capability classified as SharedCapability in the type of parameter f
+   |          f    is a parameter in an anonymous function in method mkLoggers1
+   |          f²   is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i21614.scala:15:12 ---------------------------------------

--- a/tests/neg-custom-args/captures/i23431.check
+++ b/tests/neg-custom-args/captures/i23431.check
@@ -33,8 +33,11 @@
    |Note that capability `io3` cannot flow into capture set {any}
    |because (io3 : IO^) in an enclosing function is not visible from any in variable myIO.
    |
-   |where:    ^   refers to a root capability created in anonymous function of type (io3²: IO^²): Unit of parameter parameter io3 of method $anonfun
-   |          any is a root capability in the type of variable myIO
+   |where:    ^    refers to a root capability created in anonymous function of type (io3²: IO^²): Unit of parameter parameter io3 of method $anonfun
+   |          any  is a root capability in the type of variable myIO
+   |          ^²   refers to the root capability caps.any
+   |          io3  is a parameter in an anonymous function in method test
+   |          io3² is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/i23431.scala:6:14 -------------------------------------------------------------

--- a/tests/neg-custom-args/captures/indirect-avoid.check
+++ b/tests/neg-custom-args/captures/indirect-avoid.check
@@ -15,7 +15,9 @@
    |
    |Note that capability `any.rd` cannot flow into capture set {}.
    |
-   |where:    any is a root capability created in value x1 when instantiating method filterImpl1's type (ll: Test.LL^): Test.LL^{fresh.rd, ll}
+   |where:    any   is a root capability created in value x1 when instantiating method filterImpl1's type (ll: Test.LL^): Test.LL^{fresh.rd, ll}
+   |          ^     refers to the root capability caps.any
+   |          fresh is a root capability associated with the result type of (ll: Test.LL^): Test.LL^{fresh.rd, ll}
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/indirect-avoid.scala:32:4 --------------------------------
@@ -34,4 +36,6 @@
    |Fields capturing a root capability need to be given an explicit type unless the capability is already
    |subsumed by the computed capability of the enclosing class.
    |
-   |where:    any is a root capability created in value x1 when instantiating method filterImpl1's type (ll: Test.LL^): Test.LL^{fresh.rd, ll}
+   |where:    any   is a root capability created in value x1 when instantiating method filterImpl1's type (ll: Test.LL^): Test.LL^{fresh.rd, ll}
+   |          ^     refers to the root capability caps.any
+   |          fresh is a root capability associated with the result type of (ll: Test.LL^): Test.LL^{fresh.rd, ll}

--- a/tests/neg-custom-args/captures/lazyListState.check
+++ b/tests/neg-custom-args/captures/lazyListState.check
@@ -6,5 +6,8 @@
    |
    |               where:    ^     refers to a root capability in the type of value tail
    |                         fresh is a root capability associated with the result type of -> LazyListIterable[A²]^²
+   |                         A     is a type in class Cons
+   |                         A²    is a type in trait State
+   |                         ^²    refers to a root capability in the result type of method tail
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lazylist-global.check
+++ b/tests/neg-custom-args/captures/lazylist-global.check
@@ -54,5 +54,6 @@
    |        method tail of type -> lazylists.LazyList[Nothing]^{fresh} has incompatible type
    |
    |      where:    fresh is a root capability associated with the result type of -> lazylists.LazyList[Nothing]^
+   |                ^     refers to a root capability in the result type of method tail
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lazylist.check
+++ b/tests/neg-custom-args/captures/lazylist.check
@@ -50,5 +50,6 @@
    |        method tail of type -> lazylists.LazyList[Nothing]^{fresh} has incompatible type
    |
    |      where:    fresh is a root capability associated with the result type of -> lazylists.LazyList[Nothing]^
+   |                ^     refers to a root capability in the result type of method tail
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/mut-iterator4.check
+++ b/tests/neg-custom-args/captures/mut-iterator4.check
@@ -11,7 +11,8 @@
    |
    |Note that capability `any` cannot flow into capture set {it, f}.
    |
-   |where:    any is a root capability created in method mappedIterator when constructing instance Object with (Iterator[U]^{any².rd}) {...}
+   |where:    any  is a root capability created in method mappedIterator when constructing instance Object with (Iterator[U]^{any².rd}) {...}
+   |          any² is a root capability created in method mappedIterator
    |
 22 |  def hasNext = it.hasNext
 23 |  update def next() = f(it.next())

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -41,6 +41,9 @@
    |
    |where:    ^   refers to a root capability created in anonymous function of type (x²: File^²): File^² of parameter parameter x of method $anonfun
    |          any is a root capability in the type of value id
+   |          ^²  refers to the root capability caps.any
+   |          x   is a parameter in an anonymous function in method attack2
+   |          x²  is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/reaches.scala:71:27 --------------------------------------
@@ -51,7 +54,9 @@
    |
    |Note that capability `any` cannot flow into capture set {id*}.
    |
-   |where:    any is a root capability created in value f1 when instantiating function value id's type (x: File^): File^{fresh}
+   |where:    any   is a root capability created in value f1 when instantiating function value id's type (x: File^): File^{fresh}
+   |          ^     refers to the root capability caps.any
+   |          fresh is a root capability associated with the result type of (x: File^): File^{fresh}
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/reaches.scala:39:31 -----------------------------------------------------------

--- a/tests/neg-custom-args/captures/refine-reach-shallow.check
+++ b/tests/neg-custom-args/captures/refine-reach-shallow.check
@@ -9,6 +9,9 @@
   |
   |where:    ^   refers to a root capability created in anonymous function of type (x²: IO^²): IO^² of parameter parameter x of method $anonfun
   |          any is a root capability in the type of value f
+  |          ^²  refers to the root capability caps.any
+  |          x   is a parameter in an anonymous function in method test1
+  |          x²  is a reference to a value parameter
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/refine-reach-shallow.scala:10:38 -------------------------

--- a/tests/neg-custom-args/captures/scoped-caps.check
+++ b/tests/neg-custom-args/captures/scoped-caps.check
@@ -63,8 +63,10 @@
    |Note that capability `any` cannot flow into capture set {any²}
    |because any in an enclosing function is not visible from any² in value _$13.
    |
-   |where:    any  is a root capability created in anonymous function of type (x: S): B^ when instantiating function value j's type (x: S^): B^{fresh}
-   |          any² is a root capability in the type of value _$13
+   |where:    any   is a root capability created in anonymous function of type (x: S): B^ when instantiating function value j's type (x: S^): B^{fresh}
+   |          any²  is a root capability in the type of value _$13
+   |          ^     refers to the root capability caps.any
+   |          fresh is a root capability associated with the result type of (x: S^): B^{fresh}
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps.scala:30:19 ----------------------------------
@@ -90,7 +92,9 @@
    |Note that capability `any` cannot flow into capture set {any²}
    |because any in an enclosing function is not visible from any² in value _$16.
    |
-   |where:    any  is a root capability created in anonymous function of type (x: S): B^ when instantiating function value j's type (x: S^): B^{fresh}
-   |          any² is a root capability in the type of value _$16
+   |where:    any   is a root capability created in anonymous function of type (x: S): B^ when instantiating function value j's type (x: S^): B^{fresh}
+   |          any²  is a root capability in the type of value _$16
+   |          ^     refers to the root capability caps.any
+   |          fresh is a root capability associated with the result type of (x: S^): B^{fresh}
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/scoped-caps2.check
+++ b/tests/neg-custom-args/captures/scoped-caps2.check
@@ -35,8 +35,10 @@
   |Note that capability `any` cannot flow into capture set {any²}
   |because any in an enclosing function is not visible from any² in value _$4.
   |
-  |where:    any  is a root capability classified as SharedCapability created in anonymous function of type (x: C): C when instantiating function value a's type (x: C^): C^{fresh}
-  |          any² is a root capability classified as SharedCapability in the type of value _$4
+  |where:    any   is a root capability classified as SharedCapability created in anonymous function of type (x: C): C when instantiating function value a's type (x: C^): C^{fresh}
+  |          any²  is a root capability classified as SharedCapability in the type of value _$4
+  |          ^     refers to the root capability caps.any
+  |          fresh is a root capability associated with the result type of (x: C^): C^{fresh}
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps2.scala:15:18 ---------------------------------
@@ -62,7 +64,9 @@
    |Note that capability `any` cannot flow into capture set {any²}
    |because any in an enclosing function is not visible from any² in value _$8.
    |
-   |where:    any  is a root capability classified as SharedCapability created in anonymous function of type (x: C): C when instantiating function value a's type (x: C^): C^{fresh}
-   |          any² is a root capability classified as SharedCapability in the type of value _$8
+   |where:    any   is a root capability classified as SharedCapability created in anonymous function of type (x: C): C when instantiating function value a's type (x: C^): C^{fresh}
+   |          any²  is a root capability classified as SharedCapability in the type of value _$8
+   |          ^     refers to the root capability caps.any
+   |          fresh is a root capability associated with the result type of (x: C^): C^{fresh}
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/sep-compose.check
+++ b/tests/neg-custom-args/captures/sep-compose.check
@@ -126,3 +126,5 @@
    |  The two sets overlap at               : {a, io}
    |
    |where:    => refers to a root capability created in anonymous function of type (x²: () ->{a} Unit): Unit when checking argument to parameter x of method seq8
+   |          x  is a parameter in an anonymous function in method test
+   |          x² is a reference to a value parameter

--- a/tests/neg-custom-args/captures/sep-curried-par.check
+++ b/tests/neg-custom-args/captures/sep-curried-par.check
@@ -61,6 +61,9 @@
    |
    |where:    =>  refers to a root capability in the type of parameter p1
    |          =>² refers to a root capability created in anonymous function of type (p2²: () ->{p1, any} Unit): Unit when checking argument to parameter p1 of method par
+   |          any is the root capability caps.any
+   |          p2  is a parameter in an anonymous function in method test
+   |          p2² is a reference to a value parameter
 -- Error: tests/neg-custom-args/captures/sep-curried-par.scala:24:9 ----------------------------------------------------
 24 |  bar(c)(c) // error separation
    |         ^

--- a/tests/neg-custom-args/captures/widen-reach.check
+++ b/tests/neg-custom-args/captures/widen-reach.check
@@ -16,6 +16,9 @@
   |
   |where:    ^   refers to a root capability created in anonymous function of type (x²: IO^²): IO^² of parameter parameter x of method $anonfun
   |          any is a root capability in the type of value foo
+  |          ^²  refers to the root capability caps.any
+  |          x   is a parameter in an anonymous function in trait Bar
+  |          x²  is a reference to a value parameter
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/widen-reach.scala:13:26 ----------------------------------

--- a/tests/neg-custom-args/captures/withFile.check
+++ b/tests/neg-custom-args/captures/withFile.check
@@ -42,6 +42,9 @@
    |
    |where:    ^   refers to a root capability created in anonymous function of type (f²: Test2.File^²): Test2.Box[Test2.File^²] of parameter parameter f of method $anonfun
    |          any is a root capability created in value later4
+   |          ^²  refers to the root capability caps.any
+   |          f   is a parameter in an anonymous function in object Test2
+   |          f²  is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/withFile.scala:16:20 ----------------------------------------------------------

--- a/tests/neg/cc-fresh-levels.check
+++ b/tests/neg/cc-fresh-levels.check
@@ -33,7 +33,10 @@
    |Note that capability `innerIO` cannot flow into capture set {any}
    |because (innerIO : IO^) in an enclosing function is not visible from any in value r.
    |
-   |where:    ^   refers to a root capability created in anonymous function of type (innerIO²: IO^²): Unit of parameter parameter innerIO of method $anonfun
-   |          any is a root capability in the type of value r
+   |where:    ^        refers to a root capability created in anonymous function of type (innerIO²: IO^²): Unit of parameter parameter innerIO of method $anonfun
+   |          any      is a root capability in the type of value r
+   |          ^²       refers to the root capability caps.any
+   |          innerIO  is a parameter in an anonymous function in method test1
+   |          innerIO² is a reference to a value parameter
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg/i24096.check
+++ b/tests/neg/i24096.check
@@ -6,5 +6,7 @@
    |
    |                   where:    F  is a type in class StreamPullOps with bounds <: [_²] =>> Any
    |                             F2 is a type in method flatMapOutput with bounds >: [x] =>> F[x] and <: [x] =>> Any
+   |                             _  is a type in method flatMapOutput
+   |                             _² is a type variable
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg/nested-tvar-explanation.check
+++ b/tests/neg/nested-tvar-explanation.check
@@ -4,3 +4,4 @@
   |                     No given instance of type W was found for parameter w of method min
   |
   |                     where:    W is a type variable with constraint <: Ord[V] & Double
+  |                               V is a type variable

--- a/tests/neg/nested-tvar-explanation.check
+++ b/tests/neg/nested-tvar-explanation.check
@@ -1,0 +1,6 @@
+-- [E172] Type Error: tests/neg/nested-tvar-explanation.scala:8:21 -----------------------------------------------------
+8 |def test = foo(min(3)) // error
+  |                     ^
+  |                     No given instance of type W was found for parameter w of method min
+  |
+  |                     where:    W is a type variable with constraint <: Ord[V] & Double

--- a/tests/neg/nested-tvar-explanation.scala
+++ b/tests/neg/nested-tvar-explanation.scala
@@ -1,0 +1,8 @@
+trait Ord[T]
+trait Op[A, V]
+object Op:
+  given Op[Int, Int] = new Op[Int, Int] {}
+
+def min[A, V, W <: Ord[V]](x: A)(implicit op: Op[A, V], w: W): W = w
+def foo(x: Double) = ???
+def test = foo(min(3)) // error


### PR DESCRIPTION
When a recorded type's explanation in the `where:` clause mentions another recorded type that also needs explanation, the latter is silently dropped. This happens because `explanations` collects the entries to explain once, up front, and then renders each one; rendering an explanation for entry `X` may call `ParamRefNameString` (or similar) on entries nested inside `X`'s bounds, which adds them to `seen` — but too late for the pass that produced the final output.

Concretely, for

```scala
trait Ord[T]
trait Op[A, V]
object Op:
  given Op[Int, Int] = new Op[Int, Int] {}

def min[A, V, W <: Ord[V]](x: A)(implicit op: Op[A, V], w: W): W = w
def foo(x: Double) = ???
def test = foo(min(3)) // error
```

we used to get:

```
where:    W is a type variable with constraint <: Ord[V] & Double
```

with no explanation for `V`. After this change:

```
where:    W is a type variable with constraint <: Ord[V] & Double
          V is a type variable
```

The fix is to iterate the explanation loop to a fixed point: as long as rendering an explanation causes a new entry to be recorded, collect and explain it in the next round. This also surfaces a number of previously missing explanations in capture-checking error messages (nested `^²`, anonymous-function parameters, etc.), which account for the bulk of the checkfile updates.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for everything.

## How was the solution tested?

One new test showing the change, plus existing checkfiles updates.
