### PR TITLE
Improve the test for creating protected method accessors for inlines

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
@@ -76,7 +76,7 @@ object PrepareInlineable {
         def referencesInlineContainedClassDef(tree: Tree): Boolean = tree match
           case Apply(qual, _) => referencesInlineContainedClassDef(qual)
           case TypeApply(qual, _) => referencesInlineContainedClassDef(qual)
-          case Select(qual, _) => qual.symbol.isContainedIn(inlineSym)
+          case Select(qual, _) => qual.tpe.isInstanceOf[ThisType] && qual.symbol.isContainedIn(inlineSym)
           case _ => false
         val sym = refTree.symbol
         sym.isTerm &&

--- a/tests/pos/i25542.scala
+++ b/tests/pos/i25542.scala
@@ -1,0 +1,16 @@
+class PartialRequest:
+  protected def handle(i: Int): Int = i
+
+object PartialRequest:
+  trait Bundler:
+    def bundle(req: PartialRequest): Int => Int
+
+  object Bundler:
+    inline given Bundler = new Bundler:
+      def bundle(req: PartialRequest): Int => Int =
+        (i: Int) => req.handle(i)
+
+  def apply()(using bundler: Bundler): Int => Int =
+    bundler.bundle(new PartialRequest)
+
+val request = PartialRequest()


### PR DESCRIPTION
Fixes #25542
In the regressive commit, I failed to predict that the accessed protected definition in the inline could be owner by another, unrelated instance of the class. The accessors are generated correctly for these cases now.

## How much have you relied on LLM-based tools in this contribution?

For figuring out how the self symbols in  `Idents` are recognized in the rest of the compiler.


## How was the solution tested?
Added the regression test from the issue. Unsuccessfully tried to figure out another test that would break the added check. 
