### PR TITLE
Backport "Improve the test for creating protected method accessors for inlines" to 3.8.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/PrepareInlineable.scala
@@ -76,7 +76,7 @@ object PrepareInlineable {
         def referencesInlineContainedClassDef(tree: Tree): Boolean = tree match
           case Apply(qual, _) => referencesInlineContainedClassDef(qual)
           case TypeApply(qual, _) => referencesInlineContainedClassDef(qual)
-          case Select(qual, _) => qual.symbol.isContainedIn(inlineSym)
+          case Select(qual, _) => qual.tpe.isInstanceOf[ThisType] && qual.symbol.isContainedIn(inlineSym)
           case _ => false
         val sym = refTree.symbol
         sym.isTerm &&

--- a/tests/pos/i25542.scala
+++ b/tests/pos/i25542.scala
@@ -1,0 +1,16 @@
+class PartialRequest:
+  protected def handle(i: Int): Int = i
+
+object PartialRequest:
+  trait Bundler:
+    def bundle(req: PartialRequest): Int => Int
+
+  object Bundler:
+    inline given Bundler = new Bundler:
+      def bundle(req: PartialRequest): Int => Int =
+        (i: Int) => req.handle(i)
+
+  def apply()(using bundler: Bundler): Int => Int =
+    bundler.bundle(new PartialRequest)
+
+val request = PartialRequest()


### PR DESCRIPTION
Backports #25865 to the 3.8.4-RC2.

PR submitted by the release tooling.