### PR TITLE
Honest nulls in the Scala.js backend.

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -1,7 +1,5 @@
 package dotty.tools.backend.sjs
 
-import scala.language.unsafeNulls
-
 import scala.annotation.switch
 import scala.collection.mutable
 
@@ -90,14 +88,14 @@ class JSCodeGen()(using genCtx: Context) {
   /** Resets all of the scoped state in the context of `body`. */
   private def resetAllScopedVars[T](body: => T): T = {
     withScopedVars(
-        currentClassSym := null,
-        delambdafyTargetDefDefs := null,
-        methodsAllowingJSAwait := null,
-        currentMethodSym := null,
-        localNames := null,
-        thisLocalVarName := null,
-        isModuleInitialized := null,
-        undefinedDefaultParams := null
+        currentClassSym.unset,
+        delambdafyTargetDefDefs.unset,
+        methodsAllowingJSAwait.unset,
+        currentMethodSym.unset,
+        localNames.unset,
+        thisLocalVarName.unset,
+        isModuleInitialized.unset,
+        undefinedDefaultParams.unset
     ) {
       body
     }

--- a/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSDefinitions.scala
@@ -1,7 +1,5 @@
 package dotty.tools.backend.sjs
 
-import scala.language.unsafeNulls
-
 import scala.annotation.threadUnsafe
 
 import dotty.tools.dotc.core.*

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -1,7 +1,5 @@
 package dotty.tools.backend.sjs
 
-import scala.language.unsafeNulls
-
 import scala.collection.mutable
 
 import dotty.tools.dotc.core.*

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -1,7 +1,5 @@
 package dotty.tools.backend.sjs
 
-import scala.language.unsafeNulls
-
 import scala.annotation.tailrec
 import scala.collection.mutable
 
@@ -976,7 +974,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
     private val fixedParamNames: scala.collection.immutable.IndexedSeq[jsNames.LocalName] =
       (0 until minArgc).toIndexedSeq.map(_ => freshLocalIdent("arg")(using NoPosition).name)
 
-    private val restParamName: jsNames.LocalName =
+    private val restParamName: jsNames.LocalName | Null =
       if (needsRestParam) freshLocalIdent("rest")(using NoPosition).name
       else null
 
@@ -986,7 +984,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
       }
 
       val restParam = {
-        if (needsRestParam)
+        if (restParamName != null)
           Some(js.ParamDef(js.LocalIdent(restParamName), NoOriginalName, jstpe.AnyType, mutable = false))
         else
           None
@@ -1012,7 +1010,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
     }
 
     def genRestArgRef()(implicit pos: Position): js.Tree = {
-      assert(needsRestParam, s"trying to generate a reference to non-existent rest param at $pos")
+      assert(restParamName != null, s"trying to generate a reference to non-existent rest param at $pos")
       js.VarRef(restParamName)(jstpe.AnyType)
     }
 
@@ -1021,7 +1019,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
         js.VarRef(paramName)(jstpe.AnyType)
       }
 
-      if (needsRestParam) {
+      if (restParamName != null) {
         val restArgRef = js.VarRef(restParamName)(jstpe.AnyType)
         fixedArgRefs :+ js.JSSpread(restArgRef)
       } else {

--- a/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSPositions.scala
@@ -1,7 +1,5 @@
 package dotty.tools.backend.sjs
 
-import scala.language.unsafeNulls
-
 import java.net.{URI, URISyntaxException}
 
 import dotty.tools.dotc.core.*
@@ -66,15 +64,15 @@ class JSPositions()(using Context) {
   private object span2irPosCache {
     import dotty.tools.dotc.util.*
 
-    private var lastDotcSource: SourceFile = null
-    private var lastIRSource: ir.Position.SourceFile = null
+    private var lastDotcSource: SourceFile | Null = null
+    private var lastIRSource: ir.Position.SourceFile | Null = null
 
     def toIRSource(dotcSource: SourceFile): ir.Position.SourceFile = {
       if (dotcSource != lastDotcSource) {
         lastIRSource = convert(dotcSource)
         lastDotcSource = dotcSource
       }
-      lastIRSource
+      lastIRSource.nn
     }
 
     private def convert(dotcSource: SourceFile): ir.Position.SourceFile = {

--- a/compiler/src/dotty/tools/backend/sjs/ScopedVar.scala
+++ b/compiler/src/dotty/tools/backend/sjs/ScopedVar.scala
@@ -1,18 +1,25 @@
 package dotty.tools.backend.sjs
 
-class ScopedVar[A](init: A) {
+final class ScopedVar[A <: AnyRef] private (init: A | Null, internal: Boolean) {
   import ScopedVar.Assignment
 
-  private[ScopedVar] var value = init
+  private[ScopedVar] var value: A | Null = init
 
-  def this()(implicit ev: Null <:< A) = this(ev(null))
+  def this(init: A) = this(init, true)
+  def this() = this(null, true)
 
-  def get: A = value
+  def get: A =
+    val v = value
+    assert(v != null, "Trying to read a ScopedVar that is not set in the current scope")
+    v
+
   def :=(newValue: A): Assignment[A] = new Assignment(this, newValue)
+
+  def unset: Assignment[A] = new Assignment(this, null)
 }
 
 object ScopedVar {
-  class Assignment[T](scVar: ScopedVar[T], value: T) {
+  class Assignment[T <: AnyRef] private[ScopedVar] (scVar: ScopedVar[T], value: T | Null) {
     private[ScopedVar] def push(): AssignmentStackElement[T] = {
       val stack = new AssignmentStackElement(scVar, scVar.value)
       scVar.value = value
@@ -20,13 +27,13 @@ object ScopedVar {
     }
   }
 
-  private class AssignmentStackElement[T](scVar: ScopedVar[T], oldValue: T) {
+  private class AssignmentStackElement[T <: AnyRef](scVar: ScopedVar[T], oldValue: T | Null) {
     private[ScopedVar] def pop(): Unit = {
       scVar.value = oldValue
     }
   }
 
-  implicit def toValue[T](scVar: ScopedVar[T]): T = scVar.get
+  implicit def toValue[T <: AnyRef](scVar: ScopedVar[T]): T = scVar.get
 
   def withScopedVars[T](ass: Assignment[?]*)(body: => T): T = {
     val stack = ass.map(_.push())


### PR DESCRIPTION
`ScopedVar`s are still somewhat dishonest. At least, they will fail as soon as we try to `get` their value, if it is unset. Previously, the `null` value could propagate further.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
