### PR TITLE
Enable sc:compile for stdlib package scala.math

### DIFF
--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -665,7 +665,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *  `[start;end)`, where start is the target BigDecimal.  The step
    *  must be supplied via the "by" method of the returned object in order
    *  to receive the fully constructed range.  For example:
-   *  ```
+  *  ```scala sc:compile
    *  val partial = BigDecimal(1.0) to 2.0       // not usable yet
    *  val range = partial by 0.01                // now a NumericRange
    *  val range2 = BigDecimal(0) to 1.0 by 0.01  // all at once of course is fine too

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -25,7 +25,8 @@ object Numeric {
     /** These implicits create conversions from a value for which an implicit Numeric
      *  exists to the inner class which creates infix operations.  Once imported, you
      *  can write methods as follows:
-     *  ```
+     *  ```scala sc:compile
+     *  import scala.math.Numeric.Implicits.*
      *  def plus[T: Numeric](x: T, y: T) = x + y
      *  ```
      */

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -34,7 +34,7 @@ import scala.language.implicitConversions
  *  [[scala.math.PartiallyOrdered]] is an alternative to this trait for partially ordered data.
  *
  *  For example, create a simple class that implements `Ordered` and then sort it with [[scala.util.Sorting]]:
- *  ```
+ *  ```scala sc:compile
  *  case class OrderedClass(n:Int) extends Ordered[OrderedClass] {
  *   def compare(that: OrderedClass) =  this.n - that.n
  *  }

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -29,15 +29,21 @@ import scala.annotation.unchecked.uncheckedOverride
  *  To sort instances by one or more member variables, you can take advantage
  *  of these built-in orderings using [[Ordering.by]] and [[Ordering.on]]:
  *
- *  ```
+ *  ```scala sc:compile
  *  import scala.util.Sorting
  *  val pairs = Array(("a", 5, 2), ("c", 3, 1), ("b", 1, 3))
  *
  *  // sort by 2nd element
- *  Sorting.quickSort(pairs)(Ordering.by[(String, Int, Int), Int](_._2))
+ *  {
+ *    given Ordering[(String, Int, Int)] = Ordering.by[(String, Int, Int), Int](_._2)
+ *    Sorting.quickSort(pairs)
+ *  }
  *
  *  // sort by the 3rd element, then 1st
- *  Sorting.quickSort(pairs)(Ordering[(Int, String)].on(x => (x._3, x._1)))
+ *  {
+ *    given Ordering[(String, Int, Int)] = Ordering.by[(String, Int, Int), (Int, String)](x => (x._3, x._1))
+ *    Sorting.quickSort(pairs)
+ *  }
  *  ```
  *
  *  An `Ordering[T]` is implemented by specifying the [[compare]] method,
@@ -47,7 +53,7 @@ import scala.annotation.unchecked.uncheckedOverride
  *
  *  For example:
  *
- *  ```
+ *  ```scala sc:compile
  *  import scala.util.Sorting
  *
  *  case class Person(name:String, age:Int)
@@ -57,7 +63,8 @@ import scala.annotation.unchecked.uncheckedOverride
  *  object AgeOrdering extends Ordering[Person] {
  *   def compare(a:Person, b:Person) = a.age.compare(b.age)
  *  }
- *  Sorting.quickSort(people)(AgeOrdering)
+ *  given Ordering[Person] = AgeOrdering
+ *  Sorting.quickSort(people)
  *  ```
  *
  *  This trait and [[scala.math.Ordered]] both provide this same functionality, but
@@ -134,8 +141,8 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   /** Given f, a function from U into T, creates an Ordering[U] whose compare
    *  function is equivalent to:
    *
-   *  ```
-   *  def compare(x:U, y:U) = Ordering[T].compare(f(x), f(y))
+  *  ```scala sc:compile
+  *  def compare[U, T: Ordering](x: U, y: U, f: U => T) = Ordering[T].compare(f(x), f(y))
    *  ```
    */
   def on[U](f: U => T): Ordering[U] = new Ordering[U] {
@@ -147,7 +154,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  or else the result of `other`s compare function.
    *
    *  @example
-   *  ```
+  *  ```scala sc:compile
    *  case class Pair(a: Int, b: Int)
    *
    *  val pairOrdering = Ordering.by[Pair, Int](_.a)
@@ -165,15 +172,15 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  function returns the result of this Ordering's compare function,
    *  if it is non-zero, or else a result equivalent to:
    *
-   *  ```
-   *  Ordering[S].compare(f(x), f(y))
+  *  ```scala sc:compile
+  *  def compare[T, S: Ordering](x: T, y: T, f: T => S) = Ordering[S].compare(f(x), f(y))
    *  ```
    *
    *  This function is equivalent to passing the result of `Ordering.by(f)`
    *  to `orElse`.
    *
    *  @example
-   *  ```
+  *  ```scala sc:compile
    *  case class Pair(a: Int, b: Int)
    *
    *  val pairOrdering = Ordering.by[Pair, Int](_.a)
@@ -302,8 +309,9 @@ object Ordering extends LowPriorityOrderingImplicits {
      *  implicit `Ordering` exists to the class which creates infix operations.
      *  With it imported, you can write methods as follows:
      *
-     *  ```
-     *  def lessThan[T: Ordering](x: T, y: T) = x < y
+    *  ```scala sc:compile
+    *  import scala.math.Ordering.Implicits.*
+    *  def lessThan[T: Ordering](x: T, y: T) = x < y
      *  ```
      */
     implicit def infixOrderingOps[T](x: T)(implicit ord: Ordering[T]): Ordering[T]#OrderingOps = new ord.OrderingOps(x)
@@ -325,8 +333,8 @@ object Ordering extends LowPriorityOrderingImplicits {
   /** Given f, a function from T into S, creates an Ordering[T] whose compare
    *  function is equivalent to:
    *
-   *  ```
-   *  def compare(x:T, y:T) = Ordering[S].compare(f(x), f(y))
+  *  ```scala sc:compile
+  *  def compare[T, S: Ordering](x: T, y: T, f: T => S) = Ordering[S].compare(f(x), f(y))
    *  ```
    *
    *  This function is an analogue to Ordering.on where the Ordering[S]
@@ -404,7 +412,7 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  `Float.NaN == Float.NaN` all yield `false`, analogous `None` in `flatMap`.
    *
    *
-   *  ```
+  *  ```scala sc:compile
    *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).sorted      // List(-Infinity, 0.0, 1.0, NaN)
    *  List(0.0F, 1.0F, 0.0F / 0.0F, -1.0F / 0.0F).min         // -Infinity
    *  implicitly[Ordering[Float]].lt(0.0F, 0.0F / 0.0F)       // true
@@ -501,7 +509,7 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  which brings back the `java.lang.Double.compare` semantics for all operations.
    *  The default extends `TotalOrdering`.
    *
-   *  ```
+  *  ```scala sc:compile
    *  List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).sorted      // List(-Infinity, 0.0, 1.0, NaN)
    *  List(0.0, 1.0, 0.0 / 0.0, -1.0 / 0.0).min         // -Infinity
    *  implicitly[Ordering[Double]].lt(0.0, 0.0 / 0.0)   // true


### PR DESCRIPTION
Added sc:compile to code snippets in scala source files under scala.math package.

