### PR TITLE
Prohibit Unsafe Wildcard Match-type Applications

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -127,7 +127,9 @@ object TypeApplications {
    *        C[..., ? >: L <: H, ...]
    *
    *  The `allReplaced` field indicates whether all occurrences of type lambda parameters
-   *  in the reduced type have been replaced with arguments.
+   *  in the reduced type have been replaced with arguments. This implements the
+   *  `admitsWildcard` condition of the spec section "Applications to Wildcard
+   *  Arguments": `allReplaced` is true iff it held for every wildcarded parameter.
    *
    *  2. If Mode.AllowLambdaWildcardApply is not set:
    *  All `X` arguments are replaced by:

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -171,6 +171,15 @@ object TypeApplications {
     }
 
     def apply(t: Type): Type = t match {
+      case t @ AppliedType(tycon, args1) if tycon.isRef(defn.MatchCaseClass) =>
+        // Match-type case patterns and case bodies are both invariant, unsafe
+        // positions for wildcard substitution. Substituting a wildcard here
+        // either makes a pattern spuriously match anything (for a top-level
+        // param in a pattern) or loses the relationship between occurrences
+        // (for a param used multiple times in a body). See issue #21013.
+        // Force nested-level treatment so wildcard substitution is skipped,
+        // leaving the AppliedType to be flagged by `isUnreducibleWild`.
+        t.derivedAppliedType(apply(tycon), args1.mapConserve(arg => atNestedLevel(apply(arg))))
       case t @ AppliedType(tycon, args1) if tycon.typeSymbol.isClass =>
         t.derivedAppliedType(apply(tycon), args1.mapConserve(applyArg))
       case t @ RefinedType(parent, name, TypeAlias(info)) =>

--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -112,7 +112,7 @@ object TypeApplications {
     else args.zipWithConserve(tparams)((arg, tparam) => arg.etaExpandIfHK(tparam.paramInfoOrCompleter))
 
   /** A type map that tries to reduce (part of) the result type of the type lambda `tycon`
-   *  with the given `args`(some of which are wildcard arguments represented by type bounds).
+   *  with the given `args` (some of which are wildcard arguments represented by type bounds).
    *  Non-wildcard arguments are substituted everywhere as usual. A wildcard argument
    *  `>: L <: H` is substituted for a type lambda parameter `X` only under certain conditions.
    *
@@ -134,8 +134,8 @@ object TypeApplications {
    *
    *        ? >: L <: H
    *
-   *  Any other occurrence of `X` in `tycon` is replaced by `U`, if the
-   *  occurrence of `X` in `tycon` is covariant, or nonvariant, or by `L`,
+   *  Any other occurrence of `X` in `tycon` is replaced by `H`, if the
+   *  occurrence of `X` in `tycon` is covariant or nonvariant, or by `L`,
    *  if the occurrence is contravariant.
    *
    *  The idea is that the `AllowLambdaWildcardApply` mode is used to check whether
@@ -171,14 +171,11 @@ object TypeApplications {
     }
 
     def apply(t: Type): Type = t match {
-      case t @ AppliedType(tycon, args1) if tycon.isRef(defn.MatchCaseClass) =>
-        // Match-type case patterns and case bodies are both invariant, unsafe
-        // positions for wildcard substitution. Substituting a wildcard here
-        // either makes a pattern spuriously match anything (for a top-level
-        // param in a pattern) or loses the relationship between occurrences
-        // (for a param used multiple times in a body). See issue #21013.
-        // Force nested-level treatment so wildcard substitution is skipped,
-        // leaving the AppliedType to be flagged by `isUnreducibleWild`.
+      case t @ AppliedType(tycon, args1)
+      if ctx.mode.is(Mode.AllowLambdaWildcardApply) && tycon.isRef(defn.MatchCaseClass) =>
+        // Don't substitute wildcards into case patterns or bodies: that is the
+        // unsound application we are checking for (#21013). Leaving them unreduced
+        // keeps `allReplaced` false, so `isUnreducibleWild` can flag it.
         t.derivedAppliedType(apply(tycon), args1.mapConserve(arg => atNestedLevel(apply(arg))))
       case t @ AppliedType(tycon, args1) if tycon.typeSymbol.isClass =>
         t.derivedAppliedType(apply(tycon), args1.mapConserve(applyArg))

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -401,7 +401,7 @@ object TypeOps:
           case (tp1 @ AppliedType(tycon1, args1), tp2 @ AppliedType(tycon2, args2))
           if tycon1.typeSymbol == tycon2.typeSymbol && (tycon1 =:= tycon2) =>
             mergeRefinedOrApplied(tp1, tp2) match
-              case tp: AppliedType if tp.isUnreducibleWild =>
+              case tp: AppliedType if tp.isUnreducibleWild(isInferred = true) =>
                 // fall back to or-dominators rather than inferring a type that would
                 // cause an unreducible type error later.
                 approximateOr(tp1, tp2)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4788,40 +4788,68 @@ object Types extends TypeUtils {
     /** Is this an unreducible application to wildcard arguments?
      *  This is the case if tycon is higher-kinded. This means
      *  it is a subtype of a hk-lambda. Match aliases are exempt unless the
-     *  wildcard application is unsound; see `unsoundMatchAliasWildcardArgs`.
+     *  application was written in source and is unsound; see
+     *  `unsoundMatchAliasWildcardArgs`.
      *  (normal parameterized aliases are removed in `appliedTo`).
      *  Applications of higher-kinded type constructors to wildcard arguments
      *  are equivalent to existential types, which are not supported.
+     *
+     *  @param isInferred  whether this application arose from inference
+     *                     (avoidance, lub approximation, or an inferred type)
+     *                     rather than being written in source. Inferred
+     *                     wildcard applications of match aliases are always
+     *                     accepted: inference must be able to approximate a
+     *                     type by wildcarding an argument, and rejecting the
+     *                     result (or falling back to a coarser approximation)
+     *                     regresses inference; see i15926 and i14903b.
      */
-    def isUnreducibleWild(using Context): Boolean =
+    def isUnreducibleWild(isInferred: Boolean = false)(using Context): Boolean =
       tycon.isLambdaSub && hasWildcardArg
       && !(args.sizeIs == 1 && defn.isCompiletime_S(tycon.typeSymbol)) // S is a pseudo Match Alias
-      && (tycon match
-            case lam: HKTypeLambda if lam.resType.isInstanceOf[MatchType] =>
-              unsoundMatchAliasWildcardArgs(lam)
+      && (matchAliasLambda match
+            case lam: HKTypeLambda => !isInferred && unsoundMatchAliasWildcardArgs(lam)
             case _ => true)
 
+    /** If this application's tycon is a match alias, the underlying `HKTypeLambda`
+     *  whose result is the match type, otherwise `NoType`. Both shapes occur:
+     *  a bare `HKTypeLambda` from the `Reducer`, and a `TypeRef` since `appliedTo`
+     *  keeps applications of match aliases to wildcard arguments in
+     *  `AppliedType(TypeRef, args)` form (#25866).
+     */
+    private def matchAliasLambda(using Context): Type = tycon match
+      case lam: HKTypeLambda if lam.resType.isInstanceOf[MatchType] => lam
+      case tr: TypeRef => tr.info match
+        case MatchAlias(lam: HKTypeLambda) => lam
+        case _ => NoType
+      case _ => NoType
+
     /** Is this application of the match alias eta-expanded to `lam` an unsound
-     *  wildcard application? This is the case if a wildcard argument (a
-     *  `TypeBounds`) corresponds to a parameter that occurs outside the match
-     *  scrutinee: in the declared bound, or in a case pattern or body. Only
-     *  consulted for applications that `appliedTo` could not reduce away.
-     *  Implements clause 4.2 of the spec section "Applications to Wildcard
-     *  Arguments" (clause 4.1 is the reduction that already failed).
-     *  See issue #21013.
+     *  wildcard application? This is the case if the application does not
+     *  admit the wildcards (the `Reducer` leaves it stuck, `allReplaced` is
+     *  false) and a wildcard argument (a `TypeBounds`) corresponds to a
+     *  parameter that occurs outside the match scrutinee: in the declared
+     *  bound, or in a case pattern or body.
+     *  Implements the `admitsWildcard` condition of the spec section
+     *  "Applications to Wildcard Arguments". See issue #21013.
      */
     private def unsoundMatchAliasWildcardArgs(lam: HKTypeLambda)(using Context): Boolean =
       lam.resType match
         case mt: MatchType =>
-          val collector = new TypeAccumulator[Set[Int]]:
-            def apply(acc: Set[Int], tp: Type): Set[Int] = tp match
-              case tp: TypeParamRef if tp.binder eq lam => acc + tp.paramNum
-              case _ => foldOver(acc, tp)
-          val inBound = collector(Set.empty, mt.bound)
-          val unsafe = mt.cases.foldLeft(inBound)(collector(_, _))
-          unsafe.nonEmpty && args.iterator.zipWithIndex.exists {
-            case (_: TypeBounds, i) => unsafe.contains(i)
-            case _ => false
+          withMode(Mode.AllowLambdaWildcardApply) {
+            val reducer = new TypeApplications.Reducer(lam, args)
+            reducer(mt)
+            !reducer.allReplaced
+          } && {
+            val collector = new TypeAccumulator[Set[Int]]:
+              def apply(acc: Set[Int], tp: Type): Set[Int] = tp match
+                case tp: TypeParamRef if tp.binder eq lam => acc + tp.paramNum
+                case _ => foldOver(acc, tp)
+            val inBound = collector(Set.empty, mt.bound)
+            val unsafe = mt.cases.foldLeft(inBound)(collector(_, _))
+            unsafe.nonEmpty && args.iterator.zipWithIndex.exists {
+              case (_: TypeBounds, i) => unsafe.contains(i)
+              case _ => false
+            }
           }
         case _ => false
 
@@ -6788,7 +6816,7 @@ object Types extends TypeUtils {
           if args.exists(isRange) then
             if variance > 0 then
               tp.derivedAppliedType(tycon, args.map(rangeToBounds)) match
-                case tp1: AppliedType if tp1.isUnreducibleWild && ctx.phase != checkCapturesPhase =>
+                case tp1: AppliedType if tp1.isUnreducibleWild(isInferred = true) && ctx.phase != checkCapturesPhase =>
                   // don't infer a type that would trigger an error later in
                   // Checking.checkAppliedType; fall through to default handling instead
                 case tp1 =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4786,15 +4786,41 @@ object Types extends TypeUtils {
       else super.tryNormalize
 
     /** Is this an unreducible application to wildcard arguments?
-     *  This is the case if tycon is higher-kinded. This means
-     *  it is a subtype of a hk-lambda, but not a match alias.
-     *  (normal parameterized aliases are removed in `appliedTo`).
+     *  This is the case if tycon is higher-kinded and at least one argument
+     *  is a wildcard, *unless* tycon is either:
+     *    - the pseudo match alias `compiletime.ops.int.S`, or
+     *    - a match alias whose wildcard arguments correspond only to type
+     *      parameters that appear solely in the match scrutinee.
+     *  (Normal parameterized aliases are removed in `appliedTo`.)
      *  Applications of higher-kinded type constructors to wildcard arguments
      *  are equivalent to existential types, which are not supported.
+     *
+     *  For match type aliases we restrict the exemption: substituting a
+     *  wildcard for a type parameter is unsound whenever that parameter
+     *  occurs in a pattern (because pattern captures would then see a
+     *  wildcard-refinable type), in a case body, or in the declared upper
+     *  bound. Only parameters used exclusively in the scrutinee are safe,
+     *  since in that case `M[?]` is simply an unreducible match type.
+     *  See issue #21013.
      */
     def isUnreducibleWild(using Context): Boolean =
-      tycon.isLambdaSub && hasWildcardArg && !isMatchAlias
+      tycon.isLambdaSub && hasWildcardArg
         && !(args.sizeIs == 1 && defn.isCompiletime_S(tycon.typeSymbol)) // S is a pseudo Match Alias
+        && (!isMatchAlias || matchAliasWildcardIsUnsound)
+
+    /** Pre: this is an `isMatchAlias` application with at least one wildcard
+     *  argument. Returns true iff some wildcard is applied to a type parameter
+     *  that occurs outside the scrutinee of the underlying match type (in the
+     *  declared upper bound, any pattern, or any case body).
+     */
+    private def matchAliasWildcardIsUnsound(using Context): Boolean =
+      val lam: HKTypeLambda | Null = tycon match
+        case tr: TypeRef => tr.info match
+          case MatchAlias(l: HKTypeLambda) => l
+          case _ => null
+        case l: HKTypeLambda => l
+        case _ => null
+      lam != null && unsoundMatchAliasWildcardArgs(lam, args)
 
     def tryCompiletimeConstantFold(using Context): Type =
       if myEvalRunId == ctx.runId then myEvalued
@@ -7306,4 +7332,27 @@ object Types extends TypeUtils {
   private val keepIfRefining: AnnotatedType => Context ?=> Boolean = _.isRefining
 
   val isBounds: Type => Boolean = _.isInstanceOf[TypeBounds]
+
+  /** Does applying `lam` (the HKTypeLambda body of a match alias) to `args`
+   *  yield an unsound wildcard application? The application is unsound iff
+   *  `lam.resType` is a `MatchType` and some wildcard argument (a `TypeBounds`)
+   *  corresponds to a lambda parameter that occurs outside the match scrutinee
+   *  — i.e., in the match's declared upper bound, in any case pattern, or in
+   *  any case body. See issue #21013 for the motivation: substituting `?` for
+   *  a type parameter in such a position is analogous to the classic
+   *  `type U[X] = (X, X); type V = U[?]` unsoundness.
+   */
+  def unsoundMatchAliasWildcardArgs(lam: HKTypeLambda, args: List[Type])(using Context): Boolean =
+    lam.resType match
+      case mt: MatchType =>
+        val collector = new TypeAccumulator[Set[Int]]:
+          def apply(acc: Set[Int], tp: Type): Set[Int] = tp match
+            case tp: TypeParamRef if tp.binder eq lam => acc + tp.paramNum
+            case _ => foldOver(acc, tp)
+        val unsafe = mt.cases.foldLeft(collector(Set.empty, mt.bound))(collector(_, _))
+        unsafe.nonEmpty && args.iterator.zipWithIndex.exists {
+          case (_: TypeBounds, i) => unsafe.contains(i)
+          case _ => false
+        }
+      case _ => false
 }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4798,8 +4798,32 @@ object Types extends TypeUtils {
       && !(args.sizeIs == 1 && defn.isCompiletime_S(tycon.typeSymbol)) // S is a pseudo Match Alias
       && (tycon match
             case lam: HKTypeLambda if lam.resType.isInstanceOf[MatchType] =>
-              unsoundMatchAliasWildcardArgs(lam, args)
+              unsoundMatchAliasWildcardArgs(lam)
             case _ => true)
+
+    /** Is this application of the match alias eta-expanded to `lam` an unsound
+     *  wildcard application? This is the case if a wildcard argument (a
+     *  `TypeBounds`) corresponds to a parameter that occurs outside the match
+     *  scrutinee: in the declared bound, or in a case pattern or body. Only
+     *  consulted for applications that `appliedTo` could not reduce away.
+     *  Implements clause 4.2 of the spec section "Applications to Wildcard
+     *  Arguments" (clause 4.1 is the reduction that already failed).
+     *  See issue #21013.
+     */
+    private def unsoundMatchAliasWildcardArgs(lam: HKTypeLambda)(using Context): Boolean =
+      lam.resType match
+        case mt: MatchType =>
+          val collector = new TypeAccumulator[Set[Int]]:
+            def apply(acc: Set[Int], tp: Type): Set[Int] = tp match
+              case tp: TypeParamRef if tp.binder eq lam => acc + tp.paramNum
+              case _ => foldOver(acc, tp)
+          val inBound = collector(Set.empty, mt.bound)
+          val unsafe = mt.cases.foldLeft(inBound)(collector(_, _))
+          unsafe.nonEmpty && args.iterator.zipWithIndex.exists {
+            case (_: TypeBounds, i) => unsafe.contains(i)
+            case _ => false
+          }
+        case _ => false
 
     def tryCompiletimeConstantFold(using Context): Type =
       if myEvalRunId == ctx.runId then myEvalued
@@ -7311,33 +7335,4 @@ object Types extends TypeUtils {
   private val keepIfRefining: AnnotatedType => Context ?=> Boolean = _.isRefining
 
   val isBounds: Type => Boolean = _.isInstanceOf[TypeBounds]
-
-  /** Does applying `lam` (the HKTypeLambda body of a match alias) to `args`
-   *  yield an unsound wildcard application? Returns true iff `lam.resType` is a
-   *  `MatchType` and some wildcard argument (a `TypeBounds`) corresponds to a
-   *  lambda parameter that occurs anywhere other than the scrutinee -- in a
-   *  case pattern, a case body, or the declared upper bound.
-   *
-   *  Consulted only for applications that `appliedTo` could not reduce away;
-   *  an application that reduces without its wildcard arguments taking part is
-   *  accepted there and never reaches this check. A surviving application is
-   *  sound only if its wildcarded parameters occur solely in the scrutinee,
-   *  where a wildcard merely leaves the match stuck. Elsewhere it would take
-   *  part in reduction, which may equate types that need not be equal; see
-   *  issue #21013, and compare the classic `type U[X] = (X, X); type V = U[?]`
-   *  unsoundness.
-   */
-  def unsoundMatchAliasWildcardArgs(lam: HKTypeLambda, args: List[Type])(using Context): Boolean =
-    lam.resType match
-      case mt: MatchType =>
-        val collector = new TypeAccumulator[Set[Int]]:
-          def apply(acc: Set[Int], tp: Type): Set[Int] = tp match
-            case tp: TypeParamRef if tp.binder eq lam => acc + tp.paramNum
-            case _ => foldOver(acc, tp)
-        val unsafe = mt.cases.foldLeft(collector(Set.empty, mt.bound))(collector(_, _))
-        unsafe.nonEmpty && args.iterator.zipWithIndex.exists {
-          case (_: TypeBounds, i) => unsafe.contains(i)
-          case _ => false
-        }
-      case _ => false
 }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4786,41 +4786,34 @@ object Types extends TypeUtils {
       else super.tryNormalize
 
     /** Is this an unreducible application to wildcard arguments?
-     *  This is the case if tycon is higher-kinded and at least one argument
-     *  is a wildcard, *unless* tycon is either:
-     *    - the pseudo match alias `compiletime.ops.int.S`, or
-     *    - a match alias whose wildcard arguments correspond only to type
-     *      parameters that appear solely in the match scrutinee.
-     *  (Normal parameterized aliases are removed in `appliedTo`.)
+     *  This is the case if tycon is higher-kinded. This means
+     *  it is a subtype of a hk-lambda. Match aliases are exempt unless the
+     *  wildcard application is unsound; see `unsoundMatchAliasWildcardArgs`.
+     *  (normal parameterized aliases are removed in `appliedTo`).
      *  Applications of higher-kinded type constructors to wildcard arguments
      *  are equivalent to existential types, which are not supported.
-     *
-     *  For match type aliases we restrict the exemption: substituting a
-     *  wildcard for a type parameter is unsound whenever that parameter
-     *  occurs in a pattern (because pattern captures would then see a
-     *  wildcard-refinable type), in a case body, or in the declared upper
-     *  bound. Only parameters used exclusively in the scrutinee are safe,
-     *  since in that case `M[?]` is simply an unreducible match type.
-     *  See issue #21013.
      */
     def isUnreducibleWild(using Context): Boolean =
-      tycon.isLambdaSub && hasWildcardArg
-        && !(args.sizeIs == 1 && defn.isCompiletime_S(tycon.typeSymbol)) // S is a pseudo Match Alias
-        && (!isMatchAlias || matchAliasWildcardIsUnsound)
+      if !tycon.isLambdaSub || !hasWildcardArg then false
+      else if args.sizeIs == 1 && defn.isCompiletime_S(tycon.typeSymbol) then false // S is a pseudo Match Alias
+      else matchAliasLambda match
+        case lam: HKTypeLambda => unsoundMatchAliasWildcardArgs(lam, args)
+        case _ => true
 
-    /** Pre: this is an `isMatchAlias` application with at least one wildcard
-     *  argument. Returns true iff some wildcard is applied to a type parameter
-     *  that occurs outside the scrutinee of the underlying match type (in the
-     *  declared upper bound, any pattern, or any case body).
+    /** If this application is (the eta-expansion of) a match type alias,
+     *  returns the underlying `HKTypeLambda` whose `resType` is a `MatchType`.
+     *  Otherwise returns `NoType`. Used by `isUnreducibleWild` so that sound
+     *  wildcard applications of match aliases (the parameter only appears in
+     *  the scrutinee) can be accepted, while unsound ones are rejected.
      */
-    private def matchAliasWildcardIsUnsound(using Context): Boolean =
-      val lam: HKTypeLambda | Null = tycon match
-        case tr: TypeRef => tr.info match
-          case MatchAlias(l: HKTypeLambda) => l
-          case _ => null
-        case l: HKTypeLambda => l
-        case _ => null
-      lam != null && unsoundMatchAliasWildcardArgs(lam, args)
+    private def matchAliasLambda(using Context): Type = tycon match
+      case tr: TypeRef => tr.info match
+        case MatchAlias(l: HKTypeLambda) => l
+        case _ => NoType
+      case l: HKTypeLambda => l.resType match
+        case _: MatchType => l
+        case _ => NoType
+      case _ => NoType
 
     def tryCompiletimeConstantFold(using Context): Type =
       if myEvalRunId == ctx.runId then myEvalued

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4794,26 +4794,12 @@ object Types extends TypeUtils {
      *  are equivalent to existential types, which are not supported.
      */
     def isUnreducibleWild(using Context): Boolean =
-      if !tycon.isLambdaSub || !hasWildcardArg then false
-      else if args.sizeIs == 1 && defn.isCompiletime_S(tycon.typeSymbol) then false // S is a pseudo Match Alias
-      else matchAliasLambda match
-        case lam: HKTypeLambda => unsoundMatchAliasWildcardArgs(lam, args)
-        case _ => true
-
-    /** If this application is (the eta-expansion of) a match type alias,
-     *  returns the underlying `HKTypeLambda` whose `resType` is a `MatchType`.
-     *  Otherwise returns `NoType`. Used by `isUnreducibleWild` so that sound
-     *  wildcard applications of match aliases (the parameter only appears in
-     *  the scrutinee) can be accepted, while unsound ones are rejected.
-     */
-    private def matchAliasLambda(using Context): Type = tycon match
-      case tr: TypeRef => tr.info match
-        case MatchAlias(l: HKTypeLambda) => l
-        case _ => NoType
-      case l: HKTypeLambda => l.resType match
-        case _: MatchType => l
-        case _ => NoType
-      case _ => NoType
+      tycon.isLambdaSub && hasWildcardArg
+      && !(args.sizeIs == 1 && defn.isCompiletime_S(tycon.typeSymbol)) // S is a pseudo Match Alias
+      && (tycon match
+            case lam: HKTypeLambda if lam.resType.isInstanceOf[MatchType] =>
+              unsoundMatchAliasWildcardArgs(lam, args)
+            case _ => true)
 
     def tryCompiletimeConstantFold(using Context): Type =
       if myEvalRunId == ctx.runId then myEvalued
@@ -7327,13 +7313,19 @@ object Types extends TypeUtils {
   val isBounds: Type => Boolean = _.isInstanceOf[TypeBounds]
 
   /** Does applying `lam` (the HKTypeLambda body of a match alias) to `args`
-   *  yield an unsound wildcard application? The application is unsound iff
-   *  `lam.resType` is a `MatchType` and some wildcard argument (a `TypeBounds`)
-   *  corresponds to a lambda parameter that occurs outside the match scrutinee
-   *  — i.e., in the match's declared upper bound, in any case pattern, or in
-   *  any case body. See issue #21013 for the motivation: substituting `?` for
-   *  a type parameter in such a position is analogous to the classic
-   *  `type U[X] = (X, X); type V = U[?]` unsoundness.
+   *  yield an unsound wildcard application? Returns true iff `lam.resType` is a
+   *  `MatchType` and some wildcard argument (a `TypeBounds`) corresponds to a
+   *  lambda parameter that occurs anywhere other than the scrutinee -- in a
+   *  case pattern, a case body, or the declared upper bound.
+   *
+   *  Consulted only for applications that `appliedTo` could not reduce away;
+   *  an application that reduces without its wildcard arguments taking part is
+   *  accepted there and never reaches this check. A surviving application is
+   *  sound only if its wildcarded parameters occur solely in the scrutinee,
+   *  where a wildcard merely leaves the match stuck. Elsewhere it would take
+   *  part in reduction, which may equate types that need not be equal; see
+   *  issue #21013, and compare the classic `type U[X] = (X, X); type V = U[?]`
+   *  unsoundness.
    */
   def unsoundMatchAliasWildcardArgs(lam: HKTypeLambda, args: List[Type])(using Context): Boolean =
     lam.resType match

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -248,6 +248,7 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case IllegalIdentifierID // errorNumber: 230
   case ConcreteClassHasUnimplementedMethodsID // errorNumber: 231
   case UseOfAnyMethodAsInterpolatorID // errorNumber: 232
+  case UnsoundMatchTypeWildcardApplicationID // errorNumber: 233
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ErrorMessageID.scala
@@ -248,7 +248,6 @@ enum ErrorMessageID(val isActive: Boolean = true) extends java.lang.Enum[ErrorMe
   case IllegalIdentifierID // errorNumber: 230
   case ConcreteClassHasUnimplementedMethodsID // errorNumber: 231
   case UseOfAnyMethodAsInterpolatorID // errorNumber: 232
-  case UnsoundMatchTypeWildcardApplicationID // errorNumber: 233
 
   def errorNumber = ordinal - 1
 

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1335,20 +1335,20 @@ extends TypeMsg(CantInstantiateAbstractClassOrTraitID) {
 
 class UnreducibleApplication(tycon: Type)(using Context) extends TypeMsg(UnreducibleApplicationID):
   def msg(using Context) = i"unreducible application of higher-kinded type $tycon to wildcard arguments"
-  def explain(using Context) =
-    i"""|An abstract type constructor cannot be applied to wildcard arguments.
-        |Such applications are equivalent to existential types, which are not
-        |supported in Scala 3."""
-
-class UnsoundMatchTypeWildcardApplication(tycon: Type)(using Context) extends TypeMsg(UnsoundMatchTypeWildcardApplicationID):
-  def msg(using Context) = i"unsound application of match type alias $tycon to wildcard arguments"
-  def explain(using Context) =
-    i"""|A match type alias may be applied to a wildcard argument only if the
-        |corresponding type parameter occurs solely in the scrutinee of the match.
-        |If it also occurs in a case pattern, a case body, or the declared upper
-        |bound, substituting a wildcard is unsound: each wildcard stands for a
-        |fresh, unrelated type, so the reduction could equate types that are not
-        |actually the same. See issue #21013."""
+  def explain(using Context) = tycon match
+    case lam: HKTypeLambda if lam.resType.isInstanceOf[MatchType] =>
+      i"""|Each wildcard argument stands for some unknown type, and two wildcards
+          |may stand for different types. Substituting a wildcard into the cases
+          |of a match type could therefore make the match type reduce to a wrong
+          |result. For that reason, a match type alias can be applied to a
+          |wildcard argument only if the corresponding type parameter is used
+          |solely in the scrutinee of the match type, or in a position where the
+          |wildcard can stand on its own, such as a type argument of a class in
+          |the scrutinee or the upper bound."""
+    case _ =>
+      i"""|An abstract type constructor cannot be applied to wildcard arguments.
+          |Such applications are equivalent to existential types, which are not
+          |supported in Scala 3."""
 
 class OverloadedOrRecursiveMethodNeedsResultType(val ex: CyclicReference)(using Context)
 extends CyclicMsg(OverloadedOrRecursiveMethodNeedsResultTypeID) {

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -1340,6 +1340,16 @@ class UnreducibleApplication(tycon: Type)(using Context) extends TypeMsg(Unreduc
         |Such applications are equivalent to existential types, which are not
         |supported in Scala 3."""
 
+class UnsoundMatchTypeWildcardApplication(tycon: Type)(using Context) extends TypeMsg(UnsoundMatchTypeWildcardApplicationID):
+  def msg(using Context) = i"unsound application of match type alias $tycon to wildcard arguments"
+  def explain(using Context) =
+    i"""|A match type alias may be applied to a wildcard argument only if the
+        |corresponding type parameter occurs solely in the scrutinee of the match.
+        |If it also occurs in a case pattern, a case body, or the declared upper
+        |bound, substituting a wildcard is unsound: each wildcard stands for a
+        |fresh, unrelated type, so the reduction could equate types that are not
+        |actually the same. See issue #21013."""
+
 class OverloadedOrRecursiveMethodNeedsResultType(val ex: CyclicReference)(using Context)
 extends CyclicMsg(OverloadedOrRecursiveMethodNeedsResultTypeID) {
   def msg(using Context) = i"""Overloaded or recursive $cycleSym needs return type$context"""

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -130,7 +130,7 @@ object Checking {
 
     def checkWildcardApply(tp: Type): Unit = tp match {
       case tp @ AppliedType(tycon, _) =>
-        if tp.isUnreducibleWild then
+        if tp.isUnreducibleWild(isInferred = !tpt.isEmpty) then
           report.errorOrMigrationWarning(
             showInferred(UnreducibleApplication(tycon), tp, tpt),
             tree.srcPos, MigrationVersion.Scala2to3)

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -131,13 +131,8 @@ object Checking {
     def checkWildcardApply(tp: Type): Unit = tp match {
       case tp @ AppliedType(tycon, _) =>
         if tp.isUnreducibleWild then
-          val msg = tycon match
-            case lam: HKTypeLambda if lam.resType.isInstanceOf[MatchType] =>
-              UnsoundMatchTypeWildcardApplication(tycon)
-            case _ =>
-              UnreducibleApplication(tycon)
           report.errorOrMigrationWarning(
-            showInferred(msg, tp, tpt),
+            showInferred(UnreducibleApplication(tycon), tp, tpt),
             tree.srcPos, MigrationVersion.Scala2to3)
       case _ =>
     }

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -131,8 +131,13 @@ object Checking {
     def checkWildcardApply(tp: Type): Unit = tp match {
       case tp @ AppliedType(tycon, _) =>
         if tp.isUnreducibleWild then
+          val msg = tycon match
+            case lam: HKTypeLambda if lam.resType.isInstanceOf[MatchType] =>
+              UnsoundMatchTypeWildcardApplication(tycon)
+            case _ =>
+              UnreducibleApplication(tycon)
           report.errorOrMigrationWarning(
-            showInferred(UnreducibleApplication(tycon), tp, tpt),
+            showInferred(msg, tp, tpt),
             tree.srcPos, MigrationVersion.Scala2to3)
       case _ =>
     }

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -528,9 +528,8 @@ WildcardTypeArg   ::=  ‘?‘ TypeBounds
 A _parameterized type_ ´T[T_1, ..., T_n]´ consists of a type constructor ´T´ and type arguments ´T_1, ..., T_n´ where ´n \geq 1´.
 The parameterized type is well-formed if
 
-- ´T´ is a type constructor which takes ´n´ type parameters ´a_1, ..., a_n´, i.e., it must conform to a type lambda of the form ´[\pm a_1 >: L_1 <: H_1, ..., \pm a_n >: L_n <: H_n] => U´, and
-- if ´T´ is an abstract type constructor, none of the type arguments is a wildcard type argument, and
-- if ´T´ is a _match type alias_, every wildcard type argument additionally satisfies the conditions in [Applications to Wildcard Arguments](#applications-to-wildcard-arguments), and
+- ´T´ is a type constructor which takes ´n´ type parameters ´a_1, ..., a_n´, i.e., it must conform to a type lambda of the form ´[\pm a_1 >: L_1 <: H_1, ..., \pm a_n >: L_n <: H_n] =>> U´, and
+- if some type argument is a wildcard type argument, the application satisfies the conditions in [Applications to Wildcard Arguments](#applications-to-wildcard-arguments), and
 - each type argument _conforms to its bounds_, i.e., given ´\sigma´ the substitution ´[a_1 := T_1, ..., a_n := T_n]´, for each type ´i´:
   - if ´T_i´ is a type and ´\sigma L_i <: T_i <: \sigma H_i´, or
   - ´T_i´ is a wildcard type argument ´? >: L_{Ti} <: H_{Ti}´ and ´\sigma L_i <: L_{Ti}´ and ´H_{Ti} <: \sigma H_i´.
@@ -544,9 +543,61 @@ If only one bound is omitted, `Nothing` or `Any` is used, as usual.
 Also in the concrete syntax, `_` can be used instead of `?` for compatibility reasons, with the same meaning.
 This alternative will be deprecated in the future, and is already deprecated under `-source:future`.
 
+#### Applications to Wildcard Arguments
+
+A wildcard type argument stands for some unknown type; distinct wildcard type arguments may stand for distinct types.
+Substituting a wildcard type argument for a type parameter is therefore not meaning-preserving in general.
+For instance, substituting `?` for ´X´ in `(´X´, ´X´)` yields `(?, ?)`, replacing one unknown type, used twice, by two unrelated ones.
+
+We define `admitsWildcard(´a´, ´U´)`, for a type parameter ´a´ and a type ´U´, to hold if:
+
+1. ´a´ occurs at most once in ´U´;
+2. the occurrence, if any, is a type argument of a parameterized class type, or the aliased type of a refinement; and
+3. that class type or refinement appears at the top level of ´U´, i.e., not within a type argument or refinement.
+
+If `admitsWildcard(´a´, ´U´)` holds, a wildcard type argument retains its meaning when it takes the place of the occurrence of ´a´ in ´U´, or is dropped if ´a´ does not occur; in any other position, the placed wildcard would equate types that need not be equal.
+
+The well-formedness and meaning of an application ´T[T_1, ..., T_n]´ in which some ´T_i´ are wildcard type arguments depend on ´T´.
+Let ´a_i´ range over the parameters instantiated to wildcard type arguments.
+
+1. If ´T´ is a class type constructor, the application is a parameterized class type; it retains its wildcard type arguments, and no substitution takes place.
+2. If ´T´ is an abstract type constructor, the application is ill-formed.
+3. If ´T´ is a concrete type alias to a type lambda with body ´U´, or such a type lambda itself, the application is well-formed only if `admitsWildcard(´a_i´, ´U´)` holds for each ´a_i´.
+   The application then denotes ´U´, with the other type arguments substituted for their parameters and each wildcard type argument at the place of the occurrence of its ´a_i´, if any.
+4. If ´T´ is a _match type alias_, i.e., a concrete type alias to a type lambda whose body is a [match type](#match-types) ´M´ of the form `´X´ match <: ´H´ { case ´P_1´ => ´R_1´; ...; case ´P_k´ => ´R_k´ }`:
+   1. If `admitsWildcard(´a_i´, ´M´)` holds for each ´a_i´, and each occurrence is in the scrutinee ´X´ or the upper bound ´H´, the application denotes ´M´ with the wildcard type arguments so placed.
+   2. Otherwise, if each ´a_i´ occurs solely in the scrutinee ´X´, the application denotes an irreducible match type.
+   3. Otherwise, the application is ill-formed.
+
+A type alias application that cannot be expanded denotes nothing; an irreducible match type, by contrast, is a valid type.
+This is why clause 4.2 accepts applications that clause 3 would reject.
+
+##### Example
+
+```scala
+type Id[X]   = List[X]
+type Dup[X]  = (X, X)
+type Deep[X] = List[List[X]]
+
+def ok1: Id[?]   = ???   // legal: denotes List[?]
+def no1: Dup[?]  = ???   // error: ? may not be duplicated
+def no2: Deep[?] = ???   // error: ? may not move into the nested type argument
+
+type Scrut[X]   =          X match { case Int => String }    // X only in the scrutinee
+type Pat[X]     =     Double match { case X   => Int }       // X in a pattern
+type Body[X, S] =          S match { case Int => List[X] }   // X in a case body
+type Bnd[X, S] <: List[X]  = S match { case Int => Nothing } // X in the upper bound
+
+def ok2: Scrut[?]     = ???  // legal: an irreducible match type
+def ok3: Bnd[?, Int]  = ???  // legal: X moves into the upper bound: List[?]
+def no3: Pat[?]       = ???  // error: X occurs in a case
+def no4: Body[?, Int] = ???  // error: X occurs in a case
+def no5: Bnd[?, ?]    = ???  // error: X is in the bound, and S occurs only as the bare scrutinee
+```
+
 #### Simplification Rules
 
-Wildcard type arguments used in covariant or contravariant positions can always be simplified to regular types.
+Wildcard type arguments used in covariant or contravariant positions can be simplified to regular types.
 
 Let ´T[T_1, ..., T_n]´ be a parameterized type for a concrete type constructor.
 Then, applying a wildcard type argument ´? >: L <: H´ at the ´i´'th position obeys the following equivalences:
@@ -554,7 +605,7 @@ Then, applying a wildcard type argument ´? >: L <: H´ at the ´i´'th position
 - If the type parameter ´T_i´ is declared covariant, then ´T[..., ? >: L <: H, ...] =:= T[..., H, ...]´.
 - If the type parameter ´T_i´ is declared contravariant, then ´T[..., ? >: L <: H, ...] =:= T[..., L, ...]´.
 
-These equivalences apply only to well-formed applications; a wildcard type argument that [Applications to Wildcard Arguments](#applications-to-wildcard-arguments) forbids for a _match type alias_ is therefore not simplified.
+These equivalences apply only to well-formed applications; a wildcard type argument that [Applications to Wildcard Arguments](#applications-to-wildcard-arguments) forbids is therefore not simplified.
 
 #### Example Parameterized Types
 
@@ -1158,33 +1209,7 @@ For ´n \geq 1´, it is specified as:
 
 The reduction of an "empty" match type `´X´ match { }` (which cannot be written in user programs) is a compile error.
 
-#### Applications to Wildcard Arguments
-
-Let `´M´` be a _match type alias_ of the form `type ´M´[´a_1´, ..., ´a_n´] = ´X´ match { case ´P_1´ => ´R_1´; ...; case ´P_k´ => ´R_k´ }` (optionally with a declared upper bound).
-A wildcard type argument is never substituted into the underlying match type.
-An application `´M´[´T_1´, ..., ´T_n´]` in which some `´T_i´` is a wildcard type argument is well-formed only if
-
-- the underlying match type reduces without the wildcard type arguments taking part (the application then denotes the reduct), or
-- every parameter `´a_i´` instantiated to a wildcard occurs solely in the scrutinee `´X´` (the application then denotes an irreducible match type).
-
-A wildcard type argument stands for an unknown type, and distinct wildcards may denote distinct types.
-A wildcard in the scrutinee merely leaves the match irreducible.
-Anywhere else — in a case pattern, in a case body, or in the declared upper bound of an irreducible application — it would take part in reduction, where treating distinct wildcards as the same type is unsound: the same reason `[X] =>> (X, X)` may not be applied to a wildcard type argument.
-
-##### Example
-
-```scala
-type Scrut[X]   =          X match { case Int => String }    // X only in the scrutinee
-type Pat[X]     =     Double match { case X   => Int }       // X in a pattern
-type Body[X, S] =          S match { case Int => List[X] }   // X in a case body
-type Bnd[X, S] <: List[X]  = S match { case Int => Nothing } // X in the upper bound
-
-def ok1: Scrut[?]     = ???  // legal: irreducible, X only in the scrutinee
-def ok2: Bnd[?, Int]  = ???  // legal: reduces to Nothing, X takes no part
-def no1: Pat[?]       = ???  // error: irreducible, X in a pattern
-def no2: Body[?, Int] = ???  // error: irreducible, X in a case body
-def no3: Bnd[?, ?]    = ???  // error: irreducible, X in the upper bound
-```
+Applying a match type alias to wildcard type arguments is restricted; see [Applications to Wildcard Arguments](#applications-to-wildcard-arguments).
 
 ### Skolem Types
 
@@ -1549,7 +1574,7 @@ We define `matches(´S´, ´T´)` where ´S´ and ´T´ are types or methodic ty
 Note that conformance in Scala is _not_ transitive.
 Given two abstract types ´A´ and ´B´, and one abstract `type ´C >: A <: B´` available on prefix ´p´, we have ´A <: p.C´ and ´C <: p.B´ but not necessarily ´A <: B´.
 
- [^argisnotwildcard]: In these cases, if `T_i` and/or `U_i` are wildcard type arguments, the [simplification rules](#simplification-rules) for parameterized types allow to reduce them to real types.
+ [^argisnotwildcard]: In these cases, if `T_i` and/or `U_i` are wildcard type arguments, the [simplification rules](#simplification-rules) for parameterized types allow to reduce them to real types. Such applications are subject to the conditions in [Applications to Wildcard Arguments](#applications-to-wildcard-arguments).
 
 #### Least upper bounds and greatest lower bounds
 

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -530,6 +530,7 @@ The parameterized type is well-formed if
 
 - ´T´ is a type constructor which takes ´n´ type parameters ´a_1, ..., a_n´, i.e., it must conform to a type lambda of the form ´[\pm a_1 >: L_1 <: H_1, ..., \pm a_n >: L_n <: H_n] => U´, and
 - if ´T´ is an abstract type constructor, none of the type arguments is a wildcard type argument, and
+- if ´T´ is a _match type alias_, every wildcard type argument additionally satisfies the conditions in [Applications to Wildcard Arguments](#applications-to-wildcard-arguments), and
 - each type argument _conforms to its bounds_, i.e., given ´\sigma´ the substitution ´[a_1 := T_1, ..., a_n := T_n]´, for each type ´i´:
   - if ´T_i´ is a type and ´\sigma L_i <: T_i <: \sigma H_i´, or
   - ´T_i´ is a wildcard type argument ´? >: L_{Ti} <: H_{Ti}´ and ´\sigma L_i <: L_{Ti}´ and ´H_{Ti} <: \sigma H_i´.
@@ -552,6 +553,8 @@ Then, applying a wildcard type argument ´? >: L <: H´ at the ´i´'th position
 
 - If the type parameter ´T_i´ is declared covariant, then ´T[..., ? >: L <: H, ...] =:= T[..., H, ...]´.
 - If the type parameter ´T_i´ is declared contravariant, then ´T[..., ? >: L <: H, ...] =:= T[..., L, ...]´.
+
+These equivalences apply only to well-formed applications; a wildcard type argument that [Applications to Wildcard Arguments](#applications-to-wildcard-arguments) forbids for a _match type alias_ is therefore not simplified.
 
 #### Example Parameterized Types
 
@@ -1158,10 +1161,30 @@ The reduction of an "empty" match type `´X´ match { }` (which cannot be writte
 #### Applications to Wildcard Arguments
 
 Let `´M´` be a _match type alias_ of the form `type ´M´[´a_1´, ..., ´a_n´] = ´X´ match { case ´P_1´ => ´R_1´; ...; case ´P_k´ => ´R_k´ }` (optionally with a declared upper bound).
-An application `´M´[´T_1´, ..., ´T_n´]` where some `´T_i´` is a wildcard type argument is legal only if every such `´a_i´` occurs exclusively in the scrutinee `´X´` — i.e., it does not occur in the declared upper bound, in any pattern `´P_j´`, or in any body `´R_j´`.
+A wildcard type argument is never substituted into the underlying match type.
+An application `´M´[´T_1´, ..., ´T_n´]` in which some `´T_i´` is a wildcard type argument is well-formed only if
 
-If a wildcard is substituted for a parameter that appears in a pattern, the pattern may spuriously match scrutinees that no non-wildcard substitution would match.
-If a wildcard is substituted for a parameter that appears multiple times in a body (or in the declared upper bound), the resulting type loses the identification between those occurrences, which is the same unsoundness as substituting a wildcard for `X` in `[X] =>> (X, X)`.
+- the underlying match type reduces without the wildcard type arguments taking part (the application then denotes the reduct), or
+- every parameter `´a_i´` instantiated to a wildcard occurs solely in the scrutinee `´X´` (the application then denotes an irreducible match type).
+
+A wildcard type argument stands for an unknown type, and distinct wildcards may denote distinct types.
+A wildcard in the scrutinee merely leaves the match irreducible.
+Anywhere else — in a case pattern, in a case body, or in the declared upper bound of an irreducible application — it would take part in reduction, where treating distinct wildcards as the same type is unsound: the same reason `[X] =>> (X, X)` may not be applied to a wildcard type argument.
+
+##### Example
+
+```scala
+type Scrut[X]   =          X match { case Int => String }    // X only in the scrutinee
+type Pat[X]     =     Double match { case X   => Int }       // X in a pattern
+type Body[X, S] =          S match { case Int => List[X] }   // X in a case body
+type Bnd[X, S] <: List[X]  = S match { case Int => Nothing } // X in the upper bound
+
+def ok1: Scrut[?]     = ???  // legal: irreducible, X only in the scrutinee
+def ok2: Bnd[?, Int]  = ???  // legal: reduces to Nothing, X takes no part
+def no1: Pat[?]       = ???  // error: irreducible, X in a pattern
+def no2: Body[?, Int] = ???  // error: irreducible, X in a case body
+def no3: Bnd[?, ?]    = ???  // error: irreducible, X in the upper bound
+```
 
 ### Skolem Types
 

--- a/docs/_spec/03-types.md
+++ b/docs/_spec/03-types.md
@@ -1155,6 +1155,14 @@ For ´n \geq 1´, it is specified as:
 
 The reduction of an "empty" match type `´X´ match { }` (which cannot be written in user programs) is a compile error.
 
+#### Applications to Wildcard Arguments
+
+Let `´M´` be a _match type alias_ of the form `type ´M´[´a_1´, ..., ´a_n´] = ´X´ match { case ´P_1´ => ´R_1´; ...; case ´P_k´ => ´R_k´ }` (optionally with a declared upper bound).
+An application `´M´[´T_1´, ..., ´T_n´]` where some `´T_i´` is a wildcard type argument is legal only if every such `´a_i´` occurs exclusively in the scrutinee `´X´` — i.e., it does not occur in the declared upper bound, in any pattern `´P_j´`, or in any body `´R_j´`.
+
+If a wildcard is substituted for a parameter that appears in a pattern, the pattern may spuriously match scrutinees that no non-wildcard substitution would match.
+If a wildcard is substituted for a parameter that appears multiple times in a body (or in the declared upper bound), the resulting type loses the identification between those occurrences, which is the same unsoundness as substituting a wildcard for `X` in `[X] =>> (X, X)`.
+
 ### Skolem Types
 
 ```ebnf

--- a/tests/neg/i21013.scala
+++ b/tests/neg/i21013.scala
@@ -1,25 +1,38 @@
-// Issue #21013: applying a match type alias to a wildcard argument is
-// unsound when the type parameter appears outside the match scrutinee
-// (in a pattern, a case body, or the declared upper bound).
+// #21013: a match type alias applied to a wildcard is rejected when the
+// application does not reduce and the wildcarded parameter occurs outside the
+// scrutinee -- in a case pattern, a case body, or the declared upper bound.
+// Accepted applications are in tests/pos/i21013.scala.
+// The body/bound aliases take an extra scrutinee parameter `S` so that the
+// alias itself stays a match type instead of reducing away at definition.
 
-type M1[K] = Double match
-  case K => Int // K appears in a pattern
+type InPattern[K] = Double match
+  case K => Int                      // K in a pattern
 
-type M2[K] = Double match
-  case Option[K] => Int // K appears in a pattern
+type InNestedPattern[K] = Double match
+  case List[K] => Int                // K in a nested pattern
 
-type M3[X, Y] = X match
-  case Int => (Y, Y) // Y appears in a case body
+type InBody[K, S] = S match
+  case Int => List[K]                // K in a body
 
-type M4[K, S] <: List[K] = S match // K appears in the declared upper bound
-  case Int => List[K]
+type InBodyTwice[K, S] = S match
+  case Int => (K, K)                 // K twice in a body
+
+// K in the bound of an application that stays stuck (wildcard scrutinee);
+// contrast PlainBound[?, Int] in tests/pos, which reduces and is accepted
+type InBound[K, S] <: List[K] = S match
+  case Int => Nothing
+
+// bound that is itself a match alias: InAliasBound[?] <: Bad[?], where Bad[?]
+// would reduce unsoundly -- the case that makes bound occurrences dangerous
+type Bad[K] = Double match
+  case K => Int
+type InAliasBound[K, S] <: Bad[K] = S match
+  case Int => Nothing
 
 def Test: Unit =
-  val x1: M1[?] = ??? // error
-  val x2: M2[?] = ??? // error
-  val x3: M3[Int, ?] = ??? // error
-  val x4: M4[?, String] = ??? // error
-
-  // The unsoundness observed in #21013: M1[?] should not be a valid
-  // supertype of M1[Int]. With the fix, M1[?] itself is rejected.
-  // (If it were accepted, M1[?] would reduce to Int, but M1[Int] would not.)
+  val a1: InPattern[?]         = ??? // error
+  val a2: InNestedPattern[?]   = ??? // error
+  val a3: InBody[?, Int]       = ??? // error
+  val a4: InBodyTwice[?, Int]  = ??? // error
+  val a5: InBound[?, ?]        = ??? // error
+  val a6: InAliasBound[?, Int] = ??? // error

--- a/tests/neg/i21013.scala
+++ b/tests/neg/i21013.scala
@@ -1,0 +1,25 @@
+// Issue #21013: applying a match type alias to a wildcard argument is
+// unsound when the type parameter appears outside the match scrutinee
+// (in a pattern, a case body, or the declared upper bound).
+
+type M1[K] = Double match
+  case K => Int // K appears in a pattern
+
+type M2[K] = Double match
+  case Option[K] => Int // K appears in a pattern
+
+type M3[X, Y] = X match
+  case Int => (Y, Y) // Y appears in a case body
+
+type M4[K, S] <: List[K] = S match // K appears in the declared upper bound
+  case Int => List[K]
+
+def Test: Unit =
+  val x1: M1[?] = ??? // error
+  val x2: M2[?] = ??? // error
+  val x3: M3[Int, ?] = ??? // error
+  val x4: M4[?, String] = ??? // error
+
+  // The unsoundness observed in #21013: M1[?] should not be a valid
+  // supertype of M1[Int]. With the fix, M1[?] itself is rejected.
+  // (If it were accepted, M1[?] would reduce to Int, but M1[Int] would not.)

--- a/tests/neg/i21013.scala
+++ b/tests/neg/i21013.scala
@@ -8,6 +8,12 @@ type InPattern[K] = Double match
 type InNestedPattern[K] = Double match
   case List[K] => Int
 
+// The pattern shape that would genuinely reduce with the wildcard taking
+// part: List[Double] matches List[?], so InMatchingPattern[?] would reduce
+// to Int even though InMatchingPattern[String] does not reduce.
+type InMatchingPattern[K] = List[Double] match
+  case List[K] => Int
+
 type InBody[K, S] = S match
   case Int => List[K]
 
@@ -23,9 +29,10 @@ type InAliasBound[K, S] <: Bad[K] = S match
   case Int => Nothing
 
 def Test: Unit =
-  val a1: InPattern[?]         = ??? // error
-  val a2: InNestedPattern[?]   = ??? // error
-  val a3: InBody[?, Int]       = ??? // error
-  val a4: InBodyTwice[?, Int]  = ??? // error
-  val a5: InBound[?, ?]        = ??? // error
-  val a6: InAliasBound[?, Int] = ??? // error
+  val a1: InPattern[?]          = ??? // error
+  val a2: InNestedPattern[?]    = ??? // error
+  val a3: InMatchingPattern[?]  = ??? // error
+  val a4: InBody[?, Int]        = ??? // error
+  val a5: InBodyTwice[?, Int]   = ??? // error
+  val a6: InBound[?, ?]         = ??? // error
+  val a7: InAliasBound[?, Int]  = ??? // error

--- a/tests/neg/i21013.scala
+++ b/tests/neg/i21013.scala
@@ -1,29 +1,22 @@
-// #21013: a match type alias applied to a wildcard is rejected when the
-// application does not reduce and the wildcarded parameter occurs outside the
-// scrutinee -- in a case pattern, a case body, or the declared upper bound.
+// #21013: a wildcard application of a match type alias is rejected when it
+// does not reduce and the wildcarded parameter occurs outside the scrutinee.
 // Accepted applications are in tests/pos/i21013.scala.
-// The body/bound aliases take an extra scrutinee parameter `S` so that the
-// alias itself stays a match type instead of reducing away at definition.
 
 type InPattern[K] = Double match
-  case K => Int                      // K in a pattern
+  case K => Int
 
 type InNestedPattern[K] = Double match
-  case List[K] => Int                // K in a nested pattern
+  case List[K] => Int
 
 type InBody[K, S] = S match
-  case Int => List[K]                // K in a body
+  case Int => List[K]
 
 type InBodyTwice[K, S] = S match
-  case Int => (K, K)                 // K twice in a body
+  case Int => (K, K)
 
-// K in the bound of an application that stays stuck (wildcard scrutinee);
-// contrast PlainBound[?, Int] in tests/pos, which reduces and is accepted
 type InBound[K, S] <: List[K] = S match
   case Int => Nothing
 
-// bound that is itself a match alias: InAliasBound[?] <: Bad[?], where Bad[?]
-// would reduce unsoundly -- the case that makes bound occurrences dangerous
 type Bad[K] = Double match
   case K => Int
 type InAliasBound[K, S] <: Bad[K] = S match

--- a/tests/pos/i21013.scala
+++ b/tests/pos/i21013.scala
@@ -40,3 +40,27 @@ def Test: Unit =
 
   val c1: List[Single[?]] = Nil                           // nested in a constructor
   val c2: Option[WithDefault[?]] = None
+
+// Escaping local types: avoidance must not infer an unsound wildcard application
+type Elem[X] = X match { case List[t] => t }
+type IfList[K, S] = S match { case List[t] => K }
+
+def d1 =
+  trait Local
+  val v: Elem[Local] = ???
+  v
+
+def d2[S] =
+  trait Local
+  val v: IfList[Local, S] = ???
+  v
+
+def d3 =
+  trait Local
+  val v: Elem[? <: Local] = ???
+  v
+
+def d4[S] =
+  trait Local
+  val v: List[IfList[Local, S]] = Nil
+  v

--- a/tests/pos/i21013.scala
+++ b/tests/pos/i21013.scala
@@ -1,34 +1,42 @@
-// Companion to tests/neg/i21013.scala: wildcard applications of match
-// type aliases are sound, and must be accepted, when every wildcarded
-// parameter occurs only in the scrutinee of the underlying match type.
+// Companion to tests/neg/i21013.scala: a wildcard application is accepted
+// when it reduces without the wildcard taking part, or when it stays stuck
+// with every wildcarded parameter occurring only in the scrutinee.
 
-// Sound: parameter only in scrutinee (single case)
-type Ok1[X] = X match
+type Single[X] = X match             // scrutinee only
   case Int => String
 
-val a1: Ok1[?] = ???
-def b1: Ok1[?] = ???
-val c1: List[Ok1[?]] = Nil
-val d1: Option[Ok1[?]] = None
-
-// Sound: parameter only in scrutinee (multiple cases, default)
-type Ok2[X] = X match
+type WithDefault[X] = X match        // scrutinee only, with a default
   case Int => String
   case String => Int
-  case _ => Double
+  case _ => Long
 
-val a2: Ok2[?] = ???
-def b2: Array[Ok2[?]] = null
+type UnderCtor[X] = List[X] match    // scrutinee, under a constructor
+  case List[Int] => String
+  case _ => Long
 
-// Sound mix: the wildcarded parameter only appears in the scrutinee,
-// the other parameter is given concretely and may appear anywhere.
-type Ok3[X, Y] = X match
+type Mixed[X, Y] = X match           // only the scrutinee parameter is wildcarded
   case Int => (Y, Y)
-  case String => List[Y]
+  case _ => List[Y]
 
-val a3: Ok3[?, Int] = ???
-def b3: Ok3[?, String] = ???
+// K occurs in the bound, but PlainBound[?, Int] reduces to Nothing without K
+// taking part; contrast the stuck InBound[?, ?] in tests/neg
+type PlainBound[K, S] <: List[K] = S match
+  case Int => Nothing
 
-// Bounded wildcard, still sound
-def b4: Ok1[? <: Int] = ???
-def b5: Ok2[? >: Nothing <: Int | String] = ???
+def Test: Unit =
+  val a1: Single[?]          = ???
+  val a2: WithDefault[?]     = ???
+  val a3: UnderCtor[?]       = ???
+  val a4: Mixed[?, Int]      = ???
+  val a5: PlainBound[?, Int] = ???
+
+  // a nested wildcard is an ordinary closed existential argument, not a
+  // top-level wildcard, so the application is sound (cf. M[?] in neg)
+  val a6: Single[List[?]]    = ???
+  val a7: Mixed[List[?], Int] = ???
+
+  val b1: Single[? <: Int] = ???                          // bounded wildcards
+  val b2: WithDefault[? >: Nothing <: Int | String] = ???
+
+  val c1: List[Single[?]] = Nil                           // nested in a constructor
+  val c2: Option[WithDefault[?]] = None

--- a/tests/pos/i21013.scala
+++ b/tests/pos/i21013.scala
@@ -1,0 +1,34 @@
+// Companion to tests/neg/i21013.scala: wildcard applications of match
+// type aliases are sound, and must be accepted, when every wildcarded
+// parameter occurs only in the scrutinee of the underlying match type.
+
+// Sound: parameter only in scrutinee (single case)
+type Ok1[X] = X match
+  case Int => String
+
+val a1: Ok1[?] = ???
+def b1: Ok1[?] = ???
+val c1: List[Ok1[?]] = Nil
+val d1: Option[Ok1[?]] = None
+
+// Sound: parameter only in scrutinee (multiple cases, default)
+type Ok2[X] = X match
+  case Int => String
+  case String => Int
+  case _ => Double
+
+val a2: Ok2[?] = ???
+def b2: Array[Ok2[?]] = null
+
+// Sound mix: the wildcarded parameter only appears in the scrutinee,
+// the other parameter is given concretely and may appear anywhere.
+type Ok3[X, Y] = X match
+  case Int => (Y, Y)
+  case String => List[Y]
+
+val a3: Ok3[?, Int] = ???
+def b3: Ok3[?, String] = ???
+
+// Bounded wildcard, still sound
+def b4: Ok1[? <: Int] = ???
+def b5: Ok2[? >: Nothing <: Int | String] = ???


### PR DESCRIPTION
~~Fixes #21013.~~

Applying a type alias to a wildcard argument can be unsound, because `?`
is occurrence-sensitive: distinct wildcards may stand for distinct types.
For match aliases this is also a soundness hole — `type M[K] = Double
match { case K => Int }` makes `M[?]` reduce to `Int` though `M[Int]`
does not, wrongly making `M[?]` a supertype of `M[Int]`.

The spec gains a general "Applications to Wildcard Arguments" section
under parameterized types, built on a predicate `admitsWildcard(a, U)`
(the parameter occurs at most once, where a wildcard can stand on its
own). It covers class constructors, abstract constructors, concrete
aliases, and match aliases uniformly.

For match aliases: a stuck wildcard application is legal only if every
wildcarded parameter occurs solely in the scrutinee; occurrences in a
case pattern, a case body, or the upper bound make it ill-formed.
Applications that reduce without the wildcards taking part stay accepted.

`isUnreducibleWild` defers to the syntactic `unsoundMatchAliasWildcardArgs`
check; the diagnostic reuses `UnreducibleApplication`.

Added the spec section and `tests/{neg,pos}/i21013.scala`, including pos
cases ensuring avoidance does not synthesize an unsound wildcard
application.

## How much have you relied on LLM-based tools in this contribution?

Extensively & I've iterated over the solution a lot.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)