### PR TITLE
Ignore annotations no longer on the classpath in ExtractAPI

### DIFF
--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -754,7 +754,9 @@ private class ExtractAPICollector(nonLocalClassSymbols: mutable.HashSet[Symbol])
     //   `IncOptions#useOptimizedSealed`.
     s.annotations.foreach { annot =>
       val sym = annot.symbol
-      if sym.exists && sym != defn.BodyAnnot && sym != defn.ChildAnnot then
+      // Ignore annotations of type Any, this means we couldn't actually load it,
+      // because it's no longer on the classpath compared to when the code we're loading was compiled.
+      if sym.exists && sym != defn.BodyAnnot && sym != defn.ChildAnnot && !sym.typeRef.isAny then
         annots += apiAnnotation(annot)
     }
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -756,6 +756,7 @@ private class ExtractAPICollector(nonLocalClassSymbols: mutable.HashSet[Symbol])
       val sym = annot.symbol
       // Ignore annotations of type Any, this means we couldn't actually load it,
       // because it's no longer on the classpath compared to when the code we're loading was compiled.
+      // See the i25722 special test in explicitNullsPos for an example.
       if sym.exists && sym != defn.BodyAnnot && sym != defn.ChildAnnot && !sym.typeRef.isAny then
         annots += apiAnnotation(annot)
     }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -233,6 +233,26 @@ class CompilationTests {
     ))
     runWithCoverageOrFallback[PosTestWithCoverage](compilationTest, "Pos")
 
+    // The regression test for i25722 has some atypical classpath requirements.
+    // The test consists of (a) one Java nullability annotation, (b) one Java user of the annotation, and (c) two Scala files,
+    // which must be compiled separately. In addition:
+    //   - the output from (a) must be on the classpath while compiling (b)
+    //   - the output from (b) must be on the classpath while compiling (c)
+    //   - the output from (a) _must not_ be on the classpath while compiling (c)
+    locally {
+      val i25722Group = TestGroup("tests/explicit-nulls/special/i25722")
+      val i25722Options = explicitNullsOptions.and("-Yforce-sbt-phases")
+      val outDir1 = Paths.get(defaultOutputDir.getAbsolutePath, i25722Group.name, "Nullable", "annotations", "Nullable/").toString
+      val outDir2 = Paths.get(defaultOutputDir.getAbsolutePath, i25722Group.name, "Foo", "lib", "Foo").toString
+      val tests = List(
+        withCoverage(compileFile("tests/explicit-nulls/special/25722/jstubs/jstubs/org/jetbrains/annotations/Nullable.java", i25722Options)(using i25722Group).keepOutput),
+        withCoverage(compileFile("tests/explicit-nulls/special/25722/jstubs/jstubs/lib/Foo.java", i25722Options.withClasspath(outDir1))(using i25722Group).keepOutput),
+        withCoverage(compileDir("tests/explicit-nulls/special/25722/scala", i25722Options.withClasspath(outDir2))(using i25722Group).keepOutput)
+      )
+      tests.foreach(t => runWithCoverageOrFallback[PosTestWithCoverage](t, "Pos"))
+      tests.foreach(_.delete())
+    }
+
     // locally {
     //   val tests = List(
     //     compileFile("tests/explicit-nulls/flexible-unpickle/pos/Unsafe_1.scala", explicitNullsOptions without "-Yexplicit-nulls"),

--- a/tests/explicit-nulls/special/25722/jstubs/jstubs/lib/Foo.java
+++ b/tests/explicit-nulls/special/25722/jstubs/jstubs/lib/Foo.java
@@ -1,0 +1,9 @@
+package lib;
+
+import org.jetbrains.annotations.Nullable;
+
+public class Foo {
+  public interface Bar {
+    @Nullable Object execute();
+  }
+}

--- a/tests/explicit-nulls/special/25722/jstubs/jstubs/org/jetbrains/annotations/Nullable.java
+++ b/tests/explicit-nulls/special/25722/jstubs/jstubs/org/jetbrains/annotations/Nullable.java
@@ -1,0 +1,3 @@
+package org.jetbrains.annotations;
+
+public @interface Nullable {}

--- a/tests/explicit-nulls/special/25722/scala/A.scala
+++ b/tests/explicit-nulls/special/25722/scala/A.scala
@@ -1,0 +1,1 @@
+def a = new java.util.Random()

--- a/tests/explicit-nulls/special/25722/scala/B.scala
+++ b/tests/explicit-nulls/special/25722/scala/B.scala
@@ -1,0 +1,1 @@
+abstract class B extends lib.Foo.Bar


### PR DESCRIPTION
Fixes #25722

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Automated test

~~Manual tests because writing automated tests is impractical, described below (in detail)~~

~~See the issue, it requires compiling some Java code, then manipulating the JAR to remove one classfile...~~