### PR TITLE
Keep annotations when converting in Setup to dependent function

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -498,9 +498,16 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           case t @ AppliedType(tycon, args)
           if defn.isNonRefinedFunction(t) && args.last.containsGlobalFreshDirectly =>
             // Convert to dependent function so that we have a binder for `fresh` in result type.
+            // Copy all annotations and capturing sets of the original type to the new one.
+            def copyAnnots(t: Type, from: Type): Type = from match
+              case from @ AnnotatedType(from1, ann) => from.derivedAnnotatedType(copyAnnots(t, from1), ann)
+              case _ => t
             apply(
-              depFun(args.init, args.last,
-                isContextual = defn.isContextFunctionClass(tycon.classSymbol)))
+              copyAnnots(
+                depFun(args.init, args.last,
+                  isContextual = defn.isContextFunctionClass(tycon.classSymbol)),
+                t.dealiasKeepAnnots))
+              .showing(i"convert dep $t to $result", capt)
           case t: (LazyRef | TypeVar) =>
             mapConserveSuper(t)
           case t =>

--- a/tests/neg-custom-args/captures/impure-fresh.check
+++ b/tests/neg-custom-args/captures/impure-fresh.check
@@ -1,0 +1,13 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/impure-fresh.scala:6:25 ----------------------------------
+6 |val y: () -> A^{fresh} = x  // error
+  |                         ^
+  |                         Found:    (x : () => A^{fresh})
+  |                         Required: () -> A^{fresh²}
+  |
+  |                         Note that capability `x` cannot flow into capture set {}.
+  |
+  |                         where:    =>     refers to a root capability in the type of value x
+  |                                   fresh  is a root capability associated with the result type of (): A^{fresh}
+  |                                   fresh² is a root capability associated with the result type of (): A^{fresh²}
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/impure-fresh.scala
+++ b/tests/neg-custom-args/captures/impure-fresh.scala
@@ -1,0 +1,7 @@
+import caps.fresh
+
+class A
+
+val x: () => A^{fresh} = ???
+val y: () -> A^{fresh} = x  // error
+


### PR DESCRIPTION
We lost capture sets when we converted a non-dependent function to a dependent one in Setup, as shown in the test file of this PR.
