### PR TITLE
Fix #25894: break cross-unit cyclic export on partial recompile

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3615,6 +3615,19 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val packageObjectName = desugar.packageObjectName(ctx.source)
           val topLevelClassSymbol = pkg.moduleClass.info.decls.lookup(packageObjectName.moduleClassName)
           topLevelClassSymbol.ensureCompleted()
+          // When sibling files in this package come from the classpath (TASTy),
+          // force their `<src>$package` classes now to avoid cross-unit cycles
+          // as in #25894: otherwise the first lookup on this package (e.g. an
+          // import qualifier at the top of this file) forces them during the
+          // import's completer, and their unpickling can chain through source
+          // exports back to the import itself.
+          if !pkg.isEffectiveRoot && pkg != defn.EmptyPackageVal then
+            pkg.moduleClass.denot match
+              case pcd: SymDenotations.PackageClassDenotation =>
+                for pobj <- pcd.packageObjs do
+                  if pobj.symbol.isDefinedInBinary then
+                    pobj.symbol.ensureCompleted()
+              case _ =>
           var stats1 = typedStats(tree.stats, pkg.moduleClass)._1
           if (!ctx.isAfterTyper)
             stats1 = stats1 ++ typedBlockStats(MainProxies.proxies(stats1))._1

--- a/tests/pos/i25894/DFVal_1.scala
+++ b/tests/pos/i25894/DFVal_1.scala
@@ -1,0 +1,15 @@
+package dfhdl
+
+final class DFVal[+T <: DFType, +M]
+
+type DFValAny = DFVal[DFType, ModifierAny]
+type DFConstOf[+T <: DFType] = DFVal[T, Modifier.CONST]
+type DFValTP[+T <: DFType] = DFVal[T, Modifier]
+
+inline def x = ${ ??? }
+
+object DFVal:
+  export DFXInt.Ops.{c1, c2}
+  object Ops:
+    type BoolOnlyOp
+    type CarryOp

--- a/tests/pos/i25894/MutableDB_1.scala
+++ b/tests/pos/i25894/MutableDB_1.scala
@@ -1,0 +1,2 @@
+package dfhdl
+class MutableDB

--- a/tests/pos/i25894/hdl_1.scala
+++ b/tests/pos/i25894/hdl_1.scala
@@ -1,0 +1,6 @@
+package dfhdl
+object hdl:
+  export DFBoolOrBit.given
+  export DFDecimal.Ops.*
+
+export hdl.*

--- a/tests/pos/i25894/stubs_1.scala
+++ b/tests/pos/i25894/stubs_1.scala
@@ -1,0 +1,34 @@
+package dfhdl
+import DFVal.Ops.CarryOp
+import DFVal.Ops.BoolOnlyOp
+
+trait ExactOp2Aux[Op, C, O]
+
+trait Modifier
+type ModifierAny = Modifier
+object Modifier:
+  type CONST = Modifier
+
+class DFType
+
+class DFC(mutableDB: MutableDB)
+
+object DFBoolOrBit:
+  given bl[Op, O](using
+      ExactOp2Aux[Op, DFC, O]
+  ): ExactOp2Aux[BoolOnlyOp, DFC, O] = ???
+
+object DFDecimal:
+  object Ops:
+    export DFXInt.Ops.*
+
+object DFXInt:
+  object Ops:
+    type A = Int
+    type B = String
+    given arith1[Op <: A]: ExactOp2Aux[Op, DFC, DFValTP[DFType]] = ???
+    given arith2[Op <: B]: ExactOp2Aux[Op, DFC, DFValTP[DFType]] = ???
+    given c1: ExactOp2Aux[CarryOp, DFC, DFValTP[DFType]] = ???
+    given c2: ExactOp2Aux[CarryOp, DFC, DFValTP[DFType]] = ???
+
+type DFConstInt32 = DFConstOf[DFType]

--- a/tests/pos/i25894/stubs_2.scala
+++ b/tests/pos/i25894/stubs_2.scala
@@ -1,0 +1,34 @@
+package dfhdl
+import DFVal.Ops.CarryOp
+import DFVal.Ops.BoolOnlyOp
+
+trait ExactOp2Aux[Op, C, O]
+
+trait Modifier
+type ModifierAny = Modifier
+object Modifier:
+  type CONST = Modifier
+
+class DFType
+
+class DFC(mutableDB: MutableDB)
+
+object DFBoolOrBit:
+  given bl[Op, O](using
+      ExactOp2Aux[Op, DFC, O]
+  ): ExactOp2Aux[BoolOnlyOp, DFC, O] = ???
+
+object DFDecimal:
+  object Ops:
+    export DFXInt.Ops.*
+
+object DFXInt:
+  object Ops:
+    type A = Int
+    type B = String
+    given arith1[Op <: A]: ExactOp2Aux[Op, DFC, DFValTP[DFType]] = ???
+    given arith2[Op <: B]: ExactOp2Aux[Op, DFC, DFValTP[DFType]] = ???
+    given c1: ExactOp2Aux[CarryOp, DFC, DFValTP[DFType]] = ???
+    given c2: ExactOp2Aux[CarryOp, DFC, DFValTP[DFType]] = ???
+
+type DFConstInt32 = DFConstOf[DFType]


### PR DESCRIPTION
When a file is recompiled against TASTy of its sibling files, resolving an import on the enclosing package can chain into an export in a loaded-from-TASTy sibling that points back at a definition in the file currently being typed, producing a spurious `Cyclic reference involving val <import>`.

In `typedPackageDef`, after completing the current source's `<src>$package` class (existing behaviour for i13669), also force-complete any sibling `<src>$package` classes in this package that came from the classpath. This pre-resolves their exports before any import in the current file runs its completer, breaking the cycle.

Narrowed to avoid unnecessary work:
- skipped for the root / empty package (i13669 is unaffected — it uses the existing top-level call);
- only `isDefinedInBinary` `$package` classes are forced, so source- defined siblings still complete in their natural order.

Fixes #25894

<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

Extensively, but the change is very short. The minimization was hell on earth, even with the help of AI to minimize a 10,000 LOC incremental compilation issue that only happens in sbtn on Windows to 60 LOC that surface the bug without sbt dependency and work on Linux as well. 

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
