### PR TITLE
Handle `Typed(_: SubMatch)` in PatternMatcher

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -531,12 +531,13 @@ object PatternMatcher {
 
     private def caseDefPlan(scrutinee: Symbol, cdef: CaseDef): Plan =
       val CaseDef(pat, guard, body) = cdef
-      val caseDefBodyPlan: Plan = body match
+      def caseDefBodyPlan(body: Tree = body): Plan = body match
+        case Typed(t, _) => caseDefBodyPlan(t)
         case t: SubMatch => subMatchPlan(t)
         case _ => ResultPlan(body)
       val onSuccess: Plan =
-        if guard.isEmpty then caseDefBodyPlan
-        else TestPlan(GuardTest, guard, guard.span, caseDefBodyPlan)
+        if guard.isEmpty then caseDefBodyPlan()
+        else TestPlan(GuardTest, guard, guard.span, caseDefBodyPlan())
       patternPlan(scrutinee, pat, onSuccess)
     end caseDefPlan
 

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1589,6 +1589,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       case block @ Block(stats, expr) if !expr.isInstanceOf[Closure] =>
         val expr1 = ascribeType(expr, pt)
         cpy.Block(block)(stats, expr1).withType(expr1.tpe) // no assignType here because avoid is redundant
+      case m @ Match(selector, cases) if m.isSubMatch =>
+        val newCases = cases.map: cdef =>
+          val newBody = ascribeType(cdef.body, pt)
+          cpy.CaseDef(cdef)(body = newBody).withType(newBody.tpe)
+        cpy.Match(m)(selector, newCases).withType(TypeComparer.lub(newCases.map(_.tpe)))
       case _ =>
         val target = pt.simplified
         val targetTpt = TypeTree(target, inferred = true)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1589,11 +1589,6 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       case block @ Block(stats, expr) if !expr.isInstanceOf[Closure] =>
         val expr1 = ascribeType(expr, pt)
         cpy.Block(block)(stats, expr1).withType(expr1.tpe) // no assignType here because avoid is redundant
-      case m @ Match(selector, cases) if m.isSubMatch =>
-        val newCases = cases.map: cdef =>
-          val newBody = ascribeType(cdef.body, pt)
-          cpy.CaseDef(cdef)(body = newBody).withType(newBody.tpe)
-        cpy.Match(m)(selector, newCases).withType(TypeComparer.lub(newCases.map(_.tpe)))
       case _ =>
         val target = pt.simplified
         val targetTpt = TypeTree(target, inferred = true)

--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -84,3 +84,4 @@ tailrec.scala
 traitParams.scala
 i25460.scala
 matrix.scala
+i25746.scala

--- a/tests/pos/i25746.scala
+++ b/tests/pos/i25746.scala
@@ -1,0 +1,9 @@
+import scala.language.experimental.subCases
+
+@main def test =
+  val r1 = "^foo".r.unanchored
+  val r2 = "bar$".r.unanchored
+
+  val result1 = "foo bar" match
+    case s @ r1() if s match { case r2() => s }
+    case _ => "no"


### PR DESCRIPTION
Based on #25778 by @zielinsky
Fixes #25746

Strip `Typed(_, _)` proxies around `SubMatch`es when computing pattern plan in PatternMatcher.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests from #25778