### PR TITLE
Fixes #24056 Dealias value class types in structural access

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -245,7 +245,7 @@ trait Dynamic {
           if tpe.classSymbol.isDerivedValueClass && qual.tpe <:< defn.ReflectSelectableTypeRef then
             val genericUnderlying = ValueClasses.valueClassUnbox(tpe.classSymbol.asClass)
             val underlying = tpe.select(genericUnderlying).widen.resultType
-            New(tpe.widen, tree.cast(underlying) :: Nil)
+            New(tpe.widen.dealias, tree.cast(underlying) :: Nil)
           else
             tree
         maybeBoxed.cast(tpe)

--- a/tests/pos/i24056.scala
+++ b/tests/pos/i24056.scala
@@ -1,0 +1,8 @@
+trait DFBit
+final class DFVal[+T, +M](val value: Int) extends AnyVal
+type DFValOf[+T] = DFVal[T, Any]
+
+class Top:
+  val dmn1 = new scala.reflect.Selectable:
+    val o: DFValOf[DFBit] = ???
+  val x = dmn1.o

--- a/tests/run/i24056.scala
+++ b/tests/run/i24056.scala
@@ -1,0 +1,13 @@
+trait DFBit
+final class DFVal[+T, +M](val value: Int) extends AnyVal
+type DFValOf[+T] = DFVal[T, Any]
+
+class Top:
+  val dmn1 = new scala.reflect.Selectable:
+    val o: DFValOf[DFBit] = DFVal(42)
+  val x: DFValOf[DFBit] = dmn1.o
+
+object Test:
+  def main(args: Array[String]): Unit =
+    val t = Top()
+    assert(t.x.value == 42)


### PR DESCRIPTION
When a structural refinement member has a type that is a type alias for a generic derived value class, the boxing wrapper in `maybeBoxingCast` synthesized a `New` on the alias, which provided only the alias' partial type arguments to the underlying class constructor and failed with "Not enough type arguments".

Dealias the widened type before constructing the `New` so the underlying value class receives its full type argument list.

Fixes #24056

## How much have you relied on LLM-based tools in this contribution?

Extensively, but this is a single line change.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
