### PR TITLE
Fixes #20010 Avoid crash on missing TASTy class references

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1879,6 +1879,13 @@ object SymDenotations {
     private var baseDataCache: BaseData = BaseData.None
     private var memberNamesCache: MemberNames = MemberNames.None
 
+    /** Set of parent types for which a `BadSymbolicReference` has already
+     *  been reported by `computeBaseData`. Used so the same diagnostic is
+     *  not emitted multiple times when `baseData` is recomputed (e.g. from
+     *  a separate `derivesFrom` invocation). See scala/scala3#20010.
+     */
+    private var reportedMissingParents: Set[Type] = Set.empty
+
     private def memberCache(using Context): EqHashMap[Name, PreDenotation] = {
       if (myMemberCachePeriod != ctx.period) {
         myMemberCache = EqHashMap()
@@ -2061,7 +2068,29 @@ object SymDenotations {
         case p :: parents1 =>
           p.classSymbol match {
             case pcls: ClassSymbol => builder.addAll(pcls.baseClasses)
-            case _ => assert(isRefinementClass || p.isError || ctx.mode.is(Mode.Interactive) || ctx.tolerateErrorsForBestEffort, s"$this has non-class parent: $p")
+            case _ =>
+              // The parent type couldn't be resolved to a class, e.g.
+              // because a transitive dependency was removed from the
+              // classpath. Report a BadSymbolicReference-style error
+              // rather than crashing with an internal assertion. See
+              // scala/scala3#20010.
+              if p.typeSymbol == NoSymbol && !isRefinementClass && !p.isError
+                 && !ctx.mode.is(Mode.Interactive) && !ctx.tolerateErrorsForBestEffort
+              then
+                if !reportedMissingParents.contains(p) then
+                  reportedMissingParents = reportedMissingParents + p
+                  val file = symbol.associatedFile
+                  val (location, src) =
+                    if file != null then (i" in $file", file.toString)
+                    else ("", "the signature")
+                  report.error(
+                    em"""Bad symbolic reference. A signature$location
+                        |refers to ${p.show} as a parent of ${symbol.showLocated}, but it is not available.
+                        |It may be completely missing from the current classpath, or the version on
+                        |the classpath might be incompatible with the version used when compiling $src.""",
+                    symbol.srcPos)
+              else
+                assert(isRefinementClass || p.isError || ctx.mode.is(Mode.Interactive) || ctx.tolerateErrorsForBestEffort, s"$this has non-class parent: $p")
           }
           traverse(parents1)
         case nil =>
@@ -2419,6 +2448,11 @@ object SymDenotations {
             case pcls: ClassSymbol =>
               for name <- pcls.memberNames(keepOnly) do
                 maybeAdd(name)
+            case _ =>
+              // Parent failed to resolve to a class (the missing
+              // reference has been reported by computeBaseData).
+              // Skip here to avoid a secondary MatchError.
+              // See scala/scala3#20010.
         val ownSyms =
           if (keepOnly eq implicitFilter)
             if (this.is(Package)) Iterator.empty

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1879,13 +1879,6 @@ object SymDenotations {
     private var baseDataCache: BaseData = BaseData.None
     private var memberNamesCache: MemberNames = MemberNames.None
 
-    /** Set of parent types for which a `BadSymbolicReference` has already
-     *  been reported by `computeBaseData`. Used so the same diagnostic is
-     *  not emitted multiple times when `baseData` is recomputed (e.g. from
-     *  a separate `derivesFrom` invocation). See scala/scala3#20010.
-     */
-    private var reportedMissingParents: Set[Type] = Set.empty
-
     private def memberCache(using Context): EqHashMap[Name, PreDenotation] = {
       if (myMemberCachePeriod != ctx.period) {
         myMemberCache = EqHashMap()
@@ -2071,26 +2064,23 @@ object SymDenotations {
             case _ =>
               // The parent type couldn't be resolved to a class, e.g.
               // because a transitive dependency was removed from the
-              // classpath. Report a BadSymbolicReference-style error
-              // rather than crashing with an internal assertion. See
-              // scala/scala3#20010.
-              if p.typeSymbol == NoSymbol && !isRefinementClass && !p.isError
-                 && !ctx.mode.is(Mode.Interactive) && !ctx.tolerateErrorsForBestEffort
-              then
-                if !reportedMissingParents.contains(p) then
-                  reportedMissingParents = reportedMissingParents + p
-                  val file = symbol.associatedFile
-                  val (location, src) =
-                    if file != null then (i" in $file", file.toString)
-                    else ("", "the signature")
-                  report.error(
-                    em"""Bad symbolic reference. A signature$location
-                        |refers to ${p.show} as a parent of ${symbol.showLocated}, but it is not available.
-                        |It may be completely missing from the current classpath, or the version on
-                        |the classpath might be incompatible with the version used when compiling $src.""",
-                    symbol.srcPos)
-              else
-                assert(isRefinementClass || p.isError || ctx.mode.is(Mode.Interactive) || ctx.tolerateErrorsForBestEffort, s"$this has non-class parent: $p")
+              // classpath. Report a `BadSymbolicReference` (mirroring the
+              // pattern used by `StubInfo.complete` above) rather than
+              // crashing with an internal assertion. See scala/scala3#20010.
+              p match
+                case p: TypeRef
+                  if p.symbol == NoSymbol
+                    && !isRefinementClass && !p.isError
+                    && !ctx.mode.is(Mode.Interactive) && !ctx.tolerateErrorsForBestEffort =>
+                  val stubOwner =
+                    p.prefix.classSymbol
+                      .orElse(p.prefix.termSymbol.moduleClass)
+                      .orElse(defn.RootClass)
+                  val stub = newStubSymbol(stubOwner, p.name, CompilationUnitInfo(symbol.associatedFile))
+                  report.error(BadSymbolicReference(stub.denot), symbol.srcPos)
+                case _ =>
+                  assert(isRefinementClass || p.isError || ctx.mode.is(Mode.Interactive) || ctx.tolerateErrorsForBestEffort,
+                         s"$this has non-class parent: $p")
           }
           traverse(parents1)
         case nil =>

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2067,11 +2067,11 @@ object SymDenotations {
               // classpath. Report a `BadSymbolicReference` (mirroring the
               // pattern used by `StubInfo.complete` above) rather than
               // crashing with an internal assertion. See scala/scala3#20010.
+              def ignoreBadParent =
+                isRefinementClass || p.isError
+                  || ctx.mode.is(Mode.Interactive) || ctx.tolerateErrorsForBestEffort
               p match
-                case p: TypeRef
-                  if p.symbol == NoSymbol
-                    && !isRefinementClass && !p.isError
-                    && !ctx.mode.is(Mode.Interactive) && !ctx.tolerateErrorsForBestEffort =>
+                case p: TypeRef if p.symbol == NoSymbol && !ignoreBadParent =>
                   val stubOwner =
                     p.prefix.classSymbol
                       .orElse(p.prefix.termSymbol.moduleClass)
@@ -2079,8 +2079,7 @@ object SymDenotations {
                   val stub = newStubSymbol(stubOwner, p.name, CompilationUnitInfo(symbol.associatedFile))
                   report.error(BadSymbolicReference(stub.denot), symbol.srcPos)
                 case _ =>
-                  assert(isRefinementClass || p.isError || ctx.mode.is(Mode.Interactive) || ctx.tolerateErrorsForBestEffort,
-                         s"$this has non-class parent: $p")
+                  assert(ignoreBadParent, s"$this has non-class parent: $p")
           }
           traverse(parents1)
         case nil =>

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -478,7 +478,7 @@ class TreeUnpickler(reader: TastyReader,
           if unpicklingJava && name == tpnme.Object && (pre.termSymbol eq defn.JavaLangPackageVal) then
             defn.FromJavaObjectType
           else
-            TypeRef(pre, name)
+            ensureResolvable(TypeRef(pre, name), pre, name)
         case TERMREF =>
           val sname = readName()
           val prefix = readType()
@@ -527,6 +527,25 @@ class TreeUnpickler(reader: TastyReader,
         case _ => res
       }
     }
+
+    /** If `tpe` refers to a type that is not present on the classpath
+     *  (e.g. a transitive dependency was removed), fall back to a stub
+     *  class symbol so that downstream code sees a `ClassSymbol` and
+     *  reports `BadSymbolicReference` on first use, rather than crashing
+     *  with an internal assertion. See scala/scala3#20010.
+     *
+     *  The replacement is only performed when the prefix is a
+     *  package or a module, for which member lookup is deterministic –
+     *  this avoids converting transient lookup failures into spurious
+     *  stubs during the incremental completion of in-flight symbols.
+     */
+    private def ensureResolvable(tpe: TypeRef, pre: Type, name: TypeName)(using Context): Type =
+      if tpe.symbol.exists then tpe
+      else
+        val preSym = pre.termSymbol
+        if preSym.is(Package) || preSym.is(Module) then
+          newStubSymbol(preSym.moduleClass, name).typeRef
+        else tpe
 
     private def readPackageRef()(using Context): TermSymbol = {
       val name = readName()
@@ -1303,7 +1322,9 @@ class TreeUnpickler(reader: TastyReader,
         var qualType = qual.tpe.widenIfUnstable
         val owner = denot.symbol.maybeOwner
         val tpe0 = name match
-          case name: TypeName => TypeRef(qualType, name, denot)
+          case name: TypeName =>
+            val ref = TypeRef(qualType, name, denot)
+            ensureResolvable(ref, qualType, name)
           case name: TermName => TermRef(qualType, name, denot)
         val tpe = tpe0.makePackageObjPrefixExplicit
         ConstFold.Select(untpd.Select(qual, name).withType(tpe))

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -478,7 +478,7 @@ class TreeUnpickler(reader: TastyReader,
           if unpicklingJava && name == tpnme.Object && (pre.termSymbol eq defn.JavaLangPackageVal) then
             defn.FromJavaObjectType
           else
-            ensureResolvable(TypeRef(pre, name), pre, name)
+            TypeRef(pre, name)
         case TERMREF =>
           val sname = readName()
           val prefix = readType()
@@ -527,25 +527,6 @@ class TreeUnpickler(reader: TastyReader,
         case _ => res
       }
     }
-
-    /** If `tpe` refers to a type that is not present on the classpath
-     *  (e.g. a transitive dependency was removed), fall back to a stub
-     *  class symbol so that downstream code sees a `ClassSymbol` and
-     *  reports `BadSymbolicReference` on first use, rather than crashing
-     *  with an internal assertion. See scala/scala3#20010.
-     *
-     *  The replacement is only performed when the prefix is a
-     *  package or a module, for which member lookup is deterministic –
-     *  this avoids converting transient lookup failures into spurious
-     *  stubs during the incremental completion of in-flight symbols.
-     */
-    private def ensureResolvable(tpe: TypeRef, pre: Type, name: TypeName)(using Context): Type =
-      if tpe.symbol.exists then tpe
-      else
-        val preSym = pre.termSymbol
-        if preSym.is(Package) || preSym.is(Module) then
-          newStubSymbol(preSym.moduleClass, name).typeRef
-        else tpe
 
     private def readPackageRef()(using Context): TermSymbol = {
       val name = readName()
@@ -1322,9 +1303,7 @@ class TreeUnpickler(reader: TastyReader,
         var qualType = qual.tpe.widenIfUnstable
         val owner = denot.symbol.maybeOwner
         val tpe0 = name match
-          case name: TypeName =>
-            val ref = TypeRef(qualType, name, denot)
-            ensureResolvable(ref, qualType, name)
+          case name: TypeName => TypeRef(qualType, name, denot)
           case name: TermName => TermRef(qualType, name, denot)
         val tpe = tpe0.makePackageObjPrefixExplicit
         ConstFold.Select(untpd.Select(qual, name).withType(tpe))

--- a/sbt-test/tasty-compat/i20010/Repro.scala
+++ b/sbt-test/tasty-compat/i20010/Repro.scala
@@ -1,0 +1,1 @@
+class MyTest extends child.ValidatingTest

--- a/sbt-test/tasty-compat/i20010/a/ParsingTest.scala
+++ b/sbt-test/tasty-compat/i20010/a/ParsingTest.scala
@@ -1,0 +1,3 @@
+package parent
+
+trait ParsingTest

--- a/sbt-test/tasty-compat/i20010/b/ValidatingTest.scala
+++ b/sbt-test/tasty-compat/i20010/b/ValidatingTest.scala
@@ -1,0 +1,3 @@
+package child
+
+abstract class ValidatingTest extends parent.ParsingTest

--- a/sbt-test/tasty-compat/i20010/build.sbt
+++ b/sbt-test/tasty-compat/i20010/build.sbt
@@ -1,0 +1,56 @@
+import sbt.internal.util.ConsoleAppender
+
+// Reproduces https://github.com/scala/scala3/issues/20010
+//
+// Three modules:
+//   a  : defines `parent.ParsingTest`
+//   b  : defines `child.ValidatingTest extends parent.ParsingTest`,
+//        compiled with `a` on the classpath; its output ends up in `c-input`
+//   c  : root project that extends `child.ValidatingTest`, but only sees
+//        `c-input` on its classpath – `a`'s outputs are deliberately not
+//        exposed, so loading `ValidatingTest`'s TASTy can no longer resolve
+//        its `parent.ParsingTest` parent.
+//
+// Before the fix the compiler crashed with
+//   `java.lang.AssertionError: class ValidatingTest has non-class parent: ...`
+// Now it must emit a clean `Bad symbolic reference` error.
+
+lazy val assertCleanMissingRefError = taskKey[Unit](
+  "checks that compiling c reports `Bad symbolic reference` rather than crashing"
+)
+lazy val resetMessages = taskKey[Unit]("empties the messages list")
+
+lazy val a = project.in(file("a"))
+  .settings(
+    Compile / classDirectory := (ThisBuild / baseDirectory).value / "a-only"
+  )
+
+lazy val b = project.in(file("b"))
+  .settings(
+    Compile / unmanagedClasspath += (ThisBuild / baseDirectory).value / "a-only",
+    Compile / classDirectory := (ThisBuild / baseDirectory).value / "c-input"
+  )
+
+lazy val c = project.in(file("."))
+  .settings(
+    // Only `b`'s outputs are visible here – `a-only` is *not* on the classpath.
+    Compile / unmanagedClasspath += (ThisBuild / baseDirectory).value / "c-input",
+    Compile / classDirectory := (ThisBuild / baseDirectory).value / "c-output",
+    extraAppenders := { _ => Seq(ConsoleAppender(FakePrintWriter)) },
+    resetMessages := { FakePrintWriter.resetMessages },
+    assertCleanMissingRefError := {
+      val msgs = FakePrintWriter.messages
+      assert(
+        msgs.exists(_.contains("Bad symbolic reference")),
+        s"expected 'Bad symbolic reference' in compiler output, got: ${msgs.mkString("\n")}"
+      )
+      assert(
+        !msgs.exists(_.contains("non-class parent")),
+        s"compiler crashed with 'non-class parent' assertion; got: ${msgs.mkString("\n")}"
+      )
+      assert(
+        !msgs.exists(_.contains("java.lang.AssertionError")),
+        s"compiler crashed with AssertionError; got: ${msgs.mkString("\n")}"
+      )
+    }
+  )

--- a/sbt-test/tasty-compat/i20010/project/DottyInjectedPlugin.scala
+++ b/sbt-test/tasty-compat/i20010/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/tasty-compat/i20010/project/FakePrintWriter.scala
+++ b/sbt-test/tasty-compat/i20010/project/FakePrintWriter.scala
@@ -1,0 +1,6 @@
+object FakePrintWriter extends java.io.PrintWriter("fake-print-writer") {
+  @volatile var messages = List.empty[String]
+  def resetMessages = messages = List.empty[String]
+  override def println(x: String): Unit = messages = x :: messages
+  override def print(x: String): Unit = messages = x :: messages
+}

--- a/sbt-test/tasty-compat/i20010/test
+++ b/sbt-test/tasty-compat/i20010/test
@@ -1,0 +1,10 @@
+# compile library a (defines parent.ParsingTest)
+> a/compile
+# compile library b (defines child.ValidatingTest extends parent.ParsingTest)
+> b/compile
+# compile c without a on the classpath.
+# This used to crash the compiler with an internal `non-class parent` assertion.
+# After the fix it must fail with a clean `Bad symbolic reference` error.
+> resetMessages
+-> c/compile
+> assertCleanMissingRefError


### PR DESCRIPTION
When a transitive dependency is missing from the classpath, the TASTy reader for a TYPEREF can produce a TypeRef whose symbol cannot be resolved. Downstream code in `computeBaseData` then hits an internal `non-class parent` assertion and crashes the compiler.

Replace such unresolvable `TypeRef`s with a stub class symbol (similar to what Scala2Unpickler does), so the user sees a `BadSymbolicReference` error on first use instead of a compiler crash. The substitution is limited to references whose prefix is a package or a module, where member lookup is deterministic, to avoid converting transient lookup failures into spurious stubs during incremental completion.

Adds an sbt scripted regression test (`sbt-test/tasty-compat/i20010`) that mirrors the original minimisation: three modules, `a`/`b`/`c`, where compiling `c` must not crash when `a` is absent from its classpath.

Fixes #20010

## How much have you relied on LLM-based tools in this contribution?

Extensively, but its a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

