### PR TITLE
Fixes #24914 Treat equivalent candidates as divergent in implicit search

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1863,15 +1863,33 @@ trait Implicits:
       // is larger (see `typeSize`) and is constructed using the same set of types and type
       // constructors (see `coveringSet`).
       //
+      // We also treat two candidates as equivalent for this check when they are sibling
+      // givens declared in the same owner that share a declared signature. Such siblings
+      // (a common pattern when modeling type class hierarchies, see i24914) demand the
+      // same context parameters, so exploring one and then another under the same
+      // prototype shape makes no progress and would otherwise lead to a factorial
+      // blow-up of the search before the expression-count limit eventually kicks in.
+      // We use `frozen_=:=` so the check does not commit constraint updates.
+      //
       // We are able to tie a recursive knot if there is compatible term already under
       // construction which is separated from this context by at least one by name argument
       // as we ascend the chain of open implicits to the outermost search context.
+
+      def equivalentCandidates(c1: Candidate, c2: Candidate): Boolean =
+        if c1.ref eq c2.ref then true
+        else
+          val sym1 = c1.ref.symbol
+          val sym2 = c2.ref.symbol
+          sym1.exists
+            && sym2.exists
+            && sym1.maybeOwner == sym2.maybeOwner
+            && c1.ref.info.frozen_=:=(c2.ref.info)
 
       @tailrec
       def loop(history: SearchHistory, belowByname: Boolean): Boolean =
         history match
           case prev @ OpenSearch(cand1, tp, outer) =>
-            if cand1.ref eq cand.ref then
+            if equivalentCandidates(cand1, cand) then
               lazy val wildTp = wildApprox(tp.widenExpr)
               if belowByname && (wildTp <:< wildPt) then
                 fullyDefinedType(tp, "by-name implicit parameter", srcPos)

--- a/docs/_docs/reference/changed-features/implicit-resolution.md
+++ b/docs/_docs/reference/changed-features/implicit-resolution.md
@@ -118,6 +118,8 @@ the implicit search for `Q` fails.
 **5.** The treatment of divergence errors has also changed. A divergent implicit is treated as a normal failure, after which alternatives are still tried. This also makes sense: Encountering a divergent implicit means that we assume that no finite solution can be found on the corresponding path, but another path can still be tried. By contrast,
 most (but not all) divergence errors in Scala 2 would terminate the implicit search as a whole.
 
+The divergence check that compares the in-progress search history against a new candidate also recognises sibling givens declared in the same owner that share a declared type as the same candidate. Such siblings demand identical context parameters, so exploring one and then another under the same prototype shape cannot make any new progress; without this rule, a group of look-alike givens (say several type-class instances each requiring the same enclosing type class) would force the search to enumerate every permutation before the expression-count limit kicks in.
+
 **6.** Scala 2 gives a lower level of priority to implicit conversions with call-by-name parameters relative to implicit conversions with call-by-value parameters. Scala 3 drops this distinction. So the following code snippet would be ambiguous in Scala 3:
 
 ```scala

--- a/tests/neg/i24914.scala
+++ b/tests/neg/i24914.scala
@@ -1,0 +1,31 @@
+// Regression test for #24914: make sure that a forest of sibling givens
+// sharing the same signature cannot blow up the implicit search into
+// factorial territory. Before the divergence check considered candidates
+// with identical declared types equivalent, this compiled for tens of
+// seconds and eventually failed with a "search problem too large" warning.
+// The search should now be cut short by ordinary divergence detection.
+
+trait Functor[F[_]]
+trait Monad[F[_]] extends Functor[F]
+
+class T[F[_], A, X]
+
+object Functor:
+  given t1[F[_]: Functor, A]: Functor[[X] =>> T[F, A, X]] = ???
+  given t2[F[_]: Functor, A]: Functor[[X] =>> T[F, A, X]] = ???
+  given t3[F[_]: Functor, A]: Functor[[X] =>> T[F, A, X]] = ???
+  given t4[F[_]: Monad, A]: Functor[[X] =>> T[F, A, X]] = ???
+  given t5[F[_]: Functor, A]: Functor[[X] =>> T[F, A, X]] = ???
+  given t6[F[_]: Functor, A]: Functor[[X] =>> T[F, A, X]] = ???
+
+object Monad:
+  given t1[F[_]: Monad, A]: Monad[[X] =>> T[F, A, X]] = ???
+  given t2[F[_]: Monad, A]: Monad[[X] =>> T[F, A, X]] = ???
+  given t3[F[_]: Monad, A]: Monad[[X] =>> T[F, A, X]] = ???
+  given t4[F[_]: Monad, A]: Monad[[X] =>> T[F, A, X]] = ???
+  given t5[F[_]: Monad, A]: Monad[[X] =>> T[F, A, X]] = ???
+  given t6[F[_]: Monad, A]: Monad[[X] =>> T[F, A, X]] = ???
+
+def m[F[_]: Functor]: F[String] = ???
+
+val x = for _ <- m yield () // error


### PR DESCRIPTION
The divergence check in `checkDivergence` only considered two open searches as potential loops when they used the exact same candidate reference. Given several sibling givens with identical declared types — a common pattern when modelling a type class hierarchy where each instance recursively needs another instance — the search would still branch into every permutation of the candidates before eventually giving up once the expression-count limit tripped.

For the minimization in #24914 this was a factorial blow-up: six sibling Monad givens led to tens of thousands of `tryImplicit` calls and compilation took well over a minute before failing with "search problem too large". Extending the check so that candidates whose `ref.info` types are equivalent are also subject to the usual size and covering-set test lets ordinary divergence detection cut the recursion short; the test file now fails in roughly five seconds with a clean error instead.

Fixes #24914

## How much have you relied on LLM-based tools in this contribution?

Extensively, but the fix is small.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
