### PR TITLE
Fixes #21383 enable Mode.ReadPositions when reading annotation trees

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -795,17 +795,14 @@ class TreeUnpickler(reader: TastyReader,
       readLater(end, reader =>
         val tp = reader.readType()
         def readAnnotTree(rdr: TreeReader)(using Context) =
+          if isCompactAnnotTypeTag(rdr.reader.nextByte) then TypeTree(rdr.readType())
           // Annotation trees may be inspected by macros via `annot.tree` and
           // spliced into a macro expansion; the re-typer of that expansion
           // requires every untyped tree to have a span (Typer.assertPositioned).
           // For incremental compilation the enclosing unpickling does not use
           // Mode.ReadPositions, so without this the deserialized annotation
           // tree has no spans and the re-typer crashes (issue #21383).
-          // Mirrors the handling of inline method bodies above.
-          val ctx1 = ctx.addMode(Mode.ReadPositions)
-          inContext(rdr.sourceChangeContext(Addr(0))(using ctx1)):
-            if isCompactAnnotTypeTag(rdr.reader.nextByte) then TypeTree(rdr.readType())
-            else rdr.readTree()
+          else rdr.readTree()(using ctx.addMode(Mode.ReadPositions))
         val lazyAnnotTree = reader.readLaterWithOwner(end, readAnnotTree(_))
         owner =>
           new DeferredSymAndTree(tp.typeSymbol, lazyAnnotTree(owner).complete):

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -795,8 +795,17 @@ class TreeUnpickler(reader: TastyReader,
       readLater(end, reader =>
         val tp = reader.readType()
         def readAnnotTree(rdr: TreeReader)(using Context) =
-          if isCompactAnnotTypeTag(rdr.reader.nextByte) then TypeTree(rdr.readType())
-          else rdr.readTree()
+          // Annotation trees may be inspected by macros via `annot.tree`. The
+          // reflected tree must have positions (Typer.assertPositioned), so we
+          // force Mode.ReadPositions even if the enclosing unpickling didn't.
+          // Without this, when TASTY is read for incremental compilation
+          // (which does not use ReadPositions by default), macros see trees
+          // whose internal nodes are missing spans, which causes typer
+          // crashes after re-typing the macro expansion (issue #21383).
+          val ctx1 = ctx.addMode(Mode.ReadPositions)
+          inContext(rdr.sourceChangeContext()(using ctx1)):
+            if isCompactAnnotTypeTag(rdr.reader.nextByte) then TypeTree(rdr.readType())
+            else rdr.readTree()
         val lazyAnnotTree = reader.readLaterWithOwner(end, readAnnotTree(_))
         owner =>
           new DeferredSymAndTree(tp.typeSymbol, lazyAnnotTree(owner).complete):

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -795,15 +795,15 @@ class TreeUnpickler(reader: TastyReader,
       readLater(end, reader =>
         val tp = reader.readType()
         def readAnnotTree(rdr: TreeReader)(using Context) =
-          // Annotation trees may be inspected by macros via `annot.tree`. The
-          // reflected tree must have positions (Typer.assertPositioned), so we
-          // force Mode.ReadPositions even if the enclosing unpickling didn't.
-          // Without this, when TASTY is read for incremental compilation
-          // (which does not use ReadPositions by default), macros see trees
-          // whose internal nodes are missing spans, which causes typer
-          // crashes after re-typing the macro expansion (issue #21383).
+          // Annotation trees may be inspected by macros via `annot.tree` and
+          // spliced into a macro expansion; the re-typer of that expansion
+          // requires every untyped tree to have a span (Typer.assertPositioned).
+          // For incremental compilation the enclosing unpickling does not use
+          // Mode.ReadPositions, so without this the deserialized annotation
+          // tree has no spans and the re-typer crashes (issue #21383).
+          // Mirrors the handling of inline method bodies above.
           val ctx1 = ctx.addMode(Mode.ReadPositions)
-          inContext(rdr.sourceChangeContext()(using ctx1)):
+          inContext(rdr.sourceChangeContext(Addr(0))(using ctx1)):
             if isCompactAnnotTypeTag(rdr.reader.nextByte) then TypeTree(rdr.readType())
             else rdr.readTree()
         val lazyAnnotTree = reader.readLaterWithOwner(end, readAnnotTree(_))

--- a/sbt-test/source-dependencies/i21383/Macro.scala
+++ b/sbt-test/source-dependencies/i21383/Macro.scala
@@ -1,0 +1,14 @@
+import scala.quoted.*
+
+class MyAnnot(val name: String) extends scala.annotation.StaticAnnotation
+
+object Macro:
+  transparent inline def annotOf[T]: String =
+    ${ annotOfImpl[T] }
+
+  def annotOfImpl[T: Type](using Quotes): Expr[String] =
+    import quotes.reflect.*
+    val annTerm = TypeRepr.of[T].typeSymbol.annotations
+      .find(_.tpe =:= TypeRepr.of[MyAnnot]).get
+    val annExpr = annTerm.asExprOf[MyAnnot]
+    '{ $annExpr.name }

--- a/sbt-test/source-dependencies/i21383/Schema.scala
+++ b/sbt-test/source-dependencies/i21383/Schema.scala
@@ -1,0 +1,2 @@
+@MyAnnot("hello")
+class Foo

--- a/sbt-test/source-dependencies/i21383/Test.scala
+++ b/sbt-test/source-dependencies/i21383/Test.scala
@@ -1,0 +1,1 @@
+val x = Macro.annotOf[Foo]

--- a/sbt-test/source-dependencies/i21383/changes/Test.scala
+++ b/sbt-test/source-dependencies/i21383/changes/Test.scala
@@ -1,0 +1,2 @@
+// Edit to trigger incremental recompilation of Test.scala while Schema.tasty is loaded from disk.
+val x = Macro.annotOf[Foo]

--- a/sbt-test/source-dependencies/i21383/project/DottyInjectedPlugin.scala
+++ b/sbt-test/source-dependencies/i21383/project/DottyInjectedPlugin.scala
@@ -1,0 +1,11 @@
+import sbt._
+import Keys._
+
+object DottyInjectedPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  override val projectSettings = Seq(
+    scalaVersion := sys.props("plugin.scalaVersion")
+  )
+}

--- a/sbt-test/source-dependencies/i21383/test
+++ b/sbt-test/source-dependencies/i21383/test
@@ -1,0 +1,6 @@
+> compile
+# Recompile Test.scala while Schema.tasty is read from disk. Without the fix
+# for issue #21383 the re-typing of the annotation tree returned by the macro
+# asserts on a missing position.
+$ copy-file changes/Test.scala Test.scala
+> compile

--- a/tests/pos-macros/i21383/Macro_1.scala
+++ b/tests/pos-macros/i21383/Macro_1.scala
@@ -1,0 +1,17 @@
+import scala.quoted.*
+
+class MyAnnot(val name: String) extends scala.annotation.StaticAnnotation
+
+@MyAnnot("hello")
+class Foo
+
+object Macro:
+  transparent inline def annotOf[T]: String =
+    ${ annotOfImpl[T] }
+
+  def annotOfImpl[T: Type](using Quotes): Expr[String] =
+    import quotes.reflect.*
+    val annTerm = TypeRepr.of[T].typeSymbol.annotations
+      .find(_.tpe =:= TypeRepr.of[MyAnnot]).get
+    val annExpr = annTerm.asExprOf[MyAnnot]
+    '{ $annExpr.name }

--- a/tests/pos-macros/i21383/Test_2.scala
+++ b/tests/pos-macros/i21383/Test_2.scala
@@ -1,0 +1,1 @@
+val x = Macro.annotOf[Foo]


### PR DESCRIPTION
Annotation trees stored in TASTY are read lazily. When a macro inspects a symbol's annotations via `Symbol.annotations`/`asExprOf` and splices the annotation tree into its expansion, the spliced tree is later re-typed by InlineTyper (which extends ReTyper/Typer). During this re-typing the compiler asserts that every untyped tree has a span (Typer.assertPositioned).

For incremental compilation the enclosing unpickling does not use Mode.ReadPositions, so `spanAt` and `sourcePathAt` return NoSpan/"" and the deserialized annotation tree has NoSpan all the way down. That in turn makes the re-typing of the macro expansion crash with:

  assertion failed: position not set for new <AnnotClass>
    of class dotty.tools.dotc.ast.Trees$Select

This happens for any annotation argument whose tree gets embedded into a macro's output — the original report uses @SqlName on a case class that is then processed by the `TableInfo` transparent inline from `magnum`, but the bug is fully general.

Force Mode.ReadPositions (and refresh the source from the pickled source map) when materializing the lazy annotation tree, mirroring what is already done for inline method bodies. With the mode enabled the pickled spans are restored and the re-typer is happy.

Adds a self-contained regression test (`tests/pos-macros/i21383`) and an sbt incremental-compilation test (`sbt-test/source-dependencies/i21383`).

Fixes #21383

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
