### PR TITLE
Coverage + Experimental nested match cases interaction fix

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1008,6 +1008,10 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
           }
         }
 
+        val hasDefault = default != null
+        if !hasDefault then
+          default = new asm.Label
+
         bc.emitSWITCH(mkArrayReverse(flatKeys), mkArrayL(targets.reverse), default, MIN_SWITCH_DENSITY)
 
         // emit switch-blocks.
@@ -1016,6 +1020,15 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
           markProgramPoint(caseLabel)
           genLoadTo(caseBody, generatedType, postMatchDest)
         }
+
+        if !hasDefault then
+          markProgramPoint(default)
+          bc.jmethod.visitTypeInsn(asm.Opcodes.NEW, "scala/MatchError")
+          bc.jmethod.visitInsn(asm.Opcodes.DUP)
+          bc.jmethod.visitInsn(asm.Opcodes.ACONST_NULL)
+          bc.jmethod.visitMethodInsn(asm.Opcodes.INVOKESPECIAL,
+            "scala/MatchError", "<init>", "(Ljava/lang/Object;)V", false)
+          bc.jmethod.visitInsn(asm.Opcodes.ATHROW)
       } else {
 
         /* Since the JVM doesn't have a way to switch on a string, we  switch
@@ -1078,6 +1091,11 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
           targets  ::= switchBlockPoint
         }
 
+        val hasDefault = default != null
+        if !hasDefault then
+          default = new asm.Label
+          indirectBlocks ::= (default, null)
+
         // Push the hashCode of the string (or `0` it is `null`) onto the stack and switch on it
         genLoadIfTo(
           If(
@@ -1115,7 +1133,15 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
         // emit blocks for common patterns
         for ((caseLabel, caseBody) <- indirectBlocks.reverse) {
           markProgramPoint(caseLabel)
-          genLoadTo(caseBody, generatedType, postMatchDest)
+          if caseBody == null then
+            bc.jmethod.visitTypeInsn(asm.Opcodes.NEW, "scala/MatchError")
+            bc.jmethod.visitInsn(asm.Opcodes.DUP)
+            bc.jmethod.visitInsn(asm.Opcodes.ACONST_NULL)
+            bc.jmethod.visitMethodInsn(asm.Opcodes.INVOKESPECIAL,
+              "scala/MatchError", "<init>", "(Ljava/lang/Object;)V", false)
+            bc.jmethod.visitInsn(asm.Opcodes.ATHROW)
+          else
+            genLoadTo(caseBody, generatedType, postMatchDest)
         }
       }
 

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -955,6 +955,14 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
      * Int/String values to use as keys, and a code block. The exception is the "default" case
      * clause which doesn't list any key (there is exactly one of these per match).
      */
+    private def emitThrowMatchError(): Unit =
+      bc.jmethod.visitTypeInsn(asm.Opcodes.NEW, "scala/MatchError")
+      bc.jmethod.visitInsn(asm.Opcodes.DUP)
+      bc.jmethod.visitInsn(asm.Opcodes.ACONST_NULL)
+      bc.jmethod.visitMethodInsn(asm.Opcodes.INVOKESPECIAL,
+        "scala/MatchError", "<init>", "(Ljava/lang/Object;)V", false)
+      bc.jmethod.visitInsn(asm.Opcodes.ATHROW)
+
     private def genMatchTo(tree: Match, expectedType: BType, dest: LoadDestination): BType = tree match {
       case Match(selector, cases) =>
       lineNumber(tree)
@@ -1023,12 +1031,7 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
 
         if !hasDefault then
           markProgramPoint(default)
-          bc.jmethod.visitTypeInsn(asm.Opcodes.NEW, "scala/MatchError")
-          bc.jmethod.visitInsn(asm.Opcodes.DUP)
-          bc.jmethod.visitInsn(asm.Opcodes.ACONST_NULL)
-          bc.jmethod.visitMethodInsn(asm.Opcodes.INVOKESPECIAL,
-            "scala/MatchError", "<init>", "(Ljava/lang/Object;)V", false)
-          bc.jmethod.visitInsn(asm.Opcodes.ATHROW)
+          emitThrowMatchError()
       } else {
 
         /* Since the JVM doesn't have a way to switch on a string, we  switch
@@ -1134,12 +1137,7 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives)(using ctx: Context) exte
         for ((caseLabel, caseBody) <- indirectBlocks.reverse) {
           markProgramPoint(caseLabel)
           if caseBody == null then
-            bc.jmethod.visitTypeInsn(asm.Opcodes.NEW, "scala/MatchError")
-            bc.jmethod.visitInsn(asm.Opcodes.DUP)
-            bc.jmethod.visitInsn(asm.Opcodes.ACONST_NULL)
-            bc.jmethod.visitMethodInsn(asm.Opcodes.INVOKESPECIAL,
-              "scala/MatchError", "<init>", "(Ljava/lang/Object;)V", false)
-            bc.jmethod.visitInsn(asm.Opcodes.ATHROW)
+            emitThrowMatchError()
           else
             genLoadTo(caseBody, generatedType, postMatchDest)
         }

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -324,6 +324,13 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
      * If the tree is empty, return itself and don't instrument.
      */
     private def transformBranch(tree: Tree)(using Context): Tree =
+      transformBranchWithInherited(tree, inheritedProbes = Nil)
+
+    /** Like [[transformBranch]], but runs `inheritedProbes` before the branch probe
+      *  and the transformed body. Used for sub-cases: ancestor case-arm probes are
+      *  emitted at the same successful leaves; see [[instrumentSubMatchWithProbes]].
+      */
+    private def transformBranchWithInherited(tree: Tree, inheritedProbes: List[Apply])(using Context): Tree =
       if tree.isEmpty then
         // - If t.isEmpty then `transform(t) == t` always hold,
         //   so we can avoid calling transform in that case.
@@ -331,7 +338,10 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
       else
         val transformed = transform(tree)
         val coverageCall = createInvokeCall(tree, tree.sourcePos, branch = true)
-        InstrumentedParts.singleExprTree(coverageCall, transformed)
+        val allProbes = inheritedProbes :+ coverageCall
+        allProbes match
+          case single :: Nil => InstrumentedParts.singleExprTree(single, transformed)
+          case multiple => Block(multiple, transformed)
 
     override def transform(tree: Tree)(using Context): Tree =
       inContext(transformCtx(tree)) { // necessary to position inlined code properly
@@ -498,20 +508,54 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
 
         cpy.DefDef(tree)(tree.name, transformedParamss, tree.tpt, transformedRhs)
 
+    /** Span for coverage UI: end at the guard if present, else the pattern. */
+    private def caseDefUserEndPos(cdef: CaseDef)(using Context): SourcePosition =
+      val pat = cdef.pat
+      val guard = cdef.guard
+      val friendlyEnd = if guard.span.exists then guard.span.end else pat.span.end
+      cdef.sourcePos(using ctx).withSpan(cdef.span.withEnd(friendlyEnd))
+
+    /** Re-instrument a [[SubMatch]] while keeping it a direct sub-match tree.
+      *  Downstream, [[dotty.tools.dotc.transform.PatternMatcher]] matches on
+      *  `CaseDef.body: SubMatch` and [[CaseDef.maybePartial]] checks `isInstanceOf[SubMatch]`;
+      *  wrapping the body in a [[Block]] (as in [[transformBranch]]) would break that.
+      *
+      *  Branch coverage for each case arm is recorded by `inheritedProbes` plus, for each
+      *  sub-case, a probe for that arm; we attach those probes to successful sub-match leaves
+      *  so they do not run when a partial sub-match falls through to the next outer case.
+      */
+    private def instrumentSubMatchWithProbes(sm: SubMatch, inheritedProbes: List[Apply])(using Context): SubMatch =
+      val newSelector = transform(sm.selector)
+      val newCases = sm.cases.map(cdef => transformSubMatchCaseDef(cdef, inheritedProbes))
+      cpy.Match(sm)(newSelector, newCases).asInstanceOf[SubMatch]
+
+    private def transformSubMatchCaseDef(cdef: CaseDef, inheritedProbes: List[Apply])(using Context): CaseDef =
+      val pos = caseDefUserEndPos(cdef)
+      val transformedGuard = transform(cdef.guard)
+      val newBody: Tree = cdef.body match
+        case sm: SubMatch =>
+          val p = createInvokeCall(sm, pos, branch = true)
+          instrumentSubMatchWithProbes(sm, p :: inheritedProbes)
+        case b =>
+          transformBranchWithInherited(b, inheritedProbes)
+      cpy.CaseDef(cdef)(cdef.pat, transformedGuard, newBody)
+
     /** Transforms a `case ...` and instruments the parts that can be. */
     private def transformCaseDef(tree: CaseDef)(using Context): CaseDef =
       val pat = tree.pat
       val guard = tree.guard
-
-      // compute a span that makes sense for the user that will read the coverage results
-      val friendlyEnd = if guard.span.exists then guard.span.end else pat.span.end
-      val pos = tree.sourcePos.withSpan(tree.span.withEnd(friendlyEnd)) // user-friendly span
+      val pos = caseDefUserEndPos(tree)
 
       // recursively transform the guard, but keep the pat
       val transformedGuard = transform(guard)
 
-      // ensure that the body is always instrumented as a branch
-      val instrumentedBody = transformBranch(tree.body)
+      // Sub-case bodies are [[SubMatch]]: keep that shape; see [[instrumentSubMatchWithProbes]].
+      val instrumentedBody: Tree = tree.body match
+        case sm: SubMatch =>
+          val p = createInvokeCall(sm, pos, branch = true)
+          instrumentSubMatchWithProbes(sm, p :: Nil)
+        case b =>
+          transformBranch(b)
 
       cpy.CaseDef(tree)(pat, transformedGuard, instrumentedBody)
 

--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -9,7 +9,6 @@ annotation-named-pararamters
 applied_constructor_types.scala
 capt1.scala
 capture.scala
-catch-sub-cases.scala
 colltest5
 gadt-cast-singleton.scala
 gadt-ycheck.scala


### PR DESCRIPTION
Experimental match sub-cases cause issues in interaction with coverage instrumentation phase in the test case that this PR removes from excludelist. The code in question (from the test case):

```scala
def test(op: => Nothing): String =
  try op catch
    case A(x: Int) if true if x match
      case 1 => "A(1)"
      case 2 => "A(2)"
    case B(x: String) if x match
      case "a" => "B(a)"
      case "b" => "B(b)"
    case _ => "other"
end test
```

This test failed with `NullPointerException` at the backend phase. The following is the brief sequence that leads to the failure:

- `InstrumentCoverage` phase breaks an assumption about the sub-cases tree shape that `PatternMatcher` phase downstream relies on.
- The `PatternMatcher` phase treats such instrumented sub-cases differently, breaking an assumption about the presence of a default case that the backend phase relies on.
- Backend phase fails ungracefully.

`PatternMatcher` phase relies on exact shape of sub-cases: `CaseDef(..., body=SubMatch(...))`. However scoverage rewrites them into `CaseDef(..., body=Block(invoke, SubMatch(...)))`, which is not what `PatternMatcher` phase expects. This PR adjusts the scoverage phase to preserve the tree shape expected by the Pattern Matching phase.

The test in question was failing because of the assumptions of the backend phase broken by this interaction. The backend phase expects the default clause to be always present in the rewritten `match` statements. This is satisfied by the nested cases by falling back to the parent `match`'s default case - but only when the tree shape is `CaseDef(..., body=SubMatch(...))`. If not, the nested cases are treated as ordinary cases and no default case is generated.

This PR takes a defensive approach and hardens the backend to fail gracefully in cases where the assumption about the default case is broken. In principle, that should not happen, however, in case it does (like in the case of the issue this PR addresses), the error message the user will see is `MatchError` and not `NullPointerException`, providing more information on the nature of failure.

The main fix is in the `InstrumentCoverage`. The Backend changes are an optional defensive change for a more graceful failure in case the assumption is broken again in the future.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for codebase analysis and tracing.

## How was the solution tested?

`./project/scripts/sbt "scala3-bootstrapped/testCompilation --enable-coverage-phase tests/pos"`