### PR TITLE
Enable sc:compile for stdlib package scala.reflect

### DIFF
--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -27,15 +27,13 @@ import scala.runtime.ClassValueCompat
  *  its argument types. This runtime information is enough for runtime `Array` creation.
  *
  *  For example:
- *  ```
- *   scala> def mkArray[T : ClassTag](elems: T*) = Array[T](elems*)
- *   def mkArray[T](elems: T*)(using ClassTag[T]): Array[T]
+ *  ```scala sc:compile
+ *  import scala.reflect.ClassTag
  *
- *   scala> mkArray(42, 13)
- *   val res0: Array[Int] = Array(42, 13)
+ *  def mkArray[T: ClassTag](elems: T*): Array[T] = Array[T](elems*)
  *
- *   scala> mkArray("Japan","Brazil","Germany")
- *   val res1: Array[String] = Array(Japan, Brazil, Germany)
+ *  val ints = mkArray(42, 13)
+ *  val strings = mkArray("Japan", "Brazil", "Germany")
  *  ```
  *
  *  For compile-time type information in macros, see the facilities in the

--- a/library/src/scala/reflect/Manifest.scala
+++ b/library/src/scala/reflect/Manifest.scala
@@ -27,21 +27,21 @@ import scala.collection.mutable.{ArrayBuilder, ArraySeq}
  *  which are not yet adequately represented in manifests.
  *
  *  Example usages:
- *  ```
- *    def arr[T] = new Array[T](0)                          // does not compile
- *    def arr[T](implicit m: Manifest[T]) = new Array[T](0) // compiles
- *    def arr[T: Manifest] = new Array[T](0)                // shorthand for the preceding
+ *  ```scala sc:compile
+ *    import scala.reflect.Manifest
+ *
+ *    def arr[T: Manifest]: Array[T] = new Array[T](0)
  *
  *    // Methods manifest and optManifest are in [[scala.Predef]].
- *    def isApproxSubType[T: Manifest, U: Manifest] = manifest[T] <:< manifest[U]
- *    isApproxSubType[List[String], List[AnyRef]] // true
- *    isApproxSubType[List[String], List[Int]]    // false
+ *    def isApproxSubType[T: Manifest, U: Manifest]: Boolean = manifest[T] <:< manifest[U]
+ *    val stringsAreAnyRefs = isApproxSubType[List[String], List[AnyRef]]
+ *    val stringsAreInts = isApproxSubType[List[String], List[Int]]
  *
  *    def methods[T: Manifest] = manifest[T].runtimeClass.getMethods
  *    def retType[T: Manifest](name: String) =
- *      methods[T] find (_.getName == name) map (_.getGenericReturnType)
+ *      methods[T].find(_.getName == name).map(_.getGenericReturnType)
  *
- *    retType[Map[_, _]]("values")  // Some(scala.collection.Iterable<B>)
+ *    val mapValuesReturnType = retType[Map[_, _]]("values")
  *  ```
  */
 @nowarn("""cat=deprecation&origin=scala\.reflect\.ClassManifest(DeprecatedApis.*)?""")
@@ -115,7 +115,7 @@ object Manifest {
     ManifestFactory.classType[T](clazz)
 
   /** Manifest for the class type `clazz`, where `clazz` is
-   *  a top-level or static class and args are its type arguments. 
+   *  a top-level or static class and args are its type arguments.
    */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.classType[T](clazz, arg1, args*)
@@ -131,7 +131,7 @@ object Manifest {
 
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
    *  strictly necessary as it could be obtained by reflection. It was
-   *  added so that erasure can be calculated without reflection. 
+   *  added so that erasure can be calculated without reflection.
    */
   def abstractType[T](prefix: Manifest[?], name: String, upperBound: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     ManifestFactory.abstractType[T](prefix, name, upperBound, args*)
@@ -389,7 +389,7 @@ object ManifestFactory {
     new ClassTypeManifest[T](None, clazz, Nil)
 
   /** Manifest for the class type `clazz`, where `clazz` is
-   *  a top-level or static class and args are its type arguments. 
+   *  a top-level or static class and args are its type arguments.
    */
   def classType[T](clazz: Predef.Class[T], arg1: Manifest[?], args: Manifest[?]*): Manifest[T] =
     new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
@@ -408,7 +408,7 @@ object ManifestFactory {
   }
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is
-   *  a top-level or static class. 
+   *  a top-level or static class.
    */
   @SerialVersionUID(1L)
   private class ClassTypeManifest[T](prefix: Option[Manifest[?]],
@@ -432,7 +432,7 @@ object ManifestFactory {
 
   /** Manifest for the abstract type `prefix # name`. `upperBound` is not
    *  strictly necessary as it could be obtained by reflection. It was
-   *  added so that erasure can be calculated without reflection. 
+   *  added so that erasure can be calculated without reflection.
    */
   def abstractType[T](prefix: Manifest[?], name: String, upperBound: Predef.Class[?], args: Manifest[?]*): Manifest[T] =
     new AbstractTypeManifest[T](prefix, name, upperBound, args)


### PR DESCRIPTION
Added sc:compile to scala source files under scala.reflect, adjusted code example to make sure they compile correctly.

