### PR TITLE
Avoid JLine warning about CompletingParsedLine

### DIFF
--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -386,13 +386,16 @@ private final class UserInputStream(
 }
 
 private final class SimpleParser extends reader.Parser {
-  private class ParsedLine(val inputLine: String, val inputCursor: Int) extends reader.ParsedLine {
+  private class ParsedLine(val inputLine: String, val inputCursor: Int) extends reader.CompletingParsedLine {
     def word(): String = inputLine
     def wordCursor(): Int = inputCursor
     def wordIndex(): Int = 0
     def words(): java.util.List[String] = java.util.List.of(inputLine)
     def line(): String = inputLine
     def cursor(): Int = inputCursor
+    def escape(candidate: CharSequence, complete: Boolean): CharSequence = candidate
+    def rawWordCursor(): Int = inputCursor
+    def rawWordLength(): Int = inputLine.length
   }
 
   def parse(input: String, cursor: Int, context: ParseContext): reader.ParsedLine =


### PR DESCRIPTION
Fixes #25901 

cc @lihaoyi , I don't know if this is a particularly clever fix but I guess we don't really care about this class in the first place

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Manual tests because writing automated tests is impractical, described below (in detail)

Launch the REPL from bin/replQ after a buildQuick in sbt, notice the warning, apply this fix, no more warning
