### PR TITLE
Remove obsolete checkBackendNames switch

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Config.scala
+++ b/compiler/src/dotty/tools/dotc/config/Config.scala
@@ -66,13 +66,6 @@ object Config {
    */
   inline val checkNoSkolemsInInfo = false
 
-  /** Check that Name#toString is not called directly from backend by analyzing
-   *  the stack trace of each toString call on names. This is very expensive,
-   *  so not suitable for continuous testing. But it can be used to find a problem
-   *  when running a specific test.
-   */
-  inline val checkBackendNames = false
-
   /** Check that re-used type comparers are in their initialization state */
   inline val checkTypeComparerReset = false
 

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -384,39 +384,7 @@ object Names {
 
     protected def computeToString: String =
       if (length == 0) ""
-      else {
-        if (Config.checkBackendNames)
-          if (!toStringOK) {
-            // We print the stacktrace instead of doing an assert directly,
-            // because asserts are caught in exception handlers which might
-            // cause other failures. In that case the first, important failure
-            // is lost.
-            System.err.println("Backend should not call Name#toString, Name#mangledString should be used instead.")
-            Thread.dumpStack()
-            assert(false)
-          }
-        new String(chrs, start, length)
-      }
-
-    /** It's OK to take a toString if the stacktrace does not contain a method
-     *  from GenBCode or it also contains one of the allowed methods below.
-     */
-    private def toStringOK = {
-      val trace: Array[StackTraceElement] = Thread.currentThread.getStackTrace.asInstanceOf[Array[StackTraceElement]]
-      !trace.exists(_.getClassName.endsWith("GenBCode")) ||
-      trace.exists(elem =>
-          List(
-              "mangledString",
-              "toSimpleName",
-              "decode",
-              "unmangle",
-              "dotty$tools$dotc$core$NameOps$NameDecorator$$functionArityFor$extension",
-              "dotty$tools$dotc$typer$Checking$CheckNonCyclicMap$$apply",
-              "$plus$plus",
-              "readConstant",
-              "extractedName")
-            .contains(elem.getMethodName))
-    }
+      else new String(chrs, start, length)
 
     def debugString: String = toString
   }


### PR DESCRIPTION
Enabling this switch causes every compilation test to fail, because names get printed all the time when the backend creates a DefDef or loads a required class or whatever.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
