### PR TITLE
Fix bridge generation when `erased` precedes a non-erased parameter

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -804,8 +804,9 @@ object Erasure {
       val Apply(fun, args) = tree
       val origFun = fun.asInstanceOf[tpd.Tree]
       val origFunType = origFun.tpe.widen(using preErasureCtx)
+      val insideBridge = ctx.owner.ownersIterator.exists(_.is(Flags.Bridge))
       val ownArgs = origFunType match
-        case mt: MethodType if mt.hasErasedParams =>
+        case mt: MethodType if mt.hasErasedParams && !insideBridge =>
           args.lazyZip(mt.paramErasureStatuses).flatMap: (arg, isErased) =>
             if isErased then
               checkPureErased(arg, isArgument = true,

--- a/tests/pos/i25726.scala
+++ b/tests/pos/i25726.scala
@@ -1,0 +1,48 @@
+import scala.language.experimental.erasedDefinitions
+
+class Ev
+
+trait Svc[A]:
+  def run(using erased Ev)(a: A): String
+class ISvc extends Svc[Int]:
+  def run(using erased Ev)(a: Int): String = a.toString
+
+// More than one pre-erasure parameter list with an all-erased prefix
+class Token
+trait Store[A]:
+  def put(using erased Token)(key: String)(value: A): String
+class IntStore extends Store[Int]:
+  def put(using erased Token)(key: String)(value: Int): String = s"$key=$value"
+
+// Trailing all-erased list (worked before the fix; must not regress)
+trait Trail[A]:
+  def id(a: A)(using erased Ev): A
+class IntTrail extends Trail[Int]:
+  def id(a: Int)(using erased Ev): Int = a
+
+// Erased-first inside a single parameter list
+trait Single[A]:
+  def run(erased a: Ev, b: A): String
+class IntSingle extends Single[Int]:
+  def run(erased a: Ev, b: Int): String = b.toString
+
+// Erased-first within a non-trailing parameter list
+trait Mixed[A]:
+  def run(erased e: Ev, a: A)(b: Int): String
+class IntMixed extends Mixed[Int]:
+  def run(erased e: Ev, a: Int)(b: Int): String = s"$a+$b"
+
+  trait Eta[A]:
+    def f(using erased Ev)(a: A): String ?=> Int
+
+  class IntEta extends Eta[Int]:
+    def f(using erased Ev)(a: Int): String ?=> Int = a + summon[String].length
+
+// generated bridge:
+// def f(a: Object): Function1[String, Int] = // beridge
+//   new Function1[String, Int]:
+//     def apply(s: String): Int = this$IntEta.f(a, s)
+trait Closure[A]:
+  def f(using erased Ev)(a: A): String ?=> Int
+class IntClosure extends Closure[Int]:
+  def f(using erased Ev)(a: Int): String ?=> Int = a + summon[String].length


### PR DESCRIPTION

Previously, compiling

```scala
import scala.language.experimental.erasedDefinitions
class Ev
trait Svc[A]:
  def run(using erased Ev)(a: A): String
class ISvc extends Svc[Int]:
  def run(using erased Ev)(a: Int): String = a.toString
```

crashed in erasure with `bad adapt for this.run(): (x$0: Int): String`.

The bridge body is `Apply(this.run, [a])`.
However, previously, `Erasure.Typer.typedApply` filters
erased arguments using the function's *pre-erasure* type, and zip
arguments against `paramErasureStatuses` positionally (`(erased Ev)(a: Int)`).

Hence, `a` is mistaken for the erased slot and dropped, that leads to bad adaption.

This commit fixes the issue, by just skipping the filter when the Apply is inside a
bridge body.

Fixes https://github.com/scala/scala3/issues/25726.

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively for problem investigation, minimally for writing code.


## How was the solution tested?

`testCompilation i25726`

