### PR TITLE
Mostly fix REPL in sbt

### DIFF
--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -154,7 +154,7 @@ class JLineTerminal extends java.io.Closeable {
         else if ch == NonBlockingReader.EOF then userInput.signalClosed()
         else if ch == 3 then handler()
         else
-          // if the user is trying to use stdin and we consumed a character so put it "back" into the reader's buffer,
+          // if the user is trying to use stdin and we consumed a character, put it "back" into the reader's buffer,
           // otherwise the behavior will be nonsensical
           if userLineReader.isReading then
             userLineReader.getBuffer.write(ch.toChar)

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -148,12 +148,20 @@ class JLineTerminal extends java.io.Closeable {
       while userInput.waitUntilActive() == InputState.Monitoring do
         val ch =
           try reader.read(100L)
-          catch case _: Exception => -1
+          catch case _: Exception => NonBlockingReader.READ_EXPIRED
 
         if ch == NonBlockingReader.READ_EXPIRED then ()
         else if ch == NonBlockingReader.EOF then userInput.signalClosed()
         else if ch == 3 then handler()
-        else userInput.enqueueChar(ch)
+        else
+          // if the user is trying to use stdin and we consumed a character so put it "back" into the reader's buffer,
+          // otherwise the behavior will be nonsensical
+          if userLineReader.isReading then
+            userLineReader.getBuffer.write(ch.toChar)
+            userLineReader.callWidget(LineReader.REDRAW_LINE)
+            userLineReader.callWidget(LineReader.REDISPLAY)
+          else
+            userInput.enqueueChar(ch)
     , "REPL-CtrlC-Monitor")
     monitoringThread = thread
     thread.setDaemon(true)
@@ -162,6 +170,7 @@ class JLineTerminal extends java.io.Closeable {
     try block
     finally {
       userInput.signalClosed()
+      reader.close() // ensure the reader isn't stuck waiting for further input
       Thread.interrupted() // clear interrupted flag so join below doesn't explode
       thread.join()
       monitoringThread = null
@@ -362,10 +371,8 @@ private final class UserInputStream(
             val lineBytes = (line + System.lineSeparator()).getBytes(encoding)
             enqueueBytes(lineBytes)
           catch
-            case _: EndOfFileException =>
+            case _: EndOfFileException | _: UserInterruptException | _: InterruptedException =>
               return -1
-            case _: UserInterruptException =>
-              throw new InterruptedIOException()
           finally
             resumeMonitoring()
 


### PR DESCRIPTION
Fixes #25401

Ctrl+C _still_ doesn't work within SBT to interrupt the running task, but it does work in standalone and within Mill...

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Manual tests because writing automated tests is impractical, described below (in detail)

Run the REPL:
- in standalone as bin/replQ,
- within SBT (`console`)
- within Mill

And for each of these, try:
- inputting "whatever" and hit Enter, you should see an error, and then the "scala>" prompt without having to input anything else
- inputting "Console.in.readLine()", you should see what you type, then erase what you typed, type something else, hit Enter, exactly the second input should be the result
- inputting "Console.in.readLine()", then Ctrl+C, then Ctrl+D, you should not see a stack trace


For running inside Mill, run `./mill repl` with the`./mill` from the instructions [here](https://mill-build.org/mill/cli/installation-ide.html#_bootstrap_scripts) with the following `build.mill` file (delete `out` if you need to re-run it after re-`publishLocalBin`-ing a compiler)
```scala
package build

import mill.*, scalalib.*
import mill.api.*

object `package` extends ScalaModule:
  object JvmWorker extends JvmWorkerModule:
    override def repositories =
      super.repositories() ++ Seq(CoursierModule.KnownRepositories.ScalaLangNightlies)

  override def jvmWorker: ModuleRef[JvmWorkerModule] = ModuleRef(JvmWorker)
  override def repositories =
    super.repositories() ++ Seq(CoursierModule.KnownRepositories.ScalaLangNightlies)
  def scalaVersion = "3.9.0-RC1-bin-SNAPSHOT" // change this
```