### PR TITLE
Remove self reference in Conversion class and add impure conversion test

### DIFF
--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -26,7 +26,6 @@ import annotation.internal.preview
  */
 @java.lang.FunctionalInterface
 abstract class Conversion[-T, +U] extends Function1[T, U]:
-  self =>
     /** Converts value `x` of type `T` to type `U`. */
     def apply(x: T): U
 

--- a/tests/pos-custom-args/captures/impure-conversion.scala
+++ b/tests/pos-custom-args/captures/impure-conversion.scala
@@ -1,0 +1,14 @@
+import language.experimental.captureChecking
+import caps.*
+
+trait Ctx extends SharedCapability
+
+class C[T]:
+  def value(using Ctx): T = ???
+
+object C:
+  given [T](using ctx: Ctx): (Conversion[C[T], T]^{ctx}) = _.value
+
+def test(using Ctx): Unit =
+  val c = new C[Int]
+  val n: Int = c


### PR DESCRIPTION
Removing `self` reference in `Conversion` class makes it able to capture.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New pos test in cc
