### PR TITLE
Fix stable reference check for And types with type params

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -183,8 +183,6 @@ object Types extends TypeUtils {
         // https://www.scala-lang.org/files/archive/spec/2.11/11-annotations.html#scala-compiler-annotations
         tp.annot.symbol == defn.UncheckedStableAnnot || tp.parent.isStable
       case tp: AndType =>
-        // TODO: fix And type check when tp contains type parames for explicit-nulls flow-typing
-        // see: tests/explicit-nulls/pos/flow-stable.scala.disabled
         tp.tp1.isStable && (realizability(tp.tp2) eq Realizable) ||
         tp.tp2.isStable && (realizability(tp.tp1) eq Realizable)
       case tp: AppliedType => tp.cachedIsStable

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -585,6 +585,21 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     findRefRecur(NoType, BindingPrec.NothingBound, NoContext)
   }
 
+  /** If `ref` is a trackable `TermRef` of an `OrNull` type that flow typing has
+   *  identified as non-null at this point, returns `Some(tpnn)` where `tpnn` is
+   *  the non-null leg. Otherwise returns `None`.
+   */
+  private def nonNullPart(ref: TermRef)(using Context): Option[Type] =
+    if ctx.explicitNulls
+      && ctx.notNullInfos.impliesNotNull(ref)
+      // If a reference is in the context, it is already trackable at the point we add it.
+      // Hence, we don't use isTracked in the next line, because checking use out of order is enough.
+      && !ref.usedOutOfOrder
+    then ref match
+      case OrNull(tpnn) => Some(tpnn)
+      case _            => None
+    else None
+
   /** If `tree`'s type is a `TermRef` identified by flow typing to be non-null, then
    *  cast away `tree`s nullability. Otherwise, `tree` remains unchanged.
    *
@@ -594,17 +609,29 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    */
   def toNotNullTermRef(tree: Tree, pt: Type)(using Context): Tree = tree.tpe match
     case ref: TermRef
-    if ctx.explicitNulls
-      && pt != LhsProto // Ensure it is not the lhs of Assign
-      && ctx.notNullInfos.impliesNotNull(ref)
-      // If a reference is in the context, it is already trackable at the point we add it.
-      // Hence, we don't use isTracked in the next line, because checking use out of order is enough.
-      && !ref.usedOutOfOrder =>
-      ref match
-        case OrNull(tpnn) => tree.cast(AndType(ref, tpnn))
-        case _            => tree
+    if pt != LhsProto // Ensure it is not the lhs of Assign
+      && pt != SingletonTypeProto =>
+      nonNullPart(ref) match
+        case Some(tpnn) => tree.cast(AndType(ref, tpnn))
+        case None       => tree
     case _ =>
       tree
+
+  /** If `tree` is a singleton type tree whose ref is identified by flow typing to be
+   *  non-null, wrap it in an `&`-typed `AppliedTypeTree` carrying the non-null leg,
+   *  so the resulting type is `ref.type & tpnn`. The inner singleton tree's ref is
+   *  left unintersected, so PostTyper's realizability check on `ref.tpe` (which
+   *  rejects AndTypes containing parameter `TermRef`s as non-concrete) still passes.
+   */
+  def toNotNullSingletonTypeTree(tree: SingletonTypeTree)(using Context): Tree = tree.ref.tpe match
+    case ref: TermRef =>
+      nonNullPart(ref) match
+        case Some(tpnn) =>
+          typed(
+            untpd.makeAndType(untpd.TypedSplice(tree), untpd.TypedSplice(TypeTree(tpnn)))
+              .withSpan(tree.span))
+        case None => tree
+    case _ => tree
 
   /** Attribute an identifier consisting of a simple name or wildcard
    *
@@ -2693,7 +2720,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               // Fall through to normal path if widened type is not a TypeRef
               // (can happen with naming conflicts #25025)
         checkStable(ref1.tpe, tree.srcPos, "singleton type")
-        assignType(cpy.SingletonTypeTree(tree)(ref1), ref1)
+        toNotNullSingletonTypeTree(assignType(cpy.SingletonTypeTree(tree)(ref1), ref1))
 
   def typedRefinedTypeTree(tree: untpd.RefinedTypeTree)(using Context): TypTree = {
     val tpt1 = if tree.tpt == EmptyTree then TypeTree(defn.ObjectType) else typedAheadType(tree.tpt)

--- a/tests/explicit-nulls/pos/flow-stable.scala
+++ b/tests/explicit-nulls/pos/flow-stable.scala
@@ -1,4 +1,3 @@
-// TODO: temporarily disable,
 // in the if expression, `x.type` becomes `((x : T | Null) & T).type` due to `x != null`
 // We need to make sure `(x : T | Null) & T` stable and concrete in order to use `.type`
 

--- a/tests/explicit-nulls/pos/opt.scala
+++ b/tests/explicit-nulls/pos/opt.scala
@@ -1,0 +1,9 @@
+
+type Opt[+A] = A | Null
+object Opt:
+
+  def unapply[A](o: Opt[A]): Option[A] =
+    if o != null then Some(o.asInstanceOf[o.type & A])
+    else None
+
+end Opt


### PR DESCRIPTION
Fixes existing bug that also resurfaced in open community build with explicit-nulls enabled in the following project
[neandertech/langoustine](https://scala3.westeurope.cloudapp.azure.com/dashboard/projects/neandertech/langoustine/builds/HarrisL2%2Fscala3%3Aunsafe-explicit-nulls%3A2026-04-01/logs)

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, for producing the appropriate fix

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests at
tests/explicit-nulls/pos/opt.scala
and a previously disabled test at
tests/explicit-nulls/pos/flow-stable.scala

