### PR TITLE
Fix scoverage test harness: do not add redundant -Ycheck when testing

### DIFF
--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -6,7 +6,6 @@
 
 16583.scala
 applied_constructor_types.scala
-capt1.scala
 capture.scala
 gadt-ycheck.scala
 help.scala
@@ -20,7 +19,6 @@ i15165.scala
 i15864.scala
 i18263.orig.scala
 i18263.scala
-i18589
 i19955a.scala
 i19955b.scala
 i20053b.scala
@@ -34,7 +32,6 @@ i8900a3.scala
 i9228.scala
 lazyVals_c3.0.0.scala
 lazyVals_c3.1.0.scala
-minicheck-toplevel.scala
 mt-scrutinee-widen3.scala
 null.scala
 pos_valueclasses

--- a/compiler/test/dotty/tools/dotc/CoverageSupport.scala
+++ b/compiler/test/dotty/tools/dotc/CoverageSupport.scala
@@ -149,7 +149,6 @@ trait CoverageSupport:
         val coverageDir = Files.createTempDirectory("coverage")
         val sourceRoot = Paths.get(".").toAbsolutePath.toString
         target.withFlags(
-          "-Ycheck:instrumentCoverage",
           "-coverage-out", coverageDir.toString,
           "-sourceroot", sourceRoot
         )


### PR DESCRIPTION
Currently scoverage testing harness incorrectly adds `-Ycheck` flag to the tests. This is wrong as the tests themselves decide whether to add this flag or not. This unconditional addition caused failures in few tests that opted out of `-Ycheck`.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for codebase analysis and tracing.

## How was the solution tested?

`sbt --client "testCompilation --enable-coverage-phase"`
