### PR TITLE
Make parameter types of some closures explicit

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -1241,7 +1241,7 @@ object Capabilities:
 
   abstract class CapMap(using Context) extends BiTypeMap:
     override def mapOver(t: Type): Type = t match
-      case t @ FunctionOrMethod(args, res) if variance > 0 && !t.isAliasFun =>
+      case t @ FunctionOrMethod(_, _) if variance > 0 && !t.isAliasFun =>
         t // `t` should be mapped in this case by a different call to `toResult`. See [[toResultInResults]].
       case t: (LazyRef | TypeVar) =>
         mapConserveSuper(t)

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -909,6 +909,8 @@ class CleanupRetains(using Context) extends TypeMap:
         if annot.symbol == defn.RetainsCapAnnot then tp
         else AnnotatedType(this(parent), RetainingAnnotation(annot.symbol.asClass, defn.NothingType))
       else this(parent)
+    case tp @ AnnotatedType(parent, annot) if annot.symbol == defn.DeclaredAnnot =>
+      tp
     case _ => mapOver(tp)
 
 /** A base class for extractors that match annotated types with a specific

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -502,8 +502,8 @@ extension (tp: Type)
     case tp: MethodType =>
       tp.derivedLambdaType(paramInfos = argTypes, resType = resType)
     case tp: PolyType =>
-      assert(argTypes.isEmpty)
-      tp.derivedLambdaType(resType = resType)
+      assert(argTypes.forall(_.isInstanceOf[TypeBounds]))
+      tp.derivedLambdaType(paramInfos = argTypes.asInstanceOf[List[TypeBounds]], resType = resType)
     case _ =>
       tp
 
@@ -953,14 +953,13 @@ end OnlyCapability
 
 /** An extractor for all kinds of function types as well as method and poly types.
  *  It includes aliases of function types such as `=>`. TODO: Can we do without?
- *  @return  1st half: The argument types or empty if this is a type function
+ *  @return  1st half: The argument types or type bounds if this is a type function
  *           2nd half: The result type
  */
 object FunctionOrMethod:
   def unapply(tp: Type)(using Context): Option[(List[Type], Type)] = tp match
     case defn.FunctionOf(args, res, isContextual) => Some((args, res))
-    case mt: MethodType => Some((mt.paramInfos, mt.resType))
-    case mt: PolyType => Some((Nil, mt.resType))
+    case mt: MethodOrPoly => Some((mt.paramInfos, mt.resType))
     case defn.RefinedFunctionOf(rinfo) => unapply(rinfo)
     case _ => None
 

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -903,9 +903,11 @@ class PathSelectionProto(val selector: Symbol, val pt: Type, val tree: Tree) ext
  *   argument if CC is enabled (we need to do that to keep by-name status).
  */
 class CleanupRetains(using Context) extends TypeMap:
+  var retainsFound: Boolean = false
   def apply(tp: Type): Type = tp match
     case tp @ AnnotatedType(parent, annot: RetainingAnnotation) =>
       if Feature.ccEnabled then
+        retainsFound = true
         if annot.symbol == defn.RetainsCapAnnot then tp
         else AnnotatedType(this(parent), RetainingAnnotation(annot.symbol.asClass, defn.NothingType))
       else this(parent)

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1176,8 +1176,8 @@ class CheckCaptures extends Recheck, SymTransformer:
             assert(params.hasSameLengthAs(argTypes), i"$mdef vs $pt, ${params}")
             inContext(ctx.withOwner(anonfun)) {
               // Propagate argument types to parameter types with inferred types
-              for (argType, param) <- argTypes.lazyZip(params) do
-                param.asInstanceOf[ValDef].tpt match
+              for case (argType, param: ValDef) <- argTypes.lazyZip(params) do
+                param.tpt match
                   case paramTpt: InferredTypeTree =>
                     val localArgType = globalCapToLocal(argType, Origin.Parameter(param.symbol))
                     adoptCaptures(param.symbol.info, localArgType)

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -358,12 +358,6 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           case AnnotatedType(parent, annot)
           if annot.symbol == defn.DeclaredAnnot =>
             transformExplicitType(parent, sym)
-          case tp: TypeLambda =>
-            // Don't recurse into parameter bounds, just cleanup any stray retains annotations
-            addVar(
-              tp.derivedLambdaType(
-                paramInfos = tp.paramInfos.mapConserve(_.dropAllRetains.bounds),
-                resType = this(tp.resType)))
           case tp @ RefinedType(parent, rname, rinfo) =>
             val saved = refiningNames
             refiningNames += rname

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -309,10 +309,12 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     *  @param typeArgFormal if `tp` is an an inferred type argument, the formal parameter info,
     *                       otherwise NotType
     */
-  private def transformInferredType(tp: Type, sym: Symbol, typeArgFormal: Type = NoType)(using Context): Type = {
+  private def transformInferredType(tp: Type, sym: Symbol, typeArgFormal: Type = NoType, initialVariance: Int = 1)(using Context): Type = {
+
     def mapInferred(inCaptureRefinement: Boolean): TypeMap = new TypeMap with SetupTypeMap {
       override def toString = "map inferred"
 
+      variance = initialVariance
       var refiningNames: Set[Name] = Set()
 
       /** Refine a possibly applied class type C where the class has tracked parameters
@@ -347,7 +349,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           decorate(
             addCaptureRefinements(normalizeCaptures(normalizeFunctions(tp1, tp))),
             CaptureSet.VarInTypeTree(ctx.owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner), isRefining = inCaptureRefinement),
-            transformExplicitType(_, sym),
+            transformExplicitType(_, sym, initialVariance = variance),
             typeArgFormal)
 
         tp match
@@ -357,7 +359,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             addVar(apply(parent))
           case AnnotatedType(parent, annot)
           if annot.symbol == defn.DeclaredAnnot =>
-            transformExplicitType(parent, sym)
+            transformExplicitType(parent, sym, initialVariance = variance)
           case tp @ RefinedType(parent, rname, rinfo) =>
             val saved = refiningNames
             refiningNames += rname
@@ -387,7 +389,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
    *   5. Schedule deferred well-formed tests for types with retains annotations.
    *   6. Perform normalizeCaptures
    */
-  private def transformExplicitType(tp: Type, sym: Symbol, tptToCheck: Tree = EmptyTree)(using Context): Type =
+  private def transformExplicitType(tp: Type, sym: Symbol, tptToCheck: Tree = EmptyTree, initialVariance: Int = 1)(using Context): Type =
 
     def fail(msg: Message) =
       if !tptToCheck.isEmpty then report.error(msg, tptToCheck.srcPos)
@@ -408,6 +410,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
     object toCapturing extends DeepTypeMap, SetupTypeMap {
       override def toString = "transformExplicitType"
+      variance = initialVariance
 
       private var enclMethodType: MethodType | Null =  null
 
@@ -488,7 +491,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             if ann.symbol == defn.UncheckedCapturesAnnot then
               makeUnchecked(this(parent))
             else if ann.symbol == defn.InferredAnnot then
-              transformInferredType(parent, sym)
+              transformInferredType(parent, sym, initialVariance = variance)
                 // typeArgFormal is NoType here since we are inferring inside an argument, not at the toplevel
             else
               t.derivedAnnotatedType(this(parent), ann)
@@ -533,7 +536,8 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             |The `fresh` capability may only be used in the result of a function type,
             |following a function arrow such as `=>` or `->`.""")
 
-    globalCapToLocal(tp2, Origin.InDecl(sym))
+    if initialVariance < 0 then tp2
+    else globalCapToLocal(tp2, Origin.InDecl(sym))
   end transformExplicitType
 
   /** Update info of `sym` for CheckCaptures phase only */

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -516,7 +516,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             else t1
     }
 
-    val tp1 = toCapturing(tp)
+    val tp1 = ccState.withNoVarsMapped(toCapturing(tp))
     if tp1 ne tp then capt.println(i"expanded explicit in ${ctx.owner}: $tp  -->  $tp1")
     val tp2 = if sym.isType then stripImpliedCaptureSet(tp1) else tp1
     if tp2.containsGlobalFreshDirectly then

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -304,9 +304,13 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     *  5. Perform normalizeCaptures
     *
     *  Polytype bounds are only cleaned using step 1, but not otherwise transformed.
+    *  @param tp            the type to transform
+    *  @param sym           the definition to which this type belongs
+    *  @param typeArgFormal if `tp` is an an inferred type argument, the formal parameter info,
+    *                       otherwise NotType
     */
-  private def transformInferredType(tp: Type, typeArgFormal: Type = NoType)(using Context): Type =
-    def mapInferred(inCaptureRefinement: Boolean): TypeMap = new TypeMap with SetupTypeMap:
+  private def transformInferredType(tp: Type, sym: Symbol, typeArgFormal: Type = NoType)(using Context): Type = {
+    def mapInferred(inCaptureRefinement: Boolean): TypeMap = new TypeMap with SetupTypeMap {
       override def toString = "map inferred"
 
       var refiningNames: Set[Name] = Set()
@@ -336,30 +340,39 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             case _ => tp
         case _ => tp
 
-      def innerApply(tp: Type) =
-        val tp1 = tp match
+      def innerApply(tp: Type) = {
+
+        /** Normalize `tp` and add a capture set variable to it if necessary. */
+        def addVar(tp1: Type) =
+          decorate(
+            addCaptureRefinements(normalizeCaptures(normalizeFunctions(tp1, tp))),
+            CaptureSet.VarInTypeTree(ctx.owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner), isRefining = inCaptureRefinement),
+            transformExplicitType(_, sym),
+            typeArgFormal)
+
+        tp match
           case AnnotatedType(parent, annot)
           if annot.symbol.isRetains || annot.symbol == defn.InferredAnnot =>
             // Drop explicit retains and @inferred annotations
-            apply(parent)
+            addVar(apply(parent))
+          case AnnotatedType(parent, annot)
+          if annot.symbol == defn.DeclaredAnnot =>
+            transformExplicitType(parent, sym)
           case tp: TypeLambda =>
             // Don't recurse into parameter bounds, just cleanup any stray retains annotations
-            tp.derivedLambdaType(
-              paramInfos = tp.paramInfos.mapConserve(_.dropAllRetains.bounds),
-              resType = this(tp.resType))
+            addVar(
+              tp.derivedLambdaType(
+                paramInfos = tp.paramInfos.mapConserve(_.dropAllRetains.bounds),
+                resType = this(tp.resType)))
           case tp @ RefinedType(parent, rname, rinfo) =>
             val saved = refiningNames
             refiningNames += rname
             val parent1 = try this(parent) finally refiningNames = saved
-            tp.derivedRefinedType(parent1, rname, this(rinfo))
+            addVar(tp.derivedRefinedType(parent1, rname, this(rinfo)))
           case _ =>
-            mapFollowingAliases(tp)
-        addVar(
-          addCaptureRefinements(normalizeCaptures(normalizeFunctions(tp1, tp))),
-          ctx.owner,
-          isRefining = inCaptureRefinement,
-          typeArgFormal = typeArgFormal)
-    end mapInferred
+            addVar(mapFollowingAliases(tp))
+      }
+    }
 
     try
       ccState.withNoVarsMapped:
@@ -369,7 +382,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     catch case ex: AssertionError =>
       println(i"error while mapping inferred $tp")
       throw ex
-  end transformInferredType
+  }
 
   /** Transform an explicitly given type by performing the following transformation
    *  steps everywhere in the type:
@@ -481,7 +494,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             if ann.symbol == defn.UncheckedCapturesAnnot then
               makeUnchecked(this(parent))
             else if ann.symbol == defn.InferredAnnot then
-              transformInferredType(parent)
+              transformInferredType(parent, sym)
                 // typeArgFormal is NoType here since we are inferring inside an argument, not at the toplevel
             else
               t.derivedAnnotatedType(this(parent), ann)
@@ -554,7 +567,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       if !tree.hasNuType then
         var transformed =
           if tree.isInferred || sym.is(ModuleVal)
-          then transformInferredType(tree.tpe, typeArgFormal)
+          then transformInferredType(tree.tpe, sym, typeArgFormal)
           else transformExplicitType(tree.tpe, sym, tptToCheck = tree)
         if boxed then transformed = transformed.boxDeeply
         tree.setNuType(
@@ -637,7 +650,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
         case tree @ SeqLiteral(elems, tpt: TypeTree) =>
           traverse(elems)
-          tpt.setNuType(transformInferredType(tpt.tpe).boxDeeply)
+          tpt.setNuType(transformInferredType(tpt.tpe, ctx.owner).boxDeeply)
 
         case tree @ Try(body, catches, finalizer) =>
           val tryOwner = firstCanThrowEvidence(body) match
@@ -749,7 +762,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
       case tree: Bind =>
         val sym = tree.symbol
-        updateInfo(sym, transformInferredType(sym.info), sym.owner)
+        updateInfo(sym, transformInferredType(sym.info, sym), sym.owner)
       case tree @ TypeDef(_, impl: Template) =>
         val cls: ClassSymbol = tree.symbol.asClass
 
@@ -910,7 +923,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
    *  @param tp     the type to add a capture set to
    *  @param added  A function producing the added capture set from a set of initial elements.
    */
-  def decorate(tp: Type, added: CaptureSet.Refs => CaptureSet, typeArgFormal: Type = NoType)(using Context): Type = {
+  def decorate(tp: Type, added: CaptureSet.Refs => CaptureSet, handleAlias: Type => Type, typeArgFormal: Type = NoType)(using Context): Type = {
     if tp.typeSymbol == defn.FromJavaObjectSymbol then
       // For capture checking, we assume Object from Java is the same as Any
       tp
@@ -932,14 +945,10 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
         else fallback
       val dealiased = tp.dealiasKeepAnnotsAndOpaques
       if dealiased ne tp then
-        val transformed = transformInferredType(dealiased, typeArgFormal)
+        val transformed = handleAlias(dealiased)
         maybeAdd(transformed, if transformed ne dealiased then transformed else tp)
       else maybeAdd(tp, tp)
   }
-
-  /** Add a capture set variable to `tp` if necessary. */
-  private def addVar(tp: Type, owner: Symbol, isRefining: Boolean, typeArgFormal: Type = NoType)(using Context): Type =
-    decorate(tp, CaptureSet.VarInTypeTree(owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner), isRefining), typeArgFormal)
 
   /** A map that adds <fluid> capture sets at all contra- and invariant positions
    *  in a type where a capture set would be needed. This is used to make types
@@ -969,7 +978,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           case _ =>
             mapOver(t)
         if variance > 0 then t1
-        else decorate(t1, Function.const(CaptureSet.Fluid))
+        else decorate(t1, Function.const(CaptureSet.Fluid), this)
 
   /** Replace all universal capture sets in this type by <fluid> */
   private def makeUnchecked(using Context): TypeMap = new TypeMap with FollowAliasesMap:

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1127,6 +1127,7 @@ class Definitions {
   @tu lazy val VarargsAnnot: ClassSymbol = requiredClass("scala.annotation.varargs")
   @tu lazy val ReachCapabilityAnnot = requiredClass("scala.annotation.internal.reachCapability")
   @tu lazy val InferredAnnot = requiredClass("scala.caps.internal.inferred")
+  @tu lazy val DeclaredAnnot = requiredClass("scala.caps.internal.declared")
   @tu lazy val ReadOnlyCapabilityAnnot = requiredClass("scala.annotation.internal.readOnlyCapability")
   @tu lazy val OnlyCapabilityAnnot = requiredClass("scala.annotation.internal.onlyCapability")
   @tu lazy val RequiresCapabilityAnnot: ClassSymbol = requiredClass("scala.annotation.internal.requiresCapability")

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -670,24 +670,28 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
             // TODO: Merge with isSubInfo in hasMatchingMember. Currently, we can't since
             // the isSubinfo of hasMatchingMember has problems dealing with PolyTypes
             // (---> orphan params during pickling)
-            def isSubInfo(info1: Type, info2: Type): Boolean = (info1, info2) match
-              case (info1: PolyType, info2: PolyType) =>
-                info1.paramNames.hasSameLengthAs(info2.paramNames)
-                && isSubInfo(info1.resultType, info2.resultType.subst(info2, info1))
-              case (info1: MethodType, info2: MethodType) =>
-                matchingMethodParams(info1, info2, precise = false)
-                && isSubInfo(info1.resultType, info2.resultType.subst(info2, info1))
-              case (info1 @ CapturingType(parent1, refs1), info2: Type)
-              if info2.stripCapturing.isInstanceOf[MethodOrPoly] =>
-                compareCaptures(info1, refs1, info2, info2.captureSet)
-                  && isSubInfo(parent1, info2)
-              case (info1: Type, CapturingType(parent2, refs2))
-              if info1.stripCapturing.isInstanceOf[MethodOrPoly] =>
-                val refs1 = info1.captureSet
-                (refs1.isAlwaysEmpty || compareCaptures(info1, refs1, info2, refs2))
-                  && isSubInfo(info1, parent2)
-              case _ =>
-                isSubType(info1, info2)
+            def isSubInfo(info1: Type, info2: Type): Boolean =
+              try (info1, info2) match
+                case (info1: PolyType, info2: PolyType) =>
+                  info1.paramNames.hasSameLengthAs(info2.paramNames)
+                  && isSubInfo(info1.resultType, info2.resultType.subst(info2, info1))
+                case (info1: MethodType, info2: MethodType) =>
+                  matchingMethodParams(info1, info2, precise = false)
+                  && isSubInfo(info1.resultType, info2.resultType.subst(info2, info1))
+                case (info1 @ CapturingType(parent1, refs1), info2: Type)
+                if info2.stripCapturing.isInstanceOf[MethodOrPoly] =>
+                  compareCaptures(info1, refs1, info2, info2.captureSet)
+                    && isSubInfo(parent1, info2)
+                case (info1: Type, CapturingType(parent2, refs2))
+                if info1.stripCapturing.isInstanceOf[MethodOrPoly] =>
+                  val refs1 = info1.captureSet
+                  (refs1.isAlwaysEmpty || compareCaptures(info1, refs1, info2, refs2))
+                    && isSubInfo(info1, parent2)
+                case _ =>
+                  isSubType(info1, info2)
+              catch case ex: AssertionError =>
+                println(i"error while subinfo $info1 <:< $info2")
+                throw ex
 
             if defn.isFunctionType(tp2) then
               if tp2.derivesFrom(defn.PolyFunctionClass) then

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -26,6 +26,7 @@ import cc.*
 import dotty.tools.dotc.transform.MacroAnnotations.hasMacroAnnotation
 import dotty.tools.dotc.core.NameKinds.DefaultGetterName
 import ast.TreeInfo
+import dotty.tools.dotc.cc.derivedFunctionOrMethod
 
 object PostTyper {
   val name: String = "posttyper"
@@ -454,18 +455,11 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
       case closureDef(mdef) =>
         closuresNeedingExplicify += mdef.symbol
         tp match
-          case tp @ AppliedType(tycon, args) if defn.isNonRefinedFunction(tp) =>
-            val res = args.last
-            val res1 = makeResultTypeInferred(res, mdef.rhs)
-            if res1 eq res then tp
-            else tp.derivedAppliedType(tycon, args.init :+ res1)
-          case tp @ defn.RefinedFunctionOf(rinfo) =>
-            val rinfo1 = makeResultTypeInferred(rinfo, rhs)
-            tp.derivedRefinedType(refinedInfo = rinfo1)
-          case tp: MethodType =>
-            tp.derivedLambdaType(resType = makeResultTypeInferred(tp.resType, mdef.rhs))
-          case tp: PolyType =>
-            tp.derivedLambdaType(resType = makeResultTypeInferred(tp.resType, rhs))
+          case FunctionOrMethod(args, res) =>
+            val rhs1 = args match
+              case (_: TypeBounds) :: _ => rhs
+              case _ => mdef.rhs
+            tp.derivedFunctionOrMethod(args, makeResultTypeInferred(res, rhs1))
       case _ =>
         if tp.hasAnnotation(defn.InferredAnnot) then tp
         else AnnotatedType(CleanupRetains()(tp), Annotation(defn.InferredAnnot, rhs.span))

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -405,21 +405,21 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
         case _ =>
           tpt
 
-    /** If the (return-) type of the ValDef or DefDef is an InferredType, make it
-     *  a non-inferred type under ccEnabled so that embedded retains annotations are kept,
-     *  provided one of the following three conditions holds:
-     *   (1) The definition overrides some other declaration. For an overriding symbol the
-     *       retains annotations come from the explicitly declared parent types, so should
-     *       be kept.
-     *   (2) The definition is not a closure, but its right hand side is a
+    /** Under ccEnabled, If the (return-) type of the ValDef or DefDef is an InferredType,
+     *  make (some parts of) it non-inferred types so that embedded retains annotations
+     *  are kept. Specifically:
+     *   (1) If definition overrides some other declaration, make its type non-inferred.
+     *       For an overriding symbol the retains annotations come from the explicitly
+     *       declared parent types, so should be kept.
+     *   (2) If the definition is not a closure, but its right hand side is a
      *       closure that is either itself polymorphic or is the prefix
-     *       of a curried polymorphic closure. In this case we need to keep
-     *       references to bound capset variables in retains clauses of subsequent
-     *       parameters. The final result type of the (possibly curried) closure
-     *       will be turned into an inferred type by adding a `@caps.inferred`
-     *       annotation to it.
-     *   (3) The definition is a closure that is a curried result of the
-     *       right hand side of a defininition meeting condition (2).
+     *       of a curried polymorphic closure, make all parameter types corresponding
+     *       to nested closures non-inferred by adding `@caps.declared` annotations.
+     *       In this case we need to keep references to bound capset variables in retains
+     *       clauses of subsequent parameters.
+     *   (3) If the definition is a closure that is a curried result of the
+     *       right hand side of a defininition meeting condition (2), also make
+     *       its parameter types non-inferred as specified by (2).
      */
     private def explicifyTpt(tree: ValOrDefDef)(using Context): Tree = tree.tpt match
       case tpt: InferredTypeTree if Feature.ccEnabled =>
@@ -439,30 +439,42 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             case _ =>
               false
           if needsExplicify then
-            val tpe1 = makeResultTypeInferred(tpt.tpe, tree.rhs)
+            val tpe1 = makeFormalsDeclared(tpt.tpe, tree.rhs)
             if tpe1 `ne` tpt.tpe
-            then TypeTree(tpe1, inferred = false).withSpan(tree.span).withAttachmentsFrom(tpt)
+            then TypeTree(tpe1, inferred = true).withSpan(tree.span).withAttachmentsFrom(tpt)
             else tpt
           else tpt
       case tpt =>
         tpt
 
-    /** Insert a `@caps.inferred` annotation on the final result type
-     *  if a function type `tp` corresponding to a closure `tp`. "Final"
-     *  means: a result type that does not correspond to a nested closure.
+    /** Insert a `@caps.declared` annotation on all parameter infos
+     *  of a function type `tp` corresponding to a closure `rhs` that contain
+     *  a "retains" annotation. TypeBound infos of type parameters get
+     *  a `@caps.declared` on each bound that contains a "retains" annotation.
      */
-    private def makeResultTypeInferred(tp: Type, rhs: Tree)(using Context): Type = rhs match
+    private def makeFormalsDeclared(tp: Type, rhs: Tree)(using Context): Type = rhs match
       case closureDef(mdef) =>
         closuresNeedingExplicify += mdef.symbol
+
+        def makeFormalDeclared(formal: Type)(using Context): Type = formal match
+          case formal @ TypeBounds(lo, hi) =>
+            formal.derivedTypeBounds(makeFormalDeclared(lo), makeFormalDeclared(hi))
+          case _ =>
+            val cleanup = CleanupRetains()
+            cleanup(formal) // only used for setting cleanup.retainsFound as a side effect
+            if cleanup.retainsFound && !formal.hasAnnotation(defn.DeclaredAnnot)
+            then AnnotatedType(formal, Annotation(defn.DeclaredAnnot, rhs.span))
+            else formal
+
         tp match
-          case FunctionOrMethod(args, res) =>
-            val rhs1 = args match
+          case FunctionOrMethod(formals, res) =>
+            val rhs1 = formals match
               case (_: TypeBounds) :: _ => rhs
               case _ => mdef.rhs
-            tp.derivedFunctionOrMethod(args, makeResultTypeInferred(res, rhs1))
-      case _ =>
-        if tp.hasAnnotation(defn.InferredAnnot) then tp
-        else AnnotatedType(CleanupRetains()(tp), Annotation(defn.InferredAnnot, rhs.span))
+            val formals1 = formals.map(makeFormalDeclared)
+            tp.derivedFunctionOrMethod(formals1, makeFormalsDeclared(res, rhs1))
+          case _ => tp
+      case _ => tp
 
     /** If one of `trees` is a spread of an expression that is not idempotent, lift out all
      *  non-idempotent expressions (not just the spreads) and apply `within` to the resulting

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -412,9 +412,8 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
      *       For an overriding symbol the retains annotations come from the explicitly
      *       declared parent types, so should be kept.
      *   (2) If the definition is not a closure, but its right hand side is a
-     *       closure that is either itself polymorphic or is the prefix
-     *       of a curried polymorphic closure, make all parameter types corresponding
-     *       to nested closures non-inferred by adding `@caps.declared` annotations.
+     *       closure, make all parameter types corresponding to nested closures
+     *       non-inferred by adding `@caps.declared` annotations.
      *       In this case we need to keep references to bound capset variables in retains
      *       clauses of subsequent parameters.
      *   (3) If the definition is a closure that is a curried result of the
@@ -423,27 +422,18 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
      */
     private def explicifyTpt(tree: ValOrDefDef)(using Context): Tree = tree.tpt match
       case tpt: InferredTypeTree if Feature.ccEnabled =>
-        if tree.symbol.allOverriddenSymbols.hasNext then
+        if tree.symbol.allOverriddenSymbols.hasNext then // (1)
           tpd.cpy.TypeTree(tpt)(inferred = false)
-        else
-          def hasPolyClosure(mdef: DefDef): Boolean =
-            mdef.symbol.info.isInstanceOf[PolyType]
-            || mdef.rhs.match
-                case closureDef(mdef1) => hasPolyClosure(mdef1)
-                case _ => false
-          val needsExplicify = tree.rhs match
-            case closureDef(mdef) =>
-              if tree.symbol.isAnonymousFunction
-              then closuresNeedingExplicify.remove(tree.symbol)
-              else hasPolyClosure(mdef)
-            case _ =>
-              false
-          if needsExplicify then
+        else tree.rhs match
+          case closureDef(mdef)
+          if !tree.symbol.isAnonymousFunction // (2)
+            || closuresNeedingExplicify.remove(tree.symbol) // (3)
+          =>
             val tpe1 = makeFormalsDeclared(tpt.tpe, tree.rhs)
             if tpe1 `ne` tpt.tpe
             then TypeTree(tpe1, inferred = true).withSpan(tree.span).withAttachmentsFrom(tpt)
             else tpt
-          else tpt
+          case _ => tpt
       case tpt =>
         tpt
 
@@ -471,7 +461,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
             val rhs1 = formals match
               case (_: TypeBounds) :: _ => rhs
               case _ => mdef.rhs
-            val formals1 = formals.map(makeFormalDeclared)
+            val formals1 = formals.mapConserve(makeFormalDeclared)
             tp.derivedFunctionOrMethod(formals1, makeFormalsDeclared(res, rhs1))
           case _ => tp
       case _ => tp

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -107,6 +107,13 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
     initContextCalled = true
     compilingScala2StdLib = Feature.shouldBehaveAsScala2(using ctx)
 
+  /** The anonymous function symbols that need an explicified result type
+   *  if their right hand side is also a closure. This is the case if
+   *  the closure's type forms part of the type of a valdef or defdef
+   *  that has a polymorphic closure type.
+   */
+  private val closuresNeedingExplicify = mutable.Set[Symbol]()
+
   val superAcc: SuperAccessors = new SuperAccessors(thisPhase)
   val synthMbr: SyntheticMembers = new SyntheticMembers(thisPhase)
   val beanProps: BeanProperties = new BeanProperties(thisPhase)
@@ -397,6 +404,72 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
         case _ =>
           tpt
 
+    /** If the (return-) type of the ValDef or DefDef is an InferredType, make it
+     *  a non-inferred type under ccEnabled so that embedded retains annotations are kept,
+     *  provided one of the following three conditions holds:
+     *   (1) The definition overrides some other declaration. For an overriding symbol the
+     *       retains annotations come from the explicitly declared parent types, so should
+     *       be kept.
+     *   (2) The definition is not a closure, but its right hand side is a
+     *       closure that is either itself polymorphic or is the prefix
+     *       of a curried polymorphic closure. In this case we need to keep
+     *       references to bound capset variables in retains clauses of subsequent
+     *       parameters. The final result type of the (possibly curried) closure
+     *       will be turned into an inferred type by adding a `@caps.inferred`
+     *       annotation to it.
+     *   (3) The definition is a closure that is a curried result of the
+     *       right hand side of a defininition meeting condition (2).
+     */
+    private def explicifyTpt(tree: ValOrDefDef)(using Context): Tree = tree.tpt match
+      case tpt: InferredTypeTree if Feature.ccEnabled =>
+        if tree.symbol.allOverriddenSymbols.hasNext then
+          tpd.cpy.TypeTree(tpt)(inferred = false)
+        else
+          def hasPolyClosure(mdef: DefDef): Boolean =
+            mdef.symbol.info.isInstanceOf[PolyType]
+            || mdef.rhs.match
+                case closureDef(mdef1) => hasPolyClosure(mdef1)
+                case _ => false
+          val needsExplicify = tree.rhs match
+            case closureDef(mdef) =>
+              if tree.symbol.isAnonymousFunction
+              then closuresNeedingExplicify.remove(tree.symbol)
+              else hasPolyClosure(mdef)
+            case _ =>
+              false
+          if needsExplicify then
+            val tpe1 = makeResultTypeInferred(tpt.tpe, tree.rhs)
+            if tpe1 `ne` tpt.tpe
+            then TypeTree(tpe1, inferred = false).withSpan(tree.span).withAttachmentsFrom(tpt)
+            else tpt
+          else tpt
+      case tpt =>
+        tpt
+
+    /** Insert a `@caps.inferred` annotation on the final result type
+     *  if a function type `tp` corresponding to a closure `tp`. "Final"
+     *  means: a result type that does not correspond to a nested closure.
+     */
+    private def makeResultTypeInferred(tp: Type, rhs: Tree)(using Context): Type = rhs match
+      case closureDef(mdef) =>
+        closuresNeedingExplicify += mdef.symbol
+        tp match
+          case tp @ AppliedType(tycon, args) if defn.isNonRefinedFunction(tp) =>
+            val res = args.last
+            val res1 = makeResultTypeInferred(res, mdef.rhs)
+            if res1 eq res then tp
+            else tp.derivedAppliedType(tycon, args.init :+ res1)
+          case tp @ defn.RefinedFunctionOf(rinfo) =>
+            val rinfo1 = makeResultTypeInferred(rinfo, rhs)
+            tp.derivedRefinedType(refinedInfo = rinfo1)
+          case tp: MethodType =>
+            tp.derivedLambdaType(resType = makeResultTypeInferred(tp.resType, mdef.rhs))
+          case tp: PolyType =>
+            tp.derivedLambdaType(resType = makeResultTypeInferred(tp.resType, rhs))
+      case _ =>
+        if tp.hasAnnotation(defn.InferredAnnot) then tp
+        else AnnotatedType(CleanupRetains()(tp), Annotation(defn.InferredAnnot, rhs.span))
+
     /** If one of `trees` is a spread of an expression that is not idempotent, lift out all
      *  non-idempotent expressions (not just the spreads) and apply `within` to the resulting
      *  pure references. Otherwise apply `within` to the original trees.
@@ -582,7 +655,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           annotateExperimentalCompanion(tree.symbol)
           registerIfHasMacroAnnotations(tree)
           Checking.checkPolyFunctionType(tree.tpt)
-          val tree1 = cpy.ValDef(tree)(tpt = makeOverrideTypeDeclared(tree.symbol, tree.tpt))
+          val tree1 = cpy.ValDef(tree)(tpt = explicifyTpt(tree))
           if tree1.removeAttachment(desugar.UntupledParam).isDefined then
             checkStableSelection(tree.rhs)
           processValOrDefDef(super.transform(tree1))
@@ -590,7 +663,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           registerIfHasMacroAnnotations(tree)
           Checking.checkPolyFunctionType(tree.tpt)
           annotateContextResults(tree)
-          val tree1 = cpy.DefDef(tree)(tpt = makeOverrideTypeDeclared(tree.symbol, tree.tpt))
+          val tree1 = cpy.DefDef(tree)(tpt = explicifyTpt(tree))
           processValOrDefDef(superAcc.wrapDefDef(tree1)(super.transform(tree1).asInstanceOf[DefDef]))
         case tree: TypeDef =>
           registerIfHasMacroAnnotations(tree)

--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -182,10 +182,16 @@ object internal:
   final class consume extends annotation.StaticAnnotation
 
   /** An annotation on a type indicating that the type was inferred. Added
-   *  during inlining when we want to mark portions of aotherwise explicit type
+   *  during inlining when we want to mark portions of an otherwise explicit type
    *  as inferred.
    */
   final class inferred extends annotation.StaticAnnotation
+
+  /** An annotation on a type indicating that the type was declared. Added
+   *  during PostTyper when we want to mark types of closure parameters as
+   *  explicit, even if the closure type as a whole is inferred.
+   */
+  final class declared extends annotation.StaticAnnotation
 
   /** An internal annotation placed on a refinement created by capture checking.
    *  Refinements with this annotation unconditionally override any

--- a/tests/neg-custom-args/captures/any-rd.scala
+++ b/tests/neg-custom-args/captures/any-rd.scala
@@ -1,0 +1,14 @@
+import caps.*
+
+class Shared extends SharedCapability
+
+abstract class Mut extends Mutable:
+  def get: Int
+  update def set(x: Int): Unit
+
+def Test(c: Shared, m: Mut) =
+  val f = () => println(c)
+  val _: () ->{any.rd} Unit = f // error
+  val g = () => m.get
+  val _: () ->{any.rd} Int = g // ok
+

--- a/tests/neg-custom-args/captures/i25830-nicolas-lambda.scala
+++ b/tests/neg-custom-args/captures/i25830-nicolas-lambda.scala
@@ -1,0 +1,24 @@
+import language.experimental.captureChecking
+import caps.*
+
+// Soundness regression: for nicolas1-shape poly-fn lambdas with capset
+// binder `B^`, applying with `B := {seed}` must propagate `^{seed}` into
+// the result. Assigning the result to a strict pure-bound (`Rand -> Int`)
+// must be rejected.
+
+trait Rand extends SharedCapability:
+  def range(min: Int, max: Int): Int
+
+val pickFirst =
+  [A, B^] => (head: Rand ->{B} A, tail: Rand ->{B} A) => head
+
+val oneOf =
+  [A, B^] => (head: Rand ->{B} A, tail: Seq[Rand ->{B} A]) =>
+    val all: Seq[Rand ->{B} A] = head +: tail
+    all.head
+
+def check =
+  val seed: Rand = ???
+  val f: Rand ->{seed} Int = (r: Rand) => r.range(0, 10)
+  val r2: Rand -> Int = pickFirst[Int, {seed}](f, f)            // error
+  val r4: Rand -> Int = oneOf[Int, {seed}](f, Seq(f, f))        // error

--- a/tests/neg-custom-args/captures/i25830-soundness.scala
+++ b/tests/neg-custom-args/captures/i25830-soundness.scala
@@ -1,0 +1,16 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File extends SharedCapability
+
+// Soundness regression test: applying an identity poly-fn must not
+// erase the captures of its argument. If the lambda's stored result
+// type were scrubbed to `^{}`, an impure value could be claimed pure
+// and leaked past a strict capture-set bound.
+
+object Test:
+  val id = [C^] => (x: File^{C}) => x
+
+  def check(): Unit =
+    val a = File()
+    val r: File^{} = id[{a}](a)  // error

--- a/tests/neg-custom-args/captures/sep-curried-par.check
+++ b/tests/neg-custom-args/captures/sep-curried-par.check
@@ -27,23 +27,23 @@
    |on line 18 and therefore is no longer available.
    |
    |where:    => refers to a root capability in the type of value p
--- Error: tests/neg-custom-args/captures/sep-curried-par.scala:21:9 ----------------------------------------------------
+-- Error: tests/neg-custom-args/captures/sep-curried-par.scala:21:6 ----------------------------------------------------
 21 |  foo(c)(c) // error: separation
-   |         ^
+   |      ^
    |Separation failure: argument of type  (c : () => Unit)
-   |to a function of type (() => Unit) ->{c} Unit
-   |corresponds to capture-polymorphic formal parameter v1 of type  () =>² Unit
+   |to a function of type (x$0: () => Unit) ->{} (() ->{c, any} Unit) ->{x$0} Unit
+   |corresponds to capture-polymorphic formal parameter x$0 of type  () =>² Unit
    |and hides capabilities  {c}.
-   |Some of these overlap with the captures of the function prefix.
+   |Some of these overlap with the captures of the function result with type  (() ->{c, any} Unit) ->{c} Unit.
    |
    |  Hidden set of current argument        : {c}
    |  Hidden footprint of current argument  : {c}
-   |  Capture set of function prefix        : {c}
-   |  Footprint set of function prefix      : {c}
+   |  Capture set of function result        : {c}
+   |  Footprint set of function result      : {c}
    |  The two sets overlap at               : {c}
    |
    |where:    =>  refers to a root capability in the type of parameter c
-   |          =>² refers to a root capability created in method test when checking argument to parameter v1 of method apply
+   |          =>² refers to a root capability created in method test when checking argument to parameter x$0 of method apply
 -- Error: tests/neg-custom-args/captures/sep-curried-par.scala:23:65 ---------------------------------------------------
 23 |  val bar = (p1: () => Unit) => (p2: () ->{p1, any} Unit) => par(p1, p2) // error separation
    |                                                                 ^^
@@ -61,20 +61,3 @@
    |
    |where:    =>  refers to a root capability in the type of parameter p1
    |          =>² refers to a root capability created in anonymous function of type (p2²: () ->{p1, any} Unit): Unit when checking argument to parameter p1 of method par
--- Error: tests/neg-custom-args/captures/sep-curried-par.scala:24:9 ----------------------------------------------------
-24 |  bar(c)(c) // error separation
-   |         ^
-   |Separation failure: argument of type  (c : () => Unit)
-   |to a function of type (() => Unit) ->{c} Unit
-   |corresponds to capture-polymorphic formal parameter v1 of type  () =>² Unit
-   |and hides capabilities  {c}.
-   |Some of these overlap with the captures of the function prefix.
-   |
-   |  Hidden set of current argument        : {c}
-   |  Hidden footprint of current argument  : {c}
-   |  Capture set of function prefix        : {c}
-   |  Footprint set of function prefix      : {c}
-   |  The two sets overlap at               : {c}
-   |
-   |where:    =>  refers to a root capability in the type of parameter c
-   |          =>² refers to a root capability created in method test when checking argument to parameter v1 of method apply

--- a/tests/neg-custom-args/captures/sep-curried-par.scala
+++ b/tests/neg-custom-args/captures/sep-curried-par.scala
@@ -21,7 +21,7 @@ def test(c: () => Unit) =
   foo(c)(c) // error: separation
 
   val bar = (p1: () => Unit) => (p2: () ->{p1, any} Unit) => par(p1, p2) // error separation
-  bar(c)(c) // error separation
+  bar(c)(c)
 
 
 

--- a/tests/pos-custom-args/captures/i25830-apply-workaround.scala
+++ b/tests/pos-custom-args/captures/i25830-apply-workaround.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File extends SharedCapability
+
+def test() =
+  val external = File()
+  class Convert:
+    def apply[C^, D^ <: {C}, E^ >: {C} <: {C, external}](
+        xs: List[File^{C, external}],
+        ys: List[File^{D, external}])(
+        zs: List[File^{E, external}]): List[File^{E, external}] = zs
+  val x = File()
+  val files1: List[File^{x, external}] = List(x)
+  val files2: List[File^{x, external}] = List(x)
+  val files3: List[File^{x, external}] = List(x)
+  val _ : List[File^{x, external}] =
+    Convert()[{x}, {x}, {x, external}](files1, files2)(files3)

--- a/tests/pos-custom-args/captures/i25830-bounded.scala
+++ b/tests/pos-custom-args/captures/i25830-bounded.scala
@@ -1,0 +1,27 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File extends ExclusiveCapability
+
+def testFlat() =
+  val f = { [C^, D^ <: {C}] => (xs: List[File^{D}]) => xs }
+  val a = File()
+  val _ : List[File^{a}] = f[{a}, {a}](List[File^{a}](a))
+
+def testLowerBound() =
+  val f = { [C^, D^ >: {C}] => (xs: List[File^{D}]) => xs }
+  val a = File()
+  val _ : List[File^{a}] = f[{a}, {a}](List[File^{a}](a))
+
+def testCurriedBounded() =
+  val f =
+    { [C^, D^ <: {C}, E^ >: {C} <: {C, D}] =>
+        (xs: List[File^{D}], ys: List[File^{C}]) =>
+        (zs: List[File^{E}], ws: List[File^{C, D}]) => ()
+    }
+  val a = File()
+  val xs: List[File^{a}] = List(a)
+  val ys: List[File^{a}] = List(a)
+  val zs: List[File^{a}] = List(a)
+  val ws: List[File^{a}] = List(a)
+  val _ : Unit = f[{a}, {a}, {a}](xs, ys)(zs, ws)

--- a/tests/pos-custom-args/captures/i25830-external.scala
+++ b/tests/pos-custom-args/captures/i25830-external.scala
@@ -1,0 +1,58 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File extends ExclusiveCapability
+
+// Capture-polymorphic lambdas whose retains mention enclosing capabilities
+// in addition to (or instead of) the lambda's own capset binders. Because
+// PostTyper now keeps the user-written parameter types and binder bounds
+// verbatim ("explicify"), Setup processes them through transformExplicitType
+// which preserves @retains. Only the inferred result type is cleaned up.
+
+def mixedExternal() =
+  val external = File()
+  val f =
+    { [C^] => (xs: List[File^{C, external}]) => xs }
+
+def externalOnly() =
+  val external = File()
+  val f =
+    { [C^] => (xs: List[File^{external}]) => xs }
+
+def mixedExternalWithLowerBoundedParam() =
+  val external = File()
+  val f =
+    { [C^, D^ >: {C}] => (xs: List[File^{D, external}]) => xs }
+
+def mixedExternalInLaterParamList() =
+  val external = File()
+  val f =
+    { [C^] => (xs: List[File^{C}]) => (ys: List[File^{C, external}]) => ys }
+
+def enclosingParam(external: File^) =
+  val f =
+    { [C^] => (xs: List[File^{C}]) => (ys: List[File^{external}]) => ys }
+
+def supportedDef() =
+  val external = File()
+  def f =
+    { [C^] => (xs: List[File^{C, external}]) => xs }
+
+def insideAnonymousFunction() =
+  List(File()).map: external =>
+    val f =
+      { [C^] => (xs: List[File^{C}]) => (ys: List[File^{external}]) => ys }
+
+def externalInBound() =
+  val external = File()
+  val f =
+    { [C^, D^ <: {C, external}] => (xs: List[File^{D}]) => xs }
+
+def nestedCapsetBinders() =
+  val f =
+    { [C^] => (xs: List[File^{C}]) => [D^] => (ys: List[File^{C, D}]) => ys }
+
+def literalNestedInFunction1() =
+  val external = File()
+  val f =
+    (i: Int) => { [C^] => (xs: List[File^{C, external}]) => xs }

--- a/tests/pos-custom-args/captures/i25830-nicolas-lambda.scala
+++ b/tests/pos-custom-args/captures/i25830-nicolas-lambda.scala
@@ -1,0 +1,24 @@
+import language.experimental.captureChecking
+import caps.*
+
+// Lambda forms of the nicolas1 patterns: capset binder `B^` parameterising
+// regular function types `Rand ->{B} A`. Verifies the explicify pipeline
+// keeps `^{B}` flowing through to the result so the lambda can be applied
+// with `B := {seed}` and used at the strict bound `Rand ->{seed} Int`.
+
+trait Rand extends SharedCapability:
+  def range(min: Int, max: Int): Int
+
+val pickFirst =
+  [A, B^] => (head: Rand ->{B} A, tail: Rand ->{B} A) => head
+
+val oneOf =
+  [A, B^] => (head: Rand ->{B} A, tail: Seq[Rand ->{B} A]) =>
+    val all: Seq[Rand ->{B} A] = head +: tail
+    all.head
+
+def use =
+  val seed: Rand = ???
+  val f: Rand ->{seed} Int = (r: Rand) => r.range(0, 10)
+  val r1: Rand ->{seed} Int = pickFirst[Int, {seed}](f, f)
+  val r3: Rand ->{seed} Int = oneOf[Int, {seed}](f, Seq(f, f))

--- a/tests/pos-custom-args/captures/i25830.scala
+++ b/tests/pos-custom-args/captures/i25830.scala
@@ -9,8 +9,11 @@ class File
   val files: List[File^{x}] = List(x)
   val result = convert[{x}](files)
 
+  val globalFile: File^ = File()
+
   val convertCurried =
     { [C^] => (xs: List[File^{C}]) => (ys: List[File^{C}]) =>
+        println(globalFile)
         xs.map(_ => ()) ++ ys.map(_ => ())
     }
   val resultCurried = convertCurried[{x}](files)(files)

--- a/tests/pos-custom-args/captures/i25830.scala
+++ b/tests/pos-custom-args/captures/i25830.scala
@@ -1,0 +1,63 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File
+
+@main def test =
+  val convert = { [C^] => (xs: List[File^{C}]) => xs.map(_ => ()) }
+  val x: File^ = File()
+  val files: List[File^{x}] = List(x)
+  val result = convert[{x}](files)
+
+  val convertCurried =
+    { [C^] => (xs: List[File^{C}]) => (ys: List[File^{C}]) =>
+        xs.map(_ => ()) ++ ys.map(_ => ())
+    }
+  val resultCurried = convertCurried[{x}](files)(files)
+
+  def convertDef =
+    { [C^] => (xs: List[File^{C}]) => xs.map(_ => ()) }
+  val resultDef = convertDef[{x}](files)
+
+  val resultInAnonymousFunction =
+    files.map: file =>
+      val localFiles: List[File^{file}] = List(file)
+      val localConvert =
+        { [C^] => (xs: List[File^{C}]) => xs }
+      localConvert[{file}](localFiles)
+
+  // Poly-fn literal nested inside a Function1: fine as long as retains
+  // only mention the literal's own capset binders.
+  val nestedInFunction1 = (i: Int) => { [C^] => (xs: List[File^{C}]) => xs }
+  val resultNested = nestedInFunction1(0)[{x}](files)
+
+  // Capset binders interleaved with regular type binders.
+  val interleaved1 = { [C^, A] => (xs: List[A]) => (ys: List[File^{C}]) => ys }
+  val resultInterleaved1 = interleaved1[{x}, Int](List(1))(files)
+
+  val interleaved2 = { [A, C^] => (xs: List[A]) => (ys: List[File^{C}]) => ys }
+  val resultInterleaved2 = interleaved2[Int, {x}](List(1))(files)
+
+  val interleaved3 =
+    { [A, C^, B, D^] => (xs: List[A], ys: List[B]) =>
+        (zs: List[File^{C}], ws: List[File^{D}]) => zs
+    }
+  val resultInterleaved3 = interleaved3[Int, {x}, String, {x}](List(1), List("a"))(files, files)
+
+  // Multiple capset binder blocks separated by term-parameter lists.
+  val multi1 =
+    { [C^] => (xs: List[File^{C}]) => [D^] => (ys: List[File^{D}]) => (xs, ys) }
+  val resultMulti1 = multi1[{x}](files)[{x}](files)
+
+  val multi2 =
+    { [C^] => (xs: List[File^{C}]) => [A] => (zs: List[A]) => [D^] => (ws: List[File^{D}]) => (xs, zs, ws) }
+  val resultMulti2 = multi2[{x}](files)[Int](List(1))[{x}](files)
+
+  // Non-capset block first, then capset block.
+  val multi3 = { [A] => (zs: List[A]) => [C^] => (xs: List[File^{C}]) => (zs, xs) }
+  val resultMulti3 = multi3[Int](List(1))[{x}](files)
+
+  // Inner block references both capset binders.
+  val multi4 =
+    { [C^] => (xs: List[File^{C}]) => [D^] => (ys: List[File^{C, D}]) => ys }
+  val resultMulti4 = multi4[{x}](files)[{x}](files)


### PR DESCRIPTION

If a named definition has a closure as RHS and an inferred type, make
the parameter types of the closure explicit by adding `@caps.declared` annotations. E.g.

     val a = [X^ <: C^] => (x: A) => (y: B) => e

Here, `a` will get the inferred type

     [X^ <: C^ @declared] -> (x: A @declared) -> (y: B @declared) -> D

Fixes #25830 

Alternative to #25939
