### PR TITLE
Add Mill build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,3 +25,5 @@
 *.png     binary
 *.class   binary
 *.jar     binary
+
+*.mill linguist-language=Scala

--- a/.github/workflows/scaladoc-mill.yaml
+++ b/.github/workflows/scaladoc-mill.yaml
@@ -1,0 +1,123 @@
+name: scaladoc (Mill)
+
+on:
+  push:
+    branches-ignore:
+      - 'language-reference-stable'
+      - 'gh-readonly-queue/**'
+  pull_request:
+    branches-ignore:
+      - 'language-reference-stable'
+  merge_group:
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: "github.event_name == 'merge_group'
+         || (    github.event_name == 'pull_request'
+           && !contains(github.event.pull_request.body, '[skip ci]')
+           && !contains(github.event.pull_request.body, '[skip docs]')
+         )
+         || contains(github.event.ref, 'scaladoc')
+         || contains(github.event.ref, 'main')"
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile and test scala3doc-js
+        run: ./mill -i scaladoc-js.main.test
+
+      - name: Compile and test
+        run: |
+          ./mill -i scaladoc.test
+          # Original sbt workflow comment: TODO: invalid interpolation of inherited @define #24963
+          # ./mill -i dist.jvm
+          # ./project/scripts/cmdScaladocTests
+
+      - name: Locally publish self
+        run: ./mill -i scaladoc.publishLocal
+
+      - name: Generate self documentation
+        run: ./mill -i scaladoc.generateSelfDocumentation
+
+      - name: Generate testcases documentation
+        run: ./mill -i scaladoc.generateTestcasesDocumentation
+
+      - name: Generate reference documentation
+        run: ./mill -i scaladoc.generateReferenceDocumentation
+
+      - name: Generate Scala 3 documentation
+        run: ./mill -i scaladoc.generateScalaDocumentation
+
+  validate-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - uses: coursier/cache-action@v8
+      - uses: VirtusLab/scala-cli-setup@v1.12.2
+
+      - name: Validate docs sidebars
+        run: scala-cli ./project/scripts/checkSidebarDocs.scala
+
+  stdlib-sourcelinks-test:
+    runs-on: ubuntu-latest
+    # if false - disable flaky test
+    if: "false && ((    github.event_name == 'pull_request'
+           && !contains(github.event.pull_request.body, '[skip ci]')
+           && !contains(github.event.pull_request.body, '[skip docs]')
+         )
+         || contains(github.event.ref, 'scaladoc')
+         || contains(github.event.ref, 'scala3doc')
+         || contains(github.event.ref, 'main'))"
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test sourcelinks to stdlib
+        # currently commented out in the sbt workflow
+        run: ./mill -i scaladoc.test-source-links.test || true
+
+  check-error-code-snippets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: coursier/cache-action@v8
+      - uses: VirtusLab/scala-cli-setup@v1.11
+        with:
+          jvm: temurin:17
+          apps: sbt
+      - name: Publish compiler locally
+        run: |
+          version="$(./mill -i show compiler.publishVersion | jq -r)"
+          echo "SCALA_VERSION=$version" >> $GITHUB_ENV
+          echo "Would test snippets using Scala $version"
+
+          # Publish locally minimal set of artifacts that would be required to test snippets
+          ./mill -i publishLocal
+      - name: Test error code snippets
+        shell: bash
+        run: scala-cli test -S ${{ env.SCALA_VERSION }} --with-compiler project/scripts/checkErrorCodeSnippets.test.scala -- +l +a +c
+
+      - name: "[On failure] Print reproduction/fix steps"
+        if: failure()
+        run: |
+          cat << EOF >> $GITHUB_STEP_SUMMARY
+          Snippets validation for error codes failed
+
+          If you've modified messages of positions of error codes, you might need to update the expected outputs, to do it run: following command:
+          scala -S ${{ env.SCALA_VERSION }} project/scripts/checkErrorCodeSnippets.scala --with-compiler --main-class=updateAllErrorCodeOutputs
+
+          Single error code validation can be performed using:
+          scala -S ${{ env.SCALA_VERSION }} project/scripts/checkErrorCodeSnippets.scala --with-compiler -- docs/_docs/reference/error-codes/E001.md [--verbose --update-output]
+
+          To check the validation use dedicated test suite:
+          scala test -S ${{ env.SCALA_VERSION }} --with-compiler project/scripts/checkErrorCodeSnippets.test.scala -- +l +a +c
+
+          See ./docs/.ai/skill/add-error-code-docs.md for local skill for adding new error code docs.
+          EOF

--- a/.github/workflows/stdlib-mill.yaml
+++ b/.github/workflows/stdlib-mill.yaml
@@ -1,0 +1,531 @@
+name: Compile Full Standard Library (Mill)
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  DOTTY_CI_RUN: true
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+
+jobs:
+  scala-library-nonbootstrapped:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala-library-nonbootstrapped`
+        run: ./mill -i library.non-bootstrapped.compile
+
+  test-scala-library-nonbootstrapped:
+    name: Non-Bootstrapped Library Unit Tests
+    needs: scala-library-nonbootstrapped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: ./mill -i library.non-bootstrapped.test
+
+  scala3-library-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala-library-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-library-nonbootstrapped`
+        run: ./mill -i library.non-bootstrapped.compile
+
+  scala3-interfaces:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Compile `scala3-interfaces`
+        run: ./mill -i interfaces.compile
+
+  tasty-core-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-library-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `tasty-core-nonbootstrapped`
+        run: ./mill -i tasty.non-bootstrapped.compile
+
+  scala3-compiler-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [tasty-core-nonbootstrapped, scala3-library-nonbootstrapped, scala3-interfaces]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-compiler-nonbootstrapped`
+        run: ./mill -i compiler.non-bootstrapped.compile
+
+  scala3-sbt-bridge-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-sbt-bridge-nonbootstrapped`
+        run: ./mill -i sbt-bridge.non-bootstrapped.compile
+
+  scala-library-bootstrapped:
+    runs-on: ubuntu-latest
+    needs  : [scala-library-nonbootstrapped, scala3-library-nonbootstrapped, tasty-core-nonbootstrapped,
+              scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Compile `scala-library-bootstrapped`
+        run: ./mill -i library.compile
+
+  test-scala-library-bootstrapped:
+    name: Bootstrapped Library Unit Tests
+    needs: scala-library-bootstrapped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: ./mill -i library.test
+
+  scala3-library-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala-library-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Compile `scala3-library-bootstrapped`
+        run: ./mill -i library.compile
+
+  tasty-core-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-library-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `tasty-core-bootstrapped`
+        run: ./mill -i tasty.compile
+
+  scala3-compiler-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: [tasty-core-bootstrapped, scala3-library-bootstrapped, scala3-interfaces]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-compiler-bootstrapped`
+        run: ./mill -i compiler.compile
+
+  scala3-sbt-bridge-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-sbt-bridge-bootstrapped`
+        run: ./mill -i sbt-bridge.compile
+
+  scala3-staging:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-staging`
+        run: ./mill -i staging.compile
+
+  scala3-tasty-inspector:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-staging`
+        run: ./mill -i staging.compile
+      - name: Compile `scala3-tasty-inspector`
+        run: ./mill -i tasty-inspector.compile
+
+  scala-library-sjs:
+    runs-on: ubuntu-latest
+    needs: [scala-library-nonbootstrapped, scala3-library-nonbootstrapped, tasty-core-nonbootstrapped,
+            scala3-compiler-nonbootstrapped, scala3-sbt-bridge-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-staging`
+        run: ./mill -i staging.compile
+      - name: Compile `scala-library` for Scala.js
+        run: ./mill -i library-js.compile
+
+  scala3-library-sjs:
+    runs-on: ubuntu-latest
+    needs: [scala-library-sjs]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Compile `scala3-staging`
+        run: ./mill -i staging.compile
+      - name: Compile `scala3-library` for Scala.js
+        run: ./mill -i library-js.compile
+
+  repl:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Compile REPL
+        run: ./mill -i repl.compile
+
+  scaladoc:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped, scala3-tasty-inspector]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Compile `scaladoc`
+        run: ./mill -i scaladoc.compile
+
+  presentation-compiler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Compile `scala3-presentation-compiler`
+        run: ./mill -i presentation-compiler.compile
+
+  language-server:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Compile `scala3-language-server`
+        run: ./mill -i language-server.compile
+
+  #################################################################################################
+  ########################################### MiMa JOBS ###########################################
+  #################################################################################################
+
+  mima-scala-library-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: scala-library-nonbootstrapped
+    if: false
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Report MiMa issues in `scala-library-nonbootstrapped`
+        run: ./mill -i library.non-bootstrapped.mimaReportBinaryIssues
+
+  mima-scala3-interfaces:
+    runs-on: ubuntu-latest
+    needs: scala3-interfaces
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Report MiMa issues in `scala3-interfaces`
+        run: ./mill -i interfaces.mimaReportBinaryIssues
+
+  mima-tasty-core-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: tasty-core-nonbootstrapped
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Report MiMa issues in `tasty-core-nonbootstrapped`
+        run: ./mill -i tasty.non-bootstrapped.mimaReportBinaryIssues
+
+  static-analysis-scala-library-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: scala-library-bootstrapped
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Report MiMa issues in `scala-library-bootstrapped`
+        run: ./mill -i library.mimaReportBinaryIssues
+
+      - name: Report missingLink checks
+        run: ./mill -i library.missinglinkCheck
+
+  mima-tasty-core-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: tasty-core-bootstrapped
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Report MiMa issues in `tasty-core-bootstrapped`
+        run: ./mill -i tasty.mimaReportBinaryIssues
+
+  mima-scala-library-sjs:
+    runs-on: ubuntu-latest
+    needs: scala-library-sjs
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Report MiMa issues in `scala-library-sjs`
+        run: ./mill -i library-js.mimaReportBinaryIssues
+
+  #################################################################################################
+  ########################################### TEST JOBS ###########################################
+  #################################################################################################
+
+  test-scala3-compiler-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-nonbootstrapped, tasty-core-nonbootstrapped, scala-library-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+      - name: Disable some tests for the Mill CI
+        run: |
+          # not sure why this one doesn't pass on the CI, while it passes locally for me
+          echo "magic-offset-header-d_wrapper.scala" >> compiler/test/dotc/neg-scala2-library-tasty.excludelist
+      - name: Test `scala3-compiler-nonbootstrapped`
+        run: ./mill -i compiler.non-bootstrapped.test
+
+  test-scala3-compiler-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala-library-bootstrapped, scala3-staging, scala3-tasty-inspector]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+      - name: Disable some tests for the Mill CI
+        run: |
+          # not sure why this one doesn't pass on the CI, while it passes locally for me
+          echo "magic-offset-header-d_wrapper.scala" >> compiler/test/dotc/neg-scala2-library-tasty.excludelist
+      - name: Test `scala3-compiler-bootstrapped`
+        run: ./mill -i compiler.test
+
+  test-scala3-bootstrapped-pos-coverage:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala-library-bootstrapped, scala3-staging, scala3-tasty-inspector]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Disable some tests for the Mill CI
+        run: |
+          # seems we need to disable this one on the Mill CI only for --enableCoveragePhase=true
+          echo "magic-offset-header-d_wrapper.scala" >> compiler/test/dotc/neg-scala2-library-tasty.excludelist
+      - name: Run `compiler.testCompilation --enable-coverage-phase=true`
+        run: ./mill -i compiler.testCompilation --enableCoveragePhase=true
+
+  test-scala3-sbt-bridge-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-sbt-bridge-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test `scala3-sbt-bridge-nonbootstrapped`
+        run: ./mill -i sbt-bridge.non-bootstrapped.test
+
+  test-scala3-sbt-bridge-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: [scala3-sbt-bridge-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test `scala3-sbt-bridge-bootstrapped`
+        run: ./mill -i sbt-bridge.test
+
+  test-tasty-core-nonbootstrapped:
+    runs-on: ubuntu-latest
+    needs: [tasty-core-nonbootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test `tasty-core-nonbootstrapped`
+        run: ./mill -i tasty.non-bootstrapped.test
+
+  test-tasty-core-bootstrapped:
+    runs-on: ubuntu-latest
+    needs: [tasty-core-bootstrapped]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test `tasty-core-bootstrapped`
+        run: ./mill -i tasty.test
+
+  test-scala-js:
+    runs-on: ubuntu-latest
+    needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala3-staging, scala3-tasty-inspector, scala-library-sjs]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+      - name: Scala.js compiler tests
+        run: ./mill -i "sjs-compiler-tests.test"
+      - name: Scala.js sandbox
+        run: ./mill -i sandbox.scalajs.run + sandbox.scalajs.test
+      - name: Scala.js JUnit tests
+        run: |
+          ./mill -i tests.sjs-junit.default.test
+          ./mill -i tests.sjs-junit.esm.test
+      - name: Scala.js JUnit tests with latest ES version
+        run: |
+          ./mill -i tests.sjs-junit.latest-es-version.test
+      - name: Scala.js JUnit tests with WebAssembly
+        run: |
+          ./mill -i tests.sjs-junit.latest-es-version-wasm.test
+  # TODO Scala.js on Windows
+
+  test-repl:
+    runs-on: ubuntu-latest
+    needs: [repl]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test REPL
+        run: ./mill -i repl.test
+
+  test-presentation-compiler:
+    runs-on: ubuntu-latest
+    needs: [presentation-compiler]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test Presentation Compiler
+        run: ./mill -i presentation-compiler.test
+
+  test-language-server:
+    runs-on: ubuntu-latest
+    needs: [language-server]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+      - name: Test Language Server
+        run: ./mill -i language-server.test
+
+  # Not implemented in Mill yet
+  # scripted-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: [scala3-compiler-bootstrapped, tasty-core-bootstrapped, scala3-staging, scala3-tasty-inspector, scala-library-sjs, scaladoc]
+  #   steps:
+  #     - name: Git Checkout
+  #       uses: actions/checkout@v6
+  #
+  #     - name: Run SBT scripted tests
+  #       run: ./mill -i scripted
+
+  community_build_a:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run Community Build A
+        run: |
+          ./mill -i -j1 community-build.prepareCommunityBuildDocs
+          ./mill -i community-build.test "dotty.communitybuild.CommunityBuildTestA.*"
+
+  community_build_b:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run Community Build B
+        run: |
+          ./mill -i -j1 community-build.prepareCommunityBuildDocs
+          ./mill -i community-build.test "dotty.communitybuild.CommunityBuildTestB.*"
+
+
+  community_build_c:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run Community Build C
+        run: |
+          ./mill -i -j1 community-build.prepareCommunityBuildDocs
+          ./mill -i community-build.test "dotty.communitybuild.CommunityBuildTestC.*"
+
+  #################################################################################################
+  ######################################## GENERATE DOCS ##########################################
+  #################################################################################################
+
+  scala-library-docs:
+    runs-on: ubuntu-latest
+    needs  : [scala-library-bootstrapped, scaladoc]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v6
+
+
+      - name: Generate Documentation of the Standard Library
+        run: ./mill -i show library.docJar

--- a/.github/workflows/test-launchers-mill.yml
+++ b/.github/workflows/test-launchers-mill.yml
@@ -1,0 +1,70 @@
+name: Test CLI Launchers on all the platforms (Mill)
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  linux-x86_64:
+    name: Deploy and Test on Linux x64 architecture
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and test launcher command
+        run: ./project/scripts/native-integration/bashTests
+        env:
+          LAUNCHER_EXPECTED_PROJECT: "dist-linux-x86_64"
+          DIST_USE_MILL: true
+
+  linux-aarch64:
+    name: Deploy and Test on Linux ARM64 architecture
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and test launcher command
+        run: ./project/scripts/native-integration/bashTests
+        env:
+          LAUNCHER_EXPECTED_PROJECT: "dist-linux-aarch64"
+          DIST_USE_MILL: true
+
+  mac-x86_64:
+    name: Deploy and Test on Mac x64 architecture
+    runs-on: macos-15-intel
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and test launcher command
+        run: ./project/scripts/native-integration/bashTests
+        env:
+          LAUNCHER_EXPECTED_PROJECT: "dist-mac-x86_64"
+          DIST_USE_MILL: true
+
+  mac-aarch64:
+    name: Deploy and Test on Mac ARM64 architecture
+    runs-on: macos-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and test launcher command
+        run: ./project/scripts/native-integration/bashTests
+        env:
+          LAUNCHER_EXPECTED_PROJECT: "dist-mac-aarch64"
+          DIST_USE_MILL: true
+
+  win-x86_64:
+    name: Deploy and Test on Windows x64 architecture
+    runs-on: windows-latest
+    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]') ) ||
+        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3' )
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build the launcher command
+        run: ./mill -i dist.win-x86_64
+      - name: Run the launcher command tests
+        run: './project/scripts/native-integration/winTests.bat'
+        shell: cmd
+        env:
+          DIST_USE_MILL: true

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ project/local-plugins.sbt
 .sbt-scripted/
 local.sbt
 
+# Mill specific
+out/
+
 # npm
 node_modules
 
@@ -54,7 +57,7 @@ tests/locks/
 bench/tests-generated
 
 # Ignore output files but keep the directory
-out/
+output/
 build/
 !out/.keep
 testlogs/

--- a/bin/common
+++ b/bin/common
@@ -12,15 +12,27 @@ shift # Mutates $@ by deleting the first element ($1)
 # set the $DIST_PROJECT and $DIST_DIR variables
 source "$ROOT/bin/common-platform"
 
-# Marker file used to obtain the date of latest call to sbt-back
-version="$ROOT/$DIST_DIR/target/universal/stage/VERSION"
-
-# Create the target if absent or if file changed in ROOT/compiler
-new_files="$(find "$ROOT/compiler" \( -iname "*.scala" -o -iname "*.java" \) -newer "$version" 2> /dev/null)"
-
-if [ ! -f "$version" ] || [ ! -z "$new_files" ]; then
-  echo "Building Dotty..."
-  (cd $ROOT && sbt "$DIST_PROJECT/Universal/stage")
+if [ "z${DIST_USE_MILL:-}" != "z" ]; then
+  version="$ROOT/out/dist/$DIST_MILL_PROJECT.dest/VERSION"
+else
+  # Marker file used to obtain the date of latest call to sbt-back
+  version="$ROOT/$DIST_DIR/target/universal/stage/VERSION"
 fi
 
-"$ROOT/$DIST_DIR/target/universal/stage/bin/$target" "$@"
+if [ "z${DIST_USE_MILL:-}" != "z" ]; then
+  (cd $ROOT && ./mill "dist.$DIST_MILL_PROJECT")
+else
+  # Create the target if absent or if file changed in ROOT/compiler
+  new_files="$(find "$ROOT/compiler" \( -iname "*.scala" -o -iname "*.java" \) -newer "$version" 2> /dev/null)"
+
+  if [ ! -f "$version" ] || [ ! -z "$new_files" ]; then
+    echo "Building Dotty..."
+    (cd $ROOT && sbt "$DIST_PROJECT/Universal/stage")
+  fi
+fi
+
+if [ "z${DIST_USE_MILL:-}" != "z" ]; then
+  "$ROOT/out/dist/$DIST_MILL_PROJECT.dest/bin/$target" "$@"
+else
+  "$ROOT/$DIST_DIR/target/universal/stage/bin/$target" "$@"
+fi

--- a/bin/common-platform
+++ b/bin/common-platform
@@ -21,6 +21,7 @@ esac
 unset DIST_PROJECT DIST_DIR
 
 if [[ ${cygwin-} || ${mingw-} || ${msys-} ]]; then
+  DIST_MILL_PROJECT="win-x86_64"
   DIST_PROJECT="dist-win-x86_64"
   DIST_DIR="dist/win-x86_64"
 else
@@ -40,23 +41,28 @@ else
   if [ "$(expr substr $(uname -s) 1 5 2>/dev/null)" == "Linux" ]; then
     if [[ "$ARCH_NORM" == "unknown" ]]; then
       echo >&2 "unknown Linux CPU architecture, defaulting to JVM launcher"
+      DIST_MILL_PROJECT="jvm"
       DIST_PROJECT="dist"
       DIST_DIR="dist"
     else
+      DIST_MILL_PROJECT="linux-$ARCH_NORM"
       DIST_PROJECT="dist-linux-$ARCH_NORM"
       DIST_DIR="dist/linux-$ARCH_NORM"
     fi
   elif [ "$(uname)" == "Darwin" ]; then
     if [[ "$ARCH_NORM" == "unknown" ]]; then
       echo >&2 "unknown Darwin CPU architecture, defaulting to JVM launcher"
+      DIST_MILL_PROJECT="jvm"
       DIST_PROJECT="dist"
       DIST_DIR="dist"
     else
+      DIST_MILL_PROJECT="mac-$ARCH_NORM"
       DIST_PROJECT="dist-mac-$ARCH_NORM"
       DIST_DIR="dist/mac-$ARCH_NORM"
     fi
   else
     echo >&2 "unknown OS, defaulting to JVM launcher"
+    DIST_MILL_PROJECT="jvm"
     DIST_PROJECT="dist"
     DIST_DIR="dist"
   fi

--- a/build.mill
+++ b/build.mill
@@ -1,0 +1,152 @@
+//| mill-version: 1.1.7
+//| mill-jvm-version: 17
+//| bspScriptIgnore:
+//| - "bench/"
+//| - "bin/"
+//| - "project/"
+//| - "sandbox/"
+//| - "sbt-test/"
+//| - "tests/"
+
+package build
+
+import mainargs.arg
+import mill.*
+import mill.api.BuildCtx
+
+import scala3build.*
+
+import java.io.File
+
+// projects published locally by "./mill publishLocal" and put in the distribution
+def projects(implicit mode: Mode) = Seq(
+  build.library(),
+  build.compiler(),
+  build.interfaces,
+  build.library.`library-3`(),
+  build.`directives-parser`(),
+  build.repl(),
+  build.`sbt-bridge`(), // sbt build comment: for scala-cli
+  build.staging(),
+  build.`tasty-inspector`(),
+  build.scaladoc(),
+  build.tasty()
+)
+
+
+private def insertClasspathInArgs(args: List[String], cp: String): List[String] = {
+  val (beforeCp, fromCp) = args.span(_ != "-classpath")
+  val classpath = fromCp.drop(1).headOption.fold(cp)(_ + File.pathSeparator + cp)
+  "-classpath" :: classpath :: beforeCp ::: fromCp.drop(2)
+}
+
+/** Runs scalac built from sources */
+def scalac(args0: String*): Task.Command[Unit] = {
+  val mode = Mode.NonBootstrapped
+  val project = build.compiler()(using mode)
+  val withCompilerExtraClassPath =
+    if (args0.contains("-with-compiler"))
+      Task.Anon {
+        val externalDeps = build.compiler()(using mode).resolvedMvnDeps().map(_.path)
+        def findArtifactPath(name: String) =
+          externalDeps.find(_.last.startsWith(name)).getOrElse {
+            Task.fail(s"Cannot find $name in compiler class path")
+          }
+
+        val dottyInterfaces = build.interfaces.jar().path.toString
+        val dottyStaging = build.staging()(using mode).jar().path.toString
+        val dottyTastyInspector = build.`tasty-inspector`()(using mode).jar().path.toString
+        val tastyCore = build.tasty()(using mode).jar().path.toString
+        val asm = findArtifactPath("scala-asm").toString
+        val compilerInterface = findArtifactPath("compiler-interface").toString
+        Seq(dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface)
+      }
+    else
+      Task.Anon(Nil)
+  Task.Command(exclusive = true) {
+
+    val stdlib = build.library()(using mode).jar().path.toString
+    val dottyCompiler = build.compiler()(using mode).jar().path.toString
+
+    val decompile = args0.contains("-decompile")
+    val printTasty = args0.contains("-print-tasty")
+    val debugFromTasty = args0.contains("-Ythrough-tasty")
+    val defaultOutputDirectory =
+      if (printTasty || decompile || debugFromTasty || args0.contains("-d")) Nil
+      else List("-d", (BuildCtx.workspaceRoot / "out/default-last-scalac-out.jar").toString)
+    val args = args0.toList.filter(arg => arg != "-repl" && arg != "-decompile" &&
+        arg != "-with-compiler" && arg != "-Ythrough-tasty" && arg != "-print-tasty")
+    val main =
+      if (decompile) "dotty.tools.dotc.decompiler.Main"
+      else if (printTasty) "dotty.tools.dotc.core.tasty.TastyPrinter"
+      else if (debugFromTasty) "dotty.tools.dotc.fromtasty.Debug"
+      else "dotty.tools.dotc.Main"
+
+    var extraClasspath = Seq(stdlib)
+
+    if (decompile && !args.contains("-classpath"))
+      extraClasspath ++= Seq(".")
+
+    if (args0.contains("-with-compiler"))
+      Task.fail("-with-compiler should only be used with a bootstrapped compiler")
+
+    if (args0.contains("-with-compiler")) {
+      extraClasspath ++= Seq(dottyCompiler)
+      extraClasspath ++= withCompilerExtraClassPath()
+    }
+
+    val wrappedArgs = if (printTasty) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
+
+    val runner = project.runner()
+    runner.run(args = defaultOutputDirectory ::: wrappedArgs, mainClass = main, workingDir = BuildCtx.workspaceRoot)
+  }
+}
+
+/** Runs scala built from sources, via Scala CLI */
+def scala(args: String*): Task.Command[Unit] = Task.Command(exclusive = true) {
+  val jvmDist = build.dist.jvm().path
+  val scalaScript = jvmDist / "bin/scala"
+  os.proc(scalaScript, args).call(
+    cwd = BuildCtx.workspaceRoot,
+    stdin = os.Inherit,
+    stdout = os.Inherit
+  )
+}
+
+/** Publishes locally the main Scala 3 modules */
+def publishLocal(
+  localIvyRepo: String = null,
+  sources: Boolean = true,
+  doc: Boolean = false // much faster without this
+): Task.Command[Unit] = {
+  val projects0 = projects(using Mode.Bootstrapped)
+  val tasks = Task.traverse(projects0)(_.publishLocal(localIvyRepo = localIvyRepo, sources = sources, doc = doc))
+  Task.Command {
+    tasks()
+  }
+}
+
+/**
+ * By default runs tests in dotty.tools.dotc.*CompilationTests and dotty.tools.dotc.coverage.*, excluding tests tagged with dotty.SlowTests.
+ */
+def testCompilation(
+  @arg(doc = "runs tests in dotty.tools.dotc.FromTastyTests")
+  fromTasty: Boolean = false,
+  @arg(doc = "override the checkfiles that did not match with the current output")
+  updateCheckfiles: Boolean = false,
+  @arg(doc = "re-run only failed tests")
+  failed: Boolean = false,
+  @arg(doc = "enable Scoverage instrumentation phase for compilation tests")
+  enableCoveragePhase: Boolean = false,
+  coverage: Boolean = false,
+  @arg(doc = "substring of the path of the tests file")
+  filter: Args
+): Task.Command[Unit] =
+  build.compiler.testCompilation(
+    fromTasty = fromTasty,
+    updateCheckfiles = updateCheckfiles,
+    failed = failed,
+    enableCoveragePhase = enableCoveragePhase,
+    coverage = coverage,
+    filter = filter
+  )

--- a/community-build/package.mill
+++ b/community-build/package.mill
@@ -1,0 +1,86 @@
+package build.`community-build`
+
+import scala3build.*
+
+import mill.*
+import mill.api.BuildCtx
+import mill.javalib.testrunner.TestResult
+import org.scalajs.ir.ScalaJSVersions
+
+// community-build module definition
+object `package` extends Scala3Module {
+  // NonBootstrapped mode, so that we can import that module in IDEs seamlessly
+  def mode = Mode.NonBootstrapped
+  def moduleDeps = Seq(
+    build.library.`non-bootstrapped`
+  )
+
+  def prepareCommunityBuildDocs(): Task.Command[Unit] = Task.Command {
+    build.`sbt-bridge`.docJar()
+    build.interfaces.docJar()
+    build.tasty.docJar()
+    build.library.docJar()
+    build.library.`library-3`.docJar()
+    build.`tasty-inspector`.docJar()
+    build.scaladoc.docJar()
+    build.repl.docJar()
+    build.compiler.docJar()
+    build.`library-js`.docJar()
+    build.`library-js`.`library-3`.docJar()
+    ()
+  }
+
+  def prepareCommunityBuild(): Task.Command[Unit] = Task.Command {
+    build.`sbt-bridge`.publishLocal()()
+    build.interfaces.publishLocal()()
+    build.tasty.publishLocal()()
+    build.library.publishLocal()()
+    build.library.`library-3`.publishLocal()()
+    build.`tasty-inspector`.publishLocal()()
+    build.scaladoc.publishLocal()()
+    build.`directives-parser`.publishLocal()()
+    build.repl.publishLocal()()
+    build.compiler.publishLocal()()
+    build.`library-js`.publishLocal()()
+    build.`library-js`.`library-3`.publishLocal()()
+
+    val sbtInjectPluginsFile = test.forkWorkingDir() / "sbt-injected-plugins"
+    os.write.over(
+      sbtInjectPluginsFile,
+      s"""addSbtPlugin("org.scala-js" % "sbt-scalajs" % "${ScalaJSVersions.current}")"""
+    )
+    System.err.println(s"Wrote $sbtInjectPluginsFile")
+    val scalaVersionFile = test.forkWorkingDir() / "scala3-bootstrapped.version"
+    os.write.over(scalaVersionFile, Versions.dottyVersion)
+    System.err.println(s"Wrote $scalaVersionFile")
+  }
+
+  def run(args: Task[Args]) = Task.Command[Unit] {
+    prepareCommunityBuild()()
+    super.run(args)()
+  }
+
+  object test extends Scala3Tests {
+    def forkWorkingDir = Task {
+      BuildCtx.workspaceRoot / "community-build"
+    }
+
+    def testArgsDefault = super.testArgsDefault() ++ Seq(
+      "--include-categories=dotty.communitybuild.TestCategory",
+      "--run-listener=dotty.communitybuild.FailureSummarizer"
+    )
+
+    // Ensuring prepareCommunityBuild runs before running tests
+    def testForked(args: String*): Task.Command[(msg: String, results: Seq[TestResult])] = {
+      val argsTask = Task.Anon {
+        // putting this one here to be sure it runs before Mill actually runs the tests
+        prepareCommunityBuild()()
+
+        testArgsDefault() ++ args
+      }
+      Task.Command {
+        testTask(argsTask, Task.Anon { Seq.empty[String] })()
+      }
+    }
+  }
+}

--- a/compiler/package.mill
+++ b/compiler/package.mill
@@ -1,0 +1,244 @@
+package build.compiler
+
+import scala3build.*
+
+import mainargs.arg
+import mill.*
+import mill.api.BuildCtx
+import mill.scalalib.*
+import org.scalajs.ir.ScalaJSVersions
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
+import java.util.{Arrays, TimeZone}
+
+trait Compiler extends CrossScala3Module:
+  outer =>
+  def moduleDeps = Seq(
+    build.interfaces,
+    build.library.`library-3`(),
+    build.tasty()
+  )
+  def mainSources = Task.Source("src")
+  def nonBootstrappedSources = Task.Source("src-non-bootstrapped")
+
+  def testResources = Task.Sources("test-resources")
+
+  /**
+   * Sources of scalajs-ir, pprint, fansi, and sourcecode, post-processed and ready to be compiled from the Scala 3 build
+   */
+  def shadedSources = Task {
+
+    def csDep(org: String, name: String, version: String): coursier.Dependency =
+      coursier.Dependency(
+        coursier.Module(coursier.Organization(org), coursier.ModuleName(name), Map.empty),
+        coursier.version.VersionConstraint(version)
+      )
+
+    val shadedDeps = Seq(
+      csDep("org.scala-js", "scalajs-ir_2.13", ScalaJSVersions.current),
+      csDep("com.lihaoyi", "pprint_3", "0.9.3"),
+      csDep("com.lihaoyi", "fansi_3", "0.5.1"),
+      csDep("com.lihaoyi", "sourcecode_3", "0.4.4")
+    )
+
+    // Define patches as a map from search text to replacement text
+    val patches = Map(
+      "import scala" -> "import _root_.scala",
+      " scala.collection." -> " _root_.scala.collection.",
+      "def apply(c: Char): Trie[T]" -> "def apply(c: Char): Trie[T] | Null",
+      "var head: Iterator[T] = null" -> "var head: Iterator[T] | Null = null",
+      "if (head != null && head.hasNext) true" -> "if (head != null && head.nn.hasNext) true",
+      "head.next()" -> "head.nn.next()",
+      "abstract class Walker" -> "@scala.annotation.nowarn abstract class Walker",
+      "object TPrintLowPri" -> "@scala.annotation.nowarn object TPrintLowPri",
+      "x.toString match{" -> "scala.runtime.ScalaRunTime.stringOf(x) match{"
+    )
+
+    val sourceJars = build.interfaces.defaultResolver().classpath(
+      shadedDeps.map(_.withTransitive(false)),
+      sources = true
+    )
+    for (jar <- sourceJars)
+      os.unzip(jar.path, Task.dest)
+
+    val patchUsageCounter = scala.collection.mutable.Map(patches.keys.map(_ -> 0).toSeq*)
+    val scalaJsSourcesPrefix = Task.dest / "org/scalajs"
+    for (f <- os.walk(Task.dest) if os.isFile(f) && f.last.endsWith(".scala")) {
+      val isScalaJsStuff = f.startsWith(scalaJsSourcesPrefix)
+      val lines = os.read.lines(f).toList
+      val updatedLines = Shading.replacePackage(Shading.insertUnsafeNullsImport(lines)) {
+        case "org.scalajs.ir" => "dotty.tools.sjs.ir"
+      }
+      var text = updatedLines.mkString(System.lineSeparator())
+      if (!isScalaJsStuff && f.last != "CollectionName.scala") {
+        text = "package dotty.shaded" + System.lineSeparator() + text
+
+        // Apply patches and count usage
+        for ((search, replacement) <- patches if text.contains(search)) {
+          text = text.replace(search, replacement)
+          patchUsageCounter(search) += 1
+        }
+      }
+      os.write.over(f, text)
+    }
+
+    // Assert that all patches were applied at least once
+    val unappliedPatches = patchUsageCounter.filter(_._2 == 0).keys
+    if (unappliedPatches.nonEmpty)
+      Task.fail(s"Patches were not applied: ${unappliedPatches.mkString(", ")}")
+    else
+      PathRef(Task.dest)
+  }
+
+  def sources = Task {
+    val baseSources = super.sources()
+    assert(baseSources.exists(_.path == mainSources().path))
+    baseSources
+  }
+  def generatedSources = Task {
+    super.generatedSources() ++ Seq(shadedSources())
+  }
+  def resources =
+    if (Util.isBsp)
+      super.resources
+    else
+      Task {
+        super.resources() ++ Seq(compilerPropertiesResources())
+      }
+
+  def compilerPropertiesResources = Task(persistent = true) {
+    val file = Task.dest / "compiler.properties"
+    val dateFormat = new SimpleDateFormat("yyyyMMdd-HHmmss")
+    dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"))
+    val contents =
+      s"""version.number=${build.interfaces.publishVersion()}
+         |maven.version.number=${build.interfaces.publishVersion()}
+         |git.hash=${VersionUtil.gitHash}
+         |copyright.string=Copyright 2002-${Util.currentYear}, LAMP/EPFL
+       """.stripMargin.getBytes(StandardCharsets.UTF_8)
+
+    if (!os.isFile(file) || !Arrays.equals(os.read.bytes(file), contents))
+      os.write.over(file, contents)
+
+    for (f <- os.list(Task.dest) if f != file)
+      os.remove.all(f)
+
+    PathRef(Task.dest)
+  }
+
+  def mvnDeps = Seq(
+    mvn"org.scala-lang.modules:scala-asm:9.9.0-scala-1",
+    mvn"org.scala-sbt:compiler-interface:1.12.0"
+  )
+
+  def scalacOptions = Task {
+    super.scalacOptions() ++ Seq(
+      // Original comment: Note: bench/profiles/projects.yml should be updated accordingly.
+      "-Yexplicit-nulls",
+      "-Wsafe-init",
+      // Silence `using` clause warnings in the scalajs-ir sources
+      "-Wconf:src=scalajs-ir-src/.*&msg=Implicit parameters should be provided with a `using` clause:s",
+      // Silence AnyRefMap deprecation warnings in the scalajs-ir sources
+      "-Wconf:src=scalajs-ir-src/.*&msg=object AnyRefMap in package scala\\.collection\\.mutable is deprecated:s",
+    )
+  }
+
+  def manifest = super.manifest().add(
+    "Git-Hash" -> VersionUtil.gitHash
+  )
+
+  def mainClass = Some("dotty.tools.dotc.Main")
+
+  def isCoreModule = true
+
+  object test extends Scala3Tests:
+    def moduleDeps = super.moduleDeps ++ Seq(
+      build.`directives-parser`()
+    )
+    def compileResources = Task {
+      super.compileResources() ++ outer.testResources()
+    }
+    def mvnDeps = Seq(
+      mvn"io.get-coursier:coursier_2.13:2.1.24".exclude(("org.scala-lang", "scala-library"))
+    )
+
+    def testArgsDefault = Task {
+      val bootstrapOnlyArgs = if (mode == Mode.NonBootstrapped) Seq("--exclude-categories=dotty.BootstrappedOnlyTests") else Nil
+      val extraArgs = Seq(
+        "--run-listener=dotty.tools.ContextEscapeDetector",
+        "--exclude-categories=dotty.VulpixMetaTests"
+      )
+      super.testArgsDefault() ++ bootstrapOnlyArgs ++ extraArgs
+    }
+
+    /**
+     * Arguments to pass to the JVM running compiler tests
+     *
+     * This sets a number of build-related Java properties, so that
+     * the tests know about artifacts built or pulled by the Scala 3 build.
+     */
+    def compilerTestForkArgs = Task {
+      val compilerClassPath = outer.compileClasspath().map(_.path)
+      def artifactFor(moduleName: String): os.Path =
+        compilerClassPath
+          .iterator
+          .filter(os.isFile)
+          .filter(_.last.endsWith(".jar"))
+          .find(_.last.startsWith(moduleName + "-"))
+          .getOrElse {
+            Task.fail(s"No JAR found for $moduleName in compiler class path $compilerClassPath")
+          }
+
+      Seq(
+        s"-Ddotty.tests.dottyCompilerManagedSources=${mainSources().path}",
+        s"-Ddotty.tests.classes.dottyInterfaces=${build.interfaces.jar().path}",
+        s"-Ddotty.tests.classes.dottyCompiler=${outer.jar().path}",
+        s"-Ddotty.tests.classes.tastyCore=${build.tasty().jar().path}",
+        s"-Ddotty.tests.classes.compilerInterface=${artifactFor("compiler-interface")}",
+        s"-Ddotty.tests.classes.scalaLibrary=${build.library().runClasspath().map(_.path).filter(os.exists).mkString(File.pathSeparator)}",
+        s"-Ddotty.tests.classes.scalaAsm=${artifactFor("scala-asm")}",
+        s"-Ddotty.tests.classes.dottyStaging=${build.staging().jar().path}",
+        s"-Ddotty.tests.classes.dottyTastyInspector=${build.`tasty-inspector`().jar().path}",
+        s"-Ddotty.tools.dotc.semanticdb.test=${BuildCtx.workspaceRoot / "tests/semanticdb"}"
+      )
+    }
+
+    def forkArgs: T[Seq[String]] = Task {
+      super.forkArgs() ++ compilerTestForkArgs()
+    }
+
+  /**
+   * By default runs tests in dotty.tools.dotc.*CompilationTests and dotty.tools.dotc.coverage.*, excluding tests tagged with dotty.SlowTests.
+   */
+  def testCompilation(
+    @arg(doc = "runs tests in dotty.tools.dotc.FromTastyTests")
+    fromTasty: Boolean = false,
+    @arg(doc = "override the checkfiles that did not match with the current output")
+    updateCheckfiles: Boolean = false,
+    @arg(doc = "re-run only failed tests")
+    failed: Boolean = false,
+    @arg(doc = "enable Scoverage instrumentation phase for compilation tests")
+    enableCoveragePhase: Boolean = false,
+    coverage: Boolean = false,
+    @arg(doc = "substring of the path of the tests file")
+    filter: Args
+  ): Task.Command[Unit] = {
+    val testSuite =
+      if (fromTasty) "dotty.tools.dotc.FromTastyTests"
+      else if (coverage) "dotty.tools.dotc.coverage.*"
+      else "dotty.tools.dotc.*CompilationTests"
+    val testArgs = Seq(testSuite, "--", "--exclude-categories=dotty.SlowTests") ++
+      (if (updateCheckfiles) Seq("-Ddotty.tests.updateCheckfiles=TRUE") else Nil) ++
+      (if (failed) Seq("-Ddotty.tests.rerunFailed=TRUE") else Nil) ++
+      (if (enableCoveragePhase) Seq("-Ddotty.tests.instrumentCoverage=TRUE") else Nil) ++
+      (if (filter.value.nonEmpty) Seq(s"-Ddotty.tests.filter=${filter.value.mkString(" ")}") else Nil)
+
+    Task.Command[Unit] {
+      test.testOnly(testArgs*)()
+    }
+  }
+
+object `package` extends Compiler, CrossHelper[Compiler]:
+  object `non-bootstrapped` extends Compiler, CrossHelper.NonBootstrapped

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -73,7 +73,7 @@ object Properties {
   /** compiler-interface jar */
   def compilerInterface: String = sys.props("dotty.tests.classes.compilerInterface").nn
 
-  /** scala-library jar */
+  /** scala-library jars */
   def scalaLibrary: String = sys.props("dotty.tests.classes.scalaLibrary").nn
 
   // TODO: Remove this once we migrate the test suite

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -57,7 +57,7 @@ object TestConfiguration {
   ))
 
   def mkClasspath(classpaths: List[String]): String =
-    classpaths.map({ p =>
+    classpaths.flatMap(_.split(File.pathSeparator)).map({ p =>
       val file = new java.io.File(p)
       assert(file.exists, s"File $p couldn't be found.")
       file.getAbsolutePath

--- a/directives-parser/package.mill
+++ b/directives-parser/package.mill
@@ -1,0 +1,25 @@
+package build.`directives-parser`
+
+import scala3build.*
+
+import mill.*
+
+// The directives parser used by the REPL (and elsewhere) to read `//> using` directives
+trait DirectivesParser extends CrossScala3Module:
+  def artifactName = "scala3-directives-parser"
+
+  def moduleDeps = Seq(
+    build.library.`library-3`()
+  )
+
+  // Sources use the Maven-style layout rather than the default one
+  def sourcesFolders = Seq("src/main/scala")
+
+  def scalacOptions = super.scalacOptions() ++ Seq("-Wunused:all")
+
+  def testSources = Task.Source("src/test/scala")
+
+  object test extends Scala3Tests
+
+object `package` extends DirectivesParser, CrossHelper[DirectivesParser]:
+  object `non-bootstrapped` extends DirectivesParser, CrossHelper.NonBootstrapped

--- a/dist/package.mill
+++ b/dist/package.mill
@@ -1,0 +1,254 @@
+package build.dist
+
+import scala3build.*
+
+import coursier.cache.{ArchiveCache, Cache}
+import coursier.core.Dependency
+import coursier.maven.{MavenRepository, MavenRepositoryLike}
+import coursier.util.Artifact
+import coursier.version.VersionConstraint
+import mill.*
+import mill.api.BuildCtx
+import mill.javalib.CoursierModule
+import mill.util.Jvm
+
+import scala.util.Properties
+
+object `package` extends CoursierModule {
+
+  def binDir = Task.Source("bin")
+  def libexecDir = Task.Source("libexec")
+  def libexecNativeOverridesFiles = Task.Source("libexec-native-overrides")
+
+  def jvm = Task {
+    makeDist()()
+  }
+
+  def `mac-x86_64` = Task {
+    makeDist(
+      nativeOverrides = true,
+      nativeScalaCliLauncherUrl = Some(ver => s"https://github.com/VirtusLab/scala-cli/releases/download/v$ver/scala-cli-x86_64-apple-darwin.gz!")
+    )()
+  }
+
+  def `mac-aarch64` = Task {
+    makeDist(
+      nativeOverrides = true,
+      nativeScalaCliLauncherUrl = Some(ver => s"https://github.com/VirtusLab/scala-cli/releases/download/v$ver/scala-cli-x86_64-apple-darwin.gz!")
+    )()
+  }
+
+  def `win-x86_64` = Task {
+    makeDist(
+      nativeOverrides = true,
+      nativeScalaCliLauncherUrl = Some(ver => s"https://github.com/VirtusLab/scala-cli/releases/download/v$ver/scala-cli-x86_64-pc-win32.zip!scala-cli.exe")
+    )()
+  }
+
+  def `linux-x86_64` = Task {
+    makeDist(
+      nativeOverrides = true,
+      nativeScalaCliLauncherUrl = Some(ver => s"https://github.com/VirtusLab/scala-cli/releases/download/v$ver/scala-cli-x86_64-pc-linux.gz!")
+    )()
+  }
+
+  def `linux-aarch64` = Task {
+    makeDist(
+      nativeOverrides = true,
+      nativeScalaCliLauncherUrl = Some(ver => s"https://github.com/VirtusLab/scala-cli/releases/download/v$ver/scala-cli-aarch64-pc-linux.gz!")
+    )()
+  }
+
+  /**
+   * Builds a Scala distribution directory
+   */
+  private def makeDist(
+    nativeOverrides: Boolean = false,
+    nativeScalaCliLauncherUrl: Option[(version: String) => String] = None
+  ): Task[PathRef] = {
+
+    val projects0 = build.projects(using Mode.Bootstrapped)
+
+    // Staged repositories for the POMs / JARs built by each module of projects0
+    val projectReposTask = Task.traverse(projects0)(_.publishLocalTestRepo)
+
+    // Result of dependency resolution for each module of projects0
+    val projectDependenciesTask = Task.traverse(projects0) { proj =>
+      Task.Anon {
+        proj.millResolver().fetchArtifacts(
+          Seq(proj.coursierDependencyTask())
+        )
+      }
+    }
+
+    Task.Anon {
+      val dest = Task.dest
+      os.copy(binDir().path, dest / "bin")
+      os.copy(libexecDir().path, dest / "libexec")
+
+      if (nativeOverrides)
+        for (elem <- os.list(libexecNativeOverridesFiles().path))
+          os.copy.into(elem, dest / "libexec", createFolders = true, mergeFolders = true, replaceExisting = true)
+
+      // Downloads the passed url via the coursier archive cache
+      // When passed a simple URL, this downloads it.
+      // When passed a simple URL followed by "!" (for simple compression formats like gzip),
+      // this downloads it and extracts it in the coursier archive cache.
+      // When passed a simple URL followed by "!" and a sub-path (for zip files or tar archives),
+      // this downloads it and extracts it in the coursier archive cache, and finds the sub-path in it.
+      def get(url: String): os.Path =
+        if (url.contains("!")) {
+          val archiveCache = ArchiveCache()
+          val f = archiveCache.get(Artifact(url))
+            .unsafeRun(true)(using archiveCache.cache.ec)
+            .left.map(throw _)
+            .merge
+          os.Path(f)
+        }
+        else {
+          val cache = Cache.default
+          val f = cache.file(Artifact(url))
+            .run
+            .unsafeRun(true)(using cache.ec)
+            .left.map(throw _)
+            .merge
+          os.Path(f)
+        }
+
+      nativeScalaCliLauncherUrl match {
+        case Some(f) =>
+          val file = get(f(Versions.scalaCliLauncherVersion))
+          val ext = if (Properties.isWin) ".exe" else ""
+          val dest0 = dest / "libexec" / s"scala-cli$ext"
+          os.copy(file, dest0)
+          if (!Properties.isWin)
+            dest0.toIO.setExecutable(true)
+        case None =>
+          val scalaCliJar = get(s"https://github.com/VirtusLab/scala-cli/releases/download/v${Versions.scalaCliLauncherVersion}/scala-cli.jar")
+          os.copy(scalaCliJar, dest / "libexec/scala-cli.jar")
+      }
+
+      Dist.generateVersionFile(
+        BuildCtx.workspaceRoot.toIO,
+        dest.toIO,
+        build.library.publishVersion(),
+        System.err.println(_)
+      )
+
+      val repo = dest / "maven2"
+
+      // Copy JARs and POMs for modules built in this repo
+      for (projectRepo <- projectReposTask(); f <- os.list(projectRepo.path))
+        os.copy.into(f, repo, mergeFolders = true, createFolders = true)
+
+      // Copy JARs for dependencies
+      for (res <- projectDependenciesTask(); (dep, _, _, fOpt) <- res.fullDetailedArtifacts0; f <- fOpt) {
+        val dest0 = repo / dep.module.organization.value.split('.').toSeq / dep.module.name.value /
+          dep.versionConstraint.asString /
+          s"${dep.module.name.value}-${dep.versionConstraint.asString}.jar"
+        if (!os.exists(dest0))
+          os.copy(os.Path(f), dest0, mergeFolders = true, createFolders = true)
+      }
+
+      // Copy POMs for dependencies (including POM files of BOMs and parent POMs, that don't have corresponding JARs)
+      val allArtifactsRes0 = {
+
+        val cache = Cache.default
+
+        val allArtifacts = projectDependenciesTask()
+          .flatMap { res =>
+            res.resolution.projectCache0
+              .flatMap {
+                case ((mod, _), (repo: MavenRepositoryLike, proj)) =>
+                  val path = os.sub / mod.organization.value.split('.').toSeq / mod.name.value / proj.version0.asString / s"${mod.name.value}-${proj.version0.asString}.pom"
+                  Seq((path, repo.artifactFor(repo.urlFor(path.segments, false), false)))
+                case ((mod, _), _) if mod.organization.value == "mill-internal" =>
+                  Nil
+                case other =>
+                  sys.error(s"$other")
+              }
+              .toVector
+          }
+          .distinct
+          .sortBy(_._1)
+
+        val allArtifactsTasks = coursier.util.Task.gather.gather {
+          allArtifacts.map {
+            case (path, art) =>
+              cache.file(art).map((path, _)).run
+          }
+        }
+
+        val allArtifactsRes = allArtifactsTasks.unsafeRun(true)(using cache.ec)
+        val errors = allArtifactsRes.collect {
+          case Left(err) => err
+        }
+        if (errors.nonEmpty) {
+          val err = new Exception(errors.head)
+          for (err0 <- errors.tail)
+            err.addSuppressed(err0)
+          throw err
+        }
+
+        allArtifactsRes.collect {
+          case Right(elem) => elem
+        }
+      }
+
+      for ((path, f) <- allArtifactsRes0)
+        os.copy.over(os.Path(f), repo / path, createFolders = true, replaceExisting = true)
+
+      // Ensures some Scala 3 modules can be downloaded entirely via the dist offline repo,
+      // and creates some JAR archives out of them, put in the dist under lib/ (some of
+      // the dist scripts expect them at this location).
+      val dottyVer = VersionConstraint(Versions.dottyVersion)
+      def depFor(name: String) =
+        coursier.Dependency(
+          coursier.Module(coursier.Organization("org.scala-lang"), coursier.ModuleName(name), Map()),
+          dottyVer
+        )
+      val scalaDeps = Seq(
+        depFor("scala3-interfaces"),
+        depFor("scala3-compiler_3"),
+        depFor("scala3-library_3"),
+        depFor("scala-library"),
+        depFor("tasty-core_3"),
+        depFor("scala3-repl_3")
+      )
+      val compilerDeps = Seq(
+        depFor("scala3-staging_3"),
+        depFor("scala3-tasty-inspector_3"),
+        depFor("scala3-repl_3")
+      )
+      val scaladocDeps = Seq(
+        depFor("scala3-interfaces"),
+        depFor("scala3-compiler_3"),
+        depFor("scala3-library_3"),
+        depFor("scala-library"),
+        depFor("tasty-core_3"),
+        depFor("scala3-tasty-inspector_3"),
+        depFor("scaladoc_3")
+      )
+      def localRepoFilesFor(deps: Seq[Dependency]): Seq[os.Path] =
+        coursier.Fetch()
+          .withRepositories(Seq(MavenRepository(repo.toNIO.toUri.toASCIIString)))
+          .withDependencies(deps)
+          .run()
+          .map(os.Path(_))
+      val scalaFiles = localRepoFilesFor(scalaDeps)
+      val compilerFiles = localRepoFilesFor(scalaDeps ++ compilerDeps).filterNot(scalaFiles.toSet)
+      val scaladocFiles = localRepoFilesFor(scaladocDeps)
+
+      assert(scalaFiles.forall(_.startsWith(repo)))
+      assert(compilerFiles.forall(_.startsWith(repo)))
+      assert(scaladocFiles.forall(_.startsWith(repo)))
+
+      Jvm.createClasspathPassingJar(dest / "lib/scala.jar", scalaFiles)
+      Jvm.createClasspathPassingJar(dest / "lib/with_compiler.jar", compilerFiles)
+      Jvm.createClasspathPassingJar(dest / "lib/scaladoc.jar", scaladocFiles)
+
+      PathRef(dest)
+    }
+  }
+
+}

--- a/interfaces/package.mill
+++ b/interfaces/package.mill
@@ -1,0 +1,11 @@
+package build.interfaces
+
+import scala3build.*
+
+// definition of the interfaces module
+object `package` extends Scala3JavaModule, Scala3Mima:
+  def isCoreModule = true
+  def mimaForwardIssueFilters =
+    MiMaFilters.Interfaces.ForwardsBreakingChanges
+  def mimaBackwardIssueFilters =
+    MiMaFilters.Interfaces.BackwardsBreakingChanges

--- a/language-server/package.mill
+++ b/language-server/package.mill
@@ -1,0 +1,67 @@
+package build.`language-server`
+
+import scala3build.*
+
+import mill.*
+import mill.scalalib.*
+
+trait LanguageServer extends CrossScala3Module:
+  def moduleDeps = Seq(
+    build.repl()
+  )
+  def mvnDeps = Seq(
+    mvn"org.eclipse.lsp4j:org.eclipse.lsp4j:1.0.0"
+      // Original comment: Work around https://github.com/eclipse/lsp4j/issues/295
+      .exclude(("org.eclipse.xtend", "org.eclipse.xtend.lib")),
+    mvn"org.eclipse.xtend:org.eclipse.xtend.lib:2.16.0",
+    mvn"tools.jackson.core:jackson-databind:${Dependencies.jacksonVersion}"
+  )
+  def scalacOptions = super.scalacOptions().filter(_ != "-Yexplicit-nulls")
+
+  object test extends Scala3Tests:
+    // The value of build.library().runClasspath, but computed without
+    // evaluating build.library().runClasspath itself. Useful to be used
+    // in source generation, that we don't want to depend on compiling
+    // the library module, so that computing it remains cheap for BSP.
+    def libraryPrecomputedRunClasspath: T[Seq[String]] =
+      build.library().precomputedRunClasspath
+    def libraryRunClasspath: T[Seq[PathRef]] =
+      Task {
+        build.library()
+          .runClasspath()
+          .filter(ref => os.exists(ref.path))
+      }
+    def generatedSources = Task {
+      super.generatedSources() ++ Seq(buildInfoDir())
+    }
+    def buildInfoDir = Task {
+      val tq = "\"\"\""
+      val content =
+        s"""package dotty.tools.languageserver.util.server
+          |
+          |object BuildInfo {
+          |  def ideTestsCompilerVersion = "${publishVersion()}"
+          |  def ideTestsCompilerArguments: Seq[String] = Nil
+          |  def ideTestsDependencyClasspath = ${libraryPrecomputedRunClasspath().map(p => s"new java.io.File($tq$p$tq)").mkString("Seq[java.io.File](", ", ", ")")}
+          |}
+          |""".stripMargin
+
+      os.write(Task.dest / "BuildInfo.scala", content)
+
+      PathRef(Task.dest)
+    }
+    def runClasspath = Task {
+      // Check that the pre-computed library run class path corresponds to its final value
+      val precomputedLibrary = libraryPrecomputedRunClasspath().map(os.Path(_))
+      val actualLibrary = libraryRunClasspath().map(_.path)
+      if (precomputedLibrary.filter(os.exists) != actualLibrary.filter(os.exists))
+        Task.fail(
+          "Warning: standard library class path calculation mismatch: " +
+          s"pre-computed value $precomputedLibrary differs from actual value $actualLibrary."
+        )
+      else
+        super.runClasspath()
+    }
+
+object `package` extends LanguageServer, CrossHelper[LanguageServer]:
+  object `non-bootstrapped` extends LanguageServer, CrossHelper.NonBootstrapped

--- a/library-2/package.mill
+++ b/library-2/package.mill
@@ -1,0 +1,53 @@
+package build.`library-2`
+
+import scala3build.*
+
+import mill.*
+import mill.scalalib.*
+
+object `package` extends ScalaModule {
+  def scalaVersion = Versions.scala2Version
+
+  def scalaLibraryMvnDeps = Task(Nil)
+
+  def scalacOptions = Task {
+    val baseOptions = super.scalacOptions()
+      .filterNot(_ != "--java-output-version:17")
+      .filterNot(_ != "-Yexplicit-nulls")
+      .filterNot(_ != "-Wsafe-init")
+    baseOptions ++ Seq(
+      "-release:17",
+      s"-sourcepath:${scala2LibraryDir().path}",
+      "-opt:local", // Original sbt build comment: Important: local optimization are fine, inlining is prohibited!
+    )
+  }
+
+  def scala2LibraryDir: T[PathRef] = Task {
+    val sourceJars = defaultResolver().classpath(
+      Seq(mvn"org.scala-lang:scala-library:${Versions.scala2Version}"),
+      sources = true
+    )
+    assert(sourceJars.length == 1, s"Expected a single source JAR for scala-library, got $sourceJars")
+    val sourceJar = sourceJars.head.path
+    os.unzip(sourceJar, Task.dest)
+
+    // Original sbt build comment: Auxilary source files that cannot be compield
+    val excludedSourceFiles = Seq[os.SubPath](
+      "scala/AnyRef.scala",
+      "scala/Any.scala",
+      "scala/Nothing.scala",
+      "scala/Null.scala",
+      "scala/Singleton.scala",
+    )
+
+    for (f <- excludedSourceFiles)
+      os.remove(Task.dest / f)
+
+    PathRef(Task.dest)
+  }
+
+  def sources = Nil
+  def generatedSources = Task {
+    Seq(scala2LibraryDir())
+  }
+}

--- a/library-js/package.mill
+++ b/library-js/package.mill
@@ -1,0 +1,163 @@
+package build.`library-js`
+
+import scala3build.*
+
+import mill.*
+import mill.api.BuildCtx
+import mill.scala3buildhelper.CompileClassesPathHelper
+import mill.scalalib.*
+import mill.util.Jvm
+import org.scalajs.ir.ScalaJSVersions
+
+trait LibraryJs extends SharedLibrarySettings with Scala3JsModule with Scala3Mima with CompileClassesPathHelper {
+  def isJS = true
+  def moduleDeps = Seq(
+    build.library()
+  )
+  def compileMvnDeps = Seq(
+    mvn"org.scala-js::scalajs-library:${ScalaJSVersions.current}"
+      .withDottyCompat(scalaVersion())
+      .exclude(("org.scala-lang", "scala-library"))
+  )
+  def mvnDeps = Seq(
+    mvn"org.scala-js:scalajs-javalib:${ScalaJSVersions.current}"
+  )
+  def pomSettings = super.pomSettings().copy(
+    organization = "org.scala-js"
+  )
+  def artifactName = "scalajs-scalalib" + (if (mode == Mode.NonBootstrapped) "-non-bootstrapped" else "")
+  // Original sbt build comment:
+  // This is very tricky here since this is a Scala 3 project, but to be able to smoothly
+  // migrate the ecosystem, we need to be able to evict the Scala 2 library from the classpath.
+  // The problem is that the Scala 2 library for Scala.js has a _2.13 in the module's name, so we need
+  // to release Scala 3 for Scala.js with the same _2.13 instead of the _3.
+  // Yes, I know, this is weird and feels wrong.
+  def artifactId = artifactName() + "_2.13"
+
+  def sources = Task {
+    val baseSources = super.sources()
+    val expandedBaseSources = baseSources.flatMap { ref =>
+      if (os.isDir(ref.path))
+        os.walk(ref.path)
+          .filter(os.isFile)
+          .filter(_.last.endsWith(".scala"))
+      else
+        Nil
+    }
+    val expandedRelativeBaseSourcesSet = baseSources
+      .flatMap { ref =>
+        if (os.isDir(ref.path))
+          os.walk(ref.path)
+            .filter(os.isFile)
+            .filter(_.last.endsWith(".scala"))
+            .map(_.subRelativeTo(ref.path))
+        else
+          Nil
+      }
+      .toSet
+    val excludedBaseSourcesSet = Set(
+      os.sub / "scala/runtime/BoxesRunTime.java",
+      os.sub / "scala/math/ScalaNumber.java"
+    )
+    val librarySources = build.library().sources().flatMap { ref =>
+      if (os.isDir(ref.path))
+        os.walk(ref.path)
+          .filter(os.isFile)
+          .filter { f =>
+            val subPath = f.subRelativeTo(ref.path)
+            !expandedRelativeBaseSourcesSet.contains(subPath) &&
+              !excludedBaseSourcesSet.contains(subPath)
+          }
+          .map(PathRef(_))
+      else
+        Seq(ref)
+    }
+
+    val filteredExpandedBaseSources = expandedBaseSources.filter { f =>
+      // Excluding those feels like a typo in project/Build.scala, in the original sbt build
+      // but keeping BoxesRunTime.scala makes some sjs-compiler-tests fail
+      f.last != "BoxesRunTime.scala" &&
+        f.last != "ScalaNumber.scala"
+    }
+    filteredExpandedBaseSources.map(PathRef(_)) ++ librarySources
+  }
+  def scalacOptions = Task {
+    val mapSourceOpt =
+      if (Versions.isRelease) {
+        val baseURI = BuildCtx.workspaceRoot.toNIO.toUri.toASCIIString
+        val dottyVersion = publishVersion()
+        Seq(s"-scalajs-mapSourceURI:$baseURI->${Constants.dottyGithubRawUserContentUrl}/$dottyVersion/")
+      }
+      else
+        Nil
+    super.scalacOptions() ++ Seq("-Wconf:any:s") ++ mapSourceOpt
+  }
+
+  def patches = Task {
+    val cp = defaultResolver().classpath(
+      Seq(
+        mvn"org.scala-js:scalajs-scalalib_2.13:${Versions.scala2Version}+${ScalaJSVersions.current}"
+          .exclude(("org.scala-js", "scalajs-javalib"))
+      )
+    )
+
+    assert(cp.length == 2)
+
+    cp
+  }
+
+  /** Same as `localClasspath`, but we only keep .sjsir files, and class and tasty files of some specific classes */
+  def localClassPathForJar = Task {
+    val destDir = Task.dest
+    val localCp = localClasspath()
+    for (entry <- localCp if os.isDir(entry.path); f <- os.walk(entry.path) if os.isFile(f)) {
+      val keep = f.last.endsWith(".sjsir") ||
+        f.last == "UnitOps.tasty" ||
+        f.last == "UnitOps.class" ||
+        f.last == "UnitOps$.class" ||
+        f.last == "AnonFunctionXXL.tasty" ||
+        f.last == "AnonFunctionXXL.class"
+      if (keep) {
+        val subPath = f.subRelativeTo(entry.path)
+        val dest = destDir / subPath
+        if (!os.exists(dest))
+          os.copy(f, dest, createFolders = true)
+      }
+    }
+    PathRef(destDir)
+  }
+
+  def jarName = Task {
+    s"scalajs-scalalib_2.13-${publishVersion()}.jar"
+  }
+
+  // Ensuring the JAR name has a shape expected by tools that consume it
+  def jar: T[PathRef] = Task {
+    val jar = Task.dest / jarName()
+    Jvm.createJar(jar, Seq(localClassPathForJar().path), manifest())
+    PathRef(jar)
+  }
+
+  def mimaForwardIssueFilters =
+    MiMaFilters.ScalaLibrarySJS.ForwardsBreakingChanges
+  def mimaBackwardIssueFilters =
+    MiMaFilters.ScalaLibrarySJS.BackwardsBreakingChanges
+
+  def enableBsp = Scala3JavaModule.enableBspForNonCoreModules && Scala3JavaModule.enableBspForScalaJsModules
+}
+
+object `package` extends LibraryJs with CrossHelper[LibraryJs] {
+  object `non-bootstrapped` extends LibraryJs with CrossHelper.NonBootstrapped
+
+  // this module is empty / has no sources
+  trait Library3 extends CrossScala3Module with Scala3JsModule {
+    def artifactName = "scala3-library" + (if (mode == Mode.NonBootstrapped) "-non-bootstrapped" else "")
+    def moduleDeps = Seq(
+      build.`library-js`()
+    )
+  }
+
+  object `library-3` extends Library3 with CrossHelper[Library3] {
+    object `non-bootstrapped` extends Library3 with CrossHelper.NonBootstrapped
+  }
+}

--- a/library/package.mill
+++ b/library/package.mill
@@ -1,0 +1,141 @@
+package build.library
+
+import scala3build.*
+
+import com.github.lolgab.mill.mima.*
+import io.github.alexarchambault.millmissinglink.*
+import mill.*
+import mill.scalalib.*
+
+import java.io.File
+
+trait Library extends SharedLibrarySettings with mill.scala3buildhelper.CompileClassesPathHelper with Scala3Mima with MissingLink {
+
+  def artifactId = artifactName()
+  def artifactName = "scala-library" + (if (mode == Mode.NonBootstrapped) "-non-bootstrapped" else "")
+
+  def scalacOptions = super.scalacOptions() ++ Seq(
+    "-opt", "-opt-inline:**,!java.**",
+    "-sourcepath", sources().map(_.path).distinct.mkString(File.pathSeparator),
+    // Workaround for #25897
+    "-Wconf:cat=deprecation&origin=scala\\.collection\\.Iterable\\.stringPrefix:s"
+  )
+
+  def libraryPropertiesResourceDir = Task {
+    val contents = LibraryProperties.content(publishVersion(), Util.currentYear)
+    os.write(Task.dest / "library.properties", contents)
+    PathRef(Task.dest)
+  }
+
+  def resources =
+    if (Util.isBsp)
+      super.resources
+    else
+      Task {
+        super.resources() ++ Seq(libraryPropertiesResourceDir())
+      }
+
+  def testResources = Task.Sources("test-resources")
+  def extraTestSources =
+    if (mode == Mode.NonBootstrapped) Task.Source("test-nonbootstrapped")
+    else Task.Source("test-bootstrapped")
+
+
+  def patches = Task {
+    Seq(build.`library-2`.compile().classes)
+  }
+
+  private def jarSubPath =
+    os.sub / s"scala-library-${Versions.dottyVersion}.jar"
+
+  // Ensuring the JAR name has a shape that zinc or other tools expect
+  def jar = Task {
+    val jar0 = super.jar()
+    val dest = Task.dest / jarSubPath
+    os.copy(jar0.path, dest)
+    PathRef(dest)
+  }
+
+  def runClasspath =
+    Task {
+      Seq(jar())
+    }
+
+  /**
+   * Compute expected run class path, but don't compute its content
+   *
+   * Useful for source generation, where we want the run class path but don't want to trigger compilation
+   */
+  def precomputedRunClasspath: T[Seq[String]] =
+    Task {
+      Seq((jarPath(Task.dest) / jarSubPath).toString)
+    }
+
+  def mimaForwardIssueFilters =
+    MiMaFilters.Scala3Library.ForwardsBreakingChanges
+  def mimaBackwardIssueFilters =
+    MiMaFilters.Scala3Library.BackwardsBreakingChanges
+
+  def missinglinkCheck(): Task.Command[Unit] = Task.Command {
+
+    val conflicts = missinglinkConflicts()
+
+    val filteredConflicts = conflicts.filterNot { conflict =>
+      MissingLinkFilters.excludedClassFiles.contains(
+        conflict.dependency().fromClass().getClassName()
+      )
+    }
+
+    if (filteredConflicts.isEmpty)
+      System.err.println(s"No conflicts found, filtered out ${conflicts.size} problems.")
+    else {
+      val filteredTotal = filteredConflicts.length
+      Task.log.error(s"$filteredTotal conflicts found!")
+      outputConflicts(filteredConflicts)
+      Task.fail(s"There were $filteredTotal conflicts")
+    }
+  }
+
+  def isCoreModule = true
+
+  object test extends Scala3Tests {
+    def resources = testResources
+    def sources = Task {
+      super.sources() ++ Seq(extraTestSources())
+    }
+
+    def mvnDeps = Seq(
+      mvn"org.scalacheck::scalacheck:1.19.0".exclude("org.scala-lang" -> "*")
+    )
+
+    def scalacOptions = Task {
+      val baseOptions = super.scalacOptions()
+      val sourcePathIdx = baseOptions.indexOf("-sourcepath")
+      if (sourcePathIdx >= 0)
+        // drop -sourcepath and the argument right after
+        baseOptions.take(sourcePathIdx) ++ baseOptions.drop(sourcePathIdx + 2)
+      else {
+        System.err.println(s"Warning: couldn't find -sourcepath option in main module scalac options")
+        baseOptions
+      }
+    }
+  }
+}
+
+object `package` extends Library with CrossHelper[Library] {
+  object `non-bootstrapped` extends Library with CrossHelper.NonBootstrapped
+
+  // this module is empty / has no sources
+  trait Library3 extends CrossScala3Module {
+    def artifactName = "scala3-library" + (if (mode == Mode.NonBootstrapped) "-non-bootstrapped" else "")
+    def moduleDeps = Seq(
+      build.library()
+    )
+
+    def isCoreModule = true
+  }
+
+  object `library-3` extends Library3 with CrossHelper[Library3] {
+    object `non-bootstrapped` extends Library3 with CrossHelper.NonBootstrapped
+  }
+}

--- a/mill
+++ b/mill
@@ -1,0 +1,199 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ -z "${DEFAULT_MILL_VERSION}" ] ; then DEFAULT_MILL_VERSION="1.1.3"; fi
+
+if [ -z "${GITHUB_RELEASE_CDN}" ] ; then GITHUB_RELEASE_CDN=""; fi
+
+if [ -z "$MILL_MAIN_CLI" ] ; then MILL_MAIN_CLI="${0}"; fi
+
+MILL_REPO_URL="https://github.com/com-lihaoyi/mill"
+
+MILL_BUILD_SCRIPT=""
+
+if [ -f "build.mill" ] ; then
+  MILL_BUILD_SCRIPT="build.mill"
+elif [ -f "build.mill.scala" ] ; then
+  MILL_BUILD_SCRIPT="build.mill.scala"
+elif [ -f "build.sc" ] ; then
+  MILL_BUILD_SCRIPT="build.sc"
+fi
+
+# `s/.*://`:
+#   This is a greedy match that removes everything from the beginning of the line up to (and including) the last
+#   colon (:). This effectively isolates the value part of the declaration.
+#
+#  `s/#.*//`:
+#    This removes any comments at the end of the line.
+#
+#  `s/['\"]//g`:
+#    This removes all single and double quotes from the string, wherever they appear (g is for "global").
+#
+#  `s/^[[:space:]]*//; s/[[:space:]]*$//`:
+#    These two expressions trim any leading or trailing whitespace ([[:space:]] matches spaces and tabs).
+TRIM_VALUE_SED="s/.*://; s/#.*//; s/['\"]//g; s/^[[:space:]]*//; s/[[:space:]]*$//"
+
+if [ -z "${MILL_VERSION}" ] ; then
+  if [ -f ".mill-version" ] ; then
+    MILL_VERSION="$(tr '\r' '\n' < .mill-version | head -n 1 2> /dev/null)"
+  elif [ -f ".config/mill-version" ] ; then
+    MILL_VERSION="$(tr '\r' '\n' < .config/mill-version | head -n 1 2> /dev/null)"
+  elif [ -f "build.mill.yaml" ] ; then
+    MILL_VERSION="$(grep -E "mill-version:" "build.mill.yaml" | sed -E "$TRIM_VALUE_SED")"
+  elif [ -n "${MILL_BUILD_SCRIPT}" ] ; then
+    MILL_VERSION="$(grep -E "//\|.*mill-version" "${MILL_BUILD_SCRIPT}" | sed -E "$TRIM_VALUE_SED")"
+  fi
+fi
+
+if [ -z "${MILL_VERSION}" ] ; then MILL_VERSION="${DEFAULT_MILL_VERSION}"; fi
+
+MILL_USER_CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/mill"
+
+if [ -z "${MILL_FINAL_DOWNLOAD_FOLDER}" ] ; then MILL_FINAL_DOWNLOAD_FOLDER="${MILL_USER_CACHE_DIR}/download"; fi
+
+MILL_NATIVE_SUFFIX="-native"
+MILL_JVM_SUFFIX="-jvm"
+ARTIFACT_SUFFIX=""
+
+# Check if GLIBC version is at least the required version
+# Returns 0 (true) if GLIBC >= required version, 1 (false) otherwise
+check_glibc_version() {
+  required_version="2.39"
+  required_major=$(echo "$required_version" | cut -d. -f1)
+  required_minor=$(echo "$required_version" | cut -d. -f2)
+  # Get GLIBC version from ldd --version (first line contains version like "ldd (GNU libc) 2.31")
+  glibc_version=$(ldd --version 2>/dev/null | head -n 1 | grep -oE '[0-9]+\.[0-9]+$' || echo "")
+  if [ -z "$glibc_version" ]; then
+    # If we can't determine GLIBC version, assume it's too old
+    return 1
+  fi
+  glibc_major=$(echo "$glibc_version" | cut -d. -f1)
+  glibc_minor=$(echo "$glibc_version" | cut -d. -f2)
+  if [ "$glibc_major" -gt "$required_major" ]; then
+    return 0
+  elif [ "$glibc_major" -eq "$required_major" ] && [ "$glibc_minor" -ge "$required_minor" ]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+set_artifact_suffix() {
+  if [ "$(uname -s 2>/dev/null | cut -c 1-5)" = "Linux" ]; then
+    # Native binaries require new enough GLIBC; fall back to JVM launcher if older
+    if ! check_glibc_version; then
+      return
+    fi
+    if [ "$(uname -m)" = "aarch64" ]; then ARTIFACT_SUFFIX="-native-linux-aarch64"
+    else ARTIFACT_SUFFIX="-native-linux-amd64"; fi
+  elif [ "$(uname)" = "Darwin" ]; then
+    if [ "$(uname -m)" = "arm64" ]; then ARTIFACT_SUFFIX="-native-mac-aarch64"
+    else ARTIFACT_SUFFIX="-native-mac-amd64"; fi
+  else
+    echo "This native mill launcher supports only Linux and macOS." 1>&2
+    exit 1
+  fi
+}
+
+case "$MILL_VERSION" in
+  *"$MILL_NATIVE_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_NATIVE_SUFFIX"}
+    set_artifact_suffix
+    ;;
+
+  *"$MILL_JVM_SUFFIX")
+    MILL_VERSION=${MILL_VERSION%"$MILL_JVM_SUFFIX"}
+    ;;
+
+  *)
+    case "$MILL_VERSION" in
+      0.1.* | 0.2.* | 0.3.* | 0.4.* | 0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.* | 0.12.*)
+        ;;
+      *)
+        set_artifact_suffix
+        ;;
+    esac
+    ;;
+esac
+
+MILL="${MILL_FINAL_DOWNLOAD_FOLDER}/$MILL_VERSION$ARTIFACT_SUFFIX"
+
+# If not already downloaded, download it
+if [ ! -s "${MILL}" ] || [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
+  case $MILL_VERSION in
+    0.0.* | 0.1.* | 0.2.* | 0.3.* | 0.4.*)
+      MILL_DOWNLOAD_SUFFIX=""
+      MILL_DOWNLOAD_FROM_MAVEN=0
+      ;;
+    0.5.* | 0.6.* | 0.7.* | 0.8.* | 0.9.* | 0.10.* | 0.11.0-M*)
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=0
+      ;;
+    *)
+      MILL_DOWNLOAD_SUFFIX="-assembly"
+      MILL_DOWNLOAD_FROM_MAVEN=1
+      ;;
+  esac
+  case $MILL_VERSION in
+    0.12.0 | 0.12.1 | 0.12.2 | 0.12.3 | 0.12.4 | 0.12.5 | 0.12.6 | 0.12.7 | 0.12.8 | 0.12.9 | 0.12.10 | 0.12.11)
+      MILL_DOWNLOAD_EXT="jar"
+      ;;
+    0.12.*)
+      MILL_DOWNLOAD_EXT="exe"
+      ;;
+    0.*)
+      MILL_DOWNLOAD_EXT="jar"
+      ;;
+    *)
+      MILL_DOWNLOAD_EXT="exe"
+      ;;
+  esac
+
+  MILL_TEMP_DOWNLOAD_FILE="${MILL_OUTPUT_DIR:-out}/mill-temp-download"
+  mkdir -p "$(dirname "${MILL_TEMP_DOWNLOAD_FILE}")"
+
+  if [ "$MILL_DOWNLOAD_FROM_MAVEN" = "1" ] ; then
+    MILL_DOWNLOAD_URL="https://repo1.maven.org/maven2/com/lihaoyi/mill-dist${ARTIFACT_SUFFIX}/${MILL_VERSION}/mill-dist${ARTIFACT_SUFFIX}-${MILL_VERSION}.${MILL_DOWNLOAD_EXT}"
+  else
+    MILL_VERSION_TAG=$(echo "$MILL_VERSION" | sed -E 's/([^-]+)(-M[0-9]+)?(-.*)?/\1\2/')
+    MILL_DOWNLOAD_URL="${GITHUB_RELEASE_CDN}${MILL_REPO_URL}/releases/download/${MILL_VERSION_TAG}/${MILL_VERSION}${MILL_DOWNLOAD_SUFFIX}"
+    unset MILL_VERSION_TAG
+  fi
+
+
+  if [ "$MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT" = "1" ] ; then
+    echo "$MILL_DOWNLOAD_URL"
+    echo "$MILL"
+    exit 0
+  fi
+
+  echo "Downloading mill ${MILL_VERSION} from ${MILL_DOWNLOAD_URL} ..." 1>&2
+  curl -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"
+
+  chmod +x "${MILL_TEMP_DOWNLOAD_FILE}"
+
+  mkdir -p "${MILL_FINAL_DOWNLOAD_FOLDER}"
+  mv "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL}"
+
+  unset MILL_TEMP_DOWNLOAD_FILE
+  unset MILL_DOWNLOAD_SUFFIX
+fi
+
+MILL_FIRST_ARG=""
+if [ "$1" = "--bsp" ] || [ "${1#"-i"}" != "$1" ] || [ "$1" = "--interactive" ] || [ "$1" = "--no-server" ] || [ "$1" = "--no-daemon" ] || [ "$1" = "--help" ] ; then
+  # Need to preserve the first position of those listed options
+  MILL_FIRST_ARG=$1
+  shift
+fi
+
+unset MILL_FINAL_DOWNLOAD_FOLDER
+unset MILL_OLD_DOWNLOAD_PATH
+unset OLD_MILL
+unset MILL_VERSION
+unset MILL_REPO_URL
+
+# -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
+# We don't quote MILL_FIRST_ARG on purpose, so we can expand the empty value without quotes
+# shellcheck disable=SC2086
+exec "${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"

--- a/mill-build/build.mill
+++ b/mill-build/build.mill
@@ -1,0 +1,125 @@
+import mill.Task
+import mill.api.{BuildCtx, BuildInfo, PathRef}
+import mill.meta.MillBuildRootModule
+import mill.scalalib.*
+
+/**
+ * Module that configures the Mill build itself
+ */
+object `package` extends MillBuildRootModule {
+
+  // Scala.js version, that we need here to bring Scala.js tooling in the Mill build
+  // We get that version from the sbt build, extracting it from project/plugins.sbt.
+  lazy val scalaJSVersion = {
+    val subPath = os.sub / "project/plugins.sbt"
+    val pluginsSbtLines = BuildCtx.withFilesystemCheckerDisabled {
+      os.read.lines(BuildCtx.workspaceRoot / subPath)
+    }
+    val prefix = """addSbtPlugin("org.scala-js" % "sbt-scalajs" % """"
+    val suffix = """")"""
+    pluginsSbtLines
+      .collectFirst {
+        case line if line.startsWith(prefix) && line.endsWith(suffix) =>
+          line.stripPrefix(prefix).stripSuffix(suffix)
+      }
+      .getOrElse {
+        sys.error(s"Could not find Scala.js version in $subPath")
+      }
+  }
+
+  def mvnDeps = Seq(
+    // Mill MiMA plugin
+    mvn"com.github.lolgab::mill-mima_mill1:0.2.1",
+    // Mill plugin for missinglink
+    mvn"io.github.alexarchambault::mill-missinglink_mill1:0.1.0",
+    // needed to checkout auxiliary repositories during the build, and to read
+    // the current commit hash
+    mvn"org.eclipse.jgit:org.eclipse.jgit:7.5.0.202512021534-r",
+    mvn"org.ow2.asm:asm:9.9",
+    mvn"org.yaml:snakeyaml:2.4",
+    // Scala.js-related dependencies
+    mvn"com.lihaoyi::mill-libs-scalajslib-config-1:${BuildInfo.millVersion}",
+    mvn"org.scala-js:scalajs-linker_2.13:$scalaJSVersion",
+    mvn"org.scala-js:scalajs-js-envs_2.13:1.6.0",
+    // packaging dependencies
+    mvn"org.virtuslab::scala-packager:0.2.2"
+  )
+
+  /**
+   * The `project/` directory, brought via `Task.Source`
+   *
+   * Using `Task.Source` makes Mill watch that directory for changes
+   * when running tasks that depend on it.
+   */
+  def projectDir = Task.Source(BuildCtx.workspaceRoot / "project")
+
+  // Comment at the top of sbt build sources that we also use in the Mill build
+  private def specialComment = "// This file is used in the Mill build too. Do not modify this comment."
+
+  /** Sources shared with the sbt build */
+  def sharedBuildFiles = Task {
+    val dir = projectDir().path
+    os.list(dir)
+      .filter(_.ext == "scala")
+      .filter(os.isFile)
+      .filter { f =>
+        os.read.lines(f)
+          .iterator
+          .map(_.trim)
+          .filter(_.nonEmpty)
+          .find(_ => true)
+          .contains(specialComment)
+      }
+      .map(PathRef(_))
+  }
+
+  /**
+   * Adds the sources shared with the sbt build in the Mill build
+   *
+   * We change the package of these sources, so that they're all in package scala3build.
+   *
+   * We do that using "wrapped sources". We post-process these sources, wrapping them between
+   * "package scala3build {" and "}", like how Mill does with the "*.mill" files.
+   *
+   * Doing this through `JavaModule#wrappedSources` makes Mill pass details about that wrapping
+   * to BSP clients via the buildTarget/wrappedSources request.
+   */
+  def wrappedSources = Task {
+    val dir = Task.dest
+    val nl = System.lineSeparator()
+    val extraSources = sharedBuildFiles().map { originalRef =>
+      val generated = dir / originalRef.path.subRelativeTo(BuildCtx.workspaceRoot)
+      val processedOriginalContent = {
+        val originalContent = os.read(originalRef.path)
+        val hasPackage = originalContent.linesIterator.exists(_.startsWith("package "))
+        if (hasPackage)
+          originalContent.linesIterator
+            .zip(originalContent.linesWithSeparators)
+            .map {
+              case (line, lineWithSep) =>
+                if (line.startsWith("package ")) lineWithSep.drop(line.length)
+                else lineWithSep
+            }
+            .mkString
+        else
+          originalContent
+      }
+      val generatedContent = "package scala3build {" + nl + nl +
+        s"//SOURCECODE_ORIGINAL_FILE_PATH=${originalRef.path}" + nl +
+        "//SOURCECODE_ORIGINAL_CODE_START_MARKER" + nl +
+        processedOriginalContent + nl +
+        "}"
+      os.write(generated, generatedContent, createFolders = true)
+      (originalRef, PathRef(generated))
+    }
+    super.wrappedSources() ++ extraSources
+  }
+
+  def sources = Task {
+    // Adds tasty sources in the Mill build
+    val extraSrcDir = BuildCtx.withFilesystemCheckerDisabled {
+      PathRef(BuildCtx.workspaceRoot / "tasty/src")
+    }
+    super.sources() ++ Seq(extraSrcDir)
+  }
+}

--- a/mill-build/src/com/typesafe/tools/mima/core.scala
+++ b/mill-build/src/com/typesafe/tools/mima/core.scala
@@ -1,0 +1,18 @@
+package com.typesafe.tools.mima
+
+import com.github.lolgab.mill.{mima => millmima}
+
+/**
+  * Helpers to compile MiMA-related code shared with the sbt build
+  */
+object core {
+  val ProblemFilters = millmima.ProblemFilter
+  type ProblemFilter = millmima.ProblemFilter
+
+  type DirectMissingMethodProblem = millmima.DirectMissingMethodProblem
+  type FinalClassProblem = millmima.FinalClassProblem
+  type MissingTypesProblem = millmima.MissingTypesProblem
+  type MissingClassProblem = millmima.MissingClassProblem
+  type MissingFieldProblem = millmima.MissingFieldProblem
+  type FinalMethodProblem = millmima.FinalMethodProblem
+}

--- a/mill-build/src/mill/scala3buildhelper/CompileClassesPathHelper.scala
+++ b/mill-build/src/mill/scala3buildhelper/CompileClassesPathHelper.scala
@@ -1,0 +1,37 @@
+package mill.scala3buildhelper
+
+import mill.api.BuildCtx
+import mill.scalalib.*
+import mill.constants.OutFiles.OutFiles
+
+/**
+ * Helper module to access private[mill] methods
+ */
+trait CompileClassesPathHelper extends ScalaModule {
+
+  /**
+   * Actual Mill output directory
+   *
+   * @param taskDest The dest directory of a task of this build (can be any task)
+   */
+  private def outDir(taskDest: os.Path): os.Path = {
+    val bspOut = BuildCtx.workspaceRoot / os.SubPath(OutFiles.bspOut)
+    if (taskDest.startsWith(bspOut)) bspOut
+    else BuildCtx.workspaceRoot / os.SubPath(OutFiles.out)
+  }
+
+  /**
+   * Computes the expected output directory of the compile task
+   *
+   * @param taskDest The dest directory of a task of this build (can be any task)
+   */
+  def compileClassesPath0(taskDest: os.Path) = compileClassesPath.resolve(outDir(taskDest))
+
+  /**
+   * Computes the expected output directory of the jar task
+   *
+   * @param taskDest The dest directory of a task of this build (can be any task)
+   */
+  def jarPath(taskDest: os.Path) =
+    resolveRelativeToOut(jar, identity).resolve(outDir(taskDest))
+}

--- a/mill-build/src/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/mill-build/src/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -1,0 +1,7 @@
+package org.scalajs.sbtplugin
+
+object ScalaJSPlugin {
+  object autoImport {
+    def scalaJSVersion = org.scalajs.ir.ScalaJSVersions.current
+  }
+}

--- a/mill-build/src/scala3build/CrossHelper.scala
+++ b/mill-build/src/scala3build/CrossHelper.scala
@@ -1,0 +1,22 @@
+package scala3build
+
+import mill.*
+
+trait CrossHelper[T] extends Cross.Module[Mode] { self: T =>
+  def crossValue = Mode.Bootstrapped
+
+  def `non-bootstrapped`: T & CrossHelper.NonBootstrapped
+
+  def apply()(implicit mode: Mode): T =
+    mode match {
+      case Mode.NonBootstrapped => `non-bootstrapped`
+      case Mode.Bootstrapped => self
+    }
+}
+
+object CrossHelper {
+  trait NonBootstrapped extends Cross.Module[Mode] {
+    def crossValue = Mode.NonBootstrapped
+    def moduleDir: os.Path = super.moduleDir / os.up
+  }
+}

--- a/mill-build/src/scala3build/CrossScala3Module.scala
+++ b/mill-build/src/scala3build/CrossScala3Module.scala
@@ -1,0 +1,106 @@
+package scala3build
+
+import mill.*
+import mill.api.Cross.Resolver
+import mill.api.Task.Simple
+
+/**
+ * Tasks for a bootstrapped module
+ *
+ * Compiled once with a published compiler, and again with a bootstrapped one
+ */
+trait CrossScala3Module extends Cross.Module[Mode] with Scala3Module {
+  implicit def mode: Mode = crossValue
+
+  def artifactNameParts =
+    if (mode == Mode.NonBootstrapped)
+      super.artifactNameParts
+    else
+      Task {
+        val baseValue = super.artifactNameParts()
+        if (baseValue.endsWith(Seq("bootstrapped"))) baseValue.dropRight(1)
+        else baseValue
+      }
+
+  def publishDisabled(): Task.Command[Unit] =
+    Task.Command[Unit] {
+      val org = pomSettings().organization
+      val name = artifactId()
+      val ver = publishVersion()
+      System.err.println(
+        s"Not publishing $org:$name:$ver of non-bootstrapped module ${moduleSegments.parts.mkString(".")}"
+      )
+    }
+
+  override def publishLocal(
+    localIvyRepo: String = null,
+    sources: Boolean = true,
+    doc: Boolean = true,
+    transitive: Boolean = false
+  ): Task.Command[Unit] =
+    if (mode == Mode.NonBootstrapped)
+      Task.Command(publishDisabled())
+    else
+      super.publishLocal(localIvyRepo, sources, doc, transitive)
+
+  override def publishLocalCached: T[Seq[PathRef]] =
+    if (mode == Mode.NonBootstrapped)
+      Task {
+        publishDisabled()
+        Nil
+      }
+    else
+      super.publishLocalCached
+
+  override def publishM2Local(m2RepoPath: String): Task.Command[Seq[PathRef]] =
+    if (mode == Mode.NonBootstrapped)
+      Task.Command {
+        publishDisabled()
+        Nil
+      }
+    else
+      super.publishM2Local(m2RepoPath)
+
+  override def publishM2LocalCached: T[Seq[PathRef]] =
+    if (mode == Mode.NonBootstrapped)
+      Task {
+        publishDisabled()
+        Nil
+      }
+    else
+      super.publishM2LocalCached
+
+  override def publish(
+    sonatypeCreds: String,
+    signed: Boolean,
+    gpgArgs: String,
+    release: Boolean,
+    readTimeout: Int,
+    connectTimeout: Int,
+    awaitTimeout: Int,
+    stagingRelease: Boolean
+  ): Task.Command[Unit] =
+    if (mode == Mode.NonBootstrapped)
+      Task.Command(publishDisabled())
+    else
+      super.publish(
+        sonatypeCreds,
+        signed,
+        gpgArgs,
+        release,
+        readTimeout,
+        connectTimeout,
+        awaitTimeout,
+        stagingRelease
+      )
+
+  given Resolver[CrossScala3Module] =
+    new Resolver[CrossScala3Module] {
+      def resolve[V <: CrossScala3Module](c: Cross[V]): V =
+        c.crossModules.find(_.mode == mode).getOrElse {
+          throw new Exception(
+            s"Cannot find $mode in $c's cross-modules (available modes: ${c.crossModules.map(_.mode).distinct.mkString(", ")})"
+          )
+        }
+    }
+}

--- a/mill-build/src/scala3build/Mode.scala
+++ b/mill-build/src/scala3build/Mode.scala
@@ -1,0 +1,26 @@
+package scala3build
+
+/**
+ * Enum for the two stages to build compiler-related JARs: non-bootstrapped and bootstrapped
+ */
+sealed abstract class Mode(val name: String)
+
+object Mode:
+  /**
+   * First build of a module, using an already published Scala 3 version
+   */
+  case object NonBootstrapped extends Mode("non-bootstrapped")
+
+  /**
+   * Second (and last) build of a module, using newly built compiler and standard library
+   *
+   * This uses the standard library and compiler built in the NonBootstrapped stage, and
+   * the scaladoc built in the Bootstrapped stage (in this stage, we build scaladoc and use it
+   * straightaway in the same stage).
+   */
+  case object Bootstrapped extends Mode("bootstrapped")
+
+  lazy val allValues = Seq[Mode](
+    NonBootstrapped,
+    Bootstrapped
+  )

--- a/mill-build/src/scala3build/Scala3JavaModule.scala
+++ b/mill-build/src/scala3build/Scala3JavaModule.scala
@@ -1,0 +1,68 @@
+package scala3build
+
+import com.github.lolgab.mill.mima.Mima
+import mill.*
+import mill.scalalib.*
+import mill.scalalib.publish.*
+
+/**
+ * Tasks for published Java / Scala modules in the Scala 3 build
+ *
+ * This sets up publishing, JVM version and --release options, test framework, and more.
+ */
+trait Scala3JavaModule extends JavaModule, PublishModule:
+  def artifactName = "scala3-" + super.artifactName()
+
+  def jvmId = "17" // force external zinc worker
+
+  def pomSettings = PomSettings(
+    description = artifactName(),
+    organization = "org.scala-lang",
+    url = "https://github.com/scala/scala3",
+    licenses = Seq(License.`Apache-2.0`),
+    versionControl = VersionControl.github("scala", "scala3"),
+    developers = Seq(Developer("scala", "The Scala Team", "https://scala-lang.org", email = "security@scala-lang.org"))
+  )
+  def publishVersion = Versions.dottyVersion
+
+  def javacOptions = super.javacOptions() ++ Seq(
+    "--release", Versions.minimumJVMVersion
+  )
+
+  def manifest = super.manifest().add(
+    "Automatic-Module-Name" ->
+      s"${pomSettings().organization.replaceAll("-", ".")}.${artifactName().replaceAll("-", ".")}"
+  )
+
+  def runClasspathAsJars: T[Seq[PathRef]] = Task {
+    resolvedRunMvnDeps().toSeq ++
+      transitiveJars() ++
+      Seq(jar())
+  }
+
+  def runClasspath = runClasspathAsJars
+
+  def testSources = Task.Source("test")
+
+  trait Scala3JavaTests extends JavaTests, TestModule:
+    def artifactName = "scala3-" + super.artifactName()
+    def sources = Task {
+      Seq(testSources())
+    }
+    def testParallelism = false
+    def testSandboxWorkingDir = false
+
+    // FIXME Not using Mill's TestModule.Junit4 as it forces junit-interface even on Scala.js, where
+    // it clashes with the Scala.js junit4 substitute
+    def testFramework = "com.novocode.junit.JUnitFramework"
+    def mandatoryMvnDeps = super.mandatoryMvnDeps() ++ Seq(
+      mvn"com.github.sbt:junit-interface:0.13.3"
+    )
+
+  def isCoreModule: Boolean = false
+  def enableBsp = isCoreModule || Scala3JavaModule.enableBspForNonCoreModules
+  def skipIdea = enableBsp
+
+object Scala3JavaModule:
+  def enableBspForNonCoreModules: Boolean = true
+  def enableBspForScalaJsModules: Boolean = false

--- a/mill-build/src/scala3build/Scala3JsModule.scala
+++ b/mill-build/src/scala3build/Scala3JsModule.scala
@@ -1,0 +1,90 @@
+package scala3build
+
+import mill.*
+import mill.scalajslib.*
+import mill.scalajslib.api.*
+import mill.scalajslib.config.ScalaJSConfigModule
+import mill.scalalib.*
+import org.scalajs.ir.ScalaJSVersions
+import org.scalajs.linker.{interface => sjs}
+
+/**
+ * Tasks for Scala.js modules of the Scala 3 build
+ *
+ * This configures the Scala.js linker and the JS environment, and Scala.js' JUnit 4 in the tests.
+ */
+trait Scala3JsModule extends Scala3Module with ScalaJSConfigModule { outer =>
+  def enableWebAssembly: Boolean = false
+
+  // Disable "This is often an error due to a missing second colon (:) before the version" messages
+  def resolvedDepsWarnNonPlatform = false
+
+  def scalaJSConfig = Task.Anon {
+    var config = super.scalaJSConfig()
+      .withCheckIR(true)
+
+    if (enableWebAssembly)
+      config = config
+        .withModuleKind(sjs.ModuleKind.ESModule)
+        .withESFeatures(_.withUseWebAssembly(true))
+        .withWasmFeatures(_.withUseJSPI(true)) // for async/await support in WebAssembly
+
+    config
+  }
+
+  def jsEnvConfig = Task {
+    val config = JsEnvConfig.NodeJs()
+    if (enableWebAssembly)
+      config.copy(
+        args = List(
+          "--experimental-wasm-exnref",
+          "--experimental-wasm-imported-strings", // Original sbt build comment: for JS string builtins
+          "--experimental-wasm-jspi", // Original sbt build comment: for JSPI, used by async/await
+        )
+      )
+    else
+      config
+  }
+
+  def mandatoryMvnDeps = Task {
+    super.mandatoryMvnDeps()
+      .filter { dep =>
+        val (org, name) = (dep.dep.module.organization.value, dep.dep.module.name.value)
+        org != "org.scala-lang" || !name.startsWith("scala3-library")
+      }
+      .map { dep =>
+        dep.exclude(("org.scala-lang", "scala-library"))
+      }
+  }
+
+  trait Scala3JsTests extends Scala3Tests with ScalaJSConfigTests {
+    def resolvedDepsWarnNonPlatform = false
+
+    override def discoverTestsWithZinc = true
+
+    def mandatoryMvnDeps = Task {
+      val baseDeps =
+        super.mandatoryMvnDeps().filter { dep =>
+          val org = dep.dep.module.organization.value
+          val name = dep.dep.module.name.value
+          (org, name) != ("com.github.sbt", "junit-interface")
+        } ++
+        Seq(
+          mvn"org.scala-js:scalajs-junit-test-runtime_2.13:${ScalaJSVersions.current}"
+            .exclude(("org.scala-lang", "scala-library"))
+        )
+      baseDeps
+        .filter { dep =>
+          val (org, name) = (dep.dep.module.organization.value, dep.dep.module.name.value)
+          org != "org.scala-lang" || !name.startsWith("scala3-library")
+        }
+        .map { dep =>
+          dep.exclude(("org.scala-lang", "scala-library"))
+        }
+        .filter { dep =>
+          val org = dep.dep.module.organization.value
+          !org.contains("junit")
+        }
+    }
+  }
+}

--- a/mill-build/src/scala3build/Scala3Mima.scala
+++ b/mill-build/src/scala3build/Scala3Mima.scala
@@ -1,0 +1,53 @@
+package scala3build
+
+import com.github.lolgab.mill.mima.Mima
+import com.github.lolgab.mill.mima.CheckDirection
+import mill.api.{BuildCtx, Task}
+
+/**
+ * Tasks for configuring MiMA in the Scala 3 build
+ *
+ * This sets the previous version to check compatibility against, the check direction,
+ * and the main MiMA issue filters.
+ */
+trait Scala3Mima extends Mima {
+  def mimaVersion = Scala3Mima.buildMimaVersion
+
+  def mimaPreviousVersions = Seq(Versions.mimaPreviousDottyVersion)
+  def mimaCheckDirection = Task {
+    CompatMode.value match {
+      case CompatMode.BinaryCompatible => CheckDirection.Backward
+      case CompatMode.SourceAndBinaryCompatible => CheckDirection.Both
+    }
+  }
+
+  def mimaExcludeAnnotations = super.mimaExcludeAnnotations() ++ Seq(
+    "scala.annotation.experimental"
+  )
+
+  def mimaBinaryIssueFilters =
+    // Keep these here until we can benefit from lolgab/mill-mima#214
+    mimaBackwardIssueFilters().values.toSeq.flatten ++
+      mimaForwardIssueFilters().values.toSeq.flatten
+}
+
+object Scala3Mima {
+  // The sbt-mima-plugin version, that we get from the sbt build, extracting it
+  // from project/plugins.sbt.
+  private lazy val buildMimaVersion = {
+    val subPath = os.sub / "project/plugins.sbt"
+    val pluginsSbtLines = BuildCtx.withFilesystemCheckerDisabled {
+      os.read.lines(BuildCtx.workspaceRoot / subPath)
+    }
+    val prefix = """addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % """"
+    val suffix = """")"""
+    pluginsSbtLines
+      .collectFirst {
+        case line if line.startsWith(prefix) && line.endsWith(suffix) =>
+          line.stripPrefix(prefix).stripSuffix(suffix)
+      }
+      .getOrElse {
+        sys.error(s"Could not find sbt-mima-plugin version in $subPath")
+      }
+  }
+}

--- a/mill-build/src/scala3build/Scala3Module.scala
+++ b/mill-build/src/scala3build/Scala3Module.scala
@@ -1,0 +1,116 @@
+package scala3build
+
+import build_.package_ as build
+import mill.*
+import mill.api.BuildCtx
+import mill.scalalib.*
+
+import scala.annotation.tailrec
+
+/**
+ * Tasks for Scala modules in the Scala 3 build.
+ *
+ * Beyond what [[Scala3JavaModule]] adds, this deals with setting up
+ * the library, compiler, compiler bridge, and scaladoc, when non-bootstrapped and
+ * for bootstrapped modules. This also sets some shared scalac options.
+ */
+trait Scala3Module extends Scala3JavaModule, ScalaModule:
+  outer =>
+  def mode: Mode = Mode.Bootstrapped
+
+  def sourcesFolders = super.sourcesFolders ++ Seq(
+    if (mode == Mode.NonBootstrapped) "src-non-bootstrapped" else "src-bootstrapped"
+  )
+
+  def resolutionParams = Task.Anon {
+    val baseParams = super.resolutionParams()
+    baseParams.withForceVersion0(
+      baseParams.forceVersion0.filter(_._1.organization.value != "org.scala-lang")
+    )
+  }
+
+  def scalaVersion =
+    if (mode == Mode.NonBootstrapped) Versions.referenceVersion
+    else Versions.dottyVersion
+
+  def scalaLibraryMvnDeps = Nil
+  def scalaCompilerClasspath =
+    if (mode == Mode.NonBootstrapped)
+      Task {
+        defaultResolver().classpath(
+          Seq(mvn"org.scala-lang:scala3-compiler_3:${Versions.referenceVersion}")
+        )
+      }
+    else
+      build.compiler.`non-bootstrapped`.runClasspathAsJars
+
+  def scalaCompilerBridge =
+    if (mode == Mode.NonBootstrapped)
+      Task(None)
+    else
+      Task {
+        Some(build.`sbt-bridge`.`non-bootstrapped`.jar())
+      }
+
+  def scalaDocClasspath =
+    if (mode == Mode.NonBootstrapped)
+      super.scalaDocClasspath
+    else
+      // Use the *bootstrapped* scaladoc to build all bootstrapped (that is, published) modules' scaladoc,
+      // even the one of the bootstrapped scaladoc itself (it builds its own scaladoc)
+      build.scaladoc.runClasspathAsJars
+
+  def scalacOptions = super.scalacOptions() ++ Seq(
+    "-feature",
+    "-deprecation",
+    "-unchecked",
+    //"-Wconf:cat=deprecation&msg=Unsafe:s",    // example usage
+    //"-Wunused:all",
+    //"-rewrite", // requires -Werror:false since no rewrites are applied with errors
+    "-encoding", "UTF8",
+    "-language:implicitConversions",
+    "--java-output-version", Versions.minimumJVMVersion,
+    "-sourceroot", BuildCtx.workspaceRoot.toString
+  )
+
+  def scalaDocOptions = Task {
+    val baseOptions = super.scalaDocOptions()
+    val filteredBaseOptions = {
+      @tailrec
+      def helper(opts: Seq[String]): Seq[String] = {
+        val sourcepathIdx = opts.indexOf("-sourcepath")
+        if (sourcepathIdx >= 0)
+          helper(opts.take(sourcepathIdx) ++ opts.drop(sourcepathIdx + 2))
+        else
+          opts
+      }
+      helper(baseOptions)
+    }
+    val extraOptions =
+      if (mode == Mode.Bootstrapped) {
+        val rawExtraOptions = ScaladocOptions.scalacOptionsDocSettings()
+        // Make -project-logo arg an absolute path, as scaladoc isn't going to run
+        // from the root of the project with Mill
+        val projLogoIdx = rawExtraOptions.indexOf("-project-logo")
+        if (projLogoIdx >= 0)
+          rawExtraOptions.take(projLogoIdx + 1) ++
+            Seq(os.Path(rawExtraOptions(projLogoIdx + 1), BuildCtx.workspaceRoot).toString) ++
+            rawExtraOptions.drop(projLogoIdx + 2)
+        else
+           rawExtraOptions
+      }
+      else
+        Nil
+    filteredBaseOptions ++ extraOptions
+  }
+
+  trait Scala3Tests extends ScalaTests, Scala3JavaTests:
+    // Future versions of Mill should handle these two
+    def scalaLibraryMvnDeps = outer.scalaLibraryMvnDeps
+    def scalaCompilerClasspath = outer.scalaCompilerClasspath
+
+  def enableBsp = super.enableBsp &&
+    (mode == Mode.NonBootstrapped || Scala3Module.enableBspForBootstrappedModules)
+
+object Scala3Module:
+  def enableBspForBootstrappedModules = false

--- a/mill-build/src/scala3build/SharedLibrarySettings.scala
+++ b/mill-build/src/scala3build/SharedLibrarySettings.scala
@@ -1,0 +1,96 @@
+package scala3build
+
+import mill.*
+
+/**
+ * Tasks shared by the main standard library, and the Scala.js standard library
+ */
+trait SharedLibrarySettings extends CrossScala3Module {
+
+  /** Whether we are compiling the Scala.js standard library or not */
+  def isJS: Boolean = false
+
+  def scalacOptions = super.scalacOptions() ++ Seq(
+    "-Yexplicit-nulls",
+    "-Wsafe-init"
+  )
+
+  /** JARs or directories with classes (and sjsir if `isJS` is true) to be stripped of their Scala 2 annotations and copied in the class directory of this module */
+  def patches: T[Seq[PathRef]]
+
+  def compile = Task(persistent = true) {
+
+    // Add classes (and sjsir files if isJS is true) from `patches` to the class directory of this module
+
+    // Important: given this is a persistent task, if you change anything in the stuff being done here,
+    // should should manually wipe out the compile directories to clean the cache and make this to be
+    // re-computed.
+
+    val res = super.compile()
+    val patches0 = patches()
+    val sigFile = Task.dest / "sig"
+    val updatedClassDir = Task.dest / "classes"
+
+    val signature = s"${res.classes.sig}-${patches0.map(_.sig).mkString("-")}"
+    val needsUpdate = !res.classes.validate() ||
+      patches0.exists(!_.validate()) ||
+      !os.exists(sigFile) ||
+      os.read(sigFile) != signature
+
+    if (needsUpdate) {
+      os.remove.all(updatedClassDir)
+      os.makeDir.all(updatedClassDir)
+      for (elem <- os.list(res.classes.path))
+        os.copy(elem, updatedClassDir / elem.last)
+
+      val keepExtensions = if (isJS) Seq(".class", ".sjsir") else Seq(".class")
+
+      def process(relPath: os.SubPath, dir: os.Path): Unit = {
+        val shortName = keepExtensions.foldLeft(relPath.toString)(_.stripSuffix(_))
+        val dest = updatedClassDir / relPath
+        val shouldCopy = ScalaLibraryFilesToCopy.filesToCopy.contains(shortName) || ScalaLibraryFilesToCopy.filesToCopy.exists(n => shortName.startsWith(n + "$"))
+
+        if (shouldCopy)
+          System.err.println(s"Overwriting $relPath")
+        else if (!os.exists(dest))
+          System.err.println(s"Copying $relPath")
+
+        if (shouldCopy || !os.exists(dest))
+          StripScala2Annotations.patchFile((dir / relPath).toIO, (updatedClassDir / relPath).toIO, updatedClassDir.toIO)
+      }
+
+      for ((jarOrDir, jarOrDirIdx) <- patches0.map(_.path).zipWithIndex) {
+        System.err.println(s"Copying entries from $jarOrDir")
+
+        val finalDir =
+          if (os.isDir(jarOrDir)) jarOrDir
+          else
+            // Extracting things on disk rather than reading directly from the zip,
+            // in order to pass things to the current StripScala2Annotations methods,
+            // that we'd rather not change for now, given they belong to the sbt build
+            os.unzip(jarOrDir, Task.dest / "tmp" / s"$jarOrDirIdx")
+
+        val files = os.walk(finalDir)
+          .filter(f => keepExtensions.exists(f.last.endsWith))
+          .filter(os.isFile)
+          .map(_.subRelativeTo(finalDir))
+          .sorted
+
+        for (f <- files)
+          process(f, finalDir)
+      }
+
+      os.write.over(sigFile, signature)
+    }
+
+    mill.javalib.api.CompilationResult(res.analysisFile, PathRef(updatedClassDir))
+  }
+
+  def jar = Task {
+    val jarRef = super.jar()
+    ScalaJarValidate.validateNoScala2Pickles(jarRef.path.toIO)
+    ScalaJarValidate.validateTastyAttributes(jarRef.path.toIO)
+    ScalaJarValidate.validateScalaAttributes(jarRef.path.toIO)
+    jarRef
+  }
+}

--- a/mill-build/src/scala3build/Util.scala
+++ b/mill-build/src/scala3build/Util.scala
@@ -1,0 +1,13 @@
+package scala3build
+
+import scala.jdk.CollectionConverters.*
+
+object Util {
+  lazy val currentYear: String = java.util.Calendar.getInstance().get(java.util.Calendar.YEAR).toString
+
+  lazy val isBsp: Boolean =
+    Thread.getAllStackTraces.asScala.exists {
+      case (t, _) =>
+        t.getName == "mill-bsp-evaluator"
+    }
+}

--- a/mill-build/src/scala3build/sbt.scala
+++ b/mill-build/src/scala3build/sbt.scala
@@ -1,0 +1,120 @@
+package scala3build
+
+import java.net.URL
+import scala.concurrent.Promise
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.Try
+import scala.util.Using
+import scala.util.Success
+import scala.util.Failure
+import mill.api.BuildCtx
+import java.nio.file.Path
+
+/**
+ * Helper methods allowing to compile sources shared with the sbt build
+ */
+object sbt {
+  private def root = BuildCtx.workspaceRoot
+
+  type File = java.io.File
+
+  def file(path: String): File =
+    new File(path)
+
+  extension (f: File) {
+    private[sbt] def path: os.Path = os.Path(f, root)
+    def /(str: String): File =
+      (path / str.split('/').toSeq).toIO
+
+    def relativeTo(other: File): Option[File] =
+      Option.when(path.startsWith(other.path)) {
+        path.subRelativeTo(other.path).toNIO.toFile
+      }
+  }
+
+  extension (p: Path) {
+    private[sbt] def path: os.Path = os.Path(p, root)
+    def /(str: String): Path =
+      (path / str.split('/').toSeq).toNIO
+  }
+
+  object IO {
+    def copyFile(from: File, to: File): Unit =
+      os.copy.over(from.path, to.path, createFolders = true)
+    def copyDirectory(from: File, to: File): Unit =
+      os.copy(from.path, to.path)
+    def delete(f: File): Unit =
+      os.remove.all(f.path)
+    def read(f: File): String =
+      os.read(f.path)
+    def touch(f: File): Unit = {
+      val path = f.path
+      if (os.exists(path))
+        os.mtime.set(path, System.currentTimeMillis())
+      else
+        os.write(path, Array.emptyByteArray, createFolders = true)
+    }
+    def write(f: File, content: os.Source): Unit =
+      os.write.over(f.path, content)
+    def readBytes(f: File): Array[Byte] =
+      os.read.bytes(f.path)
+    def temporaryDirectory: File =
+      os.temp.dir().toIO
+    def move(from: File, to: File): Unit =
+      os.move(from.path, to.path, replaceExisting = true)
+  }
+
+  trait ProcessBuilderLike {
+    def run(): ProcessLike
+  }
+  trait ProcessLike {
+    def destroy(): Unit
+    def exitValue(): Int
+  }
+  private final class URLProcessLike(url: URL, dest: os.Path) extends Thread(s"$url -> $dest") with ProcessLike {
+    setDaemon(true)
+    private val promise = Promise[Int]()
+    override def run(): Unit =
+      promise.success {
+        val res = Try[Unit] {
+          Using.resource(os.write.outputStream(dest)) { destOs =>
+            Using.resource(url.openStream()) { sourceIs =>
+              sourceIs.transferTo(destOs)
+            }
+          }
+        }
+
+        res match {
+          case Success(()) => 0
+          case Failure(ex) =>
+            ex.printStackTrace(System.err)
+            1
+        }
+      }
+    def destroy(): Unit =
+      interrupt()
+    def exitValue(): Int =
+      Await.result(promise.future, Duration.Inf)
+  }
+  private final class URLProcessBuilderLike(url: URL, dest: os.Path) extends ProcessBuilderLike {
+    def run(): URLProcessLike = {
+      val thread = new URLProcessLike(url, dest)
+      thread.start()
+      thread
+    }
+  }
+  extension (url: URL) {
+    def #>(dest: File): ProcessBuilderLike =
+      new URLProcessBuilderLike(url, dest.path)
+  }
+
+  final class MessageOnlyException(override val toString: String) extends RuntimeException(toString)
+
+  // only used in project/Dependencies.scala, where we only care about a few versions,
+  // and disregard the sbt dependencies defined there
+  extension(s: String) def %(other: String): String =
+    ""
+  extension(s: String) def %%(other: String): String =
+    ""
+}

--- a/mill.bat
+++ b/mill.bat
@@ -1,0 +1,296 @@
+@echo off
+
+setlocal enabledelayedexpansion
+
+if [!DEFAULT_MILL_VERSION!]==[] ( set "DEFAULT_MILL_VERSION=1.1.4" )
+
+if [!MILL_GITHUB_RELEASE_CDN!]==[] ( set "MILL_GITHUB_RELEASE_CDN=" )
+
+if [!MILL_MAIN_CLI!]==[] ( set "MILL_MAIN_CLI=%~f0" )
+
+set "MILL_REPO_URL=https://github.com/com-lihaoyi/mill"
+
+SET MILL_BUILD_SCRIPT=
+
+if exist "build.mill" (
+  set MILL_BUILD_SCRIPT=build.mill
+) else (
+    if exist "build.mill.scala" (
+      set MILL_BUILD_SCRIPT=build.mill.scala
+    ) else (
+        if exist "build.sc" (
+          set MILL_BUILD_SCRIPT=build.sc
+        ) else (
+            rem no-op
+        )
+    )
+)
+
+if [!MILL_VERSION!]==[] (
+  if exist .mill-version (
+    set /p MILL_VERSION=<.mill-version
+  ) else (
+    if exist .config\mill-version (
+      set /p MILL_VERSION=<.config\mill-version
+    ) else (
+      rem Determine which config file to use for version extraction
+      set "MILL_VERSION_CONFIG_FILE="
+      set "MILL_VERSION_SEARCH_PATTERN="
+
+      if exist build.mill.yaml (
+        set "MILL_VERSION_CONFIG_FILE=build.mill.yaml"
+        set "MILL_VERSION_SEARCH_PATTERN=mill-version:"
+      ) else (
+        if not "%MILL_BUILD_SCRIPT%"=="" (
+          set "MILL_VERSION_CONFIG_FILE=%MILL_BUILD_SCRIPT%"
+          set "MILL_VERSION_SEARCH_PATTERN=//\|.*mill-version"
+        )
+      )
+
+      rem Process the config file if found
+      if not "!MILL_VERSION_CONFIG_FILE!"=="" (
+        rem Find the line and process it
+        for /f "tokens=*" %%a in ('findstr /R /C:"!MILL_VERSION_SEARCH_PATTERN!" "!MILL_VERSION_CONFIG_FILE!"') do (
+            set "line=%%a"
+
+            rem --- 1. Replicate sed 's/.*://' ---
+            rem This removes everything up to and including the first colon
+            set "line=!line:*:=!"
+
+            rem --- 2. Replicate sed 's/#.*//' ---
+            rem Split on '#' and keep the first part
+            for /f "tokens=1 delims=#" %%b in ("!line!") do (
+                set "line=%%b"
+            )
+
+            rem --- 3. Replicate sed 's/['"]//g' ---
+            rem Remove all quotes
+            set "line=!line:'=!"
+            set "line=!line:"=!"
+
+            rem --- 4. Replicate sed's trim/space removal ---
+            rem Remove all space characters from the result. This is more robust.
+            set "MILL_VERSION=!line: =!"
+
+            rem We found the version, so we can exit the loop
+            goto :version_found
+        )
+
+        :version_found
+        rem no-op
+      )
+    )
+  )
+)
+
+if [!MILL_VERSION!]==[] (
+    set MILL_VERSION=%DEFAULT_MILL_VERSION%
+)
+
+if [!MILL_FINAL_DOWNLOAD_FOLDER!]==[] set MILL_FINAL_DOWNLOAD_FOLDER=%USERPROFILE%\.cache\mill\download
+
+rem without bat file extension, cmd doesn't seem to be able to run it
+
+set "MILL_NATIVE_SUFFIX=-native"
+set "MILL_JVM_SUFFIX=-jvm"
+set "MILL_FULL_VERSION=%MILL_VERSION%"
+set "MILL_DOWNLOAD_EXT=.bat"
+set "ARTIFACT_SUFFIX="
+REM Check if MILL_VERSION contains MILL_NATIVE_SUFFIX
+echo !MILL_VERSION! | findstr /C:"%MILL_NATIVE_SUFFIX%" >nul
+if !errorlevel! equ 0 (
+    set "MILL_VERSION=%MILL_VERSION:-native=%"
+    REM -native images compiled with graal do not support windows-arm
+    REM https://github.com/oracle/graal/issues/9215
+    IF /I NOT "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+        set "ARTIFACT_SUFFIX=-native-windows-amd64"
+        set "MILL_DOWNLOAD_EXT=.exe"
+    ) else (
+        rem no-op
+    )
+) else (
+    echo !MILL_VERSION! | findstr /C:"%MILL_JVM_SUFFIX%" >nul
+    if !errorlevel! equ 0 (
+        set "MILL_VERSION=%MILL_VERSION:-jvm=%"
+    ) else (
+        set "SKIP_VERSION=false"
+        set "MILL_PREFIX=%MILL_VERSION:~0,4%"
+        if "!MILL_PREFIX!"=="0.1." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.2." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.3." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.4." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.5." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.6." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.7." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.8." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.9." set "SKIP_VERSION=true"
+        set "MILL_PREFIX=%MILL_VERSION:~0,5%"
+        if "!MILL_PREFIX!"=="0.10." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.11." set "SKIP_VERSION=true"
+        if "!MILL_PREFIX!"=="0.12." set "SKIP_VERSION=true"
+
+        if "!SKIP_VERSION!"=="false" (
+            IF /I NOT "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+                set "ARTIFACT_SUFFIX=-native-windows-amd64"
+                set "MILL_DOWNLOAD_EXT=.exe"
+            )
+        ) else (
+            rem no-op
+        )
+    )
+)
+
+set MILL=%MILL_FINAL_DOWNLOAD_FOLDER%\!MILL_FULL_VERSION!!MILL_DOWNLOAD_EXT!
+
+set MILL_RESOLVE_DOWNLOAD=
+
+if not exist "%MILL%" (
+  set MILL_RESOLVE_DOWNLOAD=true
+) else (
+    if defined MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT (
+        set MILL_RESOLVE_DOWNLOAD=true
+    ) else (
+        rem no-op
+    )
+)
+
+
+if [!MILL_RESOLVE_DOWNLOAD!]==[true] (
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,4%
+    set MILL_SHORT_VERSION_PREFIX=%MILL_VERSION:~0,2%
+    rem Since 0.5.0
+    set MILL_DOWNLOAD_SUFFIX=-assembly
+    rem Since 0.11.0
+    set MILL_DOWNLOAD_FROM_MAVEN=1
+    if [!MILL_VERSION_PREFIX!]==[0.0.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.1.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.2.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.3.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.4.] (
+        set MILL_DOWNLOAD_SUFFIX=
+        set MILL_DOWNLOAD_FROM_MAVEN=0
+    )
+    if [!MILL_VERSION_PREFIX!]==[0.5.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.6.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.7.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.8.] set MILL_DOWNLOAD_FROM_MAVEN=0
+    if [!MILL_VERSION_PREFIX!]==[0.9.] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,5%
+    if [!MILL_VERSION_PREFIX!]==[0.10.] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,8%
+    if [!MILL_VERSION_PREFIX!]==[0.11.0-M] set MILL_DOWNLOAD_FROM_MAVEN=0
+
+    set MILL_VERSION_PREFIX=%MILL_VERSION:~0,5%
+    set DOWNLOAD_EXT=exe
+    if [!MILL_SHORT_VERSION_PREFIX!]==[0.] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION_PREFIX!]==[0.12.] set DOWNLOAD_EXT=exe
+    if [!MILL_VERSION!]==[0.12.0] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.1] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.2] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.3] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.4] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.5] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.6] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.7] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.8] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.9] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.10] set DOWNLOAD_EXT=jar
+    if [!MILL_VERSION!]==[0.12.11] set DOWNLOAD_EXT=jar
+
+    set MILL_VERSION_PREFIX=
+    set MILL_SHORT_VERSION_PREFIX=
+
+    for /F "delims=- tokens=1" %%A in ("!MILL_VERSION!") do set MILL_VERSION_BASE=%%A
+    set MILL_VERSION_MILESTONE=
+    for /F "delims=- tokens=2" %%A in ("!MILL_VERSION!") do set MILL_VERSION_MILESTONE=%%A
+    set MILL_VERSION_MILESTONE_START=!MILL_VERSION_MILESTONE:~0,1!
+    if [!MILL_VERSION_MILESTONE_START!]==[M] (
+        set MILL_VERSION_TAG=!MILL_VERSION_BASE!-!MILL_VERSION_MILESTONE!
+    ) else (
+        set MILL_VERSION_TAG=!MILL_VERSION_BASE!
+    )
+    if [!MILL_DOWNLOAD_FROM_MAVEN!]==[1] (
+        set MILL_DOWNLOAD_URL=https://repo1.maven.org/maven2/com/lihaoyi/mill-dist!ARTIFACT_SUFFIX!/!MILL_VERSION!/mill-dist!ARTIFACT_SUFFIX!-!MILL_VERSION!.!DOWNLOAD_EXT!
+    ) else (
+        set MILL_DOWNLOAD_URL=!MILL_GITHUB_RELEASE_CDN!%MILL_REPO_URL%/releases/download/!MILL_VERSION_TAG!/!MILL_VERSION!!MILL_DOWNLOAD_SUFFIX!
+    )
+
+    if defined MILL_TEST_DRY_RUN_LAUNCHER_SCRIPT (
+        echo !MILL_DOWNLOAD_URL!
+        echo !MILL!
+        exit /b 0
+    )
+
+    rem there seems to be no way to generate a unique temporary file path (on native Windows)
+    if defined MILL_OUTPUT_DIR (
+        set MILL_TEMP_DOWNLOAD_FILE=%MILL_OUTPUT_DIR%\mill-temp-download
+        if not exist "%MILL_OUTPUT_DIR%" mkdir "%MILL_OUTPUT_DIR%"
+    ) else (
+        set MILL_TEMP_DOWNLOAD_FILE=out\mill-bootstrap-download
+        if not exist "out" mkdir "out"
+    )
+
+    echo Downloading mill !MILL_VERSION! from !MILL_DOWNLOAD_URL! ... 1>&2
+
+    curl -f -L "!MILL_DOWNLOAD_URL!" -o "!MILL_TEMP_DOWNLOAD_FILE!"
+
+    if not exist "%MILL_FINAL_DOWNLOAD_FOLDER%" mkdir "%MILL_FINAL_DOWNLOAD_FOLDER%"
+    move /y "!MILL_TEMP_DOWNLOAD_FILE!" "%MILL%"
+
+    set MILL_TEMP_DOWNLOAD_FILE=
+    set MILL_DOWNLOAD_SUFFIX=
+)
+
+set MILL_FINAL_DOWNLOAD_FOLDER=
+set MILL_VERSION=
+set MILL_REPO_URL=
+
+rem Need to preserve the first position of those listed options
+set MILL_FIRST_ARG=
+if [%~1%]==[--bsp] (
+  set MILL_FIRST_ARG=%1%
+) else (
+  if [%~1%]==[-i] (
+    set MILL_FIRST_ARG=%1%
+  ) else (
+    if [%~1%]==[--interactive] (
+      set MILL_FIRST_ARG=%1%
+    ) else (
+      if [%~1%]==[--no-server] (
+        set MILL_FIRST_ARG=%1%
+      ) else (
+        if [%~1%]==[--no-daemon] (
+          set MILL_FIRST_ARG=%1%
+        ) else (
+          if [%~1%]==[--help] (
+            set MILL_FIRST_ARG=%1%
+          )
+        )
+      )
+    )
+  )
+)
+set "MILL_PARAMS=%*%"
+
+if not [!MILL_FIRST_ARG!]==[] (
+  for /f "tokens=1*" %%a in ("%*") do (
+    set "MILL_PARAMS=%%b"
+  )
+)
+
+rem -D mill.main.cli is for compatibility with Mill 0.10.9 - 0.13.0-M2
+"%MILL%" %MILL_FIRST_ARG% -D "mill.main.cli=%MILL_MAIN_CLI%" %MILL_PARAMS%

--- a/presentation-compiler-testcases/package.mill
+++ b/presentation-compiler-testcases/package.mill
@@ -1,0 +1,13 @@
+package build.`presentation-compiler-testcases`
+
+import scala3build.*
+
+import mill.*
+
+trait PresentationCompilerTestcases extends CrossScala3Module, mill.scala3buildhelper.CompileClassesPathHelper:
+  def moduleDeps = Seq(
+    build.compiler()
+  )
+
+object `package` extends PresentationCompilerTestcases, CrossHelper[PresentationCompilerTestcases]:
+  object `non-bootstrapped` extends PresentationCompilerTestcases, CrossHelper.NonBootstrapped

--- a/presentation-compiler/package.mill
+++ b/presentation-compiler/package.mill
@@ -1,0 +1,176 @@
+package build.`presentation-compiler`
+
+import scala3build.*
+
+import mill.*
+import mill.scalalib.*
+
+trait PresentationCompiler extends CrossScala3Module:
+  def moduleDeps = Seq(
+    build.compiler()
+  )
+
+  /** Expected library run class path - for source generation, this doesn't actually compile the library */
+  def libraryPrecomputedRunClasspath: T[Seq[String]] =
+    build.library().precomputedRunClasspath
+  /** Expected PC test cases JAR path - for source generation, this doesn't actually compile the test cases */
+  def pcTestCasesPrecomputedJarPath: T[String] = Task {
+    (build.`presentation-compiler-testcases`().jarPath(Task.dest) / "out.jar").toString
+  }
+  def libraryRunClasspath: T[Seq[PathRef]] =
+    Task {
+      build.library()
+        .runClasspath()
+        .filter(ref => os.exists(ref.path))
+    }
+  def pcTestCasesJar: T[PathRef] =
+    build.`presentation-compiler-testcases`().jar
+
+  def buildInfoSources = Task {
+    val dir = Task.dest
+    os.write(
+      dir / "dotty/tools/pc/buildinfo/BuildInfo.scala",
+      s"""package dotty.tools.pc.buildinfo
+         |
+         |object BuildInfo {
+         |  def scalaVersion = "${scalaVersion()}"
+         |}
+         |""".stripMargin,
+      createFolders = true
+    )
+    PathRef(dir)
+  }
+
+  /** Sources of the mtags-shared module, post-processed to be compiled in the Scala 3 build */
+  def mtagsSharedSources = Task {
+    val srcPath = defaultResolver().classpath(
+      Seq(mvn"org.scalameta:mtags-shared_${Versions.scala2Version}:${Dependencies.mtagsVersion}".dep.withTransitive(false)),
+      sources = true
+    )
+    assert(srcPath.length == 1, "Expected a single source JAR")
+    val srcJar = srcPath.head.path
+    os.unzip(srcJar, Task.dest)
+
+    for (f <- os.walk(Task.dest) if os.isFile(f) && f.last.endsWith(".scala")) {
+      val lines = os.read.lines(f).toList
+      val updatedLines = Shading.insertUnsafeNullsImport(Shading.replaceProtobuf(lines))
+      os.write.over(f, updatedLines.mkString(System.lineSeparator()))
+    }
+
+    PathRef(Task.dest)
+  }
+
+  def generatedSources = Task {
+    super.generatedSources() ++ Seq(mtagsSharedSources(), buildInfoSources())
+  }
+
+  def mvnDeps = Seq(
+    mvn"org.lz4:lz4-java:1.8.0",
+    mvn"io.get-coursier:interface:1.0.29-M4"
+      // temporary, until this is fixed in coursier/interface
+      .exclude(("org.scala-lang", "scala-library")),
+    mvn"org.scalameta:mtags-interfaces:${Dependencies.mtagsVersion}",
+    mvn"com.google.guava:guava:33.6.0-jre"
+  )
+  def scalacOptions = super.scalacOptions() ++ Seq(
+    "-Yexplicit-nulls", "-Wsafe-init",
+    "-Wconf:src=.*/scala/meta/internal/.*:s"
+  )
+
+  object test extends Scala3Tests:
+    // Without this, it seems Mill puts some abstract classes in discovered test classes,
+    // and then complains at runtime that it cannot instantiate them
+    def discoverTestsWithZinc = true
+    def moduleDeps = super.moduleDeps ++ Seq(
+      build.`presentation-compiler-testcases`(),
+      build.compiler().test
+    )
+    def generatedSources = Task {
+      super.generatedSources() ++ Seq(testBuildInfoSources())
+    }
+
+    private def scalaJSScalalibExpectedPath = Task.Anon {
+      build.`library-js`().jarPath(Task.dest) / build.`library-js`().jarName()
+    }
+
+    def ideTestsScalaJSClasspath = Task {
+      def findArtifact(deps: Seq[PathRef], name: String): String =
+        deps
+          .map(_.path)
+          .find(_.last.startsWith(name))
+          .getOrElse {
+            Task.fail(s"Artifact for $name not found in $deps")
+          }
+          .toString
+      val externalJSCommonDeps = build.`scaladoc-js`.common().resolvedMvnDeps()
+      val scalaJSCommonDom = findArtifact(externalJSCommonDeps, "scalajs-dom_sjs1_3")
+      val externalJSDeps = build.`library-js`().resolvedMvnDeps()
+      val scalaJSLibrary = findArtifact(externalJSDeps, "scalajs-library_2.13")
+      val scalaJSJavalib = findArtifact(externalJSDeps, "scalajs-javalib")
+      val scalaJSScalalib = scalaJSScalalibExpectedPath().toString
+      Seq[String](scalaJSLibrary, scalaJSJavalib, scalaJSScalalib, scalaJSCommonDom)
+    }
+
+    def testBuildInfoSources = Task {
+      val dir = Task.dest
+      val srcDir = dir / "src"
+      val tq = "\"\"\""
+      val depJars = libraryRunClasspath().map(_.path) :+ pcTestCasesJar().path
+      // PcDefinitionProvider needs directories rather than JARs
+      val testDepCp = depJars.zipWithIndex.map { case (jar, idx) =>
+        val out = dir / "deps" / s"$idx-${jar.last.stripSuffix(".jar")}"
+        os.unzip(jar, out)
+        out.toString
+      }
+      os.write(
+        srcDir / "dotty/tools/pc/tests/buildinfo/BuildInfo.scala",
+        s"""package dotty.tools.pc.tests.buildinfo
+           |
+           |import java.io.File
+           |
+           |object BuildInfo {
+           |  def scalaVersion = "${scalaVersion()}"
+           |  def ideTestsDependencyClasspath = ${testDepCp.map(p => s"new File($tq$p$tq)").mkString("Seq[File](", ", ", ")")}
+           |  def ideTestsScalaJSClasspath = ${ideTestsScalaJSClasspath().map(p => s"new File($tq$p$tq)").mkString("Seq[File](", ", ", ")")}
+           |}
+           |""".stripMargin,
+        createFolders = true
+      )
+      PathRef(srcDir)
+    }
+
+    def mvnDeps = Seq(
+      mvn"org.hamcrest:hamcrest-core:1.3"
+    )
+
+    // We ensure here that the pre-computed class paths match their actual values
+    def runClasspath = Task {
+      val precomputedScalaJsScalaLib = scalaJSScalalibExpectedPath()
+      val actualScalaJsScalaLib = build.`library-js`().jar().path
+      if (precomputedScalaJsScalaLib != actualScalaJsScalaLib)
+        Task.fail(
+          "Scala.js scala library path calculation mismatch: " +
+          s"pre-computed value $precomputedScalaJsScalaLib differs from actual value $actualScalaJsScalaLib"
+        )
+
+      val precomputedLibrary = libraryPrecomputedRunClasspath().map(os.Path(_))
+      val actualLibrary = libraryRunClasspath().map(_.path)
+      if (precomputedLibrary.filter(os.exists) != actualLibrary.filter(os.exists))
+        Task.fail(
+          "Standard library class path calculation mismatch: " +
+          s"pre-computed value $precomputedLibrary differs from actual value $actualLibrary"
+        )
+
+      val precomputedPcTestCases = os.Path(pcTestCasesPrecomputedJarPath())
+      val actualPcTestCases = pcTestCasesJar().path
+      if (precomputedPcTestCases != actualPcTestCases)
+        Task.fail(
+          "PC testcases class path calculation mismatch: " +
+          s"pre-computed value $precomputedPcTestCases differs from actual value $actualPcTestCases"
+        )
+
+      super.runClasspath()
+    }
+
+object `package` extends PresentationCompiler, CrossHelper[PresentationCompiler]:
+  object `non-bootstrapped` extends PresentationCompiler, CrossHelper.NonBootstrapped

--- a/project/CompatMode.scala
+++ b/project/CompatMode.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 object CompatMode {

--- a/project/ConstantHolderGenerator.scala
+++ b/project/ConstantHolderGenerator.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 import scala.annotation.tailrec
 
 import sbt._

--- a/project/Constants.scala
+++ b/project/Constants.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 object Constants {
   val homepageUrl = "https://scala-lang.org/"
   val dottyOrganization = "org.scala-lang"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,9 @@
-import sbt.*
-import dotty.tools.sbtplugin.Versions
+// This file is used in the Mill build too. Do not modify this comment.
 
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+package dotty.tools.sbtplugin
+
+import sbt.*
+
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 /**
@@ -14,7 +16,7 @@ object Dependencies {
   val coursier = "io.get-coursier" %% "coursier" % "2.1.24"
   val coursierInterface = "io.get-coursier" % "interface" % "1.0.29-M4"
 
-  private val flexmarkVersion = "0.64.8"
+  val flexmarkVersion = "0.64.8"
   val flexmarkDeps = Seq(
     "com.vladsch.flexmark" % "flexmark" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-util-ast" % flexmarkVersion,
@@ -32,7 +34,7 @@ object Dependencies {
 
   val guava = "com.google.guava" % "guava" % "33.6.0-jre"
 
-  private val jacksonVersion = "3.1.2"
+  val jacksonVersion = "3.1.2"
   val jacksonDatabind = "tools.jackson.core" % "jackson-databind" % jacksonVersion
   val jacksonDataformatYaml = "tools.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
 
@@ -49,7 +51,7 @@ object Dependencies {
 
   val lz4 = "org.lz4" % "lz4-java" % "1.8.1"
 
-  private val mtagsVersion = "1.6.7"
+  val mtagsVersion = "1.6.7"
   val mtagsInterfaces = "org.scalameta" % "mtags-interfaces" % mtagsVersion
   val mtagsShared = "org.scalameta" % s"mtags-shared_${Versions.scala2Version}" % mtagsVersion
 

--- a/project/Dist.scala
+++ b/project/Dist.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 import java.io.File

--- a/project/DocumentationWebsite.scala
+++ b/project/DocumentationWebsite.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 import java.io.File
 import java.net.URI
 import java.nio.file.Paths

--- a/project/LibraryProperties.scala
+++ b/project/LibraryProperties.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 object LibraryProperties {
   private val shellBanner: String =
     """%n      ________ ___   / /  ___

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 import com.typesafe.tools.mima.core._

--- a/project/MissingLinkFilters.scala
+++ b/project/MissingLinkFilters.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 object MissingLinkFilters {

--- a/project/ScalaJarValidate.scala
+++ b/project/ScalaJarValidate.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 import org.objectweb.asm.*

--- a/project/ScalaLibraryFilesToCopy.scala
+++ b/project/ScalaLibraryFilesToCopy.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 object ScalaLibraryFilesToCopy {

--- a/project/ScaladocConfigs0.scala
+++ b/project/ScaladocConfigs0.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 import java.io.File

--- a/project/ScaladocGeneration.scala
+++ b/project/ScaladocGeneration.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 import java.nio.file.Files

--- a/project/ScaladocOptions.scala
+++ b/project/ScaladocOptions.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 object ScaladocOptions {
   def scalacOptionsDocSettings(includeExternalMappings: Boolean = true) = {
     val extMap = Seq("-external-mappings:" +

--- a/project/Shading.scala
+++ b/project/Shading.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 object Shading {
   /** Replace package names in package definitions, for shading.
    * It assumes the full package def is written on a single line.

--- a/project/StripScala2Annotations.scala
+++ b/project/StripScala2Annotations.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 import dotty.tools.tasty.TastyHeaderUnpickler

--- a/project/TestSuiteLinkerOptions.scala
+++ b/project/TestSuiteLinkerOptions.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package build
 
 // This file is an exact copy of the file of the same name in scala-js/scala-js

--- a/project/VersionUtil.scala
+++ b/project/VersionUtil.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,3 +1,5 @@
+// This file is used in the Mill build too. Do not modify this comment.
+
 package dotty.tools.sbtplugin
 
 object Versions {

--- a/project/scripts/buildScalaBinary
+++ b/project/scripts/buildScalaBinary
@@ -4,9 +4,14 @@ set -e
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/../.."
 SBT="$ROOT/project/scripts/sbt" # if run on CI
+MILL="$ROOT/mill"
 
 # set the $DIST_PROJECT and $DIST_DIR variables
 source "$ROOT/bin/common-platform"
 
 # build the scala/scalac/scaladoc binary, where scala is native for the current platform.
-"$SBT" "$DIST_PROJECT/Universal/stage"
+if [ "z${DIST_USE_MILL:-}" != "z" ]; then
+  "$MILL" "dist.$DIST_MILL_PROJECT"
+else
+  "$SBT" "$DIST_PROJECT/Universal/stage"
+fi

--- a/project/scripts/cmdTestsCommon.inc.sh
+++ b/project/scripts/cmdTestsCommon.inc.sh
@@ -5,6 +5,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/../.."
 SBT="$ROOT/project/scripts/sbt" # if run on CI
 # SBT="sbt" # if run locally
 
+MILL="$ROOT/mill"
+
 SOURCE="tests/pos/HelloWorld.scala"
 MAIN="HelloWorld"
 TASTY="HelloWorld.tasty"

--- a/project/scripts/native-integration/bashTests
+++ b/project/scripts/native-integration/bashTests
@@ -8,18 +8,24 @@ set -eux
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >& /dev/null && pwd)/../../.."
 
-SBT="$ROOT/project/scripts/sbt" # if run on CI
-# SBT="sbt" # if run locally
-
 # set the $DIST_PROJECT and $DIST_DIR variables
 source "$ROOT/bin/common-platform"
+
+if [ "z${DIST_USE_MILL:-}" != "z" ]; then
+  MILL="$ROOT/mill"
+
+  PROG_HOME="out/dist/$DIST_MILL_PROJECT.dest" # we could get that with jq from the Mill command below
+else
+  SBT="$ROOT/project/scripts/sbt" # if run on CI
+  # SBT="sbt" # if run locally
+
+  PROG_HOME="$DIST_DIR/target/universal/stage"
+fi
 
 die () {
     echo >&2 "$@"
     exit 1
 }
-
-PROG_HOME="$DIST_DIR/target/universal/stage"
 
 SOURCE="$ROOT/tests/pos/HelloWorld.scala"
 SOURCE_VERSION="$ROOT/project/scripts/native-integration/reportScalaVersion.scala"
@@ -43,7 +49,11 @@ clear_cli_dotfiles()
 # *---------------*/
 
 # build the distribution
-"$SBT" "$DIST_PROJECT/Universal/stage"
+if [ "z${DIST_USE_MILL:-}" != "z" ]; then
+  "$MILL" "dist.$DIST_MILL_PROJECT"
+else
+  "$SBT" "$DIST_PROJECT/Universal/stage"
+fi
 
 SCALA_VERSION=""
 # iterate through lines in VERSION_SRC

--- a/project/scripts/native-integration/winTests.bat
+++ b/project/scripts/native-integration/winTests.bat
@@ -2,10 +2,14 @@
 setlocal
 
 @rem paths are relative to the root project directory
-set "_PREFIX=dist\win-x86_64\target\universal\stage"
+if "%DIST_USE_MILL%"=="true" (
+    set "_PREFIX=out\dist\win-x86_64.dest"
+) else (
+    set "_PREFIX=dist\win-x86_64\target\universal\stage"
+)
 set "_SOURCE=tests\pos\HelloWorld.scala"
 set "_SOURCE_TEST_BOOTSTRAPPED=project\scripts\native-integration\testBootstrappedLibrary.scala"
-set "_OUT_DIR=out"
+set "_OUT_DIR=output"
 
 @rem if-tests mimic the non-existing bash instruction 'set -e'.
 call "%_PREFIX%\bin\scalac.bat" "@project\scripts\options" "%_SOURCE%"

--- a/project/scripts/winCmdTests.bat
+++ b/project/scripts/winCmdTests.bat
@@ -4,7 +4,7 @@ setlocal
 @rem paths are relative to the root project directory
 set "_PREFIX=dist\win-x86_64\target\universal\stage"
 set "_SOURCE=tests\pos\HelloWorld.scala"
-set "_OUT_DIR=out"
+set "_OUT_DIR=output"
 set "_SITE_DIR=_site"
 
 @rem if-tests mimic the non-existing bash instruction 'set -e'.

--- a/repl/package.mill
+++ b/repl/package.mill
@@ -1,0 +1,67 @@
+package build.repl
+
+import scala3build.*
+
+import mill.*
+import mill.api.BuildCtx
+import mill.scalalib.*
+
+trait Repl extends CrossScala3Module, DefaultTaskModule:
+  outer =>
+  def testResources = Task.Source("test-resources")
+
+  def moduleDeps = Seq(
+    build.compiler(),
+    build.`directives-parser`()
+  )
+  def mvnDeps = Seq(
+    mvn"org.jline:jline-reader:4.0.14",
+    mvn"org.jline:jline-terminal:4.0.14",
+    mvn"org.jline:jline-terminal-jni:4.0.14",
+    mvn"io.get-coursier:interface:1.0.29-M4" // Original comment: used by the REPL for dependency resolution
+      // temporary, until this is fixed in coursier/interface
+      .exclude(("org.scala-lang", "scala-library"))
+  )
+  def defaultTask() = "run"
+  /** Runs the REPL - should be run in interactive mode (./mill -i) */
+  def run(args: Task[mill.api.Args] = Task.Anon(mill.api.Args())): Task.Command[Unit] =
+    val runTask = super.run(Task.Anon(mill.api.Args("-usejavacp", args().value)))
+    Task.Command(exclusive = true) {
+      runTask()
+    }
+  object test extends Scala3Tests:
+    def moduleDeps = super.moduleDeps ++ Seq(
+      build.compiler().test
+    )
+    def compileResources =
+      // Getting
+      //     Could not detect the parent class of task repl.non-bootstrapped.test.compileResources.super.test. Please report this at https://github.com/com-lihaoyi/mill/issues/new/choose .
+      // when adding
+      //     super[JavaModule].compileResources() ++
+      Seq(testResources())
+    def mvnDeps = Seq(
+      mvn"com.github.sbt:junit-interface:0.13.3"
+    )
+
+    def forkWorkingDir = BuildCtx.workspaceRoot / "repl"
+    def replTestForkArgs = Task {
+      def findArtifactPath(name: String) =
+        compileClasspath().map(_.path).find(_.last.startsWith(name)).getOrElse {
+          Task.fail(s"Cannot find $name in repl class path")
+        }
+      Seq(
+        s"-Ddotty.tests.classes.dottyRepl=${outer.jar().path}",
+        s"-Ddotty.tests.classes.jlineTerminal=${findArtifactPath("jline-terminal")}",
+        s"-Ddotty.tests.classes.jlineReader=${findArtifactPath("jline-reader")}",
+        s"-Ddotty.tests.classes.scalaXml=${findArtifactPath("scala-xml_2.13")}"
+      )
+    }
+
+    def forkArgs: T[Seq[String]] = Task {
+      super.forkArgs() ++
+        build.compiler().test.compilerTestForkArgs() ++
+        replTestForkArgs()
+    }
+
+object `package` extends Repl, CrossHelper[Repl]:
+  object `non-bootstrapped` extends Repl, CrossHelper.NonBootstrapped

--- a/sandbox/package.mill
+++ b/sandbox/package.mill
@@ -1,0 +1,15 @@
+package build.sandbox
+
+import scala3build.*
+
+import mill.*
+
+trait SandboxScalajs extends CrossScala3Module, Scala3JsModule:
+  def moduleDeps = Seq(
+    build.`library-js`()
+  )
+
+  object test extends Scala3JsTests
+
+object scalajs extends SandboxScalajs, CrossHelper[SandboxScalajs]:
+  object `non-bootstrapped` extends SandboxScalajs, CrossHelper.NonBootstrapped

--- a/sbt-bridge/package.mill
+++ b/sbt-bridge/package.mill
@@ -1,0 +1,25 @@
+package build.`sbt-bridge`
+
+import scala3build.*
+
+import mill.*
+import mill.scalalib.*
+
+trait SbtBridge extends CrossScala3Module:
+  def artifactId = artifactName()
+  def moduleDeps = Seq(build.compiler()) ++
+    (if (mode == Mode.NonBootstrapped) Nil else Seq(build.repl()))
+  def mvnDeps = Seq(
+    mvn"org.scala-sbt:compiler-interface:1.12.0"
+  )
+
+  def isCoreModule = true
+
+  object test extends Scala3Tests:
+    def mvnDeps = Seq(
+      mvn"org.scala-sbt:zinc-apiinfo_2.13:1.12.0"
+        .exclude(("org.scala-lang", "*"))
+    )
+
+object `package` extends SbtBridge, CrossHelper[SbtBridge]:
+  object `non-bootstrapped` extends SbtBridge, CrossHelper.NonBootstrapped

--- a/scaladoc-js/package.mill
+++ b/scaladoc-js/package.mill
@@ -1,0 +1,40 @@
+package build.`scaladoc-js`
+
+import scala3build.*
+
+import mill.*
+import mill.scalalib.*
+
+object `package` extends Module:
+  trait Common extends CrossScala3Module, Scala3JsModule:
+    def moduleDeps = Seq(
+      build.`library-js`.`library-3`()
+    )
+    def mvnDeps = Seq(
+      mvn"org.scala-js::scalajs-dom::2.8.1"
+    )
+
+    def css = Task.Source("css")
+
+  object common extends Common, CrossHelper[Common]:
+    object `non-bootstrapped` extends Common, CrossHelper.NonBootstrapped
+
+
+  trait Contributors extends CrossScala3Module, Scala3JsModule:
+    def moduleDeps = Seq(
+      common()
+    )
+    def css = Task.Source("css")
+
+  object contributors extends Contributors, CrossHelper[Contributors]:
+    object `non-bootstrapped` extends Contributors, CrossHelper.NonBootstrapped
+
+  trait Main extends CrossScala3Module, Scala3JsModule:
+    def moduleDeps = Seq(
+      common()
+    )
+
+    object test extends Scala3JsTests
+
+  object main extends Main, CrossHelper[Main]:
+    object `non-bootstrapped` extends Main, CrossHelper.NonBootstrapped

--- a/scaladoc-testcases/package.mill
+++ b/scaladoc-testcases/package.mill
@@ -1,0 +1,25 @@
+package build.`scaladoc-testcases`
+
+import scala3build.*
+
+import mill.*
+
+trait ScaladocTestcases extends CrossScala3Module, mill.scala3buildhelper.CompileClassesPathHelper:
+  def moduleDeps = Seq(
+    build.compiler()
+  )
+  def mainSources = Task.Source("src")
+  def sources = Task {
+    val baseSources = super.sources()
+    assert(baseSources.exists(_.path == mainSources().path))
+    baseSources
+  }
+
+object `package` extends ScaladocTestcases, CrossHelper[ScaladocTestcases]:
+  object `non-bootstrapped` extends ScaladocTestcases, CrossHelper.NonBootstrapped {
+    def allSourceFiles = Task {
+      super.allSourceFiles().filter { ref =>
+        !os.read(ref.path).contains("initially")
+      }
+    }
+  }

--- a/scaladoc/package.mill
+++ b/scaladoc/package.mill
@@ -1,0 +1,311 @@
+package build.scaladoc
+
+import scala3build.*
+
+import mill.*
+import mill.api.{BuildCtx, TaskCtx}
+import mill.javalib.api.JvmWorkerUtil
+import mill.javalib.RunModule.Runner
+import mill.scalalib.*
+
+trait Scaladoc extends CrossScala3Module:
+  scaladoc =>
+  def artifactName = "scaladoc"
+  def moduleDeps = Seq(
+    build.compiler(),
+    build.`tasty-inspector`(),
+  )
+
+  def `test-documentations` = Task.Source("test-documentations")
+
+  def buildInfoSources = Task {
+    val dir = Task.dest
+    os.write(
+      dir / "dotty/tools/scaladoc/BuildInfo.scala",
+      s"""package dotty.tools.scaladoc
+         |
+         |object BuildInfo {
+         |  def version = "${Versions.dottyVersion}"
+         |}
+         |""".stripMargin,
+      createFolders = true
+    )
+    PathRef(dir)
+  }
+
+  def generatedSources = Task {
+    super.generatedSources() ++ Seq(buildInfoSources())
+  }
+  def scalacOptions = super.scalacOptions() ++ Seq(
+    "-experimental"
+  )
+  def mvnDeps = Seq(
+    mvn"com.vladsch.flexmark:flexmark:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-util-ast:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-util-data:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-util-html:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-anchorlink:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-autolink:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-emoji:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-gfm-tasklist:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-wikilink:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-tables:${Dependencies.flexmarkVersion}",
+    mvn"com.vladsch.flexmark:flexmark-ext-yaml-front-matter:${Dependencies.flexmarkVersion}",
+    mvn"nl.big-o:liqp:0.9.2.3",
+    mvn"org.jsoup:jsoup:1.22.2", // Original comment: Needed to process .html files for static site
+    mvn"tools.jackson.dataformat:jackson-dataformat-yaml:${Dependencies.jacksonVersion}"
+  )
+  def mainClass = Some("dotty.tools.scaladoc.Main")
+
+
+  /** Expected class directory of scaladoc-testcases module - for source generate, this doesn't trigger its compilation */
+  def scaladocTestcasesCompileClassesPath(taskDest: os.Path): os.Path =
+    build.`scaladoc-testcases`().compileClassesPath0(taskDest)
+
+  def scaladocTestcasesCompile: T[mill.javalib.api.CompilationResult] =
+    build.`scaladoc-testcases`().compile
+
+  def buildInfoTestSources = Task {
+    val dir = Task.dest
+    val tq = "\"\"\""
+    os.write(
+      dir / "dotty/tools/scaladoc/test/BuildInfo.scala",
+      s"""package dotty.tools.scaladoc.test
+         |
+         |object BuildInfo {
+         |  def test_testcasesOutputDir: Seq[String] = Seq($tq${scaladocTestcasesCompileClassesPath(Task.dest)}$tq)
+         |  def test_testcasesSourceRoot: String = $tq${build.`scaladoc-testcases`().mainSources().path}$tq
+         |  def testDocumentationRoot: String = $tq${`test-documentations`().path}$tq
+         |}
+         |""".stripMargin,
+      createFolders = true
+    )
+    PathRef(dir)
+  }
+
+  def mainResourceDir = Task.Source("resources")
+
+  def bundleCssResources = Task {
+    val cssSubDir = os.sub / "dotty_res/styles/theme"
+    val cssDir = mainResourceDir().path / cssSubDir
+
+    for (dir <- os.walk(cssDir, includeTarget = true).filter(os.isDir)) {
+      val subPath = dir.subRelativeTo(cssDir)
+      val cssFiles = os.list(dir).filter(_.last.endsWith(".css")).filter(os.isFile)
+      val bundleContent = geny.Generator.from(cssFiles).map(os.read.bytes)
+      val bundlePath = Task.dest / cssSubDir / subPath / "bundle.css"
+      os.write(bundlePath, bundleContent, createFolders = true)
+    }
+
+    PathRef(Task.dest)
+  }
+
+  def websiteAssets = Task {
+    val dest = Task.dest
+    // Beware this has side-effects (writing stuff under _project-root_ / scaladoc-testcases/docs/_assets)
+    // We'd refactor that further in a Mill-only repo
+    BuildCtx.withFilesystemCheckerDisabled {
+      DocumentationWebsite.generateStaticAssets(
+        build.`scaladoc-js`.contributors().fullLinkJS().dest.path.toIO,
+        build.`scaladoc-js`.main().fullLinkJS().dest.path.toIO,
+        build.`scaladoc-js`.contributors().css().path.toIO,
+        build.`scaladoc-js`.common().css().path.toIO,
+        dest.toIO
+      )
+    }
+    PathRef(dest)
+  }
+
+  def resources =
+    if (Util.isBsp)
+      super.resources
+    else
+      Task {
+        super.resources() ++ Seq(
+          bundleCssResources(),
+          websiteAssets()
+        )
+      }
+
+  private def splitSerializedScaladocGeneration(input: String): Seq[String] = {
+    val sep = "\""
+    def helper(s: String, acc: List[String]): List[String] =
+      if (s.isEmpty) acc
+      else if (s.startsWith(sep)) {
+        val endIdx = s.indexOf(sep, sep.length)
+        if (endIdx < 0) sys.error(s"Cannot happen. Remaining: '$s'")
+        else
+          helper(s.drop(endIdx + sep.length), s.substring(sep.length, endIdx) :: acc)
+      }
+      else if (s.head == ' ')
+        helper(s.dropWhile(_ == ' '), acc)
+      else {
+        val spaceIdx = s.indexOf(' ')
+        assert(spaceIdx != 0) // handled just above
+        if (spaceIdx >= 0)
+          helper(s.drop(spaceIdx + 1), s.take(spaceIdx) :: acc)
+        else
+          s :: acc
+      }
+
+    helper(input, Nil).reverse
+  }
+
+  private def generateDocumentation(
+    config: ScaladocGeneration.GenerationConfig,
+    runner: Runner,
+    mainClass: String
+  )(implicit ctx: TaskCtx): Unit = {
+    for (outDir <- config.get[ScaladocGeneration.OutputDir])
+      os.makeDir.all(os.Path(outDir.value, BuildCtx.workspaceRoot))
+    runner.run(
+      splitSerializedScaladocGeneration(config.serialize),
+      mainClass,
+      workingDir = BuildCtx.workspaceRoot
+    )
+  }
+
+  def generateSelfDocumentation(): Task.Command[os.Path] = Task.Command {
+    val config = ScaladocConfigs0.Scaladoc(publishVersion(), compile().classes.path.toIO)
+    generateDocumentation(
+      config,
+      runner(),
+      finalMainClass()
+    )
+    os.Path(config.get[ScaladocGeneration.OutputDir].get.value, BuildCtx.workspaceRoot)
+  }
+
+  def generateTestcasesDocumentation(): Task.Command[os.Path] = Task.Command {
+    val config = ScaladocConfigs0.Testcases(
+      publishVersion(),
+      Seq(build.`scaladoc-testcases`().compile().classes.path.toString)
+    )
+    generateDocumentation(
+      config,
+      runner(),
+      finalMainClass()
+    )
+    os.Path(config.get[ScaladocGeneration.OutputDir].get.value, BuildCtx.workspaceRoot)
+  }
+
+  private def baseConfig = Task.Anon {
+    ScaladocConfigs0.Scala3(
+      publishVersion(),
+      BuildCtx.workspaceRoot.toNIO,
+      build.library().moduleDir.toNIO,
+      Seq(build.library().jar().path.toString)
+    ).add(ScaladocGeneration.UseJavacp(true))
+  }
+
+  def generateReferenceDocumentation(
+    noRegenerateExpectedLinks: Boolean = false
+  ) = Task.Command[os.Path] {
+    websiteAssets()
+
+    // sbt build comment: Move all the source files to a temporary directory and apply some changes specific to the reference documentation
+    val docs = Task.dest / "docs"
+
+    ScaladocGeneration.prepareReferenceDocumentationDir(docs.toIO)
+
+    val languageReferenceConfig = {
+      ScaladocGeneration.languageReferenceConfig(docs.toIO, baseConfig())
+    }
+
+    generateDocumentation(
+      languageReferenceConfig,
+      runner(),
+      finalMainClass()
+    )
+
+    if (!noRegenerateExpectedLinks) {
+      val cmd = ScaladocGeneration.expectedLinksRegenerationCommand()
+      os.proc(cmd).call(
+        cwd = BuildCtx.workspaceRoot,
+        stdin = os.Inherit,
+        stdout = os.Inherit,
+        check = true
+      )
+    }
+
+    docs
+  }
+
+  def generateScalaDocumentation(newDir: String = "", justAPI: Boolean = false): Task.Command[os.Path] = {
+
+    val outputDirOverride =
+      if (newDir.isEmpty)
+        identity[ScaladocGeneration.GenerationConfig]
+      else
+        (config: ScaladocGeneration.GenerationConfig) => config.add(ScaladocGeneration.OutputDir(newDir))
+
+    def justAPIOverride(config: ScaladocGeneration.GenerationConfig): ScaladocGeneration.GenerationConfig =
+      if (!justAPI) config
+      else {
+        val siteRoot = os.temp.dir()
+        config.add(ScaladocGeneration.SiteRoot(siteRoot.toString))
+      }
+
+    val docs = BuildCtx.workspaceRoot / "docs"
+
+    val configTask = Task.Anon {
+      justAPIOverride(outputDirOverride(baseConfig()))
+    }
+
+    Task.Command {
+
+      val majorVersion = JvmWorkerUtil.scalaBinaryVersion(build.library().scalaVersion())
+
+      BuildCtx.withFilesystemCheckerDisabled {
+        val sourcePatches = if (justAPI) Nil else Seq(
+          ScaladocGeneration.sidebarSourcePatch(docs.toIO),
+          ScaladocGeneration.nightlyVersionNoteSourcePatch(docs.toIO)
+        )
+
+        System.err.println(s"Generating snapshot scaladoc, applying patches to ${sourcePatches.map(_.file)}")
+        sourcePatches.foreach(_.apply())
+
+        try generateDocumentation(configTask(), runner(), finalMainClass())
+        finally sourcePatches.foreach(_.revert())
+
+        val dest = os.Path(configTask().get[ScaladocGeneration.OutputDir].get.value, BuildCtx.workspaceRoot)
+        if (!justAPI) {
+          os.write(dest / "versions" / "latest-nightly-base", majorVersion, createFolders = true)
+          // sbt build command: This file is used by GitHub Pages when the page is available in a custom domain
+          os.write(dest / "CNAME", "nightly.scala-lang.org", createFolders = true)
+        }
+
+        dest
+      }
+    }
+  }
+
+  object test extends Scala3Tests:
+    def generatedSources = Task {
+      super.generatedSources() ++ Seq(scaladoc.buildInfoTestSources())
+    }
+    def runClasspath = Task {
+      // Ensure scaladoc-testcases is compiled, so that the directory
+      // we refer to via scaladocTestcasesCompileClassesPath exists
+      val fromCompile = scaladocTestcasesCompile().classes.path
+      val beforeCompile = scaladocTestcasesCompileClassesPath(Task.dest)
+      if (fromCompile == beforeCompile)
+        super.runClasspath()
+      else
+        Task.fail(
+          "Warning: scaladoc-testcases compilation output dir calculation mismatch: " +
+          s"pre-computed value $beforeCompile differs from actual value $fromCompile."
+        )
+    }
+
+  def testSourceLinksSrc = Task.Source("test-source-links")
+  object `test-source-links` extends Scala3Tests:
+    def moduleDeps = super.moduleDeps ++ Seq(
+      build.scaladoc().test
+    )
+    def sources = Task {
+      Seq(testSourceLinksSrc())
+    }
+
+object `package` extends Scaladoc, CrossHelper[Scaladoc]:
+  object `non-bootstrapped` extends Scaladoc, CrossHelper.NonBootstrapped

--- a/sjs-compiler-tests/package.mill
+++ b/sjs-compiler-tests/package.mill
@@ -1,0 +1,50 @@
+package build.`sjs-compiler-tests`
+
+import scala3build.*
+
+import mill.*
+import mill.scalalib.*
+import org.scalajs.ir.ScalaJSVersions
+
+trait SjsCompilerTests extends CrossScala3Module {
+  def moduleDeps = Seq(
+    build.library()
+  )
+
+  object test extends Scala3Tests {
+    def moduleDeps = super.moduleDeps ++ Seq(
+      build.compiler().test
+    )
+    def mvnDeps = Seq(
+      mvn"org.scala-js:scalajs-linker_2.13:${ScalaJSVersions.current}"
+        .exclude(("org.scala-lang", "scala-library")),
+      mvn"org.scala-js:scalajs-env-nodejs_2.13:1.5.0"
+        .exclude(("org.scala-lang", "scala-library"))
+    )
+    def forkArgs = Task {
+
+      val libraryJsClassPath = build.`library-js`().compileClasspath().map(_.path)
+      def libraryJsArtifactFor(moduleName: String): os.Path =
+        libraryJsClassPath
+          .iterator
+          .filter(os.isFile)
+          .filter(_.last.endsWith(".jar"))
+          .find(_.last.startsWith(moduleName + "-"))
+          .getOrElse {
+            Task.fail(s"No JAR found for $moduleName in library-js class path $libraryJsClassPath")
+          }
+
+      super.forkArgs() ++
+        build.compiler().test.compilerTestForkArgs() ++
+        Seq(
+          s"-Ddotty.tests.classes.scalaJSScalalib=${build.`library-js`().jar().path}",
+          s"-Ddotty.tests.classes.scalaJSJavalib=${libraryJsArtifactFor("scalajs-javalib")}",
+          s"-Ddotty.tests.classes.scalaJSLibrary=${libraryJsArtifactFor("scalajs-library_2.13")}"
+        )
+    }
+  }
+}
+
+object `package` extends SjsCompilerTests with CrossHelper[SjsCompilerTests] {
+  object `non-bootstrapped` extends SjsCompilerTests with CrossHelper.NonBootstrapped
+}

--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -29,7 +29,7 @@ class ScalaJSCompilationTests {
   @Test def runScalaJS: Unit = {
     implicit val testGroup: TestGroup = TestGroup("runScalaJS")
     aggregateTests(
-      compileFilesInDir("tests/run", scalaJSOptions),
+      compileFilesInDir("tests/run", scalaJSOptions, FileFilter.include(List("i1748.scala"))),
     ).checkRuns()
   }
 }

--- a/staging/package.mill
+++ b/staging/package.mill
@@ -1,0 +1,34 @@
+package build.staging
+
+import scala3build.*
+
+import mill.*
+
+trait Staging extends CrossScala3Module:
+  def moduleDeps = Seq(
+    build.compiler()
+  )
+
+  def testResources = Task.Sources("test-resources")
+
+  object test extends Scala3Tests:
+    def moduleDeps = super.moduleDeps ++ Seq(
+      // not sure why, the sbt build only has a dependency on the compiler tests here
+      // but depending on the repl tests is required for compilation for us
+      build.repl().test
+    )
+    def resources = super.resources() ++ testResources()
+
+    def forkArgs: T[Seq[String]] = Task {
+      super.forkArgs() ++
+        build.compiler().test.compilerTestForkArgs() ++
+        build.repl().test.replTestForkArgs()
+    }
+
+    def testArgsDefault = Task {
+      val bootstrapOnlyArgs = if (mode == Mode.NonBootstrapped) Seq("--exclude-categories=dotty.BootstrappedOnlyTests") else Nil
+      super.testArgsDefault() ++ bootstrapOnlyArgs
+    }
+
+object `package` extends Staging, CrossHelper[Staging]:
+  object `non-bootstrapped` extends Staging, CrossHelper.NonBootstrapped

--- a/tasty-inspector/package.mill
+++ b/tasty-inspector/package.mill
@@ -1,0 +1,13 @@
+package build.`tasty-inspector`
+
+import scala3build.*
+
+import mill.*
+
+trait TastyInspector extends CrossScala3Module:
+  def compileModuleDeps = Seq(
+    build.compiler()
+  )
+
+object `package` extends TastyInspector, CrossHelper[TastyInspector]:
+  object `non-bootstrapped` extends TastyInspector, CrossHelper.NonBootstrapped

--- a/tasty/package.mill
+++ b/tasty/package.mill
@@ -1,0 +1,27 @@
+package build.tasty
+
+import scala3build.*
+
+import mill.*
+
+trait Tasty extends CrossScala3Module, Scala3Mima:
+  def artifactName = "tasty-core"
+
+  def moduleDeps = Seq(
+    build.library.`library-3`()
+  )
+
+  def mimaForwardIssueFilters =
+    MiMaFilters.TastyCore.ForwardsBreakingChanges
+  def mimaBackwardIssueFilters =
+    MiMaFilters.TastyCore.BackwardsBreakingChanges
+
+  def isCoreModule = true
+
+  object test extends Scala3Tests:
+    def forkEnv = super.forkEnv() ++ Seq(
+      "EXPECTED_TASTY_VERSION" -> Versions.expectedTastyVersion
+    )
+
+object `package` extends Tasty, CrossHelper[Tasty]:
+  object `non-bootstrapped` extends Tasty, CrossHelper.NonBootstrapped

--- a/tests/package.mill
+++ b/tests/package.mill
@@ -1,0 +1,3 @@
+package build.tests
+
+// dummy package so that tests/sjs-unit/package.mill is taken into account by Mill

--- a/tests/run-tasty-inspector/i8364.scala
+++ b/tests/run-tasty-inspector/i8364.scala
@@ -11,7 +11,7 @@ import scala.tasty.inspector.*
 
    // Artefact of the current test infrastructure
   // TODO improve infrastructure to avoid needing this code on each test
-  val libJarClasspath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(x => x.contains("scala-library-bootstrapped") && x.endsWith(".jar")).get
+  val libJarClasspath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(x => x.contains("scala-library-") && x.endsWith(".jar")).get
 
   TastyInspector.inspectTastyFilesInJar(libJarClasspath)(inspector)
 }

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -143,7 +143,7 @@ val experimentalDefinitionInLibrary = Set(
 
    // Artefact of the current test infrastructure
   // TODO improve infrastructure to avoid needing this code on each test
-  val libJarClasspath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(x => x.contains("scala-library-bootstrapped") && x.endsWith(".jar")).get
+  val libJarClasspath = dotty.tools.dotc.util.ClasspathFromClassloader(this.getClass.getClassLoader).split(java.io.File.pathSeparator).find(x => x.contains("scala-library-") && x.endsWith(".jar")).get
 
   TastyInspector.inspectTastyFilesInJar(libJarClasspath)(inspector)
 }

--- a/tests/sjs-junit/package.mill
+++ b/tests/sjs-junit/package.mill
@@ -1,0 +1,285 @@
+package build.tests.`sjs-junit`
+
+import scala3build.*
+
+import coursier.cache.Cache
+import coursier.util.Artifact
+import mill.*
+import mill.scalajslib.api.Report
+import mill.scalajslib.*
+import mill.scalalib.*
+import org.scalajs.ir.ScalaJSVersions
+import org.scalajs.linker.interface as sjs
+
+import java.nio.file.AtomicMoveNotSupportedException
+import java.util.UUID
+
+// definition of the sjs-unit module
+trait SjsUnit extends Cross.Module[Customization] with Scala3Module with Scala3JsModule {
+  def mode: Mode
+  def customization = crossValue
+
+  override def enableWebAssembly =
+    customization == Customization.LatestESVersionWebAssembly
+
+  def moduleDeps = Seq(
+    build.`library-js`()(using mode)
+  )
+  def mvnDeps = Seq(
+    mvn"org.scala-js:scalajs-junit-test-runtime_2.13:${ScalaJSVersions.current}"
+      .exclude(("org.scala-lang", "scala-library"))
+  )
+
+  def scalaJSConfig = Task.Anon {
+    val config = super.scalaJSConfig()
+      .withSemantics(TestSuiteLinkerOptions.semantics)
+    customization match {
+      case Customization.ESM => config.withModuleKind(sjs.ModuleKind.ESModule)
+      case Customization.LatestESVersion => config.withESFeatures(_.withESVersion(sjs.ESVersion.ES2026))
+      // The WebAssembly backend requires ECMAScript 2022 or later.
+      case Customization.LatestESVersionWebAssembly => config.withESFeatures(_.withESVersion(sjs.ESVersion.ES2022))
+      case Customization.Default => config
+    }
+  }
+
+  def scalacOptions = Task {
+    super.scalacOptions().filter { opt =>
+      opt != "-Werror" && opt != "-deprecation" && opt != "-Yexplicit-nulls"
+    } ++
+    Seq(
+      "-Ycheck:prepjsinterop,explicitJSClasses,addLocalJSFakeNews"
+    )
+  }
+
+  def buildInfoSources = Task {
+
+    val linkerConfig = scalaJSConfig()
+
+    val moduleKind0 = linkerConfig.moduleKind
+    val sems = linkerConfig.semantics
+
+    val useClosure = // isFullLinkJS &&
+      moduleKind0 != sjs.ModuleKind.ESModule
+
+    ConstantHolderGenerator.generate(
+      Task.dest.toIO,
+      "org.scalajs.testsuite.utils.BuildInfo",
+      "scalaVersion" -> scalaVersion(),
+      "hasSourceMaps" -> false, //DottyJSPlugin.wantSourceMaps.value (original sbt build comment)
+      "isNoModule" -> (moduleKind0 == sjs.ModuleKind.NoModule),
+      "isESModule" -> (moduleKind0 == sjs.ModuleKind.ESModule),
+      "isCommonJSModule" -> (moduleKind0 == sjs.ModuleKind.CommonJSModule),
+      "usesClosureCompiler" -> useClosure,
+      "hasMinifiedNames" -> (useClosure || scalaJSMinify()),
+      "compliantAsInstanceOfs" -> (sems.asInstanceOfs == sjs.CheckedBehavior.Compliant),
+      "compliantArrayIndexOutOfBounds" -> (sems.arrayIndexOutOfBounds == sjs.CheckedBehavior.Compliant),
+      "compliantArrayStores" -> (sems.arrayStores == sjs.CheckedBehavior.Compliant),
+      "compliantNegativeArraySizes" -> (sems.negativeArraySizes == sjs.CheckedBehavior.Compliant),
+      "compliantNullPointers" -> (sems.nullPointers == sjs.CheckedBehavior.Compliant),
+      "compliantStringIndexOutOfBounds" -> (sems.stringIndexOutOfBounds == sjs.CheckedBehavior.Compliant),
+      "compliantModuleInit" -> (sems.moduleInit == sjs.CheckedBehavior.Compliant),
+      "productionMode" -> sems.productionMode,
+      "esVersion" -> linkerConfig.esFeatures.esVersion.edition,
+      "useECMAScript2015Semantics" -> linkerConfig.esFeatures.useECMAScript2015Semantics,
+      "isWebAssembly" -> linkerConfig.esFeatures.useWebAssembly
+    )
+
+    PathRef(Task.dest)
+  }
+
+  def generatedSources = Task {
+    super.generatedSources() ++ Seq(buildInfoSources()) ++
+      // add sources from the Scala.js repo
+      os.walk(build.tests.`sjs-junit`.scalaJsSources().path / "test-suite/js/src/main/scala")
+        .filter(_.last.endsWith(".scala"))
+        .filter(!_.last.startsWith("Typechecking"))
+        .filter(os.isFile)
+        .map(PathRef(_)) ++
+      os.walk(build.tests.`sjs-junit`.scalaJsSources().path / "junit-async/js/src/main/scala")
+        .filter(_.last.endsWith(".scala"))
+        .filter(os.isFile)
+        .map(PathRef(_))
+  }
+
+  trait SjsUnitTests extends Scala3JsTests { self =>
+    def generatedSources = Task {
+
+      // add some test sources from the Scala.js repo
+
+      val linkerConfig = self.scalaJSConfig()
+
+      val moduleKind = linkerConfig.moduleKind
+      val hasModules: Boolean = moduleKind != sjs.ModuleKind.NoModule
+      val hasAsyncAwait: Boolean = linkerConfig.esFeatures.esVersion >= sjs.ESVersion.ES2017
+      val isWebAssembly: Boolean = linkerConfig.esFeatures.useWebAssembly
+
+      val testSuiteDir = build.tests.`sjs-junit`.scalaJsSources().path / "test-suite"
+      def scalaFilesUnder(dir: os.SubPath): Seq[os.Path] =
+        if (os.exists(testSuiteDir / dir))
+          os.walk(testSuiteDir / dir)
+            .filter(_.last.endsWith(".scala"))
+            .filter(os.isFile)
+        else
+          Nil
+      def scalaFilesIf(cond: Boolean, dir: os.SubPath): Seq[os.Path] =
+        if (cond) scalaFilesUnder(dir) else Nil
+
+      val extra = Seq(
+        scalaFilesUnder("shared/src/test/scala")
+          .filter(_.last != "ReflectiveCallTest.scala") // Original comment: uses many forms of structural calls that are not allowed in Scala 3 anymore
+          .filter(_.last != "UTF16Test.scala") // Original comment: refutable pattern match
+          .filter(_.last != "CharsetTest.scala") // Original comment: bogus @tailrec that Scala 2 ignores but Scala 3 flags as an error
+          .filter(_.last != "ClassDiffersOnlyInCaseTest.scala"), // Original comment: looks like the Scala 3 compiler itself does not deal with that
+        // scalaFilesUnder("shared/src/test/require-sam"),
+        // scalaFilesUnder("shared/src/test/require-jdk8"),
+        // scalaFilesUnder("shared/src/test/require-jdk7"),
+        scalaFilesUnder("js/src/test/scala")
+          .filter(_.last != "StackTraceTest.scala") // Original comment: would require `npm install source-map-support`
+          .filter(_.last != "UnionTypeTest.scala") // Original comment: requires the Scala 2 macro defined in Typechecking*.scala
+          .filter(_.last != "OptimizerTest.scala"), // Original comment: something crashes the optimizer, TODO investigate
+        // scalaFilesUnder("js/src/test/require-2.12"),
+        scalaFilesUnder("js/src/test/require-new-target"),
+        // scalaFilesUnder("js/src/test/require-sam"),
+        scalaFilesUnder("js/src/test/scala-new-collections"),
+        scalaFilesIf(!hasModules, "js/src/test/require-no-modules"),
+        scalaFilesIf(hasModules, "js/src/test/require-modules"),
+        scalaFilesIf(hasModules && !linkerConfig.closureCompiler && !isWebAssembly, "js/src/test/require-multi-modules"),
+        scalaFilesIf(moduleKind == sjs.ModuleKind.ESModule, "js/src/test/require-dynamic-import"),
+        scalaFilesIf(moduleKind == sjs.ModuleKind.ESModule, "js/src/test/require-esmodule"),
+        scalaFilesIf(hasAsyncAwait, "js/src/test/require-async-await"),
+        scalaFilesIf(hasAsyncAwait && isWebAssembly, "js/src/test/require-orphan-await")
+      )
+      super.generatedSources() ++ extra.flatten.map(PathRef(_))
+    }
+    def scalacOptions = super.scalacOptions() ++ Seq(
+      "-scalajs-genStaticForwardersForNonTopLevelObjects"
+    )
+
+    def testModuleInitializers = Task.Anon {
+      super.testModuleInitializers() ++ TestSuiteLinkerOptions.moduleInitializers
+    }
+
+    def scalaJsTestInputs = Task.Anon {
+      val resourceDir = build.tests.`sjs-junit`.scalaJsSources().path / "test-suite/js/src/test/resources"
+      val f = (resourceDir / "NonNativeJSTypeTestNatives.js").toNIO
+      org.scalajs.jsenv.Input.Script(f) +: super.scalaJsTestInputs()
+    }
+
+    def fastLinkJSTest = Task {
+
+      // The Scala.js test sources use @JSImport with paths like "../test-classes/modules-test.js",
+      // which are relative to the linker output directory. We need to copy the JS resource files
+      // to a "test-classes" sibling directory.
+
+      val report = super.fastLinkJSTest()
+
+      val newReportDest = Task.dest / "modules"
+      System.err.println(s"Copying ${report.dest.path} to $newReportDest")
+      os.copy(report.dest.path, newReportDest)
+
+      val destParent = newReportDest / os.up
+      assert(destParent.startsWith(Task.dest))
+
+      val resourcesStuff = {
+        val testDir = build.tests.`sjs-junit`.scalaJsSources().path / "test-suite/js/src/test"
+        def jsFilesUnder(dir: os.SubPath): Seq[os.Path] =
+          os.walk(testDir / dir)
+            .filter(_.last.endsWith(".js"))
+            .filter(os.isFile)
+
+        val common = jsFilesUnder("resources")
+
+        val moduleSpecific = self.scalaJSConfig().moduleKind match {
+          case sjs.ModuleKind.NoModule       => Nil
+          case sjs.ModuleKind.CommonJSModule => jsFilesUnder("resources-commonjs")
+          case sjs.ModuleKind.ESModule       => jsFilesUnder("resources-esmodule")
+        }
+
+        common ++ moduleSpecific
+      }
+
+      val testClassesDir = destParent / "test-classes"
+      os.makeDir.all(testClassesDir)
+      for (f <- resourcesStuff) {
+        System.err.println(s"Copying $f to ${testClassesDir / f.last}")
+        os.copy(f, testClassesDir / f.last)
+      }
+
+      // Node.js needs a package.json with {"type": "module"} to treat .js files
+      // as ESM. Without it, fail-load.js is loaded as CJS and gets cached in a
+      // broken state after the first failed import, causing subsequent dynamic
+      // imports of modules that depend on it to silently succeed instead of fail.
+      if (self.scalaJSConfig().moduleKind == sjs.ModuleKind.ESModule)
+        os.write(destParent / "package.json", """{"type": "module"}""" + System.lineSeparator())
+
+      Report(report.publicModules, PathRef(newReportDest))
+    }
+  }
+  object test extends SjsUnitTests
+}
+
+trait NonBootstrappedSjsUnit extends SjsUnit {
+  def mode = Mode.NonBootstrapped
+  def moduleDir: os.Path = super.moduleDir / os.up
+}
+
+trait BootstrappedSjsUnit extends SjsUnit {
+  def mode = Mode.Bootstrapped
+}
+
+object `package` extends Cross[BootstrappedSjsUnit](Customization.allValues) {
+  object `non-bootstrapped` extends Cross[NonBootstrappedSjsUnit](Customization.allValues)
+
+  // no need to have a copy of this one for each cross-matrix entry, so it's factored here
+
+  /** Scala.js sources obtained via GitHub */
+  def scalaJsSources = Task {
+    val ver = ScalaJSVersions.current
+    val cache = Cache.default
+    val archive = cache.file(Artifact(s"https://github.com/scala-js/scala-js/archive/refs/tags/v$ver.zip"))
+      .run.unsafeRun(true)(using cache.ec)
+      .left.map(ex => throw ex)
+      .map(os.Path(_))
+      .merge
+
+    System.err.println(s"Unzipping $archive")
+    val tmpDir = Task.dest / "__tmp"
+    os.unzip(archive, tmpDir)
+
+    val dir = os.list(tmpDir) match {
+      case Seq(dir) if os.isDir(dir) => dir
+      case other =>
+        Task.fail(s"Unexpected root files in $archive: $other")
+    }
+    for (f <- os.list(dir))
+      os.move.into(f, Task.dest)
+
+    os.remove(dir)
+    os.remove(tmpDir)
+
+    PathRef(Task.dest)
+  }
+}
+
+/** How to build the the Scala.js module */
+enum Customization:
+  case Default
+  case ESM
+  case LatestESVersion
+  case LatestESVersionWebAssembly
+
+object Customization:
+  lazy val allValues = Seq(
+    Customization.Default,
+    Customization.ESM,
+    Customization.LatestESVersion,
+    Customization.LatestESVersionWebAssembly
+  )
+
+  given Cross.ToSegments[Customization] =
+    new Cross.ToSegments({
+      case Customization.Default => List("default")
+      case Customization.ESM => List("esm")
+      case Customization.LatestESVersion => List("latest-es-version")
+      case Customization.LatestESVersionWebAssembly => List("latest-es-version-wasm")
+    })


### PR DESCRIPTION
This PR adds a Mill build in the Scala 3 repo.

Using Mill brings a number of benefits, especially in complex builds like the Scala 3 one. It makes it much easier to customize aspects of the build, and to define custom tasks and complex pipelines / chaining of those. Some of the benefits that Mill brings are listed in more detail below.

## Reviewing / overview

Commits are meant to be reviewed in order, to make sense of the changes here. The two main commits are the first one ("Split some sbt build sources"), refactoring the sbt build a bit, and the third one ("Add Mill build"), actually adding the Mill build.

About the amount of lines changed (+5475 / -954), only a part of it corresponds to actual changes.

| Commit | | Comment |
|--------|-|-|
| `Split some sbt build sources` | +1072 / -929 | _Just moves code around_ |
| `Add Mill launchers` | +495 | _Copies Mill launchers from the Mill repo_ |
| `Add Mill build` | +3187 / -25 | **Actual changes** |
| `Add Mill workflows` | +721 | _Copy of existing workflows, using Mill instead of sbt_ |

Among the +3187 / -25 of `Add Mill build`, around 700 lines are for helper definitions under `mill-build/src`, around
+60 / -20 is tweaks helper scripts so that they can use Mill too, around +125 adds the meta-build (`mill-build/build.mill`),
and around +2200 add `*.mill` Mill build files.

The Mill build is added *alongside* the sbt build, so that the two can co-exist for a while. In order for that to be manageable, the first commit of this PR moves some code from `project/Build.scala` to new or existing Scala files under `project/`. Those files are later on used by Mill too.

## Mill build structure

### Main build

The Mill build itself mainly consists in `*.mill` files spread out through the code base, along with standard Scala sources under `mill-build/src`. `build.mill` at the root defines a few helpful commands (`scalac`, `scala`, `publishLocal`, `testCompilation`, that can be run like `./mill scalac Foo.scala`, `./mill testCompilation init/crash/i2468`). `package.mill` files in sub-directories define actual modules of the Mill build: standard library module in `library/package.mill`, compiler in `compiler/package.mill`, REPL in `repl/package.mill`, etc. The sources under `mill-build/src` contain trait or object definitions shared by several modules.

### Meta-build

The build has a meta-build, defined in `mill-build/build.mill`. For Scala 3 here, it mainly adds useful plugins and libraries (mill-mima, Scala.js linker, …). It also adds build sources that are shared with sbt (see above).

### Bootstrapping / cross modules

Most modules, defined in `*/package.mill` files, are defined via a trait, later extended by two singletons, like
```scala
// presentation-compiler/package.mill

trait PresentationCompiler extends CrossScala3Module {
  // …
}

object `package` extends PresentationCompiler, CrossHelper[PresentationCompiler]:
  object `non-bootstrapped` extends PresentationCompiler, CrossHelper.NonBootstrapped
```

This allows building two "shades" of these modules: a non-bootstrapped one, and a bootstrapped one. Defining two shades of modules this way is quite straightforward with Mill. Having a non-bootstrapped version of most modules allows to load them via BSP out-of-the-box.

Like in sbt, non-bootstrapped modules are built with existing already published library / compiler / scaladoc. Bootstrapped modules are built with the library and compiler built right before during bootstrapping. Then the scaladoc built during this last step (bootstrapped) is used for the scaladoc of the bootstrapped modules (so the bootstrapped scaladoc module builds its own scaladoc in particular).

### Scala.js and Mill

Scala.js linking is handled slightly differently than in "standard" Scala.js Mill modules. Here we use [`ScalaJSConfigModule`](https://github.com/com-lihaoyi/mill/blob/0fcdd4e2b08642afacf94614e7f90602c4b0dc8d/libs/scalajslib/config/src/mill/scalajslib/config/ScalaJSConfigModule.scala) raher than [`ScalaJSModule`](https://github.com/com-lihaoyi/mill/blob/0fcdd4e2b08642afacf94614e7f90602c4b0dc8d/libs/scalajslib/src/mill/scalajslib/ScalaJSModule.scala) that Mill users are used to. `ScalaJSConfigModule` allows to customize linking using Scala.js' own API, and it requires the Scala.js linker to be added in the Mill build via the meta-build.

## Cookbook

#### Compiling all sources
```
./mill __.compile
```

#### Running non-bootstrapped library tests
```
./mill library.non-bootstrapped.test
```

#### Running bootstrapped library tests
```
./mill library.test
```

#### Running all bootstrapped compiler tests
```
./mill compiler.test
```

#### Running specific tests with the non-bootstrapped compiler
```
./mill testCompilation init/crash/i2468
./mill compiler.non-bootstrapped.testCompilation init/crash/i2468
```
(both commands are equivalent)

#### Running specific tests with the bootstrapped compiler
```
./mill compiler.testCompilation init/crash/i2468
```

#### Running JUnit test cases or test suites with the non-bootstrapped compiler
```
./mill compiler.non-bootstrapped.test dotty.tools.dotc.CompilationTests.negAll
./mill compiler.non-bootstrapped.test dotty.tools.dotc.CompilationTests
```

#### Running JUnit test cases or test suites with the bootstrapped compiler
```
./mill compiler.test dotty.tools.dotc.CompilationTests.negAll
./mill compiler.test dotty.tools.dotc.CompilationTests
```

#### Generating scaladoc
```
./mill scaladoc.generateScalaDocumentation
./mill scaladoc.generateReferenceDocumentation
./mill scaladoc.generateTestcasesDocumentation
./mill scaladoc.generateSelfDocumentation
```

#### Run presentation compiler tests
```
./mill presentation-compiler.test
```

#### Run a REPL (bootstrapped compiler)
```
./mill -i repl
./mill -i repl.run
```
(both commands are equivalent)

#### Run a REPL (non-bootstrapped compiler)
```
./mill -i repl.non-bootstrapped.run
```

#### Generate an OS-agnostic distribution
```
./mill show dist.jvm
```
(This prints the path to the distribution, which should be `out/dist/jvm.dest`)

#### Generate OS-specific distributions
```
./mill show dist.mac-aarch64
./mill show dist.win-x86_64
./mill show dist.linux-x86_64
```
(This prints the path to the distribution, which should be `out/dist/mac-aarch64.dest`, or `out/dist/win-x86_64.dest`, or `out/dist/linux-x86_64.dest`)

#### Watch mode

All these commands can be run in watch mode, by passing `-w` upfront, like
```
./mill -w library.test
./mill -i -w repl
./mill -w show dist.mac-aarch64
```

## Benefits of Mill

Using Mill brings a number of benefits:
- building non-bootstrapped and bootstrapped versions of modules is straightforward using traits
- there's no need to worry about "target" directories anymore: Mill gives each task a unique directory under `out/` via `Task.dest`, that the task can use to write any content
- watch mode that actually works: running a Mill command with `-w`, like `./mill -w scalac Foo.scala`, makes Mill re-run it upon changes in the build or meta-build that impact this task
- build easier to navigate and make sense of from one's IDE: Mill doesn't split task definitions and implementations, making it easier to browse the build sources from task to task
- no build "axes" to manage: Mill tasks are methods on singletons, possibly inherited from traits. This is all standard Scala, that's easy to make sense of and browse / edit from the IDE.
- when running a Mill command fails, Mill prints the exact task that fails. This is especially useful when reading CI logs, allowing to run the tasks that fail locally very easily.
- no more obscure `inputTask` / `inputTaskDyn` / `.evaluated` / `toTask` / … - the only care in Mill revolves around the "static" task graph: if we'd rather call a task rather than another depending on a cross parameter or a command argument, care must be taken to pick the task outside of the command or task being defined (see `generateScalaDocumentation` in `scaladoc/package.mill` for example)
- Mill makes it trivial to define commands that accept arguments, see `testCompilation` in `compiler/package.mill` or `generateScalaDocumentation` in `scaladoc/package.mill`

## CI

The Mill build is tested on the CI, by duplicating some workflows. These copies of sbt workflows run the exact same tests, but through Mill. Mill-based copies of the `stdlib`, `scaladoc`, and `test-launchers` workflows have been added. In stdlib, the `scripted` job is commented out for now (see below). Note that Mill manages JVMs itself, and the Mill launcher is committed: no need to add steps to setup these.

| Existing worflow | Workflow name | Mill copy workflow | Mill workflow name |
|---------------|---------------|-----------|--------------------|
| `stdlib.yaml` | Compile Full Standard Library | `stdlib-mill.yaml` | Compile Full Standard Library (Mill) |
| `scaladoc.yaml` | scaladoc | `scaladoc-mill.yaml` | scaladoc (Mill) |
| `test-launchers.yml` | Test CLI Launchers on all the platforms | `test-launchers-mill.yml` | Test CLI Launchers on all the platforms (Mill) |

Some scripts used from the CI now read `DIST_USE_MILL` in the environment. If set, they assume they should use
Mill rather than sbt. `DIST_USE_MILL` is set when needed in the Mill CI workflows.

## Missing features

A few things are currently missing in the Mill build, most notably:
- scripted tests, that ensure that sbt is fine with the upcoming Scala version (an sbt scripted test runner could be added, and / or those tests could ensure that Mill itself works fine with it too)
- native OS packages, like MSI and the like: sbt uses [sbt-native-packager](https://github.com/sbt/sbt-native-packager) to build those. We could use [scala-packager](https://github.com/VirtusLab/scala-packager) (used by Scala CLI) to build those from Mill.

## Benchmarks

### Compiling single file

Quick benchmark, that measures the time it takes to compile a simple file via the `scalac` task, with either Mill or sbt. The test shows these times: from a clean checkout and from already compiled Scala 3 sources.

| Initial state | sbt | Mill | Comparison | Time gain |
|---|---|---|---|---|
| Clean checkout | 1:40.89 | 1:42.07 | On par | -1% |
| Sources already compiled | 2.822 | 1.351 | Mill is faster | 52% |

Full details can be found [here](https://gist.github.com/alexarchambault/6d16a35ddf756e07cb0673f627e0eafe). Times are minutes:seconds.milliseconds or seconds.milliseconds (lower is better).

### Running single test

Quick benchmark, that measures the time it takes to run a simple test via the `testCompilation` task, with either Mill or sbt. The test shows these times: from a clean checkout and from already compiled sources, and for running the test via the non-bootstrapped or the bootstrapped compiler.

| Mode | Initial state | sbt | Mill | Comparison | Time gain |
|---|---|---|---|---|---|
| Non bootstrapped | Clean checkout | 1:45.04 | 1:37.83 | Mill is better  | 7% |
| Non bootstrapped | Sources already compiled | 4.748 | 3.849 | Mill is better | 19% |
| Bootstrapped | Clean checkout | 2:50,58 | 2:50.64 | On par |   |   |
| Bootstrapped | Sources already compiled | 6.825 | 3.932 | Mill is better | 42% |

Full details can be found [here](https://gist.github.com/alexarchambault/d6a4c084e012aa3afb4f5721fce9c3ae#file-results-txt). Times are minutes:seconds.milliseconds or seconds.milliseconds (lower is better).

## How much have you relied on LLM-based tools in this contribution?

Work on that started a bit before LLMs became widely used for coding. Occasional use during some batch edits, or to help make sense of some Scala.js errors. Almost no code here is LLM-generated.