### PR TITLE
Workaround for sbt client mode output loss

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1579,6 +1579,9 @@ object Build {
       ),
       // Specify the default entry point of the compiler
       Compile / mainClass := Some("dotty.tools.dotc.Main"),
+      // Disable connectInput to avoid losing stdout/stderr in sbt client mode
+      // Workaround for https://github.com/sbt/sbt/issues/9185
+      run / connectInput := false,
       // Add entry's to the MANIFEST
       packageOptions += ManifestAttributes(("Git-Hash", VersionUtil.gitHash)), // Used by the REPL
       // Packaging configuration of the stdlib
@@ -1715,6 +1718,9 @@ object Build {
       ),
       // Specify the default entry point of the compiler
       Compile / mainClass := Some("dotty.tools.dotc.Main"),
+      // Disable connectInput to avoid losing stdout/stderr in sbt client mode
+      // Workaround for https://github.com/sbt/sbt/issues/9185
+      run / connectInput := false,
       // Add entry's to the MANIFEST
       packageOptions += ManifestAttributes(("Git-Hash", VersionUtil.gitHash)), // Used by the REPL
       // Packaging configuration of the stdlib


### PR DESCRIPTION
This is a workaround for an upstream sbt issue: https://github.com/sbt/sbt/issues/9185.
It impacts this codebase since the update to sbt 1.12.9: https://github.com/scala/scala3/pull/25920.

## How much have you relied on LLM-based tools in this contribution?

Extensively: [Kimi K2.6](https://huggingface.co/moonshotai/Kimi-K2.6) running on EPFL's [AIaaS infrastructure](https://www.epfl.ch/research/facilities/rcp/ai-inference-as-a-service/) bisected sbt versions, identified https://github.com/sbt/sbt/issues/9185 as the root cause, and proposed the workaround.

## How was the solution tested?

Manual tests:

- Verified that `sbt --client "scalac tests/neg/i8569.scala"` now correctly shows compiler diagnostics that were previously missing (e.g. `[E083] Type Error` messages).
- Verified that `sbt "scalac tests/neg/i8569.scala"` (non-client mode) continues to work correctly.
- Confirmed the fix only affects `run` (and `runMain`) on the compiler projects; the `scala3-repl` project is unaffected because it is a separate sbt project that inherits the global `connectInput := true` setting.
