### PR TITLE
Fixes #25979: Fix strictEqualityPatternMatching with GADTs

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1075,7 +1075,7 @@ trait Implicits:
       if strictEquality then
         strictEqualityPatternMatching &&
           (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
-          (ltp <:< rtp || ltp <:< lift(rtp))
+          ltp <:< rtp
       else
         ltp <:< lift(rtp) || rtp <:< lift(ltp)
   }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1075,7 +1075,7 @@ trait Implicits:
       if strictEquality then
         strictEqualityPatternMatching &&
           (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
-          ltp <:< lift(rtp)
+          (ltp <:< rtp || ltp <:< lift(rtp))
       else
         ltp <:< lift(rtp) || rtp <:< lift(ltp)
   }

--- a/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
+++ b/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
@@ -42,3 +42,19 @@ class SIP67Tests extends DottyTest:
         (??? : Foo) match
           case Foo.Bar =>
       """
+
+  @Test
+  def sip67test3: Unit =
+    checkNoErrors:
+      """
+      import scala.language.strictEquality
+      import scala.language.experimental.strictEqualityPatternMatching
+
+      sealed trait Foo[A]
+      object Foo:
+        object Bar extends Foo[Int]
+
+      def a[A](a: Foo[A]) =
+        a match
+          case Foo.Bar =>
+      """

--- a/tests/pos/i25979.scala
+++ b/tests/pos/i25979.scala
@@ -1,0 +1,10 @@
+import scala.language.strictEquality
+import scala.language.experimental.strictEqualityPatternMatching
+
+sealed trait Foo[A]
+object Foo:
+  object Bar extends Foo[Int]
+
+def a[A](a: Foo[A]) =
+  a match
+    case Foo.Bar =>


### PR DESCRIPTION
`assumedCanEqual` lifts the scrutinee type by mapping non-opaque abstract types to their upper bound. When a GADT pattern object is matched against an invariant parameterized scrutinee (e.g. matching `object Bar extends Foo[Int]` against `Foo[A]`), this lifting raises `Foo[A]` to `Foo[Any]`, against which `Foo.Bar.type` is not a subtype because `Foo` is invariant — so the check fails even though GADT reasoning would correctly constrain `A := Int`.

Try the unlifted subtype check first so GADT reasoning gets a chance, falling back to the existing lifted check.

Fixes #25979
## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a simple fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
