### PR TITLE
Preserve user-defined parameter names under CC

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -220,6 +220,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     private var isTopLevel = true
 
     protected def innerApply(tp: Type): Type
+    protected def functionParamNames(tp: Type): List[TermName] = Nil
 
     final def apply(tp: Type) =
       val saved = isTopLevel
@@ -250,7 +251,8 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
         if expand then
           depFun(
               args.init, args.last,
-              isContextual = defn.isContextFunctionClass(tycon.classSymbol)
+              isContextual = defn.isContextFunctionClass(tycon.classSymbol),
+              paramNames = functionParamNames(original)
             ).showing(i"add function refinement $tp ($tycon, ${args.init}, ${args.last}) --> $result", capt)
         else tp
       case _ => tp
@@ -289,6 +291,60 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
   end SetupTypeMap
 
+  private val noFunctionParamNames: Type => List[TermName] = _ => Nil
+
+  /** User-written parameter names for `target`, a plain `FunctionN` type in `root`.
+   *  The names are used when that function type is expanded to a dependent function.
+   */
+  private def functionParamNamesFromRhs(root: Type, rhs: Tree, target: Type)(using Context): List[TermName] =
+    def closureOf(tree: Tree): Option[DefDef] = tree match
+      case closureDef(mdef) => Some(mdef)
+      case Block(_, expr) => closureOf(expr)
+      case Inlined(_, _, expr) => closureOf(expr)
+      case Typed(expr, _) => closureOf(expr)
+      case _ => None
+
+    def termParamClause(paramss: List[ParamClause], body: Tree): Option[(List[ValDef], List[ParamClause], Tree)] =
+      paramss match
+        case Nil :: rest =>
+          Some((Nil, rest, body))
+        case (params @ ((_: ValDef) :: _)) :: rest =>
+          Some((params.asInstanceOf[List[ValDef]], rest, body))
+        case Nil =>
+          closureOf(body).map(mdef => (mdef.paramss, mdef.rhs)).flatMap(termParamClause)
+        case _ :: rest =>
+          termParamClause(rest, body)
+
+    case class Search(paramss: List[ParamClause], body: Tree, names: List[TermName])
+
+    object find extends TypeAccumulator[Search]:
+      def apply(search: Search, tp: Type): Search =
+        tp match
+          case CapturingType(parent, _) =>
+            apply(search, parent)
+          case AnnotatedType(parent, _) =>
+            apply(search, parent)
+          case defn.RefinedFunctionOf(rinfo) =>
+            apply(search, rinfo)
+          case poly: PolyType =>
+            apply(search, poly.resType)
+          case mt: MethodType =>
+            termParamClause(search.paramss, search.body) match
+              case Some((params, rest, body1)) if params.length == mt.paramNames.length =>
+                apply(Search(rest, body1, Nil), mt.resType)
+              case _ => search
+          case AppliedType(_, args) if defn.isNonRefinedFunction(tp) =>
+            termParamClause(search.paramss, search.body) match
+              case Some((params, rest, body1)) if params.length == args.init.length =>
+                if tp eq target then search.copy(names = params.map(_.name))
+                else apply(Search(rest, body1, Nil), args.last)
+              case _ => search
+          case _ => search
+
+    closureOf(rhs) match
+      case Some(mdef) => find(Search(mdef.paramss, mdef.rhs, Nil), root).names
+      case None => Nil
+
   /** Transform the type of an InferredTypeTree by performing the following transformation
     * steps everywhere in the type:
     *  1. Drop retains annotations
@@ -308,11 +364,20 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     *  @param sym           the definition to which this type belongs
     *  @param typeArgFormal if `tp` is an an inferred type argument, the formal parameter info,
     *                       otherwise NotType
+    *  @param sourceParamNames user-written parameter names for plain function types in `tp`
     */
-  private def transformInferredType(tp: Type, sym: Symbol, typeArgFormal: Type = NoType, initialVariance: Int = 1)(using Context): Type = {
+  private def transformInferredType(
+      tp: Type,
+      sym: Symbol,
+      typeArgFormal: Type = NoType,
+      initialVariance: Int = 1,
+      sourceParamNames: Type => List[TermName] = noFunctionParamNames
+    )(using Context): Type = {
 
     def mapInferred(inCaptureRefinement: Boolean): TypeMap = new TypeMap with SetupTypeMap {
       override def toString = "map inferred"
+      override protected def functionParamNames(tp: Type): List[TermName] =
+        sourceParamNames(tp)
 
       variance = initialVariance
       var refiningNames: Set[Name] = Set()
@@ -572,65 +637,16 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       if !tree.hasNuType then
         var transformed =
           if tree.isInferred || sym.is(ModuleVal)
-          then transformInferredType(tree.tpe, sym, typeArgFormal)
+          then
+            val sourceParamNames =
+              if !rhs.isEmpty then (target: Type) => functionParamNamesFromRhs(tree.tpe, rhs, target)
+              else noFunctionParamNames
+            transformInferredType(tree.tpe, sym, typeArgFormal, sourceParamNames = sourceParamNames)
           else transformExplicitType(tree.tpe, sym, tptToCheck = tree)
         if boxed then transformed = transformed.boxDeeply
-        if !rhs.isEmpty && tree.isInferred then
-          transformed = withUserParamNames(transformed, rhs)
         tree.setNuType(
           if sym.hasAnnotation(defn.UncheckedCapturesAnnot) then makeUnchecked(transformed)
           else transformed)
-
-    /** If `tp` was expanded into a curried dependent function during inferred-type
-     *  transformation, propagate the user-written parameter names from the value's
-     *  RHS closure structure so that printed types show the names the user wrote
-     *  rather than synthetic `x$0`-style names.
-     */
-    private def withUserParamNames(tp: Type, rhs: Tree)(using Context): Type =
-      def closureOf(tree: Tree): Option[DefDef] = tree match
-        case closureDef(mdef) => Some(mdef)
-        case Inlined(_, _, expr) => closureOf(expr)
-        case Typed(expr, _) => closureOf(expr)
-        case _ => None
-
-      def walk(tp: Type, paramss: List[ParamClause], innerRhs: Tree): Type = (tp, paramss) match
-        case (_, Nil) => closureOf(innerRhs) match
-          case Some(mdef) => walk(tp, mdef.paramss, mdef.rhs)
-          case None => tp
-        case (CapturingType(parent, refs), _) =>
-          val parent1 = walk(parent, paramss, innerRhs)
-          if parent1 eq parent then tp else tp.derivedCapturingType(parent1, refs)
-        case (at @ AnnotatedType(parent, annot), _) =>
-          val parent1 = walk(parent, paramss, innerRhs)
-          if parent1 eq parent then tp else at.derivedAnnotatedType(parent1, annot)
-        case (rt @ RefinedType(parent, rname, rinfo), _) if rname == nme.apply =>
-          val rinfo1 = walk(rinfo, paramss, innerRhs)
-          if rinfo1 eq rinfo then tp else rt.derivedRefinedType(parent, rname, rinfo1)
-        case (poly: PolyType, (((_: TypeDef) :: _)) :: rest) =>
-          val newRes = walk(poly.resType, rest, innerRhs)
-          if newRes eq poly.resType then tp else poly.derivedLambdaType(resType = newRes)
-        case (mt: MethodType, (params @ ((_: ValDef) :: _)) :: rest) =>
-          val names = params.asInstanceOf[List[ValDef]].map(_.name)
-          if names.length != mt.paramNames.length then tp
-          else
-            val newRes = walk(mt.resType, rest, innerRhs)
-            if !mt.isResultDependent && !mt.isParamDependent then
-              // Construct directly without going through derivedLambdaType.
-              // The latter substitutes paramRefs from `mt` to the new MT, which
-              // wraps any capture-set Vars in a BiMapped that holds a live
-              // reference to the synthetic-named `mt`. That reference is later
-              // resurrected by cc as a TermParamRef in error messages, defeating
-              // the rename. Direct construction avoids the substitution since
-              // there are no paramRefs to retarget for a non-dependent method.
-              mt.companion(names, mt.paramInfos, newRes)
-            else
-              mt.derivedLambdaType(paramNames = names, resType = newRes)
-        case _ => tp
-
-      closureOf(rhs) match
-        case Some(mdef) => walk(tp, mdef.paramss, mdef.rhs)
-        case None => tp
-    end withUserParamNames
 
     /** Transform the type of a val or var or the result type of a def */
     def transformResultType(tpt: TypeTree, sym: Symbol, rhs: Tree = EmptyTree)(using Context): Unit =
@@ -676,7 +692,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
           inContext(ctx.withOwner(meth)):
             paramss.foreach(traverse)
-            transformResultType(tpt, meth)
+            transformResultType(tpt, meth, tree.rhs)
             traverse(tree.rhs)
 
         case tree @ ValDef(_, tpt: TypeTree, _) =>

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -614,7 +614,17 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           if names.length != mt.paramNames.length then tp
           else
             val newRes = walk(mt.resType, rest, innerRhs)
-            mt.derivedLambdaType(paramNames = names, resType = newRes)
+            if !mt.isResultDependent && !mt.isParamDependent then
+              // Construct directly without going through derivedLambdaType.
+              // The latter substitutes paramRefs from `mt` to the new MT, which
+              // wraps any capture-set Vars in a BiMapped that holds a live
+              // reference to the synthetic-named `mt`. That reference is later
+              // resurrected by cc as a TermParamRef in error messages, defeating
+              // the rename. Direct construction avoids the substitution since
+              // there are no paramRefs to retarget for a non-dependent method.
+              mt.companion(names, mt.paramInfos, newRes)
+            else
+              mt.derivedLambdaType(paramNames = names, resType = newRes)
         case _ => tp
 
       closureOf(rhs) match

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -568,23 +568,66 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     /** Transform type of tree, and remember the transformed type as the type of the tree
      *  @pre !(boxed && sym.exists)
      */
-    private def transformTT(tree: TypeTree, sym: Symbol, boxed: Boolean, typeArgFormal: Type = NoType)(using Context): Unit =
+    private def transformTT(tree: TypeTree, sym: Symbol, boxed: Boolean, typeArgFormal: Type = NoType, rhs: Tree = EmptyTree)(using Context): Unit =
       if !tree.hasNuType then
         var transformed =
           if tree.isInferred || sym.is(ModuleVal)
           then transformInferredType(tree.tpe, sym, typeArgFormal)
           else transformExplicitType(tree.tpe, sym, tptToCheck = tree)
         if boxed then transformed = transformed.boxDeeply
+        if !rhs.isEmpty && tree.isInferred then
+          transformed = withUserParamNames(transformed, rhs)
         tree.setNuType(
           if sym.hasAnnotation(defn.UncheckedCapturesAnnot) then makeUnchecked(transformed)
           else transformed)
 
+    /** If `tp` was expanded into a curried dependent function during inferred-type
+     *  transformation, propagate the user-written parameter names from the value's
+     *  RHS closure structure so that printed types show the names the user wrote
+     *  rather than synthetic `x$0`-style names.
+     */
+    private def withUserParamNames(tp: Type, rhs: Tree)(using Context): Type =
+      def closureOf(tree: Tree): Option[DefDef] = tree match
+        case closureDef(mdef) => Some(mdef)
+        case Inlined(_, _, expr) => closureOf(expr)
+        case Typed(expr, _) => closureOf(expr)
+        case _ => None
+
+      def walk(tp: Type, paramss: List[ParamClause], innerRhs: Tree): Type = (tp, paramss) match
+        case (_, Nil) => closureOf(innerRhs) match
+          case Some(mdef) => walk(tp, mdef.paramss, mdef.rhs)
+          case None => tp
+        case (CapturingType(parent, refs), _) =>
+          val parent1 = walk(parent, paramss, innerRhs)
+          if parent1 eq parent then tp else tp.derivedCapturingType(parent1, refs)
+        case (at @ AnnotatedType(parent, annot), _) =>
+          val parent1 = walk(parent, paramss, innerRhs)
+          if parent1 eq parent then tp else at.derivedAnnotatedType(parent1, annot)
+        case (rt @ RefinedType(parent, rname, rinfo), _) if rname == nme.apply =>
+          val rinfo1 = walk(rinfo, paramss, innerRhs)
+          if rinfo1 eq rinfo then tp else rt.derivedRefinedType(parent, rname, rinfo1)
+        case (poly: PolyType, (((_: TypeDef) :: _)) :: rest) =>
+          val newRes = walk(poly.resType, rest, innerRhs)
+          if newRes eq poly.resType then tp else poly.derivedLambdaType(resType = newRes)
+        case (mt: MethodType, (params @ ((_: ValDef) :: _)) :: rest) =>
+          val names = params.asInstanceOf[List[ValDef]].map(_.name)
+          if names.length != mt.paramNames.length then tp
+          else
+            val newRes = walk(mt.resType, rest, innerRhs)
+            mt.derivedLambdaType(paramNames = names, resType = newRes)
+        case _ => tp
+
+      closureOf(rhs) match
+        case Some(mdef) => walk(tp, mdef.paramss, mdef.rhs)
+        case None => tp
+    end withUserParamNames
+
     /** Transform the type of a val or var or the result type of a def */
-    def transformResultType(tpt: TypeTree, sym: Symbol)(using Context): Unit =
+    def transformResultType(tpt: TypeTree, sym: Symbol, rhs: Tree = EmptyTree)(using Context): Unit =
       // First step: Transform the type and record it as knownType of tpt.
       try
         inContext(ctx.addMode(Mode.CCPreciseOwner)):
-          transformTT(tpt, sym, boxed = false)
+          transformTT(tpt, sym, boxed = false, rhs = rhs)
       catch case ex: IllegalCaptureRef =>
         capt.println(i"fail while transforming result type $tpt of $sym")
         throw ex
@@ -630,7 +673,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
           val sym = tree.symbol
           val defCtx = if sym.isOneOf(TermParamOrAccessor) then ctx else ctx.withOwner(sym)
           inContext(defCtx):
-            transformResultType(tpt, sym)
+            transformResultType(tpt, sym, tree.rhs)
             traverse(tree.rhs)
 
         case tree @ TypeApply(fn, args) =>

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -291,12 +291,10 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
   end SetupTypeMap
 
-  private val noFunctionParamNames: Type => List[TermName] = _ => Nil
-
   /** User-written parameter names for `target`, a plain `FunctionN` type in `root`.
    *  The names are used when that function type is expanded to a dependent function.
    */
-  private def functionParamNamesFromRhs(root: Type, rhs: Tree, target: Type)(using Context): List[TermName] =
+  private def functionParamNamesFromRhs(root: Type, rhs: Tree, target: Type)(using Context): List[TermName] = {
     def closureOf(tree: Tree): Option[DefDef] = tree match
       case closureDef(mdef) => Some(mdef)
       case Block(_, expr) => closureOf(expr)
@@ -334,6 +332,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
                 apply(Search(rest, body1, Nil), mt.resType)
               case _ => search
           case AppliedType(_, args) if defn.isNonRefinedFunction(tp) =>
+            // Follow only the function result spine, keeping it aligned with the RHS closure chain.
             termParamClause(search.paramss, search.body) match
               case Some((params, rest, body1)) if params.length == args.init.length =>
                 if tp eq target then search.copy(names = params.map(_.name))
@@ -344,6 +343,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     closureOf(rhs) match
       case Some(mdef) => find(Search(mdef.paramss, mdef.rhs, Nil), root).names
       case None => Nil
+  }
 
   /** Transform the type of an InferredTypeTree by performing the following transformation
     * steps everywhere in the type:
@@ -371,7 +371,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       sym: Symbol,
       typeArgFormal: Type = NoType,
       initialVariance: Int = 1,
-      sourceParamNames: Type => List[TermName] = noFunctionParamNames
+      sourceParamNames: Type => List[TermName] = _ => Nil
     )(using Context): Type = {
 
     def mapInferred(inCaptureRefinement: Boolean): TypeMap = new TypeMap with SetupTypeMap {
@@ -637,11 +637,10 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       if !tree.hasNuType then
         var transformed =
           if tree.isInferred || sym.is(ModuleVal)
-          then
-            val sourceParamNames =
-              if !rhs.isEmpty then (target: Type) => functionParamNamesFromRhs(tree.tpe, rhs, target)
-              else noFunctionParamNames
-            transformInferredType(tree.tpe, sym, typeArgFormal, sourceParamNames = sourceParamNames)
+          then if rhs.isEmpty then transformInferredType(tree.tpe, sym, typeArgFormal)
+          else transformInferredType(
+            tree.tpe, sym, typeArgFormal,
+            sourceParamNames = target => functionParamNamesFromRhs(tree.tpe, rhs, target))
           else transformExplicitType(tree.tpe, sym, tptToCheck = tree)
         if boxed then transformed = transformed.boxDeeply
         tree.setNuType(

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -84,4 +84,7 @@ class PrintingTest {
 
   @Test
   def inlining: Unit = testIn("tests/printing/inlining", "inlining")
+
+  @Test
+  def cc: Unit = testIn("tests/printing/cc", "cc")
 }

--- a/tests/neg-custom-args/captures/i15923.check
+++ b/tests/neg-custom-args/captures/i15923.check
@@ -7,6 +7,6 @@
    |Found:    Id[Cap^{any}]^'s2
    |Required: Id[Cap^'s1]^'s3
    |
-   |where:    any is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): Cap^{lcap} ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
+   |where:    any is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): (cap: Cap^{lcap}) ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i15923b.check
+++ b/tests/neg-custom-args/captures/i15923b.check
@@ -4,7 +4,7 @@
   |Capability `lcap` outlives its scope: it leaks into outer capture set 's1 which is owned by value leak.
   |The leakage occurred when trying to match the following types:
   |
-  |Found:    (x$0: Cap^) -> Id[Cap^{x$0}]
+  |Found:    (lcap: Cap^) -> Id[Cap^{lcap}]
   |Required: (lcap: Cap^) => Id[Cap^'s1]^'s2
   |
   |where:    => refers to a root capability created in value leak when checking argument to parameter op of method withCap

--- a/tests/neg-custom-args/captures/i25971-multiarg.check
+++ b/tests/neg-custom-args/captures/i25971-multiarg.check
@@ -1,0 +1,14 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25971-multiarg.scala:10:26 ------------------------------
+10 |  val g: (IO, IO) => IO = f // error
+   |                          ^
+   |                        Found:    (Test.f : (a: IO, b: IO) -> IO^{a})
+   |                        Required: (IO^, IO^) => IO^{any}
+   |
+   |                        Note that capability `x$0` cannot flow into capture set {any}
+   |                        because (x$0 : IO) is not visible from any in value g.
+   |
+   |                        where:    =>  refers to a root capability in the type of value g
+   |                                  ^   refers to the root capability caps.any
+   |                                  any is a root capability classified as SharedCapability in the type of value g
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25971-multiarg.check
+++ b/tests/neg-custom-args/captures/i25971-multiarg.check
@@ -4,8 +4,8 @@
    |                        Found:    (Test.f : (a: IO, b: IO) -> IO^{a})
    |                        Required: (IO^, IO^) => IO^{any}
    |
-   |                        Note that capability `x$0` cannot flow into capture set {any}
-   |                        because (x$0 : IO) is not visible from any in value g.
+   |                        Note that capability `a` cannot flow into capture set {any}
+   |                        because (a : IO) is not visible from any in value g.
    |
    |                        where:    =>  refers to a root capability in the type of value g
    |                                  ^   refers to the root capability caps.any

--- a/tests/neg-custom-args/captures/i25971-multiarg.scala
+++ b/tests/neg-custom-args/captures/i25971-multiarg.scala
@@ -1,0 +1,10 @@
+// Multiple parameters per arrow: each name should be preserved in the
+// printed type that surfaces in the cc-time error.
+import language.experimental.captureChecking
+import caps.*
+
+class IO extends caps.SharedCapability
+
+object Test:
+  val f = (a: IO, b: IO) => a
+  val g: (IO, IO) => IO = f // error

--- a/tests/neg-custom-args/captures/i25971-shadow.check
+++ b/tests/neg-custom-args/captures/i25971-shadow.check
@@ -4,8 +4,8 @@
    |                        Found:    (Test.f : (x: IO) -> (x: IO) -> IO^{x})
    |                        Required: IO^ => IO^ =>² IO^{any}
    |
-   |                        Note that capability `x$0` cannot flow into capture set {any}
-   |                        because (x$0 : IO) is not visible from any in value g.
+   |                        Note that capability `x` cannot flow into capture set {any}
+   |                        because (x : IO) is not visible from any in value g.
    |
    |                        where:    =>  refers to a root capability in the type of value g
    |                                  =>² refers to a root capability in the type of value g

--- a/tests/neg-custom-args/captures/i25971-shadow.check
+++ b/tests/neg-custom-args/captures/i25971-shadow.check
@@ -1,0 +1,15 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25971-shadow.scala:10:26 --------------------------------
+10 |  val g: IO => IO => IO = f // error
+   |                          ^
+   |                        Found:    (Test.f : (x: IO) -> (x: IO) -> IO^{x})
+   |                        Required: IO^ => IO^ =>² IO^{any}
+   |
+   |                        Note that capability `x$0` cannot flow into capture set {any}
+   |                        because (x$0 : IO) is not visible from any in value g.
+   |
+   |                        where:    =>  refers to a root capability in the type of value g
+   |                                  =>² refers to a root capability in the type of value g
+   |                                  ^   refers to the root capability caps.any
+   |                                  any is a root capability classified as SharedCapability in the type of value g
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25971-shadow.scala
+++ b/tests/neg-custom-args/captures/i25971-shadow.scala
@@ -1,0 +1,10 @@
+// Shadowed names: the inner closure rebinds `x`, both levels should print as
+// `x` in the error message rather than synthetic names.
+import language.experimental.captureChecking
+import caps.*
+
+class IO extends caps.SharedCapability
+
+object Test:
+  val f = (x: IO) => (x: IO) => x
+  val g: IO => IO => IO = f // error

--- a/tests/neg-custom-args/captures/i25971.check
+++ b/tests/neg-custom-args/captures/i25971.check
@@ -4,6 +4,6 @@
    |                           Found:    (Test.f : [C^] => (xs: List[IO^{C}]) -> (ys: IO^{C}) -> IO^{C} ->{ys} Unit)
    |                           Required: [C^] => (x$1: List[IO^{C}]) -> IO^{C} -> IO^{C} -> Unit
    |
-   |                           Note that capability `x$0` cannot flow into capture set {}.
+   |                           Note that capability `ys` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25971.check
+++ b/tests/neg-custom-args/captures/i25971.check
@@ -1,0 +1,9 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25971.scala:11:69 ---------------------------------------
+11 |  val g: [C^ <: {any}] => List[IO^{C}] -> IO^{C} -> IO^{C} -> Unit = f // error
+   |                                                                     ^
+   |                           Found:    (Test.f : [C^] => (xs: List[IO^{C}]) -> (ys: IO^{C}) -> IO^{C} ->{ys} Unit)
+   |                           Required: [C^] => (x$1: List[IO^{C}]) -> IO^{C} -> IO^{C} -> Unit
+   |
+   |                           Note that capability `x$0` cannot flow into capture set {}.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25971.scala
+++ b/tests/neg-custom-args/captures/i25971.scala
@@ -1,0 +1,11 @@
+// User-written parameter names should be preserved when CC reveals
+// curried-dependent functions in error messages — including for the
+// polymorphic case from the issue.
+import language.experimental.captureChecking
+import caps.*
+
+class IO extends caps.SharedCapability
+
+object Test:
+  val f = [C^ <: {any}] => (xs: List[IO^{C}]) => (ys: IO^{C}) => (zs: IO^{C}) => { val _ = ys; () }
+  val g: [C^ <: {any}] => List[IO^{C}] -> IO^{C} -> IO^{C} -> Unit = f // error

--- a/tests/neg-custom-args/captures/scope-extrusions.check
+++ b/tests/neg-custom-args/captures/scope-extrusions.check
@@ -145,8 +145,8 @@
    |                     Found:    (f3 : (x: IO) -> IO^{x})
    |                     Required: IO^ => IO^{any}
    |
-   |                     Note that capability `x$0` cannot flow into capture set {any}
-   |                     because (x$0 : IO) is not visible from any in value f4.
+   |                     Note that capability `x` cannot flow into capture set {any}
+   |                     because (x : IO) is not visible from any in value f4.
    |
    |                     where:    =>  refers to a root capability in the type of value f4
    |                               ^   refers to the root capability caps.any

--- a/tests/neg-custom-args/captures/scope-extrusions.check
+++ b/tests/neg-custom-args/captures/scope-extrusions.check
@@ -142,7 +142,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scope-extrusions.scala:33:21 -----------------------------
 33 |  val f4: IO => IO = f3  // error
    |                     ^^
-   |                     Found:    (f3 : (x$0: IO) -> IO^{x$0})
+   |                     Found:    (f3 : (x: IO) -> IO^{x})
    |                     Required: IO^ => IO^{any}
    |
    |                     Note that capability `x$0` cannot flow into capture set {any}

--- a/tests/neg-custom-args/captures/sep-curried-par.check
+++ b/tests/neg-custom-args/captures/sep-curried-par.check
@@ -31,8 +31,8 @@
 21 |  foo(c)(c) // error: separation
    |      ^
    |Separation failure: argument of type  (c : () => Unit)
-   |to a function of type (x$0: () => Unit) -> (() ->{c, any} Unit) ->{x$0} Unit
-   |corresponds to capture-polymorphic formal parameter x$0 of type  () =>² Unit
+   |to a function of type (p1: () => Unit) -> (() ->{c, any} Unit) ->{p1} Unit
+   |corresponds to capture-polymorphic formal parameter p1 of type  () =>² Unit
    |and hides capabilities  {c}.
    |Some of these overlap with the captures of the function result with type  (() ->{c, any} Unit) ->{c} Unit.
    |
@@ -43,7 +43,7 @@
    |  The two sets overlap at               : {c}
    |
    |where:    =>  refers to a root capability in the type of parameter c
-   |          =>² refers to a root capability created in method test when checking argument to parameter x$0 of method apply
+   |          =>² refers to a root capability created in method test when checking argument to parameter p1 of method apply
 -- Error: tests/neg-custom-args/captures/sep-curried-par.scala:23:65 ---------------------------------------------------
 23 |  val bar = (p1: () => Unit) => (p2: () ->{p1, any} Unit) => par(p1, p2) // error separation
    |                                                                 ^^

--- a/tests/printing/cc/i25971.check
+++ b/tests/printing/cc/i25971.check
@@ -1,0 +1,36 @@
+[[syntax trees at end of                        cc]] // tests/printing/cc/i25971.scala
+package <empty> {
+  import language.experimental.captureChecking
+  import caps.*
+  @SourceFile("tests/printing/cc/i25971.scala") class File() extends Object() {}
+  final lazy module val Test: Test^{} = new Test()
+  @SourceFile("tests/printing/cc/i25971.scala") final module class Test()
+     extends Object() {
+    private[this] type $this = Test.type
+    private def writeReplace(): AnyRef =
+      new scala.runtime.ModuleSerializationProxy(classOf[Test.type])
+    val f:
+      [C^] => (xs: List[File^{C}]) -> (ys: File^{C}) -> File^{C} ->{ys} Unit = [
+      C^] => (xs: List[File^{C}]) => (ys: File^{C}) => (zs: File^{C}) =>
+      {
+        matchResult1[Unit]:
+          {
+            case val x1: (File^{ys}) @RuntimeChecked =
+              ys:(File^{ys}) @RuntimeChecked
+            return[matchResult1] ()
+          }
+        ()
+      }
+    val g: (ys: File^) -> File^ ->{ys} Unit = (ys: File^) => (zs: File^) =>
+      {
+        matchResult2[Unit]:
+          {
+            case val x2: (File^{ys}) @RuntimeChecked =
+              ys:(File^{ys}) @RuntimeChecked
+            return[matchResult2] ()
+          }
+        ()
+      }
+  }
+}
+

--- a/tests/printing/cc/i25971.scala
+++ b/tests/printing/cc/i25971.scala
@@ -1,0 +1,8 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File
+
+object Test:
+  val f = [C^ <: {any}] => (xs: List[File^{C}]) => (ys: File^{C}) => (zs: File^{C}) => { val _ = ys; () }
+  val g = (ys: File^) => (zs: File^) => { val _ = ys; () }


### PR DESCRIPTION
Fixes #25971 by preserving user-written lambda parameter names when CC expands inferred function types into dependent function types.

The change passes RHS closure parameter names into dependent function construction in Setup, so both printed inferred types and later capture-checking diagnostics refer to the user names rather than synthetic x$0 names. Explicit ascriptions keep using their written type parameter names.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for life.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
