### PR TITLE
Fixes #23952: Retry implicit search when method type was over-approximated

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4674,8 +4674,13 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
             val usingDefaultArgs =
               wtp.paramNames.zipWithIndex
                 .exists((n, i) => !namedArgs.exists(_.name == n) && !findDefaultArgument(i).isEmpty)
+            // When `tree` is a Block or Inlined produced by `wrapDefs`, `wtp` was
+            // approximated by `avoidingType` and may have lost the precise types
+            // needed for implicit search (issue #23952). Retry so that `typedApply`
+            // can recover the un-approximated method type via `methPart`.
+            val treeWrapsApp = tree.isInstanceOf[Block] || tree.isInstanceOf[Inlined]
 
-            if !usingDefaultArgs then
+            if !usingDefaultArgs && !treeWrapsApp then
               issueErrors(tree, args, failureType)
             else
               val app = cpy.Apply(tree)(untpd.TypedSplice(tree), namedArgs)

--- a/tests/pos/i23952.scala
+++ b/tests/pos/i23952.scala
@@ -1,0 +1,25 @@
+trait Typeclass[I]
+
+sealed trait Enumm:
+  type Insider
+
+object Enumm:
+  case object Enumm1 extends Enumm:
+    case class Insider()
+
+    object Insider:
+      given t: Typeclass[Insider] = new Typeclass[Insider] {}
+
+class Foo
+implicit val f: Foo = new Foo
+
+def pathDependentTypeDefaultParam(tpe: Enumm)(i: tpe.Insider, p: Int = 0)(using t: Typeclass[tpe.Insider]): Int = p
+def defaultParamNotPDT(tpe: Enumm)(i: tpe.Insider, p: Int = 0)(using t: Foo): Int = p
+def pathDependentTypeDefaultParamOwnList(tpe: Enumm)(i: tpe.Insider)(p: Int = 0)(using t: Typeclass[tpe.Insider]): Int = p
+
+def main =
+  pathDependentTypeDefaultParam(Enumm.Enumm1)(Enumm.Enumm1.Insider())
+  pathDependentTypeDefaultParam(Enumm.Enumm1)(Enumm.Enumm1.Insider(), p = 0)
+  defaultParamNotPDT(Enumm.Enumm1)(Enumm.Enumm1.Insider())
+  pathDependentTypeDefaultParamOwnList(Enumm.Enumm1)(Enumm.Enumm1.Insider())()
+  pathDependentTypeDefaultParamOwnList(Enumm.Enumm1)(Enumm.Enumm1.Insider())(p = 0)


### PR DESCRIPTION
When the typed application is wrapped in a Block by `wrapDefs` (because arguments must be lifted, e.g. for default-arg evaluation order), the Block's type is computed by `avoidingType`, which loses references to the locally lifted vals. For path-dependent using parameters this can turn a perfectly searchable type like `Typeclass[tpe$1.Insider]` into an unsearchable approximation like `Nothing & Typeclass[? <: ...]`, causing implicit search to fail.

PR #22458 had tightened the retry path in `addImplicitArgs` so that it runs only when there is a default arg to fill into the using clause (`usingDefaultArgs`). That tightening regressed cases where the only problem was the avoidance approximation: the retry is what allows `typedApply` to recover the un-approximated method type via `methPart`.

Re-enable the retry whenever the tree we are adapting was wrapped in a Block or Inlined, so that path-dependent using arguments can still be inferred.

Fixes #23952

## How much have you relied on LLM-based tools in this contribution?

Extensively, but this is a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
