### PR TITLE
Fixes #24537: Prevent infinite recursion in compareAppliedTypeParamRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -58,6 +58,24 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     if Config.checkTypeComparerReset then checkReset()
 
   private var pendingSubTypes: util.MutableSet[(Type, Type)] | Null = null
+  /** Tracks the (tycon, other, fromBelow) tuples currently being compared by
+   *  `compareAppliedTypeParamRef` to guard against infinite recursion where
+   *  `canInstantiate` in `compareAppliedType1`/`compareAppliedType2` calls back
+   *  into `compareAppliedTypeParamRef` with the same parameters.
+   */
+  private val pendingAppliedTypeParamRefs =
+    mutable.Set.empty[(TypeParamRef, AppliedType, Boolean)]
+
+  /** Run `op` unless a `compareAppliedTypeParamRef` call with the same key is
+   *  already in progress, in which case return false to break the cycle.
+   */
+  private inline def guardAppliedTypeParamRef(
+      tycon: TypeParamRef, other: AppliedType, fromBelow: Boolean)(inline op: Boolean): Boolean =
+    val key = (tycon, other, fromBelow)
+    !pendingAppliedTypeParamRefs.contains(key) && {
+      pendingAppliedTypeParamRefs += key
+      try op finally pendingAppliedTypeParamRefs -= key
+    }
   private var recCount = 0
   private var monitored = false
 
@@ -111,6 +129,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     pendingSubTypes match
       case null => ()
       case ps => assert(ps.isEmpty)
+    assert(pendingAppliedTypeParamRefs.isEmpty)
     assert(canCompareAtoms == true)
     assert(successCount == 0)
     assert(totalCount == 0)
@@ -1273,9 +1292,15 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                 tl => otherTycon.appliedTo(bodyArgs(tl)))
             else
               otherTycon
-          rollbackConstraintsUnless:
-            (assumedTrue(tycon) || directionalIsSubType(tycon, adaptedTycon))
-              && directionalRecur(adaptedTycon.appliedTo(args), other)
+          // Guard against infinite recursion through `canInstantiate` in
+          // `compareAppliedType1`/`compareAppliedType2`, which calls back into
+          // `compareAppliedTypeParamRef` with the same (tycon, other, fromBelow),
+          // looping indefinitely when the constraint solver can't converge on a
+          // valid instantiation. See i24537.
+          guardAppliedTypeParamRef(tycon, other, fromBelow):
+            rollbackConstraintsUnless:
+              (assumedTrue(tycon) || directionalIsSubType(tycon, adaptedTycon))
+                && directionalRecur(adaptedTycon.appliedTo(args), other)
         }
       }
     end compareAppliedTypeParamRef

--- a/tests/pos/i24537.scala
+++ b/tests/pos/i24537.scala
@@ -1,0 +1,39 @@
+// Regression test for scala/scala3#24537
+// The compiler used to hang in `TypeComparer.compareAppliedTypeParamRef` when
+// resolving chained extension methods on an opaque refinement type combined
+// with a higher-kinded lower-bounded type parameter, as exercised by the
+// Iron library (`:|`) together with `fs2.Stream.evalMapFilter`.
+
+import scala.language.implicitConversions
+
+opaque type IronType[A, C] <: A = A
+type :|[A, C] = IronType[A, C]
+
+final class Implication[C1, C2]
+type ==>[C1, C2] = Implication[C1, C2]
+object Implication:
+  given [C]: (C ==> C) = Implication()
+  given [C1, C2](using C1 <:< C2): (C1 ==> C2) = Implication()
+
+implicit inline def autoCastIron[A, C1, C2](inline v: A :| C1)(using C1 ==> C2): A :| C2 =
+  v.asInstanceOf[A :| C2]
+
+class Stream[+F[_], +O]:
+  def evalMapFilter[F2[x] >: F[x], O2](f: O => F2[Option[O2]]): Stream[F2, O2] = ???
+
+class Path
+final class A
+final class D
+type AD = D & A
+
+object FExt:
+  extension (p: Path)
+    def asD[F[_]]: F[Option[Path :| D]] = ???
+
+  extension (p: Path :| D)
+    def ls[F[_]]: Stream[F, Path] = ???
+
+  // This must compile without the compiler hanging.
+  extension (p: Path :| AD)
+    def lsD[F[_]]: Stream[F, Path :| D] =
+      p.ls.evalMapFilter(_.asD)


### PR DESCRIPTION
When comparing applied types whose constructors are both TypeParamRefs, `canInstantiate` in `compareAppliedType1`/`compareAppliedType2` calls back into `compareAppliedTypeParamRef`, which recurses via `directionalRecur` into `compareAppliedType*` again. If the constraint solver cannot make progress (for example, because the argument positions are invariant and the args do not unify), the recursion never terminates — causing the compiler to hang, as reported for code using Iron's `:|` refinement type combined with `fs2.Stream.evalMapFilter` (which has an `F2[x] >: F[x]` lower-bounded higher-kinded parameter).

Track the `(tycon, other, fromBelow)` tuples currently in flight through `compareAppliedTypeParamRef` and refuse to re-enter with the same key. This breaks the cycle without otherwise altering subtyping behaviour — when the recursion is not divergent, the set is cleaned up by the enclosing `finally` and the next call proceeds normally.

Fixes #24537

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it is a simple fix

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)