### PR TITLE
Fixes #25754: Preserve apply result type after beta reducing through opaque proxies

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
+++ b/compiler/src/dotty/tools/dotc/transform/BetaReduce.scala
@@ -90,17 +90,24 @@ object BetaReduce:
       case TypeApply(Select(expr, nme.asInstanceOfPM), List(tpt)) =>
         recur(expr, argss)
       case _ => None
+    // The reduced body's type may be narrower than the apply's result type when
+    // an opaque type was transparent inside the lambda but not at the call site
+    // (see #25754). Cast back so callers see the originally declared type.
+    def adaptReduced(reduced: Tree, expectedTpe: Type): Tree =
+      if reduced.tpe <:< expectedTpe then reduced
+      else reduced.cast(expectedTpe)
+
     tree match
       case Apply(Select(fn, nme.apply), args) if defn.isFunctionNType(fn.tpe) =>
         recur(fn, List(args)) match
           case Some(reduced) =>
-            seq(bindingsBuf.result(), reduced).withSpan(tree.span)
+            seq(bindingsBuf.result(), adaptReduced(reduced, tree.tpe)).withSpan(tree.span)
           case None =>
             tree
       case Apply(TypeApply(Select(fn, nme.apply), targs), args) if fn.tpe.typeSymbol eq dotc.core.Symbols.defn.PolyFunctionClass =>
         recur(fn, List(targs, args)) match
           case Some(reduced) =>
-            seq(bindingsBuf.result(), reduced).withSpan(tree.span)
+            seq(bindingsBuf.result(), adaptReduced(reduced, tree.tpe)).withSpan(tree.span)
           case None =>
             tree
       case _ =>

--- a/tests/pos/i25754.scala
+++ b/tests/pos/i25754.scala
@@ -1,0 +1,10 @@
+object Tag {
+  opaque type @@[A, T] = A
+  inline def tag[T]: [A] => A => A @@ T = [A] => a => a
+}
+
+import Tag.*
+
+inline def test[A](f: (Int @@ Unit) => A): A = f(tag[Unit](1))
+
+val _ = test(identity)


### PR DESCRIPTION
After PR #25126 made `Any_typeCast` calls pure (fixing #24990), opaque proxy `ValDef`s used to refine `this`/term references became pure bindings. As a side effect, `BetaReduce` now unwraps the surrounding `Block`/`Inlined` and reduces the inner polyfunction application. The substituted body's inferred type can be narrower than the apply's declared result type when an opaque alias was transparent inside the lambda but is opaque at the call site, leaving the outer expression with the wrong type (e.g. `(1: Int)` instead of `Int @@ Unit`).

Cast the reduced body back to the apply's expected result type when it is no longer a subtype, restoring the type the caller saw before reduction.

Fixes #25754

## How much have you relied on LLM-based tools in this contribution?

Extensively, but the fix is small.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)