### PR TITLE
Implement SIP-80: Target-Typed Companion Shorthand (experimental)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -122,6 +122,11 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class ContextBoundTypeTree(tycon: Tree, paramName: TypeName, ownName: TermName)(implicit @constructorOnly src: SourceFile) extends Tree
   case class MacroTree(expr: Tree)(implicit @constructorOnly src: SourceFile) extends Tree
 
+  /** `.X` in a target-typed position (SIP-80, experimental.targetTypedCompanionShorthand).
+   *  Resolved by the Typer to `Select(T, X)` where T is the principal expected type.
+   */
+  case class RelativeSelect(name: TermName)(implicit @constructorOnly src: SourceFile) extends TermTree
+
   case class ImportSelector(imported: Ident, renamed: Tree = EmptyTree, bound: Tree = EmptyTree)(implicit @constructorOnly src: SourceFile) extends Tree {
     // TODO: Make bound a typed tree?
 
@@ -764,6 +769,10 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case tree: MacroTree if expr `eq` tree.expr => tree
       case _ => finalize(tree, untpd.MacroTree(expr)(using tree.source))
     }
+    def RelativeSelect(tree: Tree)(name: TermName)(using Context): Tree = tree match {
+      case tree: RelativeSelect if name == tree.name => tree
+      case _ => finalize(tree, untpd.RelativeSelect(name)(using tree.source))
+    }
   }
 
   abstract class UntypedTreeMap(cpy: UntypedTreeCopier = untpd.cpy) extends TreeMap(cpy) {
@@ -817,6 +826,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         tree
       case MacroTree(expr) =>
         cpy.MacroTree(tree)(transform(expr))
+      case RelativeSelect(_) =>
+        tree
       case CapturesAndResult(refs, parent) =>
         cpy.CapturesAndResult(tree)(transform(refs), transform(parent))
       case UseRef(ref, initially) =>
@@ -878,6 +889,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         this(x, splice)
       case MacroTree(expr) =>
         this(x, expr)
+      case RelativeSelect(_) =>
+        x
       case CapturesAndResult(refs, parent) =>
         this(this(x, refs), parent)
       case UseRef(ref, _) =>

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -41,6 +41,7 @@ object Feature:
   val multiSpreads = experimental("multiSpreads")
   val subCases = experimental("subCases")
   val relaxedLambdaSyntax = experimental("relaxedLambdaSyntax")
+  val targetTypedCompanionShorthand = experimental("targetTypedCompanionShorthand")
   val safe = experimental("safe")
 
   val nonViralExperimentalFeatures: Set[TermName] =
@@ -80,6 +81,7 @@ object Feature:
     (multiSpreads, "Enable experimental varargs with multi-spreads"),
     (subCases, "Enable experimental match expressions with sub-cases"),
     (relaxedLambdaSyntax, "Enable experimental relaxed lambda syntax"),
+    (targetTypedCompanionShorthand, "Allow target-typed companion shorthand (`.X` for `T.X` in target-typed positions)"),
     (safe, "Require safe mode"),
   )
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2898,6 +2898,9 @@ object Parsers {
         case MACRO =>
           val start = in.skipToken()
           MacroTree(simpleExpr(Location.Elsewhere))
+        case DOT if in.lookahead.token == IDENTIFIER && in.featureEnabled(Feature.targetTypedCompanionShorthand) =>
+          val start = in.skipToken()
+          atSpan(start) { RelativeSelect(ident()) }
         case _ =>
           if isLiteral then
             literal()
@@ -3449,6 +3452,9 @@ object Parsers {
           val typed = Typed(Ident(nme.WILDCARD), refinedType())
           Bind(nme.WILDCARD, typed).withMods(addMod(Modifiers(), givenMod))
         }
+      case DOT if in.lookahead.token == IDENTIFIER && in.featureEnabled(Feature.targetTypedCompanionShorthand) =>
+        val start = in.skipToken()
+        simplePatternRest(atSpan(start) { RelativeSelect(ident()) })
       case _ =>
         if (isLiteral) literal(inPattern = true)
         else {

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -827,6 +827,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         "Thicket {" ~~ toTextGlobal(trees, "\n") ~~ "}"
       case MacroTree(call) =>
         keywordStr("macro ") ~ toTextGlobal(call)
+      case RelativeSelect(name) =>
+        Str(".") ~ toText(name)
       case tree @ Quote(body, tags) =>
         val tagsText = (keywordStr("<") ~ toTextGlobal(tags, ", ") ~ keywordStr(">")).provided(tree.tags.nonEmpty)
         val exprTypeText = (keywordStr("[") ~ toTextGlobal(tpd.bodyType(tree.asInstanceOf[tpd.Quote])) ~ keywordStr("]")).provided(printDebug && tree.typeOpt.exists)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2840,6 +2840,22 @@ trait Applications extends Compatibility {
       case arg :: args1 if !altFormals.exists(_.isEmpty) =>
         def isUniform[T](xs: List[T])(p: (T, T) => Boolean) = xs.forall(p(_, xs.head))
         val formalsForArg: List[Type] = altFormals.map(_.head)
+        // SIP-80: when an argument is `.X`, pre-type it with the common formal
+        // shared across all surviving candidates. This handles the
+        // overload-with-default-args case (`def bar(a: Animal)` vs.
+        // `def bar(a: Animal, b: Animal = ...)` — both share `Animal` at
+        // position 0, so `bar(.Cat)` resolves cleanly), and it stops a
+        // partially-typed `RelativeSelect` from leaking into PostTyper.
+        arg match
+          case _: untpd.RelativeSelect
+              if formalsForArg.forall(_.exists)
+                && isUniform(formalsForArg)(_ frozen_=:= _) =>
+            val commonFormal = formalsForArg.head
+            if isFullyDefined(commonFormal, ForceDegree.flipBottom) then
+              withMode(Mode.ImplicitsEnabled) {
+                pt.cacheArg(arg, pt.typedArg(arg, commonFormal))
+              }
+          case _ =>
         def argTypesOfFormal(formal: Type): List[Type] =
           formal.dealias match {
             case defn.FunctionOf(args, result, isImplicit) => args

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1138,6 +1138,122 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     tree1
   }
 
+  /** Type a relative selection `.X` (SIP-80) by resolving it as `T.X` where `T`
+   *  is the principal companion-bearing class derived from the expected type.
+   *
+   *  Resolution algorithm:
+   *    1. Reject when `experimental.targetTypedCompanionShorthand` is not enabled.
+   *    2. Strip prototype layers from `pt` to obtain a value type `target`.
+   *    3. Locate `target.classSymbol.companionModule`; if absent, error.
+   *    4. Build `Select(companionRef, name)` and re-typecheck against `pt`.
+   *  Implicit conversions, overload resolution, and pattern-mode handling fall
+   *  out of the reuse of `typedSelect`/`adapt`.
+   */
+  def typedRelativeSelect(tree: untpd.RelativeSelect, pt: Type)(using Context): Tree =
+    record("typedRelativeSelect")
+    // Note: gating happens at the parser via `featureEnabled(targetTypedCompanionShorthand)`,
+    // mirroring how `multiSpreads`, `subCases`, and `relaxedLambdaSyntax` are wired.
+    // If we reach here, the import (or `-language:experimental.targetTypedCompanionShorthand`)
+    // is in scope and the parser has produced a `RelativeSelect` node.
+
+    // Strip ProtoType layers (SelectionProto / IgnoredProto / FunProto / PolyProto)
+    // until we hit a real value type. WildcardType / unsolved TypeVars / TypeBounds
+    // mean the expected type isn't determined and we cannot resolve.
+    //
+    // SelectionProto wraps the original expected type as `IgnoredProto(orig)`. When
+    // the relative selection is the function part of an Apply (e.g. `.Node(1, x, y)`)
+    // or a TypeApply (e.g. `.Node[Int]`), pt is a FunProto/PolyProto whose result
+    // is what determines the target — peel it.
+    //
+    // Opaque type aliases must NOT be dealiased: they have their own companion
+    // (per SIP-80 §opaque types). We use widenSingleton + dropDependentRefinement
+    // but skip `.dealias`.
+    def principalTarget(tp: Type): Type = tp match
+      case tp: SelectionProto => principalTarget(tp.memberProto)
+      case tp: IgnoredProto   => principalTarget(tp.ignored)
+      case tp: FunProto       => principalTarget(tp.resultType)
+      case tp: PolyProto      => principalTarget(tp.resType)
+      case tp: ProtoType      => NoType
+      case tp: TypeBounds     => NoType
+      case tp: TypeVar =>
+        // If the TypeVar is instantiated, use the instance type. Otherwise,
+        // fall back to the current upper bound from the typer state's
+        // constraint. This is what unblocks `Some(.Red)` with target type
+        // `Option[Color]`: `Some.apply[A]: A => Some[A]` is constrained via
+        // `constrainResult(Some[A], Option[Color])` to `A <: Color`, so the
+        // upper bound is Color and `.Red` resolves correctly.
+        val inst = tp.instanceOpt
+        if inst.exists then principalTarget(inst)
+        else
+          val hi = TypeComparer.fullUpperBound(tp.origin)
+          if !hi.exists || hi.isExactlyAny then NoType
+          else principalTarget(hi)
+      case tp if tp eq WildcardType => NoType
+      case tp =>
+        val w = tp.widenExpr
+        w match
+          case w: TypeVar => principalTarget(w)
+          // SIP-80: special-case `T | Null` (and `Null | T`) to resolve as `T`.
+          // `Null` has no useful companion members and the union is the common
+          // idiom for nullable references — making `val c: Color | Null = .Red`
+          // resolve `.Red` against `Color` is the natural reading.
+          case OrType(lhs, rhs) if rhs.classSymbol == defn.NullClass => principalTarget(lhs)
+          case OrType(lhs, rhs) if lhs.classSymbol == defn.NullClass => principalTarget(rhs)
+          case _ => w.dropDependentRefinement
+
+    val target = principalTarget(pt)
+    if !target.exists then
+      // The expected type is undetermined here. We don't try to defer:
+      // overload-with-default-args calls are handled earlier by the SIP-80
+      // branch of `Applications.pretypeArgs`, which pre-types `.X` with the
+      // common formal shared across surviving candidates. If we reach here,
+      // there's nothing more to be done — emit a diagnostic.
+      return errorTree(tree,
+        em"the expected type of `.${tree.name}` cannot be determined here; relative ADT scoping requires a known target type",
+        tree.srcPos)
+
+    // Look up the alias's own companion via `prefix.member(name)` first. This is
+    // necessary for opaque types — `classSymbol.companionModule` would resolve to
+    // the underlying class's companion, not the alias's.
+    def companionByPrefix: Symbol = target match
+      case ref: TypeRef =>
+        val nameAsTerm = ref.name.toTermName
+        val prefix = ref.prefix
+        if prefix.exists && prefix.ne(NoPrefix) then
+          val mem = prefix.member(nameAsTerm)
+          if mem.exists then mem.suchThat(_.is(Module)).symbol else NoSymbol
+        else NoSymbol
+      case _ => NoSymbol
+
+    val viaPrefix = companionByPrefix
+    val companion =
+      if viaPrefix.exists then viaPrefix
+      else
+        val cls = target.classSymbol
+        if cls.exists then cls.companionModule else NoSymbol
+
+    if !companion.exists then
+      return errorTree(tree,
+        em"type $target has no companion object; `.${tree.name}` cannot be resolved (SIP-80)",
+        tree.srcPos)
+
+    // Build a typed reference to the companion that respects any path-dependent prefix.
+    val prefix = target match
+      case ref: TypeRef => ref.prefix
+      case _            => target.normalizedPrefix
+    val companionRef =
+      if prefix.exists && prefix.ne(NoPrefix) then
+        tpd.ref(TermRef(prefix, companion.asTerm)).withSpan(tree.span.startPos)
+      else
+        tpd.ref(companion).withSpan(tree.span.startPos)
+
+    // Re-enter the regular Select typing path with the original expected type so
+    // overload selection, implicit conversions, and pattern-mode resolution all
+    // work without bespoke handling.
+    val select = untpd.cpy.Select(tree)(untpd.TypedSplice(companionRef), tree.name)
+    typedSelect(select, pt)
+  end typedRelativeSelect
+
   def typedThis(tree: untpd.This)(using Context): Tree = {
     record("typedThis")
     assignType(tree)
@@ -3897,6 +4013,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           case tree: untpd.QuotePattern => typedQuotePattern(tree, pt)
           case tree: untpd.SplicePattern => typedSplicePattern(tree, pt)
           case tree: untpd.MacroTree => report.error("Unexpected macro", tree.srcPos); tpd.nullLiteral  // ill-formed code may reach here
+          case tree: untpd.RelativeSelect => typedRelativeSelect(tree, pt)
           case tree: untpd.Hole => typedHole(tree, pt)
           case tree: untpd.Parens =>
             checkDeprecatedAssignmentSyntax(tree)

--- a/docs/_docs/reference/experimental/target-typed-companion-shorthand.md
+++ b/docs/_docs/reference/experimental/target-typed-companion-shorthand.md
@@ -1,0 +1,162 @@
+---
+layout: doc-page
+title: "Target-Typed Companion Shorthand"
+nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/target-typed-companion-shorthand.html
+---
+
+A leading `.` followed by an identifier in a target-typed position is shorthand
+for `T.X`, where `T` is the expected type. The feature is enabled per-file with
+
+```scala
+import scala.language.experimental.targetTypedCompanionShorthand
+```
+
+## Motivation
+
+Hierarchical sealed/enum ADTs often require fully qualifying their constructors:
+
+```scala
+final case class Shape(geometry: Shape.Geometry, color: Shape.Color)
+object Shape:
+  sealed trait Geometry
+  object Geometry:
+    case object Triangle extends Geometry
+    case object Circle   extends Geometry
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+val s = Shape(Shape.Geometry.Circle, Shape.Color.Red)
+```
+
+With target-typed companion shorthand the parameters of `Shape.apply` provide the expected
+types `Geometry` and `Color`, and `.Circle` / `.Red` resolve against those:
+
+```scala
+val s = Shape(.Circle, .Red)
+```
+
+## Where it fires
+
+A `.id` form is recognised as target-typed companion shorthand when it appears at the start
+of an expression or pattern — that is, after one of the tokens `(`, `,`, `=`,
+`=>`, `case`, `then`, `else`, `{`, `[`, `using`, `;`, `do`, `yield`, `:`,
+`return`, or at the start of a block. It does **not** fire after an existing
+expression, where `.id` continues to denote selection on that expression
+(method-chain continuation is preserved):
+
+```scala
+val s: String = "abc"
+  .toUpperCase   // method chain — unchanged
+  .reverse
+
+val c: Color = .Red  // target-typed companion shorthand
+```
+
+## Patterns
+
+The same shorthand works in pattern positions, where the expected type comes
+from the scrutinee or extractor parameter:
+
+```scala
+shape match
+  case Shape(.Triangle, .Red) => "warning"
+  case Shape(.Circle,   .Red) => "stop"
+  case _                      => "unknown"
+
+color match
+  case .Red | .Blue => "primary"
+  case _            => "other"
+```
+
+## Resolution
+
+`.X` desugars to `T.X` where `T` is the principal class component of the
+expected type, after stripping prototype layers, dealiasing and dropping
+dependent refinements. The selection is then re-typed by the regular `Select`
+machinery, so:
+
+- overload selection picks the alternative that admits a member named `X`;
+- implicit conversions are inserted to bridge `T.X.type` to a wider expected
+  type;
+- the resolved member must not be an anonymous given (per SIP-80).
+
+## Errors
+
+The following are reported as compile errors:
+
+- the leading-dot syntax is used without the language import;
+- the expected type is undetermined (e.g., `def f[A](a: A); f(.Red)`);
+- the target type has no companion module;
+- the named member does not exist on the companion.
+
+## Limitations
+
+The following positions are not supported in this initial implementation.
+Each has a simple workaround.
+
+### Direct RHS of an infix operator
+
+A leading-dot expression cannot appear directly as the right operand of an
+infix operator, because the parser's infix-operand starter set does not
+include `.`:
+
+```scala
+c |+| .Red          // parse error
+c matchesColor .Red // parse error
+c == .Red           // parse error
+```
+
+Workarounds:
+
+```scala
+c |+| (.Red)            // parens
+c matchesColor (.Red)
+c.matchesColor(.Red)    // method syntax
+
+c == Color.Red          // built-in `==` has RHS expected type `Any`,
+                        // so even `c == (.Red)` cannot resolve `.Red`;
+                        // spell out `Color.Red` or pattern match.
+```
+
+### Same-arity overloads with disjoint companion members
+
+When two overloads have the same arity and only differ in their parameter
+type, the typer cannot yet resolve `.X` against each candidate's parameter
+type. The user must disambiguate:
+
+```scala
+def f(c: Color): String
+def f(d: Direction): String
+
+f(.Red)             // error: expected type cannot be determined
+f((.Red: Color))    // explicit ascription works
+```
+
+If the overloads have different arities, `narrowBySize` picks a single
+candidate before SIP-80 logic runs and `.X` resolves against that
+candidate's parameter type, so `f(.Red, 5)` works when only the 2-arg
+overload matches by arity.
+
+If the overloads agree on the parameter type at the relative-selection's
+position — for example because one adds a default-valued parameter as a
+binary-compatibility evolution — the shared formal is used and the call
+resolves cleanly:
+
+```scala
+def bar(a: Animal): Unit                          = ???
+def bar(a: Animal, b: Animal = null): Unit        = ???
+bar(.Cat)   // ok — both overloads share `a: Animal`
+```
+
+### Bare `.` cursor in IDE completion
+
+The presentation-compiler completer requires at least one identifier
+character after `.` (`.r<TAB>`) — a bare `.<TAB>` does not parse and
+therefore offers no SIP-80 suggestions. This matches Swift and Dart
+behaviour.
+
+## See also
+
+- [SIP-80](https://github.com/scala/improvement-proposals)

--- a/docs/_spec/06-expressions.md
+++ b/docs/_spec/06-expressions.md
@@ -38,6 +38,7 @@ SimpleExpr1  ::=  Literal
                |  SimpleExpr ‘.’ id
                |  SimpleExpr TypeArgs
                |  SimpleExpr1 ArgumentExprs
+               |  ‘.’ id                                 -- under experimental.targetTypedCompanionShorthand (SIP-80)
                |  XmlExpr
 Exprs        ::=  Expr {‘,’ Expr}
 MatchClause  ::=  ‘match’ ‘{’ CaseClauses ‘}’

--- a/docs/_spec/08-pattern-matching.md
+++ b/docs/_spec/08-pattern-matching.md
@@ -24,6 +24,7 @@ chapter: 8
                     |  StableId ‘(’ [Patterns] ‘)’
                     |  StableId ‘(’ [Patterns ‘,’] [id ‘@’] ‘_’ ‘*’ ‘)’
                     |  ‘(’ [Patterns] ‘)’
+                    |  ‘.’ id [TypeArgs] [ArgumentPatterns]   -- under experimental.targetTypedCompanionShorthand (SIP-80)
                     |  XmlPattern
   Patterns        ::=  Pattern {‘,’ Patterns}
 ```

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -193,6 +193,7 @@ subsection:
       - page: reference/experimental/unrolled-defs.md
       - page: reference/experimental/package-object-values.md
       - page: reference/experimental/quoted-patterns-with-polymorphic-functions.md
+      - page: reference/experimental/target-typed-companion-shorthand.md
       - page: reference/experimental/relaxed-lambdas.md
       - page: reference/experimental/sub-cases.md
   - page: reference/syntax.md

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -373,6 +373,13 @@ object language {
     @compileTimeOnly("`relaxedLambdaSyntax` can only be used at compile time in import statements")
     object relaxedLambdaSyntax
 
+    /** Experimental support for relative ADT scoping: a leading `.` followed by an
+     *  identifier in target-typed positions desugars to `T.X`, where `T` is the
+     *  expected type. See SIP-80.
+     */
+    @compileTimeOnly("`targetTypedCompanionShorthand` can only be used at compile time in import statements")
+    object targetTypedCompanionShorthand
+
     /** Experimental support for safe mode
      */
     @compileTimeOnly("`safe` can only be used at compile time in import statements")

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -181,6 +181,13 @@ private[scala] object language:
      */
     @compileTimeOnly("`relaxedLambdaSyntax` can only be used at compile time in import statements")
     object relaxedLambdaSyntax
+
+    /** Experimental support for relative ADT scoping: a leading `.` followed by an
+     *  identifier in target-typed positions desugars to `T.X`, where `T` is the
+     *  expected type. See SIP-80.
+     */
+    @compileTimeOnly("`targetTypedCompanionShorthand` can only be used at compile time in import statements")
+    object targetTypedCompanionShorthand
   end experimental
 
   /** The deprecated object contains features that are no longer officially suypported in Scala.

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -585,10 +585,13 @@ class Completions(
           config.isCompletionSnippetsEnabled()
         )
         (args, false)
-    val singletonCompletions = InferCompletionType.inferType(path).map(
+    val expectedType = InferCompletionType.inferType(path)
+    val singletonCompletions = expectedType.map(
       SingletonCompletions.contribute(path, _, completionPos)
     ).getOrElse(Nil)
-    (singletonCompletions ++ advanced, exclusive)
+    val relativeAdtCompletions =
+      RelativeAdtCompletions.contribute(path, expectedType, completionPos)
+    (relativeAdtCompletions ++ singletonCompletions ++ advanced, exclusive)
   end advancedCompletions
 
   private def isAmmoniteCompletionPosition(

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/RelativeAdtCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/RelativeAdtCompletions.scala
@@ -1,0 +1,130 @@
+package dotty.tools.pc.completions
+
+import scala.meta.internal.metals.Fuzzy
+
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.core.NameOps.*
+import dotty.tools.dotc.core.Symbols
+import dotty.tools.dotc.core.Symbols.NoSymbol
+import dotty.tools.dotc.core.Types.NoPrefix
+import dotty.tools.dotc.core.Types.OrType
+import dotty.tools.dotc.core.Types.Type
+import dotty.tools.dotc.core.Types.TypeRef
+import dotty.tools.pc.utils.InteractiveEnrichments.*
+
+/** SIP-80 leading-dot completions: when the cursor is in a target-typed
+ *  position immediately after `.`, suggest term-level members of the expected
+ *  type's companion object. Mirrors `SingletonCompletions` in shape.
+ */
+object RelativeAdtCompletions:
+
+  def contribute(
+      path: List[Tree],
+      expectedTypeOpt: Option[Type],
+      completionPos: CompletionPos
+  )(using ctx: Context): List[CompletionValue] =
+    // Determine the target type. Prefer the type we can derive from the path
+    // (the qualifier of `.X` after `Typer.typedRelativeSelect`); fall back to
+    // the InferCompletionType result, which handles term contexts but not all
+    // pattern shapes.
+    val expectedTypeFromPath: Option[Type] = path.headOption.flatMap {
+      case Select(qual, _) if qual.symbol.is(Flags.Module) =>
+        // `qual.symbol` is the companion module produced by Typer.typedRelativeSelect.
+        // Recover the corresponding type from its sourceModule.
+        val mod = qual.symbol
+        val cls = mod.companionClass
+        if cls.exists then Some(cls.typeRef) else None
+      case _ => None
+    }
+    val expectedType = expectedTypeOpt.orElse(expectedTypeFromPath)
+    expectedType match
+      case None => Nil
+      case Some(target) =>
+        if !isLeadingDotContext(completionPos, path, target) then Nil
+        else
+          val query = completionPos.query
+          val companion = companionOf(target)
+          if !companion.exists then Nil
+          else
+            val info = companion.info
+            val isMatch: Symbols.Symbol => Boolean = sym =>
+              sym.isTerm
+                && !sym.isConstructor
+                && !sym.is(Flags.Synthetic)
+                && !sym.is(Flags.Private)
+                && !sym.name.toString.contains('$')
+                && !isAnonymousGiven(sym)
+                && (query.isEmpty || Fuzzy.matches(query, sym.name.toString))
+            val members =
+              info.decls.iterator
+                .filter(isMatch)
+                .toList
+                .distinctBy(_.name.toString)
+            val range = completionPos.toEditRange
+            members.map { sym =>
+              CompletionValue.SingletonValue(sym.name.toString, sym.info, Some(range))
+            }
+
+  /** A leading-dot context exists when both:
+   *    1. The source has `.` immediately before the query, and
+   *    2. The path's head is a Select whose qualifier resolves to the
+   *       expected type's companion module (this rules out parse-recovery
+   *       cases like `paint(.@@)` where the parser produced `paint(Predef.???)`).
+   *
+   *  Note: we used to also reject the case where the character preceding the
+   *  dot was an identifier-part to filter out method-chain selection. That's
+   *  redundant — a method-chain `expr.partial` would never produce a Select
+   *  whose qualifier symbol is a Module matching the expected type's
+   *  companion, so check (2) already handles it. Dropping the source check
+   *  also lets `case .R@@` work (where `case` precedes the dot).
+   */
+  private def isLeadingDotContext(
+      completionPos: CompletionPos,
+      path: List[Tree],
+      expectedType: Type
+  )(using Context): Boolean =
+    val content = completionPos.originalCursorPosition.source.content()
+    val dotIdx = completionPos.queryStart - 1
+    val hasDotBefore =
+      dotIdx >= 0 && dotIdx < content.length && content(dotIdx) == '.'
+    if !hasDotBefore then false
+    else
+      val companion = companionOf(expectedType)
+      companion.exists && path.headOption.exists {
+        case Select(qual, _) =>
+          // Distinguish SIP-80 desugaring from a user-written `T.X` selection:
+          // `Typer.typedRelativeSelect` synthesises the qualifier with a point
+          // span at the `.`, so its span has zero width. A user-written
+          // qualifier like `TestEnum` has a non-zero span covering its name.
+          qual.symbol == companion && qual.span.start == qual.span.end
+        case _ => false
+      }
+
+  private def companionOf(tp0: Type)(using Context): Symbols.Symbol =
+    // Mirror the resolution in `Typer.typedRelativeSelect`: peel `T | Null`
+    // (or `Null | T`) to `T`, then prefer the alias's own companion
+    // (via prefix.member) so opaque types pick their alias's companion
+    // rather than the underlying class's.
+    val tp = peelNullUnion(tp0)
+    val byPrefix = tp match
+      case ref: TypeRef =>
+        val pre = ref.prefix
+        if pre.exists && pre.ne(NoPrefix) then
+          val mem = pre.member(ref.name.toTermName)
+          if mem.exists then mem.suchThat(_.is(Flags.Module)).symbol else NoSymbol
+        else NoSymbol
+      case _ => NoSymbol
+    if byPrefix.exists then byPrefix
+    else
+      val cls = tp.classSymbol
+      if cls.exists then cls.companionModule else NoSymbol
+
+  private def peelNullUnion(tp: Type)(using Context): Type = tp match
+    case OrType(lhs, rhs) if rhs.classSymbol == Symbols.defn.NullClass => peelNullUnion(lhs)
+    case OrType(lhs, rhs) if lhs.classSymbol == Symbols.defn.NullClass => peelNullUnion(rhs)
+    case _ => tp
+
+  private def isAnonymousGiven(sym: Symbols.Symbol)(using Context): Boolean =
+    sym.is(Flags.Given) && sym.name.toString.startsWith("given_")

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/RelativeAdtCompletionsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/RelativeAdtCompletionsSuite.scala
@@ -1,0 +1,139 @@
+package dotty.tools.pc.tests.completion
+
+import dotty.tools.pc.base.BaseCompletionSuite
+
+import org.junit.Test
+
+/** SIP-80: leading-dot completions in target-typed positions.
+ *
+ *  Tests use `.X@@` (at least one identifier char after the dot) so the parser
+ *  successfully produces a `RelativeSelect` and the typer rewrites it to
+ *  `Select(companionRef, X)`. The bare `.@@` form (cursor immediately after a
+ *  dot with no identifier char) does not parse and therefore offers no
+ *  completions in this v1 — users get suggestions once they type any letter.
+ */
+class RelativeAdtCompletionsSuite extends BaseCompletionSuite:
+
+  private val colorAdt =
+    """|sealed trait Color
+       |object Color:
+       |  case object Red   extends Color
+       |  case object Blue  extends Color
+       |  case object Green extends Color
+       |""".stripMargin
+
+  @Test def `val-rhs-prefix` =
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |val c: Color = .R@@
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `val-rhs-empty-prefix-letter` =
+    // Single-letter prefix that fuzzy-matches all three case objects.
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |val c: Color = .B@@
+          |""".stripMargin,
+      "Blue: Blue",
+      filter = _.startsWith("Blue")
+    )
+
+  @Test def `arg-position` =
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |def paint(c: Color): String = c.toString
+          |val s: String = paint(.R@@)
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `named-arg` =
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |def paint(c: Color): String = c.toString
+          |val s: String = paint(c = .G@@)
+          |""".stripMargin,
+      "Green: Green",
+      filter = _.startsWith("Green")
+    )
+
+  @Test def `pattern-position` =
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |val c: Color = Color.Red
+          |val s: String = c match
+          |  case .R@@ => "red"
+          |  case _    => "other"
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `pattern-named-extractor` =
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |final case class Wrap(c: Color)
+          |val w: Wrap = Wrap(Color.Red)
+          |val s: String = w match
+          |  case Wrap(c = .R@@) => "red"
+          |  case _              => "other"
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `enum-cases` =
+    check(
+      """|import scala.language.experimental.targetTypedCompanionShorthand
+         |enum Light:
+         |  case On, Off, Dim
+         |val l: Light = .O@@
+         |""".stripMargin,
+      """|On: Light
+         |Off: Light""".stripMargin,
+      filter = label => label.startsWith("On") || label.startsWith("Off")
+    )
+
+  @Test def `null-union` =
+    // `T | Null` should peel to `T` for SIP-80 completion purposes.
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |val c: Color | Null = .R@@
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `null-union-reversed` =
+    check(
+      s"""|import scala.language.experimental.targetTypedCompanionShorthand
+          |$colorAdt
+          |val c: Null | Color = .B@@
+          |""".stripMargin,
+      "Blue: Blue",
+      filter = _.startsWith("Blue")
+    )
+
+  @Test def `no-import-no-completions` =
+    // Without the language import the parser rejects `.X`, so the leading-dot
+    // completer should not contribute anything specific to SIP-80.
+    check(
+      """|sealed trait Color
+         |object Color:
+         |  case object Red extends Color
+         |val c: Color = .R@@
+         |""".stripMargin,
+      "",
+      filter = _.startsWith("Red")
+    )

--- a/tests/neg/target-typed-companion-shorthand-infix.scala
+++ b/tests/neg/target-typed-companion-shorthand-infix.scala
@@ -1,0 +1,40 @@
+// SIP-80 v1 limitation: a leading-dot expression cannot appear directly as the
+// RHS of an infix operator. The Scala parser's `canStartInfixExprTokens` set
+// does not include `.`, so `c == .Red` is parsed as the val def `c`, then a
+// stray `==`.
+//
+// Workarounds for CUSTOM infix methods (verified by hand):
+//   c matchesColor (.Red)   -- parens make `(` the starter token
+//   c.matchesColor(.Red)    -- method syntax
+//   c |+| (.Red)            -- operator-style with parens
+//
+// For BUILT-IN equality/eq/ne the RHS expected type is `Any`, so even
+// `c == (.Red)` cannot resolve `Red` (Any has no useful companion). The
+// idiomatic alternative is `c == Color.Red` or pattern matching.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red extends Color
+
+object Test:
+  val c: Color = Color.Red
+
+  // Built-in `==`: even if parsed, RHS expected type is `Any` and `.Red` would
+  // not resolve. Documented as a parse error here.
+  val q1: Boolean = c == .Red // error // error
+
+  // Custom infix likewise fails to parse.
+  extension (lhs: Color) infix def matchesColor(rhs: Color): Boolean = lhs == rhs
+  val q2: Boolean = c matchesColor .Red // error // error
+
+  // Operator-style custom method: same issue.
+  extension (lhs: Color) def |+|(rhs: Color): Color = rhs
+  val q3: Color = c |+| .Red // error
+
+  // Workarounds (each compiles fine — uncomment to verify):
+  // val ok1: Color   = c |+| (.Red)
+  // val ok2: Boolean = c.matchesColor(.Red)
+
+  // Union types as the expected type also have no companion to resolve `.X`.
+  val u: Color | Int = .Red // error

--- a/tests/neg/target-typed-companion-shorthand-missing-member.scala
+++ b/tests/neg/target-typed-companion-shorthand-missing-member.scala
@@ -1,0 +1,13 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object MissingMember:
+
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+  val ok: Color = .Red
+
+  // `Purple` is not a member of `Color`'s companion.
+  val bad: Color = .Purple // error

--- a/tests/neg/target-typed-companion-shorthand-no-companion.scala
+++ b/tests/neg/target-typed-companion-shorthand-no-companion.scala
@@ -1,0 +1,14 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+// A type without a companion module (here: a refinement of a trait) cannot
+// resolve `.X`.
+object NoCompanion:
+
+  trait Bare // no companion module
+
+  val x: Bare = .Foo // error
+
+  // Function types fall through `Function1`'s companion which has no
+  // user-declared cases — useful members (`apply`) won't match a value-type
+  // expectation.
+  val f: Int => String = .NotThere // error

--- a/tests/neg/target-typed-companion-shorthand-no-import.scala
+++ b/tests/neg/target-typed-companion-shorthand-no-import.scala
@@ -1,0 +1,10 @@
+// Without the `experimental.targetTypedCompanionShorthand` import, the leading-dot syntax
+// is a parse error.
+
+object NoImport:
+
+  sealed trait Color
+  object Color:
+    case object Red extends Color
+
+  val c: Color = .Red // error

--- a/tests/neg/target-typed-companion-shorthand-overload.scala
+++ b/tests/neg/target-typed-companion-shorthand-overload.scala
@@ -1,0 +1,19 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+// SIP-80 recommends resolving `.X` after overload selection; the initial
+// implementation requires a single-candidate target type. Overloaded calls
+// without disambiguation report "expected type ... cannot be determined".
+object Overload:
+
+  sealed trait Color
+  object Color:
+    case object Red extends Color
+
+  sealed trait Direction
+  object Direction:
+    case object North extends Direction
+
+  def f(c: Color): String     = ""
+  def f(d: Direction): String = ""
+
+  val bad: String = f(.Red) // error

--- a/tests/neg/target-typed-companion-shorthand-undetermined-pt.scala
+++ b/tests/neg/target-typed-companion-shorthand-undetermined-pt.scala
@@ -1,0 +1,15 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object UndeterminedPt:
+
+  sealed trait Color
+  object Color:
+    case object Red extends Color
+
+  // No expected type — caller can't infer a target.
+  def poly[A](a: A): A = a
+  poly(.Red) // error
+
+  // Bare expression statement; nothing constrains the expected type to Color.
+  def stmt(): Unit =
+    .Red // error

--- a/tests/pos/target-typed-companion-shorthand-aliases.scala
+++ b/tests/pos/target-typed-companion-shorthand-aliases.scala
@@ -1,0 +1,49 @@
+// SIP-80: relative ADT scoping should work with transparent type aliases,
+// `import`-introduced types, and `export`-introduced types.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object Lib:
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+object AliasUser:
+  // Transparent type alias.
+  type MyColor = Lib.Color
+
+  def foo(color: MyColor): Unit = ()
+
+  val c1: MyColor = .Red          // resolves through MyColor → Color
+  foo(.Blue)
+  foo(color = .Green)
+
+  // Match on the alias.
+  val s: String = c1 match
+    case .Red   => "r"
+    case .Blue  => "b"
+    case .Green => "g"
+
+object ImportUser:
+  // `import` brings the type into scope; relative scoping still finds the
+  // companion via the alias's own prefix.
+  import Lib.Color
+  def paint(c: Color): Unit = ()
+  val c: Color = .Red
+  paint(.Blue)
+
+object ExportingFacade:
+  // Re-export the type. Clients that import from this facade should still be
+  // able to use relative scoping.
+  export Lib.Color
+
+object ExportClient:
+  import ExportingFacade.Color
+  def use(c: Color): Unit = ()
+  val c: Color = .Red
+  use(.Green)
+
+  // Combined: alias on top of an exported type.
+  type Hue = Color
+  val h: Hue = .Blue

--- a/tests/pos/target-typed-companion-shorthand-chain.scala
+++ b/tests/pos/target-typed-companion-shorthand-chain.scala
@@ -1,0 +1,46 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object Chain:
+
+  sealed trait Animal
+  object Animal:
+    sealed trait Mammal extends Animal
+    object Mammal:
+      case object Dog extends Mammal
+      case object Cat extends Mammal
+    sealed trait Bird extends Animal
+    object Bird:
+      case object Robin extends Bird
+
+  def describe(a: Animal): String = a.toString
+
+  // Hierarchical chain: `.Mammal` is relative, `.Dog` is plain Select on Mammal.
+  val a1: String = describe(.Mammal.Dog)
+  val a2: Animal = .Bird.Robin
+
+  // Application form: `.method(args)`.
+  trait Frag
+  object Frag:
+    def color(name: String): Frag = new Frag {}
+    def text(s: String): Frag    = new Frag {}
+
+  def render(frag: Frag): String = frag.toString
+
+  val r1: String = render(.color("red"))
+  val r2: Frag   = .text("hi")
+
+  // Mixed: relative + chain + apply.
+  trait Builder
+  object Builder:
+    def of(name: String): Inner = new Inner
+    class Inner:
+      def withCount(n: Int): Builder = new Builder {}
+
+  def build(b: Builder): String = b.toString
+  val b1: String = build(.of("widget").withCount(3))
+
+  // Method-chain continuation must still work — newline + `.` on next line is
+  // a regular chain selection, NOT relative scoping.
+  val expr: String = "abc"
+    .toUpperCase
+    .reverse

--- a/tests/pos/target-typed-companion-shorthand-conversion.scala
+++ b/tests/pos/target-typed-companion-shorthand-conversion.scala
@@ -1,0 +1,23 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+import scala.language.implicitConversions
+
+object Conversion:
+
+  enum LogLevel:
+    case INFO, WARN, ERROR
+
+  // Opaque-type bridge per SIP-80.
+  opaque type ParserLogLevel = LogLevel
+  object ParserLogLevel:
+    export LogLevel.{INFO, WARN, ERROR}
+    given Conversion[LogLevel, ParserLogLevel] = identity(_)
+
+  def parseStrict(level: ParserLogLevel): Unit = ()
+
+  // `.INFO` resolves against `LogLevel`'s companion (export forwards),
+  // produces a `LogLevel`, and the `Conversion` adapts it to `ParserLogLevel`.
+  parseStrict(.INFO)
+  parseStrict(.WARN)
+
+  // Direct (no conversion needed).
+  val l: LogLevel = .ERROR

--- a/tests/pos/target-typed-companion-shorthand-default-args.scala
+++ b/tests/pos/target-typed-companion-shorthand-default-args.scala
@@ -1,0 +1,32 @@
+// SIP-80: overloads that differ only by an extra default-valued parameter
+// (a common binary-compatibility evolution pattern) should resolve `.X`
+// against the parameter type they share. See SIP review comment
+// https://github.com/scala/improvement-proposals/pull/134#discussion_r3192764486
+//
+// Both overloads can be called with one argument (the second has a default
+// for `b`). `narrowBySize` keeps both, but their first parameter type is
+// the same, so SIP-80's `pretypeArgs` extension pre-types `.Cat` with that
+// common formal — `narrowMostSpecific` then picks the no-default overload.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+sealed trait Animal
+object Animal:
+  case object Cat extends Animal
+  case object Dog extends Animal
+
+object SameFirstFormal:
+  def bar(a: Animal): Int                         = 1
+  def bar(a: Animal, b: Animal = Animal.Dog): Int = 2
+
+  // Both overloads applicable by arity. Shared formal at position 0 is
+  // `Animal`, so `.Cat` resolves there.
+  val r: Int = bar(.Cat)
+
+  // Same shape with a slightly different default expression.
+  def baz(a: Animal): String                = a.toString
+  def baz(a: Animal, sep: String = "-"): String = a.toString
+  val s: String = baz(.Dog)
+
+  // Common formal at position 0 with a relative selection followed by an
+  // explicit second arg should also work — the 2-arg overload is selected.
+  val r2: Int = bar(.Cat, Animal.Dog)

--- a/tests/pos/target-typed-companion-shorthand-enum.scala
+++ b/tests/pos/target-typed-companion-shorthand-enum.scala
@@ -1,0 +1,22 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object EnumSupport:
+
+  enum Color:
+    case Red, Blue, Green
+
+  enum Tree[+A]:
+    case Leaf
+    case Node(value: A, left: Tree[A], right: Tree[A])
+
+  def show(c: Color): String = c match
+    case .Red   => "R"
+    case .Blue  => "B"
+    case .Green => "G"
+
+  val c1: Color = .Red
+  val c2: Color = .Blue
+
+  // Parameterised enum case (value-class and type-arg interaction).
+  val t: Tree[Int] = .Leaf
+  val t2: Tree[Int] = .Node(1, .Leaf, .Leaf)

--- a/tests/pos/target-typed-companion-shorthand-inference.scala
+++ b/tests/pos/target-typed-companion-shorthand-inference.scala
@@ -1,0 +1,16 @@
+// SIP-80: when a generic call's type parameter is constrainable from the
+// surrounding expected type, type inference flows through the result and
+// the relative selection arguments resolve against the inferred parameter.
+// E.g. `Seq.apply[A](xs: A*): Seq[A]` here gets `A = Color` from the val's
+// declared type, so `.Red`/`.Blue` are typed against `Color`.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red  extends Color
+  case object Blue extends Color
+
+object Inference:
+  val xs: Seq[Color]    = Seq(.Red, .Blue)
+  val ls: List[Color]   = List(.Red, .Blue, .Red)
+  val opt: Option[Color] = Some(.Blue)

--- a/tests/pos/target-typed-companion-shorthand-null-union.scala
+++ b/tests/pos/target-typed-companion-shorthand-null-union.scala
@@ -1,0 +1,35 @@
+// SIP-80: `T | Null` (and `Null | T`) is special-cased so relative scoping
+// resolves against `T`'s companion. `Null` has no useful companion members
+// and `T | Null` is the common nullable-reference idiom.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object NullUnion:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  // RHS of typed val.
+  val c1: Color | Null = .Red
+  val c2: Null | Color = .Blue
+
+  // Argument position.
+  def paint(c: Color | Null): String = if c == null then "null" else c.toString
+  val s1: String = paint(.Green)
+  val s2: String = paint(null)
+
+  // Conditional with nullable result type.
+  def maybeColor(b: Boolean): Color | Null = if b then .Red else null
+
+  // Pattern position — the scrutinee type provides the pt.
+  val c: Color | Null = Color.Red
+  val s: String = c match
+    case .Red   => "r"
+    case .Blue  => "b"
+    case .Green => "g"
+    case null   => "null"
+
+  // Nested (rare but should work).
+  val c3: (Color | Null) | Null = .Red

--- a/tests/pos/target-typed-companion-shorthand-opaque.scala
+++ b/tests/pos/target-typed-companion-shorthand-opaque.scala
@@ -1,0 +1,23 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+// Module providing the opaque type. From outside this module the alias is
+// abstract and `.X` should resolve against the alias's own companion (per SIP-80).
+object Lib:
+  enum Severity:
+    case INFO, WARN, ERROR
+
+  opaque type Level = Severity
+  object Level:
+    val Info: Level  = Severity.INFO
+    val Warn: Level  = Severity.WARN
+    val Error: Level = Severity.ERROR
+
+object OpaqueClient:
+  import Lib.Level
+
+  // From outside Lib, Level is opaque — so `.Info` resolves on `Level`'s companion.
+  val l1: Level = .Info
+  val l2: Level = .Warn
+
+  def log(level: Level): Unit = ()
+  log(.Error)

--- a/tests/pos/target-typed-companion-shorthand-option-either.scala
+++ b/tests/pos/target-typed-companion-shorthand-option-either.scala
@@ -1,0 +1,41 @@
+// SIP-80: when the target type is `Option[T]` or `Either[L, T]` and the
+// constructor (`Some`, `Right`, `Left`) is applied to a relative selection,
+// the type parameter is inferred from the surrounding expected type and
+// the relative selection resolves against `T`'s companion.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object OptionEitherUse:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  // Wrapping `.X` in `Some` — pt of the val is `Option[Color]`, which lets
+  // type inference for `Some.apply[A]` pick `A = Color`, after which `.Red`
+  // is typed against `Color`.
+  val o1: Option[Color] = Some(.Red)
+  val o2: Option[Color] = Some(.Blue)
+  val o3: Option[Color] = None
+
+  // Argument position: the parameter type drives inference.
+  def use(o: Option[Color]): Color = o.getOrElse(Color.Red)
+  val u1: Color = use(Some(.Green))
+  val u2: Color = use(None)
+
+  // Either with a relative selection on the Right side.
+  val e1: Either[String, Color] = Right(.Red)
+  val e2: Either[Color, Int]    = Left(.Blue)
+  val e3: Either[Color, Color]  = Right(.Green)  // exercises both type params
+
+  // Pattern matching reads the same way.
+  val s: String = (o1: Option[Color]) match
+    case Some(.Red)   => "r"
+    case Some(.Blue)  => "b"
+    case Some(.Green) => "g"
+    case None         => "n"
+
+  // Direct member of the Option / Either companion is also reachable.
+  val o4: Option[Int] = .empty       // Option.empty
+  val e4: Either[String, Int] = .cond(true, 1, "x")  // Either.cond

--- a/tests/pos/target-typed-companion-shorthand-overload-arity.scala
+++ b/tests/pos/target-typed-companion-shorthand-overload-arity.scala
@@ -1,0 +1,19 @@
+// SIP-80: when overload arity narrows to a single candidate, `.X` can be
+// resolved against that candidate's formal parameter type. This is the
+// arity-disambiguation path — no special overload logic needed beyond what
+// the typer already does.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red  extends Color
+  case object Blue extends Color
+
+object Arity:
+  def foo(arg: Color): String          = "1: " + arg
+  def foo(arg: Color, arg2: Int): String = "2: " + arg + "," + arg2
+
+  // 1 arg arity → first overload wins; .Red typed with pt=Color → Color.Red.
+  val r1: String = foo(.Red)
+  // 2 args arity → second overload wins; .Red typed with pt=Color → Color.Red.
+  val r2: String = foo(.Red, 5)

--- a/tests/pos/target-typed-companion-shorthand-overload.scala
+++ b/tests/pos/target-typed-companion-shorthand-overload.scala
@@ -1,0 +1,32 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+// Overload disambiguation requires a known target type for `.X`. The SIP
+// recommends resolving relative selections after overload selection. This
+// initial implementation requires the user to disambiguate explicitly when
+// the call is overloaded — either by ascribing the argument or by preferring
+// a non-overloaded helper. The cases below exercise the supported variants.
+object Overload:
+
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+  sealed trait Direction
+  object Direction:
+    case object North extends Direction
+    case object South extends Direction
+
+  def f(c: Color): String     = "color: " + c
+  def f(d: Direction): String = "dir: " + d
+  def f(i: Int): String       = "int: " + i
+
+  // Disambiguate via ascription — `.Red` is parsed in a target-typed position.
+  val r1: String = f((.Red: Color))
+  val r2: String = f((.North: Direction))
+
+  // Or via a non-overloaded wrapper; relative scoping then sees a clean pt.
+  def fc(c: Color): String     = f(c)
+  def fd(d: Direction): String = f(d)
+  val r3: String = fc(.Red)
+  val r4: String = fd(.North)

--- a/tests/pos/target-typed-companion-shorthand-patterns.scala
+++ b/tests/pos/target-typed-companion-shorthand-patterns.scala
@@ -1,0 +1,41 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object Patterns:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  sealed trait Geometry
+  object Geometry:
+    case object Triangle extends Geometry
+    case object Circle   extends Geometry
+
+  final case class Shape(geometry: Geometry, color: Color)
+
+  // Pattern position — single relative selector.
+  def name(c: Color): String = c match
+    case .Red   => "red"
+    case .Blue  => "blue"
+    case .Green => "green"
+
+  // `|` alternatives.
+  def warm(c: Color): Boolean = c match
+    case .Red | .Green => true
+    case _             => false
+
+  // Nested in extractor pattern: the parameter type of `Shape.apply` is
+  // `Geometry` for the first arg and `Color` for the second.
+  def kind(s: Shape): String = s match
+    case Shape(.Triangle, _)        => "triangle"
+    case Shape(.Circle, .Red)       => "stop sign"
+    case Shape(.Circle, .Blue | .Green) => "wheel"
+    case _                           => "other"
+
+  // Combined with bound name: `c @ .Red` is a Bind that wraps the relative
+  // pattern, identical to `c @ Color.Red`.
+  def label(c: Color): String = c match
+    case x @ .Red => "got " + x.toString
+    case _        => "other"

--- a/tests/pos/target-typed-companion-shorthand-varargs.scala
+++ b/tests/pos/target-typed-companion-shorthand-varargs.scala
@@ -1,0 +1,43 @@
+// SIP-80: relative ADT scoping in varargs positions.
+// Each arg in a `T*` parameter is typed with element type `T`, so
+// `.X` resolves against `T`'s companion just like in non-varargs args.
+import scala.language.experimental.targetTypedCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red   extends Color
+  case object Blue  extends Color
+  case object Green extends Color
+
+object Vararg:
+  def palette(colors: Color*): Int = colors.size
+
+  // 0 args.
+  val n0: Int = palette()
+
+  // Single arg.
+  val n1: Int = palette(.Red)
+
+  // Several args.
+  val n3: Int = palette(.Red, .Blue, .Green)
+
+  // Mixed: explicit and relative.
+  val nm: Int = palette(Color.Red, .Blue)
+
+  // Splat from a `Seq[Color]` with relative selectors. The val's declared type
+  // `Seq[Color]` constrains `Seq.apply`'s type parameter to `Color`, which lets
+  // each `.X` resolve against `Color`'s companion.
+  val seq: Seq[Color] = Seq(.Red, .Blue)
+  val ns: Int = palette(seq*)
+
+  // Repeated parameter after a regular parameter.
+  def labelled(name: String, colors: Color*): Int = colors.size
+  val nl: Int = labelled("primary", .Red, .Blue, .Green)
+
+  // Varargs in extractor (pattern position) — repeated patterns get the
+  // element type as expected type. The scrutinee has known element type, so
+  // no inference is needed here.
+  val list: List[Color] = List(.Red, .Blue, .Green)
+  val s: String = list match
+    case List(.Red, _*) => "starts with red"
+    case _              => "other"

--- a/tests/pos/target-typed-companion-shorthand.scala
+++ b/tests/pos/target-typed-companion-shorthand.scala
@@ -1,0 +1,45 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+object Basic:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  sealed trait Geometry
+  object Geometry:
+    case object Triangle extends Geometry
+    case object Circle   extends Geometry
+    case object Square   extends Geometry
+
+  final case class Shape(geometry: Geometry, color: Color)
+
+  // Argument position — direct.
+  val s1: Shape = Shape(.Circle, .Red)
+
+  // Mixed positional / explicit.
+  val s2: Shape = Shape(Geometry.Triangle, .Blue)
+  val s3: Shape = Shape(.Square, Color.Green)
+
+  // RHS of typed val.
+  val c: Color = .Red
+  val g: Geometry = .Square
+
+  // Parenthesised.
+  val c2: Color = (.Red)
+
+  // `if` arms — both branches share the expected type.
+  def pick(b: Boolean): Color = if b then .Red else .Blue
+
+  // Inside lambda body with target type.
+  val mk: Boolean => Color = b => if b then .Red else .Blue
+
+  // Named argument: the name fixes the expected type.
+  val s4: Shape = Shape(color = .Red, geometry = .Circle)
+
+  // Using clause.
+  def withColor(using c: Color): Color = c
+  given Color = Color.Blue
+  val c4: Color = withColor(using .Green)

--- a/tests/run/target-typed-companion-shorthand.check
+++ b/tests/run/target-typed-companion-shorthand.check
@@ -1,0 +1,5 @@
+stop
+info
+warning
+unknown
+Red

--- a/tests/run/target-typed-companion-shorthand.scala
+++ b/tests/run/target-typed-companion-shorthand.scala
@@ -1,0 +1,35 @@
+import scala.language.experimental.targetTypedCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red   extends Color
+  case object Blue  extends Color
+  case object Green extends Color
+
+sealed trait Geometry
+object Geometry:
+  case object Triangle extends Geometry
+  case object Circle   extends Geometry
+
+final case class Shape(geometry: Geometry, color: Color)
+
+object Test:
+  def describe(s: Shape): String = s match
+    case Shape(.Triangle, .Red)  => "warning"
+    case Shape(.Circle,   .Red)  => "stop"
+    case Shape(.Circle,   .Blue) => "info"
+    case _                       => "unknown"
+
+  def main(args: Array[String]): Unit =
+    val stop:  Shape = Shape(.Circle, .Red)
+    val info:  Shape = Shape(.Circle, .Blue)
+    val warn:  Shape = Shape(.Triangle, .Red)
+    val other: Shape = Shape(.Triangle, .Green)
+    println(describe(stop))
+    println(describe(info))
+    println(describe(warn))
+    println(describe(other))
+
+    // Bare RHS form.
+    val c: Color = .Red
+    println(c)


### PR DESCRIPTION
Implements SIP-80 https://github.com/scala/improvement-proposals/pull/134/changes as an experimental feature

## How much have you relied on LLM-based tools in this contribution?

Extensively, for everything.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
