### PR TITLE
Add smoke tests for `sbt --client`

### DIFF
--- a/.github/scripts/sbt-client-check.sh
+++ b/.github/scripts/sbt-client-check.sh
@@ -5,14 +5,13 @@ set -uo pipefail
 
 COMMAND="$1"
 EXPECTED="$2"
+LOG=$(mktemp)
 
-OUTPUT=$(sbt -no-colors --client "$COMMAND" 2>&1 || true)
-if printf '%s\n' "$OUTPUT" | grep -Faq "$EXPECTED"; then
+sbt -no-colors --client "$COMMAND" 2>&1 | tee "$LOG" || true
+
+if grep -Faq "$EXPECTED" "$LOG"; then
   echo "PASS: sbt --client \"$COMMAND\" works"
 else
   echo "FAIL: sbt --client \"$COMMAND\" did not produce expected output (looking for: $EXPECTED)"
-  echo "--- OUTPUT BEGIN ---"
-  echo "$OUTPUT"
-  echo "--- OUTPUT END ---"
   exit 1
 fi

--- a/.github/scripts/sbt-client-check.sh
+++ b/.github/scripts/sbt-client-check.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Run `sbt --client <command>` and assert its output contains <expected>.
+# Usage: sbt-client-check.sh <command> <expected>
+set -uo pipefail
+
+COMMAND="$1"
+EXPECTED="$2"
+
+OUTPUT=$(sbt -no-colors --client "$COMMAND" 2>&1 || true)
+if printf '%s\n' "$OUTPUT" | grep -Faq "$EXPECTED"; then
+  echo "PASS: sbt --client \"$COMMAND\" works"
+else
+  echo "FAIL: sbt --client \"$COMMAND\" did not produce expected output (looking for: $EXPECTED)"
+  echo "--- OUTPUT BEGIN ---"
+  echo "$OUTPUT"
+  echo "--- OUTPUT END ---"
+  exit 1
+fi

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -343,6 +343,29 @@ jobs:
       - name: Test Language Server
         run: ./project/scripts/sbt scala3-language-server/test
 
+  test-dev-commands:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Kill sbt server
+        run: .github/scripts/sbt-client-check.sh "shutdown" "no sbt server is running"
+      - name: Test `sbt --client compile`
+        run: .github/scripts/sbt-client-check.sh "compile" "compiling"
+      - name: Test `sbt --client "scalac ..."`
+        run: .github/scripts/sbt-client-check.sh "scalac -color:never -Vprint:typer tests/run/hello.scala" "hello dotty!"
+      - name: Test `sbt --client "testCompilation ..."`
+        run: .github/scripts/sbt-client-check.sh "testCompilation hello" "Failed 0, Errors 0"
+
   scripted-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -360,45 +360,13 @@ jobs:
       - name: Print sbt version
         run: sbt -version
       - name: Kill sbt server
-        run: |
-          LOG=$(mktemp)
-          sbt -no-colors --client shutdown 2>&1 | tee "$LOG" || true
-          if grep -Faq "no sbt server is running" "$LOG"; then
-            echo 'PASS: sbt --client shutdown works'
-          else
-            echo 'FAIL: sbt --client shutdown did not produce expected output'
-            exit 1
-          fi
+        run: .github/scripts/sbt-client-check.sh "shutdown" "no sbt server is running"
       - name: Test `sbt --client compile`
-        run: |
-          LOG=$(mktemp)
-          sbt -no-colors --client compile 2>&1 | tee "$LOG" || true
-          if grep -Faq "compiling" "$LOG"; then
-            echo 'PASS: sbt --client compile works'
-          else
-            echo 'FAIL: sbt --client compile did not produce expected output'
-            exit 1
-          fi
+        run: .github/scripts/sbt-client-check.sh "compile" "compiling"
       - name: Test `sbt --client "scalac ..."`
-        run: |
-          LOG=$(mktemp)
-          sbt -no-colors --client "scalac -color:never -Vprint:typer tests/run/hello.scala" 2>&1 | tee "$LOG" || true
-          if grep -Faq "hello dotty!" "$LOG"; then
-            echo 'PASS: sbt --client "scalac ..." works'
-          else
-            echo 'FAIL: sbt --client "scalac ..." did not produce expected output'
-            exit 1
-          fi
+        run: .github/scripts/sbt-client-check.sh "scalac -color:never -Vprint:typer tests/run/hello.scala" "hello dotty!"
       - name: Test `sbt --client "testCompilation ..."`
-        run: |
-          LOG=$(mktemp)
-          sbt -no-colors --client "testCompilation hello" 2>&1 | tee "$LOG" || true
-          if grep -Faq "Failed 0, Errors 0" "$LOG"; then
-            echo 'PASS: sbt --client "testCompilation ..." works'
-          else
-            echo 'FAIL: sbt --client "testCompilation ..." did not produce expected output'
-            exit 1
-          fi
+        run: .github/scripts/sbt-client-check.sh "testCompilation hello" "Failed 0, Errors 0"
 
   scripted-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -361,50 +361,42 @@ jobs:
         run: sbt -version
       - name: Kill sbt server
         run: |
-          OUTPUT=$(sbt -no-colors --client shutdown 2>&1 || true)
-          if printf '%s\n' "$OUTPUT" | grep -Faq "no sbt server is running"; then
+          LOG=$(mktemp)
+          sbt -no-colors --client shutdown 2>&1 | tee "$LOG" || true
+          if grep -Faq "no sbt server is running" "$LOG"; then
             echo 'PASS: sbt --client shutdown works'
           else
             echo 'FAIL: sbt --client shutdown did not produce expected output'
-            echo "--- OUTPUT BEGIN ---"
-            echo "$OUTPUT"
-            echo "--- OUTPUT END ---"
             exit 1
           fi
       - name: Test `sbt --client compile`
         run: |
-          OUTPUT=$(sbt -no-colors --client compile 2>&1 || true)
-          if printf '%s\n' "$OUTPUT" | grep -Faq "compiling"; then
+          LOG=$(mktemp)
+          sbt -no-colors --client compile 2>&1 | tee "$LOG" || true
+          if grep -Faq "compiling" "$LOG"; then
             echo 'PASS: sbt --client compile works'
           else
             echo 'FAIL: sbt --client compile did not produce expected output'
-            echo "--- OUTPUT BEGIN ---"
-            echo "$OUTPUT"
-            echo "--- OUTPUT END ---"
             exit 1
           fi
       - name: Test `sbt --client "scalac ..."`
         run: |
-          OUTPUT=$(sbt -no-colors --client "scalac -color:never -Vprint:typer tests/run/hello.scala" 2>&1 || true)
-          if printf '%s\n' "$OUTPUT" | grep -Faq "hello dotty!"; then
+          LOG=$(mktemp)
+          sbt -no-colors --client "scalac -color:never -Vprint:typer tests/run/hello.scala" 2>&1 | tee "$LOG" || true
+          if grep -Faq "hello dotty!" "$LOG"; then
             echo 'PASS: sbt --client "scalac ..." works'
           else
             echo 'FAIL: sbt --client "scalac ..." did not produce expected output'
-            echo "--- OUTPUT BEGIN ---"
-            echo "$OUTPUT"
-            echo "--- OUTPUT END ---"
             exit 1
           fi
       - name: Test `sbt --client "testCompilation ..."`
         run: |
-          OUTPUT=$(sbt -no-colors --client "testCompilation hello" 2>&1 || true)
-          if printf '%s\n' "$OUTPUT" | grep -Faq "Failed 0, Errors 0"; then
+          LOG=$(mktemp)
+          sbt -no-colors --client "testCompilation hello" 2>&1 | tee "$LOG" || true
+          if grep -Faq "Failed 0, Errors 0" "$LOG"; then
             echo 'PASS: sbt --client "testCompilation ..." works'
           else
             echo 'FAIL: sbt --client "testCompilation ..." did not produce expected output'
-            echo "--- OUTPUT BEGIN ---"
-            echo "$OUTPUT"
-            echo "--- OUTPUT END ---"
             exit 1
           fi
 

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -361,8 +361,8 @@ jobs:
         run: sbt -version
       - name: Kill sbt server
         run: .github/scripts/sbt-client-check.sh "shutdown" "no sbt server is running"
-      - name: Test `sbt --client compile`
-        run: .github/scripts/sbt-client-check.sh "compile" "compiling"
+      #- name: Test `sbt --client compile`
+      #  run: .github/scripts/sbt-client-check.sh "compile" "compiling"
       - name: Test `sbt --client "scalac ..."`
         run: .github/scripts/sbt-client-check.sh "scalac -color:never -Vprint:typer tests/run/hello.scala" "hello dotty!"
       - name: Test `sbt --client "testCompilation ..."`

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -360,13 +360,53 @@ jobs:
       - name: Print sbt version
         run: sbt -version
       - name: Kill sbt server
-        run: .github/scripts/sbt-client-check.sh "shutdown" "no sbt server is running"
-      #- name: Test `sbt --client compile`
-      #  run: .github/scripts/sbt-client-check.sh "compile" "compiling"
+        run: |
+          OUTPUT=$(sbt -no-colors --client shutdown 2>&1 || true)
+          if printf '%s\n' "$OUTPUT" | grep -Faq "no sbt server is running"; then
+            echo 'PASS: sbt --client shutdown works'
+          else
+            echo 'FAIL: sbt --client shutdown did not produce expected output'
+            echo "--- OUTPUT BEGIN ---"
+            echo "$OUTPUT"
+            echo "--- OUTPUT END ---"
+            exit 1
+          fi
+      - name: Test `sbt --client compile`
+        run: |
+          OUTPUT=$(sbt -no-colors --client compile 2>&1 || true)
+          if printf '%s\n' "$OUTPUT" | grep -Faq "compiling"; then
+            echo 'PASS: sbt --client compile works'
+          else
+            echo 'FAIL: sbt --client compile did not produce expected output'
+            echo "--- OUTPUT BEGIN ---"
+            echo "$OUTPUT"
+            echo "--- OUTPUT END ---"
+            exit 1
+          fi
       - name: Test `sbt --client "scalac ..."`
-        run: .github/scripts/sbt-client-check.sh "scalac -color:never -Vprint:typer tests/run/hello.scala" "hello dotty!"
+        run: |
+          OUTPUT=$(sbt -no-colors --client "scalac -color:never -Vprint:typer tests/run/hello.scala" 2>&1 || true)
+          if printf '%s\n' "$OUTPUT" | grep -Faq "hello dotty!"; then
+            echo 'PASS: sbt --client "scalac ..." works'
+          else
+            echo 'FAIL: sbt --client "scalac ..." did not produce expected output'
+            echo "--- OUTPUT BEGIN ---"
+            echo "$OUTPUT"
+            echo "--- OUTPUT END ---"
+            exit 1
+          fi
       - name: Test `sbt --client "testCompilation ..."`
-        run: .github/scripts/sbt-client-check.sh "testCompilation hello" "Failed 0, Errors 0"
+        run: |
+          OUTPUT=$(sbt -no-colors --client "testCompilation hello" 2>&1 || true)
+          if printf '%s\n' "$OUTPUT" | grep -Faq "Failed 0, Errors 0"; then
+            echo 'PASS: sbt --client "testCompilation ..." works'
+          else
+            echo 'FAIL: sbt --client "testCompilation ..." did not produce expected output'
+            echo "--- OUTPUT BEGIN ---"
+            echo "$OUTPUT"
+            echo "--- OUTPUT END ---"
+            exit 1
+          fi
 
   scripted-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -357,6 +357,8 @@ jobs:
           java-version: 17
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
+      - name: Print sbt version
+        run: sbt -version
       - name: Kill sbt server
         run: .github/scripts/sbt-client-check.sh "shutdown" "no sbt server is running"
       - name: Test `sbt --client compile`


### PR DESCRIPTION
Follow-up on https://github.com/scala/scala3/pull/25995#issuecomment-4398101881.

## How much have you relied on LLM-based tools in this contribution?

Moderately, used a bit of Kimi K2.6 and Claude Opus 4.7, but most of the work was iterating through different versions and inspecting CI logs manually.

## How was the solution tested?

- I ran the CI.
- I also confirmed the tests were failing on the CI before eb2e0413812eb21372d7a96493c4cff830ee09c7.