### PR TITLE
Implement SIP-80: `#` Companion Shorthand (experimental)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -122,6 +122,11 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   case class ContextBoundTypeTree(tycon: Tree, paramName: TypeName, ownName: TermName)(implicit @constructorOnly src: SourceFile) extends Tree
   case class MacroTree(expr: Tree)(implicit @constructorOnly src: SourceFile) extends Tree
 
+  /** `#X` in a target-typed position (SIP-80, experimental.hashCompanionShorthand).
+   *  Resolved by the Typer to `Select(T, X)` where T is the principal expected type.
+   */
+  case class HashSelect(name: TermName)(implicit @constructorOnly src: SourceFile) extends TermTree
+
   case class ImportSelector(imported: Ident, renamed: Tree = EmptyTree, bound: Tree = EmptyTree)(implicit @constructorOnly src: SourceFile) extends Tree {
     // TODO: Make bound a typed tree?
 
@@ -764,6 +769,10 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       case tree: MacroTree if expr `eq` tree.expr => tree
       case _ => finalize(tree, untpd.MacroTree(expr)(using tree.source))
     }
+    def HashSelect(tree: Tree)(name: TermName)(using Context): Tree = tree match {
+      case tree: HashSelect if name == tree.name => tree
+      case _ => finalize(tree, untpd.HashSelect(name)(using tree.source))
+    }
   }
 
   abstract class UntypedTreeMap(cpy: UntypedTreeCopier = untpd.cpy) extends TreeMap(cpy) {
@@ -817,6 +826,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         tree
       case MacroTree(expr) =>
         cpy.MacroTree(tree)(transform(expr))
+      case HashSelect(_) =>
+        tree
       case CapturesAndResult(refs, parent) =>
         cpy.CapturesAndResult(tree)(transform(refs), transform(parent))
       case UseRef(ref, initially) =>
@@ -878,6 +889,8 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
         this(x, splice)
       case MacroTree(expr) =>
         this(x, expr)
+      case HashSelect(_) =>
+        x
       case CapturesAndResult(refs, parent) =>
         this(this(x, refs), parent)
       case UseRef(ref, _) =>

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -41,6 +41,7 @@ object Feature:
   val multiSpreads = experimental("multiSpreads")
   val subCases = experimental("subCases")
   val relaxedLambdaSyntax = experimental("relaxedLambdaSyntax")
+  val hashCompanionShorthand = experimental("hashCompanionShorthand")
   val safe = experimental("safe")
 
   val nonViralExperimentalFeatures: Set[TermName] =
@@ -80,6 +81,7 @@ object Feature:
     (multiSpreads, "Enable experimental varargs with multi-spreads"),
     (subCases, "Enable experimental match expressions with sub-cases"),
     (relaxedLambdaSyntax, "Enable experimental relaxed lambda syntax"),
+    (hashCompanionShorthand, "Allow `#` companion shorthand (`#X` for `T.X` in target-typed positions)"),
     (safe, "Require safe mode"),
   )
 

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -2898,6 +2898,9 @@ object Parsers {
         case MACRO =>
           val start = in.skipToken()
           MacroTree(simpleExpr(Location.Elsewhere))
+        case HASH if in.lookahead.token == IDENTIFIER && in.featureEnabled(Feature.hashCompanionShorthand) =>
+          val start = in.skipToken()
+          atSpan(start) { HashSelect(ident()) }
         case _ =>
           if isLiteral then
             literal()
@@ -3449,6 +3452,9 @@ object Parsers {
           val typed = Typed(Ident(nme.WILDCARD), refinedType())
           Bind(nme.WILDCARD, typed).withMods(addMod(Modifiers(), givenMod))
         }
+      case HASH if in.lookahead.token == IDENTIFIER && in.featureEnabled(Feature.hashCompanionShorthand) =>
+        val start = in.skipToken()
+        simplePatternRest(atSpan(start) { HashSelect(ident()) })
       case _ =>
         if (isLiteral) literal(inPattern = true)
         else {

--- a/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Tokens.scala
@@ -224,7 +224,14 @@ object Tokens extends TokensCommon {
   final val canStartInfixExprTokens =
     atomicExprTokens
     | openParensTokens
-    | BitSet(QUOTE, NEW)
+    | BitSet(QUOTE, NEW, HASH)
+    // HASH is included for SIP-80 `#X` companion shorthand. The parser checks
+    // `featureEnabled(hashCompanionShorthand)` at the actual `case HASH` arm in
+    // `simpleExpr` / `simplePattern`, so listing HASH here without the feature
+    // import does not change behaviour: it lets the operator-parsing path
+    // recognise `#X` as a starter, but `simpleExpr` then errors normally if the
+    // import is absent. (HASH still has its existing role at type position
+    // for projection `T#X`, which is unaffected.)
 
   final val canStartExprTokens3: TokenSet =
     canStartInfixExprTokens | BitSet(INDENT, IF, WHILE, FOR, TRY, THROW)

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -827,6 +827,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         "Thicket {" ~~ toTextGlobal(trees, "\n") ~~ "}"
       case MacroTree(call) =>
         keywordStr("macro ") ~ toTextGlobal(call)
+      case HashSelect(name) =>
+        Str("#") ~ toText(name)
       case tree @ Quote(body, tags) =>
         val tagsText = (keywordStr("<") ~ toTextGlobal(tags, ", ") ~ keywordStr(">")).provided(tree.tags.nonEmpty)
         val exprTypeText = (keywordStr("[") ~ toTextGlobal(tpd.bodyType(tree.asInstanceOf[tpd.Quote])) ~ keywordStr("]")).provided(printDebug && tree.typeOpt.exists)

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -2840,6 +2840,22 @@ trait Applications extends Compatibility {
       case arg :: args1 if !altFormals.exists(_.isEmpty) =>
         def isUniform[T](xs: List[T])(p: (T, T) => Boolean) = xs.forall(p(_, xs.head))
         val formalsForArg: List[Type] = altFormals.map(_.head)
+        // SIP-80: when an argument is `#X`, pre-type it with the common formal
+        // shared across all surviving overload candidates. This handles the
+        // overload-with-default-args case (`def bar(a: Animal)` together with
+        // `def bar(a: Animal, b: Animal = ...)` — both share `Animal` at
+        // position 0, so `bar(#Cat)` resolves cleanly), and it stops a
+        // partially-typed `HashSelect` from leaking into PostTyper.
+        arg match
+          case _: untpd.HashSelect
+              if formalsForArg.forall(_.exists)
+                && isUniform(formalsForArg)(_ frozen_=:= _) =>
+            val commonFormal = formalsForArg.head
+            if isFullyDefined(commonFormal, ForceDegree.flipBottom) then
+              withMode(Mode.ImplicitsEnabled) {
+                pt.cacheArg(arg, pt.typedArg(arg, commonFormal))
+              }
+          case _ =>
         def argTypesOfFormal(formal: Type): List[Type] =
           formal.dealias match {
             case defn.FunctionOf(args, result, isImplicit) => args

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -1138,6 +1138,100 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     tree1
   }
 
+  /** Type a `#`-companion shorthand `#X` (SIP-80) by resolving it as `T.X` where
+   *  `T` is the principal companion-bearing class derived from the expected type.
+   *
+   *  Resolution algorithm:
+   *    1. Reduce `pt` (strip prototype layers; read upper bound of uninstantiated
+   *       TypeVar; peel `T | Null` / `Null | T`; widen, drop dependent refinements).
+   *    2. Locate the alias's own companion via `prefix.member(name.toTermName)`,
+   *       falling back to `classSymbol.companionModule`. The first form makes
+   *       opaque type aliases pick their own companion rather than the underlying
+   *       class's; transparent aliases / `import` / `export` work transparently.
+   *    3. Build `Select(companionRef, name)` and re-typecheck against `pt`.
+   *  Implicit conversions, overload selection, and pattern-mode handling fall out
+   *  of the reuse of `typedSelect` / `adapt`.
+   */
+  def typedHashSelect(tree: untpd.HashSelect, pt: Type)(using Context): Tree =
+    record("typedHashSelect")
+    // Gating happens at the parser via `featureEnabled(hashCompanionShorthand)`.
+    // If we reach here, the import (or `-language:experimental.hashCompanionShorthand`)
+    // is in scope and the parser produced a `HashSelect` node.
+
+    def principalTarget(tp: Type): Type = tp match
+      case tp: SelectionProto => principalTarget(tp.memberProto)
+      case tp: IgnoredProto   => principalTarget(tp.ignored)
+      case tp: FunProto       => principalTarget(tp.resultType)
+      case tp: PolyProto      => principalTarget(tp.resType)
+      case tp: ProtoType      => NoType
+      case tp: TypeBounds     => NoType
+      case tp: TypeVar =>
+        // Use the constraint's current upper bound when the variable is not yet
+        // instantiated. For `Some(#Red)` with target `Option[Color]`, the typer
+        // calls `constrainResult(Some[A], Option[Color])` to bound A <: Color.
+        val inst = tp.instanceOpt
+        if inst.exists then principalTarget(inst)
+        else
+          val hi = TypeComparer.fullUpperBound(tp.origin)
+          if !hi.exists || hi.isExactlyAny then NoType
+          else principalTarget(hi)
+      case tp if tp eq WildcardType => NoType
+      case tp =>
+        val w = tp.widenExpr
+        w match
+          case w: TypeVar => principalTarget(w)
+          // SIP-80: `T | Null` (and `Null | T`) reduces to `T`. `Null` has no
+          // useful companion members, and the union is the explicit-nulls
+          // idiom for a nullable `T`.
+          case OrType(lhs, rhs) if rhs.classSymbol == defn.NullClass => principalTarget(lhs)
+          case OrType(lhs, rhs) if lhs.classSymbol == defn.NullClass => principalTarget(rhs)
+          case _ => w.dropDependentRefinement
+
+    val target = principalTarget(pt)
+    if !target.exists then
+      return errorTree(tree,
+        em"the expected type of `#${tree.name}` cannot be determined here; the `#` companion shorthand requires a known target type",
+        tree.srcPos)
+
+    // Companion lookup: prefer the alias's own companion via prefix.member so
+    // opaque type aliases pick their own companion rather than the underlying
+    // class's. For ordinary classes this also gives the right answer because
+    // the prefix has the companion module as a member.
+    def companionByPrefix: Symbol = target match
+      case ref: TypeRef =>
+        val nameAsTerm = ref.name.toTermName
+        val prefix = ref.prefix
+        if prefix.exists && prefix.ne(NoPrefix) then
+          val mem = prefix.member(nameAsTerm)
+          if mem.exists then mem.suchThat(_.is(Module)).symbol else NoSymbol
+        else NoSymbol
+      case _ => NoSymbol
+
+    val viaPrefix = companionByPrefix
+    val companion =
+      if viaPrefix.exists then viaPrefix
+      else
+        val cls = target.classSymbol
+        if cls.exists then cls.companionModule else NoSymbol
+
+    if !companion.exists then
+      return errorTree(tree,
+        em"type $target has no companion object; `#${tree.name}` cannot be resolved (SIP-80)",
+        tree.srcPos)
+
+    val prefix = target match
+      case ref: TypeRef => ref.prefix
+      case _            => target.normalizedPrefix
+    val companionRef =
+      if prefix.exists && prefix.ne(NoPrefix) then
+        tpd.ref(TermRef(prefix, companion.asTerm)).withSpan(tree.span.startPos)
+      else
+        tpd.ref(companion).withSpan(tree.span.startPos)
+
+    val select = untpd.cpy.Select(tree)(untpd.TypedSplice(companionRef), tree.name)
+    typedSelect(select, pt)
+  end typedHashSelect
+
   def typedThis(tree: untpd.This)(using Context): Tree = {
     record("typedThis")
     assignType(tree)
@@ -3897,6 +3991,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           case tree: untpd.QuotePattern => typedQuotePattern(tree, pt)
           case tree: untpd.SplicePattern => typedSplicePattern(tree, pt)
           case tree: untpd.MacroTree => report.error("Unexpected macro", tree.srcPos); tpd.nullLiteral  // ill-formed code may reach here
+          case tree: untpd.HashSelect => typedHashSelect(tree, pt)
           case tree: untpd.Hole => typedHole(tree, pt)
           case tree: untpd.Parens =>
             checkDeprecatedAssignmentSyntax(tree)

--- a/docs/_docs/reference/experimental/hash-companion-shorthand.md
+++ b/docs/_docs/reference/experimental/hash-companion-shorthand.md
@@ -1,0 +1,146 @@
+---
+layout: doc-page
+title: "`#` Companion Shorthand"
+nightlyOf: https://docs.scala-lang.org/scala3/reference/experimental/hash-companion-shorthand.html
+---
+
+A leading `#` followed by an identifier in a target-typed position is shorthand
+for `T.X`, where `T` is the expected type. The feature is enabled per-file with
+
+```scala
+import scala.language.experimental.hashCompanionShorthand
+```
+
+## Motivation
+
+Hierarchical sealed/enum ADTs often require fully qualifying their constructors:
+
+```scala
+final case class Shape(geometry: Shape.Geometry, color: Shape.Color)
+object Shape:
+  sealed trait Geometry
+  object Geometry:
+    case object Triangle extends Geometry
+    case object Circle   extends Geometry
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+val s = Shape(Shape.Geometry.Circle, Shape.Color.Red)
+```
+
+With the `#` companion shorthand the parameters of `Shape.apply` provide the
+expected types `Geometry` and `Color`, and `#Circle` / `#Red` resolve against
+those:
+
+```scala
+val s = Shape(#Circle, #Red)
+```
+
+## Where it fires
+
+`#id` is recognised wherever it would otherwise be a syntax error — that is,
+anywhere in expression or pattern position. There is no lexical-context gate
+because `#` has no current meaning at expression position in Scala (its only
+existing role is the type-level projection `T#X`, which the expression parser
+never reaches).
+
+## Patterns
+
+The same shorthand works in pattern positions, where the expected type comes
+from the scrutinee or extractor parameter:
+
+```scala
+shape match
+  case Shape(#Triangle, #Red) => "warning"
+  case Shape(#Circle,   #Red) => "stop"
+  case _                      => "unknown"
+
+color match
+  case #Red | #Blue => "primary"
+  case _            => "other"
+```
+
+## Resolution
+
+`#X` desugars to `T.X` where `T` is the principal class component of the
+expected type, after stripping prototype layers, dealiasing transparent
+aliases, dropping dependent refinements, and **peeling `T | Null` (or
+`Null | T`) to `T`**. The selection is then re-typed by the regular `Select`
+machinery, so:
+
+- overload selection picks the alternative that admits a member named `X`;
+- implicit conversions are inserted to bridge `T.X.type` to a wider expected
+  type;
+- the resolved member must not be an anonymous given (per SIP-80).
+
+## Errors
+
+The following are reported as compile errors:
+
+- the leading-`#` syntax is used without the language import;
+- the expected type is undetermined (e.g. `def f[A](a: A); f(#Red)`);
+- the target type has no companion module;
+- the named member does not exist on the companion.
+
+## Limitations
+
+The following situations are not supported in this initial implementation;
+each has a simple workaround.
+
+### Equality and inequality
+
+`==` and `!=` are defined on `Any`, so the right operand's expected type is
+`Any`, which has no companion members named `Red`, `Blue`, etc. The shorthand
+therefore does not help with equality:
+
+```scala
+c == #Red                 // ERROR — Any has no member Red.
+c == Color.Red            // OK — the standard form.
+```
+
+This is a consequence of the resolution rule, not a special-case carve-out:
+`==` simply does not propagate a useful expected type. Library authors who
+want comparison-style use sites to participate in the shorthand can provide
+typed methods (for example `def matches(other: Color): Boolean`).
+
+### Same-arity overloads with disjoint companion members
+
+When two overloads have the same arity and their parameter types at the
+`#X` position differ, the typer cannot yet resolve `#X` against each
+candidate's parameter type. The user disambiguates:
+
+```scala
+def f(c: Color): String
+def f(d: Direction): String
+
+f(#Red)             // error: expected type cannot be determined
+f((#Red: Color))    // explicit ascription works
+```
+
+If the overloads have different arities, `narrowBySize` picks a single
+candidate before SIP-80 logic runs and `#X` resolves against that
+candidate's parameter type, so `f(#Red, 5)` works when only the 2-arg
+overload matches by arity.
+
+If the overloads agree on the parameter type at the `#X` position — for
+example because one adds a default-valued parameter as a binary-compatibility
+evolution — the shared formal is used and the call resolves cleanly:
+
+```scala
+def bar(a: Animal): Unit                    = ???
+def bar(a: Animal, b: Animal = null): Unit  = ???
+bar(#Cat)   // ok — both overloads share `a: Animal`
+```
+
+### Bare `#` cursor in IDE completion
+
+The presentation-compiler completer requires at least one identifier
+character after `#` (`#r<TAB>`) — a bare `#<TAB>` does not parse and
+therefore offers no SIP-80 suggestions. This matches Swift and Dart
+behaviour for their analogous shorthand.
+
+## See also
+
+- [SIP-80 — `#` Companion Shorthand](https://github.com/scala/improvement-proposals)

--- a/docs/_spec/06-expressions.md
+++ b/docs/_spec/06-expressions.md
@@ -38,6 +38,7 @@ SimpleExpr1  ::=  Literal
                |  SimpleExpr ‘.’ id
                |  SimpleExpr TypeArgs
                |  SimpleExpr1 ArgumentExprs
+               |  ‘#’ id [TypeArgs] [ArgumentExprs]      -- under experimental.hashCompanionShorthand (SIP-80)
                |  XmlExpr
 Exprs        ::=  Expr {‘,’ Expr}
 MatchClause  ::=  ‘match’ ‘{’ CaseClauses ‘}’

--- a/docs/_spec/08-pattern-matching.md
+++ b/docs/_spec/08-pattern-matching.md
@@ -24,6 +24,7 @@ chapter: 8
                     |  StableId ‘(’ [Patterns] ‘)’
                     |  StableId ‘(’ [Patterns ‘,’] [id ‘@’] ‘_’ ‘*’ ‘)’
                     |  ‘(’ [Patterns] ‘)’
+                    |  ‘#’ id [TypeArgs] [ArgumentPatterns]   -- under experimental.hashCompanionShorthand (SIP-80)
                     |  XmlPattern
   Patterns        ::=  Pattern {‘,’ Patterns}
 ```

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -193,6 +193,7 @@ subsection:
       - page: reference/experimental/unrolled-defs.md
       - page: reference/experimental/package-object-values.md
       - page: reference/experimental/quoted-patterns-with-polymorphic-functions.md
+      - page: reference/experimental/hash-companion-shorthand.md
       - page: reference/experimental/relaxed-lambdas.md
       - page: reference/experimental/sub-cases.md
   - page: reference/syntax.md

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -373,6 +373,13 @@ object language {
     @compileTimeOnly("`relaxedLambdaSyntax` can only be used at compile time in import statements")
     object relaxedLambdaSyntax
 
+    /** Experimental support for the `#` companion shorthand: a leading `#`
+     *  followed by an identifier in target-typed positions desugars to `T.X`,
+     *  where `T` is the expected type. See SIP-80.
+     */
+    @compileTimeOnly("`hashCompanionShorthand` can only be used at compile time in import statements")
+    object hashCompanionShorthand
+
     /** Experimental support for safe mode
      */
     @compileTimeOnly("`safe` can only be used at compile time in import statements")

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -181,6 +181,13 @@ private[scala] object language:
      */
     @compileTimeOnly("`relaxedLambdaSyntax` can only be used at compile time in import statements")
     object relaxedLambdaSyntax
+
+    /** Experimental support for the `#` companion shorthand: a leading `#`
+     *  followed by an identifier in target-typed positions desugars to `T.X`,
+     *  where `T` is the expected type. See SIP-80.
+     */
+    @compileTimeOnly("`hashCompanionShorthand` can only be used at compile time in import statements")
+    object hashCompanionShorthand
   end experimental
 
   /** The deprecated object contains features that are no longer officially suypported in Scala.

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -585,10 +585,13 @@ class Completions(
           config.isCompletionSnippetsEnabled()
         )
         (args, false)
-    val singletonCompletions = InferCompletionType.inferType(path).map(
+    val expectedType = InferCompletionType.inferType(path)
+    val singletonCompletions = expectedType.map(
       SingletonCompletions.contribute(path, _, completionPos)
     ).getOrElse(Nil)
-    (singletonCompletions ++ advanced, exclusive)
+    val hashCompletions =
+      HashCompanionCompletions.contribute(path, expectedType, completionPos)
+    (hashCompletions ++ singletonCompletions ++ advanced, exclusive)
   end advancedCompletions
 
   private def isAmmoniteCompletionPosition(

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/HashCompanionCompletions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/HashCompanionCompletions.scala
@@ -1,0 +1,121 @@
+package dotty.tools.pc.completions
+
+import scala.meta.internal.metals.Fuzzy
+
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.core.NameOps.*
+import dotty.tools.dotc.core.Symbols
+import dotty.tools.dotc.core.Symbols.NoSymbol
+import dotty.tools.dotc.core.Types.NoPrefix
+import dotty.tools.dotc.core.Types.OrType
+import dotty.tools.dotc.core.Types.Type
+import dotty.tools.dotc.core.Types.TypeRef
+import dotty.tools.pc.utils.InteractiveEnrichments.*
+
+/** SIP-80 `#` companion shorthand completions: when the cursor is in a
+ *  target-typed position immediately after `#`, suggest term-level members of
+ *  the expected type's companion object. Mirrors `SingletonCompletions` in
+ *  shape.
+ */
+object HashCompanionCompletions:
+
+  def contribute(
+      path: List[Tree],
+      expectedTypeOpt: Option[Type],
+      completionPos: CompletionPos
+  )(using ctx: Context): List[CompletionValue] =
+    // Determine the target type. Prefer the type derived from the path
+    // (the qualifier of `#X` after `Typer.typedHashSelect`); fall back to
+    // the InferCompletionType result, which handles term contexts but not
+    // all pattern shapes.
+    val expectedTypeFromPath: Option[Type] = path.headOption.flatMap {
+      case Select(qual, _) if qual.symbol.is(Flags.Module) =>
+        val mod = qual.symbol
+        val cls = mod.companionClass
+        if cls.exists then Some(cls.typeRef) else None
+      case _ => None
+    }
+    val expectedType = expectedTypeOpt.orElse(expectedTypeFromPath)
+    expectedType match
+      case None => Nil
+      case Some(target) =>
+        if !isHashContext(completionPos, path, target) then Nil
+        else
+          val query = completionPos.query
+          val companion = companionOf(target)
+          if !companion.exists then Nil
+          else
+            val info = companion.info
+            val isMatch: Symbols.Symbol => Boolean = sym =>
+              sym.isTerm
+                && !sym.isConstructor
+                && !sym.is(Flags.Synthetic)
+                && !sym.is(Flags.Private)
+                && !sym.name.toString.contains('$')
+                && !isAnonymousGiven(sym)
+                && (query.isEmpty || Fuzzy.matches(query, sym.name.toString))
+            val members =
+              info.decls.iterator
+                .filter(isMatch)
+                .toList
+                .distinctBy(_.name.toString)
+            val range = completionPos.toEditRange
+            members.map { sym =>
+              CompletionValue.SingletonValue(sym.name.toString, sym.info, Some(range))
+            }
+
+  /** A `#`-shorthand context exists when both:
+   *    1. The character immediately before the query is `#`, and
+   *    2. The path's head is a Select whose qualifier symbol is the
+   *       resolved companion of the expected type and whose qualifier span
+   *       has zero width — `Typer.typedHashSelect` synthesises the
+   *       qualifier with a point span at the `#`, while a user-written
+   *       qualifier like `TestEnum` has a non-zero span covering its name.
+   *       This stops the contributor firing on regular selections.
+   */
+  private def isHashContext(
+      completionPos: CompletionPos,
+      path: List[Tree],
+      expectedType: Type
+  )(using Context): Boolean =
+    val content = completionPos.originalCursorPosition.source.content()
+    val hashIdx = completionPos.queryStart - 1
+    val hasHashBefore =
+      hashIdx >= 0 && hashIdx < content.length && content(hashIdx) == '#'
+    if !hasHashBefore then false
+    else
+      val companion = companionOf(expectedType)
+      companion.exists && path.headOption.exists {
+        case Select(qual, _) =>
+          qual.symbol == companion && qual.span.start == qual.span.end
+        case _ => false
+      }
+
+  private def companionOf(tp0: Type)(using Context): Symbols.Symbol =
+    // Mirror `Typer.typedHashSelect`: peel `T | Null` (or `Null | T`) to
+    // `T`, then prefer the alias's own companion via prefix.member so
+    // opaque type aliases pick their alias's companion rather than the
+    // underlying class's.
+    val tp = peelNullUnion(tp0)
+    val byPrefix = tp match
+      case ref: TypeRef =>
+        val pre = ref.prefix
+        if pre.exists && pre.ne(NoPrefix) then
+          val mem = pre.member(ref.name.toTermName)
+          if mem.exists then mem.suchThat(_.is(Flags.Module)).symbol else NoSymbol
+        else NoSymbol
+      case _ => NoSymbol
+    if byPrefix.exists then byPrefix
+    else
+      val cls = tp.classSymbol
+      if cls.exists then cls.companionModule else NoSymbol
+
+  private def peelNullUnion(tp: Type)(using Context): Type = tp match
+    case OrType(lhs, rhs) if rhs.classSymbol == Symbols.defn.NullClass => peelNullUnion(lhs)
+    case OrType(lhs, rhs) if lhs.classSymbol == Symbols.defn.NullClass => peelNullUnion(rhs)
+    case _ => tp
+
+  private def isAnonymousGiven(sym: Symbols.Symbol)(using Context): Boolean =
+    sym.is(Flags.Given) && sym.name.toString.startsWith("given_")

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/HashCompanionCompletionsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/HashCompanionCompletionsSuite.scala
@@ -1,0 +1,137 @@
+package dotty.tools.pc.tests.completion
+
+import dotty.tools.pc.base.BaseCompletionSuite
+
+import org.junit.Test
+
+/** SIP-80: `#` companion shorthand completions in target-typed positions.
+ *
+ *  Tests use `#X@@` (at least one identifier char after the hash) so the
+ *  parser successfully produces a `HashSelect` and the typer rewrites it to
+ *  `Select(companionRef, X)`. The bare `#@@` form (cursor immediately after a
+ *  hash with no identifier char) does not parse and therefore offers no
+ *  completions in this v1 — users get suggestions once they type any letter.
+ */
+class HashCompanionCompletionsSuite extends BaseCompletionSuite:
+
+  private val colorAdt =
+    """|sealed trait Color
+       |object Color:
+       |  case object Red   extends Color
+       |  case object Blue  extends Color
+       |  case object Green extends Color
+       |""".stripMargin
+
+  @Test def `val-rhs-prefix` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |val c: Color = #R@@
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `val-rhs-empty-prefix-letter` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |val c: Color = #B@@
+          |""".stripMargin,
+      "Blue: Blue",
+      filter = _.startsWith("Blue")
+    )
+
+  @Test def `arg-position` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |def paint(c: Color): String = c.toString
+          |val s: String = paint(#R@@)
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `named-arg` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |def paint(c: Color): String = c.toString
+          |val s: String = paint(c = #G@@)
+          |""".stripMargin,
+      "Green: Green",
+      filter = _.startsWith("Green")
+    )
+
+  @Test def `pattern-position` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |val c: Color = Color.Red
+          |val s: String = c match
+          |  case #R@@ => "red"
+          |  case _    => "other"
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `pattern-named-extractor` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |final case class Wrap(c: Color)
+          |val w: Wrap = Wrap(Color.Red)
+          |val s: String = w match
+          |  case Wrap(c = #R@@) => "red"
+          |  case _              => "other"
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `enum-cases` =
+    check(
+      """|import scala.language.experimental.hashCompanionShorthand
+         |enum Light:
+         |  case On, Off, Dim
+         |val l: Light = #O@@
+         |""".stripMargin,
+      """|On: Light
+         |Off: Light""".stripMargin,
+      filter = label => label.startsWith("On") || label.startsWith("Off")
+    )
+
+  @Test def `null-union` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |val c: Color | Null = #R@@
+          |""".stripMargin,
+      "Red: Red",
+      filter = _.startsWith("Red")
+    )
+
+  @Test def `null-union-reversed` =
+    check(
+      s"""|import scala.language.experimental.hashCompanionShorthand
+          |$colorAdt
+          |val c: Null | Color = #B@@
+          |""".stripMargin,
+      "Blue: Blue",
+      filter = _.startsWith("Blue")
+    )
+
+  @Test def `no-import-no-completions` =
+    // Without the language import the parser rejects `#X`, so the hash
+    // completer should not contribute anything specific to SIP-80.
+    check(
+      """|sealed trait Color
+         |object Color:
+         |  case object Red extends Color
+         |val c: Color = #R@@
+         |""".stripMargin,
+      "",
+      filter = _.startsWith("Red")
+    )

--- a/tests/neg/hash-companion-shorthand-equality.scala
+++ b/tests/neg/hash-companion-shorthand-equality.scala
@@ -1,0 +1,13 @@
+// SIP-80 §Equality: `==` is defined on `Any`, so the right operand's expected
+// type is `Any` — which has no member `Red`. The shorthand therefore does not
+// help with equality comparisons. Users should write `Color.Red` instead.
+import scala.language.experimental.hashCompanionShorthand
+
+object Equality:
+  sealed trait Color
+  object Color:
+    case object Red extends Color
+
+  val c: Color = Color.Red
+
+  val bad: Boolean = c == #Red // error

--- a/tests/neg/hash-companion-shorthand-missing-member.scala
+++ b/tests/neg/hash-companion-shorthand-missing-member.scala
@@ -1,0 +1,13 @@
+import scala.language.experimental.hashCompanionShorthand
+
+object MissingMember:
+
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+  val ok: Color = #Red
+
+  // `Purple` is not a member of `Color`'s companion.
+  val bad: Color = #Purple // error

--- a/tests/neg/hash-companion-shorthand-no-companion.scala
+++ b/tests/neg/hash-companion-shorthand-no-companion.scala
@@ -1,0 +1,14 @@
+import scala.language.experimental.hashCompanionShorthand
+
+// A type without a companion module (here: a refinement of a trait) cannot
+// resolve `#X`.
+object NoCompanion:
+
+  trait Bare // no companion module
+
+  val x: Bare = #Foo // error
+
+  // Function types fall through `Function1`'s companion which has no
+  // user-declared cases — useful members (`apply`) won't match a value-type
+  // expectation.
+  val f: Int => String = #NotThere // error

--- a/tests/neg/hash-companion-shorthand-no-import.scala
+++ b/tests/neg/hash-companion-shorthand-no-import.scala
@@ -1,0 +1,10 @@
+// Without the `experimental.hashCompanionShorthand` import, the leading-`#`
+// syntax is a parse error.
+
+object NoImport:
+
+  sealed trait Color
+  object Color:
+    case object Red extends Color
+
+  val c: Color = #Red // error

--- a/tests/neg/hash-companion-shorthand-overload.scala
+++ b/tests/neg/hash-companion-shorthand-overload.scala
@@ -1,0 +1,18 @@
+import scala.language.experimental.hashCompanionShorthand
+
+// SIP-80 v1: same-arity overloads with disjoint formals at the `#X` position
+// are not auto-disambiguated. The user supplies an ascription or a wrapper.
+object OverloadNeg:
+
+  sealed trait Color
+  object Color:
+    case object Red extends Color
+
+  sealed trait Direction
+  object Direction:
+    case object North extends Direction
+
+  def f(c: Color): String     = ""
+  def f(d: Direction): String = ""
+
+  val bad: String = f(#Red) // error

--- a/tests/neg/hash-companion-shorthand-undetermined-pt.scala
+++ b/tests/neg/hash-companion-shorthand-undetermined-pt.scala
@@ -1,0 +1,15 @@
+import scala.language.experimental.hashCompanionShorthand
+
+object UndeterminedPt:
+
+  sealed trait Color
+  object Color:
+    case object Red extends Color
+
+  // No expected type — caller can't infer a target.
+  def poly[A](a: A): A = a
+  poly(#Red) // error
+
+  // Bare expression statement; nothing constrains the expected type to Color.
+  def stmt(): Unit =
+    #Red // error

--- a/tests/pos/hash-companion-shorthand-aliases.scala
+++ b/tests/pos/hash-companion-shorthand-aliases.scala
@@ -1,0 +1,49 @@
+// SIP-80: `#` companion shorthand should work with transparent type aliases,
+// `import`-introduced types, and `export`-introduced types.
+import scala.language.experimental.hashCompanionShorthand
+
+object Lib:
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+object AliasUser:
+  // Transparent type alias.
+  type MyColor = Lib.Color
+
+  def foo(color: MyColor): Unit = ()
+
+  val c1: MyColor = #Red          // resolves through MyColor → Color
+  foo(#Blue)
+  foo(color = #Green)
+
+  // Match on the alias.
+  val s: String = c1 match
+    case #Red   => "r"
+    case #Blue  => "b"
+    case #Green => "g"
+
+object ImportUser:
+  // `import` brings the type into scope; resolution still finds the
+  // companion via the alias's own prefix.
+  import Lib.Color
+  def paint(c: Color): Unit = ()
+  val c: Color = #Red
+  paint(#Blue)
+
+object ExportingFacade:
+  // Re-export the type. Clients that import from this facade should still
+  // be able to use the shorthand.
+  export Lib.Color
+
+object ExportClient:
+  import ExportingFacade.Color
+  def use(c: Color): Unit = ()
+  val c: Color = #Red
+  use(#Green)
+
+  // Combined: alias on top of an exported type.
+  type Hue = Color
+  val h: Hue = #Blue

--- a/tests/pos/hash-companion-shorthand-chain.scala
+++ b/tests/pos/hash-companion-shorthand-chain.scala
@@ -1,0 +1,47 @@
+import scala.language.experimental.hashCompanionShorthand
+
+object Chain:
+
+  sealed trait Animal
+  object Animal:
+    sealed trait Mammal extends Animal
+    object Mammal:
+      case object Dog extends Mammal
+      case object Cat extends Mammal
+    sealed trait Bird extends Animal
+    object Bird:
+      case object Robin extends Bird
+
+  def describe(a: Animal): String = a.toString
+
+  // Hierarchical chain: `#Mammal` is the shorthand, `.Dog` is plain Select.
+  val a1: String = describe(#Mammal.Dog)
+  val a2: Animal = #Bird.Robin
+
+  // Application form: `#method(args)`.
+  trait Frag
+  object Frag:
+    def color(name: String): Frag = new Frag {}
+    def text(s: String): Frag    = new Frag {}
+
+  def render(frag: Frag): String = frag.toString
+
+  val r1: String = render(#color("red"))
+  val r2: Frag   = #text("hi")
+
+  // Mixed: shorthand + chain + apply.
+  trait Builder
+  object Builder:
+    def of(name: String): Inner = new Inner
+    class Inner:
+      def withCount(n: Int): Builder = new Builder {}
+
+  def build(b: Builder): String = b.toString
+  val b1: String = build(#of("widget").withCount(3))
+
+  // Method-chain continuation is unaffected by `#` (unlike the `.X` proposal).
+  // `expr\n  .toUpperCase` still chains — the `#` sigil leaves the existing
+  // chain-continuation rule untouched.
+  val expr: String = "abc"
+    .toUpperCase
+    .reverse

--- a/tests/pos/hash-companion-shorthand-conversion.scala
+++ b/tests/pos/hash-companion-shorthand-conversion.scala
@@ -1,0 +1,23 @@
+import scala.language.experimental.hashCompanionShorthand
+import scala.language.implicitConversions
+
+object Conversion:
+
+  enum LogLevel:
+    case INFO, WARN, ERROR
+
+  // Opaque-type bridge per SIP-80 §implicit-conversion bridging.
+  opaque type ParserLogLevel = LogLevel
+  object ParserLogLevel:
+    export LogLevel.{INFO, WARN, ERROR}
+    given Conversion[LogLevel, ParserLogLevel] = identity(_)
+
+  def parseStrict(level: ParserLogLevel): Unit = ()
+
+  // `#INFO` resolves against `ParserLogLevel`'s companion (export forwards),
+  // produces a `LogLevel`, and the `Conversion` adapts it to `ParserLogLevel`.
+  parseStrict(#INFO)
+  parseStrict(#WARN)
+
+  // Direct (no conversion needed).
+  val l: LogLevel = #ERROR

--- a/tests/pos/hash-companion-shorthand-default-args.scala
+++ b/tests/pos/hash-companion-shorthand-default-args.scala
@@ -1,0 +1,31 @@
+// SIP-80 §Overload resolution: overloads that differ only by an extra
+// default-valued parameter (a common binary-compatibility evolution pattern)
+// resolve `#X` against the parameter type they share.
+//
+// Both overloads can be called with one argument (the second has a default
+// for `b`). `narrowBySize` keeps both, but their first parameter type is
+// the same, so SIP-80's `pretypeArgs` extension pre-types `#Cat` with that
+// common formal — `narrowMostSpecific` then picks the no-default overload.
+import scala.language.experimental.hashCompanionShorthand
+
+sealed trait Animal
+object Animal:
+  case object Cat extends Animal
+  case object Dog extends Animal
+
+object SameFirstFormal:
+  def bar(a: Animal): Int                         = 1
+  def bar(a: Animal, b: Animal = Animal.Dog): Int = 2
+
+  // Both overloads applicable by arity. Shared formal at position 0 is
+  // `Animal`, so `#Cat` resolves there.
+  val r: Int = bar(#Cat)
+
+  // Same shape with a slightly different default expression.
+  def baz(a: Animal): String                = a.toString
+  def baz(a: Animal, sep: String = "-"): String = a.toString
+  val s: String = baz(#Dog)
+
+  // Common formal at position 0 with a shorthand followed by an explicit
+  // second arg should also work — the 2-arg overload is selected.
+  val r2: Int = bar(#Cat, Animal.Dog)

--- a/tests/pos/hash-companion-shorthand-enum.scala
+++ b/tests/pos/hash-companion-shorthand-enum.scala
@@ -1,0 +1,22 @@
+import scala.language.experimental.hashCompanionShorthand
+
+object EnumSupport:
+
+  enum Color:
+    case Red, Blue, Green
+
+  enum Tree[+A]:
+    case Leaf
+    case Node(value: A, left: Tree[A], right: Tree[A])
+
+  def show(c: Color): String = c match
+    case #Red   => "R"
+    case #Blue  => "B"
+    case #Green => "G"
+
+  val c1: Color = #Red
+  val c2: Color = #Blue
+
+  // Parameterised enum case (value-class and type-arg interaction).
+  val t: Tree[Int] = #Leaf
+  val t2: Tree[Int] = #Node(1, #Leaf, #Leaf)

--- a/tests/pos/hash-companion-shorthand-inference.scala
+++ b/tests/pos/hash-companion-shorthand-inference.scala
@@ -1,0 +1,16 @@
+// SIP-80: when a generic call's type parameter is constrainable from the
+// surrounding expected type, type inference flows through the result and
+// the shorthand arguments resolve against the inferred parameter.
+// E.g. `Seq.apply[A](xs: A*): Seq[A]` here gets `A = Color` from the val's
+// declared type, so `#Red`/`#Blue` are typed against `Color`.
+import scala.language.experimental.hashCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red  extends Color
+  case object Blue extends Color
+
+object Inference:
+  val xs: Seq[Color]    = Seq(#Red, #Blue)
+  val ls: List[Color]   = List(#Red, #Blue, #Red)
+  val opt: Option[Color] = Some(#Blue)

--- a/tests/pos/hash-companion-shorthand-infix.scala
+++ b/tests/pos/hash-companion-shorthand-infix.scala
@@ -1,0 +1,30 @@
+// SIP-80 §Infix applications: because `#` is a fresh starter token at
+// expression position, the bare infix form `a op #X` parses cleanly.
+// (This case is a parse error under the leading-`.` proposal — a key
+// structural advantage of `#`.)
+import scala.language.experimental.hashCompanionShorthand
+
+object Infix:
+
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+  extension (c: Color)
+    infix def matchesColor(other: Color): Boolean = c == other
+    infix def or(other: Color): Color = c
+    def |+|(other: Color): Color      = other
+
+  val c: Color = Color.Red
+
+  // Custom infix method — RHS expected type is Color, so `#Red` resolves.
+  val eq2: Boolean   = c matchesColor #Red
+  val combined: Color = c or #Blue
+
+  // Operator-syntax custom: `c |+| #Red`.
+  val res: Color = c |+| #Red
+
+  // Method-call form (always works regardless of sigil).
+  val res2: Color = c.|+|(#Red)
+  val eq3: Boolean = c.matchesColor(#Red)

--- a/tests/pos/hash-companion-shorthand-null-union.scala
+++ b/tests/pos/hash-companion-shorthand-null-union.scala
@@ -1,0 +1,35 @@
+// SIP-80: `T | Null` (and `Null | T`) is special-cased so the shorthand
+// resolves against `T`'s companion. `Null` has no useful companion members
+// and `T | Null` is the common nullable-reference idiom.
+import scala.language.experimental.hashCompanionShorthand
+
+object NullUnion:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  // RHS of typed val.
+  val c1: Color | Null = #Red
+  val c2: Null | Color = #Blue
+
+  // Argument position.
+  def paint(c: Color | Null): String = if c == null then "null" else c.toString
+  val s1: String = paint(#Green)
+  val s2: String = paint(null)
+
+  // Conditional with nullable result type.
+  def maybeColor(b: Boolean): Color | Null = if b then #Red else null
+
+  // Pattern position — the scrutinee type provides the pt.
+  val c: Color | Null = Color.Red
+  val s: String = c match
+    case #Red   => "r"
+    case #Blue  => "b"
+    case #Green => "g"
+    case null   => "null"
+
+  // Nested (rare but should work).
+  val c3: (Color | Null) | Null = #Red

--- a/tests/pos/hash-companion-shorthand-opaque.scala
+++ b/tests/pos/hash-companion-shorthand-opaque.scala
@@ -1,0 +1,23 @@
+import scala.language.experimental.hashCompanionShorthand
+
+// Module providing the opaque type. From outside this module the alias is
+// abstract and `#X` should resolve against the alias's own companion (per SIP-80).
+object Lib:
+  enum Severity:
+    case INFO, WARN, ERROR
+
+  opaque type Level = Severity
+  object Level:
+    val Info: Level  = Severity.INFO
+    val Warn: Level  = Severity.WARN
+    val Error: Level = Severity.ERROR
+
+object OpaqueClient:
+  import Lib.Level
+
+  // From outside Lib, Level is opaque — so `#Info` resolves on Level's companion.
+  val l1: Level = #Info
+  val l2: Level = #Warn
+
+  def log(level: Level): Unit = ()
+  log(#Error)

--- a/tests/pos/hash-companion-shorthand-option-either.scala
+++ b/tests/pos/hash-companion-shorthand-option-either.scala
@@ -1,0 +1,41 @@
+// SIP-80: when the target type is `Option[T]` or `Either[L, T]` and the
+// constructor (`Some`, `Right`, `Left`) is applied to a relative selection,
+// the type parameter is inferred from the surrounding expected type and
+// the shorthand resolves against `T`'s companion.
+import scala.language.experimental.hashCompanionShorthand
+
+object OptionEitherUse:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  // Wrapping `#X` in `Some` — pt of the val is `Option[Color]`, which lets
+  // type inference for `Some.apply[A]` pick `A = Color`, after which `#Red`
+  // is typed against `Color`.
+  val o1: Option[Color] = Some(#Red)
+  val o2: Option[Color] = Some(#Blue)
+  val o3: Option[Color] = None
+
+  // Argument position: the parameter type drives inference.
+  def use(o: Option[Color]): Color = o.getOrElse(Color.Red)
+  val u1: Color = use(Some(#Green))
+  val u2: Color = use(None)
+
+  // Either with a shorthand on the Right side.
+  val e1: Either[String, Color] = Right(#Red)
+  val e2: Either[Color, Int]    = Left(#Blue)
+  val e3: Either[Color, Color]  = Right(#Green)  // exercises both type params
+
+  // Pattern matching reads the same way.
+  val s: String = (o1: Option[Color]) match
+    case Some(#Red)   => "r"
+    case Some(#Blue)  => "b"
+    case Some(#Green) => "g"
+    case None         => "n"
+
+  // Direct member of the Option / Either companion is also reachable.
+  val o4: Option[Int] = #empty       // Option.empty
+  val e4: Either[String, Int] = #cond(true, 1, "x")  // Either.cond

--- a/tests/pos/hash-companion-shorthand-overload-arity.scala
+++ b/tests/pos/hash-companion-shorthand-overload-arity.scala
@@ -1,0 +1,20 @@
+// SIP-80: when overload arity narrows to a single candidate, `#X` resolves
+// against that candidate's formal parameter type. This is the
+// arity-disambiguation path — narrowBySize picks the unique candidate before
+// SIP-80 logic runs.
+import scala.language.experimental.hashCompanionShorthand
+
+object Arity:
+
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+  def foo(arg: Color): String              = "1: " + arg
+  def foo(arg: Color, arg2: Int): String   = "2: " + arg + "," + arg2
+
+  // 1 arg arity → first overload wins; #Red typed with pt=Color.
+  val r1: String = foo(#Red)
+  // 2 args arity → second overload wins; #Red typed with pt=Color.
+  val r2: String = foo(#Red, 5)

--- a/tests/pos/hash-companion-shorthand-overload.scala
+++ b/tests/pos/hash-companion-shorthand-overload.scala
@@ -1,0 +1,29 @@
+import scala.language.experimental.hashCompanionShorthand
+
+// Same-arity overloads with disjoint companion members require explicit
+// disambiguation in v1 (the SIP defers smarter resolution to a follow-up).
+object Overload:
+
+  sealed trait Color
+  object Color:
+    case object Red  extends Color
+    case object Blue extends Color
+
+  sealed trait Direction
+  object Direction:
+    case object North extends Direction
+    case object South extends Direction
+
+  def f(c: Color): String     = "color: " + c
+  def f(d: Direction): String = "dir: " + d
+  def f(i: Int): String       = "int: " + i
+
+  // Disambiguate via ascription — `#Red` is in a target-typed position.
+  val r1: String = f((#Red: Color))
+  val r2: String = f((#North: Direction))
+
+  // Or via a non-overloaded wrapper; `#X` then sees a clean expected type.
+  def fc(c: Color): String     = f(c)
+  def fd(d: Direction): String = f(d)
+  val r3: String = fc(#Red)
+  val r4: String = fd(#North)

--- a/tests/pos/hash-companion-shorthand-patterns.scala
+++ b/tests/pos/hash-companion-shorthand-patterns.scala
@@ -1,0 +1,41 @@
+import scala.language.experimental.hashCompanionShorthand
+
+object Patterns:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  sealed trait Geometry
+  object Geometry:
+    case object Triangle extends Geometry
+    case object Circle   extends Geometry
+
+  final case class Shape(geometry: Geometry, color: Color)
+
+  // Pattern position — single shorthand selector.
+  def name(c: Color): String = c match
+    case #Red   => "red"
+    case #Blue  => "blue"
+    case #Green => "green"
+
+  // `|` alternatives.
+  def warm(c: Color): Boolean = c match
+    case #Red | #Green => true
+    case _             => false
+
+  // Nested in extractor pattern: each sub-pattern's expected type comes from
+  // the corresponding extractor parameter.
+  def kind(s: Shape): String = s match
+    case Shape(#Triangle, _)             => "triangle"
+    case Shape(#Circle, #Red)            => "stop sign"
+    case Shape(#Circle, #Blue | #Green)  => "wheel"
+    case _                               => "other"
+
+  // Bound name combined with shorthand: `c @ #Red` is a Bind that wraps
+  // the shorthand pattern.
+  def label(c: Color): String = c match
+    case x @ #Red => "got " + x.toString
+    case _        => "other"

--- a/tests/pos/hash-companion-shorthand-varargs.scala
+++ b/tests/pos/hash-companion-shorthand-varargs.scala
@@ -1,0 +1,42 @@
+// SIP-80: `#X` in varargs positions.
+// Each arg in a `T*` parameter is typed with element type `T`, so
+// `#X` resolves against `T`'s companion just like in non-varargs args.
+import scala.language.experimental.hashCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red   extends Color
+  case object Blue  extends Color
+  case object Green extends Color
+
+object Vararg:
+  def palette(colors: Color*): Int = colors.size
+
+  // 0 args.
+  val n0: Int = palette()
+
+  // Single arg.
+  val n1: Int = palette(#Red)
+
+  // Several args.
+  val n3: Int = palette(#Red, #Blue, #Green)
+
+  // Mixed: explicit and shorthand.
+  val nm: Int = palette(Color.Red, #Blue)
+
+  // Splat from a `Seq[Color]`. The val's declared type `Seq[Color]` constrains
+  // `Seq.apply`'s type parameter to `Color`, which lets each `#X` resolve
+  // against `Color`'s companion.
+  val seq: Seq[Color] = Seq(#Red, #Blue)
+  val ns: Int = palette(seq*)
+
+  // Repeated parameter after a regular parameter.
+  def labelled(name: String, colors: Color*): Int = colors.size
+  val nl: Int = labelled("primary", #Red, #Blue, #Green)
+
+  // Varargs in extractor (pattern position) — repeated patterns get the
+  // element type as expected type.
+  val list: List[Color] = List(#Red, #Blue, #Green)
+  val s: String = list match
+    case List(#Red, _*) => "starts with red"
+    case _              => "other"

--- a/tests/pos/hash-companion-shorthand.scala
+++ b/tests/pos/hash-companion-shorthand.scala
@@ -1,0 +1,45 @@
+import scala.language.experimental.hashCompanionShorthand
+
+object Basic:
+
+  sealed trait Color
+  object Color:
+    case object Red   extends Color
+    case object Blue  extends Color
+    case object Green extends Color
+
+  sealed trait Geometry
+  object Geometry:
+    case object Triangle extends Geometry
+    case object Circle   extends Geometry
+    case object Square   extends Geometry
+
+  final case class Shape(geometry: Geometry, color: Color)
+
+  // Argument position — direct.
+  val s1: Shape = Shape(#Circle, #Red)
+
+  // Mixed positional / explicit.
+  val s2: Shape = Shape(Geometry.Triangle, #Blue)
+  val s3: Shape = Shape(#Square, Color.Green)
+
+  // RHS of typed val.
+  val c: Color = #Red
+  val g: Geometry = #Square
+
+  // Parenthesised.
+  val c2: Color = (#Red)
+
+  // `if` arms — both branches share the expected type.
+  def pick(b: Boolean): Color = if b then #Red else #Blue
+
+  // Inside lambda body with target type.
+  val mk: Boolean => Color = b => if b then #Red else #Blue
+
+  // Named argument: the name fixes the expected type.
+  val s4: Shape = Shape(color = #Red, geometry = #Circle)
+
+  // Using clause.
+  def withColor(using c: Color): Color = c
+  given Color = Color.Blue
+  val c4: Color = withColor(using #Green)

--- a/tests/run/hash-companion-shorthand.check
+++ b/tests/run/hash-companion-shorthand.check
@@ -1,0 +1,5 @@
+stop
+info
+warning
+unknown
+Red

--- a/tests/run/hash-companion-shorthand.scala
+++ b/tests/run/hash-companion-shorthand.scala
@@ -1,0 +1,35 @@
+import scala.language.experimental.hashCompanionShorthand
+
+sealed trait Color
+object Color:
+  case object Red   extends Color
+  case object Blue  extends Color
+  case object Green extends Color
+
+sealed trait Geometry
+object Geometry:
+  case object Triangle extends Geometry
+  case object Circle   extends Geometry
+
+final case class Shape(geometry: Geometry, color: Color)
+
+object Test:
+  def describe(s: Shape): String = s match
+    case Shape(#Triangle, #Red)  => "warning"
+    case Shape(#Circle,   #Red)  => "stop"
+    case Shape(#Circle,   #Blue) => "info"
+    case _                       => "unknown"
+
+  def main(args: Array[String]): Unit =
+    val stop:  Shape = Shape(#Circle, #Red)
+    val info:  Shape = Shape(#Circle, #Blue)
+    val warn:  Shape = Shape(#Triangle, #Red)
+    val other: Shape = Shape(#Triangle, #Green)
+    println(describe(stop))
+    println(describe(info))
+    println(describe(warn))
+    println(describe(other))
+
+    // Bare RHS form.
+    val c: Color = #Red
+    println(c)


### PR DESCRIPTION
Implements SIP-80 https://github.com/scala/improvement-proposals/pull/134/changes as an experimental feature

## How much have you relied on LLM-based tools in this contribution?

Extensively, for everything.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
