### PR TITLE
Preserve user-defined closure parameter names under CC

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureRunInfo.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureRunInfo.scala
@@ -2,12 +2,21 @@ package dotty.tools.dotc
 package cc
 
 import core.Contexts.{Context, ctx}
+import core.Names.TermName
+import core.Types.Type
 import config.Printers.capt
+import util.EqHashMap
 
 trait CaptureRunInfo:
   self: Run =>
   private var maxSize = 0
   private var maxPath: List[CaptureSet.DerivedVar] = Nil
+
+  /** Backing table for [[ClosureParamNames]] — see that file for the
+   *  read/write protocol. Don't access this field directly; use the
+   *  `ClosureParamNames` API.
+   */
+  private[cc] val closureParamNames: EqHashMap[Type, List[TermName]] = EqHashMap()
 
   def recordPath(size: Int, path: => List[CaptureSet.DerivedVar]): Unit =
     if size > maxSize then
@@ -22,4 +31,5 @@ trait CaptureRunInfo:
   protected def reset(): Unit =
     maxSize = 0
     maxPath = Nil
+    closureParamNames.clear()
 end CaptureRunInfo

--- a/compiler/src/dotty/tools/dotc/cc/ClosureParamNames.scala
+++ b/compiler/src/dotty/tools/dotc/cc/ClosureParamNames.scala
@@ -1,0 +1,70 @@
+package dotty.tools.dotc
+package cc
+
+import core.*
+import Contexts.*, Symbols.defn, Types.*, Names.*
+import config.Feature
+
+/** Preserves user-written closure parameter names through type rebuilds, so
+ *  that capture checking can recover them when expanding plain `FunctionN`
+ *  inferred types into dependent function types.
+ *
+ *  Lifecycle:
+ *
+ *   - [[record]] is called when a `Closure` is assigned its inferred type.
+ *     If that type is a plain (non-refined) `FunctionN` with user-given param
+ *     names, the names are stored against the `AppliedType`.
+ *
+ *   - [[propagate]] is called from [[Types.AppliedType.derivedAppliedType]]
+ *     each time an `AppliedType` is rebuilt (e.g. by PostTyper inserting
+ *     `@caps.declared` annotations, or by capture-set substitution). It
+ *     transfers the registration to the rebuilt type so identity lookups
+ *     keep working.
+ *
+ *   - [[of]] is read by `cc.Setup.normalizeFunctions` when expanding a plain
+ *     `FunctionN` to a dependent function: if names are registered, they
+ *     replace the synthetic `x$N` parameter names that would otherwise be used.
+ *
+ *  The backing table is a per-`Run` `EqHashMap` (see `cc.CaptureRunInfo`).
+ *  Off the CC code path the table stays empty, so [[propagate]] is essentially
+ *  free.
+ */
+object ClosureParamNames:
+
+  /** Register the user-written term-parameter names of a closure against the
+   *  resulting `funType`. No-op unless `funType` is a non-refined `FunctionN`
+   *  applied type with at least one named parameter.
+   */
+  def record(funType: Type, methodicType: Type)(using Context): Unit =
+    if !Feature.ccEnabledSomewhere then return
+    val run = ctx.run
+    if run == null then return
+    (funType, methodicType) match
+      case (applied: AppliedType, mt: MethodType)
+      if defn.isFunctionNType(applied) && mt.paramNames.nonEmpty =>
+        run.closureParamNames(applied) = mt.paramNames
+      case _ =>
+
+  /** Carry over any registration from `original` to `rebuilt`. Called from
+   *  every `AppliedType.derivedAppliedType` rebuild, so it returns immediately
+   *  when capture checking is not in play.
+   */
+  def propagate(original: AppliedType, rebuilt: Type)(using Context): Unit =
+    if !Feature.ccEnabledSomewhere then return
+    val run = ctx.run
+    if run == null then return
+    rebuilt match
+      case applied: AppliedType =>
+        val names = run.closureParamNames.lookup(original)
+        if names != null then run.closureParamNames(applied) = names
+      case _ =>
+
+  /** User-written parameter names registered for `tp`, or `Nil` if none. */
+  def of(tp: Type)(using Context): List[TermName] =
+    val run = ctx.run
+    if run == null then Nil
+    else
+      val names = run.closureParamNames.lookup(tp)
+      if names == null then Nil else names
+
+end ClosureParamNames

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -250,7 +250,8 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
         if expand then
           depFun(
               args.init, args.last,
-              isContextual = defn.isContextFunctionClass(tycon.classSymbol)
+              isContextual = defn.isContextFunctionClass(tycon.classSymbol),
+              paramNames = ClosureParamNames.of(original)
             ).showing(i"add function refinement $tp ($tycon, ${args.init}, ${args.last}) --> $result", capt)
         else tp
       case _ => tp

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4836,7 +4836,10 @@ object Types extends TypeUtils {
 
     def derivedAppliedType(tycon: Type, args: List[Type])(using Context): Type =
       if ((tycon eq this.tycon) && (args eq this.args)) this
-      else tycon.appliedTo(args)
+      else
+        val newTp = tycon.appliedTo(args)
+        cc.ClosureParamNames.propagate(this, newTp)
+        newTp
 
     override def computeHash(bs: Binders): Int = doHash(bs, tycon, args)
 

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -440,7 +440,9 @@ trait TypeAssigner {
           case pt: PolyType =>
             pt.derivedLambdaType(resType = methTypeWithoutEnv(pt.resType))
         val methodicType = if tree.env.isEmpty then meth.tpe.widen else methTypeWithoutEnv(meth.tpe.widen)
-        methodicType.toFunctionType(isJava = meth.symbol.is(JavaDefined))
+        val funType = methodicType.toFunctionType(isJava = meth.symbol.is(JavaDefined))
+        cc.ClosureParamNames.record(funType, methodicType)
+        funType
       else target.tpe)
 
   def assignType(tree: untpd.CaseDef, pat: Tree, body: Tree)(using Context): CaseDef = {

--- a/tests/neg-custom-args/captures/heal-tparam-cs.check
+++ b/tests/neg-custom-args/captures/heal-tparam-cs.check
@@ -16,11 +16,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:15:13 -------------------------------
 15 |    localCap { c =>  // error
    |    ^
-   |    Found:    (x$0: Capp^'s3) ->'s4 () ->{x$0} Unit
+   |    Found:    (c1: Capp^'s3) ->'s4 () ->{c1} Unit
    |    Required: (c: Capp^) -> () ->{any} Unit
    |
-   |    Note that capability `x$0` cannot flow into capture set {any}
-   |    because (x$0 : Capp^'s3) is not visible from any in value test2.
+   |    Note that capability `c1` cannot flow into capture set {any}
+   |    because (c1 : Capp^'s3) is not visible from any in value test2.
    |
    |    where:    ^   refers to the root capability caps.any
    |              any is a root capability in the type of value test2
@@ -32,10 +32,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:25:13 -------------------------------
 25 |    localCap { c =>  // error
    |    ^
-   |    Found:    (x$0: Capp^'s5) ->'s6 () ->{x$0} Unit
+   |    Found:    (c1: Capp^'s5) ->'s6 () ->{c1} Unit
    |    Required: (c: Capp^{io}) -> () ->{net} Unit
    |
-   |    Note that capability `x$0` cannot flow into capture set {net}.
+   |    Note that capability `c1` cannot flow into capture set {net}.
    |
 26 |      (c1: Capp^{io}) => () => { c1.use() }
 27 |    }

--- a/tests/neg-custom-args/captures/i15923.check
+++ b/tests/neg-custom-args/captures/i15923.check
@@ -7,6 +7,6 @@
    |Found:    Id[Cap^{any}]^'s2
    |Required: Id[Cap^'s1]^'s3
    |
-   |where:    any is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): Cap^{lcap} ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
+   |where:    any is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): (cap: Cap^{lcap}) ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i15923b.check
+++ b/tests/neg-custom-args/captures/i15923b.check
@@ -4,7 +4,7 @@
   |Capability `lcap` outlives its scope: it leaks into outer capture set 's1 which is owned by value leak.
   |The leakage occurred when trying to match the following types:
   |
-  |Found:    (x$0: Cap^) -> Id[Cap^{x$0}]
+  |Found:    (lcap: Cap^) -> Id[Cap^{lcap}]
   |Required: (lcap: Cap^) => Id[Cap^'s1]^'s2
   |
   |where:    => refers to a root capability created in value leak when checking argument to parameter op of method withCap

--- a/tests/neg-custom-args/captures/scope-extrusions.check
+++ b/tests/neg-custom-args/captures/scope-extrusions.check
@@ -142,11 +142,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scope-extrusions.scala:33:21 -----------------------------
 33 |  val f4: IO => IO = f3  // error
    |                     ^^
-   |                     Found:    (f3 : (x$0: IO) -> IO^{x$0})
+   |                     Found:    (f3 : (x: IO) -> IO^{x})
    |                     Required: IO^ => IO^{any}
    |
-   |                     Note that capability `x$0` cannot flow into capture set {any}
-   |                     because (x$0 : IO) is not visible from any in value f4.
+   |                     Note that capability `x` cannot flow into capture set {any}
+   |                     because (x : IO) is not visible from any in value f4.
    |
    |                     where:    =>  refers to a root capability in the type of value f4
    |                               ^   refers to the root capability caps.any

--- a/tests/neg-custom-args/captures/sep-curried-par.check
+++ b/tests/neg-custom-args/captures/sep-curried-par.check
@@ -31,8 +31,8 @@
 21 |  foo(c)(c) // error: separation
    |      ^
    |Separation failure: argument of type  (c : () => Unit)
-   |to a function of type (x$0: () => Unit) -> (() ->{c, any} Unit) ->{x$0} Unit
-   |corresponds to capture-polymorphic formal parameter x$0 of type  () =>² Unit
+   |to a function of type (p1: () => Unit) -> (() ->{c, any} Unit) ->{p1} Unit
+   |corresponds to capture-polymorphic formal parameter p1 of type  () =>² Unit
    |and hides capabilities  {c}.
    |Some of these overlap with the captures of the function result with type  (() ->{c, any} Unit) ->{c} Unit.
    |
@@ -43,7 +43,7 @@
    |  The two sets overlap at               : {c}
    |
    |where:    =>  refers to a root capability in the type of parameter c
-   |          =>² refers to a root capability created in method test when checking argument to parameter x$0 of method apply
+   |          =>² refers to a root capability created in method test when checking argument to parameter p1 of method apply
 -- Error: tests/neg-custom-args/captures/sep-curried-par.scala:23:65 ---------------------------------------------------
 23 |  val bar = (p1: () => Unit) => (p2: () ->{p1, any} Unit) => par(p1, p2) // error separation
    |                                                                 ^^

--- a/tests/neg-custom-args/captures/use-capset.check
+++ b/tests/neg-custom-args/captures/use-capset.check
@@ -10,10 +10,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:17:50 -----------------------------------
 17 |  val _: () -> List[Object^{io}] -> Object^{io} = h2 // error, should be ->{io}
    |                                                  ^^
-   |                                                  Found:    (h2 : () -> List[Object^{io}] ->{io} Object^{io})
-   |                                                  Required: () -> List[Object^{io}] -> Object^{io}
+   |                                               Found:    (h2 : () -> (xs: List[Object^{io}]) ->{io} Object^{io})
+   |                                               Required: () -> List[Object^{io}] -> Object^{io}
    |
-   |                                                  Note that capability `io` cannot flow into capture set {}.
+   |                                               Note that capability `io` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/use-capset.scala:5:49 ---------------------------------------------------------

--- a/tests/printing/cc/i25971.check
+++ b/tests/printing/cc/i25971.check
@@ -1,0 +1,61 @@
+[[syntax trees at end of                        cc]] // tests/printing/cc/i25971.scala
+package <empty> {
+  import language.experimental.captureChecking
+  import caps.*
+  @SourceFile("tests/printing/cc/i25971.scala") class File() extends Object() {}
+  @SourceFile("tests/printing/cc/i25971.scala") class Box[A](value: A) extends
+    Object() {
+    A
+    val value: A
+  }
+  final lazy module val Test: Test^{} = new Test()
+  @SourceFile("tests/printing/cc/i25971.scala") final module class Test()
+     extends Object() {
+    private[this] type $this = Test.type
+    private def writeReplace(): AnyRef =
+      new scala.runtime.ModuleSerializationProxy(classOf[Test.type])
+    val f:
+      [C^] => (xs: List[File^{C}]) -> (ys: File^{C}) -> File^{C} ->{ys} Unit = [
+      C^] => (xs: List[File^{C}]) => (ys: File^{C}) => (zs: File^{C}) =>
+      {
+        matchResult1[Unit]:
+          {
+            case val x1: (File^{ys}) @RuntimeChecked =
+              ys:(File^{ys}) @RuntimeChecked
+            return[matchResult1] ()
+          }
+        ()
+      }
+    val g: (ys: File^) -> File^ ->{ys} Unit = (ys: File^) => (zs: File^) =>
+      {
+        matchResult2[Unit]:
+          {
+            case val x2: (File^{ys}) @RuntimeChecked =
+              ys:(File^{ys}) @RuntimeChecked
+            return[matchResult2] ()
+          }
+        ()
+      }
+    val h:
+      Box[
+        [C^ <: {}] => (xs: List[File^{}]) ->
+          (ys: File^{}) -> File^{} ->{ys} Unit
+      ]^{}
+     =
+      new Box[
+        [C^ <: 's1] => (xs: List[File^'s2]) ->'s3
+          (ys: File^'s4) ->'s5 File^'s6 ->{ys} Unit
+      ]([C^] => (xs: List[File^{C}]) => (ys: File^{C}) => (zs: File^{C}) =>
+        {
+          matchResult3[Unit]:
+            {
+              case val x3: (File^{ys}) @RuntimeChecked =
+                ys:(File^{ys}) @RuntimeChecked
+              return[matchResult3] ()
+            }
+          ()
+        }
+      )
+  }
+}
+

--- a/tests/printing/cc/i25971.scala
+++ b/tests/printing/cc/i25971.scala
@@ -1,0 +1,10 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File
+class Box[A](val value: A)
+
+object Test:
+  val f = [C^ <: {any}] => (xs: List[File^{C}]) => (ys: File^{C}) => (zs: File^{C}) => { val _ = ys; () }
+  val g = (ys: File^) => (zs: File^) => { val _ = ys; () }
+  val h = new Box([C^ <: {any}] => (xs: List[File^{C}]) => (ys: File^{C}) => (zs: File^{C}) => { val _ = ys; () })


### PR DESCRIPTION
Fixes #25971.

Records user-written closure parameter names against their inferred plain `FunctionN` `AppliedType` at typer time, propagates that registration through type rebuilds (PostTyper's `@caps.declared` insertion, capture-set substitution), and reads it back in `cc.Setup.normalizeFunctions` when the type is expanded into a dependent function. This replaces the synthetic `x$N` names that the expansion otherwise generates.

## Design

The mechanism is encapsulated in [`cc.ClosureParamNames`](https://github.com/scala/scala3/blob/main/compiler/src/dotty/tools/dotc/cc/ClosureParamNames.scala) — three operations over a per-`Run` `EqHashMap`:

| When | Where | Op |
|---|---|---|
| Closure typing | `TypeAssigner.assignType(Closure, ...)` | `record(funType, methodicType)` |
| `AppliedType` rebuilds | `Types.AppliedType.derivedAppliedType` | `propagate(this, newTp)` |
| Plain `FunctionN` → dep function | `cc.Setup.normalizeFunctions` | `of(original)` as `paramNames` |

Off the CC code path the table stays empty, and `propagate` short-circuits on `Feature.ccEnabledSomewhere`, so the hot-path call from `core.Types` is essentially free for non-CC compilation.

## Why a side table

An earlier walker-based attempt (#25982) recovered names by aligning the val/result type spine with the rhs closure tree. It works but is invasive (~140 lines of tree-type alignment, with `peelFormal`, `collectArgsThroughFormal`, etc.) and doesn't extend cleanly to all the type shapes CC produces. The side table records once per closure and follows the type wherever it goes.

A typer-level alternative — always emitting `RefinedType(FunctionN, apply, MT)` for closures — would make every closure structurally a dependent function, which we don't want. The annotation alternative would couple `FunctionOrMethod` extractors to a CC-specific annotation, with similarly broad fallout. The side table localizes the CC concern: `cc/ClosureParamNames.scala` owns the policy, and call sites are one-liners.

## Test impact

Previously-synthetic `x$N` names in error messages now resolve to user-given names where applicable. Updated check files:

- `tests/neg-custom-args/captures/heal-tparam-cs.check` — `c1` instead of `x$0`
- `tests/neg-custom-args/captures/i15923.check`, `i15923b.check` — `cap`, `lcap`
- `tests/neg-custom-args/captures/scope-extrusions.check` — `x` instead of `x$0`
- `tests/neg-custom-args/captures/sep-curried-par.check` — `p1` instead of `x$0`
- `tests/neg-custom-args/captures/use-capset.check` — `xs` instead of unnamed

New printing test `tests/printing/cc/i25971.scala` covers three closure shapes:
1. Polymorphic closure (`[C^] => (xs) => (ys) => (zs) => …`)
2. Plain nested closures (`(ys) => (zs) => …`)
3. Closure passed as constructor arg (`new Box(closure)`) — the substitution case that breaks naive identity-based recovery.

Full `CompilationTests` suite passes (73/73).

## How much have you relied on LLM-based tools in this contribution?

Extensively, while I specified how I expect the solution to look like/work.

## How was the solution tested?

New automated tests (`tests/printing/cc/i25971.scala`, plus updated check files for affected neg tests).