### PR TITLE
[OpenCB Project Fix] Fixes #26004: don't wrap partial method application in Function0 on `_` rewrite

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -58,12 +58,26 @@ trait Migrations:
     val pt1 = if (defn.isFunctionNType(pt)) pt else AnyFunctionProto
     val nestedCtx = ctx.fresh.setNewTyperState()
     val res = typed(qual, pt1)(using nestedCtx)
+    // A method-typed expression whose `_` can be dropped because 3.4+ will
+    // auto-eta-expand the bare reference. Mirrors the condition in
+    // `Typer.adaptNoArgsUnappliedMethod` for the non-function-expected case:
+    // a single varargs parameter (or no parameters) does not auto-eta-expand.
+    def autoEtaExpands(tp: Type): Boolean = tp.stripPoly match
+      case mt: MethodType =>
+        val n = mt.paramInfos.length
+        n > 1 || n == 1 && !mt.isVarArgsMethod
+      case _ => false
+    // Type of `qual` without a prototype (i.e. what it would be without the `_`).
+    // Used to decide whether the candidate rewrite is safe.
+    lazy val unprotoTpe = typed(qual)(using ctx.fresh.setExploreTyperState()).tpe.widen
     res match {
       case blockEndingInClosure(_, _, _) =>
       case _ =>
-        val recovered = typed(qual)(using ctx.fresh.setExploreTyperState())
-        if !defn.isFunctionType(recovered.tpe.widen) then
-          val msg = OnlyFunctionsCanBeFollowedByUnderscore(recovered.tpe.widen, tree)
+        // A method-typed result that will auto-eta-expand isn't a Scala2-to-3
+        // `expr _` -> `() => expr` case; let the FunctionUnderscore migration
+        // handle it below.
+        if !defn.isFunctionType(unprotoTpe) && !autoEtaExpands(unprotoTpe) then
+          val msg = OnlyFunctionsCanBeFollowedByUnderscore(unprotoTpe, tree)
           report.errorOrMigrationWarning(msg, tree.srcPos, mv.Scala2to3)
           if mv.Scala2to3.needsPatch then
             // Under -rewrite, patch `x _` to `(() => x)`
@@ -76,7 +90,7 @@ trait Migrations:
 
     def functionPrefixSuffix(arity: Int) = if (arity > 0) ("", "") else ("(() => ", "())")
 
-    lazy val (prefix, suffix) = res match {
+    val proposedPatch: (String, String) = res match {
       case Block(DefDef(_, vparams :: Nil, _, _) :: Nil, _: Closure) =>
         functionPrefixSuffix(vparams.length)
       case Block(ValDef(_, _, _) :: Nil, Block(DefDef(_, vparams :: Nil, _, _) :: Nil, _: Closure)) =>
@@ -86,18 +100,37 @@ trait Migrations:
       case _ =>
         ("(() => ", ")")
     }
+    // Validate the proposed rewrite against the un-prototyped type of `qual`
+    // (since `res` was typed under `AnyFunctionProto`, which forces
+    // eta-expansion and hides whether the bare reference is well-typed).
+    val patchOpt: Option[(String, String)] = proposedPatch match
+      case ("", "") =>
+        // Dropping `_` is safe only when the bare reference type-checks:
+        // already a function, or a method type that auto-eta-expands.
+        Option.when(defn.isFunctionType(unprotoTpe) || autoEtaExpands(unprotoTpe))(proposedPatch)
+      case ("(() => ", ")") =>
+        // Wrapping in `(() => …)` is wrong for a partially-applied curried
+        // method: it adds a spurious Function0 layer (issue #26004).
+        Option.when(!unprotoTpe.isInstanceOf[MethodOrPoly])(proposedPatch)
+      case _ =>
+        Some(proposedPatch)
+
     val mversion = mv.FunctionUnderscore
-    def remedy =
-      if ((prefix ++ suffix).isEmpty) "simply leave out the trailing ` _`"
-      else s"use `$prefix<function>$suffix` instead"
-    def rewrite = Message.rewriteNotice("This construct", mversion.patchFrom)
+    def remedy = patchOpt match
+      case Some((prefix, suffix)) if (prefix ++ suffix).isEmpty => "simply leave out the trailing ` _`"
+      case Some((prefix, suffix)) => s"use `$prefix<function>$suffix` instead"
+      case None => "rewrite the expression explicitly as an eta-expanded function"
+    def rewrite = patchOpt match
+      case Some(_) => Message.rewriteNotice("This construct", mversion.patchFrom)
+      case None => ""
     report.errorOrMigrationWarning(
       em"""The trailing ` _` for eta-expansion is unnecessary;
         |the compiler performs eta-expansion automatically, so you can write the function value directly instead.$rewrite""",
       tree.srcPos, mversion)
     if mversion.needsPatch then
-      patch(Span(tree.span.start), prefix)
-      patch(Span(qual.span.end, tree.span.end), suffix)
+      patchOpt.foreach: (prefix, suffix) =>
+        patch(Span(tree.span.start), prefix)
+        patch(Span(qual.span.end, tree.span.end), suffix)
 
     res
   }

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -87,6 +87,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i24213.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
       compileFile("tests/rewrites/i18234.scala", defaultOptions.and("-rewrite", "-source:3.8-migration")),
       compileFile("tests/rewrites/unary-minus.scala", defaultOptions.and("-rewrite")),
+      compileFile("tests/rewrites/i26004.scala", defaultOptions.and("-rewrite", "-source:3.4-migration")),
     )).checkRewrites()
   }
 

--- a/tests/rewrites/i26004.check
+++ b/tests/rewrites/i26004.check
@@ -1,0 +1,25 @@
+// https://github.com/scala/scala3/issues/26004
+//> using options -source:3.4-migration
+
+class Bundle
+
+object PseudoLenses:
+  implicit class RicherFHIRComponent[C <: Bundle](c: C):
+    def modifyNestedFieldUnsafe[T](nestingPath: String*)(modify: T => T): C = c
+
+object Repro:
+  import PseudoLenses.RicherFHIRComponent
+  def test(bundle: Bundle): Bundle =
+    def subjectLens(b: Bundle) = b.modifyNestedFieldUnsafe[Option[String]]("entry", "resource", "subject")
+    subjectLens(bundle)(p => Some("foo"))
+
+class A:
+  def m[T](path: String)(modify: T => T): A = this
+
+def f(a: A) = a.m[Int]("x")
+
+object Foo:
+  def varargs(xs: Int*): Int = xs.sum
+  // varargs single-arg method: dropping `_` would not auto-eta-expand and
+  // wrapping in `(() => …)` would change the shape, so leave it untouched.
+  val g = varargs _

--- a/tests/rewrites/i26004.scala
+++ b/tests/rewrites/i26004.scala
@@ -1,0 +1,25 @@
+// https://github.com/scala/scala3/issues/26004
+//> using options -source:3.4-migration
+
+class Bundle
+
+object PseudoLenses:
+  implicit class RicherFHIRComponent[C <: Bundle](c: C):
+    def modifyNestedFieldUnsafe[T](nestingPath: String*)(modify: T => T): C = c
+
+object Repro:
+  import PseudoLenses.RicherFHIRComponent
+  def test(bundle: Bundle): Bundle =
+    def subjectLens(b: Bundle) = b.modifyNestedFieldUnsafe[Option[String]]("entry", "resource", "subject") _
+    subjectLens(bundle)(p => Some("foo"))
+
+class A:
+  def m[T](path: String)(modify: T => T): A = this
+
+def f(a: A) = a.m[Int]("x") _
+
+object Foo:
+  def varargs(xs: Int*): Int = xs.sum
+  // varargs single-arg method: dropping `_` would not auto-eta-expand and
+  // wrapping in `(() => …)` would change the shape, so leave it untouched.
+  val g = varargs _


### PR DESCRIPTION
Under `-rewrite -source:3.4-migration`, `expr _` for a partially-applied curried method was being rewritten to `(() => expr)`. That introduces a spurious Function0 layer and changes the result type from `(T => T) => R` to `() => (T => T) => R`, breaking any subsequent application.

The rewrite has two paths that could hit this fallback:

  - The Scala2-to-3 recovery path treats any non-function recovered type as a value-to-Function0 conversion. A partially-applied curried method has a `MethodOrPoly` widened type, not a function type, but is eta-expandable, so it isn't a Scala2-to-3 case.
  - The main rewrite's `prefix`/`suffix` match falls through to `("(() => ", ")")` whenever `res.tpe.widen` isn't a function type, even when the typer left the partial application as a `MethodOrPoly`.

In both cases, a `MethodOrPoly` result means 3.4+ auto-eta-expansion will take over once the trailing `_` is dropped, so the safe rewrite is to just remove the `_`.

Fixes #26004

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
