### PR TITLE
Fixes #25801: Handle `TypeDefs` in `ensureHasSym`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1212,7 +1212,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     def ensureHasSym(sym: Symbol)(using Context): Unit =
       if sym.exists && sym != tree.symbol then
         typr.println(i"correcting definition symbol from ${tree.symbol.showLocated} to ${sym.showLocated}")
-        tree.overwriteType(NamedType(sym.owner.thisType, sym.asTerm.name, sym.denot))
+        tree.overwriteType(NamedType(sym.owner.thisType, sym.name, sym.denot))
 
     def etaExpandCFT(using Context): Tree =
       def expand(target: Tree, tp: Type)(using Context): Tree = tp match

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3262,6 +3262,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           report.error(em"`$name` cannot have type parameters, because it ranges over capture sets", rhs.srcPos)
         case _ =>
     val res = assignType(cpy.TypeDef(tdef)(name, rhs1), sym)
+    res.ensureHasSym(sym)
     if Feature.ccEnabled && attachCap then
       res.putAttachment(CaptureVar, ())
     res

--- a/tests/pos/i25801/Lib_1.scala
+++ b/tests/pos/i25801/Lib_1.scala
@@ -1,0 +1,10 @@
+// https://github.com/scala/scala3/issues/25801
+package i25801
+
+trait A { self: B =>
+  type X
+}
+
+trait B extends A {
+  type X
+}

--- a/tests/pos/i25801/Use_2.scala
+++ b/tests/pos/i25801/Use_2.scala
@@ -1,0 +1,4 @@
+// https://github.com/scala/scala3/issues/25801
+package i25801
+
+def foo: B = ???


### PR DESCRIPTION
When a class has a self-type that refines a member, the symbol of a TypeDef in its body can resolve through the self-type prefix to a different symbol than the one being defined. This caused two problems:

- During TASTy unpickling, `tree.ensureHasSym(sym)` for a TypeDef tried to call `sym.asTerm.name`, which crashes with "asTerm called on not-a-Term" when sym is a type symbol.
- During typer, the TypeDef tree's symbol was never reconciled with the intended sym, so `-Ycheck:all` would report the trait body as missing the type member.

Use `sym.name` in `ensureHasSym` so the produced `NamedType` correctly selects between `TypeRef` and `TermRef` based on the name kind, and call `ensureHasSym` from `typedTypeDef` so the typed tree carries the right symbol before pickling.

Fixes #25801

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
