### PR TITLE
Add scalafix-migrations: mechanical fixers for Scala 3 stdlib API tightenings

### DIFF
--- a/scalafix-migrations/README.md
+++ b/scalafix-migrations/README.md
@@ -1,0 +1,71 @@
+# Scala 3 migration scalafix rules
+
+Mechanical migration rules for Scala 3 stdlib/reflect API tightenings,
+written for projects that fail under recent Scala 3 nightlies in the
+[VirtusLab Open Community Build](https://virtuslab.github.io/community-build3/).
+
+The compiler's built-in `-rewrite -source X-migration` mechanism handles
+syntax-level changes. Library API changes (where the new call shape isn't
+mechanically derivable from the old by the compiler alone) are migrated
+here via scalafix instead.
+
+## Rules
+
+| Rule | What it does |
+|------|--------------|
+| `OptionOrNullMigration` | Rewrites `opt.orNull[T]` → `opt.getOrElse(null.asInstanceOf[T])`; lints bare `opt.orNull` (semantics changed to `A \| Null`) |
+
+## Develop
+
+```
+sbt ~tests/test
+# edit rules/src/main/scala/fix/<rule>.scala
+# add input/output cases under input/ and output/
+```
+
+## Use locally
+
+Publish the rule artifact and reference it from a target project's
+`.scalafix.conf`:
+
+```sh
+sbt rules2_13/publishLocal
+```
+
+In the target project's `build.sbt`:
+
+```scala
+scalafixDependencies += "rules" %% "scala3-migrations" % "0.1.0-SNAPSHOT"
+resolvers += Resolver.mavenLocal
+semanticdbEnabled := true
+semanticdbVersion := scalafixSemanticdb.revision
+```
+
+`.scalafix.conf`:
+
+```
+rules = [ OptionOrNullMigration ]
+```
+
+Run `sbt scalafixAll`.
+
+## End-to-end validation
+
+Each rule was validated against an actual failing project from the
+community build:
+
+- **`OptionOrNullMigration`** — applied to `scalikejdbc/scalikejdbc-core`
+  call sites (`ResultSetExtractorException.scala:9`,
+  `SQL.scala:123`, `StatementExecutor.scala:213`). Rule rewrote all three
+  cleanly; rewritten files compile under `3.9.0-RC1-bin-SNAPSHOT` while
+  the originals fail with `method orNull in class Option does not take
+  type parameters`.
+
+## Future rules
+
+Candidates from the same triage run (see soronpo/dottybug#1):
+
+- `TypedTupleDestructuringSplit` — `val (a: T1 @unchecked, b: T2 @unchecked) = expr`
+  → split into separate ascriptions. Hits monix-connect, sttp, dfhdl, scdbpf.
+- `SymbolNewModuleParents` — `Symbol.newModule(..., parents: List, ...)` →
+  `Symbol.newModule(..., _ => parents, ...)`. Hits fm-serializer.

--- a/scalafix-migrations/build.sbt
+++ b/scalafix-migrations/build.sbt
@@ -1,0 +1,77 @@
+lazy val V = _root_.scalafix.sbt.BuildInfo
+
+lazy val rulesCrossVersions = Seq(V.scala213)
+lazy val scala3Version = "3.3.6"
+
+inThisBuild(
+  List(
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision
+  )
+)
+
+lazy val `scala3-migrations` = (project in file("."))
+  .aggregate(
+    rules.projectRefs ++
+      input.projectRefs ++
+      output.projectRefs ++
+      tests.projectRefs: _*
+  )
+  .settings(
+    publish / skip := true
+  )
+
+lazy val rules = projectMatrix
+  .settings(
+    moduleName := "scala3-migrations",
+    libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
+  )
+  .defaultAxes(VirtualAxis.jvm)
+  .jvmPlatform(rulesCrossVersions)
+
+lazy val input = projectMatrix
+  .settings(
+    publish / skip := true
+  )
+  .defaultAxes(VirtualAxis.jvm)
+  .jvmPlatform(scalaVersions = scala3Version :: Nil)
+
+lazy val output = projectMatrix
+  .settings(
+    publish / skip := true
+  )
+  .defaultAxes(VirtualAxis.jvm)
+  .jvmPlatform(scalaVersions = scala3Version :: Nil)
+
+lazy val testsAggregate = Project("tests", file("target/testsAggregate"))
+  .aggregate(tests.projectRefs: _*)
+
+lazy val tests = projectMatrix
+  .settings(
+    publish / skip := true,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    scalafixTestkitOutputSourceDirectories :=
+      TargetAxis
+        .resolve(output, Compile / unmanagedSourceDirectories)
+        .value,
+    scalafixTestkitInputSourceDirectories :=
+      TargetAxis
+        .resolve(input, Compile / unmanagedSourceDirectories)
+        .value,
+    scalafixTestkitInputClasspath :=
+      TargetAxis.resolve(input, Compile / fullClasspath).value,
+    scalafixTestkitInputScalacOptions :=
+      TargetAxis.resolve(input, Compile / scalacOptions).value,
+    scalafixTestkitInputScalaVersion :=
+      TargetAxis.resolve(input, Compile / scalaVersion).value
+  )
+  .defaultAxes(
+    rulesCrossVersions.map(VirtualAxis.scalaABIVersion) :+ VirtualAxis.jvm: _*
+  )
+  .customRow(
+    scalaVersions = Seq(V.scala213),
+    axisValues = Seq(TargetAxis(scala3Version), VirtualAxis.jvm),
+    settings = Seq()
+  )
+  .dependsOn(rules)
+  .enablePlugins(ScalafixTestkitPlugin)

--- a/scalafix-migrations/input/src/main/scala/fix/OptionOrNullMigrationTest.scala
+++ b/scalafix-migrations/input/src/main/scala/fix/OptionOrNullMigrationTest.scala
@@ -1,0 +1,38 @@
+/*
+rule = OptionOrNullMigration
+ */
+package fix
+
+object OptionOrNullMigrationTest {
+
+  // scalikejdbc/ResultSetExtractorException.scala:9 shape
+  val e: Option[Exception] = None
+  val msg = e.orNull[Exception]
+
+  // scalikejdbc/SQL.scala:123 shape
+  val pairs: Seq[(String, Any)] = Nil
+  val v: Any =
+    pairs
+      .find(_._1 == "x")
+      .map(_._2)
+      .orNull[Any]
+
+  // scalikejdbc-async/RowDataResultSet.scala:625 shape
+  val rows: Seq[Map[String, Any]] = Nil
+  val cell: Any = rows.headOption.map(_.get("c")).orNull[Any]
+
+  // norbert-radyk/spoiwo/Utils.scala:44 shape — generic with explicit Null<:<T
+  def cmp[T](actualData: Option[T], expectedData: T)(using ev: Null <:< T): Boolean =
+    actualData.orNull[T] == expectedData
+
+  // ruimo/scoins/PathUtil.scala:41 shape (note: type ascription not the bare form)
+  val prefix: Option[String] = None
+  val name: String = prefix.orNull[String]
+
+  // Bare .orNull — should NOT be rewritten, just lint
+  val bare: Option[String] = None
+  val asNullable = bare.orNull /* assert: OptionOrNullMigration.OrNullSemanticChange
+                        ^^^^^^
+Option.orNull now returns A | Null instead of A. If you needed A, replace with `.getOrElse(null.asInstanceOf[A])`.
+*/
+}

--- a/scalafix-migrations/output/src/main/scala/fix/OptionOrNullMigrationTest.scala
+++ b/scalafix-migrations/output/src/main/scala/fix/OptionOrNullMigrationTest.scala
@@ -1,0 +1,32 @@
+package fix
+
+object OptionOrNullMigrationTest {
+
+  // scalikejdbc/ResultSetExtractorException.scala:9 shape
+  val e: Option[Exception] = None
+  val msg = e.getOrElse(null.asInstanceOf[Exception])
+
+  // scalikejdbc/SQL.scala:123 shape
+  val pairs: Seq[(String, Any)] = Nil
+  val v: Any =
+    pairs
+      .find(_._1 == "x")
+      .map(_._2)
+      .getOrElse(null.asInstanceOf[Any])
+
+  // scalikejdbc-async/RowDataResultSet.scala:625 shape
+  val rows: Seq[Map[String, Any]] = Nil
+  val cell: Any = rows.headOption.map(_.get("c")).getOrElse(null.asInstanceOf[Any])
+
+  // norbert-radyk/spoiwo/Utils.scala:44 shape — generic with explicit Null<:<T
+  def cmp[T](actualData: Option[T], expectedData: T)(using ev: Null <:< T): Boolean =
+    actualData.getOrElse(null.asInstanceOf[T]) == expectedData
+
+  // ruimo/scoins/PathUtil.scala:41 shape (note: type ascription not the bare form)
+  val prefix: Option[String] = None
+  val name: String = prefix.getOrElse(null.asInstanceOf[String])
+
+  // Bare .orNull — should NOT be rewritten, just lint
+  val bare: Option[String] = None
+  val asNullable = bare.orNull 
+}

--- a/scalafix-migrations/project/TargetAxis.scala
+++ b/scalafix-migrations/project/TargetAxis.scala
@@ -1,0 +1,39 @@
+import sbt._
+import sbt.internal.ProjectMatrix
+import sbtprojectmatrix.ProjectMatrixPlugin.autoImport._
+
+/** Use on ProjectMatrix rows to tag an affinity to a custom scalaVersion */
+case class TargetAxis(scalaVersion: String) extends VirtualAxis.WeakAxis {
+
+  private val scalaBinaryVersion = CrossVersion.binaryScalaVersion(scalaVersion)
+
+  override val idSuffix = s"Target${scalaBinaryVersion.replace('.', '_')}"
+  override val directorySuffix = s"target$scalaBinaryVersion"
+}
+
+object TargetAxis {
+
+  private def targetScalaVersion(virtualAxes: Seq[VirtualAxis]): String =
+    virtualAxes.collectFirst { case a: TargetAxis => a.scalaVersion }.get
+
+  def resolve[T](
+      matrix: ProjectMatrix,
+      key: TaskKey[T]
+  ): Def.Initialize[Task[T]] =
+    Def.taskDyn {
+      val sv = targetScalaVersion(virtualAxes.value)
+      val project = matrix.finder().apply(sv)
+      Def.task((project / key).value)
+    }
+
+  def resolve[T](
+      matrix: ProjectMatrix,
+      key: SettingKey[T]
+  ): Def.Initialize[T] =
+    Def.settingDyn {
+      val sv = targetScalaVersion(virtualAxes.value)
+      val project = matrix.finder().apply(sv)
+      Def.setting((project / key).value)
+    }
+
+}

--- a/scalafix-migrations/project/build.properties
+++ b/scalafix-migrations/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.11.3

--- a/scalafix-migrations/project/plugins.sbt
+++ b/scalafix-migrations/project/plugins.sbt
@@ -1,0 +1,3 @@
+resolvers += Resolver.sonatypeRepo("releases")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-projectmatrix" % "0.8.0")

--- a/scalafix-migrations/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix-migrations/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,0 +1,1 @@
+fix.OptionOrNullMigration

--- a/scalafix-migrations/rules/src/main/scala/fix/OptionOrNullMigration.scala
+++ b/scalafix-migrations/rules/src/main/scala/fix/OptionOrNullMigration.scala
@@ -1,0 +1,67 @@
+/*
+ * Migration rule for the `Option.orNull` API tightening that landed in
+ * Scala 3.x (after explicit-nulls stabilization). The standard library no
+ * longer accepts a type parameter on `Option#orNull` and the result type
+ * is now `A | Null` instead of `A`.
+ *
+ * Mechanical rewrite, semantics-preserving:
+ *
+ *   opt.orNull[T]   -->   opt.getOrElse(null.asInstanceOf[T])
+ *
+ * The bare-call form (`opt.orNull`) is intentionally NOT rewritten because
+ * `A | Null` is sometimes the actually-desired type. We emit a lint
+ * diagnostic at those sites so the maintainer can decide.
+ */
+package fix
+
+import scalafix.v1._
+import scala.meta._
+
+class OptionOrNullMigration extends SemanticRule("OptionOrNullMigration") {
+
+  private val OptionOrNull = SymbolMatcher.normalized("scala/Option#orNull.")
+
+  override def fix(implicit doc: SemanticDocument): Patch =
+    doc.tree.collect {
+      // opt.orNull[T] -> opt.getOrElse(null.asInstanceOf[T])
+      case t @ Term.ApplyType.After_4_6_0(
+            Term.Select(qual, fn @ Term.Name("orNull")),
+            Type.ArgClause(List(tpe))
+          ) if OptionOrNull.matches(fn) =>
+        // Replace only the `orNull[T]` suffix to preserve `qual`'s original
+        // whitespace/newlines. fn.pos.start is the start of the method name;
+        // t.pos.end is the end of the type-arg clause.
+        Patch.replaceToken(
+          fn.tokens.head,
+          "getOrElse"
+        ) +
+          Patch.removeTokens(fn.tokens.tail) +
+          Patch.replaceToken(
+            t.tokens.find(_.text == "[").get,
+            "(null.asInstanceOf["
+          ) +
+          Patch.replaceToken(
+            t.tokens.findLast(_.text == "]").get,
+            "])"
+          )
+
+      // bare opt.orNull -> warn (semantics-changing rewrite skipped).
+      // Skip when the call is wrapped by a type application — that case is
+      // handled by the rule above.
+      case sel @ Term.Select(_, fn @ Term.Name("orNull"))
+          if OptionOrNull.matches(fn) &&
+            !sel.parent.exists {
+              case _: Term.ApplyType => true
+              case _                 => false
+            } =>
+        Patch.lint(
+          Diagnostic(
+            id = "OrNullSemanticChange",
+            message =
+              "Option.orNull now returns A | Null instead of A. " +
+                "If you needed A, replace with `.getOrElse(null.asInstanceOf[A])`.",
+            position = fn.pos
+          )
+        )
+    }.asPatch
+}

--- a/scalafix-migrations/tests/src/test/scala/fix/RuleSuite.scala
+++ b/scalafix-migrations/tests/src/test/scala/fix/RuleSuite.scala
@@ -1,0 +1,8 @@
+package fix
+
+import scalafix.testkit._
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class RuleSuite extends AbstractSemanticRuleSuite with AnyFunSuiteLike {
+  runAllTests()
+}


### PR DESCRIPTION
I don't where is the right place to put this, but several community build projects are failing due to this API change.
So we have a scalafix rule that can be leveraged to fix them.

Adds a self-contained sbt project under scalafix-migrations/ with the standard scalafix testkit layout (rules/input/output/tests). The first rule addresses the most-recurring breakage we saw in the latest community-build triage (soronpo/dottybug#1, ~10 projects affected): the post-explicit-nulls API change to Option.orNull, which lost its type parameter and now returns A | Null instead of A.

OptionOrNullMigration rewrites:
  opt.orNull[T]   ->   opt.getOrElse(null.asInstanceOf[T])

and lints bare opt.orNull (semantics-changing rewrite skipped because A | Null is sometimes the desired result).

Validated end-to-end against scalikejdbc/scalikejdbc-core call sites (ResultSetExtractorException.scala:9, SQL.scala:123, StatementExecutor.scala:213): the rule rewrote all three cleanly, the rewritten file compiles under 3.9.0-RC1-bin-SNAPSHOT, and the original fails with the expected "method orNull in class Option does not take type parameters" error.

The compiler's built-in -rewrite -source X-migration mechanism handles syntax-level changes well, but library-API changes need scalafix because the new call shape isn't mechanically derivable from the old by the compiler alone. This folder is intended as the home for that family of fixers.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for everything.

## How was the solution tested?

On one of the projects that currently failed with this error.
