### PR TITLE
[OpenCB Project Fix] Fixes #26013: Wrap `with`->`&` rewrite in parens for typed patterns

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1942,7 +1942,8 @@ object Parsers {
      */
     val refinedTypeFn: Location => Tree = _ => refinedType()
 
-    def refinedType() = refinedTypeRest(withType())
+    def refinedType(wrapWithRewriteInParens: Boolean = false): Tree =
+      refinedTypeRest(withType(wrapWithRewriteInParens))
 
     /** Disambiguation: a `^` is treated as a postfix operator meaning `^{any}`
      *  if followed by `{`, `->`, or `?->`,
@@ -1981,10 +1982,18 @@ object Parsers {
     }
 
     /** WithType ::= AnnotType {`with' AnnotType}    (deprecated)
+     *
+     *  When `wrapRewriteInParens` is set and a `with` is rewritten to `&`,
+     *  parentheses are also patched around the whole `WithType`. This is needed
+     *  in positions where the surrounding grammar expects a `RefinedType` (which
+     *  accepts `with`) but not a full `InfixType` (which would be needed for `&`),
+     *  such as the type ascription of a typed pattern (`case x: A with B =>`).
+     *  Without the parens, the rewritten code would not parse.
      */
-    def withType(): Tree = withTypeRest(annotType())
+    def withType(wrapRewriteInParens: Boolean = false): Tree =
+      withTypeRest(annotType(), wrapRewriteInParens)
 
-    def withTypeRest(t: Tree): Tree =
+    def withTypeRest(t: Tree, wrapRewriteInParens: Boolean = false): Tree =
       if in.token == WITH then
         val withOffset = in.offset
         in.nextToken()
@@ -1998,7 +2007,11 @@ object Parsers {
             MigrationVersion.WithOperator)
           if MigrationVersion.WithOperator.needsPatch then
             patch(source, withSpan, "&")
-          atSpan(startOffset(t)) { makeAndType(t, withType()) }
+          val rest = withType()
+          if MigrationVersion.WithOperator.needsPatch && wrapRewriteInParens then
+            patch(source, Span(t.span.start, t.span.start), "(")
+            patch(source, Span(rest.span.end, rest.span.end), ")")
+          atSpan(startOffset(t)) { makeAndType(t, rest) }
       else t
 
     /** AnnotType ::= SimpleType {Annotation}
@@ -2393,7 +2406,7 @@ object Parsers {
 
     def typeDependingOn(location: Location): Tree =
       if location.inParens then typ()
-      else if location.inPattern then rejectWildcardType(refinedType())
+      else if location.inPattern then rejectWildcardType(refinedType(wrapWithRewriteInParens = true))
       else infixType()
 
 /* ----------- EXPRESSIONS ------------------------------------------------ */
@@ -3446,7 +3459,7 @@ object Parsers {
       case GIVEN =>
         atSpan(in.offset) {
           val givenMod = atSpan(in.skipToken())(Mod.Given())
-          val typed = Typed(Ident(nme.WILDCARD), refinedType())
+          val typed = Typed(Ident(nme.WILDCARD), refinedType(wrapWithRewriteInParens = true))
           Bind(nme.WILDCARD, typed).withMods(addMod(Modifiers(), givenMod))
         }
       case _ =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1942,8 +1942,8 @@ object Parsers {
      */
     val refinedTypeFn: Location => Tree = _ => refinedType()
 
-    def refinedType(wrapWithRewriteInParens: Boolean = false): Tree =
-      refinedTypeRest(withType(wrapWithRewriteInParens))
+    def refinedType(inPatternType: Boolean = false): Tree =
+      refinedTypeRest(withType(inPatternType))
 
     /** Disambiguation: a `^` is treated as a postfix operator meaning `^{any}`
      *  if followed by `{`, `->`, or `?->`,
@@ -1983,17 +1983,18 @@ object Parsers {
 
     /** WithType ::= AnnotType {`with' AnnotType}    (deprecated)
      *
-     *  When `wrapRewriteInParens` is set and a `with` is rewritten to `&`,
-     *  parentheses are also patched around the whole `WithType`. This is needed
-     *  in positions where the surrounding grammar expects a `RefinedType` (which
-     *  accepts `with`) but not a full `InfixType` (which would be needed for `&`),
-     *  such as the type ascription of a typed pattern (`case x: A with B =>`).
-     *  Without the parens, the rewritten code would not parse.
+     *  `inPatternType` indicates that this type appears in a typed pattern
+     *  position (such as `case x: A with B =>` or `case given A with B =>`).
+     *  The pattern grammar here is `PatVar ':' RefinedType` (not `InfixType`),
+     *  so `with` is accepted but `&` is not. When the `-rewrite` flag is also
+     *  set, the textual `with -> &` patch on its own would therefore produce
+     *  code that no longer parses; in that case we additionally wrap the whole
+     *  rewritten `WithType` in parentheses, turning `A with B` into `(A & B)`.
      */
-    def withType(wrapRewriteInParens: Boolean = false): Tree =
-      withTypeRest(annotType(), wrapRewriteInParens)
+    def withType(inPatternType: Boolean = false): Tree =
+      withTypeRest(annotType(), inPatternType)
 
-    def withTypeRest(t: Tree, wrapRewriteInParens: Boolean = false): Tree =
+    def withTypeRest(t: Tree, inPatternType: Boolean = false): Tree =
       if in.token == WITH then
         val withOffset = in.offset
         in.nextToken()
@@ -2008,7 +2009,7 @@ object Parsers {
           if MigrationVersion.WithOperator.needsPatch then
             patch(source, withSpan, "&")
           val rest = withType()
-          if MigrationVersion.WithOperator.needsPatch && wrapRewriteInParens then
+          if MigrationVersion.WithOperator.needsPatch && inPatternType then
             patch(source, Span(t.span.start, t.span.start), "(")
             patch(source, Span(rest.span.end, rest.span.end), ")")
           atSpan(startOffset(t)) { makeAndType(t, rest) }
@@ -2406,7 +2407,7 @@ object Parsers {
 
     def typeDependingOn(location: Location): Tree =
       if location.inParens then typ()
-      else if location.inPattern then rejectWildcardType(refinedType(wrapWithRewriteInParens = true))
+      else if location.inPattern then rejectWildcardType(refinedType(inPatternType = true))
       else infixType()
 
 /* ----------- EXPRESSIONS ------------------------------------------------ */
@@ -3459,7 +3460,7 @@ object Parsers {
       case GIVEN =>
         atSpan(in.offset) {
           val givenMod = atSpan(in.skipToken())(Mod.Given())
-          val typed = Typed(Ident(nme.WILDCARD), refinedType(wrapWithRewriteInParens = true))
+          val typed = Typed(Ident(nme.WILDCARD), refinedType(inPatternType = true))
           Bind(nme.WILDCARD, typed).withMods(addMod(Modifiers(), givenMod))
         }
       case _ =>

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -58,6 +58,7 @@ class CompilationTests {
       compileFile("tests/rewrites/i21394.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
       compileFile("tests/rewrites/uninitialized-var.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
       compileFile("tests/rewrites/with-type-operator.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
+      compileFile("tests/rewrites/i26013.scala", defaultOptions.and("-rewrite", "-source", "3.4-migration")),
       compileFile("tests/rewrites/private-this.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
       compileFile("tests/rewrites/alphanumeric-infix-operator.scala", defaultOptions.and("-rewrite", "-source", "future-migration")),
       compileFile("tests/rewrites/filtering-fors.scala", defaultOptions.and("-rewrite", "-source", "3.2-migration")),

--- a/tests/rewrites/i26013.check
+++ b/tests/rewrites/i26013.check
@@ -1,0 +1,16 @@
+// https://github.com/scala/scala3/issues/26013
+trait A
+trait B
+trait C
+case class N(child: Any)
+
+def m(n: N): String = n match
+  case N(child: (A & B)) => "ab"
+  case N(child: (A & B & C)) => "abc"
+  case _ => "other"
+
+def g(x: Any): String = x match
+  case given (A & B) => "given ab"
+  case _ => "other"
+
+def h: Int & String = ???

--- a/tests/rewrites/i26013.check
+++ b/tests/rewrites/i26013.check
@@ -7,6 +7,9 @@ case class N(child: Any)
 def m(n: N): String = n match
   case N(child: (A & B)) => "ab"
   case N(child: (A & B & C)) => "abc"
+  case _: (A & B) => "wildcard"
+  case N(child: (A & B)) => "already parens"
+  case child: (A & B) { type T } => "refinement"
   case _ => "other"
 
 def g(x: Any): String = x match

--- a/tests/rewrites/i26013.scala
+++ b/tests/rewrites/i26013.scala
@@ -1,0 +1,16 @@
+// https://github.com/scala/scala3/issues/26013
+trait A
+trait B
+trait C
+case class N(child: Any)
+
+def m(n: N): String = n match
+  case N(child: A with B) => "ab"
+  case N(child: A with B with C) => "abc"
+  case _ => "other"
+
+def g(x: Any): String = x match
+  case given A with B => "given ab"
+  case _ => "other"
+
+def h: Int with String = ???

--- a/tests/rewrites/i26013.scala
+++ b/tests/rewrites/i26013.scala
@@ -7,6 +7,9 @@ case class N(child: Any)
 def m(n: N): String = n match
   case N(child: A with B) => "ab"
   case N(child: A with B with C) => "abc"
+  case _: A with B => "wildcard"
+  case N(child: (A with B)) => "already parens"
+  case child: A with B { type T } => "refinement"
   case _ => "other"
 
 def g(x: Any): String = x match


### PR DESCRIPTION
In a typed pattern (`case x: A with B`), the type ascription's grammar is `RefinedType`, which accepts `with` but not `&`. Replacing `with` with `&` blindly under `-rewrite -source 3.4-migration` produced code that no longer parsed. Wrap the whole rewritten `WithType` in parentheses when the parser is in pattern position, so `A with B` becomes `(A & B)` instead of `A & B`.

The same applies to `case given A with B` patterns, which also use `RefinedType` for the type after `given`.

Fixes #26013

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)