### PR TITLE
[OpenCB Project Fix] Fixes #26015: Start of NoSpan in adaptToArgs fallBack

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4517,7 +4517,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
               else
                 val union = tree.sourcePos.withSpan:
                   tree.srcPos.span.union(pt.args.last.srcPos.span)
-                if union.startLine != union.endLine then union // if multiline, show more context
+                if union.exists && union.startLine != union.endLine then union // if multiline, show more context
                 else tree.srcPos
             errorTree(tree, MethodDoesNotTakeParameters(tree), pos)
     }

--- a/tests/pos-macros/i26015/Converters.scala
+++ b/tests/pos-macros/i26015/Converters.scala
@@ -1,0 +1,6 @@
+package repro
+
+// Not imported in Test.scala — serves as an import-suggestion candidate.
+// importSuggestions finds it via rootsOnPath(repro.Crash.type) -> repro -> repro.Converters.
+object Converters:
+  given Conversion[Int, String] = _.toString

--- a/tests/pos-macros/i26015/Crash.scala
+++ b/tests/pos-macros/i26015/Crash.scala
@@ -1,0 +1,14 @@
+package repro
+
+import scala.quoted.*
+
+object Crash:
+  inline def trigger: Any = ${ triggerImpl }
+
+  private def triggerImpl(using q: Quotes): Expr[Any] =
+    import q.reflect.*
+    // Build `{ val x: String = 1; x }` with all-NoSpan positions.
+    // NoSpan propagates into importSuggestions.deepTest's argument span,
+    // triggering the crash in adaptToArgs fallBack via union.startLine.
+    val sym = Symbol.newVal(Symbol.spliceOwner, "x", TypeRepr.of[String], Flags.EmptyFlags, Symbol.noSymbol)
+    Block(List(ValDef(sym, Some(Literal(IntConstant(1))))), Ref(sym)).asExpr

--- a/tests/pos-macros/i26015/Test.scala
+++ b/tests/pos-macros/i26015/Test.scala
@@ -1,0 +1,11 @@
+package mytest
+
+import repro.Crash
+
+// Should not crash with AssertionError: start of NoSpan.
+// typeCheckErrors is inline -> InlineTyper (ReTyper) is active.
+// TypeMismatch lazy message -> importSuggestions.deepTest ->
+// typedImplicit -> adaptToArgs fallBack -> union.startLine on NoSpan.
+@main def Test() =
+  val errors = scala.compiletime.testing.typeCheckErrors("repro.Crash.trigger")
+  println(s"errors: ${errors.length}")


### PR DESCRIPTION
Guard union.startLine with union.exists in adaptToArgs to prevent AssertionError when union is NoSpan.

Crash path: typeCheckErrors (inline) -> InlineTyper (extends ReTyper). A macro generates ill-typed code with NoSpan positions. The TypeMismatch error's lazy message is evaluated by packError inside the InlineTyper context, which triggers importSuggestions.deepTest. deepTest calls typedImplicit -> tryConversion -> adapt -> adaptToArgs. Since InlineTyper extends ReTyper, tryInsertApplyOrImplicit immediately calls fallBack, which computes union = tree.srcPos.span.union(pt.args.last.srcPos.span). Both spans are NoSpan, so union is NoSpan, and union.startLine asserts.

The fix was introduced by commit 1610a739 (PR #25699) which added union.startLine to detect multiline spans for better error positions.

Fixes #26015

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
