### PR TITLE
Fixes #24414: Fix StaleSymbolException in Namer.addChild after compilation suspension

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -348,6 +348,17 @@ object Annotations {
         }
         else None
     }
+
+    /** Like `Child`, but yields `None` instead of throwing `StaleSymbol` when
+     *  the annotation refers to a child symbol from a previous run that is no
+     *  longer valid (e.g. after compilation was suspended and the child class
+     *  has been re-typechecked in the current run; see tests/pos/i24414).
+     */
+    object NonStaleChild {
+      def unapply(ann: Annotation)(using Context): Option[Symbol] =
+        try Child.unapply(ann)
+        catch case _: Denotations.StaleSymbol => None
+    }
   }
 
   /** An annotation that is used as a result of mapping annotations

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -536,17 +536,34 @@ class Namer { typer: Typer =>
     // to just prepending the new Child annotation.
     def isReady(ann: Annotation): Boolean =
       ann.symbol == defn.ChildAnnot && !ann.isEvaluating
+    // Forcing a Child annotation may throw `StaleSymbol` if it refers to a
+    // symbol from a previous run that is no longer valid. This happens when
+    // compilation was suspended and the child class is re-typechecked in the
+    // current run, leaving an outdated Child annotation on the parent (see
+    // tests/pos/i24414). Treat such annotations as stale and drop them.
+    def childOf(ann: Annotation): Option[Symbol] =
+      try Annotation.Child.unapply(ann)
+      catch case _: StaleSymbol => None
     def insertInto(annots: List[Annotation]): List[Annotation] =
       annots.find(isReady) match {
-        case Some(Annotation.Child(other)) if other.span.exists && childStart <= other.span.start =>
-          if (child == other)
-            annots // can happen if a class has several inaccessible children
-          else {
-            assert(childStart != other.span.start || child.source != other.source, i"duplicate child annotation $child / $other")
-            val (prefix, otherAnnot :: rest) = annots.span(ann => !isReady(ann)): @unchecked
-            prefix ::: otherAnnot :: insertInto(rest)
+        case Some(ann) =>
+          childOf(ann) match {
+            case Some(other) if other.span.exists && childStart <= other.span.start =>
+              if (child == other)
+                annots // can happen if a class has several inaccessible children
+              else {
+                assert(childStart != other.span.start || child.source != other.source, i"duplicate child annotation $child / $other")
+                val (prefix, otherAnnot :: rest) = annots.span(a => (a ne ann)): @unchecked
+                prefix ::: otherAnnot :: insertInto(rest)
+              }
+            case None =>
+              // Drop the stale Child annotation and continue searching.
+              val (prefix, rest) = annots.span(a => (a ne ann))
+              prefix ::: insertInto(rest.tail)
+            case _ =>
+              Annotation.Child(child, cls.span.startPos) :: annots
           }
-        case _ =>
+        case None =>
           Annotation.Child(child, cls.span.startPos) :: annots
       }
     cls.annotations = insertInto(cls.annotations)

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -536,34 +536,17 @@ class Namer { typer: Typer =>
     // to just prepending the new Child annotation.
     def isReady(ann: Annotation): Boolean =
       ann.symbol == defn.ChildAnnot && !ann.isEvaluating
-    // Forcing a Child annotation may throw `StaleSymbol` if it refers to a
-    // symbol from a previous run that is no longer valid. This happens when
-    // compilation was suspended and the child class is re-typechecked in the
-    // current run, leaving an outdated Child annotation on the parent (see
-    // tests/pos/i24414). Treat such annotations as stale and drop them.
-    def childOf(ann: Annotation): Option[Symbol] =
-      try Annotation.Child.unapply(ann)
-      catch case _: StaleSymbol => None
     def insertInto(annots: List[Annotation]): List[Annotation] =
       annots.find(isReady) match {
-        case Some(ann) =>
-          childOf(ann) match {
-            case Some(other) if other.span.exists && childStart <= other.span.start =>
-              if (child == other)
-                annots // can happen if a class has several inaccessible children
-              else {
-                assert(childStart != other.span.start || child.source != other.source, i"duplicate child annotation $child / $other")
-                val (prefix, otherAnnot :: rest) = annots.span(a => (a ne ann)): @unchecked
-                prefix ::: otherAnnot :: insertInto(rest)
-              }
-            case None =>
-              // Drop the stale Child annotation and continue searching.
-              val (prefix, rest) = annots.span(a => (a ne ann))
-              prefix ::: insertInto(rest.tail)
-            case _ =>
-              Annotation.Child(child, cls.span.startPos) :: annots
+        case Some(Annotation.NonStaleChild(other)) if other.span.exists && childStart <= other.span.start =>
+          if (child == other)
+            annots // can happen if a class has several inaccessible children
+          else {
+            assert(childStart != other.span.start || child.source != other.source, i"duplicate child annotation $child / $other")
+            val (prefix, otherAnnot :: rest) = annots.span(ann => !isReady(ann)): @unchecked
+            prefix ::: otherAnnot :: insertInto(rest)
           }
-        case None =>
+        case _ =>
           Annotation.Child(child, cls.span.startPos) :: annots
       }
     cls.annotations = insertInto(cls.annotations)

--- a/tests/pos/i24414/CloudEventKey_2.scala
+++ b/tests/pos/i24414/CloudEventKey_2.scala
@@ -1,0 +1,1 @@
+object CloudEventKey extends RefinedType[String, MessageKey]

--- a/tests/pos/i24414/Lib_1.scala
+++ b/tests/pos/i24414/Lib_1.scala
@@ -1,0 +1,12 @@
+// https://github.com/scala/scala3/issues/24414
+trait Constraint[A, C]:
+  inline def test: Boolean
+
+final class RuntimeConstraint[A, C](_test: Boolean)
+object RuntimeConstraint:
+  inline given fromConstraint[A, C](using c: Constraint[A, C]): RuntimeConstraint[A, C] =
+    new RuntimeConstraint[A, C](c.test)
+
+sealed trait Refined[A, C](using _rtc: RuntimeConstraint[A, C])
+
+trait RefinedType[A, C] extends Refined[A, C]

--- a/tests/pos/i24414/MessageKey_2.scala
+++ b/tests/pos/i24414/MessageKey_2.scala
@@ -1,0 +1,9 @@
+import scala.quoted.*
+
+final class MessageKey
+
+object MessageKey:
+  inline given Constraint[String, MessageKey] with
+    override inline def test: Boolean = ${ check() }
+
+  def check()(using Quotes): Expr[Boolean] = Expr(true)


### PR DESCRIPTION
When `addChild` inspects a parent's existing Child annotations, forcing their lazy tree may dereference a child symbol from a previous run. If compilation was suspended (due to inline/macro processing) and the child class has been re-typechecked in the current run, the captured symbol is stale and accessing its owner triggers `StaleSymbol`.

This manifests when a sealed parent is in a pre-compiled artifact and a subclass in user code uses an inline given that causes suspension: the parent's annotation list ends up holding a Child annotation pointing to the suspended-run version of the subclass.

Treat such Child annotations as stale and drop them; the new run will have re-registered the child anyway.

Fixes #24414

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a rather small fix to fix one of the dreadful State Symbol crashes.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
