### PR TITLE
Fixes #15830: Inline given with using parameter losing constant value

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -179,7 +179,10 @@ object Inlines:
     val tree1 = liftBindings(tree0, identity)
     val tree2  =
       if bindings.nonEmpty then
-        cpy.Block(tree0)(bindings.toList, inlineCall(tree1))
+        val expansion = inlineCall(tree1)
+        val cleaned = dropUnusedLiftedBindings(bindings.toList, expansion)
+        if cleaned.isEmpty then expansion
+        else cpy.Block(tree0)(cleaned, expansion)
       else if enclosingInlineds.length < ctx.settings.XmaxInlines.value && !reachedInlinedTreesLimit then
         val body =
           try bodyToInline(tree0.symbol) // can typecheck the tree and thereby produce errors
@@ -204,6 +207,45 @@ object Inlines:
         // reset so that further inline calls can be expanded
     tree2
   end inlineCall
+
+  /** Drop bindings that are no longer referenced in `expansion` and whose rhs is
+   *  pure (so their evaluation can be safely elided). This iterates to a fixpoint
+   *  because dropping one binding may make a previously-referenced binding unused.
+   *  This is needed for bindings that were lifted out of an inlined receiver in
+   *  `liftBindings` but became orphaned after the resulting inline call was
+   *  further reduced. See i15830.
+   */
+  private def dropUnusedLiftedBindings(bindings: List[Tree], expansion: Tree)(using Context): List[Tree] =
+    def isElideableBinding(b: Tree): Boolean = b match
+      case vdef: ValDef => Inliner.isElideableExpr(vdef.rhs)
+      case ddef: DefDef if ddef.paramss.isEmpty => Inliner.isElideableExpr(ddef.rhs)
+      case _ => false
+
+    def countRefsIn(t: Tree, refs: mutable.HashMap[Symbol, Int]): Unit =
+      t.foreachSubTree {
+        case t: RefTree =>
+          if refs.contains(t.symbol) then refs(t.symbol) = refs(t.symbol) + 1
+        case _ =>
+      }
+
+    var current = bindings
+    var changed = true
+    while changed do
+      changed = false
+      val refs = mutable.HashMap.empty[Symbol, Int]
+      for b <- current if isElideableBinding(b) do refs(b.symbol) = 0
+      countRefsIn(expansion, refs)
+      for b <- current do countRefsIn(b, refs)
+      val pruned = current.filterConserve { b =>
+        refs.get(b.symbol) match
+          case Some(0) => false
+          case _ => true
+      }
+      if pruned ne current then
+        current = pruned
+        changed = true
+    current
+  end dropUnusedLiftedBindings
 
   /** Try to inline a pattern with an inline unapply method. Fail with error if the maximal
    *  inline depth is exceeded.

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -256,7 +256,10 @@ object Inlines:
     val tree1 = liftBindings(tree0, identity)
     val tree2  =
       if bindings.nonEmpty then
-        cpy.Block(tree0)(bindings.toList, inlineCall(tree1))
+        val expansion = inlineCall(tree1)
+        val cleaned = dropUnusedLiftedBindings(bindings.toList, expansion)
+        if cleaned.isEmpty then expansion
+        else cpy.Block(tree0)(cleaned, expansion)
       else if enclosingInlineds.length < ctx.settings.XmaxInlines.value && !reachedInlinedTreesLimit then
         val body =
           try bodyToInline(symbol0) // can typecheck the tree and thereby produce errors
@@ -285,6 +288,45 @@ object Inlines:
         // reset so that further inline calls can be expanded
     tree3
   end inlineCall
+
+  /** Drop lifted bindings with a pure rhs that are unreferenced in `expansion`.
+   *  Bindings lifted out of an inlined receiver by `liftBindings` can be left
+   *  orphaned once the enclosing inline call is reduced, which then hides the
+   *  constant nature of the expansion from `Expr#value`. See i15830.
+   *  Iterated to a fixpoint, since dropping a binding can in turn make the
+   *  bindings it referred to unused.
+   */
+  private def dropUnusedLiftedBindings(bindings: List[Tree], expansion: Tree)(using Context): List[Tree] =
+    def isElideable(binding: Tree): Boolean = binding match
+      case vdef: ValDef => Inliner.isElideableExpr(vdef.rhs)
+      case ddef: DefDef if ddef.paramss.isEmpty => Inliner.isElideableExpr(ddef.rhs)
+      case _ => false
+
+    def countRefs(tree: Tree, refCount: MutableSymbolMap[Int]): Unit =
+      // A binding mentioned in a type cannot be dropped, so pin it down.
+      def pinTermRefs(t: Tree) =
+        t.typeOpt.foreachPart:
+          case ref: TermRef => if refCount.contains(ref.symbol) then refCount(ref.symbol) = 1
+          case _ =>
+      tree.foreachSubTree:
+        case t: RefTree =>
+          if refCount.contains(t.symbol) then refCount(t.symbol) = refCount(t.symbol) + 1
+          pinTermRefs(t)
+        case t @ (_: New | _: TypeTree) => pinTermRefs(t)
+        case _ =>
+
+    var retained = bindings
+    var progress = true
+    while progress do
+      val refCount = MutableSymbolMap[Int]()
+      for binding <- retained if isElideable(binding) do refCount(binding.symbol) = 0
+      countRefs(expansion, refCount)
+      for binding <- retained do countRefs(binding, refCount)
+      val remaining = retained.filterConserve(binding => refCount.get(binding.symbol) != Some(0))
+      progress = remaining ne retained
+      retained = remaining
+    retained
+  end dropUnusedLiftedBindings
 
   private def updateFlagsFromInlinedParent(child: FlagSet, parent: FlagSet): FlagSet = 
     var updatedFlags = child

--- a/tests/pos-macros/i15830/Macro_1.scala
+++ b/tests/pos-macros/i15830/Macro_1.scala
@@ -1,0 +1,16 @@
+// https://github.com/scala/scala3/issues/15830
+import scala.quoted.*
+
+object macros:
+
+  inline def assertCondition(inline cond: Boolean, inline message: String): Unit =
+    ${ assertConditionImpl('cond, 'message) }
+
+  private def assertConditionImpl(cond: Expr[Boolean], message: Expr[String])(using Quotes): Expr[Unit] =
+    val report = quotes.reflect.report
+    val condValue = cond.valueOrAbort
+    val messageValue = message.value.getOrElse("<Unknown message>")
+    if !condValue then report.errorAndAbort(messageValue)
+    else '{()}
+
+end macros

--- a/tests/pos-macros/i15830/Test_2.scala
+++ b/tests/pos-macros/i15830/Test_2.scala
@@ -1,0 +1,22 @@
+// https://github.com/scala/scala3/issues/15830
+import scala.compiletime.{constValue, summonInline}
+
+trait Constraint[T, C]:
+  inline def test(value: T): Boolean
+  inline def message: String
+
+final class Greater[V <: Int]
+
+inline given [V <: Int]: Constraint[Int, Greater[V]] with
+  override inline def test(value: Int): Boolean = value > constValue[V]
+  override inline def message: String = "Should be greater"
+
+final class DescribedAs[C, V <: String]
+
+inline given [T, C, Impl <: Constraint[T, C], V <: String](using Impl): Constraint[T, DescribedAs[C, V]] with
+  override inline def test(value: T): Boolean = summonInline[Impl].test(value)
+  override inline def message: String = constValue[V]
+
+def test() =
+  macros.assertCondition(summonInline[Constraint[Int, Greater[0]]].test(1), "test")
+  macros.assertCondition(summonInline[Constraint[Int, DescribedAs[Greater[0], "pos"]]].test(1), "test")


### PR DESCRIPTION
When inlining a method call on a receiver that itself was the result of inlining (e.g. summonInline of a given with using parameters), bindings of the inner inline are lifted out by liftBindings to wrap the outer inline. After further reduction the lifted bindings can become orphaned in the surrounding Block, defeating Expr#value/valueOrAbort because the constant expression is no longer recognized as such.

Drop lifted bindings that have a pure rhs and are unreferenced in the expansion, iterating to a fixpoint to handle chains of dependent bindings.

Fixes #15830

## How much have you relied on LLM-based tools in this contribution?

Extensively. This change looks scary. Let's see what the CI says. Don't know if I'll remove the draft.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
