### PR TITLE
[OpenCB Project Fix] Fixes #26018: Surface diverging implicit error from nested summonInline

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -3004,6 +3004,9 @@ class MissingImplicitArgument(
     ignoredConvertibleImplicits: => Iterable[TermRef]
   )(using Context) extends TypeMsg(MissingImplicitArgumentID), ShowMatchTrace(pt):
 
+  /** True iff the missing implicit was rejected because the search diverged. */
+  val isDivergingImplicit: Boolean = arg.tpe.isInstanceOf[DivergingImplicit]
+
   arg.tpe match
     case ambi: AmbiguousImplicits => withoutDisambiguation()
     case _ =>

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -1260,6 +1260,16 @@ trait Implicits:
               NoMatchingImplicitsFailure
             else if Splicer.inMacroExpansion && tpe <:< pt then
               SearchFailure(adapted.withType(new MacroErrorsFailure(ctx.reporter.allErrors.reverse, pt, argument)))
+            else if ctx.reporter.allErrors.exists(e => e.msg match
+                  case mia: reporting.MissingImplicitArgument => mia.isDivergingImplicit
+                  case _ => false)
+            then
+              // The candidate's adapt failed because of a nested divergent implicit
+              // search (typically a `summonInline` inside the candidate's inline body
+              // that recursively requests the same type being searched here). Surface
+              // the divergence directly instead of a misleading "does not match" message.
+              // See scala/scala3#26018.
+              SearchFailure(adapted.withType(new DivergingImplicit(ref, pt, argument)))
             else
               SearchFailure(adapted.withType(new MismatchedImplicit(ref, pt, argument)))
         }

--- a/tests/neg/i26018.check
+++ b/tests/neg/i26018.check
@@ -1,0 +1,16 @@
+-- [E172] Type Error: tests/neg/i26018.scala:19:44 ---------------------------------------------------------------------
+19 |  val h: Hammer[D, D] = summon[Hammer[D, D]] // error
+   |                                            ^
+   |No given instance of type Hammer[D, given_HasT.T] was found.
+   |I found:
+   |
+   |    Lib.derived[D, B](given_HasT)
+   |
+   |But given instance derived in object Lib produces a diverging implicit search when trying to match type Hammer[D, given_HasT.T].
+   |--------------------------------------------------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from i26018.scala:9
+ 9 |    val _ = summonInline[Hammer[I, h.T]]
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    --------------------------------------------------------------------------------------------------------------------

--- a/tests/neg/i26018.scala
+++ b/tests/neg/i26018.scala
@@ -1,0 +1,19 @@
+// https://github.com/scala/scala3/issues/26018
+import scala.compiletime.summonInline
+
+trait Hammer[I, O]
+trait HasT { type T }
+
+object Lib:
+  inline given derived[I, O](using h: HasT): Hammer[I, O] =
+    val _ = summonInline[Hammer[I, h.T]]
+    new Hammer[I, O] {}
+
+import Lib.given
+
+class B
+class D
+given HasT with { type T = B }
+
+@main def m(): Unit =
+  val h: Hammer[D, D] = summon[Hammer[D, D]] // error


### PR DESCRIPTION
When an inline given's body contains a `summonInline[T]` that triggers a recursive implicit search of the same type, divergence is correctly detected at the inner search but the buffered error gets wrapped by `typedImplicit` as a `MismatchedImplicit` failure ("does not match type"), which is misleading because the displayed candidate would in fact match.

Detect the buffered divergence via a new `isDivergingImplicit` predicate on `MissingImplicitArgument` and propagate as `DivergingImplicit` so the user sees "produces a diverging implicit search" instead.

Fixes #26018

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)