### PR TITLE
fix 26026: restore type parameter of Option.orNull

### DIFF
--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -248,7 +248,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  @param ev evidence that `Null` is a subtype of `A1`
    *  @return the option's value if nonempty, or `null` if empty
    */
-  @inline final def orNull: A | Null = this.getOrElse(null)
+  @inline final def orNull[A1 >: A | Null]: A1 = this.getOrElse(null)
   
   // for binary and TASTy backwards compatibility 
   @deprecated @inline protected final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)

--- a/tests/pos/i26026.scala
+++ b/tests/pos/i26026.scala
@@ -1,0 +1,3 @@
+object Repro:
+  val opt: Option[String] = Some("hi")
+  val a: String = opt.orNull[String]


### PR DESCRIPTION
Fixes #26026 

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

PR includes test from issue.