### PR TITLE
Fixes #25947, #11043: Avoid JavaArrayType in synthesized classOf for structural calls

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -234,6 +234,15 @@ object TypeErasure:
       case ErasedValueType(_, underlying) => erasure(underlying)
       case etp => etp
 
+  /** Rewrite a `JavaArrayType` (the post-erasure representation of `T[]`) to its
+   *  source-level Scala `Array[T]` form. Other types are returned unchanged. Used
+   *  when an erased type has to flow back into a tree where only Scala-level types
+   *  are valid, e.g. the type argument of a class literal.
+   */
+  def escapeJavaArray(tp: Type)(using Context): Type = tp match
+    case JavaArrayType(elemTp) => defn.ArrayOf(escapeJavaArray(elemTp))
+    case _                     => tp
+
   def sigName(tp: Type, sourceLanguage: SourceLanguage)(using Context): TypeName = {
     val normTp = tp.translateFromRepeated(toArray = sourceLanguage.isJava)
     val erase = erasureFn(sourceLanguage, semiEraseVCs = !sourceLanguage.isJava, isConstructor = false, isSymbol = false, inSigName = true)

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -267,11 +267,19 @@ trait Dynamic {
         if (isDependentMethod(tpe))
           fail(i"has a method type with inter-parameter dependencies")
         else {
+          // The erasure of an `Array[T]` parameter is a `JavaArrayType`, which is not a
+          // Scala type expressible at the source level and cannot be pickled in a
+          // class-literal constant. Convert it back to the Scala `Array[T]` form, which
+          // re-erases to the same JVM class at code generation time.
+          def toScalaClsType(tp: Type): Type = tp match
+            case JavaArrayType(elem) => defn.ArrayOf(toScalaClsType(elem))
+            case _                   => tp
           def classOfs =
             if tpe.paramInfoss.nestedExists(!TypeErasure.hasStableErasure(_)) then
               fail(i"has a parameter type with an unstable erasure") :: Nil
             else
-              TypeErasure.erasure(tpe).asInstanceOf[MethodType].paramInfos.map(clsOf(_))
+              TypeErasure.erasure(tpe).asInstanceOf[MethodType].paramInfos
+                .map(p => clsOf(toScalaClsType(p)))
           structuralCall(nme.applyDynamic, classOfs).maybeBoxingCast(tpe.finalResultType)
         }
 

--- a/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Dynamic.scala
@@ -269,17 +269,14 @@ trait Dynamic {
         else {
           // The erasure of an `Array[T]` parameter is a `JavaArrayType`, which is not a
           // Scala type expressible at the source level and cannot be pickled in a
-          // class-literal constant. Convert it back to the Scala `Array[T]` form, which
+          // class-literal constant. Rewrite it back to the Scala `Array[T]` form, which
           // re-erases to the same JVM class at code generation time.
-          def toScalaClsType(tp: Type): Type = tp match
-            case JavaArrayType(elem) => defn.ArrayOf(toScalaClsType(elem))
-            case _                   => tp
           def classOfs =
             if tpe.paramInfoss.nestedExists(!TypeErasure.hasStableErasure(_)) then
               fail(i"has a parameter type with an unstable erasure") :: Nil
             else
               TypeErasure.erasure(tpe).asInstanceOf[MethodType].paramInfos
-                .map(p => clsOf(toScalaClsType(p)))
+                .map(p => clsOf(TypeErasure.escapeJavaArray(p)))
           structuralCall(nme.applyDynamic, classOfs).maybeBoxingCast(tpe.finalResultType)
         }
 

--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -6,7 +6,7 @@ import core.*
 import util.Spans.Span
 import Contexts.*
 import Types.*, Flags.*, Symbols.*, Names.*, StdNames.*, Constants.*
-import TypeErasure.{erasure, hasStableErasure}
+import TypeErasure.{erasure, escapeJavaArray, hasStableErasure}
 import Decorators.*
 import ProtoTypes.*
 import Inferencing.{fullyDefinedType, isFullyDefined}
@@ -674,10 +674,6 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
    */
   val synthesizedMirror: SpecialHandler = (formal, span) =>
     orElse(synthesizedProductMirror(formal, span), synthesizedSumMirror(formal, span))
-
-  private def escapeJavaArray(tp: Type)(using Context): Type = tp match
-    case JavaArrayType(elemTp) => defn.ArrayOf(escapeJavaArray(elemTp))
-    case _                     => tp
 
   private enum ManifestKind:
     case Full, Opt, Clss

--- a/tests/pos/i25947.scala
+++ b/tests/pos/i25947.scala
@@ -1,0 +1,10 @@
+// https://github.com/scala/scala3/issues/25947
+import scala.language.reflectiveCalls
+
+object Repro {
+  private type WithNextBytes =
+    AnyRef { def nextBytes(bytes: Array[Byte]): Unit }
+
+  def call(value: AnyRef, bytes: Array[Byte]): Unit =
+    value.asInstanceOf[WithNextBytes].nextBytes(bytes)
+}

--- a/tests/run/i11043.scala
+++ b/tests/run/i11043.scala
@@ -1,0 +1,16 @@
+// https://github.com/scala/scala3/issues/11043
+import scala.reflect.Selectable.reflectiveSelectable
+
+object Test {
+  type Runner = { def run(args: Array[String]): Unit }
+
+  def test(args: Array[String], runner: Runner): Unit =
+    runner.run(args)
+
+  def main(args: Array[String]): Unit =
+    val out = new StringBuilder
+    test(Array("foo", "bar"), new {
+      def run(args: Array[String]): Unit = args.foreach(s => out.append(s).append('\n'))
+    })
+    assert(out.toString == "foo\nbar\n", out.toString)
+}

--- a/tests/run/i25947.scala
+++ b/tests/run/i25947.scala
@@ -1,0 +1,23 @@
+// https://github.com/scala/scala3/issues/25947
+import scala.language.reflectiveCalls
+
+class Holder {
+  def nextBytes(bytes: Array[Byte]): Unit =
+    var i = 0
+    while i < bytes.length do
+      bytes(i) = (i + 1).toByte
+      i += 1
+}
+
+object Test {
+  type WithNextBytes =
+    AnyRef { def nextBytes(bytes: Array[Byte]): Unit }
+
+  def call(value: AnyRef, bytes: Array[Byte]): Unit =
+    value.asInstanceOf[WithNextBytes].nextBytes(bytes)
+
+  def main(args: Array[String]): Unit =
+    val bs = new Array[Byte](3)
+    call(new Holder, bs)
+    assert(bs.toList == List[Byte](1, 2, 3), bs.toList)
+}


### PR DESCRIPTION
When a structural method has an `Array[T]` parameter, `Dynamic` synthesized the runtime `applyDynamic` call with `clsOf(JavaArrayType(T))` for the parameter-class array. `JavaArrayType` is not a Scala source type and has no TASTy encoding, so the pickler crashed with a `MatchError` on the class-literal constant.

Convert `JavaArrayType(T)` back to the Scala `Array[T]` form before passing it to `clsOf`. The two forms re-erase to the same JVM array class, so the runtime reflective lookup is unchanged.

Fixes #25947 #11043

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
