### PR TITLE
Fixes #25943: Track super-calls as call edges in LambdaLift

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
@@ -243,6 +243,13 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
         captureImplicitThis(tree.tpe)
       case tree: Select =>
         if isExpr(sym) && isLocal(sym) then markCalled(sym, enclosure)
+        else if sym.isConstructor && tree.qualifier.isInstanceOf[Super] then
+          // Super-call to a parent constructor (e.g. `super(args)` in the body of a
+          // local class's primary constructor, after Constructors phase has moved
+          // parent constructor calls into the constructor body). We track this as
+          // a call edge so that free variables of the parent constructor are
+          // propagated to this constructor. See i25943.
+          symSet(called, enclosure) += sym
       case tree: New =>
         val constr = tree.tpe.typeSymbol.primaryConstructor
         if constr.exists then

--- a/tests/pos/i25943.scala
+++ b/tests/pos/i25943.scala
@@ -1,0 +1,26 @@
+// https://github.com/scala/scala3/issues/25943
+class C25943(a: Any)
+
+def compilerThrows25943(): Unit =
+  val a2 = new Object
+
+  new :
+    class S extends C25943(a2)
+    new S{}
+
+val outsideA25943 = new Object
+
+def noThrow25943(): Unit =
+  val a2 = new Object
+
+  val _ =
+    class S extends C25943(a2)
+    new S {}
+
+  new :
+    class S extends C25943(a2)
+
+    class S_outsideA extends C25943(outsideA25943)
+    new S_outsideA {}
+
+    new C25943(a2) {}

--- a/tests/run/i25943.scala
+++ b/tests/run/i25943.scala
@@ -1,17 +1,19 @@
 // https://github.com/scala/scala3/issues/25943
 class C25943(val a: AnyRef)
 
-def runIt(): Unit =
+trait Probe25943:
+  def aField: AnyRef
+
+def runIt(): Boolean =
   val a2 = new Object
 
-  val obj =
-    new :
+  val obj: Probe25943 =
+    new Probe25943:
       class S extends C25943(a2)
       val s = new S{}
+      def aField = s.a
 
-  val sField = obj.getClass.getDeclaredField("s")
-  sField.setAccessible(true)
-  val sInstance = sField.get(obj).asInstanceOf[C25943]
-  assert(sInstance.a eq a2, s"expected $a2, got ${sInstance.a}")
+  obj.aField eq a2
 
-@main def Test = runIt()
+@main def Test =
+  assert(runIt(), "captured value should propagate through super-call")

--- a/tests/run/i25943.scala
+++ b/tests/run/i25943.scala
@@ -1,0 +1,17 @@
+// https://github.com/scala/scala3/issues/25943
+class C25943(val a: AnyRef)
+
+def runIt(): Unit =
+  val a2 = new Object
+
+  val obj =
+    new :
+      class S extends C25943(a2)
+      val s = new S{}
+
+  val sField = obj.getClass.getDeclaredField("s")
+  sField.setAccessible(true)
+  val sInstance = sField.get(obj).asInstanceOf[C25943]
+  assert(sInstance.a eq a2, s"expected $a2, got ${sInstance.a}")
+
+@main def Test = runIt()


### PR DESCRIPTION
When a local class extends another class that has free variables, after the Constructors phase moves the parent constructor call into the constructor body, the super-call appears as `Apply(Select(Super, <init>), ...)`. The dependency analysis in LambdaLift was missing this call edge because the parent constructor's class is not directly term-owned (its enclosing class is, but the `isLocal` check did not recurse through class owners), so its free variables were not propagated to the calling constructor.

This caused a crash when constructing `new S{}` where `S` is a member of an outer anonymous class and captures a local val in its parent constructor: the inner anonymous class's primary constructor needed a proxy for the captured val to forward to S's super-call, but no proxy was registered.

Fix by adding a call edge for super-call selects whose target is a constructor, regardless of locality. Edges to non-local constructors are no-ops in `computeFreeVars` since those constructors have no free vars, so this is safe.

Fixes #25943

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)