### PR TITLE
Fixes #25806: Eta-expand partial app of integrated context-function result

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -386,8 +386,18 @@ object Erasure {
       case _: FunProto | AnyFunctionProto => tree
       case _ => tree.tpe.widen match
         case mt: MethodType if tree.isTerm =>
-          assert(mt.paramInfos.isEmpty, i"bad adapt for $tree: $mt")
-          adaptToType(tree.appliedToNone, pt)
+          if mt.paramInfos.isEmpty then
+            adaptToType(tree.appliedToNone, pt)
+          else
+            // Partial application left over because the callee's signature has
+            // been integrated with extra parameters from a context-function
+            // result type (`@ContextResultCount`), but the call site does not
+            // supply those arguments (the result is consumed as a value, e.g.
+            // when an inline method is expanded with a concrete context-function
+            // type substituted for an abstract result type that the call site
+            // treats as a value). Eta-expand to a closure so the remaining
+            // parameters become a regular function value. See i25806.
+            adaptToType(etaExpandPartialApply(tree, mt), pt)
         case tpw =>
           if (pt.isInstanceOf[ProtoType] || tree.tpe <:< pt)
             tree
@@ -506,6 +516,33 @@ object Erasure {
       else
         tree
     end adaptClosure
+
+    /** Wrap `tree`, whose type is the method type `mt` left over from a
+     *  partial application, into a closure that supplies the missing
+     *  parameters: `(xs) => tree(xs)`. Used to recover a value when an
+     *  integrated context-function result is consumed as a value rather than
+     *  immediately applied.
+     */
+    def etaExpandPartialApply(tree: Tree, mt: MethodType)(using Context): Tree =
+      val anonFun = newAnonFun(ctx.owner, mt, coord = ctx.owner.coord)
+      anonFun.info = transformInfo(anonFun, anonFun.info)
+      // Merge the new args into the existing application chain so the
+      // resulting tree is a fully-applied call. Producing a nested partial
+      // Apply here would leave a partial-method-typed inner Apply that
+      // later phases (e.g. constructors) would re-typecheck with fewer
+      // arguments than the integrated method type expects.
+      def addArgs(t: Tree, newArgs: List[Tree]): Tree = t match
+        case Block(stats, expr) =>
+          cpy.Block(t)(stats, addArgs(expr, newArgs))
+        case Apply(fn, prevArgs) =>
+          Apply(fn, prevArgs ++ newArgs)
+        case _ =>
+          t.appliedToTermArgs(newArgs)
+      val block = Closure(anonFun, refss =>
+        addArgs(tree, refss.head).changeOwner(ctx.owner, anonFun))
+      cpy.Block(block)(block.stats,
+        adaptClosure(block.expr.asInstanceOf[Closure]))
+    end etaExpandPartialApply
   end Boxing
 
   class Typer(erasurePhase: DenotTransformer) extends typer.ReTyper with NoChecking {

--- a/tests/pos/i25806.scala
+++ b/tests/pos/i25806.scala
@@ -1,0 +1,64 @@
+// https://github.com/scala/scala3/issues/25806
+import scala.util.boundary
+import scala.util.boundary.Label
+
+type Direct[A] = Label[Either[String, Nothing]] ?=> A
+
+object Mode {
+  trait FailFast[F[+x]] {
+    def flatMap[A, B](fa: F[A], f: A => F[B]): F[B]
+    def pure[A](value: A): F[A]
+  }
+}
+
+object Transformer {
+  trait Fallible[F[+x], Source, Dest] {
+    def transform(value: Source): F[Dest]
+  }
+}
+
+object LabelMode extends Mode.FailFast[Direct] {
+
+  override def flatMap[A, B](
+      fa: Direct[A],
+      f: A => Direct[B]
+  ): Direct[B] = f(fa)
+
+  override def pure[A](value: A): Direct[A] = value
+}
+
+final case class Nat private (value: Int)
+
+object Nat {
+  def make(value: Int)(using label: Label[Either[String, Nothing]]): Nat =
+    if value < 0 then boundary.break(Left(s"Haha no - $value is not a proper Nat")) else Nat(value)
+
+  given t: Transformer.Fallible[Direct, Int, Nat] with {
+    override def transform(source: Int): Direct[Nat] = make(source)
+  }
+}
+
+case class Person(age: Nat, somethingElse: Nat, moreStuff: String)
+case class WirePerson(age: Int, somethingElse: Int, moreStuff: String)
+
+inline def transformWirePerson[F[+x]](wire: WirePerson)(using F: Mode.FailFast[F], T: Transformer.Fallible[F, Int, Nat]): F[Person] = {
+  F.flatMap(
+    T.transform(wire.age),
+    age =>
+      F.flatMap(
+        T.transform(wire.somethingElse),
+        smthElse => F.pure(Person(age, smthElse, wire.moreStuff))
+      )
+  )
+}
+
+@main def main25806 = {
+  given LabelMode.type = LabelMode
+  val res =
+    boundary {
+      val d = transformWirePerson(WirePerson(1, 2, "asd"))
+      d
+    }
+
+  println(res)
+}


### PR DESCRIPTION
When an inline method is expanded with a concrete context-function type substituted for an abstract result type, the call site can be left with a call to a method whose `@ContextResultCount`-integrated signature has more parameters than the call supplies (because the result is consumed as a context-function value rather than immediately applied). At erasure, `adaptToType` previously asserted on this case. Instead, recover by eta-expanding the partial application to a closure that supplies the missing parameters, merging the new arguments into the existing call chain so later phases see a fully-applied inner Apply.

Fixes #25806

## How much have you relied on LLM-based tools in this contribution?

Extensively. Looks to be a significant change. Let's first see what the CI says, and I may decide to take it out of a draft state.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)