### PR TITLE
Fixes #25856: Position not set crash in implicit search during import qualifier

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -889,7 +889,7 @@ trait Implicits:
     && ctx.mode.is(Mode.ImplicitsEnabled)
     && from.isValueType
     && (  from.isValueSubType(to)
-       || inferView(dummyTreeOfType(from), to)
+       || inferView(dummyTreeOfType(from).withSpan(ctx.tree.span), to)
             (using ctx.fresh.addMode(Mode.ImplicitExploration).setExploreTyperState()).isSuccess
           // TODO: investigate why we can't TyperState#test here
        || from.widen.isNamedTupleType && to.derivesFrom(defn.TupleClass)

--- a/tests/neg/i25856.scala
+++ b/tests/neg/i25856.scala
@@ -1,0 +1,5 @@
+// https://github.com/scala/scala3/issues/25856
+object parser:
+  def parse(input: String): Int = ???
+
+import parser.parse.decode // error // error


### PR DESCRIPTION
When `viewExists` synthesizes a `dummyTreeOfType` to probe for an implicit conversion, the dummy tree had no span. During typing of an `import` qualifier, `inferImplicit` walks past enclosing import contexts to avoid cyclic-reference errors (i12802), which also escapes the explore typer state set by `viewExists`. The committable typer state combined with the spanless dummy tree caused `assertPositioned` to fire on the synthesized `Apply` tree built inside `tryConversion`, crashing the compiler instead of reporting a regular type error.

Propagate the surrounding tree's span to the dummy tree so all derived trees in implicit search carry a position.

Fixes #25856

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
