### PR TITLE
[OpenCB Project Fix] Fixes #26031: Look through Inlined qualifiers in selectionType

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -164,10 +164,47 @@ trait TypeAssigner {
           else
             qualType.findMember(name, pre)
 
-        if reallyExists(mbr) && NamedType.validPrefix(qualType) then qualType.select(name, mbr)
+        if reallyExists(mbr) && NamedType.validPrefix(qualType) then
+          val sel = qualType.select(name, mbr)
+          // When the qualifier is an `Inlined` node with bindings, the qualifier's
+          // `tpe` was type-avoided to drop refs to local bindings (e.g., the proxy
+          // val for an inline-bound parameter). For invariant type-parameter args
+          // referenced in the member's signature, that avoidance widens
+          // `am$proxy.Context` to a wildcard `?` and produces an unhelpful
+          // projection like `Wrap[F, ?]#C` in the inserted-apply parameter's
+          // prototype. Fix #26031 by re-deriving the member's info from the
+          // precise expansion type when, and only when, the avoided form
+          // contains such a wildcard projection on a class type parameter that
+          // appears in the resulting parameter list. The Select's prefix stays
+          // avoided so the saved tree does not leak local-binding refs.
+          qual1 match
+            case Inlined(_, bindings, expansion) if bindings.nonEmpty
+                && containsArgWildcardProjection(sel.widen) =>
+              val precisePre = expansion.tpe.widenIfUnstable
+              val preciseMbr = precisePre.findMember(name, maybeSkolemizePrefix(precisePre, name))
+              if reallyExists(preciseMbr) && NamedType.validPrefix(precisePre)
+              then qualType.select(name, preciseMbr)
+              else sel
+            case _ => sel
         else if qualType.isErroneous || name.toTermName == nme.ERROR then UnspecifiedErrorType
         else NoType
   end selectionType
+
+  /** Does `tp` contain a `T#C` projection where `T` is an applied type whose
+   *  argument at `C`'s class-type-parameter position is a wildcard (i.e., a
+   *  `TypeBounds`)? Used by `selectionType` to detect when avoidance widening
+   *  has lost path precision needed by downstream apply-method prototypes —
+   *  see scala/scala3#26031.
+   */
+  private def containsArgWildcardProjection(tp: Type)(using Context): Boolean =
+    tp.existsPart({
+      case tr: TypeRef if tr.symbol.isAllOf(ClassTypeParam) =>
+        tr.argForParam(tr.prefix, widenAbstract = false) match
+          case other: TypeRef => (other.prefix eq tr.prefix) // not reduced — wildcard arg kept it as a projection
+          case _: TypeBounds => true
+          case _ => false
+      case _ => false
+    }, StopAt.None)
 
   def importSuggestionAddendum(pt: Type)(using Context): String = ""
 

--- a/tests/pos/i26031.scala
+++ b/tests/pos/i26031.scala
@@ -1,0 +1,49 @@
+// https://github.com/scala/scala3/issues/26031
+//
+// Regression on the dotty-cps-async @ 1.3.2 community-build run: the
+// `async[[A] =>> Either[E, A]] { ... }` macro call failed with [E007]
+// because, when inlining a `transparent inline def` whose body returned
+// `new C(using am)`, the resulting `Inlined` tree was assigned the
+// avoided type `C[F, ?]` instead of `C[F, am$proxy.Context]`. The lost
+// `am$proxy.Context` reference then propagated through the second
+// inline layer's parameter-type prototype as a bare class projection
+// `C[F, ?]#C` and made the outer context closure fail to type-check.
+//
+// Reproduction requires all of:
+//   1. `F` is a non-trivial type lambda over a parameterized type
+//      (`[A] =>> Pair[E, A]`).
+//   2. The summoned `Mon[F]` is itself parametric in `E`, so its
+//      static type does not refine `Context`.
+//   3. Two layers of `transparent inline`: the outer constructor and an
+//      `apply` that forwards to a second `transparent inline` taking
+//      the path-projected `C` as its third type argument.
+
+trait Ctx[F[_]]
+
+trait Mon[F[_]]:
+  type Context <: Ctx[F]
+
+object Mon:
+  type Aux[F[_], C <: Ctx[F]] = Mon[F] { type Context = C }
+
+class Wrap[F[_], C <: Ctx[F]](using val am: Mon.Aux[F, C]):
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    inner[F, T, C](am, expr)
+
+transparent inline def inner[F[_], T, C <: Ctx[F]](
+    inline am: Mon.Aux[F, C],
+    inline expr: C ?=> T
+): F[T] = ???
+
+transparent inline def doIt[F[_]](using am: Mon[F]) =
+  new Wrap(using am)
+
+class Pair[A, B]
+class PairCtx[E] extends Ctx[[A] =>> Pair[E, A]]
+class PairMon[E] extends Mon[[A] =>> Pair[E, A]]:
+  type Context = PairCtx[E]
+
+given pm[E]: Mon[[A] =>> Pair[E, A]] = new PairMon[E]
+
+object Test:
+  val r = doIt[[A] =>> Pair[String, A]] { 42 }


### PR DESCRIPTION
When a `transparent inline def doIt[F[_]](using am: Mon[F]) = new Wrap(using am)` is inlined, the result is wrapped in `Inlined(call, [val am$proxy = ...], new Wrap[F, am$proxy.Context](using am$proxy))`. `Inlined.tpe` is set via `avoidingType` so it cannot reference the local proxy: the precise `Wrap[F, am$proxy.Context]` is widened to `Wrap[F, ?]` (with the second arg ranged to its `<: Ctx[F]` upper bound).

That outer-avoided type then becomes the qualifier of the next member selection (`.apply { ... }`). `asSeenFrom` of `apply`'s class type parameter `C` against `Wrap[F, ?]` produces the bare projection `Wrap[F, ?]#C`, which leaks into the parameter prototype of the inserted context closure and makes the synthesized
`(contextual$1: am$proxy.Context)` fail to conform — this is the [E007] in scala/scala3#26031 (and the corresponding
`dotty-cps-async/dotty-cps-async @ 1.3.2` community-build regression).

Fix: when the qualifier of a selection is an `Inlined` node with bindings, look through to `expansion.tpe` for member lookup. The bindings remain part of the `Inlined` and stay in scope for any reference in the expansion's type, so member resolution can use the precise type and `asSeenFrom` substitutes the class type parameters correctly. The stored `Inlined.tpe` is unchanged, so pickling/unpickling and downstream typing that depends on the avoided outer type are unaffected.

Fixes #26031

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)