### PR TITLE
Backport "Move process parse exceptions to sys.error instead of a custom exception" to 3.8.4

### DIFF
--- a/library/src/scala/sys/process/Parser.scala
+++ b/library/src/scala/sys/process/Parser.scala
@@ -110,7 +110,5 @@ private[scala] object Parser {
     loop()
   }
 
-  class ParseException(msg: String) extends RuntimeException(msg)
-
-  def tokenize(line: String): List[String] = tokenize(line, x => throw new ParseException(x))
+  def tokenize(line: String): List[String] = tokenize(line, scala.sys.error)
 }

--- a/library/test/scala/sys/process/ParserTest.scala
+++ b/library/test/scala/sys/process/ParserTest.scala
@@ -5,7 +5,7 @@ import org.junit.Test
 import tools.AssertUtil.assertThrows
 
 class ParserTest {
-  import Parser.{tokenize, ParseException}
+  import Parser.tokenize
 
   private def check(tokens: String*)(input: String): Unit = assertEquals(tokens, tokenize(input))
 
@@ -44,8 +44,8 @@ class ParserTest {
     // missing quotes
     checkFails(""""x""", "Unmatched quote [0](\")")  // was assertEquals(List("\"x"), tokenize(""""x"""))
     checkFails("""x'""", "Unmatched quote [1](')")
-    assertThrows[ParseException](tokenize(""""x""")) // was assertEquals(List("\"x"), tokenize(""""x"""))
-    assertThrows[ParseException](tokenize("""x'"""))
+    assertThrows[RuntimeException](tokenize(""""x""")) // was assertEquals(List("\"x"), tokenize(""""x"""))
+    assertThrows[RuntimeException](tokenize("""x'"""))
   }
   @Test def `leading space is skipped`: Unit = check("text")(" text")
   @Test def `leading quote is escaped`: Unit = {

--- a/library/test/scala/sys/process/ProcessTest.scala
+++ b/library/test/scala/sys/process/ProcessTest.scala
@@ -126,4 +126,12 @@ class ProcessTest {
       case (_, other)                        => fail(s"Expected one IOException, got $other")
     }
   }
+
+  @Test def unmatchedQuotes(): Unit =
+    val badCommand = "echo 'Hello"
+    tools.AssertUtil.assertThrows[RuntimeException] { badCommand.!! }
+
+  @Test def trailingBackslash(): Unit =
+    val badCommand = "echo 'Hello'\\"
+    tools.AssertUtil.assertThrows[RuntimeException] { badCommand.!! }
 }


### PR DESCRIPTION
Backports #25675 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]