### PR TITLE
Backport "Ensure mistakes in CI inputs are caught early" to 3.8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
 
       # Extract the release tag
       - name: Extract the release tag
-        run : echo "RELEASE_TAG=${GITHUB_REF#*refs/tags/}" >> $GITHUB_ENV
+        run : echo "RELEASE_TAG='${GITHUB_REF#*refs/tags/}'" >> $GITHUB_ENV
 
       - name: Check compiler version
         shell: bash

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -35,5 +35,8 @@ jobs:
         with:
           name: scala.nupkg
       - name: Publish the package to Chocolatey
-        run: choco push scala.${{inputs.version}}.nupkg --source https://push.chocolatey.org/ --api-key ${{ secrets.API-KEY }}
+        env:
+          VERSION: ${{ inputs.version }}
+          KEY: ${{ secrets.API-KEY }}
+        run: choco push "scala.$VERSION.nupkg" --source https://push.chocolatey.org/ --api-key "$KEY"
         

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -45,8 +45,10 @@ jobs:
     steps:
       - name: Compute the SHA256 of scala3-${{ inputs.version }}-x86_64-pc-win32.zip in GitHub Release
         id: digest
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          curl -o artifact.zip -L https://github.com/scala/scala3/releases/download/${{ inputs.version }}/scala3-${{ inputs.version }}-x86_64-pc-win32.zip
+          curl -o artifact.zip -L "https://github.com/scala/scala3/releases/download/$VERSION/scala3-$VERSION-x86_64-pc-win32.zip"
           echo "digest=$(sha256sum artifact.zip | cut -d " " -f 1)" >> "$GITHUB_OUTPUT"
 
   build-chocolatey:

--- a/.github/workflows/test-msi.yml
+++ b/.github/workflows/test-msi.yml
@@ -18,11 +18,13 @@ on:
         type: string
       java-version:
         required: true
-        type    : string
+        type: string
 
 jobs:
   test:
     runs-on: windows-latest
+    env:
+      VERSION: ${{ inputs.version }}
     steps:
       - uses: actions/setup-java@v5
         with:
@@ -79,24 +81,24 @@ jobs:
         shell: pwsh
         run: |
           scala --version
-          if (-not (scala --version | Select-String "Scala version \(default\): ${{ inputs.version }}")) {
-            Write-Host "Invalid Scala version of MSI installed runner, expected ${{ inputs.version }}"
+          if (-not (scala --version | Select-String "Scala version \(default\): $Env:VERSION")) {
+            Write-Host "Invalid Scala version of MSI installed runner, expected $Env:VERSION"
             Exit 1
           }
       - name : Test the `scalac` command
         shell: pwsh
         run: |
           scalac --version
-          if (-not (scalac --version | Select-String "Scala compiler version ${{ inputs.version }}")) {
-            Write-Host "Invalid scalac version of MSI installed runner, expected ${{ inputs.version }}"
+          if (-not (scalac --version | Select-String "Scala compiler version $Env:VERSION")) {
+            Write-Host "Invalid scalac version of MSI installed runner, expected $Env:VERSION"
             Exit 1
           }
       - name : Test the `scaladoc` command
         shell: pwsh
         run: |
           scaladoc --version
-          if (-not (scaladoc --version | Select-String "Scaladoc version ${{ inputs.version }}")) {
-            Write-Host "Invalid scaladoc version of MSI installed runner, expected ${{ inputs.version }}"
+          if (-not (scaladoc --version | Select-String "Scaladoc version $Env:VERSION")) {
+            Write-Host "Invalid scaladoc version of MSI installed runner, expected $Env:VERSION"
             Exit 1
           }
 


### PR DESCRIPTION
Backports #25677 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]