### PR TITLE
Scoverage: correctly detect curried constructor applications

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -750,14 +750,16 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
 
     /** Check if an Apply can be instrumented. Prevents this phase from generating incorrect code. */
     private def canInstrumentApply(tree: Apply)(using Context): Boolean =
-      def isSecondaryCtorDelegateCall: Boolean = tree.fun match
+      def isSecondaryCtorDelegateCall(fun: Tree): Boolean = fun match
         case Select(This(_), nme.CONSTRUCTOR) => true
+        case Apply(fn, _)                     => isSecondaryCtorDelegateCall(fn)
+        case TypeApply(fn, _)                 => isSecondaryCtorDelegateCall(fn)
         case _                                => false
 
       val sym = tree.symbol
       !sym.isOneOf(ExcludeMethodFlags)
       && !isCompilerIntrinsicMethod(sym)
-      && !(sym.isClassConstructor && isSecondaryCtorDelegateCall)
+      && !(sym.isClassConstructor && isSecondaryCtorDelegateCall(tree.fun))
       && !sym.name.is(DefaultGetterName) // https://github.com/scala/scala3/issues/20255
       && (tree.typeOpt match
         case AppliedType(tycon: NamedType, _) =>

--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -13,7 +13,6 @@ i10889.scala
 i11247.scala
 i11556.scala
 i12739.scala
-i14164.scala
 i14947.scala
 i15165.scala
 i15864.scala


### PR DESCRIPTION
Curried constructor calls like the following broke under coverage:

```scala
this(x.toString)()
```

Normally constructor calls are excluded from coverage, this one slipped through the cracks due to currying and broke downstream phase `HoistSuperArgs`.

This PR correctly detects and excludes such a shape from coverage.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for codebase tracing and analysis.

## How was the solution tested?

Covered by existing tests - a test removed from excludelist.

```sh
sbt "testCompilation --enable-coverage-phase"
```