### PR TITLE
Scoverage: correctly lift wildcard and singleton types

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -73,14 +73,16 @@ object LiftCoverage extends LiftImpure:
     if liftingArgs then noLiftArg(expr)
     else isUnsafeAssumeSeparate(expr) || super.noLift(expr)
 
-  /** Preserve singleton precision for lifted coverage temps when the underlying value is a
-   *  compile-time constant (same notion ConstFold uses), so constant re-folding after lifting
-   *  still matches the original inferred singleton type. Everything else uses the base widen.
+  /** Preserve precision for lifted coverage temps when widening would break later checks:
+   *  compile-time constants need their singleton type, and capture-converted types need
+   *  their local TypeBox#CAP references.
    */
   override protected def liftedExprType(expr: tpd.Tree)(using Context): Type =
-    val dealiased = expr.tpe.dealias.deskolemized
-    dealiased.widenTermRefExpr.normalized.simplified match
-      case _: ConstantType => dealiased
+    val dealiased = expr.tpe.dealias
+    val deskolemized = dealiased.deskolemized
+    deskolemized.widenTermRefExpr.normalized.simplified match
+      case _: ConstantType => deskolemized
+      case _ if dealiased.existsPart(_.typeSymbol == defn.TypeBox_CAP) => dealiased
       case _ => super.liftedExprType(expr)
 
   def liftForCoverage(defs: mutable.ListBuffer[tpd.Tree], tree: tpd.Apply)(using Context) =

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -74,14 +74,15 @@ object LiftCoverage extends LiftImpure:
     else isUnsafeAssumeSeparate(expr) || super.noLift(expr)
 
   /** Preserve precision for lifted coverage temps when widening would break later checks:
-   *  compile-time constants need their singleton type, and capture-converted types need
-   *  their local TypeBox#CAP references.
+   *  compile-time constants and stable singleton types need their singleton precision,
+   *  and capture-converted types need their local TypeBox#CAP references.
    */
   override protected def liftedExprType(expr: tpd.Tree)(using Context): Type =
     val dealiased = expr.tpe.dealias
     val deskolemized = dealiased.deskolemized
     deskolemized.widenTermRefExpr.normalized.simplified match
       case _: ConstantType => deskolemized
+      case _ if dealiased.isInstanceOf[SingletonType] && dealiased.isStable => dealiased
       case _ if dealiased.existsPart(_.typeSymbol == defn.TypeBox_CAP) => dealiased
       case _ => super.liftedExprType(expr)
 

--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -12,7 +12,6 @@ help.scala
 i10889.scala
 i11247.scala
 i11556.scala
-i12739.scala
 i14164.scala
 i14947.scala
 i15165.scala
@@ -33,7 +32,6 @@ lazyVals_c3.0.0.scala
 lazyVals_c3.1.0.scala
 mt-scrutinee-widen3.scala
 null.scala
-pos_valueclasses
 spurious-overload.scala
 tailrec.scala
 traitParams.scala

--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -23,7 +23,6 @@ i19955a.scala
 i19955b.scala
 i20053b.scala
 i2146.scala
-i23179.scala
 i23489.scala
 i25460.scala
 i5039.scala


### PR DESCRIPTION
This PR treats with how certain types are lifted on coverage.

### Case 1: Wildcards
The following expression breaks under scoverage:

```scala
gMixed((x: Array[? >: AnyRef], n: Int) => (x.headOption, n))
```

`?` is the problem. `?` triggers capture-conversion mechanism (not to be confused with capture calculus) that boxes this unknown type into a skolem of type `TypeBox[Lower, Upper]`, then uses this skolem to refer to the unknown type as `typeBox.CAP`.

Coverage phase, when calculating the type of lifted expressions, uses `deskolemize` that widens `typeBox.CAP` to `TypeBox[Lower, Upper]#CAP`, which breaks `-Ycheck`.

This PR changes lifting under coverage to detect capture-conversions and refrain from deskolemizing such types.

### Case 2: Singletons

```scala
f(c.asInstanceOf[c.type])
```

Rewritten with coverage:

```scala
val r$1 = c.asInstanceOf[c.type]
f(r$1)
```

If we deskolemize singleton type, it becomes `X.C` instead of expected `X.c.type`.

This PR changes lifting under coverage to preserve the singleton types.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for codebase analysis and tracing.

## How was the solution tested?

Covered by existing tests - tests removed from excludelist.
