### PR TITLE
Allow `:help` syntax for all settings

### DIFF
--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -101,7 +101,7 @@ class Driver {
               case badReporter => report.error:
                 em"Not a reporter: ${ctx.settings.Yreporter.value}"
             catch case e: ReflectiveOperationException => report.error:
-              em"Could not create reporter ${ctx.settings.Yreporter.value}: ${e}"
+              em"Could not create reporter ${ctx.settings.Yreporter.value}: $e"
   }
 
   /** Setup extra classpath of tasty and jar files */

--- a/compiler/src/dotty/tools/dotc/Driver.scala
+++ b/compiler/src/dotty/tools/dotc/Driver.scala
@@ -79,29 +79,26 @@ class Driver {
     val ictx = rootCtx.fresh
     val summary = command.distill(args, ictx.settings)(ictx.settingsState)(using ictx)
     ictx.setSettings(summary.sstate)
-    MacroClassLoader.init(ictx)
-    Positioned.init(using ictx)
 
     inContext(ictx):
       if !ctx.settings.XdropComments.value || ctx.settings.XreadComments.value then
         ictx.setProperty(ContextDoc, new ContextDocstrings)
       val fileNamesOrNone = command.checkUsage(summary, sourcesRequired)(using ctx.settings)(using ctx.settingsState)
-      fileNamesOrNone.map: fileNames =>
-        val files = fileNames.map(ctx.getFile)
-        (files, fromTastySetup(files))
-      .tap: _ =>
-        if !ctx.settings.Yreporter.isDefault then
-          ctx.settings.Yreporter.value match
-          case "help" =>
-          case reporterClassName =>
-            try
-              Class.forName(reporterClassName).getDeclaredConstructor().newInstance() match
+      fileNamesOrNone.map(fileNames =>
+        MacroClassLoader.init(ictx)
+        Positioned.init
+        if !ctx.settings.Yreporter.isDefault && ctx.settings.Yreporter.value != "help" then
+          try
+            Class.forName(ctx.settings.Yreporter.value).getDeclaredConstructor().newInstance() match
               case userReporter: Reporter =>
                 ictx.setReporter(userReporter)
-              case badReporter => report.error:
-                em"Not a reporter: ${ctx.settings.Yreporter.value}"
-            catch case e: ReflectiveOperationException => report.error:
-              em"Could not create reporter ${ctx.settings.Yreporter.value}: $e"
+              case badReporter =>
+                report.error(em"Not a reporter: ${ctx.settings.Yreporter.value}")
+          catch case e: ReflectiveOperationException =>
+            report.error(em"Could not create reporter ${ctx.settings.Yreporter.value}: $e")
+        val files = fileNames.map(ctx.getFile)
+        (files, fromTastySetup(files))
+      )
   }
 
   /** Setup extra classpath of tasty and jar files */

--- a/compiler/src/dotty/tools/dotc/config/CliCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CliCommand.scala
@@ -60,7 +60,7 @@ trait CliCommand:
         case _: Int | _: String => s.default.toString
         case _ => ""
       val deprecationMessage = s.deprecation.map(d => s"Option deprecated.\n${d.msg}").getOrElse("")
-      val info = List(deprecationMessage, shortHelp(s), if defaultValue.nonEmpty then s"Default $defaultValue" else "", if s.legalChoices.nonEmpty then s"Choices : ${s.legalChoices}" else "")
+      val info = List(deprecationMessage, shortHelp(s), if defaultValue.nonEmpty then s"Default $defaultValue" else "", if s.legalChoices.nonEmpty then s"Choices: ${s.legalChoices}" else "")
       (s.name, info.filter(_.nonEmpty).mkString("\n"))
     end help
 

--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -9,8 +9,7 @@ abstract class CompilerCommand extends CliCommand:
 
   final def helpMsg(using settings: ConcreteSettings)(using SettingsState, Context): String =
     settings.allSettings.find(isHelping) match
-      case Some(s @ settings.language) => availableOptionsMsg(_ == s, showArgFileMsg = false)
-      case Some(s) => s.description
+      case Some(s) => availableOptionsMsg(_ == s, showArgFileMsg = false)
       case _ =>
         if (settings.help.value) usageMessage
         else if (settings.Vhelp.value) vusageMessage

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -239,7 +239,7 @@ object Settings:
       def setOutput(arg: String, args: List[String])(using ArgsSummary) =
         val path = Directory(arg)
         val isJar = path.ext.isJar
-        if (!isJar && !path.isDirectory) then
+        if !isJar && !path.isDirectory then
           state.fail(s"'$arg' does not exist or is not a directory or .jar file", args)
         else
           /* Side effect, do not change this method to evaluate eagerly */
@@ -255,29 +255,29 @@ object Settings:
           val msg = s"missing argument for option $name"
           if ignoreInvalidArgs then state.warn(s"$msg, the tag was ignored", args) else state.fail(msg, args)
 
-        if argRest == "help" then update(argRest, argRest, args)
-        else if ct == BooleanTag then setBoolean(argRest, args)
-        else if ct == OptionTag then update(Some(propertyClass.get.getConstructor().newInstance()), "", args)
-        else
-          // `-option:v` or `-option v`
-          val (arg1, args1) =
-            val argInArgRest = useArg || !argRest.isEmpty || legacyArgs
+        // `-option:v` or `-option v`
+        val (arg1, args1) =
+          if acceptsNoArg then (argRest, args)
+          else
+            val argInArgRest = useArg || argRest.nonEmpty || legacyArgs
             val useNextArg = !argInArgRest && args.nonEmpty && (ct == IntTag || !args.head.startsWith("-"))
             if argInArgRest then (argRest, args)
             else if useNextArg then (args.head, args.tail)
             else return missingArg
-          def doSet(arg: String, args: List[String]) =
-            ct match
-            case _ if preferPrevious && changed =>
-              if ignoreInvalidArgs then state.shifted(args)
-              else state.warn(s"Ignoring update of option $name", args)
-            case ListTag => setMultivalue(arg, args)
-            case StringTag => setString(arg, args)
-            case OutputTag => setOutput(arg, args)
-            case IntTag => setInt(arg, args)
-            case VersionTag => setVersion(arg, args)
-            case _ => state.fail(s"unknown $ct", args)
-          doSet(arg1, args1)
+
+        if arg1 == "help" then update(arg1, arg1, args1)
+        else if ct == BooleanTag then setBoolean(arg1, args1)
+        else if ct == OptionTag then update(Some(propertyClass.get.getConstructor().newInstance()), "", args1)
+        else if preferPrevious && changed then
+          if ignoreInvalidArgs then state.shifted(args1)
+          else state.warn(s"Ignoring update of option $name", args1)
+        else ct match
+          case ListTag => setMultivalue(arg1, args1)
+          case StringTag => setString(arg1, args1)
+          case OutputTag => setOutput(arg1, args1)
+          case IntTag => setInt(arg1, args1)
+          case VersionTag => setVersion(arg1, args1)
+          case _ => state.fail(s"unknown $ct", args1)
       end doSet
 
       def setVersion(arg: String, args: List[String])(using ArgsSummary) =

--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -136,7 +136,7 @@ object Settings:
     def valueIn(state: SettingsState): T = state.value(idx).asInstanceOf[T]
 
     def updateIn(state: SettingsState, x: Any): SettingsState = x match
-      case _: T => state.update(idx, x)
+      case "help" | _: T => state.update(idx, x) // always ok to store "help" because we'll exit after printing help text
       case _ => throw IllegalArgumentException(s"found: $x of type ${x.getClass.getName}, required: $ct")
 
     def isDefaultIn(state: SettingsState): Boolean = valueIn(state) == default
@@ -255,7 +255,8 @@ object Settings:
           val msg = s"missing argument for option $name"
           if ignoreInvalidArgs then state.warn(s"$msg, the tag was ignored", args) else state.fail(msg, args)
 
-        if ct == BooleanTag then setBoolean(argRest, args)
+        if argRest == "help" then update(argRest, argRest, args)
+        else if ct == BooleanTag then setBoolean(argRest, args)
         else if ct == OptionTag then update(Some(propertyClass.get.getConstructor().newInstance()), "", args)
         else
           // `-option:v` or `-option v`


### PR DESCRIPTION
Generally useful, motivated by me writing a help page for the fuel work, so there's an easy way to see the default.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
