### PR TITLE
Consistently use `xCheckMacroAssert` in `QuotesImpl`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -195,10 +195,10 @@ object TreeChecker {
     }
   }.apply(tp0)
 
-  def checkParents(sym: ClassSymbol, parents: List[tpd.Tree])(using Context): Unit =
+  def checkParents(sym: ClassSymbol, parents: List[tpd.Tree], assertionFunc: (Boolean, String) => Unit)(using Context): Unit =
     val symbolParents = sym.classInfo.parents.map(_.dealias.typeSymbol)
     val treeParents = parents.map(_.tpe.dealias.typeSymbol)
-    assert(symbolParents == treeParents,
+    assertionFunc(symbolParents == treeParents,
       i"""Parents of class symbol differs from the parents in the tree for $sym
           |
           |Parents in symbol: $symbolParents
@@ -576,7 +576,7 @@ object TreeChecker {
       assert(ctx.owner.isClass)
       val sym = ctx.owner.asClass
       if !sym.isPrimitiveValueClass then
-        TreeChecker.checkParents(sym, impl.parents)
+        TreeChecker.checkParents(sym, impl.parents, assert)
     }
 
     override def typedTypeDef(tdef: untpd.TypeDef, sym: Symbol)(using Context): Tree = {

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2882,7 +2882,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         cls
 
       def newModule(owner: Symbol, name: String, modFlags: Flags, clsFlags: Flags, parents: Symbol => List[TypeRepr], decls: Symbol => List[Symbol], privateWithin: Symbol): Symbol =
-        xCheckMacroAssert!privateWithin.exists || privateWithin.isType, "privateWithin must be a type symbol or `Symbol.noSymbol`")
+        xCheckMacroAssert(!privateWithin.exists || privateWithin.isType, "privateWithin must be a type symbol or `Symbol.noSymbol`")
         val mod = dotc.core.Symbols.newNormalizedModuleSymbol(
           owner,
           name.toTermName,

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1700,7 +1700,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def apply(params: List[ValDef]): TermParamClause =
         if xCheckMacro then
           val implicitParams = params.count(_.symbol.is(dotc.core.Flags.Implicit))
-          xCheckMacroAssert(implicitParams == 0 || implicitParams == params.size, "Expected all or non of parameters to be implicit")
+          xCheckMacroAssert(implicitParams == 0 || implicitParams == params.size, "Expected all or none of parameters to be implicit")
         params
       def unapply(x: TermParamClause): Some[List[ValDef]] = Some(x)
     end TermParamClause

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -1700,7 +1700,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def apply(params: List[ValDef]): TermParamClause =
         if xCheckMacro then
           val implicitParams = params.count(_.symbol.is(dotc.core.Flags.Implicit))
-          xCheckMacroAssert(implicitParams == 0 || implicitParams == params.size, "Expected all or none of parameters to be implicit")
+          xCheckMacroAssert(implicitParams == 0 || implicitParams == params.size, "Expected all or none of the parameters to be implicit")
         params
       def unapply(x: TermParamClause): Some[List[ValDef]] = Some(x)
     end TermParamClause

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -281,7 +281,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         (cdef.name.toString, cdef.constructor, cdef.parents, cdef.self, rhs.body)
 
       def module(module: Symbol, parents: List[Tree /* Term | TypeTree */], body: List[Statement]): (ValDef, ClassDef) = {
-        if xCheckMacro then TreeChecker.checkParents(module.moduleClass.asClass, parents)
+        if xCheckMacro then TreeChecker.checkParents(module.moduleClass.asClass, parents, xCheckMacroAssert)
         val cls = module.moduleClass
         val clsDef = ClassDef(cls, parents, body)
         val newCls = Apply(Select(New(TypeIdent(cls)), cls.primaryConstructor), Nil)
@@ -1700,7 +1700,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
       def apply(params: List[ValDef]): TermParamClause =
         if xCheckMacro then
           val implicitParams = params.count(_.symbol.is(dotc.core.Flags.Implicit))
-          assert(implicitParams == 0 || implicitParams == params.size, "Expected all or non of parameters to be implicit")
+          xCheckMacroAssert(implicitParams == 0 || implicitParams == params.size, "Expected all or non of parameters to be implicit")
         params
       def unapply(x: TermParamClause): Some[List[ValDef]] = Some(x)
     end TermParamClause
@@ -2882,7 +2882,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         cls
 
       def newModule(owner: Symbol, name: String, modFlags: Flags, clsFlags: Flags, parents: Symbol => List[TypeRepr], decls: Symbol => List[Symbol], privateWithin: Symbol): Symbol =
-        assert(!privateWithin.exists || privateWithin.isType, "privateWithin must be a type symbol or `Symbol.noSymbol`")
+        xCheckMacroAssert!privateWithin.exists || privateWithin.isType, "privateWithin must be a type symbol or `Symbol.noSymbol`")
         val mod = dotc.core.Symbols.newNormalizedModuleSymbol(
           owner,
           name.toTermName,
@@ -3557,7 +3557,7 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         // start stack trace at the place where the user called the reflection method
         error.setStackTrace(
           error.getStackTrace
-            .dropWhile(_.getClassName().startsWith("scala.quoted.runtime.impl")))
+            .dropWhile(l => l.getClassName().startsWith("scala.quoted.runtime.impl") || l.getClassName().startsWith("dotty.tools.dotc")))
       throw error
 
     object Printer extends PrinterModule:

--- a/tests/neg-macros/i19842-a.check
+++ b/tests/neg-macros/i19842-a.check
@@ -2,15 +2,11 @@
 9 |@main def Test = summon[Serializer[ValidationCls]] // error
   |                                                  ^
   |Exception occurred while executing macro expansion.
-  |java.lang.AssertionError: assertion failed: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
+  |java.lang.AssertionError: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
   |
   |Parents in symbol: [class Object, trait Serializer]
   |Parents in tree: [trait Serializer]
   |
-  |	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:10)
-  |	at dotty.tools.dotc.transform.TreeChecker$.checkParents(TreeChecker.scala:206)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:284)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:283)
   |	at Macros$.makeSerializer(Macro.scala:23)
   |
   |---------------------------------------------------------------------------------------------------------------------

--- a/tests/neg-macros/i19842-b.check
+++ b/tests/neg-macros/i19842-b.check
@@ -2,15 +2,11 @@
 9 |@main def Test = summon[Serializer[ValidationCls]] // error
   |                                                  ^
   |Exception occurred while executing macro expansion.
-  |java.lang.AssertionError: assertion failed: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
+  |java.lang.AssertionError: Parents of class symbol differs from the parents in the tree for object objectSerializer$macro$1
   |
   |Parents in symbol: [class Object, trait Serializer]
   |Parents in tree: [class Object, trait Serializer, trait Foo]
   |
-  |	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:10)
-  |	at dotty.tools.dotc.transform.TreeChecker$.checkParents(TreeChecker.scala:206)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:284)
-  |	at scala.quoted.runtime.impl.QuotesImpl$reflect$ClassDef$.module(QuotesImpl.scala:283)
   |	at Macros$.makeSerializer(Macro.scala:25)
   |
   |---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Root cause of those two annoying stack traces in tests.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
