### PR TITLE
Bump coursier to 2.1.25-M25 (was 2.1.25-M24)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -125,7 +125,7 @@ object Build {
   /** Version of Scala CLI to download */
   val scalaCliLauncherVersion = "1.13.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.25-M24"
+  val coursierJarVersion = "2.1.25-M25"
 
   object CompatMode {
     final val BinaryCompatible = 0


### PR DESCRIPTION
https://github.com/coursier/coursier/releases/tag/v2.1.25-M25
- note: this includes https://github.com/coursier/coursier/pull/3649, which is meant to address https://github.com/coursier/coursier/issues/3647

## How much have you relied on LLM-based tools in this contribution?
Not at all

## How was the solution tested?
Covered by existing tests (this is just a dependency bump)
