### PR TITLE
Optimize handling of -Yexplain-cycles

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -318,6 +318,9 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
    */
   var ccEnabledSomewhere = Feature.ccEnabledBySetting(using ictx)
 
+  /** If -explain-cycles is set, a trace of cyclic reference dependencies, otherwise null */
+  var cyclicReferenceTrace: CyclicReference.Trace | Null = null
+
   private var myEnrichedErrorMessage = false
 
   def compile(files: List[AbstractFile]): Unit =
@@ -440,7 +443,7 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
 
     val fusedPhases = runCtx.base.allPhases
     if ctx.settings.explainCyclic.value then
-      runCtx.setProperty(CyclicReference.Trace, new CyclicReference.Trace())
+      cyclicReferenceTrace = new CyclicReference.Trace()
     runCtx.withProgressCallback: cb =>
       _progress = Progress(cb, this, fusedPhases.map(_.traversals).sum)
     val cancelAsyncTasty: () => Unit =

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -902,7 +902,7 @@ object Contexts {
   }
 
   /** A context base defines state and associated methods that exist once per
-   *  compiler run.
+   *  logical compiler instance.
    */
   class ContextBase extends ContextState
                        with Phases.PhasesBase

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -155,7 +155,7 @@ end handleRecursive
  */
 class CyclicReference(
     val denot: SymDenotation,
-    val optTrace: Option[Array[CyclicReference.TraceElement]])(using Context)
+    val optTrace: Array[CyclicReference.TraceElement] | Null)(using Context)
 extends TypeError:
   var inImplicitSearch: Boolean = false
 
@@ -204,8 +204,16 @@ extends TypeError:
 
 object CyclicReference:
 
+  private def traceElements(using Context): Array[TraceElement] | Null =
+    val run = ctx.run
+    if run == null then null
+    else
+      val trace = run.cyclicReferenceTrace
+      if trace == null then null
+      else trace.toArray
+
   def apply(denot: SymDenotation)(using Context): CyclicReference =
-    val ex = new CyclicReference(denot, ctx.property(Trace).map(_.toArray))
+    val ex = new CyclicReference(denot, traceElements)
     if ex.computeStackTrace then
       cyclicErrors.println(s"Cyclic reference involving $denot")
       val sts = ex.getStackTrace.asInstanceOf[Array[StackTraceElement]]
@@ -215,26 +223,28 @@ object CyclicReference:
 
   type TraceElement = Context ?=> String
   type Trace = mutable.ArrayBuffer[TraceElement]
-  val Trace = Property.Key[Trace]
 
-  private def isTraced(using Context) =
-    ctx.property(CyclicReference.Trace).isDefined
+  /** Do we keep track of cyclic dependencies under -explain-cyclic? */
+  def cyclesAreTraced(using Context): Boolean =
+    val run = ctx.run
+    run != null && run.cyclicReferenceTrace != null
 
-  private def pushTrace(info: TraceElement)(using Context): Unit =
-    for buf <- ctx.property(CyclicReference.Trace) do
-      buf += info
+  /** @pre cyclesAreTraced */
+  def pushCyclicTrace(info: CyclicReference.TraceElement)(using Context): Unit =
+    ctx.run.nn.cyclicReferenceTrace.nn += info
 
-  private def popTrace()(using Context): Unit =
-    for buf <- ctx.property(CyclicReference.Trace) do
-      buf.dropRightInPlace(1)
+  /** @pre cyclesAreTraced */
+  def popCyclicTrace()(using Context): Unit =
+    ctx.run.nn.cyclicReferenceTrace.nn.dropRightInPlace(1)
 
   inline def trace[T](info: TraceElement)(inline op: => T)(using Context): T =
-    val traceCycles = isTraced
+    val run = ctx.run
+    val traceCycles = run != null && run.cyclicReferenceTrace != null
     try
-      if traceCycles then pushTrace(info)
+      if traceCycles then pushCyclicTrace(info)
       op
     finally
-      if traceCycles then popTrace()
+      if traceCycles then popCyclicTrace()
 
   inline def trace[T](prefix: String, sym: Symbol)(inline op: => T)(using Context): T =
     trace((ctx: Context) ?=> i"$prefix$sym")(op)

--- a/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErrors.scala
@@ -224,27 +224,14 @@ object CyclicReference:
   type TraceElement = Context ?=> String
   type Trace = mutable.ArrayBuffer[TraceElement]
 
-  /** Do we keep track of cyclic dependencies under -explain-cyclic? */
-  def cyclesAreTraced(using Context): Boolean =
-    val run = ctx.run
-    run != null && run.cyclicReferenceTrace != null
-
-  /** @pre cyclesAreTraced */
-  def pushCyclicTrace(info: CyclicReference.TraceElement)(using Context): Unit =
-    ctx.run.nn.cyclicReferenceTrace.nn += info
-
-  /** @pre cyclesAreTraced */
-  def popCyclicTrace()(using Context): Unit =
-    ctx.run.nn.cyclicReferenceTrace.nn.dropRightInPlace(1)
-
   inline def trace[T](info: TraceElement)(inline op: => T)(using Context): T =
     val run = ctx.run
     val traceCycles = run != null && run.cyclicReferenceTrace != null
     try
-      if traceCycles then pushCyclicTrace(info)
+      if traceCycles then run.nn.cyclicReferenceTrace.nn += info
       op
     finally
-      if traceCycles then popCyclicTrace()
+      if traceCycles then run.nn.cyclicReferenceTrace.nn.dropRightInPlace(1)
 
   inline def trace[T](prefix: String, sym: Symbol)(inline op: => T)(using Context): T =
     trace((ctx: Context) ?=> i"$prefix$sym")(op)

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -96,13 +96,14 @@ abstract class CyclicMsg(errorId: ErrorMessageID)(using Context) extends Message
       "\n\nStacktrace:" ++ ex.getStackTrace().mkString("\n    ", "\n    ", "")
     else "\n\n Run with both -explain-cyclic and -Ydebug-cyclic to see full stack trace."
 
-  protected def context: String = ex.optTrace match
-    case Some(trace) =>
+  protected def context: String =
+    val trace = ex.optTrace
+    if trace != null then
       s"\n\nThe error occurred while trying to ${
         trace.map(identity) // map with identity will turn Context ?=> String elements to String elements
           .mkString("\n  which required to ")
       }$debugInfo"
-    case None =>
+    else
       "\n\n Run with -explain-cyclic for more details."
 end CyclicMsg
 


### PR DESCRIPTION
Use a single slot in the `Run` class instead of a context property.

Inspired by a commit in #26025, where the `CycliicReference.Trace` property was moved from the properties map to the context store. Since we only set the Trace once at the start, we can go further and move it to the `Run` object.
