### PR TITLE
Preserve type info when lifting stable arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -49,7 +49,8 @@ abstract class Lifter {
 
   /** Type assigned to a lifted temporary symbol. */
   protected def liftedExprType(expr: Tree)(using Context): Type =
-    expr.tpe.widen.deskolemized
+    val tp = expr.tpe.deskolemized
+    if tp.isStable then tp else tp.widen
 
   /** Hook for lifters that need to record or mark freshly created lifted defs. */
   protected def onLiftedDef(tree: Tree)(using Context): Unit = ()

--- a/tests/pos/i25557.scala
+++ b/tests/pos/i25557.scala
@@ -1,0 +1,7 @@
+sealed trait Parent:
+  sealed trait Inner[T]
+object ConcreteParent extends Parent:
+  val myInner: Inner[Boolean] = ???
+  def foo(parent: Parent, isFoo: Boolean)(f: parent.type => parent.Inner[Boolean]) = ???
+  foo(parent = ConcreteParent, isFoo = true)(_.myInner)
+  foo(isFoo = true, parent = ConcreteParent)(_.myInner)


### PR DESCRIPTION
Fixes #25557

 The type of lifted arguments was always widened, which affects the behavior of `avoid` and breaks dependent path types in the `foo(parent, isFoo)`'s result type.

```scala
    {
      val parent$1: ConcreteParent = ConcreteParent
      ConcreteParent.foo(parent = parent$1, isFoo = true)((_$2: ConcreteParent)
         => _$2.myInner)
    }
```

## How much have you relied on LLM-based tools in this contribution?

Extensively, for finding which code trigger the bug and how to fix it.


## How was the solution tested?

Used reproducer provided from the issue.
