### PR TITLE
Scoverage: refrain from lifting closures for capture calculus compatibility

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -48,6 +48,8 @@ object LiftCoverage extends LiftImpure:
     arg match
       case arg if isUnsafeAssumeSeparate(arg) => true
       case a: tpd.Apply => a.symbol.is(Erased) // don't lift erased applications, but lift all others
+      case tpd.Block((meth: tpd.DefDef) :: Nil, closure: tpd.Closure)
+          if meth.symbol == closure.meth.symbol && closure.env.forall(noLiftArg) => true
       case tpd.Block(stats, expr) => stats.forall(noLiftArg) && noLiftArg(expr)
       case tpd.Inlined(_, bindings, expr) => noLiftArg(expr)
       case tpd.Typed(expr, _) => noLiftArg(expr)

--- a/tests/pos-custom-args/captures/coverage-binarytree-stepper.scala
+++ b/tests/pos-custom-args/captures/coverage-binarytree-stepper.scala
@@ -1,0 +1,36 @@
+//> using options -Yexplicit-nulls -Wsafe-init
+
+object RedBlackTree:
+  final class Tree[K, +V](
+      private val _value: AnyRef | Null,
+      private val _left: Tree[K, ?] | Null,
+      private val _right: Tree[K, ?] | Null):
+
+    final def value = _value.asInstanceOf[V]
+    final def left = _left.asInstanceOf[Tree[K, V] | Null]
+    final def right = _right.asInstanceOf[Tree[K, V] | Null]
+
+trait Stepper[+A]
+trait EfficientSplit
+
+object IntTreeStepper:
+  def from[T](
+      maxLength: Int,
+      tree: T | Null,
+      left: T => T | Null,
+      right: T => T | Null,
+      extract: T => Int): Stepper[Int] & EfficientSplit =
+    new Stepper[Int] with EfficientSplit {}
+
+final class TreeSteppers[K, V](tree: RedBlackTree.Tree[K, V] | Null):
+  type T = RedBlackTree.Tree[K, V]
+
+  def size: Int = 0
+
+  def valueStepper: Stepper[Int] & EfficientSplit =
+    IntTreeStepper.from[T](
+      size,
+      tree,
+      _.left,
+      _ => null,
+      _.value.asInstanceOf[Int])


### PR DESCRIPTION
Fixes #26066

## Problem
Code shape at fault:

```scala
IntTreeStepper.from[T](size, tree, _.left)
```

Instrumentation transforms `_.left` into a shape that fails capture checking:

```scala
val left$1: T => T | Null =
  {
    def $anonfun_left(x: T): T | Null = x.left
    closure($anonfun_left)
  }

IntTreeStepper.from[T](maxLength$1, tree, left$1, ..., ...)
```

For some types, like in the issue, `x.left` in the closure leads to a capability escape which produces the corresponding error.

## Solution

Exclude closure blocks from coverage argument lifting. The tradeoff is that we will get the instrumentation data for the callsite entry before the closure is evaluated but capture checking will not break on the lifted closure.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for codebase analysis and tracing.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable). Added `tests/pos-custom-args/captures/coverage-binarytree-stepper.scala` which fails on `main` and succeeds on this branch.
