### PR TITLE
Scoverage: fix lifted type computation for parameterless methods

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -80,10 +80,15 @@ object LiftCoverage extends LiftImpure:
   override protected def liftedExprType(expr: tpd.Tree)(using Context): Type =
     val dealiased = expr.tpe.dealias
     val deskolemized = dealiased.deskolemized
-    deskolemized.widenTermRefExpr.normalized.simplified match
+    val valueType = dealiased match
+      case ref: TermRef if ref.prefix.exists && ref.underlying.isInstanceOf[ExprType] =>
+        ref.prefix.memberInfo(ref.symbol).widenExpr
+      case _ =>
+        dealiased
+    valueType.widenTermRefExpr.normalized.simplified match
       case _: ConstantType => deskolemized
       case _ if dealiased.isInstanceOf[SingletonType] && dealiased.isStable => dealiased
-      case _ if dealiased.existsPart(_.typeSymbol == defn.TypeBox_CAP) => dealiased
+      case _ if valueType.existsPart(_.typeSymbol == defn.TypeBox_CAP) => valueType
       case _ => super.liftedExprType(expr)
 
   def liftForCoverage(defs: mutable.ListBuffer[tpd.Tree], tree: tpd.Apply)(using Context) =

--- a/tests/pos-custom-args/captures/coverage-arrayops-array-cap.scala
+++ b/tests/pos-custom-args/captures/coverage-arrayops-array-cap.scala
@@ -1,0 +1,11 @@
+//> using options -Yexplicit-nulls -Wsafe-init -language:experimental.captureChecking
+
+abstract class CoverageArraySeq[+A]:
+  def unsafeArray: Array[?]
+
+  def reverseArray: CoverageArraySeq[A] =
+    CoverageArraySeq.unsafeWrapArray(new scala.collection.ArrayOps(unsafeArray).reverse).asInstanceOf[CoverageArraySeq[A]]
+
+object CoverageArraySeq:
+  def unsafeWrapArray[T](x: Array[T]): CoverageArraySeq[T] =
+    null.asInstanceOf[CoverageArraySeq[T]]


### PR DESCRIPTION
Fixes #26068

## Problem

Consider the following code:

```scala
  def unsafeArray: Array[?]

  def reverseArray: CoverageArraySeq[A] =
    CoverageArraySeq.unsafeWrapArray(new scala.collection.ArrayOps(unsafeArray).reverse).asInstanceOf[CoverageArraySeq[A]]
```

Coverage lifts `new scala.collection.ArrayOps(unsafeArray).reverse` into:

```scala
val x$1: (ArrayOps[?1.CAP]#reverse : -> Array[?1.CAP]) = new ArrayOps(...).reverse
```

Obviously the type `(ArrayOps[?1.CAP]#reverse : -> Array[?1.CAP])` is wrong, it should be `Array[?1.CAP]` instead.

## Solution

The solution is to modify the coverage's lifted type calculation logic to detect the above shape and recover the correct type. The relevant diff is:

```scala
case ref: TermRef if ref.prefix.exists && ref.underlying.isInstanceOf[ExprType] =>
  ref.prefix.memberInfo(ref.symbol).widenExpr
```

Evaluated against the above snippet, the logic is as follows:

- `ref` is `(scala.collection.ArrayOps[?1.CAP]#reverse : -> Array[?1.CAP])`, the type we need to heal.
- `ref.prefix` is `scala.collection.ArrayOps[?1.CAP]`, check its existence.
- `ref.underlying.isInstanceOf[ExprType]` - `ExprType` is the type marker for parameterless method type.
- `ref.prefix.memberInfo(ref.symbol)` is `=> Array[?1.CAP]`
- `.widenExpr` converts the `=> Array[?1.CAP]` to `Array[?1.CAP]`, which is the correct type.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for minimization and codebase analysis.

## How was the solution tested?

New automated tests. Added `tests/pos-custom-args/captures/coverage-arrayops-array-cap.scala` which fails on `main` and passes on this branch.
