### PR TITLE
Add PR validation cropping to skip unaffected projects on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,11 @@ on:
       - 'release-**'
       - 'lts-**'
   pull_request:
+    # Doc-only PRs skip this workflow.
+    paths-ignore:
+      - 'docs/**'
+      - 'changelogs/**'
+      - '**.md'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -13,15 +13,48 @@ permissions:
   contents: read
 
 jobs:
-  build:
+
+  # Gate downstream jobs on what directories the PR touches.
+  # Non-PR events (push, merge_group) always run everything.
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
-    if: "github.event_name == 'merge_group'
-         || (    github.event_name == 'pull_request'
-           && !contains(github.event.pull_request.body, '[skip ci]')
-           && !contains(github.event.pull_request.body, '[skip docs]')
-         )
-         || contains(github.event.ref, 'scaladoc')
-         || contains(github.event.ref, 'main')"
+    outputs:
+      scaladoc: ${{ steps.filter.outputs.scaladoc }}
+      docs: ${{ steps.filter.outputs.docs }}
+      error_codes: ${{ steps.filter.outputs.error_codes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            FILES=$(git diff --name-only "$BASE" HEAD)
+
+            echo "scaladoc=$(echo "$FILES" | grep -qE '^(scaladoc/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            echo "docs=$(echo "$FILES" | grep -qE '^(docs/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            echo "error_codes=$(echo "$FILES" | grep -qE '^(docs/_docs/reference/error-codes/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          else
+            echo "scaladoc=true" >> "$GITHUB_OUTPUT"
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+            echo "error_codes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: |
+      (needs.changes.outputs.scaladoc == 'true' || needs.changes.outputs.docs == 'true') &&
+      (github.event_name == 'merge_group'
+       || (    github.event_name == 'pull_request'
+         && !contains(github.event.pull_request.body, '[skip ci]')
+         && !contains(github.event.pull_request.body, '[skip docs]')
+       )
+       || contains(github.event.ref, 'scaladoc')
+       || contains(github.event.ref, 'main'))
 
     steps:
       - name: Git Checkout
@@ -67,6 +100,8 @@ jobs:
           path: scaladoc/output/scala3
 
   validate-docs:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
@@ -144,6 +179,8 @@ jobs:
         run: true # ./project/scripts/sbt scaladoc/sourceLinksIntegrationTest:test
 
   check-error-code-snippets:
+    needs: changes
+    if: needs.changes.outputs.error_codes == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -14,12 +14,38 @@ env:
   DOTTY_CI_RUN: true
 
 jobs:
-  specification:
+
+  # Gate on docs/_spec/ changes so PRs that don't touch the spec skip this workflow.
+  # Non-PR events (push, workflow_dispatch, merge_group) always run.
+  changes:
+    name: Detect spec changes
     runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]'))  ||
-        (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3') ||
-        github.event_name == 'push' ||
-        github.event_name == 'merge_group'
+    outputs:
+      spec: ${{ steps.filter.outputs.spec }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            FILES=$(git diff --name-only "$BASE" HEAD)
+            echo "spec=$(echo "$FILES" | grep -qE '^(docs/_spec/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          else
+            echo "spec=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  specification:
+    needs: changes
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name != 'pull_request' || needs.changes.outputs.spec == 'true') &&
+      ((github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]')) ||
+       (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3') ||
+       github.event_name == 'push' ||
+       github.event_name == 'merge_group')
     defaults:
       run:
         working-directory: ./docs/_spec

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -15,31 +15,75 @@ env:
 
 jobs:
 
+  # Skip all downstream jobs on doc-only PRs.
+  # Non-PR events (push, workflow_call) always run everything.
+  changes:
+    name: Detect source changes
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+      compiler: ${{ steps.filter.outputs.compiler }}
+      library: ${{ steps.filter.outputs.library }}
+      interfaces: ${{ steps.filter.outputs.interfaces }}
+      tasty_core: ${{ steps.filter.outputs.tasty_core }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            FILES=$(git diff --name-only "$BASE" HEAD)
+
+            echo "source=$(echo "$FILES" | grep -qvE '^(docs/|changelogs/|.*\.md$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+            echo "compiler=$(echo "$FILES" | grep -qE '^(compiler/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            echo "library=$(echo "$FILES" | grep -qE '^(library/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            echo "interfaces=$(echo "$FILES" | grep -qE '^(interfaces/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            echo "tasty_core=$(echo "$FILES" | grep -qE '^(tasty/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          else
+            echo "source=true" >> "$GITHUB_OUTPUT"
+            echo "compiler=true" >> "$GITHUB_OUTPUT"
+            echo "library=true" >> "$GITHUB_OUTPUT"
+            echo "interfaces=true" >> "$GITHUB_OUTPUT"
+            echo "tasty_core=true" >> "$GITHUB_OUTPUT"
+          fi
+
   test-scala-library-nonbootstrapped:
     name: Non-Bootstrapped Library Unit Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
-      - run: ./project/scripts/sbt scala-library-nonbootstrapped/test
+      - run: ./project/scripts/sbt "scala-library-nonbootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   test-scala-library-bootstrapped:
     name: Bootstrapped Library Unit Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
-      - run: ./project/scripts/sbt scala-library-bootstrapped/test
+      - run: ./project/scripts/sbt "scala-library-bootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   #################################################################################################
   ########################################### MiMa JOBS ###########################################
@@ -65,6 +109,8 @@ jobs:
 
   mima-scala3-interfaces:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.interfaces == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -82,6 +128,8 @@ jobs:
 
   mima-tasty-core-nonbootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tasty_core == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -99,6 +147,8 @@ jobs:
 
   static-analysis-scala-library-bootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.library == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -119,6 +169,8 @@ jobs:
 
   mima-tasty-core-bootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tasty_core == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -136,6 +188,8 @@ jobs:
 
   mima-scala-library-sjs:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.library == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -157,9 +211,13 @@ jobs:
 
   test-scala3-compiler-nonbootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -171,18 +229,23 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Test `scala3-compiler-nonbootstrapped`
-        run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/test
+        run: ./project/scripts/sbt "scala3-compiler-nonbootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
       - name: Cmd Tests
+        if: needs.changes.outputs.compiler == 'true'
         run: |
           ./project/scripts/sbt scala3-nonbootstrapped/publishLocal
           ./project/scripts/cmdTests
 
   test-scala3-compiler-bootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -194,15 +257,18 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Test `scala3-compiler-bootstrapped`
-        run: ./project/scripts/sbt scala3-compiler-bootstrapped/test
+        run: ./project/scripts/sbt "scala3-compiler-bootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
       - name: Cmd Tests
+        if: needs.changes.outputs.compiler == 'true'
         run: |
           ./project/scripts/sbt scala3-bootstrapped/publishLocal
           ./project/scripts/bootstrappedOnlyCmdTests
 
   test-scala3-bootstrapped-compilation-coverage:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.compiler == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -219,9 +285,13 @@ jobs:
 
   test-scala3-sbt-bridge-nonbootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -231,13 +301,17 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Test `scala3-sbt-bridge-nonbootstrapped`
-        run: ./project/scripts/sbt scala3-sbt-bridge-nonbootstrapped/test
+        run: ./project/scripts/sbt "scala3-sbt-bridge-nonbootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   test-scala3-sbt-bridge-bootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -247,13 +321,17 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Test `scala3-sbt-bridge-bootstrapped`
-        run: ./project/scripts/sbt scala3-sbt-bridge-bootstrapped/test
+        run: ./project/scripts/sbt "scala3-sbt-bridge-bootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   test-tasty-core-nonbootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -263,13 +341,17 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Test `tasty-core-nonbootstrapped`
-        run: ./project/scripts/sbt tasty-core-nonbootstrapped/test
+        run: ./project/scripts/sbt "tasty-core-nonbootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   test-tasty-core-bootstrapped:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -279,10 +361,12 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Test `tasty-core-bootstrapped`
-        run: ./project/scripts/sbt tasty-core-bootstrapped/test
+        run: ./project/scripts/sbt "tasty-core-bootstrapped/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   test-scala-js:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -311,9 +395,13 @@ jobs:
 
   test-repl:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -323,13 +411,17 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Test REPL
-        run: ./project/scripts/sbt scala3-repl/test
+        run: ./project/scripts/sbt "scala3-repl/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   test-presentation-compiler:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -339,13 +431,17 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Test Presentation Compiler
-        run: ./project/scripts/sbt scala3-presentation-compiler/test
+        run: ./project/scripts/sbt "scala3-presentation-compiler/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   test-language-server:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -355,10 +451,12 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Test Language Server
-        run: ./project/scripts/sbt scala3-language-server/test
+        run: ./project/scripts/sbt "scala3-language-server/${{ github.event_name == 'pull_request' && 'validatePullRequest' || 'test' }}"
 
   scripted-tests:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6
@@ -375,6 +473,8 @@ jobs:
 
   community_build_a:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v6
@@ -393,6 +493,8 @@ jobs:
 
   community_build_b:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v6
@@ -412,6 +514,8 @@ jobs:
 
   community_build_c:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.source == 'true'
     steps:
       - name: Checkout cleanup script
         uses: actions/checkout@v6
@@ -434,6 +538,8 @@ jobs:
 
   scala-library-docs:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.library == 'true'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -37,7 +37,7 @@ jobs:
             BASE="${{ github.event.pull_request.base.sha }}"
             FILES=$(git diff --name-only "$BASE" HEAD)
 
-            echo "source=$(echo "$FILES" | grep -qvE '^(docs/|changelogs/|.*\.md$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+            echo "source=$(echo "$FILES" | grep -v '^$' | grep -qvE '^(docs/|changelogs/|.*\.md$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
             echo "compiler=$(echo "$FILES" | grep -qE '^(compiler/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
             echo "library=$(echo "$FILES" | grep -qE '^(library/|project/|.*\.sbt$)' && echo true || echo false)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-launchers.yml
+++ b/.github/workflows/test-launchers.yml
@@ -1,6 +1,11 @@
 name: Test CLI Launchers on all the platforms
 on:
   pull_request:
+    # Doc-only PRs skip the cross-platform launcher matrix.
+    paths-ignore:
+      - 'docs/**'
+      - 'changelogs/**'
+      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/project/ValidatePullRequest.scala
+++ b/project/ValidatePullRequest.scala
@@ -1,0 +1,59 @@
+import com.github.sbt.pullrequestvalidator.ValidatePullRequest
+import com.github.sbt.pullrequestvalidator.ValidatePullRequest.PathGlobFilter
+import sbt.Keys._
+import sbt._
+
+/** Maps each non-aggregator subproject to a PathGlobFilter so `validatePullRequest`
+  * skips projects whose base directory is untouched by the PR diff.
+  */
+object Scala3ValidatePullRequest extends AutoPlugin {
+
+  import ValidatePullRequest.autoImport._
+
+  override lazy val trigger = allRequirements
+  override lazy val requires = ValidatePullRequest
+
+  /** Aggregator/root projects with no source directory of their own. */
+  private val ignoredProjects: Set[String] = Set(
+    "scala3-nonbootstrapped",
+    "scala3-bootstrapped",
+  )
+
+  /** Matches top-level test-input directories that are read by the compiler /
+    * scripted test suites but live outside any project's base directory.
+    * Without this, a PR that only touches `tests/pos/i12345.scala` or `sbt-test/`
+    * would match no project glob and `validatePullRequest` would skip the
+    * compiler tests entirely. `tests/sjs-junit/` is excluded because it IS the
+    * `sjsJUnitTests` project base and is handled by the per-project filter.
+    */
+  private val externalTestInputs: FileFilter = new FileFilter {
+    override def accept(f: File): Boolean = {
+      val p = f.getPath.replace(java.io.File.separatorChar, '/')
+      (p.startsWith("tests/") && !p.startsWith("tests/sjs-junit/")) ||
+      p.startsWith("sbt-test/")
+    }
+    override def toString: String = "Scala3ExternalTestInputsFilter"
+  }
+
+  override lazy val buildSettings = Seq(
+    validatePullRequest / includeFilter := {
+      val build = loadedBuild.value
+      val rootDir = new File(build.root)
+
+      build.allProjectRefs.iterator.collect {
+        case (_, project) if !ignoredProjects.contains(project.id) =>
+          val rel = rootDir.toPath
+            .relativize(project.base.toPath)
+            .toString
+            .replace(java.io.File.separatorChar, '/')
+          if (rel.isEmpty || rel == ".") FileFilter.nothing
+          else PathGlobFilter(s"$rel/**")
+      }.foldLeft(FileFilter.nothing: FileFilter)((acc, f) => acc || f)
+    },
+    validatePullRequestBuildAll / includeFilter := {
+      (validatePullRequestBuildAll / includeFilter).value || externalTestInputs
+    },
+    prValidatorTargetBranch := sys.env.getOrElse("PR_TARGET_BRANCH", "origin/main"),
+    prValidatorGithubRepository := Some("scala/scala3"),
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,3 +24,5 @@ addSbtPlugin("com.github.sbt" % "sbt-jdi-tools" % "1.2.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % "0.3.6")
 libraryDependencies += "com.spotify" % "missinglink-core" % "0.2.11"
+
+addSbtPlugin("com.github.sbt" % "sbt-pull-request-validator" % "2.0.0")


### PR DESCRIPTION
Skip CI jobs not affected by PR changes.

- `sbt-pull-request-validator`: skips per-project sbt tests when the project's
  directory is untouched by the diff. Dependency-graph aware, so transitive
  consumers (e.g. scala3-repl when compiler/ changes) still run.
- `stdlib.yaml`: `changes` job emits `source`/`compiler`/`library`/`interfaces`/
  `tasty_core` signals. Test jobs use `source` + validatePullRequest (sbt handles
  per-project filtering with dependency awareness); MiMa/coverage/docs use
  their project's signal. Doc-only PRs skip all jobs.
- `scaladoc.yaml`: `scaladoc`/`docs`/`error_codes` signals.
- `spec.yml`: `spec` signal on `docs/_spec/`.
- `ci.yaml`, `test-launchers.yml`: `paths-ignore` for docs/changelogs/markdown.

Non-PR events (push, merge_group, workflow_dispatch, workflow_call) always run
everything. Required status checks report Success on skipped jobs.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for code review and PR description drafting.

## How was the solution tested?

Manual: sbt loads the plugin, `validatePullRequest/includeFilter` resolves to
per-project PathGlobFilter instances. CI conditionals verified against PR diff.