### PR TITLE
Scoverage: Exempt null coverage tests from Ycheck

### DIFF
--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -23,14 +23,12 @@ i20053b.scala
 i2146.scala
 i23489.scala
 i25460.scala
-i5039.scala
 i8623.scala
 i8900a3.scala
 i9228.scala
 lazyVals_c3.0.0.scala
 lazyVals_c3.1.0.scala
 mt-scrutinee-widen3.scala
-null.scala
 spurious-overload.scala
 tailrec.scala
 traitParams.scala

--- a/compiler/test/dotty/tools/dotc/CoverageSupport.scala
+++ b/compiler/test/dotty/tools/dotc/CoverageSupport.scala
@@ -115,6 +115,7 @@ trait CoverageSupport:
   def withCoverage(test: CompilationTest): CompilationTest = {
     if (Properties.testsInstrumentCoverage) {
       val ignoreList = scoverageIgnoreExcludelisted.toSet
+      val ycheckExemptList = Set("i5039.scala", "null.scala")
 
       // Filter out test sources whose filenames or directory names match the excludelist
       val filteredTargets = test.targets.filter { target =>
@@ -148,7 +149,11 @@ trait CoverageSupport:
       val modifiedTargets = filteredTargets.map { target =>
         val coverageDir = Files.createTempDirectory("coverage")
         val sourceRoot = Paths.get(".").toAbsolutePath.toString
-        target.withFlags(
+        val targetWithFlags =
+          if target.sourceFiles.exists(file => ycheckExemptList.contains(file.getName)) then target.withoutFlags("-Ycheck:all")
+          else target
+
+        targetWithFlags.withFlags(
           "-coverage-out", coverageDir.toString,
           "-sourceroot", sourceRoot
         )


### PR DESCRIPTION
## Problem

Consider code:

```scala
def foo(): Unit = ()
def bar(): Unit = ()

val x: Boolean =
  {
    foo()
    {
      bar()
      null
    } == null
  }
```

When compiled with `-Ycheck:all`, this will fail on erasure:

```
Exception in thread "main" java.lang.AssertionError: assertion failed: The type (true : Boolean) - 
ConstantType(Constant(true)) of class class dotty.tools.dotc.core.Types$CachedConstantType of tree
null == null : (true : Boolean) / class dotty.tools.dotc.ast.Trees$Apply is illegal after erasure, phase = erasure
```

Expectation made by erasure is that after it, only the JVM types are preserved. `true: Boolean` does not exist in JVM type system, it is a singleton type in Scala frontend.

Consider the following code:

```scala
val x: Boolean = null == null
```

Coverage will instrument it to:

```scala
  {
    Invoker.invoked(0, ...)
    {
      Invoker.invoked(1, ...)
      null
    } == null
  }
```

This is the exact same shape that breaks `-Ycheck` as shown above.

## Solution

Since the shape compiles fine without `-Ycheck`, the minimal fix I've chosen was to exempt two affected tests from `-Ycheck` when running coverage suit of tests. Non-coverage pass still runs them with `-Ycheck`.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for codebase analysis and tracing.

## How was the solution tested?

Covered by existing tests - two tests re-enabled.