### PR TITLE
Add `scala.Function.identity` returning a shared singleton instance

### DIFF
--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -16,6 +16,21 @@ import scala.language.`2.13`
 
 /** A module defining utility methods for higher-order functional programming. */
 object Function {
+  private final val constIdentityFunction: Any => Any = x => x
+
+  /** Returns a function that always returns its input argument as result.
+   *  Which could be used as a function argument passed to `map` or `flatMap` methods.
+   *  Learn more from [[https://en.wikipedia.org/wiki/Identity_function Identity_function]]
+   *
+   *  Unlike [[scala.Predef.identity]], this method returns a shared singleton
+   *  function value, avoiding the per-call allocation that eta-expansion of
+   *  `Predef.identity` would otherwise incur when used as a function value.
+   *
+   *  @tparam T the type of the input and output value of the function
+   *  @return a function that always returns its input argument as result.
+   */
+  def identity[T]: T => T = constIdentityFunction.asInstanceOf[T => T]
+
   /** Given a sequence of functions `f,,1,,`, ..., `f,,n,,`, return the
    *  function `f,,1,, andThen ... andThen f,,n,,`.
    *

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -15,7 +15,8 @@ object MiMaFilters {
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.iterateUntilEmpty$extension"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.scala$collection$ArrayOps$$elemTag$extension"),
         ProblemFilters.exclude[MissingFieldProblem]("scala.language#experimental.safe"),
-        ProblemFilters.exclude[MissingClassProblem]("scala.language$experimental$safe$")
+        ProblemFilters.exclude[MissingClassProblem]("scala.language$experimental$safe$"),
+        ProblemFilters.exclude[DirectMissingMethodProblem]("scala.Function.identity"),
     ))
 
     val BackwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(

--- a/tests/run/function-identity.scala
+++ b/tests/run/function-identity.scala
@@ -1,0 +1,33 @@
+// Directional tests for `scala.Function.identity`.
+object Test {
+  def main(args: Array[String]): Unit = {
+    // 1. Returns its input argument unchanged.
+    assert(Function.identity[Int].apply(42) == 42)
+    assert(Function.identity[String].apply("hello") eq "hello")
+    assert(Function.identity[AnyRef].apply(null) == null)
+
+    // 2. Singleton sharing: distinct type instantiations resolve to the same
+    //    underlying function instance (no per-call allocation).
+    val idInt: Int => Int = Function.identity
+    val idStr: String => String = Function.identity
+    val idObj: Object => Object = Function.identity
+    assert(idInt.asInstanceOf[AnyRef] eq idStr.asInstanceOf[AnyRef])
+    assert(idInt.asInstanceOf[AnyRef] eq idObj.asInstanceOf[AnyRef])
+    assert(idInt.asInstanceOf[AnyRef] eq Function.identity[Int].asInstanceOf[AnyRef])
+
+    // 3. Suitable as a function argument to higher-order combinators.
+    val xs = List(1, 2, 3)
+    assert(xs.map(Function.identity) == xs)
+    val nested = List(List(1), List(2, 3))
+    assert(nested.flatMap(Function.identity) == List(1, 2, 3))
+
+    // 4. Behaves consistently with `Predef.identity` for arbitrary inputs.
+    val sample: List[Any] = List(1, "x", null, (1, 2), Nil)
+    assert(sample.map(Function.identity) == sample.map(scala.Predef.identity))
+
+    // 5. Composes with `andThen` / `compose` like any other Function1.
+    val plusOne: Int => Int = _ + 1
+    assert((Function.identity[Int] andThen plusOne)(10) == 11)
+    assert((plusOne compose Function.identity[Int])(10) == 11)
+  }
+}


### PR DESCRIPTION
## Summary

Add an `identity` method on the `scala.Function` companion object that returns a shared, singleton `T => T`. Unlike `scala.Predef.identity` (which is a method and gets eta-expanded into a fresh `Function1` instance every time it is used as a function value, e.g. `xs.map(identity)`), this version returns the same cached function instance regardless of the type parameter, by casting a `private final val constIdentityFunction: Any => Any = x => x`.

```scala
private final val constIdentityFunction: Any => Any = x => x

/** Returns a function that always returns its input argument as result. */
def identity[T]: T => T = constIdentityFunction.asInstanceOf[T => T]
```

This gives users an allocation-free option when they need an identity function value (`map`, `flatMap`, `andThen`, etc.).
https://contributors.scala-lang.org/t/add-function-identity-method/7452

## Changes

- `library/src/scala/Function.scala`: add `constIdentityFunction` private singleton and public `identity[T]` method.
- `project/MiMaFilters.scala`: forwards-compat MiMa filter for the newly added method.
- `tests/run/function-identity.scala`: directional run test covering:
  1. identity returns its input value;
  2. **singleton sharing** across distinct type instantiations (`Function.identity[Int] eq Function.identity[String]` after erasure) — the key behavior;
  3. usage as a function argument to `map` / `flatMap`;
  4. parity with `scala.Predef.identity` for arbitrary inputs;
  5. composition via `andThen` / `compose`.

## Test plan

- [x] `library/src/scala/Function.scala` compiles (`sbt scala-library-nonbootstrapped/compile`)
- [x] `tests/run/function-identity.scala` passes via `sbt 'project scala3-nonbootstrapped; testCompilation function-identity'` (CompilationTests: 16 phases, 0 failed)
- [x] Test class also runs cleanly when invoked directly via `java` against the rebuilt library jar (exit 0)