### PR TITLE
Add `andThen` to `Function2..Function22` and `FunctionXXL`

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -2833,6 +2833,15 @@ object SymDenotations {
     def apply(sym: Symbol): LazyType = this
     def apply(module: TermSymbol, modcls: ClassSymbol): LazyType = this
 
+    /** Disambiguate `andThen` inherited from both `Function1[Symbol, LazyType]` and
+     *  `Function2[TermSymbol, ClassSymbol, LazyType]` so subclasses don't see a clash
+     *  between the two trait-default implementations. `LazyType` is only ever passed
+     *  to symbol-creation APIs as a function value, so composition via `andThen` is
+     *  not meaningful and is reported as unsupported.
+     */
+    override def andThen[A](g: LazyType => A): ((TermSymbol, ClassSymbol) => A) & (Symbol => A) =
+      throw new UnsupportedOperationException("LazyType.andThen is not supported")
+
     private var myDecls: Scope = EmptyScope
     private var mySourceModule: Symbol | Null = null
     private var myModuleClass: Symbol | Null = null

--- a/library/src/scala/Function10.scala
+++ b/library/src/scala/Function10.scala
@@ -44,6 +44,13 @@ trait Function10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10): R
+  /** Composes a `Function1` with this in a new `Function10`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)`

--- a/library/src/scala/Function11.scala
+++ b/library/src/scala/Function11.scala
@@ -46,6 +46,13 @@ trait Function11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] ex
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11): R
+  /** Composes a `Function1` with this in a new `Function11`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11)`

--- a/library/src/scala/Function12.scala
+++ b/library/src/scala/Function12.scala
@@ -48,6 +48,13 @@ trait Function12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12): R
+  /** Composes a `Function1` with this in a new `Function12`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12)`

--- a/library/src/scala/Function13.scala
+++ b/library/src/scala/Function13.scala
@@ -50,6 +50,13 @@ trait Function13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13): R
+  /** Composes a `Function1` with this in a new `Function13`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13)`

--- a/library/src/scala/Function14.scala
+++ b/library/src/scala/Function14.scala
@@ -52,6 +52,13 @@ trait Function14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14): R
+  /** Composes a `Function1` with this in a new `Function14`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14)`

--- a/library/src/scala/Function15.scala
+++ b/library/src/scala/Function15.scala
@@ -54,6 +54,13 @@ trait Function15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15): R
+  /** Composes a `Function1` with this in a new `Function15`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15)`

--- a/library/src/scala/Function16.scala
+++ b/library/src/scala/Function16.scala
@@ -56,6 +56,13 @@ trait Function16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16): R
+  /** Composes a `Function1` with this in a new `Function16`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15)(x16) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16)`

--- a/library/src/scala/Function17.scala
+++ b/library/src/scala/Function17.scala
@@ -58,6 +58,13 @@ trait Function17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17): R
+  /** Composes a `Function1` with this in a new `Function17`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15)(x16)(x17) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17)`

--- a/library/src/scala/Function18.scala
+++ b/library/src/scala/Function18.scala
@@ -60,6 +60,13 @@ trait Function18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18): R
+  /** Composes a `Function1` with this in a new `Function18`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15)(x16)(x17)(x18) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18)`

--- a/library/src/scala/Function19.scala
+++ b/library/src/scala/Function19.scala
@@ -62,6 +62,13 @@ trait Function19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19): R
+  /** Composes a `Function1` with this in a new `Function19`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15)(x16)(x17)(x18)(x19) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19)`

--- a/library/src/scala/Function2.scala
+++ b/library/src/scala/Function2.scala
@@ -38,6 +38,13 @@ trait Function2[@specialized(Specializable.Args) -T1, @specialized(Specializable
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2): R
+  /** Composes a `Function1` with this in a new `Function2`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2) == g(apply(v1, v2))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2) => A = { (v1: T1, v2: T2) => g(apply(v1, v2)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2) == apply(x1, x2)`

--- a/library/src/scala/Function20.scala
+++ b/library/src/scala/Function20.scala
@@ -64,6 +64,13 @@ trait Function20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20): R
+  /** Composes a `Function1` with this in a new `Function20`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15)(x16)(x17)(x18)(x19)(x20) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20)`

--- a/library/src/scala/Function21.scala
+++ b/library/src/scala/Function21.scala
@@ -66,6 +66,13 @@ trait Function21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21): R
+  /** Composes a `Function1` with this in a new `Function21`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15)(x16)(x17)(x18)(x19)(x20)(x21) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21)`

--- a/library/src/scala/Function22.scala
+++ b/library/src/scala/Function22.scala
@@ -68,6 +68,13 @@ trait Function22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21, v22: T22): R
+  /** Composes a `Function1` with this in a new `Function22`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9, v10: T10, v11: T11, v12: T12, v13: T13, v14: T14, v15: T15, v16: T16, v17: T17, v18: T18, v19: T19, v20: T20, v21: T21, v22: T22) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9)(x10)(x11)(x12)(x13)(x14)(x15)(x16)(x17)(x18)(x19)(x20)(x21)(x22) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22)`

--- a/library/src/scala/Function3.scala
+++ b/library/src/scala/Function3.scala
@@ -30,6 +30,13 @@ trait Function3[-T1, -T2, -T3, +R] extends AnyRef {
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3): R
+  /** Composes a `Function1` with this in a new `Function3`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3) == g(apply(v1, v2, v3))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3) => A = { (v1: T1, v2: T2, v3: T3) => g(apply(v1, v2, v3)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3) == apply(x1, x2, x3)`

--- a/library/src/scala/Function4.scala
+++ b/library/src/scala/Function4.scala
@@ -32,6 +32,13 @@ trait Function4[-T1, -T2, -T3, -T4, +R] extends AnyRef {
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4): R
+  /** Composes a `Function1` with this in a new `Function4`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4) == g(apply(v1, v2, v3, v4))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4) => A = { (v1: T1, v2: T2, v3: T3, v4: T4) => g(apply(v1, v2, v3, v4)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4) == apply(x1, x2, x3, x4)`

--- a/library/src/scala/Function5.scala
+++ b/library/src/scala/Function5.scala
@@ -34,6 +34,13 @@ trait Function5[-T1, -T2, -T3, -T4, -T5, +R] extends AnyRef {
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5): R
+  /** Composes a `Function1` with this in a new `Function5`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5) == g(apply(v1, v2, v3, v4, v5))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5) => g(apply(v1, v2, v3, v4, v5)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5) == apply(x1, x2, x3, x4, x5)`

--- a/library/src/scala/Function6.scala
+++ b/library/src/scala/Function6.scala
@@ -36,6 +36,13 @@ trait Function6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends AnyRef {
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6): R
+  /** Composes a `Function1` with this in a new `Function6`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6) == g(apply(v1, v2, v3, v4, v5, v6))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => g(apply(v1, v2, v3, v4, v5, v6)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6) == apply(x1, x2, x3, x4, x5, x6)`

--- a/library/src/scala/Function7.scala
+++ b/library/src/scala/Function7.scala
@@ -38,6 +38,13 @@ trait Function7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends AnyRef {
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7): R
+  /** Composes a `Function1` with this in a new `Function7`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7) == g(apply(v1, v2, v3, v4, v5, v6, v7))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7) => g(apply(v1, v2, v3, v4, v5, v6, v7)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7) == apply(x1, x2, x3, x4, x5, x6, x7)`

--- a/library/src/scala/Function8.scala
+++ b/library/src/scala/Function8.scala
@@ -40,6 +40,13 @@ trait Function8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends AnyRef {
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8): R
+  /** Composes a `Function1` with this in a new `Function8`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8) == apply(x1, x2, x3, x4, x5, x6, x7, x8)`

--- a/library/src/scala/Function9.scala
+++ b/library/src/scala/Function9.scala
@@ -42,6 +42,13 @@ trait Function9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends AnyRef 
    *  @return   the result of function application.
    */
   def apply(v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9): R
+  /** Composes a `Function1` with this in a new `Function9`, with this function applied first.
+   *
+   *  @tparam   A   the result type of function `g`
+   *  @param    g   a function R => A
+   *  @return       a new function `f` such that `f(v1, v2, v3, v4, v5, v6, v7, v8, v9) == g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9))`
+   */
+  @annotation.unspecialized def andThen[A](g: R => A): (T1, T2, T3, T4, T5, T6, T7, T8, T9) => A = { (v1: T1, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, v7: T7, v8: T8, v9: T9) => g(apply(v1, v2, v3, v4, v5, v6, v7, v8, v9)) }
   /** Creates a curried version of this function.
    *
    *  @return   a function `f` such that `f(x1)(x2)(x3)(x4)(x5)(x6)(x7)(x8)(x9) == apply(x1, x2, x3, x4, x5, x6, x7, x8, x9)`

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -216,11 +216,10 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
       }
       this
     case _ =>
-      class accum extends AbstractFunction2[K, V1, Unit] with Function1[(K, V1), Unit] {
+      class accum extends AbstractFunction2[K, V1, Unit] {
         var changed = false
         var shallowlyMutableNodeMap: Int = 0
         var current: BitmapIndexedMapNode[K, V1] = rootNode
-        def apply(kv: (K, V1)) = apply(kv._1, kv._2)
         def apply(key: K, value: V1): Unit = {
           val originalHash = key.##
           val improved = improve(originalHash)
@@ -256,7 +255,10 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
           if (it.isEmpty) this
           else {
             val accum = new accum
-            it.foreach(accum)
+            while (it.hasNext) {
+              val (k, v) = it.next()
+              accum(k, v)
+            }
             newHashMapOrThis(accum.current)
           }
       }

--- a/library/src/scala/runtime/FunctionXXL.scala
+++ b/library/src/scala/runtime/FunctionXXL.scala
@@ -11,5 +11,15 @@ trait FunctionXXL {
    */
   def apply(xs: IArray[Object]): Object
 
+  /** Returns a new `FunctionXXL` that applies this function and then `g` to the result.
+   *
+   *  Like `Function2..Function22.andThen`, this composes the (single-valued, here erased
+   *  to `Object`) result of `apply` with `g`, yielding a function with the same shape.
+   *
+   *  @param g a function applied to the (erased) result of this
+   *  @return  a new `FunctionXXL` `f` such that `f(xs) == g(apply(xs))`
+   */
+  def andThen(g: Object => Object): FunctionXXL^{this, g} = (xs: IArray[Object]) => g(apply(xs))
+
   override def toString() = "<functionXXL>"
 }

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -15,7 +15,30 @@ object MiMaFilters {
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.iterateUntilEmpty$extension"),
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.ArrayOps.scala$collection$ArrayOps$$elemTag$extension"),
         ProblemFilters.exclude[MissingFieldProblem]("scala.language#experimental.safe"),
-        ProblemFilters.exclude[MissingClassProblem]("scala.language$experimental$safe$")
+        ProblemFilters.exclude[MissingClassProblem]("scala.language$experimental$safe$"),
+        // Add `andThen` to FunctionN traits, mirroring `java.util.function.BiFunction.andThen`.
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function2.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function3.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function4.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function5.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function6.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function7.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function8.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function9.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function10.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function11.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function12.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function13.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function14.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function15.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function16.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function17.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function18.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function19.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function20.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function21.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.Function22.andThen"),
+        ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.runtime.FunctionXXL.andThen"),
     ))
 
     val BackwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(

--- a/project/ScalaLibraryPlugin.scala
+++ b/project/ScalaLibraryPlugin.scala
@@ -588,13 +588,84 @@ object ScalaLibraryPlugin extends AutoPlugin {
       if (targetDir.exists)
         IO.delete(targetDir)
       IO.createDirectory(targetDir)
-      IO.unzip(
+      val unpacked = IO.unzip(
         from = scalaLibSourcesJar,
         toDirectory = targetDir,
         filter = new SimpleFilter(path => !excludedSourceFiles.contains(path.replace(File.separatorChar, '/')))
       )
+      // Patch Scala 2's `Function2..Function22` sources to add `andThen`,
+      // mirroring scala/scala#11121. The Scala 2 backport lands in a separate PR;
+      // until then we inject the method here so that `Function{N}.class` produced
+      // by the `scala2-library` project (which replaces our compiled output for
+      // specialized synthetics) carries the new method.
+      patchScala2FunctionSourcesForAndThen(targetDir, log)
+      // Patch Scala 2's `HashMap.scala` to drop the `Function1[(K, V1), Unit]`
+      // mixin from its private `accum` class — once `Function2` carries `andThen`,
+      // mixing in both `Function1` and `Function2` causes a conflicting
+      // implementations clash (same fix as in our Scala 3 `HashMap.scala`).
+      patchScala2HashMapForAndThen(targetDir, log)
+      unpacked
     }(Set(scalaLibSourcesJar))
     targetDir
+  }
+
+  private def patchScala2FunctionSourcesForAndThen(targetDir: File, log: Logger): Unit = {
+    for (n <- 2 to 22) {
+      val file = targetDir / "scala" / s"Function$n.scala"
+      if (file.isFile) {
+        val content = IO.read(file)
+        if (!content.contains("def andThen[")) {
+          val tParams = (1 to n).map(i => s"T$i").mkString(", ")
+          val tParamsDecl = (1 to n).map(i => s"v$i: T$i").mkString(", ")
+          val vArgs = (1 to n).map(i => s"v$i").mkString(", ")
+          val andThen =
+            s"""  /** Composes two instances of `Function$n` in a new `Function$n`, with this function applied first.
+               | *
+               | *  @tparam A the result type of function `g`
+               | *  @param  g a function R => A
+               | *  @return a new function `f` such that `f(x1, ..., x$n) == g(apply(x1, ..., x$n))`
+               | */
+               |  @annotation.unspecialized def andThen[A](g: R => A): ($tParams) => A = { ($tParamsDecl) => g(apply($vArgs)) }
+               |""".stripMargin
+          // Inject before the existing `curried` definition, which is present in every Function2..22.
+          val curriedMarker = "  @annotation.unspecialized def curried"
+          val idx = content.indexOf(curriedMarker)
+          if (idx < 0) {
+            log.warn(s"Could not locate `curried` in $file to inject `andThen`; leaving file untouched.")
+          } else {
+            val patched = content.substring(0, idx) + andThen + content.substring(idx)
+            IO.write(file, patched)
+            log.debug(s"Patched $file to add `andThen`.")
+          }
+        }
+      }
+    }
+  }
+
+  private def patchScala2HashMapForAndThen(targetDir: File, log: Logger): Unit = {
+    val file = targetDir / "scala" / "collection" / "immutable" / "HashMap.scala"
+    if (!file.isFile) return
+    val content = IO.read(file)
+    val classDecl = "class accum extends AbstractFunction2[K, V1, Unit] with Function1[(K, V1), Unit] {"
+    val applyKv = "        def apply(kv: (K, V1)) = apply(kv._1, kv._2)"
+    val foreachAccum = "            it.foreach(accum)"
+    if (!content.contains(classDecl)) return // already patched or layout changed
+    val patched = content
+      .replace(classDecl, "class accum extends AbstractFunction2[K, V1, Unit] {")
+      .replace(applyKv + "\n", "")
+      .replace(
+        foreachAccum,
+        """            while (it.hasNext) {
+          |              val (k, v) = it.next()
+          |              accum(k, v)
+          |            }""".stripMargin
+      )
+    if (patched != content) {
+      IO.write(file, patched)
+      log.debug(s"Patched $file to drop `Function1` mixin from class accum.")
+    } else {
+      log.warn(s"Failed to patch $file for `accum` dual-inheritance fix; layout may have changed.")
+    }
   }
 }
 

--- a/tests/run/function-andthen.scala
+++ b/tests/run/function-andthen.scala
@@ -1,0 +1,67 @@
+// Directional tests for `andThen` on `Function2..Function22` and `scala.runtime.FunctionXXL`.
+// Mirrors the behavior of `java.util.function.BiFunction.andThen`.
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    // Reusable post-composition function.
+    val toStr: Any => String = _.toString
+
+    // 1. Function2.andThen — the common case (mirrors `java.util.function.BiFunction.andThen`).
+    val add: (Int, Int) => Int = _ + _
+    val addThenStr = add.andThen(toStr)
+    assert(addThenStr(1, 2) == "3")
+    // Result is a Function2 (not a Function1), so we can keep applying it as such.
+    val addThenStr2: (Int, Int) => String = add.andThen(toStr)
+    assert(addThenStr2(10, 20) == "30")
+    // Identity composition: `f.andThen(identity) == f` semantically.
+    val id: Int => Int = x => x
+    assert(add.andThen(id)(3, 4) == add(3, 4))
+
+    // 2. Function3 — sanity check at arity 3.
+    val sum3: (Int, Int, Int) => Int = _ + _ + _
+    assert(sum3.andThen(toStr)(1, 2, 3) == "6")
+
+    // 3. Function22 — exercise the largest hand-written arity.
+    val sum22: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+                Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int =
+      (a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11,
+       a12, a13, a14, a15, a16, a17, a18, a19, a20, a21, a22) =>
+        a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 +
+        a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 + a20 + a21 + a22
+    val sum22Str = sum22.andThen(toStr)
+    assert(sum22Str(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1) == "22")
+
+    // 4. Type inference — chained andThen with type-changing functions.
+    val mul: (Int, Int) => Int = _ * _
+    val pipeline: (Int, Int) => Int = mul.andThen(_ + 1).andThen(_ * 2)
+    assert(pipeline(3, 4) == (3 * 4 + 1) * 2)
+
+    // 5. Side-effects are evaluated in `apply`-then-`g` order.
+    val sb = new StringBuilder
+    val tap2: (Int, Int) => Int = (x, y) => { sb.append("apply;"); x + y }
+    val after: Any => Unit = _ => sb.append("g;")
+    tap2.andThen(after).apply(1, 2)
+    assert(sb.toString == "apply;g;", s"unexpected order: ${sb.toString}")
+
+    // 6. `andThen` returns a fresh function — no aliasing with `this`.
+    assert((add.andThen(id): AnyRef) ne (add: AnyRef))
+
+    // 7. Plays nice with `tupled` / `curried`.
+    val addTupled: ((Int, Int)) => Int = add.tupled
+    val tupledThenStr = addTupled.andThen(toStr)
+    assert(tupledThenStr((5, 6)) == "11")
+    val curriedThenStr = add.curried.andThen(_.andThen(toStr))
+    assert(curriedThenStr(5)(6) == "11")
+
+    // 8. FunctionXXL — runtime helper for arity > 22; type info is erased to Object.
+    val xxl: scala.runtime.FunctionXXL = new scala.runtime.FunctionXXL {
+      def apply(xs: IArray[Object]): Object =
+        Integer.valueOf(xs.foldLeft(0)((acc, o) => acc + o.asInstanceOf[Integer].intValue))
+    }
+    val xxlThen: scala.runtime.FunctionXXL =
+      xxl.andThen(o => ("v=" + o).asInstanceOf[Object])
+    val args23: IArray[Object] = IArray.tabulate(23)(i => Integer.valueOf(i + 1).asInstanceOf[Object])
+    assert(xxlThen.apply(args23) == "v=276") // 1+2+...+23 == 276
+  }
+}


### PR DESCRIPTION
## Summary

Mirror `java.util.function.BiFunction.andThen` for Scala's higher-arity function types. Port of scala/scala#11121.

- Adds `def andThen[A](g: R => A): (T1, .., Tn) => A` to each of `Function2..Function22` (default trait method, `@unspecialized`).
- Adds `def andThen(g: Object => Object): FunctionXXL^{this, g}` to `scala.runtime.FunctionXXL`. The capture-polymorphic return type is required because the SAM body captures `this` and `g`.
- Drops the `Function1[(K, V1), Unit]` mixin from the private `accum` class inside `HashMap.iadd`: once `Function2` carries a default `andThen`, mixing in both produces a clash between the two trait-default implementations. The iterator loop is inlined to a `while` to replace the Function1 dispatch.
- Overrides `andThen` on `dotty.tools.dotc.core.SymDenotations.LazyType`, which extends both `Function1[Symbol, LazyType]` and `Function2[(TermSymbol, ClassSymbol), LazyType]`, to disambiguate the inherited members. Composition is not meaningful for a symbol completer, so the override throws `UnsupportedOperationException`.
- Patches the extracted Scala 2 library sources in `ScalaLibraryPlugin` so the `scala2-library` project (whose compiled binaries replace ours for specialized synthetics) also carries `andThen`. The Scala 2 backport will land in a separate PR; this in-tree source patch keeps the present change self-contained until it does.
- Adds MiMa `ReversedMissingMethodProblem` filters for the 22 new default methods.

## Test plan

- [x] `testCompilation function-andthen` passes (`tests/run/function-andthen.scala` covers `Function2`, `Function3`, `Function22`, type-changing chains, evaluation order, fresh-instance return, interaction with `tupled` / `curried`, and `FunctionXXL` at arity 23).
- [x] `scala2-library` recompiles with patched sources; `Function2.class` exposes `andThen`.
- [x] `scala-library-nonbootstrapped` rebuilds cleanly with the new binaries.

## Notes

A dedicated Scala 2.13 backport will follow. The plugin-side source patch is the bridge that keeps this PR runnable in isolation until that lands; once it does, the patch can be removed.