### PR TITLE
Drop SharedCapability exception in subsumes

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -845,13 +845,15 @@ object Capabilities:
             case y: ResultCap => vs.unify(x, y)
             case _ => y.derivesFromCapTrait(defn.Caps_SharedCapability)
         case _: GlobalCap =>
+          def globalCapSubsumes =
+            canAddHidden && vs != VarState.HardSeparate && CCState.globalCapIsRoot
           y match
             case _: GlobalCap => this eq y
             case _: ResultCap => false
-            case _: LocalCap if CCState.collapseLocalCaps => true
-            case _ =>
-              y.derivesFromCapTrait(defn.Caps_SharedCapability)
-              || canAddHidden && vs != VarState.HardSeparate && CCState.globalCapIsRoot
+            case _: LocalCap if CCState.collapseLocalCaps || globalCapSubsumes => true
+            case _ => globalCapSubsumes
+              // also had: || y.derivesFromCapTrait(defn.Caps_SharedCapability)
+              // but this fails i25863a.scala, i.e compilers without errors where there should be
         case Restricted(x1, cls) =>
           y.isKnownClassifiedAs(cls) && x1.maxSubsumes(y, canAddHidden)
         case _ =>

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1568,7 +1568,8 @@ class CheckCaptures extends Recheck, SymTransformer:
       try
         // (2) Capture set of self type includes capture set of class
         val thisSet = cls.classInfo.selfType.captureSet.withDescription(i"of the self type of $cls")
-        checkSubset(localSet, thisSet, tree.srcPos)
+        withGlobalCapAsRoot: // OK? We need this here since self types use GlobalAny instead of a LocalCap
+          checkSubset(localSet, thisSet, tree.srcPos)
 
         // (3) Capture set of self type includes capture sets of tracked parameters
         for param <- cls.paramGetters do

--- a/tests/neg-custom-args/captures/i25863a.check
+++ b/tests/neg-custom-args/captures/i25863a.check
@@ -1,0 +1,12 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25863a.scala:16:28 --------------------------------------
+16 |    make[File^{file}](file, fun) // error
+   |                            ^^^
+   |Found:    File^{any} ->{file} Unit
+   |Required: File^{file} => Unit
+   |
+   |Note that capability `file` cannot flow into capture set {any}.
+   |
+   |where:    =>  refers to a root capability created in anonymous function of type (file²: File): () -> Unit when checking argument to parameter f of method make
+   |          any is the root capability caps.any
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i25863a.scala
+++ b/tests/neg-custom-args/captures/i25863a.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+import scala.caps.SharedCapability
+
+trait File extends SharedCapability {
+  def write(s: String): Unit
+}
+def usingFile[A](f: File => A): A = ???
+
+def make[A](x: A, f: A => Unit): () ->{f} Unit = {
+  () => f(x)
+}
+
+def leak: () -> Unit = {
+  val fun: File -> Unit = { f => f.write("") }
+  usingFile { file =>
+    make[File^{file}](file, fun) // error
+  }
+}


### PR DESCRIPTION
#25863 had another hole having to do with SharedCapabilities that also needed fixing.

Fixes #25863
