### PR TITLE
feature: Improve the logical sources provider

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -16,7 +16,7 @@ import java.nio.file.Files
  * Provides factory methods for classpath. When creating classpath instances for a given path,
  * it uses proper type of classpath depending on a types of particular files containing sources or classes.
  */
-class ClassPathFactory {
+class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None) {
   /**
     * Create a new classpath based on the abstract file.
     */
@@ -26,15 +26,16 @@ class ClassPathFactory {
     * Creators for sub classpaths which preserve this context.
     */
   def sourcesInPath(path: String)(using Context): List[ClassPath] =
-    // We also accept files in case of YlogicalPackageLoading
-    if ctx.settings.sourcepath.value.nonEmpty && ctx.settings.YlogicalPackageLoading.value then
-      val rootPackage: LogicalPackage = new LogicalPackagesProvider(path).root
-      List(new LogicalSourcePath(path, rootPackage))
-    else
-      for
-        file <- expandPath(path, expandStar = false)
-        dir <- Option(AbstractFile.getDirectory(file))
-      yield createSourcePath(dir)
+    precomputedSourcePackages match {
+      // We also accept files in case of YlogicalPackageLoading
+      case Some(rootPackage) if ctx.settings.YlogicalPackageLoading.value  =>
+        List(new LogicalSourcePath(path, rootPackage))
+      case _ =>
+        for
+          file <- expandPath(path, expandStar = false)
+          dir <- Option(AbstractFile.getDirectory(file))
+        yield createSourcePath(dir)
+    }
 
   def expandPath(path: String, expandStar: Boolean = true): List[String] = dotty.tools.io.ClassPath.expandPath(path, expandStar)
 

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -7,15 +7,16 @@ import classpath.AggregateClassPath
 import core.*
 import Symbols.*, Types.*, Contexts.*, StdNames.*
 import Flags.*
+import interactive.LogicalPackage
 import transform.ExplicitOuter
 
-class JavaPlatform extends Platform {
+class JavaPlatform(precomputedSourcePackages: Option[LogicalPackage] = None) extends Platform {
 
   private var currentClassPath: Option[ClassPath] = None
 
   def classPath(using Context): ClassPath = {
     if (currentClassPath.isEmpty)
-      currentClassPath = Some(new PathResolver().result)
+      currentClassPath = Some(new PathResolver(precomputedSourcePackages).result)
     val cp = currentClassPath.get
     cp
   }

--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -10,6 +10,7 @@ import PartialFunction.condOpt
 import core.Contexts.*
 import Settings.*
 import dotty.tools.io.File
+import dotty.tools.dotc.interactive.LogicalPackage
 
 object PathResolver {
 
@@ -169,10 +170,10 @@ object PathResolver {
 
 import PathResolver.{Defaults, ppcp}
 
-class PathResolver(using c: Context) {
+class PathResolver(precomputedSourcePackages: Option[LogicalPackage] = None)(using c: Context) {
   import c.base.settings
 
-  private val classPathFactory = new ClassPathFactory
+  private val classPathFactory = new ClassPathFactory(precomputedSourcePackages)
 
   private def cmdLineOrElse(name: String, alt: String) =
     commandLineFor(name) match {

--- a/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
@@ -5,6 +5,7 @@ import Contexts.*
 import Symbols.*
 
 import dotty.tools.backend.sjs.JSDefinitions
+import dotty.tools.dotc.interactive.LogicalPackage
 
 object SJSPlatform {
   /** The `SJSPlatform` for the current context. */
@@ -12,7 +13,7 @@ object SJSPlatform {
     ctx.platform.asInstanceOf[SJSPlatform]
 }
 
-class SJSPlatform extends JavaPlatform {
+class SJSPlatform(precomputedSourcePackages: Option[LogicalPackage] = None) extends JavaPlatform(precomputedSourcePackages) {
 
   /** Scala.js-specific definitions. */
   val jsDefinitions: JSDefinitions = new JSDefinitions()

--- a/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/InteractiveDriver.scala
@@ -16,6 +16,7 @@ import dotty.tools.dotc.sbt.interfaces.ProgressCallback
 import dotty.tools.io.AbstractFile
 
 import ast.{Trees, tpd}
+import config.*
 import core.*, core.Decorators.*
 import Contexts.*, Names.*, NameOps.*, Symbols.*, SymDenotations.*, Trees.*, Types.*
 import Denotations.staticRef
@@ -23,9 +24,23 @@ import classpath.*
 import reporting.*
 import util.*
 
+private class InteractiveContextBase(precomputedSourcePackages: Option[LogicalPackage]) extends ContextBase {
+
+  override protected def newPlatform(using Context): Platform =
+      if (settings.scalajs.value) new SJSPlatform(precomputedSourcePackages)
+      else new JavaPlatform(precomputedSourcePackages)
+
+}
+
 /** A Driver subclass designed to be used from IDEs */
-class InteractiveDriver(val settings: List[String]) extends Driver {
+class InteractiveDriver(
+    val settings: List[String],
+    val logicalRootPackage: Option[LogicalPackage] = None
+) extends Driver {
   import tpd.*
+
+  override protected def initCtx: Context =
+    new InteractiveContextBase(logicalRootPackage).initialCtx
 
   override def sourcesRequired: Boolean = false
 

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
@@ -13,12 +13,16 @@ import dotty.tools.io.Path
 
 import java.io.File
 import scala.collection.mutable
+import dotty.tools.dotc.core.Contexts
 
 /**
  * A compiler component that adds support for parsing Scala and Java source files and finding out
  * the logical package structure of the whole source path.
  */
-class LogicalPackagesProvider(sourcePath: String)(using Context){
+class LogicalPackagesProvider(sourcePath: String){
+
+  // We only use it for parser
+  private given Context = new ContextBase().initialCtx
 
   private lazy val sourceRoots: Seq[SourceFile] =
     allSources(sourcePath).map(f => SourceFile(f, f.toCharArray))
@@ -146,7 +150,9 @@ class LogicalPackagesProvider(sourcePath: String)(using Context){
       if isRelevantFile(e)
       f <- Option(AbstractFile.getFile(e))
     } yield f
-    rootFiles ++ rootDirs.flatMap(dir => sourcesIn(AbstractFile.getDirectory(dir).nn, "scala", "java"))
+    rootFiles ++ rootDirs.flatMap{ dir =>
+      Option(AbstractFile.getDirectory(dir)).toSeq.flatMap(sourcesIn(_, "scala", "java"))
+    }
   }
 
   /**

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -23,9 +23,10 @@ class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
   override def findClassFile(className: String): Option[AbstractFile] = None
   override def classes(inPackage: PackageName): Seq[BinaryFileEntry] = Seq.empty
 
-  override def hasPackage(inPackage: PackageName): Boolean = findPackage(
-    inPackage.dottedString
-  ).isDefined
+  override def hasPackage(inPackage: PackageName): Boolean =
+    findPackage(
+      inPackage.dottedString
+    ).isDefined
 
   /** Return all packages contained inside `inPackage`. Package entries contain the *full name* of the package. */
   override def packages(inPackage: PackageName): Seq[PackageEntry] =

--- a/compiler/src/dotty/tools/dotc/interactive/ParsedLogicalPackage.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/ParsedLogicalPackage.scala
@@ -2,6 +2,7 @@ package dotty.tools.dotc.interactive
 
 import scala.collection.mutable
 import dotty.tools.io.AbstractFile
+import scala.jdk.CollectionConverters.*
 
 /**
  * Represent a package and its contents in a way that's close to the file system.
@@ -70,4 +71,37 @@ class ParsedLogicalPackage(
 
   override def toString(): String =
     s"package $name(${packages.size} packages and ${sources.size} files)"
+}
+
+object ParsedLogicalPackage{
+
+  def fromMbtIndex(
+      packages: java.util.Map[String, java.util.Set[java.nio.file.Path]]
+  ): ParsedLogicalPackage =
+    val root = new ParsedLogicalPackage("", None)
+    val disallowedPackages: Set[String] = Set("scala", "scala.test", "_empty_")
+    val validExtensions: Set[String] = Set(".scala", ".java")
+
+    def isSupported(path: java.nio.file.Path): Boolean =
+      val filename = path.getFileName.toString
+      validExtensions.exists(filename.endsWith)
+
+    def enterNestedPackage(pkg: String) =
+      val parts = pkg.split('/')
+      var current = root
+      for part <- parts if !part.isEmpty do
+        current = current.enterPackage(part)
+      current
+
+    for ((pkg, paths) <- packages.asScala) do
+      val p = enterNestedPackage(pkg)
+      // we don't enter anything in the empty package, which is special and generally not useful (it is not)
+      // visible from other packages. Similarly, the scala package is special and we don't want to enter any
+      // symbols into it, since they might hide standard library symbols, such as scala.Option.
+      if p.name.nonEmpty && !disallowedPackages.contains(p.fullName) then
+        for path <- paths.asScala if isSupported(path) do
+          p.enterSource(path.toString)
+
+    root.removeEmptyPackages()
+    root
 }

--- a/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
@@ -1,13 +1,24 @@
 package dotty.tools.pc
 
+import java.io.File
 import java.net.URI
+import java.nio.file.Path
 import java.util as ju
 
 import scala.compiletime.uninitialized
+import scala.jdk.CollectionConverters.*
+import scala.meta.pc.SemanticdbFileManager
+import scala.meta.pc.SourcePathMode
 
+import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.interactive.LogicalPackage
+import dotty.tools.dotc.interactive.LogicalPackagesProvider
+import dotty.tools.dotc.interactive.LogicalSourcePath
+import dotty.tools.dotc.interactive.ParsedLogicalPackage
 import dotty.tools.dotc.reporting.Diagnostic
 import dotty.tools.dotc.util.SourceFile
+import dotty.tools.pc as sourcePathFiles
 
 /** CachingDriver is a wrapper class that provides a compilation cache for
  *  InteractiveDriver. CachingDriver skips running compilation if
@@ -27,7 +38,10 @@ import dotty.tools.dotc.util.SourceFile
  *  the complexity related to currentCtx, we decided to cache only when the
  *  target URI only if the same as the previous run.
  */
-class CachingDriver(override val settings: List[String]) extends InteractiveDriver(settings):
+class CachingDriver private (
+    override val settings: List[String],
+    precomputedSourcePackages: Option[LogicalPackage]
+) extends InteractiveDriver(settings, precomputedSourcePackages):
 
   private var lastCompiledURI: URI = uninitialized
   private var previousDiags = List.empty[Diagnostic]
@@ -46,3 +60,20 @@ class CachingDriver(override val settings: List[String]) extends InteractiveDriv
     previousDiags
 
 end CachingDriver
+
+object CachingDriver:
+  def apply(
+      settings: List[String],
+      sourcePath: ju.function.Supplier[ju.List[Path]],
+      semanticdbFileManager: SemanticdbFileManager,
+      sourcePathMode: SourcePathMode
+  ): CachingDriver =
+    val precomputedSourcePackages = sourcePathMode match
+      case SourcePathMode.DISABLED | SourcePathMode.FULL => None
+      case SourcePathMode.PRUNED =>
+        val sourcePathFiles = sourcePath.get().asScala.toSeq
+        val logicalSourcePath = sourcePathFiles.mkString(File.pathSeparator)
+        if sourcePathFiles.nonEmpty then Some(new LogicalPackagesProvider(logicalSourcePath).root) else None
+      case SourcePathMode.MBT =>
+        Some(ParsedLogicalPackage.fromMbtIndex(semanticdbFileManager.listAllPackages()))
+    new CachingDriver(settings, precomputedSourcePackages)

--- a/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/CachingDriver.scala
@@ -14,11 +14,9 @@ import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.interactive.LogicalPackage
 import dotty.tools.dotc.interactive.LogicalPackagesProvider
-import dotty.tools.dotc.interactive.LogicalSourcePath
 import dotty.tools.dotc.interactive.ParsedLogicalPackage
 import dotty.tools.dotc.reporting.Diagnostic
 import dotty.tools.dotc.util.SourceFile
-import dotty.tools.pc as sourcePathFiles
 
 /** CachingDriver is a wrapper class that provides a compilation cache for
  *  InteractiveDriver. CachingDriver skips running compilation if
@@ -69,8 +67,8 @@ object CachingDriver:
       sourcePathMode: SourcePathMode
   ): CachingDriver =
     val precomputedSourcePackages = sourcePathMode match
-      case SourcePathMode.DISABLED | SourcePathMode.FULL => None
-      case SourcePathMode.PRUNED =>
+      case SourcePathMode.DISABLED => None
+      case SourcePathMode.PRUNED | SourcePathMode.FULL =>
         val sourcePathFiles = sourcePath.get().asScala.toSeq
         val logicalSourcePath = sourcePathFiles.mkString(File.pathSeparator)
         if sourcePathFiles.nonEmpty then Some(new LogicalPackagesProvider(logicalSourcePath).root) else None

--- a/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
@@ -21,8 +21,6 @@ import scala.meta.pc.reports.ReportContext
 
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.InteractiveDriver
-import dotty.tools.dotc.interactive.LogicalPackage
-import dotty.tools.dotc.interactive.LogicalPackagesProvider
 import dotty.tools.pc.InferExpectedType
 import dotty.tools.pc.SymbolInformationProvider
 import dotty.tools.pc.buildinfo.BuildInfo

--- a/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
@@ -19,7 +19,10 @@ import scala.meta.pc.PcSymbolInformation as IPcSymbolInformation
 import scala.meta.pc.reports.EmptyReportContext
 import scala.meta.pc.reports.ReportContext
 
+import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.interactive.LogicalPackage
+import dotty.tools.dotc.interactive.LogicalPackagesProvider
 import dotty.tools.pc.InferExpectedType
 import dotty.tools.pc.SymbolInformationProvider
 import dotty.tools.pc.buildinfo.BuildInfo
@@ -75,9 +78,8 @@ case class RawScalaPresentationCompiler(
     val defaultFlags = List("-color:never")
     val filteredOptions = removeDoubleOptions(options.filterNot(forbiddenOptions))
     val classpathFlags = List("-classpath", classpath.mkString(File.pathSeparator))
-    val sourcePathFiles = sourcePath.get().asScala
-    val sourcePathFlags = if sourcePathFiles.size > 0 && config.sourcePathMode() != SourcePathMode.DISABLED then
-      List("-Ylogical-package-loading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
+    val sourcePathFlags = if config.sourcePathMode() != SourcePathMode.DISABLED then
+      List("-Ylogical-package-loading")
     else Nil
     filteredOptions ++
       defaultFlags ++
@@ -85,7 +87,8 @@ case class RawScalaPresentationCompiler(
       classpathFlags ++
       sourcePathFlags
 
-  lazy val driver: InteractiveDriver = CachingDriver(driverSettings)
+  lazy val driver: InteractiveDriver =
+    CachingDriver(driverSettings, sourcePath, semanticdbFileManager, config.sourcePathMode())
 
   override def codeAction[T](
       params: OffsetParams,
@@ -156,7 +159,7 @@ case class RawScalaPresentationCompiler(
     CompletionProvider(
       search,
       driver,
-      () => InteractiveDriver(driverSettings),
+      () => InteractiveDriver(driverSettings, driver.logicalRootPackage),
       params,
       config,
       buildTargetIdentifier,

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -30,8 +30,6 @@ import scala.meta.pc.reports.ReportContext
 
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.InteractiveDriver
-import dotty.tools.dotc.interactive.LogicalPackage
-import dotty.tools.dotc.interactive.LogicalPackagesProvider
 import dotty.tools.dotc.reporting.StoreReporter
 import dotty.tools.pc.InferExpectedType
 import dotty.tools.pc.SymbolInformationProvider

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -28,7 +28,10 @@ import scala.meta.pc.PcSymbolInformation as IPcSymbolInformation
 import scala.meta.pc.reports.EmptyReportContext
 import scala.meta.pc.reports.ReportContext
 
+import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.InteractiveDriver
+import dotty.tools.dotc.interactive.LogicalPackage
+import dotty.tools.dotc.interactive.LogicalPackagesProvider
 import dotty.tools.dotc.reporting.StoreReporter
 import dotty.tools.pc.InferExpectedType
 import dotty.tools.pc.SymbolInformationProvider
@@ -133,7 +136,13 @@ case class ScalaPresentationCompiler(
     Scala3CompilerAccess(
       config,
       sh,
-      () => new Scala3CompilerWrapper(CachingDriver(driverSettings))
+      () =>
+        new Scala3CompilerWrapper(CachingDriver(
+          driverSettings,
+          sourcePath,
+          semanticdbFileManager,
+          config.sourcePathMode()
+        ))
     )(using ec)
 
   val driverSettings: List[String] =
@@ -141,9 +150,8 @@ case class ScalaPresentationCompiler(
     val defaultFlags = List("-color:never")
     val filteredOptions = removeDoubleOptions(options.filterNot(forbiddenOptions))
     val classpathFlags = List("-classpath", classpath.mkString(File.pathSeparator))
-    val sourcePathFiles = sourcePath.get().asScala
-    val sourcePathFlags = if sourcePathFiles.size > 0 && config.sourcePathMode() != SourcePathMode.DISABLED then
-      List("-Ylogical-package-loading", "-sourcepath", sourcePathFiles.mkString(File.pathSeparator))
+    val sourcePathFlags = if config.sourcePathMode() != SourcePathMode.DISABLED then
+      List("-Ylogical-package-loading")
     else Nil
     filteredOptions ++
       defaultFlags ++
@@ -199,7 +207,7 @@ case class ScalaPresentationCompiler(
       new CompletionProvider(
         search,
         driver,
-        () => InteractiveDriver(driverSettings),
+        () => InteractiveDriver(driverSettings, driver.logicalRootPackage),
         params,
         config,
         buildTargetIdentifier,

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePCSuite.scala
@@ -13,6 +13,7 @@ import scala.meta.internal.metals.{ClasspathSearch, ExcludedPackagesHandler}
 import scala.meta.internal.pc.PresentationCompilerConfigImpl
 import scala.meta.pc.{PresentationCompiler, PresentationCompilerConfig}
 import scala.meta.pc.CompletionItemPriority
+import scala.meta.pc.SemanticdbFileManager
 
 import dotty.tools.pc.*
 import dotty.tools.pc.ScalaPresentationCompiler
@@ -41,6 +42,7 @@ abstract class BasePCSuite extends PcAssertions:
     TestResources.classpath.map(_.toString)
   )
   protected val sourcePath: Seq[Path] = Nil
+  protected val semanticdbFileManager: SemanticdbFileManager = SemanticdbFileManager.EMPTY
 
   lazy val presentationCompiler: PresentationCompiler =
     val myclasspath: Seq[Path] = TestResources.classpath ++ additionalClasspath
@@ -55,6 +57,7 @@ abstract class BasePCSuite extends PcAssertions:
       .withExecutorService(executorService)
       .withScheduledExecutorService(executorService)
       .withSearch(search)
+      .withSemanticdbFileManager(semanticdbFileManager)
       .withCompletionItemPriority(completionItemPriority)
       .newInstance("", myclasspath.asJava, scalacOpts.asJava, () => sourcePath.asJava)
 

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionMbtSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionMbtSuite.scala
@@ -1,0 +1,119 @@
+package dotty.tools.pc.tests.completion
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.collection.immutable
+import scala.jdk.CollectionConverters.*
+import scala.language.unsafeNulls
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.SemanticdbFileManager
+import scala.meta.pc.SourcePathMode
+
+import dotty.tools.pc.base.BaseCompletionSuite
+
+import org.junit.Test
+
+class CompletionMbtSuite extends BaseCompletionSuite:
+  private val sourcepathDir: Path = Files.createDirectories(tmp.resolve("sourcepath"))
+  private val singleSourcepathDir: Path = Files.createDirectories(tmp.resolve("sourcepath2"))
+  private val singleSourcepathFile = singleSourcepathDir.resolve("Gamma.scala")
+
+  private val pkg1Dir = Files.createDirectories(sourcepathDir.resolve("pkg1"))
+  Files.write(
+    pkg1Dir.resolve("Alpha.scala"),
+    """|package pkg1
+      |
+      |class Alpha:
+      |  def greetAlpha: String = ""
+      |  val countAlpha: Int = 0
+      |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+  )
+  private val pkg2Dir = Files.createDirectories(sourcepathDir.resolve("pkg2"))
+  Files.write(
+    pkg2Dir.resolve("Beta.scala"),
+    """|package pkg2.pkg3.pkg4
+      |
+      |object Beta:
+      |  def greetBeta(name: String): String = s"Hello $name"
+      |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+  )
+  private val pkg3Dir = Files.createDirectories(sourcepathDir.resolve("pkg3"))
+  Files.write(
+    pkg3Dir.resolve("toplevel.scala"),
+    """|package pkg3
+      |
+      |def greetFromToplevel(name: String): String = s"Hello $name"
+      |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+  )
+  Files.write(
+    singleSourcepathFile,
+    """|package pkg1
+      |package pkg2
+      |
+      |class Gamma:
+      |  def greetGamma: String = ""
+      |  val countAlpha: Int = 0
+      |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+  )
+
+  override protected def config: PresentationCompilerConfigImpl =
+    super.config.copy(sourcePathMode = SourcePathMode.MBT)
+  override protected val sourcePath: Seq[Path] = Seq(sourcepathDir, singleSourcepathFile)
+
+  override protected def scalacOptions(classpath: Seq[Path]): Seq[String] =
+    Seq("-Ylogical-package-loading")
+
+  override protected val semanticdbFileManager: SemanticdbFileManager = new SemanticdbFileManager {
+    override def listAllPackages(): java.util.Map[String, java.util.Set[java.nio.file.Path]] =
+      Map(
+        "pkg1" -> Set(pkg1Dir.resolve("Alpha.scala")).asJava,
+        "pkg2/pkg3/pkg4" -> Set(pkg2Dir.resolve("Beta.scala")).asJava,
+        "pkg3" -> Set(pkg3Dir.resolve("toplevel.scala")).asJava,
+        "pkg1/pkg2" -> Set(singleSourcepathFile).asJava
+      ).asJava
+  }
+
+  @Test def `class-from-mbt` =
+    check(
+      """|import pkg1.Alpha
+         |object Main:
+         |  val a = new Alpha
+         |  a.greetA@@
+         |""".stripMargin,
+      """|greetAlpha: String
+         |""".stripMargin
+    )
+
+  @Test def `object-from-different-package-in-mbt` =
+    check(
+      """|import pkg2.pkg3.pkg4.Beta
+         |object Main:
+         |  Beta.greetB@@
+         |""".stripMargin,
+      """|greetBeta(name: String): String
+         |""".stripMargin
+    )
+
+  @Test def `object-from-mbt` =
+    check(
+      """|import pkg1.pkg2.Gamma
+         |
+         |object ObjectFromSourceFile:
+         |  val gamma = new Gamma
+         |  gamma.greet@@
+         |""".stripMargin,
+      """|greetGamma: String
+         |""".stripMargin
+    )
+
+  @Test def `toplevel-from-mbt` =
+    check(
+      """|import pkg3.greetFromToplevel
+         |object Main:
+         |  greetFromToplevel@@
+         |""".stripMargin,
+      """|greetFromToplevel(name: String): String
+         |""".stripMargin
+    )

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSourcepathSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionSourcepathSuite.scala
@@ -58,7 +58,7 @@ class CompletionSourcepathSuite extends BaseCompletionSuite:
     )
 
   override protected def config: PresentationCompilerConfigImpl =
-    super.config.copy(sourcePathMode = SourcePathMode.FULL)
+    super.config.copy(sourcePathMode = SourcePathMode.PRUNED)
   override protected val sourcePath: Seq[Path] = Seq(sourcepathDir, singleSourcepathFile)
 
   override protected def scalacOptions(classpath: Seq[Path]): Seq[String] =


### PR DESCRIPTION
- create it only once per driver to avoid too much overhead in large codebases
- add possibility to use metals calculated packages to avoid calculating in compiler alltogether

This both should allow to use Metals 2 with the compiler itself.


## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Minimally, for adding the chain where to forward to logical packages provider.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests  and manual tests in the codebase
