### PR TITLE
Fix synthesis of mirrors for GADT with dependent type parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Synthesizer.scala
@@ -598,8 +598,14 @@ class Synthesizer(typer: Typer)(using @constructorOnly c: Context):
                   resType <:< target
                   val tparams = poly.paramRefs
                   val variances = childClass.typeParams.map(_.paramVarianceSign)
-                  val instanceTypes = tparams.lazyZip(variances).map: (tparam, variance) =>
-                    TypeComparer.instanceType(tparam, fromBelow = variance < 0, Widen.Unions)
+                  @tailrec def fixInstances(cur: List[Type]): List[Type] =
+                    val next = cur.mapConserve(_.substParams(poly, cur))
+                    if next eq cur then next else fixInstances(next)
+                  val instanceTypes = {
+                    val types0 = tparams.lazyZip(variances).map: (tparam, variance) =>
+                      TypeComparer.instanceType(tparam, fromBelow = variance < 0, Widen.Unions)
+                    fixInstances(types0)
+                  }
                   val instanceType = resType.substParams(poly, instanceTypes)
                   // this is broken in tests/run/i13332intersection.scala,
                   // because type parameters are not correctly inferred.

--- a/tests/pos/i23774.scala
+++ b/tests/pos/i23774.scala
@@ -1,0 +1,35 @@
+trait Iterable[+A]
+
+enum Expr {
+  case Case[T, C <: Iterable[T]]()
+}
+object Expr {
+  val m = summon[scala.deriving.Mirror.SumOf[Expr]]
+  summon[m.MirroredElemTypes =:= Expr.Case[Any, Iterable[Any]] *: EmptyTuple]
+}
+
+enum Trait {
+  case Upcast[Base, Case <: Base]()
+}
+
+object Trait {
+  val m = summon[scala.deriving.Mirror.SumOf[Trait]]
+  summon[m.MirroredElemTypes =:= Trait.Upcast[Any, Any] *: EmptyTuple]
+}
+
+enum MoreDeps {
+  case Case[T, C <: Iterable[T], D <: Iterable[C]]()
+}
+object MoreDeps {
+  val m = summon[scala.deriving.Mirror.SumOf[MoreDeps]]
+  summon[m.MirroredElemTypes =:= MoreDeps.Case[Any, Iterable[Any], Iterable[Iterable[Any]]] *: EmptyTuple]
+}
+
+enum Circular {
+  case Case[C <: Iterable[D], D <: C]()
+}
+object Circular {
+  val m = summon[scala.deriving.Mirror.SumOf[Circular]]
+  summon[m.MirroredElemTypes =:= Circular.Case[Iterable[Nothing], Nothing] *: EmptyTuple]
+}
+

--- a/tests/pos/i23774typeclass.scala
+++ b/tests/pos/i23774typeclass.scala
@@ -1,0 +1,74 @@
+import scala.compiletime.{erasedValue, summonInline}
+import scala.deriving.Mirror
+
+enum Expr[+T]:
+  case UpcastToIterable[T, C <: Iterable[T]](v: Expr[C]) extends Expr[Iterable[T]]
+  case Seq[T](elements: Expr[T]*) extends Expr[scala.Seq[T]]
+  case Const(value: T)
+
+trait Fold[E]:
+  def apply[Acc](acc: Acc, expr: E, f: [t] => (Acc, Expr[t]) => Acc): Acc
+
+object Fold:
+  private inline def summonAll[Elems <: Tuple]: List[Fold[?]] =
+    inline erasedValue[Elems] match
+      case _: (h *: tail) => summonInline[Fold[h]] :: summonAll[tail]
+      case _: EmptyTuple => Nil
+
+  final class Leaf[E] extends Fold[E]:
+    def apply[Acc](acc: Acc, expr: E, f: [t] => (Acc, Expr[t]) => Acc): Acc = acc
+
+  given [T: Fold as fold] => Fold[Seq[T]] = new Fold[Seq[T]] {
+    def apply[Acc](acc: Acc, expr: Seq[T], f: [t] => (Acc, Expr[t]) => Acc): Acc =
+      expr.foldLeft(acc)((a, e) => fold(a, e, f))
+  }
+
+  given Fold[EmptyTuple] = new Fold[EmptyTuple]:
+    def apply[Acc](acc: Acc, expr: EmptyTuple, f: [t] => (Acc, Expr[t]) => Acc): Acc = acc
+
+  given [H: Fold as h, T <: Tuple: Fold as t] => Fold[H *: T] =
+    new Fold[H *: T]:
+      def apply[Acc](acc: Acc, expr: H *: T, f: [t] => (Acc, Expr[t]) => Acc): Acc =
+        val acc1 = h(acc, expr.head, f)
+        t(acc1, expr.tail, f)
+
+  private def product[E](m: Mirror.ProductOf[E], tupleFold: Fold[m.MirroredElemTypes]): Fold[E] =
+    new Fold[E]:
+      def apply[Acc](acc: Acc, expr: E, f: [t] => (Acc, Expr[t]) => Acc): Acc =
+        // The mirror makes this safe according to https://github.com/scala/scala3/issues/22382#issuecomment-2613187822
+        tupleFold(acc, Tuple.fromProduct(expr.asInstanceOf[Product]).asInstanceOf[m.MirroredElemTypes], f)
+
+  private def sum[E](m: Mirror.SumOf[E], cases0: () => List[Fold[?]]): Fold[E] =
+    new Fold[E]:
+      lazy val cases = cases0()
+      def apply[Acc](acc: Acc, expr: E, f: [t] => (Acc, Expr[t]) => Acc): Acc =
+        val ord = m.ordinal(expr)
+        val caseFold = cases.apply(ord)
+        caseFold.apply(acc, expr.asInstanceOf, f)
+
+  inline given derived[E](using m: Mirror.Of[E]): Fold[E] =
+    inline m match
+      case m: Mirror.SumOf[E] => sum(m, () => summonAll[m.MirroredElemTypes])
+      case m: Mirror.ProductOf[E] => product[E](m, summonInline[Fold[m.MirroredElemTypes]])
+
+  given [T] => Fold[Expr.Const[T]] = Leaf()
+  given Fold[Expr.UpcastToIterable[Any, Iterable[Any]]] = derived
+  given [T] => Fold[Expr[T]] = new Fold[Expr[T]]:
+    val default = derived[Expr[T]]
+    def apply[Acc](acc: Acc, expr: Expr[T], f: [t] => (Acc, Expr[t]) => Acc): Acc =
+      default(f(acc, expr), expr, f)
+
+@main def test(): Unit =
+  def count[T](expr: Expr[T], f: [t] => Expr[t] => Boolean)(using fold: Fold[Expr[T]]): Int =
+    fold(0, expr, [t] => (acc, e) => if f(e) then acc + 1 else acc)
+
+  val ast: Expr[Iterable[Int]] = Expr.UpcastToIterable(Expr.Seq(Expr.Const(1), Expr.Const(2), Expr.Const(3)))
+  val constCount = count(
+    ast,
+    [t] =>
+      _ match {
+        case Expr.Const(_) => true
+        case _ => false
+      }
+  )
+  println(s"Number of Const nodes: $constCount")


### PR DESCRIPTION
This extends the current logic in Synthesizer.scala to instead of doing
a single replacement do it until a fixed point is reached.

Fixes #23774

<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, for exploring the code base and determining where the issue was.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests
