### PR TITLE
Restore cmdTests and bootstrappedOnlyCmdTests execution in CI

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -183,9 +183,17 @@ jobs:
           distribution: 'temurin'
           java-version: 17
           cache: 'sbt'
+
       - uses: sbt/setup-sbt@v1
+
       - name: Test `scala3-compiler-bootstrapped`
         run: ./project/scripts/sbt scala3-compiler-bootstrapped/test
+
+      - name: Cmd Tests
+        run: |
+          ./project/scripts/sbt 'scala3-bootstrapped/publishLocal'
+          ./project/scripts/cmdTests
+          ./project/scripts/bootstrappedOnlyCmdTests
 
   test-scala3-bootstrapped-compilation-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -174,7 +174,9 @@ jobs:
         run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/test
 
       - name: Cmd Tests
-        run: ./project/scripts/cmdTests
+        run: |
+          ./project/scripts/sbt scala3-nonbootstrapped/publishLocal
+          ./project/scripts/cmdTests
 
   test-scala3-compiler-bootstrapped:
     runs-on: ubuntu-latest
@@ -195,7 +197,9 @@ jobs:
         run: ./project/scripts/sbt scala3-compiler-bootstrapped/test
 
       - name: Cmd Tests
-        run: ./project/scripts/bootstrappedOnlyCmdTests
+        run: |
+          ./project/scripts/sbt scala3-bootstrapped/publishLocal
+          ./project/scripts/bootstrappedOnlyCmdTests
 
   test-scala3-bootstrapped-compilation-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -167,9 +167,16 @@ jobs:
           distribution: 'temurin'
           java-version: 17
           cache: 'sbt'
+
       - uses: sbt/setup-sbt@v1
+
       - name: Test `scala3-compiler-nonbootstrapped`
         run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/test
+
+      - name: Cmd Tests
+        run: |
+          ./project/scripts/sbt scala3-nonbootstrapped/publishLocal
+          ./project/scripts/cmdTests
 
   test-scala3-compiler-bootstrapped:
     runs-on: ubuntu-latest
@@ -191,8 +198,7 @@ jobs:
 
       - name: Cmd Tests
         run: |
-          ./project/scripts/sbt 'scala3-bootstrapped/publishLocal'
-          ./project/scripts/cmdTests
+          ./project/scripts/sbt scala3-bootstrapped/publishLocal
           ./project/scripts/bootstrappedOnlyCmdTests
 
   test-scala3-bootstrapped-compilation-coverage:

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -174,9 +174,7 @@ jobs:
         run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/test
 
       - name: Cmd Tests
-        run: |
-          ./project/scripts/sbt scala3-nonbootstrapped/publishLocal
-          ./project/scripts/cmdTests
+        run: ./project/scripts/cmdTests
 
   test-scala3-compiler-bootstrapped:
     runs-on: ubuntu-latest
@@ -197,9 +195,7 @@ jobs:
         run: ./project/scripts/sbt scala3-compiler-bootstrapped/test
 
       - name: Cmd Tests
-        run: |
-          ./project/scripts/sbt scala3-bootstrapped/publishLocal
-          ./project/scripts/bootstrappedOnlyCmdTests
+        run: ./project/scripts/bootstrappedOnlyCmdTests
 
   test-scala3-bootstrapped-compilation-coverage:
     runs-on: ubuntu-latest

--- a/compiler/src/dotty/tools/MainGenericCompiler.scala
+++ b/compiler/src/dotty/tools/MainGenericCompiler.scala
@@ -129,6 +129,6 @@ object MainGenericCompiler {
           properArgs
           ++ List("-script", settings.targetScript)
           ++ settings.scriptArgs
-        scripting.Main.main(properArgs.toArray)
+        scripting.Main.main(fullArgs.toArray)
   end main
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -12,8 +12,7 @@ import util.Spans.offsetToInt
 import dotty.tools.tasty.TastyFormat.{ASTsSection, AttributesSection, CommentsSection, PositionsSection}
 
 import java.nio.file.{Files, Paths}
-import dotty.tools.io.{JarArchive, Path, PlainFile}
-import dotty.tools.tasty.TastyFormat.header
+import dotty.tools.io.{AbstractFile, JarArchive, Path}
 
 import scala.collection.immutable.BitSet
 import scala.compiletime.uninitialized
@@ -60,8 +59,11 @@ object TastyPrinter:
           System.exit(1)
       else if arg.endsWith(".jar") then
         val jar = JarArchive.open(Path(arg), create = false)
+        def tastyFiles(file: AbstractFile): Iterator[AbstractFile] =
+          if file.isDirectory then file.iterator.flatMap(tastyFiles)
+          else if file.hasTastyExtension then Iterator.single(file) else Iterator.empty
         try
-          for file <- jar.allFileNames().map(f => new PlainFile(Path(f))) if file.hasTastyExtension do
+          for file <- tastyFiles(jar) do
             printTasty(s"$arg ${file.path}", file.toByteArray, isBestEffortTasty = false)
         finally jar.close()
       else

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -703,32 +703,18 @@ object Build {
         val externalDeps = (`scala3-compiler-nonbootstrapped` / Runtime / externalDependencyClasspath).value
         val stdlib = (`scala-library-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath
         val dottyCompiler = (`scala3-compiler-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath
-        val args0: List[String] = spaceDelimited("<arg>").parsed.toList
-        val decompile = args0.contains("-decompile")
-        val printTasty = args0.contains("-print-tasty")
-        val debugFromTasty = args0.contains("-Ythrough-tasty")
-        val defaultOutputDirectory =
-          if (printTasty || decompile || debugFromTasty || args0.contains("-d")) Nil
-          else List("-d", ((ThisBuild / baseDirectory).value / "out" / "default-last-scalac-out.jar").getPath)
-        val args = args0.filter(arg => arg != "-repl" && arg != "-decompile" &&
-            arg != "-with-compiler" && arg != "-Ythrough-tasty" && arg != "-print-tasty")
-        val main =
-          if (decompile) "dotty.tools.dotc.decompiler.Main"
-          else if (printTasty) "dotty.tools.dotc.core.tasty.TastyPrinter"
-          else if (debugFromTasty) "dotty.tools.dotc.fromtasty.Debug"
-          else "dotty.tools.dotc.Main"
-
+        val args: List[String] = spaceDelimited("<arg>").parsed.toList
+        val main = "dotty.tools.MainGenericCompiler"
         var extraClasspath = Seq(stdlib)
 
-        if (decompile && !args.contains("-classpath"))
+        if (args.contains("-decompile") && !args.contains("-classpath"))
           extraClasspath ++= Seq(".")
 
-        if (args0.contains("-with-compiler")) {
+        if (args.contains("-with-compiler"))
           log.error("-with-compiler should only be used with a bootstrapped compiler")
-        }
 
-        val wrappedArgs = if (printTasty) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
-        val fullArgs = main :: (defaultOutputDirectory ::: wrappedArgs).map("\""+ _ + "\"").map(_.replace("\\", "\\\\"))
+        val wrappedArgs = if (args.contains("-print-tasty")) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
+        val fullArgs = main :: wrappedArgs.map("\""+ _ + "\"").map(_.replace("\\", "\\\\"))
 
         (`scala3-compiler-nonbootstrapped` / Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
       }.evaluated,
@@ -740,7 +726,6 @@ object Build {
           val fullArgs = insertClasspathInArgs(args, List(".", scalaLib).mkString(File.pathSeparator))
           Process.runProcess("java" :: fullArgs, wait = true)
         }
-
         if (args.isEmpty) {
           println("Couldn't run `scala` without args. Use `repl` to run the repl or add args to run the dotty application")
         } else if (scalaLib == "") {
@@ -866,29 +851,17 @@ object Build {
       scalac := Def.inputTaskDyn {
         val log = streams.value.log
         val externalDeps = (`scala3-compiler-bootstrapped` / Runtime / externalDependencyClasspath).value
-        val stdlib = (`scala-library-bootstrapped` / Compile / packageBin).value.getAbsolutePath.toString
-        val dottyCompiler = (`scala3-compiler-bootstrapped` / Compile / packageBin).value.getAbsolutePath.toString
-        val args0: List[String] = spaceDelimited("<arg>").parsed.toList
-        val decompile = args0.contains("-decompile")
-        val printTasty = args0.contains("-print-tasty")
-        val debugFromTasty = args0.contains("-Ythrough-tasty")
-        val defaultOutputDirectory =
-          if (printTasty || decompile || debugFromTasty || args0.contains("-d")) Nil
-          else List("-d", ((ThisBuild / baseDirectory).value / "out" / "default-last-scalac-out.jar").getPath)
-        val args = args0.filter(arg => arg != "-repl" && arg != "-decompile" &&
-            arg != "-with-compiler" && arg != "-Ythrough-tasty" && arg != "-print-tasty")
-        val main =
-          if (decompile) "dotty.tools.dotc.decompiler.Main"
-          else if (printTasty) "dotty.tools.dotc.core.tasty.TastyPrinter"
-          else if (debugFromTasty) "dotty.tools.dotc.fromtasty.Debug"
-          else "dotty.tools.dotc.Main"
+        val stdlib = (`scala-library-bootstrapped` / Compile / packageBin).value.getAbsolutePath
+        val dottyCompiler = (`scala3-compiler-bootstrapped` / Compile / packageBin).value.getAbsolutePath
+        val args: List[String] = spaceDelimited("<arg>").parsed.toList
+        val main = "dotty.tools.MainGenericCompiler.Main"
 
         var extraClasspath = Seq(stdlib)
 
-        if (decompile && !args.contains("-classpath"))
+        if (args.contains("-decompile") && !args.contains("-classpath"))
           extraClasspath ++= Seq(".")
 
-        if (args0.contains("-with-compiler")) {
+        if (args.contains("-with-compiler")) {
           val dottyInterfaces = (`scala3-interfaces` / Compile / packageBin).value.getAbsolutePath
           val dottyStaging = (`scala3-staging` / Compile / packageBin).value.getAbsolutePath
           val dottyTastyInspector = (`scala3-tasty-inspector` / Compile / packageBin).value.getAbsolutePath
@@ -898,11 +871,35 @@ object Build {
           extraClasspath ++= Seq(dottyCompiler, dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface)
         }
 
-        val wrappedArgs = if (printTasty) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
-        val fullArgs = main :: (defaultOutputDirectory ::: wrappedArgs).map("\""+ _ + "\"").map(_.replace("\\", "\\\\"))
+        val wrappedArgs = if (args.contains("-print-tasty")) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
+        val fullArgs = main :: wrappedArgs.map("\""+ _ + "\"").map(_.replace("\\", "\\\\"))
 
         (`scala3-compiler-bootstrapped` / Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
       }.evaluated,
+      scala := {
+        val args: List[String] = spaceDelimited("<arg>").parsed.toList
+        val externalDeps = (`scala3-compiler-bootstrapped` / Runtime / externalDependencyClasspath).value
+        val scalaLib = (`scala-library-bootstrapped` / Compile / packageBin).value.getAbsolutePath
+        def run(args: List[String]): Unit = {
+          val fullArgs = insertClasspathInArgs(args, List(".", scalaLib).mkString(File.pathSeparator))
+          Process.runProcess("java" :: fullArgs, wait = true)
+        }
+        if (args.isEmpty) {
+          println("Couldn't run `scala` without args. Use `repl` to run the repl or add args to run the dotty application")
+        } else if (scalaLib == "") {
+          println("Couldn't find scala-library on classpath, please run using script in bin dir instead")
+        } else if (args.contains("-with-compiler")) {
+          val args1 = args.filter(_ != "-with-compiler")
+          val asm = findArtifactPath(externalDeps, "scala-asm")
+          val dottyCompiler = (`scala3-compiler-bootstrapped` / Compile / packageBin).value.getAbsolutePath
+          val dottyStaging = (`scala3-staging` / Compile / packageBin).value.getAbsolutePath
+          val dottyTastyInspector = (`scala3-tasty-inspector` / Compile / packageBin).value.getAbsolutePath
+          val dottyInterfaces = (`scala3-interfaces` / Compile / packageBin).value.getAbsolutePath
+          val tastyCore = (`tasty-core-bootstrapped` / Compile / packageBin).value.getAbsolutePath
+          val compilerInterface = findArtifactPath(externalDeps, "compiler-interface")
+          run(insertClasspathInArgs(args1, List(dottyCompiler, dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface).mkString(File.pathSeparator)))
+        } else run(args)
+      },
       testCompilation := Def.inputTaskDyn {
         val args = spaceDelimited("<arg>").parsed
         if (args.contains("--help")) {
@@ -1909,7 +1906,7 @@ object Build {
     .settings(
       Test / test := (Test / test).dependsOn(`scaladoc-testcases` / Compile / compile).value,
       Test / testcasesOutputDir := (`scaladoc-testcases` / Compile / products).value.map(_.getAbsolutePath),
-      Test / testcasesSourceRoot := ((`scaladoc-testcases` / baseDirectory).value / "src").getAbsolutePath.toString,
+      Test / testcasesSourceRoot := ((`scaladoc-testcases` / baseDirectory).value / "src").getAbsolutePath,
       testDocumentationRoot := (baseDirectory.value / "test-documentations").getAbsolutePath,
     )
     // Test configuration for source links integration test

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -854,14 +854,14 @@ object Build {
         val stdlib = (`scala-library-bootstrapped` / Compile / packageBin).value.getAbsolutePath
         val dottyCompiler = (`scala3-compiler-bootstrapped` / Compile / packageBin).value.getAbsolutePath
         val args: List[String] = spaceDelimited("<arg>").parsed.toList
-        val main = "dotty.tools.MainGenericCompiler.Main"
+        val main = "dotty.tools.MainGenericCompiler"
 
         var extraClasspath = Seq(stdlib)
 
         if (args.contains("-decompile") && !args.contains("-classpath"))
           extraClasspath ++= Seq(".")
 
-        if (args.contains("-with-compiler")) {
+        val args1 = if (args.contains("-with-compiler")) {
           val dottyInterfaces = (`scala3-interfaces` / Compile / packageBin).value.getAbsolutePath
           val dottyStaging = (`scala3-staging` / Compile / packageBin).value.getAbsolutePath
           val dottyTastyInspector = (`scala3-tasty-inspector` / Compile / packageBin).value.getAbsolutePath
@@ -869,9 +869,10 @@ object Build {
           val asm = findArtifactPath(externalDeps, "scala-asm")
           val compilerInterface = findArtifactPath(externalDeps, "compiler-interface")
           extraClasspath ++= Seq(dottyCompiler, dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface)
-        }
+          args.filter(_ != "-with-compiler")
+        } else args
 
-        val wrappedArgs = if (args.contains("-print-tasty")) args else insertClasspathInArgs(args, extraClasspath.mkString(File.pathSeparator))
+        val wrappedArgs = if (args1.contains("-print-tasty")) args1 else insertClasspathInArgs(args1, extraClasspath.mkString(File.pathSeparator))
         val fullArgs = main :: wrappedArgs.map("\""+ _ + "\"").map(_.replace("\\", "\\\\"))
 
         (`scala3-compiler-bootstrapped` / Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -151,6 +151,9 @@ object Build {
   // Used to compile files similar to ./bin/scalac script
   val scalac = inputKey[Unit]("run the compiler using the correct classpath, or the user supplied classpath")
 
+  // Used to run binaries similar to ./bin/scala script
+  val scala = inputKey[Unit]("run compiled binary using the correct classpath, or the user supplied classpath")
+
   val buildQuick = taskKey[Unit]("compile the compiler and REPL, write classpath to bin/.cp for use by bin/scalacQ and bin/replQ")
 
   // Settings used to configure the test language server
@@ -698,8 +701,8 @@ object Build {
       scalac := Def.inputTaskDyn {
         val log = streams.value.log
         val externalDeps = (`scala3-compiler-nonbootstrapped` / Runtime / externalDependencyClasspath).value
-        val stdlib = (`scala-library-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath.toString()
-        val dottyCompiler = (`scala3-compiler-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath.toString()
+        val stdlib = (`scala-library-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath
+        val dottyCompiler = (`scala3-compiler-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath
         val args0: List[String] = spaceDelimited("<arg>").parsed.toList
         val decompile = args0.contains("-decompile")
         val printTasty = args0.contains("-print-tasty")
@@ -729,6 +732,31 @@ object Build {
 
         (`scala3-compiler-nonbootstrapped` / Compile / runMain).toTask(fullArgs.mkString(" ", " ", ""))
       }.evaluated,
+      scala := {
+        val args: List[String] = spaceDelimited("<arg>").parsed.toList
+        val externalDeps = (`scala3-compiler-nonbootstrapped` / Runtime / externalDependencyClasspath).value
+        val scalaLib = (`scala-library-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath
+        def run(args: List[String]): Unit = {
+          val fullArgs = insertClasspathInArgs(args, List(".", scalaLib).mkString(File.pathSeparator))
+          Process.runProcess("java" :: fullArgs, wait = true)
+        }
+
+        if (args.isEmpty) {
+          println("Couldn't run `scala` without args. Use `repl` to run the repl or add args to run the dotty application")
+        } else if (scalaLib == "") {
+          println("Couldn't find scala-library on classpath, please run using script in bin dir instead")
+        } else if (args.contains("-with-compiler")) {
+          val args1 = args.filter(_ != "-with-compiler")
+          val asm = findArtifactPath(externalDeps, "scala-asm")
+          val dottyCompiler = (`scala3-compiler-nonbootstrapped` / Compile / packageBin).value.getAbsolutePath
+          val dottyStaging = (`scala3-staging` / Compile / packageBin).value.getAbsolutePath
+          val dottyTastyInspector = (`scala3-tasty-inspector` / Compile / packageBin).value.getAbsolutePath
+          val dottyInterfaces = (`scala3-interfaces` / Compile / packageBin).value.getAbsolutePath
+          val tastyCore = (`tasty-core-bootstrapped` / Compile / packageBin).value.getAbsolutePath
+          val compilerInterface = findArtifactPath(externalDeps, "compiler-interface")
+          run(insertClasspathInArgs(args1, List(dottyCompiler, dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface).mkString(File.pathSeparator)))
+        } else run(args)
+      },
       // TODO: scala3-repl depends on the bootstrapped compiler, making this slower
       // than it needs to be. A non-bootstrapped REPL project would speed this up.
       buildQuick := {
@@ -2947,7 +2975,7 @@ object Build {
   private def validateJarIsEmpty(jar: File): File = {
     val jarFile = new java.util.jar.JarFile(jar)
     try {
-      import scala.jdk.CollectionConverters._
+      import _root_.scala.jdk.CollectionConverters._
       val nonMetaInfEntries = jarFile.entries().asScala
         .map(_.getName)
         .filterNot(name => name.startsWith("META-INF/") || name == "META-INF")

--- a/project/scripts/bootstrappedOnlyCmdTests
+++ b/project/scripts/bootstrappedOnlyCmdTests
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+# TEMP -- CI DEBUGGING
+set -euxo pipefail
 
 source $(dirname $0)/cmdTestsCommon.inc.sh
 

--- a/project/scripts/bootstrappedOnlyCmdTests
+++ b/project/scripts/bootstrappedOnlyCmdTests
@@ -4,14 +4,8 @@ set -e
 
 source $(dirname $0)/cmdTestsCommon.inc.sh
 
-# check that benchmarks can run
-"$SBT" "scala3-bench/jmh:run 1 1 tests/pos/alias.scala"
-# The above is here as it relies on the bootstrapped library.
-"$SBT" "scala3-bench-bootstrapped/jmh:run 1 1 tests/pos/alias.scala"
-"$SBT" "scala3-bench-bootstrapped/jmh:run 1 1 -with-compiler compiler/src/dotty/tools/dotc/core/Types.scala"
-
 echo "testing scala.quoted.Expr.run from sbt scala"
-"$SBT" ";scala3-compiler-bootstrapped/scalac -with-compiler tests/run-staging/quote-run.scala; scala3-compiler-bootstrapped/scala -with-compiler Test" | tee "$tmp"
+"$SBT" ";scala3-bootstrapped/scalac -with-compiler tests/run-staging/quote-run.scala; scala3-bootstrapped/scala -with-compiler Test" | tee "$tmp"
 grep -qe "val a: scala.Int = 3" "$tmp"
 
 # setup for `scalac`/`scala` script tests
@@ -75,7 +69,7 @@ test "$EXPECTED_OUTPUT" = "$(cat "$tmp")"
 
 echo "testing sbt scalac with suspension"
 clear_out "$OUT"
-"$SBT" "scala3-compiler-bootstrapped/scalac -d $OUT tests/pos-macros/macros-in-same-project-1/Bar.scala tests/pos-macros/macros-in-same-project-1/Foo.scala"  | tee "$tmp"
+"$SBT" "scala3-bootstrapped/scalac -d $OUT tests/pos-macros/macros-in-same-project-1/Bar.scala tests/pos-macros/macros-in-same-project-1/Foo.scala"  | tee "$tmp"
 
 # echo ":quit" | ./$DIST_DIR/target/universal/stage/bin/scala  # not supported by CI
 

--- a/project/scripts/bootstrappedOnlyCmdTests
+++ b/project/scripts/bootstrappedOnlyCmdTests
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# TEMP -- CI DEBUGGING
-set -euxo pipefail
+set -e
 
 source $(dirname $0)/cmdTestsCommon.inc.sh
 

--- a/project/scripts/bootstrappedOnlyCmdTests
+++ b/project/scripts/bootstrappedOnlyCmdTests
@@ -12,7 +12,7 @@ source $(dirname $0)/cmdTestsCommon.inc.sh
 "$SBT" "scala3-bench-bootstrapped/jmh:run 1 1 -with-compiler compiler/src/dotty/tools/dotc/core/Types.scala"
 
 echo "testing scala.quoted.Expr.run from sbt scala"
-"$SBT" ";scala3-compiler-bootstrapped/scalac -with-compiler tests/run-staging/quote-run.scala; scala3-compiler-bootstrapped/scala -with-compiler Test" > "$tmp"
+"$SBT" ";scala3-compiler-bootstrapped/scalac -with-compiler tests/run-staging/quote-run.scala; scala3-compiler-bootstrapped/scala -with-compiler Test" | tee "$tmp"
 grep -qe "val a: scala.Int = 3" "$tmp"
 
 # setup for `scalac`/`scala` script tests
@@ -29,7 +29,7 @@ scala_version=${versionProps[2]}
 echo "testing ./bin/scalac and ./bin/scala"
 clear_out "$OUT"
 ./bin/scalac "$SOURCE" -d "$OUT"
-./bin/scala -classpath "$OUT" -M "$MAIN" > "$tmp"
+./bin/scala -classpath "$OUT" -M "$MAIN" | tee "$tmp"
 test "$EXPECTED_OUTPUT" = "$(cat "$tmp")"
 
 # Test scaladoc based on compiled classes
@@ -39,44 +39,44 @@ clear_out "$OUT1"
 # check that `scalac` and `scala` works for staging.
 clear_out "$OUT"
 ./bin/scalac tests/run-staging/i4044f.scala -d "$OUT"
-./bin/scala -with-compiler -classpath "$OUT" -M Test > "$tmp"
+./bin/scala -with-compiler -classpath "$OUT" -M Test | tee "$tmp"
 
 # check that `scalac -from-tasty` compiles and `scala` runs it
 echo "testing ./bin/scalac -from-tasty and scala -classpath"
 clear_out "$OUT1"
 ./bin/scalac "$SOURCE" -d "$OUT"
 ./bin/scalac -from-tasty -d "$OUT1" "$OUT/$TASTY"
-./bin/scala -classpath "$OUT1" -M "$MAIN" > "$tmp"
+./bin/scala -classpath "$OUT1" -M "$MAIN" | tee "$tmp"
 test "$EXPECTED_OUTPUT" = "$(cat "$tmp")"
 
 # check that `sbt scalac -decompile` runs
 echo "testing sbt scalac -decompile from file"
-./bin/scalac -decompile -color:never "$OUT/$TASTY" > "$tmp"
+./bin/scalac -decompile -color:never "$OUT/$TASTY" | tee "$tmp"
 grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tmp"
 
 # check that `sbt scalac -print-tasty` runs
 echo "testing sbt scalac -print-tasty from file"
-./bin/scalac -print-tasty -color:never "$OUT/$TASTY" > "$tmp"
+./bin/scalac -print-tasty -color:never "$OUT/$TASTY" | tee "$tmp"
 grep -qe "118:           STRINGconst 32 \[hello world\]" "$tmp"
 
 echo "testing loading tasty from .tasty file in jar"
 clear_out "$OUT"
 ./bin/scalac -d "$OUT/out.jar" "$SOURCE"
-./bin/scalac -decompile -color:never "$OUT/out.jar" > "$tmp"
+./bin/scalac -decompile -color:never "$OUT/out.jar" | tee "$tmp"
 grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tmp"
 
 echo "testing printing tasty from .tasty file in jar"
-./bin/scalac -print-tasty -color:never "$OUT/out.jar" > "$tmp"
+./bin/scalac -print-tasty -color:never "$OUT/out.jar" | tee "$tmp"
 grep -qe "118:           STRINGconst 32 \[hello world\]" "$tmp"
 
 echo "testing -script from scalac"
 clear_out "$OUT"
-./bin/scalac -script "$SOURCE" > "$tmp"
+./bin/scalac -script "$SOURCE" | tee "$tmp"
 test "$EXPECTED_OUTPUT" = "$(cat "$tmp")"
 
 echo "testing sbt scalac with suspension"
 clear_out "$OUT"
-"$SBT" "scala3-compiler-bootstrapped/scalac -d $OUT tests/pos-macros/macros-in-same-project-1/Bar.scala tests/pos-macros/macros-in-same-project-1/Foo.scala"  > "$tmp"
+"$SBT" "scala3-compiler-bootstrapped/scalac -d $OUT tests/pos-macros/macros-in-same-project-1/Bar.scala tests/pos-macros/macros-in-same-project-1/Foo.scala"  | tee "$tmp"
 
 # echo ":quit" | ./$DIST_DIR/target/universal/stage/bin/scala  # not supported by CI
 
@@ -94,10 +94,10 @@ clear_out "$OUT"
 ./bin/scalac @project/scripts/options "$SOURCE"
 
 # test command line options
-./bin/scalac -help > "$tmp" 2>&1
+./bin/scalac -help 2>&1 | tee "$tmp"
 grep -qe "Usage: scalac <options> <source files>" "$tmp"
 
-./bin/scala -help > "$tmp" 2>&1
+./bin/scala -help 2>&1 | tee "$tmp"
 grep -qe "See 'scala <command> --help' to read about a specific subcommand." "$tmp"
 
 ./bin/scala -d hello.jar tests/run/hello.scala
@@ -106,14 +106,14 @@ clear_cli_dotfiles tests/run
 
 # check that `scala` runs scripts with args
 echo "testing ./bin/scala with arguments"
-./bin/scala run project/scripts/echoArgs.sc -- abc true 123 > "$tmp"
+./bin/scala run project/scripts/echoArgs.sc -- abc true 123 | tee "$tmp"
 test "$EXPECTED_OUTPUT_ARGS" = "$(cat "$tmp")"
 clear_cli_dotfiles project/scripts
 
 #echo "testing i12973"
 #clear_out "$OUT"
 #./bin/scalac -d "$OUT/out.jar" tests/pos/i12973.scala
-#echo "Bug12973().check" | TERM=dumb ./bin/scala -cp "$OUT/out.jar" > "$tmp" 2>&1
+#echo "Bug12973().check" | TERM=dumb ./bin/scala -cp "$OUT/out.jar" | tee "$tmp" 2>&1
 #grep -qe "Bug12973 is fixed" "$tmp"
 
 echo "testing -sourcepath with incremental compile: inlining changed inline def into a def"

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -7,35 +7,35 @@ set -euxo pipefail
 
 # check that `sbt scalac` compiles and `sbt scala` runs it
 echo "testing sbt scalac and scala"
-"$SBT" ";scalac $SOURCE -d $OUT ;scala -classpath $OUT $MAIN" > "$tmp"
+"$SBT" ";scalac $SOURCE -d $OUT ;scala -classpath $OUT $MAIN" | tee "$tmp"
 grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 # check that `sbt scalac -from-tasty` compiles and `sbt scala` runs it
 echo "testing sbt scalac -from-tasty and scala -classpath"
 clear_out "$OUT"
-"$SBT" ";scalac $SOURCE -d $OUT ;scalac -from-tasty -d $OUT1 $OUT/$TASTY ;scala -classpath $OUT1 $MAIN" > "$tmp"
+"$SBT" ";scalac $SOURCE -d $OUT ;scalac -from-tasty -d $OUT1 $OUT/$TASTY ;scala -classpath $OUT1 $MAIN" | tee "$tmp"
 grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 echo "testing sbt scalac -from-tasty from a jar and scala -classpath"
 clear_out "$OUT"
-"$SBT" ";scalac -d $OUT/out.jar $SOURCE ;scalac -from-tasty -d $OUT1 $OUT/out.jar ;scala -classpath $OUT1 $MAIN" > "$tmp"
+"$SBT" ";scalac -d $OUT/out.jar $SOURCE ;scalac -from-tasty -d $OUT1 $OUT/out.jar ;scala -classpath $OUT1 $MAIN" | tee "$tmp"
 grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 echo "testing sbt scala with no -classpath"
 clear_out "$OUT"
-"$SBT" ";scalac $SOURCE ; scala $MAIN" > "$tmp"
+"$SBT" ";scalac $SOURCE ; scala $MAIN" | tee "$tmp"
 grep -qe "$EXPECTED_OUTPUT" "$tmp"
 
 echo "testing sbt scalac -print-tasty"
 clear_out "$OUT"
-"$SBT" ";scalac $SOURCE -d $OUT ;scalac -print-tasty -color:never $OUT/$TASTY" > "$tmp"
+"$SBT" ";scalac $SOURCE -d $OUT ;scalac -print-tasty -color:never $OUT/$TASTY" | tee "$tmp"
 grep -qe "0: ASTs" "$tmp"
 grep -qe "0: 41 \[tests/pos/HelloWorld.scala\]" "$tmp"
 
 echo "testing that paths SourceFile annotations are relativized"
 clear_out "$OUT"
 "$SBT" "scalac -d $OUT/out.jar -sourceroot tests/pos $(pwd)/tests/pos/i10430/lib.scala $(pwd)/tests/pos/i10430/app.scala"
-"$SBT" "scalac -print-tasty -color:never $OUT/out.jar" > "$tmp"
+"$SBT" "scalac -print-tasty -color:never $OUT/out.jar" | tee "$tmp"
 # cat "$tmp" # for debugging
 grep -q ": i10430/lib.scala" "$tmp"
 grep -q ": i10430/app.scala" "$tmp"
@@ -59,7 +59,7 @@ cp tests/neg-macros/i6371/B_2.scala $OUT/B.scala
 "$SBT" "scalac $OUT/A.scala -d $OUT1"
 rm $OUT/A.scala
 # this command is expected to fail
-"$SBT" "scalac -classpath $OUT1 -d $OUT1 $OUT/B.scala" > "$tmp" 2>&1 || echo "ok"
+"$SBT" "scalac -classpath $OUT1 -d $OUT1 $OUT/B.scala" 2>&1 | tee "$tmp" || echo "ok"
 # cat "$tmp" # for debugging
 grep -qe "B.scala:2:7" "$tmp"
 grep -qe "This location contains code that was inlined from A.scala:3" "$tmp"
@@ -71,13 +71,13 @@ clear_out "$OUT"
 ## Disabled because of flakeyness, should be changed to not depend on sbt
 # echo "running Vulpix meta test"
 # tmp=$(mktemp)
-# if "$SBT" "scala3-compiler/testOnly dotty.tools.vulpix.VulpixMetaTests" > "$tmp" 2>&1; then
+# if "$SBT" "scala3-compiler/testOnly dotty.tools.vulpix.VulpixMetaTests"  2>&1 | tee "$tmp"; then
 #   cat "$tmp"
 #   echo "failed: sbt exited without error on VulpixMetaTests, these tests are expected to fail"
 #   exit -1
 # fi
 # tmp1=$(mktemp)
-# cat "$tmp" | sed '/Test run started/,$!d' > "$tmp1"
+# cat "$tmp" | sed '/Test run started/,$!d' | tee "$tmp1"
 # set +x # Or the code below produces too much noise
 # while read expected <&4 && read actual <&3; do
 #   if [[ "$expected" != *"SKIP" ]]; then

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-source $(dirname $0)/cmdTestsCommon.inc.sh
+set -e
 
-# TEMP -- CI DEBUGGING
-set -euxo pipefail
+source $(dirname $0)/cmdTestsCommon.inc.sh
 
 # check that `sbt scalac` compiles and `sbt scala` runs it
 echo "testing sbt scalac and scala"

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -2,6 +2,9 @@
 
 source $(dirname $0)/cmdTestsCommon.inc.sh
 
+# TEMP -- CI DEBUGGING
+set -euxo pipefail
+
 # check that `sbt scalac` compiles and `sbt scala` runs it
 echo "testing sbt scalac and scala"
 "$SBT" ";scalac $SOURCE -d $OUT ;scala -classpath $OUT $MAIN" > "$tmp"

--- a/project/scripts/sbt
+++ b/project/scripts/sbt
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+
+set -e
 
 # Usage:
 # ./sbt <cmd>

--- a/project/scripts/sbt
+++ b/project/scripts/sbt
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euxo pipefail
 
 # Usage:
 # ./sbt <cmd>

--- a/tests/pos/HelloWorld.scala
+++ b/tests/pos/HelloWorld.scala
@@ -1,3 +1,5 @@
+// This test is used by end-to-end compiler tests. Do not delete it or change what it prints.
+
 object HelloWorld {
   def main(args: Array[String]): Unit = println("hello world")
 }


### PR DESCRIPTION
Accidentally (?) deleted in #24449

Covers `-print-tasty` which seems otherwise uncovered, see https://github.com/scala/scala3/pull/25678/changes#r3258439712

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

duh
