### PR TITLE
Disallow polymorphic function types over impure function types

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -83,6 +83,7 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
       assert(args.length == erasedParams.length)
 
       def hasErasedParams = erasedParams.contains(true)
+      override def toString = s"FunctionWithMods($args, $body, $mods, $erasedParams)"
     }
 
   /** A polymorphic function type */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -553,7 +553,10 @@ object Parsers {
             // into a capturing type in the typer.
             syntaxError(em"Implementation restriction: polymorphic function types cannot wrap function types that have capture sets", arrowOffset)
             errorTree
-          case Some(f) =>
+          case Some(f: FunctionWithMods) if f.mods.is(Impure) && ccEnabled =>
+            syntaxError(em"Implementation restriction: polymorphic function types cannot wrap impure function types if capture checking is enabled", arrowOffset)
+            errorTree
+          case _ =>
             PolyFunction(tparams, body)
 
 /* --------------- PLACEHOLDERS ------------------------------------------- */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -554,7 +554,10 @@ object Parsers {
             syntaxError(em"Implementation restriction: polymorphic function types cannot wrap function types that have capture sets", arrowOffset)
             errorTree
           case Some(f: FunctionWithMods) if f.mods.is(Impure) && ccEnabled =>
-            syntaxError(em"Implementation restriction: polymorphic function types cannot wrap impure function types if capture checking is enabled", arrowOffset)
+            syntaxError(
+              em"""Implementation restriction: polymorphic function types cannot wrap impure function types if capture checking is enabled.
+                  |Workaround: introduce an empty term-parameter list right after the type binder, e.g. `[A] => () -> B => C`.""",
+              arrowOffset)
             errorTree
           case _ =>
             PolyFunction(tparams, body)

--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -185,7 +185,7 @@ object NamedTupleDecomposition:
      *  the polymorphic mapping function `f`. The names of elements are preserved.
      *  If `x = (n1 = v1, ..., ni = vi)` then `x.map(f) = `(n1 = f(v1), ..., ni = f(vi))`.
      */
-    inline def map[F[_]](f: [t] => t => F[t]): Map[NamedTuple[N, V], F] =
+    inline def map[F[_]](f: [t] -> t -> F[t]): Map[NamedTuple[N, V], F] =
       x.toTuple.map[F](f)
 
     /** The named tuple consisting of all elements of this tuple in reverse. */

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -106,7 +106,7 @@ sealed trait Tuple extends Product {
    *
    *  @tparam F the type constructor applied to each element type
    */
-  inline def map[F[_]](f: [t] => t => F[t]): Map[this.type, F] =
+  inline def map[F[_]](f: [t] -> t -> F[t]): Map[this.type, F] =
     runtime.Tuples.map(this, f).asInstanceOf[Map[this.type, F]]
 
   /** Given a tuple `(a1, ..., am)`, returns the tuple `(a1, ..., an)` consisting

--- a/library/src/scala/runtime/Tuples.scala
+++ b/library/src/scala/runtime/Tuples.scala
@@ -597,7 +597,7 @@ object Tuples {
     )
   }
 
-  def map[F[_]](self: Tuple, f: [t] => t => F[t]): Tuple = self match {
+  def map[F[_]](self: Tuple, f: [t] -> t -> F[t]): Tuple = self match {
     case EmptyTuple => self
     case _ => fromIArray(self.productIterator.map(f(_).asInstanceOf[Object]).toArray.asInstanceOf[IArray[Object]]) // TODO use toIArray
   }

--- a/scaladoc-testcases/src/tests/captureCheckingSignatures.scala
+++ b/scaladoc-testcases/src/tests/captureCheckingSignatures.scala
@@ -79,9 +79,10 @@ trait Arrows:
   def polyContextImpure3[A](f: A ?->{a,b,c} Int => Int): Int //expected: def polyContextImpure3[A](f: A ?->{a, b, c} Int => Int): Int
 
   val polyPureV: [A] => A -> Int //expected: val polyPureV: [A] => A => Int
-  val polyPureV2: [A] => Int => A ->{a,b,c} Int //expected: val polyPureV2: [A] => Int => A ->{a, b, c} Int
-  val polyImpureV: [A] -> A => Int //expected: val polyImpureV: [A] => A => Int
-  val polyImpureV2: [A] -> A => Int //expected: val polyImpureV2: [A] => A => Int
+  // Disallowed by implementation restriction: polymorphic function types cannot wrap impure function types.
+  // val polyPureV2: [A] => Int => A ->{a,b,c} Int //expected: val polyPureV2: [A] => Int => A ->{a, b, c} Int
+  // val polyImpureV: [A] -> A => Int //expected: val polyImpureV: [A] => A => Int
+  // val polyImpureV2: [A] -> A => Int //expected: val polyImpureV2: [A] => A => Int
 
 trait SelfTypeCaptures[+A]:
   self: SelfTypeCaptures[A]^ =>

--- a/tests/neg-custom-args/captures/i26035.check
+++ b/tests/neg-custom-args/captures/i26035.check
@@ -1,4 +1,5 @@
 -- Error: tests/neg-custom-args/captures/i26035.scala:8:22 -------------------------------------------------------------
 8 |case class Foo(f: [A] => () => Unit) // error
   |                      ^
-  |Implementation restriction: polymorphic function types cannot wrap impure function types if capture checking is enabled
+  |Implementation restriction: polymorphic function types cannot wrap impure function types if capture checking is enabled.
+  |Workaround: introduce an empty term-parameter list right after the type binder, e.g. `[A] => () -> B => C`.

--- a/tests/neg-custom-args/captures/i26035.check
+++ b/tests/neg-custom-args/captures/i26035.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg-custom-args/captures/i26035.scala:8:22 -------------------------------------------------------------
+8 |case class Foo(f: [A] => () => Unit) // error
+  |                      ^
+  |Implementation restriction: polymorphic function types cannot wrap impure function types if capture checking is enabled

--- a/tests/neg-custom-args/captures/i26035.scala
+++ b/tests/neg-custom-args/captures/i26035.scala
@@ -1,0 +1,13 @@
+import language.experimental.captureChecking
+import scala.caps.SharedCapability
+class File() {
+  def write(s: String): Unit = ???
+}
+def usingFile[A](f: File^ => A): A = ???
+
+case class Foo(f: [A] => () => Unit) // error
+def leak = {
+  usingFile(f =>
+    Foo([A] => () => f.write(""))
+  ).f[Nothing]()
+}

--- a/tests/pos-custom-args/captures/i16871.scala
+++ b/tests/pos-custom-args/captures/i16871.scala
@@ -1,3 +1,3 @@
 import scala.language.experimental.captureChecking
 
-val f: [X] => Int => Int = [X] => (x: Int) => x
+val f: [X] => Int -> Int = [X] => (x: Int) => x

--- a/tests/pos-custom-args/captures/i24309-region.scala
+++ b/tests/pos-custom-args/captures/i24309-region.scala
@@ -17,11 +17,21 @@ object Regions:
         val r = new Region[R] {}
         f(r)
 
+      // Workaround variant: an empty term-parameter after the type binder
+      // permits an impure inner function type.
+      def subregion2[T](f: [R2^ >: R] => () -> (Region[R2]) => T): T =
+        val r = new Region[R] {}
+        f()(r)
+
 
   object Region:
     def apply[T](f: [R^] => Region[R] -> T): T =
       val r = new Region[{}] {}
       f(r)
+
+    def apply2[T](f: [R^] => () -> Region[R] => T): T =
+      val r = new Region[{}] {}
+      f()(r)
 
   @main def main() =
     import Region.*
@@ -32,4 +42,10 @@ object Regions:
         val a = r1.alloc(0)
         val b = r2.alloc(0)
         a
+      val y = r1.subregion2: [R2^ >: R] =>
+       () =>
+        r2 =>
+         val a = r1.alloc(0)
+         val b = r2.alloc(0)
+         a
       0

--- a/tests/pos-custom-args/captures/i24309-region.scala
+++ b/tests/pos-custom-args/captures/i24309-region.scala
@@ -13,13 +13,13 @@ object Regions:
     region: Region[R]^ =>
       def alloc(value: Int): Ref^{R} = Ref(value)
 
-      def subregion[T](f: [R2^ >: R] => (Region[R2]) => T): T =
+      def subregion[T](f: [R2^ >: R] => (Region[R2]) -> T): T =
         val r = new Region[R] {}
         f(r)
 
 
   object Region:
-    def apply[T](f: [R^] => Region[R] => T): T =
+    def apply[T](f: [R^] => Region[R] -> T): T =
       val r = new Region[{}] {}
       f(r)
 


### PR DESCRIPTION
Disallowed and rejected with an implementation restriction error:

    [A] => B => C

OK:

    [A] => B -> C

Also OK (and equivalent to last one):

    [A] -> B -> C

This is necessary since our current polymorphic function encoding requires that the type that's quantified over is a pure function type. We should fix that but until that's done we need to enforce the restriction.

Fixes #26035
