### PR TITLE
Tighten check of field classifiers

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1273,7 +1273,7 @@ class CheckCaptures extends Recheck, SymTransformer:
      *   - Interpolate contravariant capture set variables in result type.
      *   - for lazy vals: create a nested environment to track captures (similar to methods)
      */
-    override def recheckValDef(tree: ValDef, sym: Symbol)(using Context): Type =
+    override def recheckValDef(tree: ValDef, sym: Symbol)(using Context): Type = {
       val savedEnv = curEnv
       val runInConstructor = !sym.isOneOf(Param | ParamAccessor | Lazy | NonMember)
       try
@@ -1329,7 +1329,12 @@ class CheckCaptures extends Recheck, SymTransformer:
           // This is different from captureSetImpliedByFields since the latter produces
           // LocalCaps from inside the class.
           markFree(declaredCaptures, tree, addUseInfo = false)
-    end recheckValDef
+
+        if sym.owner.derivesFrom(defn.Caps_Classifier) then
+          todoAtPostCheck += { () =>
+            checkFieldOfClassifiedClass(sym, declaredCaptures, sym.owner.asClass, tree.namePos)
+          }
+    }
 
     /** Recheck method definitions:
      *   - check body in a nested environment that tracks uses, in  a nested level,
@@ -1471,6 +1476,30 @@ class CheckCaptures extends Recheck, SymTransformer:
         case _ =>
       tp
     }
+
+    /** Check that field `fld` with type `cs` only captures capabilities that conform to
+     *  the classifier of `cls`.
+     */
+    def checkFieldOfClassifiedClass(fld: Symbol, cs: CaptureSet, cls: ClassSymbol, pos: SrcPos)(using Context): Unit =
+      for ref <- cs.elems do
+        //println(i"checking $fld: $ref, ${ref.transClassifiers}, ${cs.transClassifiers} / ${cs.isConst}")
+        def fail(classified: String) =
+          val captures =
+            if ref.isTerminalCapability then ""
+            else i" captures ${ref.showAsCapability} which"
+          report.error(
+            em"""$fld's type ${fld.info}$captures is $classified,
+                |but it is a field of $cls which is classied as ${cls.classifier.typeRef}.
+                |Field classifiers have to conform to the classifier of the containing class.""",
+            pos)
+        ref.transClassifiers match
+          case Classifiers.Unclassified =>
+            fail("unclassified")
+          case Classifiers.ClassifiedAs(cs) =>
+            for c <- cs do
+              if !c.derivesFrom(cls.classifier) then
+                fail(i"classified as ${c.typeRef}")
+          case _ =>
 
     /** Check that capture sets of fields are compatible with declared extensions of
      *  the class. This means:

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1481,47 +1481,32 @@ class CheckCaptures extends Recheck, SymTransformer:
      *  the classifier of `cls`.
      */
     def checkFieldOfClassifiedClass(fld: Symbol, cs: CaptureSet, cls: ClassSymbol, pos: SrcPos)(using Context): Unit =
-      for ref <- cs.elems do
-        //println(i"checking $fld: $ref, ${ref.transClassifiers}, ${cs.transClassifiers} / ${cs.isConst}")
-        def fail(classified: String) =
-          val captures =
-            if ref.isTerminalCapability then ""
-            else i" captures ${ref.showAsCapability} which"
-          report.error(
-            em"""$fld's type ${fld.info}$captures is $classified,
-                |but it is a field of $cls which is classied as ${cls.classifier.typeRef}.
-                |Field classifiers have to conform to the classifier of the containing class.""",
-            pos)
-        ref.transClassifiers match
-          case Classifiers.Unclassified =>
-            fail("unclassified")
-          case Classifiers.ClassifiedAs(cs) =>
-            for c <- cs do
-              if !c.derivesFrom(cls.classifier) then
-                fail(i"classified as ${c.typeRef}")
-          case _ =>
-
-    /** Check that capture sets of fields are compatible with declared extensions of
-     *  the class. This means:
-     *   1. If `cls` extends a Classifier class, check that all any-classifiers in fields
-     *      conform to the classifier of the class.
-     *   2. If `cls` is externally visible and has fields with `any` types, it must
-     *      extend Capability.
-     */
-    def checkFieldCaptures(cls: ClassSymbol)(using Context): Unit = {
-      lazy val capFields = cls.capturesImpliedByFields(cls.appliedRef).fields
-      // (1)
-      if cls.derivesFrom(defn.Caps_Classifier) then
-        for fld <- capFields; cl <- fld.classifiersOfLocalCapsInType do
-          if !fld.name.is(WildcardParamName) && !cl.derivesFrom(cls.classifier) then
-            def fldClassifier =
-              if cl == defn.AnyClass then i"of unclassified type ${fld.info}"
-              else i"classified as ${cl.typeRef}"
+      if !fld.name.is(WildcardParamName) then
+        for ref <- cs.elems do
+          //println(i"checking $fld: $ref, ${ref.transClassifiers}, ${cs.transClassifiers} / ${cs.isConst}")
+          def fail(classified: String) =
+            val captures =
+              if ref.isTerminalCapability then ""
+              else i" captures ${ref.showAsCapability} which"
             report.error(
-              em"""$cls is classied as ${cls.classifier.typeRef} but has a field ${fld.name} $fldClassifier.
+              em"""$fld's type ${fld.info}$captures is $classified,
+                  |but it is a field of $cls which is classied as ${cls.classifier.typeRef}.
                   |Field classifiers have to conform to the classifier of the containing class.""",
-              cls.srcPos)
-      // (2)
+              pos)
+          ref.transClassifiers match
+            case Classifiers.Unclassified =>
+              fail("unclassified")
+            case Classifiers.ClassifiedAs(cs) =>
+              for c <- cs do
+                if !c.derivesFrom(cls.classifier) then
+                  fail(i"classified as ${c.typeRef}")
+            case _ =>
+
+    /** Check: If `cls` is externally visible and has fields with `any` types, it must
+     *  extend Capability.
+     */
+    def checkFieldCaptures(cls: ClassSymbol)(using Context): Unit =
+      val capFields = cls.capturesImpliedByFields(cls.appliedRef).fields
       if !cls.isExemptFromExplicitChecks
           && !cls.derivesFromCapability
           && capFields.nonEmpty
@@ -1534,7 +1519,6 @@ class CheckCaptures extends Recheck, SymTransformer:
           report.error(em"$fields need to be put in an object that extends Capability", capFields.head.srcPos)
         else
           report.error(em"$cls needs to extend Capability since it has $fields.", cls.srcPos)
-    }
 
     /** The normal rechecking if `sym` was already completed before */
     override def skipRecheck(sym: Symbol)(using Context): Boolean =

--- a/tests/neg-custom-args/captures/check-inferred.check
+++ b/tests/neg-custom-args/captures/check-inferred.check
@@ -49,6 +49,14 @@
    |           subsumed by the computed capability of the enclosing class.
    |
    |           where:    ^ refers to a root capability in the type of value count
+-- Error: tests/neg-custom-args/captures/check-inferred.scala:40:6 -----------------------------------------------------
+40 |  val x: A^ = ??? // error
+   |      ^
+   |      value x's type test.A^ is unclassified,
+   |      but it is a field of class B which is classied as scala.caps.Control.
+   |      Field classifiers have to conform to the classifier of the containing class.
+   |
+   |      where:    ^ refers to a root capability in the type of value x
 -- Error: tests/neg-custom-args/captures/check-inferred.scala:45:15 ----------------------------------------------------
 45 |  private val y = ??? : A^ // error
    |               ^

--- a/tests/neg-custom-args/captures/check-inferred.check
+++ b/tests/neg-custom-args/captures/check-inferred.check
@@ -2,11 +2,6 @@
 35 |class A: // error
    |      ^
    |      class A needs to extend Capability since it has a field `x` with `any` in its type.
--- Error: tests/neg-custom-args/captures/check-inferred.scala:39:6 -----------------------------------------------------
-39 |class B extends caps.Control: // error
-   |      ^
-   |      class B is classied as scala.caps.Control but has a field x of unclassified type test.A^.
-   |      Field classifiers have to conform to the classifier of the containing class.
 -- Error: tests/neg-custom-args/captures/check-inferred.scala:43:6 -----------------------------------------------------
 43 |class C: // error
    |      ^

--- a/tests/neg-custom-args/captures/check-inferred.scala
+++ b/tests/neg-custom-args/captures/check-inferred.scala
@@ -36,7 +36,7 @@ class A: // error
   val x: A^{any.only[caps.Control]} = ???
   private val y = ??? : A^{any.only[caps.Control]}  // ok
 
-class B extends caps.Control: // error
+class B extends caps.Control:
   val x: A^ = ??? // error
   private val y = ??? : A^{any.only[caps.Control]}  // ok
 

--- a/tests/neg-custom-args/captures/check-inferred.scala
+++ b/tests/neg-custom-args/captures/check-inferred.scala
@@ -37,7 +37,7 @@ class A: // error
   private val y = ??? : A^{any.only[caps.Control]}  // ok
 
 class B extends caps.Control: // error
-  val x: A^ = ???
+  val x: A^ = ??? // error
   private val y = ??? : A^{any.only[caps.Control]}  // ok
 
 class C: // error

--- a/tests/neg-custom-args/captures/i25464.check
+++ b/tests/neg-custom-args/captures/i25464.check
@@ -1,0 +1,28 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25464.scala:15:6 ----------------------------------------
+15 |  f(c.cf1) // error
+   |    ^^^^^
+   |    Found:    (c.cf1 : CF1)
+   |    Required: Object^{any.only[CF2]}
+   |
+   |    Note that capability `c.cf1` cannot flow into capture set {any.only[CF2]}.
+   |
+   |    where:    any is a root capability created in method test when checking argument to parameter x of method f
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/i25464.scala:17:12 ---------------------------------------
+17 |  f(c.cf2.a.cf1) // error
+   |    ^^^^^^^^^^^
+   |    Found:    (c.cf2.a.cf1 : CF1)
+   |    Required: Object^{any.only[CF2]}
+   |
+   |    Note that capability `c.cf2.a.cf1` cannot flow into capture set {any.only[CF2]}.
+   |
+   |    where:    any is a root capability created in method test when checking argument to parameter x of method f
+   |
+   | longer explanation available when compiling with `-explain`
+-- Error: tests/neg-custom-args/captures/i25464.scala:8:17 -------------------------------------------------------------
+8 |  class Impl(val a: C^{C.this}) extends CF2 // error
+  |                 ^
+  |                 value a's type C^{C.this} captures C.this which is unclassified,
+  |                 but it is a field of class Impl which is classied as CF2.
+  |                 Field classifiers have to conform to the classifier of the containing class.

--- a/tests/neg-custom-args/captures/i25464.scala
+++ b/tests/neg-custom-args/captures/i25464.scala
@@ -1,0 +1,48 @@
+import language.experimental.captureChecking
+import caps.*
+
+trait CF1 extends Classifier, SharedCapability
+trait CF2 extends CF1, Classifier
+
+class C:
+  class Impl(val a: C^{C.this}) extends CF2 // error
+  val cf1: CF1 = ???
+  val cf2 = new Impl(this)
+
+def f(x: AnyRef^{any.only[CF2]}): Unit = ()
+
+def test(c: C): Unit =
+  f(c.cf1) // error
+  f(c.cf2) // ok
+  f(c.cf2.a.cf1) // error
+  val d: AnyRef^{c.cf2} = c.cf2.a.cf1
+  f(d) // wrong, passing CF1 to CF2 only
+
+/*
+  use http4s as DataBase, bar as Output, baz as HTTP
+
+  foo.{A as B}
+
+  [x: Ord as m]
+
+  object Foo^{foo, http4s as HTTPClient, some DataBase}
+
+  (using foo: Context)
+  def goo(use Cpntext)
+
+  uses DataBase
+  uses {foo}
+
+initialization:
+  - start with main object
+  - inside an object: initilize sequentially
+  - along uses from main, with cycle detection
+  - uses_init edges may not be part of cycles
+  - keep bindings from capability class types to objects
+  - uses x as X establishes and overwrites a binding
+
+
+
+
+*/
+

--- a/tests/neg-custom-args/captures/i25464.scala
+++ b/tests/neg-custom-args/captures/i25464.scala
@@ -18,31 +18,3 @@ def test(c: C): Unit =
   val d: AnyRef^{c.cf2} = c.cf2.a.cf1
   f(d) // wrong, passing CF1 to CF2 only
 
-/*
-  use http4s as DataBase, bar as Output, baz as HTTP
-
-  foo.{A as B}
-
-  [x: Ord as m]
-
-  object Foo^{foo, http4s as HTTPClient, some DataBase}
-
-  (using foo: Context)
-  def goo(use Cpntext)
-
-  uses DataBase
-  uses {foo}
-
-initialization:
-  - start with main object
-  - inside an object: initilize sequentially
-  - along uses from main, with cycle detection
-  - uses_init edges may not be part of cycles
-  - keep bindings from capability class types to objects
-  - uses x as X establishes and overwrites a binding
-
-
-
-
-*/
-

--- a/tests/neg-custom-args/captures/implied-capability.check
+++ b/tests/neg-custom-args/captures/implied-capability.check
@@ -3,11 +3,6 @@
   |      ^
   |      Mutable variable x is defined in a class that does not extend `Stateful` or `Mutable`.
   |      The variable needs to be annotated with `untrackedCaptures` to allow this.
--- Error: tests/neg-custom-args/captures/implied-capability.scala:8:6 --------------------------------------------------
-8 |class C2 extends SharedCapability: // error
-  |      ^
-  |      class C2 is classied as scala.caps.SharedCapability but has a field r classified as scala.caps.Unscoped.
-  |      Field classifiers have to conform to the classifier of the containing class.
 -- Error: tests/neg-custom-args/captures/implied-capability.scala:9:6 --------------------------------------------------
 9 |  val r: Ref = Ref() // error
   |      ^

--- a/tests/neg-custom-args/captures/implied-capability.check
+++ b/tests/neg-custom-args/captures/implied-capability.check
@@ -8,3 +8,11 @@
   |      ^
   |      class C2 is classied as scala.caps.SharedCapability but has a field r classified as scala.caps.Unscoped.
   |      Field classifiers have to conform to the classifier of the containing class.
+-- Error: tests/neg-custom-args/captures/implied-capability.scala:9:6 --------------------------------------------------
+9 |  val r: Ref = Ref() // error
+  |      ^
+  |      value r's type Ref^{any.rd} is classified as scala.caps.Unscoped,
+  |      but it is a field of class C2 which is classied as scala.caps.SharedCapability.
+  |      Field classifiers have to conform to the classifier of the containing class.
+  |
+  |      where:    any is a root capability classified as Unscoped in the type of value r

--- a/tests/neg-custom-args/captures/implied-capability.scala
+++ b/tests/neg-custom-args/captures/implied-capability.scala
@@ -5,5 +5,5 @@ class C1 extends SharedCapability:
 
 class Ref extends Mutable
 
-class C2 extends SharedCapability: // error
+class C2 extends SharedCapability:
   val r: Ref = Ref() // error

--- a/tests/neg-custom-args/captures/implied-capability.scala
+++ b/tests/neg-custom-args/captures/implied-capability.scala
@@ -6,4 +6,4 @@ class C1 extends SharedCapability:
 class Ref extends Mutable
 
 class C2 extends SharedCapability: // error
-  val r: Ref = Ref()
+  val r: Ref = Ref() // error

--- a/tests/neg-custom-args/captures/unscoped-classifier-global.scala
+++ b/tests/neg-custom-args/captures/unscoped-classifier-global.scala
@@ -4,12 +4,12 @@ trait Async extends Control
 
 class A(a: Async) extends caps.Unscoped // error but msg could be better
 
-class B extends caps.Unscoped: // error
+class B extends caps.Unscoped:
   val a: Async^ = new Async {}  // error
 
 class C(f: () => Unit) extends caps.Unscoped // error but msg could be better
 
-class D extends caps.Unscoped: // error
+class D extends caps.Unscoped:
   val f: () => Unit = ???   // error
 
 val g: () => Unit = () => ()

--- a/tests/neg-custom-args/captures/unscoped-classifier-global.scala
+++ b/tests/neg-custom-args/captures/unscoped-classifier-global.scala
@@ -5,12 +5,12 @@ trait Async extends Control
 class A(a: Async) extends caps.Unscoped // error but msg could be better
 
 class B extends caps.Unscoped: // error
-  val a: Async^ = new Async {}  
+  val a: Async^ = new Async {}  // error
 
 class C(f: () => Unit) extends caps.Unscoped // error but msg could be better
 
 class D extends caps.Unscoped: // error
-  val f: () => Unit = ???   
+  val f: () => Unit = ???   // error
 
 val g: () => Unit = () => ()
 

--- a/tests/neg-custom-args/captures/unscoped-classifier.check
+++ b/tests/neg-custom-args/captures/unscoped-classifier.check
@@ -27,3 +27,19 @@
    |
    |      where:    any  is a root capability classified as Unscoped in the type of class E
    |                any² is a root capability classified as Unscoped created in class E when constructing instance E
+-- Error: tests/neg-custom-args/captures/unscoped-classifier.scala:8:6 -------------------------------------------------
+8 |  val a: Async^ = new Async {}  // error
+  |      ^
+  |      value a's type Async^ is classified as scala.caps.Control,
+  |      but it is a field of class B which is classied as scala.caps.Unscoped.
+  |      Field classifiers have to conform to the classifier of the containing class.
+  |
+  |      where:    ^ refers to a root capability classified as Control in the type of value a
+-- Error: tests/neg-custom-args/captures/unscoped-classifier.scala:13:6 ------------------------------------------------
+13 |  val f: () => Unit = ???   // error
+   |      ^
+   |      value f's type () => Unit is unclassified,
+   |      but it is a field of class D which is classied as scala.caps.Unscoped.
+   |      Field classifiers have to conform to the classifier of the containing class.
+   |
+   |      where:    => refers to a root capability in the type of value f

--- a/tests/neg-custom-args/captures/unscoped-classifier.check
+++ b/tests/neg-custom-args/captures/unscoped-classifier.check
@@ -4,22 +4,12 @@
   |        Reference `A.this.a` is not included in the allowed capture set {any} of the self type of class A.
   |
   |        where:    any is a root capability classified as Unscoped in the type of class A
--- Error: tests/neg-custom-args/captures/unscoped-classifier.scala:7:6 -------------------------------------------------
-7 |class B extends caps.Unscoped: // error
-  |      ^
-  |      class B is classied as scala.caps.Unscoped but has a field a classified as scala.caps.Control.
-  |      Field classifiers have to conform to the classifier of the containing class.
 -- [E223] CaptureChecking Error: tests/neg-custom-args/captures/unscoped-classifier.scala:10:8 -------------------------
 10 |class C(f: () => Unit) extends caps.Unscoped // error but msg could be better
    |        ^
    |        Reference `C.this.f` is not included in the allowed capture set {any} of the self type of class C.
    |
    |        where:    any is a root capability classified as Unscoped in the type of class C
--- Error: tests/neg-custom-args/captures/unscoped-classifier.scala:12:6 ------------------------------------------------
-12 |class D extends caps.Unscoped: // error
-   |      ^
-   |      class D is classied as scala.caps.Unscoped but has a field f of unclassified type () => Unit.
-   |      Field classifiers have to conform to the classifier of the containing class.
 -- [E223] CaptureChecking Error: tests/neg-custom-args/captures/unscoped-classifier.scala:17:15 ------------------------
 17 |    def gg() = g()     // error but msg could be better
    |               ^

--- a/tests/neg-custom-args/captures/unscoped-classifier.scala
+++ b/tests/neg-custom-args/captures/unscoped-classifier.scala
@@ -5,12 +5,12 @@ trait Async extends Control
 class A(a: Async) extends caps.Unscoped // error but msg could be better
 
 class B extends caps.Unscoped: // error
-  val a: Async^ = new Async {}  
+  val a: Async^ = new Async {}  // error
 
 class C(f: () => Unit) extends caps.Unscoped // error but msg could be better
 
 class D extends caps.Unscoped: // error
-  val f: () => Unit = ???   
+  val f: () => Unit = ???   // error
 
 def test(g: () => Unit) =
   class E extends caps.Unscoped:

--- a/tests/neg-custom-args/captures/unscoped-classifier.scala
+++ b/tests/neg-custom-args/captures/unscoped-classifier.scala
@@ -4,12 +4,12 @@ trait Async extends Control
 
 class A(a: Async) extends caps.Unscoped // error but msg could be better
 
-class B extends caps.Unscoped: // error
+class B extends caps.Unscoped:
   val a: Async^ = new Async {}  // error
 
 class C(f: () => Unit) extends caps.Unscoped // error but msg could be better
 
-class D extends caps.Unscoped: // error
+class D extends caps.Unscoped:
   val f: () => Unit = ???   // error
 
 def test(g: () => Unit) =


### PR DESCRIPTION
We now check that the transitive capture set of all fields of a classified class are classified in accordance with the class classifier.

Fixes #25464
