### PR TITLE
Scoverage: Fix coverage parameterless select qualifier casts

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -376,7 +376,12 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
 
     private def tryInstrument(tree: Select)(using Context): InstrumentedParts =
       val sym = tree.symbol
-      val qual = transform(tree.qualifier).ensureConforms(tree.qualifier.tpe)
+      val transformedQual = transform(tree.qualifier)
+      val qual =
+        if tree.qualifier.symbol.exists && canInstrumentParameterless(tree.qualifier.symbol) then
+          transformedQual
+        else
+          transformedQual.ensureConforms(tree.qualifier.tpe)
       val transformed = cpy.Select(tree)(qual, tree.name)
       if canInstrumentParameterless(sym) then
         // call to a parameterless method

--- a/tests/pos-custom-args/captures/coverage-listbuffer-tail-isempty.scala
+++ b/tests/pos-custom-args/captures/coverage-listbuffer-tail-isempty.scala
@@ -1,0 +1,13 @@
+import scala.language.experimental.captureChecking
+
+final class MiniListBuffer[A]:
+  @caps.unsafe.untrackedCaptures private var first: List[A] = Nil
+
+  def subtractOne(elem: A): this.type =
+    if first.isEmpty then ()
+    else
+      var cursor = first
+      while !cursor.tail.isEmpty && cursor.tail.head != elem do
+        cursor = cursor.tail
+      if !cursor.tail.isEmpty then ()
+    this


### PR DESCRIPTION
Fixes #26086

## Problem

Consider code:

```scala
if !cursor.tail.isEmpty then ()
```

Coverage instruments to:

```scala
if {
  Invoker.invoked(8, ...)
  {
    Invoker.invoked(7, ...)
    {
      Invoker.invoked(6, ...)
      cursor.tail
    }.isEmpty
  }.$asInstanceOf[
    ((List[A]^{(?1 : Any)})#isEmpty : -> Boolean)
  ].unary_!
} then ()
```

`.$asInstanceOf[((List[A]^{(?1 : Any)})#isEmpty : -> Boolean)]` is redundant and wrong, breaks capture checking.

## Solution

When instrumenting a `Select`, avoid forcing an already-instrumented parameterless-method qualifier back to its original qualifier type.

After the fix, instruments to:

```scala
if {
  Invoker.invoked(8, ...)
  {
    Invoker.invoked(7, ...)
    {
      Invoker.invoked(6, ...)
      cursor.tail
    }.isEmpty
  }.unary_!
} then ()
```

The cast is absent.

## How much have you relied on LLM-based tools in this contribution?

Moderately, for minimization, codebase analysis, and tracing.

## How was the solution tested?

New automated test. Added `tests/pos-custom-args/captures/coverage-listbuffer-tail-isempty.scala`.

```bash
sbt "scala3-bootstrapped/testCompilation --enable-coverage-phase coverage-listbuffer-tail-isempty"
sbt "scala3-bootstrapped/testCompilation coverage-listbuffer-tail-isempty"
```
