### PR TITLE
Don't assume classes with self aliases to be pure.

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -511,6 +511,12 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
   def bodyKind(body: List[Tree])(using Context): FlagSet =
     body.foldLeft(NoInitsInterface)((fs, stat) => fs & defKind(stat))
 
+  /** Is `tree` a DerivedTypeTree, possibly followed by type arguments? */
+  def hasDerivedTree(tree: Tree)(using Context): Boolean = tree match
+    case tree: DerivedTypeTree => true
+    case AppliedTypeTree(tpt, _) => hasDerivedTree(tpt)
+    case _ => false
+
   /** Info of a variable in a pattern: The named tree and its type */
   type VarInfo = (NameTree, Tree)
 

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -781,9 +781,15 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
         checkClassifiedInheritance(cls)
         val cinfo @ ClassInfo(prefix, _, ps, decls, selfInfo) = cls.classInfo
 
+        // Is self info inferred, i.e. only the name is given but not the type?
+        def selfInfoIsInferred =
+          impl.body.exists:
+            case TypeDef(tpnme.SELF, tpt: TypeTree) => tpt.isInferred
+            case _ => false
+
         // Compute new self type
         val selfInfo1 =
-          if (selfInfo ne NoType) && !cls.is(ModuleClass) then
+          if (selfInfo ne NoType) && !cls.is(ModuleClass) && !selfInfoIsInferred then
             // if selfInfo is explicitly given then use that one, except if
             // self info applies to a module class, these still need to be inferred
             selfInfo

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3471,7 +3471,16 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if defn.ScalaValueClasses()(cls) && Feature.shouldBehaveAsScala2 then
       constr1.symbol.resetFlag(Private)
 
-    val self1 = typed(self)(using ctx.outer).asInstanceOf[ValDef] // outer context where class members are not visible
+    // If original type of self ValDef was a DerivedTypeTree, its type was
+    //  not given explicitly, and the ValDef exists only in order to introduce
+    //  a name alias for `this`. In this case represent the `tpt` of the ValDef
+    //  as an InferredTypeTree.
+    def tweakSelf(self1: ValDef, orig: untpd.ValDef): ValDef =
+      if untpd.hasDerivedTree(orig.tpt)
+      then tpd.cpy.ValDef(self1)(tpt = tpd.cpy.TypeTree(self1.tpt)(inferred = true))
+      else self1
+
+    val self1 = tweakSelf(typed(self)(using ctx.outer).asInstanceOf[ValDef], self) // outer context where class members are not visible
     if (self1.tpt.tpe.isError || classExistsOnSelf(cls.unforcedDecls, self1))
       // fail fast to avoid typing the body with an error type
       cdef.withType(UnspecifiedErrorType)

--- a/library/src/scala/collection/BuildFrom.scala
+++ b/library/src/scala/collection/BuildFrom.scala
@@ -19,6 +19,7 @@ import scala.annotation.implicitNotFound
 import scala.collection.mutable.Builder
 import scala.collection.immutable.WrappedString
 import scala.reflect.ClassTag
+import caps.unsafe.unsafeAssumePure
 
 /** Builds a collection of type `C` from elements of type `A` when a source collection of type `From` is available.
  *  Implicit instances of `BuildFrom` are available for all collection types.
@@ -28,11 +29,11 @@ import scala.reflect.ClassTag
  *  @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
  */
 @implicitNotFound(msg = "Cannot construct a collection of type ${C} with elements of type ${A} based on a collection of type ${From}.")
-trait BuildFrom[-From, -A, +C] extends Any { self =>
+trait BuildFrom[-From, -A, +C] extends Any { self: BuildFrom[From, A, C] =>
   def fromSpecific(from: From)(it: IterableOnce[A]^): C^{it}
 
   /** Gets a Builder for the collection. For non-strict collection types this will use an intermediate buffer.
-   *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections. 
+   *  Building collections with `fromSpecific` is preferred because it can be lazy for lazy collections.
    *
    *  @param from the source collection providing the factory for creating the builder
    */
@@ -92,7 +93,9 @@ object BuildFrom extends BuildFromLowPriority1 {
 
   implicit def buildFromArray[A : ClassTag]: BuildFrom[Array[?], A, Array[A]] =
     new BuildFrom[Array[?], A, Array[A]] {
-      def fromSpecific(from: Array[?])(it: IterableOnce[A]^): Array[A] = Factory.arrayFactory[A].fromSpecific(it)
+      def fromSpecific(from: Array[?])(it: IterableOnce[A]^): Array[A] =
+        Factory.arrayFactory[A].fromSpecific(it).unsafeAssumePure
+          // .unsafeAssumePure needed since Array is technically pure, but foes not extend from Pure.
       def newBuilder(from: Array[?]): Builder[A, Array[A]] = Factory.arrayFactory[A].newBuilder
     }
 

--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
  *  @tparam A Type of elements (e.g. `Int`, `Boolean`, etc.)
  *  @tparam C Type of collection (e.g. `List[Int]`, `TreeMap[Int, String]`, etc.)
  */
-trait Factory[-A, +C] extends Any { self =>
+trait Factory[-A, +C] extends Any { self: Factory[A, C] =>
 
   /**
    *  @param it the source of elements to include in the collection
@@ -409,7 +409,7 @@ trait SpecificIterableFactory[-A, +C] extends Factory[A, C] {
  *
  *  @tparam CC Collection type constructor for the map (e.g. `Map`, `HashMap`)
  */
-trait MapFactory[+CC[_, _]] extends Serializable { self =>
+trait MapFactory[+CC[_, _]] extends Serializable { self: MapFactory[CC] =>
 
   /** An empty Map.
    *

--- a/library/src/scala/collection/concurrent/TrieMap.scala
+++ b/library/src/scala/collection/concurrent/TrieMap.scala
@@ -1103,7 +1103,8 @@ object TrieMap extends MapFactory[TrieMap] {
 }
 
 // non-final as an extension point for parallel collections
-private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: TrieMap[K, V], mustInit: Boolean = true) extends AbstractIterator[(K, V)] { self =>
+private[collection] class TrieMapIterator[K, V](var level: Int, private var ct: TrieMap[K, V], mustInit: Boolean = true) extends AbstractIterator[(K, V)] {
+  self: TrieMapIterator[K, V] =>
   private val stack = new Array[Array[BasicNode]](7)
   private val stackpos = new Array[Int](7)
   private var depth = -1

--- a/library/src/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/library/src/scala/collection/convert/JavaCollectionWrappers.scala
@@ -252,7 +252,8 @@ private[collection] object JavaCollectionWrappers extends Serializable {
   }
 
   @SerialVersionUID(3L)
-  class MapWrapper[K, V](underlying: Map[K, V]) extends ju.AbstractMap[K, V] with Serializable { self =>
+  class MapWrapper[K, V](underlying: Map[K, V]) extends ju.AbstractMap[K, V] with Serializable {
+    self: MapWrapper[K, V] =>
     override def size = underlying.size
 
     override def get(key: AnyRef): V = try {

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -730,7 +730,7 @@ private class RangeIterator(
   step: Int,
   lastElement: Int,
   initiallyEmpty: Boolean
-) extends AbstractIterator[Int] with Serializable { self =>
+) extends AbstractIterator[Int] with Serializable { self: RangeIterator =>
   private var _hasNext: Boolean = !initiallyEmpty
   private var _next: Int = start
   override def knownSize: Int = if (_hasNext) (lastElement - _next) / step + 1 else 0

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -65,9 +65,9 @@ object Sorting {
    *  @tparam K the element type of the array, which must have an `Ordering`
    *  @param a the array to sort in place
    */
-  def quickSort[K: Ordering](a: Array[K]^): Unit = {
+  def quickSort[K: Ordering](a: Array[K]): Unit = {
     // Must have iN >= i0 or math will fail.  Also, i0 >= 0.
-    def inner(a: Array[K]^, i0: Int, iN: Int, ord: Ordering[K]): Unit = {
+    def inner(a: Array[K], i0: Int, iN: Int, ord: Ordering[K]): Unit = {
       if (iN - i0 < qsortThreshold) insertionSort(a, i0, iN, ord)
       else {
         val iK = (i0 + iN) >>> 1    // Unsigned div by 2
@@ -158,7 +158,7 @@ object Sorting {
 
   // Ordering[T] might be slow especially for boxed primitives, so use binary search variant of insertion sort
   // Caller must pass iN >= i0 or math will fail.  Also, i0 >= 0.
-  private def insertionSort[@specialized T](a: Array[T]^, i0: Int, iN: Int, ord: Ordering[T]): Unit = {
+  private def insertionSort[@specialized T](a: Array[T], i0: Int, iN: Int, ord: Ordering[T]): Unit = {
     val n = iN - i0
     if (n < 2) return
     if (ord.compare(a(i0), a(i0+1)) > 0) {
@@ -191,7 +191,7 @@ object Sorting {
   }
 
   // Caller is required to pass iN >= i0, else math will fail.  Also, i0 >= 0.
-  private def mergeSort[@specialized T: ClassTag](a: Array[T]^, i0: Int, iN: Int, ord: Ordering[T], scratch: (Array[T]^) | Null = null): Unit = {
+  private def mergeSort[@specialized T: ClassTag](a: Array[T], i0: Int, iN: Int, ord: Ordering[T], scratch: Array[T] | Null = null): Unit = {
     if (iN - i0 < mergeThreshold) insertionSort(a, i0, iN, ord)
     else {
       val iK = (i0 + iN) >>> 1   // Bit shift equivalent to unsigned math, no overflow
@@ -203,7 +203,7 @@ object Sorting {
   }
 
   // Must have 0 <= i0 < iK < iN
-  private def mergeSorted[@specialized T](a: Array[T]^, i0: Int, iK: Int, iN: Int, ord: Ordering[T], scratch: Array[T]): Unit = {
+  private def mergeSorted[@specialized T](a: Array[T], i0: Int, iK: Int, iN: Int, ord: Ordering[T], scratch: Array[T]): Unit = {
     // Check to make sure we're not already in order
     if (ord.compare(a(iK-1), a(iK)) > 0) {
       var i = i0
@@ -247,7 +247,7 @@ object Sorting {
 
   // TODO: add upper bound: T <: AnyRef, propagate to callers below (not binary compatible)
   // Maybe also rename all these methods to `sort`.
-  @inline private def sort[T](a: Array[T]^, from: Int, until: Int, ord: Ordering[T]): Unit = (a: @unchecked) match {
+  @inline private def sort[T](a: Array[T], from: Int, until: Int, ord: Ordering[T]): Unit = (a: @unchecked) match {
     case a: Array[AnyRef]  =>
       // Note that runtime matches are covariant, so could actually be any Array[T] s.t. T is not primitive (even boxed value classes)
       if (a.length > 1 && (ord eq null)) throw new NullPointerException("Ordering")
@@ -270,7 +270,7 @@ object Sorting {
    *  @tparam K the element type of the array, which must have an `Ordering`
    *  @param a the array to sort in place
    */
-  @`inline` def stableSort[K: Ordering](a: Array[K]^): Unit = stableSort(a, 0, a.length)
+  @`inline` def stableSort[K: Ordering](a: Array[K]): Unit = stableSort(a, 0, a.length)
 
   /** Sorts array `a` or a part of it using the Ordering on its elements, preserving the original ordering where possible.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
@@ -280,7 +280,7 @@ object Sorting {
    *  @param from the first index in the array to sort
    *  @param until the last index (exclusive) in the array to sort
    */
-  def stableSort[K: Ordering](a: Array[K]^, from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
+  def stableSort[K: Ordering](a: Array[K], from: Int, until: Int): Unit = sort(a, from, until, Ordering[K])
 
   /** Sorts array `a` using function `f` that computes the less-than relation for each element.
    *  Uses `java.util.Arrays.sort` unless `K` is a primitive type. This is the same as `stableSort(a, f, 0, a.length)`.
@@ -289,7 +289,7 @@ object Sorting {
    *  @param a the array to sort in place
    *  @param f a function that returns `true` if its first argument is less than its second
    */
-  @`inline` def stableSort[K](a: Array[K]^, f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
+  @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
   /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
@@ -301,7 +301,7 @@ object Sorting {
    *  @param from the first index in the array to sort
    *  @param until the last index (exclusive) in the array to sort
    */
-  def stableSort[K](a: Array[K]^, f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
+  def stableSort[K](a: Array[K], f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
   /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
    *

--- a/tests/pos-custom-args/captures/i25932.scala
+++ b/tests/pos-custom-args/captures/i25932.scala
@@ -1,0 +1,30 @@
+import language.experimental.captureChecking
+import caps.*
+
+trait Ctx extends SharedCapability
+
+class C[T]:
+  def value(using Ctx): T = ???
+
+trait F1[T]:
+  def f(x: C[T]): T
+
+trait F2[T]:
+  self =>
+  def f(x: C[T]): T
+
+object C:
+  given [T](using ctx: Ctx): (Conversion[C[T], T]^{ctx}) = _.value // error
+
+def getF1[T](using ctx: Ctx): F1[T]^{ctx} = new F1[T]:
+  def f(c: C[T]): T = c.value
+
+def getF2[T](using ctx: Ctx): F2[T]^{ctx} = new F2[T]:
+  def f(c: C[T]): T = c.value // error
+
+def test(using Ctx): Unit =
+  val c = new C[Int]
+  val n1: Int = c
+  val n2: Int = getF1.f(c)
+  val n3: Int = getF2.f(c)
+


### PR DESCRIPTION
If a class has a self alias as in
```
class C:
  s =>
  ...
```
then don't assume that `C` is pure. To fix this we now mark `s`'s type as inferred in the synthetic self val `val s: C`. And we don't use inferred types in Setup as the type of `this` .

Fixes #25932
