### PR TITLE
Backport "Fix false-positive pat mat unreachable case warning" to 3.8.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -3305,8 +3305,9 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     // sjrd: I will not be surprised when this causes further issues in the future.
     // This is a compromise to be able to fix #21295 without breaking the world.
     def cannotBeNothing(tp: Type): Boolean = tp match
-      case tp: TypeParamRef => cannotBeNothing(tp.paramInfo)
-      case _                => !(tp.loBound.stripTypeVar <:< defn.NothingType)
+      case tp: TypeParamRef                       => cannotBeNothing(tp.paramInfo)
+      case tp: TypeRef if tp.symbol.is(TypeParam) => cannotBeNothing(tp.info.bounds)
+      case _                                      => !(tp.loBound.stripTypeVar <:< defn.NothingType)
 
     // It is possible to conclude that two types applied are disjoint by
     // looking at covariant type parameters if the said type parameters

--- a/tests/warn/i25928.scala
+++ b/tests/warn/i25928.scala
@@ -1,0 +1,13 @@
+sealed trait X[R]
+case class Foo() extends X[Nothing]
+case class Bar[A]() extends X[A]
+
+def test[A](x: X[A]) = {
+  x match {
+    case Foo() =>
+    case Bar() =>
+  }
+}
+
+def call =
+  test(Foo())


### PR DESCRIPTION
Backports #25978 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]