### PR TITLE
Backport "Bump coursier to 2.1.25-M25 (was 2.1.25-M24)" to 3.8.4

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -138,7 +138,7 @@ object Build {
   /** Version of Scala CLI to download */
   val scalaCliLauncherVersion = "1.13.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.25-M24"
+  val coursierJarVersion = "2.1.25-M25"
 
   object CompatMode {
     final val BinaryCompatible = 0


### PR DESCRIPTION
Backports #26057 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]