### PR TITLE
Backport "Bump Scala CLI to v1.14.0 (was v1.13.0)" to 3.8.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,5 +276,5 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.13.0
+      - uses: VirtusLab/scala-cli-setup@v1.14
       - run: scala-cli format --check

--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.12.3
+      - uses: VirtusLab/scala-cli-setup@v1.14
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.12.3
+      - uses: VirtusLab/scala-cli-setup@v1.14
 
       - name: Validate docs sidebars
         run: scala-cli ./project/scripts/checkSidebarDocs.scala

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -136,7 +136,7 @@ object Build {
   val mimaPreviousDottyVersion = "3.8.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.13.0"
+  val scalaCliLauncherVersion = "1.14.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M25"
 


### PR DESCRIPTION
Backports #26065 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]