### PR TITLE
Backport "Make type arguments to default methods InferredTypeTrees" to 3.8.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -486,7 +486,7 @@ object Applications {
       // it's crucial that the type tree is not copied directly as argument to
       // `cpy$default$1`. If it was, the variable `X'` would already be interpolated
       // when typing the default argument, which is too early.
-      spliceMeth(meth, fn).appliedToTypeTrees(targs.map(targ => TypeTree(targ.tpe).withSpan(targ.span)))
+      spliceMeth(meth, fn).appliedToTypeTrees(targs.map(targ => TypeTree(targ.tpe, inferred = true).withSpan(targ.span)))
     case _ => meth
   }
 

--- a/tests/pos-custom-args/captures/i25849.scala
+++ b/tests/pos-custom-args/captures/i25849.scala
@@ -1,0 +1,16 @@
+import language.experimental.captureChecking
+
+sealed trait Res[+T]:
+  def toOption: Option[T] = this match
+    case Ok(value) => Some(value)
+    case _         => None
+
+case class Ok[+T](value: T) extends Res[T]
+case object Bad extends Res[Nothing]
+
+def check[A](obtained: A, clue: => Any = "not equal"): Unit =
+  assert(obtained != null, clue)
+
+def test(): Unit =
+  val evens = (1 to 5).map(v => if v % 2 == 0 then Ok(v) else Bad).flatMap(_.toOption)
+  check(evens)


### PR DESCRIPTION
Backports #25852 to the 3.8.4-RC2.

PR submitted by the release tooling.
[skip ci]