### PR TITLE
Backport "Do not overwrite the supertype of non-trait super in Erasure" to 3.8.4

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Erasure.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Erasure.scala
@@ -702,13 +702,10 @@ object Erasure {
           assignType(untpd.cpy.Select(tree)(qual, tree.name.primitiveArrayOp), qual)
 
       def adaptIfSuper(qual: Tree): Tree = qual match {
-        case Super(thisQual, untpd.EmptyTypeIdent) =>
-          val SuperType(thisType, supType) = qual.tpe: @unchecked
-          if (sym.owner.is(Flags.Trait))
-            cpy.Super(qual)(thisQual, untpd.Ident(sym.owner.asClass.name))
-              .withType(SuperType(thisType, sym.owner.typeRef))
-          else
-            qual.withType(SuperType(thisType, thisType.firstParent.typeConstructor))
+        case Super(thisQual, untpd.EmptyTypeIdent) if sym.owner.is(Flags.Trait) =>
+          val SuperType(thisType, _) = qual.tpe: @unchecked
+          cpy.Super(qual)(thisQual, untpd.Ident(sym.owner.asClass.name))
+            .withType(SuperType(thisType, sym.owner.typeRef))
         case _ =>
           qual
       }

--- a/tests/run/26071.scala
+++ b/tests/run/26071.scala
@@ -1,0 +1,10 @@
+abstract class OutPort { self: Outlet =>
+  override def hashCode: Int = super.hashCode
+}
+
+class Outlet extends OutPort
+
+object Test:
+  def main(args: Array[String]): Unit =
+    val myPort = Outlet()
+    println(myPort.hashCode)


### PR DESCRIPTION
Backports #26081 to the 3.8.4-RC2.

PR submitted by the release tooling.