### PR TITLE
Fix broken `//> using jvm` directive in the bisect script

### DIFF
--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -1,4 +1,4 @@
-//> using jvm 17 // Maximal JDK version which can be used with all Scala 3 versions, can be overriden via command line arguments '--jvm=21'
+//> using jvm 17
 /*
 This script will bisect a problem with the compiler based on success/failure of the validation script passed as an argument.
 It starts with a fast bisection on released nightly builds.


### PR DESCRIPTION
Without this change, the `bisect.sc` script is in fact, broken.
The added comment is interpreted as a list of values at Scala CLI v1.14.0
Nested comments within using directives used to be allowed, so this might not have been caught due to a past bug.
cc @WojciechMazur 

```scala
[warn] ./project/scripts/bisect.scala:1:84
[warn] Use of commas as separators is deprecated. Only whitespace is necessary.
[warn] //> using jvm 17 // Maximal JDK version which can be used with all Scala 3 versions, can be overriden via command line arguments '--jvm=21'
[warn]                                                                                    ^
[error]  Encountered an error when parsing the `jvm` using directive at /Users/pchabelski/IdeaProjects/dotty2/project/scripts/bisect.scala.
Expected 1 values, but got 22 values instead.
```

## How much have you relied on LLM-based tools in this contribution?
Not at all

## How was the solution tested?
manually
