### PR TITLE
Collection mutable (2): filled in @param, @tparam, and @return tags that were missed last time

### DIFF
--- a/library-js/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library-js/src/scala/collection/mutable/ArrayBuilder.scala
@@ -57,6 +57,7 @@ sealed abstract class ArrayBuilder[T]
   /** Adds all elements of an array.
    *
    *  @param xs the array from which to add elements
+   *  @return this builder with the elements of `xs` appended
    */
   def addAll(xs: Array[_ <: T]): this.type = addAll(xs, 0, xs.length)
 
@@ -65,6 +66,7 @@ sealed abstract class ArrayBuilder[T]
    *  @param xs the array from which to add a slice of elements
    *  @param offset the starting index in `xs` from which to copy elements
    *  @param length the number of elements to copy from `xs`
+   *  @return this builder with the specified slice of `xs` appended
    */
   def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
     ensureSize(this.size + length)
@@ -106,6 +108,7 @@ object ArrayBuilder {
   /** Implementation of `make` for JS.
    *
    *  @tparam T the element type of the array builder, with a `ClassTag` context bound
+   *  @return a new generic `ArrayBuilder` optimized for Scala.js
    */
   @inline
   private def makeForJS[T: ClassTag]: ArrayBuilder[T] =
@@ -165,6 +168,7 @@ object ArrayBuilder {
      *  @param xs the array from which to add a slice of elements
      *  @param offset the starting index in `xs` from which to copy elements
      *  @param length the number of elements to copy from `xs`
+     *  @return this builder with the specified slice of `xs` appended
      */
     override def addAll(xs: Array[_ <: T], offset: Int, length: Int): this.type = {
       val end = offset + length

--- a/library-js/src/scala/collection/mutable/Buffer.scala
+++ b/library-js/src/scala/collection/mutable/Buffer.scala
@@ -43,6 +43,7 @@ trait Buffer[A]
   /** Appends the given elements to this buffer.
    *
    *  @param elem  the element to append.
+   *  @return this buffer with the element appended
    */
   @`inline` final def append(elem: A): this.type = addOne(elem)
 
@@ -50,7 +51,9 @@ trait Buffer[A]
   @`inline` final def append(elems: A*): this.type = addAll(elems)
 
   /** Appends the elements contained in a iterable object to this buffer.
+   *
    *  @param xs  the iterable object containing the elements to append.
+   *  @return this buffer with the elements appended
    */
   @`inline` final def appendAll(xs: IterableOnce[A]): this.type = addAll(xs)
 

--- a/library/src/scala/collection/mutable/AnyRefMap.scala
+++ b/library/src/scala/collection/mutable/AnyRefMap.scala
@@ -222,6 +222,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *  `defaultEntry` was supplied.
    *
    *  @param key the key to look up
+   *  @return the value associated with `key`, or the result of `defaultEntry(key)` if the key is not present
    */
   override def apply(key: K): V = {
     val i = seekEntry(hashOf(key), key)
@@ -232,6 +233,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *  exception if no other default behavior was specified.
    *
    *  @param key the key to look up a default value for
+   *  @return the default value supplied by `defaultEntry` for `key`, or throws if no `defaultEntry` was provided
    */
   override def default(key: K): V = defaultEntry(key)
 
@@ -328,6 +330,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *
    *  @param key the key to add
    *  @param value the value to associate with `key`
+   *  @return this map after the entry has been added
    */
   @inline final def addOne(key: K, value: V): this.type = { update(key, value); this }
 
@@ -476,6 +479,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *
    *  @tparam V1 the new value type
    *  @param f the transformation function to apply to each value
+   *  @return a new `AnyRefMap` with the same keys and values transformed by `f`
    */
   def mapValuesNow[V1](f: V => V1): AnyRefMap[K, V1] = {
     val arm = new AnyRefMap[K,V1](AnyRefMap.exceptionDefault, 1, initBlank = false)
@@ -505,6 +509,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *  Note: the default, if any,  is not transformed.
    *
    *  @param f the transformation function to apply to each value
+   *  @return this map after each stored value has been replaced by `f` applied to it
    */
   def transformValuesInPlace(f: V => V): this.type = {
     var i,j = 0
@@ -527,6 +532,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *  @tparam V2 the value type of the resulting map
    *  @param f the function mapping each key-value pair to a new key-value pair; the resulting key must be an `AnyRef`
    *  @param dummy implicit parameter used to distinguish this overload from the inherited version after erasure
+   *  @return a new `AnyRefMap` containing the key-value pairs produced by applying `f` to each entry of this map
    */
   def map[K2 <: AnyRef, V2](f: ((K, V)) => (K2, V2))(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.Map(this, f))
@@ -536,6 +542,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *  @tparam V2 the value type of the resulting map
    *  @param f the function mapping each key-value pair to a collection of new key-value pairs; the resulting keys must be `AnyRef`s
    *  @param dummy implicit parameter used to distinguish this overload from the inherited version after erasure
+   *  @return a new `AnyRefMap` containing all the key-value pairs produced by applying `f` to each entry of this map
    */
   def flatMap[K2 <: AnyRef, V2](f: ((K, V)) => IterableOnce[(K2, V2)]^)(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     AnyRefMap.from(new View.FlatMap(this, f))
@@ -545,6 +552,7 @@ class AnyRefMap[K <: AnyRef, V] private[collection] (defaultEntry: K -> V, initi
    *  @tparam V2 the value type of the resulting map
    *  @param pf the partial function mapping key-value pairs to new key-value pairs; the resulting key must be an `AnyRef`
    *  @param dummy implicit parameter used to distinguish this overload from the inherited version after erasure
+   *  @return a new `AnyRefMap` containing the key-value pairs produced by applying `pf` to each entry on which it is defined
    */
   def collect[K2 <: AnyRef, V2](pf: PartialFunction[(K, V), (K2, V2)])(implicit dummy: DummyImplicit): AnyRefMap[K2, V2] =
     strictOptimizedCollect(AnyRefMap.newBuilder[K2, V2], pf)
@@ -599,6 +607,7 @@ object AnyRefMap {
    *  @tparam K the type of keys, must be a subtype of `AnyRef`
    *  @tparam V the type of values
    *  @param elems the key-value pairs to initialize the map with
+   *  @return a new `AnyRefMap` containing the given key-value pairs
    */
   def apply[K <: AnyRef, V](elems: (K, V)*): AnyRefMap[K, V] = buildFromIterableOnce(elems)
 
@@ -617,6 +626,7 @@ object AnyRefMap {
    *
    *  @tparam K the type of keys, must be a subtype of `AnyRef`
    *  @tparam V the type of values
+   *  @return a new empty `AnyRefMap`
    */
   def empty[K <: AnyRef, V]: AnyRefMap[K, V] = new AnyRefMap[K, V]
 
@@ -625,6 +635,7 @@ object AnyRefMap {
    *  @tparam K the type of keys, must be a subtype of `AnyRef`
    *  @tparam V the type of values
    *  @param default the function mapping keys to default values
+   *  @return a new empty `AnyRefMap` that uses `default` to supply values for missing keys
    */
   def withDefault[K <: AnyRef, V](default: K -> V): AnyRefMap[K, V] = new AnyRefMap[K, V](default)
 
@@ -648,6 +659,7 @@ object AnyRefMap {
    *  @tparam V the type of values
    *  @param keys the array of keys
    *  @param values the array of values, paired positionally with `keys`
+   *  @return a new `AnyRefMap` containing entries `keys(i) -> values(i)` for indices up to the shorter array's length
    */
   def fromZip[K <: AnyRef, V](keys: Array[K], values: Array[V]): AnyRefMap[K, V] = {
     val sz = math.min(keys.length, values.length)
@@ -665,6 +677,7 @@ object AnyRefMap {
    *  @tparam V the type of values
    *  @param keys the collection of keys
    *  @param values the collection of values, paired positionally with `keys`
+   *  @return a new `AnyRefMap` containing the entries formed by pairing each key with the value at the same position, up to the shorter collection's size
    */
   def fromZip[K <: AnyRef, V](keys: Iterable[K], values: Iterable[V]): AnyRefMap[K, V] = {
     val sz = math.min(keys.size, values.size)

--- a/library/src/scala/collection/mutable/ArrayBuffer.scala
+++ b/library/src/scala/collection/mutable/ArrayBuffer.scala
@@ -138,6 +138,7 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
   /** Clears this buffer and shrinks to @param size (rounding up to the next
    *  natural size)
    *  @param size
+   *  @return this `ArrayBuffer`, now empty and resized to a capacity at least as large as `size`
    */
   def clearAndShrink(size: Int = ArrayBuffer.DefaultInitialSize): this.type = {
     clear()
@@ -211,6 +212,9 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   /** Note: This does not actually resize the internal representation.
    *  See trimToSize if you want to also resize internally
+   *
+   *  @param index the zero-based position of the element to remove
+   *  @return the element that was removed at position `index`
    */
   def remove(@deprecatedName("n", "2.13.0") index: Int): A = {
     checkWithinBounds(index, index + 1)
@@ -222,6 +226,11 @@ class ArrayBuffer[A] private (initialElements: Array[AnyRef], initialSize: Int)
 
   /** Note: This does not actually resize the internal representation.
    *  See trimToSize if you want to also resize internally
+   *
+   *  @param index the zero-based position of the first element to remove
+   *  @param count the number of elements to remove
+   *  @throws IllegalArgumentException if `count` is negative
+   *  @throws IndexOutOfBoundsException if the range `[index, index + count)` is out of bounds
    */
   def remove(@deprecatedName("n", "2.13.0") index: Int, count: Int): Unit =
     if (count > 0) {

--- a/library/src/scala/collection/mutable/ArrayBuilder.scala
+++ b/library/src/scala/collection/mutable/ArrayBuilder.scala
@@ -50,6 +50,7 @@ sealed abstract class ArrayBuilder[T]
   /** Adds all elements of an array.
    *
    *  @param xs the array of elements to add
+   *  @return this builder with the elements of `xs` appended
    */
   def addAll(xs: Array[? <: T]): this.type = addAll(xs, 0, xs.length)
 
@@ -58,6 +59,7 @@ sealed abstract class ArrayBuilder[T]
    *  @param xs the array from which a slice of elements is added
    *  @param offset the start index within `xs` from which to copy elements (clamped to 0 if negative)
    *  @param length the maximum number of elements to copy from `xs` (clamped to 0 if negative, and to the number of available elements)
+   *  @return this builder with the selected slice of `xs` appended
    */
   def addAll(xs: Array[? <: T], offset: Int, length: Int): this.type = {
     val offset1 = offset.max(0)

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -585,16 +585,16 @@ transparent trait ArrayDequeOps[A, +CC[_] <: caps.Pure, +C <: AnyRef] extends St
     if (idx < 0 || idx >= until)
       throw CommonErrors.indexOutOfBounds(index = idx, max = until - 1)
 
-  /**
-    * This is a more general version of copyToArray - this also accepts a srcStart unlike copyToArray
-    * This copies maxItems elements from this collections srcStart to dest's destStart
-    * If we reach the end of either collections before we could copy maxItems, we simply stop copying
-    *
-    * @param dest
-    * @param srcStart
-    * @param destStart
-    * @param maxItems
-    */
+  /** This is a more general version of copyToArray - this also accepts a srcStart unlike copyToArray
+   *  This copies maxItems elements from this collections srcStart to dest's destStart
+   *  If we reach the end of either collection before we could copy maxItems, we simply stop copying
+   *
+   *  @param dest
+   *  @param srcStart
+   *  @param destStart
+   *  @param maxItems
+   *  @return the `dest` array, after the copied elements have been written into it
+   */
   def copySliceToArray(srcStart: Int, dest: Array[?], destStart: Int, maxItems: Int): dest.type = {
     requireBounds(destStart, dest.length+1)
     val toCopy = Math.min(maxItems, Math.min(length - srcStart, dest.length - destStart))

--- a/library/src/scala/collection/mutable/ArraySeq.scala
+++ b/library/src/scala/collection/mutable/ArraySeq.scala
@@ -58,7 +58,11 @@ sealed abstract class ArraySeq[T]
    */
   def elemTag: ClassTag[?]
 
-  /** Updates element at given index. */
+  /** Updates element at given index.
+   *
+   *  @param index the zero-based position of the element to update
+   *  @param elem the new value to store at the given index
+   */
   def update(@deprecatedName("idx", "2.13.0") index: Int, elem: T): Unit
 
   /** The underlying array. Its element type does not have to be equal to the element type of this ArraySeq. A primitive

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -373,6 +373,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   /** A bitset containing all the bits in an array.
    *
    *  @param elems the array of `Long` words representing the bits; a defensive copy is made
+   *  @return a new bitset backed by a copy of `elems`
    */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
@@ -387,6 +388,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
    *  array without copying.
    *
    *  @param elems the array of `Long` words representing the bits, used directly without copying; the caller must not mutate the array afterward
+   *  @return a new bitset backed directly by `elems`
    */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length

--- a/library/src/scala/collection/mutable/Builder.scala
+++ b/library/src/scala/collection/mutable/Builder.scala
@@ -106,6 +106,7 @@ trait Builder[-A, +To] extends Growable[A] { self: Builder[A, To]^ =>
    *
    *  @tparam NewTo the type of collection produced by the returned builder
    *  @param f the function to apply to this builder's result
+   *  @return a new builder that delegates element additions to this builder and applies `f` to the result
    */
   def mapResult[NewTo](f: To => NewTo): Builder[A, NewTo]^{this, f} = new Builder[A, NewTo] {
     def addOne(x: A): this.type = { self += x; this }

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -39,6 +39,7 @@ import scala.runtime.Statics
  *  @tparam V the type of the values associated with the keys
  *  @param initialCapacity the initial capacity of the internal hash table
  *  @param loadFactor the load factor for the hash table, used to determine when to resize
+ *  @param ordering the `Ordering` used to compare keys within a bucket's red-black tree
  */
 final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double)(implicit ordering: Ordering[K])
   extends AbstractMap[K, V]
@@ -714,6 +715,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
    *  @param _root the root of the red-black tree
    *  @param to the node to be replaced in the tree
    *  @param from the node that replaces `to`
+   *  @return the (possibly updated) root of the tree, which differs from `_root` only when `to` was the root
    */
   private def transplant(_root: RBNode, to: RBNode, from: RBNode): RBNode = {
     var root = _root
@@ -859,6 +861,7 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
    *  @tparam A the key type of the tree nodes
    *  @tparam B the value type of the tree nodes
    *  @param node the node whose successor is to be found
+   *  @return the in-order successor of `node`, or `null` if `node` is the last node in the traversal
    */
   private def successor[A, B](node: RBNode[A, B]): RBNode[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)

--- a/library/src/scala/collection/mutable/GrowableBuilder.scala
+++ b/library/src/scala/collection/mutable/GrowableBuilder.scala
@@ -26,6 +26,7 @@ import language.experimental.captureChecking
  *
  *  @tparam Elem the type of elements that can be added to the builder
  *  @tparam To the type of the resulting growable collection, which must be a subtype of `Growable[Elem]`
+ *  @param elems the underlying growable collection that elements are added to and which is returned as the result
  */
 class GrowableBuilder[Elem, To <: Growable[Elem]](protected val elems: To)
   extends Builder[Elem, To] {

--- a/library/src/scala/collection/mutable/HashMap.scala
+++ b/library/src/scala/collection/mutable/HashMap.scala
@@ -65,15 +65,17 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
    *
    *  @param improvedHash the improved hash value to convert back to the original `any.##` hash
+   *  @return the original `any.##` hash code corresponding to `improvedHash`
    */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
   /** Computes the improved hash of an original (`any.##`) hash.
    *
    *  @param originalHash the original hash code from `any.##`
+   *  @return the improved hash with the high 16 bits XORed into the low 16 bits
    */
   @`inline` private def improveHash(originalHash: Int): Int = {
-    // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
+    // Improve the hash by XORing the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
     // algorithm as in java.util.HashMap.
     //
@@ -86,6 +88,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
   /** Computes the improved hash of this key.
    *
    *  @param o the key for which to compute the improved hash
+   *  @return the improved hash code of `o` (i.e., `improveHash(o.##)`)
    */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 
@@ -235,6 +238,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
    *  @param value the value to add
    *  @param hash the **improved** hashcode of `key` (see computeHash)
    *  @param getOld if true, then the previous value for `key` will be returned, otherwise, false
+   *  @return `Some` wrapping the previous value if `getOld` is true and `key` was already present; `null` otherwise (i.e., when `getOld` is false or `key` was not in the map)
    */
   private def put0(key: K, value: V, hash: Int, getOld: Boolean): Some[V] | Null = {
     if(contentSize + 1 >= threshold) growTable(table.length * 2)

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -64,12 +64,14 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   /** Performs the inverse operation of improveHash. In this case, it happens to be identical to improveHash.
    *
    *  @param improvedHash the improved hash value to convert back to a standard hash index
+   *  @return the hash index recovered by re-applying the improvement transformation (which happens to be its own inverse)
    */
   @`inline` private[collection] def unimproveHash(improvedHash: Int): Int = improveHash(improvedHash)
 
   /** Computes the improved hash of an original (`any.##`) hash.
    *
    *  @param originalHash the original hash code obtained from `##`
+   *  @return the improved hash, with high bits XORed into the low bits to spread entropy into the bits used for bucket indexing
    */
   private def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
@@ -81,6 +83,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   /** Computes the improved hash of this element.
    *
    *  @param o the element whose hash to compute
+   *  @return the improved hash of `o`, computed from `o.##`
    */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 
@@ -163,8 +166,10 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
   }
 
   /** Adds an element to this set.
+   *
    *  @param elem element to add
    *  @param hash the **improved** hash of `elem` (see computeHash)
+   *  @return `true` if `elem` was added to the set, or `false` if an equal element was already present
    */
   private def addElem(elem: A, hash: Int) : Boolean = {
     val idx = index(hash)

--- a/library/src/scala/collection/mutable/HashTable.scala
+++ b/library/src/scala/collection/mutable/HashTable.scala
@@ -70,7 +70,11 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
   /** The initial size of the hash table. */
   protected def initialSize: Int = 16
 
-  /** The initial threshold. */
+  /** The initial threshold.
+   *
+   *  @param _loadFactor the load factor expressed in units of 0.001 (e.g. `750` means 75%)
+   *  @return the threshold at which the hash table should be resized, computed from `_loadFactor` and the initial capacity
+   */
   private def initialThreshold(_loadFactor: Int): Int = newThreshold(_loadFactor, initialCapacity)
 
   private def initialCapacity = capacity(initialSize)
@@ -134,6 +138,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
   /** Finds entry with given key in table, null if not found.
    *
    *  @param key the key to look up in the hash table
+   *  @return the entry whose key equals `key`, or `null` if no such entry exists
    */
   final def findEntry(key: A): Entry | Null =
     findEntry0(key, index(elemHashCode(key)))
@@ -170,6 +175,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
    *
    *  @param key the key to find or insert
    *  @param value the value to associate with the key if a new entry is created
+   *  @return the existing entry whose key equals `key`, or `null` if a new entry was created and added
    */
   def findOrAddEntry(key: A, value: B): Entry | Null = {
     val h = index(elemHashCode(key))
@@ -183,12 +189,14 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
    *
    *  @param key the key for the new entry
    *  @param value the value to associate with the key
+   *  @return a newly constructed entry holding `key` and `value`, ready to be inserted into the table
    */
   def createNewEntry(key: A, value: B): Entry
 
   /** Removes entry from table if present.
    *
    *  @param key the key of the entry to remove
+   *  @return the removed entry, or `null` if no entry with key `key` was present
    */
   final def removeEntry(key: A) : Entry | Null = {
     removeEntry0(key, index(elemHashCode(key)))
@@ -197,6 +205,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
    *
    *  @param key the key of the entry to remove
    *  @param h the hash index into the table
+   *  @return the removed entry, or `null` if no entry with key `key` was present at index `h`
    */
   private[collection] final def removeEntry0(key: A, h: Int) : Entry | Null = {
     var e = table(h).asInstanceOf[Entry | Null]
@@ -381,6 +390,7 @@ private[collection] trait HashTable[A, B, Entry <: HashEntry[A, Entry]] extends 
    *  this is of crucial importance when populating the table in parallel
    *
    *  @param hcode the hash code of the element to index
+   *  @return a bucket index in the range `[0, table.length)` derived from `hcode`
    */
   protected[collection] final def index(hcode: Int): Int = {
     val ones = table.length - 1
@@ -414,6 +424,7 @@ private[collection] object HashTable {
      *
      *  @param hcode the original hash code to improve
      *  @param seed the seed value derived from the table size, used to rotate the hash
+     *  @return an improved hash code with better bit distribution for use as a table index
      */
     protected final def improve(hcode: Int, seed: Int): Int = rotateRight(byteswap32(hcode), seed)
   }
@@ -421,6 +432,7 @@ private[collection] object HashTable {
   /** Returns a power of two >= `target`.
    *
    *  @param target the minimum value for the returned power of two
+   *  @return the smallest positive power of two that is greater than or equal to `target`
    */
   private[collection] def nextPositivePowerOfTwo(target: Int): Int = 1 << -numberOfLeadingZeros(target - 1)
 }

--- a/library/src/scala/collection/mutable/ImmutableBuilder.scala
+++ b/library/src/scala/collection/mutable/ImmutableBuilder.scala
@@ -21,6 +21,7 @@ import language.experimental.captureChecking
  *
  *  @tparam A the element type of the collection being built
  *  @tparam C the type of the immutable collection to build (must be a subtype of `IterableOnce[?]`)
+ *  @param empty the empty collection used as the initial value and reset target when the builder is cleared
  */
 abstract class ImmutableBuilder[-A, C <: IterableOnce[?]](empty: C)
   extends ReusableBuilder[A, C] {

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -76,6 +76,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @see [[scala.collection.SeqOps.sortWith]]
    *
    *  @param lt the less-than comparison function; should return `true` if the first argument strictly precedes the second in the desired ordering
+   *  @return this $coll sorted in place according to the comparison function `lt`
    */
   def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
 
@@ -87,6 +88,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @tparam B the target type of the transformation function `f`, for which an `Ordering` must exist
    *  @param f the transformation function that extracts a sort key of type `B` from each element
    *  @param ord the implicit ordering on type `B` used to compare transformed elements
+   *  @return this $coll sorted in place according to the ordering induced by applying `f` and comparing with `ord`
    */
   def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
 

--- a/library/src/scala/collection/mutable/LinkedHashMap.scala
+++ b/library/src/scala/collection/mutable/LinkedHashMap.scala
@@ -193,6 +193,7 @@ class LinkedHashMap[K, V]
   /** Computes the improved hash of an original (`any.##`) hash.
    *
    *  @param originalHash the original hash code obtained from `any.##`
+   *  @return the improved hash code with better bit distribution
    */
   @`inline` private def improveHash(originalHash: Int): Int = {
     originalHash ^ (originalHash >>> 16)
@@ -202,6 +203,7 @@ class LinkedHashMap[K, V]
   /** Computes the improved hash of this key.
    *
    *  @param o the key whose improved hash to compute
+   *  @return the improved hash code of `o`, suitable for indexing into the hash table
    */
   @`inline` private def computeHash(o: K): Int = improveHash(o.##)
 

--- a/library/src/scala/collection/mutable/LinkedHashSet.scala
+++ b/library/src/scala/collection/mutable/LinkedHashSet.scala
@@ -155,6 +155,7 @@ class LinkedHashSet[A]
   /** Computes the improved hash of this key.
    *
    *  @param o the key whose hash to compute
+   *  @return the improved hash code of `o`, derived by mixing the high and low bits of its `##` value
    */
   @`inline` private def computeHash(o: A): Int = improveHash(o.##)
 

--- a/library/src/scala/collection/mutable/ListBuffer.scala
+++ b/library/src/scala/collection/mutable/ListBuffer.scala
@@ -97,6 +97,7 @@ class ListBuffer[A]
   /** Prepends the elements of this buffer to a given list
    *
    *  @param xs   the list to which elements are prepended
+   *  @return a list consisting of the elements of this buffer followed by `xs`, or `xs` itself if this buffer is empty
    */
   def prependToList(xs: List[A]): List[A] = {
     if (isEmpty) xs

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -252,6 +252,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *  will be returned instead.
    *
    *  @param key the key to look up
+   *  @return the value associated with `key`, or the result of `defaultEntry(key)` if not present
    */
   override def apply(key: Long): V = {
     if (key == -key) {
@@ -379,6 +380,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *
    *  @param key the key to add
    *  @param value the value to associate with `key`
+   *  @return this map after the entry has been added
    */
   @inline final def addOne(key: Long, value: V): this.type = { update(key, value); this }
 
@@ -555,6 +557,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *
    *  @tparam V1 the type of the values in the resulting map
    *  @param f the transformation function applied to each value
+   *  @return a new `LongMap` with the same keys, where each value is the result of applying `f` to the corresponding value in this map
    */
   def mapValuesNow[V1](f: V => V1): LongMap[V1] = {
     val zv = if ((extraKeys & 1) == 1) f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null] else null
@@ -585,6 +588,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *  Note: the default, if any,  is not transformed.
    *
    *  @param f the transformation function applied to each value
+   *  @return this map after each value has been replaced by `f` applied to it
    */
   def transformValuesInPlace(f: V => V): this.type = {
     if ((extraKeys & 1) == 1) zeroValue = f(zeroValue.asInstanceOf[V]).asInstanceOf[AnyRef | Null]
@@ -605,6 +609,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *
    *  @tparam V2 the value type of the resulting map
    *  @param f the mapping function
+   *  @return a new `LongMap` containing the key/value pairs produced by applying `f` to each entry of this map
    */
   def map[V2](f: ((Long, V)) => (Long, V2)): LongMap[V2] = LongMap.from(new View.Map(coll, f))
 
@@ -612,6 +617,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *
    *  @tparam V2 the value type of the resulting map
    *  @param f the mapping function
+   *  @return a new `LongMap` containing the concatenation of the key/value pairs produced by applying `f` to each entry of this map
    */
   def flatMap[V2](f: ((Long, V)) => IterableOnce[(Long, V2)]^): LongMap[V2] = LongMap.from(new View.FlatMap(coll, f))
 
@@ -619,6 +625,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
    *
    *  @tparam V2 the value type of the resulting map
    *  @param pf the partial function to apply to matching elements
+   *  @return a new `LongMap` containing the key/value pairs produced by `pf` for the entries on which it is defined
    */
   def collect[V2](pf: PartialFunction[(Long, V), (Long, V2)]): LongMap[V2] =
     strictOptimizedCollect(LongMap.newBuilder[V2], pf)
@@ -657,6 +664,7 @@ object LongMap {
    *
    *  @tparam V the type of the values
    *  @param elems the key/value pairs to initialize the map with
+   *  @return a new `LongMap` populated with the given `elems`
    */
   def apply[V](elems: (Long, V)*): LongMap[V] = buildFromIterableOnce(elems)
 
@@ -672,6 +680,7 @@ object LongMap {
   /** Creates a new empty `LongMap`.
    *
    *  @tparam V the type of the values
+   *  @return a new empty `LongMap` whose value type is `V`
    */
   def empty[V]: LongMap[V] = new LongMap[V]
 
@@ -679,6 +688,7 @@ object LongMap {
    *
    *  @tparam V the type of the values
    *  @param default the function mapping keys to default values
+   *  @return a new empty `LongMap` that uses `default` to supply values for missing keys
    */
   def withDefault[V](default: Long -> V): LongMap[V] = new LongMap[V](default)
 
@@ -702,6 +712,7 @@ object LongMap {
    *  @tparam V the type of the values
    *  @param keys the array of `Long` keys
    *  @param values the array of values corresponding to each key
+   *  @return a new `LongMap` pairing each key in `keys` with the value at the same index in `values`, up to the shorter of the two
    */
   def fromZip[V](keys: Array[Long], values: Array[V]): LongMap[V] = {
     val sz = math.min(keys.length, values.length)
@@ -718,6 +729,7 @@ object LongMap {
    *  @tparam V the type of the values
    *  @param keys the iterable of `Long` keys
    *  @param values the iterable of values corresponding to each key
+   *  @return a new `LongMap` pairing each key from `keys` with the value at the same position in `values`, up to the shorter of the two iterables
    */
   def fromZip[V](keys: scala.collection.Iterable[Long], values: scala.collection.Iterable[V]): LongMap[V] = {
     val sz = math.min(keys.size, values.size)

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -182,6 +182,7 @@ transparent trait MapOps[K, V, +CC[X, Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K,
    *  `p` returns `true`.
    *
    *  @param p  The test predicate
+   *  @return   the map itself
    */
   def filterInPlace(p: (K, V) => Boolean): this.type = {
     if (!isEmpty) this match {

--- a/library/src/scala/collection/mutable/OpenHashMap.scala
+++ b/library/src/scala/collection/mutable/OpenHashMap.scala
@@ -137,6 +137,7 @@ class OpenHashMap[Key, Value](initialSize : Int)
    *
    *  @param hash the hash code of `key`
    *  @param key the key to search for in the hash table
+   *  @return the index of the slot containing `key` if present; otherwise the index of the first deleted slot encountered during probing, or the first empty slot if no deleted slot was found
    */
   private def findIndex(key: Key, hash: Int): Int = {
     var index = hash & mask

--- a/library/src/scala/collection/mutable/PriorityQueue.scala
+++ b/library/src/scala/collection/mutable/PriorityQueue.scala
@@ -266,6 +266,7 @@ sealed class PriorityQueue[A](implicit val ord: Ordering[A])
   /** Dequeues all elements and returns them in a sequence, in priority order.
    *
    *  @tparam A1 a supertype of the element type `A`, allowing the result to be typed more broadly
+   *  @return an immutable sequence containing all elements of this queue in priority order
    */
   def dequeueAll[A1 >: A]: immutable.Seq[A1] = {
     val b = ArrayBuilder.make[Any]

--- a/library/src/scala/collection/mutable/RedBlackTree.scala
+++ b/library/src/scala/collection/mutable/RedBlackTree.scala
@@ -134,6 +134,7 @@ private[collection] object RedBlackTree {
    *  @param tree the red-black tree to search
    *  @param key the lower bound (inclusive) for the key lookup
    *  @param ord the ordering used to compare keys
+   *  @return a `Some` containing the key-value pair whose key is the smallest value greater than or equal to `key`, or `None` if no such entry exists
    */
   def minAfter[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     minNodeAfter(tree.root, key) match {
@@ -170,6 +171,7 @@ private[collection] object RedBlackTree {
    *  @param tree the red-black tree to search
    *  @param key the upper bound (exclusive) for the key lookup
    *  @param ord the ordering used to compare keys
+   *  @return a `Some` containing the key-value pair whose key is the largest value strictly less than `key`, or `None` if no such entry exists
    */
   def maxBefore[A, B](tree: Tree[A, B], key: A)(implicit ord: Ordering[A]): Option[(A, B)] =
     maxNodeBefore(tree.root, key) match {
@@ -377,6 +379,7 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the tree entries
    *  @tparam B the value type of the tree entries
    *  @param node the node whose in-order successor is to be found
+   *  @return the next node in the in-order traversal, or `null` if `node` is the last node
    */
   private def successor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)
@@ -397,6 +400,7 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the tree entries
    *  @tparam B the value type of the tree entries
    *  @param node the node whose in-order predecessor is to be found
+   *  @return the previous node in the in-order traversal, or `null` if `node` is the first node
    */
   private def predecessor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.left ne null) maxNodeNonNull(node.left)
@@ -573,6 +577,7 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the tree entries
    *  @tparam B the value type of the tree entries
    *  @param tree the red-black tree to validate
+   *  @return `true` if `tree` satisfies all of the above invariants, `false` otherwise
    */
   def isValid[A: Ordering, B](tree: Tree[A, B]): Boolean =
     isValidBST(tree.root) && hasProperParentRefs(tree) && isValidRedBlackTree(tree) && size(tree.root) == tree.size
@@ -582,6 +587,7 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the tree entries
    *  @tparam B the value type of the tree entries
    *  @param tree the red-black tree to check
+   *  @return `true` if every non-null node's children point back to it via their `parent` field and the root has a `null` parent, `false` otherwise
    */
   private def hasProperParentRefs[A, B](tree: Tree[A, B]): Boolean = {
 
@@ -604,6 +610,7 @@ private[collection] object RedBlackTree {
    *  @tparam B the value type of the tree entries
    *  @param node the root node of the subtree to validate
    *  @param ord the ordering used to compare keys
+   *  @return `true` if the subtree rooted at `node` is a valid binary search tree under `ord`, `false` otherwise
    */
   private def isValidBST[A, B](node: Node[A, B] | Null)(implicit ord: Ordering[A]): Boolean = {
     if (node eq null) true
@@ -620,6 +627,7 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the tree entries
    *  @tparam B the value type of the tree entries
    *  @param tree the red-black tree to validate
+   *  @return `true` if `tree` satisfies the red-black tree invariants, `false` otherwise
    */
   private def isValidRedBlackTree[A, B](tree: Tree[A, B]): Boolean = {
 
@@ -651,6 +659,7 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the set entries
    *  @param xs an iterator over keys in ascending order
    *  @param size the number of keys in the iterator
+   *  @return a balanced red-black tree containing the given keys, each paired with a `null` value (suitable for use as the backing store of a `TreeSet`)
    */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
@@ -676,6 +685,7 @@ private[collection] object RedBlackTree {
    *  @tparam B the value type of the map entries
    *  @param xs an iterator over key-value pairs in ascending key order
    *  @param size the number of key-value pairs in the iterator
+   *  @return a balanced red-black tree containing the given key-value pairs
    */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes

--- a/library/src/scala/collection/mutable/RedBlackTree.scala
+++ b/library/src/scala/collection/mutable/RedBlackTree.scala
@@ -379,7 +379,6 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the tree entries
    *  @tparam B the value type of the tree entries
    *  @param node the node whose in-order successor is to be found
-   *  @return the next node in the in-order traversal, or `null` if `node` is the last node
    */
   private def successor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.right ne null) minNodeNonNull(node.right)
@@ -400,7 +399,6 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type of the tree entries
    *  @tparam B the value type of the tree entries
    *  @param node the node whose in-order predecessor is to be found
-   *  @return the previous node in the in-order traversal, or `null` if `node` is the first node
    */
   private def predecessor[A, B](node: Node[A, B]): Node[A, B] | Null = {
     if (node.left ne null) maxNodeNonNull(node.left)

--- a/library/src/scala/collection/mutable/Set.scala
+++ b/library/src/scala/collection/mutable/Set.scala
@@ -97,9 +97,11 @@ transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   @inline final def retain(p: A => Boolean): Unit = filterInPlace(p)
 
   /** Removes all elements from the set for which do not satisfy a predicate.
+   *
    *  @param  p  the predicate used to test elements. Only elements for
    *             which `p` returns `true` are retained in the set; all others
    *             are removed.
+   *  @return this set after removing elements that do not satisfy `p`
    */
   def filterInPlace(p: A => Boolean): this.type = {
     if (nonEmpty) {

--- a/library/src/scala/collection/mutable/SortedSet.scala
+++ b/library/src/scala/collection/mutable/SortedSet.scala
@@ -38,6 +38,7 @@ trait SortedSet[A]
  *
  *  @tparam A the element type of the set
  *  @tparam CC the type constructor for the sorted set collection
+ *  @tparam C the concrete collection type of this sorted set (the self-type used as the return type of transformation operations)
  */
 transparent trait SortedSetOps[A, +CC[X] <: SortedSet[X], +C <: SortedSetOps[A, CC, C]]
   extends SetOps[A, Set, C]

--- a/library/src/scala/collection/mutable/StringBuilder.scala
+++ b/library/src/scala/collection/mutable/StringBuilder.scala
@@ -109,6 +109,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
   /** Overloaded version of `addAll` that takes a string.
    *
    *  @param s the string to append to this builder
+   *  @return this `StringBuilder`
    */
   def addAll(s: String): this.type = { underlying.append(s); this }
 
@@ -423,6 +424,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    *
    *  @param  index   the index to modify.
    *  @param  ch      the new Char.
+   *  @return         this `StringBuilder`.
    *  @throws IndexOutOfBoundsException  if the index is out of bounds.
    */
   def setCharAt(index: Int, ch: Char): this.type = {
@@ -459,6 +461,7 @@ final class StringBuilder(val underlying: java.lang.StringBuilder) extends Abstr
    *
    *  @param start the beginning index, inclusive
    *  @param end the ending index, exclusive
+   *  @return the subsequence between `start` and `end` as a `CharSequence`
    */
   def subSequence(start: Int, end: Int): java.lang.CharSequence =
     underlying.substring(start, end)

--- a/library/src/scala/collection/mutable/TreeMap.scala
+++ b/library/src/scala/collection/mutable/TreeMap.scala
@@ -169,6 +169,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
      *
      *  @param newFrom a possible new lower bound wrapped in a `Some`, or `None` if unconstrained
+     *  @return the more constraining of the current `from` and `newFrom` lower bounds, or `None` if both are unconstrained
      */
     private def pickLowerBound(newFrom: Option[K]): Option[K] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
@@ -179,6 +180,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
      *
      *  @param newUntil a possible new upper bound wrapped in a `Some`, or `None` if unconstrained
+     *  @return the more constraining of the current `until` and `newUntil` upper bounds, or `None` if both are unconstrained
      */
     private def pickUpperBound(newUntil: Option[K]): Option[K] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
@@ -189,6 +191,7 @@ sealed class TreeMap[K, V] private (tree: RB.Tree[K, V])(implicit val ordering: 
     /** Returns true if the argument is inside the view bounds (between `from` and `until`).
      *
      *  @param key the key to check against the view bounds
+     *  @return `true` if `key` is at or above `from` (when defined) and strictly below `until` (when defined)
      */
     private def isInsideViewBounds(key: K): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0

--- a/library/src/scala/collection/mutable/TreeSet.scala
+++ b/library/src/scala/collection/mutable/TreeSet.scala
@@ -118,6 +118,7 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
     /** Given a possible new lower bound, chooses and returns the most constraining one (the maximum).
      *
      *  @param newFrom a possible new lower bound wrapped in a `Some`, or `None` if unbounded
+     *  @return the more restrictive of the existing `from` bound and `newFrom`, or `None` if both are unbounded
      */
     private def pickLowerBound(newFrom: Option[A]): Option[A] = (from, newFrom) match {
       case (Some(fr), Some(newFr)) => Some(ordering.max(fr, newFr))
@@ -128,6 +129,7 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
     /** Given a possible new upper bound, chooses and returns the most constraining one (the minimum).
      *
      *  @param newUntil a possible new upper bound wrapped in a `Some`, or `None` if unbounded
+     *  @return the more restrictive of the existing `until` bound and `newUntil`, or `None` if both are unbounded
      */
     private def pickUpperBound(newUntil: Option[A]): Option[A] = (until, newUntil) match {
       case (Some(unt), Some(newUnt)) => Some(ordering.min(unt, newUnt))
@@ -138,6 +140,7 @@ sealed class TreeSet[A] private (private val tree: RB.Tree[A, Null])(implicit va
     /** Returns true if the argument is inside the view bounds (between `from` and `until`).
      *
      *  @param key the element to check against the view bounds
+     *  @return `true` if `key` is greater than or equal to the `from` bound (if any) and strictly less than the `until` bound (if any)
      */
     private def isInsideViewBounds(key: A): Boolean = {
       val afterFrom = from.isEmpty || ordering.compare(from.get, key) <= 0


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in `@param`, `@tparam`, and `@return` tags for `scala.collection.mutable` that were missed in the previous batch of PRs. I'm submitting it as a draft PR so to get CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and are starting to review them. We will review them all before making the PR non-draft. Please let me know if you see anything specific that you think could be improved.