### PR TITLE
Collection immutable (3): filled in @param, @tparam, and @return tags that were missed last time

### DIFF
--- a/library-js/src/scala/collection/immutable/NumericRange.scala
+++ b/library-js/src/scala/collection/immutable/NumericRange.scala
@@ -97,6 +97,7 @@ sealed class NumericRange[T](
    *  a new `step`.
    *
    *  @param newStep the new step value for the resulting range
+   *  @return a new `NumericRange` with the same `start` and `end` as this range but with `newStep` as its step
    */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
@@ -104,8 +105,9 @@ sealed class NumericRange[T](
   /** Creates a copy of this range.
    *
    *  @param start the first value of the new range
-   *  @param end the upper bound of the new range (inclusive or exclusive, matching the original range)
+   *  @param end the end boundary of the new range (inclusive or exclusive, matching this range)
    *  @param step the step value between successive elements of the new range
+   *  @return a new `NumericRange` with the given `start`, `end`, and `step`, preserving this range's inclusivity
    */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
@@ -364,6 +366,7 @@ object NumericRange {
    *  @param step the increment between successive elements
    *  @param isInclusive whether `end` is included in the range
    *  @param num the `Integral` instance used for arithmetic on `T`
+   *  @return the number of elements in the range
    */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero

--- a/library-js/src/scala/collection/immutable/Range.scala
+++ b/library-js/src/scala/collection/immutable/Range.scala
@@ -548,6 +548,7 @@ object Range {
    *  @param end the end boundary of the range (inclusive or exclusive depending on `isInclusive`)
    *  @param step the increment between successive elements; must be non-zero
    *  @param isInclusive whether `end` is included in the range
+   *  @return the number of elements in the range, or `-1` if the count exceeds `Int.MaxValue`
    */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
@@ -581,6 +582,7 @@ object Range {
    *  @param start the first element of the range
    *  @param end the exclusive upper bound of the range
    *  @param step the increment between successive elements; must be non-zero
+   *  @return an exclusive `Range` from `start` to `end` stepping by `step`
    */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
@@ -588,6 +590,7 @@ object Range {
    *
    *  @param start the first element of the range
    *  @param end the exclusive upper bound of the range
+   *  @return an exclusive `Range` from `start` to `end` with step `1`
    */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
@@ -597,6 +600,7 @@ object Range {
    *  @param start the first element of the range
    *  @param end the inclusive upper bound of the range
    *  @param step the increment between successive elements; must be non-zero
+   *  @return an inclusive `Range` from `start` to `end` stepping by `step`
    */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
@@ -604,6 +608,7 @@ object Range {
    *
    *  @param start the first element of the range
    *  @param end the inclusive upper bound of the range
+   *  @return an inclusive `Range` from `start` to `end` with step `1`
    */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 

--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -69,6 +69,7 @@ sealed abstract class BitSet
    *
    *  @param idx the index of the word to update
    *  @param w the new value for the word at index `idx`
+   *  @return a new bitset with the word at `idx` set to `w`, growing the underlying storage if needed
    */
   protected def updateWord(idx: Int, w: Long): BitSet
 
@@ -115,6 +116,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
   /** A bitset containing all the bits in an array.
    *
    *  @param elems the array of `Long` words representing the bits; the array is defensively copied
+   *  @return a new immutable bitset containing the bits represented by `elems`
    */
   def fromBitMask(elems: Array[Long]): BitSet = {
     val len = elems.length
@@ -131,6 +133,7 @@ object BitSet extends SpecificIterableFactory[Int, BitSet] {
    *  array without copying.
    *
    *  @param elems the array of `Long` words representing the bits; the caller must not modify the array after this call
+   *  @return a new immutable bitset backed by the given `elems` array
    */
   def fromBitMaskNoCopy(elems: Array[Long]): BitSet = {
     val len = elems.length

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -341,6 +341,8 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
    *
    *
    *  @tparam V1 the value type of the resulting HashMap, a supertype of `V`
+   *
+   *  @return a new `HashMap` containing all key-value pairs from both maps, with `mergef` applied to resolve collisions when non-null
    */
   def merged[V1 >: V](that: HashMap[K, V1])(mergef: ((K, V), (K, V1)) => (K, V1)): HashMap[K, V1] =
     if (mergef == null) {
@@ -629,6 +631,7 @@ private[immutable] sealed abstract class MapNode[K, +V] extends Node[MapNode[K, 
    *  @param originalHash the original hash code of `key` (via `key.##`)
    *  @param hash the improved hash of `key`
    *  @param shift the bit-level offset into the hash code, equal to `depth * BitPartitionSize`
+   *  @return the `(key, value)` tuple bound to `key` in this node
    */
   def getTuple(key: K, originalHash: Int, hash: Int, shift: Int): (K, V)
 
@@ -1049,6 +1052,7 @@ private final class BitmapIndexedMapNode[K, +V](
    *  @param bitpos the bit position of the data to migrate to node
    *  @param keyHash the improved hash of the key currently at `bitpos`
    *  @param node the node to place at `bitpos` beneath `this`
+   *  @return `this`, after mutating it so that `node` replaces the inline data at `bitpos`
    */
   def migrateFromInlineToNodeInPlace[V1 >: V](bitpos: Int, keyHash: Int, node: MapNode[K, V1]): this.type = {
     val dataIx = dataIndex(bitpos)
@@ -2204,6 +2208,7 @@ private final class MapNodeRemoveAllSetNodeIterator[K](rootSetNode: SetNode[K]) 
    *
    *  @tparam V the value type of the map node
    *  @param rootMapNode the root node of the map from which keys will be removed
+   *  @return the root node of a map with every key from `rootSetNode` removed from `rootMapNode`
    */
   def removeAll[V](rootMapNode: BitmapIndexedMapNode[K, V]): BitmapIndexedMapNode[K, V] = {
     var curr = rootMapNode
@@ -2248,6 +2253,7 @@ object HashMap extends MapFactory[HashMap] {
    *
    *  @tparam K the key type of the HashMap
    *  @tparam V the value type of the HashMap
+   *  @return a fresh `ReusableBuilder` that constructs `HashMap[K, V]` instances and can be reused across multiple results
    */
   def newBuilder[K, V]: ReusableBuilder[(K, V), HashMap[K, V]] = new HashMapBuilder[K, V]
 }
@@ -2289,6 +2295,7 @@ private[immutable] final class HashMapBuilder[K, V] extends ReusableBuilder[(K, 
    *  @param as the source array to insert into
    *  @param ix the zero-based index at which to insert `elem`
    *  @param elem the element to insert
+   *  @return a new array of length `as.length + 1` containing the elements of `as` with `elem` inserted at index `ix`
    */
   private def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -2208,7 +2208,6 @@ private final class MapNodeRemoveAllSetNodeIterator[K](rootSetNode: SetNode[K]) 
    *
    *  @tparam V the value type of the map node
    *  @param rootMapNode the root node of the map from which keys will be removed
-   *  @return the root node of a map with every key from `rootSetNode` removed from `rootMapNode`
    */
   def removeAll[V](rootMapNode: BitmapIndexedMapNode[K, V]): BitmapIndexedMapNode[K, V] = {
     var curr = rootMapNode

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -1968,6 +1968,7 @@ object HashSet extends IterableFactory[HashSet] {
    *  intermediate call to `clear()` in order to build multiple related results.
    *
    *  @tparam A the element type of the set to build
+   *  @return a new reusable builder that produces a `HashSet[A]`
    */
   def newBuilder[A]: ReusableBuilder[A, HashSet[A]] = new HashSetBuilder
 }
@@ -2000,6 +2001,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
    *  @param as the source array to insert into
    *  @param ix the index at which to insert the element
    *  @param elem the element to insert
+   *  @return a new array of length `as.length + 1` with `elem` inserted at index `ix`
    */
   private def insertElement(as: Array[Int], ix: Int, elem: Int): Array[Int] = {
     if (ix < 0) throw new ArrayIndexOutOfBoundsException

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -129,6 +129,7 @@ private[immutable] abstract class IntMapIterator[V, T](it: IntMap[V]) extends Ab
   /** What value do we assign to a tip?
    *
    *  @param tip the leaf node to extract a value from
+   *  @return the iterator element derived from `tip` (e.g. the key, the value, or the key/value pair, as determined by the concrete subclass)
    */
   def valueOf(tip: IntMap.Tip[V]): T
 

--- a/library/src/scala/collection/immutable/LazyList.scala
+++ b/library/src/scala/collection/immutable/LazyList.scala
@@ -496,6 +496,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @tparam B the element type of the returned lazy list
    *  @param z the initial value for the scan
    *  @param op the binary operator applied to the intermediate result and each element
+   *  @return a new lazy list containing `z` followed by the successive accumulated results of `op`
    */
   override def scanLeft[B](z: B)(op: (B, A) => B): LazyList[B] =
     if (knownIsEmpty) eagerCons(z, Empty)
@@ -535,6 +536,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  $preservesLaziness
    *
    *  @param p the predicate used to test elements
+   *  @return a pair of lazy lists where the first contains elements satisfying `p` and the second contains the rest
    */
   override def partition(p: A => Boolean): (LazyList[A], LazyList[A]) = (filter(p), filterNot(p))
 
@@ -545,6 +547,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @tparam A1 the element type of the first returned lazy list
    *  @tparam A2 the element type of the second returned lazy list
    *  @param f the function mapping elements to `Left` or `Right`
+   *  @return a pair of lazy lists, the first containing the unwrapped `Left` values and the second the unwrapped `Right` values
    */
   override def partitionMap[A1, A2](f: A => Either[A1, A2]): (LazyList[A1], LazyList[A2]) = {
     val (left, right) = map(f).partition(_.isLeft)
@@ -556,6 +559,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  $preservesLaziness
    *
    *  @param pred the predicate used to test elements
+   *  @return a new lazy list containing only the elements for which `pred` returns `true`
    */
   override def filter(pred: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
@@ -566,6 +570,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  $preservesLaziness
    *
    *  @param pred the predicate used to test elements
+   *  @return a new lazy list containing only the elements for which `pred` returns `false`
    */
   override def filterNot(pred: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
@@ -591,6 +596,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param elem the element to prepend
+   *  @return a new lazy list with `elem` as its head followed by all elements of this lazy list
    */
   override def prepended[B >: A](elem: B): LazyList[B] = eagerCons(elem, this)
 
@@ -600,6 +606,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param prefix the collection to prepend
+   *  @return a new lazy list containing the elements of `prefix` followed by the elements of this lazy list
    */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]): LazyList[B] =
     if (knownIsEmpty) LazyList.from(prefix)
@@ -612,6 +619,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the returned lazy list
    *  @param f the function to apply to each element
+   *  @return a new lazy list with each element transformed by `f`
    */
   override def map[B](f: A => B): LazyList[B] =
     if (knownIsEmpty) Empty
@@ -623,6 +631,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam U the return type of the function `f`, used only for side effects
    *  @param f the function to apply to each element for its side effect
+   *  @return a new lazy list with the same elements as this one, invoking `f` on each element as it is evaluated
    */
   override def tapEach[U](f: A => U): LazyList[A] = map { a => f(a); a }
 
@@ -638,6 +647,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the returned lazy list
    *  @param pf the partial function which filters and maps elements
+   *  @return a new lazy list containing `pf` applied to each element for which it is defined
    */
   override def collect[B](pf: PartialFunction[A, B]): LazyList[B] =
     if (knownIsEmpty) Empty
@@ -650,6 +660,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the result type of the partial function
    *  @param pf the partial function to apply to elements
+   *  @return `Some` of the first defined application of `pf`, or `None` if no element is in the domain of `pf`
    */
   @tailrec
   override def collectFirst[B](pf: PartialFunction[A, B]): Option[B] =
@@ -666,6 +677,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  the first element matching the predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return `Some` of the first element satisfying `p`, or `None` if no such element exists
    */
   @tailrec
   override def find(p: A => Boolean): Option[A] =
@@ -692,6 +704,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the nested collections
    *  @param asIterable an implicit conversion from elements of type `A` to `IterableOnce[B]`
+   *  @return a new lazy list resulting from concatenating all nested collections
    */
   override def flatten[B](implicit asIterable: A => IterableOnce[B]): LazyList[B] = flatMap(asIterable)
 
@@ -701,6 +714,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the second collection
    *  @param that the collection to zip with this lazy list
+   *  @return a new lazy list of pairs, truncated to the length of the shorter input
    */
   override def zip[B](that: collection.IterableOnce[B]): LazyList[(A, B)] =
     if (knownIsEmpty || that.knownSize == 0) Empty
@@ -725,6 +739,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @param that the collection to zip with this lazy list
    *  @param thisElem the element to use when this lazy list is shorter than `that`
    *  @param thatElem the element to use when `that` is shorter than this lazy list
+   *  @return a new lazy list of pairs whose length is the maximum of the two inputs, padded with `thisElem`/`thatElem` as needed
    */
   override def zipAll[A1 >: A, B](that: collection.Iterable[B], thisElem: A1, thatElem: B): LazyList[(A1, B)] = {
     if (knownIsEmpty) {
@@ -769,6 +784,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @tparam A1 the type of the first element in each pair
    *  @tparam A2 the type of the second element in each pair
    *  @param asPair an implicit conversion from elements of type `A` to pairs of `(A1, A2)`
+   *  @return a pair of lazy lists, the first containing all first components and the second containing all second components
    */
   override def unzip[A1, A2](implicit asPair: A => (A1, A2)): (LazyList[A1], LazyList[A2]) =
     (map(asPair(_)._1), map(asPair(_)._2))
@@ -781,6 +797,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @tparam A2 the type of the second element in each triple
    *  @tparam A3 the type of the third element in each triple
    *  @param asTriple an implicit conversion from elements of type `A` to triples of `(A1, A2, A3)`
+   *  @return a triple of lazy lists containing the first, second, and third components respectively
    */
   override def unzip3[A1, A2, A3](implicit asTriple: A => (A1, A2, A3)): (LazyList[A1], LazyList[A2], LazyList[A3]) =
     (map(asTriple(_)._1), map(asTriple(_)._2), map(asTriple(_)._3))
@@ -791,6 +808,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  Additionally, it preserves laziness for all except the first `n` elements.
    *
    *  @param n the number of elements to drop from this lazy list
+   *  @return a lazy list consisting of all elements of this lazy list except the first `n` (or empty if `n` exceeds the length)
    */
   override def drop(n: Int): LazyList[A] =
     if (n <= 0) this
@@ -803,6 +821,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  Additionally, it preserves laziness for all elements after the predicate returns `false`.
    *
    *  @param p the predicate used to test elements; elements are dropped while this returns `true`
+   *  @return the longest suffix of this lazy list whose first element does not satisfy `p`
    */
   override def dropWhile(p: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
@@ -813,6 +832,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  $initiallyLazy
    *
    *  @param n the number of elements to drop from the right end
+   *  @return a lazy list consisting of all elements of this lazy list except the last `n` (or empty if `n` exceeds the length)
    */
   override def dropRight(n: Int): LazyList[A] = {
     if (n <= 0) this
@@ -838,6 +858,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  $preservesLaziness
    *
    *  @param n the number of elements to take from this lazy list
+   *  @return a lazy list containing the first `n` elements of this lazy list (or all elements if `n` exceeds the length)
    */
   override def take(n: Int): LazyList[A] =
     if (knownIsEmpty) Empty
@@ -856,6 +877,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  $preservesLaziness
    *
    *  @param p the predicate used to test elements; elements are taken while this returns `true`
+   *  @return the longest prefix of this lazy list whose elements all satisfy `p`
    */
   override def takeWhile(p: A => Boolean): LazyList[A] =
     if (knownIsEmpty) Empty
@@ -872,6 +894,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  $initiallyLazy
    *
    *  @param n the number of elements to take from the right end
+   *  @return a lazy list containing the last `n` elements of this lazy list (or all elements if `n` exceeds the length)
    */
   override def takeRight(n: Int): LazyList[A] =
     if (n <= 0 || knownIsEmpty) Empty
@@ -884,6 +907,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @param from the index of the first element in the slice
    *  @param until the index of the element following the slice
+   *  @return a lazy list containing the elements at indices in the half-open interval `[from, until)`
    */
   override def slice(from: Int, until: Int): LazyList[A] = take(until).drop(from)
 
@@ -905,6 +929,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the other sequence, a supertype of `A`
    *  @param that the sequence of elements to remove from this lazy list
+   *  @return a new lazy list containing the multiset difference of this lazy list and `that`
    */
   override def diff[B >: A](that: collection.Seq[B]): LazyList[A] =
     if (knownIsEmpty) Empty
@@ -916,6 +941,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the other sequence, a supertype of `A`
    *  @param that the sequence to intersect with
+   *  @return a new lazy list containing the multiset intersection of this lazy list and `that`
    */
   override def intersect[B >: A](that: collection.Seq[B]): LazyList[A] =
     if (knownIsEmpty) Empty
@@ -933,6 +959,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  a single element ahead of the iterator is evaluated.
    *
    *  @param size the number of elements per group, must be positive
+   *  @return an iterator producing lazy lists of length `size`, except possibly the last which may be shorter
    */
   override def grouped(size: Int): Iterator[LazyList[A]] = {
     require(size > 0, "size must be positive, but was " + size)
@@ -946,6 +973,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @param size the number of elements per window, must be positive
    *  @param step the number of elements to advance per window, must be positive
+   *  @return an iterator producing sliding windows of length `size`, each advanced by `step` elements
    */
   override def sliding(size: Int, step: Int): Iterator[LazyList[A]] = {
     require(size > 0 && step > 0, s"size=$size and step=$step, but both must be positive")
@@ -963,6 +991,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param len the minimum length of the result; no padding if this lazy list is already at least `len` long
    *  @param elem the element to use for padding
+   *  @return a new lazy list consisting of this lazy list followed by enough copies of `elem` to reach length `len`, or this lazy list itself if it is already at least `len` long
    */
   override def padTo[B >: A](len: Int, elem: B): LazyList[B] =
     if (len <= 0) this
@@ -979,6 +1008,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @param from the index at which to begin patching
    *  @param other the elements to insert at the patch position
    *  @param replaced the number of elements in this lazy list to replace
+   *  @return a new lazy list with `replaced` elements starting at `from` replaced by the elements of `other`
    */
   override def patch[B >: A](from: Int, other: IterableOnce[B], replaced: Int): LazyList[B] =
     if (knownIsEmpty) LazyList from other
@@ -997,6 +1027,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *
    *  @tparam B the element type of the inner collections
    *  @param asIterable an implicit conversion from elements of type `A` to `Iterable[B]`
+   *  @return a new lazy list of lazy lists where the `i`th inner lazy list contains the `i`th element of each original inner collection
    */
   // overridden just in case a lazy implementation is developed at some point
   override def transpose[B](implicit asIterable: A => collection.Iterable[B]): LazyList[LazyList[B]] = super.transpose
@@ -1008,6 +1039,7 @@ final class LazyList[+A] private (lazyState: AnyRef /* EmptyMarker.type | () => 
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param index the zero-based position of the element to replace
    *  @param elem the new element to place at position `index`
+   *  @return a new lazy list identical to this one except for the element at `index`, which is replaced by `elem`
    */
   override def updated[B >: A](index: Int, elem: B): LazyList[B] =
     if (index < 0) throw new IndexOutOfBoundsException(s"$index")
@@ -1168,7 +1200,8 @@ object LazyList extends SeqFactory[LazyList] {
   /** Creates a new LazyList.
    *
    *  @tparam A the element type of the lazy list
-   *  @param state the by-name expression computing the initial state of the lazy list
+   *  @param state the by-name expression that, when forced, produces the lazy list
+   *  @return a new lazy list whose head and tail are computed by forcing `state`
    */
   @inline private def newLL[A](state: => LazyList[A]): LazyList[A] = new LazyList[A](() => state)
 
@@ -1177,6 +1210,7 @@ object LazyList extends SeqFactory[LazyList] {
    *  @tparam A the element type of the lazy list
    *  @param hd the head element of the lazy list
    *  @param tl the already-evaluated tail of the lazy list
+   *  @return a new lazy list whose head `hd` and tail `tl` are already evaluated
    */
   @inline private def eagerCons[A](hd: A, tl: LazyList[A]): LazyList[A] = new LazyList[A](hd, tl)
 
@@ -1315,6 +1349,7 @@ object LazyList extends SeqFactory[LazyList] {
      *  @tparam A the element type of the lazy list
      *  @param hd   The first element of the result lazy list
      *  @param tl   The remaining elements of the result lazy list
+     *  @return a lazy list with `hd` as its head and `tl` as its tail, both evaluated on demand
      */
     def apply[A](hd: => A, tl: => LazyList[A]): LazyList[A] = newLL(eagerCons(hd, newLL(tl)))
 
@@ -1322,6 +1357,7 @@ object LazyList extends SeqFactory[LazyList] {
      *
      *  @tparam A the element type of the lazy list
      *  @param xs the lazy list to decompose
+     *  @return `Some((head, tail))` if `xs` is non-empty, or `None` if it is empty
      */
     def unapply[A](xs: LazyList[A]): Option[(A, LazyList[A])] = #::.unapply(xs)
   }
@@ -1358,6 +1394,7 @@ object LazyList extends SeqFactory[LazyList] {
    *  @tparam A the element type of the lazy list
    *  @param it the iterator whose elements are prepended
    *  @param suffix the lazy list to append after the iterator's elements are exhausted
+   *  @return a lazy list containing the elements of `it` followed by the elements of `suffix`
    */
   private def eagerHeadPrependIterator[A](it: Iterator[A])(suffix: => LazyList[A]): LazyList[A] =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadPrependIterator(it)(suffix)))
@@ -1367,6 +1404,7 @@ object LazyList extends SeqFactory[LazyList] {
    *
    *  @tparam A the element type of the lazy list
    *  @param it the iterator to convert into a lazy list
+   *  @return a lazy list whose elements are produced by `it`, with the first element eagerly evaluated
    */
   private def eagerHeadFromIterator[A](it: Iterator[A]): LazyList[A] =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadFromIterator(it)))

--- a/library/src/scala/collection/immutable/LazyListIterable.scala
+++ b/library/src/scala/collection/immutable/LazyListIterable.scala
@@ -517,6 +517,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @tparam B the result type of the binary operator and the type of the initial value
    *  @param z the initial value
    *  @param op the binary operator applied to the intermediate result and the element
+   *  @return a new lazy list containing `z`, followed by the running accumulation of `op` over the elements
    */
   override def scanLeft[B](z: B)(op: (B, A) => B): LazyListIterable[B]^{this, op} =
     if (knownIsEmpty) eagerCons(z, Empty)
@@ -556,6 +557,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  @param p the predicate used to test elements
+   *  @return a pair of lazy lists, the first containing elements that satisfy `p` and the second containing those that do not
    */
   override def partition(p: A => Boolean): (LazyListIterable[A]^{this, p}, LazyListIterable[A]^{this, p}) = (filter(p), filterNot(p))
 
@@ -566,6 +568,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @tparam A1 the element type of the first resulting collection
    *  @tparam A2 the element type of the second resulting collection
    *  @param f the function applied to each element that returns `Left` or `Right`
+   *  @return a pair of lazy lists, the first containing the values from `Left` results and the second containing the values from `Right` results
    */
   override def partitionMap[A1, A2](f: A => Either[A1, A2]): (LazyListIterable[A1]^{this, f}, LazyListIterable[A2]^{this, f}) = {
     val p: (LazyListIterable[Either[A1, A2]]^{this, f}, LazyListIterable[Either[A1, A2]]^{this, f}) = map(f).partition(_.isLeft)
@@ -577,6 +580,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  @param pred the predicate used to test elements
+   *  @return a new lazy list containing only those elements of this lazy list that satisfy `pred`
    */
   override def filter(pred: A => Boolean): LazyListIterable[A]^{this, pred} =
     if (knownIsEmpty) Empty
@@ -587,6 +591,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  @param pred the predicate used to test elements
+   *  @return a new lazy list containing only those elements of this lazy list that do not satisfy `pred`
    */
   override def filterNot(pred: A => Boolean): LazyListIterable[A]^{this, pred} =
     if (knownIsEmpty) Empty
@@ -612,6 +617,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param elem the element to prepend
+   *  @return a new lazy list with `elem` as the first element followed by all elements of this lazy list
    */
   override def prepended[B >: A](elem: B): LazyListIterable[B]^{this} = eagerCons(elem, this)
 
@@ -621,6 +627,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param prefix the collection to prepend
+   *  @return a new lazy list containing the elements of `prefix` followed by all elements of this lazy list
    */
   override def prependedAll[B >: A](prefix: collection.IterableOnce[B]^): LazyListIterable[B]^{this, prefix} =
     if (knownIsEmpty) LazyListIterable.from(prefix)
@@ -633,6 +640,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned lazy list
    *  @param f the function to apply to each element
+   *  @return a new lazy list resulting from applying `f` to each element of this lazy list
    */
   override def map[B](f: A => B): LazyListIterable[B]^{this, f} =
     if (knownIsEmpty) Empty
@@ -644,6 +652,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam U the return type of the function `f`
    *  @param f the function to apply to each element for its side effect
+   *  @return a new lazy list with the same elements as this lazy list, with `f` applied to each element as it is evaluated
    */
   override def tapEach[U](f: A => U): LazyListIterable[A]^{this, f} = map { a => f(a); a }
 
@@ -659,6 +668,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned lazy list
    *  @param pf the partial function which filters and maps elements
+   *  @return a new lazy list containing the results of applying `pf` to each element for which it is defined
    */
   override def collect[B](pf: PartialFunction[A, B]^): LazyListIterable[B]^{this, pf} =
     if (knownIsEmpty) Empty
@@ -671,6 +681,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned option
    *  @param pf the partial function which filters and maps elements
+   *  @return `Some` containing the result of `pf` applied to the first element for which it is defined, or `None` if no such element exists
    */
   @tailrec
   override def collectFirst[B](pf: PartialFunction[A, B]^): Option[B] =
@@ -687,6 +698,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  the first element matching the predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return `Some` containing the first element satisfying `p`, or `None` if no such element exists
    */
   @tailrec
   override def find(p: A => Boolean): Option[A] =
@@ -713,6 +725,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned lazy list
    *  @param asIterable an implicit conversion which asserts that the element type of this lazy list is an `IterableOnce`
+   *  @return a new lazy list resulting from concatenating all nested collections of this lazy list
    */
   override def flatten[B](implicit asIterable: A -> IterableOnce[B]): LazyListIterable[B]^{this} = flatMap(asIterable)
 
@@ -722,6 +735,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the second half of the returned pairs
    *  @param that the iterable providing the second half of each result pair
+   *  @return a new lazy list of pairs whose length is the minimum of the lengths of this lazy list and `that`
    */
   override def zip[B](that: collection.IterableOnce[B]^): LazyListIterable[(A, B)]^{this, that} =
     if (knownIsEmpty || that.knownSize == 0) Empty
@@ -746,6 +760,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @param that the iterable providing the second half of each result pair
    *  @param thisElem the element to use if this lazy list is shorter than `that`
    *  @param thatElem the element to use if `that` is shorter than this lazy list
+   *  @return a new lazy list of pairs whose length is the maximum of the lengths of this lazy list and `that`, padding this lazy list with `thisElem` or `that` with `thatElem` when one is shorter
    */
   override def zipAll[A1 >: A, B](that: collection.Iterable[B]^, thisElem: A1, thatElem: B): LazyListIterable[(A1, B)]^{this, that} = {
     if (knownIsEmpty) {
@@ -790,6 +805,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @tparam A1 the type of the first element in each pair
    *  @tparam A2 the type of the second element in each pair
    *  @param asPair an implicit conversion which asserts that the element type of this lazy list is a pair
+   *  @return a pair of lazy lists containing the first and second components of each pair in this lazy list
    */
   override def unzip[A1, A2](implicit asPair: A -> (A1, A2)): (LazyListIterable[A1]^{this}, LazyListIterable[A2]^{this}) =
     (map(asPair(_)._1), map(asPair(_)._2))
@@ -802,6 +818,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @tparam A2 the type of the second element in each triple
    *  @tparam A3 the type of the third element in each triple
    *  @param asTriple an implicit conversion which asserts that the element type of this lazy list is a triple
+   *  @return a triple of lazy lists containing the first, second, and third components of each triple in this lazy list
    */
   override def unzip3[A1, A2, A3](implicit asTriple: A -> (A1, A2, A3)): (LazyListIterable[A1]^{this}, LazyListIterable[A2]^{this}, LazyListIterable[A3]^{this}) =
     (map(asTriple(_)._1), map(asTriple(_)._2), map(asTriple(_)._3))
@@ -812,6 +829,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  Additionally, it preserves laziness for all except the first `n` elements.
    *
    *  @param n the number of elements to drop from this lazy list
+   *  @return a lazy list consisting of all elements of this lazy list except the first `n`, or empty if there are fewer than `n` elements
    */
   override def drop(n: Int): LazyListIterable[A]^{this} =
     if (n <= 0) this
@@ -824,6 +842,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  Additionally, it preserves laziness for all elements after the predicate returns `false`.
    *
    *  @param p the predicate used to test elements
+   *  @return a lazy list consisting of all elements from the first one that does not satisfy `p` onward
    */
   override def dropWhile(p: A => Boolean): LazyListIterable[A]^{this, p} =
     if (knownIsEmpty) Empty
@@ -834,6 +853,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $initiallyLazy
    *
    *  @param n the number of elements to drop from the right end
+   *  @return a lazy list consisting of all elements of this lazy list except the last `n`, or empty if there are fewer than `n` elements
    */
   override def dropRight(n: Int): LazyListIterable[A]^{this} = {
     if (n <= 0) this
@@ -859,6 +879,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  @param n the number of elements to take from this lazy list
+   *  @return a lazy list consisting of the first `n` elements of this lazy list, or all elements if there are fewer than `n`; empty if `n <= 0`
    */
   override def take(n: Int): LazyListIterable[A]^{this} =
     if (knownIsEmpty) Empty
@@ -877,6 +898,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $preservesLaziness
    *
    *  @param p the predicate used to test elements
+   *  @return the longest prefix of this lazy list whose elements all satisfy `p`
    */
   override def takeWhile(p: A => Boolean): LazyListIterable[A]^{this, p} =
     if (knownIsEmpty) Empty
@@ -893,6 +915,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  $initiallyLazy
    *
    *  @param n the number of elements to take from the right end
+   *  @return a lazy list consisting of the last `n` elements of this lazy list, or all elements if there are fewer than `n`
    */
   override def takeRight(n: Int): LazyListIterable[A]^{this} =
     if (n <= 0 || knownIsEmpty) Empty
@@ -905,6 +928,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @param from the index of the first element in the slice
    *  @param until the index of the element following the slice
+   *  @return a lazy list containing the elements from index `from` (inclusive) to index `until` (exclusive)
    */
   override def slice(from: Int, until: Int): LazyListIterable[A]^{this} = take(until).drop(from)
 
@@ -926,6 +950,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param that the sequence of elements to subtract (by multiplicity)
+   *  @return a new lazy list containing the elements of this lazy list with the elements of `that` removed (respecting multiplicity)
    */
   override def diff[B >: A](that: collection.Seq[B]): LazyListIterable[A]^{this}  =
     if (knownIsEmpty) Empty
@@ -937,6 +962,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param that the sequence of elements to intersect with
+   *  @return a new lazy list containing the elements of this lazy list that also appear in `that` (respecting multiplicity)
    */
   override def intersect[B >: A](that: collection.Seq[B]): LazyListIterable[A]^{this} =
     if (knownIsEmpty) Empty
@@ -954,6 +980,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  a single element ahead of the iterator is evaluated.
    *
    *  @param size the number of elements per group, must be positive
+   *  @return an iterator producing fixed-size lazy list groups of consecutive elements (the final group may be smaller)
    */
   override def grouped(size: Int): Iterator[LazyListIterable[A]^{this}]^{this} = {
     require(size > 0, "size must be positive, but was " + size)
@@ -967,6 +994,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @param size the number of elements per window, must be positive
    *  @param step the number of elements to advance per window, must be positive
+   *  @return an iterator producing sliding lazy list windows of length `size`, advancing by `step` elements each time
    */
   override def sliding(size: Int, step: Int): Iterator[LazyListIterable[A]^{this}]^{this} = {
     require(size > 0 && step > 0, s"size=$size and step=$step, but both must be positive")
@@ -986,6 +1014,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param len the length to which this lazy list should be padded
    *  @param elem the padding element
+   *  @return a new lazy list of at least length `len`, padded with `elem` if this lazy list is shorter
    */
   override def padTo[B >: A](len: Int, elem: B): LazyListIterable[B]^{this} =
     if (len <= 0) this
@@ -1002,6 +1031,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @param from the index of the first replaced element
    *  @param other the collection of replacement elements
    *  @param replaced the number of elements to replace starting from index `from`
+   *  @return a new lazy list with `replaced` elements starting at index `from` replaced by the elements of `other`
    */
   override def patch[B >: A](from: Int, other: IterableOnce[B]^, replaced: Int): LazyListIterable[B]^{this, other} =
     if (knownIsEmpty) LazyListIterable from other
@@ -1020,6 +1050,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *
    *  @tparam B the element type of each nested iterable
    *  @param asIterable an implicit conversion which asserts that the element type of this lazy list is an `Iterable`
+   *  @return a new lazy list whose `i`th element is a lazy list of the `i`th element of each nested iterable
    */
   // overridden just in case a lazy implementation is developed at some point
   override def transpose[B](implicit asIterable: A -> collection.Iterable[B]): LazyListIterable[LazyListIterable[B]^{this}]^{this} = super.transpose
@@ -1031,6 +1062,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
    *  @tparam B the element type of the returned lazy list, a supertype of `A`
    *  @param index the zero-based index of the element to replace
    *  @param elem the replacing element
+   *  @return a new lazy list identical to this one except that the element at position `index` is `elem`
    */
   override def updated[B >: A](index: Int, elem: B): LazyListIterable[B]^{this} =
     if (index < 0) throw new IndexOutOfBoundsException(s"$index")
@@ -1192,6 +1224,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
    *
    *  @tparam A the element type of the lazy list
    *  @param state the by-name expression that computes the lazy list state when forced
+   *  @return a new lazy list whose head and tail are produced by evaluating `state` on demand
    */
   @inline private def newLL[A](state: => LazyListIterable[A]^): LazyListIterable[A]^{state} = new LazyListIterable[A](() => state)
 
@@ -1200,6 +1233,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
    *  @tparam A the element type of the lazy list
    *  @param hd the head element of the cons cell
    *  @param tl the tail lazy list of the cons cell
+   *  @return a new lazy list whose head is `hd` and whose tail is `tl`, with the cons cell constructed eagerly (no thunk wrapping `hd` or `tl`)
    */
   @inline private def eagerCons[A](hd: A, tl: LazyListIterable[A]^): LazyListIterable[A]^{tl} =
     new LazyListIterable[A](hd, tl).asInstanceOf[LazyListIterable[A]^{tl}]
@@ -1340,6 +1374,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
      *  @tparam A the element type of the lazy list
      *  @param hd   The first element of the result lazy list
      *  @param tl   The remaining elements of the result lazy list
+     *  @return a lazy list whose head is `hd` and whose tail is `tl`, both evaluated on demand
      */
     def apply[A](hd: => A, tl: => LazyListIterable[A]): LazyListIterable[A]^{hd, tl} = newLL(eagerCons(hd, newLL(tl)))
 
@@ -1347,6 +1382,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
      *
      *  @tparam A the element type of the lazy list
      *  @param xs the lazy list to decompose
+     *  @return `Some` containing the head and tail if `xs` is non-empty, or `None` if `xs` is empty
      */
     def unapply[A](xs: LazyListIterable[A]^): Option[(A, LazyListIterable[A]^{xs})] = #::.unapply(xs)
   }
@@ -1383,6 +1419,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
    *  @tparam A the element type of the lazy list
    *  @param it the iterator whose elements are prepended
    *  @param suffix the lazy list to append after the iterator elements are exhausted
+   *  @return a lazy list containing all elements of `it` followed by the elements of `suffix`
    */
   private def eagerHeadPrependIterator[A](it: Iterator[A]^)(suffix: => LazyListIterable[A]^): LazyListIterable[A]^{it, suffix} =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadPrependIterator(it)(suffix)))
@@ -1392,6 +1429,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
    *
    *  @tparam A the element type of the lazy list
    *  @param it the iterator to convert into a lazy list
+   *  @return a lazy list containing all elements produced by `it`, or empty if `it` has no elements
    */
   private def eagerHeadFromIterator[A](it: Iterator[A]^): LazyListIterable[A]^{it} =
     if (it.hasNext) eagerCons(it.next(), newLL(eagerHeadFromIterator(it)))

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -126,6 +126,7 @@ private[immutable] abstract class LongMapIterator[V, T](it: LongMap[V]) extends 
   /** What value do we assign to a tip?
    *
    *  @param tip the leaf node to extract a value from
+   *  @return the element of type `T` (e.g. the key, the value, or the key-value pair) extracted from `tip`
    */
   def valueOf(tip: LongMap.Tip[V]): T
 

--- a/library/src/scala/collection/immutable/Map.scala
+++ b/library/src/scala/collection/immutable/Map.scala
@@ -71,6 +71,7 @@ trait Map[K, +V]
  *  @tparam K the type of the keys in this map
  *  @tparam V the type of the values associated with the keys
  *  @tparam CC the type constructor of the resulting map (e.g., `Map`, `HashMap`)
+ *  @tparam C the type of the map itself, used as the return type of operations that preserve the concrete map type
  */
 transparent trait MapOps[K, +V, +CC[X, +Y] <: MapOps[X, Y, CC, ?], +C <: MapOps[K, V, CC, C]]
   extends IterableOps[(K, V), Iterable, C]

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -100,6 +100,7 @@ sealed class NumericRange[T](
    *  a new `step`.
    *
    *  @param newStep the new step value for the range
+   *  @return a new `NumericRange` with the same `start` and `end` as this range but with the given `newStep`
    */
   def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
 
@@ -109,6 +110,7 @@ sealed class NumericRange[T](
    *  @param start the start value of the new range
    *  @param end the end value of the new range
    *  @param step the step value of the new range
+   *  @return a new `NumericRange` with the given `start`, `end`, and `step`, preserving this range's `isInclusive` flag
    */
   def copy(start: T, end: T, step: T): NumericRange[T] =
     new NumericRange(start, end, step, isInclusive)
@@ -421,6 +423,7 @@ object NumericRange {
    *  @param step the increment between successive elements, must not be zero
    *  @param isInclusive whether `end` is included in the range
    *  @param num the `Integral` instance used for arithmetic on `T`
+   *  @return the number of elements that the described range would contain
    */
   def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
     val zero    = num.zero

--- a/library/src/scala/collection/immutable/Queue.scala
+++ b/library/src/scala/collection/immutable/Queue.scala
@@ -143,6 +143,7 @@ sealed class Queue[+A] protected(protected val in: List[A], protected val out: L
    *
    *  @tparam B the element type of the returned queue, a supertype of `A`
    *  @param  elem        the element to insert
+   *  @return a new queue with `elem` appended at the end
    */
   def enqueue[B >: A](elem: B): Queue[B] = new Queue(elem :: in, out)
 

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -603,6 +603,7 @@ object Range {
    *  @param end the end value of the range (exclusive or inclusive depending on `isInclusive`)
    *  @param step the step value between consecutive elements, must be non-zero
    *  @param isInclusive whether `end` is included in the range
+   *  @return the number of elements in the range, `0` if the range is empty, or a negative value (modular wrap) if the count exceeds `Int.MaxValue`
    */
   def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
     if (step == 0)
@@ -639,6 +640,7 @@ object Range {
    *  @param start the start value of the range
    *  @param end the exclusive end value of the range
    *  @param step the step value between consecutive elements, must be non-zero
+   *  @return a new exclusive `Range` from `start` (inclusive) to `end` (exclusive) with the given `step`
    */
   def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
 
@@ -646,6 +648,7 @@ object Range {
    *
    *  @param start the start value of the range
    *  @param end the exclusive end value of the range
+   *  @return a new exclusive `Range` from `start` (inclusive) to `end` (exclusive) with step `1`
    */
   def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
 
@@ -655,6 +658,7 @@ object Range {
    *  @param start the start value of the range
    *  @param end the inclusive end value of the range
    *  @param step the step value between consecutive elements, must be non-zero
+   *  @return a new inclusive `Range` from `start` to `end` (with `end` included only if reachable by `step` from `start`) with the given `step`
    */
   def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
 
@@ -662,6 +666,7 @@ object Range {
    *
    *  @param start the start value of the range
    *  @param end the inclusive end value of the range
+   *  @return a new inclusive `Range` from `start` to `end` (both inclusive) with step `1`
    */
   def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
 

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -77,6 +77,7 @@ private[collection] object RedBlackTree {
      *  @tparam B1 the value type of the result, a supertype of `B`
      *  @param tree the original tree whose left child is being replaced
      *  @param newLeft the new left subtree to substitute in
+     *  @return a rebalanced tree containing all entries of `tree` with `newLeft` replacing the original left subtree, possibly mutating `tree` or `newLeft` in place
      */
     protected final def mutableBalanceLeft[A1, B, B1 >: B](tree: Tree[A1, B], newLeft: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -127,6 +128,7 @@ private[collection] object RedBlackTree {
      *  @tparam B1 the value type of the result, a supertype of `B`
      *  @param tree the original tree whose right child is being replaced
      *  @param newRight the new right subtree to substitute in
+     *  @return a rebalanced tree containing all entries of `tree` with `newRight` replacing the original right subtree, possibly mutating `tree` or `newRight` in place
      */
     protected final def mutableBalanceRight[A1, B, B1 >: B](tree: Tree[A1, B], newRight: Tree[A1, B1]): Tree[A1, B1] = {
       // Parameter trees
@@ -265,6 +267,7 @@ private[collection] object RedBlackTree {
    *  @param tree the red-black tree to search
    *  @param x the inclusive lower bound key to search for
    *  @param ordering the ordering used to compare keys
+   *  @return the node with the smallest key greater than or equal to `x`, or `null` if no such node exists
    */
   def minAfter[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
@@ -282,6 +285,7 @@ private[collection] object RedBlackTree {
    *  @param tree the red-black tree to search
    *  @param x the exclusive upper bound key
    *  @param ordering the ordering used to compare keys
+   *  @return the node with the largest key strictly less than `x`, or `null` if no such node exists
    */
   def maxBefore[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
@@ -370,6 +374,7 @@ private[collection] object RedBlackTree {
    *  @tparam B1 the value type
    *  @param tree the original tree whose left child is being replaced
    *  @param newLeft the new left subtree to substitute in
+   *  @return a rebalanced immutable tree containing all entries of `tree` with `newLeft` replacing the original left subtree, or `tree` itself when `newLeft` is already its left child
    */
   private def balanceLeft[A, B1](tree: Tree[A, B1], newLeft: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
@@ -417,6 +422,7 @@ private[collection] object RedBlackTree {
    *  @tparam B1 the value type
    *  @param tree the original tree whose right child is being replaced
    *  @param newRight the new right subtree to substitute in
+   *  @return a rebalanced immutable tree containing all entries of `tree` with `newRight` replacing the original right subtree, or `tree` itself when `newRight` is already its right child
    */
   private def balanceRight[A, B1](tree: Tree[A, B1], newRight: Tree[A, B1]): Tree[A, B1] = {
     // Parameter trees
@@ -830,6 +836,7 @@ private[collection] object RedBlackTree {
    *  @param value the value associated with the key
    *  @param left the left subtree, or `null` if absent
    *  @param right the right subtree, or `null` if absent
+   *  @return a new immutable red tree node whose size is the combined size of the subtrees plus one
    */
   private[immutable] def RedTree[A, B](key: A, value: B, left: Tree[A, B] | Null, right: Tree[A, B] | Null): Tree[A, B] = {
     //assertNotMutable(left)
@@ -904,6 +911,7 @@ private[collection] object RedBlackTree {
      *  functionality works.
      *
      *  @param key the key from which to start iteration
+     *  @return the leftmost subtree whose key is greater than or equal to `key`, or `null` if no such subtree exists
      */
     private def startFrom(key: A) : Tree[A,B] | Null = if (root eq null) null else {
       @tailrec def find(tree: Tree[A, B] | Null): Tree[A, B] | Null =
@@ -988,6 +996,7 @@ private[collection] object RedBlackTree {
    *  @tparam A the key type
    *  @param xs an iterator yielding keys in ascending order
    *  @param size the number of keys to consume from the iterator
+   *  @return a balanced red-black tree containing the consumed keys, or `null` if `size` is zero
    */
   def fromOrderedKeys[A](xs: Iterator[A]^, size: Int): Tree[A, Null] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
@@ -1010,6 +1019,7 @@ private[collection] object RedBlackTree {
    *  @tparam B the value type
    *  @param xs an iterator yielding key-value pairs in ascending key order
    *  @param size the number of entries to consume from the iterator
+   *  @return a balanced red-black tree containing the consumed entries, or `null` if `size` is zero
    */
   def fromOrderedEntries[A, B](xs: Iterator[(A, B)]^, size: Int): Tree[A, B] | Null = {
     val maxUsedDepth = 32 - Integer.numberOfLeadingZeros(size) // maximum depth of non-leaf nodes
@@ -1153,6 +1163,7 @@ private[collection] object RedBlackTree {
    *  @tparam B the value type
    *  @param tl the left subtree to append, or `null` if empty
    *  @param tr the right subtree to append, or `null` if empty
+   *  @return a tree containing all entries of `tl` followed by all entries of `tr`, with the same black height as the inputs (the root may be red, so callers typically blacken it), or `null` if both inputs are `null`
    */
   private def append[A, B](tl: Tree[A, B] | Null, tr: Tree[A, B] | Null): Tree[A, B] | Null = {
     if (tl eq null) tr
@@ -1197,6 +1208,7 @@ private[collection] object RedBlackTree {
    *
    *  @param t the tree node, or `null` for an empty subtree
    *  @param bh the black height of `t`
+   *  @return the rank of `t`: `2*(bh - 1)` for black nodes and `2*bh - 1` for red nodes, or `0` when `t` is `null`
    */
   @`inline` private def rank(t: Tree[?, ?] | Null, bh: Int): Int = {
     if(t eq null) 0

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -267,7 +267,6 @@ private[collection] object RedBlackTree {
    *  @param tree the red-black tree to search
    *  @param x the inclusive lower bound key to search for
    *  @param ordering the ordering used to compare keys
-   *  @return the node with the smallest key greater than or equal to `x`, or `null` if no such node exists
    */
   def minAfter[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)
@@ -285,7 +284,6 @@ private[collection] object RedBlackTree {
    *  @param tree the red-black tree to search
    *  @param x the exclusive upper bound key
    *  @param ordering the ordering used to compare keys
-   *  @return the node with the largest key strictly less than `x`, or `null` if no such node exists
    */
   def maxBefore[A, B](tree: Tree[A, B] | Null, x: A)(implicit ordering: Ordering[A]): Tree[A, B] | Null = if (tree eq null) null else {
     val cmp = ordering.compare(x, tree.key)

--- a/library/src/scala/collection/immutable/Seq.scala
+++ b/library/src/scala/collection/immutable/Seq.scala
@@ -33,6 +33,7 @@ trait Seq[+A] extends Iterable[A]
  *
  *  @tparam A the element type of the sequence
  *  @tparam CC the type constructor for the collection type, constrained to be pure
+ *  @tparam C the concrete type of this sequence
  */
 transparent trait SeqOps[+A, +CC[B] <: caps.Pure, +C] extends Any with collection.SeqOps[A, CC, C] with caps.Pure
 
@@ -128,6 +129,7 @@ object IndexedSeq extends SeqFactory.Delegate[IndexedSeq](Vector) {
  *
  *  @tparam A the element type of the indexed sequence
  *  @tparam CC the type constructor for the collection type, constrained to be pure
+ *  @tparam C the concrete type of this indexed sequence
  */
 transparent trait IndexedSeqOps[+A, +CC[B] <: caps.Pure, +C]
   extends SeqOps[A, CC, C]

--- a/library/src/scala/collection/immutable/Set.scala
+++ b/library/src/scala/collection/immutable/Set.scala
@@ -38,6 +38,7 @@ trait Set[A] extends Iterable[A]
  *
  *  @tparam A the element type of the set
  *  @tparam CC the type constructor for the resulting set (e.g., `Set`)
+ *  @tparam C the concrete type of this set, returned by transformation operations
  */
 transparent trait SetOps[A, +CC[X], +C <: SetOps[A, CC, C]]
   extends collection.SetOps[A, CC, C] {

--- a/library/src/scala/collection/immutable/Stream.scala
+++ b/library/src/scala/collection/immutable/Stream.scala
@@ -168,6 +168,7 @@ sealed abstract class Stream[+A] extends AbstractSeq[A]
   /** A `collection.WithFilter` which allows GC of the head of stream during processing.
    *
    *  @param p the predicate used to test elements
+   *  @return a `WithFilter` over this stream restricted to elements satisfying `p`, suitable for chained `map`, `flatMap`, `foreach`, and further `withFilter` calls
    */
   override final def withFilter(p: A => Boolean): collection.WithFilter[A, Stream] =
     Stream.withFilter(coll, p)
@@ -371,6 +372,7 @@ object Stream extends SeqFactory[Stream] {
      *  @tparam A the element type of the stream
      *  @param hd   The first element of the result stream
      *  @param tl   The remaining elements of the result stream
+     *  @return a non-empty `Stream` whose head is `hd` and whose tail is lazily produced from `tl`
      */
     def apply[A](hd: A, tl: => Stream[A]): Stream[A] = new Cons(hd, tl)
 
@@ -378,6 +380,7 @@ object Stream extends SeqFactory[Stream] {
      *
      *  @tparam A the element type of the stream
      *  @param xs the stream to decompose
+     *  @return `Some((head, tail))` if `xs` is non-empty, or `None` if `xs` is empty
      */
     def unapply[A](xs: Stream[A]): Option[(A, Stream[A])] = #::.unapply(xs)
   }

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -270,6 +270,7 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
    *
    *  @param lo the lowest index to include (inclusive), must satisfy `0 <= lo < hi`
    *  @param hi the exclusive upper bound index, must satisfy `lo < hi <= length`
+   *  @return a new vector containing the elements from index `lo` (inclusive) to `hi` (exclusive)
    */
   protected def slice0(lo: Int, hi: Int): Vector[A]
 
@@ -278,11 +279,13 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
   /** Slices at index.
    *
    *  @param idx the zero-based slice index
+   *  @return the underlying data array (of dimension matching the slice level) for the slice at position `idx`
    */
   protected[immutable] def vectorSlice(idx: Int): Array[? <: AnyRef | Null]
   /** Length of all slices up to and including index.
    *
    *  @param idx the zero-based slice index
+   *  @return the cumulative number of elements in all slices from `0` up to and including `idx`
    */
   protected[immutable] def vectorSlicePrefixLength(idx: Int): Int
 
@@ -337,6 +340,7 @@ sealed abstract class Vector[+A] private[immutable] (private[immutable] final va
 /** This class only exists because we cannot override `slice` in `Vector` in a binary-compatible way.
  *
  *  @tparam A the element type of the vector
+ *  @param _prefix1 the leading data array containing the leftmost elements
  */
 private sealed abstract class VectorImpl[+A](_prefix1: Arr1) extends Vector[A](_prefix1) {
 
@@ -355,6 +359,7 @@ private sealed abstract class VectorImpl[+A](_prefix1: Arr1) extends Vector[A](_
  *  @tparam A the element type of the vector
  *  @param suffix1 the last data array containing the rightmost elements
  *  @param length0 the total number of elements in this vector
+ *  @param _prefix1 the leading data array containing the leftmost elements
  */
 private sealed abstract class BigVector[+A](_prefix1: Arr1, private[immutable] val suffix1: Arr1, private[immutable] val length0: Int) extends VectorImpl[A](_prefix1) {
 
@@ -413,6 +418,7 @@ private object Vector0 extends BigVector[Nothing](empty1, empty1, 0) {
 /** Flat ArraySeq-like structure.
  *
  *  @tparam A the element type of the vector
+ *  @param _data1 the single data array holding all elements of this vector (between 1 and `WIDTH` entries, since `Vector0` handles the empty case)
  */
 private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
 
@@ -476,6 +482,9 @@ private final class Vector1[+A](_data1: Arr1) extends VectorImpl[A](_data1) {
  *  @tparam A the element type of the vector
  *  @param len1 the number of elements in `prefix1`
  *  @param data2 the central 2-dimensional data array
+ *  @param _prefix1 the leading data array containing the leftmost elements
+ *  @param _suffix1 the last data array containing the rightmost elements
+ *  @param _length0 the total number of elements in this vector
  */
 private final class Vector2[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val data2: Arr2,
@@ -584,6 +593,9 @@ private final class Vector2[+A](_prefix1: Arr1, private[immutable] val len1: Int
  *  @param len12 the combined number of elements in `prefix1` and `prefix2`
  *  @param data3 the central 3-dimensional data array
  *  @param suffix2 the 2nd-level suffix data arrays
+ *  @param _prefix1 the leading data array containing the leftmost elements
+ *  @param _suffix1 the last data array containing the rightmost elements
+ *  @param _length0 the total number of elements in this vector
  */
 private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
@@ -718,6 +730,9 @@ private final class Vector3[+A](_prefix1: Arr1, private[immutable] val len1: Int
  *  @param data4 the central 4-dimensional data array
  *  @param suffix3 the 3rd-level suffix data arrays
  *  @param suffix2 the 2nd-level suffix data arrays
+ *  @param _prefix1 the leading data array containing the leftmost elements
+ *  @param _suffix1 the last data array containing the rightmost elements
+ *  @param _length0 the total number of elements in this vector
  */
 private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
@@ -876,6 +891,9 @@ private final class Vector4[+A](_prefix1: Arr1, private[immutable] val len1: Int
  *  @param suffix4 the 4th-level suffix data arrays
  *  @param suffix3 the 3rd-level suffix data arrays
  *  @param suffix2 the 2nd-level suffix data arrays
+ *  @param _prefix1 the leading data array containing the leftmost elements
+ *  @param _suffix1 the last data array containing the rightmost elements
+ *  @param _length0 the total number of elements in this vector
  */
 private final class Vector5[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
@@ -1058,6 +1076,9 @@ private final class Vector5[+A](_prefix1: Arr1, private[immutable] val len1: Int
  *  @param suffix4 the 4th-level suffix data arrays
  *  @param suffix3 the 3rd-level suffix data arrays
  *  @param suffix2 the 2nd-level suffix data arrays
+ *  @param _prefix1 the leading data array containing the leftmost elements
+ *  @param _suffix1 the last data array containing the rightmost elements
+ *  @param _length0 the total number of elements in this vector
  */
 private final class Vector6[+A](_prefix1: Arr1, private[immutable] val len1: Int,
                                  private[immutable] val prefix2: Arr2, private[immutable] val len12: Int,
@@ -2111,6 +2132,7 @@ private[immutable] object VectorInline {
    *
    *  @param count the total number of slices
    *  @param idx the zero-based slice index
+   *  @return the dimension (1-based level) of the slice at position `idx`: rises from 1 at the outermost prefix slice up to `count/2 + 1` at the central data array, then falls back to 1 at the outermost suffix slice
    */
   @inline def vectorSliceDim(count: Int, idx: Int): Int = {
     val c = count/2


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in `@param`, `@tparam`, and `@return` tags for `scala.collection.immutable` that were missed in the previous batch of PRs. I'm submitting it as a draft PR so to get CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and are starting to review them. We will review them all before making the PR non-draft. Please let me know if you see anything specific that you think could be improved.