### PR TITLE
Root files (9): filled in @param, @tparam, and @return tags that were missed last time

### DIFF
--- a/library-js/src/scala/Array.scala
+++ b/library-js/src/scala/Array.scala
@@ -65,6 +65,7 @@ object Array {
    *
    *  @tparam A the element type of the array, must have a `ClassTag`
    *  @param dummy the `Array` companion object, used to trigger the implicit conversion
+   *  @return a `Factory` that builds an `Array[A]` from an `IterableOnce[A]`
    */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
@@ -77,6 +78,7 @@ object Array {
    *
    *  @tparam T the element type of the array to build
    *  @param t the `ClassTag` for the element type, used to create the correct array type at runtime
+   *  @return a new `ArrayBuilder[T]` for incrementally constructing an `Array[T]`
    */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
@@ -212,6 +214,7 @@ object Array {
   /** Returns an array of length 0.
    *
    *  @tparam T the element type of the empty array
+   *  @return an empty `Array[T]` of length `0`
    */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
@@ -236,6 +239,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Boolean]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
@@ -253,6 +257,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Byte]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
@@ -270,6 +275,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Short]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
@@ -287,6 +293,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Char]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
@@ -304,6 +311,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Int]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
@@ -321,6 +329,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Long]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
@@ -338,6 +347,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Float]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
@@ -355,6 +365,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Double]` containing `x` followed by all elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
@@ -372,6 +383,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Unit]` containing `x` followed by all elements of `xs`
    */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
@@ -388,6 +400,7 @@ object Array {
    *
    *  @tparam T the element type of the array
    *  @param n1 the number of elements in the 1st dimension
+   *  @return a new `Array[T]` of length `n1` with all elements initialized to their default value
    */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
@@ -396,6 +409,7 @@ object Array {
    *  @tparam T the element type of the array
    *  @param n1 the number of elements in the 1st dimension
    *  @param n2 the number of elements in the 2nd dimension
+   *  @return a new `Array[Array[T]]` with dimensions `n1 x n2`, with all elements initialized to their default value
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
@@ -409,6 +423,7 @@ object Array {
    *  @param n1 the number of elements in the 1st dimension
    *  @param n2 the number of elements in the 2nd dimension
    *  @param n3 the number of elements in the 3rd dimension
+   *  @return a new `Array[Array[Array[T]]]` with dimensions `n1 x n2 x n3`, with all elements initialized to their default value
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
@@ -419,6 +434,7 @@ object Array {
    *  @param n2 the number of elements in the 2nd dimension
    *  @param n3 the number of elements in the 3rd dimension
    *  @param n4 the number of elements in the 4th dimension
+   *  @return a new `Array[Array[Array[Array[T]]]]` with dimensions `n1 x n2 x n3 x n4`, with all elements initialized to their default value
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
@@ -430,6 +446,7 @@ object Array {
    *  @param n3 the number of elements in the 3rd dimension
    *  @param n4 the number of elements in the 4th dimension
    *  @param n5 the number of elements in the 5th dimension
+   *  @return a new `Array[Array[Array[Array[Array[T]]]]]` with dimensions `n1 x n2 x n3 x n4 x n5`, with all elements initialized to their default value
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
@@ -483,6 +500,7 @@ object Array {
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
+   *  @return a 2-dimensional `Array[Array[T]]` of size `n1 x n2`, where each element is the result of a separate evaluation of `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int)(elem: => T): Array[Array[T]] =
     tabulate(n1)(_ => fill(n2)(elem))
@@ -495,6 +513,7 @@ object Array {
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   elem the element computation
+   *  @return a 3-dimensional array of size `n1 x n2 x n3`, where each element is the result of a separate evaluation of `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): Array[Array[Array[T]]] =
     tabulate(n1)(_ => fill(n2, n3)(elem))
@@ -508,6 +527,7 @@ object Array {
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   elem the element computation
+   *  @return a 4-dimensional array of size `n1 x n2 x n3 x n4`, where each element is the result of a separate evaluation of `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => T): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => fill(n2, n3, n4)(elem))
@@ -522,6 +542,7 @@ object Array {
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   elem the element computation
+   *  @return a 5-dimensional array of size `n1 x n2 x n3 x n4 x n5`, where each element is the result of a separate evaluation of `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => T): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
@@ -555,6 +576,7 @@ object Array {
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
+   *  @return a 2-dimensional `Array[Array[T]]` of size `n1 x n2`, where element `(i1, i2)` is `f(i1, i2)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int)(f: (Int, Int) => T): Array[Array[T]] =
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
@@ -567,6 +589,7 @@ object Array {
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   f   The function computing element values
+   *  @return a 3-dimensional array of size `n1 x n2 x n3`, where element `(i1, i2, i3)` is `f(i1, i2, i3)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => T): Array[Array[Array[T]]] =
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
@@ -580,6 +603,7 @@ object Array {
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   f   The function computing element values
+   *  @return a 4-dimensional array of size `n1 x n2 x n3 x n4`, where element `(i1, i2, i3, i4)` is `f(i1, i2, i3, i4)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => T): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
@@ -594,6 +618,7 @@ object Array {
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   f   The function computing element values
+   *  @return a 5-dimensional array of size `n1 x n2 x n3 x n4 x n5`, where element `(i1, i2, i3, i4, i5)` is `f(i1, i2, i3, i4, i5)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => T): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
@@ -760,6 +785,7 @@ object Array {
  *  @define undefinedorder
  *
  *  @tparam T the type of the elements in the array
+ *  @param _length the length of the array
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self =>
 

--- a/library-js/src/scala/Array.scala
+++ b/library-js/src/scala/Array.scala
@@ -214,7 +214,6 @@ object Array {
   /** Returns an array of length 0.
    *
    *  @tparam T the element type of the empty array
-   *  @return an empty `Array[T]` of length `0`
    */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 

--- a/library-js/src/scala/MatchError.scala
+++ b/library-js/src/scala/MatchError.scala
@@ -15,6 +15,8 @@ package scala
 /** This class implements errors which are thrown whenever an
  *  object doesn't match any pattern of a pattern matching
  *  expression.
+ *
+ *  @param obj the object that failed to match any pattern
  */
 final class MatchError(@transient obj: Any) extends RuntimeException {
   /** There's no reason we need to call toString eagerly,

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -50,6 +50,7 @@ object Array {
    *
    *  @tparam A the element type of the array to be created
    *  @param dummy the `Array` companion object used to trigger the implicit conversion
+   *  @return a `Factory` that builds an `Array[A]` from an `IterableOnce[A]`
    */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
@@ -62,6 +63,7 @@ object Array {
    *
    *  @tparam T the element type of the array to be built
    *  @param t the `ClassTag` providing runtime type information for `T`
+   *  @return a new `ArrayBuilder[T]` that produces an `Array[T]` when its `result()` method is called
    */
   def newBuilder[T](implicit t: ClassTag[T]): ArrayBuilder[T] = ArrayBuilder.make[T](using t)
 
@@ -198,6 +200,7 @@ object Array {
   /** Returns an array of length 0.
    *
    *  @tparam T the element type of the array
+   *  @return an empty `Array[T]` (length 0)
    */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 
@@ -232,6 +235,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Boolean]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
@@ -249,6 +253,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Byte]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
@@ -266,6 +271,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Short]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Short, xs: Short*): Array[Short] = {
@@ -283,6 +289,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Char]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Char, xs: Char*): Array[Char] = {
@@ -300,6 +307,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Int]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Int, xs: Int*): Array[Int] = {
@@ -317,6 +325,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Long]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Long, xs: Long*): Array[Long] = {
@@ -334,6 +343,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Float]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Float, xs: Float*): Array[Float] = {
@@ -351,6 +361,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Double]` containing `x` followed by the elements of `xs`
    */
   // Subject to a compiler optimization in Cleanup, see above.
   def apply(x: Double, xs: Double*): Array[Double] = {
@@ -368,6 +379,7 @@ object Array {
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an `Array[Unit]` containing `x` followed by the elements of `xs`
    */
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
@@ -384,6 +396,7 @@ object Array {
    *
    *  @tparam T the element type of the array
    *  @param n1 the number of elements in the 1st dimension
+   *  @return a new `Array[T]` of length `n1` with all elements set to the default value for `T`
    */
   def ofDim[T: ClassTag](n1: Int): Array[T] =
     new Array[T](n1)
@@ -392,6 +405,7 @@ object Array {
    *  @tparam T the element type of the array
    *  @param n1 the number of elements in the 1st dimension
    *  @param n2 the number of elements in the 2nd dimension
+   *  @return a new `Array[Array[T]]` of dimensions `n1 x n2` with all innermost `T` elements set to the default value for `T`
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int): Array[Array[T]] = {
     val arr: Array[Array[T]] = (new Array[Array[T]](n1): Array[Array[T]])
@@ -405,6 +419,7 @@ object Array {
    *  @param n1 the number of elements in the 1st dimension
    *  @param n2 the number of elements in the 2nd dimension
    *  @param n3 the number of elements in the 3rd dimension
+   *  @return a new `Array[Array[Array[T]]]` of dimensions `n1 x n2 x n3` with all innermost `T` elements set to the default value for `T`
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int): Array[Array[Array[T]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3))
@@ -415,6 +430,7 @@ object Array {
    *  @param n2 the number of elements in the 2nd dimension
    *  @param n3 the number of elements in the 3rd dimension
    *  @param n4 the number of elements in the 4th dimension
+   *  @return a new `Array[Array[Array[Array[T]]]]` of dimensions `n1 x n2 x n3 x n4` with all innermost `T` elements set to the default value for `T`
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4))
@@ -426,6 +442,7 @@ object Array {
    *  @param n3 the number of elements in the 3rd dimension
    *  @param n4 the number of elements in the 4th dimension
    *  @param n5 the number of elements in the 5th dimension
+   *  @return a new `Array[Array[Array[Array[Array[T]]]]]` of dimensions `n1 x n2 x n3 x n4 x n5` with all innermost `T` elements set to the default value for `T`
    */
   def ofDim[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => ofDim[T](n2, n3, n4, n5))
@@ -479,6 +496,7 @@ object Array {
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
+   *  @return a two-dimensional `Array` of dimensions `n1 x n2` where each element is the result of computing `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int)(elem: => T): Array[Array[T]] =
     tabulate(n1)(_ => fill(n2)(elem))
@@ -491,6 +509,7 @@ object Array {
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   elem the element computation
+   *  @return a three-dimensional `Array` of dimensions `n1 x n2 x n3` where each element is the result of computing `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): Array[Array[Array[T]]] =
     tabulate(n1)(_ => fill(n2, n3)(elem))
@@ -504,6 +523,7 @@ object Array {
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   elem the element computation
+   *  @return a four-dimensional `Array` of dimensions `n1 x n2 x n3 x n4` where each element is the result of computing `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => T): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(_ => fill(n2, n3, n4)(elem))
@@ -518,6 +538,7 @@ object Array {
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   elem the element computation
+   *  @return a five-dimensional `Array` of dimensions `n1 x n2 x n3 x n4 x n5` where each element is the result of computing `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => T): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(_ => fill(n2, n3, n4, n5)(elem))
@@ -551,6 +572,7 @@ object Array {
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
+   *  @return a two-dimensional `Array` of dimensions `n1 x n2` whose element at `(i1, i2)` is `f(i1, i2)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int)(f: (Int, Int) => T): Array[Array[T]] =
     tabulate(n1)(i1 => tabulate(n2)(f(i1, _)))
@@ -563,6 +585,7 @@ object Array {
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   f   The function computing element values
+   *  @return a three-dimensional `Array` of dimensions `n1 x n2 x n3` whose element at `(i1, i2, i3)` is `f(i1, i2, i3)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => T): Array[Array[Array[T]]] =
     tabulate(n1)(i1 => tabulate(n2, n3)(f(i1, _, _)))
@@ -576,6 +599,7 @@ object Array {
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   f   The function computing element values
+   *  @return a four-dimensional `Array` of dimensions `n1 x n2 x n3 x n4` whose element at `(i1, i2, i3, i4)` is `f(i1, i2, i3, i4)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => T): Array[Array[Array[Array[T]]]] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4)(f(i1, _, _, _)))
@@ -590,6 +614,7 @@ object Array {
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   f   The function computing element values
+   *  @return a five-dimensional `Array` of dimensions `n1 x n2 x n3 x n4 x n5` whose element at `(i1, i2, i3, i4, i5)` is `f(i1, i2, i3, i4, i5)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => T): Array[Array[Array[Array[Array[T]]]]] =
     tabulate(n1)(i1 => tabulate(n2, n3, n4, n5)(f(i1, _, _, _, _)))
@@ -760,6 +785,7 @@ object Array {
  *  @define undefinedorder
  *
  *  @tparam T the element type of the array
+ *  @param _length the size of the array to allocate; must be non-negative
  */
 final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
 

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -200,7 +200,6 @@ object Array {
   /** Returns an array of length 0.
    *
    *  @tparam T the element type of the array
-   *  @return an empty `Array[T]` (length 0)
    */
   def empty[T: ClassTag]: Array[T] = new Array[T](0)
 

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -642,6 +642,7 @@ object Byte extends AnyValCompanion {
   /** Language mandated coercions from `Byte` to "wider" types.
    *
    *  @param x the `Byte` value to convert
+   *  @return the value of `x` widened to the target numeric type
    */
   import scala.language.implicitConversions
   implicit def byte2short(x: Byte): Short = x.toShort

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -642,6 +642,7 @@ object Char extends AnyValCompanion {
   /** Language mandated coercions from `Char` to "wider" types.
    *
    *  @param x the `Char` value to convert
+   *  @return the value of `x` widened to the corresponding numeric type
    */
   import scala.language.implicitConversions
   implicit def char2int(x: Char): Int = x.toInt

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -397,6 +397,7 @@ object Float extends AnyValCompanion {
   /** Language mandated coercions from `Float` to "wider" types.
    *
    *  @param x the `Float` value to convert
+   *  @return the `Double` value resulting from widening `x`
    */
   import scala.language.implicitConversions
   implicit def float2double(x: Float): Double = x.toDouble

--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -21,6 +21,7 @@ object Function {
    *
    *  @tparam T the common input and output type of the functions in the chain
    *  @param fs the given sequence of functions
+   *  @return the composed function that applies each function in `fs` left-to-right, or the identity function if `fs` is empty
    */
   def chain[T](fs: scala.collection.Seq[T => T]): T => T = { x => fs.foldLeft(x)((x, f) => f(x)) }
 
@@ -30,6 +31,7 @@ object Function {
    *  @tparam U the type of the argument to ignore
    *  @param x the constant value to return
    *  @param y the argument that is ignored
+   *  @return `x` regardless of the value of `y`
    */
   def const[T, U](x: T)(y: U): T = x
 
@@ -57,6 +59,7 @@ object Function {
    *  @tparam T2 the type of the 2nd argument
    *  @tparam R the result type
    *  @param f the curried function to uncurry
+   *  @return an equivalent function of arity 2 that takes all arguments at once
    */
   def uncurried[T1, T2, R](f: T1 => T2 => R): (T1, T2) => R = {
     (x1, x2) => f(x1)(x2)
@@ -69,6 +72,7 @@ object Function {
    *  @tparam T3 the type of the 3rd argument
    *  @tparam R the result type
    *  @param f the curried function to uncurry
+   *  @return an equivalent function of arity 3 that takes all arguments at once
    */
   def uncurried[T1, T2, T3, R](f: T1 => T2 => T3 => R): (T1, T2, T3) => R = {
     (x1, x2, x3) => f(x1)(x2)(x3)
@@ -82,6 +86,7 @@ object Function {
    *  @tparam T4 the type of the 4th argument
    *  @tparam R the result type
    *  @param f the curried function to uncurry
+   *  @return an equivalent function of arity 4 that takes all arguments at once
    */
   def uncurried[T1, T2, T3, T4, R](f: T1 => T2 => T3 => T4 => R): (T1, T2, T3, T4) => R = {
     (x1, x2, x3, x4) => f(x1)(x2)(x3)(x4)
@@ -96,6 +101,7 @@ object Function {
    *  @tparam T5 the type of the 5th argument
    *  @tparam R the result type
    *  @param f the curried function to uncurry
+   *  @return an equivalent function of arity 5 that takes all arguments at once
    */
   def uncurried[T1, T2, T3, T4, T5, R](f: T1 => T2 => T3 => T4 => T5 => R): (T1, T2, T3, T4, T5) => R  =  {
     (x1, x2, x3, x4, x5) => f(x1)(x2)(x3)(x4)(x5)
@@ -143,6 +149,7 @@ object Function {
    *  @tparam T2 the type of the 2nd argument
    *  @tparam R the result type
    *  @param f the tupled function to untuple
+   *  @return an equivalent function of arity 2 that takes each argument separately
    */
   def untupled[T1, T2, R](f: ((T1, T2)) => R): (T1, T2) => R = {
     (x1, x2) => f((x1, x2))
@@ -156,6 +163,7 @@ object Function {
    *  @tparam T3 the type of the 3rd argument
    *  @tparam R the result type
    *  @param f the tupled function to untuple
+   *  @return an equivalent function of arity 3 that takes each argument separately
    */
   def untupled[T1, T2, T3, R](f: ((T1, T2, T3)) => R): (T1, T2, T3) => R = {
     (x1, x2, x3) => f((x1, x2, x3))
@@ -170,6 +178,7 @@ object Function {
    *  @tparam T4 the type of the 4th argument
    *  @tparam R the result type
    *  @param f the tupled function to untuple
+   *  @return an equivalent function of arity 4 that takes each argument separately
    */
   def untupled[T1, T2, T3, T4, R](f: ((T1, T2, T3, T4)) => R): (T1, T2, T3, T4) => R = {
     (x1, x2, x3, x4) => f((x1, x2, x3, x4))
@@ -185,6 +194,7 @@ object Function {
    *  @tparam T5 the type of the 5th argument
    *  @tparam R the result type
    *  @param f the tupled function to untuple
+   *  @return an equivalent function of arity 5 that takes each argument separately
    */
   def untupled[T1, T2, T3, T4, T5, R](f: ((T1, T2, T3, T4, T5)) => R): (T1, T2, T3, T4, T5) => R = {
     (x1, x2, x3, x4, x5) => f((x1, x2, x3, x4, x5))

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -51,6 +51,7 @@ object IArray:
   /** Tests whether this array contains a given value as an element.
    *
    *  @param elem the value to test for membership
+   *  @return `true` if this array has an element that is equal (as determined by `==`) to `elem`, `false` otherwise
    */
   extension [T](arr: IArray[T]) def contains(elem: T): Boolean =
     genericArrayOps(arr).contains(elem.asInstanceOf)
@@ -59,6 +60,7 @@ object IArray:
    *
    *  @tparam U the element type of the destination array, a supertype of `T`
    *  @param xs the destination array to copy to
+   *  @return the number of elements actually copied
    */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U]): Int =
     genericArrayOps(arr).copyToArray(xs)
@@ -68,6 +70,7 @@ object IArray:
    *  @tparam U the element type of the destination array, a supertype of `T`
    *  @param xs the destination array to copy to
    *  @param start the index in `xs` at which to start copying
+   *  @return the number of elements actually copied
    */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start)
@@ -78,6 +81,7 @@ object IArray:
    *  @param xs the destination array to copy to
    *  @param start the index in `xs` at which to start copying
    *  @param len the maximum number of elements to copy
+   *  @return the number of elements actually copied
    */
   extension [T](arr: IArray[T]) def copyToArray[U >: T](xs: Array[U], start: Int, len: Int): Int =
     genericArrayOps(arr).copyToArray(xs, start, len)
@@ -85,6 +89,7 @@ object IArray:
   /** Counts the number of elements in this array which satisfy a predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return the number of elements of this array for which `p` returns `true`
    */
   extension [T](arr: IArray[T]) def count(p: T => Boolean): Int =
     genericArrayOps(arr).count(p)
@@ -92,6 +97,7 @@ object IArray:
   /** The rest of the array without its `n` first elements.
    *
    *  @param n the number of elements to drop from the front
+   *  @return an array consisting of all elements of this array except the first `n` ones, the entire array if `n` is non-positive, or the empty array if `n` exceeds the length
    */
   extension [T](arr: IArray[T]) def drop(n: Int): IArray[T] =
     genericArrayOps(arr).drop(n)
@@ -99,6 +105,7 @@ object IArray:
   /** The rest of the array without its `n` last elements.
    *
    *  @param n the number of elements to drop from the end
+   *  @return an array consisting of all elements of this array except the last `n` ones, or the empty array if `n` exceeds the length
    */
   extension [T](arr: IArray[T]) def dropRight(n: Int): IArray[T] =
     genericArrayOps(arr).dropRight(n)
@@ -106,6 +113,7 @@ object IArray:
   /** Drops longest prefix of elements that satisfy a predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return the longest suffix of this array whose first element does not satisfy `p`
    */
   extension [T](arr: IArray[T]) def dropWhile(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).dropWhile(p)
@@ -113,6 +121,7 @@ object IArray:
   /** Tests whether a predicate holds for at least one element of this array.
    *
    *  @param p the predicate used to test elements
+   *  @return `true` if there exists an element of this array that satisfies `p`, `false` otherwise
    */
   extension [T](arr: IArray[T]) def exists(p: T => Boolean): Boolean =
     genericArrayOps(arr).exists(p)
@@ -120,6 +129,7 @@ object IArray:
   /** Selects all elements of this array which satisfy a predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return a new array consisting of all elements of this array that satisfy `p`
    */
   extension [T](arr: IArray[T]) def filter(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).filter(p)
@@ -127,6 +137,7 @@ object IArray:
   /** Selects all elements of this array which do not satisfy a predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return a new array consisting of all elements of this array that do not satisfy `p`
    */
   extension [T](arr: IArray[T]) def filterNot(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).filterNot(p)
@@ -134,6 +145,7 @@ object IArray:
   /** Finds the first element of the array satisfying a predicate, if any.
    *
    *  @param p the predicate used to test elements
+   *  @return a `Some` containing the first element of this array that satisfies `p`, or `None` if no such element exists
    */
   extension [T](arr: IArray[T]) def find(p: T => Boolean): Option[T] =
     genericArrayOps(arr).find(p)
@@ -143,6 +155,7 @@ object IArray:
    *
    *  @tparam U the element type of the returned array
    *  @param f the function to apply to each element, returning a collection of results
+   *  @return a new array resulting from applying `f` to each element of this array and concatenating the results
    */
   extension [T](arr: IArray[T]) def flatMap[U: ClassTag](f: T => IterableOnce[U]^): IArray[U] =
     genericArrayOps(arr).flatMap(f)
@@ -150,8 +163,10 @@ object IArray:
   /** Flattens a two-dimensional array by concatenating all its rows
    *  into a single array.
    *
-   *  @tparam U the element type of the resulting array after flattening
+   *  @tparam U the element type of the resulting array
    *  @param asIterable the implicit evidence that `T` can be viewed as `Iterable[U]`
+   *  @param ct the `ClassTag` for the resulting array's element type `U`
+   *  @return a new array consisting of all elements of the inner collections concatenated together
    */
   extension [T](arr: IArray[T]) def flatten[U](using asIterable: T => Iterable[U]^, ct: ClassTag[U]): IArray[U] =
     genericArrayOps(arr).flatten
@@ -161,6 +176,7 @@ object IArray:
    *  @tparam U the result type of the binary operator, a supertype of `T`
    *  @param z the start value
    *  @param op the associative binary operator
+   *  @return the result of applying `op` between all elements and `z`, or `z` if this array is empty
    */
   extension [T](arr: IArray[T]) def fold[U >: T](z: U)(op: (U, U) => U): U =
     genericArrayOps(arr).fold(z)(op)
@@ -171,6 +187,7 @@ object IArray:
    *  @tparam U the result type of the binary operator
    *  @param z the start value
    *  @param op the binary operator applied from left to right
+   *  @return the result of inserting `op` between consecutive elements of this array, going left to right with the start value `z`, or `z` if this array is empty
    */
   extension [T](arr: IArray[T]) def foldLeft[U](z: U)(op: (U, T) => U): U =
     genericArrayOps(arr).foldLeft(z)(op)
@@ -181,6 +198,7 @@ object IArray:
    *  @tparam U the result type of the binary operator
    *  @param z the start value
    *  @param op the binary operator applied from right to left
+   *  @return the result of inserting `op` between consecutive elements of this array, going right to left with the start value `z`, or `z` if this array is empty
    */
   extension [T](arr: IArray[T]) def foldRight[U](z: U)(op: (T, U) => U): U =
     genericArrayOps(arr).foldRight(z)(op)
@@ -188,6 +206,7 @@ object IArray:
   /** Tests whether a predicate holds for all elements of this array.
    *
    *  @param p the predicate used to test elements
+   *  @return `true` if `p` holds for every element of this array (vacuously `true` if the array is empty), `false` otherwise
    */
   extension [T](arr: IArray[T]) def forall(p: T => Boolean): Boolean =
     genericArrayOps(arr).forall(p)
@@ -212,6 +231,7 @@ object IArray:
    *
    *  @param elem the value to search for
    *  @param from the start index where the search begins
+   *  @return the index `>= from` of the first element of this array that is equal (as determined by `==`) to `elem`, or `-1` if no such element exists
    */
   extension [T](arr: IArray[T]) def indexOf(elem: T, from: Int = 0): Int =
     // `asInstanceOf` needed because `elem` does not have type `arr.T`
@@ -223,6 +243,7 @@ object IArray:
    *
    *  @param p the predicate used to test elements
    *  @param from the start index where the search begins
+   *  @return the index `>= from` of the first element of this array that satisfies `p`, or `-1` if no such element exists
    */
   extension [T](arr: IArray[T]) def indexWhere(p: T => Boolean, from: Int = 0): Int =
     genericArrayOps(arr).indexWhere(p, from)
@@ -255,6 +276,7 @@ object IArray:
    *
    *  @param elem the value to search for
    *  @param end the end index (inclusive) where the search ends
+   *  @return the index `<= end` of the last element of this array that is equal (as determined by `==`) to `elem`, or `-1` if no such element exists
    */
   extension [T](arr: IArray[T]) def lastIndexOf(elem: T, end: Int = arr.length - 1): Int =
     // see: same issue in `indexOf`
@@ -264,6 +286,7 @@ object IArray:
    *
    *  @param p the predicate used to test elements
    *  @param end the end index (inclusive) where the search ends
+   *  @return the index `<= end` of the last element of this array that satisfies `p`, or `-1` if no such element exists
    */
   extension [T](arr: IArray[T]) def lastIndexWhere(p: T => Boolean, end: Int = arr.length - 1): Int =
     genericArrayOps(arr).lastIndexWhere(p, end)
@@ -272,6 +295,7 @@ object IArray:
    *
    *  @tparam U the element type of the returned array
    *  @param f the function to apply to each element
+   *  @return a new array resulting from applying `f` to each element of this array
    */
   extension [T](arr: IArray[T]) def map[U: ClassTag](f: T => U): IArray[U] =
     genericArrayOps(arr).map(f)
@@ -283,6 +307,7 @@ object IArray:
   /** A pair of, first, all elements that satisfy predicate `p` and, second, all elements that do not.
    *
    *  @param p the predicate used to partition elements
+   *  @return a pair of arrays, the first containing all elements that satisfy `p` and the second containing all elements that do not
    */
   extension [T](arr: IArray[T]) def partition(p: T => Boolean): (IArray[T], IArray[T]) =
     genericArrayOps(arr).partition(p)
@@ -296,6 +321,7 @@ object IArray:
    *  @tparam U the element type of the returned array, a supertype of `T`
    *  @param z the initial value for the scan
    *  @param op the associative binary operator
+   *  @return a new array containing the prefix scan of the elements of this array, starting with `z`
    */
   extension [T](arr: IArray[T]) def scan[U >: T: ClassTag](z: U)(op: (U, U) => U): IArray[U] =
     genericArrayOps(arr).scan(z)(op)
@@ -306,6 +332,7 @@ object IArray:
    *  @tparam U the element type of the returned array
    *  @param z the initial value for the scan
    *  @param op the binary operator applied from left to right
+   *  @return a new array containing the cumulative results of applying `op` left to right, beginning with `z`
    */
   extension [T](arr: IArray[T]) def scanLeft[U: ClassTag](z: U)(op: (U, T) => U): IArray[U] =
     genericArrayOps(arr).scanLeft(z)(op)
@@ -316,6 +343,7 @@ object IArray:
    *  @tparam U the element type of the returned array
    *  @param z the initial value for the scan
    *  @param op the binary operator applied from right to left
+   *  @return a new array containing the cumulative results of applying `op` right to left, ending with `z`
    */
   extension [T](arr: IArray[T]) def scanRight[U: ClassTag](z: U)(op: (T, U) => U): IArray[U] =
     genericArrayOps(arr).scanRight(z)(op)
@@ -328,6 +356,7 @@ object IArray:
    *
    *  @param from the index of the first included element
    *  @param until the index of the first excluded element
+   *  @return a new array containing the elements of this array at indices `from` (inclusive) through `until` (exclusive)
    */
   extension [T](arr: IArray[T]) def slice(from: Int, until: Int): IArray[T] =
     genericArrayOps(arr).slice(from, until)
@@ -335,15 +364,17 @@ object IArray:
   /** Sorts this array according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
    *
-   *  @tparam U the target type of the transformation function, which has an `Ordering`
+   *  @tparam U the target type of the transformation function, for which an `Ordering` must be available
    *  @param f the transformation function mapping elements to their sort keys
-     */
+   *  @return a new array consisting of the elements of this array sorted by the value `f` produces for each
+   */
   extension [T](arr: IArray[T]) def sortBy[U](f: T => U)(using math.Ordering[U]): IArray[T] =
     genericArrayOps(arr).sortBy(f)
 
   /** Sorts this array according to a comparison function.
    *
    *  @param f the comparison function returning true if its first argument should come first
+   *  @return a new array consisting of the elements of this array sorted according to `f`
    */
   extension [T](arr: IArray[T]) def sortWith(f: (T, T) => Boolean): IArray[T] =
     genericArrayOps(arr).sortWith(f)
@@ -357,6 +388,7 @@ object IArray:
   /** Splits this array into a prefix/suffix pair according to a predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return a pair of arrays where the first is the longest prefix of elements satisfying `p` and the second contains the remaining elements
    */
   extension [T](arr: IArray[T]) def span(p: T => Boolean): (IArray[T], IArray[T]) =
     genericArrayOps(arr).span(p)
@@ -364,6 +396,7 @@ object IArray:
   /** Splits this array into two at a given position.
    *
    *  @param n the position at which to split
+   *  @return a pair of arrays containing the first `n` elements of this array and the remaining elements respectively
    */
   extension [T](arr: IArray[T]) def splitAt(n: Int): (IArray[T], IArray[T]) =
     genericArrayOps(arr).splitAt(n)
@@ -375,6 +408,7 @@ object IArray:
   /** An array containing the first `n` elements of this array.
    *
    *  @param n the number of elements to take from the front
+   *  @return a new array consisting of the first `n` elements of this array, or all elements if `n` exceeds the length
    */
   extension [T](arr: IArray[T]) def take(n: Int): IArray[T] =
     genericArrayOps(arr).take(n)
@@ -382,6 +416,7 @@ object IArray:
   /** An array containing the last `n` elements of this array.
    *
    *  @param n the number of elements to take from the end
+   *  @return a new array consisting of the last `n` elements of this array, or all elements if `n` exceeds the length
    */
   extension [T](arr: IArray[T]) def takeRight(n: Int): IArray[T] =
     genericArrayOps(arr).takeRight(n)
@@ -389,6 +424,7 @@ object IArray:
   /** Takes longest prefix of elements that satisfy a predicate.
    *
    *  @param p the predicate used to test elements
+   *  @return the longest prefix of this array whose elements all satisfy `p`
    */
   extension [T](arr: IArray[T]) def takeWhile(p: T => Boolean): IArray[T] =
     genericArrayOps(arr).takeWhile(p)
@@ -487,14 +523,16 @@ object IArray:
    *
    *  @tparam T the element type of the array
    *  @param arr the immutable array to wrap
+   *  @return an `ArraySeq[T]` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def genericWrapArray[T](arr: IArray[T]): ArraySeq[T] =
     mapNull(arr, ArraySeq.unsafeWrapArray(arr))
 
   /** Conversion from IArray to immutable.ArraySeq.
    *
-   *  @tparam T the element type of the array, a reference type
+   *  @tparam T the element type of the array, a reference type or `Null`
    *  @param arr the immutable array to wrap
+   *  @return an `ArraySeq.ofRef[T]` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapRefArray[T <: AnyRef | Null](arr: IArray[T]): ArraySeq.ofRef[T] =
     // Since the JVM thinks arrays are covariant, one 0-length Array[AnyRef | Null]
@@ -508,6 +546,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Int` array to wrap
+   *  @return an `ArraySeq.ofInt` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapIntArray(arr: IArray[Int]): ArraySeq.ofInt =
     mapNull(arr, new ArraySeq.ofInt(arr.asInstanceOf[Array[Int]]))
@@ -515,6 +554,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Double` array to wrap
+   *  @return an `ArraySeq.ofDouble` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapDoubleIArray(arr: IArray[Double]): ArraySeq.ofDouble =
     mapNull(arr, new ArraySeq.ofDouble(arr.asInstanceOf[Array[Double]]))
@@ -522,6 +562,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Long` array to wrap
+   *  @return an `ArraySeq.ofLong` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapLongIArray(arr: IArray[Long]): ArraySeq.ofLong =
     mapNull(arr, new ArraySeq.ofLong(arr.asInstanceOf[Array[Long]]))
@@ -529,6 +570,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Float` array to wrap
+   *  @return an `ArraySeq.ofFloat` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapFloatIArray(arr: IArray[Float]): ArraySeq.ofFloat =
     mapNull(arr, new ArraySeq.ofFloat(arr.asInstanceOf[Array[Float]]))
@@ -536,6 +578,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Char` array to wrap
+   *  @return an `ArraySeq.ofChar` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapCharIArray(arr: IArray[Char]): ArraySeq.ofChar =
     mapNull(arr, new ArraySeq.ofChar(arr.asInstanceOf[Array[Char]]))
@@ -543,6 +586,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Byte` array to wrap
+   *  @return an `ArraySeq.ofByte` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapByteIArray(arr: IArray[Byte]): ArraySeq.ofByte =
     mapNull(arr, new ArraySeq.ofByte(arr.asInstanceOf[Array[Byte]]))
@@ -550,6 +594,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Short` array to wrap
+   *  @return an `ArraySeq.ofShort` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapShortIArray(arr: IArray[Short]): ArraySeq.ofShort =
     mapNull(arr, new ArraySeq.ofShort(arr.asInstanceOf[Array[Short]]))
@@ -557,6 +602,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Boolean` array to wrap
+   *  @return an `ArraySeq.ofBoolean` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapBooleanIArray(arr: IArray[Boolean]): ArraySeq.ofBoolean =
     mapNull(arr, new ArraySeq.ofBoolean(arr.asInstanceOf[Array[Boolean]]))
@@ -564,6 +610,7 @@ object IArray:
   /** Conversion from IArray to immutable.ArraySeq.
    *
    *  @param arr the immutable `Unit` array to wrap
+   *  @return an `ArraySeq.ofUnit` backed by `arr`, or `null` if `arr` is `null`
    */
   implicit def wrapUnitIArray(arr: IArray[Unit]): ArraySeq.ofUnit =
     mapNull(arr, new ArraySeq.ofUnit(arr.asInstanceOf[Array[Unit]]))
@@ -574,12 +621,14 @@ object IArray:
    *
    *  @tparam T the element type of the array
    *  @param s the mutable array to treat as immutable (must not be mutated afterward)
+   *  @return `s` viewed as an `IArray[T]` without copying
    */
   def unsafeFromArray[T](s: Array[T]): IArray[T] = s
 
   /** An immutable array of length 0.
    *
    *  @tparam T the element type of the empty array
+   *  @return a new immutable array of length 0
    */
   def empty[T: ClassTag]: IArray[T] = new Array[T](0)
 
@@ -606,60 +655,71 @@ object IArray:
    *
    *  @tparam T the element type of the array
    *  @param xs the elements to include in the array
+   *  @param ct the `ClassTag` for the element type `T`, used to allocate the underlying array
+   *  @return an immutable array containing the given elements `xs` in order
    */
   def apply[T](xs: T*)(using ct: ClassTag[T]): IArray[T] = Array(xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Boolean` array containing `x` followed by `xs`
    */
   def apply(x: Boolean, xs: Boolean*): IArray[Boolean] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Byte` array containing `x` followed by `xs`
    */
   def apply(x: Byte, xs: Byte*): IArray[Byte] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Short` array containing `x` followed by `xs`
    */
   def apply(x: Short, xs: Short*): IArray[Short] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Char` array containing `x` followed by `xs`
    */
   def apply(x: Char, xs: Char*): IArray[Char] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Int` array containing `x` followed by `xs`
    */
   def apply(x: Int, xs: Int*): IArray[Int] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Long` array containing `x` followed by `xs`
    */
   def apply(x: Long, xs: Long*): IArray[Long] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Float` array containing `x` followed by `xs`
    */
   def apply(x: Float, xs: Float*): IArray[Float] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Double` array containing `x` followed by `xs`
    */
   def apply(x: Double, xs: Double*): IArray[Double] = Array(x, xs*)
   /** An immutable array with given elements.
    *
    *  @param x the first element
    *  @param xs the remaining elements
+   *  @return an immutable `Unit` array containing `x` followed by `xs`
    */
   def apply(x: Unit, xs: Unit*): IArray[Unit] = Array(x, xs*)
 
@@ -701,6 +761,7 @@ object IArray:
    *  @tparam T the element type of the array
    *  @param   n  the number of elements in the array
    *  @param   elem the element computation
+   *  @return an immutable array of length `n`, where each element is computed by `elem`
    */
   def fill[T: ClassTag](n: Int)(elem: => T): IArray[T] =
     Array.fill(n)(elem)
@@ -712,6 +773,7 @@ object IArray:
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   elem the element computation
+   *  @return a two-dimensional immutable array of size `n1` by `n2`, where each element is computed by `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int)(elem: => T): IArray[IArray[T]] =
     Array.fill(n1, n2)(elem)
@@ -724,6 +786,7 @@ object IArray:
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   elem the element computation
+   *  @return a three-dimensional immutable array of size `n1` by `n2` by `n3`, where each element is computed by `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int)(elem: => T): IArray[IArray[IArray[T]]] =
     Array.fill(n1, n2, n3)(elem)
@@ -737,6 +800,7 @@ object IArray:
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   elem the element computation
+   *  @return a four-dimensional immutable array of size `n1` by `n2` by `n3` by `n4`, where each element is computed by `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(elem: => T): IArray[IArray[IArray[IArray[T]]]] =
     Array.fill(n1, n2, n3, n4)(elem)
@@ -751,6 +815,7 @@ object IArray:
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   elem the element computation
+   *  @return a five-dimensional immutable array of size `n1` by `n2` by `n3` by `n4` by `n5`, where each element is computed by `elem`
    */
   def fill[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(elem: => T): IArray[IArray[IArray[IArray[IArray[T]]]]] =
     Array.fill(n1, n2, n3, n4, n5)(elem)
@@ -761,6 +826,7 @@ object IArray:
    *  @tparam T the element type of the array
    *  @param  n   The number of elements in the array
    *  @param  f   The function computing element values
+   *  @return an immutable array of length `n` whose element at index `i` is `f(i)`
    */
   def tabulate[T: ClassTag](n: Int)(f: Int => T): IArray[T] =
     Array.tabulate(n)(f)
@@ -772,6 +838,7 @@ object IArray:
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
+   *  @return a two-dimensional immutable array of size `n1` by `n2` whose element at indices `(i1, i2)` is `f(i1, i2)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int)(f: (Int, Int) => T): IArray[IArray[T]] =
     Array.tabulate(n1, n2)(f)
@@ -784,6 +851,7 @@ object IArray:
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   f   The function computing element values
+   *  @return a three-dimensional immutable array of size `n1` by `n2` by `n3` whose element at indices `(i1, i2, i3)` is `f(i1, i2, i3)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int)(f: (Int, Int, Int) => T): IArray[IArray[IArray[T]]] =
     Array.tabulate(n1, n2, n3)(f)
@@ -797,6 +865,7 @@ object IArray:
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   f   The function computing element values
+   *  @return a four-dimensional immutable array of size `n1` by `n2` by `n3` by `n4` whose element at indices `(i1, i2, i3, i4)` is `f(i1, i2, i3, i4)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int)(f: (Int, Int, Int, Int) => T): IArray[IArray[IArray[IArray[T]]]] =
     Array.tabulate(n1, n2, n3, n4)(f)
@@ -811,6 +880,7 @@ object IArray:
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   f   The function computing element values
+   *  @return a five-dimensional immutable array of size `n1` by `n2` by `n3` by `n4` by `n5` whose element at indices `(i1, i2, i3, i4, i5)` is `f(i1, i2, i3, i4, i5)`
    */
   def tabulate[T: ClassTag](n1: Int, n2: Int, n3: Int, n4: Int, n5: Int)(f: (Int, Int, Int, Int, Int) => T): IArray[IArray[IArray[IArray[IArray[T]]]]] =
     Array.tabulate(n1, n2, n3, n4, n5)(f)
@@ -931,6 +1001,7 @@ object IArray:
     /** Creates a new non-strict filter which combines this filter with the given predicate.
      *
      *  @param q the additional predicate to apply
+     *  @return a new `WithFilter` over `xs` that keeps only elements satisfying both `p` and `q`
      */
     def withFilter(q: T => Boolean): WithFilter[T]^{p, q} = new WithFilter[T](a => p(a) && q(a), xs)
 

--- a/library/src/scala/MatchError.scala
+++ b/library/src/scala/MatchError.scala
@@ -17,6 +17,8 @@ import scala.language.`2.13`
 /** This class implements errors which are thrown whenever an
  *  object doesn't match any pattern of a pattern matching
  *  expression.
+ *
+ *  @param obj the object that failed to match any pattern; included in the error message
  */
 final class MatchError(@transient obj: Any) extends RuntimeException {
   /** There's no reason we need to call toString eagerly,

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -22,6 +22,7 @@ object Option {
    *
    *  @tparam A the element type of the option
    *  @param xo the option to convert to an iterable
+   *  @return a single-element `Iterable` containing the option's value if nonempty, or an empty `Iterable` if empty
    */
   implicit def option2Iterable[A](xo: Option[A]): Iterable[A] =
     if (xo.isEmpty) Iterable.empty else Iterable.single(xo.get)
@@ -39,6 +40,7 @@ object Option {
    *  the collections hierarchy.
    *
    *  @tparam A the type of the option's value
+   *  @return `None` typed as `Option[A]`
    */
   def empty[A] : Option[A] = None
 
@@ -49,6 +51,7 @@ object Option {
    *  @tparam A the type of the value
    *  @param cond the condition to evaluate
    *  @param a the value to wrap in `Some` when `cond` is true (evaluated lazily)
+   *  @return `Some(a)` if `cond` is true, otherwise `None`
    */
   def when[A](cond: Boolean)(a: => A): Option[A] =
     if (cond) Some(a) else None
@@ -59,6 +62,7 @@ object Option {
    *  @tparam A the type of the value
    *  @param cond the condition to evaluate
    *  @param a the value to wrap in `Some` when `cond` is false (evaluated lazily)
+   *  @return `Some(a)` if `cond` is false, otherwise `None`
    */
   @inline def unless[A](cond: Boolean)(a: => A): Option[A] =
     when(!cond)(a)
@@ -396,6 +400,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  [[scala.collection.Iterable]] in `for` comprehensions.
    *
    *  @param p the predicate used to test elements
+   *  @return a `WithFilter` that applies `p` to this option before subsequent `map`, `flatMap`, `foreach`, or `withFilter` operations
    */
   @inline final def withFilter(p: A => Boolean): WithFilter = new WithFilter(p)
 

--- a/library/src/scala/Predef.scala
+++ b/library/src/scala/Predef.scala
@@ -280,6 +280,8 @@ object Predef extends LowPriorityImplicits {
    *  @group utilities
    *
    *  @tparam T the type of the expression being guarded
+   *  @param x the expression whose value is returned, used to delimit a block as a standalone expression
+   *  @return the value `x`
    */
   @inline def locally[T](@deprecatedName("x") x: T): T = x
 
@@ -465,6 +467,7 @@ object Predef extends LowPriorityImplicits {
    *  @group char-sequence-wrappers
    *
    *  @param sequenceOfChars the indexed sequence of characters to wrap as a `CharSequence`
+   *  @return a new `SeqCharSequence` backed by `sequenceOfChars`
    */
   def SeqCharSequence(sequenceOfChars: scala.collection.IndexedSeq[Char]): SeqCharSequence = new SeqCharSequence(sequenceOfChars)
 
@@ -484,6 +487,7 @@ object Predef extends LowPriorityImplicits {
    *  @group char-sequence-wrappers
    *
    *  @param arrayOfChars the array of characters to wrap as a `CharSequence`
+   *  @return a new `ArrayCharSequence` backed by `arrayOfChars`
    */
   def ArrayCharSequence(arrayOfChars: Array[Char]): ArrayCharSequence = new ArrayCharSequence(arrayOfChars)
 
@@ -491,6 +495,7 @@ object Predef extends LowPriorityImplicits {
    *  @group conversions-string
    *
    *  @param x the string to enrich with `StringOps` methods
+   *  @return a `StringOps` wrapper around `x` providing collection-like operations
    */
   @inline implicit def augmentString(x: String): StringOps = new StringOps(x)
 
@@ -562,48 +567,56 @@ object Predef extends LowPriorityImplicits {
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Byte` value to convert
+   *  @return the equivalent boxed `java.lang.Byte`
    */
   implicit def byte2Byte(x: Byte): java.lang.Byte             = x.asInstanceOf[java.lang.Byte]
   /**
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Short` value to convert
+   *  @return the equivalent boxed `java.lang.Short`
    */
   implicit def short2Short(x: Short): java.lang.Short         = x.asInstanceOf[java.lang.Short]
   /**
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Char` value to convert
+   *  @return the equivalent boxed `java.lang.Character`
    */
   implicit def char2Character(x: Char): java.lang.Character   = x.asInstanceOf[java.lang.Character]
   /**
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Int` value to convert
+   *  @return the equivalent boxed `java.lang.Integer`
    */
   implicit def int2Integer(x: Int): java.lang.Integer         = x.asInstanceOf[java.lang.Integer]
   /**
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Long` value to convert
+   *  @return the equivalent boxed `java.lang.Long`
    */
   implicit def long2Long(x: Long): java.lang.Long             = x.asInstanceOf[java.lang.Long]
   /**
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Float` value to convert
+   *  @return the equivalent boxed `java.lang.Float`
    */
   implicit def float2Float(x: Float): java.lang.Float         = x.asInstanceOf[java.lang.Float]
   /**
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Double` value to convert
+   *  @return the equivalent boxed `java.lang.Double`
    */
   implicit def double2Double(x: Double): java.lang.Double     = x.asInstanceOf[java.lang.Double]
   /**
    *  @group conversions-anyval-to-java
    *
    *  @param x the Scala `Boolean` value to convert
+   *  @return the equivalent boxed `java.lang.Boolean`
    */
   implicit def boolean2Boolean(x: Boolean): java.lang.Boolean = x.asInstanceOf[java.lang.Boolean]
 
@@ -611,48 +624,56 @@ object Predef extends LowPriorityImplicits {
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Byte` value to convert
+   *  @return the unboxed Scala `Byte` value
    */
   implicit def Byte2byte(x: java.lang.Byte): Byte             = x.asInstanceOf[Byte]
   /**
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Short` value to convert
+   *  @return the unboxed Scala `Short` value
    */
   implicit def Short2short(x: java.lang.Short): Short         = x.asInstanceOf[Short]
   /**
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Character` value to convert
+   *  @return the unboxed Scala `Char` value
    */
   implicit def Character2char(x: java.lang.Character): Char   = x.asInstanceOf[Char]
   /**
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Integer` value to convert
+   *  @return the unboxed Scala `Int` value
    */
   implicit def Integer2int(x: java.lang.Integer): Int         = x.asInstanceOf[Int]
   /**
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Long` value to convert
+   *  @return the unboxed Scala `Long` value
    */
   implicit def Long2long(x: java.lang.Long): Long             = x.asInstanceOf[Long]
   /**
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Float` value to convert
+   *  @return the unboxed Scala `Float` value
    */
   implicit def Float2float(x: java.lang.Float): Float         = x.asInstanceOf[Float]
   /**
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Double` value to convert
+   *  @return the unboxed Scala `Double` value
    */
   implicit def Double2double(x: java.lang.Double): Double     = x.asInstanceOf[Double]
   /**
    *  @group conversions-java-to-anyval
    *
    *  @param x the `java.lang.Boolean` value to convert
+   *  @return the unboxed Scala `Boolean` value
    */
   implicit def Boolean2boolean(x: java.lang.Boolean): Boolean = x.asInstanceOf[Boolean]
 
@@ -688,6 +709,7 @@ object Predef extends LowPriorityImplicits {
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`.
      *
      *  @param y the reference to compare against for reference equality
+     *  @return `true` if `x` and `y` are the same reference (including both being `null`), `false` otherwise
      */
     inline infix def eq(inline y: AnyRef | Null): Boolean =
       x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
@@ -696,6 +718,7 @@ object Predef extends LowPriorityImplicits {
      *  `eq` or `ne` methods, only `==` and `!=` inherited from `Any`.
      *
      *  @param y the reference to compare against for reference non-equality
+     *  @return `true` if `x` and `y` refer to different objects (treating both-`null` as the same reference), `false` otherwise
      */
     inline infix def ne(inline y: AnyRef | Null): Boolean =
       !(x eq y)
@@ -767,6 +790,7 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
    *
    *  @tparam T the element type of the array
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def genericWrapArray[T](xs: Array[T]): ArraySeq[T] =
     mapNull(xs, ArraySeq.make(xs))
@@ -779,6 +803,7 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
    *
    *  @tparam T the element type of the array, must be a reference type
    *  @param xs the array of reference-typed elements to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofRef` backed by `xs`, a shared empty instance if `xs` is empty, or `null` if `xs` is `null`
    */
   implicit def wrapRefArray[T <: AnyRef | Null](xs: Array[T]): ArraySeq.ofRef[T] =
     mapNull(xs,
@@ -789,54 +814,63 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofInt` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapIntArray(xs: Array[Int]): ArraySeq.ofInt = mapNull(xs, new ArraySeq.ofInt(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofDouble` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapDoubleArray(xs: Array[Double]): ArraySeq.ofDouble = mapNull(xs, new ArraySeq.ofDouble(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofLong` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapLongArray(xs: Array[Long]): ArraySeq.ofLong = mapNull(xs, new ArraySeq.ofLong(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofFloat` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapFloatArray(xs: Array[Float]): ArraySeq.ofFloat = mapNull(xs, new ArraySeq.ofFloat(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofChar` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapCharArray(xs: Array[Char]): ArraySeq.ofChar = mapNull(xs, new ArraySeq.ofChar(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofByte` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapByteArray(xs: Array[Byte]): ArraySeq.ofByte = mapNull(xs, new ArraySeq.ofByte(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofShort` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapShortArray(xs: Array[Short]): ArraySeq.ofShort = mapNull(xs, new ArraySeq.ofShort(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofBoolean` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapBooleanArray(xs: Array[Boolean]): ArraySeq.ofBoolean = mapNull(xs, new ArraySeq.ofBoolean(xs))
   /**
    *  @group conversions-array-to-wrapped-array
    *
    *  @param xs the array to wrap as an `ArraySeq`
+   *  @return an `ArraySeq.ofUnit` backed by `xs`, or `null` if `xs` is `null`
    */
   implicit def wrapUnitArray(xs: Array[Unit]): ArraySeq.ofUnit = mapNull(xs, new ArraySeq.ofUnit(xs))
 
@@ -844,6 +878,7 @@ private[scala] abstract class LowPriorityImplicits extends LowPriorityImplicits2
    *  @group conversions-string
    *
    *  @param s the string to wrap as a `WrappedString`
+   *  @return a `WrappedString` backed by `s`, or `null` if `s` is `null`
    */
   implicit def wrapString(s: String): WrappedString = mapNull(s, new WrappedString(s))
 }

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -642,6 +642,7 @@ object Short extends AnyValCompanion {
   /** Language mandated coercions from `Short` to "wider" types.
    *
    *  @param x the `Short` value to be implicitly converted
+   *  @return the value of `x` converted to the wider numeric type
    */
   import scala.language.implicitConversions
   implicit def short2int(x: Short): Int = x.toInt

--- a/library/src/scala/Tuple.scala
+++ b/library/src/scala/Tuple.scala
@@ -37,6 +37,7 @@ sealed trait Tuple extends Product {
    *
    *  @tparam This the exact type of this tuple
    *  @param n the zero-based index of the element to retrieve
+   *  @return the element at position `n`, with its precise static type `Elem[This, n.type]`
    */
   inline def apply[This >: this.type <: Tuple](n: Int): Elem[This, n.type] =
     runtime.Tuples.apply(this, n).asInstanceOf[Elem[This, n.type]]
@@ -44,6 +45,7 @@ sealed trait Tuple extends Product {
   /** Gets the head of this tuple.
    *
    *  @tparam This the exact type of this tuple
+   *  @return the first element of this tuple, with its precise static type `Head[This]`
    */
   inline def head[This >: this.type <: Tuple]: Head[This] =
     runtime.Tuples.apply(this, 0).asInstanceOf[Head[This]]
@@ -51,6 +53,7 @@ sealed trait Tuple extends Product {
   /** Gets the initial part of the tuple without its last element.
    *
    *  @tparam This the exact type of this tuple
+   *  @return a new tuple containing all elements of this tuple except the last one
    */
   inline def init[This >: this.type <: Tuple]: Init[This] =
     runtime.Tuples.init(this).asInstanceOf[Init[This]]
@@ -58,6 +61,7 @@ sealed trait Tuple extends Product {
   /** Gets the last of this tuple.
    *
    *  @tparam This the exact type of this tuple
+   *  @return the last element of this tuple, with its precise static type `Last[This]`
    */
   inline def last[This >: this.type <: Tuple]: Last[This] =
     runtime.Tuples.last(this).asInstanceOf[Last[This]]
@@ -66,6 +70,7 @@ sealed trait Tuple extends Product {
    *  This operation is O(this.size)
    *
    *  @tparam This the exact type of this tuple
+   *  @return a new tuple containing all elements of this tuple except the first one
    */
   inline def tail[This >: this.type <: Tuple]: Tail[This] =
     runtime.Tuples.tail(this).asInstanceOf[Tail[This]]
@@ -82,6 +87,7 @@ sealed trait Tuple extends Product {
   /** Returns the size (or arity) of the tuple.
    *
    *  @tparam This the exact type of this tuple
+   *  @return the arity of this tuple, returned as an `Int` whose precise static type is the singleton `Size[This]`
    */
   inline def size[This >: this.type <: Tuple]: Size[This] =
     runtime.Tuples.size(this).asInstanceOf[Size[This]]
@@ -96,6 +102,7 @@ sealed trait Tuple extends Product {
    *  @tparam This the exact type of this tuple
    *  @tparam T2 the type of the other tuple to zip with
    *  @param t2 the tuple to zip with this tuple
+   *  @return a tuple of pairs formed from corresponding elements of this tuple and `t2`, truncated to the length of the shorter tuple
    */
   inline def zip[This >: this.type <: Tuple, T2 <: Tuple](t2: T2): Zip[This, T2] =
     runtime.Tuples.zip(this, t2).asInstanceOf[Zip[This, T2]]
@@ -105,6 +112,8 @@ sealed trait Tuple extends Product {
    *  Otherwise the result type is `F[A1] *: Tuple`.
    *
    *  @tparam F the type constructor applied to each element type
+   *  @param f the polymorphic function to apply to each element, mapping a value of type `t` to a value of type `F[t]`
+   *  @return a new tuple containing the result of applying `f` to each element of this tuple
    */
   inline def map[F[_]](f: [t] -> t -> F[t]): Map[this.type, F] =
     runtime.Tuples.map(this, f).asInstanceOf[Map[this.type, F]]
@@ -114,6 +123,7 @@ sealed trait Tuple extends Product {
    *
    *  @tparam This the exact type of this tuple
    *  @param n the number of elements to take from the beginning
+   *  @return a tuple containing the first `n` elements of this tuple
    */
   inline def take[This >: this.type <: Tuple](n: Int): Take[This, n.type] =
     runtime.Tuples.take(this, n).asInstanceOf[Take[This, n.type]]
@@ -123,6 +133,7 @@ sealed trait Tuple extends Product {
    *
    *  @tparam This the exact type of this tuple
    *  @param n the number of elements to drop from the beginning
+   *  @return a tuple containing all elements of this tuple after the first `n` elements
    */
   inline def drop[This >: this.type <: Tuple](n: Int): Drop[This, n.type] =
     runtime.Tuples.drop(this, n).asInstanceOf[Drop[This, n.type]]
@@ -133,6 +144,7 @@ sealed trait Tuple extends Product {
    *
    *  @tparam This the exact type of this tuple
    *  @param n the number of elements in the first part of the split
+   *  @return a pair of tuples, the first containing the first `n` elements of this tuple, and the second containing the remaining elements
    */
   inline def splitAt[This >: this.type <: Tuple](n: Int): Split[This, n.type] =
     runtime.Tuples.splitAt(this, n).asInstanceOf[Split[This, n.type]]
@@ -141,6 +153,7 @@ sealed trait Tuple extends Product {
    *  consisting all its elements.
    *
    *  @tparam This the exact type of this tuple
+   *  @return a new tuple containing the elements of this tuple in reverse order
    */
   inline def reverse[This >: this.type <: Tuple]: Reverse[This] =
     runtime.Tuples.reverse(this).asInstanceOf[Reverse[This]]
@@ -324,12 +337,14 @@ object Tuple {
    *
    *  @tparam T the type of the element
    *  @param x the single element of the tuple
+   *  @return a `Tuple1` containing `x` as its only element
    */
   def apply[T](x: T): T *: EmptyTuple = Tuple1(x)
 
   /** Matches an empty tuple.
    *
    *  @param x the empty tuple to match
+   *  @return `true`, indicating a successful match against the empty tuple
    */
   def unapply(x: EmptyTuple): true = true
 
@@ -337,6 +352,7 @@ object Tuple {
    *
    *  @tparam T the element type of the array
    *  @param xs the array to convert into a tuple
+   *  @return a tuple whose elements are the elements of `xs` in order
    */
   def fromArray[T](xs: Array[T]): Tuple = {
     val xs2 = xs match {
@@ -350,6 +366,7 @@ object Tuple {
    *
    *  @tparam T the element type of the immutable array
    *  @param xs the immutable array to convert into a tuple
+   *  @return a tuple whose elements are the elements of `xs` in order
    */
   def fromIArray[T](xs: IArray[T]): Tuple = {
     val xs2: IArray[Object] = xs match {
@@ -363,6 +380,7 @@ object Tuple {
   /** Converts a Product into a tuple of unknown arity and types.
    *
    *  @param product the product to convert into a tuple
+   *  @return a tuple whose elements are the elements of `product` in declaration order
    */
   def fromProduct(product: Product): Tuple =
     runtime.Tuples.fromProduct(product)

--- a/tests/neg-macros/annot-crash.check
+++ b/tests/neg-macros/annot-crash.check
@@ -3,5 +3,5 @@
   |^^^^^^
   |Failed to evaluate macro annotation '@crash'.
   |  Caused by class scala.NotImplementedError: an implementation is missing
-  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:396)
+  |    scala.Predef$.$qmark$qmark$qmark(Predef.scala:398)
   |    crash.transform(Macro_1.scala:7)


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in `@param`, `@tparam`, and `@return` tags for the loose root files (`Array`, `IArray`, `Option`, `Predef`, `Function`, `Tuple`, `MatchError`, and numeric types) that were missed in the previous batch of PRs. I'm submitting it as a draft PR so to get CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and are starting to review them. We will review them all before making the PR non-draft. Please let me know if you see anything specific that you think could be improved.