### PR TITLE
 Jdk (7): filled in @param, @tparam, and @return tags that were missed last time

### DIFF
--- a/library/src/scala/jdk/Accumulator.scala
+++ b/library/src/scala/jdk/Accumulator.scala
@@ -69,6 +69,7 @@ import scala.language.implicitConversions
  *  [[DoubleAccumulator]].
  *
  *  @tparam CC the covariant higher-kinded type constructor for the specific accumulator collection, constrained to `mutable.Seq`
+ *  @tparam C the concrete result type of this accumulator's builder, constrained to `mutable.Seq[A]`
  */
 abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.Seq[X], +C <: mutable.Seq[A]]
   extends mutable.Seq[A]
@@ -98,6 +99,7 @@ abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.
    *     allocated with 1 extra slot. So `history(0)` has 17 slots of which the first 15 store elements.
    *
    *  @param i the index into the `history` array, where `0 <= i < `hIndex``
+   *  @return the total number of elements stored in `history(0)` through `history(i)`, inclusive
    */
   private[jdk] def cumulative(i: Int): Long
 
@@ -185,6 +187,7 @@ object Accumulator {
    *  @tparam A      the type of the ${coll}'s elements
    *  @tparam C the (inferred) specific type of the $coll
    *  @param canAccumulate the implicit factory shape that determines the specific accumulator type to build
+   *  @return an empty $coll of the type selected by `canAccumulate`
    */
   def empty[A, C](implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
     canAccumulate.empty
@@ -222,6 +225,7 @@ object Accumulator {
    *  @param init State initial value
    *  @param f    Computes the next element (or returns `None` to signal
    *             the end of the collection)
+   *  @param canAccumulate the implicit factory shape that determines the specific accumulator type to build
    *  @return an $coll that produces elements using `f` until `f` returns `None`
    */
   def unfold[A, S, C](init: S)(f: S => Option[(A, S)])(implicit canAccumulate: AccumulatorFactoryShape[A, C]): C =
@@ -350,6 +354,7 @@ object Accumulator {
    *  @param   n1  the number of elements in the 1st dimension
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   f   The function computing element values
+   *  @param canAccumulate the implicit factory shape that determines the specific accumulator type to build
    *  @return An $coll consisting of elements `f(i1, i2)`
    *          for `0 <= i1 < n1` and `0 <= i2 < n2`.
    */
@@ -364,6 +369,7 @@ object Accumulator {
    *  @param   n2  the number of elements in the 2nd dimension
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   f   The function computing element values
+   *  @param canAccumulate the implicit factory shape that determines the specific accumulator type to build
    *  @return An $coll consisting of elements `f(i1, i2, i3)`
    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, and `0 <= i3 < n3`.
    */
@@ -379,6 +385,7 @@ object Accumulator {
    *  @param   n3  the number of elements in the 3rd dimension
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   f   The function computing element values
+   *  @param canAccumulate the implicit factory shape that determines the specific accumulator type to build
    *  @return An $coll consisting of elements `f(i1, i2, i3, i4)`
    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, and `0 <= i4 < n4`.
    */
@@ -395,6 +402,7 @@ object Accumulator {
    *  @param   n4  the number of elements in the 4th dimension
    *  @param   n5  the number of elements in the 5th dimension
    *  @param   f   The function computing element values
+   *  @param canAccumulate the implicit factory shape that determines the specific accumulator type to build
    *  @return An $coll consisting of elements `f(i1, i2, i3, i4, i5)`
    *          for `0 <= i1 < n1`, `0 <= i2 < n2`, `0 <= i3 < n3`, `0 <= i4 < n4`, and `0 <= i5 < n5`.
    */

--- a/library/src/scala/jdk/AnyAccumulator.scala
+++ b/library/src/scala/jdk/AnyAccumulator.scala
@@ -66,6 +66,7 @@ final class AnyAccumulator[A]
   /** Appends an element to this `AnyAccumulator`.
    *
    *  @param a the element to append
+   *  @return this `AnyAccumulator`, to allow chaining of `addOne` calls
    */
   def addOne(a: A): this.type = {
     totalSize += 1
@@ -139,7 +140,8 @@ final class AnyAccumulator[A]
 
   /** Retrieves the `ix`th element.
    *
-   *  @param ix the zero-based index of the element to retrieve, as a `Long`
+   *  @param ix the zero-based index of the element to retrieve
+   *  @return the element at position `ix`
    */
   def apply(ix: Long): A = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt).asInstanceOf[A]
@@ -152,6 +154,7 @@ final class AnyAccumulator[A]
   /** Retrieves the `ix`th element, using an `Int` index.
    *
    *  @param i the zero-based index of the element to retrieve
+   *  @return the element at position `i`
    */
   def apply(i: Int): A = apply(i.toLong)
 
@@ -179,6 +182,8 @@ final class AnyAccumulator[A]
   /** Copies the elements in this `AnyAccumulator` into an `Array`.
    *
    *  @tparam B the element type of the resulting array, must be a supertype of `A`
+   *  @return a new array containing all elements of this `AnyAccumulator` in order
+   *  @throws IllegalArgumentException if the total size exceeds `Int.MaxValue`
    */
   override def toArray[B >: A : ClassTag]: Array[B] = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for an array: "+totalSize.toString)
@@ -233,6 +238,8 @@ final class AnyAccumulator[A]
    *
    *  @tparam C1 the type of the resulting collection
    *  @param factory the factory used to build the target collection
+   *  @return a collection of type `C1` containing all elements of this `AnyAccumulator`
+   *  @throws IllegalArgumentException if the total size exceeds `Int.MaxValue`
    */
   override def to[C1](factory: Factory[A, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)
@@ -254,12 +261,14 @@ object AnyAccumulator extends collection.SeqFactory[AnyAccumulator] {
   /** A `Supplier` of `AnyAccumulator`s, suitable for use with `java.util.stream.Stream`'s `collect` method.
    *
    *  @tparam A the element type of the accumulator to supply
+   *  @return a `Supplier` that creates a new empty `AnyAccumulator[A]` on each invocation
    */
   def supplier[A]: jf.Supplier[AnyAccumulator[A]] = () => new AnyAccumulator[A]
 
   /** A `BiConsumer` that adds an element to an `AnyAccumulator`, suitable for use with `java.util.stream.Stream`'s `collect` method.
    *
    *  @tparam A the element type to add to the accumulator
+   *  @return a `BiConsumer` that appends its second argument to the `AnyAccumulator` given as its first argument
    */
   def adder[A]: jf.BiConsumer[AnyAccumulator[A], A] = (ac: AnyAccumulator[A], a: A) => ac addOne a
 
@@ -275,6 +284,7 @@ object AnyAccumulator extends collection.SeqFactory[AnyAccumulator] {
   /** A `BiConsumer` that merges `AnyAccumulator`s, suitable for use with `java.util.stream.Stream`'s `collect` method.
    *
    *  @tparam A the element type of the accumulators to merge
+   *  @return a `BiConsumer` that drains the elements of the second `AnyAccumulator` into the first, leaving the second empty
    */
   def merger[A]: jf.BiConsumer[AnyAccumulator[A], AnyAccumulator[A]] = (a1: AnyAccumulator[A], a2: AnyAccumulator[A]) => a1 drain a2
 

--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -65,6 +65,7 @@ final class DoubleAccumulator
   /** Appends an element to this `DoubleAccumulator`.
    *
    *  @param a the `Double` value to append
+   *  @return this `DoubleAccumulator` (to allow chaining of operations)
    */
   def addOne(a: Double): this.type = {
     totalSize += 1
@@ -146,6 +147,7 @@ final class DoubleAccumulator
   /** Retrieves the `ix`th element.
    *
    *  @param ix the zero-based index of the element to retrieve
+   *  @return the `Double` value stored at position `ix`
    */
   def apply(ix: Long): Double = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
@@ -158,6 +160,7 @@ final class DoubleAccumulator
   /** Retrieves the `ix`th element, using an `Int` index.
    *
    *  @param i the zero-based index of the element to retrieve (converted to `Long` internally)
+   *  @return the `Double` value stored at position `i`
    */
   def apply(i: Int): Double = apply(i.toLong)
 
@@ -298,6 +301,7 @@ final class DoubleAccumulator
    *
    *  @tparam C1 the result type of the target collection (e.g., `Vector[Double]`)
    *  @param factory the factory for creating the target collection from elements
+   *  @return a new collection of type `C1` containing all elements of this `DoubleAccumulator`
    */
   override def to[C1](factory: Factory[Double, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -68,6 +68,7 @@ final class IntAccumulator
   /** Appends an element to this `IntAccumulator`.
    *
    *  @param a the `Int` value to append
+   *  @return this `IntAccumulator` with the element appended
    */
   def addOne(a: Int): this.type = {
     totalSize += 1
@@ -152,6 +153,7 @@ final class IntAccumulator
   /** Retrieves the `ix`th element.
    *
    *  @param ix the zero-based index of the element to retrieve, as a `Long`
+   *  @return the `Int` element at index `ix`
    */
   def apply(ix: Long): Int = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
@@ -164,6 +166,7 @@ final class IntAccumulator
   /** Retrieves the `ix`th element, using an `Int` index.
    *
    *  @param i the zero-based index of the element to retrieve
+   *  @return the `Int` element at index `i`
    */
   def apply(i: Int): Int = apply(i.toLong)
 
@@ -304,6 +307,7 @@ final class IntAccumulator
    *
    *  @tparam C1 the type of the target collection
    *  @param factory the factory for building the target collection from `Int` elements
+   *  @return a collection of type `C1` containing all elements of this `IntAccumulator`
    */
   override def to[C1](factory: Factory[Int, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -66,6 +66,7 @@ final class LongAccumulator
   /** Appends an element to this `LongAccumulator`.
    *
    *  @param a the `Long` value to append
+   *  @return this `LongAccumulator` with the element appended
    */
   def addOne(a: Long): this.type = {
     totalSize += 1
@@ -147,6 +148,7 @@ final class LongAccumulator
   /** Retrieves the `ix`th element.
    *
    *  @param ix the zero-based index of the element to retrieve
+   *  @return the `Long` element stored at position `ix`
    */
   def apply(ix: Long): Long = {
     if (totalSize - ix <= index || hIndex == 0) current((ix - (totalSize - index)).toInt)
@@ -159,6 +161,7 @@ final class LongAccumulator
   /** Retrieves the `ix`th element, using an `Int` index.
    *
    *  @param i the zero-based index of the element to retrieve
+   *  @return the `Long` element stored at position `i`
    */
   def apply(i: Int): Long = apply(i.toLong)
 
@@ -299,6 +302,7 @@ final class LongAccumulator
    *
    *  @tparam C1 the result type of the target collection
    *  @param factory the factory for the target collection type
+   *  @return a collection of type `C1` containing all elements of this `LongAccumulator`
    */
   override def to[C1](factory: Factory[Long, C1]): C1 = {
     if (totalSize > Int.MaxValue) throw new IllegalArgumentException("Too many elements accumulated for a Scala collection: "+totalSize.toString)

--- a/library/src/scala/jdk/OptionConverters.scala
+++ b/library/src/scala/jdk/OptionConverters.scala
@@ -62,6 +62,7 @@ object OptionConverters {
      *
      *  @tparam O the target specialized Java `Optional` type, inferred from the available `OptionShape` instance (e.g., `OptionalInt`, `OptionalDouble`, `OptionalLong`)
      *  @param shape implicit evidence that defines how to convert between `Optional[A]` and the specialized type `O`
+     *  @return the specialized Java `Optional` variant containing the same value as `o`, or an empty variant if `o` is empty
      */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromJava(o)
   }
@@ -83,6 +84,7 @@ object OptionConverters {
      *
      *  @tparam O the specialized Java `Optional` type (e.g., `OptionalInt`, `OptionalDouble`, `OptionalLong`)
      *  @param shape implicit evidence that defines how to convert between `Option[A]` and the specialized type `O`
+     *  @return the specialized Java `Optional` variant containing the value of `o`, or an empty variant if `o` is `None`
      */
     def toJavaPrimitive[O](implicit shape: OptionShape[A, O]): O = shape.fromScala(o)
   }

--- a/library/src/scala/jdk/OptionShape.scala
+++ b/library/src/scala/jdk/OptionShape.scala
@@ -29,11 +29,13 @@ sealed abstract class OptionShape[A, O] {
   /** Converts from `Optional` to the specialized variant `O`.
    *
    *  @param o the generic `Optional` to convert to the specialized variant
+   *  @return the specialized `Optional` containing the value of `o` if present, otherwise an empty specialized `Optional`
    */
   def fromJava(o: Optional[A]): O
   /** Converts from `Option` to the specialized variant `O`.
    *
    *  @param o the Scala `Option` to convert to the specialized Java variant
+   *  @return the specialized `Optional` containing the value of `o` if defined, otherwise an empty specialized `Optional`
    */
   def fromScala(o: Option[A]): O
 }

--- a/library/src/scala/jdk/javaapi/FunctionConverters.scala
+++ b/library/src/scala/jdk/javaapi/FunctionConverters.scala
@@ -36,6 +36,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the bi-consumer
    *  @tparam U the second input type of the bi-consumer
    *  @param jf the Java `BiConsumer` to convert
+   *  @return a Scala `Function2` returning `BoxedUnit` equivalent to `jf`
    */
   @inline def asScalaFromBiConsumer[T, U](jf: java.util.function.BiConsumer[T, U]): scala.Function2[T, U, scala.runtime.BoxedUnit] = jf match {
     case AsJavaBiConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, U, scala.runtime.BoxedUnit]]
@@ -51,6 +52,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the bi-consumer
    *  @tparam U the second input type of the bi-consumer
    *  @param sf the Scala `Function2` to convert to a Java `BiConsumer`
+   *  @return a Java `BiConsumer` equivalent to `sf`
    */
   @inline def asJavaBiConsumer[T, U](sf: scala.Function2[T, U, scala.runtime.BoxedUnit]): java.util.function.BiConsumer[T, U] = ((sf): AnyRef) match {
     case FromJavaBiConsumer((f @ _)) => f.asInstanceOf[java.util.function.BiConsumer[T, U]]
@@ -58,20 +60,24 @@ object FunctionConverters {
   }
   
 
-  /** @tparam T the first input type of the bi-function
+  /**
+   *  @tparam T the first input type of the bi-function
    *  @tparam U the second input type of the bi-function
    *  @tparam R the return type of the bi-function
    *  @param jf the Java `BiFunction` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromBiFunction[T, U, R](jf: java.util.function.BiFunction[T, U, R]): scala.Function2[T, U, R] = jf match {
     case AsJavaBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, R]]
     case _ => new FromJavaBiFunction[T, U, R](jf).asInstanceOf[scala.Function2[T, U, R]]
   }
   
-  /** @tparam T the first input type of the bi-function
+  /**
+   *  @tparam T the first input type of the bi-function
    *  @tparam U the second input type of the bi-function
    *  @tparam R the return type of the bi-function
    *  @param sf the Scala `Function2` to convert to a Java `BiFunction`
+   *  @return a Java `BiFunction` equivalent to `sf`
    */
   @inline def asJavaBiFunction[T, U, R](sf: scala.Function2[T, U, R]): java.util.function.BiFunction[T, U, R] = ((sf): AnyRef) match {
     case FromJavaBiFunction((f @ _)) => f.asInstanceOf[java.util.function.BiFunction[T, U, R]]
@@ -88,6 +94,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the bi-predicate
    *  @tparam U the second input type of the bi-predicate
    *  @param jf the Java `BiPredicate` to convert
+   *  @return a Scala `Function2` returning `java.lang.Boolean` equivalent to `jf`
    */
   @inline def asScalaFromBiPredicate[T, U](jf: java.util.function.BiPredicate[T, U]): scala.Function2[T, U, java.lang.Boolean] = jf match {
     case AsJavaBiPredicate((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Boolean]]
@@ -103,6 +110,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the bi-predicate
    *  @tparam U the second input type of the bi-predicate
    *  @param sf the Scala `Function2` to convert to a Java `BiPredicate`
+   *  @return a Java `BiPredicate` equivalent to `sf`
    */
   @inline def asJavaBiPredicate[T, U](sf: scala.Function2[T, U, java.lang.Boolean]): java.util.function.BiPredicate[T, U] = ((sf): AnyRef) match {
     case FromJavaBiPredicate((f @ _)) => f.asInstanceOf[java.util.function.BiPredicate[T, U]]
@@ -110,16 +118,20 @@ object FunctionConverters {
   }
   
   
-  /** @tparam T the input and output type of the binary operator
+  /**
+   *  @tparam T the input and output type of the binary operator
    *  @param jf the Java `BinaryOperator` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromBinaryOperator[T](jf: java.util.function.BinaryOperator[T]): scala.Function2[T, T, T] = jf match {
     case AsJavaBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[T, T, T]]
     case _ => new FromJavaBinaryOperator[T](jf).asInstanceOf[scala.Function2[T, T, T]]
   }
   
-  /** @tparam T the input and output type of the binary operator
+  /**
+   *  @tparam T the input and output type of the binary operator
    *  @param sf the Scala `Function2` to convert to a Java `BinaryOperator`
+   *  @return a Java `BinaryOperator` equivalent to `sf`
    */
   @inline def asJavaBinaryOperator[T](sf: scala.Function2[T, T, T]): java.util.function.BinaryOperator[T] = ((sf): AnyRef) match {
     case FromJavaBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.BinaryOperator[T]]
@@ -134,6 +146,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `BooleanSupplier` to convert
+   *  @return a Scala `Function0` equivalent to `jf`
    */
   @inline def asScalaFromBooleanSupplier(jf: java.util.function.BooleanSupplier): scala.Function0[java.lang.Boolean] = jf match {
     case AsJavaBooleanSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Boolean]]
@@ -147,6 +160,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function0` to convert to a Java `BooleanSupplier`
+   *  @return a Java `BooleanSupplier` equivalent to `sf`
    */
   @inline def asJavaBooleanSupplier(sf: scala.Function0[java.lang.Boolean]): java.util.function.BooleanSupplier = ((sf): AnyRef) match {
     case FromJavaBooleanSupplier((f @ _)) => f.asInstanceOf[java.util.function.BooleanSupplier]
@@ -162,6 +176,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the consumer
    *  @param jf the Java `Consumer` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromConsumer[T](jf: java.util.function.Consumer[T]): scala.Function1[T, scala.runtime.BoxedUnit] = jf match {
     case AsJavaConsumer((f @ _)) => f.asInstanceOf[scala.Function1[T, scala.runtime.BoxedUnit]]
@@ -176,6 +191,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the consumer
    *  @param sf the Scala `Function1` to convert to a Java `Consumer`
+   *  @return a Java `Consumer` equivalent to `sf`
    */
   @inline def asJavaConsumer[T](sf: scala.Function1[T, scala.runtime.BoxedUnit]): java.util.function.Consumer[T] = ((sf): AnyRef) match {
     case FromJavaConsumer((f @ _)) => f.asInstanceOf[java.util.function.Consumer[T]]
@@ -190,6 +206,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `DoubleBinaryOperator` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromDoubleBinaryOperator(jf: java.util.function.DoubleBinaryOperator): scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]]
@@ -203,6 +220,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function2` to convert to a Java `DoubleBinaryOperator`
+   *  @return a Java `DoubleBinaryOperator` equivalent to `sf`
    */
   @inline def asJavaDoubleBinaryOperator(sf: scala.Function2[java.lang.Double, java.lang.Double, java.lang.Double]): java.util.function.DoubleBinaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleBinaryOperator]
@@ -217,6 +235,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `DoubleConsumer` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromDoubleConsumer(jf: java.util.function.DoubleConsumer): scala.Function1[java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]]
@@ -230,6 +249,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `DoubleConsumer`
+   *  @return a Java `DoubleConsumer` equivalent to `sf`
    */
   @inline def asJavaDoubleConsumer(sf: scala.Function1[java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.DoubleConsumer = ((sf): AnyRef) match {
     case FromJavaDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.DoubleConsumer]
@@ -245,6 +265,7 @@ object FunctionConverters {
    *
    *  @tparam R the return type of the function
    *  @param jf the Java `DoubleFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromDoubleFunction[R](jf: java.util.function.DoubleFunction[R]): scala.Function1[java.lang.Double, R] = jf match {
     case AsJavaDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, R]]
@@ -259,6 +280,7 @@ object FunctionConverters {
    *
    *  @tparam R the return type of the function
    *  @param sf the Scala `Function1` to convert to a Java `DoubleFunction`
+   *  @return a Java `DoubleFunction` equivalent to `sf`
    */
   @inline def asJavaDoubleFunction[R](sf: scala.Function1[java.lang.Double, R]): java.util.function.DoubleFunction[R] = ((sf): AnyRef) match {
     case FromJavaDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleFunction[R]]
@@ -273,6 +295,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `DoublePredicate` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromDoublePredicate(jf: java.util.function.DoublePredicate): scala.Function1[java.lang.Double, java.lang.Boolean] = jf match {
     case AsJavaDoublePredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Boolean]]
@@ -286,6 +309,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `DoublePredicate`
+   *  @return a Java `DoublePredicate` equivalent to `sf`
    */
   @inline def asJavaDoublePredicate(sf: scala.Function1[java.lang.Double, java.lang.Boolean]): java.util.function.DoublePredicate = ((sf): AnyRef) match {
     case FromJavaDoublePredicate((f @ _)) => f.asInstanceOf[java.util.function.DoublePredicate]
@@ -300,6 +324,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `DoubleSupplier` to convert
+   *  @return a Scala `Function0` equivalent to `jf`
    */
   @inline def asScalaFromDoubleSupplier(jf: java.util.function.DoubleSupplier): scala.Function0[java.lang.Double] = jf match {
     case AsJavaDoubleSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Double]]
@@ -313,6 +338,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function0` to convert to a Java `DoubleSupplier`
+   *  @return a Java `DoubleSupplier` equivalent to `sf`
    */
   @inline def asJavaDoubleSupplier(sf: scala.Function0[java.lang.Double]): java.util.function.DoubleSupplier = ((sf): AnyRef) match {
     case FromJavaDoubleSupplier((f @ _)) => f.asInstanceOf[java.util.function.DoubleSupplier]
@@ -327,6 +353,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `DoubleToIntFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromDoubleToIntFunction(jf: java.util.function.DoubleToIntFunction): scala.Function1[java.lang.Double, java.lang.Integer] = jf match {
     case AsJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Integer]]
@@ -340,6 +367,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `DoubleToIntFunction`
+   *  @return a Java `DoubleToIntFunction` equivalent to `sf`
    */
   @inline def asJavaDoubleToIntFunction(sf: scala.Function1[java.lang.Double, java.lang.Integer]): java.util.function.DoubleToIntFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToIntFunction]
@@ -354,6 +382,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `DoubleToLongFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromDoubleToLongFunction(jf: java.util.function.DoubleToLongFunction): scala.Function1[java.lang.Double, java.lang.Long] = jf match {
     case AsJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Long]]
@@ -367,6 +396,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `DoubleToLongFunction`
+   *  @return a Java `DoubleToLongFunction` equivalent to `sf`
    */
   @inline def asJavaDoubleToLongFunction(sf: scala.Function1[java.lang.Double, java.lang.Long]): java.util.function.DoubleToLongFunction = ((sf): AnyRef) match {
     case FromJavaDoubleToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.DoubleToLongFunction]
@@ -381,6 +411,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `DoubleUnaryOperator` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromDoubleUnaryOperator(jf: java.util.function.DoubleUnaryOperator): scala.Function1[java.lang.Double, java.lang.Double] = jf match {
     case AsJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Double, java.lang.Double]]
@@ -394,6 +425,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `DoubleUnaryOperator`
+   *  @return a Java `DoubleUnaryOperator` equivalent to `sf`
    */
   @inline def asJavaDoubleUnaryOperator(sf: scala.Function1[java.lang.Double, java.lang.Double]): java.util.function.DoubleUnaryOperator = ((sf): AnyRef) match {
     case FromJavaDoubleUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.DoubleUnaryOperator]
@@ -401,18 +433,22 @@ object FunctionConverters {
   }
   
   
-  /** @tparam T the input type of the function
+  /**
+   *  @tparam T the input type of the function
    *  @tparam R the return type of the function
    *  @param jf the Java `Function` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromFunction[T, R](jf: java.util.function.Function[T, R]): scala.Function1[T, R] = jf match {
     case AsJavaFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, R]]
     case _ => new FromJavaFunction[T, R](jf).asInstanceOf[scala.Function1[T, R]]
   }
   
-  /** @tparam T the input type of the function
+  /**
+   *  @tparam T the input type of the function
    *  @tparam R the return type of the function
    *  @param sf the Scala `Function1` to convert to a Java `Function`
+   *  @return a Java `Function` equivalent to `sf`
    */
   @inline def asJavaFunction[T, R](sf: scala.Function1[T, R]): java.util.function.Function[T, R] = ((sf): AnyRef) match {
     case FromJavaFunction((f @ _)) => f.asInstanceOf[java.util.function.Function[T, R]]
@@ -427,6 +463,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `IntBinaryOperator` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromIntBinaryOperator(jf: java.util.function.IntBinaryOperator): scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]]
@@ -440,6 +477,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function2` to convert to a Java `IntBinaryOperator`
+   *  @return a Java `IntBinaryOperator` equivalent to `sf`
    */
   @inline def asJavaIntBinaryOperator(sf: scala.Function2[java.lang.Integer, java.lang.Integer, java.lang.Integer]): java.util.function.IntBinaryOperator = ((sf): AnyRef) match {
     case FromJavaIntBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntBinaryOperator]
@@ -454,6 +492,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `IntConsumer` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromIntConsumer(jf: java.util.function.IntConsumer): scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaIntConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]]
@@ -467,6 +506,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `IntConsumer`
+   *  @return a Java `IntConsumer` equivalent to `sf`
    */
   @inline def asJavaIntConsumer(sf: scala.Function1[java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.IntConsumer = ((sf): AnyRef) match {
     case FromJavaIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.IntConsumer]
@@ -482,6 +522,7 @@ object FunctionConverters {
    *
    *  @tparam R the return type of the function
    *  @param jf the Java `IntFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromIntFunction[R](jf: java.util.function.IntFunction[R]): scala.Function1[java.lang.Integer, R] = jf match {
     case AsJavaIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, R]]
@@ -496,6 +537,7 @@ object FunctionConverters {
    *
    *  @tparam R the return type of the function
    *  @param sf the Scala `Function1` to convert to a Java `IntFunction`
+   *  @return a Java `IntFunction` equivalent to `sf`
    */
   @inline def asJavaIntFunction[R](sf: scala.Function1[java.lang.Integer, R]): java.util.function.IntFunction[R] = ((sf): AnyRef) match {
     case FromJavaIntFunction((f @ _)) => f.asInstanceOf[java.util.function.IntFunction[R]]
@@ -510,6 +552,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `IntPredicate` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromIntPredicate(jf: java.util.function.IntPredicate): scala.Function1[java.lang.Integer, java.lang.Boolean] = jf match {
     case AsJavaIntPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Boolean]]
@@ -523,6 +566,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `IntPredicate`
+   *  @return a Java `IntPredicate` equivalent to `sf`
    */
   @inline def asJavaIntPredicate(sf: scala.Function1[java.lang.Integer, java.lang.Boolean]): java.util.function.IntPredicate = ((sf): AnyRef) match {
     case FromJavaIntPredicate((f @ _)) => f.asInstanceOf[java.util.function.IntPredicate]
@@ -537,6 +581,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `IntSupplier` to convert
+   *  @return a Scala `Function0` equivalent to `jf`
    */
   @inline def asScalaFromIntSupplier(jf: java.util.function.IntSupplier): scala.Function0[java.lang.Integer] = jf match {
     case AsJavaIntSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Integer]]
@@ -550,6 +595,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function0` to convert to a Java `IntSupplier`
+   *  @return a Java `IntSupplier` equivalent to `sf`
    */
   @inline def asJavaIntSupplier(sf: scala.Function0[java.lang.Integer]): java.util.function.IntSupplier = ((sf): AnyRef) match {
     case FromJavaIntSupplier((f @ _)) => f.asInstanceOf[java.util.function.IntSupplier]
@@ -564,6 +610,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `IntToDoubleFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromIntToDoubleFunction(jf: java.util.function.IntToDoubleFunction): scala.Function1[java.lang.Integer, java.lang.Double] = jf match {
     case AsJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Double]]
@@ -577,6 +624,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `IntToDoubleFunction`
+   *  @return a Java `IntToDoubleFunction` equivalent to `sf`
    */
   @inline def asJavaIntToDoubleFunction(sf: scala.Function1[java.lang.Integer, java.lang.Double]): java.util.function.IntToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaIntToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToDoubleFunction]
@@ -591,6 +639,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `IntToLongFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromIntToLongFunction(jf: java.util.function.IntToLongFunction): scala.Function1[java.lang.Integer, java.lang.Long] = jf match {
     case AsJavaIntToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Long]]
@@ -604,6 +653,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `IntToLongFunction`
+   *  @return a Java `IntToLongFunction` equivalent to `sf`
    */
   @inline def asJavaIntToLongFunction(sf: scala.Function1[java.lang.Integer, java.lang.Long]): java.util.function.IntToLongFunction = ((sf): AnyRef) match {
     case FromJavaIntToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.IntToLongFunction]
@@ -618,6 +668,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `IntUnaryOperator` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromIntUnaryOperator(jf: java.util.function.IntUnaryOperator): scala.Function1[java.lang.Integer, java.lang.Integer] = jf match {
     case AsJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Integer, java.lang.Integer]]
@@ -631,6 +682,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `IntUnaryOperator`
+   *  @return a Java `IntUnaryOperator` equivalent to `sf`
    */
   @inline def asJavaIntUnaryOperator(sf: scala.Function1[java.lang.Integer, java.lang.Integer]): java.util.function.IntUnaryOperator = ((sf): AnyRef) match {
     case FromJavaIntUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.IntUnaryOperator]
@@ -645,6 +697,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `LongBinaryOperator` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromLongBinaryOperator(jf: java.util.function.LongBinaryOperator): scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]]
@@ -658,6 +711,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function2` to convert to a Java `LongBinaryOperator`
+   *  @return a Java `LongBinaryOperator` equivalent to `sf`
    */
   @inline def asJavaLongBinaryOperator(sf: scala.Function2[java.lang.Long, java.lang.Long, java.lang.Long]): java.util.function.LongBinaryOperator = ((sf): AnyRef) match {
     case FromJavaLongBinaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongBinaryOperator]
@@ -672,6 +726,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `LongConsumer` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromLongConsumer(jf: java.util.function.LongConsumer): scala.Function1[java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaLongConsumer((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]]
@@ -685,6 +740,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `LongConsumer`
+   *  @return a Java `LongConsumer` equivalent to `sf`
    */
   @inline def asJavaLongConsumer(sf: scala.Function1[java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.LongConsumer = ((sf): AnyRef) match {
     case FromJavaLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.LongConsumer]
@@ -700,6 +756,7 @@ object FunctionConverters {
    *
    *  @tparam R the return type of the function
    *  @param jf the Java `LongFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromLongFunction[R](jf: java.util.function.LongFunction[R]): scala.Function1[java.lang.Long, R] = jf match {
     case AsJavaLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, R]]
@@ -714,6 +771,7 @@ object FunctionConverters {
    *
    *  @tparam R the return type of the function
    *  @param sf the Scala `Function1` to convert to a Java `LongFunction`
+   *  @return a Java `LongFunction` equivalent to `sf`
    */
   @inline def asJavaLongFunction[R](sf: scala.Function1[java.lang.Long, R]): java.util.function.LongFunction[R] = ((sf): AnyRef) match {
     case FromJavaLongFunction((f @ _)) => f.asInstanceOf[java.util.function.LongFunction[R]]
@@ -728,6 +786,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `LongPredicate` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromLongPredicate(jf: java.util.function.LongPredicate): scala.Function1[java.lang.Long, java.lang.Boolean] = jf match {
     case AsJavaLongPredicate((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Boolean]]
@@ -741,6 +800,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `LongPredicate`
+   *  @return a Java `LongPredicate` equivalent to `sf`
    */
   @inline def asJavaLongPredicate(sf: scala.Function1[java.lang.Long, java.lang.Boolean]): java.util.function.LongPredicate = ((sf): AnyRef) match {
     case FromJavaLongPredicate((f @ _)) => f.asInstanceOf[java.util.function.LongPredicate]
@@ -755,6 +815,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `LongSupplier` to convert
+   *  @return a Scala `Function0` equivalent to `jf`
    */
   @inline def asScalaFromLongSupplier(jf: java.util.function.LongSupplier): scala.Function0[java.lang.Long] = jf match {
     case AsJavaLongSupplier((f @ _)) => f.asInstanceOf[scala.Function0[java.lang.Long]]
@@ -768,6 +829,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function0` to convert to a Java `LongSupplier`
+   *  @return a Java `LongSupplier` equivalent to `sf`
    */
   @inline def asJavaLongSupplier(sf: scala.Function0[java.lang.Long]): java.util.function.LongSupplier = ((sf): AnyRef) match {
     case FromJavaLongSupplier((f @ _)) => f.asInstanceOf[java.util.function.LongSupplier]
@@ -782,6 +844,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `LongToDoubleFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromLongToDoubleFunction(jf: java.util.function.LongToDoubleFunction): scala.Function1[java.lang.Long, java.lang.Double] = jf match {
     case AsJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Double]]
@@ -795,6 +858,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `LongToDoubleFunction`
+   *  @return a Java `LongToDoubleFunction` equivalent to `sf`
    */
   @inline def asJavaLongToDoubleFunction(sf: scala.Function1[java.lang.Long, java.lang.Double]): java.util.function.LongToDoubleFunction = ((sf): AnyRef) match {
     case FromJavaLongToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToDoubleFunction]
@@ -809,6 +873,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `LongToIntFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromLongToIntFunction(jf: java.util.function.LongToIntFunction): scala.Function1[java.lang.Long, java.lang.Integer] = jf match {
     case AsJavaLongToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Integer]]
@@ -822,6 +887,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `LongToIntFunction`
+   *  @return a Java `LongToIntFunction` equivalent to `sf`
    */
   @inline def asJavaLongToIntFunction(sf: scala.Function1[java.lang.Long, java.lang.Integer]): java.util.function.LongToIntFunction = ((sf): AnyRef) match {
     case FromJavaLongToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.LongToIntFunction]
@@ -836,6 +902,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param jf the Java `LongUnaryOperator` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromLongUnaryOperator(jf: java.util.function.LongUnaryOperator): scala.Function1[java.lang.Long, java.lang.Long] = jf match {
     case AsJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[java.lang.Long, java.lang.Long]]
@@ -849,6 +916,7 @@ object FunctionConverters {
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
    *  @param sf the Scala `Function1` to convert to a Java `LongUnaryOperator`
+   *  @return a Java `LongUnaryOperator` equivalent to `sf`
    */
   @inline def asJavaLongUnaryOperator(sf: scala.Function1[java.lang.Long, java.lang.Long]): java.util.function.LongUnaryOperator = ((sf): AnyRef) match {
     case FromJavaLongUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.LongUnaryOperator]
@@ -862,8 +930,9 @@ object FunctionConverters {
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
-   *  @tparam T the type of the first (object) argument to the consumer
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
    *  @param jf the Java `ObjDoubleConsumer` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromObjDoubleConsumer[T](jf: java.util.function.ObjDoubleConsumer[T]): scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]]
@@ -876,8 +945,9 @@ object FunctionConverters {
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
-   *  @tparam T the type of the first (object) argument to the consumer
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
    *  @param sf the Scala `Function2` to convert to a Java `ObjDoubleConsumer`
+   *  @return a Java `ObjDoubleConsumer` equivalent to `sf`
    */
   @inline def asJavaObjDoubleConsumer[T](sf: scala.Function2[T, java.lang.Double, scala.runtime.BoxedUnit]): java.util.function.ObjDoubleConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjDoubleConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjDoubleConsumer[T]]
@@ -891,8 +961,9 @@ object FunctionConverters {
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
-   *  @tparam T the type of the first (object) argument to the consumer
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
    *  @param jf the Java `ObjIntConsumer` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromObjIntConsumer[T](jf: java.util.function.ObjIntConsumer[T]): scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjIntConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]]
@@ -905,8 +976,9 @@ object FunctionConverters {
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
-   *  @tparam T the type of the first (object) argument to the consumer
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
    *  @param sf the Scala `Function2` to convert to a Java `ObjIntConsumer`
+   *  @return a Java `ObjIntConsumer` equivalent to `sf`
    */
   @inline def asJavaObjIntConsumer[T](sf: scala.Function2[T, java.lang.Integer, scala.runtime.BoxedUnit]): java.util.function.ObjIntConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjIntConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjIntConsumer[T]]
@@ -920,8 +992,9 @@ object FunctionConverters {
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
-   *  @tparam T the type of the first (object) argument to the consumer
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
    *  @param jf the Java `ObjLongConsumer` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromObjLongConsumer[T](jf: java.util.function.ObjLongConsumer[T]): scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit] = jf match {
     case AsJavaObjLongConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]]
@@ -934,8 +1007,9 @@ object FunctionConverters {
    *  [scala/bug#4214](https://github.com/scala/bug/issues/4214)). In Scala code, add
    *  `import scala.jdk.FunctionConverters._` and use the extension methods instead.
    *
-   *  @tparam T the type of the first (object) argument to the consumer
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
    *  @param sf the Scala `Function2` to convert to a Java `ObjLongConsumer`
+   *  @return a Java `ObjLongConsumer` equivalent to `sf`
    */
   @inline def asJavaObjLongConsumer[T](sf: scala.Function2[T, java.lang.Long, scala.runtime.BoxedUnit]): java.util.function.ObjLongConsumer[T] = ((sf): AnyRef) match {
     case FromJavaObjLongConsumer((f @ _)) => f.asInstanceOf[java.util.function.ObjLongConsumer[T]]
@@ -951,6 +1025,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the predicate
    *  @param jf the Java `Predicate` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromPredicate[T](jf: java.util.function.Predicate[T]): scala.Function1[T, java.lang.Boolean] = jf match {
     case AsJavaPredicate((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Boolean]]
@@ -965,6 +1040,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the predicate
    *  @param sf the Scala `Function1` to convert to a Java `Predicate`
+   *  @return a Java `Predicate` equivalent to `sf`
    */
   @inline def asJavaPredicate[T](sf: scala.Function1[T, java.lang.Boolean]): java.util.function.Predicate[T] = ((sf): AnyRef) match {
     case FromJavaPredicate((f @ _)) => f.asInstanceOf[java.util.function.Predicate[T]]
@@ -972,16 +1048,20 @@ object FunctionConverters {
   }
   
   
-  /** @tparam T the return type of the supplier
+  /**
+   *  @tparam T the return type of the supplier
    *  @param jf the Java `Supplier` to convert
+   *  @return a Scala `Function0` equivalent to `jf`
    */
   @inline def asScalaFromSupplier[T](jf: java.util.function.Supplier[T]): scala.Function0[T] = jf match {
     case AsJavaSupplier((f @ _)) => f.asInstanceOf[scala.Function0[T]]
     case _ => new FromJavaSupplier[T](jf).asInstanceOf[scala.Function0[T]]
   }
   
-  /** @tparam T the return type of the supplier
+  /**
+   *  @tparam T the return type of the supplier
    *  @param sf the Scala `Function0` to convert to a Java `Supplier`
+   *  @return a Java `Supplier` equivalent to `sf`
    */
   @inline def asJavaSupplier[T](sf: scala.Function0[T]): java.util.function.Supplier[T] = ((sf): AnyRef) match {
     case FromJavaSupplier((f @ _)) => f.asInstanceOf[java.util.function.Supplier[T]]
@@ -998,6 +1078,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the function
    *  @tparam U the second input type of the function
    *  @param jf the Java `ToDoubleBiFunction` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromToDoubleBiFunction[T, U](jf: java.util.function.ToDoubleBiFunction[T, U]): scala.Function2[T, U, java.lang.Double] = jf match {
     case AsJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Double]]
@@ -1013,6 +1094,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the function
    *  @tparam U the second input type of the function
    *  @param sf the Scala `Function2` to convert to a Java `ToDoubleBiFunction`
+   *  @return a Java `ToDoubleBiFunction` equivalent to `sf`
    */
   @inline def asJavaToDoubleBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Double]): java.util.function.ToDoubleBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToDoubleBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleBiFunction[T, U]]
@@ -1028,6 +1110,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the function
    *  @param jf the Java `ToDoubleFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromToDoubleFunction[T](jf: java.util.function.ToDoubleFunction[T]): scala.Function1[T, java.lang.Double] = jf match {
     case AsJavaToDoubleFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Double]]
@@ -1042,6 +1125,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the function
    *  @param sf the Scala `Function1` to convert to a Java `ToDoubleFunction`
+   *  @return a Java `ToDoubleFunction` equivalent to `sf`
    */
   @inline def asJavaToDoubleFunction[T](sf: scala.Function1[T, java.lang.Double]): java.util.function.ToDoubleFunction[T] = ((sf): AnyRef) match {
     case FromJavaToDoubleFunction((f @ _)) => f.asInstanceOf[java.util.function.ToDoubleFunction[T]]
@@ -1058,6 +1142,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the function
    *  @tparam U the second input type of the function
    *  @param jf the Java `ToIntBiFunction` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromToIntBiFunction[T, U](jf: java.util.function.ToIntBiFunction[T, U]): scala.Function2[T, U, java.lang.Integer] = jf match {
     case AsJavaToIntBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Integer]]
@@ -1073,6 +1158,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the function
    *  @tparam U the second input type of the function
    *  @param sf the Scala `Function2` to convert to a Java `ToIntBiFunction`
+   *  @return a Java `ToIntBiFunction` equivalent to `sf`
    */
   @inline def asJavaToIntBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Integer]): java.util.function.ToIntBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToIntBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntBiFunction[T, U]]
@@ -1088,6 +1174,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the function
    *  @param jf the Java `ToIntFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromToIntFunction[T](jf: java.util.function.ToIntFunction[T]): scala.Function1[T, java.lang.Integer] = jf match {
     case AsJavaToIntFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Integer]]
@@ -1102,6 +1189,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the function
    *  @param sf the Scala `Function1` to convert to a Java `ToIntFunction`
+   *  @return a Java `ToIntFunction` equivalent to `sf`
    */
   @inline def asJavaToIntFunction[T](sf: scala.Function1[T, java.lang.Integer]): java.util.function.ToIntFunction[T] = ((sf): AnyRef) match {
     case FromJavaToIntFunction((f @ _)) => f.asInstanceOf[java.util.function.ToIntFunction[T]]
@@ -1118,6 +1206,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the function
    *  @tparam U the second input type of the function
    *  @param jf the Java `ToLongBiFunction` to convert
+   *  @return a Scala `Function2` equivalent to `jf`
    */
   @inline def asScalaFromToLongBiFunction[T, U](jf: java.util.function.ToLongBiFunction[T, U]): scala.Function2[T, U, java.lang.Long] = jf match {
     case AsJavaToLongBiFunction((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Long]]
@@ -1133,6 +1222,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the function
    *  @tparam U the second input type of the function
    *  @param sf the Scala `Function2` to convert to a Java `ToLongBiFunction`
+   *  @return a Java `ToLongBiFunction` equivalent to `sf`
    */
   @inline def asJavaToLongBiFunction[T, U](sf: scala.Function2[T, U, java.lang.Long]): java.util.function.ToLongBiFunction[T, U] = ((sf): AnyRef) match {
     case FromJavaToLongBiFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongBiFunction[T, U]]
@@ -1148,6 +1238,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the function
    *  @param jf the Java `ToLongFunction` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromToLongFunction[T](jf: java.util.function.ToLongFunction[T]): scala.Function1[T, java.lang.Long] = jf match {
     case AsJavaToLongFunction((f @ _)) => f.asInstanceOf[scala.Function1[T, java.lang.Long]]
@@ -1162,6 +1253,7 @@ object FunctionConverters {
    *
    *  @tparam T the input type of the function
    *  @param sf the Scala `Function1` to convert to a Java `ToLongFunction`
+   *  @return a Java `ToLongFunction` equivalent to `sf`
    */
   @inline def asJavaToLongFunction[T](sf: scala.Function1[T, java.lang.Long]): java.util.function.ToLongFunction[T] = ((sf): AnyRef) match {
     case FromJavaToLongFunction((f @ _)) => f.asInstanceOf[java.util.function.ToLongFunction[T]]
@@ -1169,16 +1261,20 @@ object FunctionConverters {
   }
   
   
-  /** @tparam T the input and output type of the unary operator
+  /**
+   *  @tparam T the input and output type of the unary operator
    *  @param jf the Java `UnaryOperator` to convert
+   *  @return a Scala `Function1` equivalent to `jf`
    */
   @inline def asScalaFromUnaryOperator[T](jf: java.util.function.UnaryOperator[T]): scala.Function1[T, T] = jf match {
     case AsJavaUnaryOperator((f @ _)) => f.asInstanceOf[scala.Function1[T, T]]
     case _ => new FromJavaUnaryOperator[T](jf).asInstanceOf[scala.Function1[T, T]]
   }
   
-  /** @tparam T the input and output type of the unary operator
+  /**
+   *  @tparam T the input and output type of the unary operator
    *  @param sf the Scala `Function1` to convert to a Java `UnaryOperator`
+   *  @return a Java `UnaryOperator` equivalent to `sf`
    */
   @inline def asJavaUnaryOperator[T](sf: scala.Function1[T, T]): java.util.function.UnaryOperator[T] = ((sf): AnyRef) match {
     case FromJavaUnaryOperator((f @ _)) => f.asInstanceOf[java.util.function.UnaryOperator[T]]

--- a/library/src/scala/jdk/javaapi/FunctionConverters.scala
+++ b/library/src/scala/jdk/javaapi/FunctionConverters.scala
@@ -36,7 +36,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the bi-consumer
    *  @tparam U the second input type of the bi-consumer
    *  @param jf the Java `BiConsumer` to convert
-   *  @return a Scala `Function2` returning `BoxedUnit` equivalent to `jf`
+   *  @return a Scala `Function2` returning `BoxedUnit`, equivalent to `jf`
    */
   @inline def asScalaFromBiConsumer[T, U](jf: java.util.function.BiConsumer[T, U]): scala.Function2[T, U, scala.runtime.BoxedUnit] = jf match {
     case AsJavaBiConsumer((f @ _)) => f.asInstanceOf[scala.Function2[T, U, scala.runtime.BoxedUnit]]
@@ -94,7 +94,7 @@ object FunctionConverters {
    *  @tparam T the first input type of the bi-predicate
    *  @tparam U the second input type of the bi-predicate
    *  @param jf the Java `BiPredicate` to convert
-   *  @return a Scala `Function2` returning `java.lang.Boolean` equivalent to `jf`
+   *  @return a Scala `Function2` returning `java.lang.Boolean`, equivalent to `jf`
    */
   @inline def asScalaFromBiPredicate[T, U](jf: java.util.function.BiPredicate[T, U]): scala.Function2[T, U, java.lang.Boolean] = jf match {
     case AsJavaBiPredicate((f @ _)) => f.asInstanceOf[scala.Function2[T, U, java.lang.Boolean]]


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in `@param`, `@tparam`, and `@return` tags for `scala.jdk` that were missed in the previous batch of PRs. I'm submitting it as a draft PR so to get CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and are starting to review them. We will review them all before making the PR non-draft. Please let me know if you see anything specific that you think could be improved.