### PR TITLE
Util, io, ref (8): filled in @param, @tparam, and @return tags that were missed last time

### DIFF
--- a/library-js/src/scala/util/DynamicVariable.scala
+++ b/library-js/src/scala/util/DynamicVariable.scala
@@ -62,6 +62,7 @@ class DynamicVariable[T](init: T) {
    *  @tparam S the result type of the thunk, also the return type of this method
    *  @param newval The value to which to set the variable
    *  @param thunk The code to evaluate under the new setting
+   *  @return the result of evaluating `thunk` with the variable temporarily bound to `newval`
    */
   def withValue[S](newval: T)(thunk: => S): S = {
     val oldval = v

--- a/library/src/scala/io/BufferedSource.scala
+++ b/library/src/scala/io/BufferedSource.scala
@@ -22,7 +22,8 @@ import scala.collection.mutable.StringBuilder
  *  representation of a source file.
  *
  *  @param inputStream the underlying input stream to read characters from
- *  @param bufferSize the size of the internal buffer used for reading
+ *  @param bufferSize the size, in characters, of the internal buffer used for reading
+ *  @param codec the `Codec` used to decode bytes from the input stream into characters
  */
 class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val codec: Codec) extends Source {
   def this(inputStream: InputStream)(implicit codec: Codec) = this(inputStream, DefaultBufSize)(using codec)
@@ -96,8 +97,8 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
    *  memory.
    *
    *  @param sb the string builder to append to
-   *  @param start the string to prepend before the first character
-   *  @param sep the separator string inserted between elements
+   *  @param start the string to prepend before the first element
+   *  @param sep the separator string inserted between elements; passing an empty string enables the efficient bulk-read path
    *  @param end the string to append after the last element
    *  @return the string builder `sb` with all elements appended
    */

--- a/library/src/scala/io/Position.scala
+++ b/library/src/scala/io/Position.scala
@@ -68,6 +68,7 @@ private[scala] abstract class Position {
    *
    *  @param line the 1-based line number, or 0 for undefined; values at or above `LINE_MASK` are clamped and the column is set to 0
    *  @param column the 1-based column number, or 0 for undefined; clamped to `COLUMN_MASK`, ignored when `line` >= `LINE_MASK`
+   *  @return the encoded position as a non-negative integer that packs the line number in the high bits and the column number in the low bits, suitable for decoding with `line`, `column`, and `toString`
    */
   final def encode(line: Int, column: Int): Int = {
     checkInput(line, column)
@@ -81,18 +82,21 @@ private[scala] abstract class Position {
   /** Returns the line number of the encoded position.
    *
    *  @param pos the encoded position as returned by `encode`
+   *  @return the 1-based line number decoded from `pos`, or 0 if the line is undefined
    */
   final def line(pos: Int): Int = (pos >> COLUMN_BITS) & LINE_MASK
 
   /** Returns the column number of the encoded position.
    *
    *  @param pos the encoded position as returned by `encode`
+   *  @return the 1-based column number decoded from `pos`, or 0 if the column is undefined
    */
   final def column(pos: Int): Int = pos & COLUMN_MASK
 
   /** Returns a string representation of the encoded position.
    *
    *  @param pos the encoded position as returned by `encode`
+   *  @return a string in the form `"line:column"` using the decoded line and column numbers
    */
   def toString(pos: Int): String = line(pos) + ":" + column(pos)
 }

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -41,18 +41,21 @@ object Source {
   /** Creates a Source instance from a single character.
    *
    *  @param c the character to use as the source content
+   *  @return a `Source` that yields the single character `c`
    */
   def fromChar(c: Char): Source = fromIterable(Array(c))
 
   /** Creates Source from array of characters, with empty description.
    *
    *  @param chars the array of characters to use as the source content
+   *  @return a `Source` that yields the characters from `chars`
    */
   def fromChars(chars: Array[Char]): Source = fromIterable(chars)
 
   /** Creates Source from a String, with no description.
    *
    *  @param s the string to use as the source content
+   *  @return a `Source` that yields the characters of `s`
    */
   def fromString(s: String): Source = fromIterable(s)
 
@@ -61,6 +64,7 @@ object Source {
    *
    *  @param name the name of the file to read
    *  @param codec the implicit codec used for character encoding
+   *  @return a `BufferedSource` reading from the named file, described by its filename
    */
   def fromFile(name: String)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(name))(using codec)
@@ -70,6 +74,7 @@ object Source {
    *
    *  @param name the name of the file to read
    *  @param enc the name of the character encoding to use
+   *  @return a `BufferedSource` reading from the named file with the given encoding
    */
   def fromFile(name: String, enc: String): BufferedSource =
     fromFile(name)(using Codec(enc))
@@ -78,6 +83,7 @@ object Source {
    *
    *  @param uri the file URI to read from
    *  @param codec the implicit codec used for character encoding
+   *  @return a `BufferedSource` reading from the file referenced by `uri`
    */
   def fromFile(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
@@ -86,6 +92,7 @@ object Source {
    *
    *  @param uri the file URI to read from
    *  @param enc the name of the character encoding to use
+   *  @return a `BufferedSource` reading from the file referenced by `uri` with the given encoding
    */
   def fromFile(uri: URI, enc: String): BufferedSource =
     fromFile(uri)(using Codec(enc))
@@ -95,6 +102,7 @@ object Source {
    *
    *  @param file the file to read from
    *  @param codec the implicit codec used for character encoding
+   *  @return a `BufferedSource` reading from `file` with the default buffer size
    */
   def fromFile(file: JFile)(implicit codec: Codec): BufferedSource =
     fromFile(file, Source.DefaultBufSize)(using codec)
@@ -103,6 +111,7 @@ object Source {
    *
    *  @param file the file to read from
    *  @param enc the name of the character encoding to use
+   *  @return a `BufferedSource` reading from `file` with the given encoding
    */
   def fromFile(file: JFile, enc: String): BufferedSource =
     fromFile(file)(using Codec(enc))
@@ -117,6 +126,7 @@ object Source {
    *  @param file the file to read from
    *  @param bufferSize the size of the input buffer, in characters
    *  @param codec the implicit codec used for character encoding
+   *  @return a `BufferedSource` reading from `file` with the given buffer size, described by the file's absolute path
    */
   def fromFile(file: JFile, bufferSize: Int)(implicit codec: Codec): BufferedSource = {
     val inputStream = new FileInputStream(file)
@@ -134,7 +144,7 @@ object Source {
    *
    *  @param bytes the array of bytes to decode into characters
    *  @param codec the implicit codec used for character encoding
-   *  @return      the created `Source` instance.
+   *  @return      a `Source` that yields the characters decoded from `bytes` using `codec`
    */
   def fromBytes(bytes: Array[Byte])(implicit codec: Codec): Source =
     fromString(new String(bytes, codec.name))
@@ -153,6 +163,7 @@ object Source {
    *
    *  @param uri the file URI to read from
    *  @param codec the implicit codec used for character encoding
+   *  @return a `BufferedSource` reading from the file referenced by `uri`
    */
   def fromURI(uri: URI)(implicit codec: Codec): BufferedSource =
     fromFile(new JFile(uri))(using codec)
@@ -161,6 +172,7 @@ object Source {
    *
    *  @param s the URL string to read from
    *  @param enc the name of the character encoding to use
+   *  @return a `BufferedSource` reading from the URL given by `s` with the given encoding
    */
   def fromURL(s: String, enc: String): BufferedSource =
     fromURL(s)(using Codec(enc))
@@ -169,6 +181,7 @@ object Source {
    *
    *  @param s the URL string to read from
    *  @param codec the implicit codec used for character encoding
+   *  @return a `BufferedSource` reading from the URL given by `s`
    */
   def fromURL(s: String)(implicit codec: Codec): BufferedSource =
     fromURL(new URI(s).toURL)(using codec)
@@ -177,6 +190,7 @@ object Source {
    *
    *  @param url the URL to read from
    *  @param enc the name of the character encoding to use
+   *  @return a `BufferedSource` reading from the stream opened on `url` with the given encoding
    */
   def fromURL(url: URL, enc: String): BufferedSource =
     fromURL(url)(using Codec(enc))
@@ -185,6 +199,7 @@ object Source {
    *
    *  @param url the URL to read from
    *  @param codec the implicit codec used for character encoding
+   *  @return a `BufferedSource` reading from the stream opened on `url`
    */
   def fromURL(url: URL)(implicit codec: Codec): BufferedSource =
     fromInputStream(url.openStream())(using codec)
@@ -197,7 +212,7 @@ object Source {
    *  @param  reset        a () => Source which resets the stream (if unset, reset() will throw an Exception)
    *  @param  close        a () => Unit method which closes the stream (if unset, close() will do nothing)
    *  @param  codec        (implicit) a scala.io.Codec specifying behavior (defaults to Codec.default)
-   *  @return              the buffered source
+   *  @return              a `BufferedSource` reading from `inputStream` with the given buffer size
    */
   def createBufferedSource(
     inputStream: InputStream,
@@ -221,6 +236,7 @@ object Source {
    *
    *  @param  resource     name of the resource to load from the classpath
    *  @param  classLoader  classloader to be used, or context classloader if not specified
+   *  @param codec the implicit codec used for character encoding
    *  @return              the buffered source
    */
   def fromResource(resource: String, classLoader: ClassLoader = Thread.currentThread().getContextClassLoader())(implicit codec: Codec): BufferedSource =
@@ -406,6 +422,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   /** Change or disable the positioner.
    *
    *  @param on whether to enable (`true`) or disable (`false`) position tracking
+   *  @return this `Source`, to allow chained configuration calls
    */
   def withPositioning(on: Boolean): this.type = {
     positioner = if (on) RelaxedPositioner else NoPositioner

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -26,15 +26,17 @@ object SoftReference {
 
   /** Creates a `SoftReference` pointing to `value`.
    *
-   *  @tparam T the type of the referenced object, must be a reference type
+   *  @tparam T the type of the referenced object; must be a subtype of `AnyRef`
    *  @param value the object to be softly referenced; may be reclaimed by the garbage collector when memory is low
+   *  @return a new `SoftReference` wrapping `value`
    */
   def apply[T <: AnyRef](value: T): SoftReference[T] = new SoftReference(value)
 
   /** Optionally returns the referenced value, or `None` if that value no longer exists.
    *
-   *  @tparam T the type of the referenced object, must be a reference type
+   *  @tparam T the type of the referenced object; must be a subtype of `AnyRef`
    *  @param sr the `SoftReference` to extract the value from
+   *  @return `Some(value)` if the referent has not been reclaimed, otherwise `None`
    */
   def unapply[T <: AnyRef](sr: SoftReference[T]): Option[T] = Option(sr.underlying.get)
 }

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -35,6 +35,7 @@ object WeakReference {
    *
    *  @tparam T the type of the value to wrap in a weak reference
    *  @param value the object to be weakly referenced
+   *  @return a new `WeakReference` wrapping `value`
    */
   def apply[T <: AnyRef](value: T): WeakReference[T] = new WeakReference(value)
 
@@ -42,6 +43,7 @@ object WeakReference {
    *
    *  @tparam T the type of the value to extract from the weak reference
    *  @param wr the weak reference to extract a value from
+   *  @return `Some(value)` if the referent is still reachable, or `None` if it has been garbage collected
    */
   def unapply[T <: AnyRef](wr: WeakReference[T]): Option[T] = Option(wr.underlying.get)
 }

--- a/library/src/scala/util/CommandLineParser.scala
+++ b/library/src/scala/util/CommandLineParser.scala
@@ -17,6 +17,7 @@ object CommandLineParser {
    *  @param str the command line argument string to parse
    *  @param n the zero-based index of the argument, used for error reporting
    *  @param fs the type class instance (usually provided implicitly) that converts a string to type `T`
+   *  @return the value of type `T` parsed from `str`
    *  @throws ParseError if argument cannot be converted to type `T`.
    */
   def parseString[T](str: String, n: Int)(using fs: FromString[T]^): T = {
@@ -32,6 +33,7 @@ object CommandLineParser {
    *  @param args the command line arguments array
    *  @param n the zero-based index of the argument to parse
    *  @param fs the type class instance that converts a string to type `T`
+   *  @return the value of type `T` parsed from the argument at index `n`
    *  @throws ParseError if argument does not exist or cannot be converted to type `T`.
    */
   def parseArgument[T](args: Array[String], n: Int)(using fs: FromString[T]^): T =
@@ -44,6 +46,7 @@ object CommandLineParser {
    *  @param args the command line arguments array
    *  @param n the zero-based index of the first remaining argument to parse
    *  @param fs the type class instance that converts a string to type `T`
+   *  @return a list of values of type `T` parsed from arguments at indices `n` through the end, or an empty list if `n` is past the last argument
    *  @throws ParseError if some of the arguments cannot be converted to type `T`.
    */
   def parseRemainingArguments[T](args: Array[String], n: Int)(using fs: FromString[T]^): List[T] =
@@ -66,6 +69,7 @@ object CommandLineParser {
     /** Can throw java.lang.IllegalArgumentException.
      *
      *  @param s the string to convert to type `T`
+     *  @return the value of type `T` parsed from `s`
      */
     def fromString(s: String): T
 

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -57,6 +57,7 @@ class DynamicVariable[T](init: T) {
    *  @tparam S the result type of the thunk
    *  @param newval the value to which to set the variable
    *  @param thunk the code to evaluate under the new setting
+   *  @return the result of evaluating `thunk` with the variable bound to `newval`
    */
   def withValue[S](newval: T)(thunk: => S): S = {
     val oldval = value

--- a/library/src/scala/util/Either.scala
+++ b/library/src/scala/util/Either.scala
@@ -422,6 +422,7 @@ sealed abstract class Either[+A, +B] extends Product with Serializable {
    *  @tparam A1 the supertype of `A` used to widen the left type
    *  @tparam B1 the right type of the resulting `Either`
    *  @param f the function to bind across `Right`
+   *  @return the result of applying `f` if this is a `Right`, otherwise the unchanged `Left`
    */
   def flatMap[A1 >: A, B1](f: B => Either[A1, B1]): Either[A1, B1] = this match {
     case Right(b) => f(b)
@@ -563,6 +564,7 @@ final case class Left[+A, +B](value: A) extends Either[A, B] {
    *  ```
    *
    *  @tparam B1 the target right type to widen to
+   *  @return this `Left` typed as `Either[A, B1]`
    */
   def withRight[B1 >: B]: Either[A, B1] = this
 
@@ -585,6 +587,7 @@ final case class Right[+A, +B](value: B) extends Either[A, B] {
    *  ```
    *
    *  @tparam A1 the target left type to widen to
+   *  @return this `Right` typed as `Either[A1, B]`
    */
   def withLeft[A1 >: A]: Either[A1, B] = this
 
@@ -915,6 +918,7 @@ object Either {
      *  @tparam A1 the supertype of `A` used to widen the left type
      *  @tparam B1 the right type of the resulting `Either`
      *  @param f the function to bind across `Right`
+     *  @return the result of applying `f` if this is a `Right`, otherwise the unchanged `Left`
      */
     def flatMap[A1 >: A, B1](f: B => Either[A1, B1]): Either[A1, B1] = e match {
       case Right(b) => f(b)

--- a/library/src/scala/util/FromDigits.scala
+++ b/library/src/scala/util/FromDigits.scala
@@ -41,6 +41,7 @@ object FromDigits {
      *
      *  @param digits the string representation of the numeric literal to convert
      *  @param radix the base for the number system (e.g. 10 for decimal, 16 for hexadecimal)
+     *  @return the value of type `T` represented by the digit string interpreted in the given radix
      */
     def fromDigits(digits: String, radix: Int): T
   }
@@ -95,6 +96,7 @@ object FromDigits {
    *  @param digits the string representation of the numeric literal to convert
    *  @param radix the base for the number system (e.g. 10 for decimal, 16 for hexadecimal)
    *  @param limit the upper bound for positive values of the result type (e.g. `Int.MaxValue` or `Long.MaxValue`)
+   *  @return the integer value represented by the digit string, as a `Long`
    */
   private def integerFromDigits(digits: String, radix: Int, limit: Long): Long = {
     var value: Long = 0
@@ -126,8 +128,10 @@ object FromDigits {
   }
 
   /** Converts digit string to Int number.
+   *
    *  @param digits            The string to convert
    *  @param radix             The radix
+   *  @return the `Int` value represented by the digit string in the given radix
    *  @throws NumberTooLarge   if number does not fit within Int range
    *  @throws MalformedNumber  if digits is not a legal digit string.
    *                           Legal strings consist only of digits conforming to radix,
@@ -137,8 +141,10 @@ object FromDigits {
     integerFromDigits(digits, radix, Int.MaxValue).toInt
 
   /** Converts digit string to Long number.
+   *
    *  @param digits            The string to convert
    *  @param radix             The radix
+   *  @return the `Long` value represented by the digit string in the given radix
    *  @throws NumberTooLarge   if the resulting number does not fit within Long range
    *  @throws MalformedNumber  if digits is not a legal digit string.
    *                           Legal strings consist only of digits conforming to radix,
@@ -150,7 +156,9 @@ object FromDigits {
   @sharable private val zeroFloat = raw"-?[0.]+(?:[eE][+-]?[0-9]+)?[fFdD]?".r
 
   /** Converts digit string to Float number.
+   *
    *  @param digits            The string to convert
+   *  @return the `Float` value represented by the digit string
    *  @throws NumberTooLarge   if the resulting number is infinite
    *  @throws NumberTooSmall   if the resulting number is 0.0f, yet the digits
    *                           string contains non-zero digits before the exponent.
@@ -168,7 +176,9 @@ object FromDigits {
   }
 
   /** Converts digit string to Double number.
+   *
    *  @param digits            The string to convert
+   *  @return the `Double` value represented by the digit string
    *  @throws NumberTooLarge   if the resulting number is infinite
    *  @throws NumberTooSmall   if the resulting number is 0.0d, yet the digits
    *                           string contains non-zero digits before the exponent.

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -222,7 +222,9 @@ private[scala] trait PropertiesTrait {
   }
 
   /** Compares the given specification version to the major version of the platform.
+   *
    *  @param version a specification major version number
+   *  @return `true` if the specification version of the current runtime is equal to or higher than the given version
    */
   def isJavaAtLeast(version: Int): Boolean = isJavaAtLeast(math.max(version, 0).toString)
 

--- a/library/src/scala/util/Random.scala
+++ b/library/src/scala/util/Random.scala
@@ -52,6 +52,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
   /** Generates `n` random bytes and returns them in a new array.
    *
    *  @param n the number of random bytes to generate
+   *  @return a new array filled with random bytes, of length `n` if `n` is positive, or empty otherwise
    */
   def nextBytes(n: Int): Array[Byte] = {
     val bytes = new Array[Byte](0 max n)
@@ -69,6 +70,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *
    *  @param minInclusive the lower bound (inclusive) of the range
    *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
+   *  @return a pseudorandom `Double` in the range `[minInclusive, maxExclusive)`
    */
   def between(minInclusive: Double, maxExclusive: Double): Double = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -88,6 +90,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *
    *  @param minInclusive the lower bound (inclusive) of the range
    *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
+   *  @return a pseudorandom `Float` in the range `[minInclusive, maxExclusive)`
    */
   def between(minInclusive: Float, maxExclusive: Float): Float = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -113,6 +116,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *  random number generator's sequence.
    *
    *  @param n the exclusive upper bound for the returned value (0 is the inclusive lower bound), must be positive
+   *  @return a pseudorandom `Int` in the range `[0, n)`
    */
   def nextInt(n: Int): Int = self.nextInt(n)
 
@@ -122,6 +126,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *
    *  @param minInclusive the lower bound (inclusive) of the range
    *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
+   *  @return a pseudorandom `Int` in the range `[minInclusive, maxExclusive)`
    */
   def between(minInclusive: Int, maxExclusive: Int): Int = {
     require(minInclusive < maxExclusive, "Invalid bounds")
@@ -153,6 +158,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *  random number generator's sequence.
    *
    *  @param n the exclusive upper bound for the returned value (0 is the inclusive lower bound), must be positive
+   *  @return a pseudorandom `Long` in the range `[0, n)`
    */
   def nextLong(n: Long): Long = {
     require(n > 0, "n must be positive")
@@ -187,6 +193,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *
    *  @param minInclusive the lower bound (inclusive) of the range
    *  @param maxExclusive the upper bound (exclusive) of the range, must be greater than `minInclusive`
+   *  @return a pseudorandom `Long` in the range `[minInclusive, maxExclusive)`
    */
   def between(minInclusive: Long, maxExclusive: Long): Long = {
     require(minInclusive < maxExclusive, "Invalid bounds")

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -307,6 +307,7 @@ object Sorting {
    *
    *  @tparam K the element type, which must have a `ClassTag` and an `Ordering`
    *  @param a the sequence of elements to sort
+   *  @return a new array containing the elements of `a` sorted according to the `Ordering` for `K`
    */
   def stableSort[K: ClassTag: Ordering](a: scala.collection.Seq[K]): Array[K] = {
     val ret = a.toArray
@@ -320,6 +321,7 @@ object Sorting {
    *  @tparam K the element type, which must have a `ClassTag`
    *  @param a the sequence of elements to sort
    *  @param f a function that returns `true` if its first argument is less than its second
+   *  @return a new array containing the elements of `a` sorted according to the less-than relation `f`
    */
   def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) => Boolean): Array[K] = {
     val ret = a.toArray
@@ -333,6 +335,7 @@ object Sorting {
    *  @tparam M the key type returned by the extraction function, which must have an `Ordering`
    *  @param a the sequence of elements to sort
    *  @param f a function that extracts a comparable key from each element
+   *  @return a new array containing the elements of `a` sorted by comparing the keys produced by `f`
    */
   def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K => M): Array[K] = {
     val ret = a.toArray

--- a/library/src/scala/util/Try.scala
+++ b/library/src/scala/util/Try.scala
@@ -90,6 +90,7 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *
    *  @tparam U the type of the value in the returned `Try`, a supertype of `T`
    *  @param default the fallback `Try` to return if this is a `Failure` (evaluated lazily)
+   *  @return this `Try` if it is a `Success`, otherwise `default`; any non-fatal exception thrown while evaluating `default` is caught and returned as a `Failure`
    */
   def orElse[U >: T](default: => Try[U]^): Try[U]^{default}
 
@@ -109,6 +110,7 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *
    *  @tparam U the type of the value in the resulting `Try`
    *  @param f the function to apply to the value if this is a `Success`
+   *  @return the `Try` returned by `f` applied to the value if this is a `Success`, or this `Failure` unchanged; any non-fatal exception thrown by `f` is caught and returned as a `Failure`
    */
   def flatMap[U](f: T => Try[U]^): Try[U]^{this, f}
 
@@ -116,6 +118,7 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *
    *  @tparam U the type of the mapped value
    *  @param f the function to apply to the value if this is a `Success`
+   *  @return a `Success` containing the result of applying `f` to the value if this is a `Success`, or this `Failure` unchanged; any non-fatal exception thrown by `f` is caught and returned as a `Failure`
    */
   def map[U](f: T => U): Try[U]^{this, f.only[Control]}
 
@@ -123,12 +126,14 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *
    *  @tparam U the type of the value returned by the partial function
    *  @param pf the partial function to apply to the value if this is a `Success`
+   *  @return a `Success` containing the result of `pf` applied to the value if `pf` is defined at it, a `Failure` with a `NoSuchElementException` if `pf` is not defined at the value, or this `Failure` unchanged; any non-fatal exception thrown by `pf` is caught and returned as a `Failure`
    */
   def collect[U](pf: PartialFunction[T, U]^): Try[U]^{this, pf.only[Control]}
 
   /** Converts this to a `Failure` if the predicate is not satisfied.
    *
    *  @param p the predicate to test the value against
+   *  @return this `Try` if it is a `Success` whose value satisfies `p`, a `Failure` with a `NoSuchElementException` if the value does not satisfy `p`, or this `Failure` unchanged; any non-fatal exception thrown by `p` is caught and returned as a `Failure`
    */
   def filter(p: T => Boolean): Try[T]^{this, p.only[Control]}
 
@@ -169,6 +174,7 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *
    *  @tparam U the type of the value in the resulting `Try`, a supertype of `T`
    *  @param pf the partial function to apply if this is a `Failure`
+   *  @return the `Try` produced by applying `pf` to the exception if this is a `Failure` and `pf` is defined for it, this `Failure` unchanged if `pf` is not defined for the exception, or this `Success` unchanged; any non-fatal exception thrown by `pf` is caught and returned as a `Failure`
    */
   def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]^]^): Try[U]^{this, pf}
 
@@ -177,6 +183,7 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *
    *  @tparam U the type of the value in the resulting `Try`, a supertype of `T`
    *  @param pf the partial function to apply if this is a `Failure`
+   *  @return a `Success` wrapping the result of applying `pf` to the exception if this is a `Failure` and `pf` is defined for it, this `Failure` unchanged if `pf` is not defined for the exception, or this `Success` unchanged; any non-fatal exception thrown by `pf` is caught and returned as a `Failure`
    */
   def recover[U >: T](pf: PartialFunction[Throwable, U]^): Try[U]^{this, pf.only[Control]}
 
@@ -188,6 +195,7 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *
    *  @tparam U the type of the value in the inner `Try`
    *  @param ev evidence that `T` is itself a `Try[U]`
+   *  @return the inner `Try[U]` if this is a `Success`, or this `Failure` unchanged
    */
   def flatten[U](implicit ev: T <:< Try[U]): Try[U]^{this}
 
@@ -202,6 +210,7 @@ sealed abstract class Try[+T] extends Product with Serializable { self: Try[T]^ 
    *  @tparam U the type of the value in the resulting `Try`
    *  @param s the function to apply if this is a `Success`
    *  @param f the function to apply if this is a `Failure`
+   *  @return the `Try` returned by `s` applied to the value if this is a `Success`, or the `Try` returned by `f` applied to the exception if this is a `Failure`; any non-fatal exception thrown by `s` or `f` is caught and returned as a `Failure`
    */
   def transform[U](s: T => Try[U]^, f: Throwable => Try[U]^): Try[U]^{s, f}
 

--- a/library/src/scala/util/Using.scala
+++ b/library/src/scala/util/Using.scala
@@ -196,6 +196,7 @@ object Using {
      *
      *  @tparam R the type of the resource, which must have a `Releasable` instance
      *  @param resource the resource to register with this manager
+     *  @return the same `resource`, unmodified, to allow fluent use at the call site
      */
     def apply[R: Releasable](resource: R): resource.type = {
       acquire(resource)

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -81,6 +81,7 @@ object boundary:
    *
    *  @tparam T the result type of the boundary block
    *  @param body the computation to execute, which receives a fresh `Label[T]` as a context parameter
+   *  @return the result of `body`, or the value carried by a `break` targeting the fresh label
    */
   inline def apply[T](inline body: Label[T] ?=> T): T =
     val local = Label[T]()

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -244,6 +244,7 @@ object Exception {
      *
      *  @tparam U the result type of the combined catch logic, a supertype of `T`
      *  @param pf2 the additional exception handler to combine with the existing one
+     *  @return a new `Catch` that tries this catch's handler first, falling back to `pf2`
      */
     def or[U >: T](pf2: Catcher[U]): Catch[U] = new Catch(pf orElse pf2, fin, rethrow)
     def or[U >: T](other: Catch[U]): Catch[U] = or(other.pf)
@@ -252,6 +253,7 @@ object Exception {
      *
      *  @tparam U the result type of the body, a supertype of `T`
      *  @param body the code block to execute with exception handling
+     *  @return the result of `body` on success, or the result of `pf` applied to a caught exception; exceptions for which `rethrow` returns `true` (or which `pf` does not handle) are propagated, and any `fin` logic is always invoked
      */
     def apply[U >: T](body: => U): U =
       try body
@@ -262,7 +264,9 @@ object Exception {
       finally fin foreach (_.invoke())
 
     /** Creates a new Catch container from this object and the supplied finally body.
+     *
      *  @param body the additional logic to apply after all existing finally bodies
+     *  @return a new `Catch` with the same catch logic and `body` appended to the finally logic
      */
     def andFinally(body: => Unit): Catch[T] = {
       val appendedFin = fin map(_ and body) getOrElse new Finally(body)
@@ -274,6 +278,7 @@ object Exception {
      *
      *  @tparam U the result type of the body, a supertype of `T`
      *  @param body the code block to execute, whose result is wrapped in `Some` on success
+     *  @return `Some(body)` if `body` completes successfully, or `None` if a caught exception was handled
      */
     def opt[U >: T](body: => U): Option[U] = toOption(Some(body))
 
@@ -283,6 +288,7 @@ object Exception {
      *
      *  @tparam U the result type of the body, a supertype of `T`
      *  @param body the code block to execute, whose result is wrapped in `Right` on success
+     *  @return `Right(body)` if `body` completes successfully, or `Left(exception)` if a caught exception was handled
      */
     def either[U >: T](body: => U): Either[Throwable, U] = toEither(Right(body))
 
@@ -291,6 +297,7 @@ object Exception {
      *
      *  @tparam U the result type of the body, a supertype of `T`
      *  @param body the code block to execute, whose result is wrapped in `Success` on success
+     *  @return `Success(body)` if `body` completes successfully, or `Failure(exception)` if a caught exception was handled
      */
     def withTry[U >: T](body: => U): scala.util.Try[U] = toTry(Success(body))
 
@@ -299,6 +306,7 @@ object Exception {
      *
      *  @tparam U the result type of the new exception handler
      *  @param f the function to apply to caught exceptions instead of the current handler
+     *  @return a new `Catch` that handles the same exceptions but produces results by applying `f`
      */
     def withApply[U](f: Throwable => U): Catch[U] = {
       val pf2 = new Catcher[U] {
@@ -327,6 +335,7 @@ object Exception {
    *  @group canned-behavior
    *
    *  @tparam T the result type of the `Catch` body
+   *  @return a `Catch` whose handler matches every `Throwable` (rethrowing by default); typically composed with `opt`, `either`, `withTry`, or `withApply` to transform the result
    */
   final def allCatch[T]: Catch[T] = new Catch(allCatcher[T]) withDesc "<everything>"
 
@@ -334,6 +343,7 @@ object Exception {
    *  @group canned-behavior
    *
    *  @tparam T the result type of the `Catch` body
+   *  @return a `Catch` whose handler matches every `NonFatal` `Throwable` (rethrowing by default); typically composed with `opt`, `either`, `withTry`, or `withApply` to transform the result
    */
   final def nonFatalCatch[T]: Catch[T] = new Catch(nonFatalCatcher[T]) withDesc "<non-fatal>"
 
@@ -363,6 +373,7 @@ object Exception {
    *
    *  @tparam T the result type of the `Catch` body
    *  @param exceptions the exception classes to catch, including $protectedExceptions
+   *  @return a `Catch` that catches exactly the specified exceptions, including $protectedExceptions, without auto-rethrowing them
    */
   def catchingPromiscuously[T](exceptions: Class[?]*): Catch[T] = catchingPromiscuously(pfFromExceptions(exceptions*))
   def catchingPromiscuously[T](c: Catcher[T]): Catch[T]         = new Catch(c, None, _ => false)
@@ -371,6 +382,7 @@ object Exception {
    *  @group composition-catch
    *
    *  @param exceptions the exception classes to catch and ignore
+   *  @return a `Catch[Unit]` that silently swallows any of the specified exceptions
    */
   def ignoring(exceptions: Class[?]*): Catch[Unit] =
     catching(exceptions*) withApply (_ => ())
@@ -380,6 +392,7 @@ object Exception {
    *
    *  @tparam T the value type of the resulting `Option`
    *  @param exceptions the exception classes to catch, mapping them to `None`
+   *  @return a `Catch[Option[T]]` that returns `None` when any of the specified exceptions is caught
    */
   def failing[T](exceptions: Class[?]*): Catch[Option[T]] =
     catching(exceptions*) withApply (_ => None)
@@ -390,6 +403,7 @@ object Exception {
    *  @tparam T the result type of the `Catch` body and the default value
    *  @param exceptions the exception classes to catch
    *  @param value the default value to return when one of the specified exceptions is caught
+   *  @return a `Catch[T]` that returns `value` when any of the specified exceptions is caught
    */
   def failAsValue[T](exceptions: Class[?]*)(value: => T): Catch[T] =
     catching(exceptions*) withApply (_ => value)
@@ -411,6 +425,8 @@ object Exception {
    *
    *  @tparam T the result type of the handler function passed to `by`
    *  @param exceptions the exception classes to catch
+   *
+   *  @return a `By` builder whose `by` method takes a handler function and returns a configured `Catch[T]`
    */
   def handling[T](exceptions: Class[?]*): By[Throwable => T, Catch[T]] = {
     def fun(f: Throwable => T): Catch[T] = catching(exceptions*) withApply f
@@ -422,6 +438,7 @@ object Exception {
    *
    *  @tparam T the result type of the `Catch` body
    *  @param body the finally logic to execute after the `Catch` body completes
+   *  @return a `Catch[T]` that catches no exceptions but runs `body` in a finally block
    */
   def ultimately[T](body: => Unit): Catch[T] = noCatch andFinally body
 
@@ -430,6 +447,7 @@ object Exception {
    *
    *  @tparam T the result type of the `Catch` body
    *  @param exceptions the wrapper exception classes to unwrap before rethrowing
+   *  @return a `Catch[T]` that catches any of the specified exceptions and rethrows the first cause in the chain that is not one of the supplied wrapper exceptions (or whose `getCause` is `null`)
    */
   def unwrapping[T](exceptions: Class[?]*): Catch[T] = {
     @tailrec
@@ -444,6 +462,7 @@ object Exception {
    *
    *  @param x the throwable to test against `classes`
    *  @param classes the exception classes to match against
+   *  @return `true` if `x` is an instance of any of the given `classes`, otherwise `false`
    */
   private def wouldMatch(x: Throwable, classes: scala.collection.Seq[Class[?]]): Boolean =
     classes exists (_.isAssignableFrom(x.getClass))

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -438,7 +438,6 @@ object Exception {
    *
    *  @tparam T the result type of the `Catch` body
    *  @param body the finally logic to execute after the `Catch` body completes
-   *  @return a `Catch[T]` that catches no exceptions but runs `body` in a finally block
    */
   def ultimately[T](body: => Unit): Catch[T] = noCatch andFinally body
 

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -51,6 +51,7 @@ object NonFatal {
   /** Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None`
    *
    *  @param t the `Throwable` to test for being non-fatal
+   *  @return `Some(t)` if `t` is non-fatal, otherwise `None`
    */
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 }

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -51,7 +51,6 @@ object NonFatal {
   /** Returns `Some`(t) if `NonFatal`(t) == true, otherwise `None`
    *
    *  @param t the `Throwable` to test for being non-fatal
-   *  @return `Some(t)` if `t` is non-fatal, otherwise `None`
    */
   def unapply(t: Throwable): Option[Throwable] = if (apply(t)) Some(t) else None
 }

--- a/library/src/scala/util/control/TailCalls.scala
+++ b/library/src/scala/util/control/TailCalls.scala
@@ -60,6 +60,7 @@ object TailCalls {
      *
      *  @tparam B the result type of the mapped computation
      *  @param f the function to apply to the result, transforming `A` to `B`
+     *  @return a new tailcalling computation that produces `f` applied to the result of this computation
      */
     final def map[B](f: A => B): TailRec[B] = flatMap(a => Call(() => Done(f(a))))
 
@@ -68,6 +69,7 @@ object TailCalls {
      *
      *  @tparam B the result type of the continuation
      *  @param f the function to apply to the result, returning a new tailcalling computation
+     *  @return a tailcalling computation that runs this computation and then continues with `f` applied to its result
      */
     final def flatMap[B](f: A => TailRec[B]): TailRec[B] = this match {
       case Done(a)         => Call(() => f(a))

--- a/library/src/scala/util/hashing/ByteswapHashing.scala
+++ b/library/src/scala/util/hashing/ByteswapHashing.scala
@@ -36,6 +36,7 @@ object ByteswapHashing {
    *
    *  @tparam T the type of values to be hashed
    *  @param h the hashing instance whose result is passed through byteswap hashing
+   *  @return a `Hashing[T]` that applies `h` and then passes the result through the byteswap hash
    */
   def chain[T](h: Hashing[T]): Hashing[T] = new Chained(h)
 

--- a/library/src/scala/util/hashing/MurmurHash3.scala
+++ b/library/src/scala/util/hashing/MurmurHash3.scala
@@ -21,6 +21,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param hash the intermediate hash value
    *  @param data the new block of data to mix in
+   *  @return the updated intermediate hash value with `data` mixed in
    */
   final def mix(hash: Int, data: Int): Int = {
     var h = mixLast(hash, data)
@@ -34,6 +35,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param hash the intermediate hash value
    *  @param data the last block of data to mix in
+   *  @return the hash value with `data` mixed in, without further rotation or mixing
    */
   final def mixLast(hash: Int, data: Int): Int = {
     var k = data
@@ -49,12 +51,14 @@ private[hashing] class MurmurHash3 {
    *
    *  @param hash the intermediate hash value after all mix steps
    *  @param length the number of elements hashed
+   *  @return the finalized hash value with `length` incorporated and all bits avalanched
    */
   final def finalizeHash(hash: Int, length: Int): Int = avalanche(hash ^ length)
 
   /** Force all bits of the hash to avalanche. Used for finalizing the hash.
    *
    *  @param hash the intermediate hash value whose bits should be thoroughly mixed
+   *  @return the hash value with all bits avalanched for a well-distributed result
    */
   private final def avalanche(hash: Int): Int = {
     var h = hash
@@ -102,6 +106,7 @@ private[hashing] class MurmurHash3 {
    *  @param x the case class instance to hash
    *  @param seed the initial seed for the hash computation
    *  @param caseClassName the case class name used for hashing, or `null` to fall back to `x.productPrefix`
+   *  @return the hash code of `x`, derived from the class name and each product element
    */
   final def caseClassHash(x: Product, seed: Int, caseClassName: String | Null): Int = {
     val arr = x.productArity
@@ -124,6 +129,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param str the string to hash
    *  @param seed the initial seed for the hash computation
+   *  @return the hash of `str`, computed by packing successive pairs of UTF-16 chars into 32-bit blocks and finalizing with the string length
    */
   final def stringHash(str: String, seed: Int): Int = {
     var h = seed
@@ -143,6 +149,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param xs the elements to hash (order-independent)
    *  @param seed the initial seed for the hash computation
+   *  @return a hash code that is the same for any permutation of `xs`
    */
   final def unorderedHash(xs: IterableOnce[Any], seed: Int): Int = {
     var a, b, n = 0
@@ -168,6 +175,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param xs the elements to hash in traversal order
    *  @param seed the initial seed for the hash computation
+   *  @return a hash code that depends on element order, matching `rangeHash` when `xs` has at least three elements and forms an arithmetic progression with non-zero step
    */
   final def orderedHash(xs: IterableOnce[Any], seed: Int): Int = {
     val it = xs.iterator
@@ -207,6 +215,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param a the array to hash
    *  @param seed the initial seed for the hash computation
+   *  @return the hash of `a`, compatible with `rangeHash` when `a` has at least three elements forming an arithmetic progression with non-zero step
    */
   final def arrayHash[@specialized T](a: Array[T], seed: Int): Int = {
     var h = seed
@@ -250,6 +259,7 @@ private[hashing] class MurmurHash3 {
    *  @param step the increment between successive elements
    *  @param last the actual last element produced by the range
    *  @param seed the initial seed for the hash computation
+   *  @return the hash of the range, compatible with `orderedHash` and `arrayHash` for the same element sequence
    */
   final def rangeHash(start: Int, step: Int, last: Int, seed: Int): Int =
     avalanche(mix(mix(mix(seed, start), step), last))
@@ -260,6 +270,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param data the byte array to hash
    *  @param seed the initial seed for the hash computation
+   *  @return the hash of `data` computed four bytes at a time (not compatible with `arrayHash`)
    */
   final def bytesHash(data: Array[Byte], seed: Int): Int = {
     var len = data.length
@@ -297,6 +308,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param a the indexed sequence to hash
    *  @param seed the initial seed for the hash computation
+   *  @return the hash of `a`, compatible with `rangeHash` when `a` has at least three elements forming an arithmetic progression with non-zero step
    */
   final def indexedSeqHash(a: scala.collection.IndexedSeq[Any], seed: Int): Int = {
     var h = seed
@@ -337,6 +349,7 @@ private[hashing] class MurmurHash3 {
    *
    *  @param xs the list to hash
    *  @param seed the initial seed for the hash computation
+   *  @return the hash of `xs`, compatible with `rangeHash` when `xs` has at least three elements forming an arithmetic progression with non-zero step
    */
   final def listHash(xs: scala.collection.immutable.List[?], seed: Int): Int = {
     var n = 0
@@ -452,6 +465,7 @@ object MurmurHash3 extends MurmurHash3 {
   /** To offer some potential for optimization.
    *
    *  @param xs the sequence to hash (dispatches to specialized implementations for `IndexedSeq` and `List`)
+   *  @return the order-dependent hash of `xs`, compatible with `rangeHash` for arithmetic progressions
    */
   def seqHash(xs: scala.collection.Seq[?]): Int    = xs match {
     case xs: scala.collection.IndexedSeq[?] => indexedSeqHash(xs, seqSeed)

--- a/library/src/scala/util/hashing/package.scala
+++ b/library/src/scala/util/hashing/package.scala
@@ -20,6 +20,7 @@ package object hashing {
   /** Fast multiplicative hash with a nice distribution.
    *
    *  @param v the 32-bit `Int` value to hash
+   *  @return a well-distributed 32-bit hash of `v`
    */
   def byteswap32(v: Int): Int = {
     var hc = v * 0x9e3775cd
@@ -31,6 +32,7 @@ package object hashing {
    *  for 64-bit values.
    *
    *  @param v the 64-bit `Long` value to hash
+   *  @return a well-distributed 64-bit hash of `v`
    */
   def byteswap64(v: Long): Long = {
     var hc = v * 0x9e3775cd9e3775cdL

--- a/library/src/scala/util/matching/Regex.scala
+++ b/library/src/scala/util/matching/Regex.scala
@@ -667,6 +667,7 @@ object Regex {
      *  or -1 if nothing was matched for that group.
      *
      *  @param i the index of the capturing group
+     *  @return the index of the first matched character in group `i`, or -1 if the group did not match
      */
     def start(i: Int): Int
 
@@ -677,6 +678,7 @@ object Regex {
      *  or -1 if nothing was matched for that group.
      *
      *  @param i the index of the capturing group
+     *  @return the index following the last matched character for group `i`, or -1 if the group did not match
      */
     def end(i: Int): Int
 
@@ -689,6 +691,7 @@ object Regex {
      *  or `null` if nothing was matched.
      *
      *  @param i the index of the capturing group
+     *  @return the substring matched by group `i`, or `null` if the group did not match
      */
     def group(i: Int): String | Null =
       if (start(i) >= 0) source.subSequence(start(i), end(i)).toString
@@ -708,6 +711,7 @@ object Regex {
      *  or `null` if nothing was matched for that group.
      *
      *  @param i the index of the capturing group
+     *  @return the portion of the source preceding the match of group `i`, or `null` if the group did not match
      */
     def before(i: Int): CharSequence | Null =
       if (start(i) >= 0) source.subSequence(0, start(i))
@@ -724,6 +728,7 @@ object Regex {
      *  or `null` if nothing was matched for that group.
      *
      *  @param i the index of the capturing group
+     *  @return the portion of the source following the match of group `i`, or `null` if the group did not match
      */
     def after(i: Int): CharSequence | Null =
       if (end(i) >= 0) source.subSequence(end(i), source.length)
@@ -763,6 +768,7 @@ object Regex {
    *
    *  @param source the source character sequence that was matched against
    *  @param matcher the underlying `Matcher` that performed the match
+   *  @param _groupNames the names of the capturing groups, if any, used to look up groups by name
    */
   class Match(val source: CharSequence,
               protected[matching] val matcher: Matcher,
@@ -788,12 +794,14 @@ object Regex {
     /** The index of the first matched character in group `i`.
      *
      *  @param i the index of the capturing group
+     *  @return the index of the first matched character in group `i`, or -1 if the group did not match
      */
     def start(i: Int): Int = starts(i)
 
     /** The index following the last matched character in group `i`.
      *
      *  @param i the index of the capturing group
+     *  @return the index following the last matched character for group `i`, or -1 if the group did not match
      */
     def end(i: Int): Int = ends(i)
 
@@ -908,6 +916,7 @@ object Regex {
     /** The index of the first matched character in group `i`.
      *
      *  @param i the index of the capturing group
+     *  @return the start index of the matched substring for group `i` in the current match, or -1 if the group did not match
      */
     def start(i: Int): Int = { ensure() ; matcher.start(i) }
 
@@ -917,6 +926,7 @@ object Regex {
     /** The index following the last matched character in group `i`.
      *
      *  @param i the index of the capturing group
+     *  @return the index following the last matched character for group `i` in the current match, or -1 if the group did not match
      */
     def end(i: Int): Int = { ensure() ; matcher.end(i) }
 

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -18,8 +18,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:86
-86 |    val local = Label[T]()
+   |This location contains code that was inlined from boundary.scala:87
+87 |    val local = Label[T]()
    |                ^^^^^^^^^^
     --------------------------------------------------------------------------------------------------------------------
    |
@@ -58,8 +58,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:88
-88 |    catch case ex: Break[T] @unchecked =>
+   |This location contains code that was inlined from boundary.scala:89
+89 |    catch case ex: Break[T] @unchecked =>
    |                   ^
     --------------------------------------------------------------------------------------------------------------------
    |

--- a/tests/neg-custom-args/captures/try-boundary.check
+++ b/tests/neg-custom-args/captures/try-boundary.check
@@ -16,12 +16,12 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:85
-85 |  inline def apply[T](inline body: Label[T] ?=> T): T =
+   |This location contains code that was inlined from boundary.scala:86
+86 |  inline def apply[T](inline body: Label[T] ?=> T): T =
    |                                                    ^
-86 |    val local = Label[T]()
-87 |...
-90 |      else throw ex
+87 |    val local = Label[T]()
+88 |...
+91 |      else throw ex
     --------------------------------------------------------------------------------------------------------------------
    |
    | longer explanation available when compiling with `-explain`


### PR DESCRIPTION
As a next step in improving the Scaladoc documentation for the Scala 3 standard library, this PR fills in `@param`, `@tparam`, and `@return` tags for `scala.util`, `scala.io`, and `scala.ref` that were missed in the previous batch of PRs. I'm submitting it as a draft PR so to get CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and are starting to review them. We will review them all before making the PR non-draft. Please let me know if you see anything specific that you think could be improved.