### PR TITLE
Use `\n` for missing methods patch

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
+++ b/compiler/src/dotty/tools/dotc/typer/RefChecks.scala
@@ -1392,7 +1392,7 @@ object RefChecks {
     val baseIndent = new String(content.slice(lineStart, span.end).takeWhile(c => c == ' ' || c == '\t'))
     val indent = baseIndent + "  "
 
-    val formattedMethods = methods.map(m => s"$indent$m").mkString(System.lineSeparator())
+    val formattedMethods = methods.map(m => s"$indent$m").mkString("\n")
 
     val isBracelessSyntax = untypedTree match
       case untpd.TypeDef(_, tmpl: untpd.Template) =>
@@ -1407,11 +1407,11 @@ object RefChecks {
       val bodyIsEmpty = bodyBetweenBraces.forall(_.isWhitespace)
       val bodyContainsNewLine = bodyBetweenBraces.exists(isLineBreakChar)
 
-      val prefix = if (bodyContainsNewLine) "" else System.lineSeparator()
+      val prefix = if (bodyContainsNewLine) "" else "\n"
       val patchText =
         prefix +
         formattedMethods +
-        System.lineSeparator()
+        "\n"
 
       val patch = ActionPatch(insertBeforeBrace, patchText)
       List(CodeAction("Add missing methods", None, List(patch)))
@@ -1423,7 +1423,7 @@ object RefChecks {
         case _ =>
           untypedTree.sourcePos.withSpan(Span(untypedTree.span.end))
 
-      val patchText = System.lineSeparator() + formattedMethods
+      val patchText = "\n" + formattedMethods
 
       val patch = ActionPatch(insertAfterLastDef, patchText)
       List(CodeAction("Add missing methods", None, List(patch)))
@@ -1432,8 +1432,8 @@ object RefChecks {
       val insertAfterHeader = untypedTree.sourcePos.withSpan(Span(untypedTree.span.end))
 
       val patchText =
-        " {" + System.lineSeparator() +
-        formattedMethods + System.lineSeparator() +
+        " {\n" +
+        formattedMethods + "\n" +
         "}"
 
       val patch = ActionPatch(insertAfterHeader, patchText)


### PR DESCRIPTION
Fixes #26131

As already done by the "insert missing cases" action

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)

[test_windows_full]