### PR TITLE
[CI] Fix extractions of release version tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,7 +126,7 @@ jobs:
 
       # Extract the release tag
       - name: Extract the release tag
-        run : echo "RELEASE_TAG='${GITHUB_REF#*refs/tags/}'" >> $GITHUB_ENV
+        run : echo "RELEASE_TAG=${GITHUB_REF#*refs/tags/}" >> $GITHUB_ENV
 
       - name: Check compiler version
         shell: bash


### PR DESCRIPTION
Cherry-pick of CI fix  from release-3.8.4 branch based on observed issues during 3.8.4-RC3 release 
Fixes `Compiler version for this build '3.8.4-RC3', does not match tag: '3.8.4-RC3'` observed in https://github.com/scala/scala3/actions/runs/26195068199/job/77128189137