### PR TITLE
Emit nested module classes as static inner classes

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -259,7 +259,7 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
     if (!isNested) None
     else {
       // See comment in BTypes, when is a class marked static in the InnerClass table.
-      val isStaticNestedClass = isOriginallyStaticOwner(innerClassSym.originalOwner.originalLexicallyEnclosingClass)
+      val isStaticNestedClass = innerClassSym.is(ModuleClass) || isOriginallyStaticOwner(innerClassSym.originalOwner.originalLexicallyEnclosingClass)
 
       // After lambdalift (which is where we are), the raw owner field contains the enclosing class.
       val enclosingClassSym = {

--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -37,7 +37,6 @@ import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.config.SourceVersion
 import DidYouMean.*
 import Message.{Disambiguation, Note}
-import dotty.tools.dotc.util.SimpleIdentitySet
 
 /**  Messages
   *  ========

--- a/tests/run/complex-outer/Defs_1.scala
+++ b/tests/run/complex-outer/Defs_1.scala
@@ -1,0 +1,5 @@
+object Outer:
+  class Foo[T1]:
+    class A[T2]
+    object B
+

--- a/tests/run/complex-outer/Defs_1.scala
+++ b/tests/run/complex-outer/Defs_1.scala
@@ -1,3 +1,5 @@
+// scalajs: --skip
+
 object Outer:
   class Foo[T1]:
     class A[T2]

--- a/tests/run/complex-outer/Main_3.scala
+++ b/tests/run/complex-outer/Main_3.scala
@@ -1,0 +1,5 @@
+object Test:
+  def main(args: Array[String]) =
+    assert(Use_2.testA() != null)
+    assert(Use_2.testB() != null)
+

--- a/tests/run/complex-outer/Use_2.java
+++ b/tests/run/complex-outer/Use_2.java
@@ -1,0 +1,10 @@
+class Use_2 {
+  static Object testA() {
+    var foo = new Outer.Foo<Integer>();
+    return foo.new A<Integer>();
+  }
+
+  static Object testB() {
+    return new Outer.Foo.B$();
+  }
+}


### PR DESCRIPTION
I need this for #25880

In `main` for the newly-added test you can compile `var foo = new Outer.Foo<Integer>(); foo.new B$();` but you then get a `java.lang.NoSuchMethodError: 'void Outer$Foo$B$.<init>(Outer$Foo)'` at runtime.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests