### PR TITLE
Skip mixed Scala-Java tests automatically on Scala.js

### DIFF
--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -53,7 +53,8 @@ object ScalaJSCompilationTests extends ParallelTesting {
   // Run tests -----------------------------------------------------------------
 
   override protected def shouldSkipTestSource(testSource: TestSource): Boolean =
-    testSource.allToolArgs.get(ToolName.ScalaJS).exists(_.contains("--skip"))
+    testSource.sourceFiles.exists(_.getName.endsWith(".java"))
+    || testSource.allToolArgs.get(ToolName.ScalaJS).exists(_.contains("--skip"))
     || super.shouldSkipTestSource(testSource)
 
   override protected def testPlatform: TestPlatform = TestPlatform.ScalaJS

--- a/tests/run/10838/Test.scala
+++ b/tests/run/10838/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val a = new A

--- a/tests/run/25-1/Test.java
+++ b/tests/run/25-1/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
   public static void main(String[] args) {
     p.StringSearch.search("test");

--- a/tests/run/25-2/Test.java
+++ b/tests/run/25-2/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
   public static void main(String[] args) {
     p.Bar.f("");

--- a/tests/run/annotation-info-not-erased/Test.scala
+++ b/tests/run/annotation-info-not-erased/Test.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 import scala.annotation.meta.getter
 
 class C {

--- a/tests/run/arrays-from-java/Test_2.scala
+++ b/tests/run/arrays-from-java/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     C_2.test()

--- a/tests/run/beans/Test_4.scala
+++ b/tests/run/beans/Test_4.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test:
   def main(args: Array[String]) =
     val a = JavaTest().run()

--- a/tests/run/complex-outer/Defs_1.scala
+++ b/tests/run/complex-outer/Defs_1.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Outer:
   class Foo[T1]:
     class A[T2]

--- a/tests/run/enum-java-scala/Test.java
+++ b/tests/run/enum-java-scala/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 // see: https://github.com/scala/scala3/issues/12637
 public class Test {
     public static void main(String[] args) {

--- a/tests/run/enum-java/Test.java
+++ b/tests/run/enum-java/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
   public static void log(String x) { System.out.println(x); }
   public static void check(Boolean p, String message) {

--- a/tests/run/forwarder-java-package-private/Test_2.scala
+++ b/tests/run/forwarder-java-package-private/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 package scalapackage:
   object Foo extends javapackage.Base_1
 end scalapackage

--- a/tests/run/i10884/Test_2.scala
+++ b/tests/run/i10884/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Exporter:
   export JavaExporter_1._
 

--- a/tests/run/i12086/Test_3.scala
+++ b/tests/run/i12086/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val c = new C

--- a/tests/run/i12204/Test_3.scala
+++ b/tests/run/i12204/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     B_2.test()

--- a/tests/run/i12492/Test.scala
+++ b/tests/run/i12492/Test.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 object Test:
   def main(args: Array[String]): Unit =
     go(classOf[MyTable])

--- a/tests/run/i12753/Test.java
+++ b/tests/run/i12753/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
   public static void s(Object s) {
     System.out.println(s);

--- a/tests/run/i15199/Test_2.scala
+++ b/tests/run/i15199/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class ScalaChild extends Child_1
 
 @main def Test(): Unit =

--- a/tests/run/i15318/Test.scala
+++ b/tests/run/i15318/Test.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 object Test:
   def main(args: Array[String]): Unit =
     go(classOf[Bean])

--- a/tests/run/i16474/test.scala
+++ b/tests/run/i16474/test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-// test.scala
 import repro.*
 import scala.util.Try
 

--- a/tests/run/i17021.ext-java/Test.scala
+++ b/tests/run/i17021.ext-java/Test.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 // Derives from run/i17021.defs
 // but with a Java protected member
 // and fixed calling code, that uses super

--- a/tests/run/i17255/Module.scala
+++ b/tests/run/i17255/Module.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 package p {
   object Module {
     override def toString = "Module"

--- a/tests/run/i19619/Test.scala
+++ b/tests/run/i19619/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import lib.InnerClass
 import lib.InnerClassGen
 import lib.RawTypes

--- a/tests/run/i22628/Test.scala
+++ b/tests/run/i22628/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test extends App {
   new mycode.MyServerCall().close()
 }

--- a/tests/run/i22991/Test.scala
+++ b/tests/run/i22991/Test.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 //Test java runtime reflection access to @Runtime annotations on method parameters.
 @main def Test =
   def check(actual: Int)(expect: Int)(msg: => String): Unit =

--- a/tests/run/i23479/test.scala
+++ b/tests/run/i23479/test.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 class C() extends NonSeal
 
 @main def Test = C()

--- a/tests/run/i24507/test.scala
+++ b/tests/run/i24507/test.scala
@@ -1,4 +1,3 @@
-// scalajs: --skip
 import a._
 
 class T extends A {

--- a/tests/run/i2760/Test.scala
+++ b/tests/run/i2760/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 @Fork(value = 16) class HasFork
 
 object Test {

--- a/tests/run/i2780/Test.scala
+++ b/tests/run/i2780/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class Foo extends bla.Base {
   class Inner {
     println(foo())

--- a/tests/run/i533/Test.scala
+++ b/tests/run/i533/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val x = new Array[Integer](1)

--- a/tests/run/i7212/Test.java
+++ b/tests/run/i7212/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
     public static void main(String[] args) {
         CompatVargs c = new CompatVargs();

--- a/tests/run/i7990/Test_2.scala
+++ b/tests/run/i7990/Test_2.scala
@@ -1,3 +1,1 @@
-// scalajs: --skip
-
 @main def Test = Exception_1("error")

--- a/tests/run/i8001/Test_3.scala
+++ b/tests/run/i8001/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     B_2.test()

--- a/tests/run/i8101/Test.scala
+++ b/tests/run/i8101/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class Bar extends JavaFoo with Foo {
   def read(): Int = ???
 }

--- a/tests/run/i8531/Test.scala
+++ b/tests/run/i8531/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class Foo(@Named s: String)
 
 object Test {

--- a/tests/run/i8599/Test_3.scala
+++ b/tests/run/i8599/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     val obj = new JavaClass_2

--- a/tests/run/i8602/Test_3.scala
+++ b/tests/run/i8602/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     val child = new ChildClass_2()

--- a/tests/run/i8661/Test.scala
+++ b/tests/run/i8661/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import pk.C
 object Test {
   def main(args: Array[String]): Unit = {

--- a/tests/run/java-ann-super-class-separate/Test_2.scala
+++ b/tests/run/java-ann-super-class-separate/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class Foo extends Ann_1 {
   override def bar = 3
   override def baz = 4

--- a/tests/run/java-ann-super-class/Test.scala
+++ b/tests/run/java-ann-super-class/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class Foo extends Ann {
   override def bar = 3
   override def baz = 4

--- a/tests/run/java-annot-params/Test_1.scala
+++ b/tests/run/java-annot-params/Test_1.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test:
   def main(args: Array[String]): Unit =
     annots.runTest(classOf[annots.Use_0])

--- a/tests/run/java-intersection/Test_2.scala
+++ b/tests/run/java-intersection/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import java.io.Serializable
 
 class Sub extends A_1 {

--- a/tests/run/java-longnames/Test_2.scala
+++ b/tests/run/java-longnames/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import p._
 
 object Test extends App {

--- a/tests/run/java-no-scala-import/Test.scala
+++ b/tests/run/java-no-scala-import/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test extends App {
   val c = new Config()
   c.setLongObj(10)

--- a/tests/run/java-package-private-bridge/Test.scala
+++ b/tests/run/java-package-private-bridge/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val hasBridge1 = classOf[other.ScalaChild].getDeclaredMethods.exists { m =>

--- a/tests/run/java-package-protected/Test.scala
+++ b/tests/run/java-package-protected/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test extends App:
   assert(b.C.m == 0)
 end Test

--- a/tests/run/java-varargs-2/Test.scala
+++ b/tests/run/java-varargs-2/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     A.foo(1)

--- a/tests/run/java-varargs-3/Test.scala
+++ b/tests/run/java-varargs-3/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val ai = new A[Int]

--- a/tests/run/java-varargs/Test_2.scala
+++ b/tests/run/java-varargs/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     A_1.foo(1)

--- a/tests/run/java-vc-overload/Test_3.scala
+++ b/tests/run/java-vc-overload/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val a = new A_2

--- a/tests/run/junitForwarders/Test.java
+++ b/tests/run/junitForwarders/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 package org.junit;
 
 import java.lang.annotation.ElementType;

--- a/tests/run/overload_repeated/B_2.scala
+++ b/tests/run/overload_repeated/B_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def bar1(x: Any) = 1
   def bar1(x: String*) = 2

--- a/tests/run/repeatable/Test_1.scala
+++ b/tests/run/repeatable/Test_1.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import repeatable._
 
 @Plain_0(1)

--- a/tests/run/t10889/Test.java
+++ b/tests/run/t10889/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
   public static void main(String[] args) {
     p.O l = new p.O("o");

--- a/tests/run/t12300/Test_2.scala
+++ b/tests/run/t12300/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     B_2.foo()

--- a/tests/run/t3452a/S_3.scala
+++ b/tests/run/t3452a/S_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     J_2.main(args)

--- a/tests/run/t3452b-bcode/S_3.scala
+++ b/tests/run/t3452b-bcode/S_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     J_2.j()

--- a/tests/run/t3452b/S_3.scala
+++ b/tests/run/t3452b/S_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     J_2.j()

--- a/tests/run/t3452d/Test.java
+++ b/tests/run/t3452d/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
 	public static void main(String[] args) {
 		C<String> c = new C<String>();

--- a/tests/run/t3452e/Test.scala
+++ b/tests/run/t3452e/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test extends App {
 	new B
 }

--- a/tests/run/t3452g/Test.java
+++ b/tests/run/t3452g/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
 	public static void main(String[] args) {
 		// To get better types here, we would need to

--- a/tests/run/t4119/S.scala
+++ b/tests/run/t4119/S.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class S extends foo.bar.J {
   sss =>
 

--- a/tests/run/t4238/s_2.scala
+++ b/tests/run/t4238/s_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val x = new J_1

--- a/tests/run/t4317/S_3.scala
+++ b/tests/run/t4317/S_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit = {
     val j = new J_2()

--- a/tests/run/t6138-2/ScalaClass.scala
+++ b/tests/run/t6138-2/ScalaClass.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 /* Similar to t10490 -- but defines `Foo` in the object.
  * Placing this test within t10490 makes it work without a fix, that's why it's independent.
  * Note that this was already working, we add it to make sure we don't regress

--- a/tests/run/t6138/ScalaClass.scala
+++ b/tests/run/t6138/ScalaClass.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class Foo {
   class Bar {
     override def toString: String = "Foo$Bar was instantiated!"

--- a/tests/run/t6168/main.scala
+++ b/tests/run/t6168/main.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test extends App {
   JavaTest.main(null)
 

--- a/tests/run/t6168b/main.scala
+++ b/tests/run/t6168b/main.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test extends App {
   JavaTest.main(null)
 

--- a/tests/run/t7374/Test.java
+++ b/tests/run/t7374/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public class Test {
     public static void main(String[] args) {
         System.out.println(SomeScala.list().tail());

--- a/tests/run/t8601e/Test.scala
+++ b/tests/run/t8601e/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 class C {
   def foo: Unit = {StaticInit.fld}
 }

--- a/tests/run/t9915/Test_2.scala
+++ b/tests/run/t9915/Test_2.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test extends App {
   private def dump(s: String) = s.map(c => f"${c.toInt}%02X").mkString(" ")
   def assertEqualStrings(expected: String)(actual: String) =

--- a/tests/run/targetName-interop/Test_3.scala
+++ b/tests/run/targetName-interop/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     alpha.Test_2.main(args)

--- a/tests/run/targetName-modules-1/Test_3.scala
+++ b/tests/run/targetName-modules-1/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     alpha.Test_2.main(args)

--- a/tests/run/targetName-modules-2/Test_3.scala
+++ b/tests/run/targetName-modules-2/Test_3.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 object Test {
   def main(args: Array[String]): Unit =
     alpha.Test_2.main(args)

--- a/tests/run/trait-static-forwarder/Test.java
+++ b/tests/run/trait-static-forwarder/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 public final class Test {
     public static void main(String... args) {
         System.out.println(T.foo());

--- a/tests/run/varargs-abstract/Test.java
+++ b/tests/run/varargs-abstract/Test.java
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import java.util.Comparator;
 
 public class Test {

--- a/tests/run/varargs-extend-java-2/Test.scala
+++ b/tests/run/varargs-extend-java-2/Test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import base.*
 
 object Test extends App {

--- a/tests/run/varargs-extend-java/test.scala
+++ b/tests/run/varargs-extend-java/test.scala
@@ -1,5 +1,3 @@
-// scalajs: --skip
-
 import scala.annotation.varargs
 
 class VarargImpl extends VarargAbstract {


### PR DESCRIPTION
Lowers the friction of adding new tests a little.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
