### PR TITLE
Fix SAM conversion crash on @VarArgs trait method

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -241,7 +241,7 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
 
     // For simplicity we always set the varargs flag,
     // although it's not strictly necessary for overrides.
-    val flags = original.flags | JavaVarargs
+    val flags = (original.flags &~ Deferred) | JavaVarargs
 
     // The java-compatible forwarder symbol
     val forwarder =

--- a/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimRepeated.scala
@@ -218,7 +218,8 @@ class ElimRepeated extends MiniPhase with InfoTransformer { thisPhase =>
       throw new Exception("Match error in @varargs checks. This should not happen, please open an issue " + tp)
 
   /** Add the symbol of a Java varargs forwarder to the scope.
-   *  It retains all the flags of the original method.
+   *  It retains the flags of the original method except `Deferred`,
+   *  since the forwarder's body is synthesized in `transformDefDef`.
    *
    *  @param original the original method symbol
    *  @param isBridge true if we are generating a "bridge" (synthetic override forwarder)

--- a/tests/pos/i25600.scala
+++ b/tests/pos/i25600.scala
@@ -1,0 +1,5 @@
+trait T:
+  @annotation.varargs
+  def t(s: String, a: Any*): String
+
+val x: T = (s, a) => s


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/25600

The varargs forwarder is synthesized with the `Deferred` flag, which makes the code below crash since `possibleSamMethods` returns two methods:

```scala
// from ExpandSams.scala
val Seq(samDenot) = tpe1.possibleSamMethods
```

This PR removes `Deferred` flag when synthesizes varargs forwarder.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for finding root cause

## How was the solution tested?

reproducer

