### PR TITLE
Only reset typerState when discarding results in adaptNoArgsImplicitMethod

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4663,14 +4663,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         val args = implicitArgs(wtp.paramInfos, 0, pt)
         val failureType = propagatedFailure(args)
         if failureType.exists then
-          // If there are several arguments, some arguments might already
-          // have influenced the context, binding variables, but later ones
-          // might fail. In that case the constraint and instantiated variables
-          // need to be reset.
-          ctx.typerState.resetTo(saved)
-
           // If method has default params, fall back to regular application
           // where all inferred implicits are passed as named args.
+          // In this case we do NOT reset the typer state because successfully
+          // found implicits (passed as TypedSplice) rely on constraints
+          // established during their search (e.g. type variable instantiations).
           if hasDefaultParams && !failureType.isInstanceOf[AmbiguousImplicits] then
             // Only keep the arguments that don't have an error type, or that
             // have an `AmbiguousImplicits` error type. The latter ensures that a
@@ -4702,7 +4699,13 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                   case sft: SearchFailureType => issueErrors(tree, args, sft)
                   case _ => issueErrors(tree, args, retyped.tpe)
                 case retyped => retyped
-          else issueErrors(tree, args, failureType)
+          else
+            // If there are several arguments, some arguments might already
+            // have influenced the context, binding variables, but later ones
+            // might fail. In that case the constraint and instantiated variables
+            // need to be reset.
+            ctx.typerState.resetTo(saved)
+            issueErrors(tree, args, failureType)
         else
           inContext(origCtx):
             // Reset context in case it was set to a supercall context before.

--- a/tests/pos/i10497.scala
+++ b/tests/pos/i10497.scala
@@ -1,0 +1,5 @@
+trait Foo[+A] {
+  def foo[B](implicit ev: A <:< Foo[B], s: Int = 0) = ???
+
+  def bar(a: Foo[Foo[Int]]) = a.foo
+}


### PR DESCRIPTION
Fixes #10497

Previously we would discard the typerState even when we were going to use
the successful. This triggered the following type error in the issue
```
$ scala-cli --server=false -S 3.nightly i10497.scala -uniqid
-- [E007] Type Mismatch Error: /home/ejbyfeldt/dev/scala_playground/i10497.scala:4:35
4 |  def bar(a: Foo[Foo[Int]]) = a.foo
  |                                   ^
  |                         Found:    A#921640293 =:= A#921640293
  |                         Required: Foo#4619[Int#239] <:< Foo#4619[Any#459]
  |
  | longer explanation available when compiling with `-explain`
1 error found
```

This should be correct as long as there is no state introduced by the
failing implicit searches where we are now going to use the defaults.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for finding the place in the codebase where the bug was. 

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
