### PR TITLE
Also map types in Implicits.emitDictionary

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -2020,14 +2020,24 @@ final class SearchRoot extends SearchHistory:
             val nsyms = vsyms.map(vsym => newSymbol(classSym, vsym.name, EmptyFlags, vsym.info, coord = span).entered)
             val vsymMap = (vsyms zip nsyms).toMap
 
+            def substVsymRefs(t: tpd.Tree, termRefMap: TermRef => Type, identMap: Ident => tpd.Tree): tpd.Tree =
+              new TreeTypeMap(
+                typeMap = new TypeMap {
+                  def apply(tp: Type): Type = tp match
+                    case ref: TermRef if vsymMap.contains(ref.symbol) => termRefMap(ref)
+                    case _ => mapOver(tp)
+                },
+                treeMap = {
+                  case id: Ident if vsymMap.contains(id.symbol) => identMap(id)
+                  case tree => tree
+                })(t)
+
             val rhss = pruned.map(_._2)
             // Substitute dictionary references into dictionary entry RHSs
-            val rhsMap = new TreeTypeMap(treeMap = {
-              case id: Ident if vsymMap.contains(id.symbol) =>
-                tpd.ref(vsymMap(id.symbol))(using ctx.withSource(id.source)).withSpan(id.span)
-              case tree => tree
-            })
-            val nrhss = rhss.map(rhsMap(_))
+            val nrhss = rhss.map(substVsymRefs(
+              _,
+              ref => classSym.thisType.select(vsymMap(ref.symbol)),
+              id  => tpd.ref(vsymMap(id.symbol))(using ctx.withSource(id.source)).withSpan(id.span)))
 
             val vdefs = (nsyms zip nrhss) map {
               case (nsym, nrhs) => ValDef(nsym.asTerm, nrhs.changeNonLocalOwners(nsym))
@@ -2040,13 +2050,10 @@ final class SearchRoot extends SearchHistory:
             val inst = ValDef(valSym, New(classSym.typeRef, Nil))
 
             // Substitute dictionary references into outermost result term.
-            val resMap = new TreeTypeMap(treeMap = {
-              case id: Ident if vsymMap.contains(id.symbol) =>
-                Select(tpd.ref(valSym), id.name)
-              case tree => tree
-            })
-
-            val res = resMap(success.tree)
+            val res = substVsymRefs(
+              success.tree,
+              ref => valSym.termRef.select(vsymMap(ref.symbol)),
+              id  => Select(tpd.ref(valSym), id.name))
 
             val blk = Block(classDef :: inst :: Nil, res).withSpan(span)
 

--- a/tests/pos/i20448.scala
+++ b/tests/pos/i20448.scala
@@ -1,0 +1,31 @@
+trait Generic[T] {
+  type Repr
+}
+
+object Generic {
+  type Aux[T, R] = Generic[T] { type Repr = R }
+
+  inline given [T <: Product](
+    using m: scala.deriving.Mirror.ProductOf[T]
+  ): Generic.Aux[T, m.MirroredElemTypes] = ???
+}
+
+trait Delta[In] {
+  type Out
+}
+
+object Delta {
+  type Aux[In, Out0] = Delta[In] { type Out = Out0 }
+
+  given [T](using deltaT: Delta[T]): Delta.Aux[Option[T], deltaT.Out] = ???
+
+  given [H, T <: Tuple, HO](using deltaH: => Delta.Aux[H, HO]): Delta.Aux[H *: T, H] = ???
+
+  given [F, G, O]( using gen: Generic.Aux[F, G], genDelta: Delta.Aux[G, O]): Delta.Aux[F, O] = ???
+}
+
+object Test {
+  case class Bar(of: Option[Bar])
+
+  summon[Delta[Bar]]
+}


### PR DESCRIPTION
Fixes: #20448

Before the test case would crash with
```
Exception in thread "main" java.lang.AssertionError: assertion failed: unresolved symbols: value $_lazy_implicit_$1 (line -1) #15419 when pickling /home/eejbyfeldt/dev/eejbyfeldt/scala_playground/scala3_crash.scala
	at scala.runtime.Scala3RunTime$.assertFailed(Scala3RunTime.scala:8)
	at dotty.tools.dotc.core.tasty.TreePickler.pickle(TreePickler.scala:872)
	at dotty.tools.dotc.transform.Pickler.run$$anonfun$1$$anonfun$1(Pickler.scala:136)
```
Because if there were path dependent types the types would not be
updated and still refer to the old symbols.


<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

Extensively, for finding the location in code and writing the fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
