### PR TITLE
drop use of unchecked in boundary.apply

### DIFF
--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -2,6 +2,7 @@ package scala.util
 
 import language.experimental.captureChecking
 import scala.annotation.implicitNotFound
+import scala.annotation.nowarn
 
 /** A boundary that can be exited by `break` calls.
  *  `boundary` and `break` represent a unified and superior alternative for the
@@ -84,9 +85,9 @@ object boundary:
    */
   inline def apply[T](inline body: Label[T] ?=> T): T =
     val local = Label[T]()
-    try body(using local)
-    catch case ex: Break[T] @unchecked =>
+    (try body(using local)
+    catch case ex: Break[T] =>
       if ex.isSameLabelAs(local) then ex.value
-      else throw ex
+      else throw ex): @nowarn("id=E92") // nowarn for the unchecked type test
 
 end boundary

--- a/tests/neg/safe-mode-boundary/Test_2.scala
+++ b/tests/neg/safe-mode-boundary/Test_2.scala
@@ -1,0 +1,8 @@
+//> using options -language:experimental.safe
+
+@main def Test =
+  val ans = scala.util.boundary { scala.util.boundary.break(6) } // ok with new implementation
+  assert(ans == 6)
+
+  val err = boundaryOld { scala.util.boundary.break(6) } // error: @unchecked is tagged as @rejectUnsafe
+  assert(err == 6)

--- a/tests/neg/safe-mode-boundary/boundary-old_1.scala
+++ b/tests/neg/safe-mode-boundary/boundary-old_1.scala
@@ -1,0 +1,11 @@
+// regression test - originally scala.boundary.apply used @unchecked,
+// so reintroduce the old implementation here,
+// so that in Test_2.scala we can assert that post-inlining this annotation is rejected in safe mode.
+object boundaryOld:
+  import scala.util.boundary.{Break, Label}
+  inline def apply[T](inline body: Label[T] ?=> T): T =
+    val local = Label[T]()
+    try body(using local)
+    catch case ex: Break[T] @unchecked =>
+      if ex.isSameLabelAs(local) then ex.value
+      else throw ex

--- a/tests/pos/safe-mode-boundary.scala
+++ b/tests/pos/safe-mode-boundary.scala
@@ -1,0 +1,14 @@
+//> using options -language:experimental.safe
+
+@main def Test =
+  // see tests/warn/safe-mode-boundary.scala where we instead use `case ls: List[Int] =>` to
+  // demonstrate that the @nowarn used in boundary.apply only applies to its internals,
+  // and not the argument code block.
+  val ls: List[Any] = List(1,2,3)
+  val total = scala.util.boundary {
+    ls match
+      case ls: List[Any] =>
+        val res = ls.flatMap({case i: Int => Some(i); case _ => None}).sum
+        scala.util.boundary.break(res)
+  }
+  assert(total == 6)

--- a/tests/warn/safe-mode-boundary.scala
+++ b/tests/warn/safe-mode-boundary.scala
@@ -1,0 +1,11 @@
+//> using options -language:experimental.safe
+
+@main def Test =
+  // boundary.apply uses @nowarn to avoid the "cannot be checked at runtime" warning, so
+  // check here that the argument to boundary.apply can still emit the warning.
+  val ls: List[Any] = List(1,2,3)
+  val total = scala.util.boundary {
+    ls match
+      case ls: List[Int] => scala.util.boundary.break(ls.sum) // warn
+  }
+  assert(total == 6)


### PR DESCRIPTION
manually checked that the dropBreaks optimisation still holds.

hopefully a compatible change for an inline method as we swap one annotation for another (both to silence a specific warning)

fixes #25387

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

### extra details
I checked manually that the optimisation to replace try catch with labelled jumps still works. (hopefully there are existing bytecode tests that can verify this)