### PR TITLE
V2: drop use of unchecked in boundary.apply

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -506,6 +506,7 @@ object StdNames {
     val genericArrayOps: N      = "genericArrayOps"
     val genericClass: N         = "genericClass"
     val get: N                  = "get"
+    val getAsLabelOrThrow: N    = "getAsLabelOrThrow"
     val getClass_ : N           = "getClass"
     val getOrElse: N            = "getOrElse"
     val hasNext: N              = "hasNext"

--- a/compiler/src/dotty/tools/dotc/transform/DropBreaks.scala
+++ b/compiler/src/dotty/tools/dotc/transform/DropBreaks.scala
@@ -59,11 +59,26 @@ class DropBreaks extends MiniPhase:
 
     object GuardedThrow:
 
+      def sameArgAsLabel(lbl: Tree, tpe_T: Tree)(using Context): Boolean = lbl.tpe.widen match
+        case AppliedType(_, arg :: Nil) if tpe_T.tpe eq arg => true
+        case _ => false
+
       /** `(ex, local)` provided `expr` matches
        *
        *      if ex.label.eq(local) then ex.value else throw ex
+       *
+       *   OR
+       *
+       *      ex.getAsLabelOrThrow[T](local)
        */
       def unapply(expr: Tree)(using Context): Option[(Symbol, Symbol)] = stripTyped(expr) match
+        case Apply(
+          TypeApply(Select(ex: Ident, getAsLabelOrThrow), tpe_T :: Nil),
+          (lbl @ Ident(local)) :: Nil)
+        if getAsLabelOrThrow == nme.getAsLabelOrThrow
+            && local == nme.local
+            && sameArgAsLabel(lbl, tpe_T) =>
+          Some((ex.symbol, lbl.symbol))
         case If(
           Apply(Select(ex: Ident, isSameLabelAs), (lbl @ Ident(local)) :: Nil),
           Select(ex2: Ident, value),

--- a/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
@@ -16,13 +16,28 @@ import Opcodes.*
 class LabelBytecodeTests extends DottyBytecodeTest {
   import dotty.AsmConverters.*
 
-   @Test def localLabelBreak = {
+  @Test def localLabelBreakOLD = {
+    // regression test for the old shape that will fail if that optimisation is removed.
+    // TODO: Is it worth keeping the optimisation for this shape? in case users previously
+    // "rolled their own" boundary implementation based on that old style?
     testLabelBytecodeEquals(
       """val local = boundary.Label[Long]()
         |try break(5L)(using local)
-        |catch case ex: boundary.Break[Long] @unchecked =>
+        |catch case ex: boundary.Break[Long] =>
         |  if ex.isSameLabelAs(local) then ex.value
         |  else throw ex
+      """.stripMargin,
+      "Long",
+      Ldc(LDC, 5),
+      Op(LRETURN)
+    )
+  }
+
+  @Test def localLabelBreakOLD_syntax = {
+    // syntax level equivalent of `localLabelBreakOLD`.
+    // i.e. uses the latest inlining shape.
+    testLabelBytecodeEquals(
+      """boundary(break(5L))
       """.stripMargin,
       "Long",
       Ldc(LDC, 5),
@@ -143,15 +158,15 @@ class LabelBytecodeTests extends DottyBytecodeTest {
         "`test` was not properly generated\n" + instructions)
     }
 
-   private def checkLabelBytecodeInstructions(code: String, tpe: String)(checkOutput: List[Instruction] => Unit): Unit = {
+  private def checkLabelBytecodeInstructions(code: String, tpe: String)(checkOutput: List[Instruction] => Unit): Unit = {
     val source =
       s"""import scala.util.boundary, boundary.break
-         |class Test:
-         |  def test: $tpe = {
-         |    ${code.linesIterator.toList.mkString("", "\n    ", "")}
-         |  }
-         |  def nonLocalBreak[T](value: T)(using boundary.Label[T]): Nothing = break(value)
-         |  def nonLocalBreak()(using boundary.Label[Unit]): Nothing = break(())
+        |class Test:
+        |  def test: $tpe = {
+        |    ${code.linesIterator.toList.mkString("", "\n    ", "")}
+        |  }
+        |  def nonLocalBreak[T](value: T)(using boundary.Label[T]): Nothing = break(value)
+        |  def nonLocalBreak()(using boundary.Label[Unit]): Nothing = break(())
       """.stripMargin
 
     checkBCode(source) { dir =>

--- a/library/src/scala/util/boundary.scala
+++ b/library/src/scala/util/boundary.scala
@@ -2,6 +2,7 @@ package scala.util
 
 import language.experimental.captureChecking
 import scala.annotation.implicitNotFound
+import scala.annotation.publicInBinary
 
 /** A boundary that can be exited by `break` calls.
  *  `boundary` and `break` represent a unified and superior alternative for the
@@ -47,6 +48,14 @@ object boundary:
      */
     def isSameLabelAs(other: Label[T]) = label eq other
 
+    /** Return the inner value if the given [[Label]] matches this [[Break]]'s label.
+     *  @param other the `Label` to compare against this `Break`'s label
+     */
+    @publicInBinary
+    private[boundary] def getAsLabelOrThrow[A](other: Label[A]): A =
+      if label eq other then value.asInstanceOf[A]
+      else throw this
+
   object Break:
     import caps.unsafe.unsafeAssumePure
     def apply[T](label: Label[T], value: T) =
@@ -85,8 +94,7 @@ object boundary:
   inline def apply[T](inline body: Label[T] ?=> T): T =
     val local = Label[T]()
     try body(using local)
-    catch case ex: Break[T] @unchecked =>
-      if ex.isSameLabelAs(local) then ex.value
-      else throw ex
+    catch case ex: Break[?] =>
+      ex.getAsLabelOrThrow[T](local)
 
 end boundary

--- a/tests/neg-custom-args/captures/boundary.check
+++ b/tests/neg-custom-args/captures/boundary.check
@@ -1,6 +1,6 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/boundary.scala:5:4 ---------------------------------------
  4 |  boundary[AnyRef^]:
- 5 |    l1 ?=> // error // error
+ 5 |    l1 ?=> // error
    |  ^
    |Capability `any` outlives its scope: it leaks into outer capture set 's1 which is owned by value local.
    |The leakage occurred when trying to match the following types:
@@ -18,8 +18,8 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:86
-86 |    val local = Label[T]()
+   |This location contains code that was inlined from boundary.scala:95
+95 |    val local = Label[T]()
    |                ^^^^^^^^^^
     --------------------------------------------------------------------------------------------------------------------
    |
@@ -38,29 +38,3 @@
   |          any² is a root capability classified as Control in the type of value local
   |
   | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/boundary.scala:5:4 ---------------------------------------
- 4 |  boundary[AnyRef^]:
- 5 |    l1 ?=> // error // error
-   |  ^
-   |  Found:    scala.util.boundary.Break[AnyRef^{any}] @unchecked
-   |  Required: scala.util.boundary.Break[Object^{any²}] @unchecked
-   |
-   |  Note that capability `any²` cannot flow into capture set {any}.
-   |
-   |  The error occurred for a synthesized tree:  _
-   |
-   |  where:    any  is the root capability caps.any
-   |            any² is a root capability created in object test
-   |
- 6 |      boundary[Unit]: l2 ?=>
- 7 |        boundary.break(l2)(using l1) // error
- 8 |      ???
-   |--------------------------------------------------------------------------------------------------------------------
-   |Inline stack trace
-   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:88
-88 |    catch case ex: Break[T] @unchecked =>
-   |                   ^
-    --------------------------------------------------------------------------------------------------------------------
-   |
-   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/boundary.scala
+++ b/tests/neg-custom-args/captures/boundary.scala
@@ -2,7 +2,7 @@ import scala.util.boundary
 
 object test:
   boundary[AnyRef^]:
-    l1 ?=> // error // error
+    l1 ?=> // error
       boundary[Unit]: l2 ?=>
         boundary.break(l2)(using l1) // error
       ???

--- a/tests/neg-custom-args/captures/try-boundary.check
+++ b/tests/neg-custom-args/captures/try-boundary.check
@@ -16,12 +16,12 @@
    |--------------------------------------------------------------------------------------------------------------------
    |Inline stack trace
    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-   |This location contains code that was inlined from boundary.scala:85
-85 |  inline def apply[T](inline body: Label[T] ?=> T): T =
+   |This location contains code that was inlined from boundary.scala:94
+94 |  inline def apply[T](inline body: Label[T] ?=> T): T =
    |                                                    ^
-86 |    val local = Label[T]()
-87 |...
-90 |      else throw ex
+95 |    val local = Label[T]()
+96 |...
+98 |      ex.getAsLabelOrThrow[T](local)
     --------------------------------------------------------------------------------------------------------------------
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg/safe-mode-boundary/Test_2.scala
+++ b/tests/neg/safe-mode-boundary/Test_2.scala
@@ -1,0 +1,8 @@
+//> using options -language:experimental.safe
+
+@main def Test =
+  val ans = scala.util.boundary { scala.util.boundary.break(6) } // ok with new implementation
+  assert(ans == 6)
+
+  val err = boundaryOld { scala.util.boundary.break(6) } // error: @unchecked is tagged as @rejectUnsafe
+  assert(err == 6)

--- a/tests/neg/safe-mode-boundary/boundary-old_1.scala
+++ b/tests/neg/safe-mode-boundary/boundary-old_1.scala
@@ -1,0 +1,11 @@
+// regression test - originally scala.boundary.apply used @unchecked,
+// so reintroduce the old implementation here,
+// so that in Test_2.scala we can assert that post-inlining this annotation is rejected in safe mode.
+object boundaryOld:
+  import scala.util.boundary.{Break, Label}
+  inline def apply[T](inline body: Label[T] ?=> T): T =
+    val local = Label[T]()
+    try body(using local)
+    catch case ex: Break[T] @unchecked =>
+      if ex.isSameLabelAs(local) then ex.value
+      else throw ex

--- a/tests/pos/safe-mode-boundary.scala
+++ b/tests/pos/safe-mode-boundary.scala
@@ -1,0 +1,14 @@
+//> using options -language:experimental.safe
+
+@main def Test =
+  // see tests/warn/safe-mode-boundary.scala where we instead use `case ls: List[Int] =>` to
+  // demonstrate that the @nowarn used in boundary.apply only applies to its internals,
+  // and not the argument code block.
+  val ls: List[Any] = List(1,2,3)
+  val total = scala.util.boundary {
+    ls match
+      case ls: List[Any] =>
+        val res = ls.flatMap({case i: Int => Some(i); case _ => None}).sum
+        scala.util.boundary.break(res)
+  }
+  assert(total == 6)

--- a/tests/warn/safe-mode-boundary.scala
+++ b/tests/warn/safe-mode-boundary.scala
@@ -1,0 +1,11 @@
+//> using options -language:experimental.safe
+
+@main def Test =
+  // boundary.apply uses @nowarn to avoid the "cannot be checked at runtime" warning, so
+  // check here that the argument to boundary.apply can still emit the warning.
+  val ls: List[Any] = List(1,2,3)
+  val total = scala.util.boundary {
+    ls match
+      case ls: List[Int] => scala.util.boundary.break(ls.sum) // warn
+  }
+  assert(total == 6)


### PR DESCRIPTION
introduce new method `ex.getAsLabelOrThrow[T](local)` on Break class that hides away the cast-or-rethrow logic so safe-mode checking will not see it when it inspects inlined code.

Therefore requires minor release.

Add case in dropBreaks miniphase to detect and elide the new shape for boundary.apply - tested in compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala

fixes #25387

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests
