### PR TITLE
Add note to missing implicit arg of extension

### DIFF
--- a/compiler/src/dotty/tools/dotc/reporting/messages.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/messages.scala
@@ -7,7 +7,7 @@ import Contexts.*
 import Decorators.*, Symbols.*, Names.*, NameOps.*, Types.*, Flags.*, Phases.*
 import Denotations.SingleDenotation
 import SymDenotations.SymDenotation
-import NameKinds.{WildcardParamName, ContextFunctionParamName}
+import NameKinds.{WildcardParamName, ContextFunctionParamName, SimpleNameKind}
 import parsing.Scanners.Token
 import parsing.Tokens, Tokens.showToken
 import printing.Highlighting.*
@@ -3235,6 +3235,23 @@ class MissingImplicitArgument(
             i"The following implicits in scope can be implicitly converted to ${pt.show}:" +
             ignoredConvertibleImplicits.map { imp => s"\n- ${imp.symbol.showDcl}"}.mkString
           )
+        def noteTrailingContextOfExtension: Option[String] =
+          paramSymWithMethodCallTree.flatMap: (sym, applTree) =>
+            def hasLeadingImplicit(tpe: Type): Boolean =
+              val resTypes = Iterator.iterate(tpe.resultType)(_.resultType)
+              val (prefix, suffix) = resTypes.span(_.isContextualMethod)
+              val tps = prefix ++ suffix.drop(1).takeWhile(_.isContextualMethod)
+              tps.exists:
+                case mt: MethodType => mt.paramNames.contains(sym.name)
+                case pt: PolyType => false
+            if applTree.symbol.is(Extension)
+               && sym.info.typeSymbol != defn.SameTypeClass
+               && sym.info.typeSymbol != defn.SubTypeClass
+               && !hasLeadingImplicit(applTree.symbol.info) then
+              val name = if sym.name.is(SimpleNameKind) then i"`${sym.name}`" else "the missing arg"
+              Some(i"\n\nNote: ${name} is not a leading implicit of `${applTree.symbol.name}`; "
+                + "it is not used to construct the extension.")
+            else None
         def importSuggestionAddendum: String =
           arg.tpe match
             // If the failure was caused by an underlying NoMatchingImplicits, compute the addendum for its expected type
@@ -3243,6 +3260,7 @@ class MissingImplicitArgument(
             case _ =>
               ctx.typer.importSuggestionAddendum(pt)
         super.msgPostscript
+        ++ noteTrailingContextOfExtension.getOrElse("")
         ++ ignoredInstanceNormalImport.map(hiddenImplicitNote)
             .orElse(noChainConversionsNote(ignoredConvertibleImplicits))
             .getOrElse(importSuggestionAddendum)

--- a/tests/neg/i23272.check
+++ b/tests/neg/i23272.check
@@ -1,0 +1,12 @@
+-- [E050] Type Error: tests/neg/i23272.scala:9:55 ----------------------------------------------------------------------
+9 |    def toArray: Array[Double] = v.components.map(c => c(lhs)) // error // error
+  |                                                       ^
+  |                                                       parameter c does not take parameters
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E172] Type Error: tests/neg/i23272.scala:9:62 ----------------------------------------------------------------------
+9 |    def toArray: Array[Double] = v.components.map(c => c(lhs)) // error // error
+  |                                                              ^
+  |No given instance of type Vectoric[Array[V => Double]] was found for parameter v of method map in trait VectoricOps
+  |
+  |Note: `v` is not a leading implicit of `map`; it is not used to construct the extension.

--- a/tests/neg/i23272.scala
+++ b/tests/neg/i23272.scala
@@ -1,0 +1,19 @@
+trait Vectoric[V] {
+  def components: Array[V => Double]
+  def map(a: V)(f: Double => Double): V
+}
+
+trait VectoricOps {
+  extension [V: Vectoric as v](lhs: V) {
+    def map(f: Double => Double): V = v.map(lhs)(f)
+    def toArray: Array[Double] = v.components.map(c => c(lhs)) // error // error
+  }
+}
+
+trait WorkingVectoricOps {
+  // leading implicit is not found, so undesired extension map is not constructed
+  extension [V](lhs: V)(using v: Vectoric[V]) {
+    def map(f: Double => Double): V = v.map(lhs)(f)
+    def toArray: Array[Double] = v.components.map(c => c(lhs))
+  }
+}

--- a/tests/neg/missing-implicit1.check
+++ b/tests/neg/missing-implicit1.check
@@ -21,6 +21,8 @@
    |                                          ^
    |No given instance of type testObjectInstance.Zip[Option] was found for a context parameter of method traverse in trait Traverse
    |
+   |Note: the missing arg is not a leading implicit of `traverse`; it is not used to construct the extension.
+   |
    |The following import might fix the problem:
    |
    |  import testObjectInstance.instances.zipOption

--- a/tests/neg/missing-implicit1.scala
+++ b/tests/neg/missing-implicit1.scala
@@ -22,4 +22,9 @@ object testObjectInstance:
     import instances.traverseList
     List(1, 2, 3).traverse(x => Option(x)) // error
   }
+
+  locally {
+    import instances.given
+    List(1, 2, 3).traverse(x => Option(x)) // whew
+  }
 end testObjectInstance

--- a/tests/neg/missing-implicit4.check
+++ b/tests/neg/missing-implicit4.check
@@ -21,6 +21,8 @@
    |                                          ^
    |    No given instance of type Zip[Option] was found for a context parameter of method traverse in trait Traverse
    |
+   |    Note: the missing arg is not a leading implicit of `traverse`; it is not used to construct the extension.
+   |
    |    The following import might fix the problem:
    |
    |      import instances.zipOption


### PR DESCRIPTION
A missing implicit error for an extension method implies that the extension method was selected but did not typecheck, and that other conversions are not tried. This commit adds an explanatory note for that case.

Selecting an extension requires supplying leading implicits, so that the order of parameter lists can affect how extensions are resolved. Trailing implicits are supplied after the extension is selected.

Differentiate
`extension [A: F](x: A) def f()`
which has a trailing implicit from
`extension [A](x: A)(using F[A]) def f()`
where the using clause precedes the explicit parameters to `f`.
In the first case, the extension is selected but fails to typecheck, and other conversions are not tried.

The difference is confusing in part because the syntax is subtly different and the position of the context parameter is not explicit.

Fixes #23272 

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
