### PR TITLE
Fixes #23922: Allow @throws[T] to reference method type parameters

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -935,6 +935,12 @@ class Namer { typer: Typer =>
     def setCompletedTypeParams(tparams: List[TypeSymbol]) =
       completedTypeParamSyms = tparams
 
+    /** True if `setCompletedTypeParams` has been called. Used by `defDefSig`
+     *  to avoid re-indexing leading type parameters that have already been
+     *  indexed by `indexMethodTypeParams`.
+     */
+    def hasCompletedTypeParams: Boolean = completedTypeParamSyms != null
+
     override def completerTypeParams(sym: Symbol)(using Context): List[TypeSymbol] =
       if completedTypeParamSyms != null then completedTypeParamSyms.uncheckedNN
       else Nil
@@ -1056,6 +1062,12 @@ class Namer { typer: Typer =>
      */
     def completeInCreationContext(denot: SymDenotation): Unit = {
       val sym = denot.symbol
+      // For a non-primary-constructor DefDef with leading type parameters, index
+      // and complete them before annotations are processed, so that annotations
+      // like `@throws[T]` can refer to the method's own type parameters.
+      // Without this, `addAnnotations` runs first and the type params have no
+      // symbols yet. See i23922.scala for a test case.
+      indexMethodTypeParams(sym)
       addAnnotations(sym)
       addInlineInfo(sym)
       denot.info = knownTypeSig `orElse` typeSig(sym)
@@ -1064,6 +1076,18 @@ class Namer { typer: Typer =>
       Checking.checkWellFormed(sym)
       denot.info = avoidPrivateLeaks(sym)
     }
+
+    /** Pre-index the leading type parameters of a method (DefDef), so that they
+     *  are available in the Completer's `completerTypeParams` when the method's
+     *  annotations are processed. The subsequent `defDefSig` will detect this
+     *  via `hasCompletedTypeParams` and skip re-indexing.
+     *  Has no effect for primary constructors or non-methods.
+     */
+    private def indexMethodTypeParams(sym: Symbol): Unit = original match
+      case ddef: DefDef if !sym.isPrimaryConstructor && ddef.leadingTypeParams.nonEmpty =>
+        val typer1 = nestedTyper.getOrElseUpdate(sym, ctx.typer.newLikeThis(ctx.nestingLevel + 1))
+        typer1.indexLeadingTypeParams(ddef, this)(using localContext(sym).setTyper(typer1))
+      case _ =>
 
     /** Just the type signature without forcing any of the other parts of
      *  this denotation. The denotation will still be completed later.
@@ -1878,6 +1902,20 @@ class Namer { typer: Typer =>
   def typedAheadExpr(tree: Tree, pt: Type = WildcardType)(using Context): tpd.Tree =
     typedAhead(tree, typer.typedExpr(_, pt))
 
+  /** Index, complete, and store the leading type parameters of a DefDef into
+   *  the given Completer (via `setCompletedTypeParams`). Idempotent: subsequent
+   *  calls skip indexing when the Completer already has them. Used both by
+   *  `defDefSig` (normal completion) and `Completer.indexMethodTypeParams`
+   *  (pre-completion before `addAnnotations`, so that annotations like
+   *  `@throws[T]` can refer to the method's own type parameters).
+   */
+  def indexLeadingTypeParams(ddef: DefDef, completer: Namer#Completer)(using Context): Unit =
+    if !completer.hasCompletedTypeParams then
+      index(ddef.leadingTypeParams)
+      val tparamSyms = ddef.leadingTypeParams.map(typedAheadExpr(_).symbol)
+      if tparamSyms.forall(_.isType) then
+        completer.setCompletedTypeParams(tparamSyms.asInstanceOf[List[TypeSymbol]])
+
   def typedAheadAnnotationClass(tree: Tree)(using Context): Symbol = tree match
     case Apply(fn, _) => typedAheadAnnotationClass(fn)
     case TypeApply(fn, _) => typedAheadAnnotationClass(fn)
@@ -2030,7 +2068,7 @@ class Namer { typer: Typer =>
     //   4. CP is completed.
     //   5. Info of CP is copied to DP and DP is completed.
     if !sym.isPrimaryConstructor then
-      index(ddef.leadingTypeParams)
+      indexLeadingTypeParams(ddef, completer)
     val completedTypeParams =
       for tparam <- ddef.leadingTypeParams yield typedAheadExpr(tparam).symbol
     if completedTypeParams.forall(_.isType) then

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3025,7 +3025,27 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
         // these type parameters. See i12953.scala for a test case.
         local.setScope(newScopeWith(completer.completerTypeParams(sym)*))
       case _ =>
-        if outer.owner.isClass then local else outer
+        if sym.is(Method) then
+          // When annotating a method, make its own leading type parameters
+          // available in scope so that annotations like `@throws[T]` can
+          // refer to method type parameters. We look them up via the
+          // Completer (pre-indexed by `indexMethodTypeParams` while
+          // `addAnnotations` runs) and, once the method is completed, via
+          // `paramSymss` (used when `completeAnnotations` re-types
+          // annotations during `typedDefDef`). See i23922.scala for a test.
+          val methodTypeParams: List[TypeSymbol] = sym.infoOrCompleter match
+            case completer: Namer#Completer =>
+              completer.completerTypeParams(sym)
+            case _ =>
+              sym.paramSymss match
+                case (tps @ (head :: _)) :: _ if head.isType =>
+                  tps.asInstanceOf[List[TypeSymbol]]
+                case _ => Nil
+          if methodTypeParams.nonEmpty then
+            local.setScope(newScopeWith(methodTypeParams*))
+          else if outer.owner.isClass then local
+          else outer
+        else if outer.owner.isClass then local else outer
     ctx0.addMode(Mode.InAnnotation)
 
   def completeAnnotations(mdef: untpd.MemberDef, sym: Symbol)(using Context): Unit = {

--- a/tests/run/i23922.scala
+++ b/tests/run/i23922.scala
@@ -1,0 +1,22 @@
+// scalajs: --skip
+
+class Foo:
+  @throws[T]
+  def sneakyThrow[T <: Throwable, R](t: Throwable): R =
+    throw t.asInstanceOf[T]
+
+  @throws[T]("always")
+  def typedThrow[T <: RuntimeException](t: T): Unit =
+    throw t
+
+object Test:
+  def main(args: Array[String]): Unit =
+    val m1 = classOf[Foo].getDeclaredMethod("sneakyThrow", classOf[Throwable])
+    val ex1 = m1.getExceptionTypes.toList
+    assert(ex1 == List(classOf[Throwable]),
+      s"sneakyThrow expected List(Throwable), got $ex1")
+
+    val m2 = classOf[Foo].getDeclaredMethod("typedThrow", classOf[RuntimeException])
+    val ex2 = m2.getExceptionTypes.toList
+    assert(ex2 == List(classOf[RuntimeException]),
+      s"typedThrow expected List(RuntimeException), got $ex2")


### PR DESCRIPTION
Fixes #23922

A method's own type parameters are not in scope for the method's own annotations, so `@throws[T] def m[T <: Throwable, R](...)` fails with `not found: type T` even though the Java equivalent `<T extends Throwable> ... throws T` is well-formed and the desired bytecode signature (`throws T`) is admissible on the JVM. This narrows the gap by mirroring the existing fix for *parameter* annotations (#12953 / `tests/pos/i12953.scala`) at the *method* annotation level. No semantic change to non-annotated methods; the new code path is gated on a `DefDef` that actually carries leading type parameters.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for root-cause analysis, designing the minimal fix, and verifying no regression against `@targetName`, overload resolution, default getters, and `-Ythrough-tasty` round-trips.

## How was the solution tested?

New automated tests (including the issue's reproducer).

- `tests/run/i23922.scala` exercises both `@throws[T]` and `@throws[T]("always")`, asserting via reflection that `getExceptionTypes` returns the erased bound (`Throwable` / `RuntimeException`), which confirms the `throws` declaration is in the bytecode signature.
- Verified locally: `scala-library-bootstrapped` compiles cleanly; the prior parameter-annotation fix `tests/pos/i12953.scala` still passes; the previously regressing `tests/run/i16464`, `tests/pos/i16506`, `tests/run/inline-override`, and `tests/pos/targetName-infer-result` (which an earlier reordering attempt broke) all compile cleanly; `scalac -Ythrough-tasty -Ycheck:all tests/run/i23922.scala` completes all phases without errors.

---

## Root cause

- `Namer.completeInCreationContext` runs `addAnnotations` before `typeSig`. For a `DefDef` the leading type parameters are first turned into symbols inside `defDefSig`, so at `addAnnotations` time there are no symbols for `T` or `R` and the captured annotation context has nothing to bind them to.
- The existing `annotContext` branch for type-parameter visibility only fires when the symbol is a parameter (`sym.is(Param)`) and looks at `sym.owner.infoOrCompleter`. It does not cover the case where the annotated symbol is itself a method with leading type parameters.

## Fix

- **Namer**: factor the "index + complete + record leading type params" block out of `defDefSig` into a helper `indexLeadingTypeParams`, made idempotent via a new `Completer.hasCompletedTypeParams` flag. Call that helper from `completeInCreationContext` via a new `indexMethodTypeParams` step that runs before `addAnnotations` for non-primary-constructor `DefDef`s with leading type parameters. The subsequent `defDefSig` call detects the pre-indexed state and skips re-indexing, so behaviour is unchanged for methods whose annotations do not reference their own type parameters.
- **Typer**: in `annotContext`, add a branch for methods that mirrors the existing parameter branch. While the method is still being completed the type parameters are read from the `Completer` (now populated by `indexMethodTypeParams`); once completion has finished (e.g. when `completeAnnotations` re-types the annotations during `typedDefDef`), they are read from `paramSymss`. In both cases the scope is built with `newScopeWith(...)` so the outer scope is not mutated (an earlier attempt that mutated the outer scope broke `@targetName`, overload conflict checking, and the from-tasty tests).
