### PR TITLE
Handle generic tuple in getMatch branch

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -432,7 +432,8 @@ object PatternMatcher {
                     else if isGenericTuple(getResult.info) then
                       val elemTypes = getResult.info.tupleElementTypes.getOrElse(Nil)
                       val selectors = elemTypes.zipWithIndex.map { (tp, i) =>
-                        tupleApp(i, ref(getResult)).cast(tp)
+                        val tree = tupleApp(i, ref(getResult))
+                        if i == elemTypes.length - 1 then tree.cast(tp) else tree
                       }
                       unapplyProductSeqPlan(selectors, args)
                     else { 

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -416,7 +416,7 @@ object PatternMatcher {
             else if isUnapplySeq && isProductSeqMatch(unappType, args.length, unapp.srcPos) then
               val selectors = productSelectors(unappType).map(ref(unappResult).select(_))
               unapplyProductSeqPlan(selectors, args)
-             else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
+            else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
               val components =
                 (0 until unappResult.denot.info.tupleElementTypes.getOrElse(Nil).length)
                   .toList.map(tupleApp(_, ref(unappResult)))

--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -359,10 +359,9 @@ object PatternMatcher {
        *
        *  `getResult` is a product, where the last element is a sequence of elements.
        */
-      def unapplyProductSeqPlan(getResult: Symbol, args: List[Tree], arity: Int): Plan = {
+      def unapplyProductSeqPlan(selectors: List[Tree], args: List[Tree]): Plan = {
+        val arity = selectors.length
         assert(arity <= args.size + 1)
-        val selectors = productSelectors(getResult.info).map(ref(getResult).select(_))
-
         val matchSeq =
           letAbstract(selectors.last) { seqResult =>
             unapplySeqPlan(seqResult, args.drop(arity - 1))
@@ -415,9 +414,9 @@ object PatternMatcher {
             else if isUnapplySeq && unapplySeqTypeElemTp(unappType.finalResultType).exists then
               unapplySeqPlan(unappResult, args)
             else if isUnapplySeq && isProductSeqMatch(unappType, args.length, unapp.srcPos) then
-              val arity = productArity(unappType, unapp.srcPos)
-              unapplyProductSeqPlan(unappResult, args, arity)
-            else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
+              val selectors = productSelectors(unappType).map(ref(unappResult).select(_))
+              unapplyProductSeqPlan(selectors, args)
+             else if unappResult.info <:< defn.NonEmptyTupleTypeRef then
               val components =
                 (0 until unappResult.denot.info.tupleElementTypes.getOrElse(Nil).length)
                   .toList.map(tupleApp(_, ref(unappResult)))
@@ -426,12 +425,20 @@ object PatternMatcher {
               assert(isGetMatch(unappType))
               val argsPlan = {
                 val get = getOfGetMatch(ref(unappResult))
-                val arity = productArity(get.tpe.stripNamedTuple, unapp.srcPos)
                 if (isUnapplySeq)
                   letAbstract(get) { getResult =>
-                    if unapplySeqTypeElemTp(get.tpe).exists
-                    then unapplySeqPlan(getResult, args)
-                    else unapplyProductSeqPlan(getResult, args, arity)
+                    if unapplySeqTypeElemTp(get.tpe).exists then
+                      unapplySeqPlan(getResult, args)
+                    else if isGenericTuple(getResult.info) then
+                      val elemTypes = getResult.info.tupleElementTypes.getOrElse(Nil)
+                      val selectors = elemTypes.zipWithIndex.map { (tp, i) =>
+                        tupleApp(i, ref(getResult)).cast(tp)
+                      }
+                      unapplyProductSeqPlan(selectors, args)
+                    else { 
+                      val selectors = productSelectors(getResult.info).map(ref(getResult).select(_))
+                      unapplyProductSeqPlan(selectors, args)
+                    }
                   }
                 else
                   letAbstract(get) { getResult =>

--- a/tests/pos/i25663.scala
+++ b/tests/pos/i25663.scala
@@ -1,0 +1,5 @@
+object Foo:
+  def unapplySeq(f: Int): Option[String *: Seq[Int] *: EmptyTuple] = ???
+
+def foo(f: Int) = f match
+  case Foo(name, ns*) => ???


### PR DESCRIPTION
Fixes #25663

There is already generic tuple handling, but it was missing in the getMatch branch. I mostly copied the existing logic, with an extra `.cast(tp)` since the result flows into `unapplySeqPlan` which needs the precise Seq type.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for finding root cause


## How was the solution tested?

reproducer
