### PR TITLE
Fix mismatch between `wrapArray` and `wrapArrayMethodName`

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -559,7 +559,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def wrapArray(tree: Tree, elemtp: Type)(using Context): Tree =
     val wrapper = ref(defn.getWrapVarargsArrayModule)
       .select(wrapArrayMethodName(elemtp))
-      .appliedToTypes(if (elemtp.isPrimitiveValueType) Nil else elemtp :: Nil)
+      .appliedToTypes(if elemtp.classSymbol.isPrimitiveValueClass then Nil else elemtp :: Nil)
     val actualElem = wrapper.tpe.widen.firstParamTypes.head
     wrapper.appliedTo(tree.ensureConforms(actualElem))
 

--- a/tests/pos/seqliteral-union-singletons.scala
+++ b/tests/pos/seqliteral-union-singletons.scala
@@ -1,0 +1,3 @@
+// Regression test for a crash in tpd.wrapArray when the SeqLiteral
+// element type is a union of singleton primitive types (e.g. `1 | 2 | 3`).
+def test: List[1 | 2 | 3] = List(1, 2, 3)


### PR DESCRIPTION
- `wrapArrayMethodName` selects the wrapper via `elemtp.classSymbol`, which joins `OrType` branches — for `1 | 2 | 3` it returns `wrapIntArray` (no type parameters).
- `wrapArray` decides whether to apply a type argument via `elemtp.isPrimitiveValueType`, which now returns `false` for `OrType`.

The two checks disagree.

For example when `wrapIntArray[1 | 2 | 3]` is built, the typer rejects the type application and `wrapper.tpe.widen.firstParamTypes.head` then crashes with `head of empty list` on the malformed tree.

This mismatch is due to #25880, which rewrote `Type.isPrimitiveValueType` from `self.classSymbol.isPrimitiveValueClass` to a manual pattern match that no longer handles `OrType`/`AndType`. This broke an existing implicit invariant inside `tpd.wrapArray`:

`def test: List[1 | 2 | 3] = List(1, 2, 3)` reproduces the crash on `main`.

Fixed by switching `wrapArray` to `classSymbol.isPrimitiveValueClass` so its decision agrees with `wrapArrayMethodName`.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for bisecting the regression, writing the test, and drafting the fix and commit messages.
Reviewed and verified locally.

## How was the solution tested?

New test: `tests/pos/seqliteral-union-singletons.scala`.
Confirmed the bug was introduced by #25880 by bisecting.