### PR TITLE
Fix language import description for separation checking

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -73,7 +73,7 @@ object Feature:
     (saferExceptions, "Enable safer exceptions"),
     (pureFunctions, "Enable pure functions for capture checking"),
     (captureChecking, "Enable experimental capture checking"),
-    (separationChecking, "Enable experimental separation checking (requires captureChecking)"),
+    (separationChecking, "Enable experimental separation checking (implies captureChecking)"),
     (into, "Allow into modifier on parameter types"),
     (modularity, "Enable experimental modularity features"),
     (packageObjectValues, "Enable experimental package objects as values"),

--- a/docs/_docs/reference/experimental/capture-checking/how-to-use.md
+++ b/docs/_docs/reference/experimental/capture-checking/how-to-use.md
@@ -17,9 +17,9 @@ import language.experimental.captureChecking
 
 Requires the import above:
 ```scala
-import language.experimental.captureChecking
 import language.experimental.separationChecking
 ```
+This will implicitly enable capture checking as well.
 
 ### SBT Project Template
 

--- a/docs/_docs/reference/experimental/capture-checking/separation-checking.md
+++ b/docs/_docs/reference/experimental/capture-checking/separation-checking.md
@@ -39,8 +39,8 @@ Separation checking is an extension of capture checking that enforces unique, un
 import language.experimental.separationChecking
 ```
 (or the corresponding setting `-language:experimental.separationChecking`).
-The import has to be given in addition to the `language.experimental.captureChecking` import that enables capture checking.
-The reason for the second language import is that separation checking is less mature than capture checking proper, so we are less sure
+
+The reason for this separate language import is that separation checking is less mature than capture checking proper, so we are less sure
 we got the balance of safety and expressivity right for it at the present time.
 
 In capture checking, each occurrence of [`any`](scoped-capabilities.md), and therefore each use of `^`, has a context-dependent meaning that is tied to the lifetime of capabilities. Separation checking refines that model. It keeps track of the capabilities hidden by each `any` and enforces that these hidden sets are either separated or overlap only where the types permit it.


### PR DESCRIPTION
Separation checking now implies capture checking, but that was not reflected yet on the doc page.

