### PR TITLE
[chore] Setup build for Scala 3.10.0 development cycle

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -20,6 +20,7 @@ enum SourceVersion:
   case `3.8-migration`, `3.8`
   case `3.9-migration`, `3.9`
   case `3.10-migration`, `3.10`
+  case `3.11-migration`, `3.11`
   // Add 3.x-migration and 3.x here
   // !!! Keep in sync with scala.language !!!
   case `2.13`

--- a/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
+++ b/compiler/src/dotty/tools/dotc/config/SourceVersion.scala
@@ -55,7 +55,7 @@ enum SourceVersion:
 object SourceVersion extends Property.Key[SourceVersion]:
 
   /* The default source version used by the built compiler */
-  val defaultSourceVersion = `3.9`
+  val defaultSourceVersion = `3.10`
 
   /* Illegal source versions that may not appear in the settings `-source:<...>` */
   val illegalInSettings = List(`2.13`, `3.1-migration`, `never`)

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -615,6 +615,21 @@ object language {
   @compileTimeOnly("`3.10` can only be used at compile time in import statements")
   object `3.10`
 
+
+  /** Sets source version to 3.10-migration.
+    *
+    * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
+    */
+  @compileTimeOnly("`3.11-migration` can only be used at compile time in import statements")
+  object `3.11-migration`
+
+  /** Sets source version to 3.10
+    *
+    * @see [[https://docs.scala-lang.org/scala3/guides/migration/compatibility-intro.html]]
+    */
+  @compileTimeOnly("`3.11` can only be used at compile time in import statements")
+  object `3.11`
+
   // !!! Keep in sync with dotty.tools.dotc.config.SourceVersion !!!
   // When adding a new `3.x` / `3.x-migration` here, add matching tests:
   // `tests/pos/source-import-3-x.scala` and `tests/pos/source-import-3-x-migration.scala`.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -83,7 +83,7 @@ object Build {
    *      - in release candidate branch is experimental if {patch == 0}
    *      - in stable release is always non-experimental
    */
-  val expectedTastyVersion = "28.9-experimental-1"
+  val expectedTastyVersion = "28.10-experimental-1"
   checkReleasedTastyVersion()
 
   /** Final version of Scala compiler, controlled by environment variables. */

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -56,7 +56,7 @@ object Build {
    *
    *  Warning: Change of this variable might require updating `expectedTastyVersion`
    */
-  val developedVersion = "3.9.0"
+  val developedVersion = "3.10.0"
 
   /** The version of the compiler including the RC prefix.
    *  Defined as common base before calculating environment specific suffixes in `dottyVersion`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -120,7 +120,7 @@ object Build {
    *   - `3.M.0`     if `P > 0`
    *   - `3.(M-1).0` if `P = 0`
    */
-  val mimaPreviousDottyVersion = "3.8.0"
+  val mimaPreviousDottyVersion = "3.8.0" // TODO: update to 3.9.0 when released
 
   /** Version of Scala CLI to download */
   val scalaCliLauncherVersion = "1.14.0"

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -325,7 +325,7 @@ object TastyFormat {
    *  compatibility, but remains backwards compatible, with all
    *  preceding `MinorVersion`.
    */
-  final val MinorVersion: Int = 9
+  final val MinorVersion: Int = 10
 
   /** Natural Number. The `ExperimentalVersion` allows for
    *  experimentation with changes to TASTy without committing

--- a/tests/pos/source-import-3-11-migration.scala
+++ b/tests/pos/source-import-3-11-migration.scala
@@ -1,0 +1,1 @@
+import language.`3.11-migration`

--- a/tests/pos/source-import-3-11.scala
+++ b/tests/pos/source-import-3-11.scala
@@ -1,0 +1,1 @@
+import language.`3.11`


### PR DESCRIPTION
Scala 3.9.0 has been cutoff, the next planned develop cycle is towards 3.10.0  

* Set source-version 3.10 as default 
* Prepare source version 3.11 handles 
* Update TASTy version to 28.10