### PR TITLE
Make `into` type and modifier stable

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -3527,9 +3527,7 @@ object Parsers {
           case nme.transparent => Mod.Transparent()
           case nme.infix => Mod.Infix()
           case nme.tracked => Mod.Tracked()
-          case nme.into =>
-            Feature.checkPreviewFeature("`into`", in.sourcePos())
-            Mod.Into()
+          case nme.into => Mod.Into()
           case nme.erased if in.erasedEnabled => Mod.Erased()
           case nme.update if Feature.ccEnabled => Mod.Update()
         }

--- a/docs/_docs/reference/other-new-features/into.md
+++ b/docs/_docs/reference/other-new-features/into.md
@@ -1,11 +1,13 @@
 ---
 layout: doc-page
 title: The `into` Type and Modifier
-redirectFrom: /experimental/into.html
-nightlyOf: https://docs.scala-lang.org/scala3/reference/preview/into.html
+redirectFrom:
+  - /experimental/into.html
+  - /preview/into.html
+nightlyOf: https://docs.scala-lang.org/scala3/reference/other-new-features/into.html
 ---
 
-This feature is available as a preview since Scala 3.8.0.
+This feature is available as stable since Scala 3.9.0.
 
 
 ## Summary
@@ -278,4 +280,3 @@ LocalModifier     ::=  ...  |  ‘into’
 ```
 
 `into` is a soft modifier. It is only allowed classes, traits, and opaque type aliases.
-

--- a/docs/_docs/reference/preview/overview.md
+++ b/docs/_docs/reference/preview/overview.md
@@ -21,4 +21,4 @@ This flag enables the use of all preview language feature in the project.
 
 ## List of available preview features
 
-* [The `into` Type and Modifier](into.md)
+No features currently under preview.

--- a/docs/sidebar.yml
+++ b/docs/sidebar.yml
@@ -88,6 +88,7 @@ subsection:
       - page: reference/other-new-features/toplevel-definitions.md
       - page: reference/other-new-features/better-fors.md
       - page: reference/other-new-features/runtimeChecked.md
+      - page: reference/other-new-features/into.md
   - title: Other Changed Features
     directory: changed-features
     index: reference/changed-features/changed-features.md
@@ -143,8 +144,7 @@ subsection:
   - title: Preview Features
     directory: preview
     index: reference/preview/overview.md
-    subsection:
-      - page: reference/preview/into.md
+    subsection: []
   - title: Experimental Features
     directory: experimental
     index: reference/experimental/overview.md
@@ -437,4 +437,3 @@ subsection:
       - page: reference/error-codes/E229.md
       - page: reference/error-codes/E230.md
       - page: reference/error-codes/E231.md
-

--- a/library/src/scala/Conversion.scala
+++ b/library/src/scala/Conversion.scala
@@ -41,11 +41,9 @@ object Conversion:
    *  conversions are tried from the type of `t` to `T`. `into[T]` types are erased to `T`
    *  in all covariant positions of the types of parameter symbols.
    */
-  @preview
   opaque type into[+T] >: T = T
 
   /** Unwraps an `into`. */
   extension [T](x: into[T])
-    @preview
     def underlying: T = x
 end Conversion

--- a/library/src/scala/annotation/internal/$into.scala
+++ b/library/src/scala/annotation/internal/$into.scala
@@ -7,5 +7,4 @@ package scala.annotation.internal
  *  `T`. Hence, we don't need to use `.underlying` to go from an into type to its
  *  underlying type in the types of local parameters.
  */
-@preview
 class `$into` extends annotation.StaticAnnotation

--- a/tests/neg/i23400.scala
+++ b/tests/neg/i23400.scala
@@ -1,5 +1,5 @@
-//> using options -preview
-// preview needed for into in 3.8
+// placeholder for directives line
+//
 
 import Conversion.into
 

--- a/tests/neg/i5525.scala
+++ b/tests/neg/i5525.scala
@@ -1,5 +1,5 @@
-//> using options -preview
-// preview needed for into in 3.8
+// placeholder for directives line
+//
 
 abstract enum Foo1 { case C } // error: only access modifiers allowed
 final    enum Foo2 { case C } // error: only access modifiers allowed

--- a/tests/neg/into-inferred.scala
+++ b/tests/neg/into-inferred.scala
@@ -1,4 +1,4 @@
-//> using options  -feature -preview
+//> using options -feature
 import Conversion.{into, underlying}
 
 trait Token
@@ -32,5 +32,3 @@ object Test:
   val l = List(ifKW)
   val l1: List[into[Keyword]] = l :+ "then" :+ "else"  // error
   val l2: List[into[Keyword]] = l ++ List("then", "else")  // warn // warn
-
-

--- a/tests/neg/into-mods.scala
+++ b/tests/neg/into-mods.scala
@@ -1,5 +1,5 @@
-//> using options -preview
-// preview needed for into in 3.8
+// placeholder for directives line
+//
 
 into class Test
 
@@ -12,4 +12,3 @@ object Test:
   into val x = 33   // error
   into type T = Int // error
   into opaque type U = Int // ok
-

--- a/tests/neg/into-override.scala
+++ b/tests/neg/into-override.scala
@@ -1,4 +1,4 @@
-//> using options -Werror -preview
+//> using options -Werror
 
 import Conversion.into
 
@@ -19,5 +19,3 @@ class D[X] extends B[X], C[X] // error
 
 trait E[X] extends C[X]: // error
   override def f(x: X) = super.f(x)
-
-

--- a/tests/pos/i23398.scala
+++ b/tests/pos/i23398.scala
@@ -1,4 +1,4 @@
-//> using options -feature -Werror -preview
+//> using options -feature -Werror
 
 import Conversion.into
 

--- a/tests/pos/into-bigint.scala
+++ b/tests/pos/into-bigint.scala
@@ -1,4 +1,3 @@
-//> using options -preview
 import Conversion.into
 
 class BigInt(x: Int):
@@ -19,4 +18,3 @@ object BigInt:
   val a2 = y * x // uses conversion on `y`
   val a3 = x * x
   val a4 = y + y
-

--- a/tests/pos/into-class.scala
+++ b/tests/pos/into-class.scala
@@ -1,4 +1,3 @@
-//> using options -preview
 import Conversion.into
 
 class Text(str: String)

--- a/tests/pos/into-expr.scala
+++ b/tests/pos/into-expr.scala
@@ -1,5 +1,5 @@
 
-//> using options -feature -Werror -preview
+//> using options -feature -Werror
 
 import Conversion.into
 

--- a/tests/pos/into-sam.scala
+++ b/tests/pos/into-sam.scala
@@ -1,5 +1,5 @@
 
-//> using options -feature -Werror -preview
+//> using options -feature -Werror
 
 import Conversion.into
 

--- a/tests/pos/into-separate/Test_2.scala
+++ b/tests/pos/into-separate/Test_2.scala
@@ -1,4 +1,4 @@
-//> using options -feature -preview
+//> using options -feature
 package test
 
 object Test:
@@ -11,5 +11,3 @@ object Test:
 
   val dclKeywords = Set[Keyword]("def", "val") // ok
   val keywords = dclKeywords + "if" + "then" + "else" // ok
-
-

--- a/tests/pos/into-separate/classes_1.scala
+++ b/tests/pos/into-separate/classes_1.scala
@@ -1,5 +1,3 @@
-//> using options -preview
-
 package test
 
 into trait T

--- a/tests/run/Parser.scala
+++ b/tests/run/Parser.scala
@@ -1,4 +1,3 @@
-//> using options -preview
 import Conversion.into
 
 type Input = List[String]

--- a/tests/run/convertible.scala
+++ b/tests/run/convertible.scala
@@ -1,4 +1,4 @@
-//> using options -feature -Werror -preview
+//> using options -feature -Werror
 
 import Conversion.into
 
@@ -26,5 +26,3 @@ trait C[X]:
 class D[X] extends C[X]
 
 def f = new D[Text].f("abc")
-
-

--- a/tests/warn/convertible.scala
+++ b/tests/warn/convertible.scala
@@ -1,4 +1,4 @@
-//> using options -feature -preview
+//> using options -feature
 
 import Conversion.into
 

--- a/tests/warn/into-as-mod.scala
+++ b/tests/warn/into-as-mod.scala
@@ -1,4 +1,4 @@
-//> using options -feature -preview
+//> using options -feature
 
 import Conversion.into
 


### PR DESCRIPTION
remove redundant -preview flag from test files that only require it for the into feature.

fixes #26183

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
