### PR TITLE
Parse Java annotations on wildcard type arguments

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -317,7 +317,8 @@ object JavaParsers {
 
     def typeArgs(t: Tree): Tree = {
       var wildnum = 0
-      def typeArg(): Tree =
+      def typeArg(): Tree = {
+        val annots = annotations()
         if (in.token == QMARK) {
           val offset = in.offset
           in.nextToken()
@@ -335,7 +336,8 @@ object JavaParsers {
           }
         }
         else
-          typ()
+          annots.foldLeft(typ())((tp, ann) => Annotated(tp, ann))
+      }
       if (in.token == LT) {
         in.nextToken()
         val t1 = convertToTypeId(t)

--- a/tests/pos/java-annotated-wildcards/Nullable.java
+++ b/tests/pos/java-annotated-wildcards/Nullable.java
@@ -1,0 +1,5 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface Nullable {}

--- a/tests/pos/java-annotated-wildcards/Test.java
+++ b/tests/pos/java-annotated-wildcards/Test.java
@@ -1,0 +1,5 @@
+import java.util.function.Function;
+
+public interface Test {
+  Function<@Nullable ? super String, @Nullable ? extends Object> mappingFunction();
+}


### PR DESCRIPTION
Java permits type-use annotations before wildcard type arguments, for example
```java
Function<@Nullable ? super String, @Nullable ? extends Object>
```

## Reproduce

You can use this repo's test files:
```
$ cd tests/pos/java-annotated-wildcards/

$ scala -version
Scala code runner version: 1.12.4
Scala version (default): 3.8.3

$ scalac -usejavacp Nullable.java Test.java 
-- Error: Test.java:4:21 ---------------------------------------------------------------------------------------------------------------------------
4 |  Function<@Nullable ? super String, @Nullable ? extends Object> mappingFunction();
  |                     ^^^^^^^^
  |                     illegal start of type
-- Error: Test.java:4:82 ---------------------------------------------------------------------------------------------------------------------------
4 |  Function<@Nullable ? super String, @Nullable ? extends Object> mappingFunction();
  |                                                                                  ^
  |                                                                                  null expected but ';' found.
  |
5 |}
2 errors found
```

Java however can compile it:
```
$ java -version
openjdk version "1.8.0_492"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_492-b09)
OpenJDK 64-Bit Server VM (Temurin)(build 25.492-b09, mixed mode)

$ javac Nullable.java Test.java 
$ ls -1 *.class
Nullable.class
Test.class
```

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Not at all (update: after the GitHub actions jobs failed I used codex for analysing the code and find out what broke, that lead to force push)

## How was the solution tested?

New automated tests (including the issue's reproducer)
Plus Manual tests

## See also

- #22391
  - basically same kind of fix