### PR TITLE
Test Java annotations on varargs element types

### DIFF
--- a/tests/pos/i19642/i19642.java
+++ b/tests/pos/i19642/i19642.java
@@ -6,4 +6,5 @@ import lib.*;
 public class i19642 {
   private String @lib.Valid [] flatArray;
   private String @lib.Valid [] @lib.Valid [] nestedArray;
+  void varargs(String @lib.Valid ... values) {}
 }


### PR DESCRIPTION
Commit 9c971be202ab73688dbcff50a8240cb2878097aa made the Java parser consume annotations before array dimensions.

That also permits annotations before a varargs ellipsis, since varargs parameters pass through the same type parsing path. Add a regression test for that syntax:
```java
void varargs(String @lib.Valid ... values) {}
```

## How much have you relied on LLM-based tools in this contribution?

Minimally, for analysing the code.

## How was the solution tested?

New test