### PR TITLE
Fix #26190: Copy erased flag into inline access proxies

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/AccessProxies.scala
@@ -85,6 +85,7 @@ abstract class AccessProxies {
       val sym = newSymbol(owner, name, Synthetic | Method, info, coord = accessed.span).entered
       if accessed.is(Private) then sym.setFlag(Final)
       else if sym.allOverriddenSymbols.exists(!_.is(Deferred)) then sym.setFlag(Override)
+      if accessed.is(Erased) then sym.setFlag(Erased)
       ExperimentalAnnotation.copy(accessed).foreach(sym.addAnnotation)
       sym
     }

--- a/tests/pos/i26190.scala
+++ b/tests/pos/i26190.scala
@@ -1,0 +1,11 @@
+import language.experimental.erasedDefinitions
+
+object Foo:
+    private erased val evidence: Boolean = true
+    inline def foo = Bar.bar(evidence)
+
+object Bar:
+    def bar(erased x: Boolean) = println("Hello World")
+
+def main = 
+    Foo.foo


### PR DESCRIPTION
Fixes #26190.

Copies erased flag into inline trait access proxies if the underlying field is erased.

## How much have you relied on LLM-based tools in this contribution?
Minimally to search for things in the codebase.

## How was the solution tested?
New automated tests.