### PR TITLE
Fix #24653: Erase aliases of Unit as result type to void.

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -1021,7 +1021,7 @@ class TypeErasure(sourceLanguage: SourceLanguage, semiEraseVCs: Boolean, isConst
     else tp match
       case tp: TypeRef =>
         val sym = tp.symbol
-        if (sym eq defn.UnitClass) sym.typeRef
+        if (tp.isRef(defn.UnitClass)) defn.UnitType
         else apply(tp)
       case tp: AppliedType =>
         val sym = tp.tycon.typeSymbol

--- a/tests/run/i24653.check
+++ b/tests/run/i24653.check
@@ -1,0 +1,5 @@
+public void Foo.bar()
+public scala.runtime.BoxedUnit Foo.classTypeParam()
+public void Foo.foobar(scala.runtime.BoxedUnit)
+public scala.runtime.BoxedUnit Foo.generic()
+public scala.runtime.BoxedUnit Foo.typeMember()

--- a/tests/run/i24653.scala
+++ b/tests/run/i24653.scala
@@ -1,0 +1,24 @@
+// scalajs: --skip
+
+object UnitAlias:
+  type U = Unit
+
+class Foo[W <: UnitAlias.U] {
+  import UnitAlias.*
+
+  type M <: U
+
+  def bar(): U = ()
+  def foobar(x: U): U = ()
+
+  def generic[T <: U](): T = ???
+  def classTypeParam(): W = ???
+  def typeMember(): M = ???
+}
+
+object Test {
+  def main(args: Array[String]): UnitAlias.U =
+    val ms = classOf[Foo[Unit]].getDeclaredMethods().sortBy(_.getName())
+    for m <- ms do
+      println(m)
+}


### PR DESCRIPTION
Previously, they erroneously erased to `BoxedUnit`.

Fixes #24653.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

Note that this can break binary compatibility of libraries recompiled with a newer compiler. The issue contains a workaround: https://github.com/scala/scala3/issues/24653#issuecomment-4334034784

@WojciechMazur We had decided to include this in 3.9.0, but I was completely underwater until now. So this should be backported to 3.9.0, please. :)