### PR TITLE
Several fixes around `fresh` and `Unscoped`.

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -1265,7 +1265,7 @@ object Capabilities:
       case _ =>
         super.mapOver(t)
 
-  class ToResult(localResType: Type, mt: MethodicType, sym: Symbol, fail: Message => Unit)(using Context) extends CapMap:
+  class ToResult(mt: MethodicType, sym: Symbol)(using Context) extends CapMap:
 
     def apply(t: Type) = mapOver(t)
 
@@ -1314,6 +1314,6 @@ object Capabilities:
   /** Replace all occurrences of `caps.any` or LocalCap in parts of this type by an existentially bound
    *  variable bound by `mt`. Stop at function or method types since these have been mapped before.
    */
-  def toResult(tp: Type, mt: MethodicType, sym: Symbol, fail: Message => Unit)(using Context): Type =
-    ToResult(tp, mt, sym, fail)(tp)
+  def toResult(tp: Type, mt: MethodicType, sym: Symbol)(using Context): Type =
+    ToResult(mt, sym)(tp)
 end Capabilities

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -1272,9 +1272,7 @@ object Capabilities:
     override def mapCapability(c: Capability, deep: Boolean) = c match
       case c: LocalCap =>
         if variance >= 0 then
-          if sym.isAnonymousFunction && c.classifier.derivesFrom(defn.Caps_Unscoped) then
-            c
-          else if sym.exists && !c.ccOwner.isContainedIn(sym) then
+          if sym.exists && !c.ccOwner.isContainedIn(sym) then
             //println(i"not mapping $c with ${c.ccOwner} in $sym")
             c
           else
@@ -1310,6 +1308,18 @@ object Capabilities:
       override def toString = "toVar.inverse"
     end inverse
   end ToResult
+
+  /** Map all ResultCaps that have the same primaryResultCap as one of the elements
+   *  of `rcs` to their LocalCap origins.
+   */
+  class RetractResult(rcs: SimpleIdentitySet[ResultCap])(using Context) extends TypeMap:
+    def apply(t: Type) = mapOver(t)
+    override def mapCapability(c: Capability, deep: Boolean) = c match
+      case c: ResultCap if rcs.exists(_.primaryResultCap == c.primaryResultCap) =>
+        c.primaryResultCap.origin match
+          case origin: LocalCap => origin
+          case _ => c
+      case _ => super.mapCapability(c, deep)
 
   /** Replace all occurrences of `caps.any` or LocalCap in parts of this type by an existentially bound
    *  variable bound by `mt`. Stop at function or method types since these have been mapped before.

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -408,6 +408,7 @@ object Capabilities:
       case ReadOnly(ref1) => ref1.classifier
       case Maybe(ref1) => ref1.classifier
       case self: LocalCap => self.hiddenSet.classifier
+      case self: ResultCap => self.origin.classifier
       case _ => NoSymbol
 
     /** Is this a reach reference of the form `x*` or a readOnly or maybe variant
@@ -1024,7 +1025,7 @@ object Capabilities:
     case TypeArg(tp: Type)
     case UnsafeAssumePure
     case Formal(pref: ParamRef, app: tpd.Apply)
-    case ResultInstance(methType: Type, tree: Tree)
+    case ResultInstance(result: ResultCap, methType: Type, tree: Tree = EmptyTree)
     case UnapplyInstance(info: MethodType)
     case LocalInstance(restpe: Type)
     case NewInstance(tp: Type, fields: List[Symbol])
@@ -1060,7 +1061,7 @@ object Capabilities:
         if meth.exists
         then i" when checking argument to parameter ${pref.paramName} of $meth"
         else ""
-      case ResultInstance(mt, tree) =>
+      case ResultInstance(rc, mt, tree) =>
         def methDescr(tree: Tree): String = tree match
           case app: GenericApply =>
             methDescr(app.fun)
@@ -1221,7 +1222,7 @@ object Capabilities:
   end Internalize
 
   /** Map top-level free ResultCaps one-to-one to LocalCap instances */
-  def resultToAny(tp: Type, origin: Origin)(using Context): Type =
+  def resultToAny(tp: Type, mkOrigin: ResultCap => Origin)(using Context): Type =
     val subst = new TypeMap:
       val seen = EqHashMap[ResultCap, LocalCap | GlobalCap]()
       var localBinders: SimpleIdentitySet[MethodType] = SimpleIdentitySet.empty
@@ -1245,9 +1246,9 @@ object Capabilities:
           else
             // Create a LocalCap skolem that does not subsume anything
             def localCapSkolem =
-              val c = LocalCap(origin)
-              c.hiddenSet.markSolved(provisional = false)
-              c
+              val lc = LocalCap(mkOrigin(c))
+              lc.hiddenSet.markSolved(provisional = false)
+              lc
             seen.getOrElseUpdate(c, localCapSkolem) // map free references to LocalCap
         case _ => super.mapCapability(c, deep)
     end subst

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -213,12 +213,13 @@ object Capabilities:
     /** Is this LocalCap at the right level to be able to subsume `ref`?
      */
     def acceptsLevelOf(ref: Capability)(using Context): Boolean =
-      if ccConfig.useLocalCapLevels && !CCState.collapseLocalCaps then
-        ccOwner.isContainedIn(ref.levelOwner.widenOwner(skipModules = true))
-        || classifier.derivesFrom(defn.Caps_Unscoped)
-      else ref.core match
+      ref.core match
         case ResultCap(_) | _: ParamRef => false
-        case _ => true
+        case _ =>
+          !ccConfig.useLocalCapLevels
+          || CCState.collapseLocalCaps
+          || ccOwner.isContainedIn(ref.levelOwner.widenOwner(skipModules = true))
+          || classifier.derivesFrom(defn.Caps_Unscoped)
 
     /** Classify this LocalCap as `cls`, provided `isClassified` is still false.
      *  @param  freeze  Determines future `isClassified` state.

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -528,9 +528,25 @@ extension (tp: Type)
     case _ =>
       CaptureSet.empty
 
+  /** Does this (methodic) type have `any` in the span capture set of its
+   *  result type?
+   */
+  def hasCapInResult(using Context): Boolean = tp match
+    case tp: PolyType => tp.resType.hasCapInResult
+    case tp: MethodicType =>
+      tp.resType.spanCaptureSet.elems.exists: elem =>
+        elem.core match
+          case _: LocalCap => true
+          case GlobalAny => true
+          case _ => false
+
+  /** The implied captures of a lambda that come from its result type.
+   *  This is the set that needs to be added to a lambda type to ensure
+   *  monotonicity of function types.
+   */
   def impliedLambdaCaptures(using Context): CaptureSet = tp match
     case tp: PolyType => tp.resType.impliedLambdaCaptures
-    case tp: MethodicType if ccConfig.newScheme =>
+    case tp: MethodicType =>
       val localCaps = tp.resType.embeddedLocalCaps
       val impliedClr = localCaps
         .map(_.classifier)

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -540,7 +540,10 @@ extension (tp: Type)
    *  monotonicity of function types.
    */
   def impliedLambdaCaptures(using Context): CaptureSet = tp match
-    case tp: PolyType => tp.resType.impliedLambdaCaptures
+    case RefinedType(_, rname, rinfo) if rname == nme.apply =>
+      rinfo.impliedLambdaCaptures
+    case tp: PolyType =>
+      tp.resType.impliedLambdaCaptures
     case tp: MethodicType =>
       val localCaps = tp.resType.embeddedLocalCaps
       val impliedClr = localCaps
@@ -550,6 +553,8 @@ extension (tp: Type)
         .commonAncestor
       tp.impliedCaptures(impliedClr, Nil, localCaps.forall(_.isReadOnly))
         .showing(i"implied lambda captures of $tp = $result", capt)
+    case CapturingType(parent, _) =>
+      parent.impliedLambdaCaptures
     case _ =>
       CaptureSet.empty
 

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -511,6 +511,37 @@ extension (tp: Type)
     if tp.isArrayUnderStrictMut then defn.Caps_Unscoped
     else tp.classSymbols.map(_.classifier).foldLeft(defn.AnyClass)(leastClassifier)
 
+  /** The classifiers of all terminal capabilities in the span capture set of `tp` */
+  def embeddedLocalCaps(using Context): List[Capability] =
+    tp.spanCaptureSet.elems.filter(_.core.isInstanceOf[LocalCap]).toList
+
+  /** If classifier `clsfier` exists: A localCap instance with this classifier,
+   *  possibly wrapped in a readOnly.
+   */
+  def impliedCaptures(clsfier: Symbol, contributing: List[Symbol], readOnly: => Boolean)(using Context): CaptureSet =
+    clsfier match
+    case clsfier: ClassSymbol =>
+      val lcap = LocalCap(Origin.NewInstance(tp, contributing))
+      if clsfier != defn.AnyClass then
+        lcap.hiddenSet.adoptClassifier(clsfier)
+      (if readOnly then lcap.readOnly else lcap).singletonCaptureSet
+    case _ =>
+      CaptureSet.empty
+
+  def impliedLambdaCaptures(using Context): CaptureSet = tp match
+    case tp: PolyType => tp.resType.impliedLambdaCaptures
+    case tp: MethodicType if ccConfig.newScheme =>
+      val localCaps = tp.resType.embeddedLocalCaps
+      val impliedClr = localCaps
+        .map(_.classifier)
+        .collect:
+          case cl: ClassSymbol => cl
+        .commonAncestor
+      tp.impliedCaptures(impliedClr, Nil, localCaps.forall(_.isReadOnly))
+        .showing(i"implied lambda captures of $tp = $result", capt)
+    case _ =>
+      CaptureSet.empty
+
 extension (tp: MethodOrPoly)
   /** A method marks an existential scope unless it is the prefix of a curried method */
   def marksExistentialScope(using Context): Boolean =
@@ -574,10 +605,6 @@ extension (cls: ClassSymbol) {
       ccState.fieldsWithExplicitTypes             // pick fields with explicit types for classes in this compilation unit
         .getOrElse(cls, cls.info.decls.toList)  // pick all symbols in class scope for other classes
 
-    def commonAncestor(clss: List[ClassSymbol]): Symbol =
-      if clss.isEmpty then NoSymbol
-      else clss.reduce(greatestClassifier)
-
     /** The implied classifier of the LocalCap of the class instance, derived from
      *    - the clasifiers of the LocalCaps in the span capture sets of all fields
      *    - the implied classifiers of the parent classes
@@ -588,7 +615,7 @@ extension (cls: ClassSymbol) {
     def impliedClassifier(cls: Symbol): Symbol = cls match
       case cls: ClassSymbol =>
         val fieldClassifiers =
-          knownFields(cls).flatMap(classifiersOfLocalCapsInType)
+          knownFields(cls).flatMap(classifiersOfLocalCapsInInfo)
         val parentClassifiers =
           cls.parentSyms.map(impliedClassifier).collect:
             case cl: ClassSymbol => cl
@@ -596,7 +623,7 @@ extension (cls: ClassSymbol) {
           if cls.typeRef.isStatefulType(varsOnly = true)
           then cls.classifier :: Nil
           else Nil
-        commonAncestor(fieldClassifiers ++ parentClassifiers ++ stateClassifiers)
+        (fieldClassifiers ++ parentClassifiers ++ stateClassifiers).commonAncestor
       case _ => NoSymbol
 
     def contributingFields(cls: Symbol): List[Symbol] = cls match
@@ -606,24 +633,11 @@ extension (cls: ClassSymbol) {
         ownFields ++ parentFields
       case _ => Nil
 
-    def maybeRO(ref: Capability, fields: List[Symbol]) =
-      if !cls.typeRef.isStatefulType() && fields.forall(allLocalCapsInTypeAreRO)
-      then ref.readOnly
-      else ref
-
-    def localCap(fields: List[Symbol]) =
-      LocalCap(Origin.NewInstance(core, fields))
-
     val impliedClr = impliedClassifier(cls)
     val contributing = contributingFields(cls)
-    val impliedSet = impliedClr match
-      case impliedClr: ClassSymbol =>
-        val result = localCap(contributing)
-        if impliedClr != defn.AnyClass then
-          result.hiddenSet.adoptClassifier(impliedClr)
-        maybeRO(result, contributing).singletonCaptureSet
-      case _ =>
-        CaptureSet.empty
+    def readOnly =
+      !cls.typeRef.isStatefulType() && contributing.forall(allLocalCapsInTypeAreRO)
+    val impliedSet = core.impliedCaptures(impliedClr, contributing, readOnly)
     (impliedSet, contributing)
   }
 
@@ -859,16 +873,12 @@ extension (sym: Symbol) {
    *  enclosing class.
    */
   def memberCaps(using Context): List[Capability] =
-    if sym.contributesLocalCapsToClass then
-      sym.info.spanCaptureSet.elems
-        .filter(_.isTerminalCapability)
-        .toList
-    else Nil
+    if sym.contributesLocalCapsToClass then sym.info.embeddedLocalCaps else Nil
 
   /** The classifiers of all terminal capabilities comntributed by this symbol
    *  to the capture set of the enclosing class.
    */
-  def classifiersOfLocalCapsInType(using Context): List[ClassSymbol] =
+  def classifiersOfLocalCapsInInfo(using Context): List[ClassSymbol] =
     memberCaps.map(_.classifier).collect:
       case cl: ClassSymbol => cl
 
@@ -899,6 +909,10 @@ extension (tp: AnnotatedType) {
     case ann: CaptureAnnotation => ann.boxed
     case _ => false
 }
+
+extension (clss: List[ClassSymbol])
+  def commonAncestor(using Context): Symbol =
+    if clss.isEmpty then NoSymbol else clss.reduce(greatestClassifier)
 
 /** A prototype that indicates selection */
 class PathSelectionProto(val selector: Symbol, val pt: Type, val tree: Tree) extends typer.ProtoTypes.WildcardSelectionProto

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -622,7 +622,7 @@ extension (cls: ClassSymbol) {
         .getOrElse(cls, cls.info.decls.toList)  // pick all symbols in class scope for other classes
 
     /** The implied classifier of the LocalCap of the class instance, derived from
-     *    - the clasifiers of the LocalCaps in the span capture sets of all fields
+     *    - the classifiers of the LocalCaps in the span capture sets of all fields
      *    - the implied classifiers of the parent classes
      *    - if `cls` is a stateful class, the classifier of `cls` itself
      *  @return The implied classidier, or NoSymbol is there is no LocalCap

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -531,14 +531,9 @@ extension (tp: Type)
   /** Does this (methodic) type have `any` in the span capture set of its
    *  result type?
    */
-  def hasCapInResult(using Context): Boolean = tp match
-    case tp: PolyType => tp.resType.hasCapInResult
-    case tp: MethodicType =>
-      tp.resType.spanCaptureSet.elems.exists: elem =>
-        elem.core match
-          case _: LocalCap => true
-          case GlobalAny => true
-          case _ => false
+  def hasCapInResult(using Context): Boolean =
+    val (mt: MethodicType) = tp.stripPoly.runtimeChecked
+    mt.resType.spanCaptureSet.containsGlobalOrLocalCap
 
   /** The implied captures of a lambda that come from its result type.
    *  This is the set that needs to be added to a lambda type to ensure

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -540,8 +540,6 @@ extension (tp: Type)
    *  monotonicity of function types.
    */
   def impliedLambdaCaptures(using Context): CaptureSet = tp match
-    case RefinedType(_, rname, rinfo) if rname == nme.apply =>
-      rinfo.impliedLambdaCaptures
     case tp: PolyType =>
       tp.resType.impliedLambdaCaptures
     case tp: MethodicType =>
@@ -553,6 +551,8 @@ extension (tp: Type)
         .commonAncestor
       tp.impliedCaptures(impliedClr, Nil, localCaps.forall(_.isReadOnly))
         .showing(i"implied lambda captures of $tp = $result", capt)
+    case RefinedType(_, rname, rinfo) if rname == nme.apply =>
+      rinfo.impliedLambdaCaptures
     case CapturingType(parent, _) =>
       parent.impliedLambdaCaptures
     case _ =>

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -136,10 +136,9 @@ sealed abstract class CaptureSet extends Showable:
    *  does not contain a ResultCap?
    */
   final def containsGlobalOrLocalCap(using Context) =
-    !containsResultCapability
-    && elems.exists: elem =>
+    elems.exists: elem =>
       elem.core match
-        case _: GlobalCap => true
+        case GlobalAny => true
         case _: LocalCap => true
         case _ => false
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1130,7 +1130,7 @@ class CheckCaptures extends Recheck, SymTransformer:
      *  block containing the anonymous function and the Closure node.
      */
     override def recheckClosure(tree: Closure, pt: Type, forceDependent: Boolean)(using Context): Type =
-      val cs = tree.meth.symbol.useSet ++ tree.meth.symbol.info.impliedLambdaCaptures
+      val cs = tree.meth.symbol.useSet
       capt.println(i"typing closure $tree with cvs $cs")
       super.recheckClosure(tree, pt, forceDependent).capturing(cs)
         .showing(i"rechecked closure $tree / $pt = $result", capt)
@@ -1842,7 +1842,8 @@ class CheckCaptures extends Recheck, SymTransformer:
             yield rc
           if mappable.isEmpty then NoType
           else
-            RetractResult(SimpleIdentitySet(mappable*))(actual)
+            val core = RetractResult(SimpleIdentitySet(mappable*))(actual)
+            core.capturing(core.impliedLambdaCaptures)
               .showing(i"try existential widen $actual to $result", capt)
         case _ => NoType
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -968,9 +968,12 @@ class CheckCaptures extends Recheck, SymTransformer:
             && !resultType.isBoxedCapturing
             && !tree.fun.symbol.isConstructor
             && !resultType.captureSet.containsResultCapability
-            && !resultType.captureSet.elems.exists(_.derivesFromCapTrait(defn.Caps_Unscoped))
+
             && qualCaptures.mightSubcapture(refs)
-            && argCaptures.forall(_.mightSubcapture(refs)) =>
+            && argCaptures.forall(_.mightSubcapture(refs))
+            // No longer needed since we now ensure monotonicity of closure types
+            // && !resultType.captureSet.elems.exists(_.derivesFromCapTrait(defn.Caps_Unscoped))
+        =>
           val callCaptures = argCaptures.foldLeft(qualCaptures)(_ ++ _)
           appType.derivedCapturingType(appType1, callCaptures)
             .showing(i"narrow $tree: $appType, refs = $refs, qual-cs = ${qualType.captureSet} = $result", capt)

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1395,6 +1395,16 @@ class CheckCaptures extends Recheck, SymTransformer:
             // Anonymous functions propagate their type to the enclosing environment
             // so it is not in general sound to interpolate their types.
             interpolateIfInferred(tree.tpt, sym)
+          else if sym.info.hasCapInResult then
+            // If the info has an `any` in its result, this would be propagated
+            // into the function type tp ensure monotonicity. We should do this
+            // only if the _body_ of the lambda has an `any` in its type, not
+            // if the `any` just came from the expected type. So if there is an `any`
+            // in the expected type we sharpen the declared type to be the body's type.
+            // Why not sharpen unconditionally? This would also overwrite `fresh`
+            // with the body's type, and thereby make it impossible to define lambdas
+            // that return fresh results.
+            tree.tpt.updNuType(tree.rhs.nuType)
           curEnv = saved
       }
 

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1791,7 +1791,7 @@ class CheckCaptures extends Recheck, SymTransformer:
       case _ => NoType
 
     inline def testAdapted(actual: Type, expected: Type, tree: Tree, notes: List[Note])
-        (fail: (Tree, Type, List[Note]) => Unit)(using Context): Type =
+        (fail: (Tree, Type, List[Note]) => Unit)(using Context): Type = {
 
       var expected1 = alignDependentFunction(expected, actual.stripCapturing)
       val falseDeps = expected1 ne expected
@@ -1815,30 +1815,6 @@ class CheckCaptures extends Recheck, SymTransformer:
         // Only `addOuterRefs` when there is no box adaptation
         expected1 = addOuterRefs(expected1, actual, tree.srcPos)
 
-      def tryCurrentType: Boolean =
-        isCompatible(actualBoxed, expected1)
-
-      def tryAltType(actual1: Type) =
-        actual1.exists && {
-          val actualBoxed1 = adapt(actual1, expected1, tree)
-          isCompatible(actualBoxed1, expected1)
-        }
-
-      /** When the actual type is a named type, and the previous attempt failed, try to widen the named type
-       * and try another time.
-       *
-       * This is useful for cases like:
-       *
-       *   def id[X <: box IO^{a}](x: X): IO^{a} = x
-       *
-       * When typechecking the body, we need to show that `(x: X)` can be typed at `IO^{a}`.
-       * In the first attempt, since `X` is simply a parameter reference, we treat it as non-boxed and perform
-       * no box adptation. But its upper bound is in fact boxed, and adaptation is needed for typechecking the body.
-       * In those cases, we widen such types and try box adaptation another time.
-       */
-      def tryWidenNamed: Boolean =
-        tryAltType(findImpureUpperBound(actual))
-
       def nestedLambdas(mdef: DefDef): List[Symbol] =
         mdef.symbol :: mdef.rhs.match
           case closureDef(mdef1) => nestedLambdas(mdef1)
@@ -1855,45 +1831,61 @@ class CheckCaptures extends Recheck, SymTransformer:
        *  By adapting its type to `() => Ref^` we make it fit. Test cases are in
        *  ref-with-file.scala and lambda-fresh.scala.
        */
-      def tryExistentialWiden(notes: List[Note]): Boolean = tree match
+      def existentialWiden(notes: List[Note]): Type =
+        tree match
         case closureDef(mdef) =>
           val mappable =
             for
-              case IncludeFailure(cs, rc: ResultCap, true) <- notes
+              case IncludeFailure(cs, rc: ResultCap, _) <- notes
               if rc.classifier.derivesFrom(defn.Caps_Unscoped)
                 && nestedLambdas(mdef).contains(rc.primaryResultCap.origin.ccOwner.enclosingMethod)
             yield rc
-          !mappable.isEmpty
-          && tryAltType:
+          if mappable.isEmpty then NoType
+          else
             RetractResult(SimpleIdentitySet(mappable*))(actual)
               .showing(i"try existential widen $actual to $result", capt)
-        case _ => false
+        case _ => NoType
 
-      def recoverWithExistentialWiden(cmp: TypeComparer.CompareResult): TypeComparer.CompareResult =
-        cmp match
-        case TypeComparer.CompareResult.Fail(cmpNotes) =>
-          TypeComparer.compareResult(tryExistentialWiden(cmpNotes)) match
-            case TypeComparer.CompareResult.Fail(_) => cmp
-            case cmp1 => cmp1
-        case _ => cmp
+      def tryType(actualBoxed: Type)(alt: List[Note] => Type): Type = {
+        TypeComparer.compareResult(isCompatible(actualBoxed, expected1)) match
+          case TypeComparer.CompareResult.Fail(cmpNotes) => alt(cmpNotes)
+          case _ =>
+            if debugSuccesses then tree match
+              case Ident(_) =>
+                println(i"SUCCESS $tree for $actual <:< $expected:\n${TypeComparer.explained(_.isSubType(actualBoxed, expected1))}")
+              case _ =>
+            actualBoxed
+      }
 
-      recoverWithExistentialWiden(TypeComparer.compareResult(tryCurrentType || tryWidenNamed)) match
-        case TypeComparer.CompareResult.Fail(cmpNotes) =>
-          capt.println(i"conforms failed for ${tree}: $actual vs $expected")
-          if falseDeps then expected1 = unalignFunction(expected1)
-          val toAdd0 = notes ++ cmpNotes
-          val toAdd1 = addApproxAddenda(toAdd0, expected1)
-          val failTree =
-            if definedSym(tree).exists then tree else tree.withType(actualBoxed)
-          fail(failTree, expected1, toAdd1)
-          actual
-        case /*OK*/ _ =>
-          if debugSuccesses then tree match
-            case Ident(_) =>
-              println(i"SUCCESS $tree for $actual <:< $expected:\n${TypeComparer.explained(_.isSubType(actualBoxed, expected1))}")
-            case _ =>
-          actualBoxed
-    end testAdapted
+      def tryAltType(altActual: Type)(alt: => Type): Type =
+        if altActual.exists && (altActual ne actual)
+        then
+          val altActualBoxed = adapt(altActual, expected1, tree)
+          tryType(altActualBoxed)(_ => alt)
+        else alt
+
+      tryType(actualBoxed): cmpNotes =>
+        // When the actual type is a named type, and the previous attempt failed, try to widen the named type
+        // and try another time. This is useful for cases like:
+        //
+        //    def id[X <: box IO^{a}](x: X): IO^{a} = x
+        //
+        // When typechecking the body, we need to show that `(x: X)` can be typed at `IO^{a}`.
+        // In the first attempt, since `X` is simply a parameter reference, we treat it as non-boxed and perform
+        // no box adptation. But its upper bound is in fact boxed, and adaptation is needed for typechecking the body.
+        // In those cases, we widen such types and try box adaptation another time.
+        tryAltType(findImpureUpperBound(actual)):
+          tryAltType(existentialWiden(cmpNotes)):
+            capt.println(i"conforms failed for ${tree}: $actual vs $expected")
+            if falseDeps then expected1 = unalignFunction(expected1)
+            val toAdd0 = notes ++ cmpNotes
+            val toAdd1 = addApproxAddenda(toAdd0, expected1)
+            val failTree =
+              if definedSym(tree).exists then tree
+              else tree.withType(actualBoxed)
+            fail(failTree, expected1, toAdd1)
+            actual
+    }
 
     /** Turn `expected` into a dependent function when `actual` is dependent. */
     private def alignDependentFunction(expected: Type, actual: Type)(using Context): Type =

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1130,7 +1130,7 @@ class CheckCaptures extends Recheck, SymTransformer:
      *  block containing the anonymous function and the Closure node.
      */
     override def recheckClosure(tree: Closure, pt: Type, forceDependent: Boolean)(using Context): Type =
-      val cs = tree.meth.symbol.useSet
+      val cs = tree.meth.symbol.useSet ++ tree.meth.symbol.info.impliedLambdaCaptures
       capt.println(i"typing closure $tree with cvs $cs")
       super.recheckClosure(tree, pt, forceDependent).capturing(cs)
         .showing(i"rechecked closure $tree / $pt = $result", capt)
@@ -1468,7 +1468,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           then
             todoAtPostCheck += { () =>
               val cls = sym.owner.asClass
-              val fieldClassifiers = sym.classifiersOfLocalCapsInType
+              val fieldClassifiers = sym.classifiersOfLocalCapsInInfo
               val classCapset = cls.creationCapset()
               if !covers(classCapset, fieldClassifiers) then
                 report.error(

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -721,7 +721,7 @@ class CheckCaptures extends Recheck, SymTransformer:
     def mapResultRoots(tp: Type, tree: Tree)(using Context): Type =
       tp.widenSingleton match
         case tp: ExprType if tree.symbol.is(Method) =>
-          resultToAny(tp, Origin.ResultInstance(tp, tree))
+          resultToAny(tp, Origin.ResultInstance(_, tp, tree))
         case _ =>
           tp
 
@@ -956,7 +956,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           argTypes1
         else argTypes
       val resultType = super.recheckApplication(tree, qualType, funType, instArgs)
-      val appType = resultToAny(resultType, Origin.ResultInstance(funType, tree))
+      val appType = resultToAny(resultType, Origin.ResultInstance(_, funType, tree))
       val qualCaptures = qualType.captureSet
       val argCaptures =
         for (argType, formal) <- argTypes.lazyZip(funType.paramInfos) yield
@@ -1094,7 +1094,7 @@ class CheckCaptures extends Recheck, SymTransformer:
       markFreeTypeArgs(tree.fun, meth, tree.args)
 
       val funType = super.recheckTypeApply(tree, pt)
-      val res = resultToAny(funType, Origin.ResultInstance(funType, tree))
+      val res = resultToAny(funType, Origin.ResultInstance(_, funType, tree))
       includeCallCaptures(tree.symbol, res, tree)
       checkContains(tree)
       res

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1818,6 +1818,12 @@ class CheckCaptures extends Recheck, SymTransformer:
       def tryCurrentType: Boolean =
         isCompatible(actualBoxed, expected1)
 
+      def tryAltType(actual1: Type) =
+        actual1.exists && {
+          val actualBoxed1 = adapt(actual1, expected1, tree)
+          isCompatible(actualBoxed1, expected1)
+        }
+
       /** When the actual type is a named type, and the previous attempt failed, try to widen the named type
        * and try another time.
        *
@@ -1831,13 +1837,47 @@ class CheckCaptures extends Recheck, SymTransformer:
        * In those cases, we widen such types and try box adaptation another time.
        */
       def tryWidenNamed: Boolean =
-        val actual1 = findImpureUpperBound(actual)
-        actual1.exists && {
-          val actualBoxed1 = adapt(actual1, expected1, tree)
-          isCompatible(actualBoxed1, expected1)
-        }
+        tryAltType(findImpureUpperBound(actual))
 
-      TypeComparer.compareResult(tryCurrentType || tryWidenNamed) match
+      def nestedLambdas(mdef: DefDef): List[Symbol] =
+        mdef.symbol :: mdef.rhs.match
+          case closureDef(mdef1) => nestedLambdas(mdef1)
+          case _ => Nil
+
+      /** Try to convert ResultCaps that are classified as Unscoped
+       *  back to local caps, if they were generated as parts of the types
+       *  of closures. I.e. a closure such as
+       *
+       *      () => Ref()
+       *
+       *  is initially given type `() -> Ref^{fresh}`. This means it could not
+       *  be passed to a method `withFile` declared as `withFile[T](op: File^ => T)`.
+       *  By adapting its type to `() => Ref^` we make it fit. Test cases are in
+       *  ref-with-file.scala and lambda-fresh.scala.
+       */
+      def tryExistentialWiden(notes: List[Note]): Boolean = tree match
+        case closureDef(mdef) =>
+          val mappable =
+            for
+              case IncludeFailure(cs, rc: ResultCap, true) <- notes
+              if rc.classifier.derivesFrom(defn.Caps_Unscoped)
+                && nestedLambdas(mdef).contains(rc.primaryResultCap.origin.ccOwner.enclosingMethod)
+            yield rc
+          !mappable.isEmpty
+          && tryAltType:
+            RetractResult(SimpleIdentitySet(mappable*))(actual)
+              .showing(i"try existential widen $actual to $result", capt)
+        case _ => false
+
+      def recoverWithExistentialWiden(cmp: TypeComparer.CompareResult): TypeComparer.CompareResult =
+        cmp match
+        case TypeComparer.CompareResult.Fail(cmpNotes) =>
+          TypeComparer.compareResult(tryExistentialWiden(cmpNotes)) match
+            case TypeComparer.CompareResult.Fail(_) => cmp
+            case cmp1 => cmp1
+        case _ => cmp
+
+      recoverWithExistentialWiden(TypeComparer.compareResult(tryCurrentType || tryWidenNamed)) match
         case TypeComparer.CompareResult.Fail(cmpNotes) =>
           capt.println(i"conforms failed for ${tree}: $actual vs $expected")
           if falseDeps then expected1 = unalignFunction(expected1)

--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -863,20 +863,23 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
           case _ =>
 
     /** If `tpe` appears as a (result-) type of a definition, treat its
-     *  hidden set minus its explicitly declared footprint as consumed.
-     *  If `tpe` appears as an argument to a consume parameter, treat
+     *  hidden set of locally owned LocalCaps minus its explicitly declared footprint
+     *  as consumed. If `tpe` appears as an argument to a consume parameter, treat
      *  its footprint as consumed.
      */
     def checkLegalRefs() = role match
       case TypeRole.Result(sym, _) =>
-        if !sym.isAnonymousFunction // we don't check return types of anonymous functions
-            && !sym.is(Case)        // We don't check so far binders in patterns since they
-                                    // have inferred universal types. TODO come back to this;
-                                    // either infer more precise types for such binders or
-                                    // "see through them" when we look at hidden sets.
+        if !sym.is(Case)  // We don't check so far binders in patterns since they
+                          // have inferred universal types. TODO come back to this;
+                          // either infer more precise types for such binders or
+                          // "see through them" when we look at hidden sets.
         then
-          val refs = tpe.deepCaptureSet.elems
-          val refsStar = refs.transHiddenSet
+          var refs = tpe.deepCaptureSet.elems
+          val refsCaps = refs.filter: elem =>
+            elem.core match
+              case core: LocalCap => core.ccOwner.isContainedIn(sym)
+              case _ => false
+          val refsStar = refsCaps.transHiddenSet
           val toCheck = refsStar.directFootprint.nonPeaks.deduct(refs.directFootprint.nonPeaks)
           def descr = i"${role.description} $tpe hides"
           checkConsumedRefs(toCheck, tpe, role, descr, pos)
@@ -1015,8 +1018,8 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
        && !isUnsafeAssumeSeparate(tree.rhs)
        && !isCoverageLiftedTemp(tree)
     then
+      capt.println(i"sep check def $sym: ${tree.tpt.nuType} with ${spanCaptures(tree.tpt).transHiddenSet.directFootprint}")
       checkType(tree.tpt, sym)
-      capt.println(i"sep check def $sym: ${tree.tpt} with ${spanCaptures(tree.tpt).transHiddenSet.directFootprint}")
       pushDef(tree, spanCaptures(tree.tpt).transHiddenSet.deductSymRefs(sym))
 
   def inSection[T](op: => T)(using Context): T =

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -202,7 +202,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
                   AnnotatedType(sym.info, RetainingAnnotation.fromAnnotation(ann))
                 case None => sym.info
             else sym.info
-          toResultInReturnType(sym, msg => throw TypeError(msg)):
+          toResultInReturnType(sym):
             transformExplicitType(oldInfo, sym)(using symCtx)
       if Synthetics.needsTransform(symd) then
         Synthetics.transform(symd, mappedInfo)
@@ -231,7 +231,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
   /** Apply toResult to the return types of def methods, so that local `any` capabilties
    *  are mapped to `fresh` in the return type of the resulting methodic types.
    */
-  def toResultInReturnType(sym: Symbol, fail: Message => Unit)(tp: Type)(using Context): Type =
+  def toResultInReturnType(sym: Symbol)(tp: Type)(using Context): Type =
     val needsConversion =
       sym.is(Method, butNot = Accessor)
       && !sym.name.is(DefaultGetterName)
@@ -240,12 +240,12 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       tp match
       case tp: ExprType =>
         // Map the result of parameterless `def` methods.
-        tp.derivedExprType(toResult(tp.resType, tp, sym, fail))
+        tp.derivedExprType(toResult(tp.resType, tp, sym))
       case tp: MethodOrPoly =>
         tp.derivedLambdaType(resType =
           if tp.marksExistentialScope
-          then toResult(tp.resType, tp, sym, fail)
-          else toResultInReturnType(sym, fail)(tp.resType))
+          then toResult(tp.resType, tp, sym)
+          else toResultInReturnType(sym)(tp.resType))
       case _ => tp
     else tp
 
@@ -773,7 +773,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
               val paramSymss = sym.paramSymss
               def newInfo(using Context) = // will be run in this or next phase
                 if sym.is(Method) then
-                  toResultInReturnType(sym, report.error(_, tree.srcPos)):
+                  toResultInReturnType(sym):
                     inContext(ctx.withOwner(sym)):
                       paramsToCap(paramSymss, methodType(paramSymss, localReturnType))
                 else tree.tpt.nuType

--- a/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
+++ b/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
@@ -54,7 +54,7 @@ object ccConfig:
 
   /** Not used currently. Handy for trying out new features */
   def newScheme(using ctx: Context): Boolean =
-    Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.9`)
+    Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.10`)
 
   /** Allow @use annotations */
   def allowUse(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
+++ b/compiler/src/dotty/tools/dotc/cc/ccConfig.scala
@@ -54,7 +54,7 @@ object ccConfig:
 
   /** Not used currently. Handy for trying out new features */
   def newScheme(using ctx: Context): Boolean =
-    Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.10`)
+    Feature.sourceVersion.stable.isAtLeast(SourceVersion.`3.11`)
 
   /** Allow @use annotations */
   def allowUse(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -277,7 +277,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
         val boxText: Text = Str("box ") `provided` tp.isBoxed && ccVerbose
         if elideCapabilityCaps
             && parent.derivesFromCapability
-            && refs.containsTerminalCapability
+            && refs.containsGlobalOrLocalCap
             && (!parent.derivesFromStateful || refs.isReadOnly)
         then toText(parent)
         else toTextCapturing(parent, refs, boxText)

--- a/docs/_docs/reference/experimental/capture-checking/basics.md
+++ b/docs/_docs/reference/experimental/capture-checking/basics.md
@@ -85,7 +85,7 @@ trait LzyList[+A]:
 object LzyList:
   def apply[T](xs: T*): LzyList[T] = ???
 //}
-val xs = usingLogFile { f => // error // error
+val xs = usingLogFile { f => // error
   LzyList(1, 2, 3).map { x => f.write(x); x * x }
 }
 ```

--- a/docs/_docs/reference/experimental/capture-checking/scoped-capabilities.md
+++ b/docs/_docs/reference/experimental/capture-checking/scoped-capabilities.md
@@ -388,9 +388,9 @@ absorb capabilities that would allow scoped resources to escape. Consider trying
 directly returning a closure that captures it:
 
 ```scala sc:fail sc-compile-with:scoped-withfile-context
-withFile[() => File^]("test.txt"): f =>
+withFile[() => File^]("test.txt"): f => // error
 //       ^^^^^^^^^^^ T = () => File^, i.e., () ->{any} File^{any} for some outer any
-  () => f  // error // error // error: We want to return this as () => File^
+  () => f  // error: We want to return this as () => File^
 ```
 
 The lambda `(f: File^) => () => f` has inferred type:
@@ -414,7 +414,7 @@ into this outer `any`, so the assignment fails.
 Otherwise, allowing widening `∃fresh. () ->{fresh} File^{fresh}` to `() => File^` would let the scoped file escape:
 
 ```scala sc:fail sc-compile-with:scoped-withfile-context
-val escaped: () => File^ = withFile[() => File^]("test.txt")(f => () => f) // error // error
+val escaped: () => File^ = withFile[() => File^]("test.txt")(f => () => f) // error
 //           ^^^^^^^^^^^ any here is in the outer scope
 escaped().read()  // Use-after-close!
 ```

--- a/library/src/scala/collection/immutable/LazyListIterable.scala
+++ b/library/src/scala/collection/immutable/LazyListIterable.scala
@@ -480,7 +480,7 @@ final class LazyListIterable[+A] private (lazyState: LazyListIterable.EmptyMarke
         case coll                        => eagerHeadFromIterator(coll.iterator)
       }
       else eagerCons(head, tail lazyAppendedAll suffix)
-    }
+    }.asInstanceOf // CC cannot figure out correct type
 
   /** @inheritdoc
    *
@@ -1289,7 +1289,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
         iRef    = i                      // iRef.elem    = i
       }
       rest
-    }
+    }.asInstanceOf // CC cannot figure out correct type
   }
 
   private def dropWhileImpl[A](ll: LazyListIterable[A]^, p: A => Boolean): LazyListIterable[A]^{ll, p} = {
@@ -1302,7 +1302,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
         restRef = rest                          // restRef.elem = rest
       }
       rest
-    }
+    }.asInstanceOf // CC cannot figure out correct type
   }
 
   private def takeRightImpl[A](ll: LazyListIterable[A]^, n: Int): LazyListIterable[A]^{ll} = {
@@ -1330,7 +1330,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
       }
       // `rest` is the last `n` elements (or all of them)
       rest
-    }
+    }.asInstanceOf // CC cannot figure out correct type
   }
 
   /** An alternative way of building and matching lazy lists using LazyListIterable.cons(hd, tl). */
@@ -1474,7 +1474,7 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
         case Some((elem, state)) => eagerCons(elem, unfold(state)(f))
         case None                => Empty
       }
-    }
+    }.asInstanceOf // CC cannot figure out correct type
 
   /** Unlike LazyList, the builder returned by this method will eagerly evaluate all elements
    *  passed to it in `addAll`.
@@ -1483,7 +1483,8 @@ object LazyListIterable extends IterableFactory[LazyListIterable] {
    *  @tparam A the type of the ${coll}’s elements
    *  @return A builder for $Coll objects.
    */
-  def newBuilder[A]: Builder[A, LazyListIterable[A]] = (new collection.mutable.ListBuffer[A]).mapResult(from)
+  def newBuilder[A]: Builder[A, LazyListIterable[A]] =
+    (new collection.mutable.ListBuffer[A]).mapResult(from).asInstanceOf // CC cannot figure out correct type
 
   private class LazyIterator[+A](private var lazyList: LazyListIterable[A]^) extends AbstractIterator[A] {
     override def hasNext: Boolean = !lazyList.isEmpty

--- a/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetExpectations.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/snippets/SnippetExpectations.scala
@@ -9,7 +9,8 @@ import scala.collection.mutable.ListBuffer
 
 object SnippetExpectations:
   // Mirrors the compiler test suite (ParallelTesting.scala): space after `//` is optional.
-  // Only `// error` and `// warn` are supported; `// anypos-*` is rejected.
+  // A line marked `// error` / `// warn` must produce at least one such diagnostic;
+  // the exact count is not checked. `// anypos-*` is rejected.
   private val annotation =
     raw"""// *(anypos-)?(error|warn)\b""".r
 
@@ -39,11 +40,6 @@ object SnippetExpectations:
 
     def description: String =
       s"${level.text.toLowerCase} on line ${sourceLine.fold(relativeLine + 1)(_ + 1)}"
-
-    // Matching is line-based only; column position is not checked.
-    // Diagnostic message content is intentionally ignored.
-    def matches(observed: ObservedDiagnostic): Boolean =
-      observed.message.level == level && sourceLine == observed.sourceLine
 
   case class Parsed(
     expectations: Seq[ExpectedDiagnostic],
@@ -77,27 +73,30 @@ object SnippetExpectations:
         summary +: observed.map(o =>
           SnippetCompilerMessage(o.message.position, s"Unexpected ${describeObserved(o)}", MessageLevel.Error))
     else
-      val matched = Array.fill(observed.size)(false)
+      // Line-based: a line marked `// error` / `// warn` must carry at least one
+      // such diagnostic, and lines without a marker must carry none. Counts are
+      // not checked (one marker covers a line that produces several), and matching
+      // is by line only -- columns and message text are ignored.
       val errors = ListBuffer.empty[SnippetCompilerMessage]
+      val expectedLines = expectations.map(_.sourceLine).toSet
+      val observedLines = observed.map(_.sourceLine).toSet
 
-      for expectation <- expectations.sortBy(_.relativeLine) do
-        observed.indices.find(i => !matched(i) && expectation.matches(observed(i))) match
-          case Some(i) => matched(i) = true
-          case None =>
-            errors += SnippetCompilerMessage(
-              expectation.position(sourceFile), s"Unfulfilled expectation: ${expectation.description}", MessageLevel.Error)
+      for expectation <- expectations.distinctBy(_.sourceLine).sortBy(_.relativeLine) do
+        if !observedLines.contains(expectation.sourceLine) then
+          errors += SnippetCompilerMessage(
+            expectation.position(sourceFile), s"Unfulfilled expectation: ${expectation.description}", MessageLevel.Error)
 
-      for i <- observed.indices if !matched(i) do
+      for o <- observed if !expectedLines.contains(o.sourceLine) do
         errors += SnippetCompilerMessage(
-          observed(i).message.position, s"Unexpected ${describeObserved(observed(i))}", MessageLevel.Error)
+          o.message.position, s"Unexpected ${describeObserved(o)}", MessageLevel.Error)
 
       if errors.isEmpty then Nil
       else
         val summary =
-          if expectations.size != observed.size then
-            s"Wrong number of ${levelName}s encountered when compiling snippet\nexpected: ${expectations.size}, actual: ${observed.size}"
-          else
+          if observed.exists(o => !expectedLines.contains(o.sourceLine)) then
             s"${level.text}s found on incorrect row numbers when compiling snippet"
+          else
+            s"Expected ${levelName}s not found when compiling snippet"
         SnippetCompilerMessage(None, summary, MessageLevel.Error) +: errors.toSeq
 
   private def describeObserved(o: ObservedDiagnostic): String =

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
@@ -255,14 +255,8 @@ class SnippetCompilerTest {
   @Test
   def multilineInlineExpectationsAreChecked: Unit = {
     val snippet =
-      """|import language.experimental.captureChecking
-         |import caps.*
-         |
-         |trait File extends SharedCapability
-         |def withFile[T](path: String)(block: File^ => T): T = ???
-         |
-         |withFile[() => File^]("test.txt"): f =>
-         |  () => f  // error // error // error
+      """|def f(a: Int, b: Int, c: Int): Int = a + b + c
+         |f(undefinedA, undefinedB, undefinedC) // error // error // error
          |""".stripMargin
 
     assertSuccessfulCompilation(runTest(snippet, SnippetCompilerArg(SCFlags.Fail, verifyDiagnostics = true)))

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetCompilerTest.scala
@@ -182,7 +182,7 @@ class SnippetCompilerTest {
   }
 
   @Test
-  def inlineExpectationCountMismatchesUseNegTestWording: Unit = {
+  def inlineExpectationUnfulfilledWhenAnnotatedLineHasNoError: Unit = {
     val snippet =
       """|val x = 1.missing // error
          |val y = 1 + 1 // error
@@ -191,8 +191,7 @@ class SnippetCompilerTest {
     val result = runTest(snippet, SnippetCompilerArg(SCFlags.Compile, verifyDiagnostics = true))
     assertFailedCompilation(result)
     assertEquals(2, result.messages.count(_.level == MessageLevel.Error))
-    assertTrue(result.messages.exists(_.message.contains("Wrong number of errors encountered when compiling snippet")))
-    assertTrue(result.messages.exists(_.message.contains("expected: 2, actual: 1")))
+    assertTrue(result.messages.exists(_.message.contains("Expected errors not found when compiling snippet")))
     assertTrue(result.messages.exists(_.message.contains("Unfulfilled expectation: error on line 2")))
   }
 
@@ -253,10 +252,10 @@ class SnippetCompilerTest {
   }
 
   @Test
-  def multilineInlineExpectationsAreChecked: Unit = {
+  def inlineErrorAnnotationMatchesMultipleErrorsOnLine: Unit = {
     val snippet =
       """|def f(a: Int, b: Int, c: Int): Int = a + b + c
-         |f(undefinedA, undefinedB, undefinedC) // error // error // error
+         |f(undefinedA, undefinedB, undefinedC) // error
          |""".stripMargin
 
     assertSuccessfulCompilation(runTest(snippet, SnippetCompilerArg(SCFlags.Fail, verifyDiagnostics = true)))

--- a/tests/neg-custom-args/captures/eta.check
+++ b/tests/neg-custom-args/captures/eta.check
@@ -10,9 +10,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/eta.scala:6:14 -------------------------------------------
 6 |         bar( () => f )  // error, was ok before
   |              ^^^^^^^
-  |              Found:    () ->{f} () ->{f} Unit
+  |              Found:    () ->{f} () => Unit
   |              Required: () -> () ->'s1 Unit
   |
   |              Note that capability `f` cannot flow into capture set {}.
+  |
+  |              where:    => refers to a root capability in the type of parameter f
   |
   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lambda-fresh-2.check
+++ b/tests/neg-custom-args/captures/lambda-fresh-2.check
@@ -1,16 +1,17 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:20:29 -------------------------------
 20 |  val a: () => Ref^{fresh} = () => f1  // error
    |                             ^^^^^^^^
-   |Found:    () ->{f1.rd} Ref^{any}
+   |Found:    () ->{f1.rd, any} Ref^{any²}
    |Required: () => Ref^{fresh}
    |
-   |Note that capability `any` cannot flow into capture set {fresh²}
-   |because `fresh²`, which is existentially bound in Ref^{fresh³}, cannot subsume `any`.
+   |Note that capability `any²` cannot flow into capture set {fresh²}
+   |because `fresh²`, which is existentially bound in Ref^{fresh³}, cannot subsume `any²`.
    |
    |where:    =>     refers to a root capability in the type of value a
-   |          any    is a root capability classified as Unscoped created in anonymous function of type (): Ref^{any} when instantiating expected result type Ref^{fresh} of function literal
+   |          any    is a root capability classified as Unscoped created in value a when constructing instance (): Ref^{any²}
+   |          any²   is a root capability classified as Unscoped created in anonymous function of type (): Ref^{any²} when instantiating expected result type Ref^{fresh} of function literal
    |          fresh  is a root capability associated with the result type of (): Ref^{fresh}
-   |          fresh² is a root capability associated with the result type of (): Ref^{any}
+   |          fresh² is a root capability associated with the result type of (): Ref^{any²}
    |          fresh³ is the root capability caps.fresh
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lambda-fresh-2.check
+++ b/tests/neg-custom-args/captures/lambda-fresh-2.check
@@ -1,20 +1,3 @@
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:20:29 -------------------------------
-20 |  val a: () => Ref^{fresh} = () => f1  // error
-   |                             ^^^^^^^^
-   |Found:    () ->{f1.rd, any} Ref^{any²}
-   |Required: () => Ref^{fresh}
-   |
-   |Note that capability `any²` cannot flow into capture set {fresh²}
-   |because `fresh²`, which is existentially bound in Ref^{fresh³}, cannot subsume `any²`.
-   |
-   |where:    =>     refers to a root capability in the type of value a
-   |          any    is a root capability classified as Unscoped created in value a when constructing instance (): Ref^{any²}
-   |          any²   is a root capability classified as Unscoped created in anonymous function of type (): Ref^{any²} when instantiating expected result type Ref^{fresh} of function literal
-   |          fresh  is a root capability associated with the result type of (): Ref^{fresh}
-   |          fresh² is a root capability associated with the result type of (): Ref^{any²}
-   |          fresh³ is the root capability caps.fresh
-   |
-   | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:12:36 ----------------------------------------------------
 12 |  val a: () => File^{fresh} = () => f1  // error
    |                                    ^
@@ -23,6 +6,10 @@
 14 |  def g(): File^ = f3  // error
    |           ^^^^^
    |           Separation failure: method g's result type File^ hides non-local value f3
+-- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:20:35 ----------------------------------------------------
+20 |  val a: () => Ref^{fresh} = () => f1  // error
+   |                                   ^
+   |Separation failure: anonymous function of type (): Ref^{fresh}'s inferred result type Ref^ hides non-local value f1
 -- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:22:11 ----------------------------------------------------
 22 |  def g(): Ref^ = f3  // error
    |           ^^^^

--- a/tests/neg-custom-args/captures/lambda-fresh-2.check
+++ b/tests/neg-custom-args/captures/lambda-fresh-2.check
@@ -1,0 +1,36 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:20:29 -------------------------------
+20 |  val a: () => Ref^{fresh} = () => f1  // error
+   |                             ^^^^^^^^
+   |Found:    () ->{f1.rd} Ref^{any}
+   |Required: () => Ref^{fresh}
+   |
+   |Note that capability `any` cannot flow into capture set {fresh²}
+   |because `fresh²`, which is existentially bound in Ref^{fresh³}, cannot subsume `any`.
+   |
+   |where:    =>     refers to a root capability in the type of value a
+   |          any    is a root capability classified as Unscoped created in anonymous function of type (): Ref^{any} when instantiating expected result type Ref^{fresh} of function literal
+   |          fresh  is a root capability associated with the result type of (): Ref^{fresh}
+   |          fresh² is a root capability associated with the result type of (): Ref^{any}
+   |          fresh³ is the root capability caps.fresh
+   |
+   | longer explanation available when compiling with `-explain`
+-- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:12:36 ----------------------------------------------------
+12 |  val a: () => File^{fresh} = () => f1  // error
+   |                                    ^
+   |Separation failure: anonymous function of type (): File^{fresh}'s inferred result type File^ hides non-local value f1
+-- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:14:11 ----------------------------------------------------
+14 |  def g(): File^ = f3  // error
+   |           ^^^^^
+   |           Separation failure: method g's result type File^ hides non-local value f3
+-- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:22:11 ----------------------------------------------------
+22 |  def g(): Ref^ = f3  // error
+   |           ^^^^
+   |           Separation failure: method g's result type Ref^ hides non-local value f3
+-- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:28:35 ----------------------------------------------------
+28 |  val a: () => One^{fresh} = () => f1  // error
+   |                                   ^
+   |Separation failure: anonymous function of type (): One^{fresh}'s inferred result type One^ hides non-local value f1
+-- Error: tests/neg-custom-args/captures/lambda-fresh-2.scala:30:11 ----------------------------------------------------
+30 |  def g(): One^ = f3  // error
+   |           ^^^^
+   |           Separation failure: method g's result type One^ hides non-local value f3

--- a/tests/neg-custom-args/captures/lambda-fresh-2.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh-2.scala
@@ -1,0 +1,38 @@
+import caps.*
+
+class Ref extends Mutable
+class One extends ExclusiveCapability
+class Sha extends SharedCapability
+class File
+
+def test() =
+  val f1: File^ = File()
+  val f2: File^ = File()
+  val f3: File^ = File()
+  val a: () => File^{fresh} = () => f1  // error
+  val b: () => File^ = () => f2  // ok
+  def g(): File^ = f3  // error
+
+def test1() =
+  val f1 = Ref()
+  val f2 = Ref()
+  val f3 = Ref()
+  val a: () => Ref^{fresh} = () => f1  // error
+  val b: () => Ref^ = () => f2  // ok
+  def g(): Ref^ = f3  // error
+
+def test2() =
+  val f1 = One()
+  val f2 = One()
+  val f3 = One()
+  val a: () => One^{fresh} = () => f1  // error
+  val b: () => One^ = () => f2  // ok
+  def g(): One^ = f3  // error
+
+def test3() =
+  val f1 = Sha()
+  val f2 = Sha()
+  val f3 = Sha()
+  val a: () => Sha^{fresh} = () => f1  // ok, SharedCapabilities are excluded from frhsness checking
+  val b: () => Sha^ = () => f2  // ok
+  def g(): Sha^ = f3  // ok, SharedCapabilities are excluded from frhsness checking

--- a/tests/neg-custom-args/captures/lambda-fresh-3.check
+++ b/tests/neg-custom-args/captures/lambda-fresh-3.check
@@ -1,5 +1,5 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:9:22 --------------------------------
-9 |  val _: () -> Ref^ = () => Ref() // error
+9 |  val _: () -> Ref^ = () => Ref() // error, monotonicity violation
   |                      ^^^^^^^^^^^
   |                      Found:    () ->'s1 Ref^{fresh}
   |                      Required: () -> Ref^{any}
@@ -11,30 +11,45 @@
   |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
   |
   | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:14:22 -------------------------------
-14 |  val _: () -> Ref^ = f1 // error
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:11:28 -------------------------------
+11 |  val _: () -> () => Ref^ = () => () => Ref() // error, monotonicity violation
+   |                            ^^^^^^^^^^^^^^^^^
+   |Found:    () ->'s2 () ->{fresh} Ref^
+   |Required: () -> () ->{any} Ref^²
+   |
+   |Note that capability `fresh` cannot flow into capture set {any}
+   |because fresh is not visible from any in value _$3.
+   |
+   |where:    ^     refers to a root capability classified as Unscoped created in anonymous function of type (): Ref^{fresh²} when constructing instance Ref
+   |          ^²    refers to a root capability classified as Unscoped in the type of value _$3
+   |          any   is a root capability in the type of value _$3
+   |          fresh is a root capability associated with the result type of (): () ->{fresh} Ref^
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:16:22 -------------------------------
+16 |  val _: () -> Ref^ = f1 // error
    |                      ^^
    |                      Found:    (f1 : () -> Ref^{fresh})
    |                      Required: () -> Ref^{any}
    |
    |                      Note that capability `fresh` cannot flow into capture set {any}
-   |                      because fresh is not visible from any in value _$3.
+   |                      because fresh is not visible from any in value _$5.
    |
-   |                      where:    any   is a root capability classified as Unscoped in the type of value _$3
+   |                      where:    any   is a root capability classified as Unscoped in the type of value _$5
    |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:15:22 -------------------------------
-15 |  val _: () => Ref^ = f1 // error
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:17:22 -------------------------------
+17 |  val _: () => Ref^ = f1 // error
    |                      ^^
    |                      Found:    (f1 : () -> Ref^{fresh})
    |                      Required: () => Ref^{any}
    |
    |                      Note that capability `fresh` cannot flow into capture set {any}
-   |                      because fresh is not visible from any in value _$4.
+   |                      because fresh is not visible from any in value _$6.
    |
-   |                      where:    =>    refers to a root capability in the type of value _$4
-   |                                any   is a root capability classified as Unscoped in the type of value _$4
+   |                      where:    =>    refers to a root capability in the type of value _$6
+   |                                any   is a root capability classified as Unscoped in the type of value _$6
    |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lambda-fresh-3.check
+++ b/tests/neg-custom-args/captures/lambda-fresh-3.check
@@ -1,0 +1,40 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:9:22 --------------------------------
+9 |  val _: () -> Ref^ = () => Ref() // error
+  |                      ^^^^^^^^^^^
+  |                      Found:    () ->'s1 Ref^{fresh}
+  |                      Required: () -> Ref^{any}
+  |
+  |                      Note that capability `fresh` cannot flow into capture set {any}
+  |                      because fresh is not visible from any in value _$1.
+  |
+  |                      where:    any   is a root capability classified as Unscoped in the type of value _$1
+  |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
+  |
+  | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:14:22 -------------------------------
+14 |  val _: () -> Ref^ = f1 // error
+   |                      ^^
+   |                      Found:    (f1 : () -> Ref^{fresh})
+   |                      Required: () -> Ref^{any}
+   |
+   |                      Note that capability `fresh` cannot flow into capture set {any}
+   |                      because fresh is not visible from any in value _$3.
+   |
+   |                      where:    any   is a root capability classified as Unscoped in the type of value _$3
+   |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh-3.scala:15:22 -------------------------------
+15 |  val _: () => Ref^ = f1 // error
+   |                      ^^
+   |                      Found:    (f1 : () -> Ref^{fresh})
+   |                      Required: () => Ref^{any}
+   |
+   |                      Note that capability `fresh` cannot flow into capture set {any}
+   |                      because fresh is not visible from any in value _$4.
+   |
+   |                      where:    =>    refers to a root capability in the type of value _$4
+   |                                any   is a root capability classified as Unscoped in the type of value _$4
+   |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lambda-fresh-3.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh-3.scala
@@ -6,7 +6,7 @@ class File
 
 def test() =
 
-  val _: () -> Ref^ = () => Ref() // ok
+  val _: () -> Ref^ = () => Ref() // error
   val _: () => Ref^ = () => Ref() // ok
 
   val f1 = () => Ref()

--- a/tests/neg-custom-args/captures/lambda-fresh-3.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh-3.scala
@@ -6,8 +6,10 @@ class File
 
 def test() =
 
-  val _: () -> Ref^ = () => Ref() // error
+  val _: () -> Ref^ = () => Ref() // error, monotonicity violation
   val _: () => Ref^ = () => Ref() // ok
+  val _: () -> () => Ref^ = () => () => Ref() // error, monotonicity violation
+  val _: () => () => Ref^ = () => () => Ref() // ok
 
   val f1 = () => Ref()
 

--- a/tests/neg-custom-args/captures/lambda-fresh-3.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh-3.scala
@@ -1,0 +1,15 @@
+import caps.*
+
+class Ref extends Mutable
+class One extends ExclusiveCapability
+class File
+
+def test() =
+
+  val _: () -> Ref^ = () => Ref() // ok
+  val _: () => Ref^ = () => Ref() // ok
+
+  val f1 = () => Ref()
+
+  val _: () -> Ref^ = f1 // error
+  val _: () => Ref^ = f1 // error

--- a/tests/neg-custom-args/captures/lambda-fresh.check
+++ b/tests/neg-custom-args/captures/lambda-fresh.check
@@ -1,0 +1,108 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:10:22 ---------------------------------
+10 |  val _: () -> Ref^ = f1 // error
+   |                      ^^
+   |                      Found:    (f1 : () -> Ref^{fresh})
+   |                      Required: () -> Ref^{any}
+   |
+   |                      Note that capability `fresh` cannot flow into capture set {any}
+   |                      because fresh is not visible from any in value _$1.
+   |
+   |                      where:    any   is a root capability classified as Unscoped in the type of value _$1
+   |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:11:22 ---------------------------------
+11 |  val _: () => Ref^ = f1 // error
+   |                      ^^
+   |                      Found:    (f1 : () -> Ref^{fresh})
+   |                      Required: () => Ref^{any}
+   |
+   |                      Note that capability `fresh` cannot flow into capture set {any}
+   |                      because fresh is not visible from any in value _$2.
+   |
+   |                      where:    =>    refers to a root capability in the type of value _$2
+   |                                any   is a root capability classified as Unscoped in the type of value _$2
+   |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:12:22 ---------------------------------
+12 |  val _: () -> Ref^ = () => Ref() // error, because any propagates to function
+   |                      ^^^^^^^^^^^
+   |                      Found:    () ->'s1 Ref^{fresh}
+   |                      Required: () -> Ref^{any}
+   |
+   |                      Note that capability `fresh` cannot flow into capture set {any}
+   |                      because fresh is not visible from any in value _$3.
+   |
+   |                      where:    any   is a root capability classified as Unscoped in the type of value _$3
+   |                                fresh is a root capability associated with the result type of (): Ref^{fresh}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:22:23 ---------------------------------
+22 |  val _ = withPureFile(f => () => Ref()) // error, because any propagates to function
+   |                       ^^^^^^^^^^^^^^^^
+   |          Capability `fresh` outlives its scope: it leaks into outer capture set 's2 which is owned by value x3.
+   |          The leakage occurred when trying to match the following types:
+   |
+   |          Found:    (f: File^) ->'s3 () ->'s4 Ref^{fresh²}
+   |          Required: File^ -> () ->'s5 Ref^'s2
+   |
+   |          where:    ^      refers to the root capability caps.any
+   |                    fresh  is a root capability associated with the result type of (): Ref^'s2
+   |                    fresh² is a root capability associated with the result type of (): Ref^{fresh²}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:23:23 ---------------------------------
+23 |  val _ = withPureFile(f => Ref())  // error, because any propagates to function
+   |                       ^^^^^^^^^^
+   |          Capability `fresh` outlives its scope: it leaks into outer capture set 's6 which is owned by value x4.
+   |          The leakage occurred when trying to match the following types:
+   |
+   |          Found:    (f: File^) ->'s7 Ref^{fresh²}
+   |          Required: File^ -> Ref^'s6
+   |
+   |          where:    ^      refers to the root capability caps.any
+   |                    fresh  is a root capability associated with the result type of (f: File^): Ref^'s6
+   |                    fresh² is a root capability associated with the result type of (f: File^): Ref^{fresh²}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:29:22 ---------------------------------
+29 |  val _: () -> One^ = f2 // error, need fresh
+   |                      ^^
+   |                      Found:    (f2 : () -> One^{fresh})
+   |                      Required: () -> One^{any}
+   |
+   |                      Note that capability `fresh` cannot flow into capture set {any}
+   |                      because fresh is not visible from any in value _$8.
+   |
+   |                      where:    any   is a root capability in the type of value _$8
+   |                                fresh is a root capability associated with the result type of (): One^{fresh}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:30:22 ---------------------------------
+30 |  val _: () => One^ = f2 // error, need fresh
+   |                      ^^
+   |                      Found:    (f2 : () -> One^{fresh})
+   |                      Required: () => One^{any}
+   |
+   |                      Note that capability `fresh` cannot flow into capture set {any}
+   |                      because fresh is not visible from any in value _$9.
+   |
+   |                      where:    =>    refers to a root capability in the type of value _$9
+   |                                any   is a root capability in the type of value _$9
+   |                                fresh is a root capability associated with the result type of (): One^{fresh}
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lambda-fresh.scala:31:31 ---------------------------------
+31 |  val _: () => One^ = () => One() // error, need fresh
+   |                            ^^^^^
+   |Found:    One^{any}
+   |Required: One^{any²}
+   |
+   |Note that capability `any` cannot flow into capture set {any²}
+   |because any in an enclosing function is not visible from any² in value _$10.
+   |
+   |where:    any  is a root capability created in anonymous function of type (): One^ when constructing instance One
+   |          any² is a root capability in the type of value _$10
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/lambda-fresh.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh.scala
@@ -2,16 +2,23 @@ import caps.*
 
 class Ref extends Mutable
 class One extends ExclusiveCapability
+class File
 
 def test() =
+
   val f1 = () => Ref()
-  val _: () -> Ref^ = f1 // error
+  val _: () -> Ref^ = f1 // ok
   val _: () => Ref^ = f1 // ok
   val _: () => Ref^ = () => Ref() // ok
 
-  val _: () -> Ref^{fresh} = () => Ref() // error, Unscoped are not fresh
-  val _: () => Ref^{fresh} = () => Ref() // error, Unscoped are not fresh
-  val _: () => Ref^{fresh} = f1 // error, Unscoped are not fresh
+  val _: () -> Ref^{fresh} = () => Ref() // ok
+
+  def withFile[T](op: File^ => T): T = ???
+  val _ = withFile(f => () => Ref()) // ok
+  val _ = withFile(f => Ref())  // ok
+
+  val _: () => Ref^{fresh} = () => Ref() // ok
+  val _: () => Ref^{fresh} = f1 // ok
 
   val f2 = () => One()
   val _: () -> One^ = f2 // error, need fresh

--- a/tests/neg-custom-args/captures/lambda-fresh.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh.scala
@@ -9,7 +9,7 @@ def test() =
   val f1 = () => Ref()
   val _: () -> Ref^ = f1 // error
   val _: () => Ref^ = f1 // error
-  val _: () -> Ref^ = () => Ref() // ok, but should be error
+  val _: () -> Ref^ = () => Ref() // error, because any propagates to function
   val _: () => Ref^ = () => Ref() // ok
 
   val _: () -> Ref^{fresh} = () => Ref() // ok
@@ -17,6 +17,10 @@ def test() =
   def withFile[T](op: File^ => T): T = ???
   val _ = withFile(f => () => Ref()) // ok
   val _ = withFile(f => Ref())  // ok
+
+  def withPureFile[T](op: File^ -> T): T = ???
+  val _ = withPureFile(f => () => Ref()) // error, because any propagates to function
+  val _ = withPureFile(f => Ref())  // error, because any propagates to function
 
   val _: () => Ref^{fresh} = () => Ref() // ok
   val _: () => Ref^{fresh} = f1 // ok

--- a/tests/neg-custom-args/captures/lambda-fresh.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh.scala
@@ -7,8 +7,9 @@ class File
 def test() =
 
   val f1 = () => Ref()
-  val _: () -> Ref^ = f1 // ok
-  val _: () => Ref^ = f1 // ok
+  val _: () -> Ref^ = f1 // error
+  val _: () => Ref^ = f1 // error
+  val _: () -> Ref^ = () => Ref() // ok, but should be error
   val _: () => Ref^ = () => Ref() // ok
 
   val _: () -> Ref^{fresh} = () => Ref() // ok

--- a/tests/neg-custom-args/captures/lambda-fresh.scala
+++ b/tests/neg-custom-args/captures/lambda-fresh.scala
@@ -1,0 +1,23 @@
+import caps.*
+
+class Ref extends Mutable
+class One extends ExclusiveCapability
+
+def test() =
+  val f1 = () => Ref()
+  val _: () -> Ref^ = f1 // error
+  val _: () => Ref^ = f1 // ok
+  val _: () => Ref^ = () => Ref() // ok
+
+  val _: () -> Ref^{fresh} = () => Ref() // error, Unscoped are not fresh
+  val _: () => Ref^{fresh} = () => Ref() // error, Unscoped are not fresh
+  val _: () => Ref^{fresh} = f1 // error, Unscoped are not fresh
+
+  val f2 = () => One()
+  val _: () -> One^ = f2 // error, need fresh
+  val _: () => One^ = f2 // error, need fresh
+  val _: () => One^ = () => One() // error, need fresh
+
+  val _: () -> One^{fresh} = () => One() // ok
+  val _: () => One^{fresh} = () => One() // ok
+  val _: () => One^{fresh} = f2 // ok

--- a/tests/neg-custom-args/captures/lazylist-global.check
+++ b/tests/neg-custom-args/captures/lazylist-global.check
@@ -14,10 +14,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist-global.scala:39:29 ------------------------------
 39 |  val ref1c: LazyList[Int] = ref1 // error
    |                             ^^^^
-   |         Found:    lazylists.LazyCons[Int]{val xs: () ->{lazylists.cap1} lazylists.LazyList[Int]^{ref1*}}^{ref1}
-   |         Required: lazylists.LazyList[Int]
+   |Found:    (ref1 : lazylists.LazyCons[Int]{val xs: () ->{lazylists.cap1} lazylists.LazyList[Int]^{}}^{lazylists.cap1})
+   |Required: lazylists.LazyList[Int]
    |
-   |         Note that capability `ref1` cannot flow into capture set {}.
+   |Note that capability `lazylists.cap1` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist-global.scala:41:36 ------------------------------
@@ -41,10 +41,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist-global.scala:45:42 ------------------------------
 45 |  val ref4c: LazyList[Int]^{cap1, ref3} = ref4 // error
    |                                          ^^^^
-   |                      Found:    (ref4 : lazylists.LazyList[Int]^{lazylists.cap3, ref2, ref1})
-   |                      Required: lazylists.LazyList[Int]^{lazylists.cap1, ref3}
+   |                     Found:    (ref4 : lazylists.LazyList[Int]^{lazylists.cap3, lazylists.cap1, lazylists.cap2})
+   |                     Required: lazylists.LazyList[Int]^{lazylists.cap1, ref3}
    |
-   |                      Note that capability `lazylists.cap3` cannot flow into capture set {lazylists.cap1, ref3}.
+   |                     Note that capability `lazylists.cap3` cannot flow into capture set {lazylists.cap1, ref3}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E164] Declaration Error: tests/neg-custom-args/captures/lazylist-global.scala:22:6 ---------------------------------

--- a/tests/neg-custom-args/captures/lazylist.check
+++ b/tests/neg-custom-args/captures/lazylist.check
@@ -10,10 +10,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:35:29 -------------------------------------
 35 |  val ref1c: LazyList[Int] = ref1 // error
    |                             ^^^^
-   |                   Found:    lazylists.LazyCons[Int]{val xs: () ->{cap1} lazylists.LazyList[Int]^{ref1*}}^{ref1}
-   |                   Required: lazylists.LazyList[Int]
+   |               Found:    (ref1 : lazylists.LazyCons[Int]{val xs: () ->{cap1} lazylists.LazyList[Int]^{}}^{cap1})
+   |               Required: lazylists.LazyList[Int]
    |
-   |                   Note that capability `ref1` cannot flow into capture set {}.
+   |               Note that capability `cap1` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:37:36 -------------------------------------
@@ -37,7 +37,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lazylist.scala:41:42 -------------------------------------
 41 |  val ref4c: LazyList[Int]^{cap1, ref3} = ref4 // error
    |                                          ^^^^
-   |                                          Found:    (ref4 : lazylists.LazyList[Int]^{cap3, ref2, ref1})
+   |                                          Found:    (ref4 : lazylists.LazyList[Int]^{cap3, cap1, cap2})
    |                                          Required: lazylists.LazyList[Int]^{cap1, ref3}
    |
    |                                          Note that capability `cap3` cannot flow into capture set {cap1, ref3}.

--- a/tests/neg-custom-args/captures/mutability.check
+++ b/tests/neg-custom-args/captures/mutability.check
@@ -28,8 +28,8 @@
 -- Error: tests/neg-custom-args/captures/mutability.scala:14:12 --------------------------------------------------------
 14 |    self3().set(x)  // error
    |    ^^^^^^^^^^^
-   |    Cannot call update method set of Ref[T^{}]^{Ref.this.rd}
-   |    since its capture set {Ref.this.rd} of value self3 is read-only.
+   |    Cannot call update method set of Ref[T^{}]^{self3}
+   |    since its capture set {self3} is read-only.
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/mutability.scala:15:37 -----------------------------------
 15 |    val self4: () => Ref[T]^ = () => this // error // error separation
    |                                     ^^^^

--- a/tests/neg-custom-args/captures/mutability.check
+++ b/tests/neg-custom-args/captures/mutability.check
@@ -114,6 +114,15 @@
    |               ^^^^^^^^^^^^^
    |               Separation failure: value self4's type () => Ref[T]^ hides non-local this of class class Ref.
    |               The access must be in a consume method to allow this.
+-- Error: tests/neg-custom-args/captures/mutability.scala:18:18 --------------------------------------------------------
+18 |    def self5() = this // error
+   |                  ^^^^
+   |                  Separation failure: Illegal access to {Ref.this} which is hidden by the previous definition
+   |                  of value self4 with type () => Ref[T]^.
+   |                  This type hides capabilities  {Ref.this.rd, Ref.this}
+   |
+   |                  where:    => refers to a root capability in the type of value self4
+   |                            ^  refers to a root capability classified as Unscoped in the type of value self4
 -- Error: tests/neg-custom-args/captures/mutability.scala:20:17 --------------------------------------------------------
 20 |    def self6(): Ref[T]^ = this // error // error separation
    |                 ^^^^^^^

--- a/tests/neg-custom-args/captures/mutability.scala
+++ b/tests/neg-custom-args/captures/mutability.scala
@@ -15,7 +15,7 @@ class Ref[T](init: T) extends caps.Mutable:
     val self4: () => Ref[T]^ = () => this // error // error separation
     self4().set(x) // error
 
-    def self5() = this
+    def self5() = this // error
     self5().set(x)  // error
     def self6(): Ref[T]^ = this // error // error separation
     self6().set(x) // error

--- a/tests/neg-custom-args/captures/mutvars.check
+++ b/tests/neg-custom-args/captures/mutvars.check
@@ -99,6 +99,15 @@
    |               ^^^^^^^^^^^^^
    |               Separation failure: value self4's type () => Ref[T]^ hides non-local this of class class Ref.
    |               The access must be in a consume method to allow this.
+-- Error: tests/neg-custom-args/captures/mutvars.scala:17:18 -----------------------------------------------------------
+17 |    def self5() = this // error
+   |                  ^^^^
+   |                  Separation failure: Illegal access to {Ref.this} which is hidden by the previous definition
+   |                  of value self4 with type () => Ref[T]^.
+   |                  This type hides capabilities  {Ref.this.rd, Ref.this}
+   |
+   |                  where:    => refers to a root capability in the type of value self4
+   |                            ^  refers to a root capability classified as Unscoped in the type of value self4
 -- Error: tests/neg-custom-args/captures/mutvars.scala:19:17 -----------------------------------------------------------
 19 |    def self6(): Ref[T]^ = this // error // error separation
    |                 ^^^^^^^

--- a/tests/neg-custom-args/captures/mutvars.check
+++ b/tests/neg-custom-args/captures/mutvars.check
@@ -23,8 +23,8 @@
 -- Error: tests/neg-custom-args/captures/mutvars.scala:13:16 -----------------------------------------------------------
 13 |    self3().fld = x  // error
    |    ^^^^^^^^^^^^^^^
-   |    Cannot assign to field fld of Ref[T^{}]^{Ref.this.rd}
-   |    since its capture set {Ref.this.rd} of value self3 is read-only.
+   |    Cannot assign to field fld of Ref[T^{}]^{self3}
+   |    since its capture set {self3} is read-only.
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/mutvars.scala:14:37 --------------------------------------
 14 |    val self4: () => Ref[T]^ = () => this // error // error separation
    |                                     ^^^^

--- a/tests/neg-custom-args/captures/mutvars.scala
+++ b/tests/neg-custom-args/captures/mutvars.scala
@@ -14,7 +14,7 @@ class Ref[T](init: T) extends caps.Mutable:
     val self4: () => Ref[T]^ = () => this // error // error separation
     self4().fld = x
 
-    def self5() = this
+    def self5() = this // error
     self5().fld = x  // error
     def self6(): Ref[T]^ = this // error // error separation
     self6().fld = x

--- a/tests/neg-custom-args/captures/reaches.check
+++ b/tests/neg-custom-args/captures/reaches.check
@@ -84,6 +84,16 @@
    |              ^^^^^^^^^^
    |              Separation failure: value next's type () => Unit hides parameter xs.
    |              The parameter needs to be annotated with consume to allow this.
+-- Error: tests/neg-custom-args/captures/reaches.scala:67:40 -----------------------------------------------------------
+67 |  val id: (x: File^) -> File^{fresh} = x => x // error
+   |                                        ^
+   |Separation failure: anonymous function of type (x: File^): File^{fresh}'s inferred result type File^ hides parameter x.
+   |The parameter needs to be annotated with consume to allow this.
+-- Error: tests/neg-custom-args/captures/reaches.scala:68:36 -----------------------------------------------------------
+68 |  val id2: File^ -> File^{fresh} = x => x // error
+   |                                    ^
+   |Separation failure: anonymous function of type (x: File^): File^{fresh}'s inferred result type File^ hides parameter x.
+   |The parameter needs to be annotated with consume to allow this.
 -- Error: tests/neg-custom-args/captures/reaches.scala:88:28 -----------------------------------------------------------
 88 |  ps.map((x, y) => compose1(x, y)) // error // error // error
    |                            ^

--- a/tests/neg-custom-args/captures/reaches.scala
+++ b/tests/neg-custom-args/captures/reaches.scala
@@ -64,8 +64,8 @@ def attack2 =
     f1
 
 def attack3 =
-  val id: (x: File^) -> File^{fresh} = x => x // was error, now OK
-  val id2: File^ -> File^{fresh} = x => x // now also OK
+  val id: (x: File^) -> File^{fresh} = x => x // error
+  val id2: File^ -> File^{fresh} = x => x // error
 
   val leaked = usingFile[File^{id*}]: f =>
     val f1: File^{id*} = id(f)   // error

--- a/tests/neg-custom-args/captures/ref-with-file.check
+++ b/tests/neg-custom-args/captures/ref-with-file.check
@@ -1,16 +1,16 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ref-with-file.scala:18:12 --------------------------------
 18 |  withFile: f => // error
    |            ^
-   |Capability `f` outlives its scope: it leaks into outer capture set 's1 which is owned by method Test.
+   |Capability `fresh` outlives its scope: it leaks into outer capture set 's1 which is owned by method Test.
    |The leakage occurred when trying to match the following types:
    |
-   |Found:    (f: File^) => Ref[File^{f}]^²
-   |Required: (f: File^) =>² Ref[File^'s1]^'s2
+   |Found:    (f: File^) ->'s2 Ref[File^{f}]^{fresh²}
+   |Required: (f: File^) => Ref[File^'s3]^'s1
    |
-   |where:    =>  refers to a root capability classified as Unscoped created in method Test when constructing instance (f: File^): Ref[File^{f}]^²
-   |          =>² refers to a root capability created in method Test when checking argument to parameter op of method withFile
-   |          ^   refers to the root capability caps.any
-   |          ^²  refers to a root capability classified as Unscoped in the type of value r
+   |where:    =>     refers to a root capability created in method Test when checking argument to parameter op of method withFile
+   |          ^      refers to the root capability caps.any
+   |          fresh  is a root capability associated with the result type of (f: File^): T
+   |          fresh² is a root capability associated with the result type of (f: File^): Ref[File^{f}]^{fresh²}
    |
 19 |    val r = Ref(f)
 20 |    r
@@ -19,11 +19,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ref-with-file.scala:25:18 --------------------------------
 25 |  withFileAndRef: (f, r: Ref[String]^) => // error
    |                  ^
-   |Capability `any` outlives its scope: it leaks into outer capture set 's3 which is owned by method Test.
+   |Capability `any` outlives its scope: it leaks into outer capture set 's4 which is owned by method Test.
    |The leakage occurred when trying to match the following types:
    |
-   |Found:    (f: File^{any}, r: Ref[String]^{any}) ->'s4 Ref[String]^{any}
-   |Required: (f: File^{any}, r: Ref[String]^{any}) => Ref[String]^'s3
+   |Found:    (f: File^{any}, r: Ref[String]^{any}) ->'s5 Ref[String]^{any}
+   |Required: (f: File^{any}, r: Ref[String]^{any}) => Ref[String]^'s4
    |
    |where:    =>  refers to a root capability created in method Test when checking argument to parameter op of method withFileAndRef
    |          any is the root capability caps.any

--- a/tests/neg-custom-args/captures/ref-with-file.check
+++ b/tests/neg-custom-args/captures/ref-with-file.check
@@ -4,12 +4,13 @@
    |Capability `f` outlives its scope: it leaks into outer capture set 's1 which is owned by method Test.
    |The leakage occurred when trying to match the following types:
    |
-   |Found:    (f: File^) ->'s2 Ref[File^{f}]^²
-   |Required: (f: File^) => Ref[File^'s1]^'s3
+   |Found:    (f: File^) => Ref[File^{f}]^²
+   |Required: (f: File^) =>² Ref[File^'s1]^'s2
    |
-   |where:    => refers to a root capability created in method Test when checking argument to parameter op of method withFile
-   |          ^  refers to the root capability caps.any
-   |          ^² refers to a root capability classified as Unscoped in the type of value r
+   |where:    =>  refers to a root capability classified as Unscoped created in method Test when constructing instance (f: File^): Ref[File^{f}]^²
+   |          =>² refers to a root capability created in method Test when checking argument to parameter op of method withFile
+   |          ^   refers to the root capability caps.any
+   |          ^²  refers to a root capability classified as Unscoped in the type of value r
    |
 19 |    val r = Ref(f)
 20 |    r
@@ -18,11 +19,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/ref-with-file.scala:25:18 --------------------------------
 25 |  withFileAndRef: (f, r: Ref[String]^) => // error
    |                  ^
-   |Capability `any` outlives its scope: it leaks into outer capture set 's4 which is owned by method Test.
+   |Capability `any` outlives its scope: it leaks into outer capture set 's3 which is owned by method Test.
    |The leakage occurred when trying to match the following types:
    |
-   |Found:    (f: File^{any}, r: Ref[String]^{any}) ->'s5 Ref[String]^{any}
-   |Required: (f: File^{any}, r: Ref[String]^{any}) => Ref[String]^'s4
+   |Found:    (f: File^{any}, r: Ref[String]^{any}) ->'s4 Ref[String]^{any}
+   |Required: (f: File^{any}, r: Ref[String]^{any}) => Ref[String]^'s3
    |
    |where:    =>  refers to a root capability created in method Test when checking argument to parameter op of method withFileAndRef
    |          any is the root capability caps.any

--- a/tests/neg-custom-args/captures/scoped-caps-global.scala
+++ b/tests/neg-custom-args/captures/scoped-caps-global.scala
@@ -19,7 +19,7 @@ def test(io: Object^): Unit =
 
   val h: S -> B^ = ???
   val _: (x: S) -> B^{fresh} = h          // error: direct conversion fails
-  val _: (x: S) -> B^{fresh} = (x: S) => h(x)  // eta expansion is ok
+  val _: (x: S) -> B^{fresh} = (x: S) => h(x)  // error: eta expansion also fails since `h` is non-local
 
   val h2: S -> S = ???
   val _: (x: S) -> S^{fresh} = h2               // direct conversion OK for shared S

--- a/tests/neg-custom-args/captures/scoped-caps.check
+++ b/tests/neg-custom-args/captures/scoped-caps.check
@@ -94,3 +94,7 @@
    |          any² is a root capability in the type of value _$16
    |
    | longer explanation available when compiling with `-explain`
+-- Error: tests/neg-custom-args/captures/scoped-caps.scala:20:36 -------------------------------------------------------
+20 |  val _: (x: S) -> B^{fresh} = (x: S) => h(x)  // error: eta expansion also fails since `h` is non-local
+   |                                    ^
+   |Separation failure: anonymous function of type (x: S^): B^{fresh}'s inferred result type B^ hides non-local value h

--- a/tests/neg-custom-args/captures/scoped-caps.scala
+++ b/tests/neg-custom-args/captures/scoped-caps.scala
@@ -17,7 +17,7 @@ def test(io: Object^): Unit =
 
   val h: S -> B^ = ???
   val _: (x: S) -> B^{fresh} = h          // error: direct conversion fails
-  val _: (x: S) -> B^{fresh} = (x: S) => h(x)  // eta expansion is ok
+  val _: (x: S) -> B^{fresh} = (x: S) => h(x)  // error: eta expansion also fails since `h` is non-local
 
   val h2: S -> S = ???
   val _: (x: S) -> S^{fresh} = h2               // direct conversion OK for shared S

--- a/tests/neg-custom-args/captures/scoped-caps.scala
+++ b/tests/neg-custom-args/captures/scoped-caps.scala
@@ -12,7 +12,7 @@ def test(io: Object^): Unit =
   val _: A^ -> B^ = f // error
   val _: A^ -> B^{fresh} = f // ok
   val _: A^ -> B^ = g
-  val _: A^ -> B^ = x => g(x)      // was error: g is no longer pure, since it contains the ^ of B
+  val _: A^ -> B^ = x => g(x)      // was error: g is no longer pure, since it contains the ^ of B, but now RHS it is pure since RHS is pure by APPLY via g
   val _: (x: A^) -> B^{fresh} = x => f(x) // now OK, was error: existential in B cannot subsume `x` since `x` is not shared
 
   val h: S -> B^ = ???

--- a/tests/neg-custom-args/captures/scoped-caps2.check
+++ b/tests/neg-custom-args/captures/scoped-caps2.check
@@ -15,15 +15,16 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps2.scala:7:18 ----------------------------------
 7 |  val _: C => C = a // error
   |                  ^
-  |                Found:    (a : (x: C) ->{any} C)
-  |                Required: C^ ->{any²} C^²
+  |               Found:    (a : (x: C) ->{any} C^{fresh})
+  |               Required: C^ ->{any²} C^²
   |
-  |                Note that capability `any` cannot flow into capture set {any²}.
+  |               Note that capability `any` cannot flow into capture set {any²}.
   |
-  |                where:    ^    refers to the root capability caps.any
-  |                          ^²   refers to a root capability classified as SharedCapability in the type of value _$2
-  |                          any  is a root capability in the type of value a
-  |                          any² is a root capability in the type of value _$2
+  |               where:    ^     refers to the root capability caps.any
+  |                         ^²    refers to a root capability classified as SharedCapability in the type of value _$2
+  |                         any   is a root capability in the type of value a
+  |                         any²  is a root capability in the type of value _$2
+  |                         fresh is a root capability associated with the result type of (x: C^): C^{fresh}
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps2.scala:9:29 ----------------------------------
@@ -42,7 +43,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scoped-caps2.scala:15:18 ---------------------------------
 15 |  val _: C -> C = a // error
    |                  ^
-   |                  Found:    (a : (x: C) -> C)
+   |                  Found:    (a : (x: C) -> C^{fresh})
    |                  Required: C^ -> C^{any}
    |
    |                  Note that capability `fresh` cannot flow into capture set {any}

--- a/tests/neg-custom-args/captures/withFile.check
+++ b/tests/neg-custom-args/captures/withFile.check
@@ -34,7 +34,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/withFile.scala:19:12 -------------------------------------
 19 |    f => Box(f) // error
    |         ^^^^^^
-   |Found:    Test2.Box[Test2.File^{f}]^'s7
+   |Found:    Test2.Box[Test2.File^{f}]^'s5
    |Required: Test2.Box[Test2.File^{any}]
    |
    |Note that capability `f` cannot flow into capture set {any}

--- a/tests/pos-custom-args/captures/ref-with-file.scala
+++ b/tests/pos-custom-args/captures/ref-with-file.scala
@@ -16,6 +16,8 @@ def withFileAndRef[T](op: (f: File^, r: Ref[String]^) => T): T =
 
 def Test =
   withFile: f =>
+    Ref("")
+  withFile: f =>
     val r = Ref(f.read())
     r
   withFileAndRef: (f, r: Ref[String]^) =>

--- a/tests/pos-custom-args/captures/unscoped-ref-result.scala
+++ b/tests/pos-custom-args/captures/unscoped-ref-result.scala
@@ -7,5 +7,14 @@ class Ref2[T](init: T) extends caps.Mutable:
 
 def test =
   val r4 = () => Ref2(22)
-  val _: Ref2[Int]^{r4*} = r4()
-  r4().x.set(33) // ok
+  val _: () -> Ref2[Int]^ = r4 // should be error
+  val rr4 = Ref2(22)
+  val s4 = () => rr4
+  val y = r4()
+  y.x.set(33) // ok
+
+  def r5() = Ref2(33)
+  val r6 = () => r5()
+  val z = r5()
+  z.x.set(33) // ok
+  r5().x.set(33) // ok

--- a/tests/pos-custom-args/captures/unscoped-ref-result.scala
+++ b/tests/pos-custom-args/captures/unscoped-ref-result.scala
@@ -1,3 +1,5 @@
+import caps.fresh
+
 class Ref[T](init: T) extends caps.Mutable:
   var x: T = init
   update def set(x: T) = this.x = x
@@ -7,7 +9,7 @@ class Ref2[T](init: T) extends caps.Mutable:
 
 def test =
   val r4 = () => Ref2(22)
-  val _: () => Ref2[Int]^ = r4
+  val _: () => Ref2[Int]^{fresh} = r4
   val rr4 = Ref2(22)
   val s4 = () => rr4
   val y = r4()

--- a/tests/pos-custom-args/captures/unscoped-ref-result.scala
+++ b/tests/pos-custom-args/captures/unscoped-ref-result.scala
@@ -7,7 +7,7 @@ class Ref2[T](init: T) extends caps.Mutable:
 
 def test =
   val r4 = () => Ref2(22)
-  val _: () -> Ref2[Int]^ = r4 // should be error
+  val _: () => Ref2[Int]^ = r4
   val rr4 = Ref2(22)
   val s4 = () => rr4
   val y = r4()


### PR DESCRIPTION
## 1. Ensure monotonicity in the types of closures

Previously, a closure could return an unscoped type with `any` in it
(e.g., `Ref^`) but its type would be a pure function type. We now propagate
the `any` into the function type. This has to be done with care though, since
the `^` of a closure might come from the expected type, in which case we
should ignore it. The tricky bit is distinguishing one from the other.

## 2. Never elide ResultCaps when printing Capability classes. 

They always print as `fresh`.

## 3. Tighten `Unscoped` exception in `acceptsLevelOf`. 

Previously, an `Unscoped` LocalCap could subsume a ResultCap. This is no longer possible.

## 4. Do existential widening in `testAdapated`. 

If a closure has a `Ref^{fresh}` return type of an `Unscoped` class `Ref`, and this leads to a
type mismatch in `testAdapted`, convert to `Ref^{any}`, and try again after ensuring monotonicity of 
the mapped type. This means that for `Unscoped` classes created in closures we have a choice 
whether we want to treat tha instance as `fresh` or as a locally created `any`.

 


