### PR TITLE
Backport "Fix mismatch between `wrapArray` and `wrapArrayMethodName`" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -559,7 +559,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
   def wrapArray(tree: Tree, elemtp: Type)(using Context): Tree =
     val wrapper = ref(defn.getWrapVarargsArrayModule)
       .select(wrapArrayMethodName(elemtp))
-      .appliedToTypes(if (elemtp.isPrimitiveValueType) Nil else elemtp :: Nil)
+      .appliedToTypes(if elemtp.classSymbol.isPrimitiveValueClass then Nil else elemtp :: Nil)
     val actualElem = wrapper.tpe.widen.firstParamTypes.head
     wrapper.appliedTo(tree.ensureConforms(actualElem))
 

--- a/tests/pos/seqliteral-union-singletons.scala
+++ b/tests/pos/seqliteral-union-singletons.scala
@@ -1,0 +1,3 @@
+// Regression test for a crash in tpd.wrapArray when the SeqLiteral
+// element type is a union of singleton primitive types (e.g. `1 | 2 | 3`).
+def test: List[1 | 2 | 3] = List(1, 2, 3)


### PR DESCRIPTION
Backports #26162 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]