### PR TITLE
Backport "Parse Java annotations on wildcard type arguments" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -317,7 +317,8 @@ object JavaParsers {
 
     def typeArgs(t: Tree): Tree = {
       var wildnum = 0
-      def typeArg(): Tree =
+      def typeArg(): Tree = {
+        val annots = annotations()
         if (in.token == QMARK) {
           val offset = in.offset
           in.nextToken()
@@ -335,7 +336,8 @@ object JavaParsers {
           }
         }
         else
-          typ()
+          annots.foldLeft(typ())((tp, ann) => Annotated(tp, ann))
+      }
       if (in.token == LT) {
         in.nextToken()
         val t1 = convertToTypeId(t)

--- a/tests/pos/java-annotated-wildcards/Nullable.java
+++ b/tests/pos/java-annotated-wildcards/Nullable.java
@@ -1,0 +1,5 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+public @interface Nullable {}

--- a/tests/pos/java-annotated-wildcards/Test.java
+++ b/tests/pos/java-annotated-wildcards/Test.java
@@ -1,0 +1,5 @@
+import java.util.function.Function;
+
+public interface Test {
+  Function<@Nullable ? super String, @Nullable ? extends Object> mappingFunction();
+}


### PR DESCRIPTION
Backports #26187 to the 3.9.0-RC1.

PR submitted by the release tooling.