### PR TITLE
Fix crash during generic signature emission for inner classes of type aliases

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -233,7 +233,7 @@ object GenericSignatures {
               // Hence the widenNullaryMethod.
         }
 
-      assert(sym.isClass)
+      assert(sym.isClass, s"Not a class: $sym")
       pre.widen match {
         // If the class is an inner class of a generic class, we must emit the outer generic class with its parameters
         // (see test `inner-of-generic` for an example of Java compatibility)
@@ -310,7 +310,7 @@ object GenericSignatures {
 
         case RefOrAppliedType(sym, pre, args) =>
           if isTypeParameterInSig(sym, sym0) then
-            assert(!sym.isAliasType || sym.info.isLambdaSub, "Unexpected alias type: " + sym)
+            assert(!sym.isAliasType || sym.info.isLambdaSub, s"Unexpected alias type: $sym")
             typeParamSig(sym.targetName.lastPart)
           else defn.specialErasure.get(sym) match
             case Some(special) =>

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -194,7 +194,7 @@ object GenericSignatures {
         jsig(finalType)
     }
 
-    def classSig(sym: Symbol, pre: Type = NoType, args: List[Type] = Nil): Unit = {
+    def classSig(sym: ClassSymbol, pre: Type = NoType, args: List[Type] = Nil): Unit = {
       def argSig(tp: Type): Unit =
         tp.dealias match {
           case bounds: TypeBounds =>
@@ -233,12 +233,11 @@ object GenericSignatures {
               // Hence the widenNullaryMethod.
         }
 
-      assert(sym.isClass, s"Not a class: $sym")
       pre.widen match {
         // If the class is an inner class of a generic class, we must emit the outer generic class with its parameters
         // (see test `inner-of-generic` for an example of Java compatibility)
         case RefOrAppliedType(preSym, prePre, preArgs) if preArgs.nonEmpty =>
-          classSig(preSym, prePre, preArgs)
+          classSig(preSym.asClass, prePre, preArgs)
           builder.replace(builder.length() - 1, builder.length(), ".") // instead of ending the outer name with ';', we add an inner name
           builder.append(sanitizeName(sym.targetName))
         // For the rest, we time-travel so we get the full name after inner classes have been lifted to package scope
@@ -330,10 +329,14 @@ object GenericSignatures {
                 if (vcBoxing == ValueClassBoxing.Box) jsig(defn.ObjectType)
                 else if (sym == defn.UnitClass) jsig(defn.BoxedUnitClass.typeRef)
                 else builder.append(defn.typeTag(sym.info))
-              else if (sym.isDerivedValueClass) {
-                if (vcBoxing == ValueClassBoxing.Unbox) {
-                  val underlying = ValueClasses.underlyingOfValueClass(sym.asClass)
-                  val seenUnderlying = underlying.asSeenFrom(tp, sym)
+              else if defn.isSyntheticFunctionClass(sym) then
+                defn.functionTypeErasure(sym).classSymbol match
+                  case classSym: ClassSymbol => classSig(classSym, pre, if classSym.typeParams.isEmpty then Nil else args)
+                  case NoSymbol => throw new AssertionError(s"No class symbol for erased function type $sym")
+              else sym match
+                case classSym: ClassSymbol if classSym.isDerivedValueClass && vcBoxing == ValueClassBoxing.Unbox =>
+                  val underlying = ValueClasses.underlyingOfValueClass(classSym)
+                  val seenUnderlying = underlying.asSeenFrom(tp, classSym)
                   // For binary compatibility with Scala 2, as documented in TypeErasure,
                   // we need to special cases for polymorphic value classes:
                   // `Foo[X]` erases to `X` except that primitives use their boxed type,
@@ -345,16 +348,8 @@ object GenericSignatures {
                     else if underlying.derivesFrom(defn.ArrayClass) then erasure(underlying)
                     else seenUnderlying
                   jsig(compatibleUnderlying, toplevel = toplevel)
-                } else classSig(sym, pre, args)
-              }
-              else if (defn.isSyntheticFunctionClass(sym)) {
-                val erasedSym = defn.functionTypeErasure(sym).typeSymbol
-                classSig(erasedSym, pre, if (erasedSym.typeParams.isEmpty) Nil else args)
-              }
-              else if sym.isClass then
-                classSig(sym, pre, args)
-              else
-                jsig(erasure(tp), toplevel = toplevel, vcBoxing = vcBoxing)
+                case classSym: ClassSymbol => classSig(classSym, pre, args)
+                case _ => jsig(erasure(tp), toplevel = toplevel, vcBoxing = vcBoxing)
 
         case ExprType(restpe) =>
           if toplevel then

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -233,11 +233,11 @@ object GenericSignatures {
               // Hence the widenNullaryMethod.
         }
 
-      pre.widen match {
+      pre.widenDealias match {
         // If the class is an inner class of a generic class, we must emit the outer generic class with its parameters
         // (see test `inner-of-generic` for an example of Java compatibility)
-        case RefOrAppliedType(preSym, prePre, preArgs) if preArgs.nonEmpty =>
-          classSig(preSym.asClass, prePre, preArgs)
+        case RefOrAppliedType(preSym: ClassSymbol, prePre, preArgs) if preArgs.nonEmpty =>
+          classSig(preSym, prePre, preArgs)
           builder.replace(builder.length() - 1, builder.length(), ".") // instead of ending the outer name with ';', we add an inner name
           builder.append(sanitizeName(sym.targetName))
         // For the rest, we time-travel so we get the full name after inner classes have been lifted to package scope

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -624,10 +624,11 @@ object Types extends TypeUtils {
      *  instance, or NoSymbol if none exists (either because this type is not a
      *  value type, or because superclasses are ambiguous).
      */
-    final def classSymbol(using Context): Symbol = this match
+    final def classSymbol(using Context): ClassSymbol | NoSymbol.type = this match
       case tp: TypeRef =>
-        val sym = tp.symbol
-        if (sym.isClass) sym else tp.superType.classSymbol
+        tp.symbol match
+          case classSym: ClassSymbol => classSym
+          case _ => tp.superType.classSymbol
       case tp: TypeProxy =>
         tp.superType.classSymbol
       case tp: ClassInfo =>

--- a/tests/generic-java-signatures/generic-type.scala
+++ b/tests/generic-java-signatures/generic-type.scala
@@ -1,0 +1,12 @@
+// Used to crash the compiler while emitting the generic signature
+
+class Outer[X, N]:
+  class Inner
+
+type X[A] = Outer[A, String]
+
+object Test:
+  val x: X[String] = null
+  def foo(): x.Inner = null
+
+  def main(args: Array[String]): Unit = ()


### PR DESCRIPTION
Found by OpenCB (in scalamock and katrix)

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
