### PR TITLE
Fix scaladoc link check for into

### DIFF
--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -296,7 +296,7 @@ object language {
     /** Experimental support for automatic conversions of arguments, without requiring
      *  a language import `import scala.language.implicitConversions`.
      *
-     *  @see [[https://nightly.scala-lang.org/docs/reference/preview/into]]
+     *  @see [[https://nightly.scala-lang.org/docs/reference/other-new-features/into]]
      */
     @compileTimeOnly("`into` can only be used at compile time in import statements")
     @deprecated("The `into` language import is no longer needed since the feature is now in preview", since = "3.8")

--- a/project/scripts/expected-links/reference-expected-links.txt
+++ b/project/scripts/expected-links/reference-expected-links.txt
@@ -369,6 +369,7 @@
 ./other-new-features/generalized-method-syntax.html
 ./other-new-features/indentation.html
 ./other-new-features/index.html
+./other-new-features/into.html
 ./other-new-features/kind-polymorphism.html
 ./other-new-features/matchable.html
 ./other-new-features/named-tuples.html
@@ -390,7 +391,6 @@
 ./overview.html
 ./preview/better-fors.html
 ./preview/index.html
-./preview/into.html
 ./preview/named-tuples.html
 ./preview/overview.html
 ./preview/runtimeChecked.html


### PR DESCRIPTION
Not sure why the redirect doesn't work but the link itself is easy to fix

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
