### PR TITLE
[CI] Make `language-reference-stable` a tag instead of branch

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,8 +1,6 @@
 name: Scala CLA
 on:
   pull_request:
-    branches-ignore:
-      - 'language-reference-stable'
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -2,10 +2,7 @@ name: Language reference documentation
 
 on:
   push:
-    branches:
-      - 'language-reference-stable'
-  pull_request:
-    branches:
+    tags:
       - 'language-reference-stable'
   workflow_dispatch:
 

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -3,11 +3,10 @@ name: scaladoc
 on:
   push:
     branches-ignore:
-      - 'language-reference-stable'
       - 'gh-readonly-queue/**'
-  pull_request:
-    branches-ignore:
+    tags-ignore:
       - 'language-reference-stable'
+  pull_request:
   merge_group:
 permissions:
   contents: read


### PR DESCRIPTION
`language-reference-stable` is a branch containing the revision from which `https://docs.scala-lang.org/scala3/reference/` is built. Initially it was active due to active developement of scaladoc. However, right now it's only updated on every release to sync it up with latest stable release. 

To ease to maintance we're convering a dedicated branch with a movable tag