### PR TITLE
[Regression] Disallow implicit conversion to AnyRef again.

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -34,6 +34,7 @@ import reporting.*
 import Message.Note
 import transform.Splicer
 import annotation.tailrec
+import NullOpsDecorator.stripNull
 
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
@@ -1684,14 +1685,14 @@ trait Implicits:
     def isUnderSpecifiedArgument(tp: Type): Boolean =
       tp.isRef(defn.NothingClass) || tp.isRef(defn.NullClass) || (tp eq NoPrefix)
 
-    private def isUnderspecified(tp: Type): Boolean = tp.stripTypeVar match
+    private def isUnderspecified(tp: Type): Boolean = tp.stripTypeVar.stripNull() match
       case tp: WildcardType =>
         !tp.optBounds.exists || isUnderspecified(tp.optBounds.hiBound)
       case tp: ViewProto =>
         isUnderspecified(tp.resType)
         || tp.resType.isRef(defn.UnitClass)
         || isUnderSpecifiedArgument(tp.argType.widen)
-      case _ =>
+      case tp =>
         tp.isAny || tp.isAnyRef
 
     /** Search implicit in context `ctxImplicits` or else in implicit scope

--- a/tests/explicit-nulls/neg/opaque-nullable.scala
+++ b/tests/explicit-nulls/neg/opaque-nullable.scala
@@ -7,6 +7,7 @@ object Nullables {
 
   object Nullable:
     def apply[A <: AnyRef](x: A | Null): Nullable[A] = x
+    def apply(x: Boolean): Nullable[java.lang.Boolean] = x
 
     def some[A <: AnyRef](x: A): Nullable[A] = x
     def none: Nullable[Nothing] = null
@@ -29,7 +30,7 @@ object Nullables {
     val s4: Nullable[String] = null
 
     s1.isEmpty
-    s1.flatMap((x) => true)
+    s1.flatMap((x) => Nullable(true))
 
     assert(s2 != null)
 }

--- a/tests/neg/more-specific.check
+++ b/tests/neg/more-specific.check
@@ -1,0 +1,9 @@
+-- [E007] Type Mismatch Error: tests/neg/more-specific.scala:9:17 ------------------------------------------------------
+9 |        if (x eq y) // error
+  |                 ^
+  |                 Found:    (y : T)
+  |                 Required: Object
+  |                 Note that implicit conversions were not tried because the result of an implicit conversion
+  |                 must be more specific than Object
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/more-specific.scala
+++ b/tests/neg/more-specific.scala
@@ -1,0 +1,14 @@
+import scala.math.Equiv
+
+object Test {
+  def foo[T] =
+    new Ordering[T] {
+      def compare(x: T, y: T): Int =
+        // If we don't disallow implicit conversions to AnyRef, this succeeds with a conversion to
+        // mkOrderingOps (https://github.com/scala/scala3/blob/7d4833b619d31ea9acac97fccf1e74b42b89c49f/library/src/scala/math/Ordering.scala#L206)
+        if (x eq y) // error
+          return 0
+
+        ???
+    }
+}

--- a/tests/pos/hylolib/CollectionTests.scala
+++ b/tests/pos/hylolib/CollectionTests.scala
@@ -33,7 +33,7 @@ class CollectionTests extends munit.FunSuite:
 
     val one = AnyCollection(HyArray[Int](1))
     val Some((h0, t0)) = one.headAndTail: @unchecked
-    assert(h0 eq 1)
+    assertEquals(h0, 1)
     assert(t0.isEmpty)
 
     val two = AnyCollection(HyArray[Int](1, 2))


### PR DESCRIPTION
This regressed all the way back in 3.2.

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Not at all

## How was the solution tested?

New automated tests
