### PR TITLE
Remove dead large class detection

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
@@ -58,9 +58,6 @@ class PostProcessor(frontendAccess: PostProcessorFrontendAccess,
         setInnerClasses(classNode)
         serializeClass(classNode)
       catch
-        case e: java.lang.RuntimeException if e.getMessage != null && e.getMessage.contains("too large!") =>
-          report.error(em"Could not write class $internalName because it exceeds JVM code size limits. ${e.getMessage}")
-          null
         case ex: Exception =>
           if ctx.debug then ex.printStackTrace()
           report.error(em"Error while emitting $internalName\n${ex.getMessage}")


### PR DESCRIPTION
While looking at #25989 I noticed the message this code is trying to catch doesn't exist in our fork nor in stock ASM since we upstreamed changes https://gitlab.ow2.org/asm/asm/-/merge_requests/181/diffs

In practice any such exception will be caught by the next case in the catch anyway.

I didn't try to write a test that triggers JVM code size limits because they're apparently [extremely high](https://stackoverflow.com/a/42299271).

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
