### PR TITLE
Fix a couple issues related to erased value types

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -359,10 +359,9 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader, val bTypes: WellKnownBTypes) ex
 
               // there might be a getter created after erasure by the mixin phase,
               // and if so we must use the information that the mixin phase stored for it.
-              // However, we can't do this if the result is a primitive, since field generic signatures can only be reference types (JVMS §4.7.9.1)
               val mixinGetter = atPhase(mixinPhase.next) { sym.getter }
               if mixinGetter.exists then mixinPhase.asInstanceOf[Mixin].mixinGenericInfos.get(mixinGetter) match
-                case Some(ExprType(genericInfo)) if !genericInfo.isPrimitiveValueType => return genericInfo // since we're looking for the getter, we get an ExprType
+                case Some(ExprType(genericInfo)) => return genericInfo // since we're looking for the getter, we get an ExprType
                 case _ => ()
 
           owner.denot.thisType.memberInfo(sym)

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -49,7 +49,7 @@ object GenericSignatures {
     else mayNeedSignature(info)
   }
 
-  private def javaSig0(sym0: Symbol, info: Type)(using Context): StringBuilder = {
+  private def javaSig0(sym0: Symbol, info: Type)(using Context): StringBuilder | Null = {
     // This works as long as mangled names are always valid Java identifiers (see git history of this method).
     def sanitizeName(name: Name): String = name.mangledString
 
@@ -329,6 +329,7 @@ object GenericSignatures {
                 // replace the next 2 lines with: if (vcBoxing == ValueClassBoxing.Box || sym == defn.UnitClass) jsig(defn.boxedClass(sym).typeRef)
                 if (vcBoxing == ValueClassBoxing.Box) jsig(defn.ObjectType)
                 else if (sym == defn.UnitClass) jsig(defn.BoxedUnitClass.typeRef)
+                else if (builder.length == 0 && sym0.isField) () // field generic signatures can only be reference types (JVMS §4.7.9.1)
                 else builder.append(defn.typeTag(sym.info))
               else if (sym.isDerivedValueClass) {
                 if (vcBoxing == ValueClassBoxing.Unbox) {
@@ -437,7 +438,10 @@ object GenericSignatures {
           builder.append('^')
           jsig(e, toplevel = true)
         case _ => ()
-    builder
+
+    if builder.length == 0
+    then null
+    else builder
   }
 
   /* Drop redundant types (ones which are implemented by some other parent) from the immediate parents.

--- a/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TypeTestsCasts.scala
@@ -292,7 +292,7 @@ object TypeTestsCasts {
             else derivedTree(box(expr), defn.Any_asInstanceOf, testType)
           else if (testCls.isPrimitiveValueClass)
             unbox(expr.ensureConforms(defn.ObjectType), testType)
-          else if (isDerivedValueClass(testCls))
+          else if (testType.widen.isErasedValueType || isDerivedValueClass(testCls))
             expr // adaptToType in Erasure will do the necessary type adaptation
           else if (testCls eq defn.NothingClass) {
             // In the JVM `x.asInstanceOf[Nothing]` would throw a class cast exception except when `x eq null`.

--- a/tests/pos/26211.scala
+++ b/tests/pos/26211.scala
@@ -1,0 +1,10 @@
+package example
+
+case class A(x: Int) extends AnyVal
+
+object A {
+  val A1 = A(1)
+  val A2 = A(2)
+}
+
+case class B(b: A.A1.type | A.A2.type)


### PR DESCRIPTION
Fixes #26211

It's two issues in one: erasure should unbox, and generic signature generation must not generate a signature for the resulting field because the JVM doesn't do primitive types in generic signatures.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
