### PR TITLE
Fix #26215: Exempt inline val from inliner postcondition check

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -58,6 +58,10 @@ object Inlines:
   def inInlineMethod(using Context): Boolean =
     ctx.owner.ownersIterator.exists(_.isInlineMethod)
 
+  /** Are we in an val body? */
+  def inInlineVal(using Context): Boolean =
+    ctx.owner.ownersIterator.exists(_.isInlineVal)
+
   /** Can a call to method `meth` be inlined? */
   def isInlineable(meth: Symbol)(using Context): Boolean =
     meth.is(Inline) && meth.hasAnnotation(defn.BodyAnnot) && !inInlineMethod

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -58,7 +58,7 @@ object Inlines:
   def inInlineMethod(using Context): Boolean =
     ctx.owner.ownersIterator.exists(_.isInlineMethod)
 
-  /** Are we in an val body? */
+  /** Are we in an inline val body? */
   def inInlineVal(using Context): Boolean =
     ctx.owner.ownersIterator.exists(_.isInlineVal)
 

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -81,7 +81,7 @@ class Inlining extends MacroTransform, IdentityDenotTransformer {
         new TreeTraverser {
           def traverse(tree: Tree)(using Context): Unit =
             tree match
-              case tree: RefTree if !Inlines.inInlineMethod && StagingLevel.level == 0 =>
+              case tree: RefTree if !(Inlines.inInlineMethod || Inlines.inInlineVal) && StagingLevel.level == 0 =>
                 assert(!tree.symbol.isInlineMethod, tree.show)
               case _ =>
                 traverseChildren(tree)

--- a/tests/neg/i26215.scala
+++ b/tests/neg/i26215.scala
@@ -1,0 +1,7 @@
+//> using options -Ycheck:all
+
+object O1:
+    inline def x = 10
+
+object O2:
+    inline val y = O1.x // error: inline value must have a literal constant type


### PR DESCRIPTION
Fixes #26215.

## How much have you relied on LLM-based tools in this contribution?
Not at all.

## How was the solution tested?
New automated tests.
