### PR TITLE
Restore `Automatic-Module-Name` in standard library's manifest

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -984,6 +984,7 @@ object Build {
   /* Configuration of the org.scala-lang:scala-library:*.**.**-nonbootstrapped project */
   lazy val `scala-library-nonbootstrapped` = project.in(file("library"))
     .enablePlugins(ScalaLibraryPlugin)
+    .settings(scalaLibrarySettings)
     .settings(
       name          := "scala-library-nonbootstrapped",
       moduleName    := "scala-library",
@@ -1041,6 +1042,7 @@ object Build {
   /* Configuration of the org.scala-lang:scala3-library_3:*.**.**-nonbootstrapped project */
   lazy val `scala3-library-nonbootstrapped` = project.in(file("library"))
     .dependsOn(`scala-library-nonbootstrapped`)
+    .settings(scala3LibrarySettings)
     .settings(
       name          := "scala3-library-nonbootstrapped",
       moduleName    := "scala3-library",
@@ -1068,6 +1070,7 @@ object Build {
   lazy val `scala-library-bootstrapped` = project.in(file("library"))
     .enablePlugins(ScalaLibraryPlugin)
     .settings(publishSettings)
+    .settings(scalaLibrarySettings)
     .settings(
       name          := "scala-library-bootstrapped",
       moduleName    := "scala-library",
@@ -1130,6 +1133,7 @@ object Build {
   lazy val `scala3-library-bootstrapped` = project.in(file("library"))
     .dependsOn(`scala-library-bootstrapped`)
     .settings(publishSettings)
+    .settings(scala3LibrarySettings)
     .settings(
       name          := "scala3-library-bootstrapped",
       moduleName    := "scala3-library",
@@ -1260,6 +1264,7 @@ object Build {
   lazy val `scala3-library-sjs` = project.in(file("library-js"))
     .dependsOn(`scala-library-sjs`)
     .settings(publishSettings)
+    .settings(scala3LibrarySettings)
     .settings(
       name          := "scala3-library-sjs",
       moduleName    := "scala3-library_sjs1",
@@ -2676,6 +2681,21 @@ object Build {
     } finally jarFile.close()
     jar
   }
+
+  private def automaticModuleNameAttribute(name: String): Package.ManifestAttributes =
+    ManifestAttributes("Automatic-Module-Name" -> name)
+
+  lazy val scala3LibrarySettings = Def.settings(
+    Compile / packageBin / packageOptions +=
+      automaticModuleNameAttribute(
+        s"${dottyOrganization.replaceAll("-", ".")}.${moduleName.value.replaceAll("-", ".")}"
+      )
+  )
+
+  lazy val scalaLibrarySettings = Def.settings(
+    Compile / packageBin / packageOptions +=
+      automaticModuleNameAttribute("scala.library")
+  )
 
   /** Settings for projects that should produce empty JARs (only META-INF allowed).
    *  These are dependency placeholder projects like scala3-library-bootstrapped and scala3-library-sjs.

--- a/sbt-test/sbt-dotty/automatic-module-name/build.sbt
+++ b/sbt-test/sbt-dotty/automatic-module-name/build.sbt
@@ -1,0 +1,55 @@
+import scala.sys.process._
+
+// plugin.scalaVersion: set by scripted tests (local publish). test.scalaVersion: manual runs against Maven releases.
+lazy val dottyVersion =
+  sys.props.getOrElse("test.scalaVersion", sys.props("plugin.scalaVersion"))
+
+val ExpectedAutomaticModuleName = "org.scala.lang.scala3.library"
+
+val checkManifest = taskKey[Unit](
+  "check that scala3-library_3 has Automatic-Module-Name in MANIFEST.MF"
+)
+val checkJpmsRuntime = taskKey[Unit](
+  "check JPMS can resolve org.scala.lang.scala3.library from the published jar"
+)
+
+scalaVersion := dottyVersion
+
+def findScala3LibraryJar(cp: Seq[Attributed[File]]): File =
+  cp.map(_.data)
+    .find(f => f.getName.startsWith("scala3-library_") && f.getName.endsWith(".jar"))
+    .getOrElse(sys.error("scala3-library_3 jar not found on dependency classpath"))
+
+checkManifest := {
+  val jar = findScala3LibraryJar((Runtime / dependencyClasspath).value)
+  val jarFile = new java.util.jar.JarFile(jar)
+  try {
+    val automaticModuleName =
+      Option(jarFile.getManifest)
+        .flatMap(m => Option(m.getMainAttributes.getValue("Automatic-Module-Name")))
+    automaticModuleName match {
+      case Some(`ExpectedAutomaticModuleName`) => ()
+      case other =>
+        sys.error(
+          s"Expected Automatic-Module-Name: $ExpectedAutomaticModuleName in ${jar.getName}, got: $other"
+        )
+    }
+  } finally jarFile.close()
+}
+
+checkJpmsRuntime := {
+  val jar = findScala3LibraryJar((Runtime / dependencyClasspath).value)
+  val exitCode = Process(
+    Seq(
+      "java",
+      "--module-path",
+      jar.getAbsolutePath,
+      "--describe-module",
+      ExpectedAutomaticModuleName
+    )
+  ).!
+  if (exitCode != 0)
+    sys.error(
+      s"JPMS failed to describe module $ExpectedAutomaticModuleName from ${jar.getName} (exit $exitCode)"
+    )
+}

--- a/sbt-test/sbt-dotty/automatic-module-name/src/main/scala/Main.scala
+++ b/sbt-test/sbt-dotty/automatic-module-name/src/main/scala/Main.scala
@@ -1,0 +1,2 @@
+@main def main(): Unit =
+  println("ok")

--- a/sbt-test/sbt-dotty/automatic-module-name/test
+++ b/sbt-test/sbt-dotty/automatic-module-name/test
@@ -1,0 +1,3 @@
+> compile
+> checkManifest
+> checkJpmsRuntime


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26217

Yet another thing we missed while migrating the standard library in 3.8 😕 

## How much have you relied on LLM-based tools in this contribution?
Moderately, Cursor + Claude
I made Claude to set up the SBT test verifying the manifest field and JPMS runtime.

## How was the solution tested?
New automated tests
