### PR TITLE
Fix typo in classifier cache validation

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -667,7 +667,7 @@ object Capabilities:
             if self.derivesFromCapability then toClassifiers(self.inheritedClassifier)
             else captureSetOfInfo.transClassifiers
         if myClassifiers != UnknownClassifier then
-          classifiersValid == currentId
+          classifiersValid = currentId
       myClassifiers
     end transClassifiers
 


### PR DESCRIPTION

## How much have you relied on LLM-based tools in this contribution?

LLM was used to identify this typo.

Full bug-scan report: https://folium.capless.cc/claude-review.html

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

Existing tests.
