### PR TITLE
Add missing `& caps.Pure` bounds to the ClassTagSeqFactory family

### DIFF
--- a/library/src/scala/collection/Factory.scala
+++ b/library/src/scala/collection/Factory.scala
@@ -746,14 +746,14 @@ object ClassTagIterableFactory {
 /**
  *  @tparam CC Collection type constructor (e.g. `ArraySeq`)
  */
-trait ClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends ClassTagIterableFactory[CC] {
+trait ClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] extends ClassTagIterableFactory[CC] {
   import SeqFactory.UnapplySeqWrapper
   final def unapplySeq[A](x: CC[A] @uncheckedVariance): UnapplySeqWrapper[A] = new UnapplySeqWrapper(x) // TODO is uncheckedVariance sound here?
 }
 
 object ClassTagSeqFactory {
   @SerialVersionUID(3L)
-  class Delegate[CC[A] <: SeqOps[A, Seq, Seq[A]]](delegate: ClassTagSeqFactory[CC])
+  class Delegate[CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure](delegate: ClassTagSeqFactory[CC])
     extends ClassTagIterableFactory.Delegate[CC](delegate) with ClassTagSeqFactory[CC]
 
   /** A SeqFactory that uses ClassTag.Any as the evidence for every element type. This may or may not be
@@ -764,7 +764,7 @@ object ClassTagSeqFactory {
     extends ClassTagIterableFactory.AnyIterableDelegate[CC](delegate) with SeqFactory[CC]
 }
 
-trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]]] extends ClassTagSeqFactory[CC] {
+trait StrictOptimizedClassTagSeqFactory[+CC[A] <: SeqOps[A, Seq, Seq[A]] & caps.Pure] extends ClassTagSeqFactory[CC] {
 
   override def fill[A : ClassTag](n: Int)(elem: => A): CC[A] = {
     val b = newBuilder[A]


### PR DESCRIPTION
## What

  Adds `& caps.Pure` to the `CC` upper bounds of three declarations in
  `library/src/scala/collection/Factory.scala`:

  - `trait ClassTagSeqFactory`
  - `class ClassTagSeqFactory.Delegate`
  - `trait StrictOptimizedClassTagSeqFactory`

  This brings them in line with their non-`ClassTag` counterparts, which
  already carry the bound:

  - `SeqFactory`, `SeqFactory.Delegate`, `StrictOptimizedSeqFactory`
  - `ClassTagSeqFactory.AnySeqDelegate`

  ## Why

  `Factory.scala` is compiled with `import language.experimental.captureChecking`.
  When the capture-checked collections were ported in #23769, the `& caps.Pure`
  bound was added to the `SeqFactory` family and to `AnySeqDelegate`, but the
  parallel `ClassTagSeqFactory` family was left without it. The inconsistency was
  latent until the purity checks were tightened in #26085 ("Tighten check of field
  classifiers") and #26097 ("Don't assume classes with self aliases to be pure").
  The companion stdlib patch in #26097 (commit 8748bb9, "Fix stdlib") covered other
  spots but missed this family.
  
  With the tightened checker, recompiling the capture-checked stdlib now fails on
  these three declarations because their `CC` parameter is passed to a context that
  requires `... & caps.Pure`.
  
  ## How to reproduce
  
  sbt scala3-bootstrapped/testCompilation

  fails before this change and passes after it.

  ## Notes

  Pure type-bound consistency fix; no behavioral change.