### PR TITLE
Fix named-tuple pattern resolution under -Yexplicit-nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3783,7 +3783,17 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
   }
 
   /** Translate tuples of all arities */
-  def typedTuple(tree: untpd.Tuple, pt: Type)(using Context): Tree =
+  def typedTuple(tree: untpd.Tuple, pt0: Type)(using Context): Tree =
+    // For a named-tuple pattern, strip any nullability from the expected type
+    // before desugaring. Under explicit nulls a selector type such as
+    // `(a: A, b: B) | Null` (e.g. from a nullified Java generic) would hide the
+    // named-tuple structure, so the named element patterns would fail to
+    // resolve. A tuple pattern never matches `null`, so this is sound; the
+    // `_: Null` case is still reported as inexhaustive at the match level.
+    val pt =
+      if ctx.mode.is(Mode.Pattern) && hasNamedArg(tree.trees)
+      then pt0.stripNull()
+      else pt0
     val tree1 = desugar.tuple(tree, pt).withAttachmentsFrom(tree)
     checkDeprecatedAssignmentSyntax(tree)
     if tree1 ne tree then typed(tree1, pt)

--- a/tests/explicit-nulls/pos/named-tuple-pattern.scala
+++ b/tests/explicit-nulls/pos/named-tuple-pattern.scala
@@ -1,0 +1,16 @@
+// Under explicit nulls, a named-tuple pattern should still resolve its
+// element names even when the selector type is nullable (e.g. coming from a
+// Java-defined generic method such as `java.util.stream.Stream.filter`).
+import java.util.stream.{Stream => JStream}
+
+class Store
+class OriginalPath
+
+object Test:
+
+  type SearchRootResult = (searchRoot: Store, originalPath: OriginalPath)
+
+  def test(stream: JStream[SearchRootResult]): JStream[SearchRootResult] =
+    stream.filter { case (searchRoot = sr) =>
+      sr.isInstanceOf[Store]
+    }


### PR DESCRIPTION
Issue minimized from [a run of the open community build with explicit nulls enabled by default](https://scala3.westeurope.cloudapp.azure.com/dashboard/projects/dacr/sotohp/builds/HarrisL2%2Fscala3%3Aunsafe-explicit-nulls%3A2026-05-31/logs) from #25461

A named-tuple pattern fails to compile under -Yexplicit-nulls when the scrutinee comes from a Java-defined generic (e.g. java.util.stream.Stream), even though the identical code compiles without the flag. This PR strips nullability from the expected type before desugaring such patterns, scoped to named-tuple patterns only.  
# Reproduction
```scala
import java.util.stream.{Stream => JStream}

class Store
class OriginalPath

object Test:
  type SearchRootResult = (searchRoot: Store, originalPath: OriginalPath)

  def test(stream: JStream[SearchRootResult]): JStream[SearchRootResult] =
    stream.filter { case (searchRoot = sr) => sr.isInstanceOf[Store] }
```
Run with `scalac Test.scala -Yexplicit-nulls`

# Fix

 In `Typer.typedTuple`, strip nullability from the expected type before desugaring, but only for patterns that actually carry named elements:
```scala
  val pt =
    if ctx.mode.is(Mode.Pattern) && hasNamedArg(tree.trees)
    then pt0.stripNull()
    else pt0
```
I had a back and forth with the LLM for a justification:
## Why unwrapping is sound

The change makes a `local pt = pt0.stripNull()` inside `typedTuple`, used only to desugar/type the pattern's sub-trees. A tuple pattern lowers to an unapply guarded by a non-null test:

```scala
// PatternMatcher.scala:496-497
if (scrutinee.info.isNotNull || nonNull(scrutinee)) unappPlan
else TestPlan(NonNullTest, scrutinee, ...)   // scrutinee ne null
```
So the bindings (`sr`) only ever run on non-null values.

## How much have you relied on LLM-based tools in this contribution?
Moderately, for generating a fix and the explanation

## How was the solution tested?

New automated tests
