### PR TITLE
Add Type Annotations at places where FlexibleTypes may occur if -Yexplicit-nulls is enabled.

### DIFF
--- a/docs/_docs/reference/error-codes/E008.md
+++ b/docs/_docs/reference/error-codes/E008.md
@@ -16,23 +16,23 @@ This commonly occurs when:
 ## Example
 
 ```scala sc:fail sc-opts:-explain
-val result = "hello".unknownMethod
+val result: String = "hello".unknownMethod
 ```
 
 ### Error
 
 ```scala sc:nocompile
--- [E008] Not Found Error: example.scala:1:21 ----------------------------------
-1 |val result = "hello".unknownMethod
-  |             ^^^^^^^^^^^^^^^^^^^^^
-  |             value unknownMethod is not a member of String
+-- [E008] Not Found Error: example.scala:1:29 ----------------------------------
+1 |val result: String = "hello".unknownMethod
+  |                     ^^^^^^^^^^^^^^^^^^^^^
+  |                     value unknownMethod is not a member of String
 ```
 
 ### Solution
 
 ```scala sc:compile
 // Use a method that exists on the type
-val result = "hello".toUpperCase
+val result: String = "hello".toUpperCase
 ```
 
 ```scala sc:compile

--- a/docs/_docs/reference/error-codes/E208.md
+++ b/docs/_docs/reference/error-codes/E208.md
@@ -12,14 +12,14 @@ Extension methods are typically invoked as `receiver.method()`, where the receiv
 ## Example
 
 ```scala sc:fail sc-opts:-Werror
-extension (s: String = "hello, world") def invert = s.reverse.toUpperCase
+extension (s: String = "hello, world") def invert: String = s.reverse.toUpperCase
 ```
 
 ### Error
 
 ```scala sc:nocompile
 -- [E208] Potential Issue Warning: example.scala:1:23 --------------------------
-1 |extension (s: String = "hello, world") def invert = s.reverse.toUpperCase
+1 |extension (s: String = "hello, world") def invert: String = s.reverse.toUpperCase
   |                       ^
   |Extension method invert should not have a default argument for its receiver.
   |-----------------------------------------------------------------------------
@@ -44,7 +44,7 @@ it should not be defined as an extension.
 Remove the default argument from the receiver parameter:
 
 ```scala sc:compile sc-opts:-Werror
-extension (s: String) def invert = s.reverse.toUpperCase
+extension (s: String) def invert: String = s.reverse.toUpperCase
 ```
 
 If you need a function with a default argument, define it as a regular method instead of an extension:

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -4,8 +4,9 @@ package languageserver
 import java.net.URI
 import java.io._
 import java.nio.file._
-import java.util.concurrent.{CompletableFuture, ConcurrentHashMap}
-import java.util.function.Function
+import java.util as ju
+import ju.concurrent.{CompletableFuture, ConcurrentHashMap}
+import ju.function.Function
 
 import _root_.tools.jackson.databind.json.JsonMapper
 
@@ -200,7 +201,7 @@ class DottyLanguageServer extends LanguageServer
         computation()
     }
 
-  override def initialize(params: InitializeParams) = computeAsync { cancelToken =>
+  override def initialize(params: InitializeParams): CompletableFuture[InitializeResult] = computeAsync { cancelToken =>
     rootUri = params.getRootUri
     assert(rootUri != null)
 
@@ -301,7 +302,7 @@ class DottyLanguageServer extends LanguageServer
   }
 
   // FIXME: share code with NotAMember
-  override def completion(params: CompletionParams) = computeAsync { cancelToken =>
+  override def completion(params: CompletionParams): CompletableFuture[JEither[ju.List[CompletionItem], CompletionList]] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
     implicit def ctx: Context = driver.currentCtx
@@ -322,7 +323,7 @@ class DottyLanguageServer extends LanguageServer
    *  If cursor is on a definition, show this definition together with all overridden
    *  and overriding definitions.
    */
-  override def definition(params: DefinitionParams) = computeAsync { cancelToken =>
+  override def definition(params: DefinitionParams): CompletableFuture[JEither[ju.List[? <: Location], ju.List[? <: LocationLink]]] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
     implicit def ctx: Context = driver.currentCtx
@@ -334,7 +335,7 @@ class DottyLanguageServer extends LanguageServer
     Either.forLeft(definitions.flatMap(d => location(d.namePos)).asJava)
   }
 
-  override def references(params: ReferenceParams) = computeAsync { cancelToken =>
+  override def references(params: ReferenceParams): CompletableFuture[ju.List[? <: Location]] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
 
@@ -374,7 +375,7 @@ class DottyLanguageServer extends LanguageServer
     references.flatten.distinct.asJava
   }
 
-  override def rename(params: RenameParams) = computeAsync { cancelToken =>
+  override def rename(params: RenameParams): CompletableFuture[WorkspaceEdit] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
     implicit def ctx: Context = driver.currentCtx
@@ -440,7 +441,7 @@ class DottyLanguageServer extends LanguageServer
     new WorkspaceEdit(changes.asJava)
   }
 
-  override def documentHighlight(params: DocumentHighlightParams) = computeAsync { cancelToken =>
+  override def documentHighlight(params: DocumentHighlightParams): CompletableFuture[ju.List[? <: DocumentHighlight]] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
     implicit def ctx: Context = driver.currentCtx
@@ -460,7 +461,7 @@ class DottyLanguageServer extends LanguageServer
     }.distinct.asJava
   }
 
-  override def hover(params: HoverParams) = computeAsync { cancelToken =>
+  override def hover(params: HoverParams): CompletableFuture[Hover] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
     implicit def ctx: Context = driver.currentCtx
@@ -484,7 +485,7 @@ class DottyLanguageServer extends LanguageServer
     }
   }
 
-  override def documentSymbol(params: DocumentSymbolParams) = computeAsync { cancelToken =>
+  override def documentSymbol(params: DocumentSymbolParams): CompletableFuture[ju.List[JEither[SymbolInformation, DocumentSymbol]]] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
     implicit def ctx: Context = driver.currentCtx
@@ -508,7 +509,7 @@ class DottyLanguageServer extends LanguageServer
     } yield JEither.forLeft(info)).asJava
   }
 
-  override def symbol(params: WorkspaceSymbolParams) = computeAsync { cancelToken =>
+  override def symbol(params: WorkspaceSymbolParams): CompletableFuture[JEither[ju.List[? <: SymbolInformation], ju.List[? <: WorkspaceSymbol]]] = computeAsync { cancelToken =>
     val query = params.getQuery
 
     Either.forLeft(drivers.values.toList.flatMap { driver =>
@@ -520,7 +521,7 @@ class DottyLanguageServer extends LanguageServer
     }.asJava)
   }
 
-  override def implementation(params: ImplementationParams) = computeAsync { cancelToken =>
+  override def implementation(params: ImplementationParams): CompletableFuture[JEither[ju.List[? <: Location], ju.List[? <: LocationLink]]] = computeAsync { cancelToken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
 
@@ -551,7 +552,7 @@ class DottyLanguageServer extends LanguageServer
     Either.forLeft(implementations.flatten.asJava)
   }
 
-  override def signatureHelp(params: SignatureHelpParams) = computeAsync { canceltoken =>
+  override def signatureHelp(params: SignatureHelpParams): CompletableFuture[SignatureHelp] = computeAsync { canceltoken =>
     val uri = new URI(params.getTextDocument.getUri)
     val driver = driverFor(uri)
 
@@ -574,13 +575,13 @@ class DottyLanguageServer extends LanguageServer
 
   // Unimplemented features. If you implement one of them, you may need to add a
   // capability in `initialize`
-  override def codeAction(params: CodeActionParams) = null
-  override def codeLens(params: CodeLensParams) = null
-  override def formatting(params: DocumentFormattingParams) = null
-  override def rangeFormatting(params: DocumentRangeFormattingParams) = null
-  override def onTypeFormatting(params: DocumentOnTypeFormattingParams) = null
-  override def resolveCodeLens(params: CodeLens) = null
-  override def resolveCompletionItem(params: CompletionItem) = null
+  override def codeAction(params: CodeActionParams): CompletableFuture[ju.List[JEither[Command, CodeAction]]] | Null = null
+  override def codeLens(params: CodeLensParams): CompletableFuture[ju.List[? <: CodeLens]] | Null = null
+  override def formatting(params: DocumentFormattingParams): CompletableFuture[ju.List[? <: TextEdit]] | Null = null
+  override def rangeFormatting(params: DocumentRangeFormattingParams): CompletableFuture[ju.List[? <: TextEdit]] | Null = null
+  override def onTypeFormatting(params: DocumentOnTypeFormattingParams): CompletableFuture[ju.List[? <: TextEdit]] | Null = null
+  override def resolveCodeLens(params: CodeLens): CompletableFuture[CodeLens] | Null = null
+  override def resolveCompletionItem(params: CompletionItem): CompletableFuture[CompletionItem] | Null = null
 
   /**
    * Find the set of projects that have any of `definitions` on their classpath.

--- a/language-server/src/dotty/tools/languageserver/Main.scala
+++ b/language-server/src/dotty/tools/languageserver/Main.scala
@@ -30,7 +30,7 @@ object Main {
     }
   }
 
-  def startServer(in: InputStream, out: OutputStream) = {
+  def startServer(in: InputStream, out: OutputStream): java.util.concurrent.Future[Void] = {
     val server = new DottyLanguageServer
 
     println("Starting server")

--- a/language-server/test/dotty/tools/languageserver/util/server/TestClient.scala
+++ b/language-server/test/dotty/tools/languageserver/util/server/TestClient.scala
@@ -39,7 +39,7 @@ class TestClient extends DottyClient {
     telemetry += obj
   }
 
-  override def showMessageRequest(requestParams: ShowMessageRequestParams) = {
+  override def showMessageRequest(requestParams: ShowMessageRequestParams): CompletableFuture[MessageActionItem] = {
     val reply = new CompletableFuture[MessageActionItem]
     requests += ((requestParams, reply))
     reply

--- a/tests/init/pos/Properties.scala
+++ b/tests/init/pos/Properties.scala
@@ -39,18 +39,18 @@ private[scala] trait PropertiesTrait {
 
   final def propIsSet(name: String)                   = System.getProperty(name) != null
   final def propIsSetTo(name: String, value: String)  = propOrNull(name) == value
-  final def propOrElse(name: String, alt: String)     = System.getProperty(name, alt)
-  final def propOrEmpty(name: String)                 = propOrElse(name, "")
-  final def propOrNull(name: String)                  = propOrElse(name, null)
-  final def propOrNone(name: String)                  = Option(propOrNull(name))
+  final def propOrElse(name: String, alt: String): String = System.getProperty(name, alt)
+  final def propOrEmpty(name: String): String         = propOrElse(name, "")
+  final def propOrNull(name: String): String | Null   = propOrElse(name, null)
+  final def propOrNone(name: String): Option[String]  = Option(propOrNull(name))
   final def propOrFalse(name: String)                 = propOrNone(name) exists (x => List("yes", "on", "true") contains x.toLowerCase)
-  final def setProp(name: String, value: String)      = System.setProperty(name, value)
-  final def clearProp(name: String)                   = System.clearProperty(name)
+  final def setProp(name: String, value: String): String = System.setProperty(name, value)
+  final def clearProp(name: String): String           = System.clearProperty(name)
 
-  final def envOrElse(name: String, alt: String)      = Option(System.getenv(name)) getOrElse alt
-  final def envOrNone(name: String)                   = Option(System.getenv(name))
+  final def envOrElse(name: String, alt: String): String = Option(System.getenv(name)) getOrElse alt
+  final def envOrNone(name: String): Option[String]   = Option(System.getenv(name))
 
-  final def envOrSome(name: String, alt: Option[String])       = envOrNone(name) orElse alt
+  final def envOrSome(name: String, alt: Option[String]): Option[String] = envOrNone(name) orElse alt
 
   // for values based on propFilename, falling back to System properties
   final def scalaPropOrElse(name: String, alt: String): String = scalaPropOrNone(name).getOrElse(alt)

--- a/tests/init/warn/java1.scala
+++ b/tests/init/warn/java1.scala
@@ -4,7 +4,7 @@ import java.util.function.Consumer
 class A extends Spliterator.OfDouble:
   def characteristics() = 10
   def estimateSize() = 10
-  def trySplit() = ???
+  def trySplit(): Spliterator.OfDouble = ???
   def tryAdvance(`x$0`: java.util.function.DoubleConsumer): Boolean = false
 
   val m = n + 1

--- a/tests/semanticdb/expect/semanticdb-Types.expect.scala
+++ b/tests/semanticdb/expect/semanticdb-Types.expect.scala
@@ -70,8 +70,8 @@ object Test/*<-types::Test.*/ {
     val annType2/*<-types::Test.C#annType2.*/: T/*->types::T#*/ @ann1/*->types::ann1#*/ @ann2/*->types::ann2#*/ = ???/*->scala::Predef.`???`().*/
 
     val existentialType2/*<-types::Test.C#existentialType2.*/: List/*->scala::package.List#*/[_] = ???/*->scala::Predef.`???`().*/
-    val existentialType3/*<-types::Test.C#existentialType3.*/ = Class/*->java::lang::Class#*/.forName/*->java::lang::Class#forName().*/("foo.Bar")
-    val existentialType4/*<-types::Test.C#existentialType4.*/ = Class/*->java::lang::Class#*/.forName/*->java::lang::Class#forName().*/("foo.Bar")
+    val existentialType3/*<-types::Test.C#existentialType3.*/: Class/*->scala::Predef.Class#*/[?] = Class/*->java::lang::Class#*/.forName/*->java::lang::Class#forName().*/("foo.Bar")
+    val existentialType4/*<-types::Test.C#existentialType4.*/: Class/*->scala::Predef.Class#*/[?] = Class/*->java::lang::Class#*/.forName/*->java::lang::Class#forName().*/("foo.Bar")
 
     def typeLambda1/*<-types::Test.C#typeLambda1().*/[M/*<-types::Test.C#typeLambda1().[M]*/[_]] = ???/*->scala::Predef.`???`().*/
     typeLambda1/*->types::Test.C#typeLambda1().*/[({ type L/*<-local11*/[T/*<-local10*/] = List/*->scala::package.List#*/[T/*->local10*/] })#L]

--- a/tests/semanticdb/expect/semanticdb-Types.scala
+++ b/tests/semanticdb/expect/semanticdb-Types.scala
@@ -70,8 +70,8 @@ object Test {
     val annType2: T @ann1 @ann2 = ???
 
     val existentialType2: List[_] = ???
-    val existentialType3 = Class.forName("foo.Bar")
-    val existentialType4 = Class.forName("foo.Bar")
+    val existentialType3: Class[?] = Class.forName("foo.Bar")
+    val existentialType4: Class[?] = Class.forName("foo.Bar")
 
     def typeLambda1[M[_]] = ???
     typeLambda1[({ type L[T] = List[T] })#L]

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -5589,7 +5589,7 @@ Uri => semanticdb-Types.scala
 Text => empty
 Language => Scala
 Symbols => 143 entries
-Occurrences => 246 entries
+Occurrences => 248 entries
 Diagnostics => 4 entries
 Synthetics => 1 entries
 
@@ -5889,11 +5889,13 @@ Occurrences:
 [71:26..71:30): List -> scala/package.List#
 [71:36..71:39): ??? -> scala/Predef.`???`().
 [72:8..72:24): existentialType3 <- types/Test.C#existentialType3.
-[72:27..72:32): Class -> java/lang/Class#
-[72:33..72:40): forName -> java/lang/Class#forName().
+[72:26..72:31): Class -> scala/Predef.Class#
+[72:37..72:42): Class -> java/lang/Class#
+[72:43..72:50): forName -> java/lang/Class#forName().
 [73:8..73:24): existentialType4 <- types/Test.C#existentialType4.
-[73:27..73:32): Class -> java/lang/Class#
-[73:33..73:40): forName -> java/lang/Class#forName().
+[73:26..73:31): Class -> scala/Predef.Class#
+[73:37..73:42): Class -> java/lang/Class#
+[73:43..73:50): forName -> java/lang/Class#forName().
 [75:8..75:19): typeLambda1 <- types/Test.C#typeLambda1().
 [75:20..75:21): M <- types/Test.C#typeLambda1().[M]
 [75:28..75:31): ??? -> scala/Predef.`???`().

--- a/tests/warn/i12460.check
+++ b/tests/warn/i12460.check
@@ -1,5 +1,5 @@
 -- [E208] Potential Issue Warning: tests/warn/i12460.scala:3:23 --------------------------------------------------------
-3 |extension (s: String = "hello, world") def invert = s.reverse.toUpperCase // warn
+3 |extension (s: String = "hello, world") def invert : String = s.reverse.toUpperCase // warn
   |                       ^
   |                       Extension method invert should not have a default argument for its receiver.
   |---------------------------------------------------------------------------------------------------------------------
@@ -11,7 +11,7 @@
   | it should not be defined as an extension.
    ---------------------------------------------------------------------------------------------------------------------
 -- [E208] Potential Issue Warning: tests/warn/i12460.scala:5:37 --------------------------------------------------------
-5 |extension (using String)(s: String = "hello, world") def revert = s.reverse.toUpperCase // warn
+5 |extension (using String)(s: String = "hello, world") def revert : String = s.reverse.toUpperCase // warn
   |                                     ^
   |                                     Extension method revert should not have a default argument for its receiver.
   |---------------------------------------------------------------------------------------------------------------------

--- a/tests/warn/i12460.scala
+++ b/tests/warn/i12460.scala
@@ -1,9 +1,9 @@
 //> using options -explain -Ystop-after:refchecks
 
-extension (s: String = "hello, world") def invert = s.reverse.toUpperCase // warn
+extension (s: String = "hello, world") def invert : String = s.reverse.toUpperCase // warn
 
-extension (using String)(s: String = "hello, world") def revert = s.reverse.toUpperCase // warn
+extension (using String)(s: String = "hello, world") def revert : String = s.reverse.toUpperCase // warn
 
 extension (s: String)
-  def divert(m: String = "hello, world") = (s+m).reverse.toUpperCase // ok
-  def divertimento(using String)(m: String = "hello, world") = (s+m).reverse.toUpperCase // ok
+  def divert(m: String = "hello, world") : String = (s+m).reverse.toUpperCase // ok
+  def divertimento(using String)(m: String = "hello, world") : String = (s+m).reverse.toUpperCase // ok


### PR DESCRIPTION
These are type annotations that do not affect code behavior isolated from PR #25461

## How much have you relied on LLM-based tools in this contribution?

Moderately, for automagically cherry picking changes from #25461

## How was the solution tested?

Covered by existing tests (this is a refactoring)
