### PR TITLE
make namedTupleCanEqual stable

### DIFF
--- a/library/src/scala/NamedTuple.scala
+++ b/library/src/scala/NamedTuple.scala
@@ -3,7 +3,6 @@ import compiletime.ops.boolean.*
 import collection.immutable.{SeqMap, ListMap}
 
 import language.experimental.captureChecking
-import scala.annotation.experimental
 import scala.annotation.unused
 
 object NamedTuple:
@@ -20,7 +19,6 @@ object NamedTuple:
 
   // Alternatively we could restrict `N` to be identical on both sides, but this provides less
   // useful error messages
-  @experimental
   given namedTupleCanEqual: [N1 <: Tuple, N2 <: Tuple, V1 <: Tuple, V2 <: Tuple]
     => (@unused eqN: N1 =:= N2)
     => (@unused eqV: CanEqual[V1, V2])

--- a/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
+++ b/tests/run-tasty-inspector/stdlibExperimentalDefinitions.scala
@@ -102,9 +102,6 @@ val experimentalDefinitionInLibrary = Set(
 
   // New feature: Erased trait
   "scala.compiletime.Erased",
-
-  // New API: Multiversal equality for Named Tuples
-  "scala.NamedTuple$.namedTupleCanEqual",
 )
 
 


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26242



## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
