### PR TITLE
Fix `@reserve` handling

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -773,13 +773,14 @@ extension (sym: Symbol) {
    *    @use-annotated term parameter that contains `sym` in its deep capture set.
    *  From 3.8:
    *    `sym` is a capset parameter without a `@reserve` annotation that
-   *      - belongs to a class in a class, or
+   *      - belongs to a class, or
    *      - belongs to a method where it appears in a the deep capture set of a following term parameter of the same method.
    */
   def isUseParam(using Context): Boolean =
     sym.hasAnnotation(defn.UseAnnot)
     || sym.info.hasAnnotation(defn.UseAnnot)
     || sym.is(TypeParam)
+        && !sym.hasAnnotation(defn.ReserveAnnot)
         && !sym.info.hasAnnotation(defn.ReserveAnnot)
         && (sym.owner.isClass
             || sym.owner.rawParamss.nestedExists: param =>

--- a/tests/neg-custom-args/captures/reserve-param.check
+++ b/tests/neg-custom-args/captures/reserve-param.check
@@ -1,0 +1,4 @@
+-- Error: tests/neg-custom-args/captures/reserve-param.scala:3:70 ------------------------------------------------------
+3 |def runOps[@reserve C^](ops: List[() ->{C} Unit]): Unit = ops.foreach(_())  // error
+  |                                                                      ^^^
+  |                                                Capture set parameter C leaks into capture scope of method runOps.

--- a/tests/neg-custom-args/captures/reserve-param.scala
+++ b/tests/neg-custom-args/captures/reserve-param.scala
@@ -1,0 +1,7 @@
+import language.experimental.captureChecking
+import caps.reserve
+def runOps[@reserve C^](ops: List[() ->{C} Unit]): Unit = ops.foreach(_())  // error
+trait Ops[C^] { def toList: List[() ->{C} Unit] }
+def runOpsAlt1[@reserve C1^](ops: Ops[C1]): Unit = runOps[{C1}](???)  // ok
+def runOpsAlt2[@reserve C2^](ops: Ops[{}]^{C2}): Unit = runOps[{C2}](???)  // ok
+def runOpsAlt3[@reserve C3^](ops: Ops[C3]^{C3}): Unit = runOps[{C3}](???)  // ok


### PR DESCRIPTION
We missed a case when checking whether a capset parameter carried a `@reserve` annotation.
