### PR TITLE
Add regression test for 12577.scala

### DIFF
--- a/tests/pos/i12577.scala
+++ b/tests/pos/i12577.scala
@@ -1,0 +1,15 @@
+import compiletime.constValueOpt
+transparent inline def foo[L, R]: Boolean =
+  inline (constValueOpt[L], constValueOpt[R]) match
+    case (Some(l), Some(r)) => true
+    case _                  => false
+transparent inline def fooWorks[L, R]: Boolean =
+  inline constValueOpt[L] match
+    case Some(l) =>
+      inline constValueOpt[R] match
+        case Some(l) => true
+        case _       => false
+    case _ => false
+
+val f: true = foo[1, 2] //error here
+val fWorks: true = fooWorks[1, 2]


### PR DESCRIPTION
Seems like this bug got first fixed in 3.4.0 and has worked ever since.

Fixes #12577

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
