### PR TITLE
Simplify isUseParam logic

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -774,24 +774,14 @@ extension (sym: Symbol) {
    *  From 3.8:
    *    `sym` is a capset parameter without a `@reserve` annotation that
    *      - belongs to a class in a class, or
-   *      - belongs to a method where it appears in a the deep capture set of a following term parameter of the same method.
+   *      - belongs to a method wh∂ere it appears in a the deep capture set of a following term parameter of the same method.
+   *  From 3.10:
+   *    `sym` is a capset parameter
    */
   def isUseParam(using Context): Boolean =
     sym.hasAnnotation(defn.UseAnnot)
     || sym.info.hasAnnotation(defn.UseAnnot)
-    || sym.is(TypeParam)
-        && !sym.info.hasAnnotation(defn.ReserveAnnot)
-        && (sym.owner.isClass
-            || sym.owner.rawParamss.nestedExists: param =>
-                param.is(TermParam)
-                && (!ccConfig.allowUse || param.hasAnnotation(defn.UseAnnot))
-                && param.info.deepCaptureSet.elems.exists:
-                    case c: TypeRef => c.symbol == sym
-                    case _ => false
-            || {
-              //println(i"not is use param $sym")
-              false
-            })
+    || sym.is(TypeParam) && sym.info.derivesFromCapSet
 
   /** `sym` or its info is annotated with `@consume`. */
   def isConsumeParam(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -2247,7 +2247,6 @@ class CheckCaptures extends Recheck, SymTransformer:
 
             checkAnnot(defn.UseAnnot)
             checkAnnot(defn.ConsumeAnnot)
-            checkAnnot(defn.ReserveAnnot)
       end OverridingPairsCheckerCC
 
       def traverse(t: Tree)(using Context) =

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1116,7 +1116,6 @@ class Definitions {
   @tu lazy val UncheckedCapturesAnnot: ClassSymbol = requiredClass("scala.annotation.unchecked.uncheckedCaptures")
   @tu lazy val UntrackedCapturesAnnot: ClassSymbol = requiredClass("scala.caps.unsafe.untrackedCaptures")
   @tu lazy val UseAnnot: ClassSymbol = requiredClass("scala.caps.use")
-  @tu lazy val ReserveAnnot: ClassSymbol = requiredClass("scala.caps.reserve")
   @tu lazy val AssumeSafeAnnot: ClassSymbol = requiredClass("scala.caps.assumeSafe")
   @tu lazy val RejectSafeAnnot: ClassSymbol = requiredClass("scala.caps.rejectSafe")
   @tu lazy val ConsumeAnnot: ClassSymbol = requiredClass("scala.caps.internal.consume")
@@ -2050,7 +2049,7 @@ class Definitions {
     Caps_ExclusiveCapability, Caps_Mutable, Caps_Read, Caps_Unscoped, Caps_Stateful,
     Caps_Shared, RequiresCapabilityAnnot,
     Caps_any, Caps_fresh, Caps_CapSet, Caps_ContainsTrait, Caps_ContainsModule, Caps_ContainsModule.moduleClass,
-    ConsumeAnnot, UseAnnot, ReserveAnnot, AssumeSafeAnnot, RejectSafeAnnot,
+    ConsumeAnnot, UseAnnot, AssumeSafeAnnot, RejectSafeAnnot,
     CapsUnsafeModule, CapsUnsafeModule.moduleClass, Caps_freeze, Caps_Var,
     CapsInternalModule, CapsInternalModule.moduleClass,
     RetainsAnnot, RetainsCapAnnot, RetainsByNameAnnot)

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -136,7 +136,6 @@ class PlainPrinter(_ctx: Context) extends Printer {
     keywordText("erased ").provided(isErased)
     ~ specialAnnotText(defn.UseAnnot, arg)
     ~ specialAnnotText(defn.ConsumeAnnot, arg)
-    ~ specialAnnotText(defn.ReserveAnnot, arg)
     ~ homogenizeArg(arg).match
         case arg: TypeBounds => "?" ~ toText(arg)
         case arg => toText(arg)

--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -129,16 +129,12 @@ object Contains:
   @experimental
   given containsImpl[C >: CapSet <: CapSet @retainsCap, R <: Singleton]: Contains[C, R]()
 
-/** An annotation on capset parameters `C` stating that the method's body does not
+/** Was an annotation on capset parameters `C` stating that the method's body does not
  *  have `C` in its use-set. `C` might be accessed under a box in the method
- *  or in the result type of the method. Consequently, when calling the method
- *  we do not need to charge the capture set of the actual argiment to the
- *  environment.
- *
- *  Note: This should go into annotations. For now it is here, so that we
- *  can experiment with it quickly between minor releases
+ *  or in the result type of the method.
+ *  Now deprecated and with no effect.
  */
-@experimental
+@experimental @deprecated
 final class reserve extends annotation.StaticAnnotation
 
 /** An annotation for definitions that should not be accessible from code

--- a/tests/neg-custom-args/captures/cc-poly-source.scala
+++ b/tests/neg-custom-args/captures/cc-poly-source.scala
@@ -31,10 +31,10 @@ import caps.use
       // we get an error here because we no longer allow contravariant cap
       // to subsume other capabilities. The problem can be solved by declaring
       // Label a SharedCapability, see cc-poly-source-capability.scala
-    val src = Source[{lbls*}]
+    val src = Source[{C}]
     for l <- listeners do
       src.register(l)
     val ls = src.allListeners
-    val _: Set[Listener^{lbls*}] = ls
+    val _: Set[Listener^{C}] = ls
 
 

--- a/tests/neg-custom-args/captures/i24309a.check
+++ b/tests/neg-custom-args/captures/i24309a.check
@@ -1,4 +1,0 @@
--- Error: tests/neg-custom-args/captures/i24309a.scala:4:34 ------------------------------------------------------------
-4 |def runOps2[C^](): Unit = runOps[{C}](???)  // error
-  |                                  ^
-  |                                  Capture set parameter C leaks into capture scope of method runOps2.

--- a/tests/neg-custom-args/captures/use-capset.check
+++ b/tests/neg-custom-args/captures/use-capset.check
@@ -1,5 +1,5 @@
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:15:22 -----------------------------------
-15 |  val _: () -> Unit = h // error: should be ->{io}
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:10:22 -----------------------------------
+10 |  val _: () -> Unit = h // error: should be ->{io}
    |                      ^
    |                      Found:    (h : () ->{io} Unit)
    |                      Required: () -> Unit
@@ -7,16 +7,12 @@
    |                      Note that capability `io` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`
--- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:17:50 -----------------------------------
-17 |  val _: () -> List[Object^{io}] -> Object^{io} = h2 // error, should be ->{io}
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:12:50 -----------------------------------
+12 |  val _: () -> List[Object^{io}] -> Object^{io} = h2 // error, should be ->{io}
    |                                                  ^^
-   |                                                  Found:    (h2 : () -> List[Object^{io}] ->{io} Object^{io})
-   |                                                  Required: () -> List[Object^{io}] -> Object^{io}
+   |                                                 Found:    (h2 : () ->{io} List[Object^{io}] ->{io} Object^{io})
+   |                                                 Required: () -> List[Object^{io}] -> Object^{io}
    |
-   |                                                  Note that capability `io` cannot flow into capture set {}.
+   |                                                 Note that capability `h2` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`
--- Error: tests/neg-custom-args/captures/use-capset.scala:5:49 ---------------------------------------------------------
-5 |private def g[C^] = (xs: List[Object^{C}]) => xs.head // error TODO: allow this
-  |                                              ^^^^^^^
-  |                                              Capture set parameter C leaks into capture scope of method g.

--- a/tests/neg-custom-args/captures/use-capset.scala
+++ b/tests/neg-custom-args/captures/use-capset.scala
@@ -2,12 +2,7 @@ import caps.{use, CapSet}
 
 def f[C^](xs: List[Object^{C}]): Unit = ???
 
-private def g[C^] = (xs: List[Object^{C}]) => xs.head // error TODO: allow this
-  // This fails currently since `C^` is not classified as used since it does
-  // not appear in the deep capture set of a term parameter of `g`. See CaptureOps.isUseParam.
-  // To classify it as used we'd also have to look at the RHS. But this would change again
-  // if we go to non-monotonic currying.
-
+private def g[C^] = (xs: List[Object^{C}]) => xs.head
 private def g2[C^](xs: List[Object^{C}]) = xs.head // ok
 
 def test(io: Object^)(xs: List[Object^{io}]): Unit =

--- a/tests/pos-custom-args/captures/i24309a.scala
+++ b/tests/pos-custom-args/captures/i24309a.scala
@@ -1,4 +1,4 @@
 import language.experimental.captureChecking
 def runOps[C^](ops: List[() ->{C} Unit]): Unit = ???
 def runOps1[C^](xs: Object^{C}): Unit = runOps[{C}](???)  // ok
-def runOps2[C^](): Unit = runOps[{C}](???)  // error
+def runOps2[C^](): Unit = runOps[{C}](???)  // ok

--- a/tests/pos-custom-args/captures/unbox-overrides.scala
+++ b/tests/pos-custom-args/captures/unbox-overrides.scala
@@ -1,15 +1,15 @@
 import caps.reserve
 
 trait A:
-  def foo[@reserve C^]: Object^{C}
+  def foo[C^]: Object^{C}
   def bar[C^]: Object^{C}
 
 trait B extends A:
   def foo[C^]: Object^{C}  // error
-  def bar[@reserve C^]: Object^{C} // error
+  def bar[C^]: Object^{C} // error
 
 trait B2:
   def foo[C^]: Object^{C}
-  def bar[@reserve C^]: Object^{C}
+  def bar[C^]: Object^{C}
 
 abstract class C extends A, B2 // error


### PR DESCRIPTION
 - Drop `@reserve` annotation.
 - The used parameters are now precisely the capset parameters.

The idea is that we can obtain delayed usage by placing capset parameters later in a curried parameter sequence. No other provisions are needed. This simplifies the logic and explanation and avoids corner cases where we need something to be used but the previous logic did not recognize it as such.

Supersedes #26254