### PR TITLE
fix: Iterator.distinctBy stack overflow + LongMap.put returning None for Long.MinValue

### DIFF
--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -588,15 +588,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     private var nextElementDefined: Boolean = false
     private var nextElement: A = compiletime.uninitialized
 
-    def hasNext: Boolean = nextElementDefined || (self.hasNext && {
-      val a = self.next()
-      if (traversedValues.add(f(a))) {
-        nextElement = a
-        nextElementDefined = true
-        true
+    def hasNext: Boolean = nextElementDefined || {
+      while (self.hasNext) {
+        val a = self.next()
+        if (traversedValues.add(f(a))) {
+          nextElement = a
+          nextElementDefined = true
+          return true
+        }
       }
-      else hasNext
-    })
+      false
+    }
 
     def next(): A =
       if (hasNext) {

--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -310,7 +310,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
         ans
       }
       else {
-        val ans = if ((extraKeys&2) == 1) Some(minValue.asInstanceOf[V]) else None
+        val ans = if ((extraKeys&2) == 2) Some(minValue.asInstanceOf[V]) else None
         minValue = value.asInstanceOf[AnyRef]
         extraKeys |= 2
         ans

--- a/tests/run/iterator-distinctby.scala
+++ b/tests/run/iterator-distinctby.scala
@@ -1,0 +1,27 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    // basic distinctBy
+    val xs = List(1, 2, 2, 3, 3, 3).iterator.distinctBy(identity)
+    assert(xs.toList == List(1, 2, 3), "basic distinctBy failed")
+
+    // distinctBy with transformation
+    val ys = List("apple", "ant", "banana", "avocado").iterator.distinctBy(_.head)
+    assert(ys.toList == List("apple", "banana"), "distinctBy with transformation failed")
+
+    // distinctBy on empty iterator
+    val zs = Iterator.empty[Int].distinctBy(identity)
+    assert(zs.toList == Nil, "distinctBy on empty iterator failed")
+
+    // distinctBy with all duplicates - regression test for stack overflow
+    // with consecutive duplicates (was a bug in hasNext recursion)
+    val N = 100000
+    val allSame = Array.fill(N)(1).iterator.distinctBy(identity)
+    assert(allSame.toList == List(1), "distinctBy with all duplicates failed (stack overflow?)")
+
+    // distinctBy with consecutive duplicates at start
+    val consec = (List.fill(50000)(1) ++ List(2, 3)).iterator.distinctBy(identity)
+    assert(consec.toList == List(1, 2, 3), "distinctBy with consecutive duplicates at start failed")
+
+    println("OK")
+  }
+}

--- a/tests/run/iterator-distinctby.scala
+++ b/tests/run/iterator-distinctby.scala
@@ -1,27 +1,19 @@
 object Test {
   def main(args: Array[String]): Unit = {
-    // basic distinctBy
     val xs = List(1, 2, 2, 3, 3, 3).iterator.distinctBy(identity)
-    assert(xs.toList == List(1, 2, 3), "basic distinctBy failed")
+    assert(xs.toList == List(1, 2, 3))
 
-    // distinctBy with transformation
     val ys = List("apple", "ant", "banana", "avocado").iterator.distinctBy(_.head)
-    assert(ys.toList == List("apple", "banana"), "distinctBy with transformation failed")
+    assert(ys.toList == List("apple", "banana"))
 
-    // distinctBy on empty iterator
     val zs = Iterator.empty[Int].distinctBy(identity)
-    assert(zs.toList == Nil, "distinctBy on empty iterator failed")
+    assert(zs.toList == Nil)
 
-    // distinctBy with all duplicates - regression test for stack overflow
-    // with consecutive duplicates (was a bug in hasNext recursion)
-    val N = 100000
-    val allSame = Array.fill(N)(1).iterator.distinctBy(identity)
-    assert(allSame.toList == List(1), "distinctBy with all duplicates failed (stack overflow?)")
+    // regression: stack overflow on consecutive duplicates
+    val allSame = Array.fill(100000)(1).iterator.distinctBy(identity)
+    assert(allSame.toList == List(1))
 
-    // distinctBy with consecutive duplicates at start
     val consec = (List.fill(50000)(1) ++ List(2, 3)).iterator.distinctBy(identity)
-    assert(consec.toList == List(1, 2, 3), "distinctBy with consecutive duplicates at start failed")
-
-    println("OK")
+    assert(consec.toList == List(1, 2, 3))
   }
 }

--- a/tests/run/longmap-put.scala
+++ b/tests/run/longmap-put.scala
@@ -2,28 +2,20 @@ object Test {
   def main(args: Array[String]): Unit = {
     import scala.collection.mutable.LongMap
 
-    // LongMap.put should return Some for existing keys
     val m = LongMap.empty[Int]
     m.put(0L, 1)
-    assert(m.put(0L, 2) == Some(1), "put on existing key 0 should return Some(1)")
+    assert(m.put(0L, 2) == Some(1))
 
     m.put(1L, 10)
-    assert(m.put(1L, 20) == Some(10), "put on existing key 1 should return Some(10)")
+    assert(m.put(1L, 20) == Some(10))
 
-    // Regression test: LongMap.put returning None for existing Long.MinValue key
-    // The bug was in extraKeys bit check: (extraKeys&2) == 1 instead of == 2
+    // regression: LongMap.put returning None for existing Long.MinValue key
     m.put(Long.MinValue, 100)
-    assert(m.put(Long.MinValue, 200) == Some(100),
-      s"put on existing Long.MinValue key should return Some(100), got ${m.put(Long.MinValue, 200)}")
+    assert(m.put(Long.MinValue, 200) == Some(100))
 
-    // Long.MaxValue
     m.put(Long.MaxValue, 300)
-    assert(m.put(Long.MaxValue, 400) == Some(300),
-      s"put on existing Long.MaxValue key should return Some(300), got ${m.put(Long.MaxValue, 400)}")
+    assert(m.put(Long.MaxValue, 400) == Some(300))
 
-    // put on non-existing key should return None
-    assert(m.put(999L, 1) == None, "put on non-existing key should return None")
-
-    println("OK")
+    assert(m.put(999L, 1) == None)
   }
 }

--- a/tests/run/longmap-put.scala
+++ b/tests/run/longmap-put.scala
@@ -1,0 +1,29 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    import scala.collection.mutable.LongMap
+
+    // LongMap.put should return Some for existing keys
+    val m = LongMap.empty[Int]
+    m.put(0L, 1)
+    assert(m.put(0L, 2) == Some(1), "put on existing key 0 should return Some(1)")
+
+    m.put(1L, 10)
+    assert(m.put(1L, 20) == Some(10), "put on existing key 1 should return Some(10)")
+
+    // Regression test: LongMap.put returning None for existing Long.MinValue key
+    // The bug was in extraKeys bit check: (extraKeys&2) == 1 instead of == 2
+    m.put(Long.MinValue, 100)
+    assert(m.put(Long.MinValue, 200) == Some(100),
+      s"put on existing Long.MinValue key should return Some(100), got ${m.put(Long.MinValue, 200)}")
+
+    // Long.MaxValue
+    m.put(Long.MaxValue, 300)
+    assert(m.put(Long.MaxValue, 400) == Some(300),
+      s"put on existing Long.MaxValue key should return Some(300), got ${m.put(Long.MaxValue, 400)}")
+
+    // put on non-existing key should return None
+    assert(m.put(999L, 1) == None, "put on non-existing key should return None")
+
+    println("OK")
+  }
+}


### PR DESCRIPTION
## Description

Two bug fixes for standard library collections:

1. **Iterator.distinctBy.hasNext stack overflow**: Replaced recursive `hasNext` with iterative `while` loop to prevent stack overflow on long runs of consecutive duplicates.

2. **LongMap.put returning None for existing Long.MinValue key**: Fixed bitmask check typo `(extraKeys&2) == 1` → `== 2`. Bit 1 has value 2, not 1.

## Tests

- Added `tests/run/iterator-distinctby.scala` with 5 test cases including 100k consecutive duplicates (stack overflow repro)
- Added `tests/run/longmap-put.scala` with 5 test cases covering `Long.MinValue`, `Long.MaxValue`, and non-existing keys

## LLM Policy

LLM-based tools were used moderately in this contribution. The code was reviewed and tested locally before submission.