### PR TITLE
perf: HashMap/HashSet optimizations (concat, merged, diff, from)

### DIFF
--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -2241,6 +2241,7 @@ object HashMap extends MapFactory[HashMap] {
   def from[K, V](source: collection.IterableOnce[(K, V)]^): HashMap[K, V] =
     (source: @unchecked) match {
       case hs: HashMap[K, V] => hs
+      case _ if source.knownSize == 0 => empty[K, V]
       case _ => (newBuilder[K, V] ++= source).result()
     }
 

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -362,19 +362,20 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
         } else {
           new HashMap(that.rootNode.updated(k, v, originalHash, improved, 0, replaceValue = true))
         }
-      } else if (that.size == 0) {
-        val thatPayload@(k, v) = rootNode.getPayload(0)
-        val thatOriginalHash = rootNode.getHash(0)
-        val thatImproved = improve(thatOriginalHash)
+      } else if (that.size == 1) {
+        val (k, v) = that.rootNode.getPayload(0)
+        val originalHash = that.rootNode.getHash(0)
+        val improved = improve(originalHash)
 
-        if (rootNode.containsKey(k, thatOriginalHash, thatImproved, 0)) {
-          val payload = rootNode.getTuple(k, thatOriginalHash, thatImproved, 0)
-          val (mergedK, mergedV) = mergef(payload, thatPayload)
+        if (rootNode.containsKey(k, originalHash, improved, 0)) {
+          val thisPayload = rootNode.getTuple(k, originalHash, improved, 0)
+          val thatPayload = (k, v)
+          val (mergedK, mergedV) = mergef(thisPayload, thatPayload)
           val mergedOriginalHash = mergedK.##
           val mergedImprovedHash = improve(mergedOriginalHash)
-          new HashMap(rootNode.updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0, replaceValue = true))
+          new HashMap(rootNode.removed(k, originalHash, improved, 0).updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0, replaceValue = true))
         } else {
-          new HashMap(rootNode.updated(k, v, thatOriginalHash, thatImproved, 0, replaceValue = true))
+          new HashMap(rootNode.updated(k, v, originalHash, improved, 0, replaceValue = true))
         }
       } else {
         val builder = new HashMapBuilder[K, V1]

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -1891,10 +1891,10 @@ private final class HashCollisionMapNode[K, +V ](
   releaseFence()
 
   private[immutable] def indexOf(key: Any): Int = {
-    val iter = content.iterator
+    val len = content.length
     var i = 0
-    while (iter.hasNext) {
-      if (iter.next()._1 == key) return i
+    while (i < len) {
+      if (content(i)._1 == key) return i
       i += 1
     }
     -1

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -1542,7 +1542,7 @@ private final class BitmapIndexedMapNode[K, +V](
               getNode(leftNodeIdx).updated(
                 key = bm.getKey(rightDataIdx),
                 value = bm.getValue(rightDataIdx),
-                originalHash = bm.getHash(rightDataIdx),
+                originalHash = rightOriginalHash,
                 hash = improve(rightOriginalHash),
                 shift = nextShift,
                 replaceValue = true

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -231,7 +231,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
         case hashSet: HashSet[A] =>
           if (hashSet.isEmpty) this else {
             val newRootNode = rootNode.diff(hashSet.rootNode, 0)
-            if (newRootNode.size == 0) HashSet.empty else newHashSetOrThis(rootNode.diff(hashSet.rootNode, 0))
+            if (newRootNode.size == 0) HashSet.empty else newHashSetOrThis(newRootNode)
           }
         case hashSet: collection.mutable.HashSet[A] =>
           val iter = hashSet.nodeIterator

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -45,7 +45,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
   // This release fence is present because rootNode may have previously been mutated during construction.
   releaseFence()
 
-  private def newHashSetOrThis(newRootNode: BitmapIndexedSetNode[A]): HashSet[A] =
+  @inline private def newHashSetOrThis(newRootNode: BitmapIndexedSetNode[A]): HashSet[A] =
     if (rootNode eq newRootNode) this else new HashSet(newRootNode)
 
   override def iterableFactory: IterableFactory[HashSet] = HashSet
@@ -74,7 +74,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     s.asInstanceOf[S & EfficientSplit]
   }
 
-  def contains(element: A): Boolean = {
+  override final def contains(element: A): Boolean = {
     val elementUnimprovedHash = element.##
     val elementHash = improve(elementUnimprovedHash)
     rootNode.contains(element, elementUnimprovedHash, elementHash, 0)

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -1611,7 +1611,7 @@ private final class BitmapIndexedSetNode[A](
               val leftNode = getNode(leftNodeIdx)
               val updated = leftNode.updated(
                 element = bm.getPayload(rightDataIdx),
-                originalHash = bm.getHash(rightDataIdx),
+                originalHash = rightOriginalHash,
                 hash = improve(rightOriginalHash),
                 shift = nextShift
               )


### PR DESCRIPTION
## Description

Performance optimizations for `HashMap` and `HashSet`:

1. **HashSet.diff**: Eliminated redundant `rootNode.diff` computation (was called twice)
2. **HashMap.merged**: Fixed dead code branch and added `that.size == 1` fast path (symmetric to existing `this.size == 1`)
3. **HashMap/HashSet.concat**: Eliminated redundant `getHash` calls
4. **HashSet**: Added `@inline` to `newHashSetOrThis`, `final` to `contains`
5. **HashMap.from**: Skip builder allocation when `knownSize == 0`
6. **HashCollisionMapNode.indexOf**: Use direct indexed access instead of iterator

All optimizations are semantically equivalent to the original code.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.