### PR TITLE
perf: eliminate wrapper allocation in ListMap.hashCode

### DIFF
--- a/library/src/scala/collection/immutable/ListMap.scala
+++ b/library/src/scala/collection/immutable/ListMap.scala
@@ -86,23 +86,22 @@ sealed class ListMap[K, +V]
   override def hashCode(): Int = {
     if (isEmpty) MurmurHash3.emptyMapHash
     else {
-      // Can't efficiently override foreachEntry directly in ListMap because it would need to preserve iteration
-      // order be reversing the list first. But mapHash is symmetric so the reversed order is fine here.
-      val _reversed = new immutable.AbstractMap[K, V] {
-        override def isEmpty: Boolean = ListMap.this.isEmpty
-        override def removed(key: K): Map[K, V] = ListMap.this.removed(key)
-        override def updated[V1 >: V](key: K, value: V1): Map[K, V1] = ListMap.this.updated(key, value)
-        override def get(key: K): Option[V] = ListMap.this.get(key)
-        override def iterator: Iterator[(K, V)] = ListMap.this.iterator
-        override def foreachEntry[U](f: (K, V) => U): Unit = {
-          var curr: ListMap[K, V] = ListMap.this
-          while (curr.nonEmpty) {
-            f(curr.key, curr.value)
-            curr = curr.next
-          }
-        }
+      var a, b, n = 0
+      var c = 1
+      var curr: ListMap[K, V] = this
+      while (curr.nonEmpty) {
+        val h = MurmurHash3.tuple2Hash(curr.key, curr.value)
+        a += h
+        b ^= h
+        c *= h | 1
+        n += 1
+        curr = curr.next
       }
-      MurmurHash3.mapHash(_reversed)
+      var h = MurmurHash3.mapSeed
+      h = MurmurHash3.mix(h, a)
+      h = MurmurHash3.mix(h, b)
+      h = MurmurHash3.mixLast(h, c)
+      MurmurHash3.finalizeHash(h, n)
     }
   }
 

--- a/tests/run/listmap-listset-order.scala
+++ b/tests/run/listmap-listset-order.scala
@@ -1,24 +1,13 @@
 object Test {
   def main(args: Array[String]): Unit = {
-    // ListMap iterator should preserve insertion order
     val m = scala.collection.immutable.ListMap(1 -> "a", 2 -> "b", 3 -> "c")
-    val iterList = m.iterator.toList
-    assert(iterList == List(1 -> "a", 2 -> "b", 3 -> "c"),
-      s"ListMap iterator should preserve insertion order, got $iterList")
+    assert(m.iterator.toList == List(1 -> "a", 2 -> "b", 3 -> "c"))
 
-    // ListMap hashCode should be deterministic and order-independent
     val m2 = scala.collection.immutable.ListMap(3 -> "c", 2 -> "b", 1 -> "a")
     val m3 = scala.collection.immutable.ListMap(1 -> "a", 2 -> "b", 3 -> "c")
-    // mapHash is unordered so different insertion orders should give same hash
-    assert(m2.hashCode == m3.hashCode,
-      s"ListMap hashCode should be order-independent: ${m2.hashCode} vs ${m3.hashCode}")
+    assert(m2.hashCode == m3.hashCode)
 
-    // ListSet iterator should preserve insertion order
     val s = scala.collection.immutable.ListSet(1, 2, 3)
-    val sIterList = s.iterator.toList
-    assert(sIterList == List(1, 2, 3),
-      s"ListSet iterator should preserve insertion order, got $sIterList")
-
-    println("OK")
+    assert(s.iterator.toList == List(1, 2, 3))
   }
 }

--- a/tests/run/listmap-listset-order.scala
+++ b/tests/run/listmap-listset-order.scala
@@ -1,0 +1,24 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    // ListMap iterator should preserve insertion order
+    val m = scala.collection.immutable.ListMap(1 -> "a", 2 -> "b", 3 -> "c")
+    val iterList = m.iterator.toList
+    assert(iterList == List(1 -> "a", 2 -> "b", 3 -> "c"),
+      s"ListMap iterator should preserve insertion order, got $iterList")
+
+    // ListMap hashCode should be deterministic and order-independent
+    val m2 = scala.collection.immutable.ListMap(3 -> "c", 2 -> "b", 1 -> "a")
+    val m3 = scala.collection.immutable.ListMap(1 -> "a", 2 -> "b", 3 -> "c")
+    // mapHash is unordered so different insertion orders should give same hash
+    assert(m2.hashCode == m3.hashCode,
+      s"ListMap hashCode should be order-independent: ${m2.hashCode} vs ${m3.hashCode}")
+
+    // ListSet iterator should preserve insertion order
+    val s = scala.collection.immutable.ListSet(1, 2, 3)
+    val sIterList = s.iterator.toList
+    assert(sIterList == List(1, 2, 3),
+      s"ListSet iterator should preserve insertion order, got $sIterList")
+
+    println("OK")
+  }
+}


### PR DESCRIPTION
## Description

Performance optimization for `ListMap.hashCode`: eliminated the anonymous `AbstractMap` wrapper allocation by computing the hash directly while walking the internal linked list. The hash algorithm (MurmurHash3 mapHash) is order-independent (uses commutative `+=`, `^=`, `*=`), so the reversed iteration order is correct.

Also added regression tests for `ListMap` and `ListSet` iterator ordering to ensure insertion order is preserved.

## LLM Policy

LLM-based tools were used moderately in this contribution. The code was reviewed and tested locally before submission.