### PR TITLE
perf: RedBlackTree/IntMap/LongMap allocation optimizations

### DIFF
--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -33,11 +33,10 @@ private[immutable] object IntMapUtils extends BitOperations.Int {
     else IntMap.Bin(p, m, t2, t1)
   }
 
-  def bin[T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]): IntMap[T] = (left, right) match {
-    case (left, IntMap.Nil) => left
-    case (IntMap.Nil, right) => right
-    case (left, right) => IntMap.Bin(prefix, mask, left, right)
-  }
+  @`inline` def bin[T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]): IntMap[T] =
+    if (left eq IntMap.Nil) right
+    else if (right eq IntMap.Nil) left
+    else IntMap.Bin(prefix, mask, left, right)
 }
 
 import IntMapUtils.{Int => _, _}

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -268,11 +268,11 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   override def isEmpty = this eq IntMap.Nil
   override def knownSize: Int = if (isEmpty) 0 else super.knownSize
   override def filter(f: ((Int, T)) => Boolean): IntMap[T] = this match {
-    case IntMap.Bin(prefix, mask, left, right) => {
-      val (newleft, newright) = (left.filter(f), right.filter(f))
+    case IntMap.Bin(prefix, mask, left, right) =>
+      val newleft = left.filter(f)
+      val newright = right.filter(f)
       if ((left eq newleft) && (right eq newright)) this
       else bin(prefix, mask, newleft, newright)
-    }
     case IntMap.Tip(key, value) =>
       if (f((key, value))) this
       else IntMap.Nil

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -322,7 +322,10 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
       else if (zero(key, mask)) IntMap.Bin(prefix, mask, left.updated(key, value), right)
       else IntMap.Bin(prefix, mask, left, right.updated(key, value))
     case IntMap.Tip(key2, value2) =>
-      if (key == key2) IntMap.Tip(key, value)
+      if (key == key2) {
+        if (value.asInstanceOf[AnyRef] eq value2.asInstanceOf[AnyRef]) this
+        else IntMap.Tip(key, value)
+      }
       else join(key, IntMap.Tip(key, value), key2, this)
     case IntMap.Nil => IntMap.Tip(key, value)
   }

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -262,11 +262,11 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   override def isEmpty = this eq LongMap.Nil
   override def knownSize: Int = if (isEmpty) 0 else super.knownSize
   override def filter(f: ((Long, T)) => Boolean): LongMap[T] = this match {
-    case LongMap.Bin(prefix, mask, left, right) => {
-      val (newleft, newright) = (left.filter(f), right.filter(f))
+    case LongMap.Bin(prefix, mask, left, right) =>
+      val newleft = left.filter(f)
+      val newright = right.filter(f)
       if ((left eq newleft) && (right eq newright)) this
       else bin(prefix, mask, newleft, newright)
-    }
     case LongMap.Tip(key, value) =>
       if (f((key, value))) this
       else LongMap.Nil

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -35,11 +35,10 @@ private[immutable] object LongMapUtils extends BitOperations.Long {
     else LongMap.Bin(p, m, t2, t1)
   }
 
-  def bin[T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]): LongMap[T] = (left, right) match {
-    case (left, LongMap.Nil) => left
-    case (LongMap.Nil, right) => right
-    case (left, right) => LongMap.Bin(prefix, mask, left, right)
-  }
+  @`inline` def bin[T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]): LongMap[T] =
+    if (left eq LongMap.Nil) right
+    else if (right eq LongMap.Nil) left
+    else LongMap.Bin(prefix, mask, left, right)
 }
 
 import LongMapUtils.{Long => _, _}

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -316,7 +316,10 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
       else if (zero(key, mask)) LongMap.Bin(prefix, mask, left.updated(key, value), right)
       else LongMap.Bin(prefix, mask, left, right.updated(key, value))
     case LongMap.Tip(key2, value2) =>
-      if (key == key2) LongMap.Tip(key, value)
+      if (key == key2) {
+        if (value.asInstanceOf[AnyRef] eq value2.asInstanceOf[AnyRef]) this
+        else LongMap.Tip(key, value)
+      }
       else join(key, LongMap.Tip(key, value), key2, this)
     case LongMap.Nil => LongMap.Tip(key, value)
   }

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -1062,44 +1062,40 @@ private[collection] object RedBlackTree {
 
   private val null2 = (null, null)
 
-  def partitionEntries[A, B](t: Tree[A, B] | Null, p: (A, B) => Boolean): (Tree[A, B] | Null, Tree[A, B] | Null) = if(t eq null) (null, null) else {
-    if (t eq null) null2
-    else {
-      object partitioner {
-        var tmpk, tmpd = null: Tree[A, B] | Null // shared vars to avoid returning tuples from fk
-        def fk(t: Tree[A, B]): Unit = {
-          val k                  = t.key
-          val v                  = t.value
-          var l                  = t.left
-          var r                  = t.right
-          var l2k, l2d, r2k, r2d = null: Tree[A, B] | Null
-          if (l ne null) {
-            fk(l)
-            l2k = tmpk
-            l2d = tmpd
-          }
-          val keep = p(k, v)
-          if (r ne null) {
-            fk(r)
-            r2k = tmpk
-            r2d = tmpd
-          }
-          val jk =
-            if (!keep) join2(l2k, r2k)
-            else if ((l2k eq l) && (r2k eq r)) t
-                 else join(l2k, k, v, r2k)
-          val jd =
-            if (keep) join2(l2d, r2d)
-            else if ((l2d eq l) && (r2d eq r)) t
-                 else join(l2d, k, v, r2d)
-          tmpk = jk
-          tmpd = jd
+  def partitionEntries[A, B](t: Tree[A, B] | Null, p: (A, B) => Boolean): (Tree[A, B] | Null, Tree[A, B] | Null) = if(t eq null) null2 else {
+      var tmpk: Tree[A, B] | Null = null // shared vars to avoid returning tuples from fk
+      var tmpd: Tree[A, B] | Null = null
+      def fk(t: Tree[A, B]): Unit = {
+        val k                  = t.key
+        val v                  = t.value
+        var l                  = t.left
+        var r                  = t.right
+        var l2k, l2d, r2k, r2d = null: Tree[A, B] | Null
+        if (l ne null) {
+          fk(l)
+          l2k = tmpk
+          l2d = tmpd
         }
+        val keep = p(k, v)
+        if (r ne null) {
+          fk(r)
+          r2k = tmpk
+          r2d = tmpd
+        }
+        val jk =
+          if (!keep) join2(l2k, r2k)
+          else if ((l2k eq l) && (r2k eq r)) t
+               else join(l2k, k, v, r2k)
+        val jd =
+          if (keep) join2(l2d, r2d)
+          else if ((l2d eq l) && (r2d eq r)) t
+               else join(l2d, k, v, r2d)
+        tmpk = jk
+        tmpd = jd
       }
 
-      partitioner.fk(t)
-      (blacken(partitioner.tmpk), blacken(partitioner.tmpd))
-    }
+      fk(t)
+      (blacken(tmpk), blacken(tmpd))
   }
 
   // Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -203,7 +203,7 @@ private[collection] object RedBlackTree {
       }
   }
 
-  def count(tree: Tree[?, ?] | Null) = if (tree eq null) 0 else tree.count
+  @`inline` def count(tree: Tree[?, ?] | Null) = if (tree eq null) 0 else tree.count
   def update[A: Ordering, B, B1 >: B](tree: Tree[A, B] | Null, k: A, v: B1, overwrite: Boolean): Tree[A, B1] | Null = blacken(upd(tree, k, v, overwrite))
   def delete[A: Ordering, B](tree: Tree[A, B] | Null, k: A): Tree[A, B] | Null = blacken(del(tree, k))
   def rangeImpl[A: Ordering, B](tree: Tree[A, B] | Null, from: Option[A], until: Option[A]): Tree[A, B] | Null = (from, until) match {
@@ -347,7 +347,7 @@ private[collection] object RedBlackTree {
     else tree
   }
 
-  def isBlack(tree: Tree[?, ?] | Null) = (tree eq null) || tree.isBlack
+  @`inline` def isBlack(tree: Tree[?, ?] | Null) = (tree eq null) || tree.isBlack
 
   @`inline` private def isRedTree(tree: Tree[?, ?] | Null) = (tree ne null) && tree.isRed
   @`inline` private def isBlackTree(tree: Tree[?, ?] | Null) = (tree ne null) && tree.isBlack


### PR DESCRIPTION
## Description

Performance optimizations for `RedBlackTree`, `IntMap`, and `LongMap` to reduce allocations in hot paths:

1. **RedBlackTree**: Added `@inline` to `count` and `isBlack` (high-traffic null-guard checks)
2. **IntMap/LongMap.updated**: Avoid unnecessary `Tip` allocation when re-inserting same value (`eq` check)
3. **RedBlackTree.partitionEntries**: Eliminated anonymous `object` allocation by using local `var` + nested `def`
4. **IntMap/LongMap `bin` utility**: Eliminated tuple allocation, replaced pattern match with `eq`-based `if` chain + `@inline`
5. **IntMap/LongMap `filter`**: Eliminated `Tuple2` allocation by using separate `val` bindings

All optimizations are semantically equivalent. Red-black tree invariants are preserved.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.