### PR TITLE
perf: misc collection optimizations (ArrayDeque, BitSet, ArrayOps, Iterator)

### DIFF
--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -782,7 +782,14 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @param   p     the predicate used to test elements.
    *  @return        `true` if the given predicate `p` is satisfied by at least one element of this array, otherwise `false`
    */
-  def exists(@deprecatedName("f", "2.13.3") p: A => Boolean): Boolean = indexWhere(p) >= 0
+  def exists(@deprecatedName("f", "2.13.3") p: A => Boolean): Boolean = {
+    var i = 0
+    while (i < xs.length) {
+      if (p(xs(i))) return true
+      i += 1
+    }
+    false
+  }
 
   /** Tests whether a predicate holds for all elements of this array.
    *
@@ -1273,7 +1280,14 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @return     `true` if this array has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
    */
-  def contains(elem: A): Boolean = exists (_ == elem)
+  def contains(elem: A): Boolean = {
+    var i = 0
+    while (i < xs.length) {
+      if (elem == xs(i)) return true
+      i += 1
+    }
+    false
+  }
 
   /** Returns a copy of this array with patched values.
    *  Patching at negative indices is the same as patching starting at 0.

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -118,7 +118,7 @@ object ArrayOps {
       var i = 0
       while(i < xs.length) {
         val x = xs(i)
-        if(p(x)) b ++= f(xs(i))
+        if(p(x)) b ++= f(x)
         i += 1
       }
       b.result()

--- a/library/src/scala/collection/IterableOnce.scala
+++ b/library/src/scala/collection/IterableOnce.scala
@@ -1283,13 +1283,10 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
   def collectFirst[B](pf: PartialFunction[A, B]^): Option[B] = {
     // Presumably the fastest way to get in and out of a partial function is for a sentinel function to return itself
     // (Tested to be lower-overhead than runWith.  Would be better yet to not need to (formally) allocate it)
-    val sentinel: scala.Function1[A, Any] = new AbstractFunction1[A, Any] {
-      def apply(a: A): AbstractFunction1[A, Any] = this
-    }
     val it = iterator
     while (it.hasNext) {
-      val x = pf.applyOrElse(it.next(), sentinel)
-      if (x.asInstanceOf[AnyRef] ne sentinel) return Some(x.asInstanceOf[B])
+      val x = pf.applyOrElse(it.next(), IterableOnceOps.collectFirstSentinel)
+      if (x.asInstanceOf[AnyRef] ne IterableOnceOps.collectFirstSentinel) return Some(x.asInstanceOf[B])
     }
     None
   }
@@ -1541,5 +1538,12 @@ transparent trait IterableOnceOps[+A, +CC[_], +C] extends Any { this: IterableOn
     val it = iterator
     while (it.hasNext) xs = it.next() :: xs
     xs
+  }
+}
+
+private[collection] object IterableOnceOps {
+  /** Reusable sentinel for collectFirst to avoid per-call allocation. */
+  val collectFirstSentinel: scala.Function1[Any, Any] = new scala.runtime.AbstractFunction1[Any, Any] {
+    def apply(a: Any): Any = this
   }
 }

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -444,10 +444,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *  @note   Reuse: $consumesIterator
    */
   def indexWhere(p: A => Boolean, from: Int = 0): Int = {
-    var i = math.max(from, 0)
-    val dropped = drop(from)
-    while (dropped.hasNext) {
-      if (p(dropped.next())) return i
+    var i = 0
+    while (i < from && hasNext) { next(); i += 1 }
+    while (hasNext) {
+      if (p(next())) return i
       i += 1
     }
     -1

--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -50,19 +50,20 @@ sealed abstract class BitSet
 
   def incl(elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
-    if (contains(elem)) this
-    else {
-      val idx = elem >> LogWL
-      updateWord(idx, word(idx) | (1L << elem))
-    }
+    val idx = elem >> LogWL
+    val mask = 1L << elem
+    val w = word(idx)
+    if ((w & mask) != 0) this
+    else updateWord(idx, w | mask)
   }
 
   def excl(elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
-    if (contains(elem)) {
-      val idx = elem >> LogWL
-      updateWord(idx, word(idx) & ~(1L << elem))
-    } else this
+    val idx = elem >> LogWL
+    val mask = 1L << elem
+    val w = word(idx)
+    if ((w & mask) != 0) updateWord(idx, w & ~mask)
+    else this
   }
 
   /** Updates word at index `idx`; enlarges set if `idx` outside range of set.

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -224,7 +224,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
-  override def foreachEntry[U](f: (Int, T) => U): Unit = this match {
+  override final def foreachEntry[U](f: (Int, T) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachEntry(f); right.foreachEntry(f) }
     case IntMap.Tip(key, value) => f(key, value)
     case IntMap.Nil =>

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -121,9 +121,10 @@ sealed class NumericRange[T](
   }
 
   override def foreach[@specialized(Specializable.Unit) U](f: T => U): Unit = {
+    val len = length
     var count = 0
     var current = start
-    while (count < length) {
+    while (count < len) {
       f(current)
       current += step
       count += 1

--- a/library/src/scala/collection/mutable/ArrayDeque.scala
+++ b/library/src/scala/collection/mutable/ArrayDeque.scala
@@ -447,8 +447,18 @@ class ArrayDeque[A] protected (
     * See clearAndShrink if you want to also resize internally
     */
   def clear(): Unit = {
-    while(nonEmpty) {
-      removeHeadAssumingNonEmpty()
+    if (nonEmpty) {
+      val a = array
+      val s = start
+      val e = end
+      if (s < e) {
+        java.util.Arrays.fill(a, s, e, null)
+      } else {
+        java.util.Arrays.fill(a, s, a.length, null)
+        java.util.Arrays.fill(a, 0, e, null)
+      }
+      start = 0
+      end = 0
     }
   }
 

--- a/library/src/scala/collection/mutable/BitSet.scala
+++ b/library/src/scala/collection/mutable/BitSet.scala
@@ -70,10 +70,8 @@ class BitSet(protected[collection] final var elems: Array[Long])
 
   def addOne(elem: Int): this.type = {
     require(elem >= 0)
-    if (!contains(elem)) {
-      val idx = elem >> LogWL
-      updateWord(idx, word(idx) | (1L << elem))
-    }
+    val idx = elem >> LogWL
+    updateWord(idx, word(idx) | (1L << elem))
     this
   }
 

--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -71,7 +71,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
    *
    *  @param originalHash the original hash code obtained from `##`
    */
-  private def improveHash(originalHash: Int): Int = {
+  @`inline` private def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
     // algorithm as in java.util.HashMap.

--- a/tests/run/bitsets.scala
+++ b/tests/run/bitsets.scala
@@ -52,6 +52,15 @@ object TestMutable {
   }
   assert(bs.size == 0, s"Expected size == 0 for $bs")
   assert(bs.isEmpty, s"Expected isEmpty for $bs")
+
+  // subtractOne with large nonexistent element should not grow the array
+  val small = BitSet(1, 2, 3)
+  val oldNwords = small.elems.length
+  small -= 1000000  // element far beyond current capacity
+  assert(small.elems.length == oldNwords,
+    s"subtractOne for nonexistent element should not grow array: ${small.elems.length} > $oldNwords")
+  assert(small.toList == List(1, 2, 3),
+    s"subtractOne for nonexistent element should not change contents: ${small.toList}")
 }
 
 object TestMutable2 {


### PR DESCRIPTION
## Description

Performance optimizations for various standard library collections:

1. **ArrayDeque.clear()**: O(n) → O(1) with GC-safe nulling of circular buffer
2. **mutable.BitSet.addOne**: Removed redundant `contains` guard (OR is idempotent)
3. **mutable.HashSet.improveHash**: Added `@inline` annotation
4. **collectFirst**: Made sentinel a reusable singleton instead of per-call allocation
5. **Iterator.indexWhere**: Inlined skip logic, avoiding `SliceIterator` allocation
6. **NumericRange**: Cached `length` in local var to avoid recomputation
7. **IntMap.foreachEntry**: Added `final` for JVM devirtualization
8. **immutable.BitSet.incl/excl**: Inlined `contains` check to avoid double `word(idx)` computation
9. **ArrayOps.WithFilter.flatMap**: Fixed redundant array access (`xs(i)` → `x`)
10. **ArrayOps.exists/contains**: Direct `while` loops instead of `indexWhere`/closure

Note: `mutable.BitSet.subtractOne` retains the `contains` guard to prevent unnecessary array growth when subtracting nonexistent elements.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.