### PR TITLE
fix: Iterator.distinctBy.hasNext stack overflow on consecutive duplicates

### DIFF
--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -588,15 +588,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     private var nextElementDefined: Boolean = false
     private var nextElement: A = compiletime.uninitialized
 
-    def hasNext: Boolean = nextElementDefined || (self.hasNext && {
-      val a = self.next()
-      if (traversedValues.add(f(a))) {
-        nextElement = a
-        nextElementDefined = true
-        true
+    def hasNext: Boolean = nextElementDefined || {
+      while (self.hasNext) {
+        val a = self.next()
+        if (traversedValues.add(f(a))) {
+          nextElement = a
+          nextElementDefined = true
+          return true
+        }
       }
-      else hasNext
-    })
+      false
+    }
 
     def next(): A =
       if (hasNext) {


### PR DESCRIPTION
## Description

Fix stack overflow in Iterator.distinctBy.hasNext when encountering many consecutive duplicates.

## Problem

Iterator.distinctBy.hasNext used recursive self-call (else hasNext) when encountering duplicate elements. For a run of N consecutive duplicates, this creates N stack frames, risking StackOverflowError on pathological inputs like Array.fill(100000)(1).iterator.distinctBy.

## Solution

Replace the recursive tail-call with a while loop that continues scanning until a new unique element is found or the underlying iterator is exhausted.

## Result

Iterator.distinctBy now handles arbitrary numbers of consecutive duplicate elements without stack growth.

## LLM Policy

LLM-based tools were used moderately in this contribution. The code was reviewed and tested locally before submission.