### PR TITLE
fix: LongMap.put returning None for existing Long.MinValue key

### DIFF
--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -310,7 +310,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
         ans
       }
       else {
-        val ans = if ((extraKeys&2) == 1) Some(minValue.asInstanceOf[V]) else None
+        val ans = if ((extraKeys&2) == 2) Some(minValue.asInstanceOf[V]) else None
         minValue = value.asInstanceOf[AnyRef]
         extraKeys |= 2
         ans


### PR DESCRIPTION
## Description

Fix LongMap.put returning None when updating existing Long.MinValue key.

## Problem

LongMap.put(key, value) for Long.MinValue always returned None even when the key was already present. The check (extraKeys&2) == 1 should be (extraKeys&2) == 2, since bit 1 is value 2, not 1.

## Solution

Change == 1 to == 2 on the MinValue branch of put.

## Result

LongMap.put now correctly returns Some(oldValue) when Long.MinValue is already present in the map, consistent with the behavior for 0 and all other keys.

## LLM Policy

LLM-based tools were used moderately in this contribution. The code was reviewed and tested locally before submission.