### PR TITLE
test: add regression tests for Iterator.distinctBy and LongMap.put

### DIFF
--- a/tests/run/iterator-distinctby.scala
+++ b/tests/run/iterator-distinctby.scala
@@ -1,0 +1,27 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    // basic distinctBy
+    val xs = List(1, 2, 2, 3, 3, 3).iterator.distinctBy(identity)
+    assert(xs.toList == List(1, 2, 3), "basic distinctBy failed")
+
+    // distinctBy with transformation
+    val ys = List("apple", "ant", "banana", "avocado").iterator.distinctBy(_.head)
+    assert(ys.toList == List("apple", "banana"), "distinctBy with transformation failed")
+
+    // distinctBy on empty iterator
+    val zs = Iterator.empty[Int].distinctBy(identity)
+    assert(zs.toList == Nil, "distinctBy on empty iterator failed")
+
+    // distinctBy with all duplicates - regression test for stack overflow
+    // with consecutive duplicates (was a bug in hasNext recursion)
+    val N = 100000
+    val allSame = Array.fill(N)(1).iterator.distinctBy(identity)
+    assert(allSame.toList == List(1), "distinctBy with all duplicates failed (stack overflow?)")
+
+    // distinctBy with consecutive duplicates at start
+    val consec = (List.fill(50000)(1) ++ List(2, 3)).iterator.distinctBy(identity)
+    assert(consec.toList == List(1, 2, 3), "distinctBy with consecutive duplicates at start failed")
+
+    println("OK")
+  }
+}

--- a/tests/run/longmap-put.scala
+++ b/tests/run/longmap-put.scala
@@ -1,0 +1,29 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    import scala.collection.mutable.LongMap
+
+    // LongMap.put should return Some for existing keys
+    val m = LongMap.empty[Int]
+    m.put(0L, 1)
+    assert(m.put(0L, 2) == Some(1), "put on existing key 0 should return Some(1)")
+
+    m.put(1L, 10)
+    assert(m.put(1L, 20) == Some(10), "put on existing key 1 should return Some(10)")
+
+    // Regression test: LongMap.put returning None for existing Long.MinValue key
+    // The bug was in extraKeys bit check: (extraKeys&2) == 1 instead of == 2
+    m.put(Long.MinValue, 100)
+    assert(m.put(Long.MinValue, 200) == Some(100),
+      s"put on existing Long.MinValue key should return Some(100), got ${m.put(Long.MinValue, 200)}")
+
+    // Long.MaxValue
+    m.put(Long.MaxValue, 300)
+    assert(m.put(Long.MaxValue, 400) == Some(300),
+      s"put on existing Long.MaxValue key should return Some(300), got ${m.put(Long.MaxValue, 400)}")
+
+    // put on non-existing key should return None
+    assert(m.put(999L, 1) == None, "put on non-existing key should return None")
+
+    println("OK")
+  }
+}


### PR DESCRIPTION
## Description

Add regression tests for Iterator.distinctBy and LongMap.put.

## Tests

- Added tests/run/iterator-distinctby.scala with 5 test cases including 100k consecutive duplicates (stack overflow repro)
- Added tests/run/longmap-put.scala with 5 test cases covering Long.MinValue, Long.MaxValue, and non-existing keys

## LLM Policy

LLM-based tools were used moderately in this contribution. The code was reviewed and tested locally before submission.