### PR TITLE
fix: Iterator.distinctBy.hasNext stack overflow on consecutive duplicates

### DIFF
--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -588,15 +588,17 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
     private var nextElementDefined: Boolean = false
     private var nextElement: A = compiletime.uninitialized
 
-    def hasNext: Boolean = nextElementDefined || (self.hasNext && {
-      val a = self.next()
-      if (traversedValues.add(f(a))) {
-        nextElement = a
-        nextElementDefined = true
-        true
+    def hasNext: Boolean = nextElementDefined || {
+      while (self.hasNext) {
+        val a = self.next()
+        if (traversedValues.add(f(a))) {
+          nextElement = a
+          nextElementDefined = true
+          return true
+        }
       }
-      else hasNext
-    })
+      false
+    }
 
     def next(): A =
       if (hasNext) {

--- a/tests/run/iterator-distinctby.scala
+++ b/tests/run/iterator-distinctby.scala
@@ -1,0 +1,27 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    // basic distinctBy
+    val xs = List(1, 2, 2, 3, 3, 3).iterator.distinctBy(identity)
+    assert(xs.toList == List(1, 2, 3), "basic distinctBy failed")
+
+    // distinctBy with transformation
+    val ys = List("apple", "ant", "banana", "avocado").iterator.distinctBy(_.head)
+    assert(ys.toList == List("apple", "banana"), "distinctBy with transformation failed")
+
+    // distinctBy on empty iterator
+    val zs = Iterator.empty[Int].distinctBy(identity)
+    assert(zs.toList == Nil, "distinctBy on empty iterator failed")
+
+    // distinctBy with all duplicates - regression test for stack overflow
+    // with consecutive duplicates (was a bug in hasNext recursion)
+    val N = 100000
+    val allSame = Array.fill(N)(1).iterator.distinctBy(identity)
+    assert(allSame.toList == List(1), "distinctBy with all duplicates failed (stack overflow?)")
+
+    // distinctBy with consecutive duplicates at start
+    val consec = (List.fill(50000)(1) ++ List(2, 3)).iterator.distinctBy(identity)
+    assert(consec.toList == List(1, 2, 3), "distinctBy with consecutive duplicates at start failed")
+
+    println("OK")
+  }
+}


### PR DESCRIPTION
## Description

Fix stack overflow in Iterator.distinctBy.hasNext when encountering many consecutive duplicates.

## Problem

Iterator.distinctBy.hasNext used recursive self-call (else hasNext) when encountering duplicate elements. For a run of N consecutive duplicates, this creates N stack frames, risking StackOverflowError on pathological inputs like Array.fill(100000)(1).iterator.distinctBy.

## Solution

Replace the recursive tail-call with a while loop that continues scanning until a new unique element is found or the underlying iterator is exhausted.

## Result

Iterator.distinctBy now handles arbitrary numbers of consecutive duplicate elements without stack growth.

## Tests

Added regression tests for Iterator.distinctBy including:
- basic distinctBy
- distinctBy with transformation
- distinctBy on empty iterator
- distinctBy with all duplicates (stack overflow regression test)
- distinctBy with consecutive duplicates at start

## LLM Policy

LLM-based tools were used moderately in this contribution. The code was reviewed and tested locally before submission.