### PR TITLE
fix: LongMap.put returning None for existing Long.MinValue key

### DIFF
--- a/library/src/scala/collection/mutable/LongMap.scala
+++ b/library/src/scala/collection/mutable/LongMap.scala
@@ -310,7 +310,7 @@ final class LongMap[V] private[collection] (defaultEntry: Long -> V, initialBuff
         ans
       }
       else {
-        val ans = if ((extraKeys&2) == 1) Some(minValue.asInstanceOf[V]) else None
+        val ans = if ((extraKeys&2) == 2) Some(minValue.asInstanceOf[V]) else None
         minValue = value.asInstanceOf[AnyRef]
         extraKeys |= 2
         ans

--- a/tests/run/longmap-put.scala
+++ b/tests/run/longmap-put.scala
@@ -1,0 +1,29 @@
+object Test {
+  def main(args: Array[String]): Unit = {
+    import scala.collection.mutable.LongMap
+
+    // LongMap.put should return Some for existing keys
+    val m = LongMap.empty[Int]
+    m.put(0L, 1)
+    assert(m.put(0L, 2) == Some(1), "put on existing key 0 should return Some(1)")
+
+    m.put(1L, 10)
+    assert(m.put(1L, 20) == Some(10), "put on existing key 1 should return Some(10)")
+
+    // Regression test: LongMap.put returning None for existing Long.MinValue key
+    // The bug was in extraKeys bit check: (extraKeys&2) == 1 instead of == 2
+    m.put(Long.MinValue, 100)
+    assert(m.put(Long.MinValue, 200) == Some(100),
+      s"put on existing Long.MinValue key should return Some(100), got ${m.put(Long.MinValue, 200)}")
+
+    // Long.MaxValue
+    m.put(Long.MaxValue, 300)
+    assert(m.put(Long.MaxValue, 400) == Some(300),
+      s"put on existing Long.MaxValue key should return Some(300), got ${m.put(Long.MaxValue, 400)}")
+
+    // put on non-existing key should return None
+    assert(m.put(999L, 1) == None, "put on non-existing key should return None")
+
+    println("OK")
+  }
+}


### PR DESCRIPTION
## Description

Fix LongMap.put returning None when updating existing Long.MinValue key.

## Problem

LongMap.put(key, value) for Long.MinValue always returned None even when the key was already present. The check (extraKeys&2) == 1 should be (extraKeys&2) == 2, since bit 1 is value 2, not 1.

## Solution

Change == 1 to == 2 on the MinValue branch of put.

## Result

LongMap.put now correctly returns Some(oldValue) when Long.MinValue is already present in the map, consistent with the behavior for 0 and all other keys.

## Tests

Added regression tests for LongMap.put including:
- put on existing key 0
- put on existing key 1
- put on existing Long.MinValue key (regression test)
- put on existing Long.MaxValue key
- put on non-existing key

## LLM Policy

LLM-based tools were used moderately in this contribution. The code was reviewed and tested locally before submission.