### PR TITLE
perf: fix redundant rootNode.diff computation in HashSet.diff

### DIFF
--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -231,7 +231,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
         case hashSet: HashSet[A] =>
           if (hashSet.isEmpty) this else {
             val newRootNode = rootNode.diff(hashSet.rootNode, 0)
-            if (newRootNode.size == 0) HashSet.empty else newHashSetOrThis(rootNode.diff(hashSet.rootNode, 0))
+            if (newRootNode.size == 0) HashSet.empty else newHashSetOrThis(newRootNode)
           }
         case hashSet: collection.mutable.HashSet[A] =>
           val iter = hashSet.nodeIterator


### PR DESCRIPTION
## Description

Eliminate redundant rootNode.diff computation in HashSet.diff.

## Problem

HashSet.diff calls rootNode.diff(hashSet.rootNode, 0) twice when the result is non-empty: once to compute newRootNode for the size check, and again to pass to newHashSetOrThis. This doubles the cost of HashSet-to-HashSet diff operations.

## Solution

Replace the second rootNode.diff(hashSet.rootNode, 0) with newRootNode, which was already computed on the previous line.

## Result

HashSet.diff now traverses the CHAMP trie once instead of twice, halving the cost for the common HashSet-vs-HashSet case.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.