### PR TITLE
perf: fix dead code and optimize HashMap.merged for singleton that

### DIFF
--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -362,19 +362,20 @@ final class HashMap[K, +V] private[immutable] (private[immutable] val rootNode: 
         } else {
           new HashMap(that.rootNode.updated(k, v, originalHash, improved, 0, replaceValue = true))
         }
-      } else if (that.size == 0) {
-        val thatPayload@(k, v) = rootNode.getPayload(0)
-        val thatOriginalHash = rootNode.getHash(0)
-        val thatImproved = improve(thatOriginalHash)
+      } else if (that.size == 1) {
+        val (k, v) = that.rootNode.getPayload(0)
+        val originalHash = that.rootNode.getHash(0)
+        val improved = improve(originalHash)
 
-        if (rootNode.containsKey(k, thatOriginalHash, thatImproved, 0)) {
-          val payload = rootNode.getTuple(k, thatOriginalHash, thatImproved, 0)
-          val (mergedK, mergedV) = mergef(payload, thatPayload)
+        if (rootNode.containsKey(k, originalHash, improved, 0)) {
+          val thisPayload = rootNode.getTuple(k, originalHash, improved, 0)
+          val thatPayload = (k, v)
+          val (mergedK, mergedV) = mergef(thisPayload, thatPayload)
           val mergedOriginalHash = mergedK.##
           val mergedImprovedHash = improve(mergedOriginalHash)
-          new HashMap(rootNode.updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0, replaceValue = true))
+          new HashMap(rootNode.removed(k, originalHash, improved, 0).updated(mergedK, mergedV, mergedOriginalHash, mergedImprovedHash, 0, replaceValue = true))
         } else {
-          new HashMap(rootNode.updated(k, v, thatOriginalHash, thatImproved, 0, replaceValue = true))
+          new HashMap(rootNode.updated(k, v, originalHash, improved, 0, replaceValue = true))
         }
       } else {
         val builder = new HashMapBuilder[K, V1]


### PR DESCRIPTION
## Description

Fix dead code and optimize HashMap.merged for singleton that.

## Problem

HashMap.merged had a dead code branch at line 365:  was already handled by  at line 350, making the branch unreachable. The body also incorrectly read from this.rootNode instead of that.rootNode, with confusingly reversed variable names.

Additionally, the singleton optimization (size == 1) was only applied to , not to . When merging a large map with a singleton, the code fell through to the expensive general mergeInto path.

## Solution

- Change the dead  branch to 
- Fix the body to read from that.rootNode (the singleton)
- Correct the mergef argument order (thisPayload, thatPayload)

## Result

Merging any map with a singleton HashMap now uses O(log n) single-key lookup instead of O(n) general merge. The dead code branch is now reachable and correct.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.