### PR TITLE
perf: eliminate redundant getHash calls in HashMap/HashSet concat

### DIFF
--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -1541,7 +1541,7 @@ private final class BitmapIndexedMapNode[K, +V](
               getNode(leftNodeIdx).updated(
                 key = bm.getKey(rightDataIdx),
                 value = bm.getValue(rightDataIdx),
-                originalHash = bm.getHash(rightDataIdx),
+                originalHash = rightOriginalHash,
                 hash = improve(rightOriginalHash),
                 shift = nextShift,
                 replaceValue = true

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -1611,7 +1611,7 @@ private final class BitmapIndexedSetNode[A](
               val leftNode = getNode(leftNodeIdx)
               val updated = leftNode.updated(
                 element = bm.getPayload(rightDataIdx),
-                originalHash = bm.getHash(rightDataIdx),
+                originalHash = rightOriginalHash,
                 hash = improve(rightOriginalHash),
                 shift = nextShift
               )


### PR DESCRIPTION
## Description

Eliminate redundant getHash calls in HashMap/HashSet concat.

## Problem

In BitmapIndexedMapNode.concat and BitmapIndexedSetNode.concat, the leftNodeRightData branch calls bm.getHash(rightDataIdx) twice: once to store in rightOriginalHash, and again as the originalHash argument to updated(). The second call is redundant since the value is already available.

## Solution

Replace the second bm.getHash(rightDataIdx) with rightOriginalHash in both HashMap and HashSet concat implementations.

## Result

Eliminates one redundant array access per right-side data element during concat operations in the leftNodeRightData branch.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.