### PR TITLE
perf: add @inline to newHashSetOrThis and final to contains

### DIFF
--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -45,7 +45,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
   // This release fence is present because rootNode may have previously been mutated during construction.
   releaseFence()
 
-  private def newHashSetOrThis(newRootNode: BitmapIndexedSetNode[A]): HashSet[A] =
+  @inline private def newHashSetOrThis(newRootNode: BitmapIndexedSetNode[A]): HashSet[A] =
     if (rootNode eq newRootNode) this else new HashSet(newRootNode)
 
   override def iterableFactory: IterableFactory[HashSet] = HashSet
@@ -74,7 +74,7 @@ final class HashSet[A] private[immutable](private[immutable] val rootNode: Bitma
     s.asInstanceOf[S & EfficientSplit]
   }
 
-  def contains(element: A): Boolean = {
+  override final def contains(element: A): Boolean = {
     val elementUnimprovedHash = element.##
     val elementHash = improve(elementUnimprovedHash)
     rootNode.contains(element, elementUnimprovedHash, elementHash, 0)


### PR DESCRIPTION
## Description

Add @inline to newHashSetOrThis and final to contains in HashSet.

## Problem

1. HashSet.newHashSetOrThis lacks @inline annotation while its HashMap counterpart (newHashMapOrThis) has it. This method is called from incl, excl, concat, filterImpl, and removedAll -- all high-frequency operations.

2. HashSet.contains is not final, unlike HashMap.contains which is override final. Without final, the JVM cannot devirtualize calls through Set[A] or Iterable[A] references.

## Solution

- Add @inline to newHashSetOrThis
- Add override final to contains

## Result

Enables JIT devirtualization and inlining on the two most critical HashSet hot paths: mutation (incl/excl) and lookup (contains).

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.