### PR TITLE
perf: skip builder allocation for empty source in HashMap.from

### DIFF
--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -2240,6 +2240,7 @@ object HashMap extends MapFactory[HashMap] {
   def from[K, V](source: collection.IterableOnce[(K, V)]^): HashMap[K, V] =
     (source: @unchecked) match {
       case hs: HashMap[K, V] => hs
+      case _ if source.knownSize == 0 => empty[K, V]
       case _ => (newBuilder[K, V] ++= source).result()
     }
 


### PR DESCRIPTION
## Description

Skip builder allocation for empty source in HashMap.from.

## Problem

HashMap.from did not check source.knownSize == 0 before allocating a builder, unlike HashSet.from which has this optimization. For empty sources, this unnecessarily allocates a HashMapBuilder, calls ensureUnaliased, and then returns HashMap.empty.

## Solution

Add case _ if source.knownSize == 0 => empty[K, V] to HashMap.from, matching the pattern in HashSet.from.

## Result

HashMap.from now returns the singleton empty map directly for empty sources, avoiding unnecessary builder allocation.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.