### PR TITLE
perf: use direct indexed access in HashCollisionMapNode.indexOf

### DIFF
--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -1890,10 +1890,10 @@ private final class HashCollisionMapNode[K, +V ](
   releaseFence()
 
   private[immutable] def indexOf(key: Any): Int = {
-    val iter = content.iterator
+    val len = content.length
     var i = 0
-    while (iter.hasNext) {
-      if (iter.next()._1 == key) return i
+    while (i < len) {
+      if (content(i)._1 == key) return i
       i += 1
     }
     -1


### PR DESCRIPTION
## Description

Use direct indexed access in HashCollisionMapNode.indexOf instead of iterator.

## Problem

HashCollisionMapNode.indexOf allocated a VectorIterator on every call just to iterate the content Vector. Since Vector supports O(1) indexed access, direct indexing avoids the iterator allocation.

indexOf is called from apply, get, getOrElse, containsKey, updated, removed, getTuple, and equals -- making it a hot path for collision nodes.

## Solution

Replace content.iterator loop with content(i) indexed access loop.

## Result

Eliminates one VectorIterator allocation per indexOf call on collision nodes.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.