### PR TITLE
perf: add @inline to RedBlackTree.count and isBlack

### DIFF
--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -203,7 +203,7 @@ private[collection] object RedBlackTree {
       }
   }
 
-  def count(tree: Tree[?, ?] | Null) = if (tree eq null) 0 else tree.count
+  @`inline` def count(tree: Tree[?, ?] | Null) = if (tree eq null) 0 else tree.count
   def update[A: Ordering, B, B1 >: B](tree: Tree[A, B] | Null, k: A, v: B1, overwrite: Boolean): Tree[A, B1] | Null = blacken(upd(tree, k, v, overwrite))
   def delete[A: Ordering, B](tree: Tree[A, B] | Null, k: A): Tree[A, B] | Null = blacken(del(tree, k))
   def rangeImpl[A: Ordering, B](tree: Tree[A, B] | Null, from: Option[A], until: Option[A]): Tree[A, B] | Null = (from, until) match {
@@ -347,7 +347,7 @@ private[collection] object RedBlackTree {
     else tree
   }
 
-  def isBlack(tree: Tree[?, ?] | Null) = (tree eq null) || tree.isBlack
+  @`inline` def isBlack(tree: Tree[?, ?] | Null) = (tree eq null) || tree.isBlack
 
   @`inline` private def isRedTree(tree: Tree[?, ?] | Null) = (tree ne null) && tree.isRed
   @`inline` private def isBlackTree(tree: Tree[?, ?] | Null) = (tree ne null) && tree.isBlack


### PR DESCRIPTION
## Description

Add @inline to RedBlackTree.count and isBlack.

## Problem

RedBlackTree.count and isBlack are called extremely frequently from doDrop, doTake, doSlice, nth, size, isEmpty, balance, del, join, and many other hot methods. They lack @inline annotations while the similar isRedTree and isBlackTree have them.

## Solution

Add @inline to both count and isBlack.

## Result

Ensures bytecode-level inlining for cold-start scenarios and removes method-call overhead on the most frequently called RedBlackTree utility methods.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.