### PR TITLE
perf: avoid unnecessary Tip allocation in IntMap/LongMap.updated

### DIFF
--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -322,7 +322,10 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
       else if (zero(key, mask)) IntMap.Bin(prefix, mask, left.updated(key, value), right)
       else IntMap.Bin(prefix, mask, left, right.updated(key, value))
     case IntMap.Tip(key2, value2) =>
-      if (key == key2) IntMap.Tip(key, value)
+      if (key == key2) {
+        if (value.asInstanceOf[AnyRef] eq value2.asInstanceOf[AnyRef]) this
+        else IntMap.Tip(key, value)
+      }
       else join(key, IntMap.Tip(key, value), key2, this)
     case IntMap.Nil => IntMap.Tip(key, value)
   }

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -316,7 +316,10 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
       else if (zero(key, mask)) LongMap.Bin(prefix, mask, left.updated(key, value), right)
       else LongMap.Bin(prefix, mask, left, right.updated(key, value))
     case LongMap.Tip(key2, value2) =>
-      if (key == key2) LongMap.Tip(key, value)
+      if (key == key2) {
+        if (value.asInstanceOf[AnyRef] eq value2.asInstanceOf[AnyRef]) this
+        else LongMap.Tip(key, value)
+      }
       else join(key, LongMap.Tip(key, value), key2, this)
     case LongMap.Nil => LongMap.Tip(key, value)
   }


### PR DESCRIPTION
## Description

Avoid unnecessary Tip allocation in IntMap/LongMap.updated.

## Problem

IntMap.updated and LongMap.updated always allocated a new Tip node when updating an existing key, even when the value was identical. For idempotent updates or concat with overlapping keys, this creates unnecessary garbage.

## Solution

Add an eq check on the value before allocating a new Tip. If the value is the same reference, return this unchanged.

## Result

IntMap/LongMap.updated now avoids allocation when updating an existing key with the same value reference, improving performance in union/concat scenarios with overlapping keys.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.