### PR TITLE
perf: eliminate tuple allocation in IntMap/LongMap bin utility

### DIFF
--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -33,11 +33,10 @@ private[immutable] object IntMapUtils extends BitOperations.Int {
     else IntMap.Bin(p, m, t2, t1)
   }
 
-  def bin[T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]): IntMap[T] = (left, right) match {
-    case (left, IntMap.Nil) => left
-    case (IntMap.Nil, right) => right
-    case (left, right) => IntMap.Bin(prefix, mask, left, right)
-  }
+  @`inline` def bin[T](prefix: Int, mask: Int, left: IntMap[T], right: IntMap[T]): IntMap[T] =
+    if (left eq IntMap.Nil) right
+    else if (right eq IntMap.Nil) left
+    else IntMap.Bin(prefix, mask, left, right)
 }
 
 import IntMapUtils.{Int => _, _}

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -35,11 +35,10 @@ private[immutable] object LongMapUtils extends BitOperations.Long {
     else LongMap.Bin(p, m, t2, t1)
   }
 
-  def bin[T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]): LongMap[T] = (left, right) match {
-    case (left, LongMap.Nil) => left
-    case (LongMap.Nil, right) => right
-    case (left, right) => LongMap.Bin(prefix, mask, left, right)
-  }
+  @`inline` def bin[T](prefix: Long, mask: Long, left: LongMap[T], right: LongMap[T]): LongMap[T] =
+    if (left eq LongMap.Nil) right
+    else if (right eq LongMap.Nil) left
+    else LongMap.Bin(prefix, mask, left, right)
 }
 
 import LongMapUtils.{Long => _, _}


### PR DESCRIPTION
## Description

Eliminate tuple allocation in IntMap/LongMap bin utility.

## Problem

IntMapUtils.bin and LongMapUtils.bin used tuple pattern matching (left, right) match { ... } which allocates a Tuple2 on every call. Since Nil is a singleton case object, eq checks can replace the pattern match without allocation.

bin is called from filter, modifyOrRemove, removed, intersectionWith, and unionWith -- making it a hot path.

## Solution

Replace tuple pattern match with if-else using eq checks on the singleton Nil. Add @inline to eliminate method call overhead.

## Result

Eliminates one Tuple2 allocation per bin call across all IntMap/LongMap operations.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.