### PR TITLE
perf: eliminate tuple allocation in IntMap/LongMap filter

### DIFF
--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -269,11 +269,11 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
   override def isEmpty = this eq IntMap.Nil
   override def knownSize: Int = if (isEmpty) 0 else super.knownSize
   override def filter(f: ((Int, T)) => Boolean): IntMap[T] = this match {
-    case IntMap.Bin(prefix, mask, left, right) => {
-      val (newleft, newright) = (left.filter(f), right.filter(f))
+    case IntMap.Bin(prefix, mask, left, right) =>
+      val newleft = left.filter(f)
+      val newright = right.filter(f)
       if ((left eq newleft) && (right eq newright)) this
       else bin(prefix, mask, newleft, newright)
-    }
     case IntMap.Tip(key, value) =>
       if (f((key, value))) this
       else IntMap.Nil

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -263,11 +263,11 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
   override def isEmpty = this eq LongMap.Nil
   override def knownSize: Int = if (isEmpty) 0 else super.knownSize
   override def filter(f: ((Long, T)) => Boolean): LongMap[T] = this match {
-    case LongMap.Bin(prefix, mask, left, right) => {
-      val (newleft, newright) = (left.filter(f), right.filter(f))
+    case LongMap.Bin(prefix, mask, left, right) =>
+      val newleft = left.filter(f)
+      val newright = right.filter(f)
       if ((left eq newleft) && (right eq newright)) this
       else bin(prefix, mask, newleft, newright)
-    }
     case LongMap.Tip(key, value) =>
       if (f((key, value))) this
       else LongMap.Nil


### PR DESCRIPTION
## Description

Eliminate tuple allocation in IntMap/LongMap filter.

## Problem

IntMap.filter and LongMap.filter used tuple destructuring val (newleft, newright) = (left.filter(f), right.filter(f)) which allocates a Tuple2 per Bin node during filter traversal.

## Solution

Replace tuple destructuring with two separate val bindings.

## Result

Eliminates one Tuple2 allocation per Bin node during filter operations on IntMap and LongMap.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.