### PR TITLE
perf: add @inline to mutable.HashSet.improveHash

### DIFF
--- a/library/src/scala/collection/mutable/HashSet.scala
+++ b/library/src/scala/collection/mutable/HashSet.scala
@@ -71,7 +71,7 @@ final class HashSet[A](initialCapacity: Int, loadFactor: Double)
    *
    *  @param originalHash the original hash code obtained from `##`
    */
-  private def improveHash(originalHash: Int): Int = {
+  @`inline` private def improveHash(originalHash: Int): Int = {
     // Improve the hash by xoring the high 16 bits into the low 16 bits just in case entropy is skewed towards the
     // high-value bits. We only use the lowest bits to determine the hash bucket. This is the same improvement
     // algorithm as in java.util.HashMap.


### PR DESCRIPTION
## Description

Add @inline to mutable.HashSet.improveHash.

## Problem

mutable.HashSet.improveHash lacks @inline while mutable.HashMap.improveHash has it. This is called on every add, remove, and contains operation.

## Solution

Add @inline annotation.

## Result

Ensures inlining on the hot path for all HashSet operations.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.