### PR TITLE
perf: inline skip logic in Iterator.indexWhere

### DIFF
--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -444,10 +444,10 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    *  @note   Reuse: $consumesIterator
    */
   def indexWhere(p: A => Boolean, from: Int = 0): Int = {
-    var i = math.max(from, 0)
-    val dropped = drop(from)
-    while (dropped.hasNext) {
-      if (p(dropped.next())) return i
+    var i = 0
+    while (i < from && hasNext) { next(); i += 1 }
+    while (hasNext) {
+      if (p(next())) return i
       i += 1
     }
     -1


### PR DESCRIPTION
## Description

Inline skip logic in Iterator.indexWhere.

## Problem

Iterator.indexWhere called drop(from) which allocated a SliceIterator wrapper. The indexOf method already uses inline skipping without extra allocation.

## Solution

Replace drop(from) with inline while loop that skips elements, matching the pattern used by indexOf.

## Result

Eliminates one SliceIterator allocation per indexWhere call.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.