### PR TITLE
perf: batch P2 optimizations (NumericRange, IntMap, BitSet)

### DIFF
--- a/library/src/scala/collection/immutable/BitSet.scala
+++ b/library/src/scala/collection/immutable/BitSet.scala
@@ -50,19 +50,20 @@ sealed abstract class BitSet
 
   def incl(elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
-    if (contains(elem)) this
-    else {
-      val idx = elem >> LogWL
-      updateWord(idx, word(idx) | (1L << elem))
-    }
+    val idx = elem >> LogWL
+    val mask = 1L << elem
+    val w = word(idx)
+    if ((w & mask) != 0) this
+    else updateWord(idx, w | mask)
   }
 
   def excl(elem: Int): BitSet = {
     require(elem >= 0, "bitset element must be >= 0")
-    if (contains(elem)) {
-      val idx = elem >> LogWL
-      updateWord(idx, word(idx) & ~(1L << elem))
-    } else this
+    val idx = elem >> LogWL
+    val mask = 1L << elem
+    val w = word(idx)
+    if ((w & mask) != 0) updateWord(idx, w & ~mask)
+    else this
   }
 
   /** Updates word at index `idx`; enlarges set if `idx` outside range of set.

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -224,7 +224,7 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
     case IntMap.Nil =>
   }
 
-  override def foreachEntry[U](f: (Int, T) => U): Unit = this match {
+  override final def foreachEntry[U](f: (Int, T) => U): Unit = this match {
     case IntMap.Bin(_, _, left, right) => { left.foreachEntry(f); right.foreachEntry(f) }
     case IntMap.Tip(key, value) => f(key, value)
     case IntMap.Nil =>

--- a/library/src/scala/collection/immutable/NumericRange.scala
+++ b/library/src/scala/collection/immutable/NumericRange.scala
@@ -121,9 +121,10 @@ sealed class NumericRange[T](
   }
 
   override def foreach[@specialized(Specializable.Unit) U](f: T => U): Unit = {
+    val len = length
     var count = 0
     var current = start
-    while (count < length) {
+    while (count < len) {
       f(current)
       current += step
       count += 1


### PR DESCRIPTION
## Description

Batch P2 optimizations for NumericRange, IntMap, and BitSet.

## Changes

1. NumericRange.foreach: hoist lazy val length into local variable to avoid repeated lazy val accessor overhead in hot loop.
2. IntMap.foreachEntry: add final modifier to match LongMap, enabling JVM devirtualization in the sealed hierarchy.
3. immutable.BitSet.incl/excl: compute word index and bit mask once instead of calling contains() (which recomputes them) then recomputing in the update branch.

## Result

- NumericRange: avoids repeated lazy val accessor overhead
- IntMap: enables JVM devirtualization
- immutable.BitSet: eliminates redundant computation

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.