### PR TITLE
perf: use bound variable in ArrayOps.WithFilter.flatMap

### DIFF
--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -118,7 +118,7 @@ object ArrayOps {
       var i = 0
       while(i < xs.length) {
         val x = xs(i)
-        if(p(x)) b ++= f(xs(i))
+        if(p(x)) b ++= f(x)
         i += 1
       }
       b.result()


### PR DESCRIPTION
## Description

It has been computed already, so no need to access again

## Problem

WithFilter.flatMap bound xs(i) to val x on line 120 but then re-evaluated xs(i) on line 121 instead of using x, causing a redundant array bounds check and access.

## Solution

Change f(xs(i)) to f(x).

## Result

Eliminates one redundant array access per matching element in WithFilter.flatMap.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.