### PR TITLE
perf: direct loops for ArrayOps.exists and contains

### DIFF
--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -782,7 +782,14 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @param   p     the predicate used to test elements.
    *  @return        `true` if the given predicate `p` is satisfied by at least one element of this array, otherwise `false`
    */
-  def exists(@deprecatedName("f", "2.13.3") p: A => Boolean): Boolean = indexWhere(p) >= 0
+  def exists(@deprecatedName("f", "2.13.3") p: A => Boolean): Boolean = {
+    var i = 0
+    while (i < xs.length) {
+      if (p(xs(i))) return true
+      i += 1
+    }
+    false
+  }
 
   /** Tests whether a predicate holds for all elements of this array.
    *
@@ -1273,7 +1280,14 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @return     `true` if this array has an element that is equal (as
    *              determined by `==`) to `elem`, `false` otherwise.
    */
-  def contains(elem: A): Boolean = exists (_ == elem)
+  def contains(elem: A): Boolean = {
+    var i = 0
+    while (i < xs.length) {
+      if (elem == xs(i)) return true
+      i += 1
+    }
+    false
+  }
 
   /** Returns a copy of this array with patched values.
    *  Patching at negative indices is the same as patching starting at 0.


### PR DESCRIPTION
## Description

Use direct loops for ArrayOps.exists and contains.

## Problem

ArrayOps.exists delegated to indexWhere(p) >= 0, discarding the index value and paying for non-local return overhead. ArrayOps.contains delegated to exists(_ == elem), allocating a closure per call.

## Solution

Rewrite both methods with direct while loops that return true on the first match.

## Result

Eliminates closure allocation in contains and unnecessary index computation in exists. Both methods now have minimal overhead.

## LLM Policy

LLM-based tools were used extensively in this contribution. The code was reviewed and tested locally before submission.