### PR TITLE
Fix help regressions

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/CliCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CliCommand.scala
@@ -52,7 +52,7 @@ trait CliCommand:
   end distill
 
   /** Creates a help message for a subset of options based on cond */
-  protected def availableOptionsMsg(p: Setting[?] => Boolean, showArgFileMsg: Boolean = true)(using settings: ConcreteSettings)(using SettingsState): String =
+  protected def availableOptionsMsg(p: Setting[?] => Boolean, shortDescription: Boolean = true, showArgFileMsg: Boolean = true)(using settings: ConcreteSettings)(using SettingsState): String =
     // result is (Option Name, descrption\ndefault: value\nchoices: x, y, z
     def help(s: Setting[?]): (String, String) =
       // For now, skip the default values that do not make sense for the end user, such as 'false' for the version command.
@@ -60,7 +60,10 @@ trait CliCommand:
         case _: Int | _: String => s.default.toString
         case _ => ""
       val deprecationMessage = s.deprecation.map(d => s"Option deprecated.\n${d.msg}").getOrElse("")
-      val info = List(deprecationMessage, shortHelp(s), if defaultValue.nonEmpty then s"Default $defaultValue" else "", if s.legalChoices.nonEmpty then s"Choices: ${s.legalChoices}" else "")
+      val descr =
+        if shortDescription then s.description.linesIterator.next()
+        else s.description
+      val info = List(deprecationMessage, descr, if defaultValue.nonEmpty then s"Default $defaultValue" else "", if s.legalChoices.nonEmpty then s"Choices: ${s.legalChoices}" else "")
       (s.name, info.filter(_.nonEmpty).mkString("\n"))
     end help
 
@@ -94,8 +97,6 @@ trait CliCommand:
     s.name.startsWith("-X") && s.name != "-X"
   protected def isPrivate(s: Setting[?])(using settings: ConcreteSettings)(using SettingsState): Boolean =
     s.name.startsWith("-Y") && s.name != "-Y"
-  protected def shortHelp(s: Setting[?])(using settings: ConcreteSettings)(using SettingsState): String =
-    s.description.linesIterator.next()
   protected def isHelping(s: Setting[?])(using settings: ConcreteSettings)(using SettingsState): Boolean =
     cond(s.value) {
       case ss: List[?] if s.isMultivalue => ss.contains("help")

--- a/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
+++ b/compiler/src/dotty/tools/dotc/config/CompilerCommand.scala
@@ -9,7 +9,7 @@ abstract class CompilerCommand extends CliCommand:
 
   final def helpMsg(using settings: ConcreteSettings)(using SettingsState, Context): String =
     settings.allSettings.find(isHelping) match
-      case Some(s) => availableOptionsMsg(_ == s, showArgFileMsg = false)
+      case Some(s) => availableOptionsMsg(_ == s, shortDescription = false, showArgFileMsg = false)
       case _ =>
         if (settings.help.value) usageMessage
         else if (settings.Vhelp.value) vusageMessage
@@ -23,4 +23,5 @@ abstract class CompilerCommand extends CliCommand:
   final def isHelpFlag(using settings: ConcreteSettings)(using SettingsState): Boolean =
     import settings.*
     val flags = Set(help, Vhelp,  Whelp, Xhelp, Yhelp, showPlugins, XshowPhases)
-    flags.exists(_.value) || allSettings.exists(isHelping)
+    // Check `isHelping` first so that `:help` is detected before we call `_.value` where it would fail if the setting is not a Boolean
+    allSettings.exists(isHelping) || flags.exists(_.value)


### PR DESCRIPTION
Fixes #26276

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Manual tests because writing automated tests is impractical, described below (in detail)

Running `scalac -W:help` no longer crashes, and `scalac -Wconf:help` prints the full description.

We could add tests, though they'd need updating whenever a description changes. Not sure it's worth it.
