### PR TITLE
fix: #25843 Don't add capture sets to MatchCase type encodings

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -942,6 +942,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
         val sym = tp.typeSymbol
         if sym.isClass then
           !sym.isPureClass && sym != defn.AnyClass
+          && sym != defn.MatchCaseClass
         else
           val tp1 = tp.dealiasKeepAnnotsAndOpaques
           if tp1 ne tp then needsVariable(tp1)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5412,7 +5412,7 @@ object Types extends TypeUtils {
           // Always apply the legacy algorithm under -source:3.3 and below
           LegacyPatMat(cas, null)
         case cas: HKTypeLambda =>
-          val defn.MatchCase(pat, body) = cas.resultType.stripAnnots.runtimeChecked
+          val defn.MatchCase(pat, body) = cas.resultType: @unchecked
           val missing = checkCapturesPresent(cas, pat)
           if !missing.isEmpty then
             MissingCaptures(cas, missing)
@@ -5422,8 +5422,6 @@ object Types extends TypeUtils {
                 SpeccedPatMat(cas, cas.paramNames.size, specPattern, body)
               case err: MatchTypeCaseError =>
                 LegacyPatMat(cas, err)
-        case cas: AnnotatedType =>
-          analyze(cas.parent)
         case _ =>
           val defn.MatchCase(pat, body) = cas: @unchecked
           SubTypeTest(cas, pat, body)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5412,7 +5412,7 @@ object Types extends TypeUtils {
           // Always apply the legacy algorithm under -source:3.3 and below
           LegacyPatMat(cas, null)
         case cas: HKTypeLambda =>
-          val defn.MatchCase(pat, body) = cas.resultType: @unchecked
+          val defn.MatchCase(pat, body) = cas.resultType.stripAnnots.runtimeChecked
           val missing = checkCapturesPresent(cas, pat)
           if !missing.isEmpty then
             MissingCaptures(cas, missing)
@@ -5422,6 +5422,8 @@ object Types extends TypeUtils {
                 SpeccedPatMat(cas, cas.paramNames.size, specPattern, body)
               case err: MatchTypeCaseError =>
                 LegacyPatMat(cas, err)
+        case cas: AnnotatedType =>
+          analyze(cas.parent)
         case _ =>
           val defn.MatchCase(pat, body) = cas: @unchecked
           SubTypeTest(cas, pat, body)

--- a/tests/pos-custom-args/captures/i25843.scala
+++ b/tests/pos-custom-args/captures/i25843.scala
@@ -1,0 +1,17 @@
+import language.experimental.captureChecking
+import scala.deriving.Mirror
+
+trait Show[T]:
+  def show(t: T): String
+
+object Show:
+  given Show[Int] = _.toString
+  given Show[String] = (s: String) => s
+
+  inline def derived[T <: Product](using m: Mirror.ProductOf[T]): Show[T] = t =>
+    val showables: List[Show[Any]] = ???
+    val values = Tuple.fromProductTyped(t).toList
+    showables.zip(values)
+    ???
+
+case class Foo(x: Int, y: String) derives Show


### PR DESCRIPTION
Fixes #25843 

<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, for finding the root cause. Self-reviewed before the PR.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated test `i25843.scala` added
