### PR TITLE
fix: #25245 Ensure remapping of class member infos referencing spliced types

### DIFF
--- a/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/PickledQuotes.scala
@@ -182,7 +182,17 @@ object PickledQuotes {
         class ReplaceSplicedTyped extends TypeMap() {
           override def apply(tp: Type): Type = tp match {
             case tp: ClassInfo =>
-              tp.derivedClassInfo(declaredParents = tp.declaredParents.map(apply))
+              val parents = tp.declaredParents.map(apply)
+              // If a decl of this class references a spliced type, force a different
+              // ClassInfo instance so that `mapSymbols` makes a copy of the class and
+              // remaps its decls. Otherwise members whose infos reference splice type
+              // symbols are left un-remapped, leading to unsound erased signatures
+              val declsReferenceSplicedType = tp.decls.exists: d =>
+                d.info.existsPart(t => typeSpliceMap.contains(t.typeSymbol))
+              if declsReferenceSplicedType then
+                tp.derivedClassInfo(declaredParents = parents, decls = tp.decls.cloneScope)
+              else
+                tp.derivedClassInfo(declaredParents = parents)
             case tp: TypeRef =>
               typeSpliceMap.get(tp.symbol) match
                 case Some(t) if tp.typeSymbol.hasAnnotation(defn.QuotedRuntime_SplicedTypeAnnot) => mapOver(t)

--- a/tests/run-macros/i25245/Macro_1.scala
+++ b/tests/run-macros/i25245/Macro_1.scala
@@ -1,0 +1,34 @@
+import scala.quoted.*
+
+trait UnWrapper {
+  type Type
+  type Underlying
+
+  def unwrap(value: Type): Underlying
+}
+
+object UnWrapper {
+  type Of[T] = UnWrapper { type Type = T }
+
+  transparent inline given derived[T]: UnWrapper.Of[T] = ${ wrapUnwrapImpl[T] }
+
+  private def wrapUnwrapImpl[T: Type](using Quotes): Expr[UnWrapper.Of[T]] = {
+    import quotes.reflect.*
+    val symbol = TypeRepr.of[T].typeSymbol
+    symbol.caseFields match {
+      case field :: Nil =>
+        field.termRef.widen.asType match {
+          case '[fieldType] =>
+            '{
+              new UnWrapper {
+                type Type = T
+                type Underlying = fieldType
+
+                def unwrap(value: T): fieldType = ${ '{ value }.asTerm.select(field).asExprOf[fieldType] }
+              }
+            }
+        }
+      case _ => sys.error("single case field expected")
+    }
+  }
+}

--- a/tests/run-macros/i25245/Test_2.scala
+++ b/tests/run-macros/i25245/Test_2.scala
@@ -1,0 +1,7 @@
+case class A(x: Int)
+
+@main def Test(): Unit = {
+  val derivedUnwrapped = UnWrapper.derived[A]
+  val aUnwrapped: Int = derivedUnwrapped.unwrap(A(42))
+  assert(42 == aUnwrapped)
+}


### PR DESCRIPTION
Fixes #25245

<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, for finding the root cause. Self-reviewed before the PR.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests `i25245.scala` added