### PR TITLE
Fixes #13468: Add regression test for opaque type parameter pickling

### DIFF
--- a/tests/pos/i13468/MyOpaque_1.scala
+++ b/tests/pos/i13468/MyOpaque_1.scala
@@ -1,0 +1,4 @@
+// https://github.com/scala/scala3/issues/13468
+trait Container[T]
+opaque type MyOpaque[W <: Int] = Int
+extension [W <: Int](myOpaque: MyOpaque[W]) def getContainer: Container[W] = ???

--- a/tests/pos/i13468/Test_2.scala
+++ b/tests/pos/i13468/Test_2.scala
@@ -1,0 +1,5 @@
+// https://github.com/scala/scala3/issues/13468
+// First compilation round: `container` is defined (this is the state of the
+// reporter's `Test.scala` while the `summon` line is still commented out).
+val myOpaque: MyOpaque[8] = ???
+val container = myOpaque.getContainer

--- a/tests/pos/i13468/Test_3.scala
+++ b/tests/pos/i13468/Test_3.scala
@@ -1,0 +1,5 @@
+// https://github.com/scala/scala3/issues/13468
+// Second compilation round (the reporter's "uncomment the line and recompile"):
+// `container`'s type and `MyOpaque`'s opaque parameter must come back from TASTy
+// as `Container[8]`, not `Container[Int]`, for this `summon` to resolve.
+val shouldWork = summon[container.type <:< Container[8]]


### PR DESCRIPTION
Fixes #13468

## How much have you relied on LLM-based tools in this contribution?

Extensively, but this is just adding a regression test for a fixed issue.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)