### PR TITLE
Simplify classpath handling

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/opt/BCodeRepository.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/BCodeRepository.scala
@@ -299,8 +299,8 @@ class BCodeRepository(classPath: ClassPath, optimizerUtils: OptimizerUtils) {
   private def parseClass(internalName: InternalName): Either[ClassNotFound, ClassAndModuleNodes] = {
     try
       val fullName = internalName.replace('/', '.')
-      optimizerClassPath.findClassFileAndModuleFile(fullName) match
-        case Some(classFile, moduleFile) =>
+      optimizerClassPath.findClassFile(fullName) match
+        case Some(classFile) =>
           val classNode = new ClassNode1
           val classReader = new ClassReader(classFile.toByteArray)
           // Passing the InlineInfoAttributePrototype makes the ClassReader invoke the specific `read`
@@ -317,7 +317,7 @@ class BCodeRepository(classPath: ClassPath, optimizerUtils: OptimizerUtils) {
           //   https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.11
           //   https://jcp.org/aboutJava/communityprocess/final/jsr045/index.html
           removeLineNumbersAndAddLMFImplMethods(classNode)
-          val moduleNode = moduleFile.map(f =>
+          val moduleNode = optimizerClassPath.findClassFile("module-info.class").map(f =>
             val node = new ClassNode1
             val moduleReader = new ClassReader(f.toByteArray)
             moduleReader.accept(node, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES)

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -3450,7 +3450,7 @@ class JSCodeGen()(using genCtx: Context) {
             case genReceiver: js.LinkTimeIf =>
               genReceiver
             case _ =>
-              throw FatalError(s"Unexpected tree $genReceiver is generated for $innerFun at: ${tree.sourcePos}")
+              throw new FatalError(s"Unexpected tree $genReceiver is generated for $innerFun at: ${tree.sourcePos}")
           }
           js.LinkTimeIf(genReceiver1.cond, genReceiver1.thenp, genReceiver1.elsep)(toIRType(to))(using genReceiver1.pos)
         case _ =>
@@ -4123,7 +4123,7 @@ class JSCodeGen()(using genCtx: Context) {
             val newFlags = closure.flags.withTyped(false).withAsync(true)
             js.JSFunctionApply(closure.copy(flags = newFlags), Nil)
           case other =>
-            throw FatalError(
+            throw new FatalError(
                 s"Unexpected tree generated for the Function0 argument to js.async at ${tree.sourcePos}: $other")
         }
         js.Block(genStats, asyncExpr)

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -22,29 +22,27 @@ import dotty.tools.io.{ AbstractFile, ClassPath, ClassRepresentation }
 case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
     val (pkg, _) = PackageNameUtils.separatePkgAndClassNames(className)
-    aggregatesForPackage(PackageName(pkg)).iterator.map(_.findClassFileAndModuleFile(className, findModule)).collectFirst {
+    aggregatesForPackage(pkg).iterator.map(_.findClassFileAndModuleFile(className, findModule)).collectFirst {
       case Some(x) => x
     }
   }
   private val packageIndex: collection.mutable.Map[String, Seq[ClassPath]] = collection.mutable.Map()
-  private def aggregatesForPackage(pkg: PackageName): Seq[ClassPath] = packageIndex.synchronized {
-    packageIndex.getOrElseUpdate(pkg.dottedString, aggregates.filter(_.hasPackage(pkg)))
+  private def aggregatesForPackage(pkg: String): Seq[ClassPath] = packageIndex.synchronized {
+    packageIndex.getOrElseUpdate(pkg, aggregates.filter(_.hasPackage(pkg)))
   }
 
   override def asURLs: Seq[URL] = aggregates.flatMap(_.asURLs)
 
-  override private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry] = {
-    val aggregatedPackages = aggregates.flatMap(_.packages(inPackage)).distinct
-    aggregatedPackages
-  }
+  override def packages(inPackage: String): Seq[PackageEntry] =
+    aggregates.flatMap(_.packages(inPackage)).distinct
 
-  override private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] =
+  override def classes(inPackage: String): Seq[BinaryFileEntry] =
     getDistinctEntries(_.classes(inPackage))
 
-  override private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry] =
+  override def sources(inPackage: String): Seq[SourceFileEntry] =
     getDistinctEntries(_.sources(inPackage))
 
-  override private[dotty] def hasPackage(pkg: PackageName): Boolean = aggregates.exists(_.hasPackage(pkg))
+  override def hasPackage(pkg: String): Boolean = aggregates.exists(_.hasPackage(pkg))
 
   /** Returns only one entry for each name.
    *

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -45,13 +45,6 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
     getDistinctEntries(_.sources(inPackage))
 
   override private[dotty] def hasPackage(pkg: PackageName): Boolean = aggregates.exists(_.hasPackage(pkg))
-  override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
-    val packages = new collection.mutable.HashSet[PackageEntry]()
-    val classesAndSourcesBuffer = collection.mutable.ArrayBuffer[ClassRepresentation]()
-    aggregates.foreach(cp => cp.list(inPackage, packages.add, classesAndSourcesBuffer += _))
-    packages.foreach(onPackageEntry)
-    mergeClassesAndSources(classesAndSourcesBuffer).foreach(onClassesAndSources)
-  }
 
   /** Returns only one entry for each name.
    *

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -33,10 +33,6 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
 
   override def asURLs: Seq[URL] = aggregates.flatMap(_.asURLs)
 
-  override def asClassPathStrings: Seq[String] = aggregates.map(_.asClassPathString).distinct
-
-  override def asSourcePathString: String = ClassPath.join(aggregates map (_.asSourcePathString)*)
-
   override private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry] = {
     val aggregatedPackages = aggregates.flatMap(_.packages(inPackage)).distinct
     aggregatedPackages

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.immutable.ArraySeq
 import dotc.util
 
-import dotty.tools.io.{ AbstractFile, ClassPath, ClassRepresentation, EfficientClassPath }
+import dotty.tools.io.{ AbstractFile, ClassPath, ClassRepresentation }
 
 /**
  * A classpath unifying multiple class- and sourcepath entries.
@@ -45,27 +45,12 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
     getDistinctEntries(_.sources(inPackage))
 
   override private[dotty] def hasPackage(pkg: PackageName): Boolean = aggregates.exists(_.hasPackage(pkg))
-  override private[dotty] def list(inPackage: PackageName): ClassPathEntries = {
-    val packages: java.util.HashSet[PackageEntry] = new java.util.HashSet[PackageEntry]()
+  override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
+    val packages = new collection.mutable.HashSet[PackageEntry]()
     val classesAndSourcesBuffer = collection.mutable.ArrayBuffer[ClassRepresentation]()
-    val onPackage: PackageEntry => Unit = packages.add
-    val onClassesAndSources: ClassRepresentation => Unit = classesAndSourcesBuffer += _
-
-    aggregates.foreach {
-      case ecp: EfficientClassPath =>
-        ecp.list(inPackage, onPackage, onClassesAndSources)
-      case cp =>
-        val entries = cp.list(inPackage)
-        entries._1.foreach(onPackage)
-        classesAndSourcesBuffer ++= entries._2
-    }
-
-    val distinctPackages: Seq[PackageEntry] = {
-      val arr = packages.toArray(new Array[PackageEntry](packages.size()))
-      ArraySeq.unsafeWrapArray(arr)
-    }
-    val distinctClassesAndSources = mergeClassesAndSources(classesAndSourcesBuffer)
-    ClassPathEntries(distinctPackages, distinctClassesAndSources)
+    aggregates.foreach(cp => cp.list(inPackage, packages.add, classesAndSourcesBuffer += _))
+    packages.foreach(onPackageEntry)
+    mergeClassesAndSources(classesAndSourcesBuffer).foreach(onClassesAndSources)
   }
 
   /** Returns only one entry for each name.

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -48,25 +48,16 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
   override private[dotty] def list(inPackage: PackageName): ClassPathEntries = {
     val packages: java.util.HashSet[PackageEntry] = new java.util.HashSet[PackageEntry]()
     val classesAndSourcesBuffer = collection.mutable.ArrayBuffer[ClassRepresentation]()
-    val onPackage: PackageEntry => Unit = packages.add(_)
+    val onPackage: PackageEntry => Unit = packages.add
     val onClassesAndSources: ClassRepresentation => Unit = classesAndSourcesBuffer += _
 
-    aggregates.foreach { cp =>
-      try {
-        cp match {
-          case ecp: EfficientClassPath =>
-            ecp.list(inPackage, onPackage, onClassesAndSources)
-          case _ =>
-            val entries = cp.list(inPackage)
-            entries._1.foreach(entry => packages.add(entry))
-            classesAndSourcesBuffer ++= entries._2
-        }
-      } catch {
-        case ex: java.io.IOException =>
-          val e = FatalError(ex.getMessage)
-          e.initCause(ex)
-          throw e
-      }
+    aggregates.foreach {
+      case ecp: EfficientClassPath =>
+        ecp.list(inPackage, onPackage, onClassesAndSources)
+      case cp =>
+        val entries = cp.list(inPackage)
+        entries._1.foreach(onPackage)
+        classesAndSourcesBuffer ++= entries._2
     }
 
     val distinctPackages: Seq[PackageEntry] = {
@@ -133,17 +124,5 @@ case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
       seenNames += entry.name
     }
     entriesBuffer.toIndexedSeq
-  }
-}
-
-object AggregateClassPath {
-  def createAggregate(parts: ClassPath*): ClassPath = {
-    val elems = new ArrayBuffer[ClassPath]()
-    parts foreach {
-      case AggregateClassPath(ps) => elems ++= ps
-      case p => elems += p
-    }
-    if (elems.size == 1) elems.head
-    else AggregateClassPath(elems.toIndexedSeq)
   }
 }

--- a/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/AggregateClassPath.scala
@@ -20,9 +20,9 @@ import dotty.tools.io.{ AbstractFile, ClassPath, ClassRepresentation }
  * @param aggregates classpath instances containing entries which this class processes
  */
 case class AggregateClassPath(aggregates: Seq[ClassPath]) extends ClassPath {
-  override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
+  override def findClassFile(className: String): Option[AbstractFile] = {
     val (pkg, _) = PackageNameUtils.separatePkgAndClassNames(className)
-    aggregatesForPackage(pkg).iterator.map(_.findClassFileAndModuleFile(className, findModule)).collectFirst {
+    aggregatesForPackage(pkg).iterator.map(_.findClassFile(className)).collectFirst {
       case Some(x) => x
     }
   }

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -3,7 +3,6 @@
  */
 package dotty.tools.dotc.classpath
 
-import dotty.tools.dotc.classpath.FileUtils.isTasty
 import dotty.tools.io.{AbstractFile, ClassRepresentation, FileExtension}
 
 trait PackageEntry {
@@ -20,7 +19,7 @@ sealed trait BinaryFileEntry extends ClassRepresentation {
 
 object BinaryFileEntry {
   def apply(file: AbstractFile): BinaryFileEntry =
-    if file.isTasty then
+    if file.exists && file.ext.isTasty then
       if file.resolveSiblingWithExtension(FileExtension.Class) != null then TastyWithClassFileEntry(file)
       else StandaloneTastyFileEntry(file)
     else

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -8,9 +8,7 @@ import dotty.tools.io.AbstractFile
 import dotty.tools.io.ClassRepresentation
 import dotty.tools.io.FileExtension
 
-case class ClassPathEntries(packages: scala.collection.Seq[PackageEntry], classesAndSources: scala.collection.Seq[ClassRepresentation]) {
-  def toTuple: (scala.collection.Seq[PackageEntry], scala.collection.Seq[ClassRepresentation]) = (packages, classesAndSources)
-}
+case class ClassPathEntries(packages: scala.collection.Seq[PackageEntry], classesAndSources: scala.collection.Seq[ClassRepresentation])
 
 object ClassPathEntries {
   val empty = ClassPathEntries(Seq.empty, Seq.empty)

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -5,9 +5,7 @@ package dotty.tools.dotc.classpath
 
 import dotty.tools.io.{AbstractFile, ClassRepresentation, FileExtension}
 
-trait PackageEntry {
-  def name: String
-}
+case class PackageEntry(name: String)
 
 /** A TASTy file or classfile */
 sealed trait BinaryFileEntry extends ClassRepresentation {
@@ -54,5 +52,3 @@ private[dotty] final case class BinaryAndSourceFilesEntry(binaryEntry: BinaryFil
   def binary: Option[AbstractFile] = binaryEntry.binary
   def source: Option[AbstractFile] = sourceEntry.source
 }
-
-private[dotty] case class PackageEntryImpl(name: String) extends PackageEntry

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -8,12 +8,6 @@ import dotty.tools.io.AbstractFile
 import dotty.tools.io.ClassRepresentation
 import dotty.tools.io.FileExtension
 
-case class ClassPathEntries(packages: scala.collection.Seq[PackageEntry], classesAndSources: scala.collection.Seq[ClassRepresentation])
-
-object ClassPathEntries {
-  val empty = ClassPathEntries(Seq.empty, Seq.empty)
-}
-
 case class PackageName(dottedString: String) {
   val dirPathTrailingSlashJar: String = FileUtils.dirPathInJar(dottedString) + "/"
 

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -4,31 +4,7 @@
 package dotty.tools.dotc.classpath
 
 import dotty.tools.dotc.classpath.FileUtils.isTasty
-import dotty.tools.io.AbstractFile
-import dotty.tools.io.ClassRepresentation
-import dotty.tools.io.FileExtension
-
-case class PackageName(dottedString: String) {
-  val dirPathTrailingSlashJar: String = FileUtils.dirPathInJar(dottedString) + "/"
-
-  val dirPathTrailingSlash: String =
-    if (java.io.File.separatorChar == '/')
-      dirPathTrailingSlashJar
-    else
-      FileUtils.dirPath(dottedString) + java.io.File.separator
-
-  def isRoot: Boolean = dottedString.isEmpty
-
-  def entryName(entry: String): String = {
-    if (isRoot) entry else {
-      val builder = new java.lang.StringBuilder(dottedString.length + 1 + entry.length)
-      builder.append(dottedString)
-      builder.append('.')
-      builder.append(entry)
-      builder.toString
-    }
-  }
-}
+import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation, FileExtension}
 
 trait PackageEntry {
   def name: String
@@ -83,10 +59,10 @@ private[dotty] final case class BinaryAndSourceFilesEntry(binaryEntry: BinaryFil
 private[dotty] case class PackageEntryImpl(name: String) extends PackageEntry
 
 private[dotty] trait NoSourcePaths {
-  private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry] = Seq.empty
+  def sources(inPackage: String): Seq[SourceFileEntry] = Seq.empty
 }
 
 private[dotty] trait NoClassPaths {
   def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = None
-  private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] = Seq.empty
+  def classes(inPackage: String): Seq[BinaryFileEntry] = Seq.empty
 }

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -43,14 +43,14 @@ private[dotty] final case class StandaloneTastyFileEntry(file: AbstractFile) ext
 }
 
 private[dotty] final case class SourceFileEntry(file: AbstractFile) extends ClassRepresentation {
-  final def fileName: String = file.name
+  def fileName: String = file.name
   def name: String = FileUtils.stripSourceExtension(file.name)
   def binary: Option[AbstractFile] = None
   def source: Option[AbstractFile] = Some(file)
 }
 
 private[dotty] final case class BinaryAndSourceFilesEntry(binaryEntry: BinaryFileEntry, sourceEntry: SourceFileEntry) extends ClassRepresentation {
-  final def fileName: String = binaryEntry.fileName
+  def fileName: String = binaryEntry.fileName
   def name: String = binaryEntry.name
   def binary: Option[AbstractFile] = binaryEntry.binary
   def source: Option[AbstractFile] = sourceEntry.source
@@ -63,6 +63,6 @@ private[dotty] trait NoSourcePaths {
 }
 
 private[dotty] trait NoClassPaths {
-  def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = None
+  def findClassFile(className: String): Option[AbstractFile] = None
   def classes(inPackage: String): Seq[BinaryFileEntry] = Seq.empty
 }

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -91,7 +91,6 @@ private[dotty] final case class BinaryAndSourceFilesEntry(binaryEntry: BinaryFil
 private[dotty] case class PackageEntryImpl(name: String) extends PackageEntry
 
 private[dotty] trait NoSourcePaths {
-  def asSourcePathString: String = ""
   private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry] = Seq.empty
 }
 

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPath.scala
@@ -4,7 +4,7 @@
 package dotty.tools.dotc.classpath
 
 import dotty.tools.dotc.classpath.FileUtils.isTasty
-import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation, FileExtension}
+import dotty.tools.io.{AbstractFile, ClassRepresentation, FileExtension}
 
 trait PackageEntry {
   def name: String
@@ -57,12 +57,3 @@ private[dotty] final case class BinaryAndSourceFilesEntry(binaryEntry: BinaryFil
 }
 
 private[dotty] case class PackageEntryImpl(name: String) extends PackageEntry
-
-private[dotty] trait NoSourcePaths {
-  def sources(inPackage: String): Seq[SourceFileEntry] = Seq.empty
-}
-
-private[dotty] trait NoClassPaths {
-  def findClassFile(className: String): Option[AbstractFile] = None
-  def classes(inPackage: String): Seq[BinaryFileEntry] = Seq.empty
-}

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -4,7 +4,6 @@
 package dotty.tools.dotc.classpath
 
 import dotty.tools.io.{AbstractFile, VirtualDirectory}
-import FileUtils.*
 import dotty.tools.io.ClassPath
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.LogicalSourcePath

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -8,7 +8,6 @@ import FileUtils.*
 import dotty.tools.io.ClassPath
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.LogicalSourcePath
-import dotty.tools.dotc.interactive.LogicalPackagesProvider
 import dotty.tools.dotc.interactive.LogicalPackage
 import java.nio.file.Files
 
@@ -17,10 +16,6 @@ import java.nio.file.Files
  * it uses proper type of classpath depending on a types of particular files containing sources or classes.
  */
 class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None) {
-  /**
-    * Create a new classpath based on the abstract file.
-    */
-  def newClassPath(file: AbstractFile)(using Context): ClassPath = ClassPathFactory.newClassPath(file)
 
   /**
     * Creators for sub classpaths which preserve this context.
@@ -39,7 +34,11 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
 
   def expandPath(path: String, expandStar: Boolean = true): List[String] = dotty.tools.io.ClassPath.expandPath(path, expandStar)
 
-  def expandDir(extdir: String): List[String] = dotty.tools.io.ClassPath.expandDir(extdir)
+  /** Expand dir out to contents, a la extdir */
+  private def expandDir(extdir: String): List[String] =
+    AbstractFile.getDirectory(extdir) match
+      case null => Nil
+      case dir  => dir.filter(_.isClassContainer).map(x => new java.io.File(dir.file, x.name).getPath).toList
 
   def contentsOfDirsInPath(path: String)(using Context): List[ClassPath] =
     for {
@@ -47,20 +46,14 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
       name <- expandDir(dir)
       entry <- Option(AbstractFile.getDirectory(name))
     }
-    yield newClassPath(entry)
+    yield createClassPath(entry)
 
   def classesInExpandedPath(path: String)(using Context): IndexedSeq[ClassPath] =
     classesInPathImpl(path, expand = true).toIndexedSeq
 
   def classesInPath(path: String)(using Context): List[ClassPath] = classesInPathImpl(path, expand = false)
 
-  def classesInManifest(useManifestClassPath: Boolean)(using Context): List[ClassPath] =
-    if useManifestClassPath
-    then dotty.tools.io.ClassPath.manifests.map(url => newClassPath(AbstractFile.getResources(url)))
-    else Nil
-
-  // Internal
-  protected def classesInPathImpl(path: String, expand: Boolean)(using Context): List[ClassPath] =
+  private def classesInPathImpl(path: String, expand: Boolean)(using Context): List[ClassPath] =
     val files: List[AbstractFile] = for {
       file <- expandPath(path, expand)
       dir <- {
@@ -78,11 +71,11 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
           path = java.nio.file.Paths.get(a.toURI())
           if Files.exists(path)
         yield
-          newClassPath(AbstractFile.getFile(path).nn) // .nn ok because of Files.exists(path)
+          createClassPath(AbstractFile.getFile(path).nn) // .nn ok because of Files.exists(path)
       else
         Seq.empty
 
-    files.map(newClassPath) ++ expanded
+    files.map(createClassPath) ++ expanded
 
   end classesInPathImpl
 
@@ -93,10 +86,8 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
       new DirectorySourcePath(file.file.nn)
     else
       sys.error(s"Unsupported sourcepath element: $file")
-}
 
-object ClassPathFactory {
-  def newClassPath(file: AbstractFile)(using Context): ClassPath = file match {
+  private def createClassPath(file: AbstractFile)(using Context): ClassPath = file match {
     case vd: VirtualDirectory => VirtualDirectoryClassPath(vd)
     case _ =>
       if (file.isJarOrZip)

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -18,18 +18,18 @@ import java.nio.file.Files
 class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None) {
 
   /**
-    * Creators for sub classpaths which preserve this context.
-    */
+   * Creators for sub classpaths which preserve this context.
+   */
   def sourcesInPath(path: String)(using Context): List[ClassPath] =
     precomputedSourcePackages match {
       // We also accept files in case of YlogicalPackageLoading
-      case Some(rootPackage) if ctx.settings.YlogicalPackageLoading.value  =>
+      case Some(rootPackage) if ctx.settings.YlogicalPackageLoading.value =>
         List(new LogicalSourcePath(path, rootPackage))
       case _ =>
         for
           file <- expandPath(path, expandStar = false)
           dir <- Option(AbstractFile.getDirectory(file))
-        yield createSourcePath(dir)
+        yield ClassPathFactory.newSourcePath(dir)
     }
 
   def expandPath(path: String, expandStar: Boolean = true): List[String] = dotty.tools.io.ClassPath.expandPath(path, expandStar)
@@ -38,7 +38,7 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
   private def expandDir(extdir: String): List[String] =
     AbstractFile.getDirectory(extdir) match
       case null => Nil
-      case dir  => dir.filter(_.isClassContainer).map(x => new java.io.File(dir.file, x.name).getPath).toList
+      case dir => dir.filter(_.isClassContainer).map(x => new java.io.File(dir.file, x.name).getPath).toList
 
   def contentsOfDirsInPath(path: String)(using Context): List[ClassPath] =
     for {
@@ -46,7 +46,7 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
       name <- expandDir(dir)
       entry <- Option(AbstractFile.getDirectory(name))
     }
-    yield createClassPath(entry)
+    yield ClassPathFactory.newClassPath(entry)
 
   def classesInExpandedPath(path: String)(using Context): IndexedSeq[ClassPath] =
     classesInPathImpl(path, expand = true).toIndexedSeq
@@ -58,6 +58,7 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
       file <- expandPath(path, expand)
       dir <- {
         def asImage = if (file.endsWith(".jimage")) Some(AbstractFile.getFile(file).nn) else None
+
         Option(AbstractFile.getDirectory(file)).orElse(asImage)
       }
     }
@@ -71,23 +72,17 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
           path = java.nio.file.Paths.get(a.toURI())
           if Files.exists(path)
         yield
-          createClassPath(AbstractFile.getFile(path).nn) // .nn ok because of Files.exists(path)
+          ClassPathFactory.newClassPath(AbstractFile.getFile(path).nn) // .nn ok because of Files.exists(path)
       else
         Seq.empty
 
-    files.map(createClassPath) ++ expanded
+    files.map(ClassPathFactory.newClassPath) ++ expanded
 
   end classesInPathImpl
+}
 
-  private def createSourcePath(file: AbstractFile)(using Context): ClassPath =
-    if (file.isJarOrZip)
-      ZipAndJarSourcePathFactory.create(file)
-    else if (file.isDirectory)
-      new DirectorySourcePath(file.file.nn)
-    else
-      sys.error(s"Unsupported sourcepath element: $file")
-
-  private def createClassPath(file: AbstractFile)(using Context): ClassPath = file match {
+object ClassPathFactory {
+  def newClassPath(file: AbstractFile)(using Context): ClassPath = file match {
     case vd: VirtualDirectory => VirtualDirectoryClassPath(vd)
     case _ =>
       if (file.isJarOrZip)
@@ -97,4 +92,12 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
       else
         sys.error(s"Unsupported classpath element: $file")
   }
+
+  def newSourcePath(file: AbstractFile)(using Context): ClassPath =
+    if (file.isJarOrZip)
+      ZipAndJarSourcePathFactory.create(file)
+    else if (file.isDirectory)
+      new DirectorySourcePath(file.file.nn)
+    else
+      sys.error(s"Unsupported sourcepath element: $file")
 }

--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -85,7 +85,7 @@ object ClassPathFactory {
   def newClassPath(file: AbstractFile)(using Context): ClassPath = file match {
     case vd: VirtualDirectory => VirtualDirectoryClassPath(vd)
     case _ =>
-      if (file.isJarOrZip)
+      if (file.ext.isJarOrZip)
         ZipAndJarClassPathFactory.create(file)
       else if (file.isDirectory)
         new DirectoryClassPath(file.file.nn)
@@ -94,7 +94,7 @@ object ClassPathFactory {
   }
 
   def newSourcePath(file: AbstractFile)(using Context): ClassPath =
-    if (file.isJarOrZip)
+    if (file.ext.isJarOrZip)
       ZipAndJarSourcePathFactory.create(file)
     else if (file.isDirectory)
       new DirectorySourcePath(file.file.nn)

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -119,7 +119,6 @@ trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends Directo
   assert(dir.asInstanceOf[JFile | Null] != null, "Directory file in DirectoryFileLookup cannot be null")
 
   def asURLs: Seq[URL] = Seq(dir.toURI.toURL)
-  def asClassPathStrings: Seq[String] = Seq(dir.getPath)
 }
 
 object JrtClassPath {
@@ -278,8 +277,6 @@ case class DirectoryClassPath(dir: JFile) extends JFileDirectoryLookup[BinaryFil
 }
 
 case class DirectorySourcePath(dir: JFile) extends JFileDirectoryLookup[SourceFileEntry] with NoClassPaths {
-  def asSourcePathString: String = asClassPathString
-
   protected def createFileEntry(file: AbstractFile): SourceFileEntry = SourceFileEntry(file)
   protected def isMatchingFile(f: JFile): Boolean = endsSourceExtension(f.getName)
 

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -133,7 +133,7 @@ object JrtClassPath {
   *
   * The implementation assumes that no classes exist in the empty package.
   */
-final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with NoSourcePaths {
+final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath {
   import java.nio.file.Path, java.nio.file.*
   type F = Path
   private val dir: Path = fs.getPath("/packages")
@@ -161,7 +161,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
 
   override def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
 
-  def findClassFile(className: String): Option[AbstractFile] =
+  override def findClassFile(className: String): Option[AbstractFile] =
     if (!className.contains(".")) None
     else {
       val (inPackage, _) = separatePkgAndClassNames(className)
@@ -177,7 +177,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
 /**
   * Implementation `ClassPath` based on the \$JAVA_HOME/lib/ct.sym backing http://openjdk.java.net/jeps/247
   */
-final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends ClassPath with NoSourcePaths {
+final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends ClassPath {
   import java.nio.file.Path, java.nio.file.*
 
   private val fileSystem: FileSystem = FileSystems.newFileSystem(ctSym, null: ClassLoader | Null)
@@ -217,8 +217,7 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
     }
   }
 
-  override def asURLs: Seq[URL] = Nil
-  def findClassFile(className: String): Option[AbstractFile] = {
+  override def findClassFile(className: String): Option[AbstractFile] = {
     if (!className.contains(".")) None
     else {
       val (inPackage, classSimpleName) = separatePkgAndClassNames(className)
@@ -230,9 +229,9 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
   }
 }
 
-case class DirectoryClassPath(dir: JFile) extends JFileDirectoryLookup[BinaryFileEntry] with NoSourcePaths {
+case class DirectoryClassPath(dir: JFile) extends JFileDirectoryLookup[BinaryFileEntry] {
 
-  def findClassFile(className: String): Option[AbstractFile] = {
+  override def findClassFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className)
     val classFile = new JFile(dir, relativePath + ".class")
     if classFile.exists then {
@@ -248,7 +247,7 @@ case class DirectoryClassPath(dir: JFile) extends JFileDirectoryLookup[BinaryFil
   override def classes(inPackage: String): Seq[BinaryFileEntry] = files(inPackage)
 }
 
-case class DirectorySourcePath(dir: JFile) extends JFileDirectoryLookup[SourceFileEntry] with NoClassPaths {
+case class DirectorySourcePath(dir: JFile) extends JFileDirectoryLookup[SourceFileEntry] {
   protected def createFileEntry(file: AbstractFile): SourceFileEntry = SourceFileEntry(file)
   protected def isMatchingFile(f: JFile): Boolean = endsSourceExtension(f.getName)
 

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -62,20 +62,6 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
     }
     files.iterator.map(f => createFileEntry(toAbstractFile(f))).toSeq
   }
-
-  override def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
-    val dirForPackage = getDirectory(inPackage)
-    dirForPackage match {
-      case None =>
-      case Some(directory) =>
-        for (file <- listChildren(directory)) {
-          if (isPackage(file))
-            onPackageEntry(PackageEntryImpl(inPackage.entryName(getName(file))))
-          else if (isMatchingFile(file))
-            onClassesAndSources(createFileEntry(toAbstractFile(file)))
-        }
-    }
-  }
 }
 
 trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends DirectoryLookup[FileEntryType] {
@@ -172,12 +158,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
       packageToModuleBases.getOrElse(inPackage.dottedString, Nil).flatMap(x =>
         Files.list(x.resolve(inPackage.dirPathTrailingSlash)).iterator().asScala.filter(_.getFileName.toString.endsWith(".class"))).map(x =>
         ClassFileEntry(x.toPlainFile)).toVector
-
-  override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit =
-    packages(inPackage).foreach(onPackageEntry)
-    if !inPackage.isRoot then
-      classes(inPackage).foreach(onClassesAndSources)
-
+  
   def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
   // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
   // java models them as entries in the new "module path", we'll probably need to follow this.
@@ -238,12 +219,6 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
         Files.list(p).iterator.asScala.filter(_.getFileName.toString.endsWith(".sig")))
       sigFiles.map(f => ClassFileEntry(f.toPlainFile)).toVector
     }
-  }
-
-  override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
-    packages(inPackage).foreach(onPackageEntry)
-    if !inPackage.isRoot then
-      classes(inPackage).foreach(onClassesAndSources)
   }
 
   def asURLs: Seq[URL] = Nil

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -8,7 +8,7 @@ import java.net.{URI, URL}
 import java.nio.file.{FileSystems, Files}
 
 import dotty.tools.dotc.classpath.PackageNameUtils.{packageContains, separatePkgAndClassNames}
-import dotty.tools.io.{AbstractFile, PlainFile, ClassPath, ClassRepresentation}
+import dotty.tools.io.{AbstractFile, PlainFile, ClassPath}
 import FileUtils.*
 import PlainFile.toPlainFile
 
@@ -22,7 +22,7 @@ import scala.collection.immutable.ArraySeq
  * when we have a name of a package.
  * It abstracts over the file representation to work with both JFile and AbstractFile.
  */
-trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
+trait DirectoryLookup[FileEntryType] extends ClassPath {
   type F
 
   val dir: F
@@ -64,7 +64,7 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
   }
 }
 
-trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends DirectoryLookup[FileEntryType] {
+trait JFileDirectoryLookup[FileEntryType] extends DirectoryLookup[FileEntryType] {
   type F = JFile
 
   protected def emptyFiles: Array[JFile] = Array.empty

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -8,7 +8,7 @@ import java.net.{URI, URL}
 import java.nio.file.{FileSystems, Files}
 
 import dotty.tools.dotc.classpath.PackageNameUtils.{packageContains, separatePkgAndClassNames}
-import dotty.tools.io.{AbstractFile, PlainFile, ClassPath, ClassRepresentation, EfficientClassPath}
+import dotty.tools.io.{AbstractFile, PlainFile, ClassPath, ClassRepresentation}
 import FileUtils.*
 import PlainFile.toPlainFile
 
@@ -22,7 +22,7 @@ import scala.collection.immutable.ArraySeq
  * when we have a name of a package.
  * It abstracts over the file representation to work with both JFile and AbstractFile.
  */
-trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends EfficientClassPath {
+trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
   type F
 
   val dir: F
@@ -173,9 +173,10 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
         Files.list(x.resolve(inPackage.dirPathTrailingSlash)).iterator().asScala.filter(_.getFileName.toString.endsWith(".class"))).map(x =>
         ClassFileEntry(x.toPlainFile)).toVector
 
-  override private[dotty] def list(inPackage: PackageName): ClassPathEntries =
-    if (inPackage.isRoot) ClassPathEntries(packages(inPackage), Nil)
-    else ClassPathEntries(packages(inPackage), classes(inPackage))
+  override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit =
+    packages(inPackage).foreach(onPackageEntry)
+    if !inPackage.isRoot then
+      classes(inPackage).foreach(onClassesAndSources)
 
   def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
   // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
@@ -239,9 +240,11 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
     }
   }
 
-  override private[dotty] def list(inPackage: PackageName): ClassPathEntries =
-    if (inPackage.isRoot) ClassPathEntries(packages(inPackage), Nil)
-    else ClassPathEntries(packages(inPackage), classes(inPackage))
+  override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
+    packages(inPackage).foreach(onPackageEntry)
+    if !inPackage.isRoot then
+      classes(inPackage).foreach(onClassesAndSources)
+  }
 
   def asURLs: Seq[URL] = Nil
   def asClassPathStrings: Seq[String] = Nil

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -37,24 +37,24 @@ trait DirectoryLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
   protected def createFileEntry(file: AbstractFile): FileEntryType
   protected def isMatchingFile(f: F): Boolean
 
-  private def getDirectory(forPackage: PackageName): Option[F] =
-    if (forPackage.isRoot)
+  private def getDirectory(forPackage: String): Option[F] =
+    if (forPackage == ClassPath.RootPackage)
       Some(dir)
     else
-      getSubDir(forPackage.dirPathTrailingSlash)
+      getSubDir(PackageNameUtils.dirPathTrailingSlash(forPackage))
 
-  override private[dotty] def hasPackage(pkg: PackageName): Boolean = getDirectory(pkg).isDefined
+  override def hasPackage(pkg: String): Boolean = getDirectory(pkg).isDefined
 
-  private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry] = {
+  override def packages(inPackage: String): Seq[PackageEntry] = {
     val dirForPackage = getDirectory(inPackage)
     val nestedDirs: Array[F] = dirForPackage match {
       case None => emptyFiles
       case Some(directory) => listChildren(directory, Some(isPackage))
     }
-    ArraySeq.unsafeWrapArray(nestedDirs).map(f => PackageEntryImpl(inPackage.entryName(getName(f))))
+    ArraySeq.unsafeWrapArray(nestedDirs).map(f => PackageEntryImpl(PackageNameUtils.entryName(inPackage, getName(f))))
   }
 
-  protected def files(inPackage: PackageName): Seq[FileEntryType] = {
+  protected def files(inPackage: String): Seq[FileEntryType] = {
     val dirForPackage = getDirectory(inPackage)
     val files: Array[F] = dirForPackage match {
       case None => emptyFiles
@@ -104,7 +104,7 @@ trait JFileDirectoryLookup[FileEntryType <: ClassRepresentation] extends Directo
 
   assert(dir.asInstanceOf[JFile | Null] != null, "Directory file in DirectoryFileLookup cannot be null")
 
-  def asURLs: Seq[URL] = Seq(dir.toURI.toURL)
+  override def asURLs: Seq[URL] = Seq(dir.toURI.toURL)
 }
 
 object JrtClassPath {
@@ -147,22 +147,19 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
   }
 
   /** Empty string represents root package */
-  override private[dotty] def hasPackage(pkg: PackageName): Boolean = packageToModuleBases.contains(pkg.dottedString)
+  override def hasPackage(pkg: String): Boolean = packageToModuleBases.contains(pkg)
 
-  override private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry] =
-    packageToModuleBases.keysIterator.filter(pack => packageContains(inPackage.dottedString, pack)).map(PackageEntryImpl(_)).toVector
+  override def packages(inPackage: String): Seq[PackageEntry] =
+    packageToModuleBases.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntryImpl(_)).toVector
 
-  private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] =
-    if (inPackage.isRoot) Nil
+  override def classes(inPackage: String): Seq[BinaryFileEntry] =
+    if (inPackage == ClassPath.RootPackage) Nil
     else
-      packageToModuleBases.getOrElse(inPackage.dottedString, Nil).flatMap(x =>
-        Files.list(x.resolve(inPackage.dirPathTrailingSlash)).iterator().asScala.filter(_.getFileName.toString.endsWith(".class"))).map(x =>
+      packageToModuleBases.getOrElse(inPackage, Nil).flatMap(x =>
+        Files.list(x.resolve(PackageNameUtils.dirPathTrailingSlash(inPackage))).iterator().asScala.filter(_.getFileName.toString.endsWith(".class"))).map(x =>
         ClassFileEntry(x.toPlainFile)).toVector
-  
-  def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
-  // We don't yet have a scheme to represent the JDK modules in our `-classpath`.
-  // java models them as entries in the new "module path", we'll probably need to follow this.
-  def asClassPathStrings: Seq[String] = Nil
+
+  override def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
 
   def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] =
     if (!className.contains(".")) None
@@ -208,21 +205,20 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
   }
 
   /** Empty string represents root package */
-  override private[dotty] def hasPackage(pkg: PackageName) = packageIndex.contains(pkg.dottedString)
-  override private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry] = {
-    packageIndex.keysIterator.filter(pack => packageContains(inPackage.dottedString, pack)).map(PackageEntryImpl(_)).toVector
+  override def hasPackage(pkg: String) = packageIndex.contains(pkg)
+  override def packages(inPackage: String): Seq[PackageEntry] = {
+    packageIndex.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntryImpl(_)).toVector
   }
-  private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] = {
-    if (inPackage.isRoot) Nil
+  override def classes(inPackage: String): Seq[BinaryFileEntry] = {
+    if (inPackage == ClassPath.RootPackage) Nil
     else {
-      val sigFiles = packageIndex.getOrElse(inPackage.dottedString, Nil).iterator.flatMap(p =>
+      val sigFiles = packageIndex.getOrElse(inPackage, Nil).iterator.flatMap(p =>
         Files.list(p).iterator.asScala.filter(_.getFileName.toString.endsWith(".sig")))
       sigFiles.map(f => ClassFileEntry(f.toPlainFile)).toVector
     }
   }
 
-  def asURLs: Seq[URL] = Nil
-  def asClassPathStrings: Seq[String] = Nil
+  override def asURLs: Seq[URL] = Nil
   def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
     if (!className.contains(".")) None
     else {
@@ -251,12 +247,12 @@ case class DirectoryClassPath(dir: JFile) extends JFileDirectoryLookup[BinaryFil
   protected def isMatchingFile(f: JFile): Boolean =
     f.isTasty || f.isBestEffortTasty || (f.isClass && !f.hasSiblingTasty)
 
-  private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] = files(inPackage)
+  override def classes(inPackage: String): Seq[BinaryFileEntry] = files(inPackage)
 }
 
 case class DirectorySourcePath(dir: JFile) extends JFileDirectoryLookup[SourceFileEntry] with NoClassPaths {
   protected def createFileEntry(file: AbstractFile): SourceFileEntry = SourceFileEntry(file)
   protected def isMatchingFile(f: JFile): Boolean = endsSourceExtension(f.getName)
 
-  private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry] = files(inPackage)
+  override def sources(inPackage: String): Seq[SourceFileEntry] = files(inPackage)
 }

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -51,7 +51,7 @@ trait DirectoryLookup[FileEntryType] extends ClassPath {
       case None => emptyFiles
       case Some(directory) => listChildren(directory, Some(isPackage))
     }
-    ArraySeq.unsafeWrapArray(nestedDirs).map(f => PackageEntryImpl(PackageNameUtils.entryName(inPackage, getName(f))))
+    ArraySeq.unsafeWrapArray(nestedDirs).map(f => PackageEntry(PackageNameUtils.entryName(inPackage, getName(f))))
   }
 
   protected def files(inPackage: String): Seq[FileEntryType] = {
@@ -75,7 +75,7 @@ trait JFileDirectoryLookup[FileEntryType] extends DirectoryLookup[FileEntryType]
   }
   protected def listChildren(dir: JFile, filter: Option[JFile => Boolean]): Array[JFile] = {
     val listing = filter match {
-      case Some(f) => dir.listFiles(mkFileFilter(f))
+      case Some(f) => dir.listFiles(file => f(file))
       case None => dir.listFiles()
     }
 
@@ -84,7 +84,7 @@ trait JFileDirectoryLookup[FileEntryType] extends DirectoryLookup[FileEntryType]
       // This gives stable results ordering of base type sequences for unrelated classes
       // with the same base type depth.
       //
-      // Notably, this will stably infer`Product with Serializable`
+      // Notably, this will stably infer `Product with Serializable`
       // as the type of `case class C(); case class D(); List(C(), D()).head`, rather than the opposite order.
       // On Mac, the HFS performs this sorting transparently, but on Linux the order is unspecified.
       //
@@ -150,7 +150,7 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath {
   override def hasPackage(pkg: String): Boolean = packageToModuleBases.contains(pkg)
 
   override def packages(inPackage: String): Seq[PackageEntry] =
-    packageToModuleBases.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntryImpl(_)).toVector
+    packageToModuleBases.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntry(_)).toVector
 
   override def classes(inPackage: String): Seq[BinaryFileEntry] =
     if (inPackage == ClassPath.RootPackage) Nil
@@ -206,7 +206,7 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
   /** Empty string represents root package */
   override def hasPackage(pkg: String) = packageIndex.contains(pkg)
   override def packages(inPackage: String): Seq[PackageEntry] = {
-    packageIndex.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntryImpl(_)).toVector
+    packageIndex.keysIterator.filter(pack => packageContains(inPackage, pack)).map(PackageEntry(_)).toVector
   }
   override def classes(inPackage: String): Seq[BinaryFileEntry] = {
     if (inPackage == ClassPath.RootPackage) Nil

--- a/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/DirectoryClassPath.scala
@@ -161,15 +161,14 @@ final class JrtClassPath(fs: java.nio.file.FileSystem) extends ClassPath with No
 
   override def asURLs: Seq[URL] = Seq(new URI("jrt:/").toURL)
 
-  def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] =
+  def findClassFile(className: String): Option[AbstractFile] =
     if (!className.contains(".")) None
     else {
       val (inPackage, _) = separatePkgAndClassNames(className)
       packageToModuleBases.getOrElse(inPackage, Nil).iterator.flatMap{ x =>
         val file = x.resolve(FileUtils.dirPath(className) + ".class")
         if (Files.exists(file)) {
-          val moduleFile = Option.when(findModule)(x.resolve("module-info.class")).filter(f => Files.exists(f))
-          (file.toPlainFile, moduleFile.map(_.toPlainFile)) :: Nil
+          file.toPlainFile :: Nil
         } else Nil
       }.take(1).toList.headOption
     }
@@ -219,13 +218,13 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
   }
 
   override def asURLs: Seq[URL] = Nil
-  def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
+  def findClassFile(className: String): Option[AbstractFile] = {
     if (!className.contains(".")) None
     else {
       val (inPackage, classSimpleName) = separatePkgAndClassNames(className)
       packageIndex.getOrElse(inPackage, Nil).iterator.flatMap { p =>
         val path = p.resolve(classSimpleName + ".sig")
-        if (Files.exists(path)) (path.toPlainFile, None) :: Nil else Nil
+        if (Files.exists(path)) path.toPlainFile :: Nil else Nil
       }.take(1).toList.headOption
     }
   }
@@ -233,12 +232,11 @@ final class CtSymClassPath(ctSym: java.nio.file.Path, release: Int) extends Clas
 
 case class DirectoryClassPath(dir: JFile) extends JFileDirectoryLookup[BinaryFileEntry] with NoSourcePaths {
 
-  def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
+  def findClassFile(className: String): Option[AbstractFile] = {
     val relativePath = FileUtils.dirPath(className)
     val classFile = new JFile(dir, relativePath + ".class")
     if classFile.exists then {
-      val moduleFile = Option.when(findModule)(new JFile(dir, "module-info.class")).filter(_.exists)
-      Some(classFile.toPath.toPlainFile, moduleFile.map(_.toPath.toPlainFile))
+      Some(classFile.toPath.toPlainFile)
     } else None
   }
 

--- a/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
@@ -4,8 +4,7 @@
 package dotty.tools
 package dotc.classpath
 
-import java.io.{FileFilter, File as JFile}
-import java.net.URL
+import java.io.File as JFile
 import dotty.tools.io.{AbstractFile, FileExtension}
 
 /**
@@ -14,14 +13,6 @@ import dotty.tools.io.{AbstractFile, FileExtension}
 object FileUtils {
   extension (file: AbstractFile) {
     def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.name)
-
-    /**
-     * Safe method returning a sequence containing one URL representing this file, when underlying file exists,
-     * and returning given default value in other case
-     */
-    def toURLs(default: => Seq[URL] = Seq.empty): Seq[URL] =
-      val url = file.toURL
-      if (url == null) default else Seq(url)
 
     /**
      * Returns if there is an existing sibling `.tasty` file.
@@ -74,10 +65,6 @@ object FileUtils {
   // because then some tests in partest don't pass
   def mayBeValidPackage(dirName: String): Boolean =
     (dirName != "META-INF") && (dirName != "") && (dirName.charAt(0) != '.')
-
-  def mkFileFilter(f: JFile => Boolean): FileFilter = new FileFilter {
-    def accept(pathname: JFile): Boolean = f(pathname)
-  }
 
   /** Transforms a .class file name to a .tasty file name */
   private def classNameToTasty(fileName: String): String =

--- a/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/FileUtils.scala
@@ -4,9 +4,9 @@
 package dotty.tools
 package dotc.classpath
 
-import java.io.{File => JFile, FileFilter}
+import java.io.{FileFilter, File as JFile}
 import java.net.URL
-import dotty.tools.io.AbstractFile
+import dotty.tools.io.{AbstractFile, FileExtension}
 
 /**
  * Common methods related to Java files and abstract files used in the context of classpath
@@ -14,25 +14,6 @@ import dotty.tools.io.AbstractFile
 object FileUtils {
   extension (file: AbstractFile) {
     def isPackage: Boolean = file.isDirectory && mayBeValidPackage(file.name)
-
-    def isClass: Boolean = !file.isDirectory && hasClassExtension
-
-    def hasClassExtension: Boolean = file.ext.isClass
-
-    def hasTastyExtension: Boolean = file.ext.isTasty
-
-    def hasBetastyExtension: Boolean = file.ext.isBetasty
-
-    def isTasty: Boolean = !file.isDirectory && hasTastyExtension
-
-    def isBestEffortTasty: Boolean = !file.isDirectory && hasBetastyExtension
-
-    def isScalaBinary: Boolean = file.isClass || file.isTasty
-
-    def isSource: Boolean = !file.isDirectory && file.ext.isSourceExtension
-
-    // TODO do we need to check also other files using ZipMagicNumber like in scala.tools.nsc.io.Jar.isJarOrZip?
-    def isJarOrZip: Boolean = file.ext.isJarOrZip
 
     /**
      * Safe method returning a sequence containing one URL representing this file, when underlying file exists,
@@ -46,7 +27,7 @@ object FileUtils {
      * Returns if there is an existing sibling `.tasty` file.
      */
     def hasSiblingTasty: Boolean =
-      assert(file.hasClassExtension, s"non-class: $file")
+      assert(file.ext.isClass, s"non-class: $file")
       file.resolveSibling(classNameToTasty(file.name)) != null
   }
 
@@ -55,11 +36,11 @@ object FileUtils {
 
     def isClass: Boolean = file.isFile && hasClassExtension
 
-    def hasClassExtension: Boolean = file.getName.endsWith(SUFFIX_CLASS)
+    def hasClassExtension: Boolean = file.getName.endsWith(FileExtension.Class.withDot)
 
-    def isTasty: Boolean = file.isFile && file.getName.endsWith(SUFFIX_TASTY)
+    def isTasty: Boolean = file.isFile && file.getName.endsWith(FileExtension.Tasty.withDot)
 
-    def isBestEffortTasty: Boolean = file.isFile && file.getName.endsWith(SUFFIX_BETASTY)
+    def isBestEffortTasty: Boolean = file.isFile && file.getName.endsWith(FileExtension.Betasty.withDot)
 
 
     /**
@@ -73,20 +54,12 @@ object FileUtils {
 
   }
 
-  private val SUFFIX_CLASS = ".class"
-  private val SUFFIX_SCALA = ".scala"
-  private val SUFFIX_TASTY = ".tasty"
-  private val SUFFIX_BETASTY = ".betasty"
-  private val SUFFIX_JAVA = ".java"
-
-  private val sourceSuffixes = Set(SUFFIX_SCALA, SUFFIX_JAVA)
-
   def stripSourceExtension(fileName: String): String =
     if endsSourceExtension(fileName) then stripExtension(fileName)
     else throw new FatalError("Unexpected source file ending: " + fileName)
 
   def endsSourceExtension(fileName: String): Boolean =
-    sourceSuffixes.exists(ends(fileName, _))
+    ends(fileName, FileExtension.Scala.withDot) || ends(fileName, FileExtension.Java.withDot)
 
   def dirPath(forPackage: String): String = forPackage.replace('.', JFile.separatorChar)
 
@@ -119,5 +92,5 @@ object FileUtils {
         && classOrModuleName != "$"
       then classOrModuleName.stripSuffix("$")
       else classOrModuleName
-    className + SUFFIX_TASTY
+    className + FileExtension.Tasty.withDot
 }

--- a/compiler/src/dotty/tools/dotc/classpath/PackageNameUtils.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/PackageNameUtils.scala
@@ -3,6 +3,7 @@
  */
 package dotty.tools.dotc.classpath
 
+import dotty.tools.io.ClassPath
 import dotty.tools.io.ClassPath.RootPackage
 
 /**
@@ -33,5 +34,24 @@ object PackageNameUtils {
     if (packageDottedName.contains("."))
       packageDottedName.startsWith(inPackage) && packageDottedName.lastIndexOf('.') == inPackage.length
     else inPackage == ""
+  }
+
+  def dirPathTrailingSlashJar(pkg: String): String =
+    FileUtils.dirPathInJar(pkg) + "/"
+
+  def dirPathTrailingSlash(pkg: String): String =
+    if (java.io.File.separatorChar == '/')
+      dirPathTrailingSlashJar(pkg)
+    else
+      FileUtils.dirPath(pkg) + java.io.File.separator
+
+  def entryName(pkg: String, entry: String): String = {
+    if (pkg == ClassPath.RootPackage) entry else {
+      val builder = new java.lang.StringBuilder(pkg.length + 1 + entry.length)
+      builder.append(pkg)
+      builder.append('.')
+      builder.append(entry)
+      builder.toString
+    }
   }
 }

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -48,6 +48,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
 
   protected def createFileEntry(file: AbstractFile): BinaryFileEntry = BinaryFileEntry(file)
 
-  protected def isMatchingFile(f: AbstractFile): Boolean =
-    f.isTasty || (f.isClass && !f.hasSiblingTasty)
+  protected def isMatchingFile(f: AbstractFile): Boolean = {
+    f.exists && (f.ext.isTasty || (f.ext.isClass && !f.hasSiblingTasty))
+  }
 }

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -34,8 +34,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   def isPackage(f: AbstractFile): Boolean = f.isPackage
 
   // mimic the behavior of the old nsc.util.DirectoryClassPath
-  def asURLs: Seq[URL] = Seq(new URI(dir.name).toURL)
-  def asClassPathStrings: Seq[String] = Seq(dir.path)
+  override def asURLs: Seq[URL] = Seq(new URI(dir.name).toURL)
 
   override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
     val pathSeq = FileUtils.dirPath(className).split(java.io.File.separator)
@@ -52,7 +51,7 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
         Some((classFile, optModuleFile))
   }
 
-  private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] = files(inPackage)
+  override def classes(inPackage: String): Seq[BinaryFileEntry] = files(inPackage)
 
   protected def createFileEntry(file: AbstractFile): BinaryFileEntry = BinaryFileEntry(file)
 

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -1,11 +1,11 @@
 package dotty.tools.dotc.classpath
 
-import dotty.tools.io.{ClassPath, ClassRepresentation}
+import dotty.tools.io.ClassPath
 import dotty.tools.io.{AbstractFile, VirtualDirectory}
 import FileUtils.*
 import java.net.{URI, URL}
 
-case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath with DirectoryLookup[BinaryFileEntry] with NoSourcePaths {
+case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath with DirectoryLookup[BinaryFileEntry] {
   type F = AbstractFile
 
   // From AbstractFileClassLoader

--- a/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/VirtualDirectoryClassPath.scala
@@ -36,19 +36,12 @@ case class VirtualDirectoryClassPath(dir: VirtualDirectory) extends ClassPath wi
   // mimic the behavior of the old nsc.util.DirectoryClassPath
   override def asURLs: Seq[URL] = Seq(new URI(dir.name).toURL)
 
-  override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
+  override def findClassFile(className: String): Option[AbstractFile] = {
     val pathSeq = FileUtils.dirPath(className).split(java.io.File.separator)
     val parentDir = lookupPath(dir)(pathSeq.init.toSeq, directory = true)
     if parentDir == null then None
     else
-      val classFile = lookupPath(parentDir)(pathSeq.last + ".class" :: Nil, directory = false)
-      if classFile == null then
-        None
-      else
-        val optModuleFile =
-          if findModule then Option(lookupPath(parentDir)("module-info.class" :: Nil, directory = false))
-          else None
-        Some((classFile, optModuleFile))
+      Option(lookupPath(parentDir)(pathSeq.last + ".class" :: Nil, directory = false))
   }
 
   override def classes(inPackage: String): Seq[BinaryFileEntry] = files(inPackage)

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -53,7 +53,7 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     override protected def createFileEntry(file: FileZipArchive#Entry): BinaryFileEntry = BinaryFileEntry(file)
 
     override protected def isRequiredFileType(file: AbstractFile): Boolean =
-      file.isTasty || (file.isClass && !file.hasSiblingTasty)
+      file.exists && (file.ext.isTasty || (file.ext.isClass && !file.hasSiblingTasty))
   }
 
   /**
@@ -125,7 +125,7 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     override def classes(inPackage: String): Seq[BinaryFileEntry] = cachedPackages.get(inPackage) match {
       case None => Seq.empty
       case Some(PackageFileInfo(pkg, _)) =>
-        (for (file <- pkg if file.isClass) yield ClassFileEntry(file)).toSeq
+        (for (file <- pkg if file.exists && file.ext.isClass) yield ClassFileEntry(file)).toSeq
     }
 
     override def hasPackage(pkg: String) = cachedPackages.contains(pkg)
@@ -161,7 +161,7 @@ object ZipAndJarSourcePathFactory extends ZipAndJarFileLookupFactory {
     override def sources(inPackage: String): Seq[SourceFileEntry] = files(inPackage)
 
     override protected def createFileEntry(file: FileZipArchive#Entry): SourceFileEntry = SourceFileEntry(file)
-    override protected def isRequiredFileType(file: AbstractFile): Boolean = file.isSource
+    override protected def isRequiredFileType(file: AbstractFile): Boolean = file.ext.isSourceExtension
   }
 
   override protected def createForZipFile(zipFile: AbstractFile, jFile: File | Null, release: Option[String]): ClassPath =

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -70,7 +70,9 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
       clss.find(_.name == simpleClassName).map(_.file)
     }
 
-    override def asURLs: Seq[URL] = file.toURLs()
+    override def asURLs: Seq[URL] = file.toURL match
+      case null => Seq.empty
+      case nonNull => Seq(nonNull)
 
     import ManifestResourcesClassPath.PackageFileInfo
     import ManifestResourcesClassPath.PackageInfo
@@ -119,7 +121,7 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     override def packages(inPackage: String): Seq[PackageEntry] = cachedPackages.get(inPackage) match {
       case None => Seq.empty
       case Some(PackageFileInfo(_, subpackages)) =>
-        subpackages.map(packageFile => PackageEntryImpl(PackageNameUtils.entryName(inPackage, packageFile.name)))
+        subpackages.map(packageFile => PackageEntry(PackageNameUtils.entryName(inPackage, packageFile.name)))
     }
 
     override def classes(inPackage: String): Seq[BinaryFileEntry] = cachedPackages.get(inPackage) match {

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -47,10 +47,9 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
 
     override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] =
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
-      val pkgName = PackageName(pkg)
-      file(pkgName, simpleClassName + ".class").map(c => (c.file, (if findModule then file(pkgName, "module-info.class") else None).map(_.file)))
+      file(pkg, simpleClassName + ".class").map(c => (c.file, (if findModule then file(pkg, "module-info.class") else None).map(_.file)))
 
-    override private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] = files(inPackage)
+    override def classes(inPackage: String): Seq[BinaryFileEntry] = files(inPackage)
 
     override protected def createFileEntry(file: FileZipArchive#Entry): BinaryFileEntry = BinaryFileEntry(file)
 
@@ -68,7 +67,7 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
   private case class ManifestResourcesClassPath(file: ManifestResources) extends ClassPath with NoSourcePaths {
     override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
-      val clss = classes(PackageName(pkg))
+      val clss = classes(pkg)
       clss.find(_.name == simpleClassName).map(c => (c.file, (if findModule then clss.find(_.name == "module-info") else None).map(_.file)))
     }
 
@@ -118,19 +117,19 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
       packages
     }
 
-    override private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry] = cachedPackages.get(inPackage.dottedString) match {
+    override def packages(inPackage: String): Seq[PackageEntry] = cachedPackages.get(inPackage) match {
       case None => Seq.empty
       case Some(PackageFileInfo(_, subpackages)) =>
-        subpackages.map(packageFile => PackageEntryImpl(inPackage.entryName(packageFile.name)))
+        subpackages.map(packageFile => PackageEntryImpl(PackageNameUtils.entryName(inPackage, packageFile.name)))
     }
 
-    override private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry] = cachedPackages.get(inPackage.dottedString) match {
+    override def classes(inPackage: String): Seq[BinaryFileEntry] = cachedPackages.get(inPackage) match {
       case None => Seq.empty
       case Some(PackageFileInfo(pkg, _)) =>
         (for (file <- pkg if file.isClass) yield ClassFileEntry(file)).toSeq
     }
 
-    override private[dotty] def hasPackage(pkg: PackageName) = cachedPackages.contains(pkg.dottedString)
+    override def hasPackage(pkg: String) = cachedPackages.contains(pkg)
   }
 
   private object ManifestResourcesClassPath {
@@ -162,7 +161,7 @@ object ZipAndJarSourcePathFactory extends ZipAndJarFileLookupFactory {
 
     def release: Option[String] = None
 
-    override private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry] = files(inPackage)
+    override def sources(inPackage: String): Seq[SourceFileEntry] = files(inPackage)
 
     override protected def createFileEntry(file: FileZipArchive#Entry): SourceFileEntry = SourceFileEntry(file)
     override protected def isRequiredFileType(file: AbstractFile): Boolean = file.isSource

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -42,8 +42,7 @@ sealed trait ZipAndJarFileLookupFactory {
  */
 object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
   private case class ZipArchiveClassPath(zipFile: File, override val release: Option[String])
-    extends ZipArchiveFileLookup[BinaryFileEntry]
-    with NoSourcePaths {
+    extends ZipArchiveFileLookup[BinaryFileEntry] {
 
     override def findClassFile(className: String): Option[AbstractFile] =
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
@@ -64,7 +63,7 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
    * with a particularly prepared scala-library.jar. It should have all classes listed in the manifest like e.g. this entry:
    * Name: scala/Function2$mcFJD$sp.class
    */
-  private case class ManifestResourcesClassPath(file: ManifestResources) extends ClassPath with NoSourcePaths {
+  private case class ManifestResourcesClassPath(file: ManifestResources) extends ClassPath {
     override def findClassFile(className: String): Option[AbstractFile] = {
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
       val clss = classes(pkg)
@@ -155,9 +154,7 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
  * It should be the only way of creating them as it provides caching.
  */
 object ZipAndJarSourcePathFactory extends ZipAndJarFileLookupFactory {
-  private case class ZipArchiveSourcePath(zipFile: File)
-    extends ZipArchiveFileLookup[SourceFileEntry]
-    with NoClassPaths {
+  private case class ZipArchiveSourcePath(zipFile: File) extends ZipArchiveFileLookup[SourceFileEntry] {
 
     def release: Option[String] = None
 

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -10,7 +10,7 @@ import java.nio.file.Files
 import java.nio.file.attribute.{BasicFileAttributes, FileTime}
 
 import scala.annotation.tailrec
-import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation, FileZipArchive, ManifestResources}
+import dotty.tools.io.{AbstractFile, ClassPath, FileZipArchive, ManifestResources}
 import dotty.tools.dotc.core.Contexts.*
 import FileUtils.*
 

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -131,7 +131,10 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     }
 
     override private[dotty] def hasPackage(pkg: PackageName) = cachedPackages.contains(pkg.dottedString)
-    override private[dotty] def list(inPackage: PackageName): ClassPathEntries = ClassPathEntries(packages(inPackage), classes(inPackage))
+    override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
+      packages(inPackage).foreach(onPackageEntry)
+      classes(inPackage).foreach(onClassesAndSources)
+    }
   }
 
   private object ManifestResourcesClassPath {

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -45,9 +45,9 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     extends ZipArchiveFileLookup[BinaryFileEntry]
     with NoSourcePaths {
 
-    override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] =
+    override def findClassFile(className: String): Option[AbstractFile] =
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
-      file(pkg, simpleClassName + ".class").map(c => (c.file, (if findModule then file(pkg, "module-info.class") else None).map(_.file)))
+      file(pkg, simpleClassName + ".class").map(_.file)
 
     override def classes(inPackage: String): Seq[BinaryFileEntry] = files(inPackage)
 
@@ -65,10 +65,10 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
    * Name: scala/Function2$mcFJD$sp.class
    */
   private case class ManifestResourcesClassPath(file: ManifestResources) extends ClassPath with NoSourcePaths {
-    override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = {
+    override def findClassFile(className: String): Option[AbstractFile] = {
       val (pkg, simpleClassName) = PackageNameUtils.separatePkgAndClassNames(className)
       val clss = classes(pkg)
-      clss.find(_.name == simpleClassName).map(c => (c.file, (if findModule then clss.find(_.name == "module-info") else None).map(_.file)))
+      clss.find(_.name == simpleClassName).map(_.file)
     }
 
     override def asURLs: Seq[URL] = file.toURLs()

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -131,10 +131,6 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
     }
 
     override private[dotty] def hasPackage(pkg: PackageName) = cachedPackages.contains(pkg.dottedString)
-    override private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
-      packages(inPackage).foreach(onPackageEntry)
-      classes(inPackage).foreach(onClassesAndSources)
-    }
   }
 
   private object ManifestResourcesClassPath {

--- a/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactory.scala
@@ -72,8 +72,6 @@ object ZipAndJarClassPathFactory extends ZipAndJarFileLookupFactory {
       clss.find(_.name == simpleClassName).map(c => (c.file, (if findModule then clss.find(_.name == "module-info") else None).map(_.file)))
     }
 
-    override def asClassPathStrings: Seq[String] = Seq(file.path)
-
     override def asURLs: Seq[URL] = file.toURLs()
 
     import ManifestResourcesClassPath.PackageFileInfo
@@ -164,8 +162,6 @@ object ZipAndJarSourcePathFactory extends ZipAndJarFileLookupFactory {
     with NoClassPaths {
 
     def release: Option[String] = None
-
-    override def asSourcePathString: String = asClassPathString
 
     override private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry] = files(inPackage)
 

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -9,14 +9,14 @@ import java.net.URL
 
 import dotty.tools.io.{ AbstractFile, FileZipArchive }
 import FileUtils.*
-import dotty.tools.io.{EfficientClassPath, ClassRepresentation}
+import dotty.tools.io.{ClassPath, ClassRepresentation}
 
 /**
  * A trait allowing to look for classpath entries of given type in zip and jar files.
  * It provides common logic for classes handling class and source files.
  * It's aware of things like e.g. META-INF directory which is correctly skipped.
  */
-trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends EfficientClassPath {
+trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
   val zipFile: File
   def release: Option[String]
 

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -24,22 +24,22 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
 
   private val archive = new FileZipArchive(zipFile.toPath, release)
 
-  override private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry] = {
+  override def packages(inPackage: String): Seq[PackageEntry] = {
     for {
       dirEntry <- findDirEntry(inPackage).toSeq
       entry <- dirEntry.iterator if entry.isPackage
     }
-    yield PackageEntryImpl(inPackage.entryName(entry.name))
+    yield PackageEntryImpl(PackageNameUtils.entryName(inPackage, entry.name))
   }
 
-  protected def files(inPackage: PackageName): Seq[FileEntryType] =
+  protected def files(inPackage: String): Seq[FileEntryType] =
     for {
       dirEntry <- findDirEntry(inPackage).toSeq
       entry <- dirEntry.iterator if isRequiredFileType(entry)
     }
     yield createFileEntry(entry)
 
-  protected def file(inPackage: PackageName, name: String): Option[FileEntryType] =
+  protected def file(inPackage: String, name: String): Option[FileEntryType] =
     for {
       dirEntry <- findDirEntry(inPackage)
       entry <- Option(dirEntry.lookupName(name, directory = false))
@@ -47,10 +47,10 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
     }
     yield createFileEntry(entry)
 
-  override def hasPackage(pkg: PackageName) = findDirEntry(pkg).isDefined
+  override def hasPackage(pkg: String) = findDirEntry(pkg).isDefined
 
-  private def findDirEntry(pkg: PackageName): Option[archive.DirEntry] =
-    archive.allDirs.get(pkg.dirPathTrailingSlashJar)
+  private def findDirEntry(pkg: String): Option[archive.DirEntry] =
+    archive.allDirs.get(PackageNameUtils.dirPathTrailingSlashJar(pkg))
 
   protected def createFileEntry(file: FileZipArchive#Entry): FileEntryType
   protected def isRequiredFileType(file: AbstractFile): Boolean

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -29,7 +29,7 @@ trait ZipArchiveFileLookup[FileEntryType] extends ClassPath {
       dirEntry <- findDirEntry(inPackage).toSeq
       entry <- dirEntry.iterator if entry.isPackage
     }
-    yield PackageEntryImpl(PackageNameUtils.entryName(inPackage, entry.name))
+    yield PackageEntry(PackageNameUtils.entryName(inPackage, entry.name))
   }
 
   protected def files(inPackage: String): Seq[FileEntryType] =

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -48,17 +48,6 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPa
     yield createFileEntry(entry)
 
   override def hasPackage(pkg: PackageName) = findDirEntry(pkg).isDefined
-  def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit =
-    findDirEntry(inPackage) match {
-      case Some(dirEntry) =>
-        for (entry <- dirEntry.iterator) {
-          if (entry.isPackage)
-            onPackageEntry(PackageEntryImpl(inPackage.entryName(entry.name)))
-          else if (isRequiredFileType(entry))
-            onClassesAndSources(createFileEntry(entry))
-        }
-      case None =>
-    }
 
   private def findDirEntry(pkg: PackageName): Option[archive.DirEntry] =
     archive.allDirs.get(pkg.dirPathTrailingSlashJar)

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -9,14 +9,14 @@ import java.net.URL
 
 import dotty.tools.io.{ AbstractFile, FileZipArchive }
 import FileUtils.*
-import dotty.tools.io.{ClassPath, ClassRepresentation}
+import dotty.tools.io.ClassPath
 
 /**
  * A trait allowing to look for classpath entries of given type in zip and jar files.
  * It provides common logic for classes handling class and source files.
  * It's aware of things like e.g. META-INF directory which is correctly skipped.
  */
-trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends ClassPath {
+trait ZipArchiveFileLookup[FileEntryType] extends ClassPath {
   val zipFile: File
   def release: Option[String]
 

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -21,7 +21,6 @@ trait ZipArchiveFileLookup[FileEntryType <: ClassRepresentation] extends Efficie
   def release: Option[String]
 
   override def asURLs: Seq[URL] = Seq(zipFile.toURI.toURL)
-  override def asClassPathStrings: Seq[String] = Seq(zipFile.getPath)
 
   private val archive = new FileZipArchive(zipFile.toPath, release)
 

--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -163,7 +163,7 @@ object PathResolver {
 
       pr.result match {
         case cp: AggregateClassPath =>
-          println(s"ClassPath has ${cp.aggregates.size} entries and results in:\n${cp.asClassPathStrings}")
+          println(s"ClassPath has ${cp.aggregates.size} entries and results in:\n${cp.asURLs}")
       }
     }
 }

--- a/compiler/src/dotty/tools/dotc/config/PathResolver.scala
+++ b/compiler/src/dotty/tools/dotc/config/PathResolver.scala
@@ -18,12 +18,6 @@ object PathResolver {
   // security exceptions.
   import AccessControl.*
 
-  def firstNonEmpty(xs: String*): String = xs find (_ != "") getOrElse ""
-
-  /** Map all classpath elements to absolute paths and reconstruct the classpath.
-   */
-  def makeAbsolute(cp: String): String = ClassPath.map(cp, x => Path(x).toAbsolute.path)
-
   /** pretty print class path
    */
   def ppcp(s: String): String = split(s) match {
@@ -34,7 +28,7 @@ object PathResolver {
 
   /** Values found solely by inspecting environment or property variables.
    */
-  object Environment {
+  private object Environment {
     private def searchForBootClasspath = {
       import scala.jdk.CollectionConverters.*
       val props = System.getProperties

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -6,7 +6,6 @@ import java.io.{IOException, File}
 import java.nio.channels.ClosedByInterruptException
 
 import dotty.tools.dotc.classpath.{ ClassPathFactory, PackageNameUtils }
-import dotty.tools.dotc.classpath.FileUtils.{hasTastyExtension, hasBetastyExtension}
 import dotty.tools.io.{ ClassPath, ClassRepresentation, AbstractFile, NoAbstractFile }
 
 import Contexts.*, Symbols.*, Flags.*, SymDenotations.*, Types.*, Scopes.*, Names.*
@@ -219,7 +218,7 @@ object SymbolLoaders {
         enterToplevelsFromSource(owner, nameOf(classRep), src)
       case (Some(bin), _) =>
         val completer =
-          if bin.hasTastyExtension || bin.hasBetastyExtension then ctx.platform.newTastyLoader(bin)
+          if bin.ext.isTasty || bin.ext.isBetasty then ctx.platform.newTastyLoader(bin)
           else ctx.platform.newClassLoader(bin)
         enterClassAndModule(owner, nameOf(classRep), completer)
     }
@@ -502,7 +501,7 @@ class ClassfileLoader(val classfile: AbstractFile) extends SymbolLoader {
 }
 
 class TastyLoader(val tastyFile: AbstractFile) extends SymbolLoader {
-  val isBestEffortTasty = tastyFile.hasBetastyExtension
+  val isBestEffortTasty = tastyFile.ext.isBetasty
 
   lazy val tastyBytes = tastyFile.toByteArray
 

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -299,7 +299,7 @@ object SymbolLoaders {
         !root.unforcedDecls.lookup(classRep.name.toTypeName).exists
 
       if (!root.isRoot) {
-        val classReps = classPath.list(packageName).classesAndSources
+        val classReps = classPath.classes(packageName) ++ classPath.sources(packageName)
 
         for (classRep <- classReps)
           if (!maybeModuleClass(classRep) && hasFlatName(classRep) == flat &&
@@ -340,7 +340,8 @@ object SymbolLoaders {
           // definitions. See #23043.
           val hasConflict = currentDecls.lookup(name.toTermName) != NoSymbol
           if !hasConflict
-            || classPath.list(fullName).classesAndSources.nonEmpty
+            || classPath.classes(fullName).nonEmpty
+            || classPath.sources(fullName).nonEmpty
             || classPath.packages(fullName).nonEmpty
           then
             enterPackage(root.symbol, name.toTermName,

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -30,7 +30,6 @@ import util.{SourceFile, NoSource, Property, SourcePosition, SrcPos, EqHashMap, 
 
 import scala.annotation.internal.sharable
 import config.Printers.typr
-import dotty.tools.dotc.classpath.FileUtils.isScalaBinary
 
 import scala.compiletime.uninitialized
 import dotty.tools.tasty.TastyVersion
@@ -167,11 +166,11 @@ object Symbols extends SymUtils {
       * symbols defined by the user in a prior run of the REPL, that are still valid.
       */
     final def isDefinedInSource(using Context): Boolean =
-      span.exists && isValidInCurrentRun && associatedFileMatches(!_.isScalaBinary)
+      span.exists && isValidInCurrentRun && associatedFileMatches(!_.ext.isScalaBinary)
 
     /** Is this symbol valid in the current run, but comes from the classpath? */
     final def isDefinedInBinary(using Context): Boolean =
-      isValidInCurrentRun && associatedFileMatches(_.isScalaBinary)
+      isValidInCurrentRun && associatedFileMatches(_.ext.isScalaBinary)
 
     /** Is symbol valid in current run? */
     final def isValidInCurrentRun(using Context): Boolean =
@@ -307,7 +306,7 @@ object Symbols extends SymUtils {
     /** The class file from which this class was generated, null if not applicable. */
     final def binaryFile(using Context): AbstractFile | Null = {
       val file = associatedFile
-      if file != null && file.isScalaBinary then file else null
+      if file != null && file.ext.isScalaBinary then file else null
     }
 
     /** A trap to avoid calling x.symbol on something that is already a symbol.
@@ -319,7 +318,7 @@ object Symbols extends SymUtils {
 
     final def source(using Context): SourceFile = {
       def valid(src: SourceFile): SourceFile =
-        if (src.exists && !src.file.isScalaBinary) src
+        if (src.exists && !src.file.ext.isScalaBinary) src
         else NoSource
 
       if (!denot.exists) NoSource
@@ -522,7 +521,7 @@ object Symbols extends SymUtils {
       if !mySource.exists && !denot.is(Package) then
         // this allows sources to be added in annotations after `sourceOfClass` is first called
         val file = associatedFile
-        if file != null && !file.isScalaBinary then
+        if file != null && !file.ext.isScalaBinary then
           mySource = ctx.getSource(file)
         else if !mySource.exists then
           val compUnitInfo = compilationUnitInfo

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -1088,7 +1088,7 @@ class ClassfileParser(
     for entry <- innerClasses.valuesIterator do
       // create a new class member for immediate inner classes
       if entry.outer.name == currentClassName then
-        val file = ctx.platform.classPath.findClassFile(entry.externalName.toString) getOrElse {
+        val file = ctx.platform.classPath.findClassFile(entry.externalName) getOrElse {
           throw new AssertionError(entry.externalName)
         }
         enterClassAndModule(entry, file, entry.jflags)

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -3,7 +3,7 @@ package dotc
 package core
 package classfile
 
-import dotty.tools.tasty.{ TastyReader, TastyHeaderUnpickler, UnpickleException }
+import dotty.tools.tasty.UnpickleException
 
 import Contexts.*, Symbols.*, Types.*, Names.*, StdNames.*, NameOps.*, Scopes.*, Decorators.*
 import SymDenotations.*, unpickleScala2.Scala2Unpickler.*, Constants.*, Annotations.*, util.Spans.*
@@ -13,13 +13,12 @@ import ast.tpd.*, util.*
 import java.io.IOException
 
 import java.lang.Integer.toHexString
-import java.util.UUID
 
 import scala.collection.immutable
 import scala.collection.mutable.{ ListBuffer, ArrayBuffer }
 import scala.annotation.switch
 import typer.Checking.checkNonCyclic
-import io.{AbstractFile, ZipArchive}
+import io.AbstractFile
 import dotty.tools.dotc.classpath.FileUtils.hasSiblingTasty
 
 import scala.compiletime.uninitialized

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyPrinter.scala
@@ -18,7 +18,6 @@ import scala.collection.immutable.BitSet
 import scala.compiletime.uninitialized
 import dotty.tools.tasty.TastyBuffer.Addr
 import dotty.tools.dotc.core.Names.TermName
-import dotty.tools.dotc.classpath.FileUtils.hasTastyExtension
 
 object TastyPrinter:
 
@@ -61,7 +60,7 @@ object TastyPrinter:
         val jar = JarArchive.open(Path(arg), create = false)
         def tastyFiles(file: AbstractFile): Iterator[AbstractFile] =
           if file.isDirectory then file.iterator.flatMap(tastyFiles)
-          else if file.hasTastyExtension then Iterator.single(file) else Iterator.empty
+          else if file.ext.isTasty then Iterator.single(file) else Iterator.empty
         try
           for file <- tastyFiles(jar) do
             printTasty(s"$arg ${file.path}", file.toByteArray, isBestEffortTasty = false)

--- a/compiler/src/dotty/tools/dotc/fromtasty/TastyFileUtil.scala
+++ b/compiler/src/dotty/tools/dotc/fromtasty/TastyFileUtil.scala
@@ -4,8 +4,6 @@ package fromtasty
 import dotty.tools.dotc.core.tasty.TastyClassName
 import dotty.tools.dotc.core.StdNames.nme.EMPTY_PACKAGE
 import dotty.tools.io.AbstractFile
-import dotty.tools.dotc.classpath.FileUtils.hasTastyExtension
-import dotty.tools.dotc.classpath.FileUtils.hasBetastyExtension
 
 object TastyFileUtil {
   /** Get the class path of a tasty file
@@ -35,9 +33,9 @@ object TastyFileUtil {
    */
   def getClassName(file: AbstractFile, withBestEffortTasty: Boolean = false): Option[String] =
     assert(file.exists)
-    assert(file.hasTastyExtension || (withBestEffortTasty && file.hasBetastyExtension))
+    assert(file.ext.isTasty || (withBestEffortTasty && file.ext.isBetasty))
     val bytes = file.toByteArray
-    val names = new TastyClassName(bytes, file.hasBetastyExtension).readName()
+    val names = new TastyClassName(bytes, file.ext.isBetasty).readName()
     names.map: (packageName, className) =>
       if packageName == EMPTY_PACKAGE then
         s"${className.lastPart.encode}"

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -3,7 +3,6 @@ package dotty.tools.dotc.interactive
 import dotty.tools.dotc.classpath.BinaryFileEntry
 import dotty.tools.dotc.classpath.PackageEntry
 import dotty.tools.dotc.classpath.PackageEntryImpl
-import dotty.tools.dotc.classpath.PackageName
 import dotty.tools.dotc.classpath.SourceFileEntry
 import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation}
 
@@ -19,25 +18,21 @@ class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
 
   override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = None
   override def findClassFile(className: String): Option[AbstractFile] = None
-  override def classes(inPackage: PackageName): Seq[BinaryFileEntry] = Seq.empty
+  override def classes(inPackage: String): Seq[BinaryFileEntry] = Seq.empty
 
-  override def hasPackage(inPackage: PackageName): Boolean =
-    findPackage(
-      inPackage.dottedString
-    ).isDefined
+  override def hasPackage(inPackage: String): Boolean =
+    findPackage(inPackage).isDefined
 
   /** Return all packages contained inside `inPackage`. Package entries contain the *full name* of the package. */
-  override def packages(inPackage: PackageName): Seq[PackageEntry] =
-    val rawPackage = inPackage.dottedString
-    findPackage(rawPackage) match
-      case Some(pkg) => packagesIn(pkg, rawPackage)
+  override def packages(inPackage: String): Seq[PackageEntry] =
+    findPackage(inPackage) match
+      case Some(pkg) => packagesIn(pkg, inPackage)
       case None => Seq.empty[PackageEntry]
 
 
   /** Return all sources contained directly inside `inPackage` */
-  override def sources(inPackage: PackageName): Seq[SourceFileEntry] =
-    val rawPackage = inPackage.dottedString
-    findPackage(rawPackage) match
+  override def sources(inPackage: String): Seq[SourceFileEntry] =
+    findPackage(inPackage) match
       case Some(pkg) =>
         sourcesIn(pkg)
       case None => Seq.empty[SourceFileEntry]

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -15,9 +15,6 @@ import java.net.URL
 class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
     extends ClassPath {
 
-  override def findClassFile(className: String): Option[AbstractFile] = None
-  override def classes(inPackage: String): Seq[BinaryFileEntry] = Seq.empty
-
   override def hasPackage(inPackage: String): Boolean =
     findPackage(inPackage).isDefined
 

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -1,10 +1,8 @@
 package dotty.tools.dotc.interactive
 
-import dotty.tools.dotc.classpath.BinaryFileEntry
 import dotty.tools.dotc.classpath.PackageEntry
-import dotty.tools.dotc.classpath.PackageEntryImpl
 import dotty.tools.dotc.classpath.SourceFileEntry
-import dotty.tools.io.{AbstractFile, ClassPath}
+import dotty.tools.io.ClassPath
 
 import java.io.File
 import java.net.URL
@@ -37,7 +35,7 @@ class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
 
   private def packagesIn(pkg: LogicalPackage, prefix: String) =
     val pre = if (prefix.isEmpty) prefix else s"$prefix."
-    pkg.packages.map(p => PackageEntryImpl(pre + p.name))
+    pkg.packages.map(p => PackageEntry(pre + p.name))
 
   override def asURLs: Seq[URL] = sourcepath.split(File.pathSeparator).toIndexedSeq.map(new File(_)).map(_.toURI.toURL)
 

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -61,10 +61,6 @@ class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
 
   override def asURLs: Seq[URL] = sourcepath.split(File.pathSeparator).toIndexedSeq.map(new File(_)).map(_.toURI.toURL)
 
-  override def asClassPathStrings: Seq[String] = Seq()
-
-  override def asSourcePathString: String = sourcepath
-
   /** Return the package for the given fullName, if any */
   private def findPackage(fullName: String): Option[LogicalPackage] =
     if fullName == "" then Option(rootPackage)

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -6,8 +6,7 @@ import dotty.tools.dotc.classpath.PackageEntry
 import dotty.tools.dotc.classpath.PackageEntryImpl
 import dotty.tools.dotc.classpath.PackageName
 import dotty.tools.dotc.classpath.SourceFileEntry
-import dotty.tools.io.AbstractFile
-import dotty.tools.io.ClassPath
+import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation}
 
 import java.io.File
 import java.net.URL
@@ -51,13 +50,14 @@ class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
     val pre = if (prefix.isEmpty) prefix else s"$prefix."
     pkg.packages.map(p => PackageEntryImpl(pre + p.name))
 
-  override def list(inPackage: PackageName): ClassPathEntries =
+  override def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
     val rawPackage = inPackage.dottedString
-    val res = findPackage(rawPackage) match
+    findPackage(rawPackage) match
       case Some(pkg) =>
-        ClassPathEntries(packagesIn(pkg, rawPackage), sourcesIn(pkg))
-      case None => ClassPathEntries(Seq(), Seq())
-    res
+        packagesIn(pkg, rawPackage).foreach(onPackageEntry)
+        sourcesIn(pkg).foreach(onClassesAndSources)
+      case None => ()
+  }
 
   override def asURLs: Seq[URL] = sourcepath.split(File.pathSeparator).toIndexedSeq.map(new File(_)).map(_.toURI.toURL)
 

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -1,7 +1,6 @@
 package dotty.tools.dotc.interactive
 
 import dotty.tools.dotc.classpath.BinaryFileEntry
-import dotty.tools.dotc.classpath.ClassPathEntries
 import dotty.tools.dotc.classpath.PackageEntry
 import dotty.tools.dotc.classpath.PackageEntryImpl
 import dotty.tools.dotc.classpath.PackageName
@@ -49,15 +48,6 @@ class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
   private def packagesIn(pkg: LogicalPackage, prefix: String) =
     val pre = if (prefix.isEmpty) prefix else s"$prefix."
     pkg.packages.map(p => PackageEntryImpl(pre + p.name))
-
-  override def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit = {
-    val rawPackage = inPackage.dottedString
-    findPackage(rawPackage) match
-      case Some(pkg) =>
-        packagesIn(pkg, rawPackage).foreach(onPackageEntry)
-        sourcesIn(pkg).foreach(onClassesAndSources)
-      case None => ()
-  }
 
   override def asURLs: Seq[URL] = sourcepath.split(File.pathSeparator).toIndexedSeq.map(new File(_)).map(_.toURI.toURL)
 

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalSourcePath.scala
@@ -4,11 +4,10 @@ import dotty.tools.dotc.classpath.BinaryFileEntry
 import dotty.tools.dotc.classpath.PackageEntry
 import dotty.tools.dotc.classpath.PackageEntryImpl
 import dotty.tools.dotc.classpath.SourceFileEntry
-import dotty.tools.io.{AbstractFile, ClassPath, ClassRepresentation}
+import dotty.tools.io.{AbstractFile, ClassPath}
 
 import java.io.File
 import java.net.URL
-import java.nio.file.Path
 
 /**
  * A ClassPath implementation that can find sources regardless of the directory where they're declared.
@@ -16,7 +15,6 @@ import java.nio.file.Path
 class LogicalSourcePath(val sourcepath: String, rootPackage: LogicalPackage)
     extends ClassPath {
 
-  override def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])] = None
   override def findClassFile(className: String): Option[AbstractFile] = None
   override def classes(inPackage: String): Seq[BinaryFileEntry] = Seq.empty
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -6,7 +6,6 @@ import java.nio.file.Path
 import java.util.EnumSet
 
 import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.classpath.FileUtils.{hasClassExtension, hasTastyExtension}
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.*
 import dotty.tools.dotc.core.Flags.*
@@ -531,7 +530,7 @@ class DependencyRecorder {
     if depFile != null then {
       // Cannot ignore inheritance relationship coming from the same source (see sbt/zinc#417)
       def allowLocal = depCtx == DependencyByInheritance || depCtx == LocalDependencyByInheritance
-      val isTastyOrSig = depFile.hasTastyExtension
+      val isTastyOrSig = depFile.ext.isTasty
 
       def processExternalDependency() = {
         val binaryClassName = depClass.binaryClassName
@@ -548,7 +547,7 @@ class DependencyRecorder {
         }
       }
 
-      if isTastyOrSig || depFile.hasClassExtension then
+      if isTastyOrSig || depFile.ext.isClass then
         processExternalDependency()
       else if allowLocal || depFile != sourceFile.file then
         // We cannot ignore dependencies coming from the same source file because

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -70,19 +70,6 @@ trait ClassPath {
     findClassFileAndModuleFile(className, findModule = true)
 
   def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])]
-
-  def asClassPathStrings: Seq[String]
-
-  /** The whole classpath in the form of one String.
-    */
-  def asClassPathString: String = ClassPath.join(asClassPathStrings*)
-  // for compatibility purposes
-  @deprecated("use asClassPathString instead of this one", "2.11.5")
-  def asClasspathString: String = asClassPathString
-
-  /** The whole sourcepath in the form of one String.
-    */
-  def asSourcePathString: String
 }
 
 trait EfficientClassPath extends ClassPath {
@@ -95,11 +82,6 @@ trait EfficientClassPath extends ClassPath {
     if (packageBuf.isEmpty && classRepBuf.isEmpty) ClassPathEntries.empty
     else ClassPathEntries(packageBuf, classRepBuf)
   }
-}
-
-trait EfficientClassPathCallBack {
-  def packageEntry(entry: PackageEntry): Unit
-  def classesAndSources(entry: ClassRepresentation): Unit
 }
 
 object ClassPath {
@@ -159,7 +141,7 @@ object ClassPath {
     )
   }
 
-  def specToURL(spec: String, basedir: Directory): Option[URL] =
+  private def specToURL(spec: String, basedir: Directory): Option[URL] =
     try
       val uri = new URI(spec)
       if uri.isAbsolute() then Some(uri.toURL())

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -111,22 +111,10 @@ object ClassPath {
   /** Split classpath using platform-dependent path separator */
   def split(path: String): List[String] = path.split(pathSeparator).toList.filterNot(_ == "").distinct
 
-  /** Join classpath using platform-dependent path separator */
-  def join(paths: String*): String  = paths.filterNot(_ == "").mkString(pathSeparator)
-
-  /** Split the classpath, apply a transformation function, and reassemble it. */
-  def map(cp: String, f: String => String): String = join(split(cp).map(f)*)
-
   /** Expand path and possibly expanding stars */
   def expandPath(path: String, expandStar: Boolean = true): List[String] =
     if (expandStar) split(path).flatMap(expandS)
     else split(path)
-
-  /** Expand dir out to contents, a la extdir */
-  def expandDir(extdir: String): List[String] =
-    AbstractFile.getDirectory(extdir) match
-      case null => Nil
-      case dir  => dir.filter(_.isClassContainer).map(x => new java.io.File(dir.file, x.name).getPath).toList
 
   /** Expand manifest jar classpath entries: these are either urls, or paths
    *  relative to the location of the jar.
@@ -149,12 +137,6 @@ object ClassPath {
         Some(basedir.resolve(Path(spec)).toURL)
     catch
       case _: MalformedURLException | _: URISyntaxException => None
-
-  def manifests: List[java.net.URL] = {
-    import scala.jdk.CollectionConverters.EnumerationHasAsScala
-    val resources = Thread.currentThread().getContextClassLoader().getResources("META-INF/MANIFEST.MF")
-    resources.asScala.filter(_.getProtocol == "jar").toList
-  }
 
   @deprecated("shim for sbt's compiler interface", since = "2.12.0")
   sealed abstract class ClassPathContext

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -9,38 +9,19 @@ package io
 
 import java.net.{MalformedURLException, URI, URISyntaxException, URL}
 import java.util.regex.PatternSyntaxException
-
 import File.pathSeparator
 import Jar.isJarOrZip
-
-import dotc.classpath.{ PackageEntry, PackageName, BinaryFileEntry, SourceFileEntry }
+import dotc.classpath.{BinaryFileEntry, FileUtils, PackageEntry, SourceFileEntry}
 
 /**
   * A representation of the compiler's class- or sourcepath.
   */
 trait ClassPath {
   def asURLs: Seq[URL]
-
-  final def hasPackage(pkg: String): Boolean = hasPackage(PackageName(pkg))
-  final def packages(inPackage: String): Seq[PackageEntry] = packages(PackageName(inPackage))
-  final def classes(inPackage: String): Seq[BinaryFileEntry] = classes(PackageName(inPackage))
-  final def sources(inPackage: String): Seq[SourceFileEntry] = sources(PackageName(inPackage))
-
-  /*
-   * These methods are mostly used in the ClassPath implementation to implement the `list` and
-   * `findX` methods below.
-   *
-   * However, there are some other uses in the compiler, to implement `invalidateClassPathEntries`,
-   * which is used by the repl's `:require` (and maybe the spark repl, https://github.com/scala/scala/pull/4051).
-   * Using these methods directly is more efficient than calling `list`.
-   *
-   * The `inPackage` contains a full package name, e.g. "" or "scala.collection".
-   */
-
-  private[dotty] def hasPackage(pkg: PackageName): Boolean
-  private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry]
-  private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry]
-  private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry]
+  def hasPackage(pkg: String): Boolean
+  def packages(inPackage: String): Seq[PackageEntry]
+  def classes(inPackage: String): Seq[BinaryFileEntry]
+  def sources(inPackage: String): Seq[SourceFileEntry]
 
   /**
    * Returns *only* the classfile for an external name, e.g., "java.lang.String". This method does not
@@ -114,7 +95,7 @@ object ClassPath {
         Some(basedir.resolve(Path(spec)).toURL)
     catch
       case _: MalformedURLException | _: URISyntaxException => None
-
+  
   @deprecated("shim for sbt's compiler interface", since = "2.12.0")
   sealed abstract class ClassPathContext
 

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -11,7 +11,7 @@ import java.net.{MalformedURLException, URI, URISyntaxException, URL}
 import java.util.regex.PatternSyntaxException
 import File.pathSeparator
 import Jar.isJarOrZip
-import dotc.classpath.{BinaryFileEntry, FileUtils, PackageEntry, SourceFileEntry}
+import dotc.classpath.{BinaryFileEntry, PackageEntry, SourceFileEntry}
 
 /**
   * A representation of the compiler's class- or sourcepath.
@@ -95,12 +95,6 @@ object ClassPath {
         Some(basedir.resolve(Path(spec)).toURL)
     catch
       case _: MalformedURLException | _: URISyntaxException => None
-  
-  @deprecated("shim for sbt's compiler interface", since = "2.12.0")
-  sealed abstract class ClassPathContext
-
-  @deprecated("shim for sbt's compiler interface", since = "2.12.0")
-  sealed abstract class JavaContext
 }
 
 trait ClassRepresentation {
@@ -118,12 +112,3 @@ trait ClassRepresentation {
     if (ix < 0) fileName.length else ix
   }
 }
-
-@deprecated("shim for sbt's compiler interface", since = "2.12.0")
-sealed abstract class DirectoryClassPath
-
-@deprecated("shim for sbt's compiler interface", since = "2.12.0")
-sealed abstract class MergedClassPath
-
-@deprecated("shim for sbt's compiler interface", since = "2.12.0")
-sealed abstract class JavaClassPath

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -32,14 +32,7 @@ trait ClassPath {
    * It is also used in the backend, by the inliner, to obtain the bytecode when inlining from the
    * classpath. It's also used by scalap.
    */
-  def findClassFile(className: String): Option[AbstractFile] =
-    findClassFileAndModuleFile(className, findModule = false).map(_._1)
-
-  /** Same as `findClassFile`, but also returns the corresponding module-info class file if there is any. */
-  def findClassFileAndModuleFile(className: String): Option[(AbstractFile, Option[AbstractFile])] =
-    findClassFileAndModuleFile(className, findModule = true)
-
-  def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])]
+  def findClassFile(className: String): Option[AbstractFile]
 }
 
 object ClassPath {

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -17,11 +17,11 @@ import dotc.classpath.{BinaryFileEntry, PackageEntry, SourceFileEntry}
   * A representation of the compiler's class- or sourcepath.
   */
 trait ClassPath {
-  def asURLs: Seq[URL]
-  def hasPackage(pkg: String): Boolean
-  def packages(inPackage: String): Seq[PackageEntry]
-  def classes(inPackage: String): Seq[BinaryFileEntry]
-  def sources(inPackage: String): Seq[SourceFileEntry]
+  def asURLs: Seq[URL] = Seq.empty
+  def hasPackage(pkg: String): Boolean = false
+  def packages(inPackage: String): Seq[PackageEntry] = Seq.empty
+  def classes(inPackage: String): Seq[BinaryFileEntry] = Seq.empty
+  def sources(inPackage: String): Seq[SourceFileEntry] = Seq.empty
 
   /**
    * Returns *only* the classfile for an external name, e.g., "java.lang.String". This method does not
@@ -32,7 +32,7 @@ trait ClassPath {
    * It is also used in the backend, by the inliner, to obtain the bytecode when inlining from the
    * classpath. It's also used by scalap.
    */
-  def findClassFile(className: String): Option[AbstractFile]
+  def findClassFile(className: String): Option[AbstractFile] = None
 }
 
 object ClassPath {

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -13,7 +13,7 @@ import java.util.regex.PatternSyntaxException
 import File.pathSeparator
 import Jar.isJarOrZip
 
-import dotc.classpath.{ PackageEntry, ClassPathEntries, PackageName, BinaryFileEntry, SourceFileEntry }
+import dotc.classpath.{ PackageEntry, PackageName, BinaryFileEntry, SourceFileEntry }
 
 /**
   * A representation of the compiler's class- or sourcepath.
@@ -25,7 +25,6 @@ trait ClassPath {
   final def packages(inPackage: String): Seq[PackageEntry] = packages(PackageName(inPackage))
   final def classes(inPackage: String): Seq[BinaryFileEntry] = classes(PackageName(inPackage))
   final def sources(inPackage: String): Seq[SourceFileEntry] = sources(PackageName(inPackage))
-  final def list(inPackage: String): ClassPathEntries = list(PackageName(inPackage))
 
   /*
    * These methods are mostly used in the ClassPath implementation to implement the `list` and
@@ -42,22 +41,6 @@ trait ClassPath {
   private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry]
   private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry]
   private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry]
-  private def list(inPackage: PackageName): ClassPathEntries = {
-    val packageBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
-    val classRepBuf = collection.mutable.ArrayBuffer.empty[ClassRepresentation]
-    list(inPackage, packageBuf += _, classRepBuf += _)
-    if (packageBuf.isEmpty && classRepBuf.isEmpty) ClassPathEntries.empty
-    else ClassPathEntries(packageBuf, classRepBuf)
-  }
-
-  /**
-    * Lists packages and classes (source or classfile) that are members of `inPackage` (not
-    * recursively). The `inPackage` contains a full package name, e.g., "scala.collection".
-    *
-    * This is the main method uses to find classes, see class `PackageLoader`. The
-    * `rootMirror.rootLoader` is created with `inPackage = ""`.
-    */
-  private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit
 
   /**
    * Returns *only* the classfile for an external name, e.g., "java.lang.String". This method does not

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -13,13 +13,12 @@ import java.util.regex.PatternSyntaxException
 import File.pathSeparator
 import Jar.isJarOrZip
 
-import dotc.classpath.{ PackageEntry, ClassPathEntries, PackageName }
+import dotc.classpath.{ PackageEntry, ClassPathEntries, PackageName, BinaryFileEntry, SourceFileEntry }
 
 /**
   * A representation of the compiler's class- or sourcepath.
   */
 trait ClassPath {
-  import dotty.tools.dotc.classpath.*
   def asURLs: Seq[URL]
 
   final def hasPackage(pkg: String): Boolean = hasPackage(PackageName(pkg))

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -42,15 +42,22 @@ trait ClassPath {
   private[dotty] def packages(inPackage: PackageName): Seq[PackageEntry]
   private[dotty] def classes(inPackage: PackageName): Seq[BinaryFileEntry]
   private[dotty] def sources(inPackage: PackageName): Seq[SourceFileEntry]
+  private def list(inPackage: PackageName): ClassPathEntries = {
+    val packageBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
+    val classRepBuf = collection.mutable.ArrayBuffer.empty[ClassRepresentation]
+    list(inPackage, packageBuf += _, classRepBuf += _)
+    if (packageBuf.isEmpty && classRepBuf.isEmpty) ClassPathEntries.empty
+    else ClassPathEntries(packageBuf, classRepBuf)
+  }
 
   /**
-    * Returns packages and classes (source or classfile) that are members of `inPackage` (not
+    * Lists packages and classes (source or classfile) that are members of `inPackage` (not
     * recursively). The `inPackage` contains a full package name, e.g., "scala.collection".
     *
     * This is the main method uses to find classes, see class `PackageLoader`. The
     * `rootMirror.rootLoader` is created with `inPackage = ""`.
     */
-  private[dotty] def list(inPackage: PackageName): ClassPathEntries
+  private[dotty] def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit
 
   /**
    * Returns *only* the classfile for an external name, e.g., "java.lang.String". This method does not
@@ -69,18 +76,6 @@ trait ClassPath {
     findClassFileAndModuleFile(className, findModule = true)
 
   def findClassFileAndModuleFile(className: String, findModule: Boolean): Option[(AbstractFile, Option[AbstractFile])]
-}
-
-trait EfficientClassPath extends ClassPath {
-  def list(inPackage: PackageName, onPackageEntry: PackageEntry => Unit, onClassesAndSources: ClassRepresentation => Unit): Unit
-
-  override def list(inPackage: PackageName): ClassPathEntries = {
-    val packageBuf = collection.mutable.ArrayBuffer.empty[PackageEntry]
-    val classRepBuf = collection.mutable.ArrayBuffer.empty[ClassRepresentation]
-    list(inPackage, packageBuf += _, classRepBuf += _)
-    if (packageBuf.isEmpty && classRepBuf.isEmpty) ClassPathEntries.empty
-    else ClassPathEntries(packageBuf, classRepBuf)
-  }
 }
 
 object ClassPath {

--- a/compiler/src/dotty/tools/io/FileExtension.scala
+++ b/compiler/src/dotty/tools/io/FileExtension.scala
@@ -18,6 +18,9 @@ enum FileExtension(val toLowerCase: String):
   /** represents an empty file extension. */
   def isEmpty: Boolean = this == Empty
 
+  /** the full extension including a leading dot */
+  val withDot: String = "." + toLowerCase
+
   override def toString: String = toLowerCase
 
   /** represents `".tasty"` */
@@ -40,6 +43,8 @@ enum FileExtension(val toLowerCase: String):
   def isJarOrZip: Boolean = isJar || isZip
   /** represents `".scala"` or `".java"` */
   def isSourceExtension: Boolean = isScala || isJava
+  /** represents `".class"` or `".tasty"` */
+  def isScalaBinary: Boolean = isClass || isTasty
 
 object FileExtension:
 

--- a/compiler/src/dotty/tools/io/Jar.scala
+++ b/compiler/src/dotty/tools/io/Jar.scala
@@ -42,8 +42,8 @@ class Jar(file: File) {
 
   import Jar.*
 
-  lazy val jarFile: JarFile  = new JarFile(file.jpath.toFile)
-  lazy val manifest: Option[Manifest] = withJarInput(s => Option(s.getManifest))
+  private lazy val jarFile: JarFile  = new JarFile(file.jpath.toFile)
+  private lazy val manifest: Option[Manifest] = withJarInput(s => Option(s.getManifest))
 
   def mainClass: Option[String]     = manifest.flatMap(_.attrs.get(Name.MAIN_CLASS))
   /** The manifest-defined classpath String if available. */

--- a/compiler/test/dotty/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/DottyBytecodeTest.scala
@@ -14,7 +14,7 @@ import dotty.tools.vulpix.TestConfiguration
 import scala.tools.asm
 import scala.tools.asm.*
 import scala.tools.asm.tree.*
-import dotty.tools.io.{AbstractFile, JavaClassPath, VirtualDirectory}
+import dotty.tools.io.{AbstractFile, VirtualDirectory}
 
 import scala.jdk.CollectionConverters.*
 import java.io.{InputStream, File as JFile}

--- a/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala
@@ -41,8 +41,7 @@ class JrtClassPathTest {
       node
     }
     assertEquals("java/lang/Object", jl_Class.name)
-    assertTrue(cp.list("java.lang").packages.exists(_.name == "java.lang.annotation"))
-    assertTrue(cp.list("java.lang").classesAndSources.exists(_.name == "Object"))
+    assertTrue(cp.packages("java.lang").exists(_.name == "java.lang.annotation"))
     assertTrue(cp.findClassFile("java.lang.Object").isDefined)
   }
 }

--- a/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
+++ b/language-server/src/dotty/tools/languageserver/DottyLanguageServer.scala
@@ -22,7 +22,6 @@ import dotc._
 import ast.{Trees, tpd, untpd}
 import core._, core.Decorators._
 import Comments._, Constants._, Contexts._, Flags._, Names._, NameOps._, Symbols._, SymDenotations._, Trees._, Types._
-import classpath.ClassPathEntries
 import reporting._
 import typer.Typer
 import util._


### PR DESCRIPTION
Prep for #26232
Part of #26492

Removes unused methods, inlines overly simple forwarders, inlines single-use overly-specific utility methods

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)
