### PR TITLE
Keep parameter names of closures under cc

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -258,13 +258,14 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
       val saved = isTopLevel
       if variance < 0 then isTopLevel = false
       try tp match
-        case defn.RefinedFunctionOf(rinfo: MethodType) =>
-          val rinfo1 = apply(rinfo)
-          if rinfo1 ne rinfo then rinfo1.toFunctionType(alwaysDependent = true)
-          else tp
-        case _ =>
-          innerApply(tp)
+        case defn.RefinedFunctionOf(rinfo: MethodType) => mapRefinedFunction(tp, rinfo)
+        case _ => innerApply(tp)
       finally isTopLevel = saved
+
+    def mapRefinedFunction(tp: Type, rinfo: MethodType): Type =
+      val rinfo1 = apply(rinfo)
+      if rinfo1 ne rinfo then rinfo1.toFunctionType(alwaysDependent = true)
+      else tp
 
     override def mapArg(arg: Type, tparam: ParamInfo): Type =
       super.mapArg(Recheck.mapExprType(arg), tparam)
@@ -375,21 +376,23 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             case _ => tp
         case _ => tp
 
-      def innerApply(tp: Type) = {
+      /** Normalize `tp1` and add a capture set variable to it if necessary. */
+      def addVar(tp1: Type, orig: Type) =
+        decorate(
+          addCaptureRefinements(normalizeCaptures(normalizeFunctions(tp1, orig))),
+          CaptureSet.VarInTypeTree(ctx.owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner), isRefining = inCaptureRefinement),
+          transformExplicitType(_, sym, initialVariance = variance),
+          typeArgFormal)
 
-        /** Normalize `tp` and add a capture set variable to it if necessary. */
-        def addVar(tp1: Type) =
-          decorate(
-            addCaptureRefinements(normalizeCaptures(normalizeFunctions(tp1, tp))),
-            CaptureSet.VarInTypeTree(ctx.owner, _, nestedOK = !ctx.mode.is(Mode.CCPreciseOwner), isRefining = inCaptureRefinement),
-            transformExplicitType(_, sym, initialVariance = variance),
-            typeArgFormal)
+      override def mapRefinedFunction(tp: Type, rinfo: MethodType): Type =
+        addVar(super.mapRefinedFunction(tp, rinfo), tp)
 
+      def innerApply(tp: Type) =
         tp match
           case AnnotatedType(parent, annot)
           if annot.symbol.isRetains || annot.symbol == defn.InferredAnnot =>
             // Drop explicit retains and @inferred annotations
-            addVar(apply(parent))
+            addVar(apply(parent), tp)
           case AnnotatedType(parent, annot)
           if annot.symbol == defn.DeclaredAnnot =>
             transformExplicitType(parent, sym, initialVariance = variance)
@@ -397,10 +400,9 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             val saved = refiningNames
             refiningNames += rname
             val parent1 = try this(parent) finally refiningNames = saved
-            addVar(tp.derivedRefinedType(parent1, rname, this(rinfo)))
+            addVar(tp.derivedRefinedType(parent1, rname, this(rinfo)), tp)
           case _ =>
-            addVar(mapFollowingAliases(tp))
-      }
+            addVar(mapFollowingAliases(tp), tp)
     }
 
     try

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -271,5 +271,19 @@ class TypeUtils:
       case self: SingletonType => ctx.printer.toTextRef(self).show
       case _ => self.show
 
+    /** True if `tp` is a method or poly type whose term parameter names are
+     *  worth surfacing in printed types and capture sets — they are
+     *  user-given (not all `x$N` synthetic, not all `_$N` wildcard) and there
+     *  is at least one of them.
+     */
+    def hasMeaningfulParamNames(using Context): Boolean = self match
+      case mt: MethodType =>
+        mt.paramNames.nonEmpty
+        && !mt.allParamNamesSynthetic
+        && !mt.paramNames.forall(_.is(NameKinds.WildcardParamName))
+      case pt: PolyType =>
+        pt.resType.hasMeaningfulParamNames
+      case _ =>
+        false
 end TypeUtils
 

--- a/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PickleQuotes.scala
@@ -325,7 +325,7 @@ object PickleQuotes {
               defn.QuotedExprClass.typeRef.appliedTo(defn.AnyType)),
             args =>
               val cases = holeContents.zipWithIndex.map { case (splice, idx) =>
-                val defn.FunctionNOf(argTypes, defn.FunctionNOf(quotesType :: _, _, _), _) = splice.tpe: @unchecked
+                val defn.FunctionOf(argTypes, defn.FunctionOf(quotesType :: _, _, _), _) = splice.tpe: @unchecked
                 val rhs = {
                   val spliceArgs = argTypes.zipWithIndex.map { (argType, i) =>
                     args(1).select(nme.apply).appliedTo(Literal(Constant(i))).asInstance(argType)

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -443,7 +443,7 @@ trait TypeAssigner {
           case pt: PolyType =>
             pt.derivedLambdaType(resType = methTypeWithoutEnv(pt.resType))
         val methodicType = if tree.env.isEmpty then meth.tpe.widen else methTypeWithoutEnv(meth.tpe.widen)
-        // Gross hack to support boostrapping with 3.8.4:
+        // Gross hack to support bootstrapping with 3.8.4:
         // PickleQuotes expected a quote closure to be of FunctionN form.
         // This is now fixed, but 3.8.4 still has the old behavior. So we cannot
         // generate closures with RefinedTypes under 3.8.4.
@@ -458,7 +458,7 @@ trait TypeAssigner {
         // expose its user-written parameter names as a dependent function
         // type, so they print and appear in capture sets as written. We do
         // this only for closures that actually carry meaningful names
-        // originating from user source .
+        // originating from user source.
         val keepsParamNamesUnderCC =
           Feature.ccEnabled
           && !ctx.erasedTypes                       // RefinedType is invalid after erasure

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -13,6 +13,7 @@ import reporting.*
 import Checking.{checkNoPrivateLeaks, checkNoWildcard}
 import util.Property
 import transform.Splicer
+import config.Feature
 
 trait TypeAssigner {
   import tpd.*
@@ -442,7 +443,30 @@ trait TypeAssigner {
           case pt: PolyType =>
             pt.derivedLambdaType(resType = methTypeWithoutEnv(pt.resType))
         val methodicType = if tree.env.isEmpty then meth.tpe.widen else methTypeWithoutEnv(meth.tpe.widen)
-        methodicType.toFunctionType(isJava = meth.symbol.is(JavaDefined))
+        // Gross hack to support boostrapping with 3.8.4:
+        // PickleQuotes expected a quote closure to be of FunctionN form.
+        // This is now fixed, but 3.8.4 still has the old behavior. So we cannot
+        // generate closures with RefinedTypes under 3.8.4.
+        // TODO: Remove quotesException once we bootstrap with 3.10.
+        val quotesException = meth.tpe.widen match
+          case mt: MethodType =>
+            mt.paramInfos.exists: pinfo =>
+              pinfo.typeSymbol == defn.QuotesClass
+          case _ =>
+            false
+        // When capture checking is on, we want a closure's inferred type to
+        // expose its user-written parameter names as a dependent function
+        // type, so they print and appear in capture sets as written. We do
+        // this only for closures that actually carry meaningful names
+        // originating from user source .
+        val keepsParamNamesUnderCC =
+          Feature.ccEnabled
+          && !ctx.erasedTypes                       // RefinedType is invalid after erasure
+          && methodicType.hasMeaningfulParamNames   // skip empty/synthetic/wildcard/contextual params
+          && !quotesException                       // TODO drop once we bootstrap with 3.10
+        methodicType.toFunctionType(
+          isJava = meth.symbol.is(JavaDefined),
+          alwaysDependent = keepsParamNamesUnderCC)
       else target.tpe)
 
   def assignType(tree: untpd.CaseDef, pat: Tree, body: Tree)(using Context): CaseDef = {

--- a/repl/test-resources/repl/cc-print-dep-fun
+++ b/repl/test-resources/repl/cc-print-dep-fun
@@ -1,0 +1,47 @@
+//> using options -language:experimental.captureChecking
+scala> import caps.*
+scala> import caps.fresh
+scala> class A
+// defined class A
+scala> class B
+// defined class B
+scala> class C
+// defined class C
+scala> class Box[+T](val value: T)
+// defined class Box
+scala> def unused: (x: A) -> B = ???
+def unused: (x: A) -> B
+scala> def used(a: A^): A^{a} -> B = ???
+def used(a: A^): A^{a} -> B
+scala> def freshScope: (x: A^) -> B^{fresh} = ???
+def freshScope: (x: A^) -> B^{fresh}
+scala> def curriedAllUnused: (x: A) -> (y: B) -> C = ???
+def curriedAllUnused: (x: A) -> (y: B) -> C
+scala> def curriedFirstUsed(io: A^): (xs: A^{io}) -> (ys: B) -> C = ???
+def curriedFirstUsed(io: A^): (xs: A^{io}) -> (ys: B) -> C
+scala> def curriedInnerFresh: (x: A) -> (y: B^) -> C^{fresh} = ???
+def curriedInnerFresh: (x: A) -> (y: B^) -> C^{fresh}
+scala> def curriedOuterFresh: (x: A^) -> B^{fresh} -> C = ???
+def curriedOuterFresh: (x: A^) -> B^{fresh} -> C
+scala> def multiParamUnused: (x: A, y: B) -> C = ???
+def multiParamUnused: (x: A, y: B) -> C
+scala> def multiParamOneUsed(io: A^): (a: A^{io}, b: B) -> C = ???
+def multiParamOneUsed(io: A^): (a: A^{io}, b: B) -> C
+scala> def depFun(io: A^): (x: A^{io}) -> B^{x} = ???
+def depFun(io: A^): (x: A^{io}) -> B^{x}
+scala> def insideBox: Box[(x: A) -> B] = ???
+def insideBox: Box[(x: A) -> B]
+scala> def insideBoxFresh: Box[(x: A^) -> B^{fresh}] = ???
+def insideBoxFresh: Box[(x: A^) -> B^{fresh}]
+scala> def polyFn: [T] => (x: A) -> T = ???
+def polyFn: [T] => (x: A) -> T
+scala> def polyFnUsed: [T] => (a: A^) -> A^{a} = ???
+def polyFnUsed: [T] => (a: A^) -> A^{a}
+scala> def ctxUnused: (x: A) ?-> B = ???
+def ctxUnused: (x: A) ?-> B
+scala> def ctxUsed(io: A^): (a: A^{io}) ?-> B = ???
+def ctxUsed(io: A^): (a: A^{io}) ?-> B
+scala> def impureUnused: (x: A) => B = ???
+def impureUnused: (x: A) ->{fresh} B
+scala> def freshArrow: (x: A) ->{fresh} B = ???
+def freshArrow: (x: A) ->{fresh} B

--- a/repl/test-resources/repl/i25971
+++ b/repl/test-resources/repl/i25971
@@ -1,0 +1,9 @@
+//> using options -language:experimental.captureChecking
+scala> import caps.*
+scala> class File
+// defined class File
+scala> def f: [C^ <: {any}] => (xs: List[File^{C}]) -> (ys: File^{C}) -> (zs: File^{C}) ->{ys} Unit = ???
+def f: [C^] => (xs: List[File^{C}]) -> (ys: File^{C}) ->
+  (zs: File^{C}) ->{ys} Unit
+scala> def g = (ys: File^) => (zs: File^) => { val _ = ys; () }
+def g: (ys: File^) -> (zs: File^) ->{ys} Unit

--- a/repl/test/dotty/tools/repl/TypeTests.scala
+++ b/repl/test/dotty/tools/repl/TypeTests.scala
@@ -131,7 +131,7 @@ class TypeTests extends ReplTest:
       storedOutput()
       // :type on a method reference shows its eta-expanded function type
       run(":type readRef")
-      assertEquals("Ref^{any.rd} -> Int", storedOutput().trim)
+      assertEquals("(r: Ref^{any.rd}) -> Int", storedOutput().trim)
     }
 
   // :type should display classifier-restricted captures (.only[...])
@@ -148,7 +148,7 @@ class TypeTests extends ReplTest:
     } andThen {
       storedOutput()
       run(":type restricted")
-      assertEquals("(() ->{any.only[Control]} Unit) -> Unit", storedOutput().trim)
+      assertEquals("(f: () ->{any.only[Control]} Unit) -> Unit", storedOutput().trim)
     }
 
   // :type should display capture sets on values

--- a/tests/neg-custom-args/captures/byname.check
+++ b/tests/neg-custom-args/captures/byname.check
@@ -7,7 +7,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/byname.scala:10:6 ----------------------------------------
 10 |  h(f2())  // error
    |    ^^^^
-   |    Found:    Int ->{cap1} Int
+   |    Found:    (x: Int) ->{cap1} Int
    |    Required: Int ->{cap2} Int
    |
    |    Note that capability `cap1` cannot flow into capture set {cap2}.

--- a/tests/neg-custom-args/captures/filevar.check
+++ b/tests/neg-custom-args/captures/filevar.check
@@ -4,7 +4,7 @@
    |Capability `l` outlives its scope: it leaks into outer capture set 's1 of parameter f.
    |The leakage occurred when trying to match the following types:
    |
-   |Found:    (l: scala.caps.Capability^) ?->'s2 File^'s3 ->'s4 Unit
+   |Found:    (l: scala.caps.Capability^) ?->'s2 (f: File^'s3) ->'s4 Unit
    |Required: (l²: scala.caps.Capability^) ?-> (f: File^{l²}) => Unit
    |
    |where:    => refers to a root capability created in method test when checking argument to parameter op of method withFile

--- a/tests/neg-custom-args/captures/freeze-double-flip.check
+++ b/tests/neg-custom-args/captures/freeze-double-flip.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/freeze-double-flip.scala:15:4 ----------------------------
 15 |    (x: Ref^) => (op: Ref^ => IRef) => op(x) // error
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |    Found:    Ref^ -> (Ref^ => IRef) -> IRef
+   |    Found:    (x: Ref^) -> (op: Ref^ => IRef) -> IRef
    |    Required: scala.caps.Mutable | Array[?]
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/heal-tparam-cs.check
+++ b/tests/neg-custom-args/captures/heal-tparam-cs.check
@@ -16,11 +16,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:15:13 -------------------------------
 15 |    localCap { c =>  // error
    |    ^
-   |    Found:    (x$0: Capp^'s3) ->'s4 () ->{x$0} Unit
+   |    Found:    (c1: Capp^'s3) ->'s4 () ->{c1} Unit
    |    Required: (c: Capp^) -> () ->{any} Unit
    |
-   |    Note that capability `x$0` cannot flow into capture set {any}
-   |    because (x$0 : Capp^'s3) is not visible from any in value test2.
+   |    Note that capability `c1` cannot flow into capture set {any}
+   |    because (c1 : Capp^'s3) is not visible from any in value test2.
    |
    |    where:    ^   refers to the root capability caps.any
    |              any is a root capability in the type of value test2
@@ -32,10 +32,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/heal-tparam-cs.scala:25:13 -------------------------------
 25 |    localCap { c =>  // error
    |    ^
-   |    Found:    (x$0: Capp^'s5) ->'s6 () ->{x$0} Unit
+   |    Found:    (c1: Capp^'s5) ->'s6 () ->{c1} Unit
    |    Required: (c: Capp^{io}) -> () ->{net} Unit
    |
-   |    Note that capability `x$0` cannot flow into capture set {net}.
+   |    Note that capability `c1` cannot flow into capture set {net}.
    |
 26 |      (c1: Capp^{io}) => () => { c1.use() }
 27 |    }

--- a/tests/neg-custom-args/captures/i15923.check
+++ b/tests/neg-custom-args/captures/i15923.check
@@ -7,6 +7,6 @@
    |Found:    Id[Cap^{any}]^'s2
    |Required: Id[Cap^'s1]^'s3
    |
-   |where:    any is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): Cap^{lcap} ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
+   |where:    any is a root capability created in anonymous function of type (using lcap: scala.caps.Capability^): (cap: Cap^{lcap}) ->'s4 Id[Cap^{any}]^'s5 of parameter parameter lcap² of method $anonfun
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/i15923b.check
+++ b/tests/neg-custom-args/captures/i15923b.check
@@ -4,7 +4,7 @@
   |Capability `lcap` outlives its scope: it leaks into outer capture set 's1 which is owned by value leak.
   |The leakage occurred when trying to match the following types:
   |
-  |Found:    (x$0: Cap^) -> Id[Cap^{x$0}]
+  |Found:    (lcap: Cap^) -> Id[Cap^{lcap}]
   |Required: (lcap: Cap^) => Id[Cap^'s1]^'s2
   |
   |where:    => refers to a root capability created in value leak when checking argument to parameter op of method withCap

--- a/tests/neg-custom-args/captures/levels.check
+++ b/tests/neg-custom-args/captures/levels.check
@@ -1,7 +1,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/levels.scala:19:33 ---------------------------------------
 19 |  val _: Ref[String -> String] = r // error
    |                                 ^
-   |                                 Found:    Ref[String -> String]^{r.rd}
+   |                                 Found:    Ref[(x: String) -> String]^{r.rd}
    |                                 Required: Ref[String -> String]
    |
    |                                 Note that capability `r.rd` cannot flow into capture set {}.
@@ -11,8 +11,8 @@
 23 |    r.setV(g) // error
    |           ^
    |           Found:    (x: String) ->{cap3} String
-   |           Required: String -> String
+   |           Required: (x: String) -> String
    |
-   |           Note that capability `cap3` cannot flow into capture set {}.
+   |           Note that capability `cap3` cannot flow into capture set {} of value r.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/local-mutables-2.check
+++ b/tests/neg-custom-args/captures/local-mutables-2.check
@@ -1,9 +1,9 @@
 -- Error: tests/neg-custom-args/captures/local-mutables-2.scala:7:9 ----------------------------------------------------
 7 |def foo() = // error: separation failure
   |         ^
-  |Separation failure in method foo's inferred result type (() ->{any.rd} Int, Int => Unit)^{}.
+  |Separation failure in method foo's inferred result type (() ->{any.rd} Int, (x: Int) => Unit)^{}.
   |One part,  () ->{any.rd} Int, hides capabilities  {any².rd}.
-  |Another part,  Int => Unit,  captures capabilities  {any³, any, any²}.
+  |Another part,  (x: Int) => Unit,  captures capabilities  {any³, any, any²}.
   |The two sets overlap at  {`any` of value r}.
   |
   |where:    => and any³ refer to a root capability classified as Unscoped in the result type of method foo
@@ -12,8 +12,8 @@
 -- Error: tests/neg-custom-args/captures/local-mutables-2.scala:11:10 --------------------------------------------------
 11 |def foo2() = // error: separation failure
    |          ^
-   |          Separation failure in method foo2's inferred result type (() ->{any.rd} Int, Int => Unit)^{}.
-   |          One part,  Int => Unit, hides capabilities  {any}.
+   |          Separation failure in method foo2's inferred result type (() ->{any.rd} Int, (x: Int) => Unit)^{}.
+   |          One part,  (x: Int) => Unit, hides capabilities  {any}.
    |          Another part,  () ->{any.rd} Int,  captures capabilities  {any.rd}.
    |          The two sets overlap at  {`any` of variable r}.
    |

--- a/tests/neg-custom-args/captures/readOnly.check
+++ b/tests/neg-custom-args/captures/readOnly.check
@@ -10,10 +10,10 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/readOnly.scala:17:23 -------------------------------------
 17 |  val _: Int -> Unit = putA // error
    |                       ^^^^
-   |                       Found:    (putA : Int ->{a} Unit)
+   |                       Found:    (putA : (x: Int) ->{a} Unit)
    |                       Required: Int -> Unit
    |
-   |                       Note that capability `a` cannot flow into capture set {}.
+   |                       Note that capability `putA` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`
 -- Error: tests/neg-custom-args/captures/readOnly.scala:20:23 ----------------------------------------------------------

--- a/tests/neg-custom-args/captures/scope-extrusions.check
+++ b/tests/neg-custom-args/captures/scope-extrusions.check
@@ -142,11 +142,11 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/scope-extrusions.scala:33:21 -----------------------------
 33 |  val f4: IO => IO = f3  // error
    |                     ^^
-   |                     Found:    (f3 : (x$0: IO) -> IO^{x$0})
+   |                     Found:    (f3 : (x: IO) -> IO^{x})
    |                     Required: IO^ => IO^{any}
    |
-   |                     Note that capability `x$0` cannot flow into capture set {any}
-   |                     because (x$0 : IO) is not visible from any in value f4.
+   |                     Note that capability `x` cannot flow into capture set {any}
+   |                     because (x : IO) is not visible from any in value f4.
    |
    |                     where:    =>  refers to a root capability in the type of value f4
    |                               ^   refers to the root capability caps.any

--- a/tests/neg-custom-args/captures/sep-compose.check
+++ b/tests/neg-custom-args/captures/sep-compose.check
@@ -98,8 +98,8 @@
 40 |  p1(f) // error
    |     ^
    |Separation failure: argument of type  (f : () ->{a} Unit)
-   |to a function of type (() => Unit) ->{f} Unit
-   |corresponds to capture-polymorphic formal parameter v1 of type  () => Unit
+   |to a function of type (x: () => Unit) ->{f} Unit
+   |corresponds to capture-polymorphic formal parameter x of type  () => Unit
    |and hides capabilities  {f}.
    |Some of these overlap with the captures of the function prefix.
    |
@@ -109,7 +109,7 @@
    |  Footprint set of function prefix      : {p1, f, a, io}
    |  The two sets overlap at               : {f, a, io}
    |
-   |where:    => refers to a root capability created in method test when checking argument to parameter v1 of method apply
+   |where:    => refers to a root capability created in method test when checking argument to parameter x of method apply
 -- Error: tests/neg-custom-args/captures/sep-compose.scala:41:38 -------------------------------------------------------
 41 |  val p8 = (x: () ->{a} Unit) => seq8(f)(x) // error
    |                                      ^

--- a/tests/neg-custom-args/captures/sep-curried-par.check
+++ b/tests/neg-custom-args/captures/sep-curried-par.check
@@ -31,10 +31,10 @@
 21 |  foo(c)(c) // error: separation
    |      ^
    |Separation failure: argument of type  (c : () => Unit)
-   |to a function of type (x$0: () => Unit) -> (() ->{c, any} Unit) ->{x$0} Unit
-   |corresponds to capture-polymorphic formal parameter x$0 of type  () =>² Unit
+   |to a function of type (p1: () => Unit) -> (p2: () ->{c, any} Unit) ->{p1} Unit
+   |corresponds to capture-polymorphic formal parameter p1 of type  () =>² Unit
    |and hides capabilities  {c}.
-   |Some of these overlap with the captures of the function result with type  (() ->{c, any} Unit) ->{c} Unit.
+   |Some of these overlap with the captures of the function result with type  (p2: () ->{c, any} Unit) ->{c} Unit.
    |
    |  Hidden set of current argument        : {c}
    |  Hidden footprint of current argument  : {c}
@@ -43,7 +43,7 @@
    |  The two sets overlap at               : {c}
    |
    |where:    =>  refers to a root capability in the type of parameter c
-   |          =>² refers to a root capability created in method test when checking argument to parameter x$0 of method apply
+   |          =>² refers to a root capability created in method test when checking argument to parameter p1 of method apply
 -- Error: tests/neg-custom-args/captures/sep-curried-par.scala:23:65 ---------------------------------------------------
 23 |  val bar = (p1: () => Unit) => (p2: () ->{p1, any} Unit) => par(p1, p2) // error separation
    |                                                                 ^^

--- a/tests/neg-custom-args/captures/sep-go.check
+++ b/tests/neg-custom-args/captures/sep-go.check
@@ -2,8 +2,8 @@
 15 |  f(x)   // error
    |    ^
    |Separation failure: argument of type  (x : Matrix^)
-   |to a function of type Matrix^ ->{x.rd} Unit
-   |corresponds to capture-polymorphic formal parameter v1 of type  Matrix^²
+   |to a function of type (y: Matrix^) ->{x.rd} Unit
+   |corresponds to capture-polymorphic formal parameter y of type  Matrix^²
    |and hides capabilities  {x}.
    |Some of these overlap with the captures of the function prefix.
    |
@@ -14,7 +14,7 @@
    |  The two sets overlap at               : {x}
    |
    |where:    ^  refers to a root capability classified as Unscoped in the type of parameter x
-   |          ^² refers to a root capability classified as Unscoped created in method race when checking argument to parameter v1 of method apply
+   |          ^² refers to a root capability classified as Unscoped created in method race when checking argument to parameter y of method apply
 -- Error: tests/neg-custom-args/captures/sep-go.scala:16:5 -------------------------------------------------------------
 16 |  go(x)  // error
    |     ^

--- a/tests/neg-custom-args/captures/use-capset.check
+++ b/tests/neg-custom-args/captures/use-capset.check
@@ -10,9 +10,9 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/use-capset.scala:12:50 -----------------------------------
 12 |  val _: () -> List[Object^{io}] -> Object^{io} = h2 // error, should be ->{io}
    |                                                  ^^
-   |                                                 Found:    (h2 : () ->{io} List[Object^{io}] ->{io} Object^{io})
-   |                                                 Required: () -> List[Object^{io}] -> Object^{io}
+   |                                           Found:    (h2 : () ->{io} (xs: List[Object^{io}]) ->{io} Object^{io})
+   |                                           Required: () -> List[Object^{io}] -> Object^{io}
    |
-   |                                                 Note that capability `h2` cannot flow into capture set {}.
+   |                                           Note that capability `h2` cannot flow into capture set {}.
    |
    | longer explanation available when compiling with `-explain`

--- a/tests/neg-custom-args/captures/usingLogFile.check
+++ b/tests/neg-custom-args/captures/usingLogFile.check
@@ -30,8 +30,8 @@
    |Capability `f` outlives its scope: it leaks into outer capture set 's7 which is owned by value later.
    |The leakage occurred when trying to match the following types:
    |
-   |Found:    (f: java.io.OutputStream^) ->'s8 Int ->{f} Unit
-   |Required: java.io.OutputStream^ => Int ->'s7 Unit
+   |Found:    (f: java.io.OutputStream^) ->'s8 (y: Int) ->{f} Unit
+   |Required: java.io.OutputStream^ => (y: Int) ->'s7 Unit
    |
    |where:    => refers to a root capability created in value later when checking argument to parameter op of method usingFile
    |          ^  refers to the root capability caps.any

--- a/tests/neg-custom-args/captures/vars-simple.check
+++ b/tests/neg-custom-args/captures/vars-simple.check
@@ -17,7 +17,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/vars-simple.scala:17:12 ----------------------------------
 17 |    b = List(g) // error
    |        ^^^^^^^
-   |        Found:    List[String ->{cap3} String]
+   |        Found:    List[(x: String) ->{cap3} String]
    |        Required: List[String ->{cap1, cap2} String]
    |
    |        Note that capability `cap3` cannot flow into capture set {cap1, cap2}.

--- a/tests/neg-custom-args/captures/vars.check
+++ b/tests/neg-custom-args/captures/vars.check
@@ -27,7 +27,7 @@
 -- [E007] Type Mismatch Error: tests/neg-custom-args/captures/vars.scala:28:12 -----------------------------------------
 28 |    b = List(g) // error
    |        ^^^^^^^
-   |        Found:    List[String ->{cap3} String]
+   |        Found:    List[(x: String) ->{cap3} String]
    |        Required: List[String ->{cap1, cap2} String]
    |
    |        Note that capability `cap3` cannot flow into capture set {cap1, cap2}.
@@ -39,8 +39,8 @@
    |        Capability `cap3` outlives its scope: it leaks into outer capture set 's1 which is owned by method test.
    |        The leakage occurred when trying to match the following types:
    |
-   |        Found:    (cap3: CC^) ->'s2 String ->{cap3} String
-   |        Required: CC^ -> String ->'s1 String
+   |        Found:    (cap3: CC^) ->'s2 (x: String) ->{cap3} String
+   |        Required: CC^ -> (x: String) ->'s1 String
    |
    |        where:    ^ refers to the root capability caps.any
    |


### PR DESCRIPTION
This is similar to #26001 and takes some code and tests from it, but is simpler.

We use the dependent function form under cc for closures that define meaningful parameter names. All other changes of #26001 were dropped.
