### PR TITLE
chore: Add batch semanticdb for Metals 2

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/package.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/package.scala
@@ -22,9 +22,13 @@ package object semanticdb {
 
   /** Serializes a SemanticDB text document as bytes for the given tree, path, and textual source code. */
   def textDocumentBytes(tree: tpd.Tree, path: String, sourceCode: String)(using Context): Array[Byte] =
+    textDocument(tree, path, sourceCode).toByteArray
+
+  /** Creates a SemanticDB text document for the given tree, path, and textual source code. */
+  def textDocument(tree: tpd.Tree, path: String, sourceCode: String)(using Context): TextDocument =
     val extractor = ExtractSemanticDB.Extractor()
     extractor.traverse(tree)
-    val document = TextDocument(
+    TextDocument(
       schema = Schema.SEMANTICDB4,
       language = Language.SCALA,
       uri = path,
@@ -33,11 +37,6 @@ package object semanticdb {
       symbols = extractor.symbolInfos.toList,
       occurrences = extractor.occurrences.toList
     )
-    val byteStream = new ByteArrayOutputStream()
-    val out = SemanticdbOutputStream.newInstance(byteStream)
-    document.writeTo(out)
-    out.flush()
-    byteStream.toByteArray.nn
 
   /** Gets SemanticDB symbols from the given name. */
   def symbolsFromName(sym: String)(using ctx: Context): List[Symbol] =

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -3,12 +3,14 @@ package dotty.tools.pc
 import java.io.File
 import java.net.URI
 import java.nio.file.Path
+import java.time.Duration
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util as ju
 
+import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContextExecutor
 import scala.jdk.CollectionConverters.*
@@ -27,9 +29,12 @@ import scala.meta.pc.*
 import scala.meta.pc.PcSymbolInformation as IPcSymbolInformation
 import scala.meta.pc.reports.EmptyReportContext
 import scala.meta.pc.reports.ReportContext
+import scala.util.control.NonFatal
 
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.reporting.StoreReporter
+import dotty.tools.dotc.semanticdb.TextDocument
+import dotty.tools.dotc.semanticdb.TextDocuments
 import dotty.tools.pc.InferExpectedType
 import dotty.tools.pc.SymbolInformationProvider
 import dotty.tools.pc.buildinfo.BuildInfo
@@ -301,6 +306,59 @@ case class ScalaPresentationCompiler(
       val provider = SemanticdbTextDocumentProvider(driver, folderPath)
       provider.textDocument(filename, code)
     }(using virtualFile.toQueryContext)
+
+  def supportsBatchSemanticdbTextDocuments(): Boolean = true
+
+  def batchSemanticdbTextDocuments(
+      params: ju.List[VirtualFileParams],
+      timeout: Duration
+  ): CompletableFuture[Array[Byte]] =
+    if params.isEmpty() then
+      CompletableFuture.completedFuture(Array.emptyByteArray)
+    else
+      processBatchSequential(params, timeout)
+
+  private def processBatchSequential(
+      params: ju.List[VirtualFileParams],
+      timeout: Duration
+  ): CompletableFuture[Array[Byte]] =
+    val param = params.get(0)
+    compilerAccess.withInterruptableCompiler(
+      Array.emptyByteArray,
+      param.token()
+    ) { access =>
+      val driver = access.compiler()
+      val provider = SemanticdbTextDocumentProvider(driver, folderPath)
+      val startTime = System.nanoTime()
+      val timeoutNanos = timeout.toNanos()
+      val docs = processFiles(params.asScala.toSeq, provider, startTime, timeoutNanos)
+      TextDocuments(docs.toList).toByteArray
+    }(using param.toQueryContext)
+
+  private def processFiles(
+      files: Seq[VirtualFileParams],
+      provider: SemanticdbTextDocumentProvider,
+      startTime: Long,
+      timeoutNanos: Long
+  ): Seq[TextDocument] =
+    val docsBuffer = mutable.ListBuffer.empty[TextDocument]
+    val filesIterator = files.iterator
+    var timedOut = false
+
+    while filesIterator.hasNext && !timedOut do
+      val elapsed = System.nanoTime() - startTime
+      if elapsed >= timeoutNanos then
+        timedOut = true
+      else
+        val fileParam = filesIterator.next()
+        try
+          val doc = provider.textDocumentData(fileParam.uri(), fileParam.text())
+            .withUri(fileParam.uri().toString())
+          docsBuffer += doc
+        catch
+          case NonFatal(_) =>
+            docsBuffer += TextDocument.defaultInstance.withUri(fileParam.uri().toString())
+    docsBuffer.toSeq
 
   def completionItemResolve(
       item: l.CompletionItem,

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -18,6 +18,7 @@ import scala.language.unsafeNulls
 import scala.meta.internal.metals.CompilerVirtualFileParams
 import scala.meta.internal.metals.EmptyCancelToken
 import scala.meta.internal.metals.PcQueryContext
+import scala.meta.internal.metals.Report
 import scala.meta.internal.metals.ReportLevel
 import scala.meta.internal.mtags.CommonMtagsEnrichments.*
 import scala.meta.internal.pc.CompilerAccess
@@ -357,6 +358,14 @@ case class ScalaPresentationCompiler(
           docsBuffer += doc
         catch
           case NonFatal(_) =>
+            val report =
+              Report(
+                "empty-semanticdb-text-document",
+                s"""|file: ${fileParam.uri().toString()}
+                    |""".stripMargin,
+                s"${fileParam.uri().toString()}"
+              )
+            reportContext.unsanitized.create(() => report, /*ifVerbose =*/ true)
             docsBuffer += TextDocument.defaultInstance.withUri(fileParam.uri().toString())
     docsBuffer.toSeq
 

--- a/presentation-compiler/src/main/dotty/tools/pc/SemanticdbTextDocumentProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/SemanticdbTextDocumentProvider.scala
@@ -8,6 +8,7 @@ import scala.util.Properties
 
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.semanticdb
+import dotty.tools.dotc.semanticdb.TextDocument
 import dotty.tools.dotc.util.SourceFile
 
 class SemanticdbTextDocumentProvider(
@@ -19,6 +20,12 @@ class SemanticdbTextDocumentProvider(
       uri: URI,
       sourceCode: String
   ): Array[Byte] =
+    textDocumentData(uri, sourceCode).toByteArray
+
+  def textDocumentData(
+      uri: URI,
+      sourceCode: String
+  ): TextDocument =
     val filePath = Paths.get(uri).nn
     val validCode = removeMagicImports(sourceCode, filePath)
     driver.run(
@@ -36,6 +43,6 @@ class SemanticdbTextDocumentProvider(
       }
       .getOrElse(filePath.toString())
 
-    semanticdb.textDocumentBytes(tree, path.nn, sourceCode)(using driver.currentCtx)
+    semanticdb.textDocument(tree, path.nn, sourceCode)(using driver.currentCtx)
 
 end SemanticdbTextDocumentProvider


### PR DESCRIPTION
This method is used in Metals 2 and should be useful if we need to improve the efficiency of generating semanticdb.

## How much have you relied on LLM-based tools in this contribution?

Extensively, but mostly it's code copied over and adjusted to the Scala 3 repo.

## How was the solution tested?

Existing tests should be enough.