### PR TITLE
Fix typos across the codebase

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -4011,7 +4011,7 @@ class MatchReducer(initctx: Context) extends TypeComparer(initctx) {
 }
 
 /** A type comparer that can record traces of subtype operations
- *  @param short  if true print only failing forward traces; never print succesful
+ *  @param short  if true print only failing forward traces; never print successful
  *                subtraces; never print backtraces starting with `<==`.
  */
 class ExplainingTypeComparer(initctx: Context, short: Boolean) extends TypeComparer(initctx) {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -1393,7 +1393,7 @@ class TreeUnpickler(reader: TastyReader,
        *  Otherwise, adapt calls where class has only using clauses from old to new scheme.
        *  or class has mixed using clauses and other clauses.
        *  Old: leading (), new: nothing, or trailing () if all clauses are using clauses.
-       *  This is neccessary so that we can read pre-3.2 Tasty correctly. There,
+       *  This is necessary so that we can read pre-3.2 Tasty correctly. There,
        *  constructor calls use the old scheme, but constructor definitions already
        *  use the new scheme, since they are reconstituted with normalizeIfConstructor.
        */

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -5089,7 +5089,7 @@ object Parsers {
 
         // See test 17579. We allow `final` on `given` because these can be
         // translated to class definitions, for which `final` is allowed but
-        // redundant--there is a seperate warning for this.
+        // redundant--there is a separate warning for this.
         if isDclIntro && in.token != GIVEN then syntaxError(FinalLocalDef())
 
         tmplDef(start, mods)

--- a/compiler/src/dotty/tools/dotc/profile/Profiler.scala
+++ b/compiler/src/dotty/tools/dotc/profile/Profiler.scala
@@ -181,7 +181,7 @@ private [profile] class RealProfiler(reporter : ProfileReporter)(using Context) 
     else
       val filename = ctx.settings.YprofileTrace.value
       // Compilation units requiring multi-stage compilation (macros) would create a new profiler instances
-      // We need to store the traces in the seperate file to prevent overriding its content.
+      // We need to store the traces in the separate file to prevent overriding its content.
       // Alternatives: sharing ChromeTrace instance between all runs / manual concatation after all runs are done
       // FIXME: The first assigned runId is equal to 2 instead of 1 (InitialRunId).
       // Fix me when bug described in Compiler.runId is resolved by removing +/- 1 adjustments

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -407,7 +407,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
      *  clean retains annotations from such types. But for an overriding symbol the
      *  retains annotations come from the explicitly declared parent types, so should
      *  be kept.
-     *  TODO: If the overriden type is an InferredType, we should probably clean retains
+     *  TODO: If the overridden type is an InferredType, we should probably clean retains
      *  from both types as well.
      */
     private def makeOverrideTypeDeclared(symbol: Symbol, tpt: Tree)(using Context): Tree =

--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -2160,7 +2160,7 @@ class Namer { typer: Typer =>
   )(using Context): Type =
     /** Is this member tracked? This is true if it is marked as `tracked` or if
      *  it overrides a `tracked` member. To account for the later, `isTracked`
-     *  is overriden to `true` as a side-effect of computing `inherited`.
+     *  is overridden to `true` as a side-effect of computing `inherited`.
      */
     var isTracked: Boolean = sym.is(Tracked)
 

--- a/compiler/src/dotty/tools/dotc/util/Signatures.scala
+++ b/compiler/src/dotty/tools/dotc/util/Signatures.scala
@@ -340,7 +340,7 @@ object Signatures {
    * @param resultType Function result type
    * @param denot      Function denotation
    *
-   * @return List of lists of names of parameters if `resultType` is case class without overriden unapply
+   * @return List of lists of names of parameters if `resultType` is case class without overridden unapply
    */
   private def extractParamNamess(resultType: Type, denot: Denotation)(using Context): List[List[Name]] =
     if resultType.typeSymbol.flags.is(Flags.CaseClass) && denot.symbol.flags.is(Flags.Synthetic) then

--- a/compiler/test/dotty/tools/dotc/SettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/SettingsTests.scala
@@ -309,7 +309,7 @@ class SettingsTests:
       val args = List(s"-testOutput:${file.toString}")
       val summary = processArguments(args, processAll = true)
 
-      assertNotEquals(fileStateBefore, String(Files.readAllBytes(file)), "Jar should have been overriden")
+      assertNotEquals(fileStateBefore, String(Files.readAllBytes(file)), "Jar should have been overridden")
 
   @Test def `Output setting respects previous setting`: Unit =
     val result = Using.resources(

--- a/docs/_blog/_posts/2020-11-09-scala3-m1.md
+++ b/docs/_blog/_posts/2020-11-09-scala3-m1.md
@@ -107,7 +107,7 @@ val sm: Opt.Sm[23] = Sm(23)
 ```
 Previously, when an enumeration declared cases with value parameters, such as `Opt.Sm`, then the `Opt.values` array would no longer have indexes that match the enum case ordinals. We feel that this is problematic, so the `values` and `valueOf` methods will only be generated when an enum has exclusively singleton cases.
 
-If an enumeration adds a case with value parameters, then consumers will recieve an error that explains why `values` has been removed.
+If an enumeration adds a case with value parameters, then consumers will receive an error that explains why `values` has been removed.
 ```scala
 scala> Opt.values
 1 |Opt.values

--- a/docs/_docs/contributing/architecture/time.md
+++ b/docs/_docs/contributing/architecture/time.md
@@ -4,7 +4,7 @@ title: Time in the Compiler
 ---
 
 In the [compiler overview](lifecycle.md) section, we saw that `dotc` is an interactive compiler,
-and so can answer questions about entities as they come into existance and change throughout time,
+and so can answer questions about entities as they come into existence and change throughout time,
 for example:
 - which new definitions were added in a REPL session?
 - which definitions were replaced in an incremental build?

--- a/docs/_docs/internals/best-effort-compilation.md
+++ b/docs/_docs/internals/best-effort-compilation.md
@@ -58,7 +58,7 @@ maintenance load. This way phases like PostTyper do not have to be continually a
 with errors from typer and usually the IDE is able to retrieve enough information with just the typer phase.
 
 An unfortunate consequence of this structure is the fact that we lose access to phases allowing for incremental
-compilation, which is something that could be adressed in the future.
+compilation, which is something that could be addressed in the future.
 
 `-Ywith-best-effort-tasty` option allows reading Best Effort TASTy files from classpath. If such file is read, then
 the compiler is disallowed from proceeding to any non-frontend phase. This is to be used either in combination with

--- a/docs/_docs/reference/experimental/quoted-patterns-with-polymorphic-functions.md
+++ b/docs/_docs/reference/experimental/quoted-patterns-with-polymorphic-functions.md
@@ -21,7 +21,7 @@ def decomposeFunc(x: Expr[Any])(using Quotes): Expr[Int] =
     case _ => Expr(0)
 ```
 
-In the example above, the first case matches the case where `x` is a function and `y` is bound to the body of the function. The higher-order pattern `$y(a, b)` states that it matches any code with free occurence of variables `a` and `b`. If it is `$y(a)` instead, an expression like `(a: Int, b: Int) => a + b` will not match because `a + b` has an occurence of `b`, which is not included in the higher-order pattern.
+In the example above, the first case matches the case where `x` is a function and `y` is bound to the body of the function. The higher-order pattern `$y(a, b)` states that it matches any code with free occurrence of variables `a` and `b`. If it is `$y(a)` instead, an expression like `(a: Int, b: Int) => a + b` will not match because `a + b` has an occurrence of `b`, which is not included in the higher-order pattern.
 
 ## Motivation
 This experimental feature extends this higher-order pattern syntax to allow type variables.
@@ -34,7 +34,7 @@ def decomposePoly(x: Expr[Any])(using Quotes): Expr[Int] =
     case _ => Expr(0)
 ```
 
-Now we can use a higher-order pattern `$y[A](x)` with type variables. `y` is bound to the body of code with occurences of `A` and `x`, and has the type `[A] => (x: List[A]) => Int`.
+Now we can use a higher-order pattern `$y[A](x)` with type variables. `y` is bound to the body of code with occurrences of `A` and `x`, and has the type `[A] => (x: List[A]) => Int`.
 
 ## Type Dependency
 If a higher-order pattern carries a value parameter with a type that has type parameters defined in the quoted pattern, those type parameters should also be captured in the higher-order pattern. For example, the following pattern will not be typed.

--- a/docs/_docs/reference/preview/unrolled-defs.md
+++ b/docs/_docs/reference/preview/unrolled-defs.md
@@ -143,7 +143,7 @@ object C:
 
 ## Background Motivation
 
-The Scala language library ecosystem is based upon compatability of API's represented via both the TASTy format (TASTy compatibility), and the Java class file format (binary compatibility).
+The Scala language library ecosystem is based upon compatibility of API's represented via both the TASTy format (TASTy compatibility), and the Java class file format (binary compatibility).
 
 Adding a parameter to a method or constructor is a binary backwards incompatible change:
 clients compiled against the previous version will expect the old signature to exist, and cause a `LinkageError` to be thrown at runtime.

--- a/language-server/test/dotty/tools/languageserver/CompletionTest.scala
+++ b/language-server/test/dotty/tools/languageserver/CompletionTest.scala
@@ -1306,7 +1306,7 @@ class CompletionTest {
           |
           |val quux = new Quux:
           |  def aaa: Foo = ???
-          |  def bbb: Bar = ??? // overriden signature
+          |  def bbb: Bar = ??? // overridden signature
           |  def ccc(s: String): String = ???
           |  def ccc(i: Int): Int = ??? // overloaded
           |  private def ddd(): Boolean = ???
@@ -1346,7 +1346,7 @@ class CompletionTest {
           |
           |val quux = new Quux:
           |  def aaa: Foo = ???
-          |  def bbb: Bar = ??? // overriden signature
+          |  def bbb: Bar = ??? // overridden signature
           |  def ccc(s: String): String = ???
           |  def ccc(i: Int): Int = ??? // overloaded
           |  private def ddd(): Boolean = ???

--- a/library/src/scala/concurrent/Future.scala
+++ b/library/src/scala/concurrent/Future.scala
@@ -453,7 +453,7 @@ trait Future[+T] extends Awaitable[T] {
    *  @group Transformations
    */
   def zipWith[U, R](that: Future[U])(f: (T, U) => R)(implicit executor: ExecutionContext): Future[R] = {
-    // This is typically overriden by the implementation in DefaultPromise, which provides
+    // This is typically overridden by the implementation in DefaultPromise, which provides
     // symmetric fail-fast behavior regardless of which future fails first.
     //
     // TODO: remove this implementation and make Future#zipWith abstract

--- a/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcCollector.scala
@@ -25,7 +25,7 @@ trait PcCollector[T]:
 
   def allowZeroExtentImplicits: Boolean = false
 
-  def resultAllOccurences(): Set[T] =
+  def resultAllOccurrences(): Set[T] =
     def noTreeFilter = (_: Tree) => true
     def noSoughtFilter = (_: Symbol => Boolean) => true
 
@@ -293,7 +293,7 @@ object PcCollector:
     def apply(x: X, tree: Tree)(using Context) =
       traverser.traverse(x, tree, None)
 
-case class ExtensionParamOccurence(
+case class ExtensionParamOccurrence(
     name: Name,
     pos: SourcePosition,
     sym: Symbol,
@@ -347,4 +347,4 @@ abstract class SimpleCollector[T](
     params: VirtualFileParams
 ) extends WithCompilationUnit(driver, params)
     with PcCollector[T]:
-  def result(): List[T] = resultAllOccurences().toList
+  def result(): List[T] = resultAllOccurrences().toList

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlineValueProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlineValueProvider.scala
@@ -20,7 +20,7 @@ import org.eclipse.lsp4j as l
 final class PcInlineValueProvider(
     driver: InteractiveDriver,
     val params: OffsetParams
-) extends WithSymbolSearchCollector[Option[Occurence]](driver, params):
+) extends WithSymbolSearchCollector[Option[Occurrence]](driver, params):
 
   // We return a result or an error
   def getInlineTextEdits(): Either[String, List[l.TextEdit]] =
@@ -90,26 +90,26 @@ final class PcInlineValueProvider(
       tree: Tree | EndMarker,
       pos: SourcePosition,
       sym: Option[Symbol]
-  ): Option[Occurence] =
+  ): Option[Occurrence] =
     tree match
       case tree: Tree =>
         val (adjustedPos, _) = pos.adjust(text)
-        Some(Occurence(tree, parent, adjustedPos))
+        Some(Occurrence(tree, parent, adjustedPos))
       case _ => None
 
   def defAndRefs(): Either[String, (Definition, List[Reference])] =
     val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
-    val allOccurences = result().flatten
+    val allOccurrences = result().flatten
     for
-      definition <- allOccurences
-        .collectFirst { case Occurence(defn: ValDef, _, pos) =>
+      definition <- allOccurrences
+        .collectFirst { case Occurrence(defn: ValDef, _, pos) =>
           DefinitionTree(defn, pos)
         }
         .toRight(Errors.didNotFindDefinition)
       path = Interactive.pathTo(unit.tpdTree, definition.tree.rhs.span)(using newctx)
       indexedContext = IndexedContext(definition.tree.namePos, path, newctx)
       symbols = symbolsUsedInDefn(definition.tree.rhs, indexedContext)
-      references <- getReferencesToInline(definition, allOccurences, symbols)
+      references <- getReferencesToInline(definition, allOccurrences, symbols)
     yield
       val (deleteDefinition, refsEdits) = references
 
@@ -220,13 +220,13 @@ final class PcInlineValueProvider(
 
   private def getReferencesToInline(
       definition: DefinitionTree,
-      allOccurences: List[Occurence],
+      allOccurrences: List[Occurrence],
       symbols: Set[Symbol]
   ): Either[String, (Boolean, List[Reference])] =
     val defIsLocal = definition.tree.symbol.ownersIterator
       .drop(1)
       .exists(e => e.isTerm)
-    def allreferences = allOccurences.filterNot(_.isDefn)
+    def allreferences = allOccurrences.filterNot(_.isDefn)
     def inlineAll() =
       makeRefsEdits(allreferences, symbols, definition).map((true, _))
     if definition.tree.sourcePos.toLsp.encloses(position)
@@ -254,12 +254,12 @@ final class PcInlineValueProvider(
       pad.result()
 
   private def makeRefsEdits(
-      refs: List[Occurence],
+      refs: List[Occurrence],
       symbols: Set[Symbol],
       definition: DefinitionTree
   ): Either[String, List[Reference]] =
     val newctx = driver.currentCtx.fresh.setCompilationUnit(unit)
-    def buildRef(occurrence: Occurence): Either[String, Reference] =
+    def buildRef(occurrence: Occurrence): Either[String, Reference] =
       val path =
         Interactive.pathTo(unit.tpdTree, occurrence.pos.span)(using newctx)
       val indexedContext = IndexedContext(pos, path, newctx)
@@ -302,7 +302,7 @@ final class PcInlineValueProvider(
 
 end PcInlineValueProvider
 
-case class Occurence(tree: Tree, parent: Option[Tree], pos: SourcePosition):
+case class Occurrence(tree: Tree, parent: Option[Tree], pos: SourcePosition):
   def isDefn =
     tree match
       case _: ValDef => true

--- a/presentation-compiler/src/main/dotty/tools/pc/PcSymbolSearch.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcSymbolSearch.scala
@@ -178,19 +178,19 @@ trait PcSymbolSearch:
   private def seekInExtensionParameters() =
     def collectParams(
         extMethods: ExtMethods
-    ): Option[ExtensionParamOccurence] =
+    ): Option[ExtensionParamOccurrence] =
       NavigateAST
         .pathTo(pos.span, extMethods.paramss.flatten)(using compilatonUnitContext)
         .collectFirst {
           case v: untpd.ValOrTypeDef =>
-            ExtensionParamOccurence(
+            ExtensionParamOccurrence(
               v.name,
               v.namePos,
               v.symbol,
               extMethods.methods
             )
           case i: untpd.Ident =>
-            ExtensionParamOccurence(
+            ExtensionParamOccurrence(
               i.name,
               i.sourcePos,
               i.symbol,
@@ -209,15 +209,15 @@ trait PcSymbolSearch:
 
   private def collectAllExtensionParamSymbols(
       tree: tpd.Tree,
-      occurrence: ExtensionParamOccurence
+      occurrence: ExtensionParamOccurrence
   ): Option[(Set[Symbol], SourcePosition)] =
     occurrence match
-      case ExtensionParamOccurence(_, namePos, symbol, _)
+      case ExtensionParamOccurrence(_, namePos, symbol, _)
           if symbol != NoSymbol && !symbol.isError && !symbol.owner.is(
             Flags.ExtensionMethod
           ) =>
         Some((symbolAlternatives(symbol), namePos))
-      case ExtensionParamOccurence(name, namePos, _, methods) =>
+      case ExtensionParamOccurrence(name, namePos, _, methods) =>
         val symbols =
           for
             method <- methods.toSet
@@ -245,7 +245,7 @@ trait PcSymbolSearch:
         methods <- extensionMethods.map(_.methods)
         symbols <- collectAllExtensionParamSymbols(
           unit.tpdTree,
-          ExtensionParamOccurence(name, pos, sym, methods)
+          ExtensionParamOccurrence(name, pos, sym, methods)
         )
       yield symbols
     symbols.getOrElse((symbolAlternatives(sym), pos))

--- a/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/completion/CompletionOverrideSuite.scala
@@ -960,7 +960,7 @@ class CompletionOverrideSuite extends BaseCompletionSuite:
          |""".stripMargin
     )
 
-  @Test def `overriden-twice` =
+  @Test def `overridden-twice` =
     checkEdit(
       """
         |trait A {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2598,7 +2598,7 @@ object Build {
     .settings(
       Windows / name := "scala",
       // Windows/version is used to create ProductInfo - it requires a version without any -RC suffixes
-      // If not explicitly overriden it would try to use `dottyVersion` assigned to `dist-win-x86_64/version`
+      // If not explicitly overridden it would try to use `dottyVersion` assigned to `dist-win-x86_64/version`
       Windows / version    := developedVersion,
       Windows / mappings   := (Universal / mappings).value,
       Windows / packageBin := (Windows / packageBin).dependsOn(republish).value,

--- a/sbt-bridge/src/dotty/tools/xsbt/FallbackVirtualFile.java
+++ b/sbt-bridge/src/dotty/tools/xsbt/FallbackVirtualFile.java
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets;
  * the real virtual file can not be found.
  *
  * This has a very basic implementation of contentHash that is almost certainly colliding more than the implementation
- * in Zinc. It does not matter anyway as Zinc will recompile the associated source file, because it did not recieve the
+ * in Zinc. It does not matter anyway as Zinc will recompile the associated source file, because it did not receive the
  * same virtual file back.
  */
 public class FallbackVirtualFile extends xsbti.BasicVirtualFileRef implements xsbti.VirtualFile {

--- a/scaladoc-testcases/src/example/Inheritance.scala
+++ b/scaladoc-testcases/src/example/Inheritance.scala
@@ -5,7 +5,7 @@ import example.level2.Documentation
 abstract class DocumentationInheritance[T, A <: Int, B >: String, -X, +Y] extends Documentation[T, A, B, X, Y] {}
 
 class DocumentationInheritanceMethod:
-  def wierdMethod[T, A <: Int, B >: String](t: T, a: A): B = ???
+  def weirdMethod[T, A <: Int, B >: String](t: T, a: A): B = ???
   def threOtherWay[A <: Nothing, B >: Any](a: A, c: B): Unit = ???
 
 class A:

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/Renderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/Renderer.scala
@@ -162,7 +162,7 @@ abstract class Renderer(rootPackage: Member, val members: Map[DRI, Member], prot
   def pageContent(page: Page, parents: Vector[Link]): AppliedTag
 
   /**
-   * Method to be overriden by concrete renderer to render single page
+   * Method to be overridden by concrete renderer to render single page
    */
   def renderPage(page: Page, parents: Vector[Link]): Seq[String] =
     val newParents = parents :+ page.link

--- a/tasty/src/dotty/tools/tasty/TastyFormat.scala
+++ b/tasty/src/dotty/tools/tasty/TastyFormat.scala
@@ -315,7 +315,7 @@ object TastyFormat {
   /** Natural number. Each increment of the `MajorVersion` begins a
    *  new series of backward compatible TASTy versions.
    *
-   *  A TASTy file in either the preceeding or succeeding series is
+   *  A TASTy file in either the preceding or succeeding series is
    *  incompatible with the current value.
    */
   final val MajorVersion: Int = 28

--- a/tests/pos-macros/i12221/Macro_1.scala
+++ b/tests/pos-macros/i12221/Macro_1.scala
@@ -72,7 +72,7 @@ object Macros {
                                     (arg, index) =>
                                         treePrint(arg, level +1)
                                         if args.size > 1 && index < args.size -1  then
-                                            // Used to seperate list of parameters
+                                            // Used to separate list of parameters
                                             sb.append(pre + ",\n")
                                     )
                         case _ =>

--- a/tests/run/i16006.check
+++ b/tests/run/i16006.check
@@ -1,1 +1,1 @@
-overriden (3, 10)
+overridden (3, 10)

--- a/tests/run/i16006.scala
+++ b/tests/run/i16006.scala
@@ -2,7 +2,7 @@ class X:
   def toString(maxLines: Int = 10, maxWidth: Int = 10): String = (maxLines -> maxWidth).toString
 
 class Foo extends X:
-  override def toString(maxLines: Int, maxWidth: Int): String = s"overriden ($maxLines, $maxWidth)"
+  override def toString(maxLines: Int, maxWidth: Int): String = s"overridden ($maxLines, $maxWidth)"
   override def toString(): String = toString(maxLines = 3)
 
 


### PR DESCRIPTION
Non-code change: fix typos across the codebase.

Fixes ~40 spelling errors in 27 files (comments, docs, class names, string literals). Notable renames in presentation-compiler: `Occurence` → `Occurrence`, `ExtensionParamOccurence` → `ExtensionParamOccurrence`.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for searching and identifying typos across the codebase. All changes were reviewed before committing.

## How was the solution tested?

Non-code change, no tests needed. Most changes are in comments and documentation. Presentation-compiler class renames are internal with no external references (verified via grep).