### PR TITLE
Better transparent inline errors (add note about transparent inline limitation)

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -22,6 +22,7 @@ import cc.CleanupRetains
 
 import collection.mutable
 import reporting.{NotConstant, trace}
+import util.Property
 import util.Spans.Span
 import dotty.tools.dotc.core.Periods.PhaseId
 import dotty.tools.dotc.util.chaining.*
@@ -29,6 +30,13 @@ import dotty.tools.dotc.util.chaining.*
 /** Support for querying inlineable methods and for inlining calls to such methods */
 object Inlines:
   import tpd.*
+
+  /** Method name of the transparent inline call.
+   *
+   *  Used for reporting type errors on the expansion, to add a note that
+   *  precise type isn't available in transparent inline call inside an inline method.
+   */
+  private[dotc] val TransparentInlinedCall: Property.Key[String] = new Property.Key
 
   /** An exception signalling that an inline info cannot be computed due to a
    *  cyclic reference. i14772.scala shows a case where this happens.
@@ -198,11 +206,15 @@ object Inlines:
                |You can use ${setting.name} to change the limit.""",
           (tree :: enclosingInlineds).last.srcPos
         )
+    // if tree0 (inline call tree before expansion) is transparent
+    // attach the method name to the tree2 (expanded tree)
+    val tree3 =
+      if tree0.symbol.is(Transparent) then tree2.withAttachment(TransparentInlinedCall, tree0.symbol.show) else tree2
     if ctx.base.stopInlining && enclosingInlineds.isEmpty then
       ctx.base.stopInlining = false
         // we have completely backed out of the call that overflowed;
         // reset so that further inline calls can be expanded
-    tree2
+    tree3
   end inlineCall
 
   /** Try to inline a pattern with an inline unapply method. Fail with error if the maximal

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -221,6 +221,10 @@ object ErrorReporting {
            |- It is used inside another inline body.
            |- Its result type depends on another inline expansion or on an inline parameter."""
 
+    def transparentInlineSelectAddendum(qual: Tree)(using Context): String =
+      if qual.symbol.is(Transparent) then transparentInlineExpansionNote(qual.symbol.show).render
+      else ""
+
     /** A subtype log explaining why `found` does not conform to `expected` */
     def whyNoMatchStr(found: Type, expected: Type): String =
       val header =

--- a/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ErrorReporting.scala
@@ -11,6 +11,7 @@ import NameOps.*
 import util.Spans.NoSpan
 import util.SrcPos
 import config.Feature
+import inlines.Inlines
 import reporting.*
 import Message.Note
 import collection.mutable
@@ -203,11 +204,22 @@ object ErrorReporting {
             then i"definition of ${tree.symbol} in:  $tree"
             else i"tree:  $tree"
           Note(i"\n\nThe error occurred for a synthesized $synthText") :: Nil
+        case _ if tree.hasAttachment(Inlines.TransparentInlinedCall) =>
+          tree.getAttachment(Inlines.TransparentInlinedCall).map(transparentInlineExpansionNote).toList
         case _ =>
           Nil
 
       errorTree(tree, TypeMismatch(treeTp, expectedTp, Some(tree), notes ++ moreNotes))
     }
+
+    def transparentInlineExpansionNote(inlined: String)(using Context): Note =
+      Note:
+        i"""
+           |
+           |Note: `$inlined` is transparent inline, but its precise type may not be available here.
+           |This can happen when:
+           |- It is used inside another inline body.
+           |- Its result type depends on another inline expansion or on an inline parameter."""
 
     /** A subtype log explaining why `found` does not conform to `expected` */
     def whyNoMatchStr(found: Type, expected: Type): String =

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -180,7 +180,9 @@ trait TypeAssigner {
         val pre = maybeSkolemizePrefix(qualType1, name)
         reallyExists(qualType1.findMember(name, pre))
       case _ => false
-    def addendum = err.selectErrorAddendum(tree, qual, qualType, importSuggestionAddendum, foundWithoutNull)
+    def addendum =
+      err.selectErrorAddendum(tree, qual, qualType, importSuggestionAddendum, foundWithoutNull)
+      ++ err.transparentInlineSelectAddendum(qual)
     val msg: Message =
       if tree.name == nme.CONSTRUCTOR then em"$qualType does not have a constructor"
       else NotAMember(qualType, tree.name, kind, proto, addendum)

--- a/tests/neg/inline-non-transparent-no-note.check
+++ b/tests/neg/inline-non-transparent-no-note.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/inline-non-transparent-no-note.scala:7:26 -------------------------------------
+7 |val d: Succ[Zero.type] = s(Zero) // error
+  |                         ^^^^^^^
+  |                         Found:    Nat
+  |                         Required: Succ[Zero.type]
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/inline-non-transparent-no-note.scala
+++ b/tests/neg/inline-non-transparent-no-note.scala
@@ -1,0 +1,7 @@
+trait Nat
+case object Zero extends Nat
+case class Succ[N <: Nat](pred: N) extends Nat
+
+inline def s(inline y: Nat): Nat = Succ(y)
+
+val d: Succ[Zero.type] = s(Zero) // error

--- a/tests/neg/transparent-inline-heuristic-note.check
+++ b/tests/neg/transparent-inline-heuristic-note.check
@@ -1,0 +1,12 @@
+-- [E007] Type Mismatch Error: tests/neg/transparent-inline-heuristic-note.scala:7:17 ----------------------------------
+7 |val x: String = s(Zero) // error
+  |                ^^^^^^^
+  |                Found:    Succ[Nat]
+  |                Required: String
+  |
+  |                Note: `method s` is transparent inline, but its precise type may not be available here.
+  |                This can happen when:
+  |                - It is used inside another inline body.
+  |                - Its result type depends on another inline expansion or on an inline parameter.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/transparent-inline-heuristic-note.scala
+++ b/tests/neg/transparent-inline-heuristic-note.scala
@@ -1,0 +1,9 @@
+trait Nat
+case object Zero extends Nat
+case class Succ[N <: Nat](pred: N) extends Nat
+
+transparent inline def s(inline y: Nat): Nat = Succ(y)
+
+val x: String = s(Zero) // error
+// limitation: note about transparent inline expansion is emitted
+// even when the root cause of type mistmatch isn't transparent inline limitatation

--- a/tests/neg/transparent-inline-i12754-message.check
+++ b/tests/neg/transparent-inline-i12754-message.check
@@ -1,0 +1,16 @@
+-- [E008] Not Found Error: tests/neg/transparent-inline-i12754-message.scala:11:15 -------------------------------------
+11 |  transform(a) < b // error
+   |  ^^^^^^^^^^^^^^
+   |  value < is not a member of Any, but could be made available as an extension method.
+   |
+   |  One of the following imports might make progress towards fixing the problem:
+   |
+   |    import scala.math.Ordered.orderingToOrdered
+   |    import scala.math.Ordering.Implicits.infixOrderingOps
+   |
+   |
+   |
+   |  Note: `method transform` is transparent inline, but its precise type may not be available here.
+   |  This can happen when:
+   |  - It is used inside another inline body.
+   |  - Its result type depends on another inline expansion or on an inline parameter.

--- a/tests/neg/transparent-inline-i12754-message.scala
+++ b/tests/neg/transparent-inline-i12754-message.scala
@@ -1,0 +1,11 @@
+transparent inline def transform(inline a: Any): Any = inline a match
+  case x: Byte   => x
+  case x: Short  => x
+  case x: Int    => x
+  case x: Long   => x
+  case x: Float  => x
+  case x: Double => x
+  case _         => a
+
+inline def lt(inline a: Any, inline b: Double): Boolean =
+  transform(a) < b // error

--- a/tests/neg/transparent-inline-i15506-message.check
+++ b/tests/neg/transparent-inline-i15506-message.check
@@ -1,0 +1,12 @@
+-- [E007] Type Mismatch Error: tests/neg/transparent-inline-i15506-message.scala:5:19 ----------------------------------
+5 |val x: Some[Int] = bar // error
+  |                   ^^^
+  |                   Found:    Some[Int | Boolean]
+  |                   Required: Some[Int]
+  |
+  |                   Note: `method bar` is transparent inline, but its precise type may not be available here.
+  |                   This can happen when:
+  |                   - It is used inside another inline body.
+  |                   - Its result type depends on another inline expansion or on an inline parameter.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/transparent-inline-i15506-message.scala
+++ b/tests/neg/transparent-inline-i15506-message.scala
@@ -1,0 +1,5 @@
+transparent inline def foo: Int | Boolean = 2
+
+transparent inline def bar: Option[Int | Boolean] = Some(foo)
+
+val x: Some[Int] = bar // error

--- a/tests/neg/transparent-inline-nested-note.check
+++ b/tests/neg/transparent-inline-nested-note.check
@@ -1,0 +1,12 @@
+-- [E007] Type Mismatch Error: tests/neg/transparent-inline-nested-note.scala:12:11 ------------------------------------
+12 |val i: 1 = id // error
+   |           ^^
+   |           Found:    Int
+   |           Required: (1 : Int)
+   |
+   |           Note: `method id` is transparent inline, but its precise type may not be available here.
+   |           This can happen when:
+   |           - It is used inside another inline body.
+   |           - Its result type depends on another inline expansion or on an inline parameter.
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/transparent-inline-nested-note.scala
+++ b/tests/neg/transparent-inline-nested-note.scala
@@ -1,0 +1,12 @@
+trait Id[T]:
+  type Out <: Int
+
+transparent inline def internal[T <: Int]: Id[T] =
+  new Id[T]:
+    type Out = T
+
+transparent inline def id: Int =
+  val one = internal[1]
+  ??? : one.Out
+
+val i: 1 = id // error

--- a/tests/neg/transparent-inline-param-note.check
+++ b/tests/neg/transparent-inline-param-note.check
@@ -1,0 +1,12 @@
+-- [E007] Type Mismatch Error: tests/neg/transparent-inline-param-note.scala:7:26 --------------------------------------
+7 |val d: Succ[Zero.type] = s(Zero) // error
+  |                         ^^^^^^^
+  |                         Found:    Succ[Nat]
+  |                         Required: Succ[Zero.type]
+  |
+  |                         Note: `method s` is transparent inline, but its precise type may not be available here.
+  |                         This can happen when:
+  |                         - It is used inside another inline body.
+  |                         - Its result type depends on another inline expansion or on an inline parameter.
+  |
+  | longer explanation available when compiling with `-explain`

--- a/tests/neg/transparent-inline-param-note.scala
+++ b/tests/neg/transparent-inline-param-note.scala
@@ -1,0 +1,7 @@
+trait Nat
+case object Zero extends Nat
+case class Succ[N <: Nat](pred: N) extends Nat
+
+transparent inline def s(inline y: Nat): Nat = Succ(y)
+
+val d: Succ[Zero.type] = s(Zero) // error

--- a/tests/neg/transparent-inline-refined-no-note.check
+++ b/tests/neg/transparent-inline-refined-no-note.check
@@ -1,0 +1,7 @@
+-- [E007] Type Mismatch Error: tests/neg/transparent-inline-refined-no-note.scala:13:22 --------------------------------
+13 |    val s: String = b.value // error
+   |                    ^^^^^^^
+   |                    Found:    b.Out
+   |                    Required: String
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/transparent-inline-refined-no-note.scala
+++ b/tests/neg/transparent-inline-refined-no-note.scala
@@ -1,0 +1,16 @@
+trait Box[A]:
+  type Out
+  def value: Out
+
+transparent inline def box[A](a: A): Box[A] =
+  new Box[A]:
+    type Out = A
+    def value: A = a
+
+object SavedTest:
+  inline def check =
+    val b = box("ok")
+    val s: String = b.value // error
+    // limination: note about transparent inline expansion isn't available
+    // if the type mismatch error is reported at the different place than transparent inline call
+    // (at `val b = box("ok")`).

--- a/tests/neg/transparent-inline-select-note.check
+++ b/tests/neg/transparent-inline-select-note.check
@@ -1,0 +1,9 @@
+-- [E008] Not Found Error: tests/neg/transparent-inline-select-note.scala:9:24 -----------------------------------------
+9 |    val x: Int = choose.m // error
+  |                 ^^^^^^^^
+  |                 value m is not a member of A
+  |
+  |                 Note: `method choose` is transparent inline, but its precise type may not be available here.
+  |                 This can happen when:
+  |                 - It is used inside another inline body.
+  |                 - Its result type depends on another inline expansion or on an inline parameter.

--- a/tests/neg/transparent-inline-select-note.scala
+++ b/tests/neg/transparent-inline-select-note.scala
@@ -1,0 +1,9 @@
+class A
+class B extends A:
+  def m: Int = 1
+
+transparent inline def choose: A = new B
+
+object Test:
+  inline def check =
+    val x: Int = choose.m // error


### PR DESCRIPTION
fix https://github.com/scala/scala3/issues/26310

When a `transparent inline` method is called inside another `inline` method,
the inner call is not expanded while typing the outer inline method body.
This is the limitation of semantic-preserving inlining:
https://biboudis.github.io/papers/inlining-scala20.pdf

> 2.3 Recursion
> Calls to an inline function f within another inline function g are not
immediately inlined within the body of g
> Instead they are only inlined once g has itself be inlined in third, non-inline
function h.

```scala
inline def f() = 3
inline def g() = f() // f not inlined here
def h() = g() // first inlines g then inlines f
```

This limitation also affects `transparent inline`: if its precise return type depends on
another inline method or on inline parameters, the type available while
typing the current inline body may be less precise than the type obtained after
all expansions are done.

However, this behavior is not (to my knowledge) explicitly documented, and as a
result, it is difficult to notice this limitation from the error messages.

**fix**

This commit adds an additional note explaining that the type seen at a
`transparent inline` call site may be less precise than expected (the type obtained after all inlining is fully applied)

**examples**

```scala
trait Nat
case object Zero extends Nat
case class Succ[N <: Nat](pred: N) extends Nat
transparent inline def s(inline y: Nat): Nat = Succ(y)
val d: Succ[Zero.type] = s(Zero) // error
//                       ^^^^^^^
//                       Found:    Succ[Nat]
//                       Required: Succ[Zero.type]
//
//                       Note: `method s` is transparent inline, but its precise type may not be available here.
//                       - It is used inside another inline body.
//                       - Its result type depends on another inline expansion or on an inline parameter.
```


**limitations**
- The note is only available when the error is reported on the
  transparent inline call itself. (The note isn't avaialbe if the expansion is first assigned to a value and the error happens later iwth a refined member).
- The note is heuristic: we emit the note when type error happens at the
  `transparent inline` call site, even when the unavailable precise type
  is not the root cause of the error.

<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

Moderately for investigation and writing

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, for ...
Moderately, for ...
Minimally, for ...
Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable) 