### PR TITLE
Fixes #26340: Break cross-unit cyclic export across recompiled source siblings

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3657,17 +3657,21 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
           val packageObjectName = desugar.packageObjectName(ctx.source)
           val topLevelClassSymbol = pkg.moduleClass.info.decls.lookup(packageObjectName.moduleClassName)
           topLevelClassSymbol.ensureCompleted()
-          // When sibling files in this package come from the classpath (TASTy),
-          // force their `<src>$package` classes now to avoid cross-unit cycles
-          // as in #25894: otherwise the first lookup on this package (e.g. an
-          // import qualifier at the top of this file) forces them during the
-          // import's completer, and their unpickling can chain through source
-          // exports back to the import itself.
+          // Force the `<src>$package` classes of the sibling files in this
+          // package now to avoid cross-unit cycles as in #25894 / #26340:
+          // otherwise the first lookup on this package (e.g. an import qualifier
+          // at the top of this file) forces them during the import's completer,
+          // and resolving their exports can chain back to the import itself.
+          // This must cover both classpath (TASTy) siblings and sibling source
+          // units recompiled in the same run (#26340): a top-level `export` in
+          // any of them is the link that closes the cycle, so pre-resolving them
+          // all through the regular member path breaks it. We skip any package
+          // object that is already being completed to avoid forcing a cycle.
           if !pkg.isEffectiveRoot && pkg != defn.EmptyPackageVal then
             pkg.moduleClass.denot match
               case pcd: SymDenotations.PackageClassDenotation =>
                 for pobj <- pcd.packageObjs do
-                  if pobj.symbol.isDefinedInBinary then
+                  if !pobj.symbol.isCompleting then
                     pobj.symbol.ensureCompleted()
               case _ =>
           var stats1 = typedStats(tree.stats, pkg.moduleClass)._1

--- a/tests/pos/i26340/DFVal_1.scala
+++ b/tests/pos/i26340/DFVal_1.scala
@@ -1,0 +1,7 @@
+// https://github.com/scala/scala3/issues/26340
+package dfhdl
+
+object DFVal:
+  export DFXInt.Ops.c1
+  object Ops:
+    type CarryOp

--- a/tests/pos/i26340/Defs_1.scala
+++ b/tests/pos/i26340/Defs_1.scala
@@ -1,0 +1,13 @@
+// https://github.com/scala/scala3/issues/26340
+package dfhdl
+import DFVal.Ops.CarryOp
+
+trait ExactOp2Aux[Op]
+
+object DFDecimal:
+  object Ops:
+    export DFXInt.Ops.*
+
+object DFXInt:
+  object Ops:
+    given c1: ExactOp2Aux[CarryOp] = ???

--- a/tests/pos/i26340/Defs_2.scala
+++ b/tests/pos/i26340/Defs_2.scala
@@ -1,0 +1,13 @@
+// https://github.com/scala/scala3/issues/26340
+package dfhdl
+import DFVal.Ops.CarryOp
+
+trait ExactOp2Aux[Op]
+
+object DFDecimal:
+  object Ops:
+    export DFXInt.Ops.*
+
+object DFXInt:
+  object Ops:
+    given c1: ExactOp2Aux[CarryOp] = ???

--- a/tests/pos/i26340/Exports_1.scala
+++ b/tests/pos/i26340/Exports_1.scala
@@ -1,0 +1,6 @@
+// https://github.com/scala/scala3/issues/26340
+package dfhdl
+object hdl:
+  export DFDecimal.Ops.*
+
+export hdl.*

--- a/tests/pos/i26340/Exports_2.scala
+++ b/tests/pos/i26340/Exports_2.scala
@@ -1,0 +1,6 @@
+// https://github.com/scala/scala3/issues/26340
+package dfhdl
+object hdl:
+  export DFDecimal.Ops.*
+
+export hdl.*


### PR DESCRIPTION
The fix for #25894 (#25900) force-completes only the sibling <src>$package classes that come from the classpath (isDefinedInBinary), so the import on the enclosing package no longer chains through a *binary* sibling's export back to itself. But when a second source unit recompiled in the same run re-exports the same givens at top level (e.g. 'export hdl.*'), that sibling is source-defined, was skipped by the isDefinedInBinary guard, and its export is resolved lazily during the import's completer, reintroducing the cycle.

Force-complete all sibling package objects in typedPackageDef (binary and source), skipping any that are already completing, so every package-level export is pre-resolved through the regular member path before any import in the current file runs its completer.

Fixes #26340

## How much have you relied on LLM-based tools in this contribution?

Extensively, but it's a small fix to review.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
