### PR TITLE
Regression test

### DIFF
--- a/tests/pos/i14575.scala
+++ b/tests/pos/i14575.scala
@@ -1,0 +1,6 @@
+//> using options -Ycheck:all
+
+class ann(xs: Any) extends annotation.StaticAnnotation
+
+class Ops1(s: String) extends AnyVal:
+  def m: Int @ann(this) = 1


### PR DESCRIPTION
Closes #14575 

Previously fixed in 3.4.2 apparently by fixes to this in capture sets.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

