### PR TITLE
Synthetic cast must not break tailrec

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TailRec.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TailRec.scala
@@ -97,7 +97,7 @@ import dotty.tools.initialize
  *  the same parameters as type arguments. This is no longer the case in
  *  dotc thanks to being located after erasure.
  *  In scalac, this is named tailCall but it does only provide optimization for
- *  self recursive functions, that's why it's renamed to tailrec
+ *  self recursive functions, that's why it's renamed to tailrec.
  *
  *  @author
  *    Erik Stenman, Iulian Dragos,
@@ -414,7 +414,12 @@ class TailRec extends MiniPhase {
             rewriteApply(tree)
 
         case tree @ Select(qual, name) =>
-          cpy.Select(tree)(noTailTransform(qual), name)
+          val qual1 =
+            if tree.symbol == defn.Any_asInstanceOf && tree.span.isSynthetic then
+              transform(qual) // synthetic cast is still tailrec
+            else
+              noTailTransform(qual)
+          cpy.Select(tree)(qual1, name)
 
         case tree @ Block(stats, expr) =>
           cpy.Block(tree)(

--- a/tests/pos/i21642.scala
+++ b/tests/pos/i21642.scala
@@ -1,0 +1,10 @@
+import annotation.tailrec
+
+final class C {
+  @tailrec def minimal9_2[A](value: Option[Int]): A =
+    value match {
+      case Some(n) => minimal9_2(None)
+      case _ => ???
+      //case _ => (??? : A) // workaround eliminates or relocates the cast by patmat
+    }
+}


### PR DESCRIPTION
Fixes #21642 

Pattern matcher inserted a cast, which is no longer tail recursive.
The fix ignores synthetic select of asInstanceOf for tail position.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

