### PR TITLE
Skip i25830-external.scala under the coverage phase

### DIFF
--- a/compiler/test/dotc/scoverage-ignore.excludelist
+++ b/compiler/test/dotc/scoverage-ignore.excludelist
@@ -16,6 +16,7 @@ i19955b.scala
 i20053b.scala
 i2146.scala
 i23489.scala
+i25830-external.scala
 i8900a3.scala
 lazyVals_c3.0.0.scala
 lazyVals_c3.1.0.scala


### PR DESCRIPTION
Ignore a CC test for coverage after merging PR https://github.com/scala/scala3/pull/26246. 

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Tested locally with coverage on.