### PR TITLE
bugfix: Don't show errors from other files

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/DiagnosticProvider.scala
@@ -16,11 +16,24 @@ import org.eclipse.lsp4j
 
 class DiagnosticProvider(driver: InteractiveDriver, params: VirtualFileParams):
   def diagnostics(): List[lsp4j.Diagnostic] =
+    diagnostics(localOnly = false)
+
+  def diagnostics(localOnly: Boolean): List[lsp4j.Diagnostic] =
     if params.shouldReturnDiagnostics then
       val diags = driver.run(params.uri().nn, params.text().nn)
       given Context = driver.currentCtx
-      diags.flatMap(toLsp)
+      val uri = params.uri().nn
+      val filteredDiags =
+        if localOnly then diags.filter(isLocal(_, uri))
+        else diags
+      filteredDiags.flatMap(toLsp)
     else Nil
+
+  private def isLocal(diag: Diagnostic, uri: java.net.URI): Boolean =
+    diag.pos.exists && {
+      val sourcePath = diag.pos.source.jfile.map(_.toPath())
+      sourcePath.isPresent() && sourcePath.get().toUri().equals(uri)
+    }
 
   private def toLsp(diag: Diagnostic)(using Context): Option[lsp4j.Diagnostic] =
     Option.when(diag.pos.exists):
@@ -42,7 +55,6 @@ class DiagnosticProvider(driver: InteractiveDriver, params: VirtualFileParams):
       lspDiag.setData(actions)
       if diag.msg.errorId == ErrorMessageID.UnusedSymbolID then
         lspDiag.setTags(List(lsp4j.DiagnosticTag.Unnecessary).asJava)
-
       lspDiag
 
   private def toLspScalaAction(action: CodeAction): lsp4j.CodeAction =

--- a/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/RawScalaPresentationCompiler.scala
@@ -338,7 +338,7 @@ case class RawScalaPresentationCompiler(
     SignatureHelpProvider.signatureHelp(driver, params, search)
 
   override def didChange(params: VirtualFileParams): ju.List[l.Diagnostic] =
-    DiagnosticProvider(driver, params).diagnostics().asJava
+    DiagnosticProvider(driver, params).diagnostics(localOnly = true).asJava
 
   override def didClose(uri: URI): Unit =
     driver.close(uri)

--- a/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/ScalaPresentationCompiler.scala
@@ -530,7 +530,7 @@ case class ScalaPresentationCompiler(
       EmptyCancelToken
     ) { access =>
       val driver = access.compiler()
-      DiagnosticProvider(driver, params).diagnostics().asJava
+      DiagnosticProvider(driver, params).diagnostics(localOnly = true).asJava
     }(using params.toQueryContext)
 
   override def didClose(uri: URI): Unit =

--- a/presentation-compiler/test/dotty/tools/pc/base/BaseDiagnosticsSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BaseDiagnosticsSuite.scala
@@ -8,6 +8,7 @@ import scala.meta.pc.CancelToken
 import scala.meta.pc.VirtualFileParams
 
 import dotty.tools.pc.RawScalaPresentationCompiler
+import dotty.tools.pc.ScalaPresentationCompiler
 import dotty.tools.pc.base.TestResources
 import dotty.tools.pc.utils.PcAssertions
 import dotty.tools.pc.utils.TestExtensions.getOffset
@@ -15,7 +16,8 @@ import dotty.tools.pc.utils.TestExtensions.getOffset
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DiagnosticSeverity
 
-class BaseDiagnosticsSuite extends PcAssertions:
+trait DiagnosticTestHelpers extends PcAssertions {
+
   case class TestDiagnostic(
       startIndex: Int,
       endIndex: Int,
@@ -23,18 +25,13 @@ class BaseDiagnosticsSuite extends PcAssertions:
       severity: DiagnosticSeverity
   )
 
-  def options: List[String] = Nil
-
-  val pc = RawScalaPresentationCompiler().newInstance(
-    "",
-    TestResources.classpath.asJava,
-    options.asJava
-  )
-
   case class TestVirtualFileParams(uri: URI, text: String)
-      extends VirtualFileParams:
+      extends VirtualFileParams {
     override def shouldReturnDiagnostics: Boolean = true
     override def token: CancelToken = EmptyCancelToken
+  }
+
+  def getDiagnostics(text: String): List[Diagnostic]
 
   def diagnosticMessageAsString(d: Diagnostic): String = {
     val msg = d.getMessage()
@@ -48,11 +45,7 @@ class BaseDiagnosticsSuite extends PcAssertions:
       expected: List[TestDiagnostic],
       additionalChecks: List[Diagnostic] => Unit = identity
   ): Unit =
-    val diagnostics = pc
-      .didChange(
-        TestVirtualFileParams(URI.create("file:/Diagnostic.scala"), text)
-      )
-      .asScala
+    val diagnostics = getDiagnostics(text)
 
     val actual = diagnostics.map(d =>
       TestDiagnostic(
@@ -68,3 +61,23 @@ class BaseDiagnosticsSuite extends PcAssertions:
       s"Expected [${expected.mkString(", ")}] but got [${actual.mkString(", ")}]"
     )
     additionalChecks(diagnostics.toList)
+}
+
+class BaseDiagnosticsSuite extends PcAssertions with DiagnosticTestHelpers:
+
+  def options: List[String] = Nil
+
+  val pc = RawScalaPresentationCompiler().newInstance(
+    "",
+    TestResources.classpath.asJava,
+    options.asJava
+  )
+
+  def getDiagnostics(text: String): List[Diagnostic] = {
+    pc
+      .didChange(
+        TestVirtualFileParams(URI.create("file:/Diagnostic.scala"), text)
+      )
+      .asScala
+      .toList
+  }

--- a/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticSourcepathSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/DiagnosticSourcepathSuite.scala
@@ -1,0 +1,99 @@
+package dotty.tools.pc.tests
+
+import java.net.URI
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+
+import scala.language.unsafeNulls
+import scala.meta.internal.jdk.CollectionConverters.*
+import scala.meta.internal.metals.EmptyCancelToken
+import scala.meta.internal.pc.PresentationCompilerConfigImpl
+import scala.meta.pc.CancelToken
+import scala.meta.pc.SourcePathMode
+import scala.meta.pc.VirtualFileParams
+
+import dotty.tools.pc.base.BasePCSuite
+import dotty.tools.pc.base.DiagnosticTestHelpers
+import dotty.tools.pc.utils.TestExtensions.getOffset
+
+import org.eclipse.lsp4j.Diagnostic
+import org.eclipse.lsp4j.DiagnosticSeverity
+import org.junit.Test
+
+class DiagnosticSourcepathSuite extends BasePCSuite with DiagnosticTestHelpers:
+  private val sourcepathDir: Path = Files.createDirectories(tmp.resolve("sourcepath"))
+
+  def getDiagnostics(text: String): List[Diagnostic] =
+    presentationCompiler
+      .didChange(
+        TestVirtualFileParams(URI.create("file:/Diagnostic.scala"), text)
+      )
+      .get()
+      .asScala
+      .toList
+
+  locally:
+    val pkg1Dir = Files.createDirectories(sourcepathDir.resolve("pkg1"))
+    Files.write(
+      pkg1Dir.resolve("Alpha.scala"),
+      """|package pkg1
+         |
+         |class Alpha:
+         |  def greetAlpha: String = ""
+         |  val countAlpha: Int = 0
+         |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+    )
+    val pkg2Dir = Files.createDirectories(sourcepathDir.resolve("pkg2"))
+    Files.write(
+      pkg2Dir.resolve("WithError.scala"),
+      """|package pkg2
+         |
+         |class WithError:
+         |  val greeting: String = 42
+         |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+    )
+
+  override protected def config: PresentationCompilerConfigImpl =
+    super.config.copy(sourcePathMode = SourcePathMode.PRUNED)
+  override protected val sourcePath: Seq[Path] = Seq(sourcepathDir)
+
+  override protected def scalacOptions(classpath: Seq[Path]): Seq[String] =
+    Seq("-Ylogical-package-loading")
+
+  @Test def `uses-class-from-sourcepath-without-error` =
+    check(
+      """|import pkg1.Alpha
+         |object Main:
+         |  val a = new Alpha
+         |  val greeting: String = a.greetAlpha
+         |""".stripMargin,
+      List()
+    )
+
+  @Test def `type-mismatch-using-sourcepath-class` =
+    check(
+      """|import pkg1.Alpha
+         |object Main:
+         |  val a = new Alpha
+         |  val count: String = a.countAlpha
+         |""".stripMargin,
+      List(
+        TestDiagnostic(
+          73,
+          85,
+          "Found:    (Main.a.countAlpha : Int)\nRequired: String",
+          DiagnosticSeverity.Error
+        )
+      )
+    )
+
+  @Test def `uses-class-with-error-from-sourcepath` =
+    check(
+      """|import pkg2.WithError
+         |object Main:
+         |  val w = new WithError
+         |  val greeting: String = w.greeting
+         |""".stripMargin,
+      List()
+    )


### PR DESCRIPTION
The diagnostics provider should only be interested in the current file even if sourcepath is set, which can sometimes show flaky errors.

Also, currently we would return all the errors show in the current file, even if the position is from another one.

## How much have you relied on LLM-based tools in this contribution?

Ended up writing it mostly manually.

## How was the solution tested?

Automatic presentation compiler tests.