### PR TITLE
bugfix: Don't invoke atSpan on EmptyTree

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1525,18 +1525,18 @@ object Parsers {
       val startOffset = in.charOffset
       in.nextToken()
 
-      def interpolationExpr() = atSpan(in.offset):
+      def interpolationExpr() =
         if in.token == IDENTIFIER then
-          termIdent()
+          atSpan(in.offset)(termIdent())
         else if in.token == USCORE && inPattern then
           in.nextToken()
-          Ident(nme.WILDCARD)
+          atSpan(in.offset)(Ident(nme.WILDCARD))
         else if in.token == THIS then
           in.nextToken()
-          This(EmptyTypeIdent)
+          atSpan(in.offset)(This(EmptyTypeIdent))
         else if in.token == LBRACE then
-          if inPattern then Block(Nil, inBraces(pattern()))
-          else expr()
+          if inPattern then atSpan(in.offset)(Block(Nil, inBraces(pattern())))
+          else atSpan(in.offset)(expr())
         else
           report.error(InterpolatedStringError(), source.atSpan(Span(in.offset)))
           EmptyTree


### PR DESCRIPTION
There is an assertion that will throw. I noticed it while testing the new sourcepath mode in metals.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests, I wasn't able to find the exact place why it failed, but it seemed obvious we shouldn't call withSpan (invoked underneath) on an EmptyTree
