### PR TITLE
Fixes #26350: Don't eagerly error on not-taken match-type branches

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeEval.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeEval.scala
@@ -10,8 +10,18 @@ import reporting.trace
 import StdNames.tpnme
 import Flags.CaseClass
 import TypeOps.nestedPairs
+import util.Property
 
 object TypeEval:
+
+  /** When present in the context, a `compiletime.ops` application whose constant
+   *  folding *fails* (e.g. `1 / 0`) is left unreduced (stuck) instead of raising
+   *  a hard error. This is set only while typing match-type case bodies and
+   *  computing a match type's upper bound, so a branch that is never selected —
+   *  such as `case _ => 1 / 0` — does not turn into a definition-time error. A
+   *  genuine use elsewhere (e.g. `val x: 1 / 0 = 5`) still reports the failure.
+   */
+  val SuppressFoldErrors: Property.Key[Unit] = Property.Key()
 
   def tryCompiletimeConstantFold(tp: AppliedType)(using Context): Type = tp.tycon match
     case tycon: TypeRef if defn.isCompiletimeAppliedType(tycon.symbol) =>
@@ -80,13 +90,15 @@ object TypeEval:
       def natValue(tp: Type): Option[Int] = intValue(tp).filter(n => n >= 0 && n < Int.MaxValue)
 
       // Runs the op and returns the result as a constant type.
-      // If the op throws an exception, then this exception is converted into a type error.
+      // If the op throws an exception, the exception is converted into a type
+      // error — unless `SuppressFoldErrors` is set in the context (while typing a
+      // match-type case body), in which case the application is left unreduced so
+      // that a never-selected branch like `case _ => 1 / 0` is not a hard error.
       def runConstantOp[T](op: => T)(using Constant.ValueToConstant[T]): Type =
-        val result =
-          try op
-          catch case ex: Exception =>
-            throw TypeError(em"${ex.getMessage}")
-        ConstantType(Constant.fromValue(result))
+        try ConstantType(Constant.fromValue(op))
+        catch case ex: Exception =>
+          if ctx.property(SuppressFoldErrors).isDefined then NoType
+          else throw TypeError(em"${ex.getMessage}")
 
       def fieldsOf: Option[Type] =
         expectArgsNum(1)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -4800,7 +4800,10 @@ object Types extends TypeUtils {
       if myEvalRunId == ctx.runId then myEvalued
       else
         val res = TypeEval.tryCompiletimeConstantFold(this)
-        if !isProvisional then
+        // Don't cache while `SuppressFoldErrors` is set (typing a match-type case
+        // body): a failed fold yields a context-dependent `NoType` there, which
+        // must not poison genuine uses elsewhere in the same run.
+        if !isProvisional && ctx.property(TypeEval.SuppressFoldErrors).isEmpty then
           myEvalRunId = ctx.runId
           myEvalued = res
         res

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -78,7 +78,10 @@ class PlainPrinter(_ctx: Context) extends Printer {
         case tp: LazyRef =>
           homogenize(tp.ref)
         case tp @ AppliedType(tycon, args) =>
-          if (defn.isCompiletimeAppliedType(tycon.typeSymbol)) tp.tryCompiletimeConstantFold
+          // Printing must never crash: a `compiletime.ops` application whose
+          // constant folding fails (e.g. `1 / 0`) is shown unreduced.
+          if (defn.isCompiletimeAppliedType(tycon.typeSymbol))
+            try tp.tryCompiletimeConstantFold catch case _: TypeError => tp
           else if !tycon.typeSymbol.isOpaqueAlias then tycon.dealias.appliedTo(args)
           else tp
         case tp: NamedType =>

--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -902,7 +902,8 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         case tp => tp
       }
       val tp2 = {
-        val tp = tp1.tryNormalize
+        // Printing must never crash on a failed `compiletime.ops` fold (e.g. `1 / 0`).
+        val tp = try tp1.tryNormalize catch case _: TypeError => NoType
         if (tp != NoType) tp else tp1
       }
       val tp3 =

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -2889,19 +2889,27 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     if sel1Tpe.isLambdaSub then
       report.error(MatchTypeScrutineeCannotBeHigherKinded(sel1Tpe), sel1.srcPos)
     val pt1 = if (bound1.isEmpty) pt else bound1.tpe
-    val cases1 = tree.cases.mapconserve(typedTypeCase(_, sel1Tpe, pt1))
-    val bound2 = if tree.bound.isEmpty then
-      val lub = cases1.foldLeft(defn.NothingType: Type): (acc, case1) =>
-        if !acc.exists then NoType
-        else if case1.body.tpe.isProvisional then NoType
-        else acc | TypeOps.avoid(case1.body.tpe, case1.pat.bindTypeSymbols)
-      if lub.exists then
-        if !lub.isAny then
-          val msg = em"Match type upper bound inferred as $lub, where previously it was defaulted to Any"
-          warnOnMigration(msg, tree, `3.6`)
-        TypeTree(lub, inferred = true)
+    // While typing case bodies and inferring the match type's upper bound, a
+    // `compiletime.ops` body that fails to constant-fold (e.g. `case _ => 1 / 0`)
+    // is left unreduced rather than raising a hard error: a branch that is never
+    // selected must not make the match type undefinable. The error still surfaces
+    // when such a branch is actually selected during reduction at a use site.
+    val (cases1, bound2) = inContext(ctx.fresh.setProperty(TypeEval.SuppressFoldErrors, ())) {
+      val cs = tree.cases.mapconserve(typedTypeCase(_, sel1Tpe, pt1))
+      val b2 = if tree.bound.isEmpty then
+        val lub = cs.foldLeft(defn.NothingType: Type): (acc, case1) =>
+          if !acc.exists then NoType
+          else if case1.body.tpe.isProvisional then NoType
+          else acc | TypeOps.avoid(case1.body.tpe, case1.pat.bindTypeSymbols)
+        if lub.exists then
+          if !lub.isAny then
+            val msg = em"Match type upper bound inferred as $lub, where previously it was defaulted to Any"
+            warnOnMigration(msg, tree, `3.6`)
+          TypeTree(lub, inferred = true)
+        else bound1
       else bound1
-    else bound1
+      (cs, b2)
+    }
     assignType(cpy.MatchTypeTree(tree)(bound2, sel1, cases1), bound2, sel1, cases1)
   }
 

--- a/tests/neg/i26350.check
+++ b/tests/neg/i26350.check
@@ -1,0 +1,15 @@
+-- Error: tests/neg/i26350.scala:10:9 ----------------------------------------------------------------------------------
+10 |val a: 1 / 0 = 5           // error
+   |         ^
+   |         / by zero
+-- Error: tests/neg/i26350.scala:11:7 ----------------------------------------------------------------------------------
+11 |val b: AnInt[String] = ??? // error
+   |       ^
+   |       / by zero
+-- [E007] Type Mismatch Error: tests/neg/i26350.scala:15:16 ------------------------------------------------------------
+15 |  case _   => 1 / 0        // error
+   |              ^^^^^
+   |              Found:    (1 : Int) / (0 : Int)
+   |              Required: String
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/neg/i26350.scala
+++ b/tests/neg/i26350.scala
@@ -1,0 +1,15 @@
+// https://github.com/scala/scala3/issues/26350
+// Failing `compiletime.ops` folds must still be reported when a branch is
+// genuinely selected, on a direct use, or when declared bounds do not align.
+import scala.compiletime.ops.int.*
+
+type AnInt[T] <: Int = T match
+  case Int => T & Int
+  case _   => 1 / 0
+
+val a: 1 / 0 = 5           // error
+val b: AnInt[String] = ??? // error
+
+type Bad[T] <: String = T match
+  case Int => "i"
+  case _   => 1 / 0        // error

--- a/tests/pos/i26350.scala
+++ b/tests/pos/i26350.scala
@@ -1,0 +1,17 @@
+// https://github.com/scala/scala3/issues/26350
+// A match-type case body that fails to constant-fold must not error at
+// definition when that branch is never selected.
+import scala.compiletime.ops.int.*
+
+// Never applied; the `case _ => 1 / 0` branch must not be evaluated.
+type AnIntA[T] <: Int = T match
+  case Int => Int
+  case _   => 1 / 0
+
+// Explicit bound; using it with a scrutinee that selects `case Int` must work.
+type AnIntB[T] <: Int = T match
+  case Int => T & Int
+  case _   => 1 / 0
+
+val x: AnIntB[Int] = 5
+val _ = summon[AnIntB[Int] =:= Int]


### PR DESCRIPTION
A match-type case body that fails to constant-fold (e.g. `case _ => 1 / 0`, or any `compiletime.ops` application that throws) made the whole match type undefinable, even when that branch is never selected. Typing a match type eagerly normalizes every case body (cosmetic `simplify`, conformance against the declared bound, and `baseType` during upper-bound inference), so the failing fold raised a hard error at definition time.

Scope the leniency to match-type definition: a `SuppressFoldErrors` context property, set in `typedMatchTypeTree` while typing case bodies and inferring the bound, makes a failed constant fold leave the op unreduced (stuck at its declared bound) instead of throwing. Because every forcing path (simplify, conformance, lub) funnels through `TypeEval.runConstantOp`, suppressing once at that funnel covers them all and lets typing continue in place rather than unwinding. The fold cache is skipped while the property is set so the context-dependent stuck result cannot poison a genuine use of the same op elsewhere in the same run.

Printing must likewise not crash on a now-persistable unreduced failing op: the homogenizing printers (PlainPrinter.homogenize, RefinedPrinter) show it unreduced instead of re-folding (surfaced by -Ytest-pickler/-Xprint-types).

Preserved behavior: a genuine use (`val x: 1 / 0 = 5`) and a *selected* failing branch (`AnInt[String]` reducing to `1 / 0`) still report `/ by zero`; a case body whose declared bound does not conform to the match type's bound is still rejected. 

Fixes #26350

## How much have you relied on LLM-based tools in this contribution?

Extensively, but the change is rather small. I reviewed it and tried to find an approach without using a `Property` with no luck.
It's basically trapping the error at three different places, and creating the `SuppressFoldErrors` context property accordingly.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)