### PR TITLE
semanticdb: emit occurrence for generated main entry points

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -567,10 +567,20 @@ private[semanticdb] object ExtractSemanticDB:
       else
         Span(span.start)
 
-      if namePresentInSource(sym, span, treeSource) || sym.isAnonymousClass then
+      if namePresentInSource(sym, span, treeSource)
+        || sym.isAnonymousClass
+        || isPositionedMainEntryPoint(sym, span)
+      then
         registerOccurrence(sname, finalSpan, SymbolOccurrence.Role.DEFINITION, treeSource)
       if !sym.is(Package) then
         registerSymbol(sym, symkinds)
+
+    /** A generated main entry point may be anchored on a source span that does
+     *  not contain its name, so `namePresentInSource` is false and no
+     *  occurrence is emitted. Still emit one for such entry points so tooling
+     *  can locate them, restricted to runnable main classes. */
+    private def isPositionedMainEntryPoint(sym: Symbol, span: Span)(using Context): Boolean =
+      span.hasLength && ctx.platform.hasMainMethod(sym)
 
     private def spanOfSymbol(sym: Symbol, span: Span, treeSource: SourceFile)(using Context): Span =
       val contents = if treeSource.exists then treeSource.content() else Array.empty[Char]


### PR DESCRIPTION
Follow up to https://github.com/scalameta/metals/discussions/6729 and https://github.com/scalameta/metals/issues/6738 which was fixed in https://github.com/scalameta/metals/pull/6745

`registerDefinition` only emits a definition occurrence when the symbol's name is present at its source span (`namePresentInSource`) or it is an anonymous class. A generated program entry point (an object with a `main(Array[String]): Unit` method) may be anchored on a span that does not contain its name, so no occurrence was emitted and tooling relying on occurrences (run/debug code lenses, go-to-definition) could not locate it.

Emit a definition occurrence for such definitions, restricted to runnable main classes via `platform.hasMainMethod`. Occurrences for ordinary sources are unchanged.

<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, but it's a small change to review.

## How was the solution tested?

Manual tests because writing automated tests is impractical. It involves a compiler plugin, so it's rather complex test for this basic change.
