### PR TITLE
Fixes #24936: "missing outer accessor" crash for static module reached via trait self type

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1520,7 +1520,19 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
         case mt: MethodType if mt.paramInfos.isEmpty && mt.resultType.typeSymbol.is(Module) =>
           ref(mt.resultType.typeSymbol.sourceModule)
         case _ =>
-          ref(prefix)
+          val psym = prefix.symbol
+          if ctx.erasedTypes && psym.is(Module) && psym.isStatic then
+            // After erasure (i.e. when generating code), reference a statically
+            // reachable module through its own (static) path rather than through
+            // `prefix`, whose own prefix may be a `this` that is not addressable here --
+            // e.g. when the module is reached via the self type of a trait, `prefix` is
+            // `Trait.this.Module`, and building an outer path to `Trait.this` fails.
+            // The simplification is only sound for code generation, so it is guarded by
+            // `ctx.erasedTypes` to leave earlier purity/stability analysis untouched.
+            // See i24936.
+            ref(psym)
+          else
+            ref(prefix)
     case TermRef(prefix: ThisType, _) =>
       This(prefix.cls)
     case _ =>

--- a/tests/pos/i24936/A1.scala
+++ b/tests/pos/i24936/A1.scala
@@ -1,0 +1,7 @@
+// https://github.com/scala/scala3/issues/24936
+package example
+
+trait A1 { self: O1.type =>
+  import O2.someKey
+  def taskImpl: Unit = println(someKey)
+}

--- a/tests/pos/i24936/O1.scala
+++ b/tests/pos/i24936/O1.scala
@@ -1,0 +1,6 @@
+package example
+
+object O1 extends A1:
+  object O2:
+    val someKey = Int
+end O1


### PR DESCRIPTION
When a trait's self type is a (statically reachable) module and the trait body selects a member through a nested module of that self type, the reference has the shape `Trait.this.Module.member`. At code generation `desugarIdentPrefix` recovered the prefix with `ref(Trait.this.Module)`, which builds a `This(Trait)` and then asks ExplicitOuter for an outer path to `Trait.this`. In the backend the context owner is the root package, so the path computation overshoots to the root package and crashes with "missing outer accessor in package <root>".

Whether the reference ends up in this shape depends on completion order (hence the issue's "alphabetically before O1.scala"): if the module is completed first the prefix is already a static module getter, which was handled, but otherwise the prefix stays `Trait.this.Module`.

Since a static module has a single global instance, reference it through its own static path instead of through `Trait.this`. The rewrite is only sound for code generation, so it is guarded by `ctx.erasedTypes` to leave earlier purity/stability analysis (which also goes through `desugarIdentPrefix` via `TreeInfo.qualifier`) untouched.

Fixes #24936

<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## How much have you relied on LLM-based tools in this contribution?

<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Extensively, but it's a small fix to review

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
