### PR TITLE
Check inhabitedness of counter-examples in satisfiable

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -796,6 +796,12 @@ object SpaceEngine {
   def satisfiable(sp: Space)(using Context): Boolean = {
     def impossible: Nothing = throw new AssertionError("`satisfiable` only accepts flattened space.")
 
+    def getLeaves(sp: Space): List[Type] = sp match {
+      case Prod(_, _, ss) => ss.flatMap(getLeaves)
+      case t: Typ => List(t.tp)
+      case _ => impossible
+    }
+
     def genConstraint(space: Space): List[(Type, Type)] = space match {
       case Prod(tp, unappTp, ss) =>
         val tps = signature(unappTp, tp, ss.length)
@@ -808,7 +814,7 @@ object SpaceEngine {
       case _ => impossible
     }
 
-    def checkConstraint(constrs: List[(Type, Type)])(using Context): Boolean = {
+    def checkConstraint(constrs: List[(Type, Type)], leaves: List[Type])(using Context): Boolean = {
       val tvarMap = collection.mutable.Map.empty[Symbol, TypeVar]
       val typeParamMap = new TypeMap() {
         override def apply(tp: Type): Type = tp match {
@@ -819,9 +825,32 @@ object SpaceEngine {
       }
 
       constrs.forall { case (tp1, tp2) => typeParamMap(tp1) <:< typeParamMap(tp2) }
+      && {
+        val constraint = ctx.typerState.constraint
+
+        val instantiateTVars = new TypeMap {
+          override def apply(tp: Type): Type = tp match {
+            case tvar: TypeVar =>
+              val inst = tvar.instanceOpt
+              if inst.exists then inst
+              else if constraint.entry(tvar.origin).exists then
+                val bounds = TypeComparer.fullBounds(tvar.origin)
+                if bounds.lo =:= bounds.hi then bounds.lo
+                else tvar
+              else tvar
+            case tp => mapOver(tp)
+          }
+        }
+
+        leaves.forall { leaf =>
+          val inst = instantiateTVars(typeParamMap(leaf))
+          inst.existsPart(_.isInstanceOf[TypeVar])
+            || simplify(Typ(inst, decomposed = false)) != Empty
+        }
+      }
     }
 
-    checkConstraint(genConstraint(sp))(using ctx.fresh.setNewTyperState())
+    checkConstraint(genConstraint(sp), getLeaves(sp))(using ctx.fresh.setNewTyperState())
   }
 
   /** Display spaces.  Used for printing uncovered spaces in the in-exhaustive error message. */

--- a/tests/patmat/i25965.scala
+++ b/tests/patmat/i25965.scala
@@ -1,0 +1,10 @@
+sealed trait Expr1[T]
+case class IntExpr1(x: Int) extends Expr1[Int]
+case class BooleanExpr(b: Boolean) extends Expr1[Boolean]
+
+sealed trait Expr2[T]
+case class IntExpr2(x: Int) extends Expr2[Int]
+
+def foo[T](x: Expr1[T], y: Expr2[T]) = (x, y) match {
+  case (IntExpr1(_), IntExpr2(_)) =>
+}

--- a/tests/warn/i25965.check
+++ b/tests/warn/i25965.check
@@ -1,0 +1,8 @@
+-- [E029] Pattern Match Exhaustivity Warning: tests/warn/i25965.scala:16:39 --------------------------------------------
+16 |def bar[T](x: Expr1[T], y: Expr3[T]) = (x, y) match { // warn
+   |                                       ^^^^^^
+   |                                       match may not be exhaustive.
+   |
+   |                                       It would fail on pattern case: (BooleanExpr(_), _), (_, BoolExpr3(_))
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/warn/i25965.scala
+++ b/tests/warn/i25965.scala
@@ -8,3 +8,11 @@ case class IntExpr2(x: Int) extends Expr2[Int]
 def foo[T](x: Expr1[T], y: Expr2[T]) = (x, y) match {
   case (IntExpr1(_), IntExpr2(_)) =>
 }
+
+sealed trait Expr3[T]
+case class IntExpr3(x: Int) extends Expr3[Int]
+case class BoolExpr3(b: Boolean) extends Expr3[Boolean]
+
+def bar[T](x: Expr1[T], y: Expr3[T]) = (x, y) match { // warn
+  case (IntExpr1(_), IntExpr3(_)) =>
+}


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/25965

Checking that the constraints are satisfiable isn't enough to tell whether a counter-example is real. We also need an inhabitedness check to confirm a value can actually match it. This PR adds inhabitedness checking in `satisfiable`.

## How much have you relied on LLM-based tools in this contribution?

Extensively, for finding root cause, understanding the codes, finding solution

## How was the solution tested?

reproducer + existing tests