### PR TITLE
Improve contributor docs around LLM use

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,16 @@
 Fixes #XYZ
 
-<!-- where #XYZ is the issue number; create as draft if this is still a WIP;
-     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md
+<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
+     do not paste LLM output here, describe the PR in your own words;
+     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
      don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->
 
-## How much have you relied on LLM-based tools in this contribution?
+## Have you relied on LLM-based tools in this contribution?
 
 <!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->
 
-Extensively, for ...
-Moderately, for ...
-Minimally, for ...
-Not at all
+Yes, and I checked the output by ...
+No
 
 ## How was the solution tested?
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Fixes #XYZ
 
 ## Have you relied on LLM-based tools in this contribution?
 
-<!-- Pick one; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->
+<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->
 
 Yes, and I checked the output by ...
 No

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file provides guidance to AI coding agents when working with code in this repository.
 
 **Important**:
-- PR descriptions, comments, and code reviews must be 100% human-written. Provide details to the human operator but do not write those for them.
+- All AI-assisted contributions, including  code, PR/issue descriptions, comments, and code reviews, must comply with the [LLM usage policy](LLM_POLICY.md) . **Important**: state LLM usage clearly in descriptions, commit messages, etc.
 - Read `CONTRIBUTING.md`, in particular the "Forbidden" section!
 
 ## Project Overview

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
-**Important**: Read `CONTRIBUTING.md`, in particular the "Forbidden" section!
+**Important**:
+- PR descriptions, comments, and code reviews must be 100% human-written. Provide details to the human operator but do not write those for them.
+- Read `CONTRIBUTING.md`, in particular the "Forbidden" section!
 
 ## Project Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@ This file provides guidance to AI coding agents when working with code in this r
 
 Dotty is the Scala 3 compiler (`dotc`). It compiles Scala source code into JVM bytecode (and optionally Scala.js IR). The compiler is itself written in Scala 3.
 
+We care about maintainability. "The tests pass" is not enough to justify that a change is good.
+
 ## Build Commands
 
 Use `sbt --client` (sbt with native thin client) to run commands. This keeps an sbt server running for faster subsequent invocations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,7 @@ You may also find the ["Compiler Academy"](https://www.youtube.com/channel/UCIH0
 - Don't make stylistic changes based on your personal taste that make pull requests harder to review
 - Don't open pull requests you cannot explain even if they pass tests, such as "don't call this method on those inputs because it crashes"
   (one can accidentally introduce unsoundness this way, and special cases are generally not the way to go)
+- Don't justify a pull request purely with "the tests pass", we also care about maintainability, and we will never cover 100% of edge cases in tests
 - Don't try to fix `TODO`s or `FIXME`s in the codebase without a deep understanding of their context
   (remember, if they took 5 minutes to fix, the person writing them would most likely have fixed them instead of adding a comment)
 - Don't ask general questions such as "how does a compiler work" or "what is JVM bytecode", these are better answered by existing resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,9 +58,12 @@ You may also find the ["Compiler Academy"](https://www.youtube.com/channel/UCIH0
 
 ## Forbidden
 
-**Do not look at the source code of the Oracle JDK or OpenJDK** when working on anything related to the JVM backend!
-This is for license considerations: these JDKs are under a GPL-based license, which is not compatible with our Apache 2.0 license.
-It is also recommended not to look at any other JDK implementation (such as Apache Harmony), to minimize the chance of copyright debate.
+- **Do not look at the source code of the Oracle JDK or OpenJDK** when working on anything related to the JVM backend!
+  This is for license considerations: these JDKs are under a GPL-based license, which is not compatible with our Apache 2.0 license.
+  It is also recommended not to look at any other JDK implementation (such as Apache Harmony), to minimize the chance of copyright debate.
+- **Do not paste LLM output into a PR description, comment, or code review**. Rewrite it in your own words instead to ensure you understand it.
+  This includes LLM code reviews; if you use such a tool and it finds a bug, you are welcome to report it in a comment,
+  but only if you understand the bug and can explain it without copy-pasting the tool's output.
 
 ## Maintainers
 
@@ -92,7 +95,7 @@ Principal areas of the compiler and internal team members responsible for their 
 - Standard library: @lrytz, @SethTisue, @natsukagami, @noti0na1 
 
 **Tooling**
-- REPL:
+- REPL: @SolalPirelli
 - Runner/CLI: @Gedochao, (@tgodzik)
 - IDE: @tgodzik, @zielinsky
 - Scaladoc: (@Florian3k)
@@ -108,7 +111,7 @@ Principal areas of the compiler and internal team members responsible for their 
 - CI: @WojciechMazur
 - Community Build: @WojciechMazur
 - Open Community Build: @WojciechMazur
-- Vulpix:
+- Vulpix: @SolalPirelli
 - Benchmarks: @mbovel
 - Releases: @WojciechMazur (Scala 3 Next), @tgodzik (Scala 3.3 LTS)
 

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -50,6 +50,7 @@ given contribution from the maintainers’ perspective.
   useful aid for code reviewers.
 - Do not open pull requests without the intention of answering code reviews and pushing it to its completion.
 - Do not forward code review questions and other discussion to an LLM.
+- Do not contribute large volumes of LLM-generated code all at once. Try to scope them down to something digestible for code reviewers.
 
 # Examples
 

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -59,7 +59,7 @@ given contribution from the maintainers’ perspective.
 - The author of the contribution understands every line of code they contributed and can explain how it works and what
   purpose it serves.
 - The code fulfills the requirements of the issue in the bug tracker it is meant to solve.
-- The code is well documented and covered with tests.
+- The code is well scoped, well documented and covered with tests.
 - The solution is clearly of high quality, regardless if it was coded manually or generated automatically.
 
 #### A contribution is likely to be rejected with a warning, if:

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -20,7 +20,7 @@ keeping the maintainers’ workload manageable.
 The following rules are non-negotiable and necessary for a contribution to be considered.
 
 - All interactions (issues, pull requests, discussions, etc.) must be 100% human-written.
-  Pasting LLM-generated text is not allowed, you must rewrite it in your own words to ensure you understand it.
+  LLM-generated text has to be processed and understood by a human, pasting LLM outputs verbatim is not allowed.
 - The author of the contribution is responsible for every line of code, comment, documentation, test or decision
   contained in it, regardless if it was done by hand or generated automatically by tooling.
 - Any potential changes to requirements from a bug tracker issue must be discussed under the issue, not suggested in a PR.

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -27,8 +27,8 @@ The following rules are non-negotiable and necessary for a contribution to be co
 - The author of a PR must be capable of answering reviewer questions and explaining their solution in detail.
 - Contributed code should be covered by automated tests. If test automation is not feasible, an explanation has to be
   given in the pull request description, including a description of exactly how the change was tested manually.
-  - Tests are not by themselves enough evidence that a contribution is good. We also care about maintainability,
-    and we acknowledge that our test coverage will never be 100% for edge cases so passing tests is not a guarantee of correctness.
+  - Tests are not enough evidence that a contribution is good all on their own. We also care about maintainability,
+    and we acknowledge that our test coverage will never be 100% for edge cases, and so passing tests is not a guarantee of correctness.
 - The contributed solutions have to have been tested by the contributor on their local machine before submitting for
   review.
     - Contributed code has to compile successfully.

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -19,12 +19,11 @@ keeping the maintainers’ workload manageable.
 
 The following rules are non-negotiable and necessary for a contribution to be considered.
 
-- All interactions (issues, pull requests, discussions, etc.) must be performed by a human, posts by bots are not allowed.
+- All interactions (issues, pull requests, discussions, etc.) must be 100% human-written.
+  Pasting LLM-generated text is not allowed, you must rewrite it in your own words to ensure you understand it.
 - The author of the contribution is responsible for every line of code, comment, documentation, test or decision
   contained in it, regardless if it was done by hand or generated automatically by tooling.
-- What is contained in the description of a given pull request **must match** what is contained in the code.
-- If a contribution is described as fixing an issue from the bug tracking system, it has to cover the defined
-  requirements, as discussed in the bug tracker. Changes to the requirements should be discussed under the issue.
+- Any potential changes to requirements from a bug tracker issue must be discussed under the issue, not suggested in a PR.
 - The author of a PR must be capable of answering reviewer questions and explaining their solution in detail.
 - Contributed code should be covered by automated tests. If test automation is not feasible, an explanation has to be
   given in the pull request description, including a description of exactly how the change was tested manually.
@@ -38,8 +37,7 @@ The following rules are non-negotiable and necessary for a contribution to be co
 The following is a set of guidelines. Their purpose is to highlight what increases the quality of a
 given contribution from the maintainers’ perspective.
 
-- **State clearly in the pull request description, whether LLM-based tools were used and to what extent (
-  extensively/moderately/minimally/not at all).**
+- **State clearly in the pull request description, whether LLM-based tools were used and how their output was checked.**
 - Code generated with an LLM needs to be reviewed and tested by the contributor in accordance with
   established best practices. Using an LLM is no excuse for bad code quality.
     - In particular, validation and tests should first be done on the author’s local machine, rather than submitted

--- a/LLM_POLICY.md
+++ b/LLM_POLICY.md
@@ -27,6 +27,8 @@ The following rules are non-negotiable and necessary for a contribution to be co
 - The author of a PR must be capable of answering reviewer questions and explaining their solution in detail.
 - Contributed code should be covered by automated tests. If test automation is not feasible, an explanation has to be
   given in the pull request description, including a description of exactly how the change was tested manually.
+  - Tests are not by themselves enough evidence that a contribution is good. We also care about maintainability,
+    and we acknowledge that our test coverage will never be 100% for edge cases so passing tests is not a guarantee of correctness.
 - The contributed solutions have to have been tested by the contributor on their local machine before submitting for
   review.
     - Contributed code has to compile successfully.


### PR DESCRIPTION
As discussed in the LAMP Slack.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
