### PR TITLE
Simplify REPL test configuration

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -1058,7 +1058,7 @@ object Capabilities:
         case t @ AnnotatedType(parent, ann: RetainingAnnotation)
         if ann.isStrict && ann.toCaptureSet.elems.exists(_.core.isInstanceOf[GlobalCap]) =>
           // Applying `this` can cause infinite recursion in some cases during printing.
-          // scalac -Xprint:all tests/pos/i23885/S_1.scala tests/pos/i23885/S_2.scala
+          // scalac -Vprint:all tests/pos/i23885/S_1.scala tests/pos/i23885/S_2.scala
           mapOver(CapturingType(this(parent), ann.toCaptureSet))
         case t @ AnnotatedType(parent, ann) =>
           t.derivedAnnotatedType(this(parent), ann)

--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -20,6 +20,7 @@ import scala.annotation.switch
 import typer.Checking.checkNonCyclic
 import io.AbstractFile
 import dotty.tools.dotc.classpath.FileUtils.hasSiblingTasty
+import dotty.tools.dotc.config.Printers
 
 import scala.compiletime.uninitialized
 
@@ -911,7 +912,7 @@ final class ClassfileParser(
         else {
           val newType = sigToType(sig, sym, isVarargs)
           if (ctx.debug && ctx.verbose)
-            println("" + sym + "; signature = " + sig + " type = " + newType)
+            Printers.debug.println("" + sym + "; signature = " + sig + " type = " + newType)
           newType
         }
 

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -63,9 +63,6 @@ object Properties {
   /** dotty-compiler jar */
   def dottyCompiler: String = sys.props("dotty.tests.classes.dottyCompiler")
 
-  /** dotty-repl jar */
-  def dottyRepl: String = sys.props("dotty.tests.classes.dottyRepl")
-
   /** dotty-staging jar */
   def dottyStaging: String = sys.props("dotty.tests.classes.dottyStaging")
 
@@ -95,18 +92,6 @@ object Properties {
 
   /** jline-reader jar */
   def jlineReader: String = sys.props("dotty.tests.classes.jlineReader")
-
-  /** pprint jar */
-  def pprint: String = sys.props("dotty.tests.classes.pprint")
-
-  /** fansi jar */
-  def fansi: String = sys.props("dotty.tests.classes.fansi")
-
-  /** fansi jar */
-  def sourcecode: String = sys.props("dotty.tests.classes.sourcecode")
-
-  /** scala-xml jar */
-  def scalaXml: String = sys.props("dotty.tests.classes.scalaXml")
 
   /** scalajs-javalib jar */
   def scalaJSJavalib: String = sys.props("dotty.tests.classes.scalaJSJavalib")

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -36,7 +36,7 @@ object TestConfiguration {
 
   val basicClasspath = mkClasspath(List(Properties.scalaLibrary))
 
-  val withCompilerClasspath = mkClasspath(List(
+  lazy val withCompilerClasspath = mkClasspath(List(
     Properties.scalaLibrary,
     Properties.scalaAsm,
     Properties.compilerInterface,
@@ -57,20 +57,6 @@ object TestConfiguration {
     Properties.scalaJSLibrary,
   ))
 
-  lazy val replClassPath =
-    withCompilerClasspath + File.pathSeparator + mkClasspath(List(
-      Properties.dottyRepl,
-      Properties.jlineTerminal,
-      Properties.jlineReader,
-      Properties.fansi,
-      Properties.pprint,
-      Properties.sourcecode,
-      Properties.scalaXml
-  ))
-
-  lazy val replWithStagingClasspath = 
-    replClassPath + File.pathSeparator + mkClasspath(List(Properties.dottyStaging))
-
   def mkClasspath(classpaths: List[String]): String =
     classpaths.map({ p =>
       val file = new java.io.File(p)
@@ -86,10 +72,8 @@ object TestConfiguration {
   val noYcheckOptions = TestFlags(basicClasspath, noYcheckCommonOptions)
   val bestEffortBaselineOptions = TestFlags(basicClasspath, noCheckOptions)
   val unindentOptions = TestFlags(basicClasspath, Array("-no-indent") ++ checkOptions ++ noCheckOptions ++ yCheckOptions)
-  val withCompilerOptions =
+  lazy val withCompilerOptions =
     defaultOptions.and("-Yexplicit-nulls").withClasspath(withCompilerClasspath).withRunClasspath(withCompilerClasspath)
-  lazy val withReplOptions =
-    defaultOptions.withRunClasspath(replClassPath)
   lazy val withStagingOptions =
     defaultOptions.withClasspath(withStagingClasspath).withRunClasspath(withStagingClasspath)
   lazy val withTastyInspectorOptions =
@@ -104,7 +88,7 @@ object TestConfiguration {
     "-Yprint-pos",
     "-Yprint-pos-syms"
   )
-  val picklingWithCompilerOptions =
+  lazy val picklingWithCompilerOptions =
     picklingOptions.and("-Yexplicit-nulls").withClasspath(withCompilerClasspath).withRunClasspath(withCompilerClasspath)
 
   val explicitNullsOptions = defaultOptions `and` "-Yexplicit-nulls"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -888,7 +888,7 @@ object Build {
       scalaVersion  := dottyNonBootstrappedVersion,
       crossPaths    := true,
       autoScalaLibrary := false,
-      // Add the source directories for the sbt-bridge (boostrapped)
+      // Add the source directories for the sbt-bridge (bootstrapped)
       Compile / unmanagedSourceDirectories   := Seq(baseDirectory.value / "src"),
       Compile / unmanagedResourceDirectories := Seq(baseDirectory.value / "resources"),
       Test    / unmanagedSourceDirectories   := Seq(baseDirectory.value / "test"),
@@ -913,37 +913,8 @@ object Build {
       ),
       // Configure to use the non-bootstrapped compiler
       bootstrappedScalaInstanceSettings,
-      Test / javaOptions ++= {
-        val log = streams.value.log
-        val managedSrcDir = {
-          // Populate the directory
-          (Compile / managedSources).value
-
-          (Compile / sourceManaged).value
-        }
-        val externalDeps = (ThisProject / Runtime / externalDependencyClasspath).value
-        val testExternalDeps = (ThisProject / Test / externalDependencyClasspath).value
-        Seq(
-          s"-Ddotty.tests.dottyCompilerManagedSources=${managedSrcDir}",
-          s"-Ddotty.tests.classes.dottyInterfaces=${(`scala3-interfaces` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.dottyCompiler=${(`scala3-compiler-bootstrapped` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.dottyRepl=${(ThisProject / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.tastyCore=${(`tasty-core-bootstrapped` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.compilerInterface=${findArtifactPath(externalDeps, "compiler-interface")}",
-          s"-Ddotty.tests.classes.scalaLibrary=${(`scala-library-bootstrapped` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.scalaJSScalalib=${(`scala-library-sjs` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.scalaAsm=${findArtifactPath(externalDeps, "scala-asm")}",
-          s"-Ddotty.tests.classes.jlineTerminal=${findArtifactPath(externalDeps, "jline-terminal")}",
-          s"-Ddotty.tests.classes.jlineReader=${findArtifactPath(externalDeps, "jline-reader")}",
-          s"-Ddotty.tests.classes.dottyStaging=${(LocalProject("scala3-staging") / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.dottyTastyInspector=${(LocalProject("scala3-tasty-inspector") / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.pprint=${findArtifactPath(externalDeps, "pprint_3")}",
-          s"-Ddotty.tests.classes.fansi=${findArtifactPath(externalDeps, "fansi_3")}",
-          s"-Ddotty.tests.classes.sourcecode=${findArtifactPath(externalDeps, "sourcecode_3")}",
-          s"-Ddotty.tests.classes.scalaXml=${findArtifactPath(testExternalDeps, "scala-xml_2.13")}",
-          s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
-        )
-      },
+      // Needed for the JSR223 tests which are "run" tests
+      Test / javaOptions += s"-Ddotty.tests.classes.scalaLibrary=${(`scala-library-bootstrapped` / Compile / packageBin).value}",
       run / fork := true,
       excludeDependencies += "org.scala-lang" %% "scala3-library",
       excludeDependencies += "org.scala-lang" % "scala-library",
@@ -2020,7 +1991,7 @@ object Build {
         Dependencies.lsp4j,
         Dependencies.jacksonDatabind
       ),
-      // Exclude the dependency that is resolved transively, the stdlib
+      // Exclude the dependency that is resolved transitively, the stdlib
       // is a project dependency instead
       excludeDependencies += "org.scala-lang" %% "scala3-library",
       javaOptions := (`scala3-compiler-bootstrapped` / javaOptions).value,

--- a/repl/test/dotty/tools/repl/JSR223Tests.scala
+++ b/repl/test/dotty/tools/repl/JSR223Tests.scala
@@ -14,7 +14,9 @@ final class JSR223Tests:
 
   @Test def filetests: Unit =
     given TestGroup = TestGroup("runWithCompiler")
-    compileFilesInDir("test-resources/jsr223", TestConfiguration.withReplOptions)
+    // We want this test to run with the REPL inside the classpath so it can access the script engine,
+    // and by default Vulpix only gives a restricted class path, so pass the full one
+    compileFilesInDir("test-resources/jsr223", TestConfiguration.defaultOptions.withRunClasspath(System.getProperty("java.class.path")))
       .checkRuns()
   end filetests
 

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -905,7 +905,7 @@ class ReplHighlightTests extends ReplTest(ReplTest.defaultOptions.filterNot(_.st
       def deepTree(depth: Int): Tree
       deepTree(300)""")
 
-class ReplUnrollTests extends ReplTest(ReplTest.defaultOptions ++ Seq("-preview", "-Xprint:pickler")):
+class ReplUnrollTests extends ReplTest(ReplTest.defaultOptions ++ Seq("-preview", "-Vprint:pickler")):
   override val redirectOutput = true
   @Test def i23408: Unit = initially:
     run("""

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -25,7 +25,7 @@ class ReplCompilerTests extends ReplTest:
     initially {
       run("import scala.collection.*")
     } andThen {
-      println(lines().mkString("* ", "\n  * ", ""))
+      assertEquals(0, lines().length)
     }
   }
 

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -15,7 +15,6 @@ class ReplDependencyMacroTests extends ReplTest:
   private def resolveUpickle()(using State): Unit =
     run(":dep com.lihaoyi::upickle:4.4.3")
     val output = storedOutput()
-    println(s"[debug][i25291] :dep output:\n$output")
     assertTrue(output, output.contains("Resolved 1 dependencies"))
     assertNoMacroFailure(output)
 
@@ -40,7 +39,6 @@ class ReplDependencyMacroTests extends ReplTest:
     filesToAdd.foreach: file =>
       run(s":jar ${file.getAbsolutePath}")
       val output = storedOutput()
-      println(s"[debug][i25291] :jar output (${file.getName}):\n$output")
       assertTrue(output, output.contains("Added"))
       assertNoMacroFailure(output)
 
@@ -49,7 +47,6 @@ class ReplDependencyMacroTests extends ReplTest:
       resolveUpickle()
       run("case class FooDerives(x: Int) derives upickle.default.ReadWriter")
       val output = storedOutput()
-      println(s"[debug][i25291] derives output:\n$output")
       assertNoMacroFailure(output)
       assertTrue(output, output.contains("// defined case class FooDerives"))
 
@@ -58,7 +55,6 @@ class ReplDependencyMacroTests extends ReplTest:
       resolveUpickle()
       run("case class FooMacroRw(x: Int); object FooMacroRw { given upickle.default.ReadWriter[FooMacroRw] = upickle.default.macroRW }")
       val second = storedOutput()
-      println(s"[debug][i25291] macroRW output:\n$second")
       assertNoMacroFailure(second)
       assertTrue(second, second.contains("// defined case class FooMacroRw"))
 
@@ -67,7 +63,6 @@ class ReplDependencyMacroTests extends ReplTest:
       addUpickleViaJar()
       run("case class FooJar(x: Int) derives upickle.default.ReadWriter")
       val output = storedOutput()
-      println(s"[debug][i25291] :jar derives output:\n$output")
       assertNoMacroFailure(output)
       assertTrue(output, output.contains("// defined case class FooJar"))
 
@@ -76,6 +71,5 @@ class ReplDependencyMacroTests extends ReplTest:
       resolveUpickle()
       run("case class FooSummon(x: Int) derives upickle.default.ReadWriter; summon[upickle.default.ReadWriter[FooSummon]]")
       val second = storedOutput()
-      println(s"[debug][i25291] summon output:\n$second")
       assertNoMacroFailure(second)
       assertTrue(second, second.contains("// defined case class FooSummon"))

--- a/repl/test/dotty/tools/repl/ReplTest.scala
+++ b/repl/test/dotty/tools/repl/ReplTest.scala
@@ -113,9 +113,9 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
         println(s"Wrote updated script file to $checkFile")
         None
       else
-        println(dotty.tools.dotc.util.DiffUtil.mkColoredHorizontalLineDiff(actualOutput.mkString(EOL), expectedOutput.mkString(EOL)))
+        val diff = dotty.tools.dotc.util.DiffUtil.mkColoredHorizontalLineDiff(actualOutput.mkString(EOL), expectedOutput.mkString(EOL))
 
-        Some(s"Error in script $name, expected output did not match actual")
+        Some(s"Error in script $name, expected output did not match actual:\n$diff")
     end if
   }
 

--- a/repl/test/dotty/tools/repl/ReplTest.scala
+++ b/repl/test/dotty/tools/repl/ReplTest.scala
@@ -120,6 +120,17 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
   }
 
 object ReplTest:
-  val commonOptions = Array("-color:never", "-pagewidth", "80", "-Ydebug")
-  val defaultOptions = commonOptions ++ Array("-classpath", TestConfiguration.replClassPath)
-  lazy val withStagingOptions = commonOptions ++ Array("-classpath", TestConfiguration.replWithStagingClasspath)
+  // Because we test REPL features like completion,
+  // we don't want other test stuff to get in the way,
+  // e.g., "Pred" should complete to "Predef" and not "PredefTest" just because some dependency has a test named like that
+  private val classpath =
+    System.getProperty("java.class.path")
+      .split(JFile.pathSeparator)
+      .filter(!_.contains("test-classes"))
+      .mkString(JFile.pathSeparator)
+
+  def createOptions(extraClasspath: String*): Array[String] =
+    Array("-color:never", "-pagewidth", "80", "-Ydebug",
+          "-classpath", classpath + JFile.pathSeparator + extraClasspath.mkString(JFile.pathSeparator))
+
+  val defaultOptions: Array[String] = createOptions()

--- a/repl/test/dotty/tools/repl/ShadowingTests.scala
+++ b/repl/test/dotty/tools/repl/ShadowingTests.scala
@@ -25,9 +25,11 @@ import vulpix.{TestConfiguration, TestFlags}
  *  and running scripted REPL tests with them on the claspath.
  */
 object ShadowingTests:
-  def classpath = TestConfiguration.replClassPath + File.pathSeparator + shadowDir
-  def options = ReplTest.commonOptions ++ Array("-classpath", classpath)
+  // The directory on the classpath containing artifacts to be shadowed
+  private var dir: Path = null
+
   def shadowDir = dir.toAbsolutePath.toString
+  def options = ReplTest.createOptions(shadowDir)
 
   def createSubDir(name: String): Path =
     val subdir = dir.resolve(name)
@@ -35,9 +37,6 @@ object ShadowingTests:
     catch case _: java.nio.file.FileAlreadyExistsException =>
       assert(Files.isDirectory(subdir), s"failed to create shadowed subdirectory $subdir")
     subdir
-
-  // The directory on the classpath containing artifacts to be shadowed
-  private var dir: Path = null
 
   @BeforeClass def setupDir: Unit =
     dir = Files.createTempDirectory("repl-shadow")

--- a/staging/test/scala/quoted/staging/repl/StagingScriptedReplTests.scala
+++ b/staging/test/scala/quoted/staging/repl/StagingScriptedReplTests.scala
@@ -8,7 +8,7 @@ import org.junit.Test
 import org.junit.experimental.categories.Category
 
 /** Runs all tests contained in `staging/test-resources/repl-staging` */
-class StagingScriptedReplTests extends ReplTest(ReplTest.withStagingOptions) {
+class StagingScriptedReplTests extends ReplTest {
 
   @Category(Array(classOf[BootstrappedOnlyTests]))
   @Test def replStagingTests = scripts("/repl-staging").foreach(testFile)


### PR DESCRIPTION
I'd like to do this for more projects, but let me get some feedback on the approach for the REPL for now.

The idea is to stop duplicating SBT's dependency management job. If we want something to be on the classpath for tests, we should declare it as a dependency of the project. If we don't want something to be on the classpath for tests, we should explicitly exclude it. But having to declare everything that _is_ on the classpath is error-prone, especially for the REPL which is designed to keep working even if some dependencies aren't there, so tests can accidentally test a scenario they didn't expect.

## How much have you relied on LLM-based tools in this contribution?

Not at all

## How was the solution tested?

Covered by existing tests (this is a refactoring)