### PR TITLE
Don't eliminate var used by anonfun

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Constructors.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Constructors.scala
@@ -80,7 +80,7 @@ class Constructors extends MiniPhase with IdentityDenotTransformer { thisPhase =
             }
           // restriction on module because lambdalift doesn't transform correctly (to do)
           val inConstructor =
-               (method.isPrimaryConstructor || !sym.owner.is(Module) && checkAnonFun(method))
+               (method.isPrimaryConstructor || !sym.owner.is(Module) && !sym.is(Mutable) && checkAnonFun(method))
             && ctx.owner.enclosingClass == sym.owner
           val noField =
                inConstructor

--- a/tests/run/i26349.scala
+++ b/tests/run/i26349.scala
@@ -1,0 +1,10 @@
+
+class Counter:
+  private var count = 0L
+  val next: () => Long = () => { count += 1; count }
+
+@main def Test =
+  val c = Counter()
+  assert(c.next() == 1)  // 1
+  assert(c.next() == 2)  // expected 2; 3.9.0-RC1 prints 1
+  assert(c.next() == 3)  // expected 3; 3.9.0-RC1 prints 1


### PR DESCRIPTION
Fixes #26349 

Retain mutable fields used by an anonymous function.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
