### PR TITLE
perf: optimize type maps & substitution (~11.51% estimated speedup)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeTypeMap.scala
@@ -68,11 +68,18 @@ class TreeTypeMap(
     }
   }
 
+  // Cached so the SubstSymMap's IdentityHashMap lookup (built once) is reused
+  // across all mapType calls on this TreeTypeMap, instead of re-walking substFrom
+  // for every NamedType.
+  private lazy val cachedSubstSymMap: Substituters.SubstSymMap =
+    new Substituters.SubstSymMap(substFrom, substTo)
+
+  private lazy val substMap: TypeMap = new TypeMap():
+    def apply(tp: Type): Type = tp match
+      case tp: TermRef if tp.symbol.isImport => mapOver(tp)
+      case tp => cachedSubstSymMap(tp)
+
   def mapType(tp: Type): Type =
-    val substMap = new TypeMap():
-      def apply(tp: Type): Type = tp match
-        case tp: TermRef if tp.symbol.isImport => mapOver(tp)
-        case tp => tp.substSym(substFrom, substTo)
     mapOwnerThis(substMap(typeMap(tp)))
   end mapType
 

--- a/compiler/src/dotty/tools/dotc/core/Atoms.scala
+++ b/compiler/src/dotty/tools/dotc/core/Atoms.scala
@@ -19,7 +19,14 @@ enum Atoms:
   def & (that: Atoms): Atoms = this match
     case Range(lo1, hi1) =>
       that match
-        case Range(lo2, hi2) => Range(lo1 & lo2, hi1 & hi2)
+        case Range(lo2, hi2) =>
+          if (lo1 eq hi1) && (lo2 eq hi2) then
+            // Both ranges are exact, so the intersections of the lower and upper
+            // bounds are the same set; compute it once and share it. Sharing also
+            // keeps the result exact, so exactness propagates up nested chains.
+            val u = lo1 & lo2
+            Range(u, u)
+          else Range(lo1 & lo2, hi1 & hi2)
         case Unknown => Range(Set.empty, hi1)
     case Unknown =>
       that match
@@ -29,7 +36,14 @@ enum Atoms:
   def | (that: Atoms): Atoms = this match
     case Range(lo1, hi1) =>
       that match
-        case Range(lo2, hi2) => Range(lo1 | lo2, hi1 | hi2)
+        case Range(lo2, hi2) =>
+          if (lo1 eq hi1) && (lo2 eq hi2) then
+            // Both ranges are exact, so the unions of the lower and upper
+            // bounds are the same set; compute it once and share it. Sharing also
+            // keeps the result exact, so exactness propagates up nested chains.
+            val u = lo1 | lo2
+            Range(u, u)
+          else Range(lo1 | lo2, hi1 | hi2)
         case Unknown => Unknown
     case Unknown => Unknown
 

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -786,6 +786,18 @@ object Denotations {
     def skipRemoved(using Context): SingleDenotation =
       if (validFor == Nowhere) nextDefined else this
 
+    /** A 1-step probe along the `nextInRun` ring: if the immediate `nextInRun`
+     *  denotation is valid for `currentPeriod` and denotes the same symbol as
+     *  this denotation, return it. Otherwise return `null`. Used by
+     *  `NamedType.computeDenot` to skip the dispatch through `current` /
+     *  `goForward` in the common case where the next flock member already
+     *  covers the current period.
+     */
+    final def nextInRunIfFast(currentPeriod: Period): SingleDenotation | Null =
+      val next = nextInRun
+      if (next ne this) && next.validFor.contains(currentPeriod) && (next.symbol eq symbol) then next
+      else null
+
     /** Produce a denotation that is valid for the given context.
      *  Usually called when !(validFor contains ctx.period)
      *  (even though this is not a precondition).

--- a/compiler/src/dotty/tools/dotc/core/Hashable.scala
+++ b/compiler/src/dotty/tools/dotc/core/Hashable.scala
@@ -78,6 +78,25 @@ trait Hashable {
     finishHash(h, len)
   }
 
+  /** Specialised version of `finishHash` for the `bs == null` case.
+   *  Skips the megamorphic `typeHash` dispatch (which checks
+   *  `bs == null || tp.hashIsStable` before reading `tp.hash`) and reads
+   *  `tp.hash` directly. Semantically identical when `bs == null`.
+   */
+  protected final def finishHashNoBinders(seed: Int, arity: Int, tps: List[Type]): Int = {
+    var h = seed
+    var xs = tps
+    var len = arity
+    while (!xs.isEmpty) {
+      val elemHash = xs.head.hash
+      if (elemHash == NotCached) return NotCached
+      h = hashing.mix(h, elemHash)
+      xs = xs.tail
+      len += 1
+    }
+    finishHash(h, len)
+  }
+
   protected def finishHash(bs: Binders, seed: Int, arity: Int, tp: Type, tps: List[Type]): Int = {
     val elemHash = typeHash(bs, tp)
     if (elemHash == NotCached) return NotCached
@@ -108,6 +127,18 @@ trait Hashable {
 
   protected final def doHash(bs: Binders, tp1: Type, tps2: List[Type]): Int =
     finishHash(bs, hashSeed, 0, tp1, tps2)
+
+  /** Specialised version of `doHash(null, tycon, args)` that reads `tp.hash`
+   *  directly instead of dispatching through `typeHash(null, tp)`. Produces
+   *  the same hash value (verified: with `bs == null`, `typeHash` returns
+   *  `tp.hash` unconditionally). Used by `AppliedUniques.enterIfNew` to
+   *  shave the megamorphic `typeHash` call out of the hot path.
+   */
+  protected final def doHashNoBinders(tycon: Type, args: List[Type]): Int = {
+    val elemHash = tycon.hash
+    if (elemHash == NotCached) NotCached
+    else finishHashNoBinders(hashing.mix(hashSeed, elemHash), 1, args)
+  }
 
   protected final def doHash(bs: Binders, x1: Any, tp2: Type, tps3: List[Type]): Int =
     finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2, tps3)

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -157,7 +157,9 @@ object Substituters:
   final def substParam(tp: Type, from: ParamRef, to: Type, theMap: SubstParamMap | Null)(using Context): Type =
     tp match {
       case tp: BoundType =>
-        if (tp == from) to else tp
+        // `eq` short-circuit avoids the wrapper `Objects.equals` call on the
+        // common reference-equal case.
+        if ((tp eq from) || tp == from) to else tp
       case tp: NamedType =>
         if (tp.prefix `eq` NoPrefix) tp
         else tp.derivedSelect(substParam(tp.prefix, from, to, theMap))
@@ -171,7 +173,10 @@ object Substituters:
   final def substParams(tp: Type, from: BindingType, to: List[Type], theMap: SubstParamsMap | Null)(using Context): Type =
     tp match {
       case tp: ParamRef =>
-        if (tp.binder == from) to(tp.paramNum) else tp
+        // `eq` short-circuit avoids the wrapper `Objects.equals` call on the
+        // common case where ParamRefs are created via `binder.paramRefs(n)`
+        // with cached results, so the binder is reference-equal.
+        if ((tp.binder eq from) || tp.binder == from) to(tp.paramNum) else tp
       case tp: NamedType =>
         if (tp.prefix `eq` NoPrefix) tp
         else tp.derivedSelect(substParams(tp.prefix, from, to, theMap))

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -58,6 +58,13 @@ object Substituters:
     tp match {
       case tp: NamedType =>
         val sym = tp.symbol
+        if theMap != null then
+          val lookup = theMap.lookup
+          if lookup != null then
+            val replacement = lookup.get(sym)
+            if replacement != null then return replacement.nn
+            if tp.prefix `eq` NoPrefix then return tp
+            else return tp.derivedSelect(subst(tp.prefix, from, to, theMap))
         var fs = from
         var ts = to
         while (fs.nonEmpty && ts.nonEmpty) {
@@ -78,6 +85,14 @@ object Substituters:
     tp match {
       case tp: NamedType =>
         val sym = tp.symbol
+        if theMap != null then
+          val lookup = theMap.lookup
+          if lookup != null then
+            val replacement = lookup.get(sym)
+            if replacement != null then
+              return substSym(tp.prefix, from, to, theMap).select(replacement.nn)
+            if tp.prefix `eq` NoPrefix then return tp
+            else return tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
         var fs = from
         var ts = to
         while (fs.nonEmpty) {
@@ -90,6 +105,12 @@ object Substituters:
         else tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
       case tp: ThisType =>
         val sym = tp.cls
+        if theMap != null then
+          val lookup = theMap.lookup
+          if lookup != null then
+            val replacement = lookup.get(sym)
+            if replacement != null then return replacement.nn.asClass.thisType
+            return tp
         var fs = from
         var ts = to
         while (fs.nonEmpty) {
@@ -220,10 +241,43 @@ object Substituters:
   }
 
   final class SubstMap(from: List[Symbol], to: List[Type])(using Context) extends DeepTypeMap {
+    private val useLookup = from.lengthCompare(4) >= 0
+    private var lookupCache: java.util.IdentityHashMap[Symbol, Type] | Null = null
+
+    private[Substituters] def lookup: java.util.IdentityHashMap[Symbol, Type] | Null =
+      if !useLookup then null
+      else
+        var m = lookupCache
+        if m == null then
+          m = new java.util.IdentityHashMap[Symbol, Type]
+          var fs = from
+          var ts = to
+          while fs.nonEmpty && ts.nonEmpty do
+            // first-occurrence wins; matches the linear-scan semantics
+            if !m.containsKey(fs.head) then m.put(fs.head, ts.head)
+            fs = fs.tail
+            ts = ts.tail
+          lookupCache = m
+        m
+
     def apply(tp: Type): Type = subst(tp, from, to, this)(using mapCtx)
   }
 
   final class SubstSymMap(from: List[Symbol], to: List[Symbol])(using Context) extends DeepTypeMap {
+    // Above this length the per-NamedType linear scan of `from` becomes
+    // measurable in deep inlining; cache an identity-keyed lookup once.
+    private[Substituters] val lookup: java.util.IdentityHashMap[Symbol, Symbol] | Null =
+      if from.lengthCompare(4) >= 0 then
+        val m = new java.util.IdentityHashMap[Symbol, Symbol]
+        var fs = from
+        var ts = to
+        while fs.nonEmpty && ts.nonEmpty do
+          // first-occurrence wins; matches the linear-scan semantics
+          if !m.containsKey(fs.head) then m.put(fs.head, ts.head)
+          fs = fs.tail
+          ts = ts.tail
+        m
+      else null
     def apply(tp: Type): Type = substSym(tp, from, to, this)(using mapCtx)
     def inverse = SubstSymMap(to, from) // implicitly requires that `to` contains no duplicates.
   }

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -356,20 +356,41 @@ object Substituters:
 
   /** An approximating substitution that can handle wildcards in the `to` list */
   final class SubstApproxMap(from: List[Symbol], to: List[Type])(using Context) extends ApproximatingTypeMap {
+    private inline val ThisTypeSubst = 1
+    private inline val TermRefSubst = 2
+    private inline val TypeRefSubst = 4
+
+    private val substKindMask: Int =
+      var mask = 0
+      var fs = from
+      var ts = to
+      while fs.nonEmpty && ts.nonEmpty do
+        val sym = fs.head
+        if sym.isClass then mask |= ThisTypeSubst | TypeRefSubst
+        else if sym.originDenotation.name.isTypeName then mask |= TypeRefSubst
+        else mask |= TermRefSubst
+        fs = fs.tail
+        ts = ts.tail
+      mask
+
+    private inline def maySubstNamed(tp: NamedType): Boolean =
+      (substKindMask & (if tp.isTerm then TermRefSubst else TypeRefSubst)) != 0
+
     def apply(tp: Type): Type = tp match {
       case tp: NamedType =>
-        val sym = tp.symbol
-        var fs = from
-        var ts = to
-        while (fs.nonEmpty && ts.nonEmpty) {
-          if (fs.head eq sym)
-            return ts.head match {
-              case TypeBounds(lo, hi) => range(lo, hi)
-              case tp1 => tp1
-            }
-          fs = fs.tail
-          ts = ts.tail
-        }
+        if maySubstNamed(tp) then
+          val sym = tp.symbol
+          var fs = from
+          var ts = to
+          while (fs.nonEmpty && ts.nonEmpty) {
+            if (fs.head eq sym)
+              return ts.head match {
+                case TypeBounds(lo, hi) => range(lo, hi)
+                case tp1 => tp1
+              }
+            fs = fs.tail
+            ts = ts.tail
+          }
         if (tp.prefix `eq` NoPrefix) tp else derivedSelect(tp, apply(tp.prefix))
       case _: ThisType | _: BoundType =>
         tp

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -91,19 +91,23 @@ object Substituters:
             val replacement = lookup.get(sym)
             if replacement != null then
               val prefix = tp.prefix
-              return (if prefix `eq` NoPrefix then NoPrefix else substSym(prefix, from, to, theMap)).select(replacement.nn)
+              return (if prefix `eq` NoPrefix then NoPrefix else theMap.substPrefix(prefix, from, to)).select(replacement.nn)
             if tp.prefix `eq` NoPrefix then return tp
-            else return tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
+            else return tp.derivedSelect(theMap.substPrefix(tp.prefix, from, to))
         var fs = from
         var ts = to
         while (fs.nonEmpty) {
           if (fs.head eq sym)
             val prefix = tp.prefix
-            return (if prefix `eq` NoPrefix then NoPrefix else substSym(prefix, from, to, theMap)).select(ts.head)
+            return (if prefix `eq` NoPrefix then NoPrefix
+                    else if theMap != null then theMap.substPrefix(prefix, from, to)
+                    else substSym(prefix, from, to, theMap)
+                   ).select(ts.head)
           fs = fs.tail
           ts = ts.tail
         }
         if (tp.prefix `eq` NoPrefix) tp
+        else if theMap != null then tp.derivedSelect(theMap.substPrefix(tp.prefix, from, to))
         else tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
       case tp: ThisType =>
         val sym = tp.cls
@@ -285,6 +289,24 @@ object Substituters:
           ts = ts.tail
         m
       else null
+
+    // One-slot MRU keyed by reference equality on the input prefix:
+    // sibling NamedTypes selecting different names from the same prefix
+    // (e.g. `outer.this.x` / `outer.this.y`) reuse the substituted prefix
+    // instead of re-walking it. The result is a pure function of the input
+    // prefix and the (from, to) lists, all immutable for this instance.
+    private var prefixIn: Type | Null = null
+    private var prefixOut: Type | Null = null
+
+    private[Substituters] def substPrefix(prefix: Type, from: List[Symbol], to: List[Symbol])(using Context): Type =
+      val cached = prefixIn
+      if cached != null && (prefix eq cached) then prefixOut.nn
+      else
+        val out = substSym(prefix, from, to, this)
+        prefixIn = prefix
+        prefixOut = out
+        out
+
     def apply(tp: Type): Type = substSym(tp, from, to, this)(using mapCtx)
     def inverse = SubstSymMap(to, from) // implicitly requires that `to` contains no duplicates.
   }

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -90,16 +90,16 @@ object Substituters:
           if lookup != null then
             val replacement = lookup.get(sym)
             if replacement != null then
-              if tp.prefix `eq` NoPrefix then return NoPrefix.select(replacement.nn)
-              else return substSym(tp.prefix, from, to, theMap).select(replacement.nn)
+              val prefix = tp.prefix
+              return (if prefix `eq` NoPrefix then NoPrefix else substSym(prefix, from, to, theMap)).select(replacement.nn)
             if tp.prefix `eq` NoPrefix then return tp
             else return tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
         var fs = from
         var ts = to
         while (fs.nonEmpty) {
           if (fs.head eq sym)
-            if tp.prefix `eq` NoPrefix then return NoPrefix.select(ts.head)
-            else return substSym(tp.prefix, from, to, theMap).select(ts.head)
+            val prefix = tp.prefix
+            return (if prefix `eq` NoPrefix then NoPrefix else substSym(prefix, from, to, theMap)).select(ts.head)
           fs = fs.tail
           ts = ts.tail
         }

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -85,6 +85,9 @@ object Substituters:
     tp match {
       case tp: NamedType =>
         val sym = tp.symbol
+        if theMap != null && !theMap.maySubstNamed(tp) then
+          if tp.prefix `eq` NoPrefix then return tp
+          else return tp.derivedSelect(theMap.substPrefix(tp.prefix, from, to))
         if theMap != null then
           val lookup = theMap.lookup
           if lookup != null then
@@ -110,6 +113,7 @@ object Substituters:
         else if theMap != null then tp.derivedSelect(theMap.substPrefix(tp.prefix, from, to))
         else tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
       case tp: ThisType =>
+        if theMap != null && !theMap.maySubstThisType then return tp
         val sym = tp.cls
         if theMap != null then
           val lookup = theMap.lookup
@@ -289,6 +293,29 @@ object Substituters:
           ts = ts.tail
         m
       else null
+
+    private inline val ThisTypeSubst = 1
+    private inline val TermRefSubst = 2
+    private inline val TypeRefSubst = 4
+
+    private val substKindMask: Int =
+      var mask = 0
+      var fs = from
+      var ts = to
+      while fs.nonEmpty && ts.nonEmpty do
+        val sym = fs.head
+        if sym.isClass then mask |= ThisTypeSubst | TypeRefSubst
+        else if sym.originDenotation.name.isTypeName then mask |= TypeRefSubst
+        else mask |= TermRefSubst
+        fs = fs.tail
+        ts = ts.tail
+      mask
+
+    private[Substituters] inline def maySubstThisType: Boolean =
+      (substKindMask & ThisTypeSubst) != 0
+
+    private[Substituters] inline def maySubstNamed(tp: NamedType): Boolean =
+      (substKindMask & (if tp.isTerm then TermRefSubst else TypeRefSubst)) != 0
 
     // One-slot MRU keyed by reference equality on the input prefix:
     // sibling NamedTypes selecting different names from the same prefix

--- a/compiler/src/dotty/tools/dotc/core/Substituters.scala
+++ b/compiler/src/dotty/tools/dotc/core/Substituters.scala
@@ -90,14 +90,16 @@ object Substituters:
           if lookup != null then
             val replacement = lookup.get(sym)
             if replacement != null then
-              return substSym(tp.prefix, from, to, theMap).select(replacement.nn)
+              if tp.prefix `eq` NoPrefix then return NoPrefix.select(replacement.nn)
+              else return substSym(tp.prefix, from, to, theMap).select(replacement.nn)
             if tp.prefix `eq` NoPrefix then return tp
             else return tp.derivedSelect(substSym(tp.prefix, from, to, theMap))
         var fs = from
         var ts = to
         while (fs.nonEmpty) {
           if (fs.head eq sym)
-            return substSym(tp.prefix, from, to, theMap).select(ts.head)
+            if tp.prefix `eq` NoPrefix then return NoPrefix.select(ts.head)
+            else return substSym(tp.prefix, from, to, theMap).select(ts.head)
           fs = fs.tail
           ts = ts.tail
         }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -2,7 +2,7 @@ package dotty.tools
 package dotc
 package core
 
-import Contexts.*, Types.*, Symbols.*, Names.*, NameKinds.*, Flags.*
+import Contexts.*, Types.*, Symbols.*, Names.*, NameKinds.*, Flags.*, Periods.*
 import SymDenotations.*
 import util.Spans.*
 import util.Stats
@@ -21,6 +21,7 @@ import reporting.TestingReporter
 import Annotations.Annotation
 import cc.{CapturingType, derivedCapturingType, CaptureSet, captureSet, isBoxed, isBoxedCapturing}
 import CaptureSet.{IdentityCaptRefMap, VarState}
+import Periods.*
 
 import scala.annotation.internal.sharable
 import scala.annotation.threadUnsafe
@@ -67,6 +68,27 @@ object TypeOps:
      */
     private[TypeOps] var approxCount: Int = 0
 
+    private var myToPrefixBasePre: Type | Null = null
+    private var myToPrefixBaseCls: Symbol = NoSymbol
+    private var myToPrefixBasePeriod: Period = Nowhere
+    private var myToPrefixBaseType: Type = NoType
+
+    private def toPrefixBaseType(pre: Type, cls: Symbol)(using Context): Type =
+      val now = ctx.period
+      if (myToPrefixBasePre eq pre) && (myToPrefixBaseCls eq cls) && myToPrefixBasePeriod == now
+          && !ctx.gadt.isNarrowing && !CapturingType.isUncachable(pre)
+      then myToPrefixBaseType
+      else
+        val baseTp = pre.baseType(cls)
+        if (baseTp ne NoPrefix)
+            && !(pre.isProvisional || baseTp.isProvisional || CapturingType.isUncachable(pre) || ctx.gadt.isNarrowing)
+        then
+          myToPrefixBasePre = pre
+          myToPrefixBaseCls = cls
+          myToPrefixBasePeriod = now
+          myToPrefixBaseType = baseTp
+        baseTp
+
     def apply(tp: Type): Type = {
 
       /** Map a `C.this` type to the right prefix. If the prefix is unstable, and
@@ -81,7 +103,7 @@ object TypeOps:
         else pre match {
           case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
           case _ =>
-            if (thiscls.derivesFrom(cls) && pre.baseType(thiscls).exists)
+            if (thiscls.derivesFrom(cls) && toPrefixBaseType(pre, thiscls).exists)
               if (variance <= 0 && !isLegalPrefix(pre))
                 approxCount += 1
                 range(defn.NothingType, pre)
@@ -89,7 +111,7 @@ object TypeOps:
             else if (pre.termSymbol.is(Package) && !thiscls.is(Package))
               toPrefix(pre.select(nme.PACKAGE), cls, thiscls)
             else
-              toPrefix(pre.baseType(cls).normalizedPrefix, cls.owner, thiscls)
+              toPrefix(toPrefixBaseType(pre, cls).normalizedPrefix, cls.owner, thiscls)
         }
       }
 

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -98,10 +98,11 @@ object TypeOps:
         // TODO: generalize the inlining trick?
         tp match {
           case tp: NamedType =>
-            val sym = tp.symbol
-            if sym.isStatic && !sym.maybeOwner.seesOpaques || (tp.prefix `eq` NoPrefix)
-            then tp
-            else derivedSelect(tp, atVariance(variance max 0)(this(tp.prefix)))
+            if tp.prefix `eq` NoPrefix then tp
+            else
+              val sym = tp.symbol
+              if sym.isStatic && !sym.maybeOwner.seesOpaques then tp
+              else derivedSelect(tp, atVariance(variance max 0)(this(tp.prefix)))
           case tp: LambdaType =>
             mapOverLambda(tp) // special cased common case
           case tp: ThisType =>

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -132,10 +132,15 @@ object TypeOps:
               val sym = tp.symbol
               if sym.isStatic && !sym.maybeOwner.seesOpaques then tp
               else
-                val saved = variance
-                variance = saved max 0
-                val prefix = this(tp.prefix)
-                variance = saved
+                // `saved max 0` is the identity when variance >= 0, so skip the save/restore.
+                val prefix =
+                  if variance >= 0 then this(tp.prefix)
+                  else
+                    val saved = variance
+                    variance = 0
+                    val res = this(tp.prefix)
+                    variance = saved
+                    res
                 derivedSelect(tp, prefix)
           case tp: LambdaType =>
             mapOverLambda(tp) // special cased common case

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -110,7 +110,7 @@ object TypeOps:
         else pre match {
           case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)
           case _ =>
-            if (thiscls.derivesFrom(cls) && toPrefixBaseType(pre, thiscls).exists)
+            if (((thiscls eq cls) || thiscls.derivesFrom(cls)) && toPrefixBaseType(pre, thiscls).exists)
               if (variance <= 0 && !isLegalPrefix(pre))
                 approxCount += 1
                 range(defn.NothingType, pre)

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -68,6 +68,11 @@ object TypeOps:
      */
     private[TypeOps] var approxCount: Int = 0
 
+    private val outerPre: Type = pre
+    private val outerCls: Symbol = cls
+    private val outerPreIsTrivial: Boolean = (pre eq NoType) || (pre eq NoPrefix)
+    private val outerClsIsPackage: Boolean = cls.is(PackageClass)
+
     private var myToPrefixBasePre: Type | Null = null
     private var myToPrefixBaseCls: Symbol = NoSymbol
     private var myToPrefixBasePeriod: Period = Nowhere
@@ -98,7 +103,9 @@ object TypeOps:
        *  @param  thiscls The prefix `C` of the `C.this` type.
        */
       def toPrefix(pre: Type, cls: Symbol, thiscls: ClassSymbol): Type = /*>|>*/ trace.conditionally(track, s"toPrefix($pre, $cls, $thiscls)", show = true) /*<|<*/ {
-        if ((pre eq NoType) || (pre eq NoPrefix) || cls.is(PackageClass))
+        val isOuterCall = (pre eq outerPre) && (cls eq outerCls)
+        if isOuterCall && (outerPreIsTrivial || outerClsIsPackage) then tp
+        else if !isOuterCall && ((pre eq NoType) || (pre eq NoPrefix) || cls.is(PackageClass)) then
           tp
         else pre match {
           case pre: SuperType => toPrefix(pre.thistpe, cls, thiscls)

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -143,6 +143,23 @@ object TypeOps:
             toPrefix(pre, cls, tp.cls)
           case _: BoundType =>
             tp
+          case tp: AppliedType =>
+            val tycon1 = this(tp.tycon)
+            val args = tp.args
+            val args1 = if args.isEmpty then args else mapArgs(args, tyconTypeParams(tp))
+            if (tycon1 eq tp.tycon) && (args1 eq args) then tp
+            else derivedAppliedType(tp, tycon1, args1)
+          case tp: AliasingBounds =>
+            val saved = variance
+            variance = 0
+            val alias1 = this(tp.alias)
+            variance = saved
+            derivedAlias(tp, alias1)
+          case tp: TypeBounds =>
+            variance = -variance
+            val lo1 = this(tp.lo)
+            variance = -variance
+            derivedTypeBounds(tp, lo1, this(tp.hi))
           case _ =>
             mapOver(tp)
         }

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -102,7 +102,12 @@ object TypeOps:
             else
               val sym = tp.symbol
               if sym.isStatic && !sym.maybeOwner.seesOpaques then tp
-              else derivedSelect(tp, atVariance(variance max 0)(this(tp.prefix)))
+              else
+                val saved = variance
+                variance = saved max 0
+                val prefix = this(tp.prefix)
+                variance = saved
+                derivedSelect(tp, prefix)
           case tp: LambdaType =>
             mapOverLambda(tp) // special cased common case
           case tp: ThisType =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6337,14 +6337,19 @@ object Types extends TypeUtils {
 
     protected def mapOverLambda(tp: LambdaType) =
       val restpe = tp.resultType
-      val saved = variance
-      // TermLambda (MethodType) result types are never MatchCase, so skip the check.
-      variance =
-        if tp.isInstanceOf[TermLambda] then -variance
-        else if defn.MatchCase.isInstance(restpe) then 0
-        else -variance
-      val ptypes1 = tp.paramInfos.mapConserve(this).asInstanceOf[List[tp.PInfo]]
-      variance = saved
+      val ptypes = tp.paramInfos
+      val ptypes1 =
+        if ptypes.isEmpty then ptypes
+        else
+          val saved = variance
+          // TermLambda (MethodType) result types are never MatchCase, so skip the check.
+          variance =
+            if tp.isInstanceOf[TermLambda] then -variance
+            else if defn.MatchCase.isInstance(restpe) then 0
+            else -variance
+          val res = ptypes.mapConserve(this).asInstanceOf[List[tp.PInfo]]
+          variance = saved
+          res
       derivedLambdaType(tp)(ptypes1, this(restpe))
 
     protected def mapOverTypeVar(tp: TypeVar) =
@@ -6448,8 +6453,9 @@ object Types extends TypeUtils {
 
         case tp: AppliedType =>
           val tycon1 = this(tp.tycon)
-          val args1 = mapArgs(tp.args, tyconTypeParams(tp))
-          if (tycon1 eq tp.tycon) && (args1 eq tp.args) then tp
+          val args = tp.args
+          val args1 = if args.isEmpty then args else mapArgs(args, tyconTypeParams(tp))
+          if (tycon1 eq tp.tycon) && (args1 eq args) then tp
           else derivedAppliedType(tp, tycon1, args1)
 
         case tp: LambdaType =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6444,10 +6444,13 @@ object Types extends TypeUtils {
             variance = saved max 0
             val prefix1 = this(tp.prefix)
             variance = saved
-            derivedSelect(tp, prefix1)
+            if (prefix1 eq tp.prefix) then tp else derivedSelect(tp, prefix1)
 
         case tp: AppliedType =>
-          derivedAppliedType(tp, this(tp.tycon), mapArgs(tp.args, tyconTypeParams(tp)))
+          val tycon1 = this(tp.tycon)
+          val args1 = mapArgs(tp.args, tyconTypeParams(tp))
+          if (tycon1 eq tp.tycon) && (args1 eq tp.args) then tp
+          else derivedAppliedType(tp, tycon1, args1)
 
         case tp: LambdaType =>
           mapOverLambda(tp)

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6330,7 +6330,11 @@ object Types extends TypeUtils {
     protected def mapOverLambda(tp: LambdaType) =
       val restpe = tp.resultType
       val saved = variance
-      variance = if (defn.MatchCase.isInstance(restpe)) 0 else -variance
+      // TermLambda (MethodType) result types are never MatchCase, so skip the check.
+      variance =
+        if tp.isInstanceOf[TermLambda] then -variance
+        else if defn.MatchCase.isInstance(restpe) then 0
+        else -variance
       val ptypes1 = tp.paramInfos.mapConserve(this).asInstanceOf[List[tp.PInfo]]
       variance = saved
       derivedLambdaType(tp)(ptypes1, this(restpe))

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6982,7 +6982,15 @@ object Types extends TypeUtils {
      *  more relaxed scheme is used.
      */
     protected def applyToPrefix(x: T, tp: NamedType): T =
-      atVariance(variance max 0)(this(x, tp.prefix))
+      // Inline `atVariance(variance max 0)(this(x, tp.prefix))` to eliminate the
+      // by-name `op$proxy` thunk on this hot foldOver path. Mirrors precedent
+      // 94af7d7d55 for the TypeMap.mapOver NamedType arm. Overridable: subclasses
+      // (e.g. OrderingConstraint.ConstraintAwareTraversal) replace this entirely.
+      val saved = variance
+      variance = saved max 0
+      val res = this(x, tp.prefix)
+      variance = saved
+      res
 
     def foldOver(x: T, tp: Type): T = {
       record(s"foldOver $getClass")
@@ -7001,7 +7009,12 @@ object Types extends TypeUtils {
             val tparam = tparams.head
             val acc = args.head match {
               case arg: TypeBounds => this(x, arg)
-              case arg => atVariance(variance * tparam.paramVarianceSign)(this(x, arg))
+              case arg =>
+                val saved = variance
+                variance = saved * tparam.paramVarianceSign
+                val res = this(x, arg)
+                variance = saved
+                res
             }
             foldArgs(acc, tparams.tail, args.tail)
           }

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6317,11 +6317,14 @@ object Types extends TypeUtils {
     protected def mapArg(arg: Type, tparam: ParamInfo): Type = arg match
       case arg: TypeBounds => this(arg)
       case arg =>
-        val saved = variance
-        variance = saved * tparam.paramVarianceSign
-        val res = this(arg)
-        variance = saved
-        res
+        val sign = tparam.paramVarianceSign
+        if sign == 1 then this(arg)
+        else
+          val saved = variance
+          variance = saved * sign
+          val res = this(arg)
+          variance = saved
+          res
 
     protected def mapArgs(args: List[Type], tparams: List[ParamInfo]): List[Type] = args match
       case arg :: otherArgs if tparams.nonEmpty =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6445,10 +6445,16 @@ object Types extends TypeUtils {
           if stopBecauseStaticOrLocal(tp) then tp
           else
             // see comment of TypeAccumulator's applyToPrefix
-            val saved = variance
-            variance = saved max 0
-            val prefix1 = this(tp.prefix)
-            variance = saved
+            // `saved max 0` is the identity when variance >= 0 (prefixes are
+            // never visited contravariantly there), so skip the save/restore.
+            val prefix1 =
+              if variance >= 0 then this(tp.prefix)
+              else
+                val saved = variance
+                variance = 0
+                val res = this(tp.prefix)
+                variance = saved
+                res
             if (prefix1 eq tp.prefix) then tp else derivedSelect(tp, prefix1)
 
         case tp: AppliedType =>
@@ -6986,11 +6992,14 @@ object Types extends TypeUtils {
       // by-name `op$proxy` thunk on this hot foldOver path. Mirrors precedent
       // 94af7d7d55 for the TypeMap.mapOver NamedType arm. Overridable: subclasses
       // (e.g. OrderingConstraint.ConstraintAwareTraversal) replace this entirely.
-      val saved = variance
-      variance = saved max 0
-      val res = this(x, tp.prefix)
-      variance = saved
-      res
+      // `saved max 0` is the identity when variance >= 0, so skip the save/restore.
+      if variance >= 0 then this(x, tp.prefix)
+      else
+        val saved = variance
+        variance = 0
+        val res = this(x, tp.prefix)
+        variance = saved
+        res
 
     def foldOver(x: T, tp: Type): T = {
       record(s"foldOver $getClass")

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6316,7 +6316,12 @@ object Types extends TypeUtils {
 
     protected def mapArg(arg: Type, tparam: ParamInfo): Type = arg match
       case arg: TypeBounds => this(arg)
-      case arg => atVariance(variance * tparam.paramVarianceSign)(this(arg))
+      case arg =>
+        val saved = variance
+        variance = saved * tparam.paramVarianceSign
+        val res = this(arg)
+        variance = saved
+        res
 
     protected def mapArgs(args: List[Type], tparams: List[ParamInfo]): List[Type] = args match
       case arg :: otherArgs if tparams.nonEmpty =>
@@ -6431,7 +6436,11 @@ object Types extends TypeUtils {
         case tp: NamedType =>
           if stopBecauseStaticOrLocal(tp) then tp
           else
-            val prefix1 = atVariance(variance max 0)(this(tp.prefix)) // see comment of TypeAccumulator's applyToPrefix
+            // see comment of TypeAccumulator's applyToPrefix
+            val saved = variance
+            variance = saved max 0
+            val prefix1 = this(tp.prefix)
+            variance = saved
             derivedSelect(tp, prefix1)
 
         case tp: AppliedType =>
@@ -6441,7 +6450,11 @@ object Types extends TypeUtils {
           mapOverLambda(tp)
 
         case tp: AliasingBounds =>
-          derivedAlias(tp, atVariance(0)(this(tp.alias)))
+          val saved = variance
+          variance = 0
+          val alias1 = this(tp.alias)
+          variance = saved
+          derivedAlias(tp, alias1)
 
         case tp: TypeBounds =>
           variance = -variance
@@ -6512,7 +6525,10 @@ object Types extends TypeUtils {
 
         case tp: MatchType =>
           val bound1 = this(tp.bound)
-          val scrut1 = atVariance(0)(this(tp.scrutinee))
+          val saved = variance
+          variance = 0
+          val scrut1 = this(tp.scrutinee)
+          variance = saved
           derivedMatchType(tp, bound1, scrut1, tp.cases.mapConserve(this))
 
         case tp: SkolemType =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2546,7 +2546,7 @@ object Types extends TypeUtils {
           else
             val newd = lastd match
               case lastd: SymDenotation =>
-                if stillValid(lastd) && checkedPeriod != Nowhere && !needsRecompute
+                if checkedPeriod != Nowhere && stillValid(lastd) && !needsRecompute
                 then finish(lastd.current)
                 else finish(memberDenot(lastd.initial.name, allowPrivate = lastd.is(Private)))
               case _ =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -7020,6 +7020,9 @@ object Types extends TypeUtils {
           }
         foldArgs(this(x, tycon), tyconTypeParams(tp), args)
 
+      case _: ConstantType | NoType | _: ErrorType =>
+        x
+
       case _: BoundType | _: ThisType => x
 
       case tp: LambdaType =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6800,7 +6800,8 @@ object Types extends TypeUtils {
       else tp.derivedSuperType(thistp, supertp)
 
     override protected def derivedAppliedType(tp: AppliedType, tycon: Type, args: List[Type]): Type =
-      tycon match {
+      if (tycon eq tp.tycon) && (args eq tp.args) then tp
+      else tycon match {
         case Range(tyconLo, tyconHi) =>
           range(derivedAppliedType(tp, tyconLo, args), derivedAppliedType(tp, tyconHi, args))
         case _ =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2415,7 +2415,23 @@ object Types extends TypeUtils {
       // We can rely on checkedPeriod (unlike in the definition of `denot` below)
       // because SymDenotation#installAfter never changes the symbol
       if (checkedPeriod == ctx.period) lastSymbol.asInstanceOf[Symbol]
-      else computeSymbol
+      else designator match
+        // Per-runId fast-path narrowed to symbolic designators only: when the
+        // designator is itself a Symbol and its last-known denotation is from
+        // the current run AND still maps back to this symbol (the same gate
+        // `isValidInCurrentRun` applies), `computeSymbol` would just return
+        // `sym` via its `isValidInCurrentRun` first disjunct without invoking
+        // `stillValid`. Narrowing to symbolic designators distinguishes this
+        // from the rejected widened cache: there's no validFor probe on the
+        // type's own lastDenotation and no extra stamp field. The check piggy-
+        // backs on `sym.lastKnownDenotation` (no Context-keyed work).
+        case sym: Symbol =>
+          val symd = sym.lastKnownDenotation
+          if symd.validFor.runId == ctx.runId && (symd.symbol eq sym) then
+            if checkedPeriod != Nowhere then checkedPeriod = ctx.period
+            sym
+          else computeSymbol
+        case _ => computeSymbol
 
     private def computeSymbol(using Context): Symbol =
       val result = designator match

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2816,6 +2816,21 @@ object Types extends TypeUtils {
       }
     }
 
+    /** True if `lookupRefined` cannot reduce this prefix shape.
+     *
+     *  Keep this as an allowlist of shapes that the current `lookupRefined`
+     *  implementation does not normalize through. Prefixes that can contain,
+     *  wrap, or reveal refinements must keep using `lookupRefined`.
+     */
+    private inline def prefixSkipsRefinedLookup(prefix: Type): Boolean = prefix match
+      case _: TermRef | _: Types.ThisType | _: SuperType | _: ConstantType
+         | _: AppliedType | _: AndOrType | _: FlexibleType | _: BoundType
+         | _: MatchType | _: JavaArrayType | _: FlexType | _: WildcardType
+         | NoPrefix | NoType =>
+        true
+      case _ =>
+        false
+
     /** A selection of the same kind, but with potentially a different prefix.
      *  The following normalizations are performed for type selections T#A:
      *
@@ -2834,6 +2849,7 @@ object Types extends TypeUtils {
       else
         val reduced =
           if isType && currentValidSymbol.isAllOf(ClassTypeParam) then argForParam(prefix)
+          else if prefixSkipsRefinedLookup(prefix) then NoType
           else prefix.lookupRefined(name)
         if reduced.exists then return reduced
         if Config.splitProjections && isType then
@@ -7008,8 +7024,23 @@ object Types extends TypeUtils {
       case tp: NamedType =>
         if stopBecauseStaticOrLocal(tp) then x
         else
-          val tp1 = tp.prefix.lookupRefined(tp.name)
-          if (tp1.exists) this(x, tp1) else applyToPrefix(x, tp)
+          val prefix = tp.prefix
+          // Fast-path: skip lookupRefined when the prefix shape cannot carry
+          // refinements.  Mirrors NamedType.prefixSkipsRefinedLookup (which is
+          // private to NamedType).  For these prefix shapes lookupRefined always
+          // returns NoType, so we can go straight to applyToPrefix.
+          inline def prefixSkipsRefined: Boolean = prefix match
+            case _: TermRef | _: ThisType | _: SuperType | _: ConstantType
+               | _: AppliedType | _: AndOrType | _: FlexibleType | _: BoundType
+               | _: MatchType | _: JavaArrayType | _: FlexType | _: WildcardType
+               | NoPrefix | NoType =>
+              true
+            case _ =>
+              false
+          if prefixSkipsRefined then applyToPrefix(x, tp)
+          else
+            val tp1 = prefix.lookupRefined(tp.name)
+            if tp1.exists then this(x, tp1) else applyToPrefix(x, tp)
 
       case tp @ AppliedType(tycon, args) =>
         @tailrec def foldArgs(x: T, tparams: List[ParamInfo], args: List[Type]): T =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6461,6 +6461,28 @@ object Types extends TypeUtils {
         case tp: LambdaType =>
           mapOverLambda(tp)
 
+        case tp: ConstantType =>
+          // Ground leaf: literal ConstantTypes map to themselves; only a
+          // class-literal constant (ClazzTag) carries a Type value that must be
+          // remapped through erasure (see tests/run/classof.scala). The tag
+          // compare is exactly equivalent to the old `Constant(_: Type)` test
+          // (ClazzTag is the only tag whose value is a Type), and handling
+          // ConstantType here skips the ~15-arm tail of the match for the common
+          // primitive/String literals.
+          if tp.value.tag == ClazzTag then
+            val classType = tp.value.tpe
+            val classType1 = this(classType)
+            if classType eq classType1 then tp
+            else classType1
+          else tp
+
+        case _ if (tp eq NoType) || tp.isInstanceOf[ErrorType] =>
+          // Ground leaves with no mappable substructure; return directly instead
+          // of walking the rest of the match to the default arm. ErrorType is the
+          // only FlexType caught here (TryDynamicCallType, the other FlexType, is
+          // left to the default arm).
+          tp
+
         case tp: AliasingBounds =>
           val saved = variance
           variance = 0
@@ -6504,12 +6526,6 @@ object Types extends TypeUtils {
         case tp @ SuperType(thistp, supertp) =>
           derivedSuperType(tp, this(thistp), this(supertp))
 
-        case tp @ ConstantType(const @ Constant(_: Type)) =>
-          val classType = const.tpe
-          val classType1 = this(classType)
-          if classType eq classType1 then tp
-          else classType1
-
         case tp: LazyRef =>
           LazyRef { refCtx =>
             given Context = refCtx
@@ -6547,7 +6563,10 @@ object Types extends TypeUtils {
           derivedSkolemType(tp, this(tp.info))
 
         case tp: WildcardType =>
-          derivedWildcardType(tp, mapOver(tp.optBounds))
+          // An unbounded wildcard has NoType bounds; derivedWildcardType(tp, NoType)
+          // returns tp, so skip the full mapOver(NoType) dispatch for it.
+          val ob = tp.optBounds
+          if ob.exists then derivedWildcardType(tp, mapOver(ob)) else tp
 
         case tp: JavaArrayType =>
           derivedJavaArrayType(tp, this(tp.elemType))
@@ -6833,11 +6852,13 @@ object Types extends TypeUtils {
       case _             => false
 
     override protected def derivedAndType(tp: AndType, tp1: Type, tp2: Type): Type =
-      if (isRange(tp1) || isRange(tp2)) range(lower(tp1) & lower(tp2), upper(tp1) & upper(tp2))
+      if (tp1 eq tp.tp1) && (tp2 eq tp.tp2) then tp
+      else if (isRange(tp1) || isRange(tp2)) range(lower(tp1) & lower(tp2), upper(tp1) & upper(tp2))
       else tp.derivedAndType(tp1, tp2)
 
     override protected def derivedOrType(tp: OrType, tp1: Type, tp2: Type): Type =
-      if (isRange(tp1) || isRange(tp2)) range(lower(tp1) | lower(tp2), upper(tp1) | upper(tp2))
+      if (tp1 eq tp.tp1) && (tp2 eq tp.tp2) then tp
+      else if (isRange(tp1) || isRange(tp2)) range(lower(tp1) | lower(tp2), upper(tp1) | upper(tp2))
       else tp.derivedOrType(tp1, tp2)
 
     override protected def derivedAnnotatedType(tp: AnnotatedType, underlying: Type, annot: Annotation): Type =

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2521,7 +2521,12 @@ object Types extends TypeUtils {
                     }
                   )
           then
-            finish(lastd.current)
+            // 1-step nextInRun fast-path: if the immediate next flock member
+            // already covers ctx.period and denotes the same symbol, skip the
+            // dispatch through `lastd.current` / `goForward`.
+            val fast = lastd.nextInRunIfFast(ctx.period)
+            if fast != null then finish(fast)
+            else finish(lastd.current)
           else
             val newd = lastd match
               case lastd: SymDenotation =>

--- a/tests/pos/derived-select-lookup-refined.scala
+++ b/tests/pos/derived-select-lookup-refined.scala
@@ -1,0 +1,45 @@
+trait DerivedSelectBase:
+  type A
+  type B
+  type C
+  val tag: String
+
+type DirectRefinement =
+  DerivedSelectBase { type A = String; type B = List[A]; val tag: "direct" }
+
+type AliasRefinement = DirectRefinement
+
+type RecursiveRefinement =
+  DerivedSelectBase { type A = String; type B = A; type C = B }
+
+def directRefined(x: DirectRefinement): x.A =
+  val value: String = ""
+  value
+
+def aliasRefined(x: AliasRefinement): x.B =
+  List("")
+
+def recursiveRefined(x: RecursiveRefinement): x.C =
+  val value: String = ""
+  value
+
+trait StableOuter:
+  type Elem
+  val member: DerivedSelectBase { type A = Elem; type B = List[A]; val tag: "stable" }
+
+def singletonPrefix(o: StableOuter { type Elem = Int }): o.member.B =
+  List(1)
+
+trait UnstableOuter:
+  type Elem
+  def member: DerivedSelectBase { type A = Elem; type B = List[A]; val tag: "unstable" }
+
+def useSkolemPrefix(x: DerivedSelectBase { type A = Boolean }): x.A =
+  true
+
+def skolemPrefix(o: UnstableOuter { type Elem = Boolean }): Boolean =
+  useSkolemPrefix(o.member)
+
+def inferredTypeParam[T <: DerivedSelectBase { type A = Char; type B = List[A] }](x: T): x.B =
+  val value: x.A = 'a'
+  List(value)


### PR DESCRIPTION
Optimizes **type maps & substitution** — one subsystem split out of the large performance PR scala/scala3#26025 to make review tractable.

**Estimated speedup:** ~11.51% (sum of 28 per-commit profiler estimates across 28 commits)

Full context, benchmarking methodology, and per-commit JFR profiling deltas are in the parent PR scala/scala3#26025.