### PR TITLE
perf: optimize AST trees & positions (~5.63% estimated speedup)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -97,14 +97,19 @@ abstract class Positioned private[ast] (initialSpan: Positioned.InitialSpan)(imp
       def include(span: Span, x: Any): Span = x match {
         case p: Positioned =>
           if (p.source `ne` src) span
-          else if (p.span.exists) span.union(p.span)
-          else if (span.exists) {
-            if (span.end != MaxOffset)
-              p.span = p.envelope(src, span.endPos)
-            span
-          }
-          else // No span available to assign yet, signal this by returning a span with MaxOffset end
-            Span(MaxOffset, MaxOffset)
+          else
+            val pspan = p.span
+            if (pspan.exists) {
+              if (span.exists) Span(span.start min pspan.start, span.end max pspan.end, span.point)
+              else pspan
+            }
+            else if (span.exists) {
+              if (span.end != MaxOffset)
+                p.span = p.envelope(src, span.endPos)
+              span
+            }
+            else // No span available to assign yet, signal this by returning a span with MaxOffset end
+              Span(MaxOffset, MaxOffset)
         case m: untpd.Modifiers =>
           include(include(span, m.mods), m.annotations)
         case y :: ys =>

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -90,75 +90,143 @@ abstract class Positioned private[ast] (initialSpan: Positioned.InitialSpan)(imp
    *  the left, or, if that one does not exist, to the start position of the envelope
    *  of all children to the right.
    */
-  def envelope(src: SourceFile, startSpan: Span = NoSpan): Span = (this: @unchecked) match {
-    case Trees.Inlined(call, _, _) =>
-      call.span
-    case tree: Trees.Select[?] =>
-      val qualifier = tree.qualifier
-      def includeQualifier(span: Span): Span =
-        if (qualifier.source `ne` src) span
+  def envelope(src: SourceFile, startSpan: Span = NoSpan): Span = {
+    def include(span: Span, x: Any): Span = x match {
+      case p: Positioned =>
+        if (p.source `ne` src) span
         else
-          val pspan = qualifier.span
+          val pspan = p.span
           if (pspan.exists) {
-            if (span.exists) Span(span.start min pspan.start, span.end max pspan.end, span.point)
+            if (span.exists) Span(span.start min pspan.start, span.end max pspan.end)
             else pspan
           }
           else if (span.exists) {
             if (span.end != MaxOffset)
-              qualifier.span = qualifier.envelope(src, span.endPos)
+              p.span = p.envelope(src, span.endPos)
             span
           }
           else // No span available to assign yet, signal this by returning a span with MaxOffset end
             Span(MaxOffset, MaxOffset)
-      val span1 = includeQualifier(startSpan)
-      val span2 =
-        if (!span1.exists || span1.end != MaxOffset)
-          span1
-        else if (span1.start == MaxOffset)
-          NoSpan
-        else
-          includeQualifier(span1.startPos)
-      span2.toSynthetic
-    case _ =>
-      def include(span: Span, x: Any): Span = x match {
-        case p: Positioned =>
-          if (p.source `ne` src) span
+      case m: untpd.Modifiers =>
+        include(include(span, m.mods), m.annotations)
+      case y :: ys =>
+        include(include(span, y), ys)
+      case _ => span
+    }
+
+    (this: @unchecked) match {
+      case Trees.Inlined(call, _, _) =>
+        call.span
+      case tree: Trees.Select[?] =>
+        val qualifier = tree.qualifier
+        def includeQualifier(span: Span): Span =
+          if (qualifier.source `ne` src) span
           else
-            val pspan = p.span
+            val pspan = qualifier.span
             if (pspan.exists) {
-              if (span.exists) Span(span.start min pspan.start, span.end max pspan.end)
+              if (span.exists) Span(span.start min pspan.start, span.end max pspan.end, span.point)
               else pspan
             }
             else if (span.exists) {
               if (span.end != MaxOffset)
-                p.span = p.envelope(src, span.endPos)
+                qualifier.span = qualifier.envelope(src, span.endPos)
               span
             }
             else // No span available to assign yet, signal this by returning a span with MaxOffset end
               Span(MaxOffset, MaxOffset)
-        case m: untpd.Modifiers =>
-          include(include(span, m.mods), m.annotations)
-        case y :: ys =>
-          include(include(span, y), ys)
-        case _ => span
-      }
-      val limit = productArity
-      def includeChildren(span: Span, n: Int): Span =
-        if (n < limit) includeChildren(include(span, productElement(n): @unchecked), n + 1)
-        else span
-      val span1 = includeChildren(startSpan, 0)
-      val span2 =
-        if (!span1.exists || span1.end != MaxOffset)
-          span1
-        else if (span1.start == MaxOffset)
-          // No positioned child was found
-          NoSpan
-        else
-          ///println(s"revisit $uniqueId with $span1")
-          // We have some children left whose span could not be assigned.
-          // Go through it again with the known start position.
-          includeChildren(span1.startPos, 0)
-      span2.toSynthetic
+        val span1 = includeQualifier(startSpan)
+        val span2 =
+          if (!span1.exists || span1.end != MaxOffset)
+            span1
+          else if (span1.start == MaxOffset)
+            NoSpan
+          else
+            includeQualifier(span1.startPos)
+        span2.toSynthetic
+      case tree: Trees.ValDef[?] =>
+        def includeChildren(span: Span): Span =
+          include(include(span, tree.tpt), tree.unforcedRhs)
+        val span1 = includeChildren(startSpan)
+        val span2 =
+          if (!span1.exists || span1.end != MaxOffset)
+            span1
+          else if (span1.start == MaxOffset)
+            // No positioned child was found
+            NoSpan
+          else
+            includeChildren(span1.startPos)
+        span2.toSynthetic
+      case tree: Trees.DefDef[?] =>
+        def includeChildren(span: Span): Span =
+          include(include(include(span, tree.paramss), tree.tpt), tree.unforcedRhs)
+        val span1 = includeChildren(startSpan)
+        val span2 =
+          if (!span1.exists || span1.end != MaxOffset)
+            span1
+          else if (span1.start == MaxOffset)
+            // No positioned child was found
+            NoSpan
+          else
+            includeChildren(span1.startPos)
+        span2.toSynthetic
+      case tree: Trees.TypeDef[?] =>
+        def includeChildren(span: Span): Span =
+          include(span, tree.rhs)
+        val span1 = includeChildren(startSpan)
+        val span2 =
+          if (!span1.exists || span1.end != MaxOffset)
+            span1
+          else if (span1.start == MaxOffset)
+            // No positioned child was found
+            NoSpan
+          else
+            includeChildren(span1.startPos)
+        span2.toSynthetic
+      case tree: Trees.GenericApply[?] =>
+        def includeChildren(span: Span): Span =
+          include(include(span, tree.fun), tree.args)
+        val span1 = includeChildren(startSpan)
+        val span2 =
+          if (!span1.exists || span1.end != MaxOffset)
+            span1
+          else if (span1.start == MaxOffset)
+            // No positioned child was found
+            NoSpan
+          else
+            includeChildren(span1.startPos)
+        span2.toSynthetic
+      case tree: untpd.TypedSplice =>
+        def includeChildren(span: Span): Span =
+          include(span, tree.splice)
+        val span1 = includeChildren(startSpan)
+        val span2 =
+          if (!span1.exists || span1.end != MaxOffset)
+            span1
+          else if (span1.start == MaxOffset)
+            // No positioned child was found
+            NoSpan
+          else
+            includeChildren(span1.startPos)
+        span2.toSynthetic
+      case _ =>
+        val limit = productArity
+        def includeChildren(span: Span, n: Int): Span =
+          if (n < limit) includeChildren(include(span, productElement(n): @unchecked), n + 1)
+          else span
+        val span1 = includeChildren(startSpan, 0)
+        val span2 =
+          if (!span1.exists || span1.end != MaxOffset)
+            span1
+          else if (span1.start == MaxOffset)
+            // No positioned child was found
+            NoSpan
+          else
+            ///println(s"revisit $uniqueId with $span1")
+            // We have some children left whose span could not be assigned.
+            // Go through it again with the known start position.
+            includeChildren(span1.startPos, 0)
+        span2.toSynthetic
+    }
   }
 
   /** Clone this node but assign it a fresh id which marks it as a node in `file`. */

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -100,7 +100,7 @@ abstract class Positioned private[ast] (initialSpan: Positioned.InitialSpan)(imp
           else
             val pspan = p.span
             if (pspan.exists) {
-              if (span.exists) Span(span.start min pspan.start, span.end max pspan.end, span.point)
+              if (span.exists) Span(span.start min pspan.start, span.end max pspan.end)
               else pspan
             }
             else if (span.exists) {

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -17,8 +17,10 @@ import scala.compiletime.uninitialized
 
 /** A base class for things that have positions (currently: modifiers and trees)
  */
-abstract class Positioned(implicit @constructorOnly src: SourceFile) extends SrcPos, Product, Cloneable {
+abstract class Positioned private[ast] (initialSpan: Positioned.InitialSpan)(implicit @constructorOnly src: SourceFile) extends SrcPos, Product, Cloneable {
   import Positioned.{ids, nextId, debugId}
+
+  def this()(implicit src: SourceFile) = this(Positioned.ComputeSpan)(using src)
 
   private var mySpan: Span = uninitialized
 
@@ -47,7 +49,9 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
   def span_=(span: Span): Unit =
     mySpan = span
 
-  span = envelope(src)
+  span =
+    if initialSpan.coords == Positioned.ComputeSpan.coords then envelope(src)
+    else Span(initialSpan.coords)
 
   def source: SourceFile = mySource
 
@@ -239,6 +243,10 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
 }
 
 object Positioned {
+  private[ast] final class InitialSpan(val coords: Long) extends AnyVal
+  private[ast] val ComputeSpan: InitialSpan = new InitialSpan(Long.MinValue)
+  private[ast] def initialSpan(span: Span): InitialSpan = new InitialSpan(span.coords)
+
   @sharable private var debugId = Int.MinValue
   @sharable private var ids: java.util.WeakHashMap[Positioned, Int] | Null = null
   @sharable private var nextId: Int = 0

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -92,7 +92,7 @@ abstract class Positioned(implicit @constructorOnly src: SourceFile) extends Src
     case _ =>
       def include(span: Span, x: Any): Span = x match {
         case p: Positioned =>
-          if (p.source != src) span
+          if (p.source `ne` src) span
           else if (p.span.exists) span.union(p.span)
           else if (span.exists) {
             if (span.end != MaxOffset)

--- a/compiler/src/dotty/tools/dotc/ast/Positioned.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Positioned.scala
@@ -93,6 +93,32 @@ abstract class Positioned private[ast] (initialSpan: Positioned.InitialSpan)(imp
   def envelope(src: SourceFile, startSpan: Span = NoSpan): Span = (this: @unchecked) match {
     case Trees.Inlined(call, _, _) =>
       call.span
+    case tree: Trees.Select[?] =>
+      val qualifier = tree.qualifier
+      def includeQualifier(span: Span): Span =
+        if (qualifier.source `ne` src) span
+        else
+          val pspan = qualifier.span
+          if (pspan.exists) {
+            if (span.exists) Span(span.start min pspan.start, span.end max pspan.end, span.point)
+            else pspan
+          }
+          else if (span.exists) {
+            if (span.end != MaxOffset)
+              qualifier.span = qualifier.envelope(src, span.endPos)
+            span
+          }
+          else // No span available to assign yet, signal this by returning a span with MaxOffset end
+            Span(MaxOffset, MaxOffset)
+      val span1 = includeQualifier(startSpan)
+      val span2 =
+        if (!span1.exists || span1.end != MaxOffset)
+          span1
+        else if (span1.start == MaxOffset)
+          NoSpan
+        else
+          includeQualifier(span1.startPos)
+      span2.toSynthetic
     case _ =>
       def include(span: Span, x: Any): Span = x match {
         case p: Positioned =>

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -52,8 +52,10 @@ object Trees {
    *   - Type checking an untyped tree should remove all embedded `TypedSplice`
    *     nodes.
    */
-  abstract class Tree[+T <: Untyped](implicit @constructorOnly src: SourceFile)
-  extends Positioned, SrcPos, Product, Attachment.Container, printing.Showable {
+  abstract class Tree[+T <: Untyped] private[ast] (initialSpan: Positioned.InitialSpan)(implicit @constructorOnly src: SourceFile)
+  extends Positioned(initialSpan), SrcPos, Product, Attachment.Container, printing.Showable {
+
+    def this()(implicit src: SourceFile) = this(Positioned.ComputeSpan)(using src)
 
     if (Stats.enabled) ntrees += 1
 
@@ -281,7 +283,8 @@ object Trees {
   /** Tree's denot/isType/isTerm properties come from a subtree
    *  identified by `forwardTo`.
    */
-  abstract class ProxyTree[+T <: Untyped](implicit @constructorOnly src: SourceFile)  extends Tree[T] {
+  abstract class ProxyTree[+T <: Untyped] private[ast] (initialSpan: Positioned.InitialSpan)(implicit @constructorOnly src: SourceFile)  extends Tree[T](initialSpan) {
+    def this()(implicit src: SourceFile) = this(Positioned.ComputeSpan)(using src)
     type ThisTree[+T <: Untyped] <: ProxyTree[T]
     def forwardTo: Tree[T]
     override def denot(using Context): Denotation = forwardTo.denot
@@ -559,7 +562,8 @@ object Trees {
     def forwardTo: Tree[T] = qual
   }
 
-  abstract class GenericApply[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends ProxyTree[T] with TermTree[T] {
+  abstract class GenericApply[+T <: Untyped](implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+  extends ProxyTree[T](initialSpan) with TermTree[T] {
     type ThisTree[+T <: Untyped] <: GenericApply[T]
     val fun: Tree[T]
     val args: List[Tree[T]]
@@ -578,7 +582,7 @@ object Trees {
     case InfixTuple // r f (x1, ..., xN) where N != 1; needs to be treated specially for an error message in typedApply
 
   /** fun(args) */
-  case class Apply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class Apply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
     extends GenericApply[T] {
     type ThisTree[+T <: Untyped] = Apply[T]
 
@@ -594,7 +598,7 @@ object Trees {
   }
 
   /** fun[args] */
-  case class TypeApply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class TypeApply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
     extends GenericApply[T] {
     type ThisTree[+T <: Untyped] = TypeApply[T]
   }
@@ -631,8 +635,8 @@ object Trees {
   }
 
   /** { stats; expr } */
-  case class Block[+T <: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])(implicit @constructorOnly src: SourceFile)
-    extends Tree[T] {
+  case class Block[+T <: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) {
     type ThisTree[+T <: Untyped] = Block[T]
     override def isType: Boolean = expr.isType
     override def isTerm: Boolean = !isType // this will classify empty trees as terms, which is necessary
@@ -747,8 +751,8 @@ object Trees {
    *  different context: `bindings` represent the arguments to the inlined
    *  call, whereas `expansion` represents the body of the inlined function.
    */
-  case class Inlined[+T <: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile)
-    extends Tree[T] {
+  case class Inlined[+T <: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) {
 
     def inlinedFromOuterScope: Boolean = call eq theEmptyTree
 
@@ -776,8 +780,8 @@ object Trees {
    *  @param  body  The tree that was quoted
    *  @param  tags  Term references to instances of `Type[T]` for `T`s that are used in the quote
    */
-  case class Quote[+T <: Untyped] private[ast] (body: Tree[T], tags: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
-    extends TermTree[T] {
+  case class Quote[+T <: Untyped] private[ast] (body: Tree[T], tags: List[Tree[T]])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) with TermTree[T] {
     type ThisTree[+T <: Untyped] = Quote[T]
 
     /** Is this a type quote `'[tpe]' */
@@ -805,8 +809,8 @@ object Trees {
    *
    *  @param expr The tree that was spliced
    */
-  case class Splice[+T <: Untyped] private[ast] (expr: Tree[T])(implicit @constructorOnly src: SourceFile)
-    extends TermTree[T] {
+  case class Splice[+T <: Untyped] private[ast] (expr: Tree[T])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) with TermTree[T] {
     type ThisTree[+T <: Untyped] = Splice[T]
   }
 
@@ -1333,6 +1337,20 @@ object Trees {
         Stats.record(s"TreeCopier.finalize/${tree.getClass == copied.getClass}")
         postProcess(tree, copied.withSpan(tree.span).withAttachmentsFrom(tree))
 
+      protected def finalizeKnownSpan(tree: Tree, copied: untpd.Tree): copied.ThisTree[T] =
+        Stats.record(s"TreeCopier.finalize/${tree.getClass == copied.getClass}")
+        postProcess(tree, copied.withAttachmentsFrom(tree))
+
+      private def childHasSpanOrForeignSource(src: SourceFile, child: Trees.Tree[?]): Boolean =
+        (child.source ne src) || child.span.exists
+
+      private def childrenHaveSpansOrForeignSource(src: SourceFile, children: List[? <: Trees.Tree[?]]): Boolean =
+        var rest = children
+        while rest.nonEmpty do
+          if !childHasSpanOrForeignSource(src, rest.head) then return false
+          rest = rest.tail
+        true
+
       def Ident(tree: Tree)(name: Name)(using Context): Ident = tree match {
         case tree: Ident if name == tree.name => tree
         case _ => finalize(tree, untpd.Ident(name)(using sourceFile(tree)))
@@ -1360,12 +1378,22 @@ object Trees {
       }
       def Apply(tree: Tree)(fun: Tree, args: List[Tree])(using Context): Apply = tree match {
         case tree: Apply if (fun eq tree.fun) && (args eq tree.args) => tree
-        case _ => finalize(tree, untpd.Apply(fun, args)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, fun) && childrenHaveSpansOrForeignSource(src, args) then
+            finalizeKnownSpan(tree, untpd.Apply(fun, args, tree.span)(using src))
+          else
+            finalize(tree, untpd.Apply(fun, args)(using src))
             //.ensuring(res => res.uniqueId != 2213, s"source = $tree, ${tree.uniqueId}, ${tree.span}")
       }
       def TypeApply(tree: Tree)(fun: Tree, args: List[Tree])(using Context): TypeApply = tree match {
         case tree: TypeApply if (fun eq tree.fun) && (args eq tree.args) => tree
-        case _ => finalize(tree, untpd.TypeApply(fun, args)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, fun) && childrenHaveSpansOrForeignSource(src, args) then
+            finalizeKnownSpan(tree, untpd.TypeApply(fun, args, tree.span)(using src))
+          else
+            finalize(tree, untpd.TypeApply(fun, args)(using src))
       }
       def Literal(tree: Tree)(const: Constant)(using Context): Literal = tree match {
         case tree: Literal if const == tree.const => tree
@@ -1389,7 +1417,12 @@ object Trees {
       }
       def Block(tree: Tree)(stats: List[Tree], expr: Tree)(using Context): Block = tree match {
         case tree: Block if (stats eq tree.stats) && (expr eq tree.expr) => tree
-        case _ => finalize(tree, untpd.Block(stats, expr)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childrenHaveSpansOrForeignSource(src, stats) && childHasSpanOrForeignSource(src, expr) then
+            finalizeKnownSpan(tree, untpd.Block(stats, expr, tree.span)(using src))
+          else
+            finalize(tree, untpd.Block(stats, expr)(using src))
       }
       def If(tree: Tree)(cond: Tree, thenp: Tree, elsep: Tree)(using Context): If = tree match {
         case tree: If if (cond eq tree.cond) && (thenp eq tree.thenp) && (elsep eq tree.elsep) => tree
@@ -1442,15 +1475,26 @@ object Trees {
           val expansionWithSpan =
             if expansion.span.exists then expansion
             else expansion.withSpan(tree.expansion.span)
-          finalize(tree, untpd.Inlined(call, bindings, expansionWithSpan)(using sourceFile(tree)))
+          val src = sourceFile(tree)
+          finalizeKnownSpan(tree, untpd.Inlined(call, bindings, expansionWithSpan, tree.span)(using src))
 
       def Quote(tree: Tree)(body: Tree, tags: List[Tree])(using Context): Quote = tree match {
         case tree: Quote if (body eq tree.body) && (tags eq tree.tags) => tree
-        case _ => finalize(tree, untpd.Quote(body, tags)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, body) && childrenHaveSpansOrForeignSource(src, tags) then
+            finalizeKnownSpan(tree, untpd.Quote(body, tags, tree.span)(using src))
+          else
+            finalize(tree, untpd.Quote(body, tags)(using src))
       }
       def Splice(tree: Tree)(expr: Tree)(using Context): Splice = tree match {
         case tree: Splice if (expr eq tree.expr) => tree
-        case _ => finalize(tree, untpd.Splice(expr)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, expr) then
+            finalizeKnownSpan(tree, untpd.Splice(expr, tree.span)(using src))
+          else
+            finalize(tree, untpd.Splice(expr)(using src))
       }
       def QuotePattern(tree: Tree)(bindings: List[Tree], body: Tree, quotes: Tree)(using Context): QuotePattern = tree match {
         case tree: QuotePattern if (bindings eq tree.bindings) && (body eq tree.body) && (quotes eq tree.quotes) => tree

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -749,7 +749,7 @@ object Trees {
   case class Inlined[+T <: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] {
 
-    def inlinedFromOuterScope: Boolean = call.isEmpty
+    def inlinedFromOuterScope: Boolean = call eq theEmptyTree
 
     type ThisTree[+T <: Untyped] = Inlined[T]
     override def isTerm = expansion.isTerm

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -147,7 +147,7 @@ object Trees {
     def denot(using Context): Denotation = NoDenotation
 
     /** Shorthand for `denot.symbol`. */
-    final def symbol(using Context): Symbol = denot.symbol
+    def symbol(using Context): Symbol = denot.symbol
 
     /** The owner to install when running a MegaPhase transform under this tree.
      *  Equal to `symbol` for every tree except `PackageDef`, which folds in the
@@ -487,6 +487,18 @@ object Trees {
         case tpe: ThisType => tpe.cls.denot
         case _ => NoDenotation
 
+    // Symbol-side fast path: when the cached NamedType denotation is valid for the
+    // current period (the same gate `NamedType.denot` uses, looser than the strict
+    // `checkedPeriod == ctx.period` gate in `NamedType.symbol`), skip the full
+    // denot-then-`.symbol` indirection and read the cached symbol directly.
+    // Falls back bit-for-bit to `denot.symbol` on a cache miss or non-NamedType
+    // type, preserving the ConstantType / stripped fallbacks in `denotSlowPath`.
+    override def symbol(using Context): Symbol = typeOpt match
+      case tpe: NamedType =>
+        val s = tpe.cachedSymbolOrNull
+        if s != null then s else denot.symbol
+      case _ => denot.symbol
+
     def nameSpan(using Context): Span =
       if span.exists then
         val point = span.point
@@ -520,6 +532,18 @@ object Trees {
         case _ =>
           super.denot
       }
+    // Symbol-side fast path: avoid the `asSeenFrom` allocation and full denot path
+    // for the common case where we only need the symbol. For Module TermRefs we
+    // return the moduleClass directly (matching the denot.symbol above); for
+    // ThisType / non-module NamedType we use the cached-symbol fast path.
+    override def symbol(using Context): Symbol = typeOpt match
+      case tpe: ThisType => tpe.cls
+      case tpe: NamedType =>
+        val s = tpe.cachedSymbolOrNull
+        if s == null then denot.symbol
+        else if s.is(Module) then s.moduleClass
+        else s
+      case _ => denot.symbol
   }
 
   /** C.super[mix], where qual = C.this */

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -465,6 +465,12 @@ object Trees {
     type ThisTree[+T <: Untyped] = Ident[T]
     def qualifier: Tree[T] = genericEmptyTree
 
+    override def symbol(using Context): Symbol = typeOpt match
+      case tpe: NamedType =>
+        val s = tpe.cachedSymbolOrNull
+        if s != null then s else denot.symbol
+      case _ => denot.symbol
+
     def isBackquoted: Boolean = hasAttachment(Backquoted)
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -149,6 +149,13 @@ object Trees {
     /** Shorthand for `denot.symbol`. */
     final def symbol(using Context): Symbol = denot.symbol
 
+    /** The owner to install when running a MegaPhase transform under this tree.
+     *  Equal to `symbol` for every tree except `PackageDef`, which folds in the
+     *  `PackageVal -> moduleClass` adjustment that `MegaPhase.inLocalContext`
+     *  used to perform on every ValDef/DefDef/TypeDef.
+     */
+    def localCtxOwner(using Context): Symbol = symbol
+
     /** Does this tree represent a type? */
     def isType: Boolean = false
 
@@ -374,6 +381,10 @@ object Trees {
   abstract class NamedDefTree[+T <: Untyped](implicit @constructorOnly src: SourceFile)
   extends NameTree[T] with DefTree[T] with WithEndMarker[T] {
     type ThisTree[+T <: Untyped] <: NamedDefTree[T]
+
+    override def localCtxOwner(using Context): Symbol = typeOpt match
+      case tpe: ThisType => tpe.cls
+      case _ => symbol
 
     protected def srcName(using Context): Name =
       if name == nme.CONSTRUCTOR then nme.this_
@@ -1049,6 +1060,9 @@ object Trees {
     type ThisTree[+T <: Untyped] = PackageDef[T]
     def forwardTo: RefTree[T] = pid
     protected def srcName(using Context): Name = pid.name
+    override def localCtxOwner(using Context): Symbol =
+      val sym = symbol
+      if sym.is(PackageVal) then sym.moduleClass else sym
   }
 
   /** arg @annot */

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -121,9 +121,10 @@ object Trees {
           }
 
     def withTypeUnchecked(tpe: Type): ThisTree[Type] = {
+      if myTpe.asInstanceOf[AnyRef] eq tpe.asInstanceOf[AnyRef] then
+        return this.asInstanceOf[ThisTree[Type]]
       val tree =
-        (if (myTpe == null ||
-          (myTpe.asInstanceOf[AnyRef] eq tpe.asInstanceOf[AnyRef])) this
+        (if (myTpe == null) this
          else cloneIn(source)).asInstanceOf[Tree[Type]]
       tree.overwriteType(tpe)
       tree.asInstanceOf[ThisTree[Type]]

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -284,6 +284,11 @@ object Trees {
     type ThisTree[+T <: Untyped] <: ProxyTree[T]
     def forwardTo: Tree[T]
     override def denot(using Context): Denotation = forwardTo.denot
+    // Symbol-side fast path: forward directly to `forwardTo.symbol` instead of
+    // routing through `denot.symbol`, so that any `symbol` override on the
+    // forwardTo target (e.g. Select.symbol's cached-symbol fast path) applies
+    // to Apply / TypeApply / Typed / Annotated reads as well.
+    override def symbol(using Context): Symbol = forwardTo.symbol
     override def isTerm: Boolean = forwardTo.isTerm
     override def isType: Boolean = forwardTo.isType
   }

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -257,10 +257,17 @@ object Trees {
   /** Tree's denotation can be derived from its type */
   abstract class DenotingTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends Tree[T] {
     type ThisTree[+T <: Untyped] <: DenotingTree[T]
-    override def denot(using Context): Denotation = typeOpt.stripped match
+    // Fast path: inline the common NamedType / ThisType cases of typeOpt
+    // so JIT keeps the body inlineable, avoiding the megamorphic virtual
+    // `stripped` dispatch on every denot read.
+    override def denot(using Context): Denotation = typeOpt match
       case tpe: NamedType => tpe.denot
       case tpe: ThisType => tpe.cls.denot
-      case _ => NoDenotation
+      case NoType => NoDenotation
+      case tpe => tpe.stripped match
+        case tpe: NamedType => tpe.denot
+        case tpe: ThisType => tpe.cls.denot
+        case _ => NoDenotation
   }
 
   /** Tree's denot/isType/isTerm properties come from a subtree
@@ -452,12 +459,22 @@ object Trees {
     extends RefTree[T] {
     type ThisTree[+T <: Untyped] = Select[T]
 
+    // iter46 D-#1: inline the DenotingTree.denot common path so JIT keeps Select.denot
+    // within its inline budget. ConstantType + stripped fallbacks live in denotSlowPath.
     override def denot(using Context): Denotation = typeOpt match
+      case tpe: NamedType => tpe.denot
+      case tpe: ThisType => tpe.cls.denot
+      case NoType => NoDenotation
+      case _ => denotSlowPath
+
+    private def denotSlowPath(using Context): Denotation = typeOpt match
       case ConstantType(_) if ConstFold.foldedUnops.contains(name) =>
         // Recover the denotation of a constant-folded selection
         qualifier.typeOpt.member(name).atSignature(Signature.NotAMethod, name)
-      case _ =>
-        super.denot
+      case tpe => tpe.stripped match
+        case tpe: NamedType => tpe.denot
+        case tpe: ThisType => tpe.cls.denot
+        case _ => NoDenotation
 
     def nameSpan(using Context): Span =
       if span.exists then
@@ -1538,6 +1555,20 @@ object Trees {
 
     abstract class TreeMap(val cpy: TreeCopier = inst.cpy) { self =>
       def transform(tree: Tree)(using Context): Tree = {
+        // iter4 opt-03: leaf-tree shortcut. For Ident/Literal/This/TypeTree
+        // the slow-path body is just `tree` (no children to recurse into),
+        // so when transformCtx would have returned ctx unchanged
+        // (i.e. tree.source eq ctx.source, or no source) and skipTransform
+        // is false (its default), we can skip the inContext+transformCtx
+        // wrapper entirely. Mirrors MegaPhase's f02474360f leaf shortcut.
+        if ((tree.isInstanceOf[Ident @unchecked]
+              || tree.isInstanceOf[Literal @unchecked]
+              || tree.isInstanceOf[This @unchecked]
+              || tree.isInstanceOf[TypeTree @unchecked])
+            && ((tree.source `eq` ctx.source) || !tree.source.exists)
+            && !skipTransform(tree))
+          tree
+        else
         inContext(transformCtx(tree)) {
           Stats.record(s"TreeMap.transform/$getClass")
           if (skipTransform(tree)) tree
@@ -1684,7 +1715,19 @@ object Trees {
         fold(x, trees)
 
       def foldOver(x: X, tree: Tree)(using Context): X =
-        if ((tree.source `ne` ctx.source) && tree.source.exists)
+        // iter3 opt-3: leaf-tree shortcut. For Ident/Literal/This/TypeTree
+        // the slow-path body is just `x` (no children to fold), so when the
+        // source-switch branch would not have fired (tree.source eq ctx.source,
+        // or no source) we can return `x` directly and skip the Stats.record
+        // + pattern match. Symmetric analogue of 8f9f1f43d0 (TreeMap leaf
+        // shortcut).
+        if ((tree.isInstanceOf[Ident @unchecked]
+              || tree.isInstanceOf[Literal @unchecked]
+              || tree.isInstanceOf[This @unchecked]
+              || tree.isInstanceOf[TypeTree @unchecked])
+            && ((tree.source `eq` ctx.source) || !tree.source.exists))
+          x
+        else if ((tree.source `ne` ctx.source) && tree.source.exists)
           foldOver(x, tree)(using ctx.withSource(tree.source))
         else {
           Stats.record(s"TreeAccumulator.foldOver/$getClass")

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1155,10 +1155,13 @@ object Trees {
    */
   trait WithLazyFields:
 
-    /** If `x` is lazy, computes the underlying value */
-    protected def force[T <: AnyRef](x: T | Lazy[T])(using Context): T = x match
-      case x: Lazy[T] @unchecked => x.complete
-      case x: T @unchecked => x
+    /** If `x` is lazy, computes the underlying value.
+     *  Inlined so the hot path (already-forced Tree) avoids the pattern-match
+     *  overhead from `force`'s 0.14 self / 0.27 tot profile share.
+     */
+    protected inline def force[T <: AnyRef](x: T | Lazy[T])(using Context): T =
+      if x.isInstanceOf[Lazy[?]] then x.asInstanceOf[Lazy[T]].complete
+      else x.asInstanceOf[T]
 
     /** Assigns all lazy fields their underlying non-lazy value. */
     def forceFields()(using Context): Unit

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1527,7 +1527,7 @@ object Trees {
       */
     def transformCtx(tree: Tree)(using Context): Context =
       val sourced =
-        if tree.source.exists && tree.source != ctx.source
+        if tree.source.exists && (tree.source `ne` ctx.source)
         then ctx.withSource(tree.source)
         else ctx
       tree match
@@ -1684,7 +1684,7 @@ object Trees {
         fold(x, trees)
 
       def foldOver(x: X, tree: Tree)(using Context): X =
-        if (tree.source != ctx.source && tree.source.exists)
+        if ((tree.source `ne` ctx.source) && tree.source.exists)
           foldOver(x, tree)(using ctx.withSource(tree.source))
         else {
           Stats.record(s"TreeAccumulator.foldOver/$getClass")

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1533,7 +1533,7 @@ object Trees {
       */
     def transformCtx(tree: Tree)(using Context): Context =
       val sourced =
-        if tree.source.exists && tree.source != ctx.source
+        if tree.source.exists && (tree.source `ne` ctx.source)
         then ctx.withSource(tree.source)
         else ctx
       tree match
@@ -1690,7 +1690,7 @@ object Trees {
         fold(x, trees)
 
       def foldOver(x: X, tree: Tree)(using Context): X = ctx.handleRecursive("folding over", tree):
-        if (tree.source != ctx.source && tree.source.exists)
+        if ((tree.source `ne` ctx.source) && tree.source.exists)
           foldOver(x, tree)(using ctx.withSource(tree.source))
         else {
           Stats.record(s"TreeAccumulator.foldOver/$getClass")

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -467,6 +467,12 @@ object Trees {
     type ThisTree[+T <: Untyped] = Ident[T]
     def qualifier: Tree[T] = genericEmptyTree
 
+    override def symbol(using Context): Symbol = typeOpt match
+      case tpe: NamedType =>
+        val s = tpe.cachedSymbolOrNull
+        if s != null then s else denot.symbol
+      case _ => denot.symbol
+
     def isBackquoted: Boolean = hasAttachment(Backquoted)
   }
 

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -755,7 +755,7 @@ object Trees {
   case class Inlined[+T <: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile)
     extends Tree[T] {
 
-    def inlinedFromOuterScope: Boolean = call.isEmpty
+    def inlinedFromOuterScope: Boolean = call eq theEmptyTree
 
     type ThisTree[+T <: Untyped] = Inlined[T]
     override def isTerm = expansion.isTerm

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -147,7 +147,7 @@ object Trees {
     def denot(using Context): Denotation = NoDenotation
 
     /** Shorthand for `denot.symbol`. */
-    final def symbol(using Context): Symbol = denot.symbol
+    def symbol(using Context): Symbol = denot.symbol
 
     /** The owner to install when running a MegaPhase transform under this tree.
      *  Equal to `symbol` for every tree except `PackageDef`, which folds in the
@@ -489,6 +489,18 @@ object Trees {
         case tpe: ThisType => tpe.cls.denot
         case _ => NoDenotation
 
+    // Symbol-side fast path: when the cached NamedType denotation is valid for the
+    // current period (the same gate `NamedType.denot` uses, looser than the strict
+    // `checkedPeriod == ctx.period` gate in `NamedType.symbol`), skip the full
+    // denot-then-`.symbol` indirection and read the cached symbol directly.
+    // Falls back bit-for-bit to `denot.symbol` on a cache miss or non-NamedType
+    // type, preserving the ConstantType / stripped fallbacks in `denotSlowPath`.
+    override def symbol(using Context): Symbol = typeOpt match
+      case tpe: NamedType =>
+        val s = tpe.cachedSymbolOrNull
+        if s != null then s else denot.symbol
+      case _ => denot.symbol
+
     def nameSpan(using Context): Span =
       if span.exists then
         val point = span.point
@@ -522,6 +534,18 @@ object Trees {
         case _ =>
           super.denot
       }
+    // Symbol-side fast path: avoid the `asSeenFrom` allocation and full denot path
+    // for the common case where we only need the symbol. For Module TermRefs we
+    // return the moduleClass directly (matching the denot.symbol above); for
+    // ThisType / non-module NamedType we use the cached-symbol fast path.
+    override def symbol(using Context): Symbol = typeOpt match
+      case tpe: ThisType => tpe.cls
+      case tpe: NamedType =>
+        val s = tpe.cachedSymbolOrNull
+        if s == null then denot.symbol
+        else if s.is(Module) then s.moduleClass
+        else s
+      case _ => denot.symbol
   }
 
   /** C.super[mix], where qual = C.this */

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -1161,10 +1161,13 @@ object Trees {
    */
   trait WithLazyFields:
 
-    /** If `x` is lazy, computes the underlying value */
-    protected def force[T <: AnyRef](x: T | Lazy[T])(using Context): T = x match
-      case x: Lazy[T] @unchecked => x.complete
-      case x: T @unchecked => x
+    /** If `x` is lazy, computes the underlying value.
+     *  Inlined so the hot path (already-forced Tree) avoids the pattern-match
+     *  overhead from `force`'s 0.14 self / 0.27 tot profile share.
+     */
+    protected inline def force[T <: AnyRef](x: T | Lazy[T])(using Context): T =
+      if x.isInstanceOf[Lazy[?]] then x.asInstanceOf[Lazy[T]].complete
+      else x.asInstanceOf[T]
 
     /** Assigns all lazy fields their underlying non-lazy value. */
     def forceFields()(using Context): Unit

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -52,8 +52,10 @@ object Trees {
    *   - Type checking an untyped tree should remove all embedded `TypedSplice`
    *     nodes.
    */
-  abstract class Tree[+T <: Untyped](implicit @constructorOnly src: SourceFile)
-  extends Positioned, SrcPos, Product, Attachment.Container, printing.Showable {
+  abstract class Tree[+T <: Untyped] private[ast] (initialSpan: Positioned.InitialSpan)(implicit @constructorOnly src: SourceFile)
+  extends Positioned(initialSpan), SrcPos, Product, Attachment.Container, printing.Showable {
+
+    def this()(implicit src: SourceFile) = this(Positioned.ComputeSpan)(using src)
 
     if (Stats.enabled) ntrees += 1
 
@@ -281,7 +283,8 @@ object Trees {
   /** Tree's denot/isType/isTerm properties come from a subtree
    *  identified by `forwardTo`.
    */
-  abstract class ProxyTree[+T <: Untyped](implicit @constructorOnly src: SourceFile)  extends Tree[T] {
+  abstract class ProxyTree[+T <: Untyped] private[ast] (initialSpan: Positioned.InitialSpan)(implicit @constructorOnly src: SourceFile)  extends Tree[T](initialSpan) {
+    def this()(implicit src: SourceFile) = this(Positioned.ComputeSpan)(using src)
     type ThisTree[+T <: Untyped] <: ProxyTree[T]
     def forwardTo: Tree[T]
     override def denot(using Context): Denotation = forwardTo.denot
@@ -561,7 +564,8 @@ object Trees {
     def forwardTo: Tree[T] = qual
   }
 
-  abstract class GenericApply[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends ProxyTree[T] with TermTree[T] {
+  abstract class GenericApply[+T <: Untyped](implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+  extends ProxyTree[T](initialSpan) with TermTree[T] {
     type ThisTree[+T <: Untyped] <: GenericApply[T]
     val fun: Tree[T]
     val args: List[Tree[T]]
@@ -580,7 +584,7 @@ object Trees {
     case InfixTuple // r f (x1, ..., xN) where N != 1; needs to be treated specially for an error message in typedApply
 
   /** fun(args) */
-  case class Apply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class Apply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
     extends GenericApply[T] {
     type ThisTree[+T <: Untyped] = Apply[T]
 
@@ -600,7 +604,7 @@ object Trees {
   }
 
   /** fun[args] */
-  case class TypeApply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
+  case class TypeApply[+T <: Untyped] private[ast] (fun: Tree[T], args: List[Tree[T]])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
     extends GenericApply[T] {
     type ThisTree[+T <: Untyped] = TypeApply[T]
   }
@@ -637,8 +641,8 @@ object Trees {
   }
 
   /** { stats; expr } */
-  case class Block[+T <: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])(implicit @constructorOnly src: SourceFile)
-    extends Tree[T] {
+  case class Block[+T <: Untyped] private[ast] (stats: List[Tree[T]], expr: Tree[T])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) {
     type ThisTree[+T <: Untyped] = Block[T]
     override def isType: Boolean = expr.isType
     override def isTerm: Boolean = !isType // this will classify empty trees as terms, which is necessary
@@ -753,8 +757,8 @@ object Trees {
    *  different context: `bindings` represent the arguments to the inlined
    *  call, whereas `expansion` represents the body of the inlined function.
    */
-  case class Inlined[+T <: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile)
-    extends Tree[T] {
+  case class Inlined[+T <: Untyped] private[ast] (call: tpd.Tree, bindings: List[MemberDef[T]], expansion: Tree[T])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) {
 
     def inlinedFromOuterScope: Boolean = call eq theEmptyTree
 
@@ -782,8 +786,8 @@ object Trees {
    *  @param  body  The tree that was quoted
    *  @param  tags  Term references to instances of `Type[T]` for `T`s that are used in the quote
    */
-  case class Quote[+T <: Untyped] private[ast] (body: Tree[T], tags: List[Tree[T]])(implicit @constructorOnly src: SourceFile)
-    extends TermTree[T] {
+  case class Quote[+T <: Untyped] private[ast] (body: Tree[T], tags: List[Tree[T]])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) with TermTree[T] {
     type ThisTree[+T <: Untyped] = Quote[T]
 
     /** Is this a type quote `'[tpe]' */
@@ -811,8 +815,8 @@ object Trees {
    *
    *  @param expr The tree that was spliced
    */
-  case class Splice[+T <: Untyped] private[ast] (expr: Tree[T])(implicit @constructorOnly src: SourceFile)
-    extends TermTree[T] {
+  case class Splice[+T <: Untyped] private[ast] (expr: Tree[T])(implicit @constructorOnly src: SourceFile, @constructorOnly initialSpan: Positioned.InitialSpan = Positioned.ComputeSpan)
+    extends Tree[T](initialSpan) with TermTree[T] {
     type ThisTree[+T <: Untyped] = Splice[T]
   }
 
@@ -1339,6 +1343,20 @@ object Trees {
         Stats.record(s"TreeCopier.finalize/${tree.getClass == copied.getClass}")
         postProcess(tree, copied.withSpan(tree.span).withAttachmentsFrom(tree))
 
+      protected def finalizeKnownSpan(tree: Tree, copied: untpd.Tree): copied.ThisTree[T] =
+        Stats.record(s"TreeCopier.finalize/${tree.getClass == copied.getClass}")
+        postProcess(tree, copied.withAttachmentsFrom(tree))
+
+      private def childHasSpanOrForeignSource(src: SourceFile, child: Trees.Tree[?]): Boolean =
+        (child.source ne src) || child.span.exists
+
+      private def childrenHaveSpansOrForeignSource(src: SourceFile, children: List[? <: Trees.Tree[?]]): Boolean =
+        var rest = children
+        while rest.nonEmpty do
+          if !childHasSpanOrForeignSource(src, rest.head) then return false
+          rest = rest.tail
+        true
+
       def Ident(tree: Tree)(name: Name)(using Context): Ident = tree match {
         case tree: Ident if name == tree.name => tree
         case _ => finalize(tree, untpd.Ident(name)(using sourceFile(tree)))
@@ -1366,12 +1384,22 @@ object Trees {
       }
       def Apply(tree: Tree)(fun: Tree, args: List[Tree])(using Context): Apply = tree match {
         case tree: Apply if (fun eq tree.fun) && (args eq tree.args) => tree
-        case _ => finalize(tree, untpd.Apply(fun, args)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, fun) && childrenHaveSpansOrForeignSource(src, args) then
+            finalizeKnownSpan(tree, untpd.Apply(fun, args, tree.span)(using src))
+          else
+            finalize(tree, untpd.Apply(fun, args)(using src))
             //.ensuring(res => res.uniqueId != 2213, s"source = $tree, ${tree.uniqueId}, ${tree.span}")
       }
       def TypeApply(tree: Tree)(fun: Tree, args: List[Tree])(using Context): TypeApply = tree match {
         case tree: TypeApply if (fun eq tree.fun) && (args eq tree.args) => tree
-        case _ => finalize(tree, untpd.TypeApply(fun, args)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, fun) && childrenHaveSpansOrForeignSource(src, args) then
+            finalizeKnownSpan(tree, untpd.TypeApply(fun, args, tree.span)(using src))
+          else
+            finalize(tree, untpd.TypeApply(fun, args)(using src))
       }
       def Literal(tree: Tree)(const: Constant)(using Context): Literal = tree match {
         case tree: Literal if const == tree.const => tree
@@ -1395,7 +1423,12 @@ object Trees {
       }
       def Block(tree: Tree)(stats: List[Tree], expr: Tree)(using Context): Block = tree match {
         case tree: Block if (stats eq tree.stats) && (expr eq tree.expr) => tree
-        case _ => finalize(tree, untpd.Block(stats, expr)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childrenHaveSpansOrForeignSource(src, stats) && childHasSpanOrForeignSource(src, expr) then
+            finalizeKnownSpan(tree, untpd.Block(stats, expr, tree.span)(using src))
+          else
+            finalize(tree, untpd.Block(stats, expr)(using src))
       }
       def If(tree: Tree)(cond: Tree, thenp: Tree, elsep: Tree)(using Context): If = tree match {
         case tree: If if (cond eq tree.cond) && (thenp eq tree.thenp) && (elsep eq tree.elsep) => tree
@@ -1448,15 +1481,26 @@ object Trees {
           val expansionWithSpan =
             if expansion.span.exists then expansion
             else expansion.withSpan(tree.expansion.span)
-          finalize(tree, untpd.Inlined(call, bindings, expansionWithSpan)(using sourceFile(tree)))
+          val src = sourceFile(tree)
+          finalizeKnownSpan(tree, untpd.Inlined(call, bindings, expansionWithSpan, tree.span)(using src))
 
       def Quote(tree: Tree)(body: Tree, tags: List[Tree])(using Context): Quote = tree match {
         case tree: Quote if (body eq tree.body) && (tags eq tree.tags) => tree
-        case _ => finalize(tree, untpd.Quote(body, tags)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, body) && childrenHaveSpansOrForeignSource(src, tags) then
+            finalizeKnownSpan(tree, untpd.Quote(body, tags, tree.span)(using src))
+          else
+            finalize(tree, untpd.Quote(body, tags)(using src))
       }
       def Splice(tree: Tree)(expr: Tree)(using Context): Splice = tree match {
         case tree: Splice if (expr eq tree.expr) => tree
-        case _ => finalize(tree, untpd.Splice(expr)(using sourceFile(tree)))
+        case _ =>
+          val src = sourceFile(tree)
+          if childHasSpanOrForeignSource(src, expr) then
+            finalizeKnownSpan(tree, untpd.Splice(expr, tree.span)(using src))
+          else
+            finalize(tree, untpd.Splice(expr)(using src))
       }
       def QuotePattern(tree: Tree)(bindings: List[Tree], body: Tree, quotes: Tree)(using Context): QuotePattern = tree match {
         case tree: QuotePattern if (bindings eq tree.bindings) && (body eq tree.body) && (quotes eq tree.quotes) => tree

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -257,10 +257,17 @@ object Trees {
   /** Tree's denotation can be derived from its type */
   abstract class DenotingTree[+T <: Untyped](implicit @constructorOnly src: SourceFile) extends Tree[T] {
     type ThisTree[+T <: Untyped] <: DenotingTree[T]
-    override def denot(using Context): Denotation = typeOpt.stripped match
+    // Fast path: inline the common NamedType / ThisType cases of typeOpt
+    // so JIT keeps the body inlineable, avoiding the megamorphic virtual
+    // `stripped` dispatch on every denot read.
+    override def denot(using Context): Denotation = typeOpt match
       case tpe: NamedType => tpe.denot
       case tpe: ThisType => tpe.cls.denot
-      case _ => NoDenotation
+      case NoType => NoDenotation
+      case tpe => tpe.stripped match
+        case tpe: NamedType => tpe.denot
+        case tpe: ThisType => tpe.cls.denot
+        case _ => NoDenotation
   }
 
   /** Tree's denot/isType/isTerm properties come from a subtree
@@ -454,12 +461,22 @@ object Trees {
     extends RefTree[T] {
     type ThisTree[+T <: Untyped] = Select[T]
 
+    // iter46 D-#1: inline the DenotingTree.denot common path so JIT keeps Select.denot
+    // within its inline budget. ConstantType + stripped fallbacks live in denotSlowPath.
     override def denot(using Context): Denotation = typeOpt match
+      case tpe: NamedType => tpe.denot
+      case tpe: ThisType => tpe.cls.denot
+      case NoType => NoDenotation
+      case _ => denotSlowPath
+
+    private def denotSlowPath(using Context): Denotation = typeOpt match
       case ConstantType(_) if ConstFold.foldedUnops.contains(name) =>
         // Recover the denotation of a constant-folded selection
         qualifier.typeOpt.member(name).atSignature(Signature.NotAMethod, name)
-      case _ =>
-        super.denot
+      case tpe => tpe.stripped match
+        case tpe: NamedType => tpe.denot
+        case tpe: ThisType => tpe.cls.denot
+        case _ => NoDenotation
 
     def nameSpan(using Context): Span =
       if span.exists then
@@ -1544,6 +1561,20 @@ object Trees {
 
     abstract class TreeMap(val cpy: TreeCopier = inst.cpy) { self =>
       def transform(tree: Tree)(using Context): Tree = {
+        // iter4 opt-03: leaf-tree shortcut. For Ident/Literal/This/TypeTree
+        // the slow-path body is just `tree` (no children to recurse into),
+        // so when transformCtx would have returned ctx unchanged
+        // (i.e. tree.source eq ctx.source, or no source) and skipTransform
+        // is false (its default), we can skip the inContext+transformCtx
+        // wrapper entirely. Mirrors MegaPhase's f02474360f leaf shortcut.
+        if ((tree.isInstanceOf[Ident @unchecked]
+              || tree.isInstanceOf[Literal @unchecked]
+              || tree.isInstanceOf[This @unchecked]
+              || tree.isInstanceOf[TypeTree @unchecked])
+            && ((tree.source `eq` ctx.source) || !tree.source.exists)
+            && !skipTransform(tree))
+          tree
+        else
         inContext(transformCtx(tree)) {
           Stats.record(s"TreeMap.transform/$getClass")
           if (skipTransform(tree)) tree
@@ -1690,7 +1721,19 @@ object Trees {
         fold(x, trees)
 
       def foldOver(x: X, tree: Tree)(using Context): X = ctx.handleRecursive("folding over", tree):
-        if ((tree.source `ne` ctx.source) && tree.source.exists)
+        // iter3 opt-3: leaf-tree shortcut. For Ident/Literal/This/TypeTree
+        // the slow-path body is just `x` (no children to fold), so when the
+        // source-switch branch would not have fired (tree.source eq ctx.source,
+        // or no source) we can return `x` directly and skip the Stats.record
+        // + pattern match. Symmetric analogue of 8f9f1f43d0 (TreeMap leaf
+        // shortcut).
+        if ((tree.isInstanceOf[Ident @unchecked]
+              || tree.isInstanceOf[Literal @unchecked]
+              || tree.isInstanceOf[This @unchecked]
+              || tree.isInstanceOf[TypeTree @unchecked])
+            && ((tree.source `eq` ctx.source) || !tree.source.exists))
+          x
+        else if ((tree.source `ne` ctx.source) && tree.source.exists)
           foldOver(x, tree)(using ctx.withSource(tree.source))
         else {
           Stats.record(s"TreeAccumulator.foldOver/$getClass")

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -149,6 +149,13 @@ object Trees {
     /** Shorthand for `denot.symbol`. */
     final def symbol(using Context): Symbol = denot.symbol
 
+    /** The owner to install when running a MegaPhase transform under this tree.
+     *  Equal to `symbol` for every tree except `PackageDef`, which folds in the
+     *  `PackageVal -> moduleClass` adjustment that `MegaPhase.inLocalContext`
+     *  used to perform on every ValDef/DefDef/TypeDef.
+     */
+    def localCtxOwner(using Context): Symbol = symbol
+
     /** Does this tree represent a type? */
     def isType: Boolean = false
 
@@ -374,6 +381,10 @@ object Trees {
   abstract class NamedDefTree[+T <: Untyped](implicit @constructorOnly src: SourceFile)
   extends NameTree[T] with DefTree[T] with WithEndMarker[T] {
     type ThisTree[+T <: Untyped] <: NamedDefTree[T]
+
+    override def localCtxOwner(using Context): Symbol = typeOpt match
+      case tpe: ThisType => tpe.cls
+      case _ => symbol
 
     protected def srcName(using Context): Name =
       if name == nme.CONSTRUCTOR then nme.this_
@@ -1055,6 +1066,9 @@ object Trees {
     type ThisTree[+T <: Untyped] = PackageDef[T]
     def forwardTo: RefTree[T] = pid
     protected def srcName(using Context): Name = pid.name
+    override def localCtxOwner(using Context): Symbol =
+      val sym = symbol
+      if sym.is(PackageVal) then sym.moduleClass else sym
   }
 
   /** arg @annot */

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1301,7 +1301,32 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
               if mapped == null then unchanged
               else mapped.prependToList(unchanged))
 
-      loop(null, trees, trees)
+      @tailrec
+      def sameOwnerPrefixLoop(mapped: mutable.ListBuffer[Tree] | Null, unchanged: List[Tree], pending: List[Tree])(using Context): T =
+        pending match
+          case (stat: ImportOrExport) :: _ =>
+            loop(mapped, unchanged, pending)
+          case stat :: rest =>
+            val stat1 = op(stat)
+            if stat1 eq stat then
+              sameOwnerPrefixLoop(mapped, unchanged, rest)
+            else
+              val buf = if mapped == null then new mutable.ListBuffer[Tree] else mapped
+              var xc = unchanged
+              while xc ne pending do
+                buf += xc.head
+                xc = xc.tail
+              stat1 match
+                case Thicket(stats1) => buf ++= stats1
+                case _ => buf += stat1
+              sameOwnerPrefixLoop(buf, rest, rest)
+          case nil =>
+            wrapResult(
+              if mapped == null then unchanged
+              else mapped.prependToList(unchanged))
+
+      if exprOwner == ctx.owner then sameOwnerPrefixLoop(null, trees, trees)
+      else loop(null, trees, trees)
     end mapStatements
   end extension
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1359,8 +1359,11 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     final override def transformStats(trees: List[Tree], exprOwner: Symbol)(using Context): List[Tree] =
       transformStats(trees, exprOwner, sameStats)
     override def transformBlock(blk: Block)(using Context) =
-      transformStats(blk.stats, ctx.owner,
-        stats1 => ctx ?=> cpy.Block(blk)(stats1, transform(blk.expr)))
+      if blk.stats.isEmpty then
+        cpy.Block(blk)(Nil, transform(blk.expr))
+      else
+        transformStats(blk.stats, ctx.owner,
+          stats1 => ctx ?=> cpy.Block(blk)(stats1, transform(blk.expr)))
 
   val sameStats: List[Tree] => Context ?=> List[Tree] = stats => stats
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -324,6 +324,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    */
   def ClassDef(cls: ClassSymbol, constr: DefDef, body: List[Tree],
       superArgs: List[Tree] = Nil, adaptVarargs: Boolean = false)(using Context): TypeDef =
+    ClassDef(cls, constr, body, superArgs, adaptVarargs, NoSymbol)
+
+  def ClassDef(cls: ClassSymbol, constr: DefDef, body: List[Tree],
+      superArgs: List[Tree], adaptVarargs: Boolean, localDummy: Symbol)(using Context): TypeDef =
     val firstParent :: otherParents = cls.info.parents: @unchecked
 
     def adaptedSuperArgs(ctpe: Type): List[Tree] = ctpe match
@@ -346,10 +350,13 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           case _ => assert(false, i"multiple applicable parent constructors of $firstParent for supercall arguments $superArgs")
         New(firstParent, parentConstr.asTerm, adaptedSuperArgs(parentConstr.info))
 
-    ClassDefWithParents(cls, constr, superRef :: otherParents.map(TypeTree(_)), body)
+    ClassDefWithParents(cls, constr, superRef :: otherParents.map(TypeTree(_)), body, localDummy)
   end ClassDef
 
-  def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree])(using Context): TypeDef = {
+  def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree])(using Context): TypeDef =
+    ClassDefWithParents(cls, constr, parents, body, NoSymbol)
+
+  def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree], localDummy: Symbol)(using Context): TypeDef = {
     val selfType =
       if (cls.classInfo.selfInfo ne NoType) ValDef(newSelfSym(cls))
       else EmptyValDef
@@ -359,11 +366,17 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     val newTypeParams =
       for (tparam <- cls.typeParams if !(bodyTypeParams contains tparam))
       yield TypeDef(tparam)
-    val findLocalDummy = FindLocalDummyAccumulator(cls)
-    val localDummy = body.foldLeft(NoSymbol: Symbol)(findLocalDummy.apply)
-      .orElse(newLocalDummy(cls))
+    val templateDummy =
+      if localDummy.exists then
+        assert(isTemplateLocalDummy(cls, localDummy),
+          i"local dummy $localDummy has owner ${localDummy.owner}, expected $cls")
+        localDummy
+      else
+        val findLocalDummy = FindLocalDummyAccumulator(cls)
+        body.foldLeft(NoSymbol: Symbol)(findLocalDummy.apply)
+          .orElse(newLocalDummy(cls))
     val impl = untpd.Template(constr, parents, Nil, selfType, newTypeParams ++ body)
-      .withType(localDummy.termRef)
+      .withType(templateDummy.termRef)
     ta.assignType(untpd.TypeDef(cls.name, impl), cls)
   }
 
@@ -604,11 +617,14 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    *  the RHS of a method contains a class owned by the method, this would be
    *  an error.)
    */
-  def ModuleDef(sym: TermSymbol, body: List[Tree])(using Context): tpd.Thicket = {
+  def ModuleDef(sym: TermSymbol, body: List[Tree])(using Context): tpd.Thicket =
+    ModuleDef(sym, body, NoSymbol)
+
+  def ModuleDef(sym: TermSymbol, body: List[Tree], localDummy: Symbol)(using Context): tpd.Thicket = {
     val modcls = sym.moduleClass.asClass
     val constrSym = modcls.primaryConstructor `orElse` newDefaultConstructor(modcls).entered
     val constr = DefDef(constrSym.asTerm, EmptyTree)
-    val clsdef = ClassDef(modcls, constr, body)
+    val clsdef = ClassDef(modcls, constr, body, Nil, adaptVarargs = false, localDummy)
     val valdef = ValDef(sym, New(modcls.typeRef).select(constrSym).appliedToNone)
     Thicket(valdef, clsdef)
   }
@@ -630,13 +646,15 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     else nullLiteral.select(defn.Any_asInstanceOf).appliedToType(tpe)
   }
 
+  private def isTemplateLocalDummy(cls: ClassSymbol, sym: Symbol)(using Context): Boolean =
+    sym.isLocalDummy && sym.owner == cls
+
   private class FindLocalDummyAccumulator(cls: ClassSymbol)(using Context) extends TreeAccumulator[Symbol] {
     def apply(sym: Symbol, tree: Tree)(using Context) =
       if (sym.exists) sym
       else if (tree.isDef) {
         val owner = tree.symbol.owner
-        if (owner.isLocalDummy && owner.owner == cls) owner
-        else if (owner == cls) foldOver(sym, tree)
+        if (isTemplateLocalDummy(cls, owner)) owner
         else sym
       }
       else foldOver(sym, tree)

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1458,7 +1458,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   @tailrec
   def sameTypes(trees: List[tpd.Tree], trees1: List[tpd.Tree]): Boolean =
-    if (trees.isEmpty) trees1.isEmpty
+    if (trees eq trees1) true
+    else if (trees.isEmpty) trees1.isEmpty
     else if (trees1.isEmpty) trees.isEmpty
     else (trees.head.tpe eq trees1.head.tpe) && sameTypes(trees.tail, trees1.tail)
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1471,7 +1471,8 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   @tailrec
   def sameTypes(trees: List[tpd.Tree], trees1: List[tpd.Tree]): Boolean =
-    if (trees.isEmpty) trees1.isEmpty
+    if (trees eq trees1) true
+    else if (trees.isEmpty) trees1.isEmpty
     else if (trees1.isEmpty) trees.isEmpty
     else (trees.head.tpe eq trees1.head.tpe) && sameTypes(trees.tail, trees1.tail)
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1372,8 +1372,11 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     final override def transformStats(trees: List[Tree], exprOwner: Symbol)(using Context): List[Tree] =
       transformStats(trees, exprOwner, sameStats)
     override def transformBlock(blk: Block)(using Context) =
-      transformStats(blk.stats, ctx.owner,
-        stats1 => ctx ?=> cpy.Block(blk)(stats1, transform(blk.expr)))
+      if blk.stats.isEmpty then
+        cpy.Block(blk)(Nil, transform(blk.expr))
+      else
+        transformStats(blk.stats, ctx.owner,
+          stats1 => ctx ?=> cpy.Block(blk)(stats1, transform(blk.expr)))
 
   val sameStats: List[Tree] => Context ?=> List[Tree] = stats => stats
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1314,7 +1314,32 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
               if mapped == null then unchanged
               else mapped.prependToList(unchanged))
 
-      loop(null, trees, trees)
+      @tailrec
+      def sameOwnerPrefixLoop(mapped: mutable.ListBuffer[Tree] | Null, unchanged: List[Tree], pending: List[Tree])(using Context): T =
+        pending match
+          case (stat: ImportOrExport) :: _ =>
+            loop(mapped, unchanged, pending)
+          case stat :: rest =>
+            val stat1 = op(stat)
+            if stat1 eq stat then
+              sameOwnerPrefixLoop(mapped, unchanged, rest)
+            else
+              val buf = if mapped == null then new mutable.ListBuffer[Tree] else mapped
+              var xc = unchanged
+              while xc ne pending do
+                buf += xc.head
+                xc = xc.tail
+              stat1 match
+                case Thicket(stats1) => buf ++= stats1
+                case _ => buf += stat1
+              sameOwnerPrefixLoop(buf, rest, rest)
+          case nil =>
+            wrapResult(
+              if mapped == null then unchanged
+              else mapped.prependToList(unchanged))
+
+      if exprOwner == ctx.owner then sameOwnerPrefixLoop(null, trees, trees)
+      else loop(null, trees, trees)
     end mapStatements
   end extension
 

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -328,6 +328,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    */
   def ClassDef(cls: ClassSymbol, constr: DefDef, body: List[Tree],
       superArgs: List[Tree] = Nil, adaptVarargs: Boolean = false)(using Context): TypeDef =
+    ClassDef(cls, constr, body, superArgs, adaptVarargs, NoSymbol)
+
+  def ClassDef(cls: ClassSymbol, constr: DefDef, body: List[Tree],
+      superArgs: List[Tree], adaptVarargs: Boolean, localDummy: Symbol)(using Context): TypeDef =
     val firstParent :: otherParents = cls.info.parents: @unchecked
 
     def adaptedSuperArgs(ctpe: Type): List[Tree] = ctpe match
@@ -350,10 +354,13 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
           case _ => assert(false, i"multiple applicable parent constructors of $firstParent for supercall arguments $superArgs")
         New(firstParent, parentConstr.asTerm, adaptedSuperArgs(parentConstr.info))
 
-    ClassDefWithParents(cls, constr, superRef :: otherParents.map(TypeTree(_)), body)
+    ClassDefWithParents(cls, constr, superRef :: otherParents.map(TypeTree(_)), body, localDummy)
   end ClassDef
 
-  def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree])(using Context): TypeDef = {
+  def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree])(using Context): TypeDef =
+    ClassDefWithParents(cls, constr, parents, body, NoSymbol)
+
+  def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree], localDummy: Symbol)(using Context): TypeDef = {
     val selfType =
       if (cls.info ne NoType) && (cls.classInfo.selfInfo ne NoType) then ValDef(newSelfSym(cls))
       else EmptyValDef
@@ -363,11 +370,17 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     val newTypeParams =
       for (tparam <- cls.typeParams if !(bodyTypeParams contains tparam))
       yield TypeDef(tparam)
-    val findLocalDummy = FindLocalDummyAccumulator(cls)
-    val localDummy = body.foldLeft(NoSymbol: Symbol)(findLocalDummy.apply)
-      .orElse(newLocalDummy(cls))
+    val templateDummy =
+      if localDummy.exists then
+        assert(isTemplateLocalDummy(cls, localDummy),
+          i"local dummy $localDummy has owner ${localDummy.owner}, expected $cls")
+        localDummy
+      else
+        val findLocalDummy = FindLocalDummyAccumulator(cls)
+        body.foldLeft(NoSymbol: Symbol)(findLocalDummy.apply)
+          .orElse(newLocalDummy(cls))
     val impl = untpd.Template(constr, parents, Nil, selfType, newTypeParams ++ body)
-      .withType(localDummy.termRef)
+      .withType(templateDummy.termRef)
     ta.assignType(untpd.TypeDef(cls.name, impl), cls)
   }
 
@@ -608,11 +621,14 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    *  the RHS of a method contains a class owned by the method, this would be
    *  an error.)
    */
-  def ModuleDef(sym: TermSymbol, body: List[Tree])(using Context): tpd.Thicket = {
+  def ModuleDef(sym: TermSymbol, body: List[Tree])(using Context): tpd.Thicket =
+    ModuleDef(sym, body, NoSymbol)
+
+  def ModuleDef(sym: TermSymbol, body: List[Tree], localDummy: Symbol)(using Context): tpd.Thicket = {
     val modcls = sym.moduleClass.asClass
     val constrSym = modcls.primaryConstructor `orElse` newDefaultConstructor(modcls).entered
     val constr = DefDef(constrSym.asTerm, EmptyTree)
-    val clsdef = ClassDef(modcls, constr, body)
+    val clsdef = ClassDef(modcls, constr, body, Nil, adaptVarargs = false, localDummy)
     val valdef = ValDef(sym, New(modcls.typeRef).select(constrSym).appliedToNone)
     Thicket(valdef, clsdef)
   }
@@ -634,13 +650,15 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
     else nullLiteral.select(defn.Any_asInstanceOf).appliedToType(tpe)
   }
 
+  private def isTemplateLocalDummy(cls: ClassSymbol, sym: Symbol)(using Context): Boolean =
+    sym.isLocalDummy && sym.owner == cls
+
   private class FindLocalDummyAccumulator(cls: ClassSymbol)(using Context) extends TreeAccumulator[Symbol] {
     def apply(sym: Symbol, tree: Tree)(using Context) =
       if (sym.exists) sym
       else if (tree.isDef) {
         val owner = tree.symbol.owner
-        if (owner.isLocalDummy && owner.owner == cls) owner
-        else if (owner == cls) foldOver(sym, tree)
+        if (isTemplateLocalDummy(cls, owner)) owner
         else sym
       }
       else foldOver(sym, tree)

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -402,13 +402,19 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def This(qual: Ident)(implicit src: SourceFile): This = new This(qual)
   def Super(qual: Tree, mix: Ident)(implicit src: SourceFile): Super = new Super(qual, mix)
   def Apply(fun: Tree, args: List[Tree])(implicit src: SourceFile): Apply = new Apply(fun, args)
+  def Apply(fun: Tree, args: List[Tree], span: Span)(implicit src: SourceFile): Apply =
+    new Apply(fun, args)(using src, Positioned.initialSpan(span))
   def TypeApply(fun: Tree, args: List[Tree])(implicit src: SourceFile): TypeApply = new TypeApply(fun, args)
+  def TypeApply(fun: Tree, args: List[Tree], span: Span)(implicit src: SourceFile): TypeApply =
+    new TypeApply(fun, args)(using src, Positioned.initialSpan(span))
   def Literal(const: Constant)(implicit src: SourceFile): Literal = new Literal(const)
   def New(tpt: Tree)(implicit src: SourceFile): New = new New(tpt)
   def Typed(expr: Tree, tpt: Tree)(implicit src: SourceFile): Typed = new Typed(expr, tpt)
   def NamedArg(name: Name, arg: Tree)(implicit src: SourceFile): NamedArg = new NamedArg(name, arg)
   def Assign(lhs: Tree, rhs: Tree)(implicit src: SourceFile): Assign = new Assign(lhs, rhs)
   def Block(stats: List[Tree], expr: Tree)(implicit src: SourceFile): Block = new Block(stats, expr)
+  def Block(stats: List[Tree], expr: Tree, span: Span)(implicit src: SourceFile): Block =
+    new Block(stats, expr)(using src, Positioned.initialSpan(span))
   def If(cond: Tree, thenp: Tree, elsep: Tree)(implicit src: SourceFile): If = new If(cond, thenp, elsep)
   def InlineIf(cond: Tree, thenp: Tree, elsep: Tree)(implicit src: SourceFile): If = new InlineIf(cond, thenp, elsep)
   def Closure(env: List[Tree], meth: Tree, tpt: Tree)(implicit src: SourceFile): Closure = new Closure(env, meth, tpt)
@@ -423,8 +429,14 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def SeqLiteral(elems: List[Tree], elemtpt: Tree)(implicit src: SourceFile): SeqLiteral = new SeqLiteral(elems, elemtpt)
   def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree)(implicit src: SourceFile): JavaSeqLiteral = new JavaSeqLiteral(elems, elemtpt)
   def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree)(implicit src: SourceFile): Inlined = new Inlined(call, bindings, expansion)
+  def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree, span: Span)(implicit src: SourceFile): Inlined =
+    new Inlined(call, bindings, expansion)(using src, Positioned.initialSpan(span))
   def Quote(body: Tree, tags: List[Tree])(implicit src: SourceFile): Quote = new Quote(body, tags)
+  def Quote(body: Tree, tags: List[Tree], span: Span)(implicit src: SourceFile): Quote =
+    new Quote(body, tags)(using src, Positioned.initialSpan(span))
   def Splice(expr: Tree)(implicit src: SourceFile): Splice = new Splice(expr)
+  def Splice(expr: Tree, span: Span)(implicit src: SourceFile): Splice =
+    new Splice(expr)(using src, Positioned.initialSpan(span))
   def QuotePattern(bindings: List[Tree], body: Tree, quotes: Tree)(implicit src: SourceFile): QuotePattern = new QuotePattern(bindings, body, quotes)
   def SplicePattern(body: Tree, typeargs: List[Tree], args: List[Tree])(implicit src: SourceFile): SplicePattern = new SplicePattern(body, typeargs, args)
   def TypeTree()(implicit src: SourceFile): TypeTree = new TypeTree()

--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -405,13 +405,19 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def This(qual: Ident)(implicit src: SourceFile): This = new This(qual)
   def Super(qual: Tree, mix: Ident)(implicit src: SourceFile): Super = new Super(qual, mix)
   def Apply(fun: Tree, args: List[Tree])(implicit src: SourceFile): Apply = new Apply(fun, args)
+  def Apply(fun: Tree, args: List[Tree], span: Span)(implicit src: SourceFile): Apply =
+    new Apply(fun, args)(using src, Positioned.initialSpan(span))
   def TypeApply(fun: Tree, args: List[Tree])(implicit src: SourceFile): TypeApply = new TypeApply(fun, args)
+  def TypeApply(fun: Tree, args: List[Tree], span: Span)(implicit src: SourceFile): TypeApply =
+    new TypeApply(fun, args)(using src, Positioned.initialSpan(span))
   def Literal(const: Constant)(implicit src: SourceFile): Literal = new Literal(const)
   def New(tpt: Tree)(implicit src: SourceFile): New = new New(tpt)
   def Typed(expr: Tree, tpt: Tree)(implicit src: SourceFile): Typed = new Typed(expr, tpt)
   def NamedArg(name: Name, arg: Tree)(implicit src: SourceFile): NamedArg = new NamedArg(name, arg)
   def Assign(lhs: Tree, rhs: Tree)(implicit src: SourceFile): Assign = new Assign(lhs, rhs)
   def Block(stats: List[Tree], expr: Tree)(implicit src: SourceFile): Block = new Block(stats, expr)
+  def Block(stats: List[Tree], expr: Tree, span: Span)(implicit src: SourceFile): Block =
+    new Block(stats, expr)(using src, Positioned.initialSpan(span))
   def If(cond: Tree, thenp: Tree, elsep: Tree)(implicit src: SourceFile): If = new If(cond, thenp, elsep)
   def InlineIf(cond: Tree, thenp: Tree, elsep: Tree)(implicit src: SourceFile): If = new InlineIf(cond, thenp, elsep)
   def Closure(env: List[Tree], meth: Tree, tpt: Tree)(implicit src: SourceFile): Closure = new Closure(env, meth, tpt)
@@ -426,8 +432,14 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def SeqLiteral(elems: List[Tree], elemtpt: Tree)(implicit src: SourceFile): SeqLiteral = new SeqLiteral(elems, elemtpt)
   def JavaSeqLiteral(elems: List[Tree], elemtpt: Tree)(implicit src: SourceFile): JavaSeqLiteral = new JavaSeqLiteral(elems, elemtpt)
   def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree)(implicit src: SourceFile): Inlined = new Inlined(call, bindings, expansion)
+  def Inlined(call: tpd.Tree, bindings: List[MemberDef], expansion: Tree, span: Span)(implicit src: SourceFile): Inlined =
+    new Inlined(call, bindings, expansion)(using src, Positioned.initialSpan(span))
   def Quote(body: Tree, tags: List[Tree])(implicit src: SourceFile): Quote = new Quote(body, tags)
+  def Quote(body: Tree, tags: List[Tree], span: Span)(implicit src: SourceFile): Quote =
+    new Quote(body, tags)(using src, Positioned.initialSpan(span))
   def Splice(expr: Tree)(implicit src: SourceFile): Splice = new Splice(expr)
+  def Splice(expr: Tree, span: Span)(implicit src: SourceFile): Splice =
+    new Splice(expr)(using src, Positioned.initialSpan(span))
   def QuotePattern(bindings: List[Tree], body: Tree, quotes: Tree)(implicit src: SourceFile): QuotePattern = new QuotePattern(bindings, body, quotes)
   def SplicePattern(body: Tree, typeargs: List[Tree], args: List[Tree])(implicit src: SourceFile): SplicePattern = new SplicePattern(body, typeargs, args)
   def TypeTree()(implicit src: SourceFile): TypeTree = new TypeTree()

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2417,6 +2417,21 @@ object Types extends TypeUtils {
       if (checkedPeriod == ctx.period) lastSymbol.asInstanceOf[Symbol]
       else computeSymbol
 
+    /** Returns `lastDenotation.symbol` if there is a cached denotation valid for the
+     *  current period, otherwise `null`. Uses the SAME `validFor.contains(ctx.period)`
+     *  gate as `NamedType.denot`, so the fast-path hit rate matches `denot`'s -- which
+     *  is looser than the strict `checkedPeriod == ctx.period` gate used by `symbol`.
+     *  Returning `null` lets callers fall back to `denot.symbol` without allocating
+     *  an Option. Used to short-circuit `Tree.symbol` reads on hot typed-arm callers
+     *  (e.g. `Select.symbol`) where the cached denotation is virtually always valid.
+     */
+    final def cachedSymbolOrNull(using Context): Symbol | Null =
+      val lastd = lastDenotation
+      if lastd != null && checkedPeriod != Nowhere && lastd.validFor.contains(ctx.period) then
+        lastd.symbol: Symbol | Null
+      else
+        null
+
     private def computeSymbol(using Context): Symbol =
       val result = designator match
         case sym: Symbol =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -2415,6 +2415,21 @@ object Types extends TypeUtils {
       if (checkedPeriod == ctx.period) lastSymbol.asInstanceOf[Symbol]
       else computeSymbol
 
+    /** Returns `lastDenotation.symbol` if there is a cached denotation valid for the
+     *  current period, otherwise `null`. Uses the SAME `validFor.contains(ctx.period)`
+     *  gate as `NamedType.denot`, so the fast-path hit rate matches `denot`'s -- which
+     *  is looser than the strict `checkedPeriod == ctx.period` gate used by `symbol`.
+     *  Returning `null` lets callers fall back to `denot.symbol` without allocating
+     *  an Option. Used to short-circuit `Tree.symbol` reads on hot typed-arm callers
+     *  (e.g. `Select.symbol`) where the cached denotation is virtually always valid.
+     */
+    final def cachedSymbolOrNull(using Context): Symbol | Null =
+      val lastd = lastDenotation
+      if lastd != null && checkedPeriod != Nowhere && lastd.validFor.contains(ctx.period) then
+        lastd.symbol: Symbol | Null
+      else
+        null
+
     private def computeSymbol(using Context): Symbol =
       val result = designator match
         case sym: Symbol =>

--- a/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/unpickleScala2/Scala2Unpickler.scala
@@ -1138,11 +1138,12 @@ class Scala2Unpickler(bytes: Array[Byte], classRoot: ClassDenotation, moduleClas
         val cls = symbol.asClass
         val ((constr: DefDef) :: Nil, stats) =
           impl.body.partition(_.symbol == cls.primaryConstructor): @unchecked
-        ClassDef(cls, constr, tparams ++ stats)
+        ClassDef(cls, constr, tparams ++ stats, Nil, adaptVarargs = false, impl.symbol)
 
       case MODULEtree =>
         val symbol = setSymModsName()
-        ModuleDef(symbol.asTerm, readTemplateRef().body)
+        val impl = readTemplateRef()
+        ModuleDef(symbol.asTerm, impl.body, impl.symbol)
 
       case VALDEFtree =>
         val symbol = setSymModsName()

--- a/compiler/src/dotty/tools/dotc/staging/CrossStageSafety.scala
+++ b/compiler/src/dotty/tools/dotc/staging/CrossStageSafety.scala
@@ -57,7 +57,7 @@ class CrossStageSafety extends TreeMapWithStages {
   private val InAnnotation = Property.Key[Unit]()
 
   override def transform(tree: Tree)(using Context): Tree =
-    if (tree.source != ctx.source && tree.source.exists)
+    if ((tree.source `ne` ctx.source) && tree.source.exists)
       transform(tree)(using ctx.withSource(tree.source))
     else tree match
       case CancelledQuote(tree) =>

--- a/compiler/src/dotty/tools/dotc/staging/TreeMapWithStages.scala
+++ b/compiler/src/dotty/tools/dotc/staging/TreeMapWithStages.scala
@@ -15,7 +15,7 @@ abstract class TreeMapWithStages extends TreeMapWithImplicits {
   import tpd.*
 
   override def transform(tree: Tree)(using Context): Tree =
-    if (tree.source != ctx.source && tree.source.exists)
+    if ((tree.source `ne` ctx.source) && tree.source.exists)
       transform(tree)(using ctx.withSource(tree.source))
     else reporting.trace(i"TreeMapWithStages.transform $tree at $level", staging, show = true) {
       tree match {

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -448,6 +448,16 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
     // try
       if ((tree.source `ne` ctx.source) && tree.source.exists)
         transformTree(tree, start)(using ctx.withSource(tree.source))
+      else if (tree.isInstanceOf[Ident]
+          && (nxIdentPrepPhase(start) eq null)
+          && (nxIdentTransPhase(start) eq null))
+        // iter46 E1: leaf-tree shortcut when no mini-phase registers prep/trans for Ident
+        tree
+      else if (tree.isInstanceOf[TypeTree]
+          && (nxTypeTreePrepPhase(start) eq null)
+          && (nxTypeTreeTransPhase(start) eq null))
+        // iter46 E1: leaf-tree shortcut when no mini-phase registers prep/trans for TypeTree
+        tree
       else if (tree.isInstanceOf[NameTree])
         transformNamed(tree, start, ctx)
       else

--- a/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MegaPhase.scala
@@ -446,7 +446,7 @@ class MegaPhase(val miniPhases: Array[MiniPhase]) extends Phase {
     }
 
     // try
-      if (tree.source != ctx.source && tree.source.exists)
+      if ((tree.source `ne` ctx.source) && tree.source.exists)
         transformTree(tree, start)(using ctx.withSource(tree.source))
       else if (tree.isInstanceOf[NameTree])
         transformNamed(tree, start, ctx)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4066,7 +4066,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       record("typed total")
       if ctx.phase.isTyper then
         assertPositioned(tree)
-      if tree.source != ctx.source && tree.source.exists then
+      if (tree.source `ne` ctx.source) && tree.source.exists then
         typed(tree, pt, locked)(using ctx.withSource(tree.source))
       else if ctx.run.nn.isCancelled then
         tree.withType(WildcardType)

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4120,7 +4120,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       record("typed total")
       if ctx.phase.isTyper then
         assertPositioned(tree)
-      if tree.source != ctx.source && tree.source.exists then
+      if (tree.source `ne` ctx.source) && tree.source.exists then
         typed(tree, pt, locked)(using ctx.withSource(tree.source))
       else if ctx.run.nn.isCancelled then
         tree.withType(WildcardType)


### PR DESCRIPTION
Optimizes **AST trees & positions** — one subsystem split out of the large performance PR scala/scala3#26025 to make review tractable.

**Estimated speedup:** ~5.63% (sum of 18 per-commit profiler estimates across 18 commits)

Full context, benchmarking methodology, and per-commit JFR profiling deltas are in the parent PR scala/scala3#26025.