### PR TITLE
perf: optimize Symbols & Names (~2.93% estimated speedup)

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1885,7 +1885,13 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
    *  which we represent as classes.
    */
   private def isEmittedInterface(sym: Symbol)(using Context): Boolean =
-    sym.is(Trait) ||
-      sym.is(JavaDefined) && (toDenot(sym).isAnnotation || sym.is(ModuleClass) && (sym.companionClass.is(PureInterface)) || sym.companionClass.is(Trait))
+    val denot = sym.denot
+    denot.is(Trait) ||
+      denot.is(JavaDefined) && {
+        denot.isAnnotation || {
+          val companion = denot.companionClass.denot
+          denot.is(ModuleClass) && companion.is(PureInterface) || companion.is(Trait)
+        }
+      }
 
 }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1891,7 +1891,13 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
    *  which we represent as classes.
    */
   private def isEmittedInterface(sym: Symbol)(using Context): Boolean =
-    sym.is(Trait) ||
-      sym.is(JavaDefined) && (toDenot(sym).isAnnotation || sym.is(ModuleClass) && (sym.companionClass.is(PureInterface)) || sym.companionClass.is(Trait))
+    val denot = sym.denot
+    denot.is(Trait) ||
+      denot.is(JavaDefined) && {
+        denot.isAnnotation || {
+          val companion = denot.companionClass.denot
+          denot.is(ModuleClass) && companion.is(PureInterface) || companion.is(Trait)
+        }
+      }
 
 }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
@@ -486,37 +486,41 @@ object BCodeUtils {
    *      and they would fail verification after lifted.
    */
   final def javaFlags(sym: Symbol)(using Context): Int = {
+    val denot = sym.denot
+    val isClass = denot.isClass
+    val isAbstractOrTrait = denot.isOneOf(AbstractOrTrait)
+    val isTrait = denot.is(Trait)
     // Classes are always emitted as public. This matches the behavior of Scala 2
     // and is necessary for object deserialization to work properly, otherwise
     // ModuleSerializationProxy may fail with an accessiblity error (see
     // tests/run/serialize.scala and https://github.com/typelevel/cats-effect/pull/2360).
-    val privateFlag = !sym.isClass && (sym.is(Private) || (sym.isPrimaryConstructor && sym.owner.isTopLevelModuleClass))
+    val privateFlag = !isClass && (denot.is(Private) || (denot.isPrimaryConstructor && denot.owner.isTopLevelModuleClass))
 
-    val finalFlag = sym.is(Final) && !toDenot(sym).isClassConstructor && !sym.isMutableVar && !sym.enclosingClass.is(Trait)
+    val finalFlag = denot.is(Final) && !denot.isClassConstructor && !denot.isMutableVar && !denot.enclosingClass.denot.is(Trait)
 
     import asm.Opcodes.*
     import GenBCodeOps.addFlagIf
     0 .addFlagIf(privateFlag, ACC_PRIVATE)
       .addFlagIf(!privateFlag, ACC_PUBLIC)
-      .addFlagIf(sym.is(Deferred) || sym.isOneOf(AbstractOrTrait), ACC_ABSTRACT)
-      .addFlagIf(sym.is(Trait), ACC_INTERFACE)
+      .addFlagIf(denot.is(Deferred) || isAbstractOrTrait, ACC_ABSTRACT)
+      .addFlagIf(isTrait, ACC_INTERFACE)
       .addFlagIf(finalFlag
         // Primitives are "abstract final" to prohibit instantiation
         // without having to provide any implementations, but that is an
         // illegal combination of modifiers at the bytecode level so
         // suppress final if abstract if present.
-        && !sym.isOneOf(AbstractOrTrait)
+        && !isAbstractOrTrait
         // Bridges can be final, but final bridges confuse some frameworks
-        && !sym.is(Bridge), ACC_FINAL)
-      .addFlagIf(sym.isStaticMember && !sym.isClass, ACC_STATIC)
-      .addFlagIf(sym.is(Bridge), ACC_BRIDGE | ACC_SYNTHETIC)
-      .addFlagIf(sym.is(Artifact), ACC_SYNTHETIC)
-      .addFlagIf(sym.isClass && !sym.is(Trait), ACC_SUPER)
-      .addFlagIf(sym.isAllOf(JavaEnum), ACC_ENUM)
-      .addFlagIf(sym.is(JavaVarargs), ACC_VARARGS)
-      .addFlagIf(sym.is(Synchronized), ACC_SYNCHRONIZED)
+        && !denot.is(Bridge), ACC_FINAL)
+      .addFlagIf(sym.isStaticMember && !isClass, ACC_STATIC)
+      .addFlagIf(denot.is(Bridge), ACC_BRIDGE | ACC_SYNTHETIC)
+      .addFlagIf(denot.is(Artifact), ACC_SYNTHETIC)
+      .addFlagIf(isClass && !isTrait, ACC_SUPER)
+      .addFlagIf(denot.isAllOf(JavaEnum), ACC_ENUM)
+      .addFlagIf(denot.is(JavaVarargs), ACC_VARARGS)
+      .addFlagIf(denot.is(Synchronized), ACC_SYNCHRONIZED)
       .addFlagIf(sym.isDeprecated, ACC_DEPRECATED)
-      .addFlagIf(sym.is(Enum), ACC_ENUM)
+      .addFlagIf(denot.is(Enum), ACC_ENUM)
   }
 
 

--- a/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
@@ -484,38 +484,42 @@ object BCodeUtils {
    *      and they would fail verification after lifted.
    */
   final def javaFlags(sym: Symbol)(using Context): Int = {
+    val denot = sym.denot
+    val isClass = denot.isClass
+    val isAbstractOrTrait = denot.isOneOf(AbstractOrTrait)
+    val isTrait = denot.is(Trait)
     // Classes are always emitted as public. This matches the behavior of Scala 2
     // and is necessary for object deserialization to work properly, otherwise
     // ModuleSerializationProxy may fail with an accessiblity error (see
     // tests/run/serialize.scala and https://github.com/typelevel/cats-effect/pull/2360).
-    val privateFlag = !sym.isClass && (sym.is(Private) || (sym.isPrimaryConstructor && sym.owner.isTopLevelModuleClass))
+    val privateFlag = !isClass && (denot.is(Private) || (denot.isPrimaryConstructor && denot.owner.isTopLevelModuleClass))
 
-    val finalFlag = sym.is(Final) && !toDenot(sym).isClassConstructor && !sym.isMutableVar && !sym.enclosingClass.is(Trait)
+    val finalFlag = denot.is(Final) && !denot.isClassConstructor && !denot.isMutableVar && !denot.enclosingClass.denot.is(Trait)
 
     import asm.Opcodes.*
     import GenBCodeOps.addFlagIf
     0 .addFlagIf(privateFlag, ACC_PRIVATE)
       .addFlagIf(!privateFlag, ACC_PUBLIC)
-      .addFlagIf(sym.is(Deferred) || sym.isOneOf(AbstractOrTrait), ACC_ABSTRACT)
-      .addFlagIf(sym.is(Trait), ACC_INTERFACE)
+      .addFlagIf(denot.is(Deferred) || isAbstractOrTrait, ACC_ABSTRACT)
+      .addFlagIf(isTrait, ACC_INTERFACE)
       .addFlagIf(finalFlag
         // Primitives are "abstract final" to prohibit instantiation
         // without having to provide any implementations, but that is an
         // illegal combination of modifiers at the bytecode level so
         // suppress final if abstract is present.
-        && !sym.isOneOf(AbstractOrTrait)
+        && !isAbstractOrTrait
         // Bridges can be final, but final bridges confuse some frameworks
         && !sym.is(Bridge), ACC_FINAL)
       .addFlagIf(sym.isStaticMember && !sym.isClass, ACC_STATIC)
       .addFlagIf(sym.is(Bridge), ACC_BRIDGE | ACC_SYNTHETIC)
       .addFlagIf(sym.is(Artifact), ACC_SYNTHETIC)
-      .addFlagIf(sym.isClass && !sym.is(Trait), ACC_SUPER)
+      .addFlagIf(isClass && !isTrait, ACC_SUPER)
       .addFlagIf(sym.isAllOf(JavaEnum), ACC_ENUM)
       .addFlagIf(sym.is(JavaVarargs), ACC_VARARGS)
       // The JVM does not support synchronized interface methods, we implement those ourselves
-      .addFlagIf(sym.is(Synchronized) && !sym.owner.is(Trait), ACC_SYNCHRONIZED)
+      .addFlagIf(sym.is(Synchronized) && !denot.owner.is(Trait), ACC_SYNCHRONIZED)
       .addFlagIf(sym.isDeprecated, ACC_DEPRECATED)
-      .addFlagIf(sym.is(Enum), ACC_ENUM)
+      .addFlagIf(denot.is(Enum), ACC_ENUM)
   }
 
 

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -274,28 +274,32 @@ abstract class NestedClassesCollector[T](nestedOnly: Boolean) extends GenericSig
 
   // we are only interested in the class references in the descriptor, so we can skip over
   // primitives and the brackets of array descriptors
-  def visitDescriptor(desc: String): Unit = (desc.charAt(0): @switch) match {
-    case '(' =>
-      var i = 1
-      while (i < desc.length) {
-        if (desc.charAt(i) == 'L') {
-          val start = i + 1 // skip the L
-          var seenDollar = false
-          while ({val ch = desc.charAt(i); seenDollar ||= (ch == '$'); ch != ';'}) i += 1
-          if (seenDollar)
-            visitInternalName(desc, start, i)
+  def visitDescriptor(desc: String): Unit = {
+    if (desc.indexOf('$') < 0) return
+
+    (desc.charAt(0): @switch) match {
+      case '(' =>
+        var i = 1
+        while (i < desc.length) {
+          if (desc.charAt(i) == 'L') {
+            val start = i + 1 // skip the L
+            var seenDollar = false
+            while ({val ch = desc.charAt(i); seenDollar ||= (ch == '$'); ch != ';'}) i += 1
+            if (seenDollar)
+              visitInternalName(desc, start, i)
+          }
+          // skips over '[', ')', primitives
+          i += 1
         }
-        // skips over '[', ')', primitives
-        i += 1
-      }
 
-    case 'L' =>
-      visitInternalName(desc, 1, desc.length - 1)
+      case 'L' =>
+        visitInternalName(desc, 1, desc.length - 1)
 
-    case '[' =>
-      visitInternalNameOrArrayReference(desc)
+      case '[' =>
+        visitInternalNameOrArrayReference(desc)
 
-    case _ => // skip over primitive types
+      case _ => // skip over primitive types
+    }
   }
 
   def visitConstant(const: AnyRef): Unit = const match {
@@ -320,4 +324,3 @@ abstract class NestedClassesCollector[T](nestedOnly: Boolean) extends GenericSig
     visitDescriptor(handle.getDesc)
   }
 }
-

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -254,28 +254,32 @@ abstract class NestedClassesCollector[T](nestedOnly: Boolean) extends GenericSig
 
   // we are only interested in the class references in the descriptor, so we can skip over
   // primitives and the brackets of array descriptors
-  def visitDescriptor(desc: String): Unit = (desc.charAt(0): @switch) match {
-    case '(' =>
-      var i = 1
-      while (i < desc.length) {
-        if (desc.charAt(i) == 'L') {
-          val start = i + 1 // skip the L
-          var seenDollar = false
-          while ({val ch = desc.charAt(i); seenDollar ||= (ch == '$'); ch != ';'}) i += 1
-          if (seenDollar)
-            visitInternalName(desc, start, i)
+  def visitDescriptor(desc: String): Unit = {
+    if (desc.indexOf('$') < 0) return
+
+    (desc.charAt(0): @switch) match {
+      case '(' =>
+        var i = 1
+        while (i < desc.length) {
+          if (desc.charAt(i) == 'L') {
+            val start = i + 1 // skip the L
+            var seenDollar = false
+            while ({val ch = desc.charAt(i); seenDollar ||= (ch == '$'); ch != ';'}) i += 1
+            if (seenDollar)
+              visitInternalName(desc, start, i)
+          }
+          // skips over '[', ')', primitives
+          i += 1
         }
-        // skips over '[', ')', primitives
-        i += 1
-      }
 
-    case 'L' =>
-      visitInternalName(desc, 1, desc.length - 1)
+      case 'L' =>
+        visitInternalName(desc, 1, desc.length - 1)
 
-    case '[' =>
-      visitInternalNameOrArrayReference(desc)
+      case '[' =>
+        visitInternalNameOrArrayReference(desc)
 
-    case _ => // skip over primitive types
+      case _ => // skip over primitive types
+    }
   }
 
   def visitConstant(const: AnyRef): Unit = const match {
@@ -300,4 +304,3 @@ abstract class NestedClassesCollector[T](nestedOnly: Boolean) extends GenericSig
     visitDescriptor(handle.getDesc)
   }
 }
-

--- a/compiler/src/dotty/tools/backend/jvm/SymbolUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/SymbolUtils.scala
@@ -5,6 +5,7 @@ import dotty.tools.dotc.core.*
 import Contexts.*
 import Symbols.*
 import Phases.*
+import SymDenotations.*
 import NameKinds.{LazyBitMapName, LazyLocalName}
 import dotty.tools.dotc.core.Names.TermName
 import dotty.tools.dotc.core.StdNames.nme
@@ -36,27 +37,31 @@ object SymbolUtils:
        *  TODO: remove the special handing of `LazyBitMapName` once we swtich to
        *        the new lazy val encoding: https://github.com/scala/scala3/issues/7140
        */
-      private def isStaticModuleField(using Context): Boolean =
-        sym.owner.isStaticModuleClass && sym.isField && !sym.name.is(LazyBitMapName) && !sym.name.is(LazyLocalName)
+      private def isStaticModuleField(denot: SymDenotation)(using Context): Boolean =
+        denot.owner.isStaticModuleClass && isField(denot) && !denot.name.is(LazyBitMapName) && !denot.name.is(LazyLocalName)
 
       def isStaticMember(using Context): Boolean =
         // guard against no symbol cause this code is executed to select which call type(static\dynamic) to use to call array.clone
         (sym ne NoSymbol) &&
-        (sym.is(JavaStatic) || sym.isScalaStatic || sym.isStaticModuleField)
+        {
+          val denot = sym.denot
+          denot.is(JavaStatic) || sym.isScalaStatic || isStaticModuleField(denot)
+        }
 
       /**
       * True for module classes of modules that are top-level or owned only by objects. Module classes
       * for such objects will get a MODULE$ flag and a corresponding static initializer.
       */
       def isStaticModuleClass(using Context): Boolean =
-        sym.is(Module) && {
+        val denot = sym.denot
+        denot.is(Module) && {
           // scalac uses atPickling here
           // this would not work if modules are created after pickling
           // for example by specialization
-          val original = toDenot(sym).initial
+          val original = denot.initial
           val validity = original.validFor
           atPhase(validity.lastPhaseId) {
-            toDenot(sym).isStatic
+            original.isStatic
           }
         }
       
@@ -64,9 +69,10 @@ object SymbolUtils:
         // used to populate the EnclosingMethod attribute.
         // it is very tricky in presence of classes(and anonymous classes) defined inside supper calls.
         if (sym.exists) {
-          val validity = toDenot(sym).initial.validFor
+          val original = sym.denot.initial
+          val validity = original.validFor
           atPhase(validity.lastPhaseId) {
-            toDenot(sym).lexicallyEnclosingClass
+            original.lexicallyEnclosingClass
           }
         } else NoSymbol
 
@@ -75,7 +81,10 @@ object SymbolUtils:
       * such objects.
       */
       def isTopLevelModuleClass(using Context): Boolean =
-        sym.is(ModuleClass) &&
+        sym.denot.is(ModuleClass) &&
         atPhase(flattenPhase) {
-          toDenot(sym).owner.is(PackageClass)
+          sym.denot.owner.denot.is(PackageClass)
         }
+
+      private def isField(denot: SymDenotation)(using Context): Boolean =
+        denot.isTerm && !denot.isOneOf(Method | PhantomSymbol | NonMember | Package)

--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -26,8 +26,10 @@ class CompilationUnit protected (val source: SourceFile, val info: CompilationUn
 
   var tpdTree: tpd.Tree = tpd.EmptyTree
 
+  private val myIsJava: Boolean = source.file.ext.isJava // `source` and `ext` are immutable, so cache the answer
+
   /** Is this the compilation unit of a Java file */
-  def isJava: Boolean = source.file.ext.isJava
+  def isJava: Boolean = myIsJava
 
   /** Is this the compilation unit of a Java file, or TASTy derived from a Java file */
   def typedAsJava =

--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -27,8 +27,10 @@ class CompilationUnit protected (val source: SourceFile, val info: CompilationUn
 
   var tpdTree: tpd.Tree = tpd.EmptyTree
 
+  private val myIsJava: Boolean = source.ext.isJava // `source` and `ext` are immutable, so cache the answer
+
   /** Is this the compilation unit of a Java file */
-  def isJava: Boolean = source.ext.isJava
+  def isJava: Boolean = myIsJava
 
   /** Is this the compilation unit of a Java file, or TASTy derived from a Java file */
   def typedAsJava: Boolean =

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -220,15 +220,22 @@ object Decorators {
       loop(xs, ys)
     }
 
-    @tailrec final def eqElements(ys: List[AnyRef]): Boolean = xs match {
-      case x :: _ =>
-        ys match {
-          case y :: _ =>
-            x.asInstanceOf[AnyRef].eq(y) &&
-            xs.tail.eqElements(ys.tail)
-          case _ => false
+    final def eqElements(ys: List[AnyRef]): Boolean = {
+      var xs0: List[T] = xs
+      var ys0: List[AnyRef] = ys
+      while true do
+        xs0 match {
+          case xc: ::[T @unchecked] =>
+            ys0 match {
+              case yc: ::[AnyRef @unchecked] =>
+                if !xc.head.asInstanceOf[AnyRef].eq(yc.head) then return false
+                xs0 = xc.tail
+                ys0 = yc.tail
+              case _ => return false
+            }
+          case _ => return ys0.isEmpty
         }
-      case nil => ys.isEmpty
+      false
     }
 
     /** Union on lists seen as sets */

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -198,15 +198,22 @@ object Decorators {
       loop(xs, ys)
     }
 
-    @tailrec final def eqElements(ys: List[AnyRef]): Boolean = xs match {
-      case x :: _ =>
-        ys match {
-          case y :: _ =>
-            x.asInstanceOf[AnyRef].eq(y) &&
-            xs.tail.eqElements(ys.tail)
-          case _ => false
+    final def eqElements(ys: List[AnyRef]): Boolean = {
+      var xs0: List[T] = xs
+      var ys0: List[AnyRef] = ys
+      while true do
+        xs0 match {
+          case xc: ::[T @unchecked] =>
+            ys0 match {
+              case yc: ::[AnyRef @unchecked] =>
+                if !xc.head.asInstanceOf[AnyRef].eq(yc.head) then return false
+                xs0 = xc.tail
+                ys0 = yc.tail
+              case _ => return false
+            }
+          case _ => return ys0.isEmpty
         }
-      case nil => ys.isEmpty
+      false
     }
 
     /** Union on lists seen as sets */

--- a/compiler/src/dotty/tools/dotc/core/Denotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Denotations.scala
@@ -786,6 +786,18 @@ object Denotations {
     def skipRemoved(using Context): SingleDenotation =
       if (validFor == Nowhere) nextDefined else this
 
+    /** A 1-step probe along the `nextInRun` ring: if the immediate `nextInRun`
+     *  denotation is valid for `currentPeriod` and denotes the same symbol as
+     *  this denotation, return it. Otherwise return `null`. Used by
+     *  `NamedType.computeDenot` to skip the dispatch through `current` /
+     *  `goForward` in the common case where the next flock member already
+     *  covers the current period.
+     */
+    final def nextInRunIfFast(currentPeriod: Period): SingleDenotation | Null =
+      val next = nextInRun
+      if (next ne this) && next.validFor.contains(currentPeriod) && (next.symbol eq symbol) then next
+      else null
+    
     /** Produce a denotation that is valid for the given context.
      *  Usually called when !(validFor contains ctx.period)
      *  (even though this is not a precondition).

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -80,10 +80,9 @@ object NameKinds {
     def apply(underlying: TermName): TermName = underlying.derived(info)
 
     /** Extractor operation for names of this kind */
-    def unapply(name: DerivedName): Option[TermName] =  name match {
-      case DerivedName(underlying, `info`) => Some(underlying)
-      case _ => None
-    }
+    def unapply(name: DerivedName): Option[TermName] =
+      // `eq` since `Info` has no `equals` override; avoids the virtual dispatch on this hot path
+      if name.info eq info then Some(name.underlying) else None
 
     simpleNameKinds(tag) = this: @unchecked
   }

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -14,6 +14,11 @@ import nme.*
 
 object NameOps {
 
+  private def hasModuleClassSeparator(name: SimpleName): Boolean =
+    var idx = name.length - 1
+    while idx >= 0 && name(idx) != '$' do idx -= 1
+    idx >= 0
+
   object compactify {
     lazy val md5: MessageDigest = MessageDigest.getInstance("MD5")
 
@@ -152,12 +157,23 @@ object NameOps {
      *  method needs to work on mangled as well as unmangled names because
      *  it is also called from the backend.
      */
-    def stripModuleClassSuffix: N = likeSpacedN {
-      val semName = name.toTermName match
-        case name: SimpleName if name.endsWith(str.MODULE_SUFFIX) && name.lastPart != MODULE_SUFFIX => name.unmangleClassName
-        case _ => name
-      semName.exclude(ModuleClassName)
-    }
+    def stripModuleClassSuffix: N =
+      def stripSlow: N = likeSpacedN {
+        val semName = name.toTermName match
+          case name: SimpleName if name.endsWith(str.MODULE_SUFFIX) && name.lastPart != MODULE_SUFFIX => name.unmangleClassName
+          case _ => name
+        semName.exclude(ModuleClassName)
+      }
+
+      name match
+        case simple: SimpleName if !hasModuleClassSeparator(simple) =>
+          name
+        case tname: TypeName =>
+          tname.toTermName match
+            case simple: SimpleName if !hasModuleClassSeparator(simple) => name
+            case _ => stripSlow
+        case _ =>
+          stripSlow
 
     /** If flags is a ModuleClass but not a Package, add module class suffix */
     def adjustIfModuleClass(flags: FlagSet): N = likeSpacedN {

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -59,6 +59,23 @@ object NameOps {
     }
   }
 
+  /** Bit layout of the packed function-name classification cached in
+   *  `Name#myFunKind`. Bits 0..24 hold `funArity + 1` if the arity fits the
+   *  field (with `FunKindArityBig` as a sentinel for values that do not),
+   *  the remaining bits are flags. `FunKindComputed` is always set, so a
+   *  computed encoding is never 0 and 0 can serve as the
+   *  not-yet-computed sentinel.
+   */
+  private inline val FunKindArityMask    = (1 << 25) - 1
+  private inline val FunKindArityBig     = FunKindArityMask
+  private inline val FunKindSuffixFound  = 1 << 25
+  private inline val FunKindSuffixAtZero = 1 << 26
+  private inline val FunKindPrefixOK     = 1 << 27
+  private inline val FunKindHasContext   = 1 << 28
+  private inline val FunKindHasImpure    = 1 << 29
+  private inline val FunKindArityNonNeg  = 1 << 30
+  private inline val FunKindComputed     = 1 << 31
+
   extension [N <: Name](name: N) {
 
     def testSimple(f: SimpleName => Boolean): Boolean = name match {
@@ -243,60 +260,88 @@ object NameOps {
           else collectDigits(acc * 10 + d, idx + 1)
       collectDigits(0, suffixStart + 8)
 
-    private def isFunctionPrefix(suffixStart: Int, mustHave: String = "")(using Context): Boolean =
-      suffixStart >= 0
-      && {
-        val first = name.firstPart
-        var found = mustHave.isEmpty
-        def skip(idx: Int, str: String) =
-          if first.startsWith(str, idx) then
-            if str == mustHave then found = true
-            idx + str.length
-          else idx
-        skip(skip(0, "Impure"), "Context") == suffixStart
-        && found
-      }
-
-    /** Same as `funArity`, except that it returns -1 if the prefix
-     *  is not one of a (possibly empty) concatenation of a subset of
-     *  "Impure" (only under pureFunctions), "Erased" and "Context" (in that order).
+    /** The packed function-name classification of this name, computed once
+     *  and cached on the name itself. The parse only reads `firstPart`'s
+     *  characters, so the result is a pure function of the (interned,
+     *  process-lifetime) name and the cache can never go stale.
+     *
+     *  The prefix is accepted (`FunKindPrefixOK`) if it is a (possibly
+     *  empty) concatenation of a subset of "Impure" and "Context"
+     *  (in that order).
      */
-    private def checkedFunArity(suffixStart: Int)(using Context): Int =
-      if isFunctionPrefix(suffixStart) then funArity(suffixStart) else -1
+    private def funKind: Int =
+      val k = name.myFunKind
+      if k != 0 then k
+      else
+        val suffixStart = functionSuffixStart
+        var computed = FunKindComputed
+        if suffixStart >= 0 then
+          computed |= FunKindSuffixFound
+          if suffixStart == 0 then computed |= FunKindSuffixAtZero
+          val first = name.firstPart
+          var idx = 0
+          if first.startsWith("Impure", idx) then
+            computed |= FunKindHasImpure
+            idx += "Impure".length
+          if first.startsWith("Context", idx) then
+            computed |= FunKindHasContext
+            idx += "Context".length
+          if idx == suffixStart then computed |= FunKindPrefixOK
+          val arity = funArity(suffixStart)
+          if arity >= 0 then computed |= FunKindArityNonNeg
+          computed |=
+            (if arity >= -1 && arity < FunKindArityBig - 1 then arity + 1
+             else FunKindArityBig)
+        name.myFunKind = computed
+        computed
+
+    /** The `funArity` of this name as recorded in classification `k`,
+     *  re-parsing the name in the unlikely case that the arity did not fit
+     *  the packed encoding. Only meaningful if the function suffix was found.
+     */
+    private def funKindArity(k: Int): Int =
+      val enc = k & FunKindArityMask
+      if enc == FunKindArityBig then funArity(functionSuffixStart)
+      else enc - 1
 
     /** Is a function name, i.e one of FunctionXXL, FunctionN, ContextFunctionN, ImpureFunctionN, ImpureContextFunctionN for N >= 0
      */
     def isFunction(using Context): Boolean =
       (name eq tpnme.FunctionXXL)
-      || checkedFunArity(functionSuffixStart) >= 0
+      || {
+        val k = funKind
+        (k & (FunKindPrefixOK | FunKindArityNonNeg)) == (FunKindPrefixOK | FunKindArityNonNeg)
+      }
 
     /** Is a function name
      *    - FunctionN for N >= 0
      */
     def isPlainFunction(using Context): Boolean = functionArity >= 0
 
-    /** Is a function name that contains `mustHave` as a substring
+    /** Is a function name whose prefix contains the part corresponding to
+     *  `mustHaveFlag` (`FunKindHasContext` or `FunKindHasImpure`)
      *  and has arity `minArity` or greater.
      */
-    private def isSpecificFunction(mustHave: String, minArity: Int = 0)(using Context): Boolean =
-      val suffixStart = functionSuffixStart
-      isFunctionPrefix(suffixStart, mustHave) && funArity(suffixStart) >= minArity
+    private def isSpecificFunction(mustHaveFlag: Int, minArity: Int = 0)(using Context): Boolean =
+      val k = funKind
+      (k & (FunKindPrefixOK | mustHaveFlag)) == (FunKindPrefixOK | mustHaveFlag)
+      && funKindArity(k) >= minArity
 
-    def isContextFunction(using Context): Boolean = isSpecificFunction("Context")
-    def isImpureFunction(using Context): Boolean = isSpecificFunction("Impure")
+    def isContextFunction(using Context): Boolean = isSpecificFunction(FunKindHasContext)
+    def isImpureFunction(using Context): Boolean = isSpecificFunction(FunKindHasImpure)
 
     /** Is a synthetic function name, i.e. one of
      *    - FunctionN for N > 22
      *    - ContextFunctionN for N >= 0
      */
     def isSyntheticFunction(using Context): Boolean =
-      val suffixStart = functionSuffixStart
-      if suffixStart == 0 then funArity(suffixStart) > MaxImplementedFunctionArity
-      else checkedFunArity(suffixStart) >= 0
+      val k = funKind
+      if (k & FunKindSuffixAtZero) != 0 then funKindArity(k) > MaxImplementedFunctionArity
+      else (k & (FunKindPrefixOK | FunKindArityNonNeg)) == (FunKindPrefixOK | FunKindArityNonNeg)
 
     def functionArity(using Context): Int =
-      val suffixStart = functionSuffixStart
-      if suffixStart >= 0 then checkedFunArity(suffixStart) else -1
+      val k = funKind
+      if (k & FunKindPrefixOK) != 0 then funKindArity(k) else -1
 
     /** The name of the generic runtime operation corresponding to an array operation */
     def genericArrayOp: TermName = name match {

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -14,6 +14,11 @@ import nme.*
 
 object NameOps {
 
+  private def hasModuleClassSeparator(name: SimpleName): Boolean =
+    var idx = name.length - 1
+    while idx >= 0 && name(idx) != '$' do idx -= 1
+    idx >= 0
+
   object compactify {
     lazy val md5: MessageDigest = MessageDigest.getInstance("MD5")
 
@@ -160,12 +165,23 @@ object NameOps {
      *  method needs to work on mangled as well as unmangled names because
      *  it is also called from the backend.
      */
-    def stripModuleClassSuffix: N = likeSpacedN {
-      val semName = name.toTermName match
-        case name: SimpleName if name.endsWith(str.MODULE_SUFFIX) && name.lastPart != MODULE_SUFFIX => name.unmangleClassName
-        case _ => name
-      semName.exclude(ModuleClassName)
-    }
+    def stripModuleClassSuffix: N =
+      def stripSlow: N = likeSpacedN {
+        val semName = name.toTermName match
+          case name: SimpleName if name.endsWith(str.MODULE_SUFFIX) && name.lastPart != MODULE_SUFFIX => name.unmangleClassName
+          case _ => name
+        semName.exclude(ModuleClassName)
+      }
+
+      name match
+        case simple: SimpleName if !hasModuleClassSeparator(simple) =>
+          name
+        case tname: TypeName =>
+          tname.toTermName match
+            case simple: SimpleName if !hasModuleClassSeparator(simple) => name
+            case _ => stripSlow
+        case _ =>
+          stripSlow
 
     /** If flags is a ModuleClass but not a Package, add module class suffix */
     def adjustIfModuleClass(flags: FlagSet): N = likeSpacedN {

--- a/compiler/src/dotty/tools/dotc/core/NameOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameOps.scala
@@ -59,6 +59,23 @@ object NameOps {
     }
   }
 
+  /** Bit layout of the packed function-name classification cached in
+   *  `Name#myFunKind`. Bits 0..24 hold `funArity + 1` if the arity fits the
+   *  field (with `FunKindArityBig` as a sentinel for values that do not),
+   *  the remaining bits are flags. `FunKindComputed` is always set, so a
+   *  computed encoding is never 0 and 0 can serve as the
+   *  not-yet-computed sentinel.
+   */
+  private inline val FunKindArityMask    = (1 << 25) - 1
+  private inline val FunKindArityBig     = FunKindArityMask
+  private inline val FunKindSuffixFound  = 1 << 25
+  private inline val FunKindSuffixAtZero = 1 << 26
+  private inline val FunKindPrefixOK     = 1 << 27
+  private inline val FunKindHasContext   = 1 << 28
+  private inline val FunKindHasImpure    = 1 << 29
+  private inline val FunKindArityNonNeg  = 1 << 30
+  private inline val FunKindComputed     = 1 << 31
+
   extension [N <: Name](name: N) {
 
     def testSimple(f: SimpleName => Boolean): Boolean = name match {
@@ -251,60 +268,88 @@ object NameOps {
           else collectDigits(acc * 10 + d, idx + 1)
       collectDigits(0, suffixStart + 8)
 
-    private def isFunctionPrefix(suffixStart: Int, mustHave: String = "")(using Context): Boolean =
-      suffixStart >= 0
-      && {
-        val first = name.firstPart
-        var found = mustHave.isEmpty
-        def skip(idx: Int, str: String) =
-          if first.startsWith(str, idx) then
-            if str == mustHave then found = true
-            idx + str.length
-          else idx
-        skip(skip(0, "Impure"), "Context") == suffixStart
-        && found
-      }
-
-    /** Same as `funArity`, except that it returns -1 if the prefix
-     *  is not one of a (possibly empty) concatenation of a subset of
-     *  "Impure" (only under pureFunctions), "Erased" and "Context" (in that order).
+    /** The packed function-name classification of this name, computed once
+     *  and cached on the name itself. The parse only reads `firstPart`'s
+     *  characters, so the result is a pure function of the (interned,
+     *  process-lifetime) name and the cache can never go stale.
+     *
+     *  The prefix is accepted (`FunKindPrefixOK`) if it is a (possibly
+     *  empty) concatenation of a subset of "Impure" and "Context"
+     *  (in that order).
      */
-    private def checkedFunArity(suffixStart: Int)(using Context): Int =
-      if isFunctionPrefix(suffixStart) then funArity(suffixStart) else -1
+    private def funKind: Int =
+      val k = name.myFunKind
+      if k != 0 then k
+      else
+        val suffixStart = functionSuffixStart
+        var computed = FunKindComputed
+        if suffixStart >= 0 then
+          computed |= FunKindSuffixFound
+          if suffixStart == 0 then computed |= FunKindSuffixAtZero
+          val first = name.firstPart
+          var idx = 0
+          if first.startsWith("Impure", idx) then
+            computed |= FunKindHasImpure
+            idx += "Impure".length
+          if first.startsWith("Context", idx) then
+            computed |= FunKindHasContext
+            idx += "Context".length
+          if idx == suffixStart then computed |= FunKindPrefixOK
+          val arity = funArity(suffixStart)
+          if arity >= 0 then computed |= FunKindArityNonNeg
+          computed |=
+            (if arity >= -1 && arity < FunKindArityBig - 1 then arity + 1
+             else FunKindArityBig)
+        name.myFunKind = computed
+        computed
+
+    /** The `funArity` of this name as recorded in classification `k`,
+     *  re-parsing the name in the unlikely case that the arity did not fit
+     *  the packed encoding. Only meaningful if the function suffix was found.
+     */
+    private def funKindArity(k: Int): Int =
+      val enc = k & FunKindArityMask
+      if enc == FunKindArityBig then funArity(functionSuffixStart)
+      else enc - 1
 
     /** Is a function name, i.e one of FunctionXXL, FunctionN, ContextFunctionN, ImpureFunctionN, ImpureContextFunctionN for N >= 0
      */
     def isFunction(using Context): Boolean =
       (name eq tpnme.FunctionXXL)
-      || checkedFunArity(functionSuffixStart) >= 0
+      || {
+        val k = funKind
+        (k & (FunKindPrefixOK | FunKindArityNonNeg)) == (FunKindPrefixOK | FunKindArityNonNeg)
+      }
 
     /** Is a function name
      *    - FunctionN for N >= 0
      */
     def isPlainFunction(using Context): Boolean = functionArity >= 0
 
-    /** Is a function name that contains `mustHave` as a substring
+    /** Is a function name whose prefix contains the part corresponding to
+     *  `mustHaveFlag` (`FunKindHasContext` or `FunKindHasImpure`)
      *  and has arity `minArity` or greater.
      */
-    private def isSpecificFunction(mustHave: String, minArity: Int = 0)(using Context): Boolean =
-      val suffixStart = functionSuffixStart
-      isFunctionPrefix(suffixStart, mustHave) && funArity(suffixStart) >= minArity
+    private def isSpecificFunction(mustHaveFlag: Int, minArity: Int = 0)(using Context): Boolean =
+      val k = funKind
+      (k & (FunKindPrefixOK | mustHaveFlag)) == (FunKindPrefixOK | mustHaveFlag)
+      && funKindArity(k) >= minArity
 
-    def isContextFunction(using Context): Boolean = isSpecificFunction("Context")
-    def isImpureFunction(using Context): Boolean = isSpecificFunction("Impure")
+    def isContextFunction(using Context): Boolean = isSpecificFunction(FunKindHasContext)
+    def isImpureFunction(using Context): Boolean = isSpecificFunction(FunKindHasImpure)
 
     /** Is a synthetic function name, i.e. one of
      *    - FunctionN for N > 22
      *    - ContextFunctionN for N >= 0
      */
     def isSyntheticFunction(using Context): Boolean =
-      val suffixStart = functionSuffixStart
-      if suffixStart == 0 then funArity(suffixStart) > MaxImplementedFunctionArity
-      else checkedFunArity(suffixStart) >= 0
+      val k = funKind
+      if (k & FunKindSuffixAtZero) != 0 then funKindArity(k) > MaxImplementedFunctionArity
+      else (k & (FunKindPrefixOK | FunKindArityNonNeg)) == (FunKindPrefixOK | FunKindArityNonNeg)
 
     def functionArity(using Context): Int =
-      val suffixStart = functionSuffixStart
-      if suffixStart >= 0 then checkedFunArity(suffixStart) else -1
+      val k = funKind
+      if (k & FunKindPrefixOK) != 0 then funKindArity(k) else -1
 
     /** The name of the generic runtime operation corresponding to an array operation */
     def genericArrayOp: TermName = name match {

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -33,6 +33,16 @@ object Names {
     /** A type for names of the same kind as this name */
     type ThisName <: Name
 
+    /** A packed encoding of this name's function-name classification
+     *  (FunctionN, ContextFunctionN, ImpureFunctionN, ...), computed and
+     *  decoded by NameOps. 0 means not yet computed. The classification is
+     *  a pure function of the name and names are interned for the lifetime
+     *  of the process, so the cache can never go stale; racy initialization
+     *  is benign since all threads compute the same value.
+     */
+    @sharable // because it's just a cache for performance
+    private[core] var myFunKind: Int = 0
+
     /** Is this name a type name? */
     def isTypeName: Boolean
 

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -541,6 +541,29 @@ object Names {
           enterIfNew(cs, offset, len)
       }
 
+    def enterIfNewAscii(bs: Array[Byte], offset: Int, len: Int): SimpleName =
+      Stats.record(statsItem("put"))
+      val myTable = currentTable // could be outdated under parallel execution
+      var idx = hashValueAscii(bs, offset, len) & (myTable.length - 1)
+      var name: SimpleName | Null = myTable(idx).asInstanceOf[SimpleName | Null]
+      while name != null do
+        if name.nn.length == len && Names.equalsAscii(name.nn.start, bs, offset, len) then
+          return name.nn
+        Stats.record(statsItem("miss"))
+        idx = (idx + 1) & (myTable.length - 1)
+        name = myTable(idx).asInstanceOf[SimpleName | Null]
+      Stats.record(statsItem("addEntryAt"))
+      synchronized {
+        if (myTable eq currentTable) && myTable(idx) == null then
+          name = SimpleName(nc, len)
+          ensureCapacity(nc + len)
+          copyAscii(bs, offset, chrs, nc, len)
+          nc += len
+          addEntryAt(idx, name.nn)
+        else
+          enterIfNewAscii(bs, offset, len)
+      }
+
     addEntryAt(0, EmptyTermName: @unchecked)
   end NameTable
 
@@ -559,6 +582,17 @@ object Names {
     hash
   }
 
+  /** The hash of an ASCII name made from bytes bs[offset..offset+len-1]. */
+  private def hashValueAscii(bs: Array[Byte], offset: Int, len: Int): Int = {
+    var i = offset
+    var hash = 0
+    while (i < len + offset) {
+      hash = 31 * hash + bs(i)
+      i += 1
+    }
+    hash
+  }
+
   /** Is (the ASCII representation of) name at given index equal to
    *  cs[offset..offset+len-1]?
    */
@@ -567,6 +601,30 @@ object Names {
     while ((i < len) && (chrs(index + i) == cs(offset + i)))
       i += 1
     i == len
+  }
+
+  /** Is name at given index equal to the ASCII bytes bs[offset..offset+len-1]? */
+  private def equalsAscii(index: Int, bs: Array[Byte], offset: Int, len: Int): Boolean = {
+    var i = 0
+    while ((i < len) && (chrs(index + i) == bs(offset + i).toChar))
+      i += 1
+    i == len
+  }
+
+  /** Are all bytes in bs[offset..offset+len-1] single-byte UTF-8 characters? */
+  private def isAscii(bs: Array[Byte], offset: Int, len: Int): Boolean = {
+    var i = offset
+    while (i < len + offset && bs(i) >= 0) i += 1
+    i == len + offset
+  }
+
+  /** Copy ASCII bytes to chars without UTF-8 decoding. */
+  private def copyAscii(bs: Array[Byte], offset: Int, dst: Array[Char], dstOffset: Int, len: Int): Unit = {
+    var i = 0
+    while (i < len) {
+      dst(dstOffset + i) = bs(offset + i).toChar
+      i += 1
+    }
   }
 
   /** Create a term name from the characters in cs[offset..offset+len-1].
@@ -585,8 +643,10 @@ object Names {
    *  Assume they are already encoded.
    */
   def termName(bs: Array[Byte], offset: Int, len: Int): SimpleName = {
-    val chars = Codec.fromUTF8(bs, offset, len)
-    termName(chars, 0, chars.length)
+    if isAscii(bs, offset, len) then nameTable.enterIfNewAscii(bs, offset, len)
+    else
+      val chars = Codec.fromUTF8(bs, offset, len)
+      termName(chars, 0, chars.length)
   }
 
   /** Create a type name from the UTF8 encoded bytes in bs[offset..offset+len-1].

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -225,7 +225,7 @@ object Names {
 
     override def is(kind: NameKind): Boolean = {
       val thisKind = this.info.kind
-      thisKind == kind ||
+      (thisKind eq kind) || // `eq` since NameKind has no `equals` override; avoids the virtual dispatch on this hot path
       !shadows(thisKind, kind) && underlying.is(kind)
     }
 

--- a/compiler/src/dotty/tools/dotc/core/Signature.scala
+++ b/compiler/src/dotty/tools/dotc/core/Signature.scala
@@ -48,9 +48,25 @@ import Signature.*
  */
 case class Signature(paramsSig: List[ParamSig], resSig: TypeName) {
 
-  /** Two names are consistent if they are the same or one of them is tpnme.Uninstantiated */
-  private def consistent(name1: ParamSig, name2: ParamSig) =
-    name1 == name2 || name1 == tpnme.Uninstantiated || name2 == tpnme.Uninstantiated
+  /** Two names are consistent if they are the same or one of them is tpnme.Uninstantiated.
+   *
+   *  `ParamSig = TypeName | Int` erases to `AnyRef`, so a plain `==` compiles to
+   *  `BoxesRunTime.equals(_, _)` and dispatches through `equals2` (instanceof Number /
+   *  Character / null / virtual `Object.equals`). The dominant `TypeName` arm
+   *  collapses to `eq` once that chain unwinds (Names.scala:157), so we
+   *  hand-write a typed-arm match that emits `if_acmpeq` / `if_icmpeq` directly
+   *  and never re-enters the boxing helper.
+   */
+  private def consistent(name1: ParamSig, name2: ParamSig): Boolean =
+    name1 match
+      case n1: TypeName =>
+        name2 match
+          case n2: TypeName => (n1 eq n2) || (n1 eq tpnme.Uninstantiated) || (n2 eq tpnme.Uninstantiated)
+          case _: Int      => (n1 eq tpnme.Uninstantiated)
+      case i1: Int =>
+        name2 match
+          case _: TypeName => name2.asInstanceOf[AnyRef] eq tpnme.Uninstantiated
+          case i2: Int     => i1 == i2
 
   /** Does this signature coincide with that signature on their parameter parts?
    *  This is the case if all parameter signatures are _consistent_, i.e. they are either
@@ -87,7 +103,7 @@ case class Signature(paramsSig: List[ParamSig], resSig: TypeName) {
    */
   final def matchDegree(that: Signature)(using Context): MatchDegree =
     if consistentParams(that) then
-      if resSig == that.resSig || isWildcard(resSig) || isWildcard(that.resSig) then
+      if (resSig eq that.resSig) || isWildcard(resSig) || isWildcard(that.resSig) then
         FullMatch
       else if (this == NotAMethod) != (that == NotAMethod) then
         MethodNotAMethodMatch
@@ -100,7 +116,7 @@ case class Signature(paramsSig: List[ParamSig], resSig: TypeName) {
   def clashes(that: Signature)(using Context): Boolean =
     matchDegree(that) == FullMatch
 
-  private def isWildcard(name: TypeName) = name == tpnme.WILDCARD
+  private def isWildcard(name: TypeName) = name eq tpnme.WILDCARD
 
   /** Construct a signature by prepending the signature names of the given `params`
    *  to the parameter part of this signature.
@@ -123,7 +139,17 @@ case class Signature(paramsSig: List[ParamSig], resSig: TypeName) {
    *  of a type that still contains uninstantiated type variables.
    */
   def isUnderDefined(using Context): Boolean =
-    paramsSig.contains(tpnme.Uninstantiated) || resSig == tpnme.Uninstantiated
+    containsUninstantiated(paramsSig) || (resSig eq tpnme.Uninstantiated)
+
+  /** Same as `paramsSig.contains(tpnme.Uninstantiated)` but typed on the union arms
+   *  so the per-element comparator emits `if_acmpeq` instead of going through
+   *  `BoxesRunTime.equals` for each element. Int arms can never equal the
+   *  TypeName `tpnme.Uninstantiated` and are skipped without dispatch.
+   */
+  @tailrec private def containsUninstantiated(xs: List[ParamSig]): Boolean = xs match
+    case Nil          => false
+    case (n: TypeName) :: rest => (n eq tpnme.Uninstantiated) || containsUninstantiated(rest)
+    case _ :: rest    => containsUninstantiated(rest)
 }
 
 object Signature {

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1329,14 +1329,18 @@ object SymDenotations {
      */
     final def companionModule(using Context): Symbol =
       if (is(Module)) sourceModule
-      else if registeredCompanion.isAbsent() then NoSymbol
-      else registeredCompanion.sourceModule
+      else
+        val companion = registeredCompanion.denot
+        if companion.isAbsent() then NoSymbol
+        else companion.sourceModule
 
     private def companionType(using Context): Symbol =
       if (is(Package)) NoSymbol
       else if (is(ModuleVal)) moduleClass.denot.companionType
-      else if registeredCompanion.isAbsent() then NoSymbol
-      else registeredCompanion
+      else
+        val companion = registeredCompanion.denot
+        if companion.isAbsent() then NoSymbol
+        else companion.symbol
 
     /** The class with the same (type-) name as this module or module class,
      *  and which is also defined in the same scope and compilation unit.

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -1372,14 +1372,18 @@ object SymDenotations {
      */
     final def companionModule(using Context): Symbol =
       if (is(Module)) sourceModule
-      else if registeredCompanion.isAbsent() then NoSymbol
-      else registeredCompanion.sourceModule
+      else
+        val companion = registeredCompanion.denot
+        if companion.isAbsent() then NoSymbol
+        else companion.sourceModule
 
     private def companionType(using Context): Symbol =
       if (is(Package)) NoSymbol
       else if (is(ModuleVal)) moduleClass.denot.companionType
-      else if registeredCompanion.isAbsent() then NoSymbol
-      else registeredCompanion
+      else
+        val companion = registeredCompanion.denot
+        if companion.isAbsent() then NoSymbol
+        else companion.symbol
 
     /** The class with the same (type-) name as this module or module class,
      *  and which is also defined in the same scope and compilation unit.

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -182,10 +182,8 @@ object Symbols extends SymUtils {
         // periods check out OK. But once a package member is overridden it is not longer
         // valid. If the option would be removed, the check would be no longer needed.
 
-    final def isTerm(using Context): Boolean =
-      (if (defRunId == ctx.runId) lastDenot else denot).isTerm
-    final def isType(using Context): Boolean =
-      (if (defRunId == ctx.runId) lastDenot else denot).isType
+    final def isTerm(using Context): Boolean = lastDenot.isTerm
+    final def isType(using Context): Boolean = lastDenot.isType
     final def asTerm(using Context): TermSymbol = {
       assert(isTerm, s"asTerm called on not-a-Term $this" );
       asInstanceOf[TermSymbol]

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -108,7 +108,7 @@ object Symbols extends SymUtils {
     /** The current denotation of this symbol */
     final def denot(using Context): SymDenotation = {
       util.Stats.record("Symbol.denot")
-      if checkedPeriod == ctx.period then lastDenot
+      if checkedPeriod.contains(ctx.period) then lastDenot
       else computeDenot(lastDenot)
     }
 
@@ -117,8 +117,9 @@ object Symbols extends SymUtils {
       // the JIT (reputedly, cutoff is at 35 bytes)
       util.Stats.record("Symbol.computeDenot")
       val now = ctx.period
-      checkedPeriod = now
-      if lastd.validFor.contains(now) then lastd else recomputeDenot(lastd)
+      val vf = lastd.validFor
+      if vf.contains(now) then { checkedPeriod = vf; lastd }
+      else { checkedPeriod = now; recomputeDenot(lastd) }
     }
 
     /** Overridden in NoSymbol */

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -122,6 +122,13 @@ object Symbols extends SymUtils {
       else { checkedPeriod = now; recomputeDenot(lastd) }
     }
 
+    protected final def validLastDenot(using Context): SymDenotation | Null = {
+      val lastd = lastDenot
+      val vf = lastd.validFor
+      if vf.contains(ctx.period) then { checkedPeriod = vf; lastd }
+      else null
+    }
+
     /** Overridden in NoSymbol */
     protected def recomputeDenot(lastd: SymDenotation)(using Context): SymDenotation = {
       util.Stats.record("Symbol.recomputeDenot")
@@ -540,7 +547,9 @@ object Symbols extends SymUtils {
     }
 
     final def classDenot(using Context): ClassDenotation =
-      denot.asInstanceOf[ClassDenotation]
+      val lastd = validLastDenot
+      if lastd == null then denot.asInstanceOf[ClassDenotation]
+      else lastd.asInstanceOf[ClassDenotation]
 
     override protected def prefixString: String = "ClassSymbol"
   }

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -94,6 +94,21 @@ object Symbols extends SymUtils {
     private var lastDenot: SymDenotation = uninitialized
     private var checkedPeriod: Period = Nowhere
 
+    /** A cache for `SourceLanguage(this)`, which is stable for a whole run:
+     *  the language a symbol was defined in does not change between phases
+     *  (see the comment in `SourceLanguage.apply`). Keyed by run id since the
+     *  symbol can be re-completed with different flags in a later run.
+     */
+    private var mySourceLanguage: SourceLanguage | Null = null
+    private var mySourceLanguageRunId: RunId = NoRunId
+
+    private[core] final def cachedSourceLanguage(runId: RunId): SourceLanguage | Null =
+      if mySourceLanguageRunId == runId then mySourceLanguage else null
+
+    private[core] final def setCachedSourceLanguage(language: SourceLanguage, runId: RunId): Unit =
+      mySourceLanguage = language
+      mySourceLanguageRunId = runId
+
     private[core] def invalidateDenotCache(): Unit = { checkedPeriod = Nowhere }
 
     /** Set the denotation of this symbol

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -132,7 +132,10 @@ object Symbols extends SymUtils {
     /** Overridden in NoSymbol */
     protected def recomputeDenot(lastd: SymDenotation)(using Context): SymDenotation = {
       util.Stats.record("Symbol.recomputeDenot")
-      val newd = lastd.current.asInstanceOf[SymDenotation]
+      val fast = lastd.nextInRunIfFast(ctx.period)
+      val newd =
+        if fast == null then lastd.current.asInstanceOf[SymDenotation]
+        else fast.asInstanceOf[SymDenotation]
       if newd.exists || lastd.initial.validFor.firstPhaseId <= ctx.phaseId then
         lastDenot = newd
       else

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -122,6 +122,13 @@ object Symbols extends SymUtils {
       else { checkedPeriod = now; recomputeDenot(lastd) }
     }
 
+    protected final def validLastDenot(using Context): SymDenotation | Null = {
+      val lastd = lastDenot
+      val vf = lastd.validFor
+      if vf.contains(ctx.period) then { checkedPeriod = vf; lastd }
+      else null
+    }
+
     /** Overridden in NoSymbol */
     protected def recomputeDenot(lastd: SymDenotation)(using Context): SymDenotation = {
       util.Stats.record("Symbol.recomputeDenot")
@@ -533,7 +540,9 @@ object Symbols extends SymUtils {
     }
 
     final def classDenot(using Context): ClassDenotation =
-      denot.asInstanceOf[ClassDenotation]
+      val lastd = validLastDenot
+      if lastd == null then denot.asInstanceOf[ClassDenotation]
+      else lastd.asInstanceOf[ClassDenotation]
 
     override protected def prefixString: String = "ClassSymbol"
   }

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -21,8 +21,21 @@ enum SourceLanguage:
   def isScala2: Boolean = this eq Scala2
   def isScala3: Boolean = this eq Scala3
 object SourceLanguage:
-  /** The language in which `sym` was defined. */
+  /** The language in which `sym` was defined.
+   *
+   *  The result is cached in `sym` for the current run, see `compute` for
+   *  why this is sound.
+   */
   def apply(sym: Symbol)(using Context): SourceLanguage =
+    val cached = sym.cachedSourceLanguage(ctx.runId)
+    if cached != null then cached
+    else
+      val language = compute(sym)
+      sym.setCachedSourceLanguage(language, ctx.runId)
+      language
+
+  /** Compute the language in which `sym` was defined. */
+  private def compute(sym: Symbol)(using Context): SourceLanguage =
     // We might be using this method while recalculating the denotation,
     // so let's use `lastKnownDenotation`.
     // This is ok as the source of the symbol and whether it is inline should

--- a/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeErasure.scala
@@ -24,8 +24,21 @@ enum SourceLanguage:
   def isScala2: Boolean = this eq Scala2
   def isScala3: Boolean = this eq Scala3
 object SourceLanguage:
-  /** The language in which `sym` was defined. */
+  /** The language in which `sym` was defined.
+   *
+   *  The result is cached in `sym` for the current run, see `compute` for
+   *  why this is sound.
+   */
   def apply(sym: Symbol)(using Context): SourceLanguage =
+    val cached = sym.cachedSourceLanguage(ctx.runId)
+    if cached != null then cached
+    else
+      val language = compute(sym)
+      sym.setCachedSourceLanguage(language, ctx.runId)
+      language
+
+  /** Compute the language in which `sym` was defined. */
+  private def compute(sym: Symbol)(using Context): SourceLanguage =
     // We might be using this method while recalculating the denotation,
     // so let's use `lastKnownDenotation`.
     // This is ok as the source of the symbol and whether it is inline should

--- a/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
@@ -17,6 +17,15 @@ class NameBuffer extends TastyBuffer(10000) {
   import NameBuffer.*
 
   private val nameRefs = new mutable.LinkedHashMap[Name, NameRef]
+  private val stringLiteralRefs = new mutable.HashMap[String, NameRef]
+  private val utf8NameRefs = new mutable.HashMap[String, NameRef]
+  private val nameEntries = new mutable.ArrayBuffer[Name | String]
+
+  private def addEntry(entry: Name | String): NameRef = {
+    val ref = NameRef(nameEntries.size)
+    nameEntries += entry
+    ref
+  }
 
   def nameIndex(name: Name): NameRef = {
     val name1 = name.toTermName
@@ -43,15 +52,42 @@ class NameBuffer extends TastyBuffer(10000) {
             nameIndex(original)
           case _ =>
         }
-        val ref = NameRef(nameRefs.size)
+        val ref = name1 match
+          case name: SimpleName =>
+            val value = simpleNameValue(name)
+            stringLiteralRefs.get(value) match
+              case Some(ref) => ref
+              case None =>
+                val ref = addEntry(name1)
+                utf8NameRefs(value) = ref
+                ref
+          case _ =>
+            addEntry(name1)
         nameRefs(name1) = ref
         ref
     }
   }
 
-  def utf8Index(value: String): NameRef =
-    import Decorators.toTermName
-    nameIndex(value.toTermName)
+  /** Reserve a UTF8 name-table entry for a raw string, keyed by the string
+   *  itself rather than by an interned `Name`. Source paths (`utf8Index`,
+   *  `PositionPickler.pickleSource`) and TASTy string constants all funnel
+   *  through here so that, e.g., the `@SourceFile` annotation argument, the
+   *  position source path, and the `SOURCEFILEattr` value still collapse to a
+   *  single entry without allocating a global `TermName`.
+   */
+  def stringLiteralIndex(value: String): NameRef =
+    stringLiteralRefs.get(value) match
+      case Some(ref) => ref
+      case None =>
+        val ref = utf8NameRefs.getOrElse(value, {
+          val ref = addEntry(value)
+          utf8NameRefs(value) = ref
+          ref
+        })
+        stringLiteralRefs(value) = ref
+        ref
+
+  def utf8Index(value: String): NameRef = stringLiteralIndex(value)
 
   private inline def withLength(inline op: Unit, lengthWidth: Int = 1): Unit = {
     val lengthAddr = currentAddr
@@ -75,6 +111,15 @@ class NameBuffer extends TastyBuffer(10000) {
         -paramSig
     }
     writeInt(encodedValue)
+  }
+
+  private def pickleUtf8String(value: String): Unit = {
+    writeByte(NameTags.UTF8)
+    val bytes =
+      if value.isEmpty then new Array[Byte](0)
+      else Codec.toUTF8(value)
+    writeNat(bytes.length)
+    writeBytes(bytes, bytes.length)
   }
 
   def pickleNameContents(name: Name): Unit = {
@@ -118,11 +163,21 @@ class NameBuffer extends TastyBuffer(10000) {
 
   override def assemble(): Unit = {
     var i = 0
-    for (name, ref) <- nameRefs do
-      val ref = nameRefs(name)
-      assert(ref.index == i)
+    for entry <- nameEntries do
+      entry match
+        case name: Name =>
+          assert(nameRefs(name).index == i)
+          pickleNameContents(name)
+        case value: String =>
+          assert(stringLiteralRefs(value).index == i)
+          pickleUtf8String(value)
       i += 1
-      pickleNameContents(name)
+    assert(i == nameEntries.size)
+    val refs = new mutable.HashSet[Int]
+    refs.sizeHint(nameRefs.size + stringLiteralRefs.size)
+    nameRefs.valuesIterator.foreach(ref => refs += ref.index)
+    stringLiteralRefs.valuesIterator.foreach(ref => refs += ref.index)
+    assert(refs.size == nameEntries.size)
   }
 }
 
@@ -130,4 +185,8 @@ object NameBuffer {
   private val maxIndexWidth = 3  // allows name indices up to 2^21.
   private val payloadBitsPerByte = 7 // determined by nat encoding in TastyBuffer
   private val maxNumInByte = (1 << payloadBitsPerByte) - 1
+
+  private def simpleNameValue(name: SimpleName): String =
+    if name.length == 0 then ""
+    else new String(chrs, name.start, name.length)
 }

--- a/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
@@ -17,6 +17,15 @@ class NameBuffer extends TastyBuffer(10000) {
   import NameBuffer.*
 
   private val nameRefs = new mutable.LinkedHashMap[Name, NameRef]
+  private val stringLiteralRefs = new mutable.HashMap[String, NameRef]
+  private val utf8NameRefs = new mutable.HashMap[String, NameRef]
+  private val nameEntries = new mutable.ArrayBuffer[Name | String]
+
+  private def addEntry(entry: Name | String): NameRef = {
+    val ref = NameRef(nameEntries.size)
+    nameEntries += entry
+    ref
+  }
 
   def nameIndex(name: Name): NameRef = {
     val name1 = name.toTermName
@@ -43,15 +52,42 @@ class NameBuffer extends TastyBuffer(10000) {
             nameIndex(original)
           case _ =>
         }
-        val ref = NameRef(nameRefs.size)
+        val ref = name1 match
+          case name: SimpleName =>
+            val value = name.toString
+            stringLiteralRefs.get(value) match
+              case Some(ref) => ref
+              case None =>
+                val ref = addEntry(name1)
+                utf8NameRefs(value) = ref
+                ref
+          case _ =>
+            addEntry(name1)
         nameRefs(name1) = ref
         ref
     }
   }
 
-  def utf8Index(value: String): NameRef =
-    import Decorators.toTermName
-    nameIndex(value.toTermName)
+  /** Reserve a UTF8 name-table entry for a raw string, keyed by the string
+   *  itself rather than by an interned `Name`. Source paths (`utf8Index`,
+   *  `PositionPickler.pickleSource`) and TASTy string constants all funnel
+   *  through here so that, e.g., the `@SourceFile` annotation argument, the
+   *  position source path, and the `SOURCEFILEattr` value still collapse to a
+   *  single entry without allocating a global `TermName`.
+   */
+  def stringLiteralIndex(value: String): NameRef =
+    stringLiteralRefs.get(value) match
+      case Some(ref) => ref
+      case None =>
+        val ref = utf8NameRefs.getOrElse(value, {
+          val ref = addEntry(value)
+          utf8NameRefs(value) = ref
+          ref
+        })
+        stringLiteralRefs(value) = ref
+        ref
+
+  def utf8Index(value: String): NameRef = stringLiteralIndex(value)
 
   private inline def withLength(inline op: Unit, lengthWidth: Int = 1): Unit = {
     val lengthAddr = currentAddr
@@ -75,6 +111,15 @@ class NameBuffer extends TastyBuffer(10000) {
         -paramSig
     }
     writeInt(encodedValue)
+  }
+
+  private def pickleUtf8String(value: String): Unit = {
+    writeByte(NameTags.UTF8)
+    val bytes =
+      if value.isEmpty then new Array[Byte](0)
+      else Codec.toUTF8(value)
+    writeNat(bytes.length)
+    writeBytes(bytes, bytes.length)
   }
 
   def pickleNameContents(name: Name): Unit = {
@@ -116,11 +161,21 @@ class NameBuffer extends TastyBuffer(10000) {
 
   override def assemble(): Unit = {
     var i = 0
-    for (name, ref) <- nameRefs do
-      val ref = nameRefs(name)
-      assert(ref.index == i)
+    for entry <- nameEntries do
+      entry match
+        case name: Name =>
+          assert(nameRefs(name).index == i)
+          pickleNameContents(name)
+        case value: String =>
+          assert(stringLiteralRefs(value).index == i)
+          pickleUtf8String(value)
       i += 1
-      pickleNameContents(name)
+    assert(i == nameEntries.size)
+    val refs = new mutable.HashSet[Int]
+    refs.sizeHint(nameRefs.size + stringLiteralRefs.size)
+    nameRefs.valuesIterator.foreach(ref => refs += ref.index)
+    stringLiteralRefs.valuesIterator.foreach(ref => refs += ref.index)
+    assert(refs.size == nameEntries.size)
   }
 }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -80,7 +80,7 @@ object PositionPickler:
     def pickleSource(source: SourceFile): Unit = {
       buf.writeInt(SOURCE)
       val relativePath = SourceFile.relativePath(source, relativePathReference)
-      buf.writeInt(pickler.nameBuffer.nameIndex(relativePath.toTermName).index)
+      buf.writeInt(pickler.nameBuffer.stringLiteralIndex(relativePath).index)
     }
 
     /** True if x's position shouldn't be reconstructed automatically from its initial span

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -77,7 +77,7 @@ object PositionPickler:
 
     def pickleSource(source: SourceFile): Unit = {
       buf.writeInt(SOURCE)
-      buf.writeInt(pickler.nameBuffer.nameIndex(source.pathRelativeToSourceRoot.toTermName).index)
+      buf.writeInt(pickler.nameBuffer.stringLiteralIndex(source.pathRelativeToSourceRoot).index)
     }
 
     /** True if x's position shouldn't be reconstructed automatically from its initial span

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreePickler.scala
@@ -151,7 +151,7 @@ class TreePickler(pickler: TastyPickler, attributes: Attributes) {
       writeLongInt(java.lang.Double.doubleToRawLongBits(c.doubleValue))
     case StringTag =>
       writeByte(STRINGconst)
-      pickleName(c.stringValue.toTermName)
+      writeNat(pickler.nameBuffer.stringLiteralIndex(c.stringValue).index)
     case NullTag =>
       writeByte(NULLconst)
     case ClazzTag =>

--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -37,7 +37,8 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
     override def parents = Array(root.superClass)
 
     override def exclude(sym: Symbol) =
-      !sym.isOneOf(MethodOrModule) || sym.isAllOf(Module | JavaDefined) || super.exclude(sym)
+      val denot = sym.denot
+      !denot.isOneOf(MethodOrModule) || denot.isAllOf(Module | JavaDefined) || super.exclude(denot)
 
     override def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parent: Symbol): Boolean =
       OverridingPairs.isOverridingPair(sym1, sym2, parent.thisType)

--- a/compiler/src/dotty/tools/dotc/transform/Bridges.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Bridges.scala
@@ -38,7 +38,8 @@ class Bridges(root: ClassSymbol, thisPhase: DenotTransformer)(using Context) {
     override def parents = Array(root.superClass)
 
     override def exclude(sym: Symbol) =
-      !sym.isOneOf(MethodOrModule) || sym.isAllOf(Module | JavaDefined) || super.exclude(sym)
+      val denot = sym.denot
+      !denot.isOneOf(MethodOrModule) || denot.isAllOf(Module | JavaDefined) || super.exclude(denot)
 
     override def canBeHandledByParent(sym1: Symbol, sym2: Symbol, parent: Symbol): Boolean =
       OverridingPairs.isOverridingPair(sym1, sym2, parent.thisType)

--- a/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Dependencies.scala
@@ -3,7 +3,7 @@ package dotc
 package transform
 
 import core.*
-import Symbols.*, Contexts.*, Types.*, Flags.*, Decorators.*
+import Symbols.*, Contexts.*, Types.*, Flags.*, Decorators.*, SymDenotations.*
 
 import collection.mutable.{LinkedHashMap, LinkedHashSet}
 import annotation.constructorOnly
@@ -70,10 +70,14 @@ abstract class Dependencies(root: ast.tpd.Tree, @constructorOnly rootContext: Co
    *  free variable proxies from their enclosing class.
    */
   private def isLocal(sym: Symbol)(using Context): Boolean =
-    val owner = sym.maybeOwner
-    owner.isTerm
-    || owner.is(Trait) && isLocal(owner)
-    || sym.isConstructor && isLocal(owner)
+    isLocal(sym.denot)
+
+  private def isLocal(denot: SymDenotation)(using Context): Boolean =
+    val owner = denot.maybeOwner
+    val ownerDenot = owner.denot
+    ownerDenot.isTerm
+    || ownerDenot.is(Trait) && isLocal(ownerDenot)
+    || denot.isConstructor && isLocal(ownerDenot)
 
   /** Set `logicOwner(sym)` to `owner` if `owner` is more deeply nested
    *  than the previous value of `logicOwner(sym)`.

--- a/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ElimErasedValueType.scala
@@ -90,7 +90,8 @@ class ElimErasedValueType extends MiniPhase with InfoTransformer { thisPhase =>
           // that are bypassed with different types. See neg/11719a.scala.
           atPhase(elimRepeatedPhase.next) { super.isSubParent(parent, bc) }
         override def exclude(sym: Symbol) =
-          !sym.is(Method) || sym.is(Bridge) || super.exclude(sym)
+          val denot = sym.denot
+          !denot.is(Method) || denot.is(Bridge) || super.exclude(denot)
         override def matches(sym1: Symbol, sym2: Symbol) =
           sym1.signature == sym2.signature
       }

--- a/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
+++ b/compiler/src/dotty/tools/dotc/transform/OverridingPairs.scala
@@ -4,6 +4,7 @@ package transform
 
 import core.*
 import Flags.*, Symbols.*, Contexts.*, Scopes.*, Decorators.*, Types.Type
+import SymDenotations.*
 import NameKinds.DefaultGetterName
 import NullOpsDecorator.*
 import collection.immutable.BitSet
@@ -33,8 +34,11 @@ object OverridingPairs:
      *  But it may be refined in subclasses.
      */
     protected def exclude(sym: Symbol): Boolean =
-      !sym.memberCanMatchInheritedSymbols
-      || isCaptureChecking && atPhase(ctx.phase.prev)(sym.is(Private))
+      exclude(sym.denot)
+
+    protected final def exclude(denot: SymDenotation): Boolean =
+      !denot.memberCanMatchInheritedSymbols
+      || isCaptureChecking && atPhase(ctx.phase.prev)(denot.symbol.is(Private))
         // for capture checking we drop the private flag of certain parameter accessors
         // but these still need no overriding checks
 

--- a/compiler/src/dotty/tools/io/FileExtension.scala
+++ b/compiler/src/dotty/tools/io/FileExtension.scala
@@ -15,8 +15,13 @@ enum FileExtension(val toLowerCase: String):
   /** Fallback extension */
   case External(override val toLowerCase: String) extends FileExtension(toLowerCase)
 
+  // The comparisons below use `eq` rather than `==`: all the compared cases are
+  // singletons without `equals` overrides, and the only equals-overriding case
+  // `External` can never equal a singleton case, so `==` and `eq` agree while
+  // `eq` avoids the virtual `equals` dispatch on this very hot path.
+
   /** represents an empty file extension. */
-  def isEmpty: Boolean = this == Empty
+  def isEmpty: Boolean = this eq Empty
 
   /** the full extension including a leading dot */
   val withDot: String = "." + toLowerCase
@@ -24,21 +29,21 @@ enum FileExtension(val toLowerCase: String):
   override def toString: String = toLowerCase
 
   /** represents `".tasty"` */
-  def isTasty = this == Tasty
+  def isTasty = this eq Tasty
   /** represents `".betasty"` */
-  def isBetasty = this == Betasty
+  def isBetasty = this eq Betasty
   /** represents `".class"` */
-  def isClass = this == Class
+  def isClass = this eq Class
   /** represents `".scala"` */
-  def isScala = this == Scala
+  def isScala = this eq Scala
   /** represents `".sc"` */
-  def isScalaScript = this == ScalaScript
+  def isScalaScript = this eq ScalaScript
   /** represents `".java"` */
-  def isJava = this == Java
+  def isJava = this eq Java
   /** represents `".jar"` */
-  def isJar: Boolean = this == Jar
+  def isJar: Boolean = this eq Jar
   /** represents `".zip"` */
-  def isZip: Boolean = this == Zip
+  def isZip: Boolean = this eq Zip
   /** represents `".jar"` or `".zip"` */
   def isJarOrZip: Boolean = isJar || isZip
   /** represents `".scala"` or `".java"` */

--- a/compiler/src/dotty/tools/io/FileExtension.scala
+++ b/compiler/src/dotty/tools/io/FileExtension.scala
@@ -15,8 +15,13 @@ enum FileExtension(val toLowerCase: String):
   /** Fallback extension */
   private case External(override val toLowerCase: String) extends FileExtension(toLowerCase)
 
+  // The comparisons below use `eq` rather than `==`: all the compared cases are
+  // singletons without `equals` overrides, and the only equals-overriding case
+  // `External` can never equal a singleton case, so `==` and `eq` agree while
+  // `eq` avoids the virtual `equals` dispatch on this very hot path.
+
   /** represents an empty file extension. */
-  def isEmpty: Boolean = this == Empty
+  def isEmpty: Boolean = this eq Empty
 
   /** the full extension including a leading dot */
   val withDot: String = "." + toLowerCase
@@ -24,21 +29,21 @@ enum FileExtension(val toLowerCase: String):
   override def toString: String = toLowerCase
 
   /** represents `".tasty"` */
-  def isTasty = this == Tasty
+  def isTasty = this eq Tasty
   /** represents `".betasty"` */
-  def isBetasty = this == Betasty
+  def isBetasty = this eq Betasty
   /** represents `".class"` */
-  def isClass = this == Class
+  def isClass = this eq Class
   /** represents `".scala"` */
-  def isScala = this == Scala
+  def isScala = this eq Scala
   /** represents `".sc"` */
-  def isScalaScript = this == ScalaScript
+  def isScalaScript = this eq ScalaScript
   /** represents `".java"` */
-  def isJava = this == Java
+  def isJava = this eq Java
   /** represents `".jar"` */
-  def isJar: Boolean = this == Jar
+  def isJar: Boolean = this eq Jar
   /** represents `".zip"` */
-  def isZip: Boolean = this == Zip
+  def isZip: Boolean = this eq Zip
   /** represents `".jar"` or `".zip"` */
   def isJarOrZip: Boolean = isJar || isZip
   /** represents `".scala"` or `".java"` */

--- a/compiler/test/dotty/tools/dotc/core/NameOpsTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/NameOpsTest.scala
@@ -1,8 +1,10 @@
 package dotty.tools.dotc.core
 
-import dotty.tools.dotc.core.NameOps.isOperatorName
-import dotty.tools.dotc.core.Names.{termName, SimpleName}
+import dotty.tools.dotc.core.NameOps.{isOperatorName, moduleClassName, stripModuleClassSuffix}
+import dotty.tools.dotc.core.Names.{termName, typeName, SimpleName}
+import dotty.tools.dotc.core.StdNames.nme
 
+import org.junit.Assert.*
 import org.junit.Test
 
 class NameOpsTest:
@@ -13,3 +15,15 @@ class NameOpsTest:
   @Test def isOperatorNameNeg: Unit =
     for name <- List("foo", "*_*", "<init>", "$reserved", "a*", "2*") do
       assert(!isOperatorName(termName(name)))
+
+  @Test def stripModuleClassSuffixNoOpPreservesSimpleNames: Unit =
+    val term = termName("ordinary")
+    assertSame(term, term.stripModuleClassSuffix)
+
+    val tpe = typeName("Ordinary")
+    assertSame(tpe, tpe.stripModuleClassSuffix)
+
+  @Test def stripModuleClassSuffixStillHandlesModuleNames: Unit =
+    assertEquals(termName("Foo"), termName("Foo$").stripModuleClassSuffix)
+    assertEquals(typeName("Foo"), termName("Foo").moduleClassName.stripModuleClassSuffix)
+    assertSame(nme.nothingClass, nme.nothingClass.stripModuleClassSuffix)


### PR DESCRIPTION
Optimizes **Symbols & Names** — one subsystem split out of the large performance PR scala/scala3#26025 to make review tractable.

**Estimated speedup:** ~2.93% (sum of 13 per-commit profiler estimates across 14 commits); plus ~4.3 MiB allocation reduction

Full context, benchmarking methodology, and per-commit JFR profiling deltas are in the parent PR scala/scala3#26025.