### PR TITLE
perf: optimize Contexts & Definitions (~2.75% estimated speedup)

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1474,7 +1474,10 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
    */
   override def inlineContext(tree: Inlined)(using Context): Context = {
     // We assume enclosingInlineds is already normalized, and only process the new call with the head.
-    val oldIC = enclosingInlineds
+    val oldICIndex = ctx.propertyIndex(InlinedCalls)
+    val oldIC =
+      if oldICIndex >= 0 then ctx.propertyAt[List[Tree]](oldICIndex)
+      else Nil
 
     val newIC =
       if tree.inlinedFromOuterScope then
@@ -1485,7 +1488,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
         tree.call :: oldIC
 
     if oldIC.isEmpty then ctx.fresh.setProperties(InlinedCalls, newIC, InlinedTrees, new Counter)
-    else ctx.fresh.setProperty(InlinedCalls, newIC)
+    else ctx.fresh.replacePropertyAt(oldICIndex, InlinedCalls, newIC)
   }
 
   /** All enclosing calls that are currently inlined, from innermost to outermost.

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1484,24 +1484,24 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       else
         tree.call :: oldIC
 
-    val ctx1 = ctx.fresh.setProperty(InlinedCalls, newIC)
-    if oldIC.isEmpty then ctx1.setProperty(InlinedTrees, new Counter) else ctx1
+    if oldIC.isEmpty then ctx.fresh.setProperties(InlinedCalls, newIC, InlinedTrees, new Counter)
+    else ctx.fresh.setProperty(InlinedCalls, newIC)
   }
 
   /** All enclosing calls that are currently inlined, from innermost to outermost.
    */
   def enclosingInlineds(using Context): List[Tree] =
-    ctx.property(InlinedCalls).getOrElse(Nil)
+    ctx.propertyOrElse(InlinedCalls, Nil)
 
   /** Record inlined trees */
   def addInlinedTrees(n: Int)(using Context): Unit =
-    ctx.property(InlinedTrees).foreach(_.count += n)
+    val counter = ctx.propertyOrElse(InlinedTrees, null)
+    if counter != null then counter.count += n
 
   /** Check if the limit on the number of inlined trees has been reached */
   def reachedInlinedTreesLimit(using Context): Boolean =
-    ctx.property(InlinedTrees) match
-      case Some(c) => c.count > ctx.settings.XmaxInlinedTrees.value
-      case None => false
+    val counter = ctx.propertyOrElse(InlinedTrees, null)
+    counter != null && counter.count > ctx.settings.XmaxInlinedTrees.value
 
   /** The source file where the symbol of the `inline` method referred to by `call`
    *  is defined

--- a/compiler/src/dotty/tools/dotc/core/Annotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/Annotations.scala
@@ -129,6 +129,15 @@ object Annotations {
   }
 
   case class ConcreteAnnotation(t: Tree) extends Annotation:
+    // Cache annotClass(t); invariant per-instance since t is immutable.
+    private var mySymbol: Symbol | Null = null
+    override def symbol(using Context): Symbol =
+      val s = mySymbol
+      if s != null then s.uncheckedNN
+      else
+        val s2 = annotClass(t)
+        mySymbol = s2
+        s2
     def tree(using Context): Tree = t
 
   /** A class for optimized, compact annotations that are defined by a type

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -558,8 +558,12 @@ object Contexts {
       if outer eq this then fresh.fastInit(this)
       else fresh.init(outer, this).setTyperState(this.typerState)
 
+    /** A fresh clone of this context with only the owner changed. */
+    private[Contexts] def freshWithOwner(owner: Symbol): FreshContext =
+      FreshContext(base).fastInitWithOwner(this, owner)
+
     final def withOwner(owner: Symbol): Context =
-      if (owner ne this.owner) fresh.setOwner(owner) else this
+      if (owner ne this.owner) freshWithOwner(owner) else this
 
     final def withTyperState(typerState: TyperState): Context =
       if typerState ne this.typerState then fresh.setTyperState(typerState) else this
@@ -698,9 +702,35 @@ object Contexts {
       this
     }
 
+    /** Fast path for owner-only context changes. */
+    private[Contexts] def fastInitWithOwner(origin: Context, owner: Symbol): this.type = {
+      assert(owner != NoSymbol)
+      initWithOwner(origin, origin, owner)
+    }
+
+    private[Contexts] def initWithOwner(outer: Context, origin: Context, owner: Symbol): this.type = {
+      _outer = outer
+      _period = origin.period
+      _mode = origin.mode
+      _owner = owner
+      _tree = origin.tree
+      _scope = origin.scope
+      _typerState = origin.typerState
+      _gadtState = origin.gadtState
+      _searchHistory = origin.searchHistory
+      _source = origin.source
+      _morePropertiesArr = origin.morePropertiesArr
+      _store = origin.store
+      this
+    }
+
     def reuseIn(outer: Context): this.type =
       resetCaches()
       init(outer, outer)
+
+    private[Contexts] def reuseInWithOwner(outer: Context, owner: Symbol): this.type =
+      resetCaches()
+      initWithOwner(outer, outer, owner)
 
     def setPeriod(period: Period): this.type =
       util.Stats.record("Context.setPeriod")
@@ -966,10 +996,10 @@ object Contexts {
   inline def runWithOwner[T](owner: Symbol)(inline op: Context ?=> T)(using Context): T =
     if Config.reuseOwnerContexts then
       val pool = ctx.base.generalContextPool
-      try op(using pool.next().setOwner(owner).setTyperState(ctx.typerState))
+      try op(using pool.nextWithOwner(owner))
       finally pool.free()
     else
-      op(using ctx.fresh.setOwner(owner))
+      op(using ctx.freshWithOwner(owner))
 
   /** The type comparer of the kind created by `maker` to be used.
    *  This is the currently active type comparer CMP if
@@ -1075,6 +1105,9 @@ object Contexts {
     protected def fresh()(using Context): FreshContext =
       FreshContext(ctx.base).init(ctx, ctx)
 
+    protected def freshWithOwner(owner: Symbol)(using Context): FreshContext =
+      FreshContext(ctx.base).fastInitWithOwner(ctx, owner)
+
     private var inUse: Int = 0
     private var pool = new mutable.ArrayBuffer[FreshContext]
 
@@ -1086,6 +1119,19 @@ object Contexts {
           pool(inUse).reuseIn(ctx)
         else
           val c = fresh()
+          pool += c
+          c
+      inUse += 1
+      nestedCtx
+
+    def nextWithOwner(owner: Symbol)(using Context): FreshContext =
+      val base = ctx.base
+      import base.*
+      val nestedCtx =
+        if inUse < pool.size then
+          pool(inUse).reuseInWithOwner(ctx, owner)
+        else
+          val c = freshWithOwner(owner)
           pool += c
           c
       inUse += 1

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -180,6 +180,19 @@ object Contexts {
         i += 2
       None
 
+    /** Like `property`, but returns the raw stored value (or `null` if absent)
+     *  without allocating a `Some` wrapper. Use this on hot paths where the
+     *  caller immediately tests presence / extracts the value.
+     */
+    def propertyRaw[T](key: Key[T]): T | Null =
+      val arr = morePropertiesArr
+      var i = 0
+      val len = arr.length
+      while i < len do
+        if arr(i) eq key then return arr(i + 1).asInstanceOf[T]
+        i += 2
+      null
+
     def propertyOrElse[T](key: Key[T], default: => T): T =
       val arr = morePropertiesArr
       var i = 0

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -59,6 +59,8 @@ object Contexts {
 
   private val initialStore = store11
 
+  private val emptyMoreProps: Array[AnyRef] = new Array[AnyRef](0)
+
   /** The current context */
   inline def ctx(using ctx: Context): Context = ctx
 
@@ -151,11 +153,32 @@ object Contexts {
 
     /** A map in which more contextual properties can be stored
      *  Typically used for attributes that are read and written only in special situations.
+     *  Backed by a flat `Array[AnyRef]` of interleaved `[key0, value0, key1, value1, ...]`
+     *  to avoid `HashMap.updated` allocations on the hot `setProperty` path; keys use
+     *  identity equality (`Property.Key` has no overridden `equals`).
      */
-    def moreProperties: Map[Key[Any], Any]
+    def moreProperties: Map[Key[Any], Any] =
+      val arr = morePropertiesArr
+      if arr.length == 0 then Map.empty
+      else
+        val b = Map.newBuilder[Key[Any], Any]
+        var i = 0
+        while i < arr.length do
+          b += ((arr(i).asInstanceOf[Key[Any]], arr(i + 1)))
+          i += 2
+        b.result()
+
+    /** Raw interleaved `[key, value, ...]` array backing storage for properties. */
+    private[Contexts] def morePropertiesArr: Array[AnyRef]
 
     def property[T](key: Key[T]): Option[T] =
-      moreProperties.get(key).asInstanceOf[Option[T]]
+      val arr = morePropertiesArr
+      var i = 0
+      val len = arr.length
+      while i < len do
+        if arr(i) eq key then return Some(arr(i + 1).asInstanceOf[T])
+        i += 2
+      None
 
     /** A store that can be used by sub-components.
      *  Typically used for attributes that are defined only once per compilation unit.
@@ -610,8 +633,8 @@ object Contexts {
     private var _source: SourceFile = uninitialized
     final def source: SourceFile = _source
 
-    private var _moreProperties: Map[Key[Any], Any] = uninitialized
-    final def moreProperties: Map[Key[Any], Any] = _moreProperties
+    private var _morePropertiesArr: Array[AnyRef] = emptyMoreProps
+    final def morePropertiesArr: Array[AnyRef] = _morePropertiesArr
 
     private var _store: Store = uninitialized
     final def store: Store = _store
@@ -630,7 +653,7 @@ object Contexts {
       _gadtState = origin.gadtState
       _searchHistory = origin.searchHistory
       _source = origin.source
-      _moreProperties = origin.moreProperties
+      _morePropertiesArr = origin.morePropertiesArr
       _store = origin.store
       this
     }
@@ -701,9 +724,9 @@ object Contexts {
       this._source = source
       this
 
-    private def setMoreProperties(moreProperties: Map[Key[Any], Any]): this.type =
+    private def setMorePropertiesArr(arr: Array[AnyRef]): this.type =
       util.Stats.record("Context.setMoreProperties")
-      this._moreProperties = moreProperties
+      this._morePropertiesArr = arr
       this
 
     private def setStore(store: Store): this.type =
@@ -736,10 +759,35 @@ object Contexts {
     def setTypeAssigner(typeAssigner: TypeAssigner): this.type = updateStore(typeAssignerLoc, typeAssigner)
 
     def setProperty[T](key: Key[T], value: T): this.type =
-      setMoreProperties(moreProperties.updated(key, value))
+      val arr = morePropertiesArr
+      val oldLen = arr.length
+      var i = 0
+      while i < oldLen do
+        if arr(i) eq key then
+          val copy = new Array[AnyRef](oldLen)
+          System.arraycopy(arr, 0, copy, 0, oldLen)
+          copy(i + 1) = value.asInstanceOf[AnyRef]
+          return setMorePropertiesArr(copy)
+        i += 2
+      val copy = new Array[AnyRef](oldLen + 2)
+      if oldLen > 0 then System.arraycopy(arr, 0, copy, 0, oldLen)
+      copy(oldLen) = key.asInstanceOf[AnyRef]
+      copy(oldLen + 1) = value.asInstanceOf[AnyRef]
+      setMorePropertiesArr(copy)
 
     def dropProperty(key: Key[?]): this.type =
-      setMoreProperties(moreProperties - key)
+      val arr = morePropertiesArr
+      val oldLen = arr.length
+      var i = 0
+      while i < oldLen do
+        if arr(i) eq key then
+          if oldLen == 2 then return setMorePropertiesArr(emptyMoreProps)
+          val copy = new Array[AnyRef](oldLen - 2)
+          if i > 0 then System.arraycopy(arr, 0, copy, 0, i)
+          if i + 2 < oldLen then System.arraycopy(arr, i + 2, copy, i, oldLen - i - 2)
+          return setMorePropertiesArr(copy)
+        i += 2
+      this
 
     def addLocation[T](initial: T): Store.Location[T] = {
       val (loc, store1) = store.newLocation(initial)
@@ -775,7 +823,7 @@ object Contexts {
       c._typerState = TyperState.initialState()
       c._owner = NoSymbol
       c._tree = untpd.EmptyTree
-      c._moreProperties = Map(MessageLimiter -> DefaultMessageLimiter())
+      c._morePropertiesArr = Array[AnyRef](MessageLimiter, DefaultMessageLimiter())
       c._scope = EmptyScope
       c._source = NoSource
       c._store = initialStore

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -554,7 +554,9 @@ object Contexts {
 
     /** A fresh clone of this context embedded in the specified `outer` context. */
     def freshOver(outer: Context): FreshContext =
-      FreshContext(base).init(outer, this).setTyperState(this.typerState)
+      val fresh = FreshContext(base)
+      if outer eq this then fresh.fastInit(this)
+      else fresh.init(outer, this).setTyperState(this.typerState)
 
     final def withOwner(owner: Symbol): Context =
       if (owner ne this.owner) fresh.setOwner(owner) else this
@@ -670,6 +672,24 @@ object Contexts {
       _owner = origin.owner
       _tree = origin.tree
       _scope = origin.scope
+      _gadtState = origin.gadtState
+      _searchHistory = origin.searchHistory
+      _source = origin.source
+      _morePropertiesArr = origin.morePropertiesArr
+      _store = origin.store
+      this
+    }
+
+    /** Fast path for `freshOver(this)`: outer and origin are the same context,
+     *  and the typerState is the origin's typerState (fused setTyperState). */
+    private[Contexts] def fastInit(origin: Context): this.type = {
+      _outer = origin
+      _period = origin.period
+      _mode = origin.mode
+      _owner = origin.owner
+      _tree = origin.tree
+      _scope = origin.scope
+      _typerState = origin.typerState
       _gadtState = origin.gadtState
       _searchHistory = origin.searchHistory
       _source = origin.source

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -180,6 +180,15 @@ object Contexts {
         i += 2
       None
 
+    def propertyOrElse[T](key: Key[T], default: => T): T =
+      val arr = morePropertiesArr
+      var i = 0
+      val len = arr.length
+      while i < len do
+        if arr(i) eq key then return arr(i + 1).asInstanceOf[T]
+        i += 2
+      default
+
     /** A store that can be used by sub-components.
      *  Typically used for attributes that are defined only once per compilation unit.
      *  Access to store entries is much faster than access to properties, and only
@@ -784,6 +793,34 @@ object Contexts {
       if oldLen > 0 then System.arraycopy(arr, 0, copy, 0, oldLen)
       copy(oldLen) = key.asInstanceOf[AnyRef]
       copy(oldLen + 1) = value.asInstanceOf[AnyRef]
+      setMorePropertiesArr(copy)
+
+    def setProperties[T, U](key1: Key[T], value1: T, key2: Key[U], value2: U): this.type =
+      if key1 eq key2 then return setProperty(key2, value2)
+
+      val arr = morePropertiesArr
+      val oldLen = arr.length
+      var idx1 = -1
+      var idx2 = -1
+      var i = 0
+      while i < oldLen do
+        val key = arr(i)
+        if key eq key1 then idx1 = i
+        else if key eq key2 then idx2 = i
+        i += 2
+
+      val newLen = oldLen + (if idx1 < 0 then 2 else 0) + (if idx2 < 0 then 2 else 0)
+      val copy = new Array[AnyRef](newLen)
+      if oldLen > 0 then System.arraycopy(arr, 0, copy, 0, oldLen)
+      if idx1 >= 0 then copy(idx1 + 1) = value1.asInstanceOf[AnyRef]
+      else
+        copy(oldLen) = key1.asInstanceOf[AnyRef]
+        copy(oldLen + 1) = value1.asInstanceOf[AnyRef]
+      if idx2 >= 0 then copy(idx2 + 1) = value2.asInstanceOf[AnyRef]
+      else
+        val idx = if idx1 < 0 then oldLen + 2 else oldLen
+        copy(idx) = key2.asInstanceOf[AnyRef]
+        copy(idx + 1) = value2.asInstanceOf[AnyRef]
       setMorePropertiesArr(copy)
 
     def dropProperty(key: Key[?]): this.type =

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -202,6 +202,18 @@ object Contexts {
         i += 2
       default
 
+    private[dotc] def propertyIndex(key: Key[?]): Int =
+      val arr = morePropertiesArr
+      var i = 0
+      val len = arr.length
+      while i < len do
+        if arr(i) eq key then return i
+        i += 2
+      -1
+
+    private[dotc] def propertyAt[T](index: Int): T =
+      morePropertiesArr(index + 1).asInstanceOf[T]
+
     /** A store that can be used by sub-components.
      *  Typically used for attributes that are defined only once per compilation unit.
      *  Access to store entries is much faster than access to properties, and only
@@ -857,6 +869,16 @@ object Contexts {
       copy(oldLen) = key.asInstanceOf[AnyRef]
       copy(oldLen + 1) = value.asInstanceOf[AnyRef]
       setMorePropertiesArr(copy)
+
+    private[dotc] def replacePropertyAt[T](index: Int, key: Key[T], value: T): this.type =
+      val arr = morePropertiesArr
+      val oldLen = arr.length
+      if index >= 0 && (index & 1) == 0 && index + 1 < oldLen && (arr(index) eq key) then
+        val copy = new Array[AnyRef](oldLen)
+        System.arraycopy(arr, 0, copy, 0, oldLen)
+        copy(index + 1) = value.asInstanceOf[AnyRef]
+        setMorePropertiesArr(copy)
+      else setProperty(key, value)
 
     def setProperties[T, U](key1: Key[T], value1: T, key2: Key[U], value2: U): this.type =
       if key1 eq key2 then return setProperty(key2, value2)

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -441,9 +441,20 @@ object Contexts {
      *    from constructor parameters to class parameter accessors.
      */
     def superCallContext: Context =
-      val locals = owner.typeParams
+      def filteredLocals =
+        owner.typeParams
           ++ owner.asClass.unforcedDecls.filter: sym =>
-              sym.is(ParamAccessor) || sym.isContextBoundCompanion || sym.isDummyCaptureParam
+            sym.is(ParamAccessor) || sym.isContextBoundCompanion || sym.isDummyCaptureParam
+      val locals =
+        if isAfterTyper then
+          val cache = base.superCallLocalsAfterTyper
+          val cached = cache.lookup(owner)
+          if cached != null then cached
+          else
+            val locals = filteredLocals
+            cache.update(owner, locals)
+            locals
+        else filteredLocals
       superOrThisCallContext(owner.primaryConstructor, newScopeWith(locals*))
 
     /** The context for the arguments of a this(...) constructor call.
@@ -1104,6 +1115,12 @@ object Contexts {
      */
     private[core] val errorTypeMsg: mutable.Map[Types.ErrorType, Message] = mutable.Map()
 
+    /** The filtered locals used by super-call contexts after typer.
+     *  These class declaration subsets are stable after typer, but the returned
+     *  context still receives a fresh mutable scope on every call.
+     */
+    private[core] val superCallLocalsAfterTyper: MutableSymbolMap[List[Symbol]] = MutableSymbolMap()
+
     // Phases state
 
     private[core] var phasesPlan: List[List[Phase]] = uninitialized
@@ -1169,6 +1186,7 @@ object Contexts {
       emptyWildcardBounds = null
       errorsToBeReported = false
       errorTypeMsg.clear()
+      superCallLocalsAfterTyper.clear()
       sources.clear()
       files.clear()
       comparers.clear()  // forces re-evaluation of top and bottom classes in TypeComparer

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -563,7 +563,7 @@ object Contexts {
     def tolerateErrorsForBestEffort = isBestEffort || usedBestEffortTasty
 
     /** A fresh clone of this context embedded in this context. */
-    def fresh: FreshContext = freshOver(this)
+    def fresh: FreshContext = FreshContext(base).fastInit(this)
 
     /** A fresh clone of this context embedded in the specified `outer` context. */
     def freshOver(outer: Context): FreshContext =

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1843,16 +1843,40 @@ class Definitions {
   /** Is `tp` (an alias) of either a scala.FunctionN or a scala.ContextFunctionN
    *  instance?
    */
-  def isNonRefinedFunction(tp: Type)(using Context): Boolean = {
-    val arity = functionArity(tp)
-    val sym = tp.dealias.typeSymbol
+  def isNonRefinedFunction(tp: Type)(using Context): Boolean =
+    isNonRefinedFunctionDealiased(tp.dealias)
 
-    arity >= 0
-    && isFunctionClass(sym)
-    && tp.isRef(
-        FunctionType(arity, sym.name.isContextFunction).typeSymbol,
-        skipRefined = false)
-  }
+  /** Like `isNonRefinedFunction`, but `d` must already be the result of
+   *  `tp.dealias`. Threads a single dealias through the function-type
+   *  pipeline (functionArity / typeSymbol / isRef previously each dealiased
+   *  on their own).
+   */
+  private def isNonRefinedFunctionDealiased(d: Type)(using Context): Boolean =
+    // For a RefinedType (including PolyFunctionOf), `isRef(..., skipRefined = false)`
+    // below would return false, so short-circuit here. This also avoids walking
+    // `argInfos` through `functionArgInfos`' RefinedType arm.
+    if d.isInstanceOf[RefinedType] then false
+    else
+      val arity = d.argInfos.length - 1
+      if arity < 0 then false
+      else
+        val sym = d.typeSymbol
+        if !isFunctionClass(sym) then false
+        else
+          val target = FunctionType(arity, sym.name.isContextFunction).typeSymbol
+          // Inline `d.isRef(target, skipRefined = false)`: `d` is already
+          // dealiased, so the AppliedType arm's inner `dealias` is redundant.
+          d match
+            case at: AppliedType =>
+              at.tycon match
+                case tref: TypeRef if tref.symbol.isClass => tref.symbol eq target
+                case _ => d.isRef(target, skipRefined = false)
+            case tref: TypeRef =>
+              if tref.symbol.isClass then tref.symbol eq target
+              else tref.info match
+                case TypeAlias(tp) => tp.isRef(target, skipRefined = false)
+                case _ => tref.symbol eq target
+            case _ => d.isRef(target, skipRefined = false)
 
   /** Is a dependent function type represented as a RefinedType?
    */
@@ -1864,7 +1888,13 @@ class Definitions {
    *  - scala.ContextFunctionN
    */
   def isFunctionNType(tp: Type)(using Context): Boolean =
-    isNonRefinedFunction(tp.dropDependentRefinement)
+    // Inline `tp.dropDependentRefinement` and `isNonRefinedFunction` so we
+    // dealias `tp` only once. The previous chain dealiased inside
+    // dropDependentRefinement and then again inside isNonRefinedFunction.
+    val d = tp.dealias
+    d match
+      case RefinedType(parent, nme.apply, _) => isNonRefinedFunction(parent)
+      case _ => isNonRefinedFunctionDealiased(d)
 
   /** Returns whether `tp` is an instance or a refined instance of:
    *  - scala.FunctionN
@@ -1982,8 +2012,17 @@ class Definitions {
       case tp: FlexibleType =>
         asContextFunctionType(tp.hi)
       case tp1 =>
-        if tp1.typeSymbol.name.isContextFunction && isFunctionNType(tp1) then tp1
+        // tp1 is already dealiased: thread it through isFunctionNType to
+        // avoid a redundant dealias inside dropDependentRefinement/
+        // isNonRefinedFunction.
+        if tp1.typeSymbol.name.isContextFunction && isFunctionNTypeFromDealiased(tp1) then tp1
         else NoType
+
+  /** Variant of `isFunctionNType` whose input `d` is already a dealiased type. */
+  private def isFunctionNTypeFromDealiased(d: Type)(using Context): Boolean =
+    d match
+      case RefinedType(parent, nme.apply, _) => isNonRefinedFunction(parent)
+      case _ => isNonRefinedFunctionDealiased(d)
 
   /** Is `tp` an context function type? */
   def isContextFunctionType(tp: Type)(using Context): Boolean =

--- a/compiler/src/dotty/tools/dotc/core/MatchTypeTrace.scala
+++ b/compiler/src/dotty/tools/dotc/core/MatchTypeTrace.scala
@@ -41,15 +41,14 @@ object MatchTypeTrace:
 
   /** Are we running an operation that records a match type trace? */
   def isRecording(using Context): Boolean =
-    ctx.property(MatchTrace).isDefined
+    ctx.propertyRaw(MatchTrace) != null
 
   private def matchTypeFail(entry: TraceEntry)(using Context) =
-    ctx.property(MatchTrace) match
-      case Some(trace) =>
-        trace.entries match
-          case (e: TryReduce) :: es => trace.entries = entry :: trace.entries
-          case _ =>
-      case _ =>
+    val trace = ctx.propertyRaw(MatchTrace)
+    if trace != null then
+      trace.entries match
+        case (e: TryReduce) :: es => trace.entries = entry :: trace.entries
+        case _ =>
 
   /** Record a failure that scrutinee `scrut` does not match any case in `cases`.
    *  Only the first failure is recorded.
@@ -77,15 +76,14 @@ object MatchTypeTrace:
    *  If `op` succeeds the entry is removed after exit. If `op` fails, it stays.
    */
   def recurseWith(scrut: Type)(op: => Type)(using Context): Type =
-    ctx.property(MatchTrace) match
-      case Some(trace) if !trace.entries.contains(TryReduce(scrut)) =>
-        val prev = trace.entries
-        trace.entries = TryReduce(scrut) :: prev
-        val res = op
-        if res.exists then trace.entries = prev
-        res
-      case _ =>
-        op
+    val trace = ctx.propertyRaw(MatchTrace)
+    if trace != null && !trace.entries.contains(TryReduce(scrut)) then
+      val prev = trace.entries
+      trace.entries = TryReduce(scrut) :: prev
+      val res = op
+      if res.exists then trace.entries = prev
+      res
+    else op
 
   def caseText(spec: MatchTypeCaseSpec)(using Context): String =
     caseText(spec.origMatchCase)

--- a/compiler/src/dotty/tools/dotc/core/Scopes.scala
+++ b/compiler/src/dotty/tools/dotc/core/Scopes.scala
@@ -220,6 +220,31 @@ object Scopes {
 
     private[dotc] var lastEntry: ScopeEntry | Null = initElems
 
+    /** A 64-bit Bloom filter over the name hashes of the entries stored in this
+     *  scope. A bit is set whenever a name is entered; a clear bit therefore
+     *  proves that no entry with that name exists (no false negatives), which
+     *  lets `lookupEntry` skip the chain/hash probe for absent names. The vast
+     *  majority of probed scopes are empty or do not contain the queried name.
+     */
+    private var membersBloom: Long = 0L
+
+    private inline def addToBloom(name: Name): Unit =
+      membersBloom |= 1L << (name.hashCode & 63)
+
+    /** Fold the name hashes of `e` and all its predecessors into the Bloom
+     *  filter. Used when entries are shared from a base scope without going
+     *  through `newScopeEntry`.
+     */
+    private def addAllToBloom(e: ScopeEntry | Null): Unit = {
+      var entry = e
+      while (entry != null) {
+        addToBloom(entry.name)
+        entry = entry.prev
+      }
+    }
+
+    addAllToBloom(initElems)
+
     /** The size of the scope */
     private var _size = initSize
 
@@ -267,6 +292,7 @@ object Scopes {
       e.prev = lastEntry
       lastEntry = e
       if (hashTable != null) enterInHash(e)
+      addToBloom(name)
       size += 1
       elemsCache = null
       e
@@ -378,16 +404,21 @@ object Scopes {
      */
     override def lookupEntry(name: Name)(using Context): ScopeEntry | Null = {
       var e: ScopeEntry | Null = null
-      val ht = hashTable
-      if (ht != null) {
-        e = ht(name.hashCode & (ht.length - 1))
-        while ((e != null) && (e.name ne name))
-          e = e.tail
-      }
-      else {
-        e = lastEntry
-        while ((e != null) && (e.name ne name))
-          e = e.prev
+      // A clear Bloom bit proves the name is absent from the stored entries,
+      // so we can skip the chain/hash probe entirely and only consult the
+      // synthesizer below. Bits are set-only, hence there are no false negatives.
+      if ((membersBloom & (1L << (name.hashCode & 63))) != 0L) {
+        val ht = hashTable
+        if (ht != null) {
+          e = ht(name.hashCode & (ht.length - 1))
+          while ((e != null) && (e.name ne name))
+            e = e.tail
+        }
+        else {
+          e = lastEntry
+          while ((e != null) && (e.name ne name))
+            e = e.prev
+        }
       }
       if e != null then e
       else synthesize match

--- a/compiler/src/dotty/tools/dotc/core/Scopes.scala
+++ b/compiler/src/dotty/tools/dotc/core/Scopes.scala
@@ -378,14 +378,15 @@ object Scopes {
      */
     override def lookupEntry(name: Name)(using Context): ScopeEntry | Null = {
       var e: ScopeEntry | Null = null
-      if (hashTable != null) {
-        e = hashTable.nn(name.hashCode & (hashTable.nn.length - 1))
-        while ((e != null) && e.name != name)
+      val ht = hashTable
+      if (ht != null) {
+        e = ht(name.hashCode & (ht.length - 1))
+        while ((e != null) && (e.name ne name))
           e = e.tail
       }
       else {
         e = lastEntry
-        while ((e != null) && e.name != name)
+        while ((e != null) && (e.name ne name))
           e = e.prev
       }
       if e != null then e
@@ -398,13 +399,14 @@ object Scopes {
 
     /** lookup next entry with same name as this one */
     override final def lookupNextEntry(entry: ScopeEntry)(using Context): ScopeEntry | Null = {
+      val target = entry.name
       if hashTable != null then
         var e: ScopeEntry | Null = entry.tail
-        while e != null && e.name != entry.name do e = e.tail
+        while e != null && (e.name ne target) do e = e.tail
         e
       else
         var e: ScopeEntry | Null = entry.prev
-        while e != null && e.name != entry.name do e = e.prev
+        while e != null && (e.name ne target) do e = e.prev
         e
     }
 

--- a/compiler/src/dotty/tools/dotc/staging/CrossStageSafety.scala
+++ b/compiler/src/dotty/tools/dotc/staging/CrossStageSafety.scala
@@ -63,7 +63,7 @@ class CrossStageSafety extends TreeMapWithStages {
       case CancelledQuote(tree) =>
         transform(tree) // Optimization: `'{ $x }` --> `x`
       case tree: Quote =>
-        if (ctx.property(InAnnotation).isDefined)
+        if (ctx.propertyRaw(InAnnotation) != null)
           report.error("Cannot have a quote in an annotation", tree.srcPos)
 
         val tree1 =
@@ -88,7 +88,7 @@ class CrossStageSafety extends TreeMapWithStages {
         untpd.cpy.Splice(tree)(body1).withType(tpe1)
 
       case tree @ QuotedTypeOf(body) =>
-        if (ctx.property(InAnnotation).isDefined)
+        if (ctx.propertyRaw(InAnnotation) != null)
           report.error("Cannot have a quote in an annotation", tree.srcPos)
 
         if level == 0 then

--- a/compiler/src/dotty/tools/dotc/staging/StagingLevel.scala
+++ b/compiler/src/dotty/tools/dotc/staging/StagingLevel.scala
@@ -21,7 +21,8 @@ object StagingLevel {
 
   /** All enclosing calls that are currently inlined, from innermost to outermost. */
   def level(using Context): Int =
-    ctx.property(LevelKey).getOrElse(0)
+    val v = ctx.propertyRaw(LevelKey)
+    if v == null then 0 else v
 
   /** Context with an incremented staging level. */
   def quoteContext(using Context): FreshContext =
@@ -33,19 +34,19 @@ object StagingLevel {
 
   /** If we are inside a quote or a splice */
   def inQuoteOrSpliceScope(using Context): Boolean =
-    ctx.property(LevelKey).isDefined
+    ctx.propertyRaw(LevelKey) != null
 
   /** The quotation level of the definition of the locally defined symbol */
   def levelOf(sym: Symbol)(using Context): Int =
-    ctx.property(LevelOfKey) match
-      case Some(map) => map.getOrElse(sym, 0)
-      case None => 0
+    val map = ctx.propertyRaw(LevelOfKey)
+    if map == null then 0 else map.getOrElse(sym, 0)
 
   /** Context with the current staging level set for the symbols */
   def symbolsInCurrentLevel(syms: List[Symbol])(using Context): Context =
     if level == 0 then ctx
     else
-      val levelOfMap = ctx.property(LevelOfKey).getOrElse(Map.empty)
+      val raw = ctx.propertyRaw(LevelOfKey)
+      val levelOfMap: Map[Symbol, Int] = if raw == null then Map.empty else raw
       val syms1 = syms//.filter(sym => !levelOfMap.contains(sym))
       val newMap = syms1.foldLeft(levelOfMap)((acc, sym) => acc.updated(sym, level))
       ctx.fresh.setProperty(LevelOfKey, newMap)


### PR DESCRIPTION
Optimizes **Contexts & Definitions** — one subsystem split out of the large performance PR scala/scala3#26025 to make review tractable.

**Estimated speedup:** ~2.75% (sum of 12 per-commit profiler estimates across 12 commits)

Full context, benchmarking methodology, and per-commit JFR profiling deltas are in the parent PR scala/scala3#26025.