### PR TITLE
perf: optimize the JVM backend & TASTy (un)pickling (~0.86% estimated speedup)

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -1840,20 +1840,25 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
       // scala/bug#10334: make sure that a lambda object for `T => U` has a method `apply(T)U`, not only the `(Object)Object`
       // version. Using the lambda a structural type `{def apply(t: T): U}` causes a reflective lookup for this method.
       val needsGenericBridge = samMethodType != instantiatedMethodType
-      val bridgeMethods = atPhase(erasurePhase){
-        samMethod.allOverriddenSymbols.toList
+      val bridgeMethods = atPhase(erasurePhase) {
+        val overridden = samMethod.allOverriddenSymbols
+        if overridden.hasNext then overridden.toList else Nil
       }
-      val overriddenMethodTypes = bridgeMethods.map(b => bTypeLoader.methodBTypeFromSymbol(b).toASMType)
 
       // any methods which `samMethod` overrides need bridges made for them
       // this is done automatically during erasure for classes we generate, but LMF needs to have them explicitly mentioned
       // so we have to compute them at this relatively late point.
-      val bridgeTypes = (
-        if (needsGenericBridge)
-          instantiatedMethodType +: overriddenMethodTypes
+      val bridgeTypes =
+        if bridgeMethods.isEmpty then
+          if needsGenericBridge then instantiatedMethodType :: Nil else Nil
         else
-          overriddenMethodTypes
-      ).distinct.filterNot(_ == samMethodType)
+          val overriddenMethodTypes = bridgeMethods.map(b => bTypeLoader.methodBTypeFromSymbol(b).toASMType)
+          (
+            if (needsGenericBridge)
+              instantiatedMethodType +: overriddenMethodTypes
+            else
+              overriddenMethodTypes
+          ).distinct.filterNot(_ == samMethodType)
 
       val needsBridges = bridgeTypes.nonEmpty
 

--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -788,7 +788,7 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
           // scala/bug#10290: qual can be `this.$outer()` (not just `this`), so we call genLoad (not just ALOAD_0)
           val superQualTK = genLoad(superQual)
           stack.push(superQualTK)
-          genLoadArguments(args, paramTKs(app))
+          genLoadArguments(args, if args.isEmpty then Nil else paramTKs(app))
           stack.pop()
           // The receiver in bytecode should be based on the call site qualifier type,
           // instead of method declaration owner class
@@ -826,7 +826,7 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
               bc.dup(generatedType)
               stack.push(rt)
               stack.push(rt)
-              genLoadArguments(args, paramTKs(app))
+              genLoadArguments(args, if args.isEmpty then Nil else paramTKs(app))
               stack.pop(2)
               genCallMethod(ctor, InvokeStyle.Special, app)
 
@@ -864,7 +864,7 @@ trait BCodeBodyBuilder(val primitives: ScalaPrimitives, val bTypes: KnownBTypes)
             val savedStackSize = stack.recordSize()
             if invokeStyle.hasInstance then
               stack.push(genLoadQualifier(fun))
-            genLoadArguments(args, paramTKs(app))
+            genLoadArguments(args, if args.isEmpty then Nil else paramTKs(app))
             stack.restoreSize(savedStackSize)
 
             val DesugaredSelect(qual, name) = fun: @unchecked // fun is a Select, also checked in genLoadQualifier

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -14,6 +14,7 @@ import dotty.tools.dotc.core.Phases.{Phase, flattenPhase, lambdaLiftPhase, pickl
 import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.{StdNames, Types}
 import dotty.tools.dotc.core.Types.{JavaArrayType, Type, TypeRef, abstractTermNameFilter}
+import dotty.tools.dotc.util.EqHashMap
 
 import scala.annotation.tailrec
 import scala.tools.asm
@@ -60,10 +61,32 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
     specialBTypes.nn.getOrElse(sym, classBTypeFromSymbol(sym))
   }
 
+  /** Identity-keyed front cache for `classBTypeFromSymbol`. The method is called hundreds of
+   *  thousands of times per compile but resolves only a few thousand distinct class symbols,
+   *  and every call rebuilds `javaBinaryName` (a fresh string), hashes it, and probes the
+   *  string-keyed `classBTypeCache`. Caching the result by symbol identity skips all of that
+   *  on hits. Keyed by the symbol as passed in (before the JavaDefined-module normalization
+   *  below), so the linkedClass mapping is baked into the cached value, which is
+   *  deterministic within a run. A plain (non-concurrent) map is fine: unlike
+   *  `classBTypeCache`, this cache is only touched from the single-threaded code generation
+   *  path; the class writer threads computing stack map frames never call this method.
+   *  The lifetime is per-Run because BTypeLoader itself is a per-Run field of GenBCode.
+   */
+  private val symbolClassBTypeCache = new EqHashMap[Symbol, ClassBType](initialCapacity = 2048)
+
   /**
    * The ClassBType for a class symbol `sym`.
    */
   def classBTypeFromSymbol(classSym0: Symbol)(using Context): ClassBType = {
+    val cached = symbolClassBTypeCache.lookup(classSym0)
+    if cached != null then cached
+    else
+      val result = computeClassBTypeFromSymbol(classSym0)
+      symbolClassBTypeCache(classSym0) = result
+      result
+  }
+
+  private def computeClassBTypeFromSymbol(classSym0: Symbol)(using Context): ClassBType = {
     // For each java class, the scala compiler creates a class and a module (thus a module class).
     // If the symbol is a java module class, we use the java class instead. This ensures that the
     // ClassBType is created from the main class (instead of the module class).

--- a/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
@@ -228,6 +228,9 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
      *
      * Returns a pair of booleans (codeChanged, requireEliminateUnusedLocals).
      */
+    var dceCheckedLineNumbers = false
+    var hasLineNumbers = false
+
     def removalRound(
         requestNullness: Boolean,
         requestDCE: Boolean,
@@ -253,7 +256,15 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
       val runDCE = (settings.optUnreachableCode && (requestDCE || nullnessOptChanged)) ||
         settings.optBoxUnbox ||
         settings.optCopyPropagation
-      val codeRemoved = if (runDCE) LocalOptImpls.removeUnreachableCodeImpl(method, ownerClassName, callGraph, optimizerUtils) else false
+      val dceResult =
+        if (runDCE) {
+          val result = LocalOptImpls.removeUnreachableCodeImplResult(method, ownerClassName, callGraph, optimizerUtils)
+          dceCheckedLineNumbers = true
+          hasLineNumbers ||= LocalOptImpls.dceSawLineNumbers(result)
+          result
+        }
+        else 0
+      val codeRemoved = LocalOptImpls.dceRemovedCode(dceResult)
       traceIfChanged("dce")
 
       // BOX-UNBOX
@@ -351,10 +362,10 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
       else false
     traceIfChanged("localVariables")
 
-    // The asm.MethodWriter writes redundant line numbers 1:1 to the classfile, so we filter them out
-    // Note that this traversal also cleans up `LABEL_REACHABLE_STATUS` flags that were added to Label's
-    // `stats` fields during `removeUnreachableCodeImpl`
-    val lineNumbersRemoved = removeEmptyLineNumbers(method)
+    // The asm.MethodWriter writes redundant line numbers 1:1 to the classfile, so we filter them out.
+    val lineNumbersRemoved =
+      if (dceCheckedLineNumbers && !hasLineNumbers) false
+      else removeEmptyLineNumbers(method)
     traceIfChanged("lineNumbers")
 
     // assert that local variable annotations are empty (we don't emit them) - otherwise we'd have
@@ -642,6 +653,11 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
 }
 
 object LocalOptImpls {
+  private final val DceCodeRemoved = 1
+  private final val DceLineNumbersSeen = 2
+
+  def dceRemovedCode(result: Int): Boolean = (result & DceCodeRemoved) != 0
+  def dceSawLineNumbers(result: Int): Boolean = (result & DceLineNumbersSeen) != 0
 
   /**
    * Remove unreachable code from a method.
@@ -650,7 +666,7 @@ object LocalOptImpls {
    * interpreter. This ensures that future analyses will not produce `null` frames. The inliner
    * depends on this property.
    *
-   * @return A set containing the eliminated instructions
+   * @return `true` if any instructions were removed
    */
   def minimalRemoveUnreachableCode(method: MethodNode, ownerClassName: InternalName, callGraph: CallGraph, optimizerUtils: OptimizerUtils): Boolean = {
     // In principle, for the inliner, a single removeUnreachableCodeImpl would be enough. But that
@@ -663,13 +679,13 @@ object LocalOptImpls {
     // handlers, see scaladoc of def methodOptimizations. Removing a live handler may render more
     // code unreachable and therefore requires running another round.
     def removalRound(): Boolean = {
-      val insnsRemoved = removeUnreachableCodeImpl(method, ownerClassName, callGraph, optimizerUtils)
+      val dceResult = removeUnreachableCodeImplResult(method, ownerClassName, callGraph, optimizerUtils)
+      val insnsRemoved = dceRemovedCode(dceResult)
       if (insnsRemoved) {
         val removeHandlersResult = removeEmptyExceptionHandlers(method)
         if (removeHandlersResult.liveHandlerRemoved) removalRound()
       }
-      // Note that `removeUnreachableCodeImpl` adds `LABEL_REACHABLE_STATUS` to label.status fields. We don't clean up
-      // this flag here (in `minimalRemoveUnreachableCode`), we rely on that being done later in `methodOptimizations`.
+      else clearExceptionHandlerStartReachability(method)
       insnsRemoved
     }
 
@@ -680,12 +696,16 @@ object LocalOptImpls {
   }
 
   /**
-   * Removes unreachable basic blocks, returns `true` if instructions were removed.
+   * Removes unreachable basic blocks and returns a bitset describing what the traversal found.
    *
-   * When this method returns, each `labelNode.getLabel` has a status set whether the label is live
-   * or not. This can be queried using `OptimizerUtils.isLabelReachable`.
+   * When this method returns, each try-block start label has a status set whether the label is live
+   * or not. This can be queried using `OptimizerUtils.isLabelReachable` until
+   * `removeEmptyExceptionHandlers` consumes and clears it.
    */
-  def removeUnreachableCodeImpl(method: MethodNode, ownerClassName: InternalName, callGraph: CallGraph, optimizerUtils: OptimizerUtils): Boolean = {
+  def removeUnreachableCodeImpl(method: MethodNode, ownerClassName: InternalName, callGraph: CallGraph, optimizerUtils: OptimizerUtils): Boolean =
+    dceRemovedCode(removeUnreachableCodeImplResult(method, ownerClassName, callGraph, optimizerUtils))
+
+  def removeUnreachableCodeImplResult(method: MethodNode, ownerClassName: InternalName, callGraph: CallGraph, optimizerUtils: OptimizerUtils): Int = {
     val size = method.instructions.size
 
     // queue of instruction indices where analysis should start
@@ -707,9 +727,12 @@ object LocalOptImpls {
     }
 
     val handlers = new Array[mutable.ArrayBuffer[TryCatchBlockNode]](size)
+    var handlerStarts: java.util.IdentityHashMap[LabelNode, java.lang.Boolean] | Null = null
     val tcbIt = method.tryCatchBlocks.iterator()
     while (tcbIt.hasNext) {
       val tcb = tcbIt.next()
+      if (handlerStarts == null) handlerStarts = new java.util.IdentityHashMap[LabelNode, java.lang.Boolean]()
+      handlerStarts.put(tcb.start, java.lang.Boolean.TRUE)
       var i = method.instructions.indexOf(tcb.start)
       val e = method.instructions.indexOf(tcb.end)
       while (i < e) {
@@ -791,9 +814,10 @@ object LocalOptImpls {
         insnHandlers.foreach(h => enqInsn(h.handler))
     }
 
-    def dce(): Boolean = {
+    def dce(): Int = {
       var i = 0
       var changed = false
+      var lineNumbersSeen = false
       val itr = method.instructions.iterator()
       while (itr.hasNext) {
         val insn = itr.next()
@@ -801,10 +825,13 @@ object LocalOptImpls {
 
         insn match {
           case l: LabelNode =>
-            // label nodes are not removed: they might be referenced for example in a LocalVariableNode
-            if (isLive) OptimizerUtils.setLabelReachable(l) else OptimizerUtils.clearLabelReachable(l)
+            // Label nodes are not removed: they might be referenced for example in a LocalVariableNode.
+            // removeEmptyExceptionHandlers only needs reachability for try-block start labels.
+            if (handlerStarts != null && handlerStarts.nn.containsKey(l))
+              if (isLive) OptimizerUtils.setLabelReachable(l) else OptimizerUtils.clearLabelReachable(l)
 
           case _: LineNumberNode =>
+            lineNumbersSeen = true
 
           case _ =>
             if (!isLive || insn.getOpcode == NOP) {
@@ -823,7 +850,7 @@ object LocalOptImpls {
         }
         i += 1
       }
-      changed
+      (if (changed) DceCodeRemoved else 0) | (if (lineNumbersSeen) DceLineNumbersSeen else 0)
     }
 
     dce()
@@ -864,11 +891,19 @@ object LocalOptImpls {
         if (!result.handlerRemoved) result = RemoveHandlersResult.HandlerRemoved
         if (!result.liveHandlerRemoved && OptimizerUtils.isLabelReachable(handler.start))
           result = RemoveHandlersResult.LiveHandlerRemoved
+        OptimizerUtils.clearLabelReachable(handler.start)
         handlersIter.remove()
       }
     }
+    clearExceptionHandlerStartReachability(method)
 
     result
+  }
+
+  private def clearExceptionHandlerStartReachability(method: MethodNode): Unit = {
+    val remainingHandlersIter = method.tryCatchBlocks.iterator
+    while (remainingHandlersIter.hasNext)
+      OptimizerUtils.clearLabelReachable(remainingHandlersIter.next().start)
   }
 
   sealed abstract class RemoveHandlersResult {
@@ -994,36 +1029,40 @@ object LocalOptImpls {
   /**
    * Removes LineNumberNodes that don't describe any executable instructions.
    *
-   * As a side effect, this traversal removes the `LABEL_REACHABLE_STATUS` flag from all label's
-   * `status` fields.
-   *
    * This method expects (and asserts) that the `start` label of each LineNumberNode is the
    * lexically preceding label declaration.
    */
   def removeEmptyLineNumbers(method: MethodNode): Boolean = {
-    @tailrec
-    def isEmpty(node: AbstractInsnNode): Boolean = node.getNext match {
-      case null => true
-      case _: LineNumberNode => true
-      case n if n.getOpcode >= 0 => false
-      case n => isEmpty(n)
-    }
-
-    val initialSize = method.instructions.size
-    val iterator = method.instructions.iterator
+    var changed = false
     var previousLabel: LabelNode | Null = null
-    while (iterator.hasNext) {
-      iterator.next match {
+    var pendingLine: LineNumberNode | Null = null
+    var insn = method.instructions.getFirst
+    while (insn != null) {
+      val next = insn.getNext
+      insn match {
         case label: LabelNode =>
-          OptimizerUtils.clearLabelReachable(label)
           previousLabel = label
-        case line: LineNumberNode if isEmpty(line) =>
+
+        case line: LineNumberNode =>
           assert(line.start == previousLabel)
-          iterator.remove()
+          if (pendingLine != null) {
+            method.instructions.remove(pendingLine)
+            changed = true
+          }
+          pendingLine = line
+
+        case n if n.getOpcode >= 0 =>
+          pendingLine = null
+
         case _ =>
       }
+      insn = next
     }
-    method.instructions.size != initialSize
+    if (pendingLine != null) {
+      method.instructions.remove(pendingLine)
+      changed = true
+    }
+    changed
   }
 
   /**

--- a/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
@@ -222,6 +222,9 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
       currentTrace = after
     }
 
+    var lineNumberCleanupNeeded = OptimizerUtils.isDceDone(method)
+    var labelReachabilityCleanupNeeded = false
+
     /*
      * Runs the optimizations that depend on each other in a loop until reaching a fixpoint. See
      * comment in class [[LocalOpt]].
@@ -256,6 +259,8 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
       val runDCE = (settings.optUnreachableCode && (requestDCE || nullnessOptChanged)) ||
         settings.optBoxUnbox ||
         settings.optCopyPropagation
+      if (runDCE && !method.tryCatchBlocks.isEmpty)
+        labelReachabilityCleanupNeeded = true
       val dceResult =
         if (runDCE) {
           val result = LocalOptImpls.removeUnreachableCodeImplResult(method, ownerClassName, callGraph, optimizerUtils)
@@ -337,7 +342,14 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
         storeLoadRemoved ||
         removeHandlersResult.handlerRemoved
 
-      val codeChanged = nullnessOptChanged || codeRemoved || boxUnboxChanged || copyPropChanged || storesRemoved || intrinsicRewrittenByStaleStores || callInlinedByStaleStores || typeInsnChanged || intrinsicRewrittenByCasts || pushPopRemoved || storeLoadRemoved || removeHandlersResult.handlerRemoved || jumpsChanged
+      val removedOrRewrittenInstructions =
+        nullnessOptChanged || codeRemoved || boxUnboxChanged || copyPropChanged || storesRemoved ||
+        intrinsicRewrittenByStaleStores || callInlinedByStaleStores || typeInsnChanged ||
+        intrinsicRewrittenByCasts || pushPopRemoved || storeLoadRemoved || jumpsChanged
+      if (removedOrRewrittenInstructions)
+        lineNumberCleanupNeeded = true
+
+      val codeChanged = removedOrRewrittenInstructions || removeHandlersResult.handlerRemoved
       (codeChanged, requireEliminateUnusedLocals)
     }
 
@@ -364,8 +376,10 @@ class LocalOpt(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: In
 
     // The asm.MethodWriter writes redundant line numbers 1:1 to the classfile, so we filter them out.
     val lineNumbersRemoved =
-      if (dceCheckedLineNumbers && !hasLineNumbers) false
-      else removeEmptyLineNumbers(method)
+      if (lineNumberCleanupNeeded && (!dceCheckedLineNumbers || hasLineNumbers)) removeEmptyLineNumbers(method)
+      else
+        if (labelReachabilityCleanupNeeded) clearLabelReachableFlags(method)
+        false
     traceIfChanged("lineNumbers")
 
     // assert that local variable annotations are empty (we don't emit them) - otherwise we'd have
@@ -1023,6 +1037,16 @@ object LocalOptImpls {
         case _ =>
       }
       true
+    }
+  }
+
+  def clearLabelReachableFlags(method: MethodNode): Unit = {
+    val iterator = method.instructions.iterator
+    while (iterator.hasNext) {
+      iterator.next match {
+        case label: LabelNode => OptimizerUtils.clearLabelReachable(label)
+        case _ =>
+      }
     }
   }
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/PositionPickler.scala
@@ -43,17 +43,33 @@ object PositionPickler:
 
     pickler.newSection(PositionsSection, buf)
 
-    /** Pickle the number of lines followed by the size of each line */
+    /** Pickle the number of lines followed by the size of each line.
+     *  Manual `while` loop over the `Array[Char]` to avoid `ArrayOps.count`
+     *  (which allocates a `Function1` and boxes each `Char` through
+     *  `BoxesRunTime.equals`) and `ArrayOps.indexOf` (same boxing cost).
+     *  Line break semantics are `'\n'`-only, matching
+     *  `SourceFile.setLineIndicesFromLineSizes` which expects an `'\n'`
+     *  terminator on every line except the last.
+     */
     def pickleLinesSizes(): Unit = {
       val content = source.content()
-      buf.writeNat(content.count(_ == '\n') + 1) // number of lines
-      var lastIndex = content.indexOf('\n')
-      buf.writeNat(if lastIndex != -1 then lastIndex else content.length) // size of first line
-      while lastIndex != -1 do
-        val nextIndex = content.indexOf('\n', lastIndex + 1)
-        val end = if nextIndex != -1 then nextIndex else content.length
-        buf.writeNat(end - lastIndex - 1) // size of the next line
-        lastIndex = nextIndex
+      val len = content.length
+      // First pass: count line breaks (primitive `if_icmpeq`, no boxing, no closure).
+      var nlCount = 0
+      var i = 0
+      while i < len do
+        if content(i) == '\n' then nlCount += 1
+        i += 1
+      buf.writeNat(nlCount + 1) // number of lines
+      // Second pass: emit line sizes.
+      var lineStart = 0
+      i = 0
+      while i < len do
+        if content(i) == '\n' then
+          buf.writeNat(i - lineStart) // size of this line (without the '\n')
+          lineStart = i + 1
+        i += 1
+      buf.writeNat(len - lineStart) // size of the last (unterminated) line
     }
     pickleLinesSizes()
 

--- a/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TastyUnpickler.scala
@@ -7,7 +7,7 @@ import dotty.tools.tasty.{TastyFormat, TastyVersion, TastyBuffer, TastyReader, T
 import dotty.tools.tasty.besteffort.{BestEffortTastyHeader, BestEffortTastyHeaderUnpickler}
 
 import TastyFormat.NameTags.*, TastyFormat.nameTagToString
-import TastyBuffer.NameRef
+import TastyBuffer.{Addr, NameRef}
 
 import scala.collection.mutable
 import Names.{TermName, termName, EmptyTermName}
@@ -33,10 +33,31 @@ object TastyUnpickler {
   }
 
   class NameTable extends (NameRef => TermName) {
-    private val names = new mutable.ArrayBuffer[TermName]
-    def add(name: TermName): mutable.ArrayBuffer[TermName] = names += name
+    private var names = new Array[TermName](0)
+    private var length = 0
+
+    def reserve(size: Int): Unit =
+      if size > names.length then names = new Array[TermName](size)
+
+    def add(name: TermName): Unit =
+      if length == names.length then
+        val newLength = if length == 0 then 16 else length * 2
+        val newNames = new Array[TermName](newLength)
+        System.arraycopy(names, 0, newNames, 0, length)
+        names = newNames
+      names(length) = name
+      length += 1
+
     def apply(ref: NameRef): TermName = names(ref.index)
-    def contents: Iterable[TermName] = names
+
+    def contents: Iterable[TermName] = new Iterable[TermName]:
+      def iterator: Iterator[TermName] = new Iterator[TermName]:
+        private var index = 0
+        def hasNext: Boolean = index < NameTable.this.length
+        def next(): TermName =
+          val name = names(index)
+          index += 1
+          name
   }
 
   trait Scala3CompilerConfig extends UnpicklerConfig:
@@ -142,8 +163,24 @@ class TastyUnpickler(protected val reader: TastyReader, isBestEffortTasty: Boole
     else
       new CommonTastyHeader(new TastyHeaderUnpickler(reader).readFullHeader())
 
+  private def countNameEntries(end: Addr): Int =
+    val start = currentAddr
+    var count = 0
+    while currentAddr.index < end.index do
+      readByte()
+      val length = readNat()
+      goto(currentAddr + length)
+      count += 1
+    assert(currentAddr == end)
+    goto(start)
+    count
+
   def readNames(): Unit =
-    until(readEnd()) { nameAtRef.add(readNameContents()) }
+    val end = readEnd()
+    nameAtRef.reserve(countNameEntries(end))
+    while currentAddr.index < end.index do
+      nameAtRef.add(readNameContents())
+    assert(currentAddr == end)
 
   def loadSections(): Unit = {
     while (!isAtEnd) {

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeBuffer.scala
@@ -12,7 +12,14 @@ import config.Printers.pickling
 import ast.untpd.Tree
 import java.util.Arrays
 
-class TreeBuffer extends TastyBuffer(50000) {
+object TreeBuffer:
+  private inline val DefaultInitialByteSize = 16384
+  private inline val DefaultInitialTreeAddrCapacity = 2048
+
+class TreeBuffer(
+    initialByteSize: Int = TreeBuffer.DefaultInitialByteSize,
+    initialTreeAddrCapacity: Int = TreeBuffer.DefaultInitialTreeAddrCapacity)
+extends TastyBuffer(initialByteSize) {
 
   private inline val ItemsOverOffsets = 2
   private val initialOffsetSize = bytes.length / (AddrWidth * ItemsOverOffsets)
@@ -21,7 +28,7 @@ class TreeBuffer extends TastyBuffer(50000) {
   private var numOffsets = 0
 
   /** A map from trees to the address at which a tree is pickled. */
-  private val treeAddrs = util.IntMap[Tree](initialCapacity = 8192)
+  private val treeAddrs = util.IntMap[Tree](initialCapacity = initialTreeAddrCapacity)
 
   def registerTreeAddr(tree: Tree): Addr =
     val idx = treeAddrs(tree)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -123,6 +123,32 @@ class TreeUnpickler(reader: TastyReader,
   private def registerSym(addr: Addr, sym: Symbol) =
     symAtAddr(addr) = sym
 
+  private final val EmptyOwnerTrees: Array[OwnerTree] = new Array[OwnerTree](0)
+
+  final class OwnerTreeBuilder {
+    private var elems: Array[OwnerTree] = EmptyOwnerTrees
+    private var len = 0
+
+    def +=(elem: OwnerTree): Unit = {
+      if (len == elems.length) {
+        val newElems = new Array[OwnerTree](if (len == 0) 1 else len * 2)
+        System.arraycopy(elems, 0, newElems, 0, len)
+        elems = newElems
+      }
+      elems(len) = elem
+      len += 1
+    }
+
+    def result(): Array[OwnerTree] =
+      if (len == 0) EmptyOwnerTrees
+      else if (len == elems.length) elems
+      else {
+        val result = new Array[OwnerTree](len)
+        System.arraycopy(elems, 0, result, 0, len)
+        result
+      }
+  }
+
   /** Enter all toplevel classes and objects into their scopes
    *  @param roots          a set of SymDenotations that should be overwritten by unpickling
    */
@@ -202,7 +228,7 @@ class TreeUnpickler(reader: TastyReader,
      *  Template node, but need to be listed separately in the OwnerTree of the enclosing class
      *  in order not to confuse owner chains.
      */
-    def scanTree(buf: ListBuffer[OwnerTree], mode: MemberDefMode = AllDefs): Unit = {
+    def scanTree(buf: OwnerTreeBuilder, mode: MemberDefMode = AllDefs): Unit = {
       val start = currentAddr
       val tag = readByte()
       tag match {
@@ -246,7 +272,7 @@ class TreeUnpickler(reader: TastyReader,
     /** Record all directly nested definitions and templates between current address and `end`
      *  as `OwnerTree`s in `buf`
      */
-    def scanTrees(buf: ListBuffer[OwnerTree], end: Addr, mode: MemberDefMode = AllDefs): Unit = {
+    def scanTrees(buf: OwnerTreeBuilder, end: Addr, mode: MemberDefMode = AllDefs): Unit = {
       while (currentAddr.index < end.index) scanTree(buf, mode)
       assert(currentAddr.index == end.index)
     }
@@ -1884,37 +1910,39 @@ class TreeUnpickler(reader: TastyReader,
    */
   class OwnerTree(val addr: Addr, tag: Int, reader: TreeReader, val end: Addr) {
 
-    private var myChildren: List[OwnerTree] | Null = null
+    private var myChildren: Array[OwnerTree] | Null = null
 
     /** All definitions that have the definition at `addr` as closest enclosing definition */
-    def children: List[OwnerTree] = {
+    def children: Array[OwnerTree] = {
       if (myChildren == null) myChildren = {
-        val buf = new ListBuffer[OwnerTree]
+        val buf = new OwnerTreeBuilder
         reader.scanTrees(buf, end, if (tag == TEMPLATE) NoMemberDefs else AllDefs)
-        buf.toList
+        buf.result()
       }
       myChildren.nn
     }
 
     /** Find the owner of definition at `addr` */
     def findOwner(addr: Addr)(using Context): Symbol = {
-      def search(cs: List[OwnerTree], current: Symbol): Symbol =
-        try cs match {
-          case ot :: cs1 =>
+      def search(cs: Array[OwnerTree], current: Symbol): Symbol =
+        try {
+          var i = 0
+          while (i < cs.length) {
+            val ot = cs(i)
             if (ot.addr.index == addr.index) {
               assert(current.exists, i"no symbol at $addr")
-              current
+              return current
             }
             else if (ot.addr.index < addr.index && addr.index < ot.end.index)
-              search(ot.children, reader.symbolAt(ot.addr))
+              return search(ot.children, reader.symbolAt(ot.addr))
             else
-              search(cs1, current)
-          case Nil =>
-            throw new TreeWithoutOwner
+              i += 1
+          }
+          throw new TreeWithoutOwner
         }
         catch {
           case ex: TreeWithoutOwner =>
-            pickling.println(i"no owner for $addr among $cs%, %")
+            pickling.println(i"no owner for $addr among ${cs.iterator.mkString(", ")}")
             throw ex
         }
       try search(children, rootOwner)

--- a/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala
@@ -412,6 +412,18 @@ class TreeUnpickler(reader: TastyReader,
             tp.withVariances(vs)
           case _ => tp
 
+        def readAppliedType(end: Addr): Type = {
+          val tycon = readType()
+          if currentAddr.index >= end.index then tycon.appliedTo(Nil)
+          else
+            val arg1 = readType()
+            if currentAddr.index >= end.index then tycon.appliedTo(arg1)
+            else
+              val arg2 = readType()
+              if currentAddr.index >= end.index then tycon.appliedTo(arg1, arg2)
+              else tycon.appliedTo(arg1 :: arg2 :: until(end)(readType()))
+        }
+
         val result =
           (tag: @switch) match {
             case TERMREFin =>
@@ -441,7 +453,7 @@ class TreeUnpickler(reader: TastyReader,
                 // Note that the lambda "rt => ..." is not equivalent to a wildcard closure!
                 // Eta expansion of the latter puts readType() out of the expression.
             case APPLIEDtype =>
-              readType().appliedTo(until(end)(readType()))
+              readAppliedType(end)
             case TYPEBOUNDS =>
               val lo = readType()
               if nothingButMods(end) then AliasingBounds(readVariances(lo))

--- a/tasty/src/dotty/tools/tasty/TastyReader.scala
+++ b/tasty/src/dotty/tools/tasty/TastyReader.scala
@@ -61,7 +61,31 @@ class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: Int = 
   /** Read a 31-bit natural (nonnegative) integer number in big endian format, base 128, each digit being a byte.
    *  All bytes except the last one have bit 0x80 unset.
    */
-  def readNat(): Int = {
+  def readNat(): Int = readNatInt()
+
+  private def readNatInt(): Int = {
+    val ogBp = bp
+    var b = bytes(bp)
+    var x = b & 0x7f
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    b = bytes(bp)
+    x = (x << 7) | (b & 0x7f)
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    b = bytes(bp)
+    x = (x << 7) | (b & 0x7f)
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    b = bytes(bp)
+    x = (x << 7) | (b & 0x7f)
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    bp = ogBp
     val l = readLongNat()
     if (l > Int.MaxValue) {
       throw new UnpickleException(s"Expected a 31-bit nat, got: $l")
@@ -72,7 +96,31 @@ class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: Int = 
   /** Read a 32-bit integer number in 2's complement big endian format, base 128, each digit being a byte.
    *  All bytes except the last one have bit 0x80 unset.
    */
-  def readInt(): Int = {
+  def readInt(): Int = readInt32()
+
+  private def readInt32(): Int = {
+    val ogBp = bp
+    var b = bytes(bp)
+    var x = (b << 1).toByte >> 1 // sign extend with bit 6.
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    b = bytes(bp)
+    x = (x << 7) | (b & 0x7f)
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    b = bytes(bp)
+    x = (x << 7) | (b & 0x7f)
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    b = bytes(bp)
+    x = (x << 7) | (b & 0x7f)
+    bp += 1
+    if ((b & 0x80) != 0) return x
+
+    bp = ogBp
     val l = readLongInt()
     val i = l.toInt
     if (i.toLong != l) {
@@ -138,7 +186,7 @@ class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: Int = 
   }
 
   /** Read a natural number and return as a NameRef */
-  def readNameRef(): NameRef = NameRef(readNat())
+  def readNameRef(): NameRef = NameRef(readNatInt())
 
   /** Read a natural number and return as an address */
   def readAddr(): Addr = Addr(readNat())
@@ -146,7 +194,7 @@ class TastyReader(val bytes: Array[Byte], start: Int, end: Int, val base: Int = 
   /** Read a length number and return the absolute end address implied by it,
    *  given as <address following length field> + <length-value-read>.
    */
-  def readEnd(): Addr = addr(readNat() + bp)
+  def readEnd(): Addr = addr(readNatInt() + bp)
 
   /** Set read position to the one pointed to by `addr` */
   def goto(addr: Addr): Unit =


### PR DESCRIPTION
Optimizes **the JVM backend & TASTy (un)pickling** — one subsystem split out of the large performance PR scala/scala3#26025 to make review tractable.

**Estimated speedup:** ~0.86% (sum of 11 per-commit profiler estimates across 11 commits)

Full context, benchmarking methodology, and per-commit JFR profiling deltas are in the parent PR scala/scala3#26025.