### PR TITLE
Add -Ycheck check for antagonistic flag combinations (#1329)

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
+++ b/compiler/src/dotty/tools/dotc/transform/TreeChecker.scala
@@ -82,6 +82,11 @@ class TreeChecker extends Phase with SymTransformer {
 
     assert(!badDeferredAndPrivate, i"$sym is both Deferred and Private")
 
+    for fc <- antagonisticFlags do
+      assert(!fc.violatedBy(sym),
+        i"""$sym carries antagonistic flags ${fc.conflict.flagsString} after ${ctx.phase.prev}: ${fc.explain}
+           |flags = ${symd.flagsString}""")
+
     checkCompanion(symd)
 
     // Signatures are used to disambiguate overloads and need to stay stable
@@ -156,6 +161,37 @@ class TreeChecker extends Phase with SymTransformer {
 }
 
 object TreeChecker {
+
+  /** Restricts a rule to term- or type-symbols; needed because their flag
+   *  variants share carrier bits (bit 10 is `Lazy` for terms, `Trait` for types).
+   */
+  private enum Applies:
+    case Term, Type, Any
+
+  /** Flags that must never appear together on a symbol of the given kind. */
+  private class FlagConflict(
+    val conflict: FlagSet,
+    val explain: String,
+    val applies: Applies = Applies.Any):
+
+    def violatedBy(sym: Symbol)(using Context): Boolean =
+      (applies match
+        case Applies.Term => sym.isTerm
+        case Applies.Type => sym.isType
+        case Applies.Any  => true)
+      && sym.isAllOf(conflict)
+
+  /** Flag combinations that are nonsensical at every phase. See #1329. Most
+   *  apparent contradictions are in fact produced somewhere (capture checking
+   *  reuses `Mutable` on methods, value classes are `abstract final`, ...), so
+   *  validate any new entry against the full corpus under `-Ycheck:all`.
+   */
+  private val antagonisticFlags: List[FlagConflict] = List(
+    new FlagConflict(VarianceFlags, "a type parameter cannot be both covariant and contravariant", Applies.Type),
+    new FlagConflict(Lazy | Label, "a symbol cannot be both a lazy value and a label", Applies.Term),
+    new FlagConflict(Module | Trait, "a module cannot be a trait", Applies.Type),
+  )
+
   /** - Check that TypeParamRefs and MethodParams refer to an enclosing type.
    *  - Check that all type variables are instantiated.
    */


### PR DESCRIPTION
Relates to #1329

Adds a `-Ycheck` check: `TreeChecker.transformSym` asserts no symbol carries a nonsensical flag combination, after every checkable phase. Seeded with combinations invalid at every phase — `Covariant|Contravariant` (type params), `Lazy|Label` (terms, the issue's example), `Module|Trait`.

#1329 is open-ended (no spec of valid combinations): this is the framework plus initial invariants, not full coverage. Several apparent contradictions were dropped as legitimate (value classes are `abstract final`, outer accessors `deferred final`, capture checking reuses `Mutable`).

## Have you relied on LLM-based tools in this contribution?

Yes. I reviewed every line and validated by running the modified compiler over the full local corpus under `-Ycheck:all`, removing the combinations that caused false positives.

## How was the solution tested?

Manual tests because automated tests are impractical, described below.

No source-level reproducer is possible — these are internal flag invariants not expressible in user code (like the existing untested `badDeferredAndPrivate` check beside it). Validated by compiling `tests/{pos,neg,run}` (which run `-Ycheck:all`) with the modified compiler: no assertions fired across ~6000 files.
