### PR TITLE
Remove `Context` dependency from `io.FileWriters`

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
@@ -10,7 +10,6 @@ import dotty.tools.dotc.core.Decorators.em
 import scala.tools.asm.{ClassWriter, Handle}
 import scala.tools.asm.tree.{ClassNode, InvokeDynamicInsnNode}
 import dotty.tools.backend.jvm.opt.*
-import dotty.tools.dotc.core.Symbols.defn
 import dotty.tools.dotc.report
 import dotty.tools.io.PlainFile.toPlainFile
 
@@ -28,7 +27,6 @@ import scala.util.chaining.scalaUtilChainingOps
  */
 class PostProcessor(bTypeLoader: BTypeLoader, bTypes: KnownBTypes)(using Context) {
 
-  given FileWriters.ReadOnlyContext = FileWriters.ReadOnlyContext.eager
   private val classfileWriter: FileWriters.ClassfileWriter = {
     val dumpClassesPath =
       ctx.settings.Xdumpclasses.valueSetByUser
@@ -36,7 +34,7 @@ class PostProcessor(bTypeLoader: BTypeLoader, bTypes: KnownBTypes)(using Context
         .filter(path => Files.exists(path).tap(ok => if !ok then report.error(em"Output dir does not exist: ${path.toString}")))
         .map(_.toPlainFile)
 
-    FileWriters.ClassfileWriter(ctx.settings.outputDir.value, ctx.settings.XmainClass.valueSetByUser, dumpClassesPath)
+    FileWriters.ClassfileWriter(ctx.settings.outputDir.value, ctx.settings.XmainClass.valueSetByUser, ctx.settings.XjarCompressionLevel.value, dumpClassesPath)
   }
 
   private type ClassnamePosition = (String, SourcePosition)

--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -36,8 +36,8 @@ import scala.io.Codec
 import Run.Progress
 import scala.compiletime.uninitialized
 import dotty.tools.dotc.transform.MegaPhase
+import dotty.tools.dotc.transform.Pickler
 import dotty.tools.dotc.transform.Pickler.AsyncTastyHolder
-import dotty.tools.io.FileWriters
 import dotty.tools.dotc.util.chaining.*
 import java.util.{Timer, TimerTask}
 
@@ -301,11 +301,11 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
     do
       import reporting.Diagnostic
       report match
-        case FileWriters.Report.Error(msg, pos) =>
+        case Pickler.Report.Error(msg, pos) =>
           ctx.reporter.report(Diagnostic.Error(msg(ctx), pos))
-        case FileWriters.Report.Warning(msg, pos) =>
+        case Pickler.Report.Warning(msg, pos) =>
           ctx.reporter.report(Diagnostic.Warning(msg(ctx), pos))
-        case FileWriters.Report.Log(msg) =>
+        case Pickler.Report.Log(msg) =>
           ctx.reporter.report(Diagnostic.Info(msg, NoSourcePosition))
 
   /** Will be set to true if any of the compiled compilation units contains

--- a/compiler/src/dotty/tools/dotc/sbt/package.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/package.scala
@@ -7,7 +7,7 @@ import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.core.Names.termName
 
 import interfaces.IncrementalCallback
-import dotty.tools.io.FileWriters.BufferingReporter
+import dotty.tools.dotc.transform.Pickler.BufferingReporter
 import dotty.tools.dotc.core.Decorators.em
 
 inline val TermNameHash = 1987 // 300th prime

--- a/compiler/src/dotty/tools/dotc/transform/Pickler.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Pickler.scala
@@ -8,30 +8,34 @@ import Decorators.*
 import tasty.*
 import config.Printers.{noPrinter, pickling}
 import config.Feature
+
 import java.io.PrintStream
-import io.FileWriters.{TastyWriter, ReadOnlyContext}
-import StdNames.{str, nme}
+import io.FileWriters.TastyWriter
+import StdNames.{nme, str}
 import Periods.*
 import Phases.*
 import Symbols.*
 import Flags.Module
-import reporting.{ThrowingReporter, Profile, Message}
+import reporting.{Message, Profile, ThrowingReporter}
 import collection.mutable
 import util.concurrent.Executor
+
 import compiletime.uninitialized
-import dotty.tools.io.{JarArchive, AbstractFile}
+import dotty.tools.io.{AbstractFile, JarArchive}
 import dotty.tools.dotc.printing.OutlinePrinter
+
 import scala.annotation.constructorOnly
 import scala.concurrent.Promise
-import dotty.tools.dotc.transform.Pickler.writeSigFilesAsync
-
-import dotty.tools.io.FileWriters.{EagerReporter, BufferingReporter}
+import dotty.tools.dotc.transform.Pickler.*
 import dotty.tools.dotc.sbt.interfaces.IncrementalCallback
 import dotty.tools.dotc.sbt.asyncZincPhasesCompleted
+import dotty.tools.dotc.util.{NoSourcePosition, SourcePosition}
 import dotty.tools.dotc.util.chaining.*
+
 import scala.concurrent.ExecutionContext
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.nio.file.Files
+import java.util.ConcurrentModificationException
 
 object Pickler {
   val name: String = "pickler"
@@ -174,6 +178,118 @@ object Pickler {
     def this(dest: AbstractFile)(using @constructorOnly ctx: ReadOnlyContext) = this(TastyWriter(dest))
 
     export writer.{writeTasty, close}
+
+
+  sealed trait DelayedReporter {
+    def hasErrors: Boolean
+    def error(message: Context ?=> Message, position: SourcePosition): Unit
+    def warning(message: Context ?=> Message, position: SourcePosition): Unit
+    def log(message: String): Unit
+
+    final def toBuffered: Option[BufferingReporter] = this match
+      case buffered: BufferingReporter =>
+        if buffered.hasReports then Some(buffered) else None
+      case _: EagerReporter => None
+
+    def error(message: Context ?=> Message): Unit = error(message, NoSourcePosition)
+    def warning(message: Context ?=> Message): Unit = warning(message, NoSourcePosition)
+    final def exception(reason: Context ?=> Message, throwable: Throwable): Unit =
+      error({
+        val trace = throwable.getStackTrace().mkString("\n  ")
+        em"An unhandled exception was thrown in the compiler while\n  ${reason.message}.\n${throwable}\n  $trace"
+      }, NoSourcePosition)
+  }
+
+  final class EagerReporter(using captured: Context) extends DelayedReporter:
+    private var _hasErrors = false
+
+    def hasErrors: Boolean = _hasErrors
+
+    def error(message: Context ?=> Message, position: SourcePosition): Unit =
+      report.error(message, position)
+      _hasErrors = true
+
+    def warning(message: Context ?=> Message, position: SourcePosition): Unit =
+      report.warning(message, position)
+
+    def log(message: String): Unit = report.echo(message)
+
+  enum Report:
+    case Error(message: Context => Message, position: SourcePosition)
+    case Warning(message: Context => Message, position: SourcePosition)
+    case Log(message: String)
+
+  final class BufferingReporter extends DelayedReporter {
+    // We optimise access to the buffered reports for the common case - that there are no warning/errors to report
+    // We could use a listBuffer etc - but that would be extra allocation in the common case
+    // buffered logs are updated atomically.
+
+    private val _bufferedReports = AtomicReference(List.empty[Report])
+    private val _hasErrors = AtomicBoolean(false)
+
+
+    /** Atomically record that an error occurred */
+    private def recordError(): Unit =
+      _hasErrors.set(true)
+
+    /** Atomically add a report to the log */
+    private def recordReport(report: Report): Unit =
+      _bufferedReports.getAndUpdate(report :: _)
+
+    /** atomically extract and clear the buffered reports, must only be called at a synchronization point. */
+    def resetReports(): List[Report] =
+      val curr = _bufferedReports.get()
+      if curr.nonEmpty && !_bufferedReports.compareAndSet(curr, Nil) then
+        throw ConcurrentModificationException("concurrent modification of buffered reports")
+      else curr
+
+    def hasErrors: Boolean = _hasErrors.get()
+    def hasReports: Boolean = _bufferedReports.get().nonEmpty
+
+    def error(message: Context ?=> Message, position: SourcePosition): Unit =
+      recordReport(Report.Error({case given Context => message}, position))
+      recordError()
+
+    def warning(message: Context ?=> Message, position: SourcePosition): Unit =
+      recordReport(Report.Warning({case given Context => message}, position))
+
+    def log(message: String): Unit =
+      recordReport(Report.Log(message))
+  }
+
+  trait ReadOnlySettings:
+    def jarCompressionLevel: Int
+    def debug: Boolean
+
+  trait ReadOnlyRun:
+    def suspendedAtTyperPhase: Boolean
+
+  trait ReadOnlyContext:
+    val run: ReadOnlyRun
+    val settings: ReadOnlySettings
+    val reporter: DelayedReporter
+
+  trait BufferedReadOnlyContext extends ReadOnlyContext:
+    val reporter: BufferingReporter
+
+  object ReadOnlyContext:
+    def readSettings(using ctx: Context): ReadOnlySettings = new:
+      val jarCompressionLevel = ctx.settings.XjarCompressionLevel.value
+      val debug = ctx.settings.Ydebug.value
+
+    def readRun(using ctx: Context): ReadOnlyRun = new:
+      val suspendedAtTyperPhase = ctx.run.nn.suspendedAtTyperPhase
+
+    def buffered(using Context): BufferedReadOnlyContext = new:
+      val settings = readSettings
+      val reporter = BufferingReporter()
+      val run = readRun
+
+    def eager(using Context): ReadOnlyContext = new:
+      val settings = readSettings
+      val reporter = EagerReporter()
+      val run = readRun
+
 }
 
 /** This phase pickles trees */

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -20,11 +20,6 @@ import java.util.zip.Deflater
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import scala.collection.mutable
-import dotty.tools.dotc.core.Contexts.*
-import dotty.tools.dotc.core.Decorators.em
-import dotty.tools.dotc.util.{NoSourcePosition, SourcePosition}
-import dotty.tools.dotc.reporting.Message
-import dotty.tools.dotc.report
 
 import scala.annotation.constructorOnly
 import java.util.concurrent.atomic.AtomicReference
@@ -59,7 +54,7 @@ object FileWriters {
   }
 
   object TastyWriter {
-    def apply(output: AbstractFile)(using Context): TastyWriter =
+    def apply(output: AbstractFile): TastyWriter =
       // In Scala 2 depending on cardinality of distinct output dirs MultiClassWriter could have been used
       // In Dotty we always use single output directory
       new SingleTastyWriter(FileWriter(output, None))
@@ -96,10 +91,10 @@ object FileWriters {
   }
 
   object ClassfileWriter {
-    def apply(output: AbstractFile, jarManifestMainClass: Option[String], dumpClassesPath: Option[AbstractFile])(using Context): ClassfileWriter = {
+    def apply(output: AbstractFile, jarManifestMainClass: Option[String], jarCompressionLevel: Int, dumpClassesPath: Option[AbstractFile]): ClassfileWriter = {
       // In Scala 2 depending on cardinality of distinct output dirs MultiClassWriter could have been used
       // In Dotty we always use single output directory
-      val basicClassWriter = new SingleClassWriter(FileWriter(output, jarManifestMainClass))
+      val basicClassWriter = new SingleClassWriter(FileWriter(output, jarManifestMainClass, jarCompressionLevel))
       dumpClassesPath match
         case None => basicClassWriter
         case Some(out) => new DebugClassWriter(basicClassWriter, FileWriter(out, None))
@@ -141,19 +136,17 @@ object FileWriters {
   }
 
   object FileWriter {
-    def apply(file: AbstractFile, jarManifestMainClass: Option[String])(using Context): FileWriter =
-      if (file.isInstanceOf[JarArchive]) {
-        val jarCompressionLevel = ctx.settings.jarCompressionLevel
+    def apply(file: AbstractFile, jarManifestMainClass: Option[String], jarCompressionLevel: Int = Deflater.DEFAULT_COMPRESSION): FileWriter =
+      if file.isInstanceOf[JarArchive] then
         // Writing to non-empty JAR might be an undefined behaviour, e.g. in case if other files where
         // created using `AbstractFile.bufferedOutputStream` instead of JarWriter
-        val jarFile = file.underlyingSource.getOrElse{
+        val jarFile = file.underlyingSource.getOrElse {
           throw new IllegalStateException("No underlying source for jar")
         }
         assert(file.isEmpty, s"Unsafe writing to non-empty JAR: $jarFile")
         new JarEntryWriter(jarFile, jarManifestMainClass, jarCompressionLevel)
-      }
-      else if (file.isVirtual) new VirtualFileWriter(file)
-      else if (file.isDirectory) new DirEntryWriter(file.file.nn.toPath)
+      else if file.isVirtual then new VirtualFileWriter(file)
+      else if file.isDirectory then new DirEntryWriter(file.file.nn.toPath)
       else throw new IllegalStateException(s"don't know how to handle an output of $file [${file.getClass}]")
   }
 
@@ -222,7 +215,7 @@ object FileWriters {
         catch {
           case e: FileAlreadyExistsException =>
             // `createDirectories` reports this exception if `parent` is an existing symlink to a directory
-            // but that's fine for us (and common enough, `scalac -d /tmp` on mac targets symlink).
+            // but that's fine for us (and common enough, `scalac -d /tmp` on Mac targets symlink).
             if (!Files.isDirectory(parent))
               throw new FileConflictException(s"Can't create directory $parent; there is an existing (non-directory) file in its path", e)
         }
@@ -235,7 +228,7 @@ object FileWriters {
     }
 
     // the common case is that we are creating a new file, and on MS Windows the create and truncate is expensive
-    // because there is not an options in the windows API that corresponds to this so the truncate is applied as a separate call
+    // because there is not an options in the Windows API that corresponds to this so the truncate is applied as a separate call
     // even if the file is new.
     // as this is rare, it's best to always try to create a new file, and it that fails, then open with truncate if that fails
 
@@ -274,8 +267,8 @@ object FileWriters {
       val components = path.split('/')
       var dir = base
       for i <- 0 until components.length - 1 do
-        dir = ensureDirectory(dir).subdirectoryNamed(components(i).toString)
-      ensureDirectory(dir).fileNamed(components.last.toString)
+        dir = ensureDirectory(dir).subdirectoryNamed(components(i))
+      ensureDirectory(dir).fileNamed(components.last)
     }
 
     private def writeBytes(outFile: AbstractFile, bytes: Array[Byte]): Unit = {

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -50,7 +50,7 @@ object FileWriters {
      *
      * @param name the internal name of the class, e.g. "scala.Option"
      */
-    def writeTasty(name: String, bytes: Array[Byte])(using Context): AbstractFile
+    def writeTasty(name: String, bytes: Array[Byte]): AbstractFile
 
     /**
      * Close the writer. Behavior is undefined after a call to `close`.
@@ -59,7 +59,6 @@ object FileWriters {
   }
 
   object TastyWriter {
-
     def apply(output: AbstractFile)(using Context): TastyWriter =
       // In Scala 2 depending on cardinality of distinct output dirs MultiClassWriter could have been used
       // In Dotty we always use single output directory
@@ -67,15 +66,13 @@ object FileWriters {
 
     private final class SingleTastyWriter(underlying: FileWriter) extends TastyWriter {
 
-      override def writeTasty(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
+      override def writeTasty(className: String, bytes: Array[Byte]): AbstractFile = {
         underlying.writeFile(classRelativePath(className, ".tasty"), bytes)
       }
 
       override def close(): Unit = underlying.close()
     }
-
   }
-
 
   /**
    * The interface to writing classfiles. GeneratedClassHandler calls these methods to generate the
@@ -90,7 +87,7 @@ object FileWriters {
     /**
      * Write a classfile
      */
-    def writeClass(name: String, bytes: Array[Byte])(using Context): AbstractFile
+    def writeClass(name: String, bytes: Array[Byte]): AbstractFile
 
     /**
      * Close the writer. Behavior is undefined after a call to `close`.
@@ -109,11 +106,11 @@ object FileWriters {
     }
 
     private final class SingleClassWriter(underlying: FileWriter) extends ClassfileWriter {
-      override def writeClass(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
+      override def writeClass(className: String, bytes: Array[Byte]): AbstractFile = {
         underlying.writeFile(classRelativePath(className, ".class"), bytes)
       }
 
-      override def writeTasty(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
+      override def writeTasty(className: String, bytes: Array[Byte]): AbstractFile = {
         underlying.writeFile(classRelativePath(className, ".tasty"), bytes)
       }
 
@@ -121,13 +118,13 @@ object FileWriters {
     }
 
     private final class DebugClassWriter(basic: ClassfileWriter, dump: FileWriter) extends ClassfileWriter {
-      override def writeClass(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
+      override def writeClass(className: String, bytes: Array[Byte]): AbstractFile = {
         val outFile = basic.writeClass(className, bytes)
         dump.writeFile(classRelativePath(className, ".class"), bytes)
         outFile
       }
 
-      override def writeTasty(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
+      override def writeTasty(className: String, bytes: Array[Byte]): AbstractFile = {
         basic.writeTasty(className, bytes)
       }
 
@@ -138,9 +135,8 @@ object FileWriters {
     }
   }
 
-
   sealed trait FileWriter {
-    def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile
+    def writeFile(relativePath: String, bytes: Array[Byte]): AbstractFile
     def close(): Unit
   }
 
@@ -149,7 +145,7 @@ object FileWriters {
       if (file.isInstanceOf[JarArchive]) {
         val jarCompressionLevel = ctx.settings.jarCompressionLevel
         // Writing to non-empty JAR might be an undefined behaviour, e.g. in case if other files where
-        // created using `AbstractFile.bufferedOutputStream`instead of JarWriter
+        // created using `AbstractFile.bufferedOutputStream` instead of JarWriter
         val jarFile = file.underlyingSource.getOrElse{
           throw new IllegalStateException("No underlying source for jar")
         }
@@ -184,7 +180,7 @@ object FileWriters {
 
     lazy val crc = new CRC32
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile = this.synchronized {
+    override def writeFile(relativePath: String, bytes: Array[Byte]): AbstractFile = this.synchronized {
       val entry = new ZipEntry(relativePath)
       if (storeOnly) {
         // When using compression method `STORED`, the ZIP spec requires the CRC and compressed/
@@ -218,18 +214,10 @@ object FileWriters {
     val noAttributes = Array.empty[FileAttribute[?]]
     private val isWindows = scala.util.Properties.isWin
 
-    private def checkName(component: Path)(using Context): Unit = if (isWindows) {
-      val specials = raw"(?i)CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]".r
-      val name = component.toString
-      def warnSpecial(): Unit = ctx.reporter.warning(em"path component is special Windows device: ${name}")
-      specials.findPrefixOf(name).foreach(prefix => if (prefix.length == name.length || name(prefix.length) == '.') warnSpecial())
-    }
-
-    def ensureDirForPath(baseDir: Path, filePath: Path)(using Context): Unit = {
+    private def ensureDirForPath(baseDir: Path, filePath: Path): Unit = {
       import java.lang.Boolean.TRUE
       val parent = filePath.getParent
       if (!builtPaths.containsKey(parent)) {
-        parent.iterator.forEachRemaining(checkName)
         try Files.createDirectories(parent, noAttributes*)
         catch {
           case e: FileAlreadyExistsException =>
@@ -244,7 +232,6 @@ object FileWriters {
           current = current.getParent
         }
       }
-      checkName(filePath.getFileName())
     }
 
     // the common case is that we are creating a new file, and on MS Windows the create and truncate is expensive
@@ -255,32 +242,24 @@ object FileWriters {
     private val fastOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
     private val fallbackOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile = {
+    override def writeFile(relativePath: String, bytes: Array[Byte]): AbstractFile = {
       val path = base.resolve(relativePath)
-      try {
-        ensureDirForPath(base, path)
-        val os = if (isWindows) {
-          try FileChannel.open(path, fastOpenOptions)
-          catch {
-            case _: FileAlreadyExistsException => FileChannel.open(path, fallbackOpenOptions)
-          }
-        } else FileChannel.open(path, fallbackOpenOptions)
-
-        try os.write(ByteBuffer.wrap(bytes), 0L)
+      ensureDirForPath(base, path)
+      val os = if (isWindows) {
+        try FileChannel.open(path, fastOpenOptions)
         catch {
-          case ex: ClosedByInterruptException =>
-            try Files.deleteIfExists(path) // don't leave an empty of half-written classfile around after an interrupt
-            catch { case _: java.io.IOException => () }
-            throw ex
+          case _: FileAlreadyExistsException => FileChannel.open(path, fallbackOpenOptions)
         }
-        os.close()
-      } catch {
-        case e: FileConflictException =>
-          ctx.reporter.error(em"error writing ${path.toString}: ${e.getMessage}")
-        case e: java.nio.file.FileSystemException =>
-          if (ctx.settings.debug) e.printStackTrace()
-          ctx.reporter.error(em"error writing ${path.toString}: ${e.getClass.getName} ${e.getMessage}")
+      } else FileChannel.open(path, fallbackOpenOptions)
+
+      try os.write(ByteBuffer.wrap(bytes), 0L)
+      catch {
+        case ex: ClosedByInterruptException =>
+          try Files.deleteIfExists(path) // don't leave an empty of half-written classfile around after an interrupt
+          catch { case _: java.io.IOException => () }
+          throw ex
       }
+      os.close()
       AbstractFile.getFile(path).nn // we just wrote to it so it better still exist
     }
 
@@ -305,7 +284,7 @@ object FileWriters {
       finally out.close()
     }
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile = {
+    override def writeFile(relativePath: String, bytes: Array[Byte]): AbstractFile = {
       val outFile = getFile(base, relativePath)
       writeBytes(outFile, bytes)
       outFile

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -19,12 +19,6 @@ import java.util.zip.CRC32
 import java.util.zip.Deflater
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
-import scala.collection.mutable
-
-import scala.annotation.constructorOnly
-import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.ConcurrentModificationException
 
 object FileWriters {
   private def classRelativePath(className: String, suffix: String): String =
@@ -155,9 +149,9 @@ object FileWriters {
     import java.util.jar.Attributes.Name.{MANIFEST_VERSION, MAIN_CLASS}
     import java.util.jar.{JarOutputStream, Manifest}
 
-    val storeOnly = compressionLevel == Deflater.NO_COMPRESSION
+    private val storeOnly = compressionLevel == Deflater.NO_COMPRESSION
 
-    val jarWriter: JarOutputStream = {
+    private val jarWriter: JarOutputStream = {
       import scala.util.Properties.*
       val manifest = new Manifest
       val attrs = manifest.getMainAttributes
@@ -171,7 +165,7 @@ object FileWriters {
       jar
     }
 
-    lazy val crc = new CRC32
+    private lazy val crc = new CRC32
 
     override def writeFile(relativePath: String, bytes: Array[Byte]): AbstractFile = this.synchronized {
       val entry = new ZipEntry(relativePath)
@@ -203,14 +197,15 @@ object FileWriters {
   }
 
   private final class DirEntryWriter(base: Path) extends FileWriter {
-    val builtPaths = new ConcurrentHashMap[Path, java.lang.Boolean]()
-    val noAttributes = Array.empty[FileAttribute[?]]
-    private val isWindows = scala.util.Properties.isWin
+    import DirEntryWriter.*
+    private val builtPaths = new ConcurrentHashMap[Path, java.lang.Boolean]()
+    private val noAttributes = Array.empty[FileAttribute[?]]
 
     private def ensureDirForPath(baseDir: Path, filePath: Path): Unit = {
       import java.lang.Boolean.TRUE
       val parent = filePath.getParent
       if (!builtPaths.containsKey(parent)) {
+        parent.iterator.forEachRemaining(checkName)
         try Files.createDirectories(parent, noAttributes*)
         catch {
           case e: FileAlreadyExistsException =>
@@ -225,45 +220,64 @@ object FileWriters {
           current = current.getParent
         }
       }
+      checkName(filePath.getFileName)
     }
 
     // the common case is that we are creating a new file, and on MS Windows the create and truncate is expensive
     // because there is not an options in the Windows API that corresponds to this so the truncate is applied as a separate call
     // even if the file is new.
     // as this is rare, it's best to always try to create a new file, and it that fails, then open with truncate if that fails
-
     private val fastOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
     private val fallbackOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
 
     override def writeFile(relativePath: String, bytes: Array[Byte]): AbstractFile = {
       val path = base.resolve(relativePath)
-      ensureDirForPath(base, path)
-      val os = if (isWindows) {
-        try FileChannel.open(path, fastOpenOptions)
-        catch {
-          case _: FileAlreadyExistsException => FileChannel.open(path, fallbackOpenOptions)
-        }
-      } else FileChannel.open(path, fallbackOpenOptions)
+      try {
+        ensureDirForPath(base, path)
+        val os = if (isWindows) {
+          try FileChannel.open(path, fastOpenOptions)
+          catch {
+            case _: FileAlreadyExistsException => FileChannel.open(path, fallbackOpenOptions)
+          }
+        } else FileChannel.open(path, fallbackOpenOptions)
 
-      try os.write(ByteBuffer.wrap(bytes), 0L)
-      catch {
-        case ex: ClosedByInterruptException =>
-          try Files.deleteIfExists(path) // don't leave an empty of half-written classfile around after an interrupt
-          catch { case _: java.io.IOException => () }
-          throw ex
+        try os.write(ByteBuffer.wrap(bytes), 0L)
+        catch {
+          case ex: ClosedByInterruptException =>
+            try Files.deleteIfExists(path) // don't leave an empty of half-written classfile around after an interrupt
+            catch { case _: java.io.IOException => () }
+            throw ex
+        }
+        os.close()
+      } catch {
+        case e: IOException => throw new IOException(s"Error writing $path: ${e.getClass.getName}: ${e.getMessage}", e)
       }
-      os.close()
       AbstractFile.getFile(path).nn // we just wrote to it so it better still exist
     }
 
     override def close(): Unit = ()
   }
 
+  private object DirEntryWriter {
+    private val isWindows = scala.util.Properties.isWin
+    private val windowsSpecialPaths = raw"(?i)CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]".r
+
+    // Otherwise users will get an obscure error when trying to create a file
+    private def checkName(component: Path): Unit = if (isWindows) {
+      val name = component.toString
+      for
+        prefix <- windowsSpecialPaths.findPrefixOf(name)
+        if prefix.length == name.length || name(prefix.length) == '.'
+      do
+        throw new IOException(s"Path component is special Windows device: $name")
+    }
+  }
+
   private final class VirtualFileWriter(base: AbstractFile) extends FileWriter {
     private def getFile(base: AbstractFile, path: String): AbstractFile = {
       def ensureDirectory(dir: AbstractFile): AbstractFile =
         if (dir.isDirectory) dir
-        else throw new FileConflictException(s"${base.path}/${path}: ${dir.path} is not a directory")
+        else throw new FileConflictException(s"${base.path}/$path: ${dir.path} is not a directory")
       val components = path.split('/')
       var dir = base
       for i <- 0 until components.length - 1 do

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -199,7 +199,6 @@ object FileWriters {
   private final class DirEntryWriter(base: Path) extends FileWriter {
     import DirEntryWriter.*
     private val builtPaths = new ConcurrentHashMap[Path, java.lang.Boolean]()
-    private val noAttributes = Array.empty[FileAttribute[?]]
 
     private def ensureDirForPath(baseDir: Path, filePath: Path): Unit = {
       import java.lang.Boolean.TRUE
@@ -259,6 +258,7 @@ object FileWriters {
   }
 
   private object DirEntryWriter {
+    private val noAttributes = Array.empty[FileAttribute[?]]
     private val isWindows = scala.util.Properties.isWin
     private val windowsSpecialPaths = raw"(?i)CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]".r
 

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -35,118 +35,6 @@ object FileWriters {
   private def classRelativePath(className: String, suffix: String): String =
     className.replace('.', '/') + suffix
 
-  inline def ctx(using ReadOnlyContext): ReadOnlyContext = summon[ReadOnlyContext]
-
-  sealed trait DelayedReporter {
-    def hasErrors: Boolean
-    def error(message: Context ?=> Message, position: SourcePosition): Unit
-    def warning(message: Context ?=> Message, position: SourcePosition): Unit
-    def log(message: String): Unit
-
-    final def toBuffered: Option[BufferingReporter] = this match
-      case buffered: BufferingReporter =>
-        if buffered.hasReports then Some(buffered) else None
-      case _: EagerReporter => None
-
-    def error(message: Context ?=> Message): Unit = error(message, NoSourcePosition)
-    def warning(message: Context ?=> Message): Unit = warning(message, NoSourcePosition)
-    final def exception(reason: Context ?=> Message, throwable: Throwable): Unit =
-      error({
-        val trace = throwable.getStackTrace().mkString("\n  ")
-        em"An unhandled exception was thrown in the compiler while\n  ${reason.message}.\n${throwable}\n  $trace"
-      }, NoSourcePosition)
-  }
-
-  final class EagerReporter(using captured: Context) extends DelayedReporter:
-    private var _hasErrors = false
-
-    def hasErrors: Boolean = _hasErrors
-
-    def error(message: Context ?=> Message, position: SourcePosition): Unit =
-      report.error(message, position)
-      _hasErrors = true
-
-    def warning(message: Context ?=> Message, position: SourcePosition): Unit =
-      report.warning(message, position)
-
-    def log(message: String): Unit = report.echo(message)
-
-  enum Report:
-    case Error(message: Context => Message, position: SourcePosition)
-    case Warning(message: Context => Message, position: SourcePosition)
-    case Log(message: String)
-
-  final class BufferingReporter extends DelayedReporter {
-    // We optimise access to the buffered reports for the common case - that there are no warning/errors to report
-    // We could use a listBuffer etc - but that would be extra allocation in the common case
-    // buffered logs are updated atomically.
-
-    private val _bufferedReports = AtomicReference(List.empty[Report])
-    private val _hasErrors = AtomicBoolean(false)
-
-
-    /** Atomically record that an error occurred */
-    private def recordError(): Unit =
-      _hasErrors.set(true)
-
-    /** Atomically add a report to the log */
-    private def recordReport(report: Report): Unit =
-      _bufferedReports.getAndUpdate(report :: _)
-
-    /** atomically extract and clear the buffered reports, must only be called at a synchronization point. */
-    def resetReports(): List[Report] =
-      val curr = _bufferedReports.get()
-      if curr.nonEmpty && !_bufferedReports.compareAndSet(curr, Nil) then
-        throw ConcurrentModificationException("concurrent modification of buffered reports")
-      else curr
-
-    def hasErrors: Boolean = _hasErrors.get()
-    def hasReports: Boolean = _bufferedReports.get().nonEmpty
-
-    def error(message: Context ?=> Message, position: SourcePosition): Unit =
-      recordReport(Report.Error({case given Context => message}, position))
-      recordError()
-
-    def warning(message: Context ?=> Message, position: SourcePosition): Unit =
-      recordReport(Report.Warning({case given Context => message}, position))
-
-    def log(message: String): Unit =
-      recordReport(Report.Log(message))
-  }
-
-  trait ReadOnlySettings:
-    def jarCompressionLevel: Int
-    def debug: Boolean
-
-  trait ReadOnlyRun:
-    def suspendedAtTyperPhase: Boolean
-
-  trait ReadOnlyContext:
-    val run: ReadOnlyRun
-    val settings: ReadOnlySettings
-    val reporter: DelayedReporter
-
-  trait BufferedReadOnlyContext extends ReadOnlyContext:
-    val reporter: BufferingReporter
-
-  object ReadOnlyContext:
-    def readSettings(using ctx: Context): ReadOnlySettings = new:
-      val jarCompressionLevel = ctx.settings.XjarCompressionLevel.value
-      val debug = ctx.settings.Ydebug.value
-
-    def readRun(using ctx: Context): ReadOnlyRun = new:
-      val suspendedAtTyperPhase = ctx.run.nn.suspendedAtTyperPhase
-
-    def buffered(using Context): BufferedReadOnlyContext = new:
-      val settings = readSettings
-      val reporter = BufferingReporter()
-      val run = readRun
-
-    def eager(using Context): ReadOnlyContext = new:
-      val settings = readSettings
-      val reporter = EagerReporter()
-      val run = readRun
-
   /**
    * The interface to writing classfiles. GeneratedClassHandler calls these methods to generate the
    * directory and files that are created, and eventually calls `close` when the writing is complete.
@@ -162,7 +50,7 @@ object FileWriters {
      *
      * @param name the internal name of the class, e.g. "scala.Option"
      */
-    def writeTasty(name: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile
+    def writeTasty(name: String, bytes: Array[Byte])(using Context): AbstractFile
 
     /**
      * Close the writer. Behavior is undefined after a call to `close`.
@@ -172,14 +60,14 @@ object FileWriters {
 
   object TastyWriter {
 
-    def apply(output: AbstractFile)(using ReadOnlyContext): TastyWriter =
+    def apply(output: AbstractFile)(using Context): TastyWriter =
       // In Scala 2 depending on cardinality of distinct output dirs MultiClassWriter could have been used
       // In Dotty we always use single output directory
       new SingleTastyWriter(FileWriter(output, None))
 
     private final class SingleTastyWriter(underlying: FileWriter) extends TastyWriter {
 
-      override def writeTasty(className: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = {
+      override def writeTasty(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
         underlying.writeFile(classRelativePath(className, ".tasty"), bytes)
       }
 
@@ -202,7 +90,7 @@ object FileWriters {
     /**
      * Write a classfile
      */
-    def writeClass(name: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile
+    def writeClass(name: String, bytes: Array[Byte])(using Context): AbstractFile
 
     /**
      * Close the writer. Behavior is undefined after a call to `close`.
@@ -211,7 +99,7 @@ object FileWriters {
   }
 
   object ClassfileWriter {
-    def apply(output: AbstractFile, jarManifestMainClass: Option[String], dumpClassesPath: Option[AbstractFile])(using ReadOnlyContext): ClassfileWriter = {
+    def apply(output: AbstractFile, jarManifestMainClass: Option[String], dumpClassesPath: Option[AbstractFile])(using Context): ClassfileWriter = {
       // In Scala 2 depending on cardinality of distinct output dirs MultiClassWriter could have been used
       // In Dotty we always use single output directory
       val basicClassWriter = new SingleClassWriter(FileWriter(output, jarManifestMainClass))
@@ -221,11 +109,11 @@ object FileWriters {
     }
 
     private final class SingleClassWriter(underlying: FileWriter) extends ClassfileWriter {
-      override def writeClass(className: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = {
+      override def writeClass(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
         underlying.writeFile(classRelativePath(className, ".class"), bytes)
       }
 
-      override def writeTasty(className: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = {
+      override def writeTasty(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
         underlying.writeFile(classRelativePath(className, ".tasty"), bytes)
       }
 
@@ -233,13 +121,13 @@ object FileWriters {
     }
 
     private final class DebugClassWriter(basic: ClassfileWriter, dump: FileWriter) extends ClassfileWriter {
-      override def writeClass(className: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = {
+      override def writeClass(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
         val outFile = basic.writeClass(className, bytes)
         dump.writeFile(classRelativePath(className, ".class"), bytes)
         outFile
       }
 
-      override def writeTasty(className: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = {
+      override def writeTasty(className: String, bytes: Array[Byte])(using Context): AbstractFile = {
         basic.writeTasty(className, bytes)
       }
 
@@ -252,12 +140,12 @@ object FileWriters {
 
 
   sealed trait FileWriter {
-    def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile
+    def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile
     def close(): Unit
   }
 
   object FileWriter {
-    def apply(file: AbstractFile, jarManifestMainClass: Option[String])(using ReadOnlyContext): FileWriter =
+    def apply(file: AbstractFile, jarManifestMainClass: Option[String])(using Context): FileWriter =
       if (file.isInstanceOf[JarArchive]) {
         val jarCompressionLevel = ctx.settings.jarCompressionLevel
         // Writing to non-empty JAR might be an undefined behaviour, e.g. in case if other files where
@@ -296,7 +184,7 @@ object FileWriters {
 
     lazy val crc = new CRC32
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = this.synchronized {
+    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile = this.synchronized {
       val entry = new ZipEntry(relativePath)
       if (storeOnly) {
         // When using compression method `STORED`, the ZIP spec requires the CRC and compressed/
@@ -330,14 +218,14 @@ object FileWriters {
     val noAttributes = Array.empty[FileAttribute[?]]
     private val isWindows = scala.util.Properties.isWin
 
-    private def checkName(component: Path)(using ReadOnlyContext): Unit = if (isWindows) {
+    private def checkName(component: Path)(using Context): Unit = if (isWindows) {
       val specials = raw"(?i)CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9]".r
       val name = component.toString
       def warnSpecial(): Unit = ctx.reporter.warning(em"path component is special Windows device: ${name}")
       specials.findPrefixOf(name).foreach(prefix => if (prefix.length == name.length || name(prefix.length) == '.') warnSpecial())
     }
 
-    def ensureDirForPath(baseDir: Path, filePath: Path)(using ReadOnlyContext): Unit = {
+    def ensureDirForPath(baseDir: Path, filePath: Path)(using Context): Unit = {
       import java.lang.Boolean.TRUE
       val parent = filePath.getParent
       if (!builtPaths.containsKey(parent)) {
@@ -367,7 +255,7 @@ object FileWriters {
     private val fastOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
     private val fallbackOpenOptions = util.EnumSet.of(StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = {
+    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile = {
       val path = base.resolve(relativePath)
       try {
         ensureDirForPath(base, path)
@@ -417,7 +305,7 @@ object FileWriters {
       finally out.close()
     }
 
-    override def writeFile(relativePath: String, bytes: Array[Byte])(using ReadOnlyContext): AbstractFile = {
+    override def writeFile(relativePath: String, bytes: Array[Byte])(using Context): AbstractFile = {
       val outFile = getFile(base, relativePath)
       writeBytes(outFile, bytes)
       outFile


### PR DESCRIPTION
I need this for #26328 which stops capturing a `Context` in `PostProcessor`.

Moves the `ReadOnlyContext` abstraction to `Pickler` where it is currently necessary.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
