### PR TITLE
Fix PcInlayHints crash on inlined trees from external dependencies

### DIFF
--- a/presentation-compiler-testcases/src/tests/inlayHints/InlayForeign.scala
+++ b/presentation-compiler-testcases/src/tests/inlayHints/InlayForeign.scala
@@ -1,0 +1,14 @@
+package tests.inlayHints
+
+/** Fixture for [[dotty.tools.pc.tests.inlayHints.InlayHintsInlinedDependencySuite]];
+ *  see that suite for the full explanation of the crash it reproduces.
+ *
+ *  Must stay a `transparent inline def` returning a constructor `Apply`: the
+ *  `transparent inline` expansion keeps its trees positioned in *this* source,
+ *  whereas a plain `inline def` would remap them to the call site and would not
+ *  reproduce the crash.
+ */
+final class Into(val source: String)
+
+transparent inline def into(source: String): Into =
+  new Into(source)

--- a/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcInlayHintsProvider.scala
@@ -67,6 +67,16 @@ class PcInlayHintsProvider(
       tree: Tree,
       parent: Option[Tree]
   ): InlayHints =
+    // Skip trees positioned outside the analyzed file (inlined expansions from
+    // other sources). See [[dotty.tools.pc.tests.inlayHints.InlayHintsInlinedDependencySuite]].
+    if tree.source.path != source.path then inlayHints
+    else collectDecorationsImpl(inlayHints, tree, parent)
+
+  private def collectDecorationsImpl(
+      inlayHints: InlayHints,
+      tree: Tree,
+      parent: Option[Tree]
+  ): InlayHints =
     /*
       XRay hints and closing labels are not mutually exclusive with other hints,
       so they must be matched separately
@@ -564,9 +574,11 @@ object XRayModeHint:
 
   private def isEndOfLine(pos: SourcePosition): Boolean =
     if pos.exists then
-      val source = pos.source
+      // Bound on `content().length`, not `source.length`: a TASTy-only source has
+      // empty `content()` but a non-zero `length`. See InlayHintsInlinedDependencySuite.
+      val content = pos.source.content()
       val end = pos.end
-      end >= source.length || source(end) == '\n' || source(end) == '\r'
+      end >= content.length || content(end) == '\n' || content(end) == '\r'
     else false
 
 end XRayModeHint
@@ -594,5 +606,8 @@ object ClosingLabel:
 
   private def endsWithBrace(tree: Tree)(using Context): Boolean =
     val pos = tree.sourcePos
-    pos.exists && !pos.span.isZeroExtent && pos.source(pos.end - 1) == '}'
+    // Bound on `content().length` before indexing: a TASTy-only source has empty
+    // `content()` but a non-zero span. See InlayHintsInlinedDependencySuite.
+    pos.exists && !pos.span.isZeroExtent &&
+    pos.end - 1 < pos.source.content().length && pos.source(pos.end - 1) == '}'
 end ClosingLabel

--- a/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsInlinedDependencySuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/inlayHints/InlayHintsInlinedDependencySuite.scala
@@ -1,0 +1,80 @@
+package dotty.tools.pc.tests.inlayHints
+
+import java.net.URI
+
+import scala.jdk.CollectionConverters.*
+import scala.language.unsafeNulls
+import scala.meta.internal.metals.{CompilerInlayHintsParams, CompilerRangeParams}
+
+import dotty.tools.pc.RawScalaPresentationCompiler
+import dotty.tools.pc.base.TestResources
+import dotty.tools.pc.utils.PcAssertions
+
+import org.junit.Test
+
+/** Regression test for a crash thrown while computing inlay hints over code
+ *  that expands a `transparent inline` member from a *separately compiled*
+ *  dependency (the real-world trigger was chimney's `into[...].transform`, but
+ *  nothing chimney-specific is required).
+ *
+ *  A `transparent inline` expansion keeps its trees' positions pointing into
+ *  the *defining* dependency's source (unlike a plain `inline def`, whose
+ *  expansion is remapped to the call site). For a real classpath dependency
+ *  that source is only available as TASTy: the line sizes are pickled (so
+ *  `source.length` is non-zero) but `source.content()` is empty (the text is
+ *  not pickled and the `.scala` file is not on disk). `XRayModeHint.isEndOfLine`
+ *  then evaluates `end >= source.length || source(end) == '\n'`: the guard
+ *  passes because `length` comes from the line sizes, and `source(end)` indexes
+ *  the empty `content()` array -> ArrayIndexOutOfBoundsException.
+ *
+ *  The fixture lives in the `scala3-presentation-compiler-testcases` module,
+ *  which is compiled with a `-sourceroot` that makes its `SOURCEFILEattr`
+ *  unresolvable from the test working directory - so the presentation compiler
+ *  sees it as TASTy-only, with empty `content()`, just like a distributed jar.
+ *  See [[tests.inlayHints.into]].
+ *
+ *  IMPORTANT: this drives the *raw* presentation compiler on purpose. The
+ *  default `ScalaPresentationCompiler.inlayHints` runs inside
+ *  `withInterruptableCompiler(emptyDefault, ...)`, which catches the throwable
+ *  and returns an empty list - hiding the crash. sls (and this test) use
+ *  `RawScalaPresentationCompiler`, whose `inlayHints` calls `provide()`
+ *  directly, so the exception propagates.
+ */
+class InlayHintsInlinedDependencySuite extends PcAssertions:
+
+  private lazy val pc =
+    RawScalaPresentationCompiler().newInstance(
+      "",
+      TestResources.classpath.asJava,
+      List.empty[String].asJava
+    )
+
+  @Test def `inlay-hints-over-inlined-foreign-source`: Unit =
+    val code =
+      """|package test
+         |
+         |import tests.inlayHints.*
+         |
+         |object Main:
+         |  val s: String = ???
+         |  val w = into(s)
+         |""".stripMargin
+
+    val rangeParams =
+      CompilerRangeParams(URI.create("file:/InlayHints.scala"), code, 0, code.length())
+    val pcParams = CompilerInlayHintsParams(
+      rangeParams = rangeParams,
+      inferredTypes = true,
+      typeParameters = true,
+      implicitParameters = true,
+      hintsXRayMode = true,
+      byNameParameters = true,
+      implicitConversions = true,
+      namedParameters = true,
+      hintsInPatternMatch = true,
+      closingLabels = true
+    )
+
+    // Must not throw. Pre-fix this raises ArrayIndexOutOfBoundsException from
+    // XRayModeHint.isEndOfLine on the fixture's TASTy-only (empty-content) source.
+    pc.inlayHints(pcParams)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2010,6 +2010,16 @@ object Build {
     .settings(
       commonBootstrappedSettings,
       bspEnabled := enableBspAllProjects,
+      // Compile these fixtures with a sourceroot pointing at their own `src`
+      // dir, so the source path baked into TASTy (SOURCEFILEattr) is relative
+      // to `src` (e.g. `tests/macros/Foo.scala`) and does NOT resolve from the
+      // test working directory (the repo root). This makes the module behave
+      // like a real distributed dependency: available as TASTy only, with no
+      // source on disk. `SourceFile.content()` is then empty for these symbols,
+      // matching what the presentation compiler sees for classpath deps.
+      Compile / scalacOptions ++= Seq(
+        "-sourceroot", ((Compile / scalaSource).value).getAbsolutePath
+      ),
     )
 
   lazy val `scala3-language-server` = project.in(file("language-server")).


### PR DESCRIPTION
The inlay-hints provider walks the analyzed file's typed tree, which after inlining contains sub-trees whose `sourcePos.source` points into the defining dependency's source (a `transparent inline` expansion keeps its own source). For a classpath dependency available only as TASTy, that `SourceFile` has empty `content()` but a non-zero `length` (set from pickled line sizes). The provider then indexed the empty `content()` array via an offset valid against `length`, throwing `ArrayIndexOutOfBoundsException` in `XRayModeHint.isEndOfLine`. With an on-disk dependency source the same omission produces misplaced hints, since `pos.toLsp` derives line/col from the foreign source.

Make `collectDecorations` source-aware: skip trees whose `source` is not the analyzed file (precedent: `labelPart` checks `symbol.source == pos.source`). This fixes both the crash and the misplaced-hint case. Also defensively bound `isEndOfLine` and `endsWithBrace` on `content().length` rather than `length`.

Regression test drives the raw presentation compiler (the default one swallows the throwable via `withInterruptableCompiler`) over a `transparent inline def` fixture in the testcases module. That module is now compiled with a `-sourceroot` pointing at its own `src`, so its pickled source path does not resolve from the test working directory, making it behave like a real distributed dependency: TASTy only, empty `content()`.

Fixes #26384

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, whole implementation done by Claude under my supervision and guidance

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests
Manual tests
