### PR TITLE
fix markdown code fences in PartialFunction.scala

### DIFF
--- a/library/src/scala/PartialFunction.scala
+++ b/library/src/scala/PartialFunction.scala
@@ -211,7 +211,9 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
    *  Applies fallback function where this partial function is not defined.
    *
    *  Note that expression `pf.applyOrElse(x, default)` is equivalent to
-   *  ``` if(pf isDefinedAt x) pf(x) else default(x) ```
+   *  ```
+   *  if(pf isDefinedAt x) pf(x) else default(x)
+   *  ```
    *  except that `applyOrElse` method can be implemented more efficiently.
    *  For all partial function literals the compiler generates an `applyOrElse` implementation which
    *  avoids double evaluation of pattern matchers and guards.
@@ -242,7 +244,9 @@ trait PartialFunction[-A, +B] extends Function1[A, B] { self: PartialFunction[A,
    *  The action function is invoked only for its side effects; its result is ignored.
    *
    *  Note that expression `pf.runWith(action)(x)` is equivalent to
-   *  ``` if(pf isDefinedAt x) { action(pf(x)); true } else false ```
+   *  ```
+   *  if(pf isDefinedAt x) { action(pf(x)); true } else false
+   *  ```
    *  except that `runWith` is implemented via `applyOrElse` and thus potentially more efficient.
    *  Using `runWith` avoids double evaluation of pattern matchers and guards for partial function literals.
    *  @see `applyOrElse`.


### PR DESCRIPTION
it appears to be breaking the formatting of `@param` docs e.g. at https://www.scala-lang.org/api/3.8.4/scala/PartialFunction.html#applyOrElse-fffffdbf

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

Non-code change, no tests needed
