### PR TITLE
Preserve refinement types in SpaceEngine's erase

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
+++ b/compiler/src/dotty/tools/dotc/transform/patmat/Space.scala
@@ -506,8 +506,8 @@ object SpaceEngine {
       case AndType(tp1, tp2) =>
         AndType(erase(tp1, inArray, isValue, isTyped), erase(tp2, inArray, isValue, isTyped))
 
-      case tp @ RefinedType(parent, _, _) =>
-        erase(parent, inArray, isValue, isTyped)
+      case tp @ RefinedType(parent, name, info) =>
+        tp.derivedRefinedType(erase(parent, inArray, isValue, isTyped), name, erase(info, inArray, isValue, isTyped))
 
       case tref: TypeRef if tref.symbol.isPatternBound =>
         if inArray then erase(tref.underlying, inArray, isValue, isTyped)

--- a/tests/pos/i26388.scala
+++ b/tests/pos/i26388.scala
@@ -1,0 +1,7 @@
+//> using options -Werror
+
+case class Foo[A](x: A)
+
+def bar(x: Foo[[A] => A => A]): String =
+  x match
+    case Foo(f) => f("")


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26388

Refinement type `[A] => A => A` was erased into `PolyFunction` when projecting `Foo(f)`, which makes  `Space(Foo[[A] => A => A])`  not a subspace of  `Space(Foo(f))`.
This PR makes `erase` of SpaceEngine preserve refinement type.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by code reviews, debugging with println.

## How was the solution tested?

New automated tests (used reproducer from the issue)