### PR TITLE
CC: Implement Classifier Exclusion Pt. 2

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/untpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/untpd.scala
@@ -579,6 +579,9 @@ object untpd extends Trees.Instance[Untyped] with UntypedTreeInfo {
   def makeOnlyAnnot(qid: Tree)(using Context) =
     New(AppliedTypeTree(scalaAnnotationInternalDot(tpnme.onlyCapability), qid :: Nil), Nil :: Nil)
 
+  def makeExceptAnnot(qid: Tree)(using Context) =
+    New(AppliedTypeTree(scalaAnnotationInternalDot(tpnme.exceptCapability), qid :: Nil), Nil :: Nil)
+
   def makeConsumeAnnot()(using Context): Tree =
     New(scalaCapsInternalDot(tpnme.consume), Nil :: Nil)
 

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -1023,7 +1023,7 @@ object Capabilities:
           case _: ReadOnly => ReadOnlyCapability(c1)
           case Classified(_, only, except) =>
             val t0 = if only == defn.AnyClass then c1 else OnlyCapability(c1, only)
-            except.foldLeft(t0)((t, e) => ExceptCapability(t, e))
+            ExceptCapability(t0, except)
           case _: Maybe => MaybeCapability(c1)
           case _ => c1
 

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -150,11 +150,13 @@ object Capabilities:
    *   - dominator-prune the exclusions to a maximal antichain and sort them canonically;
    *   - drop the wrapper entirely if it is the identity (`only = AnyClass`, no exclusions).
    */
-  def mkClassified(ref: CoreCapability | RootCapability, only: ClassSymbol, rawExcept: List[ClassSymbol])(using Context): Capability =
+  def mkClassified(ref: CoreCapability | RootCapability, only: ClassSymbol, rawExcept: List[ClassSymbol])(using Context): CoreCapability | RootCapability | Classified =
     if only == defn.NothingClass || rawExcept.exists(e => only.isSubClass(e)) then
       classifiedNode(ref, defn.NothingClass, Nil)
     else
-      val inside = rawExcept.filter(e => e.isSubClass(only) && e != only).distinct
+      // `e == only` and any `e` above `only` were already collapsed to empty above,
+      // so every surviving exclusion is strictly inside the `only` subtree.
+      val inside = rawExcept.filter(_.isSubClass(only)).distinct
       val maximal = inside.filter(e => !inside.exists(o => (o ne e) && e.isSubClass(o)))
       val canon = maximal.sortBy(_.fullName.toString)
       if only == defn.AnyClass && canon.isEmpty then ref
@@ -353,9 +355,9 @@ object Capabilities:
   end ResultCap
 
   /** A trait for references in CaptureSets. These can be NamedTypes, ThisTypes or ParamRefs,
-   *  as well as three kinds of AnnotatedTypes representing readOnly, only, and maybe capabilities.
+   *  as well as four kinds of AnnotatedTypes representing only, except, readOnly, and maybe capabilities.
    *  If there are several annotations they come with an order:
-   *  `*` first, `.only` next, `.except` next, `.rd` next, `?` last.
+   *  `.only` first, `.except` next, `.rd` next, `?` last.
    */
   trait Capability extends Showable:
 
@@ -673,7 +675,12 @@ object Capabilities:
       case ReadOnly(elem1) => elem1.computeHiddenSet(f).map(_.readOnly)
       case _ => emptyRefs
 
-    /** The transitive classifiers of this capability. */
+    /** A sound upper bound of the classifier classes all parts of this capability
+     *  derive from (following `captureSetOfInfo`). One of, per the `Classifiers` enum:
+     *  `ClassifiedAs(cs)` (each part derives from some class in `cs`), `Unclassified`
+     *  (a part has no known classifier), `UnknownClassifier` (an unsolved capture-set var).
+     *  Exclusions are transparent: `x.except[E]` has the same classifiers as `x`.
+     */
     def transClassifiers(using Context): Classifiers =
       def toClassifiers(cls: ClassSymbol): Classifiers =
         if cls == defn.AnyClass then Unclassified
@@ -702,6 +709,10 @@ object Capabilities:
       myClassifiers
     end transClassifiers
 
+    /** May this capability be admitted into a capture set classified as `cls`? The
+     *  classifier gate for adding an element to a classified variable. Permissive:
+     *  roots fit anywhere, a `.only[O]` fits iff `O <: cls`.
+     */
     def tryClassifyAs(cls: ClassSymbol)(using Context): Boolean =
       cls == defn.AnyClass
       || this.match
@@ -711,7 +722,6 @@ object Capabilities:
         case self: RootCapability =>
           true
         case Classified(ref1, only, _) =>
-          assert(cls != defn.AnyClass)
           if only == defn.AnyClass then ref1.tryClassifyAs(cls)
           else only.isSubClass(cls)
         case ReadOnly(ref1) =>
@@ -722,15 +732,17 @@ object Capabilities:
           if self.derivesFromCapability then self.derivesFrom(cls)
           else captureSetOfInfo.tryClassifyAs(cls)
 
+    /** Is every part of this capability provably classified as `cls` or a subclass? */
+    // Ignores exclusions: sound but loose.
+    // TODO: when attempting classifier-splitting, tighten for the remainder algorithm.
     def isKnownClassifiedAs(cls: ClassSymbol)(using Context): Boolean =
       transClassifiers match
         case ClassifiedAs(cs) => cs.forall(_.isSubClass(cls))
         case _ => false
 
-    /** Is this capability known to have no parts in common with the classifier
-     *  subtree rooted at `cls`? This is the case if all transitive classifiers
-     *  of the capability are unrelated to `cls`, or if all parts that could fall
-     *  under `cls` are removed by an exclusion.
+    /** Is this capability provably free of any parts classified under `cls`?
+     *  True if all its classifiers are on branches unrelated to `cls`, or an exclusion
+     *  already removed the `cls` subtree.
      */
     def isKnownDisjointFrom(cls: ClassSymbol)(using Context): Boolean =
       def disjointByClassifiers: Boolean = transClassifiers match
@@ -746,6 +758,7 @@ object Capabilities:
         case _ =>
           disjointByClassifiers
 
+    /** Is this capability provably the empty capture set? */
     def isKnownEmpty(using Context): Boolean = this match
       case Classified(ref1, only, except) =>
         // empty if the `only` restriction removes everything ...
@@ -773,8 +786,11 @@ object Capabilities:
     /**  x subsumes x
      *   x =:= y       ==>  x subsumes y
      *   x subsumes y  ==>  x subsumes y.f
-     *   x subsumes y  ==>  x* subsumes y, x subsumes y?
-     *   x subsumes y  ==>  x* subsumes y*, x? subsumes y?
+     *   x subsumes y  ==>  x subsumes y?
+     *   x subsumes y  ==>  x? subsumes y?
+     *   x subsumes y  ==>  x subsumes y.rd
+     *   x subsumes y, y classified as O, y disjoint from each Ei  ==>  x.only[O].except[Ei..] subsumes y
+     *   x subsumes y  ==>  x subsumes y.only[O].except[Ei..]
      *   x: x1.type /\ x1 subsumes y  ==>  x subsumes y
      *   X = CapSet^cx, exists rx in cx, rx subsumes y     ==>  X subsumes y
      *   Y = CapSet^cy, forall ry in cy, x subsumes ry     ==>  x subsumes Y
@@ -936,7 +952,7 @@ object Capabilities:
      *   x covers y  ==>  x.except[C] covers y, x covers y.except[C]
      *
      *   TODO what other clauses from subsumes do we need to port here?
-     *   The last clause is a conservative over-approximation: basically, we can't achieve
+     *   The last two clauses are a conservative over-approximation: basically, we can't achieve
      *   separation by having different classifiers for now. It would be good to
      *   have a test that would expect such separation, then we can try to refine
      *   the clause to make the test pass.

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -39,8 +39,7 @@ import collection.immutable
  *               |                      +-- SetCapability -----+-- TypeRef
  *               |                                             +-- TypeParamRef
  *               |
- *               +-- DerivedCapability -+-- Restricted
- *                                      +-- Excluded
+ *               +-- DerivedCapability -+-- Classified
  *                                      +-- ReadOnly
  *                                      +-- Maybe
  *
@@ -108,37 +107,58 @@ object Capabilities:
    *
    *  Read-only capabilities cannot wrap maybe capabilities.
    */
-  case class ReadOnly(underlying: CoreCapability | RootCapability | Restricted | Excluded)
+  case class ReadOnly(underlying: CoreCapability | RootCapability | Classified)
   extends DerivedCapability:
     def newLikeThis(c: Capability) = ReadOnly(c.asInstanceOf)
 
-  /** The restricted capability `x.only[C]`. We have {x.only[C]} <: {x}.
+  /** A classified capability `x.only[O].except[E1]...except[En]`, in normal form.
+   *  It stands for the parts of `x` that are classified as `only` but as none of
+   *  the `except` classifiers. We have {x.only[O].except[...]} <: {x}.
    *
-   *  Restricted capabilities cannot wrap maybe capabilities, read-only capabilities,
-   *  or excluded capabilities. We have
-   *      (x?).restrict[T] = (x.restrict[T])?
-   *      (x.rd).restrict[T] = (x.restrict[T]).rd
-   *      (x.except[T]).restrict[U] = (x.restrict[U]).exclude[T]  if T is a proper subclass of U
+   *  Invariants of a normalized node (established by `restrict`/`exclude`):
+   *   - `only` is `AnyClass` if there is no `.only` restriction (the identity),
+   *     `NothingClass` if the capability is known empty, otherwise a classifier class.
+   *   - `except` is a canonical antichain (sorted, dominator-pruned, deduplicated) of
+   *     classifiers strictly below `only`. If `only` is `NothingClass`, `except` is `Nil`.
+   *
+   *  Classified capabilities cannot wrap maybe or read-only capabilities. We have
+   *      (x?).only[O]  = (x.only[O])?
+   *      (x.rd).only[O] = (x.only[O]).rd
+   *  and likewise for `.except`. The case class constructor does NOT normalize;
+   *  use `restrict`/`exclude` (or `mkClassified`) to build normalized nodes.
    */
-  case class Restricted(underlying: CoreCapability | RootCapability, cls: ClassSymbol)
+  case class Classified(
+      underlying: CoreCapability | RootCapability,
+      only: ClassSymbol,
+      except: List[ClassSymbol])
   extends DerivedCapability:
-    def newLikeThis(c: Capability) = Restricted(c.asInstanceOf, cls)
+    def newLikeThis(c: Capability) = Classified(c.asInstanceOf, only, except)
 
-  /** The excluded capability `x.except[C]`, which stands for the parts of `x`
-   *  that are not classified as `C` or a subclass of `C`. We have {x.except[C]} <: {x}.
-   *
-   *  Excluded capabilities cannot wrap maybe capabilities or read-only capabilities,
-   *  but they can wrap restricted capabilities. We have
-   *      (x?).exclude[T] = (x.exclude[T])?
-   *      (x.rd).exclude[T] = (x.exclude[T]).rd
-   *  Excluded capabilities can also wrap other excluded capabilities, which
-   *  represents the exclusion of several unrelated classifiers. The surface syntax
-   *  allows only a single `.except[C]` per capture reference, but nested exclusions
-   *  can arise internally when capabilities are mapped or widened.
+  /** Build a cached `Classified(ref, only, except)`, except for `GlobalCap` refs
+   *  which do not support caching.
    */
-  case class Excluded(underlying: CoreCapability | RootCapability | Restricted | Excluded, cls: ClassSymbol)
-  extends DerivedCapability:
-    def newLikeThis(c: Capability) = Excluded(c.asInstanceOf, cls)
+  private def classifiedNode(ref: CoreCapability | RootCapability, only: ClassSymbol, except: List[ClassSymbol]): Classified =
+    val node = Classified(ref, only, except)
+    ref match
+      case _: GlobalCap => node
+      case _ => ref.cached(node)
+
+  /** Build the normal form of `ref.only[only].except[rawExcept...]`:
+   *   - collapse to empty (`only = NothingClass`) if `only` is empty or some exclusion
+   *     covers the whole `only` subtree;
+   *   - keep only exclusions strictly inside the `only` subtree (drop vacuous ones);
+   *   - dominator-prune the exclusions to a maximal antichain and sort them canonically;
+   *   - drop the wrapper entirely if it is the identity (`only = AnyClass`, no exclusions).
+   */
+  def mkClassified(ref: CoreCapability | RootCapability, only: ClassSymbol, rawExcept: List[ClassSymbol])(using Context): Capability =
+    if only == defn.NothingClass || rawExcept.exists(e => only.isSubClass(e)) then
+      classifiedNode(ref, defn.NothingClass, Nil)
+    else
+      val inside = rawExcept.filter(e => e.isSubClass(only) && e != only).distinct
+      val maximal = inside.filter(e => !inside.exists(o => (o ne e) && e.isSubClass(o)))
+      val canon = maximal.sortBy(_.fullName.toString)
+      if only == defn.AnyClass && canon.isEmpty then ref
+      else classifiedNode(ref, only, canon)
 
   /** A class for the global root capabilities referenced as `caps.any` and `caps.fresh`.
    *  They do not subsume other capabilities, except in arguments of `withCapAsRoot` calls.
@@ -147,11 +167,11 @@ object Capabilities:
     def descr(using Context) = s"the root capability $fullName"
     override val maybe = Maybe(this)
     override val readOnly = ReadOnly(this)
-    override def restrict(cls: ClassSymbol)(using Context) = Restricted(this, cls)
-    override def exclude(cls: ClassSymbol)(using Context) = Excluded(this, cls)
+    override def restrict(cls: ClassSymbol)(using Context) = mkClassified(this, cls, Nil)
+    override def exclude(cls: ClassSymbol)(using Context) = mkClassified(this, defn.AnyClass, cls :: Nil)
     override def singletonCaptureSet(using Context) = CaptureSet.universal
     override def captureSetOfInfo(using Context) = singletonCaptureSet
-    override def cached[C <: DerivedCapability](newRef: C): C = unsupported("cached")
+    private[Capabilities] override def cached[C <: DerivedCapability](newRef: C): C = unsupported("cached")
     override def invalidateCaches() = ()
 
   /** The global root capability referenced as `caps.any` */
@@ -346,17 +366,13 @@ object Capabilities:
     private var myClassifiers: Classifiers = UnknownClassifier
     private var classifiersValid: Validity = invalid
 
-    protected def cached[C <: DerivedCapability](newRef: C): C =
+    private[Capabilities] def cached[C <: DerivedCapability](newRef: C): C =
       def recur(refs: List[DerivedCapability]): C = refs match
         case ref :: refs1 =>
           val exists = ref match
-            case Restricted(_, cls) =>
+            case Classified(_, only, except) =>
               newRef match
-                case Restricted(_, newCls) => cls == newCls
-                case _ => false
-            case Excluded(_, cls) =>
-              newRef match
-                case Excluded(_, newCls) => cls == newCls
+                case Classified(_, newOnly, newExcept) => only == newOnly && except == newExcept
                 case _ => false
             case _ =>
               ref.getClass == newRef.getClass
@@ -374,54 +390,29 @@ object Capabilities:
     def readOnly: ReadOnly | Maybe = this match
       case Maybe(ref1) => Maybe(ref1.readOnly)
       case self: ReadOnly => self
-      case self: (CoreCapability | RootCapability | Restricted | Excluded) => cached(ReadOnly(self))
+      case self: (CoreCapability | RootCapability | Classified) => cached(ReadOnly(self))
 
-    def restrict(cls: ClassSymbol)(using Context): Restricted | Excluded | ReadOnly | Maybe = this match
-      case Maybe(ref1) => Maybe(ref1.restrict(cls))
-      case ReadOnly(ref1) => ReadOnly(ref1.restrict(cls).asInstanceOf[Restricted | Excluded])
-      case Excluded(ref1, prevCls) =>
-        if cls.isSubClass(prevCls) then
-          // Everything admitted by `cls` is excluded by `prevCls`, the result is empty.
-          ref1.restrict(defn.NothingClass)
-        else if prevCls.isSubClass(cls) then
-          // The exclusion is a proper subtree of `cls`, keep it.
-          ref1.restrict(cls).exclude(prevCls)
-        else
-          // The exclusion is unrelated to `cls`, so it is vacuous after the restriction.
-          ref1.restrict(cls)
-      case self @ Restricted(ref1, prevCls) =>
-        val combinedCls = leastClassifier(prevCls, cls)
-        if combinedCls == prevCls then self
-        else cached(Restricted(ref1, combinedCls))
-      case self: (CoreCapability | RootCapability) => cached(Restricted(self, cls))
+    /** The restricted version `this.only[cls]` of this capability, which stands
+     *  for the parts of this capability that are classified as `cls` or a subclass.
+     *  `cls == AnyClass` is the identity.
+     */
+    def restrict(cls: ClassSymbol)(using Context): Capability =
+      if cls == defn.AnyClass then this
+      else this match
+        case Maybe(ref1) => Maybe(ref1.restrict(cls))
+        case ReadOnly(ref1) => ReadOnly(ref1.restrict(cls).asInstanceOf[CoreCapability | RootCapability | Classified])
+        case Classified(ref1, only, except) => mkClassified(ref1, leastClassifier(only, cls), except)
+        case self: (CoreCapability | RootCapability) => mkClassified(self, cls, Nil)
 
     /** The excluded version `this.except[cls]` of this capability, which stands
      *  for the parts of this capability that are not classified as `cls` or a
      *  subclass of `cls`.
      */
-    def exclude(cls: ClassSymbol)(using Context): Restricted | Excluded | ReadOnly | Maybe = this match
+    def exclude(cls: ClassSymbol)(using Context): Capability = this match
       case Maybe(ref1) => Maybe(ref1.exclude(cls))
-      case ReadOnly(ref1) => ReadOnly(ref1.exclude(cls).asInstanceOf[Restricted | Excluded])
-      case self @ Excluded(ref1, prevCls) =>
-        if cls.isSubClass(prevCls) then
-          // The new exclusion is already covered by the previous one.
-          self
-        else if prevCls.isSubClass(cls) then
-          // The new exclusion supersedes the previous one.
-          ref1.exclude(cls)
-        else
-          // Unrelated exclusions are represented by nesting.
-          cached(Excluded(self, cls))
-      case self @ Restricted(ref1, prevCls) =>
-        if prevCls.isSubClass(cls) then
-          // Everything admitted by the restriction is excluded, the result is empty.
-          self.restrict(defn.NothingClass)
-        else if cls.isSubClass(prevCls) then
-          cached(Excluded(self, cls))
-        else
-          // The exclusion is unrelated to the restriction, so it is vacuous.
-          self
-      case self: (CoreCapability | RootCapability) => cached(Excluded(self, cls))
+      case ReadOnly(ref1) => ReadOnly(ref1.exclude(cls).asInstanceOf[CoreCapability | RootCapability | Classified])
+      case Classified(ref1, only, except) => mkClassified(ref1, only, except :+ cls)
+      case self: (CoreCapability | RootCapability) => mkClassified(self, defn.AnyClass, cls :: Nil)
 
     /** Is this a maybe reference of the form `x?`? */
     final def isMaybe(using Context): Boolean = this ne stripMaybe
@@ -438,8 +429,7 @@ object Capabilities:
      *  classifier is given.
      */
     final def classifier(using Context): Symbol = this match
-      case Restricted(_, cls) => cls
-      case Excluded(ref1, _) => ref1.classifier
+      case Classified(ref1, only, _) => if only == defn.AnyClass then ref1.classifier else only
       case ReadOnly(ref1) => ref1.classifier
       case Maybe(ref1) => ref1.classifier
       case self: LocalCap => self.hiddenSet.classifier
@@ -459,8 +449,9 @@ object Capabilities:
      *  keeping exclusions in place.
      */
     final def stripRestricted(cls: ClassSymbol)(using Context): Capability = this match
-      case Restricted(ref1, cls1) if cls.isSubClass(cls1) => ref1
-      case Excluded(ref1, cls1) => ref1.stripRestricted(cls).exclude(cls1)
+      case Classified(ref1, only, except) =>
+        if only != defn.AnyClass && cls.isSubClass(only) then mkClassified(ref1, defn.AnyClass, except)
+        else this
       case ReadOnly(ref1) => ref1.stripRestricted(cls).readOnly
       case Maybe(ref1) => ref1.stripRestricted(cls).maybe
       case _ => this
@@ -472,8 +463,9 @@ object Capabilities:
      *  keeping restrictions in place.
      */
     final def stripExcluded(cls: ClassSymbol)(using Context): Capability = this match
-      case Excluded(ref1, cls1) if cls1.isSubClass(cls) => ref1.stripExcluded(cls)
-      case Excluded(ref1, cls1) => ref1.stripExcluded(cls).exclude(cls1)
+      case Classified(ref1, only, except) =>
+        val kept = except.filterNot(e => e.isSubClass(cls))
+        if kept.length == except.length then this else mkClassified(ref1, only, kept)
       case ReadOnly(ref1) => ref1.stripExcluded(cls).readOnly
       case Maybe(ref1) => ref1.stripExcluded(cls).maybe
       case _ => this
@@ -675,8 +667,9 @@ object Capabilities:
      */
     def computeHiddenSet(f: Refs => Refs)(using Context): Refs = this match
       case self: LocalCap => f(self.hiddenSet.elems)
-      case Restricted(elem1, cls) => elem1.computeHiddenSet(f).map(_.restrict(cls))
-      case Excluded(elem1, cls) => elem1.computeHiddenSet(f).map(_.exclude(cls))
+      case Classified(elem1, only, except) =>
+        elem1.computeHiddenSet(f).map: r =>
+          except.foldLeft(if only == defn.AnyClass then r else r.restrict(only))((c, e) => c.exclude(e))
       case ReadOnly(elem1) => elem1.computeHiddenSet(f).map(_.readOnly)
       case _ => emptyRefs
 
@@ -691,14 +684,12 @@ object Capabilities:
             toClassifiers(self.hiddenSet.classifier)
           case self: RootCapability =>
             Unclassified
-          case Restricted(_, cls) =>
-            assert(cls != defn.AnyClass)
-            if cls == defn.NothingClass then ClassifiedAs(Nil)
-            else ClassifiedAs(cls :: Nil)
-          case Excluded(ref1, _) =>
+          case Classified(ref1, only, _) =>
             // An exclusion only removes capabilities, so the transitive classifiers
-            // of the underlying capability remain a sound upper bound.
-            ref1.transClassifiers
+            // of the restricted underlying capability remain a sound upper bound.
+            if only == defn.AnyClass then ref1.transClassifiers
+            else if only == defn.NothingClass then ClassifiedAs(Nil)
+            else ClassifiedAs(only :: Nil)
           case ReadOnly(ref1) =>
             ref1.transClassifiers
           case Maybe(ref1) =>
@@ -719,11 +710,10 @@ object Capabilities:
           else self.hiddenSet.tryClassifyAs(cls)
         case self: RootCapability =>
           true
-        case Restricted(_, cls1) =>
+        case Classified(ref1, only, _) =>
           assert(cls != defn.AnyClass)
-          cls1.isSubClass(cls)
-        case Excluded(ref1, _) =>
-          ref1.tryClassifyAs(cls)
+          if only == defn.AnyClass then ref1.tryClassifyAs(cls)
+          else only.isSubClass(cls)
         case ReadOnly(ref1) =>
           ref1.tryClassifyAs(cls)
         case Maybe(ref1) =>
@@ -742,34 +732,33 @@ object Capabilities:
      *  of the capability are unrelated to `cls`, or if all parts that could fall
      *  under `cls` are removed by an exclusion.
      */
-    def isKnownDisjointFrom(cls: ClassSymbol)(using Context): Boolean = this match
-      case Excluded(ref1, cls1) =>
-        cls.isSubClass(cls1) || ref1.isKnownDisjointFrom(cls)
-      case ReadOnly(ref1) =>
-        ref1.isKnownDisjointFrom(cls)
-      case Maybe(ref1) =>
-        ref1.isKnownDisjointFrom(cls)
-      case _ =>
-        transClassifiers match
-          case ClassifiedAs(cs) =>
-            cs.forall(c => leastClassifier(c, cls) == defn.NothingClass)
-          case _ => false
+    def isKnownDisjointFrom(cls: ClassSymbol)(using Context): Boolean =
+      def disjointByClassifiers: Boolean = transClassifiers match
+        case ClassifiedAs(cs) => cs.forall(c => leastClassifier(c, cls) == defn.NothingClass)
+        case _ => false
+      this match
+        case Classified(_, _, except) =>
+          except.exists(e => cls.isSubClass(e)) || disjointByClassifiers
+        case ReadOnly(ref1) =>
+          ref1.isKnownDisjointFrom(cls)
+        case Maybe(ref1) =>
+          ref1.isKnownDisjointFrom(cls)
+        case _ =>
+          disjointByClassifiers
 
     def isKnownEmpty(using Context): Boolean = this match
-      case Restricted(ref1, cls) =>
-        val isEmpty =
-          cls == defn.NothingClass
-          || ref1.transClassifiers.match
-              case ClassifiedAs(cs) =>
-                cs.forall(c => leastClassifier(c, cls) == defn.NothingClass)
-              case _ => false
-        isEmpty || ref1.isKnownEmpty
-      case Excluded(ref1, cls) =>
-        val isEmpty = ref1.transClassifiers match
-          case ClassifiedAs(cs) =>
-            cs.forall(_.isSubClass(cls))
+      case Classified(ref1, only, except) =>
+        // empty if the `only` restriction removes everything ...
+        val emptyByOnly =
+          only == defn.NothingClass
+          || only != defn.AnyClass && (ref1.transClassifiers match
+              case ClassifiedAs(cs) => cs.forall(c => leastClassifier(c, only) == defn.NothingClass)
+              case _ => false)
+        // ... or if some exclusion covers all classifiers of the restricted underlying.
+        val emptyByExcept = transClassifiers match
+          case ClassifiedAs(cs) => except.exists(e => cs.forall(_.isSubClass(e)))
           case _ => false
-        isEmpty || ref1.isKnownEmpty
+        emptyByOnly || emptyByExcept || ref1.isKnownEmpty
       case ReadOnly(ref1) => ref1.isKnownEmpty
       case Maybe(ref1) => ref1.isKnownEmpty
       case _: RootCapability => false
@@ -835,8 +824,8 @@ object Capabilities:
           || viaInfo(y.info)(subsumingRefs(this, _))
         case Maybe(y1) => this.stripMaybe.subsumes(y1)
         case ReadOnly(y1) => this.stripReadOnly.subsumes(y1)
-        case Restricted(y1, cls) => this.stripRestricted(cls).subsumes(y1)
-        case Excluded(y1, cls) => this.stripExcluded(cls).subsumes(y1)
+        case Classified(y1, only, except) =>
+          except.foldLeft(this)((c, e) => c.stripExcluded(e)).stripRestricted(only).subsumes(y1)
         case y: TypeRef if y.derivesFromCapSet =>
           // The upper and lower bounds don't have to be in the form of `CapSet^{...}`.
           // They can be other capture set variables, which are bounded by `CapSet`,
@@ -852,8 +841,10 @@ object Capabilities:
           this.subsumes(y.cls.sourceModule.termRef)
         case _ => false
       || this.match
-          case Restricted(x1, cls) => y.isKnownClassifiedAs(cls) && x1.subsumes(y)
-          case Excluded(x1, cls) => y.isKnownDisjointFrom(cls) && x1.subsumes(y)
+          case Classified(x1, only, except) =>
+            (only == defn.AnyClass || y.isKnownClassifiedAs(only))
+            && except.forall(e => y.isKnownDisjointFrom(e))
+            && x1.subsumes(y)
           case x: TermRef => viaInfo(x.info)(subsumingRefs(_, y))
           case x: TypeRef if assumedContainsOf(x).contains(y) => true
           case x: TypeRef if x.derivesFromCapSet =>
@@ -921,15 +912,15 @@ object Capabilities:
             case _ => globalCapSubsumes
               // also had: || y.derivesFromCapTrait(defn.Caps_SharedCapability)
               // but this fails i25863a.scala, i.e compilers without errors where there should be
-        case Restricted(x1, cls) =>
-          y.isKnownClassifiedAs(cls) && x1.maxSubsumes(y, canAddHidden)
-        case Excluded(x1, cls) =>
-          y.isKnownDisjointFrom(cls) && x1.maxSubsumes(y, canAddHidden)
+        case Classified(x1, only, except) =>
+          (only == defn.AnyClass || y.isKnownClassifiedAs(only))
+          && except.forall(e => y.isKnownDisjointFrom(e))
+          && x1.maxSubsumes(y, canAddHidden)
         case _ =>
           y match
             case ReadOnly(y1) => this.stripReadOnly.maxSubsumes(y1, canAddHidden)
-            case Restricted(y1, cls) => this.stripRestricted(cls).maxSubsumes(y1, canAddHidden)
-            case Excluded(y1, cls) => this.stripExcluded(cls).maxSubsumes(y1, canAddHidden)
+            case Classified(y1, only, except) =>
+              except.foldLeft(this)((c, e) => c.stripExcluded(e)).stripRestricted(only).maxSubsumes(y1, canAddHidden)
             case _ => false
 
     /** `x covers y` if we should retain `y` when computing the overlap of
@@ -962,9 +953,7 @@ object Capabilities:
               x match
                 case Maybe(x1) => recur(x1, y1)
                 case _ => false
-            case Restricted(y1, _) =>
-              recur(x, y1)
-            case Excluded(y1, _) =>
+            case Classified(y1, _, _) =>
               recur(x, y1)
             case _ =>
               false
@@ -975,8 +964,7 @@ object Capabilities:
                 seen.add(x)
                 x.hiddenSet.exists(recur(_, y))
               else false
-            case Restricted(x1, _) => recur(x1, y)
-            case Excluded(x1, _) => recur(x1, y)
+            case Classified(x1, _, _) => recur(x1, y)
             case _ => false
 
       recur(this, y)
@@ -1017,8 +1005,9 @@ object Capabilities:
         val c1 = c.underlying.toType
         c match
           case _: ReadOnly => ReadOnlyCapability(c1)
-          case Restricted(_, cls) => OnlyCapability(c1, cls)
-          case Excluded(_, cls) => ExceptCapability(c1, cls)
+          case Classified(_, only, except) =>
+            val t0 = if only == defn.AnyClass then c1 else OnlyCapability(c1, only)
+            except.foldLeft(t0)((t, e) => ExceptCapability(t, e))
           case _: Maybe => MaybeCapability(c1)
           case _ => c1
 

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -39,7 +39,8 @@ import collection.immutable
  *               |                      +-- SetCapability -----+-- TypeRef
  *               |                                             +-- TypeParamRef
  *               |
- *               +-- DerivedCapability -+-- Only
+ *               +-- DerivedCapability -+-- Restricted
+ *                                      +-- Excluded
  *                                      +-- ReadOnly
  *                                      +-- Maybe
  *
@@ -107,20 +108,37 @@ object Capabilities:
    *
    *  Read-only capabilities cannot wrap maybe capabilities.
    */
-  case class ReadOnly(underlying: CoreCapability | RootCapability | Restricted)
+  case class ReadOnly(underlying: CoreCapability | RootCapability | Restricted | Excluded)
   extends DerivedCapability:
     def newLikeThis(c: Capability) = ReadOnly(c.asInstanceOf)
 
   /** The restricted capability `x.only[C]`. We have {x.only[C]} <: {x}.
    *
-   *  Restricted capabilities cannot wrap maybe capabilities or read-only capabilities.
-   *  We have
+   *  Restricted capabilities cannot wrap maybe capabilities, read-only capabilities,
+   *  or excluded capabilities. We have
    *      (x?).restrict[T] = (x.restrict[T])?
    *      (x.rd).restrict[T] = (x.restrict[T]).rd
+   *      (x.except[T]).restrict[U] = (x.restrict[U]).exclude[T]  if T is a proper subclass of U
    */
   case class Restricted(underlying: CoreCapability | RootCapability, cls: ClassSymbol)
   extends DerivedCapability:
     def newLikeThis(c: Capability) = Restricted(c.asInstanceOf, cls)
+
+  /** The excluded capability `x.except[C]`, which stands for the parts of `x`
+   *  that are not classified as `C` or a subclass of `C`. We have {x.except[C]} <: {x}.
+   *
+   *  Excluded capabilities cannot wrap maybe capabilities or read-only capabilities,
+   *  but they can wrap restricted capabilities. We have
+   *      (x?).exclude[T] = (x.exclude[T])?
+   *      (x.rd).exclude[T] = (x.exclude[T]).rd
+   *  Excluded capabilities can also wrap other excluded capabilities, which
+   *  represents the exclusion of several unrelated classifiers. The surface syntax
+   *  allows only a single `.except[C]` per capture reference, but nested exclusions
+   *  can arise internally when capabilities are mapped or widened.
+   */
+  case class Excluded(underlying: CoreCapability | RootCapability | Restricted | Excluded, cls: ClassSymbol)
+  extends DerivedCapability:
+    def newLikeThis(c: Capability) = Excluded(c.asInstanceOf, cls)
 
   /** A class for the global root capabilities referenced as `caps.any` and `caps.fresh`.
    *  They do not subsume other capabilities, except in arguments of `withCapAsRoot` calls.
@@ -130,6 +148,7 @@ object Capabilities:
     override val maybe = Maybe(this)
     override val readOnly = ReadOnly(this)
     override def restrict(cls: ClassSymbol)(using Context) = Restricted(this, cls)
+    override def exclude(cls: ClassSymbol)(using Context) = Excluded(this, cls)
     override def singletonCaptureSet(using Context) = CaptureSet.universal
     override def captureSetOfInfo(using Context) = singletonCaptureSet
     override def cached[C <: DerivedCapability](newRef: C): C = unsupported("cached")
@@ -316,7 +335,7 @@ object Capabilities:
   /** A trait for references in CaptureSets. These can be NamedTypes, ThisTypes or ParamRefs,
    *  as well as three kinds of AnnotatedTypes representing readOnly, only, and maybe capabilities.
    *  If there are several annotations they come with an order:
-   *  `*` first, `.only` next, `.rd` next, `?` last.
+   *  `*` first, `.only` next, `.except` next, `.rd` next, `?` last.
    */
   trait Capability extends Showable:
 
@@ -335,6 +354,10 @@ object Capabilities:
               newRef match
                 case Restricted(_, newCls) => cls == newCls
                 case _ => false
+            case Excluded(_, cls) =>
+              newRef match
+                case Excluded(_, newCls) => cls == newCls
+                case _ => false
             case _ =>
               ref.getClass == newRef.getClass
           if exists then ref.asInstanceOf[C]
@@ -351,16 +374,54 @@ object Capabilities:
     def readOnly: ReadOnly | Maybe = this match
       case Maybe(ref1) => Maybe(ref1.readOnly)
       case self: ReadOnly => self
-      case self: (CoreCapability | RootCapability | Restricted) => cached(ReadOnly(self))
+      case self: (CoreCapability | RootCapability | Restricted | Excluded) => cached(ReadOnly(self))
 
-    def restrict(cls: ClassSymbol)(using Context): Restricted | ReadOnly | Maybe = this match
+    def restrict(cls: ClassSymbol)(using Context): Restricted | Excluded | ReadOnly | Maybe = this match
       case Maybe(ref1) => Maybe(ref1.restrict(cls))
-      case ReadOnly(ref1) => ReadOnly(ref1.restrict(cls).asInstanceOf[Restricted])
+      case ReadOnly(ref1) => ReadOnly(ref1.restrict(cls).asInstanceOf[Restricted | Excluded])
+      case Excluded(ref1, prevCls) =>
+        if cls.isSubClass(prevCls) then
+          // Everything admitted by `cls` is excluded by `prevCls`, the result is empty.
+          ref1.restrict(defn.NothingClass)
+        else if prevCls.isSubClass(cls) then
+          // The exclusion is a proper subtree of `cls`, keep it.
+          ref1.restrict(cls).exclude(prevCls)
+        else
+          // The exclusion is unrelated to `cls`, so it is vacuous after the restriction.
+          ref1.restrict(cls)
       case self @ Restricted(ref1, prevCls) =>
         val combinedCls = leastClassifier(prevCls, cls)
         if combinedCls == prevCls then self
         else cached(Restricted(ref1, combinedCls))
       case self: (CoreCapability | RootCapability) => cached(Restricted(self, cls))
+
+    /** The excluded version `this.except[cls]` of this capability, which stands
+     *  for the parts of this capability that are not classified as `cls` or a
+     *  subclass of `cls`.
+     */
+    def exclude(cls: ClassSymbol)(using Context): Restricted | Excluded | ReadOnly | Maybe = this match
+      case Maybe(ref1) => Maybe(ref1.exclude(cls))
+      case ReadOnly(ref1) => ReadOnly(ref1.exclude(cls).asInstanceOf[Restricted | Excluded])
+      case self @ Excluded(ref1, prevCls) =>
+        if cls.isSubClass(prevCls) then
+          // The new exclusion is already covered by the previous one.
+          self
+        else if prevCls.isSubClass(cls) then
+          // The new exclusion supersedes the previous one.
+          ref1.exclude(cls)
+        else
+          // Unrelated exclusions are represented by nesting.
+          cached(Excluded(self, cls))
+      case self @ Restricted(ref1, prevCls) =>
+        if prevCls.isSubClass(cls) then
+          // Everything admitted by the restriction is excluded, the result is empty.
+          self.restrict(defn.NothingClass)
+        else if cls.isSubClass(prevCls) then
+          cached(Excluded(self, cls))
+        else
+          // The exclusion is unrelated to the restriction, so it is vacuous.
+          self
+      case self: (CoreCapability | RootCapability) => cached(Excluded(self, cls))
 
     /** Is this a maybe reference of the form `x?`? */
     final def isMaybe(using Context): Boolean = this ne stripMaybe
@@ -378,6 +439,7 @@ object Capabilities:
      */
     final def classifier(using Context): Symbol = this match
       case Restricted(_, cls) => cls
+      case Excluded(ref1, _) => ref1.classifier
       case ReadOnly(ref1) => ref1.classifier
       case Maybe(ref1) => ref1.classifier
       case self: LocalCap => self.hiddenSet.classifier
@@ -393,15 +455,31 @@ object Capabilities:
       case Maybe(ref1) => ref1.stripReadOnly.maybe
       case _ => this
 
-    /** Drop restrictions with clss `cls` or a superclass of `cls` */
+    /** Drop restrictions with class `cls` or a superclass of `cls`,
+     *  keeping exclusions in place.
+     */
     final def stripRestricted(cls: ClassSymbol)(using Context): Capability = this match
       case Restricted(ref1, cls1) if cls.isSubClass(cls1) => ref1
+      case Excluded(ref1, cls1) => ref1.stripRestricted(cls).exclude(cls1)
       case ReadOnly(ref1) => ref1.stripRestricted(cls).readOnly
       case Maybe(ref1) => ref1.stripRestricted(cls).maybe
       case _ => this
 
     final def stripRestricted(using Context): Capability =
       stripRestricted(defn.NothingClass)
+
+    /** Drop exclusions with classes that are subclasses of `cls`,
+     *  keeping restrictions in place.
+     */
+    final def stripExcluded(cls: ClassSymbol)(using Context): Capability = this match
+      case Excluded(ref1, cls1) if cls1.isSubClass(cls) => ref1.stripExcluded(cls)
+      case Excluded(ref1, cls1) => ref1.stripExcluded(cls).exclude(cls1)
+      case ReadOnly(ref1) => ref1.stripExcluded(cls).readOnly
+      case Maybe(ref1) => ref1.stripExcluded(cls).maybe
+      case _ => this
+
+    final def stripExcluded(using Context): Capability =
+      stripExcluded(defn.AnyClass)
 
     /** Is this reference a root capability or a derived version of one?
      *  These capabilities have themselves as their captureSetOfInfo.
@@ -598,6 +676,7 @@ object Capabilities:
     def computeHiddenSet(f: Refs => Refs)(using Context): Refs = this match
       case self: LocalCap => f(self.hiddenSet.elems)
       case Restricted(elem1, cls) => elem1.computeHiddenSet(f).map(_.restrict(cls))
+      case Excluded(elem1, cls) => elem1.computeHiddenSet(f).map(_.exclude(cls))
       case ReadOnly(elem1) => elem1.computeHiddenSet(f).map(_.readOnly)
       case _ => emptyRefs
 
@@ -616,6 +695,10 @@ object Capabilities:
             assert(cls != defn.AnyClass)
             if cls == defn.NothingClass then ClassifiedAs(Nil)
             else ClassifiedAs(cls :: Nil)
+          case Excluded(ref1, _) =>
+            // An exclusion only removes capabilities, so the transitive classifiers
+            // of the underlying capability remain a sound upper bound.
+            ref1.transClassifiers
           case ReadOnly(ref1) =>
             ref1.transClassifiers
           case Maybe(ref1) =>
@@ -639,6 +722,8 @@ object Capabilities:
         case Restricted(_, cls1) =>
           assert(cls != defn.AnyClass)
           cls1.isSubClass(cls)
+        case Excluded(ref1, _) =>
+          ref1.tryClassifyAs(cls)
         case ReadOnly(ref1) =>
           ref1.tryClassifyAs(cls)
         case Maybe(ref1) =>
@@ -652,11 +737,37 @@ object Capabilities:
         case ClassifiedAs(cs) => cs.forall(_.isSubClass(cls))
         case _ => false
 
-    def isKnownEmpty(using Context): Boolean = this match
-      case Restricted(ref1, cls) =>
-        val isEmpty = ref1.transClassifiers match
+    /** Is this capability known to have no parts in common with the classifier
+     *  subtree rooted at `cls`? This is the case if all transitive classifiers
+     *  of the capability are unrelated to `cls`, or if all parts that could fall
+     *  under `cls` are removed by an exclusion.
+     */
+    def isKnownDisjointFrom(cls: ClassSymbol)(using Context): Boolean = this match
+      case Excluded(ref1, cls1) =>
+        cls.isSubClass(cls1) || ref1.isKnownDisjointFrom(cls)
+      case ReadOnly(ref1) =>
+        ref1.isKnownDisjointFrom(cls)
+      case Maybe(ref1) =>
+        ref1.isKnownDisjointFrom(cls)
+      case _ =>
+        transClassifiers match
           case ClassifiedAs(cs) =>
             cs.forall(c => leastClassifier(c, cls) == defn.NothingClass)
+          case _ => false
+
+    def isKnownEmpty(using Context): Boolean = this match
+      case Restricted(ref1, cls) =>
+        val isEmpty =
+          cls == defn.NothingClass
+          || ref1.transClassifiers.match
+              case ClassifiedAs(cs) =>
+                cs.forall(c => leastClassifier(c, cls) == defn.NothingClass)
+              case _ => false
+        isEmpty || ref1.isKnownEmpty
+      case Excluded(ref1, cls) =>
+        val isEmpty = ref1.transClassifiers match
+          case ClassifiedAs(cs) =>
+            cs.forall(_.isSubClass(cls))
           case _ => false
         isEmpty || ref1.isKnownEmpty
       case ReadOnly(ref1) => ref1.isKnownEmpty
@@ -725,6 +836,7 @@ object Capabilities:
         case Maybe(y1) => this.stripMaybe.subsumes(y1)
         case ReadOnly(y1) => this.stripReadOnly.subsumes(y1)
         case Restricted(y1, cls) => this.stripRestricted(cls).subsumes(y1)
+        case Excluded(y1, cls) => this.stripExcluded(cls).subsumes(y1)
         case y: TypeRef if y.derivesFromCapSet =>
           // The upper and lower bounds don't have to be in the form of `CapSet^{...}`.
           // They can be other capture set variables, which are bounded by `CapSet`,
@@ -741,6 +853,7 @@ object Capabilities:
         case _ => false
       || this.match
           case Restricted(x1, cls) => y.isKnownClassifiedAs(cls) && x1.subsumes(y)
+          case Excluded(x1, cls) => y.isKnownDisjointFrom(cls) && x1.subsumes(y)
           case x: TermRef => viaInfo(x.info)(subsumingRefs(_, y))
           case x: TypeRef if assumedContainsOf(x).contains(y) => true
           case x: TypeRef if x.derivesFromCapSet =>
@@ -810,10 +923,13 @@ object Capabilities:
               // but this fails i25863a.scala, i.e compilers without errors where there should be
         case Restricted(x1, cls) =>
           y.isKnownClassifiedAs(cls) && x1.maxSubsumes(y, canAddHidden)
+        case Excluded(x1, cls) =>
+          y.isKnownDisjointFrom(cls) && x1.maxSubsumes(y, canAddHidden)
         case _ =>
           y match
             case ReadOnly(y1) => this.stripReadOnly.maxSubsumes(y1, canAddHidden)
             case Restricted(y1, cls) => this.stripRestricted(cls).maxSubsumes(y1, canAddHidden)
+            case Excluded(y1, cls) => this.stripExcluded(cls).maxSubsumes(y1, canAddHidden)
             case _ => false
 
     /** `x covers y` if we should retain `y` when computing the overlap of
@@ -826,6 +942,7 @@ object Capabilities:
      *   x covers y  ==>  x* covers y*, x? covers y?
      *   x covers y  ==>  <any hiding x> covers y
      *   x covers y  ==>  x.only[C] covers y, x covers y.only[C]
+     *   x covers y  ==>  x.except[C] covers y, x covers y.except[C]
      *
      *   TODO what other clauses from subsumes do we need to port here?
      *   The last clause is a conservative over-approximation: basically, we can't achieve
@@ -847,6 +964,8 @@ object Capabilities:
                 case _ => false
             case Restricted(y1, _) =>
               recur(x, y1)
+            case Excluded(y1, _) =>
+              recur(x, y1)
             case _ =>
               false
         || x.match
@@ -857,6 +976,7 @@ object Capabilities:
                 x.hiddenSet.exists(recur(_, y))
               else false
             case Restricted(x1, _) => recur(x1, y)
+            case Excluded(x1, _) => recur(x1, y)
             case _ => false
 
       recur(this, y)
@@ -898,6 +1018,7 @@ object Capabilities:
         c match
           case _: ReadOnly => ReadOnlyCapability(c1)
           case Restricted(_, cls) => OnlyCapability(c1, cls)
+          case Excluded(_, cls) => ExceptCapability(c1, cls)
           case _: Maybe => MaybeCapability(c1)
           case _ => c1
 

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -70,9 +70,9 @@ extension (tp: Type)
     case OnlyCapability(tp1, cls) =>
       if cls.isTopClassifier then tp1.toCapability // identity projection
       else tp1.toCapability.restrict(cls)
-    case ExceptCapability(tp1, cls) =>
-      if cls.isTopClassifier then tp1.toCapability.restrict(defn.NothingClass) // empty projection
-      else tp1.toCapability.exclude(cls)
+    case ExceptCapability(tp1, clss) =>
+      if clss.exists(_.isTopClassifier) then tp1.toCapability.restrict(defn.NothingClass) // empty projection
+      else clss.foldLeft(tp1.toCapability)((c, cls) => c.exclude(cls))
     case ref: TermRef if ref.isCapsAnyRef =>
       GlobalAny
     case ref: TermRef if ref.isCapsFreshRef =>
@@ -112,7 +112,7 @@ extension (tp: Type)
       elem match
         case CapturingType(parent, refs) if parent.derivesFromCapSet =>
           refs.elems.toList
-        case ExceptCapability(_, cls) if cls.isTopClassifier =>
+        case ExceptCapability(_, clss) if clss.exists(_.isTopClassifier) =>
           Nil // empty projection
         case _ =>
           elem.toCapability :: Nil
@@ -929,10 +929,32 @@ end ClassifiedCapability
  */
 object OnlyCapability extends ClassifiedCapability(defn.OnlyCapabilityAnnot)
 
-/** An extractor for `ref @exceptCapability[C]`, which is used to express
- *  the excluded capability `ref.except[C]` as a type.
+/** An extractor for `ref @exceptCapability[A | B | ...]`, which expresses the excluded
+ *  capability `ref.except[A].except[B]...` as a type. The excluded classifiers are rolled
+ *  into a single annotation whose argument is their union.
  */
-object ExceptCapability extends ClassifiedCapability(defn.ExceptCapabilityAnnot)
+object ExceptCapability:
+  def apply(tp: Type, clss: List[ClassSymbol])(using Context): Type = clss match
+    case Nil => tp
+    case _ =>
+      val arg = clss.map(_.typeRef: Type).reduce((a, b) => OrType(a, b, soft = false))
+      AnnotatedType(tp,
+        Annotation(defn.ExceptCapabilityAnnot.typeRef.appliedTo(arg), Nil, util.Spans.NoSpan))
+
+  def unapply(tree: AnnotatedType)(using Context): Option[(Type, List[ClassSymbol])] = tree match
+    case AnnotatedType(parent: Type, ann) if ann.hasSymbol(defn.ExceptCapabilityAnnot) =>
+      classifiersOf(ann.tree.tpe.argTypes.head) match
+        case Nil => None
+        case clss => Some((parent, clss))
+    case _ => None
+
+  /** The classifier classes in a possibly-union annotation argument. */
+  private def classifiersOf(tp: Type)(using Context): List[ClassSymbol] = tp.dealias match
+    case OrType(tp1, tp2) => classifiersOf(tp1) ++ classifiersOf(tp2)
+    case tp => tp.typeSymbol match
+      case cls: ClassSymbol => cls :: Nil
+      case _ => Nil
+end ExceptCapability
 
 /** An extractor for all kinds of function types as well as method and poly types.
  *  It includes aliases of function types such as `=>`. TODO: Can we do without?

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -68,9 +68,11 @@ extension (tp: Type)
     case ReadOnlyCapability(tp1) =>
       tp1.toCapability.readOnly
     case OnlyCapability(tp1, cls) =>
-      tp1.toCapability.restrict(cls)
+      if cls.isTopClassifier then tp1.toCapability // identity projection
+      else tp1.toCapability.restrict(cls)
     case ExceptCapability(tp1, cls) =>
-      tp1.toCapability.exclude(cls)
+      if cls.isTopClassifier then tp1.toCapability.restrict(defn.NothingClass) // empty projection
+      else tp1.toCapability.exclude(cls)
     case ref: TermRef if ref.isCapsAnyRef =>
       GlobalAny
     case ref: TermRef if ref.isCapsFreshRef =>
@@ -110,6 +112,8 @@ extension (tp: Type)
       elem match
         case CapturingType(parent, refs) if parent.derivesFromCapSet =>
           refs.elems.toList
+        case ExceptCapability(_, cls) if cls.isTopClassifier =>
+          Nil // empty projection
         case _ =>
           elem.toCapability :: Nil
 
@@ -543,6 +547,11 @@ extension (cls: ClassSymbol) {
 
   def isClassifiedCapabilityClass(using Context): Boolean =
     cls.derivesFromCapability && cls.parentSyms.contains(defn.Caps_Classifier)
+
+  /** The top of the classifier tree (`Any` or `caps.Capability`): not a classifier
+   *  class, but usable as a projection argument: `only[top]` = identity, `except[top]` = empty. */
+  def isTopClassifier(using Context): Boolean =
+    cls == defn.AnyClass || cls == defn.Caps_Capability
 
   def classifier(using Context): ClassSymbol =
     if cls.derivesFromCapability then

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -293,8 +293,8 @@ extension (tp: Type)
       case tp: OrType => tp.tp1.isBoxedCapturing || tp.tp2.isBoxedCapturing
       case _ => false
 
-  /** Is the box status of `tp` and `tp2` compatible? I.ee  they are
-   *  box boxed, or both unboxed, or one of them has an empty capture set.
+  /** Is the box status of `tp` and `tp2` compatible? I.e. they are
+   *  both boxed, or both unboxed, or one of them has an empty capture set.
    */
   def isBoxCompatibleWith(tp2: Type)(using Context): Boolean =
     isBoxedCapturing == tp2.isBoxedCapturing

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -69,6 +69,8 @@ extension (tp: Type)
       tp1.toCapability.readOnly
     case OnlyCapability(tp1, cls) =>
       tp1.toCapability.restrict(cls)
+    case ExceptCapability(tp1, cls) =>
+      tp1.toCapability.exclude(cls)
     case ref: TermRef if ref.isCapsAnyRef =>
       GlobalAny
     case ref: TermRef if ref.isCapsFreshRef =>
@@ -897,18 +899,31 @@ object ReadOnlyCapability extends AnnotatedCapability(defn.ReadOnlyCapabilityAnn
  */
 object MaybeCapability extends AnnotatedCapability(defn.MaybeCapabilityAnnot)
 
-object OnlyCapability:
+/** A base class for extractors that match annotated types carrying a classifier
+ *  class as type argument of their annotation.
+ */
+abstract class ClassifiedCapability(annotCls: Context ?=> ClassSymbol):
   def apply(tp: Type, cls: ClassSymbol)(using Context): AnnotatedType =
     AnnotatedType(tp,
-      Annotation(defn.OnlyCapabilityAnnot.typeRef.appliedTo(cls.typeRef), Nil, util.Spans.NoSpan))
+      Annotation(annotCls.typeRef.appliedTo(cls.typeRef), Nil, util.Spans.NoSpan))
 
   def unapply(tree: AnnotatedType)(using Context): Option[(Type, ClassSymbol)] = tree match
-    case AnnotatedType(parent: Type, ann) if ann.hasSymbol(defn.OnlyCapabilityAnnot) =>
+    case AnnotatedType(parent: Type, ann) if ann.hasSymbol(annotCls) =>
       ann.tree.tpe.argTypes.head.dealias.typeSymbol match
         case cls: ClassSymbol => Some((parent, cls))
         case _ => None
     case _ => None
-end OnlyCapability
+end ClassifiedCapability
+
+/** An extractor for `ref @onlyCapability[C]`, which is used to express
+ *  the restricted capability `ref.only[C]` as a type.
+ */
+object OnlyCapability extends ClassifiedCapability(defn.OnlyCapabilityAnnot)
+
+/** An extractor for `ref @exceptCapability[C]`, which is used to express
+ *  the excluded capability `ref.except[C]` as a type.
+ */
+object ExceptCapability extends ClassifiedCapability(defn.ExceptCapabilityAnnot)
 
 /** An extractor for all kinds of function types as well as method and poly types.
  *  It includes aliases of function types such as `=>`. TODO: Can we do without?

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -448,7 +448,7 @@ sealed abstract class CaptureSet extends Showable:
 
   def restrict(cls: ClassSymbol)(using Context): CaptureSet = map(RestrictMap(cls))
 
-  def exclude(cls: ClassSymbol)(using Context): CaptureSet = map(ExceptMap(cls))
+  def exclude(cls: ClassSymbol)(using Context): CaptureSet = map(ExceptMap(cls :: Nil))
 
   def readOnly(using Context): CaptureSet =
     val res = map(ReadOnlyMap())
@@ -1712,15 +1712,16 @@ object CaptureSet:
       case other: RestrictMap => cls == other.cls
       case _ => false
 
-  /** Maps `x` to `x.except[cls]` */
-  private class ExceptMap(val cls: ClassSymbol)(using Context) extends NarrowingCapabilityMap:
-    override def mapCapability(c: Capability) = c.exclude(cls)
+  /** Maps `x` to `x.except[clss...]`; adjacent exclusions fuse into one map. */
+  private class ExceptMap(val clss: List[ClassSymbol])(using Context) extends NarrowingCapabilityMap:
+    override def mapCapability(c: Capability) = clss.foldLeft(c)((c, cls) => c.exclude(cls))
     override def toString = "Except"
-    // TODO: once except carries a list of classes, fuse except[A] ∘ except[B] into one map;
-    // distinct-cls excepts don't fuse today (sound, just unoptimized).
     override def isSameMap(other: BiTypeMap) = other match
-      case other: ExceptMap => cls == other.cls
+      case other: ExceptMap => clss.toSet == other.clss.toSet
       case _ => false
+    override def fuse(next: BiTypeMap)(using Context) = next match
+      case next: ExceptMap => Some(ExceptMap((clss ++ next.clss).distinct))
+      case _ => super.fuse(next)
 
   /* Not needed:
   def ofClass(cinfo: ClassInfo, argTypes: List[Type])(using Context): CaptureSet =

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1615,7 +1615,7 @@ object CaptureSet:
      *  In effect this means that no new elements or dependent sets can be added
      *  in these states (since the previous state cannot be recorded in a snapshot)
      *  On the other hand, these states do allow by default local roots to
-     *  subsume arbitary types, which are then recorded in their hidden sets.
+     *  subsume arbitrary types, which are then recorded in their hidden sets.
      */
     class Closed extends VarState:
       override def canRecord = false
@@ -1716,6 +1716,8 @@ object CaptureSet:
   private class ExceptMap(val cls: ClassSymbol)(using Context) extends NarrowingCapabilityMap:
     override def mapCapability(c: Capability) = c.exclude(cls)
     override def toString = "Except"
+    // TODO: once except carries a list of classes, fuse except[A] ∘ except[B] into one map;
+    // distinct-cls excepts don't fuse today (sound, just unoptimized).
     override def isSameMap(other: BiTypeMap) = other match
       case other: ExceptMap => cls == other.cls
       case _ => false

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1744,12 +1744,11 @@ object CaptureSet:
 
   /** The capture set of the type underlying the capability `c` */
   def ofInfo(c: Capability)(using Context): CaptureSet = c match
-    case Restricted(c1, cls) =>
-      if cls == defn.NothingClass then CaptureSet.empty
-      else c1.captureSetOfInfo.restrict(cls) // todo: should we simplify using subsumption here?
-    case c @ Excluded(c1, cls) =>
+    case c @ Classified(c1, only, except) =>
       if c.isKnownEmpty then CaptureSet.empty
-      else c1.captureSetOfInfo.exclude(cls)
+      else
+        val cs0 = if only == defn.AnyClass then c1.captureSetOfInfo else c1.captureSetOfInfo.restrict(only)
+        except.foldLeft(cs0)((s, e) => s.exclude(e))
     case ReadOnly(c1) =>
       c1.captureSetOfInfo.readOnly
     case Maybe(c1) =>

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -448,6 +448,8 @@ sealed abstract class CaptureSet extends Showable:
 
   def restrict(cls: ClassSymbol)(using Context): CaptureSet = map(RestrictMap(cls))
 
+  def exclude(cls: ClassSymbol)(using Context): CaptureSet = map(ExceptMap(cls))
+
   def readOnly(using Context): CaptureSet =
     val res = map(ReadOnlyMap())
     if mutability != Ignored then res.mutability = Reader
@@ -1676,8 +1678,8 @@ object CaptureSet:
     protected def isSameMap(other: BiTypeMap) = other.getClass == getClass
 
     override def fuse(next: BiTypeMap)(using Context) = next match
-      case next: Inverse if next.inverse.getClass == getClass => Some(IdentityTypeMap)
-      case next: NarrowingCapabilityMap if next.getClass == getClass => Some(this)
+      case next: Inverse if isSameMap(next.inverse) => Some(IdentityTypeMap)
+      case next: NarrowingCapabilityMap if isSameMap(next) => Some(this)
       case _ => None
 
     class Inverse extends BiTypeMap:
@@ -1710,6 +1712,14 @@ object CaptureSet:
       case other: RestrictMap => cls == other.cls
       case _ => false
 
+  /** Maps `x` to `x.except[cls]` */
+  private class ExceptMap(val cls: ClassSymbol)(using Context) extends NarrowingCapabilityMap:
+    override def mapCapability(c: Capability) = c.exclude(cls)
+    override def toString = "Except"
+    override def isSameMap(other: BiTypeMap) = other match
+      case other: ExceptMap => cls == other.cls
+      case _ => false
+
   /* Not needed:
   def ofClass(cinfo: ClassInfo, argTypes: List[Type])(using Context): CaptureSet =
     CaptureSet.empty
@@ -1737,6 +1747,9 @@ object CaptureSet:
     case Restricted(c1, cls) =>
       if cls == defn.NothingClass then CaptureSet.empty
       else c1.captureSetOfInfo.restrict(cls) // todo: should we simplify using subsumption here?
+    case c @ Excluded(c1, cls) =>
+      if c.isKnownEmpty then CaptureSet.empty
+      else c1.captureSetOfInfo.exclude(cls)
     case ReadOnly(c1) =>
       c1.captureSetOfInfo.readOnly
     case Maybe(c1) =>

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -126,6 +126,18 @@ object CheckCaptures:
                 |A classifier class is a class extending `caps.Capability` and directly extending `caps.Classifier`.""",
             ann.srcPos)
         check(ref)
+      case ExceptCapability(ref, cls) =>
+        if !cls.isClassifiedCapabilityClass then
+          // `ref` can itself carry an `.only` qualifier; show it as a capability
+          // if possible instead of in its raw annotated form.
+          val refStr =
+            try ref.toCapability.showAsCapability
+            catch case _: IllegalCaptureRef => ref.showRef
+          report.error(
+            em"""$refStr.except[${cls.name}] is not well-formed since $cls is not a classifier class.
+                |A classifier class is a class extending `caps.Capability` and directly extending `caps.Classifier`.""",
+            ann.srcPos)
+        check(ref)
       case elem =>
         report.error(em"$elem is not a legal element of a capture set", ann.srcPos)
     ann.retainedSet.retainedElementsRaw.foreach(check)

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -126,13 +126,13 @@ object CheckCaptures:
                 |A classifier class is a class extending `caps.Capability` and directly extending `caps.Classifier`.""",
             ann.srcPos)
         check(ref)
-      case ExceptCapability(ref, cls) =>
-        if !cls.isClassifiedCapabilityClass && !cls.isTopClassifier then
-          // `ref` can itself carry an `.only` qualifier; show it as a capability
-          // if possible instead of in its raw annotated form.
-          val refStr =
-            try ref.toCapability.showAsCapability
-            catch case _: IllegalCaptureRef => ref.showRef
+      case ExceptCapability(ref, clss) =>
+        // `ref` can itself carry an `.only` qualifier; show it as a capability
+        // if possible instead of in its raw annotated form.
+        lazy val refStr =
+          try ref.toCapability.showAsCapability
+          catch case _: IllegalCaptureRef => ref.showRef
+        for cls <- clss if !cls.isClassifiedCapabilityClass && !cls.isTopClassifier do
           report.error(
             em"""$refStr.except[${cls.name}] is not well-formed since $cls is not a classifier class.
                 |A classifier class is a class extending `caps.Capability` and directly extending `caps.Classifier`.""",

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -120,14 +120,14 @@ object CheckCaptures:
       case ReadOnlyCapability(ref) =>
         check(ref)
       case OnlyCapability(ref, cls) =>
-        if !cls.isClassifiedCapabilityClass then
+        if !cls.isClassifiedCapabilityClass && !cls.isTopClassifier then
           report.error(
             em"""${ref.showRef}.only[${cls.name}] is not well-formed since $cls is not a classifier class.
                 |A classifier class is a class extending `caps.Capability` and directly extending `caps.Classifier`.""",
             ann.srcPos)
         check(ref)
       case ExceptCapability(ref, cls) =>
-        if !cls.isClassifiedCapabilityClass then
+        if !cls.isClassifiedCapabilityClass && !cls.isTopClassifier then
           // `ref` can itself carry an `.only` qualifier; show it as a capability
           // if possible instead of in its raw annotated form.
           val refStr =

--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -192,7 +192,7 @@ object SepCheck:
         case newElem :: newElems1 =>
           if seen.contains(newElem) then
             recur(seen, acc, newElems1)
-          else newElem.stripRestricted.stripReadOnly match
+          else newElem.stripRestricted.stripExcluded.stripReadOnly match
             case _: LocalCap if !newElem.isKnownClassifiedAs(defn.Caps_SharedCapability) =>
               val hiddens = if followHidden then newElem.hiddenSet.toList else Nil
               recur(seen + newElem, acc + newElem, hiddens ++ newElems1)
@@ -231,8 +231,8 @@ object SepCheck:
         var acc: Refs = emptyRefs
         refs1.foreach: ref =>
           if !ref.isReadOnly then
-            val coreRef = ref.stripRestricted
-            if refs2.exists(_.stripRestricted.stripReadOnly.coversLocalCap(coreRef)) then
+            val coreRef = ref.stripRestricted.stripExcluded
+            if refs2.exists(_.stripRestricted.stripExcluded.stripReadOnly.coversLocalCap(coreRef)) then
               acc += coreRef
         acc
       assert(refs.forall(_.isTerminalCapability))

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -1068,17 +1068,20 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             && !ref.coreType.derivesFromCapSet
         then
           if ref.captureSetOfInfo.elems.isEmpty then
-            report.error(em"$ref cannot be tracked since its capture set is empty", pos)
-          check(parent.captureSet, parent)
+            // an empty projection of a tracked ref denotes {}; only an untracked core is vacuous
+            if !ref.core.isTracked then
+              report.error(em"$ref cannot be tracked since its capture set is empty", pos)
+          else
+            check(parent.captureSet, parent)
 
-          val others =
-            for
-              j <- 0 until retained.length if j != i
-              r = retained(j)
-              if !r.isTerminalCapability
-            yield r
-          val remaining = CaptureSet(others*)
-          check(remaining, remaining)
+            val others =
+              for
+                j <- 0 until retained.length if j != i
+                r = retained(j)
+                if !r.isTerminalCapability
+              yield r
+            val remaining = CaptureSet(others*)
+            check(remaining, remaining)
       end for
     catch case ex: IllegalCaptureRef =>
       report.error(em"Illegal capture reference: ${ex.getMessage}", tpt.srcPos)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1139,6 +1139,7 @@ class Definitions {
   @tu lazy val DeclaredAnnot = requiredClass("scala.caps.internal.declared")
   @tu lazy val ReadOnlyCapabilityAnnot = requiredClass("scala.annotation.internal.readOnlyCapability")
   @tu lazy val OnlyCapabilityAnnot = requiredClass("scala.annotation.internal.onlyCapability")
+  @tu lazy val ExceptCapabilityAnnot = requiredClass("scala.annotation.internal.exceptCapability")
   @tu lazy val RequiresCapabilityAnnot: ClassSymbol = requiredClass("scala.annotation.internal.requiresCapability")
   @tu lazy val RetainsAnnot: ClassSymbol = requiredClass("scala.annotation.retains")
   @tu lazy val RetainsCapAnnot: ClassSymbol = requiredClass("scala.annotation.retainsCap")

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -488,6 +488,8 @@ object StdNames {
     val eval: N                 = "eval"
     val eqlAny: N               = "eqlAny"
     val ex: N                   = "ex"
+    val except: N               = "except"
+    val exceptCapability: N     = "exceptCapability"
     val extension: N            = "extension"
     val experimental: N         = "experimental"
     val f: N                    = "f"

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6385,6 +6385,10 @@ object Types extends TypeUtils {
         mapCapability(c1) match
           case c2: Capability => c2.restrict(cls)
           case (cs: CaptureSet, exact) => (cs.restrict(cls), exact)
+      case Excluded(c1, cls) =>
+        mapCapability(c1) match
+          case c2: Capability => c2.exclude(cls)
+          case (cs: CaptureSet, exact) => (cs.exclude(cls), exact)
       case ReadOnly(c1) =>
         mapCapability(c1) match
           case c2: Capability => c2.readOnly

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6381,14 +6381,12 @@ object Types extends TypeUtils {
                 skolem
         c.derivedLocalCap(ensurePath(apply(prefix)))
       case c: RootCapability => c
-      case Restricted(c1, cls) =>
+      case Classified(c1, only, except) =>
         mapCapability(c1) match
-          case c2: Capability => c2.restrict(cls)
-          case (cs: CaptureSet, exact) => (cs.restrict(cls), exact)
-      case Excluded(c1, cls) =>
-        mapCapability(c1) match
-          case c2: Capability => c2.exclude(cls)
-          case (cs: CaptureSet, exact) => (cs.exclude(cls), exact)
+          case c2: Capability =>
+            except.foldLeft(if only == defn.AnyClass then c2 else c2.restrict(only))((c, e) => c.exclude(e))
+          case (cs: CaptureSet, exact) =>
+            (except.foldLeft(if only == defn.AnyClass then cs else cs.restrict(only))((s, e) => s.exclude(e)), exact)
       case ReadOnly(c1) =>
         mapCapability(c1) match
           case c2: Capability => c2.readOnly

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6359,8 +6359,8 @@ object Types extends TypeUtils {
         null
 
     /** Map capability `c` with this type map.
-     *  @return  Either a the mapped capability, or a captureset containing mapped capabilities,
-     *           together with a boolen indicating whether the map is exact, rather than approximated.
+     *  @return  Either the mapped capability, or a captureset containing mapped capabilities,
+     *           together with a boolean indicating whether the map is exact, rather than approximated.
      */
     def mapCapability(c: Capability): Capability | (CaptureSet, Boolean) = c match
       case c @ LocalCap(prefix) =>

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1810,13 +1810,16 @@ object Parsers {
         else ref
 
       def exceptOpt(ref: Tree): Tree =
-        if in.token == DOT && in.lookahead.isIdent(nme.except) then
-          val ref1 = atSpan(startOffset(ref)):
+        def excepts(acc: List[Tree]): List[Tree] =
+          if in.token == DOT && in.lookahead.isIdent(nme.except) then
             in.nextToken()
             in.nextToken()
-            Annotated(ref, makeExceptAnnot(inBrackets(convertToTypeId(qualId()))))
-          exceptOpt(ref1)
-        else ref
+            excepts(acc :+ inBrackets(convertToTypeId(qualId())))
+          else acc
+        excepts(Nil) match
+          case Nil => ref
+          case clss => atSpan(startOffset(ref)):
+            Annotated(ref, makeExceptAnnot(clss.reduce((l, r) => makeOrType(l, r))))
 
       def readOnlyOpt(ref: Tree): Tree =
         if in.token == DOT && in.lookahead.isIdent(nme.rd) then

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1789,8 +1789,9 @@ object Parsers {
       case _ => None
     }
 
-    /** CaptureRef  ::=  { SimpleRef `.` } SimpleRef [`*`] [CapFilter] [`.` `rd`] -- under captureChecking
-     *  CapFilter   ::=  `.` `only` `[` QualId `]`
+    /** CaptureRef    ::=  { SimpleRef `.` } SimpleRef [`*`] [OnlyFilter] [ExceptFilter] [`.` `rd`] -- under captureChecking
+     *  OnlyFilter    ::=  `.` `only` `[` QualId `]`
+     *  ExceptFilter  ::=  `.` `except` `[` QualId `]`
      */
     def captureRef(): Tree =
 
@@ -1808,6 +1809,14 @@ object Parsers {
             Annotated(ref, makeOnlyAnnot(inBrackets(convertToTypeId(qualId()))))
         else ref
 
+      def exceptOpt(ref: Tree): Tree =
+        if in.token == DOT && in.lookahead.isIdent(nme.except) then
+          atSpan(startOffset(ref)):
+            in.nextToken()
+            in.nextToken()
+            Annotated(ref, makeExceptAnnot(inBrackets(convertToTypeId(qualId()))))
+        else ref
+
       def readOnlyOpt(ref: Tree): Tree =
         if in.token == DOT && in.lookahead.isIdent(nme.rd) then
           atSpan(startOffset(ref)):
@@ -1817,7 +1826,7 @@ object Parsers {
         else ref
 
       def recur(ref: Tree): Tree =
-        val ref1 = readOnlyOpt(restrictedOpt(reachOpt(ref)))
+        val ref1 = readOnlyOpt(exceptOpt(restrictedOpt(reachOpt(ref))))
         if (ref1 eq ref) && in.token == DOT then
           in.nextToken()
           recur(selector(ref))

--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -1811,10 +1811,11 @@ object Parsers {
 
       def exceptOpt(ref: Tree): Tree =
         if in.token == DOT && in.lookahead.isIdent(nme.except) then
-          atSpan(startOffset(ref)):
+          val ref1 = atSpan(startOffset(ref)):
             in.nextToken()
             in.nextToken()
             Annotated(ref, makeExceptAnnot(inBrackets(convertToTypeId(qualId()))))
+          exceptOpt(ref1)
         else ref
 
       def readOnlyOpt(ref: Tree): Tree =

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -461,8 +461,11 @@ class PlainPrinter(_ctx: Context) extends Printer {
 
   def toTextCapability(c: Capability): Text = c match
     case ReadOnly(c1) => toTextCapability(c1) ~ ".rd"
-    case Restricted(c1, cls) => toTextCapability(c1) ~ s".only[${nameString(cls)}]"
-    case Excluded(c1, cls) => toTextCapability(c1) ~ s".except[${nameString(cls)}]"
+    case Classified(c1, only, except) =>
+      val withOnly =
+        if only == defn.AnyClass then toTextCapability(c1)
+        else toTextCapability(c1) ~ s".only[${nameString(only)}]"
+      except.foldLeft(withOnly)((t, e) => t ~ s".except[${nameString(e)}]")
     case Maybe(c1) => toTextCapability(c1) ~ "?"
     case GlobalAny => "any"
     case GlobalFresh => "fresh"

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -462,6 +462,7 @@ class PlainPrinter(_ctx: Context) extends Printer {
   def toTextCapability(c: Capability): Text = c match
     case ReadOnly(c1) => toTextCapability(c1) ~ ".rd"
     case Restricted(c1, cls) => toTextCapability(c1) ~ s".only[${nameString(cls)}]"
+    case Excluded(c1, cls) => toTextCapability(c1) ~ s".except[${nameString(cls)}]"
     case Maybe(c1) => toTextCapability(c1) ~ "?"
     case GlobalAny => "any"
     case GlobalFresh => "fresh"

--- a/docs/_docs/internals/syntax.md
+++ b/docs/_docs/internals/syntax.md
@@ -237,7 +237,7 @@ NamesAndTypes     ::=  NameAndType {‘,’ NameAndType}
 NameAndType       ::=  id ':' Type
 CaptureSet        ::=  '{' CaptureRef {',' CaptureRef} '}'                      -- under captureChecking
 CaptureRef        ::=  { SimpleRef '.' } SimpleRef
-                       [OnlyFilter] [ExceptFilter] ['.' 'rd']                   -- under captureChecking
+                       [OnlyFilter] {ExceptFilter} ['.' 'rd']                   -- under captureChecking
 OnlyFilter        ::=  '.' 'only' '[' QualId ']'                                -- under captureChecking
 ExceptFilter      ::=  '.' 'except' '[' QualId ']'                              -- under captureChecking
 ```

--- a/docs/_docs/internals/syntax.md
+++ b/docs/_docs/internals/syntax.md
@@ -236,8 +236,10 @@ TypeBound         ::=  Type
 NamesAndTypes     ::=  NameAndType {‘,’ NameAndType}
 NameAndType       ::=  id ':' Type
 CaptureSet        ::=  '{' CaptureRef {',' CaptureRef} '}'                      -- under captureChecking
-CaptureRef        ::=  { SimpleRef '.' } SimpleRef [CapFilter] ['.' 'rd']       -- under captureChecking
-CapFilter         ::=  '.' 'only' '[' QualId ']'                                -- under captureChecking
+CaptureRef        ::=  { SimpleRef '.' } SimpleRef
+                       [OnlyFilter] [ExceptFilter] ['.' 'rd']                   -- under captureChecking
+OnlyFilter        ::=  '.' 'only' '[' QualId ']'                                -- under captureChecking
+ExceptFilter      ::=  '.' 'except' '[' QualId ']'                              -- under captureChecking
 ```
 
 ### Expressions

--- a/docs/_docs/reference/experimental/capture-checking/classifiers.md
+++ b/docs/_docs/reference/experimental/capture-checking/classifiers.md
@@ -123,8 +123,8 @@ def test(io: IO, async: Async, proc: () => Unit) =
 
 ### Classifier Exclusion
 
-Restriction selects the capabilities that fall under a classifier. Sometimes we need the opposite: keep all capabilities _except_ those that fall under a classifier. Consider a method that runs a computation on a different thread. The computation must not capture capabilities that are tied to the originating thread's stack, such as `Control` capabilities: using a `boundary.Label` from a different thread would attempt a non-local return across threads. But any other capability is fine. This is expressed with an _excluded capability_:
-```scala sc-compile-with:classifiers-cc-context
+Restriction keeps the capabilities that fall under a classifier; exclusion does the reverse, keeping everything _except_ those. Suppose a method runs its argument on a separate thread. That argument must not capture a `Control` capability such as a `boundary.Label` or a `CanThrow`, since each is bound to the stack of the thread that created it; invoking one from another thread would jump into a different thread's stack. Capabilities of every other kind are admitted. We express this with an _excluded capability_:
+```scala sc-name:classifiers-except sc-compile-with:classifiers-cc-context
 def runOnNewThread[T](body: () ->{any.except[Control]} T): T = ???
 ```
 The general form of an excluded capability is `c.except[A]` where
@@ -132,14 +132,24 @@ The general form of an excluded capability is `c.except[A]` where
  - `c` is a regular capability, possibly carrying an `only` restriction
  - `A` is a classifier trait.
 
-`c.except[A]` stands for the parts of `c` that are _not_ classified as `A` or a subclass of `A`. A capability `x` is covered by `c.except[A]` only if `x` is covered by `c` and `x` is known to be unrelated to the classifier `A`. For instance, given
-```scala sc:nocompile
+`c.except[A]` stands for the parts of `c` that are _not_ classified as `A` or a subclass of `A`. A capability `x` is covered by `c.except[A]` only if `x` is covered by `c` and `x` is known to be unrelated to the classifier `A`. For instance, take a `FileSystem` capability whose classifier `IO` is a sibling of `Control`:
+```scala sc-name:classifiers-fs sc-compile-with:classifiers-except
 trait IO extends SharedCapability, Classifier
-class FileSystem extends IO
+class FileSystem extends IO:
+  def read(): Unit = ()
 ```
-a closure `() => fs.read()` over a capability `fs: FileSystem^` can be passed to `runOnNewThread`: the classifier of `fs` is `IO`, which is a sibling of `Control` in the classifier tree, so the two are unrelated. By contrast, a closure using an `Async` capability is rejected. A closure over an unclassified capability such as a plain function value `proc: () => Unit` is also rejected, since we cannot exclude that `proc` retains `Control` capabilities. The same holds for a capability classified as `SharedCapability`: since `Control` is a sub-classifier of `SharedCapability`, such a capability could retain `Control` capabilities.
+A closure over a `FileSystem` is accepted, since `IO` is unrelated to `Control`:
+```scala sc-compile-with:classifiers-fs
+def onIO(fs: FileSystem^) = runOnNewThread(() => fs.read())
+```
+A closure that might retain a `Control` capability is rejected — whether it captures an `Async` (which _is_ a `Control`), an unclassified function value, or a capability classified only as `SharedCapability` (of which `Control` is a sub-classifier):
+```scala sc:fail sc-compile-with:classifiers-except,classifiers-async
+def onControl(async: Async^)            = runOnNewThread(() => async.toString)  // error
+def onUnclassified(proc: () => Unit)    = runOnNewThread(() => proc())          // error
+def onShared(shared: SharedCapability^) = runOnNewThread(() => shared.toString) // error
+```
 
-Restriction and exclusion can be combined: `c.only[A].except[B]` keeps those capabilities of `c` that are classified as `A` but not as `B`. This is useful only if `B` is a proper sub-classifier of `A`; if `B` covers all of `A` the resulting capture set is empty, and the capture reference is usually rejected as vacuous. Currently at most one `except` clause can be given per capture reference.
+Restriction and exclusion can be combined: `c.only[A].except[B]` keeps those capabilities of `c` that are classified as `A` but not as `B`. If `B` covers all of `A`, the result is the empty capture set. Currently at most one `except` clause can be given per capture reference. <!--  TODO: fix in implementation -->
 
 Subcapturing relates excluded capabilities as follows, where `B` is a subtrait of classifier trait `A`:
 ```
@@ -148,3 +158,10 @@ Subcapturing relates excluded capabilities as follows, where `B` is a subtrait o
 {c.except[A]} <: {c.except[B]}
 ```
 The last rule holds since excluding a larger classifier `A` removes more capabilities than excluding a smaller one `B`. Exclusions of unrelated classifiers are not comparable.
+
+#### The top classifier
+
+A projection can also name the top above all classifiers, with either `caps.Capability` or `Any`. Neither is itself a classifier trait, but both are accepted as the argument of `.only` and `.except`, where they stand for all capabilities. This gives two limiting cases:
+
+ - `c.only[Any]` (equivalently `c.only[Capability]`) is the _identity_ restriction: it keeps all of `c`, so `{c.only[Any]}` is the same as `{c}`.
+ - `c.except[Any]` (equivalently `c.except[Capability]`) is the _empty_ exclusion: it removes all of `c`, so `{c.except[Any]}` is the empty capture set. Like any projection that comes out empty (for instance `c.only[A].except[A]`), it is allowed, not an error.

--- a/docs/_docs/reference/experimental/capture-checking/classifiers.md
+++ b/docs/_docs/reference/experimental/capture-checking/classifiers.md
@@ -120,3 +120,31 @@ def test(io: IO, async: Async, proc: () => Unit) =
     // code accessing `io`, `async`, and `proc` and returning an `Int.
   val _: Try[Int]^{async, proc} = r
 ```
+
+### Classifier Exclusion
+
+Restriction selects the capabilities that fall under a classifier. Sometimes we need the opposite: keep all capabilities _except_ those that fall under a classifier. Consider a method that runs a computation on a different thread. The computation must not capture capabilities that are tied to the originating thread's stack, such as `Control` capabilities: using a `boundary.Label` from a different thread would attempt a non-local return across threads. But any other capability is fine. This is expressed with an _excluded capability_:
+```scala sc-compile-with:classifiers-cc-context
+def runOnNewThread[T](body: () ->{any.except[Control]} T): T = ???
+```
+The general form of an excluded capability is `c.except[A]` where
+
+ - `c` is a regular capability, possibly carrying an `only` restriction
+ - `A` is a classifier trait.
+
+`c.except[A]` stands for the parts of `c` that are _not_ classified as `A` or a subclass of `A`. A capability `x` is covered by `c.except[A]` only if `x` is covered by `c` and `x` is known to be unrelated to the classifier `A`. For instance, given
+```scala sc:nocompile
+trait IO extends SharedCapability, Classifier
+class FileSystem extends IO
+```
+a closure `() => fs.read()` over a capability `fs: FileSystem^` can be passed to `runOnNewThread`: the classifier of `fs` is `IO`, which is a sibling of `Control` in the classifier tree, so the two are unrelated. By contrast, a closure using an `Async` capability is rejected. A closure over an unclassified capability such as a plain function value `proc: () => Unit` is also rejected, since we cannot exclude that `proc` retains `Control` capabilities. The same holds for a capability classified as `SharedCapability`: since `Control` is a sub-classifier of `SharedCapability`, such a capability could retain `Control` capabilities.
+
+Restriction and exclusion can be combined: `c.only[A].except[B]` keeps those capabilities of `c` that are classified as `A` but not as `B`. This is useful only if `B` is a proper sub-classifier of `A`; if `B` covers all of `A` the resulting capture set is empty, and the capture reference is usually rejected as vacuous. Currently at most one `except` clause can be given per capture reference.
+
+Subcapturing relates excluded capabilities as follows, where `B` is a subtrait of classifier trait `A`:
+```
+{c.except[A]} <: {c}
+{c.only[A].except[B]} <: {c.only[A]}
+{c.except[A]} <: {c.except[B]}
+```
+The last rule holds since excluding a larger classifier `A` removes more capabilities than excluding a smaller one `B`. Exclusions of unrelated classifiers are not comparable.

--- a/docs/_docs/reference/experimental/capture-checking/overview.md
+++ b/docs/_docs/reference/experimental/capture-checking/overview.md
@@ -25,7 +25,7 @@ For a more systematic description of all the details we refer you to the followi
  - [Capture Checking of Classes](./classes.md): Rules for capture checking classes and objects.
  - [Capability Polymorphism](./polymorphism.md): Subtyping of capturing types and capture set variables.
  - [Scoping of Capabilities](./scoped-capabilities.md): Scoping of `any` and `fresh` capabilities.
- - [Capability Classifiers](./classifiers.md): Classifiers for capabilities and projection with the `.only[...]` operator.
+ - [Capability Classifiers](./classifiers.md): Classifiers for capabilities and projection with the `.only[...]` and `.except[...]` operators.
  - [Checked Exceptions](./checked-exceptions.md): `CanThrow` capabilities and `throws` clauses.
  - [Stateful Capabilities](./mutability.md): Capabilities for mutable data structures.
  - [Separation Checking](./separation-checking.md): More detailed checking for controlling aliasing and sharing of capabilities.

--- a/library/src/scala/annotation/internal/exceptCapability.scala
+++ b/library/src/scala/annotation/internal/exceptCapability.scala
@@ -1,0 +1,7 @@
+package scala.annotation
+package internal
+
+/** An annotation that represents a capability  `c.except[T]`,
+ *  encoded as `x.type @exceptCapability[T]`
+ */
+class exceptCapability[T] extends StaticAnnotation

--- a/library/src/scala/caps/package.scala
+++ b/library/src/scala/caps/package.scala
@@ -29,7 +29,7 @@ import annotation.meta.*
 sealed trait Capability extends Any
 
 /** A marker trait for classifier capabilities that can appear in `.only`
- *  qualifiers. Capability classes directly extending `Classifier` are treated
+ *  and `.except` qualifiers. Capability classes directly extending `Classifier` are treated
  *  as classifier capbilities.
  *
  *  [[Classifier]] has a formal meaning when

--- a/project/MiMaFilters.scala
+++ b/project/MiMaFilters.scala
@@ -13,6 +13,8 @@ object MiMaFilters {
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.NamedTuple.namedTupleCanEqual"),
         // IArray integration with Scala Collections:
         ProblemFilters.exclude[DirectMissingMethodProblem]("scala.collection.BuildFrom.buildFromIArray"),
+        // new annotation encoding capture checking's `x.except[C]` capabilities
+        ProblemFilters.exclude[MissingClassProblem]("scala.annotation.internal.exceptCapability"),
     ))
 
     val BackwardsBreakingChanges: Map[String, Seq[ProblemFilter]] = Map(

--- a/project/ScaladocConfigs0.scala
+++ b/project/ScaladocConfigs0.scala
@@ -99,6 +99,7 @@ object ScaladocConfigs0 {
   def captureCheckingSnippetTestTargets(docsRoot: String) = List(
     s"$docsRoot/_docs/reference/experimental/capture-checking/basics.md=compile+test",
     s"$docsRoot/_docs/reference/experimental/capture-checking/checked-exceptions.md=compile+test",
+    s"$docsRoot/_docs/reference/experimental/capture-checking/classifiers.md=compile+test",
     s"$docsRoot/_docs/reference/experimental/capture-checking/scoped-capabilities.md=compile+test"
   )
   def referenceSnippetCompilerTargets(docsRoot: String) =

--- a/repl/test-resources/repl/cc-classifier-except
+++ b/repl/test-resources/repl/cc-classifier-except
@@ -1,0 +1,10 @@
+//> using options -language:experimental.captureChecking
+scala> import caps.*
+scala> trait IO extends SharedCapability, Classifier
+// defined trait IO
+scala> def f(x: Object^): Object^{x.except[Control]} = ???
+def f(x: Object^): Object^{x.except[Control]}
+scala> def g(x: Object^): Object^{x.only[IO]} = ???
+def g(x: Object^): Object^{x.only[IO]}
+scala> def widen(x: Object^): Object^{x} = f(x)
+def widen(x: Object^): Object^{x}

--- a/scaladoc-testcases/src/tests/captureCheckingSignatures.scala
+++ b/scaladoc-testcases/src/tests/captureCheckingSignatures.scala
@@ -134,6 +134,14 @@ trait ClassifierExamples:
   def restricted(f: () ->{any.only[Control]} Unit): Unit //expected: def restricted(f: () ->{any.only[Control]} Unit): Unit
   def sharedOnly: AnyRef^{any.only[Control]} //expected: def sharedOnly: AnyRef^{any.only[Control]}
 
+// .except[Classifier] excluded capabilities
+trait ExceptExamples:
+  val a: AnyRef^
+  def excluded(f: () ->{any.except[Control]} Unit): Unit //expected: def excluded(f: () ->{any.except[Control]} Unit): Unit
+  def sharedExcept: AnyRef^{any.except[Control]} //expected: def sharedExcept: AnyRef^{any.except[Control]}
+  def pathExcept: AnyRef^{a.except[Control]} //expected: def pathExcept: AnyRef^{a.except[Control]}
+  def onlyThenExcept: AnyRef^{a.only[Control].except[Control]} //expected: def onlyThenExcept: AnyRef^{a.only[Control].except[Control]}
+
 // --- Capture set variables and capability members ---
 
 class Box[X^](val value: AnyRef^{X})

--- a/scaladoc-testcases/src/tests/captureCheckingSignatures.scala
+++ b/scaladoc-testcases/src/tests/captureCheckingSignatures.scala
@@ -127,6 +127,7 @@ trait ConsumeMethodExamples extends Mutable:
 // --- Classifiers ---
 
 class MyIO extends SharedCapability
+trait Async extends SharedCapability, Classifier
 trait Control extends SharedCapability, Classifier
 
 // .only[Classifier] restricted capabilities
@@ -141,6 +142,8 @@ trait ExceptExamples:
   def sharedExcept: AnyRef^{any.except[Control]} //expected: def sharedExcept: AnyRef^{any.except[Control]}
   def pathExcept: AnyRef^{a.except[Control]} //expected: def pathExcept: AnyRef^{a.except[Control]}
   def onlyThenExcept: AnyRef^{a.only[Control].except[Control]} //expected: def onlyThenExcept: AnyRef^{a.only[Control].except[Control]}
+  def multiExcept: AnyRef^{a.except[Async].except[Control]} //expected: def multiExcept: AnyRef^{a.except[Async].except[Control]}
+  def onlyMultiExcept: AnyRef^{a.only[SharedCapability].except[Async].except[Control]} //expected: def onlyMultiExcept: AnyRef^{a.only[SharedCapability].except[Async].except[Control]}
 
 // --- Capture set variables and capability members ---
 

--- a/scaladoc/src/dotty/tools/scaladoc/cc/CaptureOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/cc/CaptureOps.scala
@@ -40,6 +40,8 @@ object CaptureDefs:
     qctx.reflect.Symbol.requiredClass("scala.annotation.internal.requiresCapability")
   def OnlyCapabilityAnnot(using qctx: Quotes) =
     qctx.reflect.Symbol.requiredClass("scala.annotation.internal.onlyCapability")
+  def ExceptCapabilityAnnot(using qctx: Quotes) =
+    qctx.reflect.Symbol.requiredClass("scala.annotation.internal.exceptCapability")
 
   def LanguageExperimental(using qctx: Quotes) =
     qctx.reflect.Symbol.requiredPackage("scala.language.experimental")
@@ -80,6 +82,9 @@ extension (using qctx: Quotes)(ann: qctx.reflect.Symbol)
 
   def isOnlyCapabilityAnnot: Boolean =
     ann == CaptureDefs.OnlyCapabilityAnnot
+
+  def isExceptCapabilityAnnot: Boolean =
+    ann == CaptureDefs.ExceptCapabilityAnnot
 end extension
 
 extension (using qctx: Quotes)(tpe: qctx.reflect.TypeRepr) // FIXME clean up and have versions on Symbol for those
@@ -205,6 +210,17 @@ object OnlyCapability:
       case _ => None
 end OnlyCapability
 
+object ExceptCapability:
+  def unapply(using qctx: Quotes)(ty: qctx.reflect.TypeRepr): Option[(qctx.reflect.TypeRepr, qctx.reflect.Symbol)] =
+    import qctx.reflect._
+    ty match
+      case AnnotatedType(base, app @ Apply(TypeApply(Select(New(annot), _), _), Nil)) if annot.tpe.typeSymbol.isExceptCapabilityAnnot =>
+        app.tpe.typeArgs.head.classSymbol.match
+          case Some(clazzsym) => Some((base, clazzsym))
+          case None => None
+      case _ => None
+end ExceptCapability
+
 /** Decompose capture sets in the union-type-encoding into the sequence of atomic `TypeRepr`s.
  *  Returns `None` if the type is not a capture set.
 */
@@ -222,6 +238,7 @@ def decomposeCaptureRefs(using qctx: Quotes)(typ0: qctx.reflect.TypeRepr): Optio
       case t @ ReachCapability(_)    => include(t)
       case t @ ReadOnlyCapability(_) => include(t)
       case t @ OnlyCapability(_, _)  => include(t)
+      case t @ ExceptCapability(_, _) => include(t)
       case t : TypeRef               => include(t)
       case _ => report.warning(s"Unexpected type tree $typ while trying to extract capture references from $typ0"); false
   if traverse(typ0) then Some(buffer.toList) else None

--- a/scaladoc/src/dotty/tools/scaladoc/cc/CaptureOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/cc/CaptureOps.scala
@@ -26,14 +26,8 @@ object CaptureDefs:
     qctx.reflect.Symbol.requiredClass("scala.caps.Mutable")
   def Caps_SharedCapability(using qctx: Quotes) =
     qctx.reflect.Symbol.requiredClass("scala.caps.SharedCapability")
-  def UseAnnot(using qctx: Quotes) =
-    qctx.reflect.Symbol.requiredClass("scala.caps.use")
   def ConsumeAnnot(using qctx: Quotes) =
     qctx.reflect.Symbol.requiredClass("scala.caps.internal.consume")
-  def ReachCapabilityAnnot(using qctx: Quotes) =
-    qctx.reflect.Symbol.requiredClass("scala.annotation.internal.reachCapability")
-  def RootCapabilityAnnot(using qctx: Quotes) =
-    qctx.reflect.Symbol.requiredClass("scala.caps.internal.rootCapability")
   def ReadOnlyCapabilityAnnot(using qctx: Quotes) =
     qctx.reflect.Symbol.requiredClass("scala.annotation.internal.readOnlyCapability")
   def RequiresCapabilityAnnot(using qctx: Quotes) =
@@ -58,7 +52,6 @@ object CaptureDefs:
   def ContextFunction1(using qctx: Quotes) =
     qctx.reflect.Symbol.requiredClass("scala.ContextFunction1")
 
-  val useAnnotFullName: String = "scala.caps.use.<init>"
   val consumeAnnotFullName: String = "scala.caps.consume.<init>"
   val ccImportSelector = "captureChecking"
   val captureRootName = "any"
@@ -73,9 +66,6 @@ extension (using qctx: Quotes)(ann: qctx.reflect.Symbol)
   /** This symbol is one of `retains`, `retainsCap`, or `retainsByName` */
   def isRetainsLike: Boolean =
     ann.isRetains || ann == CaptureDefs.retainsByName
-
-  def isReachCapabilityAnnot: Boolean =
-    ann == CaptureDefs.ReachCapabilityAnnot
 
   def isReadOnlyCapabilityAnnot: Boolean =
     ann == CaptureDefs.ReadOnlyCapabilityAnnot
@@ -181,15 +171,6 @@ object CCImport:
   end unapply
 end CCImport
 
-object ReachCapability:
-  def unapply(using qctx: Quotes)(ty: qctx.reflect.TypeRepr): Option[qctx.reflect.TypeRepr] =
-    import qctx.reflect._
-    ty match
-      case AnnotatedType(base, Apply(Select(New(annot), _), Nil)) if annot.symbol.isReachCapabilityAnnot =>
-        Some(base)
-      case _ => None
-end ReachCapability
-
 object ReadOnlyCapability:
   def unapply(using qctx: Quotes)(ty: qctx.reflect.TypeRepr): Option[qctx.reflect.TypeRepr] =
     import qctx.reflect._
@@ -235,7 +216,6 @@ def decomposeCaptureRefs(using qctx: Quotes)(typ0: qctx.reflect.TypeRepr): Optio
       case t @ ThisType(_)           => include(t)
       case t @ TermRef(_, _)         => include(t)
       case t @ ParamRef(_, _)        => include(t)
-      case t @ ReachCapability(_)    => include(t)
       case t @ ReadOnlyCapability(_) => include(t)
       case t @ OnlyCapability(_, _)  => include(t)
       case t @ ExceptCapability(_, _) => include(t)

--- a/scaladoc/src/dotty/tools/scaladoc/cc/CaptureOps.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/cc/CaptureOps.scala
@@ -192,14 +192,22 @@ object OnlyCapability:
 end OnlyCapability
 
 object ExceptCapability:
-  def unapply(using qctx: Quotes)(ty: qctx.reflect.TypeRepr): Option[(qctx.reflect.TypeRepr, qctx.reflect.Symbol)] =
+  def unapply(using qctx: Quotes)(ty: qctx.reflect.TypeRepr): Option[(qctx.reflect.TypeRepr, List[qctx.reflect.Symbol])] =
     import qctx.reflect._
     ty match
       case AnnotatedType(base, app @ Apply(TypeApply(Select(New(annot), _), _), Nil)) if annot.tpe.typeSymbol.isExceptCapabilityAnnot =>
-        app.tpe.typeArgs.head.classSymbol.match
-          case Some(clazzsym) => Some((base, clazzsym))
-          case None => None
+        classifierSyms(app.tpe.typeArgs.head) match
+          case Nil => None
+          case clss => Some((base, clss))
       case _ => None
+
+  // Split the union-encoded classifiers. No dealias needed: the reflect API already
+  // presents `|` as an OrType (as in decomposeCaptureRefs below).
+  private def classifierSyms(using qctx: Quotes)(ty: qctx.reflect.TypeRepr): List[qctx.reflect.Symbol] =
+    import qctx.reflect._
+    ty match
+      case OrType(t1, t2) => classifierSyms(t1) ++ classifierSyms(t2)
+      case t => t.classSymbol.toList
 end ExceptCapability
 
 /** Decompose capture sets in the union-type-encoding into the sequence of atomic `TypeRepr`s.

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/BasicSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/BasicSupport.scala
@@ -55,10 +55,7 @@ trait BasicSupport:
         "scala.annotation.threadUnsafe",
         "scala.annotation.varargs",
       )
-      val fqNameAllowlist =
-        if ccEnabled then
-          fqNameAllowlist0 + CaptureDefs.useAnnotFullName
-        else fqNameAllowlist0
+      val fqNameAllowlist = fqNameAllowlist0
       val documentedSymbol = summon[Quotes].reflect.Symbol.requiredClass("java.lang.annotation.Documented")
       val annotations = sym.annotations.filter { a =>
         a.tpe.typeSymbol.hasAnnotation(documentedSymbol) || fqNameAllowlist.contains(a.symbol.fullName)

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -547,6 +547,7 @@ trait TypesSupport:
       case ReachCapability(c)     => emitCapability(c, skipThisTypePrefix) :+ Keyword("*")
       case ReadOnlyCapability(c)  => emitCapability(c, skipThisTypePrefix) :+ Keyword(".rd")
       case OnlyCapability(c, cls) => emitCapability(c, skipThisTypePrefix) ++ List(Plain("."), Keyword("only"), Plain("[")) ++ inner(cls.typeRef, skipThisTypePrefix) :+ Plain("]")
+      case ExceptCapability(c, cls) => emitCapability(c, skipThisTypePrefix) ++ List(Plain("."), Keyword("except"), Plain("[")) ++ inner(cls.typeRef, skipThisTypePrefix) :+ Plain("]")
       case t @ ThisType(tpe)      =>
         // Render `this` for self-references and `EnclosingClass.this` otherwise.
         // We deliberately call `inner` without `inCC` in scope so the enclosing
@@ -584,7 +585,7 @@ trait TypesSupport:
 
   // Determines whether a capture set reference should be rendered in the current context.
   // Some capabilities (like `this` in a pure class) are elided. We need to handle all
-  // capability wrappers (reach `c*`, read-only `c.rd`, classifier `.only[C]`) by
+  // capability wrappers (reach `c*`, read-only `c.rd`, classifier `.only[C]` and `.except[C]`) by
   // recursing into the underlying capability, and always render root capabilities
   // (`cap`/`any`) and `fresh`.
   private def isCapturedInContext(using Quotes)(ref: reflect.TypeRepr)(using elideThis: reflect.ClassDef): Boolean =
@@ -595,6 +596,7 @@ trait TypesSupport:
       case ReachCapability(c)     => isCapturedInContext(c)
       case ReadOnlyCapability(c)  => isCapturedInContext(c)
       case OnlyCapability(c, _)   => isCapturedInContext(c)
+      case ExceptCapability(c, _) => isCapturedInContext(c)
       case ThisType(tr)           => !elideThis.symbol.typeRef.isPureClass(elideThis)
       case t                      => !t.isPureClass(elideThis)
 

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -546,7 +546,9 @@ trait TypesSupport:
     ref match
       case ReadOnlyCapability(c)  => emitCapability(c, skipThisTypePrefix) :+ Keyword(".rd")
       case OnlyCapability(c, cls) => emitCapability(c, skipThisTypePrefix) ++ List(Plain("."), Keyword("only"), Plain("[")) ++ inner(cls.typeRef, skipThisTypePrefix) :+ Plain("]")
-      case ExceptCapability(c, cls) => emitCapability(c, skipThisTypePrefix) ++ List(Plain("."), Keyword("except"), Plain("[")) ++ inner(cls.typeRef, skipThisTypePrefix) :+ Plain("]")
+      case ExceptCapability(c, clss) =>
+        clss.foldLeft(emitCapability(c, skipThisTypePrefix)): (acc, cls) =>
+          acc ++ List(Plain("."), Keyword("except"), Plain("[")) ++ inner(cls.typeRef, skipThisTypePrefix) :+ Plain("]")
       case t @ ThisType(tpe)      =>
         // Render `this` for self-references and `EnclosingClass.this` otherwise.
         // We deliberately call `inner` without `inCC` in scope so the enclosing

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TypesSupport.scala
@@ -544,7 +544,6 @@ trait TypesSupport:
   private def emitCapability(using Quotes)(ref: reflect.TypeRepr, skipThisTypePrefix: Boolean)(using elideThis: reflect.ClassDef, originalOwner: reflect.Symbol): SSignature =
     import reflect._
     ref match
-      case ReachCapability(c)     => emitCapability(c, skipThisTypePrefix) :+ Keyword("*")
       case ReadOnlyCapability(c)  => emitCapability(c, skipThisTypePrefix) :+ Keyword(".rd")
       case OnlyCapability(c, cls) => emitCapability(c, skipThisTypePrefix) ++ List(Plain("."), Keyword("only"), Plain("[")) ++ inner(cls.typeRef, skipThisTypePrefix) :+ Plain("]")
       case ExceptCapability(c, cls) => emitCapability(c, skipThisTypePrefix) ++ List(Plain("."), Keyword("except"), Plain("[")) ++ inner(cls.typeRef, skipThisTypePrefix) :+ Plain("]")
@@ -593,7 +592,6 @@ trait TypesSupport:
     ref match
       case t if t.isCaptureRoot   => true
       case t if t.isFreshCap      => true
-      case ReachCapability(c)     => isCapturedInContext(c)
       case ReadOnlyCapability(c)  => isCapturedInContext(c)
       case OnlyCapability(c, _)   => isCapturedInContext(c)
       case ExceptCapability(c, _) => isCapturedInContext(c)

--- a/tests/neg-custom-args/captures/except-chain.scala
+++ b/tests/neg-custom-args/captures/except-chain.scala
@@ -3,4 +3,5 @@ import caps.{any, Classifier, SharedCapability}
 trait C extends SharedCapability, Classifier
 trait D extends SharedCapability, Classifier
 
+// TODO: permit multiple except clauses on the same capture reference.
 def f(c: Object^): Object^{c.except[C].except[D]} = ??? // error: at most one except clause per capture reference

--- a/tests/neg-custom-args/captures/except-chain.scala
+++ b/tests/neg-custom-args/captures/except-chain.scala
@@ -1,0 +1,6 @@
+import caps.{any, Classifier, SharedCapability}
+
+trait C extends SharedCapability, Classifier
+trait D extends SharedCapability, Classifier
+
+def f(c: Object^): Object^{c.except[C].except[D]} = ??? // error: at most one except clause per capture reference

--- a/tests/neg-custom-args/captures/except-chain.scala
+++ b/tests/neg-custom-args/captures/except-chain.scala
@@ -1,7 +1,0 @@
-import caps.{any, Classifier, SharedCapability}
-
-trait C extends SharedCapability, Classifier
-trait D extends SharedCapability, Classifier
-
-// TODO: permit multiple except clauses on the same capture reference.
-def f(c: Object^): Object^{c.except[C].except[D]} = ??? // error: at most one except clause per capture reference

--- a/tests/neg-custom-args/captures/except-chaining.scala
+++ b/tests/neg-custom-args/captures/except-chaining.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+import caps.{any, Classifier, Control, SharedCapability, ExclusiveCapability}
+
+// "Classifying Capabilities" §2.1: chaining only then except.
+// only[SharedCapability].except[Control] admits exactly the shared, non-Control capabilities.
+trait IOCap extends SharedCapability, Classifier   // shared, sibling of Control
+class File extends IOCap:
+  def read(): Unit = ()
+class CanThrow[-T] extends Control                 // shared, but in the excluded subtree
+class Buffer extends ExclusiveCapability:          // not shared
+  def write(): Unit = ()
+
+def runShared[T](task: () ->{any.only[SharedCapability].except[Control]} T): T = task()
+
+def test(f: File^, exc: CanThrow[Int]^, buf: Buffer^): Unit =
+  runShared(() => f.read())        // ok
+  runShared(() => println(exc))    // error: exc is Control
+  runShared(() => buf.write())     // error: Buffer is exclusive

--- a/tests/neg-custom-args/captures/except-empty.scala
+++ b/tests/neg-custom-args/captures/except-empty.scala
@@ -1,7 +1,0 @@
-import caps.{any, Classifier, SharedCapability}
-
-trait C extends SharedCapability, Classifier
-trait C1 extends C, Classifier
-
-def test(c: Object^): Unit =
-  val x: Object^{c.only[C1].except[C]} = ??? // error: the capture set is empty

--- a/tests/neg-custom-args/captures/except-empty.scala
+++ b/tests/neg-custom-args/captures/except-empty.scala
@@ -1,0 +1,7 @@
+import caps.{any, Classifier, SharedCapability}
+
+trait C extends SharedCapability, Classifier
+trait C1 extends C, Classifier
+
+def test(c: Object^): Unit =
+  val x: Object^{c.only[C1].except[C]} = ??? // error: the capture set is empty

--- a/tests/neg-custom-args/captures/except-environment.scala
+++ b/tests/neg-custom-args/captures/except-environment.scala
@@ -1,0 +1,18 @@
+import caps.{any, Classifier, Control, SharedCapability}
+
+// Section 2.1 of "Classifying Capabilities": a function that dispatches work to a
+// new thread must forbid its closure from using thread-local Control capabilities.
+// `File` is a resource capability classified disjoint from `Control`.
+trait IOCap extends SharedCapability, Classifier
+class File extends IOCap:
+  def read(): Unit = ()
+
+class CanThrow[-T] extends Control
+
+case class Environment(file: File^, exc: CanThrow[Int]^)
+
+def runOnNewThread(task: () ->{any.except[Control]} Unit): Unit = task()
+
+def f(env: Environment^) =
+  runOnNewThread(() => env.file.read())   // ok: File is not a Control capability
+  runOnNewThread(() => println(env.exc))  // error: exc is Control

--- a/tests/neg-custom-args/captures/except-future.scala
+++ b/tests/neg-custom-args/captures/except-future.scala
@@ -1,0 +1,20 @@
+import caps.{any, Classifier, SharedCapability}
+
+// Section 2.3 of "Classifying Capabilities": a Future cannot capture thread-local
+// resources. Following the paper, the control classifier sits *under* ThreadLocal,
+// so a single exclusion of the ancestor ThreadLocal also excludes Control.
+trait ThreadLocal extends SharedCapability, Classifier
+trait Control     extends ThreadLocal, Classifier
+trait Resource    extends SharedCapability, Classifier   // a sibling of ThreadLocal
+
+class Label extends Control
+class File  extends Resource:
+  def read(): Unit = ()
+
+class Future[T]
+object Future:
+  def apply[T](body: () ->{any.except[ThreadLocal]} T): Future[T]^{body} = ???
+
+def test(label: Label^, file: File^) =
+  Future(() => file.read())     // ok: File is a Resource, disjoint from ThreadLocal
+  Future(() => println(label))  // error: Label is Control, a descendant of ThreadLocal

--- a/tests/neg-custom-args/captures/except-multi-subsumes.scala
+++ b/tests/neg-custom-args/captures/except-multi-subsumes.scala
@@ -1,0 +1,21 @@
+import caps.{Classifier, Control, SharedCapability}
+
+trait IOCap  extends SharedCapability, Classifier
+trait NetCap extends IOCap, Classifier
+
+def reverseMonotonicity(c: Object^): Unit =
+  // dropping an exclusion yields a larger set, not a subset:
+  // {c.except[Control]} </: {c.except[Control].except[IOCap]}
+  val x: Object^{c.except[Control]}               = ???
+  val y: Object^{c.except[Control].except[IOCap]} = x // error
+
+def fullNotInDoubleExcept(c: Object^): Unit =
+  // {c} </: {c.except[Control].except[IOCap]}
+  val x: Object^{c}                               = ???
+  val y: Object^{c.except[Control].except[IOCap]} = x // error
+
+def excludedPartRejected(c: Object^): Unit =
+  // the second exclusion removes exactly the IOCap part:
+  // {c.only[IOCap]} </: {c.except[Control].except[IOCap]}
+  val x: Object^{c.only[IOCap]}                   = ???
+  val y: Object^{c.except[Control].except[IOCap]} = x // error

--- a/tests/neg-custom-args/captures/except-poly-chain.scala
+++ b/tests/neg-custom-args/captures/except-poly-chain.scala
@@ -1,0 +1,15 @@
+import language.experimental.captureChecking
+import caps.{Control, Classifier, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+
+class Box[+T]
+def excludeControl[T, D^](box: Box[T]^{D}): Box[T]^{D.except[Control]} = ???
+def excludeIO[T, E^](box: Box[T]^{E}): Box[T]^{E.except[IOCap]} = ???
+
+def test(w: Object^) =
+  val w0: Box[Unit]^{w} = ???
+  val r1 = excludeIO(w0)
+  val r2 = excludeControl(r1)
+  val good: Box[Unit]^{w}                                = r2
+  val bad:  Box[Unit]^{w.except[Control].except[IOCap]} = r1 // error

--- a/tests/neg-custom-args/captures/except-poly.scala
+++ b/tests/neg-custom-args/captures/except-poly.scala
@@ -1,0 +1,16 @@
+import caps.{Control, Classifier, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+class Console extends IOCap:
+  def print(): Unit = ()
+class Label extends Control:
+  def break(): Unit = ()
+
+class Box[+T]
+def run[T, C^](body: () ->{C} T): Box[T]^{C.except[Control]} = ???
+
+def test(console: Console^, l: Label^) =
+  val r = run: () =>
+    console.print()
+    l.break()
+  val keepControl: Box[Unit]^{l} = r // error

--- a/tests/neg-custom-args/captures/except-spore.scala
+++ b/tests/neg-custom-args/captures/except-spore.scala
@@ -1,0 +1,18 @@
+import caps.{any, Classifier, SharedCapability, Unscoped}
+
+// "Classifying Capabilities" §6.5: a Spore may only capture Serializable capabilities.
+trait Serializable extends Classifier, SharedCapability:
+  def serialize(): Array[Byte]
+  def deserialize(from: Array[Byte]): Unit
+
+class Spore(inner: () ->{any.only[Serializable]} Unit)
+
+class SerCap extends Serializable:
+  def serialize(): Array[Byte] = ???
+  def deserialize(from: Array[Byte]): Unit = ???
+class UnsCap extends Unscoped   // disjoint from Serializable
+
+def test(s: SerCap^, u: UnsCap^, o: Object^): Unit =
+  val a = Spore(() => s.serialize())   // ok
+  val b = Spore(() => println(u))      // error: UnsCap is Unscoped
+  val c = Spore(() => println(o))      // error: o is unclassified

--- a/tests/neg-custom-args/captures/except-subsumes.scala
+++ b/tests/neg-custom-args/captures/except-subsumes.scala
@@ -1,23 +1,38 @@
 import caps.{any, Classifier, Control, SharedCapability}
 
-trait IOCap extends SharedCapability, Classifier
+trait IOCap   extends SharedCapability, Classifier
+trait NetCap  extends IOCap, Classifier
+class Label   extends Control
+class Shared1 extends SharedCapability   // classified exactly as SharedCapability
 
-class File extends IOCap:
-  def read(): Int = 1
+def reverseWidening(c: Object^): Unit =
+  // {c} is not included in {c.except[IOCap]}
+  val x: Object^{c}               = ???
+  val y: Object^{c.except[IOCap]} = x // error
 
-class Label extends Control
+def antiMonotonicity(c: Object^): Unit =
+  // excluding less is not a subset of excluding more:
+  // {c.except[NetCap]} </: {c.except[IOCap]}
+  val x: Object^{c.except[NetCap]} = ???
+  val y: Object^{c.except[IOCap]}  = x // error
+
+def unrelatedExclusions(c: Object^): Unit =
+  // exclusions of unrelated classifiers do not subsume each other
+  val x: Object^{c.except[Control]} = ???
+  val y: Object^{c.except[IOCap]}   = x // error
 
 def runOnNewThread[T](body: () ->{any.except[Control]} T): T = body()
 
-def test(f: File^, l: Label^, o: Object^) =
+def controlRejected(l: Label^): Unit =
   runOnNewThread: () =>
-    f.read() // ok: f is classified as IOCap, which is unrelated to Control
     println(l) // error: l is classified as Control
+
+def unclassifiedRejected(o: Object^): Unit =
   runOnNewThread: () =>
     println(o) // error: o is unclassified, so it could capture Control capabilities
 
-def test2(c: Object^): Unit =
-  val x1: Object^{c} = ???
-  val y1: Object^{c.except[IOCap]} = x1 // error: {c} is not included in {c.except[IOCap]}
-  val x2: Object^{c.except[Control]} = ???
-  val y2: Object^{c.except[IOCap]} = x2 // error: unrelated exclusions do not subsume each other
+def ancestorRejected(s: Shared1^): Unit =
+  // SharedCapability is an ancestor of Control, so a SharedCapability-classified
+  // capability could still capture a Control capability and must be rejected.
+  runOnNewThread: () =>
+    println(s) // error

--- a/tests/neg-custom-args/captures/except-subsumes.scala
+++ b/tests/neg-custom-args/captures/except-subsumes.scala
@@ -1,0 +1,23 @@
+import caps.{any, Classifier, Control, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+
+class File extends IOCap:
+  def read(): Int = 1
+
+class Label extends Control
+
+def runOnNewThread[T](body: () ->{any.except[Control]} T): T = body()
+
+def test(f: File^, l: Label^, o: Object^) =
+  runOnNewThread: () =>
+    f.read() // ok: f is classified as IOCap, which is unrelated to Control
+    println(l) // error: l is classified as Control
+  runOnNewThread: () =>
+    println(o) // error: o is unclassified, so it could capture Control capabilities
+
+def test2(c: Object^): Unit =
+  val x1: Object^{c} = ???
+  val y1: Object^{c.except[IOCap]} = x1 // error: {c} is not included in {c.except[IOCap]}
+  val x2: Object^{c.except[Control]} = ???
+  val y2: Object^{c.except[IOCap]} = x2 // error: unrelated exclusions do not subsume each other

--- a/tests/neg-custom-args/captures/except-transaction-double.scala
+++ b/tests/neg-custom-args/captures/except-transaction-double.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+import language.experimental.erasedDefinitions
+import caps.{Classifier, SharedCapability}
+
+// "Classifying Capabilities" §6.2: withTransaction forbids the body's result from capturing
+// the transaction's commit/rollback authority. The paper uses two exclusions; the single-
+// exclusion form is in pos-custom-args/captures/except-transaction.scala.
+trait Commit   extends SharedCapability, Classifier
+trait Rollback extends SharedCapability, Classifier
+
+trait Transaction extends SharedCapability:
+  erased val cm: Commit^
+  erased val rb: Rollback^
+  val commit:   () ->{this.only[Commit]} Unit
+  val rollback: () ->{this.only[Rollback]} Unit
+
+// TODO: permit multiple except clauses on the same capture reference.
+def withTransaction[T, E^](body: (tx: Transaction^) -> (() ->{E, tx.except[Commit].except[Rollback]} T)): T = ??? // error: at most one except clause per capture reference

--- a/tests/neg-custom-args/captures/except-wf.check
+++ b/tests/neg-custom-args/captures/except-wf.check
@@ -1,0 +1,5 @@
+-- Error: tests/neg-custom-args/captures/except-wf.scala:7:19 ----------------------------------------------------------
+7 |def foo(x: Object^{any.except[Async]}) = ??? // error
+  |                   ^^^^^^^^^^^^^^^^^
+  |               any.except[Async] is not well-formed since class Async is not a classifier class.
+  |               A classifier class is a class extending `caps.Capability` and directly extending `caps.Classifier`.

--- a/tests/neg-custom-args/captures/except-wf.scala
+++ b/tests/neg-custom-args/captures/except-wf.scala
@@ -1,0 +1,8 @@
+import caps.*
+
+class Async extends SharedCapability
+
+class IO extends SharedCapability, Classifier
+
+def foo(x: Object^{any.except[Async]}) = ??? // error
+def bar(x: Object^{any.except[IO]}) = ??? // ok

--- a/tests/neg-custom-args/captures/restrict-try-poly.scala
+++ b/tests/neg-custom-args/captures/restrict-try-poly.scala
@@ -1,0 +1,17 @@
+import caps.{Control, Classifier, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+class Console extends IOCap:
+  def print(): Unit = ()
+class Label extends Control:
+  def break(): Unit = ()
+
+class Try[+T]
+object Try:
+  def apply[T, C^](body: () ->{C} T): Try[T]^{C.only[Control]} = ???
+
+def test(console: Console^, l: Label^) =
+  val t = Try: () =>
+    console.print()
+    l.break()
+  val keepConsole: Try[Unit]^{console} = t // error

--- a/tests/pos-custom-args/captures/classifier-defs.scala
+++ b/tests/pos-custom-args/captures/classifier-defs.scala
@@ -1,0 +1,19 @@
+import language.experimental.captureChecking
+import caps.{Classifier, SharedCapability}
+
+// "Classifying Capabilities" §2.1: defining classifiers by extending caps.Classifier directly.
+//   SharedCapability <- ThreadLocal <- Control <- CanThrow[-T]
+trait ThreadLocal extends Classifier, SharedCapability
+trait Control     extends Classifier, ThreadLocal
+class CanThrow[-T] extends Control
+
+class Ex1 extends Exception
+class Ex2 extends Ex1
+
+def use(ct: CanThrow[Ex1]^): Unit = ()
+
+def test(ct1: CanThrow[Ex1]^, ct2: CanThrow[Ex2]^) =
+  use(ct1)
+  val widened: CanThrow[Ex2]^ = ct1       // contravariant in the exception type
+  val asShared: SharedCapability^ = ct2   // CanThrow <: Control <: ThreadLocal <: SharedCapability
+  ()

--- a/tests/pos-custom-args/captures/except-captureexception.scala
+++ b/tests/pos-custom-args/captures/except-captureexception.scala
@@ -1,0 +1,10 @@
+import language.experimental.captureChecking
+import caps.Control
+
+// "Classifying Capabilities" §6.5: a stored Failure holds the CanThrow for a captured
+// exception. CanThrow is a Control capability, so the result advertises f.only[Control].
+class CanThrow[-E <: Exception] extends Control   // stdlib's is `extends caps.Control`
+
+case class Failure(e: Exception, ct: CanThrow[e.type]^)
+
+def captureException(f: () => Unit): Option[Failure^{f.only[Control]}] = ???

--- a/tests/pos-custom-args/captures/except-chain.scala
+++ b/tests/pos-custom-args/captures/except-chain.scala
@@ -1,0 +1,7 @@
+import caps.{Classifier, SharedCapability}
+
+trait C extends SharedCapability, Classifier
+trait D extends SharedCapability, Classifier
+
+// multiple `except` clauses on the same capture reference
+def f(c: Object^): Object^{c.except[C].except[D]} = ???

--- a/tests/pos-custom-args/captures/except-classified.scala
+++ b/tests/pos-custom-args/captures/except-classified.scala
@@ -1,0 +1,12 @@
+import caps.{any, Classifier, Control, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+
+class File extends IOCap:
+  def read(): Int = 1
+
+def runOnNewThread[T](body: () ->{any.except[Control]} T): T = body()
+
+def test(f: File^) =
+  runOnNewThread: () =>
+    f.read() // ok: f is classified as IOCap, which is unrelated to Control

--- a/tests/pos-custom-args/captures/except-database.scala
+++ b/tests/pos-custom-args/captures/except-database.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+import caps.{Classifier, ExclusiveCapability}
+
+// "Classifying Capabilities" §6.1: a Database classifier tree splitting into two disjoint
+// branches, so only[UserTable] flows into except[TransactionTable].
+//            Database
+//            /       \
+//      UserTable   TransactionTable
+trait Database         extends Classifier, ExclusiveCapability
+trait UserTable        extends Classifier, Database
+trait TransactionTable extends Classifier, Database
+
+trait User
+
+class DBImpl extends Database:
+  val readUsers: () ->{this.only[UserTable]} List[User] = ???
+  val doesntTouchTransactions: () ->{this.except[TransactionTable]} List[User] =
+    this.readUsers   // UserTable disjoint from TransactionTable

--- a/tests/pos-custom-args/captures/except-effects.scala
+++ b/tests/pos-custom-args/captures/except-effects.scala
@@ -1,0 +1,19 @@
+import caps.{any, Classifier, Control}
+
+// Section 6.2 of "Classifying Capabilities": real-world effect-exclusion patterns
+// catalogued by Lutze et al., expressed with classifier exclusion.
+
+// amule: a data-reading callback that must not invoke any CSafeIOException.
+trait CSafeIOException extends Classifier, Control
+case class CFileDataIO[T](doRead: (T, Long) -> {any.except[CSafeIOException]} Long)
+
+// dune: runWithErrHandler requires the body not to create a nested error handler,
+// and the no-raise handler not to use any control (exception) capability.
+trait ErrHandler extends Classifier, Control
+object RunWithErrHandler extends ErrHandler:
+  type Fiber[_]
+  type Raise
+  def apply[A](
+    f: this.Raise ?->{any.except[ErrHandler]} A,
+    handleErrNoRaise: Exception ->{any.except[Control]} Fiber[Unit],
+  ): Fiber[A] = ???

--- a/tests/pos-custom-args/captures/except-empty.scala
+++ b/tests/pos-custom-args/captures/except-empty.scala
@@ -1,0 +1,10 @@
+import caps.{any, Classifier, SharedCapability}
+
+trait C  extends SharedCapability, Classifier
+trait C1 extends C, Classifier
+
+// An empty projection of a tracked ref denotes {} and is accepted; only retaining a
+// genuinely untracked pure value is rejected. only[C1].except[C] is empty since C1 <: C.
+def test(c: Object^): Unit =
+  val x: Object^{c.only[C1].except[C]} = ???
+  val y: Object                        = x   // {} <: pure

--- a/tests/pos-custom-args/captures/except-multi-subsumes.scala
+++ b/tests/pos-custom-args/captures/except-multi-subsumes.scala
@@ -1,0 +1,45 @@
+import caps.{Classifier, Control, SharedCapability, Unscoped}
+
+// Multiple exclusions on one capture reference. Hierarchy as in except-subsumes.scala:
+//        SharedCapability        ExclusiveCapability
+//         /          \                  |
+//     Control       IOCap            Unscoped
+//                     |
+//                   NetCap
+trait IOCap  extends SharedCapability, Classifier
+trait NetCap extends IOCap, Classifier
+class Uns    extends Unscoped
+
+def monotonicity(c: Object^): Unit =
+  // each added exclusion shrinks the set:
+  // {c.except[Control].except[IOCap]} <: {c.except[Control]}, {c.except[IOCap]}, {c}
+  val x:  Object^{c.except[Control].except[IOCap]} = ???
+  val y1: Object^{c.except[Control]}               = x
+  val y2: Object^{c.except[IOCap]}                 = x
+  val y3: Object^{c}                               = x
+
+def orderIndependent(c: Object^): Unit =
+  // exclusion is a set, so order does not matter:
+  // {c.except[Control].except[IOCap]} =:= {c.except[IOCap].except[Control]}
+  val x: Object^{c.except[Control].except[IOCap]} = ???
+  val y: Object^{c.except[IOCap].except[Control]} = x
+  val z: Object^{c.except[Control].except[IOCap]} = y
+
+def subclassRedundant(c: Object^): Unit =
+  // excluding IOCap already drops the NetCap subtree, so excluding NetCap on top adds
+  // nothing: {c.except[IOCap].except[NetCap]} =:= {c.except[IOCap]}
+  val x:  Object^{c.except[IOCap].except[NetCap]} = ???
+  val y:  Object^{c.except[IOCap]}                = x
+  val x2: Object^{c.except[IOCap].except[NetCap]} = y
+
+def disjointPartSurvives(u: Uns^): Unit =
+  // Unscoped is on a different branch than Control and IOCap, so neither exclusion
+  // removes it: {u} =:= {u.except[Control].except[IOCap]}
+  val x: Object^{u.except[Control].except[IOCap]} = ???
+  val y: Object^{u}                               = x
+  val z: Object^{u.except[Control].except[IOCap]} = y
+
+def onlyThenMultipleExcept(c: Object^): Unit =
+  // {c.only[SharedCapability].except[Control].except[IOCap]} <: {c.only[SharedCapability].except[Control]}
+  val x: Object^{c.only[SharedCapability].except[Control].except[IOCap]} = ???
+  val y: Object^{c.only[SharedCapability].except[Control]}               = x

--- a/tests/pos-custom-args/captures/except-openworld/Defs_1.scala
+++ b/tests/pos-custom-args/captures/except-openworld/Defs_1.scala
@@ -1,0 +1,19 @@
+import language.experimental.captureChecking
+import caps.{any, Classifier, SharedCapability}
+
+// Open-world classifiers and separate compilation.
+//
+// Exclusion systems based on a closed-world assumption (e.g. some boolean-algebra effect
+// systems) need to know all members of a classifier to form its complement. Excluding
+// every *known* sub-classifier of A would make `only[A].except[<known children>]` collapse
+// to the empty set, so a body bounded by it would suddenly "appear pure" -- and a
+// sub-classifier introduced by another module later would silently break that reasoning.
+//
+// The classifier tree is open: every node is assumed to have infinitely many children, so
+// excluding the only currently-known child B does NOT empty `only[A].except[B]`. Module 1
+// need not know every sub-classifier of A, which keeps separate compilation sound.
+trait A extends SharedCapability, Classifier
+trait B extends A, Classifier
+
+def onlyAButNotB[T](body: () ->{any.only[A].except[B]} T): T = body()
+def use(x: Any): Unit = ()

--- a/tests/pos-custom-args/captures/except-openworld/Use_2.scala
+++ b/tests/pos-custom-args/captures/except-openworld/Use_2.scala
@@ -1,0 +1,12 @@
+import language.experimental.captureChecking
+import caps.{Classifier, SharedCapability}
+
+// A fresh sub-classifier of A, introduced after Module 1 was compiled.
+trait D extends A, Classifier
+class DCap extends D
+
+// The D-classified capability flows into Module 1's `only[A].except[B]`: D is a sibling of
+// B, hence disjoint from it. Module 1 was not recompiled, and `only[A].except[B]` never
+// collapsed to pure -- the open tree admits the later-defined classifier.
+def laterModule(d: DCap^): Unit =
+  onlyAButNotB(() => use(d))

--- a/tests/pos-custom-args/captures/except-poly-chain.scala
+++ b/tests/pos-custom-args/captures/except-poly-chain.scala
@@ -1,0 +1,15 @@
+import language.experimental.captureChecking
+import caps.{Control, Classifier, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+
+class Box[+T]
+def excludeControl[T, D^](box: Box[T]^{D}): Box[T]^{D.except[Control]} = ???
+def excludeIO[T, E^](box: Box[T]^{E}): Box[T]^{E.except[IOCap]} = ???
+
+def test(w: Object^) =
+  val w0: Box[Unit]^{w} = ???
+  val r1 = excludeIO(w0)
+  val r2 = excludeControl(r1)
+  val chain: Box[Unit]^{w.except[Control].except[IOCap]} = r2
+  val wide:  Box[Unit]^{w}                                = r2

--- a/tests/pos-custom-args/captures/except-poly.scala
+++ b/tests/pos-custom-args/captures/except-poly.scala
@@ -1,0 +1,16 @@
+import caps.{Control, Classifier, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+class Console extends IOCap:
+  def print(): Unit = ()
+class Label extends Control:
+  def break(): Unit = ()
+
+class Box[+T]
+def run[T, C^](body: () ->{C} T): Box[T]^{C.except[Control]} = ???
+
+def test(console: Console^, l: Label^) =
+  val r = run: () =>
+    console.print()
+    l.break()
+  val keepNonControl: Box[Unit]^{console} = r

--- a/tests/pos-custom-args/captures/except-sep/Defs_1.scala
+++ b/tests/pos-custom-args/captures/except-sep/Defs_1.scala
@@ -1,0 +1,12 @@
+import caps.{any, Classifier, Control, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+
+class File extends IOCap:
+  def read(): Int = 1
+
+def runOnNewThread[T](body: () ->{any.except[Control]} T): T = body()
+
+def restricted(c: Object^): Object^{c.only[SharedCapability].except[Control]} = ???
+
+def readOnlyPart(c: Object^): Object^{c.except[Control].rd} = ???

--- a/tests/pos-custom-args/captures/except-sep/Use_2.scala
+++ b/tests/pos-custom-args/captures/except-sep/Use_2.scala
@@ -1,0 +1,5 @@
+def test(f: File^) =
+  runOnNewThread: () =>
+    f.read()
+  val r = restricted(f)
+  val ro = readOnlyPart(f)

--- a/tests/pos-custom-args/captures/except-subsumes.scala
+++ b/tests/pos-custom-args/captures/except-subsumes.scala
@@ -1,23 +1,52 @@
-import caps.{any, Classifier, Control, SharedCapability}
+import caps.{any, Classifier, Control, SharedCapability, Unscoped}
 
-trait C extends SharedCapability, Classifier
-trait C1 extends C, Classifier
+// A classifier hierarchy:   SharedCapability        ExclusiveCapability
+//                            /          \                  |
+//                        Control       IOCap            Unscoped
+//                                        |
+//                                      NetCap
+trait IOCap  extends SharedCapability, Classifier
+trait NetCap extends IOCap, Classifier
+class Label  extends Control
+class Net    extends NetCap
+class Uns    extends Unscoped
 
-class Label extends Control
+def widening(c: Object^): Unit =
+  // {c.except[C]} <: {c}
+  val x1: Object^{c.except[IOCap]} = ???
+  val y1: Object^{c}               = x1
 
-def test(c: Object^): Unit =
-  val x1: Object^{c.except[C1]} = ???
-  val y1: Object^{c} = x1            // {c.except[C1]} <: {c}
-  val x2: Object^{c.only[C].except[C1]} = ???
-  val y2: Object^{c.only[C]} = x2    // {c.only[C].except[C1]} <: {c.only[C]}
-  val y3: Object^{c} = x2            // ... and transitively {c.only[C].except[C1]} <: {c}
-  val x3: Object^{c.except[C1].rd} = ???
-  val y4: Object^{c.rd} = x3         // {c.except[C1].rd} <: {c.rd}
-  val x4: Object^{c.except[C]} = ???
-  val y5: Object^{c.except[C1]} = x4 // {c.except[C]} <: {c.except[C1]} since C1 extends C
+def monotonicity(c: Object^): Unit =
+  // excluding a larger subtree yields a smaller capture set:
+  // {c.except[IOCap]} <: {c.except[NetCap]}   since NetCap extends IOCap
+  val x: Object^{c.except[IOCap]}  = ???
+  val y: Object^{c.except[NetCap]} = x
 
-def testEmpty(l: Label^): Unit =
-  // The exclusion removes everything `l` could capture, so the
-  // capture set {l.except[Control]} is known to be empty.
-  val x: Object^{l.except[Control]} = ???
-  val y: Object = x
+def onlyThenExcept(c: Object^): Unit =
+  // {c.only[IOCap].except[NetCap]} <: {c.only[IOCap]} <: {c}
+  val x: Object^{c.only[IOCap].except[NetCap]} = ???
+  val y: Object^{c.only[IOCap]}                = x
+  val z: Object^{c}                            = x
+
+def readOnlyComposition(c: Object^): Unit =
+  // {c.except[IOCap].rd} <: {c.rd}
+  val x: Object^{c.except[IOCap].rd} = ???
+  val y: Object^{c.rd}               = x
+
+def unrelatedExclusionIsVacuous(c: Object^): Unit =
+  // Control is unrelated to IOCap, so excluding it from c.only[IOCap] removes
+  // nothing: {c.only[IOCap].except[Control]} =:= {c.only[IOCap]}.
+  val a: Object^{c.only[IOCap]}                 = ???
+  val b: Object^{c.only[IOCap].except[Control]} = a
+  val c2: Object^{c.only[IOCap]}                = b
+
+def excludingAnAncestor(l: Label^): Unit =
+  // Label is a Control, which extends SharedCapability; excluding SharedCapability
+  // removes everything Label could be, so {l.except[SharedCapability]} is empty.
+  val x: Object^{l.except[SharedCapability]} = ???
+  val y: Object                              = x
+
+def unscopedIsDisjointFromShared(u: Uns^): Unit =
+  // Unscoped and SharedCapability are unrelated branches, so the exclusion keeps u.
+  val x: Object^{u.except[SharedCapability]} = ???
+  val y: Object^{u}                          = x

--- a/tests/pos-custom-args/captures/except-subsumes.scala
+++ b/tests/pos-custom-args/captures/except-subsumes.scala
@@ -1,0 +1,23 @@
+import caps.{any, Classifier, Control, SharedCapability}
+
+trait C extends SharedCapability, Classifier
+trait C1 extends C, Classifier
+
+class Label extends Control
+
+def test(c: Object^): Unit =
+  val x1: Object^{c.except[C1]} = ???
+  val y1: Object^{c} = x1            // {c.except[C1]} <: {c}
+  val x2: Object^{c.only[C].except[C1]} = ???
+  val y2: Object^{c.only[C]} = x2    // {c.only[C].except[C1]} <: {c.only[C]}
+  val y3: Object^{c} = x2            // ... and transitively {c.only[C].except[C1]} <: {c}
+  val x3: Object^{c.except[C1].rd} = ???
+  val y4: Object^{c.rd} = x3         // {c.except[C1].rd} <: {c.rd}
+  val x4: Object^{c.except[C]} = ???
+  val y5: Object^{c.except[C1]} = x4 // {c.except[C]} <: {c.except[C1]} since C1 extends C
+
+def testEmpty(l: Label^): Unit =
+  // The exclusion removes everything `l` could capture, so the
+  // capture set {l.except[Control]} is known to be empty.
+  val x: Object^{l.except[Control]} = ???
+  val y: Object = x

--- a/tests/pos-custom-args/captures/except-top.scala
+++ b/tests/pos-custom-args/captures/except-top.scala
@@ -1,0 +1,25 @@
+import language.experimental.captureChecking
+import caps.*
+
+// `Any` and `caps.Capability` denote the top of the classifier tree. They are not
+// classifier classes, but are accepted as projection arguments:
+//   `only[top]` is the identity projection, `except[top]` is the empty projection.
+
+def onlyTopIsIdentity(c: Object^): Unit =
+  val a:  Object^{c.only[Any]}        = ???
+  val a1: Object^{c}                  = a    // {c.only[Any]} <: {c}
+  val a2: Object^{c.only[Any]}        = a1   // ... and back: identity
+  val b:  Object^{c.only[Capability]} = ???
+  val b1: Object^{c}                  = b
+  val b2: Object^{c.only[Capability]} = b1
+
+def exceptTopIsEmpty(c: Object^): Unit =
+  val a:  Object^{c.except[Any]}        = ???
+  val a1: Object                        = a    // pure: {c.except[Any]} =:= {}
+  val b:  Object^{c.except[Capability]} = ???
+  val b1: Object                        = b
+
+// `except[top]` drops only that element from the surrounding set
+def exceptTopInSet(c: Object^, d: Object^): Unit =
+  val x: Object^{c.except[Any], d} = ???
+  val y: Object^{d}                = x         // {c.except[Any], d} =:= {d}

--- a/tests/pos-custom-args/captures/except-transaction-double.scala
+++ b/tests/pos-custom-args/captures/except-transaction-double.scala
@@ -3,8 +3,8 @@ import language.experimental.erasedDefinitions
 import caps.{Classifier, SharedCapability}
 
 // "Classifying Capabilities" §6.2: withTransaction forbids the body's result from capturing
-// the transaction's commit/rollback authority. The paper uses two exclusions; the single-
-// exclusion form is in pos-custom-args/captures/except-transaction.scala.
+// the transaction's commit/rollback authority, using two exclusions. The single-exclusion
+// form is in except-transaction.scala.
 trait Commit   extends SharedCapability, Classifier
 trait Rollback extends SharedCapability, Classifier
 
@@ -14,5 +14,4 @@ trait Transaction extends SharedCapability:
   val commit:   () ->{this.only[Commit]} Unit
   val rollback: () ->{this.only[Rollback]} Unit
 
-// TODO: permit multiple except clauses on the same capture reference.
-def withTransaction[T, E^](body: (tx: Transaction^) -> (() ->{E, tx.except[Commit].except[Rollback]} T)): T = ??? // error: at most one except clause per capture reference
+def withTransaction[T, E^](body: (tx: Transaction^) -> (() ->{E, tx.except[Commit].except[Rollback]} T)): T = ???

--- a/tests/pos-custom-args/captures/except-transaction.scala
+++ b/tests/pos-custom-args/captures/except-transaction.scala
@@ -3,10 +3,9 @@ import language.experimental.erasedDefinitions
 import caps.{Classifier, SharedCapability}
 
 // Section 6.2 of "Classifying Capabilities": the withTransaction pattern restricts a
-// specific reference rather than banning a whole effect class. The paper's version
-// uses two exclusions (`tx.except[Commit].except[Rollback]`); here we show the
-// single-exclusion projection that the implementation supports: a view of the
-// transaction that drops its commit capability.
+// specific reference rather than banning a whole effect class. Here we use a single
+// exclusion — a view of the transaction that drops its commit capability; the
+// two-exclusion form the paper uses is in except-transaction-double.scala.
 trait Commit   extends SharedCapability, Classifier
 trait Rollback extends SharedCapability, Classifier
 

--- a/tests/pos-custom-args/captures/except-transaction.scala
+++ b/tests/pos-custom-args/captures/except-transaction.scala
@@ -1,0 +1,25 @@
+import language.experimental.captureChecking
+import language.experimental.erasedDefinitions
+import caps.{Classifier, SharedCapability}
+
+// Section 6.2 of "Classifying Capabilities": the withTransaction pattern restricts a
+// specific reference rather than banning a whole effect class. The paper's version
+// uses two exclusions (`tx.except[Commit].except[Rollback]`); here we show the
+// single-exclusion projection that the implementation supports: a view of the
+// transaction that drops its commit capability.
+trait Commit   extends SharedCapability, Classifier
+trait Rollback extends SharedCapability, Classifier
+
+trait Transaction extends SharedCapability:
+  erased val cm: Commit^
+  erased val rb: Rollback^
+  val commit:   () ->{this.only[Commit]} Unit
+  val rollback: () ->{this.only[Rollback]} Unit
+
+def test(tx: Transaction^): Unit =
+  val limited: Object^{tx.except[Commit]} = ???
+  val full:    Object^{tx}                = limited   // {tx.except[Commit]} <: {tx}
+  val rb:      Object^{tx.only[Rollback]} = ???
+  // the rollback part survives the exclusion of commit, since Rollback and Commit
+  // are disjoint classifiers
+  val viaExc:  Object^{tx.except[Commit]} = rb

--- a/tests/pos-custom-args/captures/only-encapsulated-file.scala
+++ b/tests/pos-custom-args/captures/only-encapsulated-file.scala
@@ -1,0 +1,21 @@
+import language.experimental.captureChecking
+import language.experimental.erasedDefinitions
+import caps.{Classifier, SharedCapability}
+
+// "Classifying Capabilities" §6.3: an encapsulated File whose operations are typed with
+// `this`-projections, so read needs only the Read part and write only the ReadWrite part.
+trait Read      extends Classifier, SharedCapability
+trait ReadWrite extends Classifier, SharedCapability
+
+trait File(val name: String) extends SharedCapability:
+  erased val r:  Read^        // paper marks these private; abstract members cannot be
+  erased val rw: ReadWrite^
+  val read:  () ->{this.only[Read]}      Int
+  val write: Int ->{this.only[ReadWrite]} Unit
+
+def test(f: File^): Unit =
+  val ro:   Object^{f.only[Read]}  = ???
+  val full: Object^{f}             = ro    // {f.only[Read]} <: {f}
+  val rd:   () ->{f.only[Read]} Int = f.read
+  val rw:   Object^{f.only[ReadWrite]} = ???
+  val viaExc: Object^{f.except[Read]}  = rw   // Read and ReadWrite are disjoint

--- a/tests/pos-custom-args/captures/restrict-try-poly.scala
+++ b/tests/pos-custom-args/captures/restrict-try-poly.scala
@@ -1,0 +1,18 @@
+import caps.{Control, Classifier, SharedCapability}
+
+trait IOCap extends SharedCapability, Classifier
+class Console extends IOCap:
+  def print(): Unit = ()
+class Label extends Control:
+  def break(): Unit = ()
+
+class Try[+T]
+object Try:
+  def apply[T, C^](body: () ->{C} T): Try[T]^{C.only[Control]} = ???
+
+def test(console: Console^, l: Label^) =
+  val t = Try: () =>
+    console.print()
+    l.break()
+  val keepControl: Try[Unit]^{l}          = t
+  val widen:       Try[Unit]^{l, console} = t


### PR DESCRIPTION
Builds on https://github.com/scala/scala3/pull/26383 

This makes multiple `except`s available in the surface syntax.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by carefully reviewing it.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)