### PR TITLE
CC: Implement Classifier Exclusion Pt. 3

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -734,13 +734,23 @@ object Capabilities:
           if self.derivesFromCapability then self.derivesFrom(cls)
           else captureSetOfInfo.tryClassifyAs(cls)
 
-    /** Is every part of this capability provably classified as `cls` or a subclass? */
-    // Ignores exclusions: sound but loose.
-    // TODO: when attempting classifier-splitting, tighten for the remainder algorithm.
+    /** Is every part of this capability provably classified as `cls` or a subclass?
+     *  (Subkinding: the classifier kind subtracts to empty against `cls`, exclusions included.)
+     */
     def isKnownClassifiedAs(cls: ClassSymbol)(using Context): Boolean =
-      transClassifiers match
-        case ClassifiedAs(cs) => cs.forall(_.isSubClass(cls))
-        case _ => false
+      def emptyUnder(roots: List[ClassSymbol], except: List[ClassSymbol]) =
+        roots.forall(k => subtractClassifiers(k, except, cls, Nil).isEmpty)
+      this match
+        case Classified(_, only, except) if only != defn.AnyClass =>
+          emptyUnder(only :: Nil, except)
+        case Classified(ref, _, except) => // only == AnyClass
+          ref.transClassifiers match
+            case ClassifiedAs(cs) => emptyUnder(cs, except)
+            case _ => false
+        case _ =>
+          transClassifiers match
+            case ClassifiedAs(cs) => emptyUnder(cs, Nil)
+            case _ => false
 
     /** Is this capability provably free of any parts classified under `cls`?
      *  True if all its classifiers are on branches unrelated to `cls`, or an exclusion
@@ -1063,6 +1073,24 @@ object Capabilities:
     if cls1.isSubClass(cls2) then cls1
     else if cls2.isSubClass(cls1) then cls2
     else defn.NothingClass
+
+  /** The classifier subtrees making up the kind subtraction
+   *  `(only1 - except1) \ (only2 - except2)`, i.e. the remainder of the first classifier
+   *  projection after subtracting the second, as a union of `(only, except)` subtrees.
+   *  Empty subtrees are dropped. The subtrahend is assumed non-empty.
+   *  Follows the kind subtraction of "Classifying Capabilities" (Fig. 3).
+   */
+  def subtractClassifiers(only1: ClassSymbol, except1: List[ClassSymbol],
+      only2: ClassSymbol, except2: List[ClassSymbol])(using Context): List[(ClassSymbol, List[ClassSymbol])] =
+    def isEmpty(only: ClassSymbol, except: List[ClassSymbol]) = except.exists(only.isSubClass)
+    def recur(rhsExcept: List[ClassSymbol]): List[(ClassSymbol, List[ClassSymbol])] = rhsExcept match
+      case Nil => (only1, only2 :: except1) :: Nil          // st-tree: subtract the bare `only2` subtree
+      case l :: rest =>
+        if !l.isSubClass(only2) then recur(rest)            // st-irrel-r: `l` outside `only2`, no effect
+        else if l.isSubClass(only1) then (l, except1) :: recur(rest)  // st-sub-r: `only1.only[l]` survives
+        else if only1.isSubClass(l) then (only1, except1) :: Nil      // st-sub-l: all of `only1` survives
+        else recur(rest)                                    // st-irrel-l: `l` disjoint from `only1`
+    recur(except2).filterNot(isEmpty)
 
   /** The least classifier that both `cls1` and `cls2` extend, or `AnyClass`,
    *  if `cls1` and `cls2` don't have a common ancestor classifier. It is

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -724,13 +724,23 @@ object Capabilities:
           if self.derivesFromCapability then self.derivesFrom(cls)
           else captureSetOfInfo.tryClassifyAs(cls)
 
-    /** Is every part of this capability provably classified as `cls` or a subclass? */
-    // Ignores exclusions: sound but loose.
-    // TODO: when attempting classifier-splitting, tighten for the remainder algorithm.
+    /** Is every part of this capability provably classified as `cls` or a subclass?
+     *  (Subkinding: the classifier kind subtracts to empty against `cls`, exclusions included.)
+     */
     def isKnownClassifiedAs(cls: ClassSymbol)(using Context): Boolean =
-      transClassifiers match
-        case ClassifiedAs(cs) => cs.forall(_.isSubClass(cls))
-        case _ => false
+      def emptyUnder(roots: List[ClassSymbol], except: List[ClassSymbol]) =
+        roots.forall(k => subtractClassifiers(k, except, cls, Nil).isEmpty)
+      this match
+        case Classified(_, only, except) if only != defn.AnyClass =>
+          emptyUnder(only :: Nil, except)
+        case Classified(ref, _, except) => // only == AnyClass
+          ref.transClassifiers match
+            case ClassifiedAs(cs) => emptyUnder(cs, except)
+            case _ => false
+        case _ =>
+          transClassifiers match
+            case ClassifiedAs(cs) => emptyUnder(cs, Nil)
+            case _ => false
 
     /** Is this capability provably free of any parts classified under `cls`?
      *  True if all its classifiers are on branches unrelated to `cls`, or an exclusion
@@ -1053,6 +1063,24 @@ object Capabilities:
     if cls1.isSubClass(cls2) then cls1
     else if cls2.isSubClass(cls1) then cls2
     else defn.NothingClass
+
+  /** The classifier subtrees making up the kind subtraction
+   *  `(only1 - except1) \ (only2 - except2)`, i.e. the remainder of the first classifier
+   *  projection after subtracting the second, as a union of `(only, except)` subtrees.
+   *  Empty subtrees are dropped. The subtrahend is assumed non-empty.
+   *  Follows the kind subtraction of "Classifying Capabilities" (Fig. 3).
+   */
+  def subtractClassifiers(only1: ClassSymbol, except1: List[ClassSymbol],
+      only2: ClassSymbol, except2: List[ClassSymbol])(using Context): List[(ClassSymbol, List[ClassSymbol])] =
+    def isEmpty(only: ClassSymbol, except: List[ClassSymbol]) = except.exists(only.isSubClass)
+    def recur(rhsExcept: List[ClassSymbol]): List[(ClassSymbol, List[ClassSymbol])] = rhsExcept match
+      case Nil => (only1, only2 :: except1) :: Nil          // st-tree: subtract the bare `only2` subtree
+      case l :: rest =>
+        if !l.isSubClass(only2) then recur(rest)            // st-irrel-r: `l` outside `only2`, no effect
+        else if l.isSubClass(only1) then (l, except1) :: recur(rest)  // st-sub-r: `only1.only[l]` survives
+        else if only1.isSubClass(l) then (only1, except1) :: Nil      // st-sub-l: all of `only1` survives
+        else recur(rest)                                    // st-irrel-l: `l` disjoint from `only1`
+    recur(except2).filterNot(isEmpty)
 
   /** The least classifier that both `cls1` and `cls2` extend, or `AnyClass`,
    *  if `cls1` and `cls2` don't have a common ancestor classifier. It is

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -739,7 +739,10 @@ object Capabilities:
      */
     def isKnownClassifiedAs(cls: ClassSymbol)(using Context): Boolean =
       def emptyUnder(roots: List[ClassSymbol], except: List[ClassSymbol]) =
-        roots.forall(k => subtractClassifiers(k, except, cls, Nil).isEmpty)
+        // The right-hand side is the bare `cls` subtree, so subtraction is empty iff
+        // the root lies below `cls`, or an outer exclusion already removed that root.
+        // This is the no-allocation specialization of `subtractClassifiers`.
+        roots.forall(k => k.isSubClass(cls) || except.exists(e => k.isSubClass(e)))
       this match
         case Classified(_, only, except) if only != defn.AnyClass =>
           emptyUnder(only :: Nil, except)
@@ -747,6 +750,8 @@ object Capabilities:
           ref.transClassifiers match
             case ClassifiedAs(cs) => emptyUnder(cs, except)
             case _ => false
+        case ReadOnly(ref) => ref.isKnownClassifiedAs(cls)
+        case Maybe(ref) => ref.isKnownClassifiedAs(cls)
         case _ =>
           transClassifiers match
             case ClassifiedAs(cs) => emptyUnder(cs, Nil)
@@ -1077,20 +1082,51 @@ object Capabilities:
   /** The classifier subtrees making up the kind subtraction
    *  `(only1 - except1) \ (only2 - except2)`, i.e. the remainder of the first classifier
    *  projection after subtracting the second, as a union of `(only, except)` subtrees.
-   *  Empty subtrees are dropped. The subtrahend is assumed non-empty.
+   *
+   *  Both inputs are normalized subtrees: their exclusions are antichains strictly below
+   *  their roots. Results keep the exclusions relevant and dominator-pruned; their order
+   *  is immaterial to the remainder computation. The computation uses
+   *
+   *    A \ (B \ E) = (A \ B) union (A intersect E)
+   *
+   *  so it first cuts out the bare `only2` subtree, then adds back the parts under the
+   *  exclusions of the second operand. Empty and irrelevant subtrees are dropped, and
+   *  at most `except2.size + 1` subtrees are returned.
    *  Follows the kind subtraction of "Classifying Capabilities" (Fig. 3).
    */
   def subtractClassifiers(only1: ClassSymbol, except1: List[ClassSymbol],
       only2: ClassSymbol, except2: List[ClassSymbol])(using Context): List[(ClassSymbol, List[ClassSymbol])] =
-    def isEmpty(only: ClassSymbol, except: List[ClassSymbol]) = except.exists(only.isSubClass)
-    def recur(rhsExcept: List[ClassSymbol]): List[(ClassSymbol, List[ClassSymbol])] = rhsExcept match
-      case Nil => (only1, only2 :: except1) :: Nil          // st-tree: subtract the bare `only2` subtree
-      case l :: rest =>
-        if !l.isSubClass(only2) then recur(rest)            // st-irrel-r: `l` outside `only2`, no effect
-        else if l.isSubClass(only1) then (l, except1) :: recur(rest)  // st-sub-r: `only1.only[l]` survives
-        else if only1.isSubClass(l) then (only1, except1) :: Nil      // st-sub-l: all of `only1` survives
-        else recur(rest)                                    // st-irrel-l: `l` disjoint from `only1`
-    recur(except2).filterNot(isEmpty)
+    val lhs = (only1, except1)
+
+    def rootsDisjoint(cls1: ClassSymbol, cls2: ClassSymbol) =
+      !cls1.isSubClass(cls2) && !cls2.isSubClass(cls1)
+
+    if only1 == defn.NothingClass || except1.exists(only1.isSubClass) then
+      Nil
+    else if only2 == defn.NothingClass || except2.exists(only2.isSubClass) then
+      lhs :: Nil
+    else if rootsDisjoint(only1, only2)
+        || except1.exists(only2.isSubClass) // the RHS lies in a hole of the LHS
+        || except2.exists(only1.isSubClass) // the LHS lies in a hole of the RHS
+    then
+      lhs :: Nil
+    else
+      // A \ B. Since the roots overlap, either B covers A, or B becomes a new
+      // exclusion of A. In the latter case, remove exclusions now dominated by B.
+      val outsideRoot =
+        if only1.isSubClass(only2) then Nil
+        else
+          val kept = except1.filterNot(_.isSubClass(only2))
+          (only1, only2 :: kept) :: Nil
+
+      // A intersect E. A RHS exclusion that is below A contributes one remainder.
+      // Keep only LHS exclusions below its new root; the others are irrelevant.
+      except2.foldRight(outsideRoot): (excluded, result) =>
+        if excluded.isSubClass(only1)
+            && !except1.exists(excluded.isSubClass)
+        then
+          (excluded, except1.filter(_.isSubClass(excluded))) :: result
+        else result
 
   /** The least classifier that both `cls1` and `cls2` extend, or `AnyClass`,
    *  if `cls1` and `cls2` don't have a common ancestor classifier. It is

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -254,9 +254,24 @@ sealed abstract class CaptureSet extends Showable:
       val suffix = if ctx.settings.YccVerbose.value then i" with ${x.captureSetOfInfo}" else ""
       i"$this accountsFor $x$suffix"
 
+    // Classifier splitting: a classified projection `b.only[..].except[..]` is accounted for
+    // when no single element subsumes it but the same-base projections in this set collectively
+    // cover its classifier region. Equivalent to its kind subtracting to empty against theirs
+    // (subkinding, "Classifying Capabilities" Fig. 3).
+    def classifierSplit(using Context): Boolean = x match
+      case Classified(xbase, onlyX, exceptX) =>
+        val peers = elems.toList.collect:
+          case Classified(b, o, e) if (b eq xbase) && o != defn.NothingClass => (o, e)
+        peers.nonEmpty
+        && peers.foldLeft((onlyX, exceptX) :: Nil): (rem, peer) =>
+             rem.flatMap((o1, e1) => subtractClassifiers(o1, e1, peer._1, peer._2))
+          .isEmpty
+      case _ => false
+
     def test(using Context) = reporting.trace(debugInfo):
       TypeComparer.noNotes: // Any failures in accountsFor should not lead to error notes
         elems.exists(_.subsumes(x))
+        || classifierSplit
         || // Even though subsumes already follows captureSetOfInfo, this is not enough.
            // For instance x: C^{y, z}. Then neither y nor z subsumes x but {y, z} accounts for x.
           !x.isTerminalCapability

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -15,6 +15,7 @@ import printing.{Showable, Printer}
 import printing.Texts.*
 import util.{SimpleIdentitySet, MutableIdentitySet, Property, EqHashMap}
 import scala.collection.{mutable, immutable}
+import scala.annotation.tailrec
 import CCState.*
 import TypeOps.AvoidMap
 import compiletime.uninitialized
@@ -254,19 +255,124 @@ sealed abstract class CaptureSet extends Showable:
       val suffix = if ctx.settings.YccVerbose.value then i" with ${x.captureSetOfInfo}" else ""
       i"$this accountsFor $x$suffix"
 
-    // Classifier splitting: a classified projection `b.only[..].except[..]` is accounted for
-    // when no single element subsumes it but the same-base projections in this set collectively
-    // cover its classifier region. Equivalent to its kind subtracting to empty against theirs
-    // (subkinding, "Classifying Capabilities" Fig. 3).
-    def classifierSplit(using Context): Boolean = x match
-      case Classified(xbase, onlyX, exceptX) =>
-        val peers = elems.toList.collect:
-          case Classified(b, o, e) if (b eq xbase) && o != defn.NothingClass => (o, e)
-        peers.nonEmpty
-        && peers.foldLeft((onlyX, exceptX) :: Nil): (rem, peer) =>
-             rem.flatMap((o1, e1) => subtractClassifiers(o1, e1, peer._1, peer._2))
-          .isEmpty
-      case _ => false
+    // Classifier splitting: a projection is accounted for when no single element
+    // subsumes it but same-base projections in this set collectively cover its
+    // classifier region. Start with that region and subtract every peer; it is
+    // covered exactly when no remainder is left. This is union subtraction from
+    // "Classifying Capabilities" (Fig. 3).
+    def classifierSplit(using Context): Boolean =
+      type Subtree = (ClassSymbol, List[ClassSymbol])
+      case class Projection(
+          base: CoreCapability | RootCapability,
+          only: ClassSymbol,
+          except: List[ClassSymbol],
+          readOnly: Boolean,
+          maybe: Boolean)
+
+      // Only elements with a classified core can be splitting peers — a same-base
+      // element without one subsumes the source outright.
+      @tailrec def hasClassifiedCore(cap: Capability): Boolean = cap match
+        case Classified(_, only, _) => only != defn.NothingClass
+        case ReadOnly(cap1) => hasClassifiedCore(cap1)
+        case Maybe(cap1) => hasClassifiedCore(cap1)
+        case _ => false
+
+      @tailrec def projectionOf(
+          cap: Capability,
+          readOnly: Boolean = false,
+          maybe: Boolean = false): Option[Projection] = cap match
+        case ReadOnly(cap1) => projectionOf(cap1, readOnly = true, maybe = maybe)
+        case Maybe(cap1) => projectionOf(cap1, readOnly = readOnly, maybe = true)
+        case Classified(base, only, except) =>
+          Some(Projection(base, only, except, readOnly, maybe))
+        // Do not inspect a bare RootCapability here. Local roots can still acquire a
+        // classifier in the existing accountsFor fallback, and querying their transitive
+        // classifiers early would cache an open classification.
+        case base: CoreCapability =>
+          Some(Projection(base, defn.AnyClass, Nil, readOnly, maybe))
+        case _ => None
+
+      def sourceSubtrees(
+          base: CoreCapability | RootCapability,
+          only: ClassSymbol,
+          except: List[ClassSymbol]): List[Subtree] =
+        def intersectRoot(root: ClassSymbol): Option[Subtree] =
+          val restricted =
+            if only.isTopClassifier || root.isSubClass(only) then root
+            else if only.isSubClass(root) then only
+            else defn.NothingClass
+          if restricted == defn.NothingClass || except.exists(restricted.isSubClass) then None
+          else Some((restricted, except.filter(_.isSubClass(restricted))))
+
+        if only == defn.NothingClass then Nil
+        else if base.isInstanceOf[RootCapability] then
+          intersectRoot(defn.AnyClass).toList
+        else base.transClassifiers match
+          case ClassifiedAs(roots) => roots.flatMap(intersectRoot)
+          case _ => intersectRoot(defn.AnyClass).toList
+
+      // The gate keeps the common miss path free of allocations and
+      // transClassifiers queries.
+      elems.exists(hasClassifiedCore)
+      && projectionOf(x).exists: source =>
+        val initial = sourceSubtrees(source.base, source.only, source.except)
+        if initial.isEmpty then true
+        else
+          def overlapsSource(
+              source: Subtree,
+              only: ClassSymbol,
+              except: List[ClassSymbol]) =
+            val (sourceOnly, sourceExcept) = source
+            (only.isSubClass(sourceOnly) || sourceOnly.isSubClass(only))
+            && !sourceExcept.exists(only.isSubClass)
+            && !except.exists(sourceOnly.isSubClass)
+
+          def containsSourceRoot(sourceOnly: ClassSymbol, peer: Subtree) =
+            val (only, except) = peer
+            sourceOnly.isSubClass(only) && !except.exists(sourceOnly.isSubClass)
+
+          def compatible(peer: Projection) =
+            (!peer.readOnly || source.readOnly) && (!peer.maybe || source.maybe)
+
+          val peers = elems.toList.flatMap: elem =>
+            if !hasClassifiedCore(elem) then Nil
+            else projectionOf(elem) match
+              case Some(peer)
+              if (peer.base eq source.base)
+                  && peer.only != defn.NothingClass
+                  && compatible(peer)
+                  && initial.exists(overlapsSource(_, peer.only, peer.except)) =>
+                (peer.only, peer.except) :: Nil
+              case _ => Nil
+
+          // Pairwise `subsumes` above catches most single-peer coverage, but not
+          // regions narrowed by the base's classifiers, so subtract from one peer up.
+          // The root of every initial subtree belongs to it, hence one compatible
+          // peer must contain each root.
+          if peers.isEmpty then false
+          else if !initial.forall((only, _) =>
+              peers.exists(peer => containsSourceRoot(only, peer)))
+          then false
+          else
+            // Bare subtrees cannot split a remainder. Applying them first keeps the
+            // common `(C - C1 - ... - Cn) union C1 union ... union Cn` shape to one
+            // live piece for as long as possible. Fewer-hole peers come next.
+            val ordered = peers.sortBy((_, except) => except.length)
+
+            // Remainder subtrees stay disjoint. On a classifier tree, each peer
+            // exclusion can add at most one new piece, so their number grows additively
+            // with the exclusions, rather than multiplying at every subtraction.
+            @tailrec def subtractAll(remainder: List[Subtree], rest: List[Subtree]): Boolean =
+              remainder match
+                case Nil => true
+                case _ => rest match
+                  case Nil => false
+                  case (only, except) :: rest1 =>
+                    subtractAll(
+                      remainder.flatMap((o, e) => subtractClassifiers(o, e, only, except)),
+                      rest1)
+
+            subtractAll(initial, ordered)
 
     def test(using Context) = reporting.trace(debugInfo):
       TypeComparer.noNotes: // Any failures in accountsFor should not lead to error notes

--- a/tests/neg-custom-args/captures/except-split.scala
+++ b/tests/neg-custom-args/captures/except-split.scala
@@ -1,0 +1,11 @@
+import language.experimental.captureChecking
+import caps.{Classifier, SharedCapability}
+
+trait C  extends SharedCapability, Classifier
+trait C1 extends C, Classifier
+
+class A[+T]
+
+def noSplit(c: Object^) =
+  val src: A[Unit]^{c.only[C]}              = ???
+  val dst: A[Unit]^{c.only[C].except[C1]}   = src // error

--- a/tests/neg-custom-args/captures/except-split.scala
+++ b/tests/neg-custom-args/captures/except-split.scala
@@ -3,9 +3,49 @@ import caps.{Classifier, SharedCapability}
 
 trait C  extends SharedCapability, Classifier
 trait C1 extends C, Classifier
+trait C11 extends C1, Classifier
+trait C2 extends C, Classifier
 
 class A[+T]
 
 def noSplit(c: Object^) =
   val src: A[Unit]^{c.only[C]}              = ???
   val dst: A[Unit]^{c.only[C].except[C1]}   = src // error
+
+def narrowFillerDoesNotCoverHole(c: Object^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1],
+    c.only[C11]
+  } = src // error
+
+def excludedFillerLeavesItsHole(c: Object^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1],
+    c.only[C1].except[C11]
+  } = src // error
+
+def missingOneOfSeveralHoles(c: Object^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1].except[C2],
+    c.only[C1]
+  } = src // error
+
+def readOnlyPiecesDoNotCoverWritable(c: Object^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1].rd,
+    c.only[C1].rd
+  } = src // error
+
+// Narrowing {c.only[C]} to c's C1 kind must not overshoot: the region is the
+// full C1 subtree, not less.
+def narrowedRootNotInPeer(c: C1^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{c.only[C11]} = src // error
+
+def narrowedMissingHole(c: C1^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{c.only[C1].except[C11]} = src // error

--- a/tests/pos-custom-args/captures/except-known-classified.scala
+++ b/tests/pos-custom-args/captures/except-known-classified.scala
@@ -1,0 +1,14 @@
+import language.experimental.captureChecking
+import caps.{Classifier, SharedCapability}
+
+trait C extends SharedCapability, Classifier
+trait C1 extends C, Classifier
+trait C2 extends C, Classifier
+
+class A[+T]
+
+// Excluding C1 from an underlying C1 | C2 kind leaves a capability known to be C2.
+def exclusionRefinesClassification(c1: Object^, c2: Object^) =
+  val x: A[Unit]^{c1.only[C1], c2.only[C2]} = ???
+  val src: A[Unit]^{x.except[C1]} = ???
+  val dst: A[Unit]^{x.only[C2]} = src

--- a/tests/pos-custom-args/captures/except-split.scala
+++ b/tests/pos-custom-args/captures/except-split.scala
@@ -1,0 +1,14 @@
+import language.experimental.captureChecking
+import caps.{Classifier, SharedCapability}
+
+trait C  extends SharedCapability, Classifier
+trait C1 extends C, Classifier
+
+class A[+T]
+
+def concreteSplit(c: Object^) =
+  val src: A[Unit]^{c.only[C]}                          = ???
+  val dst: A[Unit]^{c.only[C].except[C1], c.only[C1]}   = src
+
+def f[X^](x: A[Unit]^{X.only[C].except[C1], X.only[C1]}): Unit = ???
+def g[Y^](x: A[Unit]^{Y.only[C]}): Unit = f[Y](x)

--- a/tests/pos-custom-args/captures/except-split.scala
+++ b/tests/pos-custom-args/captures/except-split.scala
@@ -3,12 +3,92 @@ import caps.{Classifier, SharedCapability}
 
 trait C  extends SharedCapability, Classifier
 trait C1 extends C, Classifier
+trait C11 extends C1, Classifier
+trait C2 extends C, Classifier
+trait C3 extends C, Classifier
+trait C4 extends C, Classifier
+trait C5 extends C, Classifier
+trait C6 extends C, Classifier
+trait C7 extends C, Classifier
+trait C8 extends C, Classifier
+trait D extends SharedCapability, Classifier
 
 class A[+T]
 
 def concreteSplit(c: Object^) =
   val src: A[Unit]^{c.only[C]}                          = ???
   val dst: A[Unit]^{c.only[C].except[C1], c.only[C1]}   = src
+
+def concreteSplitReverse(c: Object^) =
+  val src: A[Unit]^{c.only[C]}                          = ???
+  val dst: A[Unit]^{c.only[C1], c.only[C].except[C1]}   = src
+
+def topSplit(c: Object^) =
+  val src: A[Unit]^{c}                                 = ???
+  val dst: A[Unit]^{c.except[C1], c.only[C1]}           = src
+
+def classifiedRawSplit(c: C^) =
+  val src: A[Unit]^{c}                                 = ???
+  val dst: A[Unit]^{c.only[C].except[C1], c.only[C1]}   = src
+
+def readOnlySplit(c: Object^) =
+  val src: A[Unit]^{c.only[C].rd} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1].rd,
+    c.only[C1].rd
+  } = src
+
+def multiSplit(c: Object^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1].except[C2],
+    c.only[C1],
+    c.only[C2]
+  } = src
+
+def splitAlreadyExcludedSource(c: Object^) =
+  val src: A[Unit]^{c.only[C].except[C2]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1].except[C2],
+    c.only[C1]
+  } = src
+
+def nestedSplit(c: Object^) =
+  val src: A[Unit]^{c.only[C].except[C11]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1],
+    c.only[C1].except[C11]
+  } = src
+
+def splitIgnoresDisjointPeer(c: Object^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1],
+    c.only[C1],
+    c.only[D]
+  } = src
+
+def manySplit(c: Object^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C].except[C1].except[C2].except[C3].except[C4]
+      .except[C5].except[C6].except[C7].except[C8],
+    c.only[C1], c.only[C2], c.only[C3], c.only[C4],
+    c.only[C5], c.only[C6], c.only[C7], c.only[C8]
+  } = src
+
+// The source region narrows to the base's classifiers: c is C1-classified, so
+// {c.only[C]} covers only the C1 subtree.
+def narrowedSplit(c: C1^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{
+    c.only[C1].except[C11],
+    c.only[C11]
+  } = src
+
+def narrowedSinglePeer(c: C1^) =
+  val src: A[Unit]^{c.only[C]} = ???
+  val dst: A[Unit]^{c.only[C1]} = src
 
 def f[X^](x: A[Unit]^{X.only[C].except[C1], X.only[C1]}): Unit = ???
 def g[Y^](x: A[Unit]^{Y.only[C]}): Unit = f[Y](x)


### PR DESCRIPTION
Builds on https://github.com/scala/scala3/pull/26383

This PR implements the remainder computation as outlined in the [discussion](https://github.com/scala/scala3/discussions/23463#discussioncomment-17223458), increasing the expressiveness of exclusion.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by carefully reviewing it. 

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable).