### PR TITLE
Emit definition occurrence for primary constructor parameters in SemanticDB

### DIFF
--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -679,7 +679,11 @@ private[semanticdb] object ExtractSemanticDB:
           val symkinds =
             getters.get(vparam.name).fold(SymbolKind.emptySet)(getter =>
               if getter.mods.is(Mutable) then SymbolKind.VarSet else SymbolKind.ValSet)
-          registerSymbol(vparam.symbol, symkinds)
+          // Emit a definition occurrence for the constructor parameter at its name span (and
+          // record the symbol; registerDefinition calls registerSymbol internally). The param
+          // symbol `C#<init>().(x)` then shares the name range with the param-accessor
+          // occurrence emitted from the template body.
+          registerDefinition(vparam.symbol, vparam.nameSpan, symkinds, vparam.source)
         traverse(vparam.tpt)
       tparams.foreach(tp => traverse(tp.rhs))
   end Extractor

--- a/tests/semanticdb/expect/Annotations.expect.scala
+++ b/tests/semanticdb/expect/Annotations.expect.scala
@@ -5,7 +5,7 @@ import scala.annotation.meta.*
 import scala.language/*->scala::language.*/.experimental/*->scala::language.experimental.*/.macros/*->scala::language.experimental.macros.*/
 
 @ClassAnnotation/*->com::javacp::annot::ClassAnnotation#*/
-class Annotations/*<-annot::Annotations#*/[@TypeParameterAnnotation/*->com::javacp::annot::TypeParameterAnnotation#*/ T/*<-annot::Annotations#[T]*/](@ParameterAnnotation/*->com::javacp::annot::ParameterAnnotation#*/ x/*<-annot::Annotations#x.*/: T/*->annot::Annotations#[T]*/) { self/*<-local0*/: AnyRef/*->scala::AnyRef#*/ =>
+class Annotations/*<-annot::Annotations#*/[@TypeParameterAnnotation/*->com::javacp::annot::TypeParameterAnnotation#*/ T/*<-annot::Annotations#[T]*/](@ParameterAnnotation/*->com::javacp::annot::ParameterAnnotation#*/ x/*<-annot::Annotations#x.*//*<-annot::Annotations#`<init>`().(x)*/: T/*->annot::Annotations#[T]*/) { self/*<-local0*/: AnyRef/*->scala::AnyRef#*/ =>
   @FieldAnnotation/*->com::javacp::annot::FieldAnnotation#*/
   val field/*<-annot::Annotations#field.*/ = 42
 
@@ -19,7 +19,7 @@ class Annotations/*<-annot::Annotations#*/[@TypeParameterAnnotation/*->com::java
   type S/*<-annot::Annotations#S#*/
 }
 
-class B/*<-annot::B#*/ @ConstructorAnnotation/*->com::javacp::annot::ConstructorAnnotation#*/()(x/*<-annot::B#x.*/: Int/*->scala::Int#*/) {
+class B/*<-annot::B#*/ @ConstructorAnnotation/*->com::javacp::annot::ConstructorAnnotation#*/()(x/*<-annot::B#x.*//*<-annot::B#`<init>`().(x)*/: Int/*->scala::Int#*/) {
   @ConstructorAnnotation/*->com::javacp::annot::ConstructorAnnotation#*/
   def this/*<-annot::B#`<init>`(+1).*/() = this(42)
 

--- a/tests/semanticdb/expect/CaseClass.expect.scala
+++ b/tests/semanticdb/expect/CaseClass.expect.scala
@@ -1,6 +1,6 @@
 package caseclass
 
-case class CaseClass/*<-caseclass::CaseClass#*/(int1/*<-caseclass::CaseClass#int1.*/: Int/*->scala::Int#*/, int2/*<-caseclass::CaseClass#int2.*/: Int/*->scala::Int#*/)
+case class CaseClass/*<-caseclass::CaseClass#*/(int1/*<-caseclass::CaseClass#int1.*//*<-caseclass::CaseClass#`<init>`().(int1)*/: Int/*->scala::Int#*/, int2/*<-caseclass::CaseClass#int2.*//*<-caseclass::CaseClass#`<init>`().(int2)*/: Int/*->scala::Int#*/)
 
 object CaseClass/*<-caseclass::CaseClass.*/:
   def apply/*<-caseclass::CaseClass.apply().*/(int/*<-caseclass::CaseClass.apply().(int)*/: Int/*->scala::Int#*/): CaseClass/*->caseclass::CaseClass#*/ = CaseClass/*->caseclass::CaseClass.*/(int/*->caseclass::CaseClass.apply().(int)*/, 0)

--- a/tests/semanticdb/expect/Classes.expect.scala
+++ b/tests/semanticdb/expect/Classes.expect.scala
@@ -1,28 +1,28 @@
 package classes
 import scala.language/*->scala::language.*/.experimental/*->scala::language.experimental.*/.macros/*->scala::language.experimental.macros.*/
-class C1/*<-classes::C1#*/(val x1/*<-classes::C1#x1.*/: Int/*->scala::Int#*/) extends AnyVal/*->scala::AnyVal#*/
+class C1/*<-classes::C1#*/(val x1/*<-classes::C1#x1.*//*<-classes::C1#`<init>`().(x1)*/: Int/*->scala::Int#*/) extends AnyVal/*->scala::AnyVal#*/
 
-class C2/*<-classes::C2#*/(val x2/*<-classes::C2#x2.*/: Int/*->scala::Int#*/) extends AnyVal/*->scala::AnyVal#*/
+class C2/*<-classes::C2#*/(val x2/*<-classes::C2#x2.*//*<-classes::C2#`<init>`().(x2)*/: Int/*->scala::Int#*/) extends AnyVal/*->scala::AnyVal#*/
 object C2/*<-classes::C2.*/
 
-case class C3/*<-classes::C3#*/(x/*<-classes::C3#x.*/: Int/*->scala::Int#*/)
+case class C3/*<-classes::C3#*/(x/*<-classes::C3#x.*//*<-classes::C3#`<init>`().(x)*/: Int/*->scala::Int#*/)
 
-case class C4/*<-classes::C4#*/(x/*<-classes::C4#x.*/: Int/*->scala::Int#*/)
+case class C4/*<-classes::C4#*/(x/*<-classes::C4#x.*//*<-classes::C4#`<init>`().(x)*/: Int/*->scala::Int#*/)
 object C4/*<-classes::C4.*/
 
 object M/*<-classes::M.*/ {
-  implicit class C5/*<-classes::M.C5#*/(x/*<-classes::M.C5#x.*/: Int/*->scala::Int#*/)
+  implicit class C5/*<-classes::M.C5#*/(x/*<-classes::M.C5#x.*//*<-classes::M.C5#`<init>`().(x)*/: Int/*->scala::Int#*/)
 }
 
-case class C6/*<-classes::C6#*/(private val x/*<-classes::C6#x.*/: Int/*->scala::Int#*/)
+case class C6/*<-classes::C6#*/(private val x/*<-classes::C6#x.*//*<-classes::C6#`<init>`().(x)*/: Int/*->scala::Int#*/)
 
-class C7/*<-classes::C7#*/(x/*<-classes::C7#x.*/: Int/*->scala::Int#*/)
+class C7/*<-classes::C7#*/(x/*<-classes::C7#x.*//*<-classes::C7#`<init>`().(x)*/: Int/*->scala::Int#*/)
 
-class C8/*<-classes::C8#*/(private[this] val x/*<-classes::C8#x.*/: Int/*->scala::Int#*/)
+class C8/*<-classes::C8#*/(private[this] val x/*<-classes::C8#x.*//*<-classes::C8#`<init>`().(x)*/: Int/*->scala::Int#*/)
 
-class C9/*<-classes::C9#*/(private[this] var x/*<-classes::C9#x().*/: Int/*->scala::Int#*/)
+class C9/*<-classes::C9#*/(private[this] var x/*<-classes::C9#x().*//*<-classes::C9#`<init>`().(x)*/: Int/*->scala::Int#*/)
 
-class C10/*<-classes::C10#*/(s/*<-classes::C10#s.*/: => String/*->scala::Predef.String#*/)
+class C10/*<-classes::C10#*/(s/*<-classes::C10#s.*//*<-classes::C10#`<init>`().(s)*/: => String/*->scala::Predef.String#*/)
 
 class C11/*<-classes::C11#*/ {
   def foo/*<-classes::C11#foo().*/: Int/*->scala::Int#*/ = macro ???/*->scala::Predef.`???`().*/

--- a/tests/semanticdb/expect/CtorParams.expect.scala
+++ b/tests/semanticdb/expect/CtorParams.expect.scala
@@ -1,0 +1,29 @@
+package ctorparams
+
+// Constructor-parameter occurrence edge cases (parity with scalameta #4650 / #1327).
+// dotc retains every primary-constructor parameter as a param-accessor field, so each
+// parameter's name range carries TWO definition occurrences: the accessor `C#x.` and the
+// constructor parameter `C#<init>().(x)`. References still resolve to the accessor.
+
+trait Show/*<-ctorparams::Show#*/[A/*<-ctorparams::Show#[A]*/]:
+  def show/*<-ctorparams::Show#show().*/(a/*<-ctorparams::Show#show().(a)*/: A/*->ctorparams::Show#[A]*/): String/*->scala::Predef.String#*/
+
+// parameter used in the constructor body: accessor + constructor-parameter occurrences;
+// the body reference resolves to the accessor
+class UsedInCtorOnly/*<-ctorparams::UsedInCtorOnly#*/(x/*<-ctorparams::UsedInCtorOnly#x.*//*<-ctorparams::UsedInCtorOnly#`<init>`().(x)*/: Int/*->scala::Int#*/):
+  println/*->scala::Predef.println(+1).*/(x/*->ctorparams::UsedInCtorOnly#x.*/)
+
+// parameter referenced from a method: same dual occurrence at the definition site
+class UsedInMethod/*<-ctorparams::UsedInMethod#*/(x/*<-ctorparams::UsedInMethod#x.*//*<-ctorparams::UsedInMethod#`<init>`().(x)*/: Int/*->scala::Int#*/):
+  def get/*<-ctorparams::UsedInMethod#get().*/: Int/*->scala::Int#*/ = x/*->ctorparams::UsedInMethod#x.*/
+
+// context bound desugars to a synthetic `given` evidence parameter. Like method evidence
+// parameters (which dotc already anchors), it gets a zero-length definition occurrence at
+// the bound position for both the accessor and the constructor parameter.
+class WithContextBound/*<-ctorparams::WithContextBound#*/[T/*<-ctorparams::WithContextBound#[T]*/: Show/*->ctorparams::Show#*//*->ctorparams::WithContextBound#[T]*//*<-ctorparams::WithContextBound#evidence$1.*//*<-ctorparams::WithContextBound#`<init>`().(evidence$1)*/]
+
+// explicit, source-named using parameter: gets a constructor-parameter occurrence
+class WithUsing/*<-ctorparams::WithUsing#*/(using s/*<-ctorparams::WithUsing#s.*//*<-ctorparams::WithUsing#`<init>`().(s)*/: Show/*->ctorparams::Show#*/[Int/*->scala::Int#*/])
+
+// repeated parameter: the occurrence spans the source name `xs`, not a zero-extent point
+class Repeated/*<-ctorparams::Repeated#*/(xs/*<-ctorparams::Repeated#xs.*//*<-ctorparams::Repeated#`<init>`().(xs)*/: Int/*->scala::Int#*/*)

--- a/tests/semanticdb/expect/CtorParams.scala
+++ b/tests/semanticdb/expect/CtorParams.scala
@@ -1,0 +1,29 @@
+package ctorparams
+
+// Constructor-parameter occurrence edge cases (parity with scalameta #4650 / #1327).
+// dotc retains every primary-constructor parameter as a param-accessor field, so each
+// parameter's name range carries TWO definition occurrences: the accessor `C#x.` and the
+// constructor parameter `C#<init>().(x)`. References still resolve to the accessor.
+
+trait Show[A]:
+  def show(a: A): String
+
+// parameter used in the constructor body: accessor + constructor-parameter occurrences;
+// the body reference resolves to the accessor
+class UsedInCtorOnly(x: Int):
+  println(x)
+
+// parameter referenced from a method: same dual occurrence at the definition site
+class UsedInMethod(x: Int):
+  def get: Int = x
+
+// context bound desugars to a synthetic `given` evidence parameter. Like method evidence
+// parameters (which dotc already anchors), it gets a zero-length definition occurrence at
+// the bound position for both the accessor and the constructor parameter.
+class WithContextBound[T: Show]
+
+// explicit, source-named using parameter: gets a constructor-parameter occurrence
+class WithUsing(using s: Show[Int])
+
+// repeated parameter: the occurrence spans the source name `xs`, not a zero-extent point
+class Repeated(xs: Int*)

--- a/tests/semanticdb/expect/EndMarkers.expect.scala
+++ b/tests/semanticdb/expect/EndMarkers.expect.scala
@@ -1,6 +1,6 @@
 package endmarkers:
 
-  class MultiCtor/*<-endmarkers::MultiCtor#*/(val i/*<-endmarkers::MultiCtor#i.*/: Int/*->scala::Int#*/):
+  class MultiCtor/*<-endmarkers::MultiCtor#*/(val i/*<-endmarkers::MultiCtor#i.*//*<-endmarkers::MultiCtor#`<init>`().(i)*/: Int/*->scala::Int#*/):
     def this/*<-endmarkers::MultiCtor#`<init>`(+1).*/() =
       this(23)
     end this/*->endmarkers::MultiCtor#`<init>`(+1).*/

--- a/tests/semanticdb/expect/EnumVal.expect.scala
+++ b/tests/semanticdb/expect/EnumVal.expect.scala
@@ -5,7 +5,7 @@ import scala.runtime.EnumValue/*->scala::runtime::EnumValue.*/
 
 trait A/*<-enumVal::A#*/
 
-enum Color/*<-enumVal::Color#*/(val rgb/*<-enumVal::Color#rgb.*/: Int/*->scala::Int#*/):
+enum Color/*<-enumVal::Color#*/(val rgb/*<-enumVal::Color#rgb.*//*<-enumVal::Color#`<init>`().(rgb)*/: Int/*->scala::Int#*/):
   case Red/*<-enumVal::Color.Red.*/   extends Color/*->enumVal::Color#*/(0xFF0000) with EnumValue/*->scala::runtime::EnumValue#*/
   case Green/*<-enumVal::Color.Green.*/ extends Color/*->enumVal::Color#*/(0x00FF00) with A/*->enumVal::A#*/
   case Blue/*<-enumVal::Color.Blue.*/  extends Color/*->enumVal::Color#*/(0x0000FF)

--- a/tests/semanticdb/expect/Enums.expect.scala
+++ b/tests/semanticdb/expect/Enums.expect.scala
@@ -28,7 +28,7 @@ object Enums/*<-_empty_::Enums.*/:
     case Saturday/*<-_empty_::Enums.WeekDays.Saturday.*/
     case Sunday/*<-_empty_::Enums.WeekDays.Sunday.*/
 
-  enum Coin/*<-_empty_::Enums.Coin#*/(value/*<-_empty_::Enums.Coin#value.*/: Int/*->scala::Int#*/):
+  enum Coin/*<-_empty_::Enums.Coin#*/(value/*<-_empty_::Enums.Coin#value.*//*<-_empty_::Enums.Coin#`<init>`().(value)*/: Int/*->scala::Int#*/):
     case Penny/*<-_empty_::Enums.Coin.Penny.*/    extends Coin/*->_empty_::Enums.Coin#*/(1)
     case Nickel/*<-_empty_::Enums.Coin.Nickel.*/   extends Coin/*->_empty_::Enums.Coin#*/(5)
     case Dime/*<-_empty_::Enums.Coin.Dime.*/     extends Coin/*->_empty_::Enums.Coin#*/(10)
@@ -36,7 +36,7 @@ object Enums/*<-_empty_::Enums.*/:
     case Dollar/*<-_empty_::Enums.Coin.Dollar.*/   extends Coin/*->_empty_::Enums.Coin#*/(100)
 
   enum Maybe/*<-_empty_::Enums.Maybe#*/[+A/*<-_empty_::Enums.Maybe#[A]*/]:
-    case Just/*<-_empty_::Enums.Maybe.Just#*/(value/*<-_empty_::Enums.Maybe.Just#value.*/: A/*->_empty_::Enums.Maybe.Just#[A]*/)
+    case Just/*<-_empty_::Enums.Maybe.Just#*/(value/*<-_empty_::Enums.Maybe.Just#value.*//*<-_empty_::Enums.Maybe.Just#`<init>`().(value)*/: A/*->_empty_::Enums.Maybe.Just#[A]*/)
     case None/*<-_empty_::Enums.Maybe.None.*/
 
   enum Tag/*<-_empty_::Enums.Tag#*/[A/*<-_empty_::Enums.Tag#[A]*/]:
@@ -54,7 +54,7 @@ object Enums/*<-_empty_::Enums.*/:
 
   val some1/*<-_empty_::Enums.some1.*/ = Some/*->scala::Some.*/(Some/*->scala::Some.*/(1)).unwrap/*->_empty_::Enums.unwrap().*/
 
-  enum Planet/*<-_empty_::Enums.Planet#*/(mass/*<-_empty_::Enums.Planet#mass.*/: Double/*->scala::Double#*/, radius/*<-_empty_::Enums.Planet#radius.*/: Double/*->scala::Double#*/) extends Enum/*->java::lang::Enum#*/[Planet/*->_empty_::Enums.Planet#*/]:
+  enum Planet/*<-_empty_::Enums.Planet#*/(mass/*<-_empty_::Enums.Planet#mass.*//*<-_empty_::Enums.Planet#`<init>`().(mass)*/: Double/*->scala::Double#*/, radius/*<-_empty_::Enums.Planet#radius.*//*<-_empty_::Enums.Planet#`<init>`().(radius)*/: Double/*->scala::Double#*/) extends Enum/*->java::lang::Enum#*/[Planet/*->_empty_::Enums.Planet#*/]:
     private final val G/*<-_empty_::Enums.Planet#G.*/ = 6.67300E-11
     def surfaceGravity/*<-_empty_::Enums.Planet#surfaceGravity().*/ = G/*->_empty_::Enums.Planet#G.*/ */*->scala::Double#`*`(+6).*/ mass/*->_empty_::Enums.Planet#mass.*/ //*->scala::Double#`::`(+6).*/ (radius/*->_empty_::Enums.Planet#radius.*/ */*->scala::Double#`*`(+6).*/ radius/*->_empty_::Enums.Planet#radius.*/)
     def surfaceWeight/*<-_empty_::Enums.Planet#surfaceWeight().*/(otherMass/*<-_empty_::Enums.Planet#surfaceWeight().(otherMass)*/: Double/*->scala::Double#*/) = otherMass/*->_empty_::Enums.Planet#surfaceWeight().(otherMass)*/ */*->scala::Double#`*`(+6).*/ surfaceGravity/*->_empty_::Enums.Planet#surfaceGravity().*/

--- a/tests/semanticdb/expect/ImplicitConversion.expect.scala
+++ b/tests/semanticdb/expect/ImplicitConversion.expect.scala
@@ -31,7 +31,7 @@ class ImplicitConversion/*<-example::ImplicitConversion#*/ {
 }
 
 object ImplicitConversion/*<-example::ImplicitConversion.*/ {
-  implicit final class newAny2stringadd/*<-example::ImplicitConversion.newAny2stringadd#*/[A/*<-example::ImplicitConversion.newAny2stringadd#[A]*/](private val self/*<-example::ImplicitConversion.newAny2stringadd#self.*/: A/*->example::ImplicitConversion.newAny2stringadd#[A]*/) extends AnyVal/*->scala::AnyVal#*/ {
+  implicit final class newAny2stringadd/*<-example::ImplicitConversion.newAny2stringadd#*/[A/*<-example::ImplicitConversion.newAny2stringadd#[A]*/](private val self/*<-example::ImplicitConversion.newAny2stringadd#self.*//*<-example::ImplicitConversion.newAny2stringadd#`<init>`().(self)*/: A/*->example::ImplicitConversion.newAny2stringadd#[A]*/) extends AnyVal/*->scala::AnyVal#*/ {
     def +/*<-example::ImplicitConversion.newAny2stringadd#`+`().*/(other/*<-example::ImplicitConversion.newAny2stringadd#`+`().(other)*/: String/*->scala::Predef.String#*/): String/*->scala::Predef.String#*/ = String/*->java::lang::String#*/.valueOf/*->java::lang::String#valueOf().*/(self/*->example::ImplicitConversion.newAny2stringadd#self.*/) +/*->java::lang::String#`+`().*/ other/*->example::ImplicitConversion.newAny2stringadd#`+`().(other)*/
   }
 }

--- a/tests/semanticdb/expect/NamedApplyBlock.expect.scala
+++ b/tests/semanticdb/expect/NamedApplyBlock.expect.scala
@@ -8,7 +8,7 @@ object NamedApplyBlockMethods/*<-example::NamedApplyBlockMethods.*/ {
 }
 
 object NamedApplyBlockCaseClassConstruction/*<-example::NamedApplyBlockCaseClassConstruction.*/ {
-  case class Msg/*<-example::NamedApplyBlockCaseClassConstruction.Msg#*/(body/*<-example::NamedApplyBlockCaseClassConstruction.Msg#body.*/: String/*->scala::Predef.String#*/, head/*<-example::NamedApplyBlockCaseClassConstruction.Msg#head.*/: String/*->scala::Predef.String#*/ = "default", tail/*<-example::NamedApplyBlockCaseClassConstruction.Msg#tail.*/: String/*->scala::Predef.String#*/)
+  case class Msg/*<-example::NamedApplyBlockCaseClassConstruction.Msg#*/(body/*<-example::NamedApplyBlockCaseClassConstruction.Msg#body.*//*<-example::NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(body)*/: String/*->scala::Predef.String#*/, head/*<-example::NamedApplyBlockCaseClassConstruction.Msg#head.*//*<-example::NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(head)*/: String/*->scala::Predef.String#*/ = "default", tail/*<-example::NamedApplyBlockCaseClassConstruction.Msg#tail.*//*<-example::NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(tail)*/: String/*->scala::Predef.String#*/)
   val bodyText/*<-example::NamedApplyBlockCaseClassConstruction.bodyText.*/ = "body"
   val msg/*<-example::NamedApplyBlockCaseClassConstruction.msg.*/ = Msg/*->example::NamedApplyBlockCaseClassConstruction.Msg.*/(bodyText/*->example::NamedApplyBlockCaseClassConstruction.bodyText.*/, tail/*->example::NamedApplyBlockCaseClassConstruction.Msg.apply().(tail)*/ = "tail")
 }

--- a/tests/semanticdb/expect/NamedArguments.expect.scala
+++ b/tests/semanticdb/expect/NamedArguments.expect.scala
@@ -1,7 +1,7 @@
 package example
 
 class NamedArguments/*<-example::NamedArguments#*/ {
-  case class User/*<-example::NamedArguments#User#*/(name/*<-example::NamedArguments#User#name.*/: String/*->scala::Predef.String#*/)
+  case class User/*<-example::NamedArguments#User#*/(name/*<-example::NamedArguments#User#name.*//*<-example::NamedArguments#User#`<init>`().(name)*/: String/*->scala::Predef.String#*/)
   User/*->example::NamedArguments#User.*/(name/*->example::NamedArguments#User.apply().(name)*/ = "John")
   User/*->example::NamedArguments#User.*/.apply/*->example::NamedArguments#User.apply().*/(name/*->example::NamedArguments#User.apply().(name)*/ = "John")
 }

--- a/tests/semanticdb/expect/RecOrRefined.expect.scala
+++ b/tests/semanticdb/expect/RecOrRefined.expect.scala
@@ -12,7 +12,7 @@ def m5/*<-example::RecOrRefined$package.m5().*/[Z/*<-example::RecOrRefined$packa
 
 type m6/*<-example::RecOrRefined$package.m6#*/ = [X/*<-example::RecOrRefined$package.m6#[X]*/] =>> PolyHolder/*->example::PolyHolder#*/ { def foo/*<-example::RecOrRefined$package.m6#foo().*/[T/*<-example::RecOrRefined$package.m6#foo().[T]*/](t/*<-example::RecOrRefined$package.m6#foo().(t)*/: T/*->example::RecOrRefined$package.m6#foo().[T]*/): T/*->example::RecOrRefined$package.m6#foo().[T]*/ }
 
-class Record/*<-example::Record#*/(elems/*<-example::Record#elems.*/: (String/*->scala::Predef.String#*/, Any/*->scala::Any#*/)*) extends Selectable/*->scala::Selectable#*/:
+class Record/*<-example::Record#*/(elems/*<-example::Record#elems.*//*<-example::Record#`<init>`().(elems)*/: (String/*->scala::Predef.String#*/, Any/*->scala::Any#*/)*) extends Selectable/*->scala::Selectable#*/:
   private val fields/*<-example::Record#fields.*/ = elems/*->example::Record#elems.*/.toMap/*->scala::collection::IterableOnceOps#toMap().*/
   def selectDynamic/*<-example::Record#selectDynamic().*/(name/*<-example::Record#selectDynamic().(name)*/: String/*->scala::Predef.String#*/): Any/*->scala::Any#*/ = fields/*->example::Record#fields.*/(name/*->example::Record#selectDynamic().(name)*/)
 

--- a/tests/semanticdb/expect/Synthetic.expect.scala
+++ b/tests/semanticdb/expect/Synthetic.expect.scala
@@ -30,7 +30,7 @@ class Synthetic/*<-example::Synthetic#*/ {
     null.asInstanceOf/*->scala::Any#asInstanceOf().*/[Int/*->scala::Int#*/ => Int/*->scala::Int#*/](2)
   }
 
-  class J/*<-example::Synthetic#J#*/[T/*<-example::Synthetic#J#[T]*/: Manifest/*->scala::Predef.Manifest#*//*->example::Synthetic#J#[T]*//*<-example::Synthetic#J#evidence$1.*/] { val arr/*<-example::Synthetic#J#arr.*/ = Array/*->scala::Array.*/.empty/*->scala::Array.empty().*/[T/*->example::Synthetic#J#[T]*/] }
+  class J/*<-example::Synthetic#J#*/[T/*<-example::Synthetic#J#[T]*/: Manifest/*->scala::Predef.Manifest#*//*->example::Synthetic#J#[T]*//*<-example::Synthetic#J#evidence$1.*//*<-example::Synthetic#J#`<init>`().(evidence$1)*/] { val arr/*<-example::Synthetic#J#arr.*/ = Array/*->scala::Array.*/.empty/*->scala::Array.empty().*/[T/*->example::Synthetic#J#[T]*/] }
 
   class F/*<-example::Synthetic#F#*/
   implicit val ordering/*<-example::Synthetic#ordering.*/: Ordering/*->scala::package.Ordering#*/[F/*->example::Synthetic#F#*/] = ???/*->scala::Predef.`???`().*/

--- a/tests/semanticdb/expect/Vals.expect.scala
+++ b/tests/semanticdb/expect/Vals.expect.scala
@@ -1,6 +1,6 @@
 package example
 
-abstract class Vals/*<-example::Vals#*/(p/*<-example::Vals#p.*/: Int/*->scala::Int#*/, val xp/*<-example::Vals#xp.*/: Int/*->scala::Int#*/, var yp/*<-example::Vals#yp().*/: Int/*->scala::Int#*/) {
+abstract class Vals/*<-example::Vals#*/(p/*<-example::Vals#p.*//*<-example::Vals#`<init>`().(p)*/: Int/*->scala::Int#*/, val xp/*<-example::Vals#xp.*//*<-example::Vals#`<init>`().(xp)*/: Int/*->scala::Int#*/, var yp/*<-example::Vals#yp().*//*<-example::Vals#`<init>`().(yp)*/: Int/*->scala::Int#*/) {
   val xm/*<-example::Vals#xm.*/: Int/*->scala::Int#*/ = ???/*->scala::Predef.`???`().*/
   val xam/*<-example::Vals#xam.*/: Int/*->scala::Int#*/
   private[this] val xlm/*<-example::Vals#xlm.*/: Int/*->scala::Int#*/ = ???/*->scala::Predef.`???`().*/

--- a/tests/semanticdb/expect/exports-example-Codec.expect.scala
+++ b/tests/semanticdb/expect/exports-example-Codec.expect.scala
@@ -8,7 +8,7 @@ trait Encoder/*<-exports::example::Encoder#*/[-T/*<-exports::example::Encoder#[T
   def encode/*<-exports::example::Encoder#encode().*/(t/*<-exports::example::Encoder#encode().(t)*/: T/*->exports::example::Encoder#[T]*/): Array/*->scala::Array#*/[Byte/*->scala::Byte#*/]
 }
 
-trait Codec/*<-exports::example::Codec#*/[T/*<-exports::example::Codec#[T]*/](decode/*<-exports::example::Codec#decode.*/: Decoder/*->exports::example::Decoder#*/[T/*->exports::example::Codec#[T]*/], encode/*<-exports::example::Codec#encode.*/: Encoder/*->exports::example::Encoder#*/[T/*->exports::example::Codec#[T]*/])
+trait Codec/*<-exports::example::Codec#*/[T/*<-exports::example::Codec#[T]*/](decode/*<-exports::example::Codec#decode.*//*<-exports::example::Codec#`<init>`().(decode)*/: Decoder/*->exports::example::Decoder#*/[T/*->exports::example::Codec#[T]*/], encode/*<-exports::example::Codec#encode.*//*<-exports::example::Codec#`<init>`().(encode)*/: Encoder/*->exports::example::Encoder#*/[T/*->exports::example::Codec#[T]*/])
   extends Decoder/*->exports::example::Decoder#*/[T/*->exports::example::Codec#[T]*/] with Encoder/*->exports::example::Encoder#*/[T/*->exports::example::Codec#[T]*/] {
   export decode/*->exports::example::Codec#decode.*/._
   export encode/*->exports::example::Codec#encode.*/._

--- a/tests/semanticdb/expect/i9727.expect.scala
+++ b/tests/semanticdb/expect/i9727.expect.scala
@@ -1,5 +1,5 @@
 package i9727
 
-class Test/*<-i9727::Test#*/(a/*<-i9727::Test#a.*/: Int/*->scala::Int#*/)
+class Test/*<-i9727::Test#*/(a/*<-i9727::Test#a.*//*<-i9727::Test#`<init>`().(a)*/: Int/*->scala::Int#*/)
 val a/*<-i9727::i9727$package.a.*/ = new Test/*->i9727::Test#*/(1)
 val b/*<-i9727::i9727$package.b.*/ = new Test/*->i9727::Test#*/(2)

--- a/tests/semanticdb/expect/recursion.expect.scala
+++ b/tests/semanticdb/expect/recursion.expect.scala
@@ -13,7 +13,7 @@ object Nats/*<-recursion::Nats.*/ {
   }
 
   case object Zero/*<-recursion::Nats.Zero.*/ extends Nat/*->recursion::Nats.Nat#*/
-  case class Succ/*<-recursion::Nats.Succ#*/[N/*<-recursion::Nats.Succ#[N]*/ <: Nat/*->recursion::Nats.Nat#*/](p/*<-recursion::Nats.Succ#p.*/: N/*->recursion::Nats.Succ#[N]*/) extends Nat/*->recursion::Nats.Nat#*/
+  case class Succ/*<-recursion::Nats.Succ#*/[N/*<-recursion::Nats.Succ#[N]*/ <: Nat/*->recursion::Nats.Nat#*/](p/*<-recursion::Nats.Succ#p.*//*<-recursion::Nats.Succ#`<init>`().(p)*/: N/*->recursion::Nats.Succ#[N]*/) extends Nat/*->recursion::Nats.Nat#*/
 
   transparent inline def toIntg/*<-recursion::Nats.toIntg().*/(inline n/*<-recursion::Nats.toIntg().(n)*/: Nat/*->recursion::Nats.Nat#*/): Int/*->scala::Int#*/ =
     inline n/*->recursion::Nats.toIntg().(n)*/ match {

--- a/tests/semanticdb/expect/semanticdb-Flags.expect.scala
+++ b/tests/semanticdb/expect/semanticdb-Flags.expect.scala
@@ -7,7 +7,7 @@ package object p/*<-flags::p::package.*/ {
   protected implicit var y/*<-flags::p::package.y().*/: Int/*->scala::Int#*/ = 2
   def z/*<-flags::p::package.z().*/(pp/*<-flags::p::package.z().(pp)*/: Int/*->scala::Int#*/) = 3
   def m/*<-flags::p::package.m().*/[TT/*<-flags::p::package.m().[TT]*/]: Int/*->scala::Int#*/ = macro ???/*->scala::Predef.`???`().*/
-  abstract class C/*<-flags::p::package.C#*/[+T/*<-flags::p::package.C#[T]*/, -U/*<-flags::p::package.C#[U]*/, V/*<-flags::p::package.C#[V]*/](x/*<-flags::p::package.C#x.*/: T/*->flags::p::package.C#[T]*/, y/*<-flags::p::package.C#y.*/: U/*->flags::p::package.C#[U]*/, z/*<-flags::p::package.C#z.*/: V/*->flags::p::package.C#[V]*/) {
+  abstract class C/*<-flags::p::package.C#*/[+T/*<-flags::p::package.C#[T]*/, -U/*<-flags::p::package.C#[U]*/, V/*<-flags::p::package.C#[V]*/](x/*<-flags::p::package.C#x.*//*<-flags::p::package.C#`<init>`().(x)*/: T/*->flags::p::package.C#[T]*/, y/*<-flags::p::package.C#y.*//*<-flags::p::package.C#`<init>`().(y)*/: U/*->flags::p::package.C#[U]*/, z/*<-flags::p::package.C#z.*//*<-flags::p::package.C#`<init>`().(z)*/: V/*->flags::p::package.C#[V]*/) {
     def this/*<-flags::p::package.C#`<init>`(+1).*/() = this(???/*->scala::Predef.`???`().*/, ???/*->scala::Predef.`???`().*/, ???/*->scala::Predef.`???`().*/)
     def this/*<-flags::p::package.C#`<init>`(+2).*/(t/*<-flags::p::package.C#`<init>`(+2).(t)*/: T/*->flags::p::package.C#[T]*/) = this(t/*->flags::p::package.C#`<init>`(+2).(t)*/, ???/*->scala::Predef.`???`().*/, ???/*->scala::Predef.`???`().*/)
     def w/*<-flags::p::package.C#w().*/: Int/*->scala::Int#*/
@@ -19,7 +19,7 @@ package object p/*<-flags::p::package.*/ {
   case object X/*<-flags::p::package.X.*/
   final class Y/*<-flags::p::package.Y#*/
   sealed trait Z/*<-flags::p::package.Z#*/
-  class AA/*<-flags::p::package.AA#*/(x/*<-flags::p::package.AA#x.*/: Int/*->scala::Int#*/, val y/*<-flags::p::package.AA#y.*/: Int/*->scala::Int#*/, var z/*<-flags::p::package.AA#z().*/: Int/*->scala::Int#*/)
+  class AA/*<-flags::p::package.AA#*/(x/*<-flags::p::package.AA#x.*//*<-flags::p::package.AA#`<init>`().(x)*/: Int/*->scala::Int#*/, val y/*<-flags::p::package.AA#y.*//*<-flags::p::package.AA#`<init>`().(y)*/: Int/*->scala::Int#*/, var z/*<-flags::p::package.AA#z().*//*<-flags::p::package.AA#`<init>`().(z)*/: Int/*->scala::Int#*/)
   class S/*<-flags::p::package.S#*/[@specialized/*->scala::specialized#*/ T/*<-flags::p::package.S#[T]*/]
   val List/*->scala::package.List.*/(xs1/*<-flags::p::package.xs1.*/) = ???/*->scala::Predef.`???`().*/
   ???/*->scala::Predef.`???`().*/ match { case List/*->scala::package.List.*/(xs2/*<-local0*/) => ???/*->scala::Predef.`???`().*/ }

--- a/tests/semanticdb/expect/semanticdb-Types.expect.scala
+++ b/tests/semanticdb/expect/semanticdb-Types.expect.scala
@@ -3,7 +3,7 @@ package types
 import scala.language/*->scala::language.*/.existentials/*->scala::language.existentials.*/
 import scala.language/*->scala::language.*/.higherKinds/*->scala::language.higherKinds.*/
 
-class ann/*<-types::ann#*/[T/*<-types::ann#[T]*/](x/*<-types::ann#x.*/: T/*->types::ann#[T]*/) extends scala.annotation.StaticAnnotation/*->scala::annotation::StaticAnnotation#*/
+class ann/*<-types::ann#*/[T/*<-types::ann#[T]*/](x/*<-types::ann#x.*//*<-types::ann#`<init>`().(x)*/: T/*->types::ann#[T]*/) extends scala.annotation.StaticAnnotation/*->scala::annotation::StaticAnnotation#*/
 class ann1/*<-types::ann1#*/ extends scala.annotation.StaticAnnotation/*->scala::annotation::StaticAnnotation#*/
 class ann2/*<-types::ann2#*/ extends scala.annotation.StaticAnnotation/*->scala::annotation::StaticAnnotation#*/
 
@@ -23,7 +23,7 @@ class T/*<-types::T#*/ {
   val x/*<-types::T#x.*/ = new X/*->types::T#X#*/
 }
 
-case class Foo/*<-types::Foo#*/(s/*<-types::Foo#s.*/: "abc")
+case class Foo/*<-types::Foo#*/(s/*<-types::Foo#s.*//*<-types::Foo#`<init>`().(s)*/: "abc")
 
 object Foo/*<-types::Foo.*/ {
   val x/*<-types::Foo.x.*/: "abc" @deprecated/*->scala::deprecated#*/ = "abc"
@@ -93,7 +93,7 @@ object Test/*<-types::Test.*/ {
       def m1/*<-types::Test.C#ByNameType.m1().*/(x/*<-types::Test.C#ByNameType.m1().(x)*/: => Int/*->scala::Int#*/): Int/*->scala::Int#*/ = ???/*->scala::Predef.`???`().*/
     }
 
-    case class RepeatedType/*<-types::Test.C#RepeatedType#*/(s/*<-types::Test.C#RepeatedType#s.*/: String/*->scala::Predef.String#*/*) {
+    case class RepeatedType/*<-types::Test.C#RepeatedType#*/(s/*<-types::Test.C#RepeatedType#s.*//*<-types::Test.C#RepeatedType#`<init>`().(s)*/: String/*->scala::Predef.String#*/*) {
       def m1/*<-types::Test.C#RepeatedType#m1().*/(x/*<-types::Test.C#RepeatedType#m1().(x)*/: Int/*->scala::Int#*/*): Int/*->scala::Int#*/ = s/*->types::Test.C#RepeatedType#s.*/.length/*->scala::collection::SeqOps#length().*/
     }
 

--- a/tests/semanticdb/expect/semanticdb-extract.expect.scala
+++ b/tests/semanticdb/expect/semanticdb-extract.expect.scala
@@ -14,5 +14,5 @@ object AnObject/*<-_empty_::AnObject.*/ {
   List/*->scala::package.List.*/.`apply`/*->scala::collection::IterableFactory#apply().*/()
   println/*->scala::Predef.println(+1).*/(1 +/*->scala::Int#`+`(+4).*/ 2)
 
-  case class Foo/*<-_empty_::AnObject.Foo#*/(x/*<-_empty_::AnObject.Foo#x.*/: Int/*->scala::Int#*/)
+  case class Foo/*<-_empty_::AnObject.Foo#*/(x/*<-_empty_::AnObject.Foo#x.*//*<-_empty_::AnObject.Foo#`<init>`().(x)*/: Int/*->scala::Int#*/)
 }

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -294,7 +294,7 @@ Uri => Annotations.scala
 Text => empty
 Language => Scala
 Symbols => 23 entries
-Occurrences => 55 entries
+Occurrences => 57 entries
 Diagnostics => 2 entries
 
 Symbols:
@@ -341,6 +341,7 @@ Occurrences:
 [7:43..7:44): T <- annot/Annotations#[T]
 [7:47..7:66): ParameterAnnotation -> com/javacp/annot/ParameterAnnotation#
 [7:67..7:68): x <- annot/Annotations#x.
+[7:67..7:68): x <- annot/Annotations#`<init>`().(x)
 [7:70..7:71): T -> annot/Annotations#[T]
 [7:75..7:79): self <- local0
 [7:81..7:87): AnyRef -> scala/AnyRef#
@@ -357,6 +358,7 @@ Occurrences:
 [21:7..21:7): <- annot/B#`<init>`().
 [21:9..21:30): ConstructorAnnotation -> com/javacp/annot/ConstructorAnnotation#
 [21:33..21:34): x <- annot/B#x.
+[21:33..21:34): x <- annot/B#`<init>`().(x)
 [21:36..21:39): Int -> scala/Int#
 [22:3..22:24): ConstructorAnnotation -> com/javacp/annot/ConstructorAnnotation#
 [23:6..23:10): <- annot/B#`<init>`(+1).
@@ -518,7 +520,7 @@ Uri => CaseClass.scala
 Text => empty
 Language => Scala
 Symbols => 22 entries
-Occurrences => 17 entries
+Occurrences => 19 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -550,8 +552,10 @@ Occurrences:
 [2:11..2:20): CaseClass <- caseclass/CaseClass#
 [2:20..2:20): <- caseclass/CaseClass#`<init>`().
 [2:21..2:25): int1 <- caseclass/CaseClass#int1.
+[2:21..2:25): int1 <- caseclass/CaseClass#`<init>`().(int1)
 [2:27..2:30): Int -> scala/Int#
 [2:32..2:36): int2 <- caseclass/CaseClass#int2.
+[2:32..2:36): int2 <- caseclass/CaseClass#`<init>`().(int2)
 [2:38..2:41): Int -> scala/Int#
 [4:7..4:16): CaseClass <- caseclass/CaseClass.
 [5:6..5:11): apply <- caseclass/CaseClass.apply().
@@ -577,7 +581,7 @@ Uri => Classes.scala
 Text => empty
 Language => Scala
 Symbols => 108 entries
-Occurrences => 127 entries
+Occurrences => 137 entries
 Diagnostics => 11 entries
 Synthetics => 3 entries
 
@@ -700,47 +704,57 @@ Occurrences:
 [2:6..2:8): C1 <- classes/C1#
 [2:8..2:8): <- classes/C1#`<init>`().
 [2:13..2:15): x1 <- classes/C1#x1.
+[2:13..2:15): x1 <- classes/C1#`<init>`().(x1)
 [2:17..2:20): Int -> scala/Int#
 [2:30..2:36): AnyVal -> scala/AnyVal#
 [4:6..4:8): C2 <- classes/C2#
 [4:8..4:8): <- classes/C2#`<init>`().
 [4:13..4:15): x2 <- classes/C2#x2.
+[4:13..4:15): x2 <- classes/C2#`<init>`().(x2)
 [4:17..4:20): Int -> scala/Int#
 [4:30..4:36): AnyVal -> scala/AnyVal#
 [5:7..5:9): C2 <- classes/C2.
 [7:11..7:13): C3 <- classes/C3#
 [7:13..7:13): <- classes/C3#`<init>`().
 [7:14..7:15): x <- classes/C3#x.
+[7:14..7:15): x <- classes/C3#`<init>`().(x)
 [7:17..7:20): Int -> scala/Int#
 [9:11..9:13): C4 <- classes/C4#
 [9:13..9:13): <- classes/C4#`<init>`().
 [9:14..9:15): x <- classes/C4#x.
+[9:14..9:15): x <- classes/C4#`<init>`().(x)
 [9:17..9:20): Int -> scala/Int#
 [10:7..10:9): C4 <- classes/C4.
 [12:7..12:8): M <- classes/M.
 [13:17..13:19): C5 <- classes/M.C5#
 [13:19..13:19): <- classes/M.C5#`<init>`().
 [13:20..13:21): x <- classes/M.C5#x.
+[13:20..13:21): x <- classes/M.C5#`<init>`().(x)
 [13:23..13:26): Int -> scala/Int#
 [16:11..16:13): C6 <- classes/C6#
 [16:13..16:13): <- classes/C6#`<init>`().
 [16:26..16:27): x <- classes/C6#x.
+[16:26..16:27): x <- classes/C6#`<init>`().(x)
 [16:29..16:32): Int -> scala/Int#
 [18:6..18:8): C7 <- classes/C7#
 [18:8..18:8): <- classes/C7#`<init>`().
 [18:9..18:10): x <- classes/C7#x.
+[18:9..18:10): x <- classes/C7#`<init>`().(x)
 [18:12..18:15): Int -> scala/Int#
 [20:6..20:8): C8 <- classes/C8#
 [20:8..20:8): <- classes/C8#`<init>`().
 [20:27..20:28): x <- classes/C8#x.
+[20:27..20:28): x <- classes/C8#`<init>`().(x)
 [20:30..20:33): Int -> scala/Int#
 [22:6..22:8): C9 <- classes/C9#
 [22:8..22:8): <- classes/C9#`<init>`().
 [22:27..22:28): x <- classes/C9#x().
+[22:27..22:28): x <- classes/C9#`<init>`().(x)
 [22:30..22:33): Int -> scala/Int#
 [24:6..24:9): C10 <- classes/C10#
 [24:9..24:9): <- classes/C10#`<init>`().
 [24:10..24:11): s <- classes/C10#s.
+[24:10..24:11): s <- classes/C10#`<init>`().(s)
 [24:16..24:22): String -> scala/Predef.String#
 [26:6..26:9): C11 <- classes/C11#
 [27:2..27:2): <- classes/C11#`<init>`().
@@ -844,6 +858,95 @@ Synthetics:
 [51:16..51:20):List => *.apply[Int]
 [51:16..51:23):List(1) => List.apply[Int](*)
 
+expect/CtorParams.scala
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => CtorParams.scala
+Text => empty
+Language => Scala
+Symbols => 27 entries
+Occurrences => 41 entries
+Diagnostics => 3 entries
+
+Symbols:
+ctorparams/Repeated# => class Repeated extends Object { self: Repeated => +2 decls }
+ctorparams/Repeated#`<init>`(). => primary ctor <init> (param xs: Int*): Repeated
+ctorparams/Repeated#`<init>`().(xs) => param xs: Int*
+ctorparams/Repeated#xs. => private[this] val method xs Int*
+ctorparams/Show# => trait Show [typeparam A ] extends Object { self: Show[A] => +3 decls }
+ctorparams/Show#[A] => typeparam A 
+ctorparams/Show#`<init>`(). => primary ctor <init> [typeparam A ](): Show[A]
+ctorparams/Show#show(). => abstract method show (param a: A): String
+ctorparams/Show#show().(a) => param a: A
+ctorparams/UsedInCtorOnly# => class UsedInCtorOnly extends Object { self: UsedInCtorOnly => +2 decls }
+ctorparams/UsedInCtorOnly#`<init>`(). => primary ctor <init> (param x: Int): UsedInCtorOnly
+ctorparams/UsedInCtorOnly#`<init>`().(x) => param x: Int
+ctorparams/UsedInCtorOnly#x. => private[this] val method x Int
+ctorparams/UsedInMethod# => class UsedInMethod extends Object { self: UsedInMethod => +3 decls }
+ctorparams/UsedInMethod#`<init>`(). => primary ctor <init> (param x: Int): UsedInMethod
+ctorparams/UsedInMethod#`<init>`().(x) => param x: Int
+ctorparams/UsedInMethod#get(). => method get => Int
+ctorparams/UsedInMethod#x. => private[this] val method x Int
+ctorparams/WithContextBound# => class WithContextBound [typeparam T ] extends Object { self: WithContextBound[T] => +3 decls }
+ctorparams/WithContextBound#[T] => typeparam T 
+ctorparams/WithContextBound#`<init>`(). => primary ctor <init> [typeparam T ](implicit given param evidence$1: Show[T])(): WithContextBound[T]
+ctorparams/WithContextBound#`<init>`().(evidence$1) => implicit given param evidence$1: Show[T]
+ctorparams/WithContextBound#evidence$1. => private[this] implicit val given method evidence$1 Show[T]
+ctorparams/WithUsing# => class WithUsing extends Object { self: WithUsing => +2 decls }
+ctorparams/WithUsing#`<init>`(). => primary ctor <init> (implicit given param s: Show[Int])(): WithUsing
+ctorparams/WithUsing#`<init>`().(s) => implicit given param s: Show[Int]
+ctorparams/WithUsing#s. => private[this] implicit val given method s Show[Int]
+
+Occurrences:
+[0:8..0:18): ctorparams <- ctorparams/
+[7:6..7:10): Show <- ctorparams/Show#
+[7:10..7:10): <- ctorparams/Show#`<init>`().
+[7:11..7:12): A <- ctorparams/Show#[A]
+[8:6..8:10): show <- ctorparams/Show#show().
+[8:11..8:12): a <- ctorparams/Show#show().(a)
+[8:14..8:15): A -> ctorparams/Show#[A]
+[8:18..8:24): String -> scala/Predef.String#
+[12:6..12:20): UsedInCtorOnly <- ctorparams/UsedInCtorOnly#
+[12:20..12:20): <- ctorparams/UsedInCtorOnly#`<init>`().
+[12:21..12:22): x <- ctorparams/UsedInCtorOnly#x.
+[12:21..12:22): x <- ctorparams/UsedInCtorOnly#`<init>`().(x)
+[12:24..12:27): Int -> scala/Int#
+[13:2..13:9): println -> scala/Predef.println(+1).
+[13:10..13:11): x -> ctorparams/UsedInCtorOnly#x.
+[16:6..16:18): UsedInMethod <- ctorparams/UsedInMethod#
+[16:18..16:18): <- ctorparams/UsedInMethod#`<init>`().
+[16:19..16:20): x <- ctorparams/UsedInMethod#x.
+[16:19..16:20): x <- ctorparams/UsedInMethod#`<init>`().(x)
+[16:22..16:25): Int -> scala/Int#
+[17:6..17:9): get <- ctorparams/UsedInMethod#get().
+[17:11..17:14): Int -> scala/Int#
+[17:17..17:18): x -> ctorparams/UsedInMethod#x.
+[22:6..22:22): WithContextBound <- ctorparams/WithContextBound#
+[22:22..22:22): <- ctorparams/WithContextBound#`<init>`().
+[22:23..22:24): T <- ctorparams/WithContextBound#[T]
+[22:26..22:30): Show -> ctorparams/Show#
+[22:26..22:30): Show -> ctorparams/WithContextBound#[T]
+[22:30..22:30): <- ctorparams/WithContextBound#evidence$1.
+[22:30..22:30): <- ctorparams/WithContextBound#`<init>`().(evidence$1)
+[25:6..25:15): WithUsing <- ctorparams/WithUsing#
+[25:15..25:15): <- ctorparams/WithUsing#`<init>`().
+[25:22..25:23): s <- ctorparams/WithUsing#s.
+[25:22..25:23): s <- ctorparams/WithUsing#`<init>`().(s)
+[25:25..25:29): Show -> ctorparams/Show#
+[25:30..25:33): Int -> scala/Int#
+[28:6..28:14): Repeated <- ctorparams/Repeated#
+[28:14..28:14): <- ctorparams/Repeated#`<init>`().
+[28:15..28:17): xs <- ctorparams/Repeated#xs.
+[28:15..28:17): xs <- ctorparams/Repeated#`<init>`().(xs)
+[28:19..28:22): Int -> scala/Int#
+
+Diagnostics:
+[22:30..22:30): [warning] unused implicit parameter
+[25:22..25:23): [warning] unused implicit parameter
+[28:15..28:17): [warning] unused explicit parameter
+
 expect/Deprecated.scala
 -----------------------
 
@@ -930,7 +1033,7 @@ Uri => EndMarkers.scala
 Text => empty
 Language => Scala
 Symbols => 30 entries
-Occurrences => 49 entries
+Occurrences => 50 entries
 Diagnostics => 3 entries
 Synthetics => 2 entries
 
@@ -971,6 +1074,7 @@ Occurrences:
 [2:8..2:17): MultiCtor <- endmarkers/MultiCtor#
 [2:17..2:17): <- endmarkers/MultiCtor#`<init>`().
 [2:22..2:23): i <- endmarkers/MultiCtor#i.
+[2:22..2:23): i <- endmarkers/MultiCtor#`<init>`().(i)
 [2:25..2:28): Int -> scala/Int#
 [3:8..3:12): <- endmarkers/MultiCtor#`<init>`(+1).
 [5:8..5:12): this -> endmarkers/MultiCtor#`<init>`(+1).
@@ -1057,7 +1161,7 @@ Uri => EnumVal.scala
 Text => empty
 Language => Scala
 Symbols => 16 entries
-Occurrences => 18 entries
+Occurrences => 19 entries
 
 Symbols:
 enumVal/A# => trait A extends Object { self: A => +1 decls }
@@ -1087,6 +1191,7 @@ Occurrences:
 [7:5..7:10): Color <- enumVal/Color#
 [7:10..7:10): <- enumVal/Color#`<init>`().
 [7:15..7:18): rgb <- enumVal/Color#rgb.
+[7:15..7:18): rgb <- enumVal/Color#`<init>`().(rgb)
 [7:20..7:23): Int -> scala/Int#
 [8:7..8:10): Red <- enumVal/Color.Red.
 [8:21..8:26): Color -> enumVal/Color#
@@ -1106,7 +1211,7 @@ Uri => Enums.scala
 Text => empty
 Language => Scala
 Symbols => 181 entries
-Occurrences => 159 entries
+Occurrences => 163 entries
 Diagnostics => 1 entries
 Synthetics => 9 entries
 
@@ -1346,6 +1451,7 @@ Occurrences:
 [30:7..30:11): Coin <- _empty_/Enums.Coin#
 [30:11..30:11): <- _empty_/Enums.Coin#`<init>`().
 [30:12..30:17): value <- _empty_/Enums.Coin#value.
+[30:12..30:17): value <- _empty_/Enums.Coin#`<init>`().(value)
 [30:19..30:22): Int -> scala/Int#
 [31:9..31:14): Penny <- _empty_/Enums.Coin.Penny.
 [31:26..31:30): Coin -> _empty_/Enums.Coin#
@@ -1363,6 +1469,7 @@ Occurrences:
 [38:9..38:13): Just <- _empty_/Enums.Maybe.Just#
 [38:13..38:13): <- _empty_/Enums.Maybe.Just#`<init>`().
 [38:14..38:19): value <- _empty_/Enums.Maybe.Just#value.
+[38:14..38:19): value <- _empty_/Enums.Maybe.Just#`<init>`().(value)
 [38:21..38:22): A -> _empty_/Enums.Maybe.Just#[A]
 [39:9..39:13): None <- _empty_/Enums.Maybe.None.
 [41:7..41:10): Tag <- _empty_/Enums.Tag#
@@ -1417,8 +1524,10 @@ Occurrences:
 [56:7..56:13): Planet <- _empty_/Enums.Planet#
 [56:13..56:13): <- _empty_/Enums.Planet#`<init>`().
 [56:14..56:18): mass <- _empty_/Enums.Planet#mass.
+[56:14..56:18): mass <- _empty_/Enums.Planet#`<init>`().(mass)
 [56:20..56:26): Double -> scala/Double#
 [56:28..56:34): radius <- _empty_/Enums.Planet#radius.
+[56:28..56:34): radius <- _empty_/Enums.Planet#`<init>`().(radius)
 [56:36..56:42): Double -> scala/Double#
 [56:52..56:56): Enum -> java/lang/Enum#
 [56:57..56:63): Planet -> _empty_/Enums.Planet#
@@ -1935,7 +2044,7 @@ Uri => ImplicitConversion.scala
 Text => empty
 Language => Scala
 Symbols => 23 entries
-Occurrences => 52 entries
+Occurrences => 53 entries
 Synthetics => 9 entries
 
 Symbols:
@@ -2005,6 +2114,7 @@ Occurrences:
 [33:39..33:39): <- example/ImplicitConversion.newAny2stringadd#`<init>`().
 [33:40..33:41): A <- example/ImplicitConversion.newAny2stringadd#[A]
 [33:55..33:59): self <- example/ImplicitConversion.newAny2stringadd#self.
+[33:55..33:59): self <- example/ImplicitConversion.newAny2stringadd#`<init>`().(self)
 [33:61..33:62): A -> example/ImplicitConversion.newAny2stringadd#[A]
 [33:72..33:78): AnyVal -> scala/AnyVal#
 [34:8..34:9): + <- example/ImplicitConversion.newAny2stringadd#`+`().
@@ -3040,7 +3150,7 @@ Uri => NamedApplyBlock.scala
 Text => empty
 Language => Scala
 Symbols => 41 entries
-Occurrences => 41 entries
+Occurrences => 44 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -3118,10 +3228,13 @@ Occurrences:
 [10:13..10:16): Msg <- example/NamedApplyBlockCaseClassConstruction.Msg#
 [10:16..10:16): <- example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().
 [10:17..10:21): body <- example/NamedApplyBlockCaseClassConstruction.Msg#body.
+[10:17..10:21): body <- example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(body)
 [10:23..10:29): String -> scala/Predef.String#
 [10:31..10:35): head <- example/NamedApplyBlockCaseClassConstruction.Msg#head.
+[10:31..10:35): head <- example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(head)
 [10:37..10:43): String -> scala/Predef.String#
 [10:57..10:61): tail <- example/NamedApplyBlockCaseClassConstruction.Msg#tail.
+[10:57..10:61): tail <- example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(tail)
 [10:63..10:69): String -> scala/Predef.String#
 [11:6..11:14): bodyText <- example/NamedApplyBlockCaseClassConstruction.bodyText.
 [12:6..12:9): msg <- example/NamedApplyBlockCaseClassConstruction.msg.
@@ -3141,7 +3254,7 @@ Uri => NamedArguments.scala
 Text => empty
 Language => Scala
 Symbols => 16 entries
-Occurrences => 12 entries
+Occurrences => 13 entries
 Diagnostics => 2 entries
 Synthetics => 1 entries
 
@@ -3170,6 +3283,7 @@ Occurrences:
 [3:13..3:17): User <- example/NamedArguments#User#
 [3:17..3:17): <- example/NamedArguments#User#`<init>`().
 [3:18..3:22): name <- example/NamedArguments#User#name.
+[3:18..3:22): name <- example/NamedArguments#User#`<init>`().(name)
 [3:24..3:30): String -> scala/Predef.String#
 [4:2..4:6): User -> example/NamedArguments#User.
 [4:7..4:11): name -> example/NamedArguments#User.apply().(name)
@@ -3374,7 +3488,7 @@ Uri => RecOrRefined.scala
 Text => empty
 Language => Scala
 Symbols => 68 entries
-Occurrences => 115 entries
+Occurrences => 116 entries
 Diagnostics => 1 entries
 Synthetics => 4 entries
 
@@ -3509,6 +3623,7 @@ Occurrences:
 [14:6..14:12): Record <- example/Record#
 [14:12..14:12): <- example/Record#`<init>`().
 [14:13..14:18): elems <- example/Record#elems.
+[14:13..14:18): elems <- example/Record#`<init>`().(elems)
 [14:21..14:27): String -> scala/Predef.String#
 [14:29..14:32): Any -> scala/Any#
 [14:44..14:54): Selectable -> scala/Selectable#
@@ -3908,7 +4023,7 @@ Uri => Synthetic.scala
 Text => empty
 Language => Scala
 Symbols => 62 entries
-Occurrences => 165 entries
+Occurrences => 166 entries
 Diagnostics => 4 entries
 Synthetics => 48 entries
 
@@ -4048,6 +4163,7 @@ Occurrences:
 [32:13..32:21): Manifest -> scala/Predef.Manifest#
 [32:13..32:21): Manifest -> example/Synthetic#J#[T]
 [32:21..32:21): <- example/Synthetic#J#evidence$1.
+[32:21..32:21): <- example/Synthetic#J#`<init>`().(evidence$1)
 [32:29..32:32): arr <- example/Synthetic#J#arr.
 [32:35..32:40): Array -> scala/Array.
 [32:41..32:46): empty -> scala/Array.empty().
@@ -4441,7 +4557,7 @@ Uri => Vals.scala
 Text => empty
 Language => Scala
 Symbols => 42 entries
-Occurrences => 129 entries
+Occurrences => 132 entries
 Diagnostics => 5 entries
 
 Symbols:
@@ -4493,10 +4609,13 @@ Occurrences:
 [2:15..2:19): Vals <- example/Vals#
 [2:19..2:19): <- example/Vals#`<init>`().
 [2:20..2:21): p <- example/Vals#p.
+[2:20..2:21): p <- example/Vals#`<init>`().(p)
 [2:23..2:26): Int -> scala/Int#
 [2:32..2:34): xp <- example/Vals#xp.
+[2:32..2:34): xp <- example/Vals#`<init>`().(xp)
 [2:36..2:39): Int -> scala/Int#
 [2:45..2:47): yp <- example/Vals#yp().
+[2:45..2:47): yp <- example/Vals#`<init>`().(yp)
 [2:49..2:52): Int -> scala/Int#
 [3:6..3:8): xm <- example/Vals#xm.
 [3:10..3:13): Int -> scala/Int#
@@ -4740,7 +4859,7 @@ Uri => exports-example-Codec.scala
 Text => empty
 Language => Scala
 Symbols => 21 entries
-Occurrences => 33 entries
+Occurrences => 35 entries
 
 Symbols:
 exports/example/Codec# => trait Codec [typeparam T ] extends Object with Decoder[T] with Encoder[T] { self: Codec[T] => +6 decls }
@@ -4788,9 +4907,11 @@ Occurrences:
 [10:11..10:11): <- exports/example/Codec#`<init>`().
 [10:12..10:13): T <- exports/example/Codec#[T]
 [10:15..10:21): decode <- exports/example/Codec#decode.
+[10:15..10:21): decode <- exports/example/Codec#`<init>`().(decode)
 [10:23..10:30): Decoder -> exports/example/Decoder#
 [10:31..10:32): T -> exports/example/Codec#[T]
 [10:35..10:41): encode <- exports/example/Codec#encode.
+[10:35..10:41): encode <- exports/example/Codec#`<init>`().(encode)
 [10:43..10:50): Encoder -> exports/example/Encoder#
 [10:51..10:52): T -> exports/example/Codec#[T]
 [11:10..11:17): Decoder -> exports/example/Decoder#
@@ -4997,7 +5118,7 @@ Uri => i9727.scala
 Text => empty
 Language => Scala
 Symbols => 7 entries
-Occurrences => 9 entries
+Occurrences => 10 entries
 Diagnostics => 1 entries
 
 Symbols:
@@ -5014,6 +5135,7 @@ Occurrences:
 [2:6..2:10): Test <- i9727/Test#
 [2:10..2:10): <- i9727/Test#`<init>`().
 [2:11..2:12): a <- i9727/Test#a.
+[2:11..2:12): a <- i9727/Test#`<init>`().(a)
 [2:14..2:17): Int -> scala/Int#
 [3:4..3:5): a <- i9727/i9727$package.a.
 [3:12..3:16): Test -> i9727/Test#
@@ -5295,7 +5417,7 @@ Uri => recursion.scala
 Text => empty
 Language => Scala
 Symbols => 36 entries
-Occurrences => 48 entries
+Occurrences => 49 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -5363,6 +5485,7 @@ Occurrences:
 [15:18..15:19): N <- recursion/Nats.Succ#[N]
 [15:23..15:26): Nat -> recursion/Nats.Nat#
 [15:28..15:29): p <- recursion/Nats.Succ#p.
+[15:28..15:29): p <- recursion/Nats.Succ#`<init>`().(p)
 [15:31..15:32): N -> recursion/Nats.Succ#[N]
 [15:42..15:45): Nat -> recursion/Nats.Nat#
 [17:25..17:31): toIntg <- recursion/Nats.toIntg().
@@ -5433,7 +5556,7 @@ Uri => semanticdb-Flags.scala
 Text => empty
 Language => Scala
 Symbols => 50 entries
-Occurrences => 78 entries
+Occurrences => 84 entries
 Diagnostics => 5 entries
 Synthetics => 2 entries
 
@@ -5513,10 +5636,13 @@ Occurrences:
 [9:24..9:25): U <- flags/p/package.C#[U]
 [9:27..9:28): V <- flags/p/package.C#[V]
 [9:30..9:31): x <- flags/p/package.C#x.
+[9:30..9:31): x <- flags/p/package.C#`<init>`().(x)
 [9:33..9:34): T -> flags/p/package.C#[T]
 [9:36..9:37): y <- flags/p/package.C#y.
+[9:36..9:37): y <- flags/p/package.C#`<init>`().(y)
 [9:39..9:40): U -> flags/p/package.C#[U]
 [9:42..9:43): z <- flags/p/package.C#z.
+[9:42..9:43): z <- flags/p/package.C#`<init>`().(z)
 [9:45..9:46): V -> flags/p/package.C#[V]
 [10:8..10:12): <- flags/p/package.C#`<init>`(+1).
 [10:22..10:25): ??? -> scala/Predef.`???`().
@@ -5548,10 +5674,13 @@ Occurrences:
 [21:8..21:10): AA <- flags/p/package.AA#
 [21:10..21:10): <- flags/p/package.AA#`<init>`().
 [21:11..21:12): x <- flags/p/package.AA#x.
+[21:11..21:12): x <- flags/p/package.AA#`<init>`().(x)
 [21:14..21:17): Int -> scala/Int#
 [21:23..21:24): y <- flags/p/package.AA#y.
+[21:23..21:24): y <- flags/p/package.AA#`<init>`().(y)
 [21:26..21:29): Int -> scala/Int#
 [21:35..21:36): z <- flags/p/package.AA#z().
+[21:35..21:36): z <- flags/p/package.AA#`<init>`().(z)
 [21:38..21:41): Int -> scala/Int#
 [22:8..22:9): S <- flags/p/package.S#
 [22:9..22:9): <- flags/p/package.S#`<init>`().
@@ -5589,7 +5718,7 @@ Uri => semanticdb-Types.scala
 Text => empty
 Language => Scala
 Symbols => 143 entries
-Occurrences => 248 entries
+Occurrences => 251 entries
 Diagnostics => 4 entries
 Synthetics => 1 entries
 
@@ -5750,6 +5879,7 @@ Occurrences:
 [5:9..5:9): <- types/ann#`<init>`().
 [5:10..5:11): T <- types/ann#[T]
 [5:13..5:14): x <- types/ann#x.
+[5:13..5:14): x <- types/ann#`<init>`().(x)
 [5:16..5:17): T -> types/ann#[T]
 [5:27..5:32): scala -> scala/
 [5:33..5:43): annotation -> scala/annotation/
@@ -5787,6 +5917,7 @@ Occurrences:
 [25:11..25:14): Foo <- types/Foo#
 [25:14..25:14): <- types/Foo#`<init>`().
 [25:15..25:16): s <- types/Foo#s.
+[25:15..25:16): s <- types/Foo#`<init>`().(s)
 [27:7..27:10): Foo <- types/Foo.
 [28:6..28:7): x <- types/Foo.x.
 [28:16..28:26): deprecated -> scala/deprecated#
@@ -5945,6 +6076,7 @@ Occurrences:
 [95:15..95:27): RepeatedType <- types/Test.C#RepeatedType#
 [95:27..95:27): <- types/Test.C#RepeatedType#`<init>`().
 [95:28..95:29): s <- types/Test.C#RepeatedType#s.
+[95:28..95:29): s <- types/Test.C#RepeatedType#`<init>`().(s)
 [95:31..95:37): String -> scala/Predef.String#
 [96:10..96:12): m1 <- types/Test.C#RepeatedType#m1().
 [96:13..96:14): x <- types/Test.C#RepeatedType#m1().(x)
@@ -6009,7 +6141,7 @@ Uri => semanticdb-extract.scala
 Text => empty
 Language => Scala
 Symbols => 18 entries
-Occurrences => 21 entries
+Occurrences => 22 entries
 Synthetics => 6 entries
 
 Symbols:
@@ -6053,6 +6185,7 @@ Occurrences:
 [16:13..16:16): Foo <- _empty_/AnObject.Foo#
 [16:16..16:16): <- _empty_/AnObject.Foo#`<init>`().
 [16:17..16:18): x <- _empty_/AnObject.Foo#x.
+[16:17..16:18): x <- _empty_/AnObject.Foo#`<init>`().(x)
 [16:20..16:23): Int -> scala/Int#
 
 Synthetics:

--- a/tests/semanticdb/todo.md
+++ b/tests/semanticdb/todo.md
@@ -1,13 +1,9 @@
 # Todo List
 Differences between scalameta implementation and dotc.
 
-- Generally put all zero length method calls or arguments in Synthetics section
-  - Pattern val defs -- [unapply|unapplySeq is zero-length]
-  - For comprehensions -- [map|flatMap|withFilter|foreach etc is zero-length].
-  - Implicit conversions -- [span of Apply node is same as its single argument (which has a length)].
-  - Implicit arguments -- [span of argument is zero length].
-- Record signature information in Symbols section.
-- Record access modifier information in Symbols section.
+- Emit for-comprehension desugaring (map|flatMap|withFilter|foreach) in the Synthetics section.
+  These calls are currently skipped (see `SyntheticsExtractor.isForSynthetic`); Scala 2 emits the
+  full desugared tree as a synthetic.
 
 ## Completed
 
@@ -22,3 +18,11 @@ Differences between scalameta implementation and dotc.
 - [x] Avoid symbols with volatile names. - [$1$, $2$, etc].
 - [x] Skip module val
 - [x] Add metac printer.
+- [x] Emit a definition occurrence for primary-constructor parameters, so the accessor and the
+      constructor parameter share the parameter's name range (parity with scalameta#4650; closes the
+      dotc side of scalameta#1327).
+- [x] Emit synthetics for pattern val definitions (unapply|unapplySeq, zero-length).
+- [x] Emit synthetics for implicit conversions.
+- [x] Emit synthetics for implicit|given arguments.
+- [x] Record signature information in Symbols section.
+- [x] Record access modifier information in Symbols section.


### PR DESCRIPTION
Fixes parity with scalameta/scalameta#4650 (see also scalameta/scalameta#1327); no separate scala 3 issue.

A primary constructor parameter previously emitted only its accessor occurrence (`C#x.`); the parameter symbol `C#<init>().(x)` had a `SymbolInformation` but no occurrence, unlike method parameters. `ctorParams` now also registers a definition occurrence at the param's name span, so accessor and parameter share that range. References are unchanged.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by reviewing the change + full golden diff (additive only), ran SemanticdbTests, cross-checked vs Scala 2 output.

## How was the solution tested?

New automated tests (`tests/semanticdb/expect/CtorParams.scala` + regenerated goldens); SemanticdbTests passes locally.