### PR TITLE
reset dirty unimported state after findRef

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -185,7 +185,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    */
   val scope: MutableScope = newScope(nestingLevel)
 
-  /** A temporary data item valid for a single typed ident:
+  /** A temporary data item valid for a single `findRef`:
    *  The set of all root import symbols that have been
    *  encountered as a qualifier of an import so far.
    *  Note: It would be more proper to move importedFromRoot into typedIdent.
@@ -584,7 +584,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       loop(NoContext)
     }
 
-    findRefRecur(NoType, BindingPrec.NothingBound, NoContext)
+    // Root imports hidden during this lookup should not affect later lookups.
+    val savedUnimported = unimported
+    unimported = Set.empty
+    try findRefRecur(NoType, BindingPrec.NothingBound, NoContext)
+    finally unimported = savedUnimported
   }
 
   /** If `ref` is a trackable `TermRef` of an `OrNull` type that flow typing has

--- a/tests/pos/predef-runtimechecked-import.scala
+++ b/tests/pos/predef-runtimechecked-import.scala
@@ -1,0 +1,9 @@
+package example
+
+import scala.Predef.{assert => _, *}
+
+class PredefRuntimeCheckedImport:
+  def f: Any = {
+    for (_ <- 1 to 1) ()
+    Map(1.runtimeChecked -> "")
+  }


### PR DESCRIPTION
add regression test for extension method resolution after corruption via a combination of Predef import shadowing and implicit conversion resolution.

in `findRef`, the mutable `unimported` field of `Typer` can be updated by calling `updateUnimported()`, specifically when a root import (i.e. Predef) has something unimported.

> https://github.com/scala/scala3/blob/ccf349d19dcb3021d339da482151d31c47095a15/compiler/src/dotty/tools/dotc/typer/Typer.scala#L557-L558

on exit of `findRef`, the `unimported` field was not restored to its original state, meaning subsequent `findRef` calls were assuming the same `unimported` set.

So restoring the temporary edits to previous state makes the state isolated to each `findRef` call.

Fixes #26411

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by code review. The problem is that the `unimported` cache is not reset accross calls to `findRef`, so can leave root imports such as `Predef` unimported accross several calls even if the scope should have it visible. The doc comment for `unimported` says it is temporary state, and I dug into the blame, and I found that in commit [cc4533dec9018075bac06d33c353e0ea814ea1f8](https://github.com/scala/scala3/blob/cc4533dec9018075bac06d33c353e0ea814ea1f8/compiler/src/dotty/tools/dotc/typer/Typer.scala) it actually did previously restore the `unimported` after calling `updateUnimported()` but a later refactoring moved the code so perhaps it was unintentional semantic change.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
