### PR TITLE
enable strictEqualityPatternMatching (SIP-67) by default

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -28,7 +28,6 @@ object Feature:
 
   val dependent = experimental("dependent")
   val erasedDefinitions = experimental("erasedDefinitions")
-  val strictEqualityPatternMatching = experimental("strictEqualityPatternMatching")
   val symbolLiterals = deprecated("symbolLiterals")
   val saferExceptions = experimental("saferExceptions")
   val pureFunctions = experimental("pureFunctions")
@@ -68,7 +67,6 @@ object Feature:
     (scala2macros, "Allow Scala 2 macros"),
     (dependent, "Allow dependent method types"),
     (erasedDefinitions, "Allow erased definitions"),
-    (strictEqualityPatternMatching, "relaxed CanEqual checks for ADT pattern matching"),
     (symbolLiterals, "Allow symbol literals"),
     (saferExceptions, "Enable safer exceptions"),
     (pureFunctions, "Enable pure functions for capture checking"),

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -86,10 +86,6 @@ object Implicits:
   def strictEquality(using Context): Boolean =
     ctx.mode.is(Mode.StrictEquality) || Feature.enabled(nme.strictEquality)
 
-  def strictEqualityPatternMatching(using Context): Boolean =
-    Feature.enabled(Feature.strictEqualityPatternMatching)
-
-
   /** A common base class of contextual implicits and of-type implicits which
    *  represents a set of references to implicit definitions.
    */
@@ -319,7 +315,7 @@ object Implicits:
 
       outerImplicits match
         case null => 1
-        case oi if migrateTo3(using irefCtx) 
+        case oi if migrateTo3(using irefCtx)
                 || (irefCtx.owner eq oi.irefCtx.owner) && (isImport || (irefCtx.scope eq oi.irefCtx.scope) && !isLazyImplicit) => oi.level
         case oi => oi.level + 1
     end level
@@ -1045,7 +1041,7 @@ trait Implicits:
    *   - if one of T, U is an error type, or
    *   - if one of T, U is a subtype of the lifted version of the other,
    *     unless strict equality is set.
-   *   - if strictEqualityPatternMatching is set and the necessary conditions are met
+   *   - if the strictEqualityPatternMatching (SIP-67) conditions apply
    */
   def assumedCanEqual(ltp: Type, rtp: Type, leftTree: Tree = EmptyTree)(using Context): Boolean = {
     // Map all non-opaque abstract types to their upper bound.
@@ -1072,15 +1068,14 @@ trait Implicits:
     || rtp.isError
     || locally:
       if strictEquality then
-        strictEqualityPatternMatching &&
-          (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
+        (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
           ltp <:< rtp
       else
         ltp <:< lift(rtp) || rtp <:< lift(ltp)
   }
 
   /** Check that equality tests between types `ltp` and `left.tpe` make sense.
-   * `left` is required to check for the condition for language.strictEqualityPatternMatching.
+   * `left` is required to check for the condition for language.strictEqualityPatternMatching (SIP-67)
    */
   def checkCanEqual(left: Tree, rtp: Type, span: Span)(using Context): Unit =
     val ltp = left.tpe.widen

--- a/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
+++ b/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
@@ -12,13 +12,13 @@ class SIP67Tests extends DottyTest:
     val ctx = checkCompile("typer", source)((_, _) => ())
     if ctx.reporter.hasErrors then
       fail("Unexpected compilation errors were reported")
-  
+
   @Test
   def sip67test1: Unit =
     checkNoErrors:
       """
       import scala.language.strictEquality
-      import scala.language.experimental.strictEqualityPatternMatching
+
       enum Foo:
         case Bar
 
@@ -31,10 +31,8 @@ class SIP67Tests extends DottyTest:
     checkNoErrors:
       """
       import scala.language.strictEquality
-      import scala.language.experimental.strictEqualityPatternMatching
 
       sealed trait Foo
-
       object Foo:
         object Bar extends Foo
 
@@ -48,7 +46,6 @@ class SIP67Tests extends DottyTest:
     checkNoErrors:
       """
       import scala.language.strictEquality
-      import scala.language.experimental.strictEqualityPatternMatching
 
       sealed trait Foo[A]
       object Foo:

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -248,6 +248,7 @@ object language {
      * @see [[https://github.com/scala/improvement-proposals/pull/97]]
      */
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
+    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.9")
     object strictEqualityPatternMatching
 
     /** Experimental support for using indentation for arguments

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -57,6 +57,7 @@ private[scala] object language:
      * @see [[https://github.com/scala/improvement-proposals/pull/97]]
      */
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
+    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.9")
     object strictEqualityPatternMatching
 
     /** Experimental support for using indentation for arguments

--- a/tests/pos/i25979.scala
+++ b/tests/pos/i25979.scala
@@ -1,5 +1,4 @@
 import scala.language.strictEquality
-import scala.language.experimental.strictEqualityPatternMatching
 
 sealed trait Foo[A]
 object Foo:


### PR DESCRIPTION
Hi,

SIP-67 was now accepted by the committee.

https://github.com/scala/improvement-proposals/pull/97#issuecomment-4810777898

This change enables the new behaviour by default, removes the command line flag and deprecates the language import.
Regarding the command line flag, maybe it would be nice to leave it in place but issue a warning that it's a no-op? Otherwise it might confuse users who are using it. But I didn't know how to implement that 🤷‍♂️

## How much have you relied on LLM-based tools in this contribution?

Minimally (code completion)

## How was the solution tested?

Covered by existing tests
