### PR TITLE
Implement relaxed null checks under strictEquality (SIP-79)

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -29,6 +29,7 @@ object Feature:
   val dependent = experimental("dependent")
   val erasedDefinitions = experimental("erasedDefinitions")
   val strictEqualityPatternMatching = experimental("strictEqualityPatternMatching")
+  val relaxedNullChecks = experimental("relaxedNullChecks")
   val symbolLiterals = deprecated("symbolLiterals")
   val saferExceptions = experimental("saferExceptions")
   val pureFunctions = experimental("pureFunctions")
@@ -69,6 +70,7 @@ object Feature:
     (dependent, "Allow dependent method types"),
     (erasedDefinitions, "Allow erased definitions"),
     (strictEqualityPatternMatching, "relaxed CanEqual checks for ADT pattern matching"),
+    (relaxedNullChecks, "relaxed null checks under strictEquality (SIP-79)"),
     (symbolLiterals, "Allow symbol literals"),
     (saferExceptions, "Enable safer exceptions"),
     (pureFunctions, "Enable pure functions for capture checking"),

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1549,7 +1549,7 @@ trait Applications extends Compatibility {
           case Apply(fn @ Select(left, _), right :: Nil) if fn.hasType =>
             val op = fn.symbol
             if (op == defn.Any_== || op == defn.Any_!=)
-              checkCanEqual(left, right.tpe.widen, app.span)
+              checkCanEqual(left, right, app.span)
           case _ =>
         }
         app

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -89,6 +89,9 @@ object Implicits:
   def strictEqualityPatternMatching(using Context): Boolean =
     Feature.enabled(Feature.strictEqualityPatternMatching)
 
+  def relaxedNullChecks(using Context): Boolean =
+    Feature.enabled(Feature.relaxedNullChecks)
+
 
   /** A common base class of contextual implicits and of-type implicits which
    *  represents a set of references to implicit definitions.
@@ -1079,8 +1082,8 @@ trait Implicits:
         strictEqualityPatternMatching &&
           (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
           ltp <:< rtp
-        || isNull(leftTree) && ltp <:< rtp
-        || isNull(rightTree) && rtp <:< ltp
+        || relaxedNullChecks && isNull(leftTree) && ltp <:< rtp
+        || relaxedNullChecks && isNull(rightTree) && rtp <:< ltp
       else
         ltp <:< lift(rtp) || rtp <:< lift(ltp)
   }

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -319,7 +319,7 @@ object Implicits:
 
       outerImplicits match
         case null => 1
-        case oi if migrateTo3(using irefCtx) 
+        case oi if migrateTo3(using irefCtx)
                 || (irefCtx.owner eq oi.irefCtx.owner) && (isImport || (irefCtx.scope eq oi.irefCtx.scope) && !isLazyImplicit) => oi.level
         case oi => oi.level + 1
     end level
@@ -1046,8 +1046,9 @@ trait Implicits:
    *   - if one of T, U is a subtype of the lifted version of the other,
    *     unless strict equality is set.
    *   - if strictEqualityPatternMatching is set and the necessary conditions are met
+   *   - if one of the sides is Null and the other is a supertype of Null
    */
-  def assumedCanEqual(ltp: Type, rtp: Type, leftTree: Tree = EmptyTree)(using Context): Boolean = {
+  def assumedCanEqual(ltp: Type, rtp: Type, leftTree: Tree = EmptyTree, rightTree: Tree = EmptyTree)(using Context): Boolean = {
     // Map all non-opaque abstract types to their upper bound.
     // This is done to check whether such types might plausibly be comparable to each other.
     val lift = new TypeMap {
@@ -1072,9 +1073,14 @@ trait Implicits:
     || rtp.isError
     || locally:
       if strictEquality then
+        def isNull(t: Tree) = t match
+          case Literal(Constants.Constant(null)) => true
+          case _ => false
         strictEqualityPatternMatching &&
           (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
           ltp <:< rtp
+        || isNull(leftTree) && ltp <:< rtp
+        || isNull(rightTree) && rtp <:< ltp
       else
         ltp <:< lift(rtp) || rtp <:< lift(ltp)
   }
@@ -1082,9 +1088,10 @@ trait Implicits:
   /** Check that equality tests between types `ltp` and `left.tpe` make sense.
    * `left` is required to check for the condition for language.strictEqualityPatternMatching.
    */
-  def checkCanEqual(left: Tree, rtp: Type, span: Span)(using Context): Unit =
+  def checkCanEqual(left: Tree, right: Tree, span: Span)(using Context): Unit =
     val ltp = left.tpe.widen
-    if !ctx.isAfterTyper && !assumedCanEqual(ltp, rtp, left) then
+    val rtp = right.tpe.widen
+    if !ctx.isAfterTyper && !assumedCanEqual(ltp, rtp, left, right) then
       val res = implicitArgTree(defn.CanEqualClass.typeRef.appliedTo(ltp, rtp), span)
       implicits.println(i"CanEqual witness found for $ltp / $rtp: $res: ${res.tpe}")
 

--- a/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ReTyper.scala
@@ -174,7 +174,7 @@ class ReTyper(nestingLevel: Int = 0) extends Typer(nestingLevel) with ReChecking
 
   override def inferView(from: Tree, to: Type)(using Context): Implicits.SearchResult =
     Implicits.NoMatchingImplicitsFailure
-  override def checkCanEqual(left: Tree, rtp: Type, span: Span)(using Context): Unit = ()
+  override def checkCanEqual(left: Tree, right: Tree, span: Span)(using Context): Unit = ()
 
   override def widenEnumCase(tree: Tree, pt: Type)(using Context): Tree = tree
 

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -250,6 +250,13 @@ object language {
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
     object strictEqualityPatternMatching
 
+    /** Experimental support for relaxed null checks under strictEquality (SIP-79)
+     *
+     * @see [[https://github.com/scala/improvement-proposals/pull/133]]
+     */
+    @compileTimeOnly("`relaxedNullChecks` can only be used at compile time in import statements")
+    object relaxedNullChecks
+
     /** Experimental support for using indentation for arguments
      */
     @compileTimeOnly("`fewerBraces` can only be used at compile time in import statements")

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -59,6 +59,13 @@ private[scala] object language:
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
     object strictEqualityPatternMatching
 
+    /** Experimental support for relaxed null checks under strictEquality (SIP-79)
+     *
+     * @see [[https://github.com/scala/improvement-proposals/pull/133]]
+     */
+    @compileTimeOnly("`relaxedNullChecks` can only be used at compile time in import statements")
+    object relaxedNullChecks
+
     /** Experimental support for using indentation for arguments
      */
     @compileTimeOnly("`fewerBraces` can only be used at compile time in import statements")

--- a/tests/explicit-nulls/neg/strict-equality.scala
+++ b/tests/explicit-nulls/neg/strict-equality.scala
@@ -1,0 +1,3 @@
+import scala.language.strictEquality
+val x: Int = 42
+val _ = x == null // error

--- a/tests/explicit-nulls/pos/strict-equality.scala
+++ b/tests/explicit-nulls/pos/strict-equality.scala
@@ -1,0 +1,9 @@
+import scala.language.strictEquality
+val x: Int | Null = 42
+val _ = x == null
+val _ = null == x
+val _ = x != null
+val _ = null != x
+val _ = x match
+  case null => 
+  case _: Int =>

--- a/tests/explicit-nulls/pos/strict-equality.scala
+++ b/tests/explicit-nulls/pos/strict-equality.scala
@@ -1,9 +1,10 @@
 import scala.language.strictEquality
+import scala.language.experimental.relaxedNullChecks
 val x: Int | Null = 42
 val _ = x == null
 val _ = null == x
 val _ = x != null
 val _ = null != x
 val _ = x match
-  case null => 
+  case null =>
   case _: Int =>


### PR DESCRIPTION
Experimental implementation of relaxed null checks under strictEquality [SIP-79](https://github.com/scala/improvement-proposals/pull/133), see there for details.

It adds an experimental language option to enable the new behaviour. The implementation is largely analogous to my SIP-67 implementation, #23803.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests
