### PR TITLE
Tests for #26416

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1502,6 +1502,8 @@ class CheckCaptures extends Recheck, SymTransformer:
       finally
         if cls.is(ModuleClass) then
           interpolate(cls.sourceModule.info, cls.sourceModule)
+        else
+          capt.println(i"Use set of $cls = ${cls.useSet}, self type: ${cls.classInfo.selfType}")
         completed += cls
         curEnv = saved
     end recheckClassDef

--- a/tests/neg/i26416.check
+++ b/tests/neg/i26416.check
@@ -1,0 +1,36 @@
+-- [E007] Type Mismatch Error: tests/neg/i26416.scala:10:43 ------------------------------------------------------------
+10 |    val supersecret: Secret^{this} = Secret("Blahblah") // error // error
+   |                                     ^^^^^^^^^^^^^^^^^^
+   |Found:    test1.Secret^{any}
+   |Required: test1.Secret^{SecretService.this}
+   |
+   |Note that capability `any` cannot flow into capture set {SecretService.this}.
+   |
+   |where:    any is a root capability classified as SharedCapability created in value supersecret when constructing instance test1.Secret
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i26416.scala:7:2 --------------------------------------------------------------
+7 |  var commonsecret: Secret^ = new Secret("Goldfinger") // error // error
+  |  ^
+  |Found:    object test1.i26416$package^{any}
+  |Required: object test1.i26416$package^'s1
+  |
+  |Note that capability `any` cannot flow into capture set {}.
+  |
+  |The error occurred for a synthesized tree:  new test1.i26416$package()
+  |
+  |where:    any is a root capability classified as SharedCapability created in package test1 with contributing field val commonsecret
+  |
+  | longer explanation available when compiling with `-explain`
+-- Error: tests/neg/i26416.scala:7:6 -----------------------------------------------------------------------------------
+7 |  var commonsecret: Secret^ = new Secret("Goldfinger") // error // error
+  |      ^
+  |      a field `commonsecret` with `any` in its type need to be put in an object that extends Capability
+-- Error: tests/neg/i26416.scala:10:21 ---------------------------------------------------------------------------------
+10 |    val supersecret: Secret^{this} = Secret("Blahblah") // error // error
+   |                     ^^^^^^^^^^^^^
+   |                 (SecretService.this : test1.SecretService^'s2) cannot be tracked since its capture set is empty
+-- Error: tests/neg/i26416.scala:35:21 ---------------------------------------------------------------------------------
+35 |    val supersecret: Secret^{this} = Secret("Blahblah") // error
+   |                     ^^^^^^^^^^^^^
+   |                     (SecretService.this : SecretService^'s3) cannot be tracked since its capture set is empty

--- a/tests/neg/i26416.check
+++ b/tests/neg/i26416.check
@@ -26,6 +26,41 @@
 7 |  var commonsecret: Secret^ = new Secret("Goldfinger") // error // error
   |      ^
   |      a field `commonsecret` with `any` in its type need to be put in an object that extends Capability
+-- [E007] Type Mismatch Error: tests/neg/i26416.scala:61:43 ------------------------------------------------------------
+61 |    val supersecret: Secret^{this} = Secret("Blahblah") // error
+   |                                     ^^^^^^^^^^^^^^^^^^
+   |Found:    test5.Secret^{any}
+   |Required: test5.Secret^{SecretService.this}
+   |
+   |Note that capability `any` cannot flow into capture set {SecretService.this}.
+   |
+   |where:    any is a root capability classified as SharedCapability created in value supersecret when constructing instance test5.Secret
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i26416.scala:76:21 ------------------------------------------------------------
+76 |      commonsecret = supersecret // error
+   |                     ^^^^^^^^^^^
+   |Found:    (SecretService.this.supersecret : test6.Secret^{SecretService.this})
+   |Required: test6.Secret^{any}
+   |
+   |Note that capability `SecretService.this.supersecret` cannot flow into capture set {any}
+   |because (SecretService.this.supersecret : test6.Secret^{SecretService.this}) in class SecretService is not visible from any in variable commonsecret.
+   |
+   |where:    any is a root capability in the type of variable commonsecret
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg/i26416.scala:91:21 ------------------------------------------------------------
+91 |      commonsecret = supersecret // error
+   |                     ^^^^^^^^^^^
+   |Found:    (SecretService.this.supersecret : test7.Secret^{SecretService.this})
+   |Required: test7.Secret^{any}
+   |
+   |Note that capability `SecretService.this.supersecret` cannot flow into capture set {any}
+   |because (SecretService.this.supersecret : test7.Secret^{SecretService.this}) in class SecretService is not visible from any in variable commonsecret.
+   |
+   |where:    any is a root capability in the type of variable commonsecret
+   |
+   | longer explanation available when compiling with `-explain`
 -- Error: tests/neg/i26416.scala:10:21 ---------------------------------------------------------------------------------
 10 |    val supersecret: Secret^{this} = Secret("Blahblah") // error // error
    |                     ^^^^^^^^^^^^^

--- a/tests/neg/i26416.scala
+++ b/tests/neg/i26416.scala
@@ -1,0 +1,41 @@
+import language.experimental.captureChecking
+
+// Version 1: in package
+package test1 {
+  class Secret(private var s: String) extends caps.SharedCapability:
+    def read(): String = s
+  var commonsecret: Secret^ = new Secret("Goldfinger") // error // error
+  class SecretService():
+    //self: SecretService =>
+    val supersecret: Secret^{this} = Secret("Blahblah") // error // error
+    def leak(): Unit =
+      commonsecret = supersecret
+}
+
+// Version 2: in object in empty package
+object test2 {
+  class Secret(private var s: String) extends caps.SharedCapability:
+    def read(): String = s
+  var commonsecret: Secret^ = new Secret("Goldfinger") // ok
+  class SecretService():
+    //self: SecretService =>
+    val supersecret: Secret^{this} = Secret("Blahblah") // ok
+    def leak(): Unit =
+      commonsecret = supersecret
+        // ok since this: SecretService^{test2} and test2 contains commonsecret
+}
+
+// Version 3: in method
+def test3 = {
+  class Secret(private var s: String) extends caps.SharedCapability:
+    def read(): String = s
+  var commonsecret: Secret^ = new Secret("Goldfinger")
+  class SecretService():
+    //self: SecretService =>
+    val supersecret: Secret^{this} = Secret("Blahblah") // error
+    def leak(): Unit =
+      commonsecret = supersecret
+}
+
+
+

--- a/tests/neg/i26416.scala
+++ b/tests/neg/i26416.scala
@@ -37,5 +37,61 @@ def test3 = {
       commonsecret = supersecret
 }
 
+// Version 4: Explicit use declarations to enclosing object: ok
+object test4 {
+  class Secret(private var s: String) extends caps.SharedCapability:
+    def read(): String = s
+  var commonsecret: Secret^ = new Secret("Goldfinger")
+  class SecretService() uses test4:
+    //self: SecretService =>
+    val supersecret: Secret^{this} = Secret("Blahblah")
+    def leak(): Unit =
+      commonsecret = supersecret
+}
+
+// Version 5: Explicit use declarations to nested object
+package test5 {
+  class Secret(private var s: String) extends caps.SharedCapability:
+    def read(): String = s
+
+  object Common extends caps.SharedCapability:
+    var commonsecret: Secret^ = new Secret("Goldfinger")
+
+  class SecretService() uses Common:
+    val supersecret: Secret^{this} = Secret("Blahblah") // error
+    def leak(): Unit =
+      Common.commonsecret = supersecret
+}
+
+// Version 6: Extends SharedCapability
+object test6 {
+  class Secret(private var s: String):
+    def read(): String = s
+
+  private var commonsecret: Secret^ = new Secret("Goldfinger")
+
+  class SecretService extends caps.SharedCapability:
+    val supersecret: Secret^{this} = Secret("Blahblah")
+    def leak(): Unit =
+      commonsecret = supersecret // error
+}
+
+// Version 7: Has self type with any
+object test7 {
+
+  class Secret(private var s: String):
+    def read(): String = s
+
+  private var commonsecret: Secret^ = new Secret("Goldfinger")
+
+  class SecretService { this: SecretService^ =>
+
+    val supersecret: Secret^{this} = Secret("Blahblah")
+    def leak(): Unit =
+      commonsecret = supersecret // error
+  }
+}
+
+
 
 


### PR DESCRIPTION
Tests that exercise variants of #26416. See the issue comment for an explanation of results.

Closes #26416

