### PR TITLE
Enable strictEqualityPatternMatching (SIP-67) by default & add deprecation mechanics for `-language` feature flags

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -361,6 +361,8 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
 
     compiling = true
 
+    Feature.checkDeprecatedSettingFeatures
+
     profile =
       if ctx.settings.Vprofile.value
         || !ctx.settings.VprofileSortedBy.value.isEmpty

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -13,6 +13,7 @@ import NameKinds.QualifiedName
 import Annotations.ExperimentalAnnotation
 import Annotations.PreviewAnnotation
 import Settings.Setting.ChoiceWithHelp
+import ast.untpd
 
 object Feature:
 
@@ -82,6 +83,26 @@ object Feature:
     (safe, "Require safe mode"),
     (dedentedStringLiterals, "Enable experimental dedented string literals"),
   )
+
+  /** Features that are now standard; the language import / -language choice is
+   *  still accepted but deprecated and has no effect. name -> deprecation message. */
+  val deprecatedFeatures: List[(TermName, String)] = List()
+
+  /** Deprecated features that were enabled via the -language command-line setting. */
+  def deprecatedSettingFeatures(using Context): List[(TermName, String)] =
+    deprecatedFeatures.filter((n, _) => enabledBySetting(n))
+
+  /** Emit a deprecation warning for each deprecated feature enabled via -language. */
+  def checkDeprecatedSettingFeatures(using Context): Unit =
+    for (name, msg) <- deprecatedSettingFeatures do
+      report.deprecationWarning(em"Option -language:$name is deprecated: $msg", NoSourcePosition)
+
+  /** Warn when a deprecated language feature is imported. */
+  def warnDeprecatedLanguageImports(prefix: TermName, selectors: List[untpd.ImportSelector])(using Context): Unit =
+    for sel <- selectors if !sel.isWildcard && !sel.isUnimport do
+      val feature = QualifiedName(prefix, sel.name)
+      deprecatedFeatures.collectFirst:
+        case (`feature`, msg) => report.deprecationWarning(em"$msg", sel.srcPos)
 
   // legacy language features from Scala 2 that are no longer supported.
   val legacyFeatures = List(

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -69,7 +69,6 @@ object Feature:
     (scala2macros, "Allow Scala 2 macros"),
     (dependent, "Allow dependent method types"),
     (erasedDefinitions, "Allow erased definitions"),
-    (strictEqualityPatternMatching, "relaxed CanEqual checks for ADT pattern matching"),
     (symbolLiterals, "Allow symbol literals"),
     (saferExceptions, "Enable safer exceptions"),
     (pureFunctions, "Enable pure functions for capture checking"),
@@ -86,7 +85,10 @@ object Feature:
 
   /** Features that are now standard; the language import / -language choice is
    *  still accepted but deprecated and has no effect. name -> deprecation message. */
-  val deprecatedFeatures: List[(TermName, String)] = List()
+  val deprecatedFeatures: List[(TermName, String)] = List(
+    (strictEqualityPatternMatching,
+     "`strictEqualityPatternMatching` is now standard, no language import is needed"),
+  )
 
   /** Deprecated features that were enabled via the -language command-line setting. */
   def deprecatedSettingFeatures(using Context): List[(TermName, String)] =

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
@@ -22,7 +22,8 @@ object ScalaSettingsProperties:
       .map(_.toString).toList
 
   def supportedLanguageFeatures: List[ChoiceWithHelp[String]] =
-    Feature.values.map((n, d) => ChoiceWithHelp(n.toString, d))
+    (Feature.values ++ Feature.deprecatedFeatures.map((n, _) => (n, "(deprecated, no effect)")))
+      .map((n, d) => ChoiceWithHelp(n.toString, d))
 
   val legacyLanguageFeatures: List[String] =
     Feature.legacyFeatures

--- a/compiler/src/dotty/tools/dotc/typer/Implicits.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Implicits.scala
@@ -86,10 +86,6 @@ object Implicits:
   def strictEquality(using Context): Boolean =
     ctx.mode.is(Mode.StrictEquality) || Feature.enabled(nme.strictEquality)
 
-  def strictEqualityPatternMatching(using Context): Boolean =
-    Feature.enabled(Feature.strictEqualityPatternMatching)
-
-
   /** A common base class of contextual implicits and of-type implicits which
    *  represents a set of references to implicit definitions.
    */
@@ -319,7 +315,7 @@ object Implicits:
 
       outerImplicits match
         case null => 1
-        case oi if migrateTo3(using irefCtx) 
+        case oi if migrateTo3(using irefCtx)
                 || (irefCtx.owner eq oi.irefCtx.owner) && (isImport || (irefCtx.scope eq oi.irefCtx.scope) && !isLazyImplicit) => oi.level
         case oi => oi.level + 1
     end level
@@ -1045,7 +1041,7 @@ trait Implicits:
    *   - if one of T, U is an error type, or
    *   - if one of T, U is a subtype of the lifted version of the other,
    *     unless strict equality is set.
-   *   - if strictEqualityPatternMatching is set and the necessary conditions are met
+   *   - if the strictEqualityPatternMatching (SIP-67) conditions apply
    */
   def assumedCanEqual(ltp: Type, rtp: Type, leftTree: Tree = EmptyTree)(using Context): Boolean = {
     // Map all non-opaque abstract types to their upper bound.
@@ -1072,15 +1068,14 @@ trait Implicits:
     || rtp.isError
     || locally:
       if strictEquality then
-        strictEqualityPatternMatching &&
-          (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
+        (leftTree.symbol.isAllOf(Flags.EnumValue) || leftTree.symbol.is(Flags.Module)) &&
           ltp <:< rtp
       else
         ltp <:< lift(rtp) || rtp <:< lift(ltp)
   }
 
   /** Check that equality tests between types `ltp` and `left.tpe` make sense.
-   * `left` is required to check for the condition for language.strictEqualityPatternMatching.
+   * `left` is required to check for the condition for language.strictEqualityPatternMatching (SIP-67)
    */
   def checkCanEqual(left: Tree, rtp: Type, span: Span)(using Context): Unit =
     val ltp = left.tpe.widen

--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -3625,6 +3625,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     checkLegalImportPath(expr1)
     val selectors1 = typedSelectors(imp.selectors)
     checkImportSelectors(expr1.tpe, selectors1)
+    untpd.languageImport(imp.expr).foreach(Feature.warnDeprecatedLanguageImports(_, imp.selectors))
     assignType(cpy.Import(imp)(expr1, selectors1), sym)
 
   def typedExport(exp: untpd.Export)(using Context): Tree =

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -5,6 +5,9 @@ import CommandLineParser.tokenize
 import Settings.*
 import dotty.tools.Useables.given
 import dotty.tools.dotc.config.ScalaSettingCategories.*
+import dotty.tools.dotc.reporting.StoreReporter
+import core.Contexts.{Context, ContextBase}
+import dotty.tools.vulpix.TestConfiguration
 import org.junit.Test
 import org.junit.Assert.*
 import core.Decorators.toMessage
@@ -264,6 +267,30 @@ class ScalaSettingsTests:
     assertEquals(2, result.warnings.length)
     assertEquals("Option -Xfatal-warnings is a deprecated alias: use -Werror instead", result.warnings.head)
     assertEquals(0, result.errors.length)
+
+  private def deprecatedLanguageSettingWarnings(deprecation: Boolean): (Int, List[String]) =
+    val rep = new StoreReporter()
+    val base = new ContextBase {}
+    given Context = base.initialCtx.fresh
+      .setReporter(rep)
+      .setSetting(ScalaSettings.classpath, TestConfiguration.basicClasspath)
+      .setSetting(ScalaSettings.language, List("experimental.strictEqualityPatternMatching").asInstanceOf)
+      .setSetting(ScalaSettings.deprecation, deprecation)
+    base.initialize()(using summon[Context])
+    Feature.checkDeprecatedSettingFeatures
+    (rep.warningCount, rep.removeBufferedMessages.map(_.message))
+
+  @Test def `deprecated -language features warn with option name when -deprecation is on`: Unit =
+    val (count, messages) = deprecatedLanguageSettingWarnings(deprecation = true)
+    assertEquals(1, count)
+    assertEquals(
+      "Option -language:experimental.strictEqualityPatternMatching is deprecated: `strictEqualityPatternMatching` is now standard, no language import is needed",
+      messages.head,
+    )
+
+  @Test def `deprecated -language features are summarized when -deprecation is off`: Unit =
+    val (count, _) = deprecatedLanguageSettingWarnings(deprecation = false)
+    assertEquals(0, count)
 
   // see sbt-test/pipelining/pipelining-test/test
   @Test def `-Xearly-tasty-output preferPrevious does not warn on change of value`: Unit =

--- a/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
+++ b/compiler/test/dotty/tools/dotc/typer/SIP67Tests.scala
@@ -12,13 +12,13 @@ class SIP67Tests extends DottyTest:
     val ctx = checkCompile("typer", source)((_, _) => ())
     if ctx.reporter.hasErrors then
       fail("Unexpected compilation errors were reported")
-  
+
   @Test
   def sip67test1: Unit =
     checkNoErrors:
       """
       import scala.language.strictEquality
-      import scala.language.experimental.strictEqualityPatternMatching
+
       enum Foo:
         case Bar
 
@@ -31,10 +31,8 @@ class SIP67Tests extends DottyTest:
     checkNoErrors:
       """
       import scala.language.strictEquality
-      import scala.language.experimental.strictEqualityPatternMatching
 
       sealed trait Foo
-
       object Foo:
         object Bar extends Foo
 
@@ -48,7 +46,6 @@ class SIP67Tests extends DottyTest:
     checkNoErrors:
       """
       import scala.language.strictEquality
-      import scala.language.experimental.strictEqualityPatternMatching
 
       sealed trait Foo[A]
       object Foo:

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -248,6 +248,7 @@ object language {
      * @see [[https://github.com/scala/improvement-proposals/pull/97]]
      */
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
+    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.9")
     object strictEqualityPatternMatching
 
     /** Experimental support for using indentation for arguments

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -57,6 +57,7 @@ private[scala] object language:
      * @see [[https://github.com/scala/improvement-proposals/pull/97]]
      */
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
+    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.9")
     object strictEqualityPatternMatching
 
     /** Experimental support for using indentation for arguments

--- a/tests/warn/sip67-deprecated-flag.scala
+++ b/tests/warn/sip67-deprecated-flag.scala
@@ -1,0 +1,13 @@
+//> using options -deprecation -language:experimental.strictEqualityPatternMatching
+
+import scala.language.strictEquality
+
+sealed trait Foo[A]
+object Foo:
+  object Bar extends Foo[Int]
+
+def a[A](a: Foo[A]) =
+  a match
+    case Foo.Bar =>
+
+// nopos-warn `strictEqualityPatternMatching` is now standard, no language import is needed

--- a/tests/warn/sip67-deprecated-import.scala
+++ b/tests/warn/sip67-deprecated-import.scala
@@ -1,4 +1,7 @@
+//> using options -deprecation
+
 import scala.language.strictEquality
+import scala.language.experimental.strictEqualityPatternMatching // warn
 
 sealed trait Foo[A]
 object Foo:


### PR DESCRIPTION
Alternative to https://github.com/scala/scala3/pull/26415

The main difference is that this PR adds mechanics for deprecation of `-language` feature flags, sets `-language:experimental.strictEqualityPatternMatching` as deprecated and no-op.

```
Option -language:experimental.strictEqualityPatternMatching is deprecated: `strictEqualityPatternMatching` is now standard, no language import is needed
```

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by reviewing the changes, running tests both automatically and manually

## How was the solution tested?
Both new and existing automated tests

## Additional notes
cc @mberndt123 
