### PR TITLE
Add back and deprecate already stabilised/in-preview language feature flags

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -88,6 +88,18 @@ object Feature:
   val deprecatedFeatures: List[(TermName, String)] = List(
     (strictEqualityPatternMatching,
      "`strictEqualityPatternMatching` is now standard, no language import is needed"),
+    (experimental("fewerBraces"),
+     "`fewerBraces` is now standard, no language import is needed"),
+    (experimental("relaxedExtensionImports"),
+     "`experimental.relaxedExtensionImports` is now standard, no language import is needed"),
+    (experimental("clauseInterleaving"),
+     "`clauseInterleaving` is now standard, no language import is needed"),
+    (experimental("betterMatchTypeExtractors"),
+     "`experimental.betterMatchTypeExtractors` is now standard, no language import is needed"),
+    (experimental("namedTuples"),
+     "`experimental.namedTuples` is now standard, no language import is needed"),
+    (experimental("betterFors"),
+     "`experimental.betterFors` is now standard, no language import is needed"),
   )
 
   /** Deprecated features that were enabled via the -language command-line setting. */

--- a/compiler/src/dotty/tools/dotc/config/Feature.scala
+++ b/compiler/src/dotty/tools/dotc/config/Feature.scala
@@ -74,7 +74,6 @@ object Feature:
     (pureFunctions, "Enable pure functions for capture checking"),
     (captureChecking, "Enable experimental capture checking"),
     (separationChecking, "Enable experimental separation checking (implies captureChecking)"),
-    (into, "Allow into modifier on parameter types"),
     (modularity, "Enable experimental modularity features"),
     (multiSpreads, "Enable experimental varargs with multi-spreads"),
     (subCases, "Enable experimental match expressions with sub-cases"),
@@ -100,6 +99,10 @@ object Feature:
      "`experimental.namedTuples` is now standard, no language import is needed"),
     (experimental("betterFors"),
      "`experimental.betterFors` is now standard, no language import is needed"),
+    (into,
+     "The `into` language import is no longer needed; the `into` modifier is now in preview and can be enabled with the -preview flag"),
+    (experimental("packageObjectValues"),
+     "The `experimental.packageObjectValues` language import is no longer needed; the feature is now in preview and can be enabled with the -preview flag"),
   )
 
   /** Deprecated features that were enabled via the -language command-line setting. */

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -292,6 +292,22 @@ class ScalaSettingsTests:
     val (count, _) = deprecatedLanguageSettingWarnings(deprecation = false)
     assertEquals(0, count)
 
+  @Test def `deprecated -language fewerBraces warns with option name when -deprecation is on`: Unit =
+    val rep = new StoreReporter()
+    val base = new ContextBase {}
+    given Context = base.initialCtx.fresh
+      .setReporter(rep)
+      .setSetting(ScalaSettings.classpath, TestConfiguration.basicClasspath)
+      .setSetting(ScalaSettings.language, List("experimental.fewerBraces").asInstanceOf)
+      .setSetting(ScalaSettings.deprecation, true)
+    base.initialize()(using summon[Context])
+    Feature.checkDeprecatedSettingFeatures
+    assertEquals(1, rep.warningCount)
+    assertEquals(
+      "Option -language:experimental.fewerBraces is deprecated: `fewerBraces` is now standard, no language import is needed",
+      rep.removeBufferedMessages.head.message,
+    )
+
   // see sbt-test/pipelining/pipelining-test/test
   @Test def `-Xearly-tasty-output preferPrevious does not warn on change of value`: Unit =
     val settings = ScalaSettings

--- a/tests/init/neg/interleaving-params.scala
+++ b/tests/init/neg/interleaving-params.scala
@@ -1,5 +1,3 @@
-import scala.language.experimental.clauseInterleaving
-
 class Params{
     def bar[T](x: T)[T]: String = ??? // error
     def zoo(x: Int)[T, U](x: U): T = ??? // error

--- a/tests/init/pos/interleaving-overload.scala
+++ b/tests/init/pos/interleaving-overload.scala
@@ -1,5 +1,3 @@
-import scala.language.experimental.clauseInterleaving
-
 class A{
 
     def f1[T](x: Any)[U] = ???

--- a/tests/init/pos/interleaving-params.scala
+++ b/tests/init/pos/interleaving-params.scala
@@ -1,6 +1,5 @@
 import scala.collection.mutable.AbstractSet
 import scala.collection.mutable.BitSet
-import scala.language.experimental.clauseInterleaving
 
 class Params{
     type U

--- a/tests/neg/named-tuples-4.check
+++ b/tests/neg/named-tuples-4.check
@@ -1,16 +1,16 @@
--- Error: tests/neg/named-tuples-4.scala:10:35 -------------------------------------------------------------------------
-10 |    case PersonCaseClass(name = n, age) => () // error
-   |                                   ^^^
-   |                                   Illegal combination of named and unnamed tuple elements
--- Error: tests/neg/named-tuples-4.scala:11:31 -------------------------------------------------------------------------
-11 |    case PersonCaseClass(name, age = a) => () // error
-   |                               ^^^^^^^
-   |                               Illegal combination of named and unnamed tuple elements
--- Error: tests/neg/named-tuples-4.scala:15:20 -------------------------------------------------------------------------
-15 |    case (name = n, age) => () // error
+-- Error: tests/neg/named-tuples-4.scala:7:35 --------------------------------------------------------------------------
+7 |    case PersonCaseClass(name = n, age) => () // error
+  |                                   ^^^
+  |                                   Illegal combination of named and unnamed tuple elements
+-- Error: tests/neg/named-tuples-4.scala:8:31 --------------------------------------------------------------------------
+8 |    case PersonCaseClass(name, age = a) => () // error
+  |                               ^^^^^^^
+  |                               Illegal combination of named and unnamed tuple elements
+-- Error: tests/neg/named-tuples-4.scala:12:20 -------------------------------------------------------------------------
+12 |    case (name = n, age) => () // error
    |                    ^^^
    |                    Illegal combination of named and unnamed tuple elements
--- Error: tests/neg/named-tuples-4.scala:16:16 -------------------------------------------------------------------------
-16 |    case (name, age = a) => () // error
+-- Error: tests/neg/named-tuples-4.scala:13:16 -------------------------------------------------------------------------
+13 |    case (name, age = a) => () // error
    |                ^^^^^^^
    |                Illegal combination of named and unnamed tuple elements

--- a/tests/neg/named-tuples-4.scala
+++ b/tests/neg/named-tuples-4.scala
@@ -1,7 +1,4 @@
-import language.experimental.namedTuples
-import scala.annotation.experimental
-
-@experimental object Test:
+object Test:
 
   case class PersonCaseClass(name: String, age: Int)
 

--- a/tests/warn/better-fors-deprecated-flag.scala
+++ b/tests/warn/better-fors-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.betterFors
+
+val x = 1
+
+// nopos-warn `experimental.betterFors` is now standard, no language import is needed

--- a/tests/warn/better-fors-deprecated-import.scala
+++ b/tests/warn/better-fors-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.betterFors // warn
+
+val x = 1

--- a/tests/warn/better-match-type-extractors-deprecated-flag.scala
+++ b/tests/warn/better-match-type-extractors-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.betterMatchTypeExtractors
+
+val x = 1
+
+// nopos-warn `experimental.betterMatchTypeExtractors` is now standard, no language import is needed

--- a/tests/warn/better-match-type-extractors-deprecated-import.scala
+++ b/tests/warn/better-match-type-extractors-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.betterMatchTypeExtractors // warn
+
+val x = 1

--- a/tests/warn/clause-interleaving-deprecated-flag.scala
+++ b/tests/warn/clause-interleaving-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.clauseInterleaving
+
+val x = 1
+
+// nopos-warn `clauseInterleaving` is now standard, no language import is needed

--- a/tests/warn/clause-interleaving-deprecated-import.scala
+++ b/tests/warn/clause-interleaving-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.clauseInterleaving // warn
+
+val x = 1

--- a/tests/warn/fewerbraces-deprecated-flag.scala
+++ b/tests/warn/fewerbraces-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.fewerBraces
+
+val x = 1
+
+// nopos-warn `fewerBraces` is now standard, no language import is needed

--- a/tests/warn/fewerbraces-deprecated-import.scala
+++ b/tests/warn/fewerbraces-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.fewerBraces // warn
+
+val x = 1

--- a/tests/warn/into-deprecated-flag.scala
+++ b/tests/warn/into-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.into
+
+val x = 1
+
+// nopos-warn The `into` language import is no longer needed; the `into` modifier is now in preview and can be enabled with the -preview flag

--- a/tests/warn/into-deprecated-import.scala
+++ b/tests/warn/into-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.into // warn
+
+val x = 1

--- a/tests/warn/named-tuples-deprecated-flag.scala
+++ b/tests/warn/named-tuples-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.namedTuples
+
+val x = 1
+
+// nopos-warn `experimental.namedTuples` is now standard, no language import is needed

--- a/tests/warn/named-tuples-deprecated-import.scala
+++ b/tests/warn/named-tuples-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.namedTuples // warn
+
+val x = 1

--- a/tests/warn/package-object-values-deprecated-flag.scala
+++ b/tests/warn/package-object-values-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.packageObjectValues
+
+val x = 1
+
+// nopos-warn The `experimental.packageObjectValues` language import is no longer needed; the feature is now in preview and can be enabled with the -preview flag

--- a/tests/warn/package-object-values-deprecated-import.scala
+++ b/tests/warn/package-object-values-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.packageObjectValues // warn
+
+val x = 1

--- a/tests/warn/relaxed-extension-imports-deprecated-flag.scala
+++ b/tests/warn/relaxed-extension-imports-deprecated-flag.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation -language:experimental.relaxedExtensionImports
+
+val x = 1
+
+// nopos-warn `experimental.relaxedExtensionImports` is now standard, no language import is needed

--- a/tests/warn/relaxed-extension-imports-deprecated-import.scala
+++ b/tests/warn/relaxed-extension-imports-deprecated-import.scala
@@ -1,0 +1,5 @@
+//> using options -deprecation
+
+import scala.language.experimental.relaxedExtensionImports // warn
+
+val x = 1


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala3/pull/26424#issuecomment-4830631030 (as suggested by @bishabosha, thanks!)

This adds back language feature flags, which were removed when their features got stabilised. We can now add them back, leverage the deprecation mechanism and ease the upgrade from earlier versions.

Preview features got similar treatment.

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by reviewing the content and running tests

## How was the solution tested?
New automated tests
