### PR TITLE
Fix experimental flags for SIP-67 to be enabled at Scala 3.10

### DIFF
--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -248,7 +248,7 @@ object language {
      * @see [[https://github.com/scala/improvement-proposals/pull/97]]
      */
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
-    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.9")
+    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.10")
     object strictEqualityPatternMatching
 
     /** Experimental support for using indentation for arguments

--- a/library/src/scala/runtime/stdLibPatches/language.scala
+++ b/library/src/scala/runtime/stdLibPatches/language.scala
@@ -57,7 +57,7 @@ private[scala] object language:
      * @see [[https://github.com/scala/improvement-proposals/pull/97]]
      */
     @compileTimeOnly("`strictEqualityPatternMatching` can only be used at compile time in import statements")
-    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.9")
+    @deprecated("`strictEqualityPatternMatching` is now standard, no language import is needed", since = "3.10")
     object strictEqualityPatternMatching
 
     /** Experimental support for using indentation for arguments


### PR DESCRIPTION
As per https://github.com/scala/scala3/pull/26424#issuecomment-4833792920, I missed this 🤦 
cc @mberndt123 

## Have you relied on LLM-based tools in this contribution?
No

## How was the solution tested?
existing tests