### PR TITLE
Io, ref, nums (1): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -21,12 +21,19 @@ import scala.language.`2.13`
  *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Byte private extends AnyVal {
+  /** Returns the value of this as a [[scala.Byte]]. */
   def toByte: Byte
+  /** Returns the value of this as a [[scala.Short]]. */
   def toShort: Short
+  /** Returns the value of this as a [[scala.Char]]. */
   def toChar: Char
+  /** Returns the value of this as an [[scala.Int]]. */
   def toInt: Int
+  /** Returns the value of this as a [[scala.Long]]. */
   def toLong: Long
+  /** Returns the value of this as a [[scala.Float]]. */
   def toFloat: Float
+  /** Returns the value of this as a [[scala.Double]]. */
   def toDouble: Double
 
   /** Returns the bitwise negation of this value.
@@ -644,10 +651,30 @@ object Byte extends AnyValCompanion {
    *  @return the value of `x` widened to the target numeric type
    */
   import scala.language.implicitConversions
+  /** Returns the given `Byte` value as a [[scala.Short]].
+   *
+   *  @param x the `Byte` value to convert
+   */
   implicit def byte2short(x: Byte): Short = x.toShort
+  /** Returns the given `Byte` value as an [[scala.Int]].
+   *
+   *  @param x the `Byte` value to convert
+   */
   implicit def byte2int(x: Byte): Int = x.toInt
+  /** Returns the given `Byte` value as a [[scala.Long]].
+   *
+   *  @param x the `Byte` value to convert
+   */
   implicit def byte2long(x: Byte): Long = x.toLong
+  /** Returns the given `Byte` value as a [[scala.Float]].
+   *
+   *  @param x the `Byte` value to convert
+   */
   implicit def byte2float(x: Byte): Float = x.toFloat
+  /** Returns the given `Byte` value as a [[scala.Double]].
+   *
+   *  @param x the `Byte` value to convert
+   */
   implicit def byte2double(x: Byte): Double = x.toDouble
 
   extension (self: Byte) {

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -23,12 +23,23 @@ import scala.collection.immutable.NumericRange
  *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Char private extends AnyVal {
+  /** Returns the value of this `Char` as a `Byte`, which may involve
+   *  truncation.
+   */
   def toByte: Byte
+  /** Returns the value of this `Char` as a `Short`, which may involve a change
+   *  of sign.
+   */
   def toShort: Short
+  /** Returns this `Char` value, unmodified. */
   def toChar: Char
+  /** Returns the value of this `Char` as an `Int`. */
   def toInt: Int
+  /** Returns the value of this `Char` as a `Long`. */
   def toLong: Long
+  /** Returns the value of this `Char` as a `Float`. */
   def toFloat: Float
+  /** Returns the value of this `Char` as a `Double`. */
   def toDouble: Double
 
   /** Returns the bitwise negation of this value.
@@ -646,9 +657,25 @@ object Char extends AnyValCompanion {
    *  @return the value of `x` widened to the corresponding numeric type
    */
   import scala.language.implicitConversions
+  /** Returns the given `Char` value widened to an `Int`.
+   *
+   *  @param x the `Char` value to convert
+   */
   implicit def char2int(x: Char): Int = x.toInt
+  /** Returns the given `Char` value widened to a `Long`.
+   *
+   *  @param x the `Char` value to convert
+   */
   implicit def char2long(x: Char): Long = x.toLong
+  /** Returns the given `Char` value widened to a `Float`.
+   *
+   *  @param x the `Char` value to convert
+   */
   implicit def char2float(x: Char): Float = x.toFloat
+  /** Returns the given `Char` value widened to a `Double`.
+   *
+   *  @param x the `Char` value to convert
+   */
   implicit def char2double(x: Char): Double = x.toDouble
 
   extension (self: Char) {

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -21,12 +21,37 @@ import scala.language.`2.13`
  *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Double private extends AnyVal {
+  /** Returns this value first converted to an `Int` (NaN to `0`, an infinite
+   *  value or a finite value outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`, otherwise rounded toward zero), then narrowed to a `Byte`
+   *  by keeping only its low-order 8 bits.
+   */
   def toByte: Byte
+  /** Returns this value first converted to an `Int` (NaN to `0`, an infinite
+   *  value or a finite value outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`, otherwise rounded toward zero), then narrowed to a `Short`
+   *  by keeping only its low-order 16 bits.
+   */
   def toShort: Short
+  /** Returns this value first converted to an `Int` (NaN to `0`, an infinite
+   *  value or a finite value outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`, otherwise rounded toward zero), then narrowed to a `Char`
+   *  by keeping only its low-order 16 bits.
+   */
   def toChar: Char
+  /** Returns this value as an `Int`, rounded toward zero. A NaN value converts
+   *  to `0`, and an infinite value or a finite value outside the `Int` range
+   *  converts to `Int.MinValue` or `Int.MaxValue`.
+   */
   def toInt: Int
+  /** Returns this value as a `Long`, rounded toward zero. A NaN value converts
+   *  to `0L`, and an infinite value or a finite value outside the `Long` range
+   *  converts to `Long.MinValue` or `Long.MaxValue`.
+   */
   def toLong: Long
+  /** Returns this value as a `Float`, which may lose precision. */
   def toFloat: Float
+  /** Returns this value, unmodified. */
   def toDouble: Double
 
   /** Returns this value, unmodified. */

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -21,12 +21,39 @@ import scala.language.`2.13`
  *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Float private extends AnyVal {
+  /** Returns this value first converted to an `Int` (NaN to `0`, an infinite
+   *  value or a finite value outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`, otherwise rounded toward zero), then narrowed to a `Byte`
+   *  by keeping only its low-order 8 bits.
+   */
   def toByte: Byte
+  /** Returns this value first converted to an `Int` (NaN to `0`, an infinite
+   *  value or a finite value outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`, otherwise rounded toward zero), then narrowed to a `Short`
+   *  by keeping only its low-order 16 bits.
+   */
   def toShort: Short
+  /** Returns this value first converted to an `Int` (NaN to `0`, an infinite
+   *  value or a finite value outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`, otherwise rounded toward zero), then narrowed to a `Char`
+   *  by keeping only its low-order 16 bits.
+   */
   def toChar: Char
+  /** Returns this value as an `Int`, rounded toward zero. A NaN value converts
+   *  to `0`, and an infinite value or a finite value outside the `Int` range
+   *  converts to `Int.MinValue` or `Int.MaxValue`.
+   */
   def toInt: Int
+  /** Returns this value as a `Long`, rounded toward zero. A NaN value converts
+   *  to `0L`, and an infinite value or a finite value outside the `Long` range
+   *  converts to `Long.MinValue` or `Long.MaxValue`.
+   */
   def toLong: Long
+  /** Returns this value, unmodified. */
   def toFloat: Float
+  /** Returns this value widened to a `Double`. The conversion is exact, since
+   *  every `Float` value is representable as a `Double`.
+   */
   def toDouble: Double
 
   /** Returns this value, unmodified. */
@@ -399,6 +426,11 @@ object Float extends AnyValCompanion {
    *  @return the `Double` value resulting from widening `x`
    */
   import scala.language.implicitConversions
+  /** Returns `x` widened to a `Double`, the language-mandated coercion from
+   *  `Float` to the "wider" `Double` type.
+   *
+   *  @param x the `Float` value to convert
+   */
   implicit def float2double(x: Float): Double = x.toDouble
 
   extension (self: Float) {

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -21,12 +21,25 @@ import scala.language.`2.13`
  *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Int private extends AnyVal {
+  /** Returns this value as a [[scala.Byte]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toByte: Byte
+  /** Returns this value as a [[scala.Short]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toShort: Short
+  /** Returns this value as a [[scala.Char]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toChar: Char
+  /** Returns this value unchanged. */
   def toInt: Int
+  /** Returns this value as a [[scala.Long]]. */
   def toLong: Long
+  /** Returns this value as a [[scala.Float]], which may lose precision. */
   def toFloat: Float
+  /** Returns this value as a [[scala.Double]]. */
   def toDouble: Double
 
   /** Returns the bitwise negation of this value.
@@ -641,8 +654,21 @@ object Int extends AnyValCompanion {
   /** Language mandated coercions from `Int` to "wider" types. */
   import scala.language.implicitConversions
   @deprecated("Implicit conversion from Int to Float is dangerous because it loses precision. Write `.toFloat` instead.", "2.13.1")
+  /** Returns `x` converted to a `Float`.
+   *
+   *  @param x the `Int` value to convert
+   *  @return `x` as a `Float`; because `Float` has fewer significant bits than `Int`, the result may lose precision
+   */
   implicit def int2float(x: Int): Float = x.toFloat
+  /** Returns `x` converted to a `Long`.
+   *
+   *  @param x the `Int` value to convert
+   */
   implicit def int2long(x: Int): Long = x.toLong
+  /** Returns `x` converted to a `Double`.
+   *
+   *  @param x the `Int` value to convert
+   */
   implicit def int2double(x: Int): Double = x.toDouble
 
   extension (self: Int) {

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -23,12 +23,27 @@ import scala.collection.immutable.NumericRange
  *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Long private extends AnyVal {
+  /** Returns this value as a [[scala.Byte]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toByte: Byte
+  /** Returns this value as a [[scala.Short]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toShort: Short
+  /** Returns this value as a [[scala.Char]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toChar: Char
+  /** Returns this value as an [[scala.Int]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toInt: Int
+  /** Returns this value unchanged. */
   def toLong: Long
+  /** Returns this value as a [[scala.Float]], which may lose precision. */
   def toFloat: Float
+  /** Returns this value as a [[scala.Double]], which may lose precision. */
   def toDouble: Double
 
   /** Returns the bitwise negation of this value.
@@ -646,8 +661,18 @@ object Long extends AnyValCompanion {
   /** Language mandated coercions from `Long` to "wider" types. */
   import scala.language.implicitConversions
   @deprecated("Implicit conversion from Long to Float is dangerous because it loses precision. Write `.toFloat` instead.", "2.13.1")
+  /** Returns `x` converted to a [[scala.Float]].
+   *
+   *  @param x the `Long` value to convert
+   *  @return the `Float` resulting from converting `x`, which may lose precision
+   */
   implicit def long2float(x: Long): Float = x.toFloat
   @deprecated("Implicit conversion from Long to Double is dangerous because it loses precision. Write `.toDouble` instead.", "2.13.1")
+  /** Returns `x` converted to a [[scala.Double]].
+   *
+   *  @param x the `Long` value to convert
+   *  @return the `Double` resulting from converting `x`, which may lose precision
+   */
   implicit def long2double(x: Long): Double = x.toDouble
 
   extension (self: Long) {

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -21,12 +21,21 @@ import scala.language.`2.13`
  *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Short private extends AnyVal {
+  /** Returns this value as a [[scala.Byte]], which may involve truncation of
+   *  the high-order bits.
+   */
   def toByte: Byte
+  /** Returns this value unchanged. */
   def toShort: Short
+  /** Returns this value as a [[scala.Char]]. */
   def toChar: Char
+  /** Returns this value as an [[scala.Int]]. */
   def toInt: Int
+  /** Returns this value as a [[scala.Long]]. */
   def toLong: Long
+  /** Returns this value as a [[scala.Float]]. */
   def toFloat: Float
+  /** Returns this value as a [[scala.Double]]. */
   def toDouble: Double
 
   /** Returns the bitwise negation of this value.
@@ -644,9 +653,25 @@ object Short extends AnyValCompanion {
    *  @return the value of `x` converted to the wider numeric type
    */
   import scala.language.implicitConversions
+  /** Returns `x` converted to an `Int`.
+   *
+   *  @param x the `Short` value to convert
+   */
   implicit def short2int(x: Short): Int = x.toInt
+  /** Returns `x` converted to a `Long`.
+   *
+   *  @param x the `Short` value to convert
+   */
   implicit def short2long(x: Short): Long = x.toLong
+  /** Returns `x` converted to a `Float`.
+   *
+   *  @param x the `Short` value to convert
+   */
   implicit def short2float(x: Short): Float = x.toFloat
+  /** Returns `x` converted to a `Double`.
+   *
+   *  @param x the `Short` value to convert
+   */
   implicit def short2double(x: Short): Double = x.toDouble
 
   extension (self: Short) {

--- a/library/src/scala/io/BufferedSource.scala
+++ b/library/src/scala/io/BufferedSource.scala
@@ -26,8 +26,20 @@ import scala.collection.mutable.StringBuilder
  *  @param codec the `Codec` used to decode bytes from the input stream into characters
  */
 class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val codec: Codec) extends Source {
+  /** Creates a `BufferedSource` from the given input stream using the default
+   *  buffer size.
+   *
+   *  @param inputStream the underlying input stream to read characters from
+   *  @param codec the codec used to decode bytes into characters
+   */
   def this(inputStream: InputStream)(implicit codec: Codec) = this(inputStream, DefaultBufSize)(using codec)
+  /** Returns a new `InputStreamReader` that decodes the underlying input stream
+   *  using `codec`.
+   */
   def reader() = new InputStreamReader(inputStream, codec.decoder)
+  /** Returns a new `BufferedReader` wrapping `reader()` with a buffer of
+   *  `bufferSize` characters.
+   */
   def bufferedReader() = new BufferedReader(reader(), bufferSize)
 
   // The same reader has to be shared between the iterators produced
@@ -69,16 +81,25 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
   }
 
 
+  /** An `Iterator` over the lines remaining in this source, not including the
+   *  line separator characters.
+   */
   class BufferedLineIterator extends AbstractIterator[String] with Iterator[String] {
     private val lineReader = decachedReader
     @annotation.stableNull var nextLine: String | Null = null
 
+    /** Returns `true` if another line is available, reading and buffering the
+     *  next line if necessary.
+     */
     override def hasNext = {
       if (nextLine == null)
         nextLine = lineReader.readLine
 
       nextLine != null
     }
+    /** Returns the next line, or throws a `NoSuchElementException` if no more
+     *  lines remain.
+     */
     override def next(): String = {
       val result = {
         if (nextLine == null) lineReader.readLine
@@ -89,6 +110,9 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
     }
   }
 
+  /** Returns an iterator over the lines remaining in this source, not including
+   *  the line separator characters.
+   */
   override def getLines(): Iterator[String] = new BufferedLineIterator
 
   /** Efficiently appends the entire remaining input.

--- a/library/src/scala/io/Codec.scala
+++ b/library/src/scala/io/Codec.scala
@@ -30,7 +30,7 @@ import scala.language.implicitConversions
 // MacRoman vs. UTF-8: see https://groups.google.com/d/msg/jruby-developers/-qtwRhoE1WM/whSPVpTNV28J
 // -Dfile.encoding: see https://bugs.java.com/view_bug.do?bug_id=4375816
 
-/** A class for character encoding/decoding preferences.
+/** A mutable builder class for character encoding/decoding preferences.
  *
  *  @param charSet the character set used for encoding and decoding operations
  */
@@ -50,13 +50,46 @@ class Codec(val charSet: Charset) {
   override def toString(): String = name
 
   // these methods can be chained to configure the variables above
+  /** Configures the action to take when malformed input is encountered during
+   *  encoding or decoding.
+   *
+   *  @param newAction the action to apply to malformed input
+   *  @return this `Codec`, to allow configuration calls to be chained
+   */
   def onMalformedInput(newAction: Action): this.type              = { _onMalformedInput = newAction ; this }
+  /** Configures the action to take when an unmappable character is encountered
+   *  during encoding or decoding.
+   *
+   *  @param newAction the action to apply to unmappable characters
+   *  @return this `Codec`, to allow configuration calls to be chained
+   */
   def onUnmappableCharacter(newAction: Action): this.type         = { _onUnmappableCharacter = newAction ; this }
+  /** Configures the string substituted for input that cannot be decoded.
+   *
+   *  @param newReplacement the replacement string used by the decoder
+   *  @return this `Codec`, to allow configuration calls to be chained
+   */
   def decodingReplaceWith(newReplacement: String): this.type      = { _decodingReplacement = newReplacement ; this }
+  /** Configures the bytes substituted for characters that cannot be encoded.
+   *
+   *  @param newReplacement the replacement bytes used by the encoder
+   *  @return this `Codec`, to allow configuration calls to be chained
+   */
   def encodingReplaceWith(newReplacement: Array[Byte]): this.type = { _encodingReplacement = newReplacement ; this }
+  /** Configures the handler to be invoked by `wrap` when a `CharacterCodingException`
+   *  is thrown.
+   *
+   *  @param handler the handler applied to a coding exception
+   *  @return this `Codec`, to allow configuration calls to be chained
+   */
   def onCodingException(handler: Handler): this.type              = { _onCodingException = handler ; this }
 
+  /** Returns the name of the character set used by this `Codec`. */
   def name: String = charSet.name
+  /** Returns a `CharsetEncoder` for this `Codec`'s character set, configured
+   *  with this `Codec`'s malformed-input, unmappable-character, and replacement
+   *  settings.
+   */
   def encoder: CharsetEncoder = {
     val enc = charSet.newEncoder()
     if (_onMalformedInput ne null) enc.onMalformedInput(_onMalformedInput)
@@ -64,6 +97,10 @@ class Codec(val charSet: Charset) {
     if (_encodingReplacement ne null) enc.replaceWith(_encodingReplacement)
     enc
   }
+  /** Returns a `CharsetDecoder` for this `Codec`'s character set, configured
+   *  with this `Codec`'s malformed-input, unmappable-character, and replacement
+   *  settings.
+   */
   def decoder: CharsetDecoder = {
     val dec = charSet.newDecoder()
     if (_onMalformedInput ne null) dec.onMalformedInput(_onMalformedInput)
@@ -72,10 +109,19 @@ class Codec(val charSet: Charset) {
     dec
   }
 
+  /** Evaluates `body`, routing any thrown `CharacterCodingException` to the
+   *  configured exception handler.
+   *
+   *  @param body the encoding or decoding operation to evaluate
+   *  @return the result of `body`, or the handler's result if a `CharacterCodingException` is thrown
+   */
   def wrap(body: => Int): Int =
     try body catch { case e: CharacterCodingException => _onCodingException(e) }
 }
 
+/** Provides the lowest-priority implicit `Codec`, used as a fallback when no
+ *  other `Codec` is in scope.
+ */
 trait LowPriorityCodecImplicits {
   self: Codec.type =>
 
@@ -93,18 +139,49 @@ object Codec extends LowPriorityCodecImplicits {
    *  as an accident, with any anomalies considered "not a bug".
    */
   def defaultCharsetCodec: Codec = apply(Charset.defaultCharset)
+  /** Returns a `Codec` for the encoding named by the `file.encoding` system
+   *  property.
+   */
   def fileEncodingCodec: Codec = apply(scala.util.Properties.encodingString)
+  /** Returns the default `Codec`, which uses the JVM's default charset. */
   def default: Codec = defaultCharsetCodec
 
+  /** Creates a `Codec` that uses a named character set.
+   *
+   *  @param encoding the name of the character set, as understood by `Charset.forName`
+   *  @return a `Codec` that uses the named character set
+   */
   def apply(encoding: String): Codec        = new Codec(Charset.forName(encoding))
+  /** Creates a `Codec` that uses a given character set.
+   *
+   *  @param charSet the character set to use for encoding and decoding
+   *  @return a `Codec` that uses `charSet`
+   */
   def apply(charSet: Charset): Codec        = new Codec(charSet)
+  /** Creates a `Codec` that uses the given `CharsetDecoder` for decoding.
+   *
+   *  @param decoder the decoder to use; its `charset` becomes the `Codec`'s character set
+   *  @return a `Codec` whose `decoder` is `decoder`
+   */
   def apply(decoder: CharsetDecoder): Codec = {
     val _decoder = decoder
     new Codec(decoder.charset()) { override def decoder = _decoder }
   }
 
   @migration("This method was previously misnamed `toUTF8`. Converts from Array[Byte] to Array[Char].", "2.9.0")
+  /** Decodes UTF-8 encoded bytes into an array of characters.
+   *
+   *  @param bytes the UTF-8 encoded bytes to decode
+   *  @return the decoded characters
+   */
   def fromUTF8(bytes: Array[Byte]): Array[Char] = fromUTF8(bytes, 0, bytes.length)
+  /** Decodes a range of UTF-8 encoded bytes into an array of characters.
+   *
+   *  @param bytes the array containing the UTF-8 encoded bytes
+   *  @param offset the index of the first byte to decode
+   *  @param len the number of bytes to decode
+   *  @return the decoded characters
+   */
   def fromUTF8(bytes: Array[Byte], offset: Int, len: Int): Array[Char] = {
     val bbuffer = java.nio.ByteBuffer.wrap(bytes, offset, len)
     val cbuffer = UTF8.charSet.decode(bbuffer)
@@ -115,6 +192,11 @@ object Codec extends LowPriorityCodecImplicits {
   }
 
   @migration("This method was previously misnamed `fromUTF8`. Converts from character sequence to Array[Byte].", "2.9.0")
+  /** Encodes a character sequence into UTF-8 bytes.
+   *
+   *  @param cs the characters to encode
+   *  @return the UTF-8 encoded bytes
+   */
   def toUTF8(cs: CharSequence): Array[Byte] = {
     val cbuffer = java.nio.CharBuffer.wrap(cs, 0, cs.length)
     val bbuffer = UTF8.charSet.encode(cbuffer)
@@ -123,6 +205,13 @@ object Codec extends LowPriorityCodecImplicits {
 
     bytes
   }
+  /** Encodes a range of characters into UTF-8 bytes.
+   *
+   *  @param chars the array containing the characters to encode
+   *  @param offset the index of the first character to encode
+   *  @param len the number of characters to encode
+   *  @return the UTF-8 encoded bytes
+   */
   def toUTF8(chars: Array[Char], offset: Int, len: Int): Array[Byte] = {
     val cbuffer = java.nio.CharBuffer.wrap(chars, offset, len)
     val bbuffer = UTF8.charSet.encode(cbuffer)
@@ -132,7 +221,22 @@ object Codec extends LowPriorityCodecImplicits {
     bytes
   }
 
+  /** Converts a character set name to a `Codec`.
+   *
+   *  @param s the name of the character set
+   *  @return a `Codec` for the named character set
+   */
   implicit def string2codec(s: String): Codec           = apply(s)
+  /** Converts a `Charset` to a `Codec`.
+   *
+   *  @param c the character set to wrap
+   *  @return a `Codec` backed by the `CharSet` `c`
+   */
   implicit def charset2codec(c: Charset): Codec         = apply(c)
+  /** Converts a `CharsetDecoder` to a `Codec`.
+   *
+   *  @param cd the decoder to wrap
+   *  @return a `Codec` that uses `cd` for decoding
+   */
   implicit def decoder2codec(cd: CharsetDecoder): Codec = apply(cd)
 }

--- a/library/src/scala/io/Position.scala
+++ b/library/src/scala/io/Position.scala
@@ -103,6 +103,15 @@ private[scala] abstract class Position {
 
 @nowarn
 private[scala] object Position extends Position {
+  /** Validates a line and column number, throwing an `IllegalArgumentException`
+   *  for an invalid combination.
+   *
+   *  A negative `line` or `column` is rejected, as is a nonzero `column` paired
+   *  with a `line` of 0.
+   *
+   *  @param line the 1-based line number to validate (0 for undefined, negative values throw)
+   *  @param column the 1-based column number to validate (must be 0 when `line` is 0, negative values throw)
+   */
   def checkInput(line: Int, column: Int): Unit = {
     if (line < 0)
       throw new IllegalArgumentException(s"$line < 0")

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -116,6 +116,14 @@ object Source {
   def fromFile(file: JFile, enc: String): BufferedSource =
     fromFile(file)(using Codec(enc))
 
+  /** Creates a `Source` from `file`, using the named character encoding, with
+   *  input buffered in a buffer of size `bufferSize`, setting its description
+   *  to the filename.
+   *
+   *  @param file the file to read from
+   *  @param enc the name of the character encoding to use
+   *  @param bufferSize the size of the input buffer, in characters
+   */
   def fromFile(file: JFile, enc: String, bufferSize: Int): BufferedSource =
     fromFile(file, bufferSize)(using Codec(enc))
 
@@ -149,11 +157,21 @@ object Source {
   def fromBytes(bytes: Array[Byte])(implicit codec: Codec): Source =
     fromString(new String(bytes, codec.name))
 
+  /** Creates a `Source` from array of bytes, decoding the bytes according to
+   *  the named character encoding.
+   *
+   *  @param bytes the array of bytes to decode into characters
+   *  @param enc the name of the character encoding to use
+   *  @return the created `Source` instance
+   */
   def fromBytes(bytes: Array[Byte], enc: String): Source =
     fromBytes(bytes)(using Codec(enc))
 
-  /** Creates a `Source` from array of bytes, assuming
-   *  one byte per character (ISO-8859-1 encoding.)
+  /** Creates a `Source` from array of bytes, assuming one byte per character
+   *  (ISO-8859-1 encoding).
+   *
+   *  @param bytes the array of bytes to decode into characters
+   *  @return the created `Source` instance
    */
   @deprecated("Use `fromBytes` and specify an encoding", since="2.13.9")
   def fromRawBytes(bytes: Array[Byte]): Source =
@@ -226,9 +244,23 @@ object Source {
     new BufferedSource(inputStream, bufferSize)(using codec) withReset resetFn withClose close
   }
 
+  /** Creates a `Source` reading from an input stream, using the named character
+   *  encoding.
+   *
+   *  @param is the input stream from which to read
+   *  @param enc the name of the character encoding to use
+   *  @return the buffered source
+   */
   def fromInputStream(is: InputStream, enc: String): BufferedSource =
     fromInputStream(is)(using Codec(enc))
 
+  /** Creates a `Source` reading from an input stream, using the encoding
+   *  specified by `codec`.
+   *
+   *  @param is the input stream from which to read
+   *  @param codec the implicit codec used for character encoding
+   *  @return the buffered source
+   */
   def fromInputStream(is: InputStream)(implicit codec: Codec): BufferedSource =
     createBufferedSource(is, reset = () => fromInputStream(is)(using codec), close = () => is.close())(using codec)
 
@@ -275,11 +307,21 @@ abstract class Source extends Iterator[Char] with Closeable {
 
   private def lineNum(line: Int): String = (getLines() drop (line - 1) take 1).mkString
 
+  /** An iterator over the lines of this source, excluding any line separator
+   *  characters.
+   */
   class LineIterator extends AbstractIterator[String] with Iterator[String] {
     private val sb = new StringBuilder
 
     lazy val iter: BufferedIterator[Char] = Source.this.iter.buffered
+    /** Returns `true` if `ch` is a carriage return or line feed character.
+     *
+     *  @param ch the character to test
+     */
     def isNewline(ch: Char): Boolean = ch == '\r' || ch == '\n'
+    /** Returns `true` after appending the next non-terminating character to the
+     *  current line buffer, or `false` at a line separator or end of input.
+     */
     def getc(): Boolean = iter.hasNext && {
       val ch = iter.next()
       if (ch == '\n') false
@@ -294,7 +336,9 @@ abstract class Source extends Iterator[Char] with Closeable {
         true
       }
     }
+    /** Returns `true` if this source has more lines to read. */
     def hasNext: Boolean = iter.hasNext
+    /** Returns the next line, excluding its line separator. */
     def next(): String = {
       sb.clear()
       while (getc()) { }
@@ -315,7 +359,14 @@ abstract class Source extends Iterator[Char] with Closeable {
   def next(): Char = positioner.next()
 
   @nowarn("cat=deprecation")
+  /** Mutable object that tracks the line and column position of each character as it is read from
+   *  this source.
+   *
+   *  @param encoder the `Position` used to encode line and column numbers into a single position value
+   */
   class Positioner(encoder: Position) {
+    /** Creates a `Positioner` that encodes positions using `RelaxedPosition`.
+     */
     def this() = this(RelaxedPosition)
     /** the last character returned by next. */
     var ch: Char = compiletime.uninitialized
@@ -330,6 +381,9 @@ abstract class Source extends Iterator[Char] with Closeable {
     /** Default col increment for tabs '\t', set to 4 initially. */
     var tabinc = 4
 
+    /** Returns the next character from the underlying iterator, updating the
+     *  current character, encoded position, line, and column.
+     */
     def next(): Char = {
       ch = iter.next()
       pos = encoder.encode(cline, ccol)
@@ -350,13 +404,28 @@ abstract class Source extends Iterator[Char] with Closeable {
    */
   @nowarn("cat=deprecation")
   object RelaxedPosition extends Position {
+    /** Performs no validation, accepting any line and column without throwing.
+     *
+     *  @param line the line number that would otherwise be validated
+     *  @param column the column number that would otherwise be validated
+     */
     def checkInput(line: Int, column: Int): Unit = ()
   }
   object RelaxedPositioner extends Positioner(RelaxedPosition) { }
   object NoPositioner extends Positioner(Position) {
+    /** Returns the next character from the underlying iterator without tracking
+     *  its position.
+     */
     override def next(): Char = iter.next()
   }
+  /** Returns the character recorded by the current positioner, which for a
+   *  position-tracking positioner is the last character returned by `next`.
+   */
   def ch: Char = positioner.ch
+  /** Returns the encoded position recorded by the current positioner, which for
+   *  a position-tracking positioner is the position of the last character
+   *  returned by `next`.
+   */
   def pos: Int = positioner.pos
 
   /** Reports an error message to the output stream `out`.
@@ -407,14 +476,30 @@ abstract class Source extends Iterator[Char] with Closeable {
   private var closeFunction: (() => Unit) | Null = null
   private var positioner: Positioner = RelaxedPositioner
 
+  /** Sets the function that [[reset]] uses to produce a fresh copy of this
+   *  source.
+   *
+   *  @param f a `() => Source` that produces a fresh copy of this source, or `null` to leave [[reset]] throwing
+   *  @return this source
+   */
   def withReset(f: (() => Source) | Null): this.type = {
     resetFunction = f
     this
   }
+  /** Sets the function that [[close]] uses to close the underlying resource.
+   *
+   *  @param f a `() => Unit` that closes the underlying resource, or `null` to make [[close]] a no-op
+   *  @return this source
+   */
   def withClose(f: (() => Unit) | Null): this.type = {
     closeFunction = f
     this
   }
+  /** Sets the description of this source.
+   *
+   *  @param text the description to use
+   *  @return this source
+   */
   def withDescription(text: String): this.type = {
     descr = text
     this
@@ -428,6 +513,11 @@ abstract class Source extends Iterator[Char] with Closeable {
     positioner = if (on) RelaxedPositioner else NoPositioner
     this
   }
+  /** Sets a custom positioner used to track line and column positions.
+   *
+   *  @param pos the positioner to use
+   *  @return this source
+   */
   def withPositioning(pos: Positioner): this.type = {
     positioner = pos
     this

--- a/library/src/scala/ref/PhantomReference.scala
+++ b/library/src/scala/ref/PhantomReference.scala
@@ -14,6 +14,12 @@ package scala.ref
 
 import scala.language.`2.13`
 
+/** A wrapper class for `java.lang.ref.PhantomReference`.
+ *
+ *  @tparam T the covariant type of the phantom-referenced object, must be a subtype of `AnyRef`
+ *  @param value the object to be phantom referenced
+ *  @param queue the reference queue to which this reference will be enqueued when the referent becomes phantom reachable
+ */
 class PhantomReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {
   val underlying: java.lang.ref.PhantomReference[? <: T] =
     new PhantomReferenceWithWrapper[T](value, queue, this)

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -24,8 +24,21 @@ trait Reference[+T <: AnyRef] extends Function0[T] {
   def apply(): T
   /** Returns `Some` underlying if it hasn't been collected, otherwise `None`. */
   def get: Option[T]
+  /** Returns the string representation of the referenced value, or
+   *  `"<deleted>"` if it has been cleared or collected.
+   */
   override def toString(): String = get.map(_.toString).getOrElse("<deleted>")
+  /** Clears this reference so that it no longer refers to its referent. This
+   *  does not enqueue the reference.
+   */
   def clear(): Unit
+  /** Adds this reference to the reference queue with which it was registered,
+   *  if any. Returns `true` if it was successfully enqueued, or `false` if it
+   *  was already enqueued or was not registered with a queue.
+   */
   def enqueue(): Boolean
+  /** Tests whether this reference is currently enqueued in the reference queue
+   *  with which it was registered, if any.
+   */
   def isEnqueued: Boolean
 }

--- a/library/src/scala/ref/ReferenceQueue.scala
+++ b/library/src/scala/ref/ReferenceQueue.scala
@@ -14,19 +14,47 @@ package scala.ref
 
 import scala.language.`2.13`
 
+/** A queue onto which registered references are appended by the garbage
+ *  collector once it determines that their referents have become unreachable.
+ *
+ *  @tparam T the type of the referents of the references enqueued on this queue
+ */
 class ReferenceQueue[+T <: AnyRef] {
 
   private[ref] val underlying: java.lang.ref.ReferenceQueue[? <: T] = new java.lang.ref.ReferenceQueue[T]
+  /** Returns the string representation of the underlying Java reference queue.
+   */
   override def toString(): String = underlying.toString
 
+  /** Extracts the Scala `Reference` wrapper from a reference dequeued from the
+   *  underlying queue.
+   *
+   *  @param jref a reference dequeued from the underlying queue, or `null` if none was available
+   *  @return `Some` wrapper associated with `jref`, or `None` if `jref` is `null`
+   */
   protected def Wrapper(jref: java.lang.ref.Reference[?] | Null): Option[Reference[T]] =
     jref match {
       case null => None
       case ref => Some(ref.asInstanceOf[ReferenceWithWrapper[T]].wrapper)
     }
 
+  /** Returns and removes the next available reference from this queue without
+   *  blocking, or `None` if the queue is empty.
+   */
   def poll: Option[Reference[T]] = Wrapper(underlying.poll)
+  /** Returns and removes the next reference from this queue, blocking until one
+   *  becomes available.
+   *
+   *  @throws java.lang.InterruptedException if the current thread is interrupted while waiting
+   */
   def remove: Option[Reference[T]] = Wrapper(underlying.remove)
+  /** Removes and returns the next reference from this queue, blocking until one
+   *  becomes available or the given timeout elapses.
+   *
+   *  @param timeout the maximum number of milliseconds to wait, where `0` means wait indefinitely and a negative value throws `IllegalArgumentException`
+   *  @return `Some` reference if one became available within the timeout, or `None` if the timeout elapsed first
+   *  @throws java.lang.InterruptedException if the current thread is interrupted while waiting
+   */
   def remove(timeout: Long): Option[Reference[T]] = Wrapper(underlying.remove(timeout))
 
 }

--- a/library/src/scala/ref/ReferenceWrapper.scala
+++ b/library/src/scala/ref/ReferenceWrapper.scala
@@ -16,17 +16,43 @@ import scala.language.`2.13`
 import scala.annotation.nowarn
 
 @nowarn("cat=deprecation")
+/** Implements the Scala [[scala.ref.Reference]] interface by delegating to an
+ *  underlying `java.lang.ref.Reference`.
+ *
+ *  @tparam T the type of the referenced object, constrained to `AnyRef` (i.e., non-primitive types)
+ */
 trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
   val underlying: java.lang.ref.Reference[? <: T]
+  /** Returns `Some(value)` wrapping `underlying.get` if it is non-null, or
+   *  `None` otherwise. For phantom references, `underlying.get` always returns
+   *  `null`, so this is always `None`.
+   */
   override def get = Option(underlying.get)
+  /** Returns `underlying.get` when it is non-null, throwing
+   *  `NoSuchElementException` when it is `null`. For phantom references,
+   *  `underlying.get` always returns `null`, so this always throws.
+   */
   def apply() = {
     val ret = underlying.get
     if (ret eq null) throw new NoSuchElementException
     ret
   }
+  /** Clears this reference so that it no longer refers to its referent. This
+   *  does not enqueue the reference.
+   */
   def clear(): Unit = underlying.clear()
+  /** Returns `true` if this reference was successfully added to the reference
+   *  queue with which it was registered, or `false` if it was already enqueued
+   *  or was not registered with a queue.
+   */
   def enqueue(): Boolean = underlying.enqueue()
+  /** Tests whether this reference is currently enqueued in the reference queue
+   *  with which it was registered, if any.
+   */
   def isEnqueued: Boolean = underlying.isEnqueued
+  /** Returns the underlying `java.lang.ref.Reference`, to which `Proxy`
+   *  delegates equality, hashing, and string conversion.
+   */
   def self: java.lang.ref.Reference[? <: T] = underlying
 }
 

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -14,7 +14,19 @@ package scala.ref
 
 import scala.language.`2.13`
 
+/** A wrapper class for `java.lang.ref.SoftReference`. New functionality
+ *  includes: (1) results are `Option` values instead of `null`, and (2) an
+ *  extractor that maps the soft reference itself into an option.
+ *
+ *  @tparam T the covariant type of the softly referenced object, must be a subtype of `AnyRef`
+ *  @param value the object to be softly referenced
+ *  @param queue a reference queue to which the reference may be enqueued after it is cleared by the garbage collector, or `null` for no queue
+ */
 class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T] | Null) extends ReferenceWrapper[T] {
+  /** Creates a `SoftReference` with no associated reference queue.
+   *
+   *  @param value the object to be softly referenced
+   */
   def this(value : T) = this(value, null)
 
   val underlying: java.lang.ref.SoftReference[? <: T] =

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -23,6 +23,10 @@ import scala.language.`2.13`
  *  @param queue an optional reference queue to which the reference will be enqueued when the referent becomes weakly reachable, or `null` for no queue
  */
 class WeakReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T] | Null) extends ReferenceWrapper[T] {
+  /** Creates a weak reference to `value` with no associated reference queue.
+   *
+   *  @param value the object to be weakly referenced
+   */
   def this(value: T) = this(value, null)
   val underlying: java.lang.ref.WeakReference[? <: T] =
     new WeakReferenceWithWrapper[T](value, queue, this)


### PR DESCRIPTION
This PR fills in a main doc comment plus @param, @tparam, and @return tags for io, ref, and number classes that are completed missing any Scaladoc documentation. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.