### PR TITLE
Bump Scala CLI to 1.15.0 (was 1.14.0) and `coursier` to 2.1.25-M26 (was 2.1.25-M25)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,7 +276,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
+      - uses: VirtusLab/scala-cli-setup@v1.15
       - name: Check formatting
         run: |
           if ! scala-cli format --check; then

--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
+      - uses: VirtusLab/scala-cli-setup@v1.15
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
+      - uses: VirtusLab/scala-cli-setup@v1.15
 
       - name: Validate docs sidebars
         run: scala-cli ./project/scripts/checkSidebarDocs.scala
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
+      - uses: VirtusLab/scala-cli-setup@v1.15
         with:
           jvm: temurin:17
           apps: sbt

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -94,7 +94,7 @@ object Versions {
   /** Version of Scala CLI to download */
   val scalaCliLauncherVersion = "1.15.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.25-M25"
+  val coursierJarVersion = "2.1.25-M26"
 
   /* Tests TASTy version invariants during NIGHLY, RC or Stable releases */
   def checkReleasedTastyVersion(): Unit = {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -92,7 +92,7 @@ object Versions {
   val mimaPreviousDottyVersion = "3.9.0-RC1" // TODO: update to 3.9.0 when released
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.14.0"
+  val scalaCliLauncherVersion = "1.15.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M25"
 


### PR DESCRIPTION
https://github.com/VirtusLab/scala-cli/releases/tag/v1.15.0
https://github.com/VirtusLab/scala-cli-setup/releases/tag/v1.15.0
https://github.com/coursier/coursier/releases/tag/v2.1.25-M26

## Have you relied on LLM-based tools in this contribution?
No

## How was the solution tested?
Covered by existing tests (dependency update)
