### PR TITLE
feat: add -Yrepl-print-tostring to render REPL results via toString

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettings.scala
@@ -537,6 +537,7 @@ private sealed trait YSettings:
   val YprintLevel: Setting[Boolean] = BooleanSetting(ForkSetting, "Yprint-level", "print nesting levels of symbols and type variables.")
   val YshowPrintErrors: Setting[Boolean] = BooleanSetting(ForkSetting, "Yshow-print-errors", "Don't suppress exceptions thrown during tree printing.")
   val YprintTasty: Setting[Boolean] = BooleanSetting(ForkSetting, "Yprint-tasty", "Prints the generated TASTY to stdout.")
+  val YreplPrintToString: Setting[Boolean] = BooleanSetting(ForkSetting, "Yrepl-print-tostring", "Render REPL results with their `toString` instead of the pretty-printer.")
   val YtestPickler: Setting[Boolean] = BooleanSetting(ForkSetting, "Ytest-pickler", "Self-test for pickling functionality; should be used with -Ystop-after:pickler.")
   val YtestPicklerCheck: Setting[Boolean] = BooleanSetting(ForkSetting, "Ytest-pickler-check", "Self-test for pickling -print-tasty output; should be used with -Ytest-pickler.")
   val YcheckReentrant: Setting[Boolean] = BooleanSetting(ForkSetting, "Ycheck-reentrant", "Check that compiled program does not contain vars that can be accessed from a global root.")

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -4,7 +4,7 @@ package repl
 import scala.language.unsafeNulls
 
 import dotc.*, core.*
-import Contexts.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*, Types.*
+import Contexts.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*
 import printing.ReplPrinter
 import printing.SyntaxHighlighting
 import reporting.Diagnostic
@@ -108,17 +108,10 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
     if ncp <= maxPrintCharacters then str
     else str.substring(0, str.offsetByCodePoints(0, maxPrintCharacters - 1))
 
-  /** Whether `staticType` has a user-written `toString` override. */
-  private def hasUserDefinedToString(staticType: Type)(using Context): Boolean =
-    if staticType.derivesFrom(defn.ProductClass) && !staticType.derivesFrom(defn.TupleClass) then
-      val toStringSym = staticType.member(nme.toString_).symbol
-      toStringSym.exists && toStringSym.owner != defn.AnyClass && !toStringSym.is(Synthetic)
-    else false
-
   /** Return a colored fansi.Str representation of a value we got from `classLoader()`. */
-  private[repl] def replStringOf(value: Object, prefixLength: Int, staticType: Type)(using Context): fansi.Str = {
+  private[repl] def replStringOf(value: Object, prefixLength: Int)(using Context): fansi.Str = {
     val res =
-      if hasUserDefinedToString(staticType) then String.valueOf(value)
+      if ctx.settings.YreplPrintToString.value then String.valueOf(value)
       else pprintRender(
         value,
         width = ctx.settings.pageWidth.value,
@@ -141,7 +134,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       .flatMap(result => rewrapValueClass(sym.info.classSymbol, result.invoke(null)))
     symValue
       .filter(_ => sym.is(Flags.Method) || sym.info != defn.UnitType)
-      .map(value => stripReplPrefixFansi(replStringOf(value, prefixLength, sym.info.finalResultType)))
+      .map(value => stripReplPrefixFansi(replStringOf(value, prefixLength)))
 
   private def stripReplPrefixFansi(s: fansi.Str): fansi.Str =
     val plain = s.plainText

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -110,7 +110,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
 
   /** Whether `staticType` has a user-written `toString` override. */
   private def hasUserDefinedToString(staticType: Type)(using Context): Boolean =
-    if staticType.derivesFrom(defn.ProductClass) then
+    if staticType.derivesFrom(defn.ProductClass) && !staticType.derivesFrom(defn.TupleClass) then
       val toStringSym = staticType.member(nme.toString_).symbol
       toStringSym.exists && toStringSym.owner != defn.AnyClass && !toStringSym.is(Synthetic)
     else false

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -4,7 +4,7 @@ package repl
 import scala.language.unsafeNulls
 
 import dotc.*, core.*
-import Contexts.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*
+import Contexts.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*, Types.*
 import printing.ReplPrinter
 import printing.SyntaxHighlighting
 import reporting.Diagnostic
@@ -108,14 +108,23 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
     if ncp <= maxPrintCharacters then str
     else str.substring(0, str.offsetByCodePoints(0, maxPrintCharacters - 1))
 
+  /** Whether `staticType` has a user-written `toString` override. */
+  private def hasUserDefinedToString(staticType: Type)(using Context): Boolean =
+    if staticType.derivesFrom(defn.ProductClass) then
+      val toStringSym = staticType.member(nme.toString_).symbol
+      toStringSym.exists && toStringSym.owner != defn.AnyClass && !toStringSym.is(Synthetic)
+    else false
+
   /** Return a colored fansi.Str representation of a value we got from `classLoader()`. */
-  private[repl] def replStringOf(value: Object, prefixLength: Int)(using Context): fansi.Str = {
-    val res = pprintRender(
-      value,
-      width = ctx.settings.pageWidth.value,
-      height = ctx.settings.XreplPrintHeight.value,
-      initialOffset = prefixLength
-    )
+  private[repl] def replStringOf(value: Object, prefixLength: Int, staticType: Type)(using Context): fansi.Str = {
+    val res =
+      if hasUserDefinedToString(staticType) then String.valueOf(value)
+      else pprintRender(
+        value,
+        width = ctx.settings.pageWidth.value,
+        height = ctx.settings.XreplPrintHeight.value,
+        initialOffset = prefixLength
+      )
     if (ctx.settings.color.value == "never") fansi.Str(res).plainText else res
   }
 
@@ -132,7 +141,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       .flatMap(result => rewrapValueClass(sym.info.classSymbol, result.invoke(null)))
     symValue
       .filter(_ => sym.is(Flags.Method) || sym.info != defn.UnitType)
-      .map(value => stripReplPrefixFansi(replStringOf(value, prefixLength)))
+      .map(value => stripReplPrefixFansi(replStringOf(value, prefixLength, sym.info.finalResultType)))
 
   private def stripReplPrefixFansi(s: fansi.Str): fansi.Str =
     val plain = s.plainText

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -843,6 +843,46 @@ class ReplCompilerTests extends ReplTest:
     )
     assertEquals(expected, lines())
 
+  @Test def `i26329 user toString is used instead of pprint`: Unit = initially:
+    run:
+      """case class Conjunction(left: String, right: String):
+        |  override def toString = s"$left ∧ $right"
+        |
+        |Conjunction("p", "q")
+        |""".stripMargin
+    val expected = List(
+      "// defined case class Conjunction",
+      "val res0: Conjunction = p ∧ q"
+    )
+    assertEquals(expected, lines())
+
+  @Test def `i26329 synthetic toString is not used instead of pprint`: Unit = initially:
+    run:
+      """case class Point(x: Int, y: Int)
+        |
+        |Point(1, 2)
+        |""".stripMargin
+    val expected = List(
+      "// defined case class Point",
+      "val res0: Point = Point(x = 1, y = 2)"
+    )
+    assertEquals(expected, lines())
+
+  @Test def `i26329 widened static type ignores overriden toString`: Unit = initially:
+    run:
+      """trait Formula
+        |case class Conjunction(left: String, right: String) extends Formula:
+        |  override def toString = s"$left ∧ $right"
+        |
+        |val x: Formula = Conjunction("p", "q")
+        |""".stripMargin
+    val expected = List(
+      "// defined trait Formula",
+      "// defined case class Conjunction",
+      """val x: Formula = Conjunction(left = "p", right = "q")"""
+    )
+    assertEquals(expected, lines())
+
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -843,46 +843,6 @@ class ReplCompilerTests extends ReplTest:
     )
     assertEquals(expected, lines())
 
-  @Test def `i26329 user toString is used instead of pprint`: Unit = initially:
-    run:
-      """case class Conjunction(left: String, right: String):
-        |  override def toString = s"$left ∧ $right"
-        |
-        |Conjunction("p", "q")
-        |""".stripMargin
-    val expected = List(
-      "// defined case class Conjunction",
-      "val res0: Conjunction = p ∧ q"
-    )
-    assertEquals(expected, lines())
-
-  @Test def `i26329 synthetic toString is not used instead of pprint`: Unit = initially:
-    run:
-      """case class Point(x: Int, y: Int)
-        |
-        |Point(1, 2)
-        |""".stripMargin
-    val expected = List(
-      "// defined case class Point",
-      "val res0: Point = Point(x = 1, y = 2)"
-    )
-    assertEquals(expected, lines())
-
-  @Test def `i26329 widened static type ignores overriden toString`: Unit = initially:
-    run:
-      """trait Formula
-        |case class Conjunction(left: String, right: String) extends Formula:
-        |  override def toString = s"$left ∧ $right"
-        |
-        |val x: Formula = Conjunction("p", "q")
-        |""".stripMargin
-    val expected = List(
-      "// defined trait Formula",
-      "// defined case class Conjunction",
-      """val x: Formula = Conjunction(left = "p", right = "q")"""
-    )
-    assertEquals(expected, lines())
-
 object ReplCompilerTests:
 
   private val pattern = Pattern.compile("\\r[\\n]?|\\n");
@@ -894,6 +854,24 @@ object ReplCompilerTests:
     assertEquals(expected0, actual0)
 
 end ReplCompilerTests
+
+class ReplPrintToStringTests extends ReplTest(ReplTest.defaultOptions :+ "-Yrepl-print-tostring"):
+  private def lines() =
+    storedOutput().trim.linesIterator.toList
+
+  @Test def `i26329 -Yrepl-print-tostring renders results via toString`: Unit = initially:
+    run:
+      """case class Conjunction(left: String, right: String):
+        |  override def toString = s"$left ∧ $right"
+        |
+        |Conjunction("p", "q")
+        |""".stripMargin
+    val expected = List(
+      "// defined case class Conjunction",
+      "val res0: Conjunction = p ∧ q"
+    )
+    assertEquals(expected, lines())
+end ReplPrintToStringTests
 
 class ReplXPrintTyperTests extends ReplTest(ReplTest.defaultOptions :+ "-Vprint:typer"):
   @Test def i9111 = initially {


### PR DESCRIPTION
Fixes #26329

By default, the value was rendered with pprint, which ignored and never called `toString`. This adds a flag that makes the REPL render results with `String.valueOf(smth)` instead of pprint.

### Code:
```scala
//> using scala 3.10.0-RC1-bin-SNAPSHOT
//> using dep org.scala-lang::scala3-repl:3.10.0-RC1-bin-SNAPSHOT

import dotty.tools.repl.ReplDriver

case class Conjunction(left: String, right: String) {
  override def toString = s"$left ∧ $right"
}

@main def main() = {
  val repl = ReplDriver(
    Array("-classpath", System.getProperty("java.class.path"), "-Yrepl-print-tostring"),
    System.out,
  )
  given dotty.tools.repl.State = repl.initialState
  repl.run("""Conjunction("p", "q")""")
}
```

### Output without the flag:
```scala
val res0: Conjunction = Conjunction(left = "p", right = "q")
```
### Output with the flag:
```scala
val res0: Conjunction = p ∧ q
```


<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

Test added in `ReplCompilerTests.scala` + manually
