### PR TITLE
Stop emitting SourceFile annotation

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -517,7 +517,7 @@ object Symbols extends SymUtils {
 
     private var mySource: SourceFile = NoSource
 
-    final def sourceOfClass(using Context): SourceFile = {
+    final def sourceOfClass(using Context): SourceFile = atPhaseNoLater(flattenPhase) {
       if !mySource.exists && !denot.is(Package) then
         // this allows sources to be added in annotations after `sourceOfClass` is first called
         val file = associatedFile
@@ -530,12 +530,12 @@ object Symbols extends SymUtils {
               case Some(path) => mySource = ctx.getSource(path)
               case _ =>
           if !mySource.exists then
-            mySource = atPhaseNoLater(flattenPhase) {
+            mySource = {
               denot.topLevelClass.unforcedAnnotation(defn.SourceFileAnnot) match
                 case Some(sourceAnnot) => sourceAnnot.argumentConstant(0) match
                   case Some(Constant(path: String)) => ctx.getSource(path)
-                  case none => NoSource
-                case none => NoSource
+                  case _ => NoSource
+                case _ => NoSource
             }
       mySource
     }

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -699,13 +699,6 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
                   if illegalRefs.nonEmpty then
                     report.error(
                       em"The type of a class parent cannot refer to constructor parameters, but ${parent.tpe} refers to ${illegalRefs.map(_.name.show).mkString(",")}", parent.srcPos)
-            if sym.owner.is(Package) then
-              // Add SourceFile annotation to top-level classes
-              // TODO remove this annotation once the reference compiler uses the TASTy source file attribute.
-              if ctx.compilationUnit.source.exists && sym != defn.SourceFileAnnot then
-                val reference = ctx.settings.sourceroot.value
-                val relativePath = util.SourceFile.relativePath(ctx.compilationUnit.source, reference)
-                sym.addAnnotation(Annotation(defn.SourceFileAnnot, Literal(Constants.Constant(relativePath)), tree.span))
           else
             if !sym.is(Param) && !sym.owner.isOneOf(AbstractOrTrait) then
               Checking.checkGoodBounds(tree.symbol)

--- a/compiler/test/dotty/tools/AnnotationsTests.scala
+++ b/compiler/test/dotty/tools/AnnotationsTests.scala
@@ -115,7 +115,7 @@ class AnnotationsTest:
         val cls = requiredClass("Foo")
         val param = requiredClass("Param")
         val annots = cls.annotations
-        assert(annots.size == 2, i"$annots") // includes SourceFile
+        assert(annots.size == 1, i"$annots")
         val annot = annots.find(_.symbol == param).getOrElse(assert(false, s"Missing $param"))
         assert(annot.arguments.size == 1, i"${annot.arguments}")
         extension (t: tpd.Tree)

--- a/project/scripts/bootstrappedOnlyCmdTests
+++ b/project/scripts/bootstrappedOnlyCmdTests
@@ -50,7 +50,7 @@ grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tm
 # check that `sbt scalac -print-tasty` runs
 echo "testing sbt scalac -print-tasty from file"
 ./bin/scalac -print-tasty -color:never "$OUT/$TASTY" | tee "$tmp"
-grep -qe "118:           STRINGconst 32 \[hello world\]" "$tmp"
+grep -qe "117:           STRINGconst 32 \[hello world\]" "$tmp"
 
 echo "testing loading tasty from .tasty file in jar"
 clear_out "$OUT"
@@ -60,7 +60,7 @@ grep -qe "def main(args: scala.Array\[scala.Predef.String\]): scala.Unit =" "$tm
 
 echo "testing printing tasty from .tasty file in jar"
 ./bin/scalac -print-tasty -color:never "$OUT/out.jar" | tee "$tmp"
-grep -qe "118:           STRINGconst 32 \[hello world\]" "$tmp"
+grep -qe "117:           STRINGconst 32 \[hello world\]" "$tmp"
 
 echo "testing -script from scalac"
 clear_out "$OUT"

--- a/project/scripts/cmdTests
+++ b/project/scripts/cmdTests
@@ -29,7 +29,7 @@ echo "testing sbt scalac -print-tasty"
 clear_out "$OUT"
 "$SBT" ";scalac $SOURCE -d $OUT ;scalac -print-tasty -color:never $OUT/$TASTY" | tee "$tmp"
 grep -qe "0: ASTs" "$tmp"
-grep -qe "0: 41 \[tests/pos/HelloWorld.scala\]" "$tmp"
+grep -qe "0: 34 \[tests/pos/HelloWorld.scala\]" "$tmp"
 
 echo "testing that paths SourceFile annotations are relativized"
 clear_out "$OUT"

--- a/tests/neg-macros/i18677-a.check
+++ b/tests/neg-macros/i18677-a.check
@@ -6,10 +6,10 @@
   |The tree does not conform to the compiler's tree invariants.
   |
   |Macro was:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo()
+  |@scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo()
   |
   |The macro returned:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-a/Test_2.scala") @scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo() extends Foo
+  |@scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo() extends Foo
   |
   |Error:
   |assertion failed: Parents of class symbol differs from the parents in the tree for class AFoo

--- a/tests/neg-macros/i18677-b.check
+++ b/tests/neg-macros/i18677-b.check
@@ -6,10 +6,10 @@
   |The tree does not conform to the compiler's tree invariants.
   |
   |Macro was:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo()
+  |@scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo()
   |
   |The macro returned:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/i18677-b/Test_2.scala") @scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo() extends Foo
+  |@scala.annotation.experimental("Added by -experimental") @extendFoo class AFoo() extends Foo
   |
   |Error:
   |assertion failed: Parents of class symbol differs from the parents in the tree for class AFoo

--- a/tests/neg-macros/wrong-owner.check
+++ b/tests/neg-macros/wrong-owner.check
@@ -7,10 +7,10 @@
   |The tree does not conform to the compiler's tree invariants.
   |
   |Macro was:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/wrong-owner/Test_2.scala") @wrongOwner @scala.annotation.experimental class Foo()
+  |@wrongOwner @scala.annotation.experimental class Foo()
   |
   |The macro returned:
-  |@scala.annotation.internal.SourceFile("tests/neg-macros/wrong-owner/Test_2.scala") @wrongOwner @scala.annotation.experimental class Foo() {
+  |@wrongOwner @scala.annotation.experimental class Foo() {
   |  override def toString(): java.lang.String = "Hello from macro"
   |}
   |

--- a/tests/pos-macros/i16318/Macro_1.scala
+++ b/tests/pos-macros/i16318/Macro_1.scala
@@ -1,5 +1,6 @@
 import scala.quoted.*
 
+@deprecated("test")
 final case class Record(a: String, b: Int)
 
 transparent inline def ann[T]: List[Any] = ${ annsImpl[T] }

--- a/tests/pos/i20901/Foo.tastycheck
+++ b/tests/pos/i20901/Foo.tastycheck
@@ -3,7 +3,7 @@ Header:
   tooling: <elided>
      UUID: <elided>
 
-Names (276 bytes, starting from <elided base index>):
+Names (213 bytes, starting from <elided base index>):
      0: ASTs
      1: <empty>
      2: scala
@@ -27,27 +27,18 @@ Names (276 bytes, starting from <elided base index>):
     20: [Unique evidence$ 1]
     21: ???
     22: Predef
-    23: SourceFile
-    24: annotation
-    25: scala[Qualified . annotation]
-    26: internal
-    27: scala[Qualified . annotation][Qualified . internal]
-    28: scala[Qualified . annotation][Qualified . internal][Qualified . SourceFile]
-    29: String
-    30: java[Qualified . lang][Qualified . String]
-    31: <init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]
-    32: <elided source file name>
-    33: Positions
-    34: Comments
-    35: Attributes
+    23: Positions
+    24: <elided source file name>
+    25: Comments
+    26: Attributes
 
-Trees (98 bytes, starting from <elided base index>):
-     0: PACKAGE(96)
+Trees (80 bytes, starting from <elided base index>):
+     0: PACKAGE(78)
      2:   TERMREFpkg 1 [<empty>]
      4:   IMPORT(4)
      6:     TERMREFpkg 4 [scala[Qualified . reflect]]
      8:     IMPORTED 5 [ClassTag]
-    10:   TYPEDEF(86) 6 [Foo]
+    10:   TYPEDEF(68) 6 [Foo]
     13:     TEMPLATE(65)
     15:       APPLY(10)
     17:         SELECTin(8) 13 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
@@ -81,18 +72,9 @@ Trees (98 bytes, starting from <elided base index>):
     74:         TERMREF 21 [???]
     76:           TERMREF 22 [Predef]
     78:             SHAREDtype 33
-    80:     ANNOTATION(16)
-    82:       TYPEREF 23 [SourceFile]
-    84:         TERMREFpkg 27 [scala[Qualified . annotation][Qualified . internal]]
-    86:       APPLY(10)
-    88:         SELECTin(6) 31 [<init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]]
-    91:           NEW
-    92:             SHAREDtype 82
-    94:           SHAREDtype 82
-    96:         STRINGconst 32 [<elided source file name>]
-    98:
+    80:
 
-Positions (75 bytes, starting from <elided base index>):
+Positions (67 bytes, starting from <elided base index>):
   lines: 7
   line sizes:
      38, 0, 23, 0, 10, 41, 0
@@ -115,12 +97,9 @@ Positions (75 bytes, starting from <elided base index>):
     63: 93 .. 101
     68: 104 .. 111
     74: 114 .. 117
-    86: 65 .. 117
-    92: 65 .. 65
-    96: 65 .. 65
 
   source paths:
-     0: 32 [<elided source file name>]
+     0: 24 [<elided source file name>]
 
 Attributes (2 bytes, starting from <elided base index>):
-  SOURCEFILEattr 32 [<elided source file name>]
+  SOURCEFILEattr 24 [<elided source file name>]

--- a/tests/pos/i21154/Z.tastycheck
+++ b/tests/pos/i21154/Z.tastycheck
@@ -3,7 +3,7 @@ Header:
   tooling: <elided>
      UUID: <elided>
 
-Names (332 bytes, starting from <elided base index>):
+Names (299 bytes, starting from <elided base index>):
      0: ASTs
      1: <empty>
      2: Z
@@ -14,44 +14,39 @@ Names (332 bytes, starting from <elided base index>):
      7: <init>
      8: Unit
      9: scala
-    10: SourceFile
+    10: Child
     11: annotation
     12: scala[Qualified . annotation]
     13: internal
     14: scala[Qualified . annotation][Qualified . internal]
-    15: scala[Qualified . annotation][Qualified . internal][Qualified . SourceFile]
-    16: String
-    17: java[Qualified . lang][Qualified . String]
-    18: <init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]
-    19: <elided source file name>
-    20: Child
-    21: scala[Qualified . annotation][Qualified . internal][Qualified . Child]
-    22: <init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]
-    23: Z[ModuleClass]
-    24: <init>[Signed Signature(List(),Z$) @<init>]
-    25: java[Qualified . lang][Qualified . Object]
-    26: <init>[Signed Signature(List(),java.lang.Object) @<init>]
-    27: _
-    28: writeReplace
-    29: AnyRef
-    30: runtime
-    31: scala[Qualified . runtime]
-    32: ModuleSerializationProxy
-    33: scala[Qualified . runtime][Qualified . ModuleSerializationProxy]
-    34: Class
-    35: java[Qualified . lang][Qualified . Class]
-    36: <init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]
-    37: AOptions
-    38: BOptions
-    39: COptions
-    40: Positions
-    41: Comments
-    42: Attributes
+    15: scala[Qualified . annotation][Qualified . internal][Qualified . Child]
+    16: <init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]
+    17: Z[ModuleClass]
+    18: <init>[Signed Signature(List(),Z$) @<init>]
+    19: java[Qualified . lang][Qualified . Object]
+    20: <init>[Signed Signature(List(),java.lang.Object) @<init>]
+    21: _
+    22: writeReplace
+    23: AnyRef
+    24: runtime
+    25: scala[Qualified . runtime]
+    26: ModuleSerializationProxy
+    27: scala[Qualified . runtime][Qualified . ModuleSerializationProxy]
+    28: Class
+    29: java[Qualified . lang][Qualified . Class]
+    30: <init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]
+    31: AOptions
+    32: BOptions
+    33: COptions
+    34: Positions
+    35: <elided source file name>
+    36: Comments
+    37: Attributes
 
-Trees (288 bytes, starting from <elided base index>):
-     0: PACKAGE(285)
+Trees (253 bytes, starting from <elided base index>):
+     0: PACKAGE(250)
      3:   TERMREFpkg 1 [<empty>]
-     5:   TYPEDEF(106) 2 [Z]
+     5:   TYPEDEF(87) 2 [Z]
      8:     TEMPLATE(13)
     10:       TYPEREF 3 [Object]
     12:         TERMREFpkg 6 [java[Qualified . lang]]
@@ -62,139 +57,122 @@ Trees (288 bytes, starting from <elided base index>):
     22:         STABLE
     23:     SEALED
     24:     TRAIT
-    25:     ANNOTATION(16)
-    27:       TYPEREF 10 [SourceFile]
+    25:     ANNOTATION(25)
+    27:       TYPEREF 10 [Child]
     29:         TERMREFpkg 14 [scala[Qualified . annotation][Qualified . internal]]
-    31:       APPLY(10)
-    33:         SELECTin(6) 18 [<init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]]
-    36:           NEW
-    37:             SHAREDtype 27
-    39:           SHAREDtype 27
-    41:         STRINGconst 19 [<elided source file name>]
-    43:     ANNOTATION(26)
-    45:       TYPEREF 20 [Child]
-    47:         SHAREDtype 29
-    49:       APPLY(20)
-    51:         TYPEAPPLY(18)
-    53:           SELECTin(6) 22 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
-    56:             NEW
-    57:               SHAREDtype 45
-    59:             SHAREDtype 45
-    61:           TYPEREFsymbol 244
-    64:             THIS
-    65:               TYPEREFsymbol 131
-    68:                 THIS
-    69:                   TYPEREFpkg 1 [<empty>]
-    71:     ANNOTATION(19)
-    73:       SHAREDtype 45
-    75:       APPLY(15)
-    77:         TYPEAPPLY(13)
-    79:           SELECTin(6) 22 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
-    82:             NEW
-    83:               SHAREDtype 45
-    85:             SHAREDtype 45
-    87:           TYPEREFsymbol 217
-    90:             SHAREDtype 64
-    92:     ANNOTATION(19)
-    94:       SHAREDtype 45
-    96:       APPLY(15)
-    98:         TYPEAPPLY(13)
-   100:           SELECTin(6) 22 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
-   103:             NEW
-   104:               SHAREDtype 45
-   106:             SHAREDtype 45
-   108:           TYPEREFsymbol 189
-   111:             SHAREDtype 64
-   113:   VALDEF(16) 2 [Z]
-   116:     IDENTtpt 23 [Z[ModuleClass]]
-   118:       SHAREDtype 65
-   120:     APPLY(8)
-   122:       SELECTin(6) 24 [<init>[Signed Signature(List(),Z$) @<init>]]
-   125:         NEW
-   126:           SHAREDterm 116
-   128:         SHAREDtype 65
-   130:     OBJECT
-   131:   TYPEDEF(154) 23 [Z[ModuleClass]]
-   135:     TEMPLATE(133)
-   138:       APPLY(8)
-   140:         SELECTin(6) 26 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
-   143:           NEW
-   144:             SHAREDtype 10
-   146:           SHAREDtype 10
-   148:       SELFDEF 27 [_]
-   150:         SINGLETONtpt
-   151:           TERMREFsymbol 113
-   153:             SHAREDtype 68
-   155:       DEFDEF(5) 7 [<init>]
-   158:         EMPTYCLAUSE
-   159:         SHAREDtype 18
-   161:         STABLE
-   162:       DEFDEF(25) 28 [writeReplace]
-   165:         EMPTYCLAUSE
-   166:         TYPEREF 29 [AnyRef]
-   168:           SHAREDtype 20
-   170:         APPLY(15)
-   172:           SELECTin(9) 36 [<init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]]
-   175:             NEW
-   176:               TYPEREF 32 [ModuleSerializationProxy]
-   178:                 TERMREFpkg 31 [scala[Qualified . runtime]]
-   180:             SHAREDtype 176
-   183:           CLASSconst
-   184:             SHAREDtype 151
-   187:         PRIVATE
-   188:         SYNTHETIC
-   189:       TYPEDEF(26) 37 [AOptions]
-   192:         TEMPLATE(23)
-   194:           APPLY(8)
-   196:             SELECTin(6) 26 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
-   199:               NEW
-   200:                 SHAREDtype 10
-   202:               SHAREDtype 10
-   204:           IDENTtpt 2 [Z]
-   206:             TYPEREFsymbol 5
-   208:               SHAREDtype 68
-   210:           DEFDEF(5) 7 [<init>]
-   213:             EMPTYCLAUSE
-   214:             SHAREDtype 18
-   216:             STABLE
-   217:       TYPEDEF(25) 38 [BOptions]
-   220:         TEMPLATE(22)
-   222:           APPLY(8)
-   224:             SELECTin(6) 26 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
-   227:               NEW
-   228:                 SHAREDtype 10
-   230:               SHAREDtype 10
-   232:           IDENTtpt 2 [Z]
-   234:             SHAREDtype 206
-   237:           DEFDEF(5) 7 [<init>]
-   240:             EMPTYCLAUSE
-   241:             SHAREDtype 18
-   243:             STABLE
-   244:       TYPEDEF(25) 39 [COptions]
-   247:         TEMPLATE(22)
-   249:           APPLY(8)
-   251:             SELECTin(6) 26 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
-   254:               NEW
-   255:                 SHAREDtype 10
-   257:               SHAREDtype 10
-   259:           IDENTtpt 2 [Z]
-   261:             SHAREDtype 206
-   264:           DEFDEF(5) 7 [<init>]
-   267:             EMPTYCLAUSE
-   268:             SHAREDtype 18
-   270:             STABLE
-   271:     OBJECT
-   272:     ANNOTATION(14)
-   274:       SHAREDtype 27
-   276:       APPLY(10)
-   278:         SELECTin(6) 18 [<init>[Signed Signature(List(java.lang.String),scala.annotation.internal.SourceFile) @<init>]]
-   281:           NEW
-   282:             SHAREDtype 27
-   284:           SHAREDtype 27
-   286:         STRINGconst 19 [<elided source file name>]
-   288:
+    31:       APPLY(19)
+    33:         TYPEAPPLY(17)
+    35:           SELECTin(6) 16 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
+    38:             NEW
+    39:               SHAREDtype 27
+    41:             SHAREDtype 27
+    43:           TYPEREFsymbol 225
+    46:             THIS
+    47:               TYPEREFsymbol 112
+    49:                 THIS
+    50:                   TYPEREFpkg 1 [<empty>]
+    52:     ANNOTATION(19)
+    54:       SHAREDtype 27
+    56:       APPLY(15)
+    58:         TYPEAPPLY(13)
+    60:           SELECTin(6) 16 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
+    63:             NEW
+    64:               SHAREDtype 27
+    66:             SHAREDtype 27
+    68:           TYPEREFsymbol 198
+    71:             SHAREDtype 46
+    73:     ANNOTATION(19)
+    75:       SHAREDtype 27
+    77:       APPLY(15)
+    79:         TYPEAPPLY(13)
+    81:           SELECTin(6) 16 [<init>[Signed Signature(List(1),scala.annotation.internal.Child) @<init>]]
+    84:             NEW
+    85:               SHAREDtype 27
+    87:             SHAREDtype 27
+    89:           TYPEREFsymbol 170
+    92:             SHAREDtype 46
+    94:   VALDEF(16) 2 [Z]
+    97:     IDENTtpt 17 [Z[ModuleClass]]
+    99:       SHAREDtype 47
+   101:     APPLY(8)
+   103:       SELECTin(6) 18 [<init>[Signed Signature(List(),Z$) @<init>]]
+   106:         NEW
+   107:           SHAREDterm 97
+   109:         SHAREDtype 47
+   111:     OBJECT
+   112:   TYPEDEF(138) 17 [Z[ModuleClass]]
+   116:     TEMPLATE(133)
+   119:       APPLY(8)
+   121:         SELECTin(6) 20 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+   124:           NEW
+   125:             SHAREDtype 10
+   127:           SHAREDtype 10
+   129:       SELFDEF 21 [_]
+   131:         SINGLETONtpt
+   132:           TERMREFsymbol 94
+   134:             SHAREDtype 49
+   136:       DEFDEF(5) 7 [<init>]
+   139:         EMPTYCLAUSE
+   140:         SHAREDtype 18
+   142:         STABLE
+   143:       DEFDEF(25) 22 [writeReplace]
+   146:         EMPTYCLAUSE
+   147:         TYPEREF 23 [AnyRef]
+   149:           SHAREDtype 20
+   151:         APPLY(15)
+   153:           SELECTin(9) 30 [<init>[Signed Signature(List(java.lang.Class),scala.runtime.ModuleSerializationProxy) @<init>]]
+   156:             NEW
+   157:               TYPEREF 26 [ModuleSerializationProxy]
+   159:                 TERMREFpkg 25 [scala[Qualified . runtime]]
+   161:             SHAREDtype 157
+   164:           CLASSconst
+   165:             SHAREDtype 132
+   168:         PRIVATE
+   169:         SYNTHETIC
+   170:       TYPEDEF(26) 31 [AOptions]
+   173:         TEMPLATE(23)
+   175:           APPLY(8)
+   177:             SELECTin(6) 20 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+   180:               NEW
+   181:                 SHAREDtype 10
+   183:               SHAREDtype 10
+   185:           IDENTtpt 2 [Z]
+   187:             TYPEREFsymbol 5
+   189:               SHAREDtype 49
+   191:           DEFDEF(5) 7 [<init>]
+   194:             EMPTYCLAUSE
+   195:             SHAREDtype 18
+   197:             STABLE
+   198:       TYPEDEF(25) 32 [BOptions]
+   201:         TEMPLATE(22)
+   203:           APPLY(8)
+   205:             SELECTin(6) 20 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+   208:               NEW
+   209:                 SHAREDtype 10
+   211:               SHAREDtype 10
+   213:           IDENTtpt 2 [Z]
+   215:             SHAREDtype 187
+   218:           DEFDEF(5) 7 [<init>]
+   221:             EMPTYCLAUSE
+   222:             SHAREDtype 18
+   224:             STABLE
+   225:       TYPEDEF(25) 33 [COptions]
+   228:         TEMPLATE(22)
+   230:           APPLY(8)
+   232:             SELECTin(6) 20 [<init>[Signed Signature(List(),java.lang.Object) @<init>]]
+   235:               NEW
+   236:                 SHAREDtype 10
+   238:               SHAREDtype 10
+   240:           IDENTtpt 2 [Z]
+   242:             SHAREDtype 187
+   245:           DEFDEF(5) 7 [<init>]
+   248:             EMPTYCLAUSE
+   249:             SHAREDtype 18
+   251:             STABLE
+   252:     OBJECT
+   253:
 
-Positions (154 bytes, starting from <elided base index>):
+Positions (138 bytes, starting from <elided base index>):
   lines: 12
   line sizes:
      38, 0, 98, 90, 106, 14, 0, 9, 28, 28, 28, 0
@@ -205,51 +183,45 @@ Positions (154 bytes, starting from <elided base index>):
     10: 350 .. 350
     14: 337 .. 337
     18: 337 .. 337
-    31: 337 .. 351
-    37: 337 .. 337
-    41: 337 .. 337
-    57: 350 .. 350
-    61: 350 .. 350
-    83: 350 .. 350
-    87: 350 .. 350
-   104: 350 .. 350
-   108: 350 .. 350
-   113: 353 .. 353
-   116: 353 .. 353
-   131: 353 .. 449
-   135: 365 .. 449
-   144: 360 .. 360
-   151: 365 .. 365
-   155: 365 .. 365
-   159: 365 .. 365
-   162: 360 .. 360
-   166: 360 .. 360
-   176: 360 .. 360
-   183: 360 .. 360
-   189: 365 .. 391
-   192: 379 .. 391
-   200: 371 .. 371
-   204: 390 .. 391
-   210: 379 .. 381
-   214: 379 .. 379
-   217: 394 .. 420
-   220: 408 .. 420
-   228: 400 .. 400
-   232: 419 .. 420
-   237: 408 .. 410
-   241: 408 .. 408
-   244: 423 .. 449
-   247: 437 .. 449
-   255: 429 .. 429
-   259: 448 .. 449
-   264: 437 .. 439
-   268: 437 .. 437
-   276: 353 .. 449
-   282: 353 .. 353
-   286: 353 .. 353
+    39: 350 .. 350
+    43: 350 .. 350
+    64: 350 .. 350
+    68: 350 .. 350
+    85: 350 .. 350
+    89: 350 .. 350
+    94: 353 .. 353
+    97: 353 .. 353
+   112: 353 .. 449
+   116: 365 .. 449
+   125: 360 .. 360
+   132: 365 .. 365
+   136: 365 .. 365
+   140: 365 .. 365
+   143: 360 .. 360
+   147: 360 .. 360
+   157: 360 .. 360
+   164: 360 .. 360
+   170: 365 .. 391
+   173: 379 .. 391
+   181: 371 .. 371
+   185: 390 .. 391
+   191: 379 .. 381
+   195: 379 .. 379
+   198: 394 .. 420
+   201: 408 .. 420
+   209: 400 .. 400
+   213: 419 .. 420
+   218: 408 .. 410
+   222: 408 .. 408
+   225: 423 .. 449
+   228: 437 .. 449
+   236: 429 .. 429
+   240: 448 .. 449
+   245: 437 .. 439
+   249: 437 .. 437
 
   source paths:
-     0: 19 [<elided source file name>]
+     0: 35 [<elided source file name>]
 
 Attributes (2 bytes, starting from <elided base index>):
-  SOURCEFILEattr 19 [<elided source file name>]
+  SOURCEFILEattr 35 [<elided source file name>]

--- a/tests/pos/i6375.scala
+++ b/tests/pos/i6375.scala
@@ -2,7 +2,7 @@
  * The output of the program should instead look like this:
 
       package <empty> {
-        @scala.annotation.internal.SourceFile("i6375.scala") class Test() extends
+        class Test() extends
           Object
         () {
           final given def given_Int: Int = 0

--- a/tests/printing/getters/var-should-not-be-update-def-get.check
+++ b/tests/printing/getters/var-should-not-be-update-def-get.check
@@ -1,8 +1,7 @@
 [[syntax trees at end of MegaPhase{pruneErasedDefs, uninitialized, inlinePatterns, vcInlineMethods, seqLiterals, intercepted, getters, specializeFunctions, specializeTuples, collectNullableFields, elimOuterSelect, resolveSuper, functionXXLForwarders, paramForwarding, genericTuples, letOverApply, arrayConstructors}]] // tests/printing/getters/var-should-not-be-update-def-get.scala
 package <empty> {
   import scala.language.experimental.captureChecking
-  @SourceFile("tests/printing/getters/var-should-not-be-update-def-get.scala")
-    trait Foo() extends Object, scala.caps.Mutable {
+  trait Foo() extends Object, scala.caps.Mutable {
     def x: Int
     update def x_=(x$1: Int): Unit
   }

--- a/tests/printing/inlining/i24347.check
+++ b/tests/printing/inlining/i24347.check
@@ -1,12 +1,11 @@
 [[syntax trees at end of                  inlining]] // tests/printing/inlining/i24347.scala
 package <empty> {
-  @SourceFile("tests/printing/inlining/i24347.scala") class Box(value: Int)
-     extends Object() {
+  class Box(value: Int) extends Object() {
     val value: Int
   }
   final lazy module val i24347$package: i24347$package = new i24347$package()
-  @SourceFile("tests/printing/inlining/i24347.scala") final module class
-    i24347$package() extends Object() { this: i24347$package.type =>
+  final module class i24347$package() extends Object() {
+    this: i24347$package.type =>
     private def writeReplace(): AnyRef =
       new scala.runtime.ModuleSerializationProxy(classOf[i24347$package.type])
     inline def unbox(b: Box): Int =
@@ -25,8 +24,7 @@ package <empty> {
         }:Int
       }
   }
-  @SourceFile("tests/printing/inlining/i24347.scala") final class Test() extends
-     Object() {
+  final class Test() extends Object() {
     <static> def main(args: Array[String]): Unit =
       try
         {

--- a/tests/printing/posttyper/i22533.check
+++ b/tests/printing/posttyper/i22533.check
@@ -1,11 +1,10 @@
 [[syntax trees at end of                 posttyper]] // tests/printing/posttyper/i22533.scala
 package <empty> {
-  @SourceFile("tests/printing/posttyper/i22533.scala") trait A() extends Any {
+  trait A() extends Any {
     override def equals(x: Any): Boolean = ???
     override def hashCode(): Int = ???
   }
-  @SourceFile("tests/printing/posttyper/i22533.scala") final class Foo(u: Int)
-     extends AnyVal(), A {
+  final class Foo(u: Int) extends AnyVal(), A {
     override def hashCode(): Int = Foo.this.u.hashCode()
     override def equals(x$0: Any): Boolean =
       x$0 match
@@ -16,8 +15,7 @@ package <empty> {
     private[this] val u: Int
   }
   final lazy module val Foo: Foo = new Foo()
-  @SourceFile("tests/printing/posttyper/i22533.scala") final module class Foo()
-     extends AnyRef() { this: Foo.type =>
+  final module class Foo() extends AnyRef() { this: Foo.type =>
     private def writeReplace(): AnyRef =
       new scala.runtime.ModuleSerializationProxy(classOf[Foo.type])
   }

--- a/tests/printing/posttyper/patdef.check
+++ b/tests/printing/posttyper/patdef.check
@@ -1,8 +1,8 @@
 [[syntax trees at end of                 posttyper]] // tests/printing/posttyper/patdef.scala
 package <empty> {
   final lazy module val patdef$package: patdef$package = new patdef$package()
-  @SourceFile("tests/printing/posttyper/patdef.scala") final module class
-    patdef$package() extends Object() { this: patdef$package.type =>
+  final module class patdef$package() extends Object() {
+    this: patdef$package.type =>
     private def writeReplace(): AnyRef =
       new scala.runtime.ModuleSerializationProxy(classOf[patdef$package.type])
     val a: Int =

--- a/tests/printing/transformed/lazy-vals-legacy.check
+++ b/tests/printing/transformed/lazy-vals-legacy.check
@@ -1,7 +1,6 @@
 [[syntax trees at end of MegaPhase{dropOuterAccessors, dropParentRefinements, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-legacy.scala
 package <empty> {
-  @SourceFile("tests/printing/transformed/lazy-vals-legacy.scala") final module
-    class A extends Object {
+  final module class A extends Object {
     def <init>(): Unit =
       {
         super()

--- a/tests/printing/transformed/lazy-vals-new.check
+++ b/tests/printing/transformed/lazy-vals-new.check
@@ -1,7 +1,6 @@
 [[syntax trees at end of MegaPhase{dropOuterAccessors, dropParentRefinements, checkNoSuperThis, flatten, transformWildcards, moveStatic, expandPrivate, restoreScopes, selectStatic, repeatableAnnotations}]] // tests/printing/transformed/lazy-vals-new.scala
 package <empty> {
-  @SourceFile("tests/printing/transformed/lazy-vals-new.scala") final module
-    class A extends Object {
+  final module class A extends Object {
     def <init>(): Unit =
       {
         super()

--- a/tests/run-macros/term-show.check
+++ b/tests/run-macros/term-show.check
@@ -10,7 +10,7 @@
   }
   ()
 }
-@scala.annotation.internal.SourceFile("tests/run-macros/term-show/Test_2.scala") @scala.annotation.experimental("Added by top level import scala.language.experimental.erasedDefinitions") trait A() extends java.lang.Object {
+@scala.annotation.experimental("Added by top level import scala.language.experimental.erasedDefinitions") trait A() extends java.lang.Object {
   def imp(x: scala.Int)(implicit str: scala.Predef.String): scala.Int
   def use(`x₂`: scala.Int)(using `str₂`: scala.Predef.String): scala.Int
   def era(`x₃`: scala.Int)(erased `str₃`: scala.Predef.String): scala.Int


### PR DESCRIPTION
TODO from a while ago.

Noticed while asking myself "what things in the compiler currently use absolute paths?"

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
