### PR TITLE
Vendor `pprint`, `sourcecode` & `fansi`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,6 +216,7 @@ jobs:
               scala3-library-sjs/publishSigned \
               scala3-presentation-compiler/publishSigned \
               scala3-repl/publishSigned \
+              scala3-repl-deps/publishSigned \
               scala3-sbt-bridge-bootstrapped/publishSigned \
               scala3-staging/publishSigned \
               scala3-tasty-inspector/publishSigned \

--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -325,6 +325,33 @@ jobs:
       - name: Test REPL
         run: ./project/scripts/sbt scala3-repl/test
 
+  test-repl-deps:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [17, 25]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+      - name: Set up JDK ${{ matrix.jdk }} (REPL subprocess)
+        id: jdk
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.jdk }}
+      - name: Set up JDK 17 (build, default)
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test REPL lazy vals warning and shading on JDK ${{ matrix.jdk }}
+        env:
+          DOTTY_REPL_TEST_JAVA_HOME: ${{ steps.jdk.outputs.path }}
+        run: ./project/scripts/sbt "scala3-repl/testOnly *LazyValsWarningTest *ShadingTest"
+
   test-presentation-compiler:
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ val `scala3-compiler-nonbootstrapped` = Build.`scala3-compiler-nonbootstrapped`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
 
 val `scala3-repl` = Build.`scala3-repl`
+val `scala3-repl-deps` = Build.`scala3-repl-deps`
 
 // The Standard Library
 val `scala2-library` = Build.`scala2-library`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -968,7 +968,8 @@ object Build {
    *  compile for `scala3-repl-deps`.
    */
   lazy val fetchReplDepsSources: Def.Initialize[Task[Seq[File]]] = Def.task {
-    val log = streams.value.log
+    val s = streams.value
+    val cacheDir = s.cacheDirectory
     val outDir = (Compile / sourceManaged).value / "repl-deps-src"
     // (upstream repo, git tag, source subdirectories to include)
     val libs = Seq(
@@ -979,10 +980,10 @@ object Build {
     // The leading token is a shading-scheme version: bump it to force regeneration
     // when the shading/fetching logic (`shadeReplDepSource`, `fetchReplDepsSources`) changes.
     val stamp = (s"scheme:3:$replDepsShadedPackage" +: libs.map { case (r, v, ds) => s"$r:$v:${ds.mkString(",")}" }).mkString("|")
-    val stampFile = outDir / ".stamp"
-    val upToDate = stampFile.exists && IO.read(stampFile) == stamp
-    if (!upToDate) {
-      log.info(s"Fetching and shading vendored REPL dependency sources into $outDir ...")
+    val stampFile = cacheDir / "fetchReplDepsSources.stamp"
+    IO.write(stampFile, stamp)
+    val cached = FileFunction.cached(cacheDir / "fetchReplDepsSources", FilesInfo.hash, FilesInfo.exists) { _ =>
+      s.log.info(s"Fetching and shading vendored REPL dependency sources into $outDir ...")
       IO.delete(outDir)
       IO.createDirectory(outDir)
       IO.withTemporaryDirectory { tmp =>
@@ -1007,9 +1008,9 @@ object Build {
             sys.error(s"No Scala sources vendored for $repo $tag (looked in ${subdirs.mkString(", ")}); check the archive layout.")
         }
       }
-      IO.write(stampFile, stamp)
+      (outDir ** "*.scala").get.toSet
     }
-    (outDir ** "*.scala").get
+    cached(Set(stampFile)).toSeq
   }
 
   /** Shades a single vendored source file into `dotty.tools.repl.shaded.*`.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -723,7 +723,7 @@ object Build {
     .aggregate(`scala3-interfaces`, `scala3-library-bootstrapped` , `scala-library-bootstrapped`,
       `tasty-core-bootstrapped`, `scala3-compiler-bootstrapped`, `scala3-sbt-bridge-bootstrapped`,
       `scala3-staging`, `scala3-tasty-inspector`, `scala-library-sjs`, `scala3-library-sjs`,
-      scaladoc, `scala3-repl`, `scala3-presentation-compiler`, `scala3-language-server`)
+      scaladoc, `scala3-repl`, `scala3-repl-deps`, `scala3-presentation-compiler`, `scala3-language-server`)
     .settings(
       name          := "scala3-bootstrapped",
       moduleName    := "scala3-bootstrapped",
@@ -774,6 +774,7 @@ object Build {
         (`scala3-tasty-inspector` / publishLocalBin),
         (scaladoc / publishLocalBin),
         (`scala3-repl` / publishLocalBin),
+        (`scala3-repl-deps` / publishLocalBin),
         publishLocalBin,
       ).evaluated,
       bspEnabled := false,
@@ -879,6 +880,7 @@ object Build {
 
   lazy val `scala3-repl` = project.in(file("repl"))
     .dependsOn(`scala3-compiler-bootstrapped` % "compile->compile;test->test")
+    .dependsOn(`scala3-repl-deps`)
     .settings(publishSettings)
     .settings(
       name          := "scala3-repl",
@@ -904,9 +906,6 @@ object Build {
         Dependencies.jlineReader,
         Dependencies.jlineTerminal,
         Dependencies.jlineTerminalJni,
-        Dependencies.pprint,
-        Dependencies.fansi,
-        Dependencies.sourcecode,
         Dependencies.sbtJunitInterface % Test,
         Dependencies.coursierInterface, // used by the REPL for dependency resolution
         Dependencies.usingDirectives, // used by the REPL for parsing magic comments
@@ -926,6 +925,110 @@ object Build {
       },
       bspEnabled := enableBspAllProjects,
     )
+
+  /* Vendored and shaded REPL dependencies.
+   *
+   * The recompiled classes are shaded under `dotty.tools.repl.shaded.*`
+   */
+  lazy val `scala3-repl-deps` = project.in(file("repl-deps"))
+    // The compiler is needed on the compile classpath for the pprint/sourcecode
+    // macros (`scala.quoted`), and at runtime, but must not leak to downstream
+    // consumers (the REPL already depends on it). Mirrors `scala3-staging`.
+    .dependsOn(`scala3-compiler-bootstrapped` % "provided; compile->runtime")
+    .settings(publishSettings)
+    .settings(
+      name          := "scala3-repl-deps",
+      moduleName    := "scala3-repl-deps",
+      version       := dottyVersion,
+      versionScheme := Some("semver-spec"),
+      scalaVersion  := dottyNonBootstrappedVersion,
+      crossPaths    := true,
+      autoScalaLibrary := false,
+      Compile / unmanagedSourceDirectories := Nil,
+      Compile / unmanagedResourceDirectories := Nil,
+      Test / unmanagedSourceDirectories := Nil,
+      scalacOptions := Seq("-encoding", "UTF8", "-release:17"),
+      // Fetch and shade the upstream sources, then compile them with the in-tree compiler.
+      Compile / sourceGenerators += fetchReplDepsSources.taskValue,
+      bootstrappedScalaInstanceSettings,
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := false,
+      Compile / doc / sources := Seq(),
+      Test / publishArtifact := false,
+      publish / skip := false,
+      target := target.value / "scala3-repl-deps",
+      bspEnabled := false,
+    )
+
+  /** Package all vendored REPL dependencies are shaded into. */
+  private val replDepsShadedPackage = "dotty.tools.repl.shaded"
+
+  /** Fetches the upstream sources of pprint/fansi/sourcecode from their git tags,
+   *  shades them into `dotty.tools.repl.shaded.*`, and returns the Scala sources to
+   *  compile for `scala3-repl-deps`.
+   */
+  lazy val fetchReplDepsSources: Def.Initialize[Task[Seq[File]]] = Def.task {
+    val log = streams.value.log
+    val outDir = (Compile / sourceManaged).value / "repl-deps-src"
+    // (upstream repo, git tag, source subdirectories to include)
+    val libs = Seq(
+      ("fansi",      Dependencies.fansiVersion,      Seq("fansi/src")),
+      ("sourcecode", Dependencies.sourcecodeVersion, Seq("sourcecode/src", "sourcecode/src-3")),
+      ("pprint",     Dependencies.pprintVersion,     Seq("pprint/src", "pprint/src-3")),
+    )
+    // The leading token is a shading-scheme version: bump it to force regeneration
+    // when the shading/fetching logic (`shadeReplDepSource`, `fetchReplDepsSources`) changes.
+    val stamp = (s"scheme:3:$replDepsShadedPackage" +: libs.map { case (r, v, ds) => s"$r:$v:${ds.mkString(",")}" }).mkString("|")
+    val stampFile = outDir / ".stamp"
+    val upToDate = stampFile.exists && IO.read(stampFile) == stamp
+    if (!upToDate) {
+      log.info(s"Fetching and shading vendored REPL dependency sources into $outDir ...")
+      IO.delete(outDir)
+      IO.createDirectory(outDir)
+      IO.withTemporaryDirectory { tmp =>
+        libs.foreach { case (repo, tag, subdirs) =>
+          val url = new java.net.URI(s"https://codeload.github.com/com-lihaoyi/$repo/zip/refs/tags/$tag").toURL
+          val zip = tmp / s"$repo-$tag.zip"
+          sbt.io.Using.urlInputStream(url)(in => IO.transfer(in, zip))
+          val extractDir = tmp / s"$repo-$tag-extracted"
+          IO.unzip(zip, extractDir)
+          val root = IO.listFiles(extractDir).filter(_.isDirectory).toList match {
+            case dir :: Nil => dir
+            case dirs => sys.error(s"Expected one top-level directory in the $repo archive, found: ${dirs.map(_.getName).mkString(", ")}")
+          }
+          subdirs.foreach { sub =>
+            val srcRoot = root / sub
+            (srcRoot ** "*.scala").get.foreach { f =>
+              val rel = IO.relativize(srcRoot, f).getOrElse(f.getName)
+              IO.write(outDir / repo / rel, shadeReplDepSource(IO.read(f)))
+            }
+          }
+          if ((outDir / repo ** "*.scala").get.isEmpty)
+            sys.error(s"No Scala sources vendored for $repo $tag (looked in ${subdirs.mkString(", ")}); check the archive layout.")
+        }
+      }
+      IO.write(stampFile, stamp)
+    }
+    (outDir ** "*.scala").get
+  }
+
+  /** Shades a single vendored source file into `dotty.tools.repl.shaded.*`.
+   *
+   *  pprint/fansi/sourcecode reference each other only through fully-qualified names
+   *  (there are no `import fansi.*` etc.), so wrapping every compilation unit in an
+   *  outer `package dotty.tools.repl.shaded` clause is enough: the top-level
+   *  `pprint`/`fansi`/`sourcecode` packages become siblings under that package and
+   *  keep resolving each other, while being invisible under their original names.
+   *
+   *  The one file that stays put is pprint's `scala.collection.internal.pprint`
+   *  helper: it relies on a `private[scala]` accessor, so it must remain in the
+   *  `scala` namespace and cannot be relocated.
+   */
+  private def shadeReplDepSource(content: String): String = {
+    val firstPackage = content.linesIterator.find(_.trim.startsWith("package ")).map(_.trim).getOrElse("")
+    if (firstPackage.startsWith("package scala")) content
+    else s"package $replDepsShadedPackage\n\n$content"
+  }
 
   // ==============================================================================================
   // =================================== SCALA STANDARD LIBRARY ===================================
@@ -2444,6 +2547,7 @@ object Build {
         (`scala3-tasty-inspector` / publishLocalBin).value
         (scaladoc / publishLocalBin).value
         (`scala3-repl` / publishLocalBin).value
+        (`scala3-repl-deps` / publishLocalBin).value
         (`scala3-compiler-bootstrapped` / publishLocalBin).value
         (`scala-library-sjs` / publishLocalBin).value
         (`scala3-library-sjs` / publishLocalBin).value
@@ -2538,8 +2642,10 @@ object Build {
     Universal / mappings ++= directory(republishRepo.value / "libexec"),
     Universal / mappings +=  (republishRepo.value / "VERSION") -> "VERSION",
     // ========
-    republishCommandLibs += ("scala" -> List("scala3-interfaces", "scala3-compiler", "scala3-library", "scala-library", "tasty-core", "scala3-repl")),
-    republishCommandLibs += ("with_compiler" -> List("scala3-staging", "scala3-tasty-inspector", "scala3-repl", "^!scala3-interfaces", "^!scala3-compiler", "^!scala3-library", "^!scala-library", "^!tasty-core")),
+    // NB: use the `_3`-suffixed artifact id for scala3-repl so the fuzzy lookup in
+    // RepublishPlugin does not also match `scala3-repl-deps_3` (the vendored libs).
+    republishCommandLibs += ("scala" -> List("scala3-interfaces", "scala3-compiler", "scala3-library", "scala-library", "tasty-core", "scala3-repl_3")),
+    republishCommandLibs += ("with_compiler" -> List("scala3-staging", "scala3-tasty-inspector", "scala3-repl_3", "^!scala3-interfaces", "^!scala3-compiler", "^!scala3-library", "^!scala-library", "^!tasty-core")),
     republishCommandLibs += ("scaladoc" -> List("scala3-interfaces", "scala3-compiler", "scala3-library", "scala-library", "tasty-core", "scala3-tasty-inspector", "scaladoc")),
   )
 
@@ -2641,6 +2747,7 @@ object Build {
         `scala3-interfaces`,
         `scala3-library-bootstrapped`,
         `scala3-repl`,
+        `scala3-repl-deps`, // vendored & shaded pprint/fansi/sourcecode, published to maven2
         `scala3-sbt-bridge-bootstrapped`, // for scala-cli
         `scala3-staging`,
         `scala3-tasty-inspector`,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val coursier = "io.get-coursier" %% "coursier" % "2.1.24"
   val coursierInterface = "io.get-coursier" % "interface" % "1.0.29-M4"
 
-  val fansi = "com.lihaoyi" %% "fansi" % "0.5.1"
+  val fansiVersion = "0.5.1" // vendored and shaded into `scala3-repl-deps` (see repl-deps/)
 
   private val flexmarkVersion = "0.64.8"
   val flexmarkDeps = Seq(
@@ -55,7 +55,7 @@ object Dependencies {
   val mtagsInterfaces = "org.scalameta" % "mtags-interfaces" % mtagsVersion
   val mtagsShared = "org.scalameta" % s"mtags-shared_${Versions.scala2Version}" % mtagsVersion
 
-  val pprint = "com.lihaoyi" %% "pprint" % "0.9.3"
+  val pprintVersion = "0.9.3" // vendored and shaded into `scala3-repl-deps` (see repl-deps/)
 
   val sbtCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.12.0"
   val sbtJunitInterface = "com.github.sbt" % "junit-interface" % "0.13.3"
@@ -71,7 +71,7 @@ object Dependencies {
   val scalaJsLibrary = "org.scala-js" %% "scalajs-library" % scalaJSVersion
   val scalaJsLinker = "org.scala-js" %% "scalajs-linker" % scalaJSVersion
 
-  val sourcecode = "com.lihaoyi" %% "sourcecode" % "0.4.4"
+  val sourcecodeVersion = "0.4.4" // vendored and shaded into `scala3-repl-deps` (see repl-deps/)
 
   val usingDirectives = "org.virtuslab" % "using_directives" % "1.1.4"
 }

--- a/project/scripts/native-integration/bashTests
+++ b/project/scripts/native-integration/bashTests
@@ -95,3 +95,22 @@ std_output=$("$PROG_HOME/bin/scala" run "$SOURCE_TEST_BOOTSTRAPPED" --power --of
 echo "$std_output" | grep -q "BOOTSTRAPPED_LIBRARY_TEST_PASSED" || die "Bootstrapped library test failed, output: $std_output"
 clear_cli_dotfiles "$ROOT/project/scripts/native-integration"
 
+echo "testing REPL does not emit legacy lazy vals warnings on JDK 25 (scala/scala3#25508)"
+# The vendored pprint/fansi/sourcecode must be compiled with the new lazy vals
+# scheme, otherwise scala.runtime.LazyVals$ calls sun.misc.Unsafe::objectFieldOffset,
+# which the JVM reports as a terminally deprecated method starting with JDK 24+
+std_output=$("$PROG_HOME/bin/scala" --jvm 25 --server=false -repl-init-script 'val replCheck = 1 + 1' -repl-quit-after-init 2>&1)
+echo "$std_output" | grep -q "replCheck" || die "REPL init script did not run on JDK 25, output: $std_output"
+if echo "$std_output" | grep "has been called by scala.runtime.LazyVals" | grep -qv "scala-cli"; then
+  die "REPL emitted a legacy lazy vals warning on JDK 25, output: $std_output"
+fi
+clear_cli_dotfiles "$ROOT"
+
+echo "testing REPL coexists with a user dependency on fansi (shaded internally)"
+# The REPL vendors pprint/fansi/sourcecode shaded under dotty.tools.repl.shaded.*,
+# so a user can depend on the original (unshaded, possibly different-versioned)
+# libraries without clashing with the REPL's internal copy.
+std_output=$("$PROG_HOME/bin/scala" --server=false --dependency com.lihaoyi::fansi:0.4.0 -repl-init-script 'println(fansi.Color.Red("COEXIST_OK").plainText)' -repl-quit-after-init 2>&1)
+echo "$std_output" | grep -q "COEXIST_OK" || die "REPL failed to use a user-provided fansi dependency, output: $std_output"
+clear_cli_dotfiles "$ROOT"
+

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -10,6 +10,8 @@ import printing.SyntaxHighlighting
 import reporting.Diagnostic
 import StackTraceOps.*
 
+import dotty.tools.repl.shaded.{fansi, pprint}
+
 import scala.compiletime.uninitialized
 import scala.util.control.NonFatal
 
@@ -55,8 +57,8 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       // Due to the possible interruption instrumentation, it is unlikely that we can get
       // rid of reflection here.
       val cl = classLoader()
-      val pprintCls = Class.forName("pprint.PPrinter$Color$", false, cl)
-      val fansiStrCls = Class.forName("fansi.Str", false, cl)
+      val pprintCls = Class.forName("dotty.tools.repl.shaded.pprint.PPrinter$Color$", false, cl)
+      val fansiStrCls = Class.forName("dotty.tools.repl.shaded.fansi.Str", false, cl)
       val Color = pprintCls.getField("MODULE$").get(null)
       val Color_apply = pprintCls.getMethod("apply",
         classOf[Any],     // value

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -741,4 +741,4 @@ class ReplDriver(settings: Array[String],
 
 end ReplDriver
 object ReplDriver:
-  def pprintImport = "import pprint.pprintln\n"
+  def pprintImport = "import dotty.tools.repl.shaded.pprint.pprintln\n"

--- a/repl/src/dotty/tools/repl/StackTraceOps.scala
+++ b/repl/src/dotty/tools/repl/StackTraceOps.scala
@@ -17,6 +17,8 @@ import collection.mutable, mutable.ListBuffer
 import dotty.tools.dotc.util.chaining.*
 import java.lang.System.lineSeparator
 
+import dotty.tools.repl.shaded.fansi
+
 object StackTraceOps:
 
   extension (t: Throwable)

--- a/repl/test/dotty/tools/repl/LazyValsWarningTest.scala
+++ b/repl/test/dotty/tools/repl/LazyValsWarningTest.scala
@@ -1,0 +1,65 @@
+package dotty.tools.repl
+
+import java.io.File
+import java.nio.charset.StandardCharsets.UTF_8
+
+import scala.io.Source
+import scala.util.Using
+
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+/** Anti-regression test for the `sun.misc.Unsafe`/`LazyVals` warnings
+ *
+ *  See https://github.com/scala/scala3/issues/25508
+ *
+ *  The warning is only emitted by the JVM on JDK 24+ (and is to become an error on
+ *  a future JDK). When the REPL subprocess runs on the same JVM as the test, the
+ *  assertion is therefore skipped on older JDKs. Point the subprocess at a
+ *  JDK 24+ to reproduce locally.
+ */
+class LazyValsWarningTest:
+
+  @Test def noUnsafeLazyValsWarning(): Unit =
+    val javaHomeOverride =
+      sys.props.get("dotty.tests.replJavaHome").orElse(sys.env.get("DOTTY_REPL_TEST_JAVA_HOME"))
+    assumeTrue(
+      "warning is only emitted on JDK 24+",
+      javaHomeOverride.isDefined || Runtime.version.feature >= 24
+    )
+
+    val output = runReplInitScript(javaHomeOverride, "val replCheck = 1 + 1")
+
+    assertTrue(
+      s"REPL did not evaluate the init script, output was:\n$output",
+      output.contains("replCheck")
+    )
+    for marker <- List("sun.misc.Unsafe", "objectFieldOffset", "LazyVals") do
+      assertFalse(
+        s"REPL emitted a legacy lazy vals warning ($marker):\n$output",
+        output.contains(marker)
+      )
+
+  /** Runs `initScript` in a freshly spawned REPL subprocess and returns its
+   *  merged stdout/stderr output.
+   */
+  private def runReplInitScript(javaHomeOverride: Option[String], initScript: String): String =
+    val javaHome = javaHomeOverride.getOrElse(sys.props("java.home"))
+    val javaBin = List(javaHome, "bin", "java").mkString(File.separator)
+    val classpath = sys.props("java.class.path")
+    val command = List(
+      javaBin,
+      "-Dscala.usejavacp=true",
+      "-classpath", classpath,
+      "dotty.tools.repl.Main",
+      "-usejavacp",
+      "-color:never",
+      "--repl-quit-after-init",
+      "--repl-init-script", initScript,
+    )
+    val process = ProcessBuilder(command*).redirectErrorStream(true).start()
+    val output = Using.resource(Source.fromInputStream(process.getInputStream, UTF_8.name))(_.mkString)
+    process.waitFor()
+    output
+end LazyValsWarningTest

--- a/repl/test/dotty/tools/repl/ShadingTest.scala
+++ b/repl/test/dotty/tools/repl/ShadingTest.scala
@@ -1,0 +1,42 @@
+package dotty.tools.repl
+
+import scala.util.Try
+
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Test
+
+/** Verifies that the vendored pprint/fansi/sourcecode used by the REPL are shaded
+ *  under `dotty.tools.repl.shaded.*`, and that their original top-level packages are
+ *  not present on the REPL's classpath. This guarantees that a user depending on
+ *  pprint/fansi/sourcecode (possibly at a different version) inside the REPL cannot
+ *  clash with the REPL's internal copy.
+ */
+class ShadingTest:
+
+  private val shadedClasses = List(
+    "dotty.tools.repl.shaded.fansi.Str",
+    "dotty.tools.repl.shaded.pprint.PPrinter",
+    "dotty.tools.repl.shaded.pprint.PPrinter$Color$",
+    "dotty.tools.repl.shaded.sourcecode.Name",
+  )
+
+  private val unshadedClasses = List(
+    "fansi.Str",
+    "pprint.PPrinter",
+    "sourcecode.Name",
+  )
+
+  private def loads(name: String): Boolean =
+    Try(Class.forName(name, false, getClass.getClassLoader)).isSuccess
+
+  @Test def shadedClassesArePresent(): Unit =
+    for name <- shadedClasses do
+      assertTrue(s"expected shaded class $name to be on the REPL classpath", loads(name))
+
+  @Test def unshadedClassesAreAbsent(): Unit =
+    for name <- unshadedClasses do
+      assertFalse(
+        s"unshaded class $name must not leak onto the REPL classpath",
+        loads(name)
+      )
+end ShadingTest


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/25508
Fixes https://github.com/scala/scala3/issues/24382
An alternative to https://github.com/scala/scala3/pull/26433

Rather than commit the code of the 3 libraries in the repo, this fetches them on the fly in the build, shades and rebuilds into a `scala3-repl-deps` artifact.

This also includes anti-regression tests for handling on newer JDKs (tests run on JDK 25)

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by reviewing and tweaking the code, as well as including automated tests that verify it.

## How was the solution tested?
New automated tests
