### PR TITLE
fix: make REPL completion interruptible

### DIFF
--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -63,8 +63,19 @@ class JLineTerminal(providedTerminal: org.jline.terminal.Terminal | Null = null)
   private val userInput = new UserInputStream(userLineReader, terminal.encoding())
 
   private def bindCtrlCInterrupt(lr: LineReader): Unit =
+    val ctrlCWidgetName = "userInterrupt"
+
+    lr.getWidgets.put(
+      ctrlCWidgetName,
+      new Widget { override def apply(): Boolean = throw new UserInterruptException("") }
+    )
+    // The keybind must be a `Reference` to a registered widget, not a raw `Widget`.
+    // While a completion list is shown, JLine's loop (`LineReaderImpl.doList`)
+    // only dispatches `Reference` bindings; a raw `Widget` is silently ignored,
+    // so Ctrl-C would do nothing during completion.
+    // See https://github.com/scala/scala3/issues/26074.
     lr.getKeyMaps.get(LineReader.MAIN).bind(
-      new Widget { override def apply(): Boolean = throw new UserInterruptException("") },
+      new Reference(ctrlCWidgetName),
       "\u0003"
     )
 


### PR DESCRIPTION
Fixes #26074

While a completion list was displayed (e.g. after `"".split`, Tab), pressing ctrl-c did nothing.

The cause was that ctrl-c was bound to an anonymous Widget. JLine's completion-list loop only dispatches Reference (named-widget) bindings, so a raw Widget was silently ignored.


Code that dispatched the bindings:
(https://github.com/jline/jline3/blob/master/reader/src/main/java/org/jline/reader/impl/LineReaderImpl.java#L5625)
```java
if (b instanceof Reference) {
    [...]
} else if (b == null) {
    post = null;
    return false;
}
```

## Have you relied on LLM-based tools in this contribution?

Yes - it helped me navigate JLine's codebase. I verified its output by reading the code myself.

## How was the solution tested?

Manually
