### PR TITLE
Internally preserve avoided singleton types as witness

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1624,39 +1624,42 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
     // begin recur
     if tp2 eq NoType then false
     else if tp1 eq tp2 then true
-    else
-      val savedCstr = constraint
-      val savedGadt = ctx.gadt
-      val savedLogSize = undoLog.size
-      inline def restore() =
-        state.constraint = savedCstr
-        ctx.gadtState.restore(savedGadt)
-        if undoLog.size != savedLogSize then
-          //println(i"ROLLBACK $tp1 <:< $tp2")
-          rollBack(savedLogSize)
-      val savedSuccessCount = successCount
-      try
-        val result = inNestedLevel:
-          if recCount >= Config.LogPendingSubTypesThreshold then monitored = true
-          if monitored then monitoredIsSubType else firstTry
-        if !result then restore()
-        else if recCount == 0 && needsGc then
-          state.gc()
-          needsGc = false
-        if (Stats.monitored) recordStatistics(result, savedSuccessCount)
-        result
-      catch
-        case ex: AssertionError =>
-          showGoal(tp1, tp2)
-          recCount -= 1
-          restore()
-          successCount = savedSuccessCount
-          throw ex
-        case ex: Exception =>
-          recCount -= 1
-          restore()
-          successCount = savedSuccessCount
-          throw ex
+    else (tp1, tp2) match
+      case (tp1: WitnessSkolemType, _) => recur(tp1.witness, tp2)
+      case (_, tp2: WitnessSkolemType) => recur(tp1, tp2.witness)
+      case _ =>
+        val savedCstr = constraint
+        val savedGadt = ctx.gadt
+        val savedLogSize = undoLog.size
+        inline def restore() =
+          state.constraint = savedCstr
+          ctx.gadtState.restore(savedGadt)
+          if undoLog.size != savedLogSize then
+            //println(i"ROLLBACK $tp1 <:< $tp2")
+            rollBack(savedLogSize)
+        val savedSuccessCount = successCount
+        try
+          val result = inNestedLevel:
+            if recCount >= Config.LogPendingSubTypesThreshold then monitored = true
+            if monitored then monitoredIsSubType else firstTry
+          if !result then restore()
+          else if recCount == 0 && needsGc then
+            state.gc()
+            needsGc = false
+          if (Stats.monitored) recordStatistics(result, savedSuccessCount)
+          result
+        catch
+          case ex: AssertionError =>
+            showGoal(tp1, tp2)
+            recCount -= 1
+            restore()
+            successCount = savedSuccessCount
+            throw ex
+          case ex: Exception =>
+            recCount -= 1
+            restore()
+            successCount = savedSuccessCount
+            throw ex
   }
 
   /** Undo all actions in undoLog following prevSize */

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -461,6 +461,7 @@ object TypeOps:
   /** An approximating map that drops NamedTypes matching `toAvoid` and wildcard types. */
   abstract class AvoidMap(using Context) extends AvoidWildcardsMap:
     @threadUnsafe lazy val localParamRefs = util.HashSet[Type]()
+    private val witnessSkolems = mutable.HashMap.empty[Symbol, SkolemType]
 
     def toAvoid(tp: NamedType): Boolean
 
@@ -477,6 +478,9 @@ object TypeOps:
           case tp: TermRef if toAvoid(tp) =>
             tp.info.widenExpr.dealiasKeepRefiningAnnots match {
               case info: SingletonType => apply(info)
+              case info if tp.isStable =>
+                // Preserve dependent selections on stable local paths; see `WitnessSkolemType`.
+                witnessSkolems.getOrElseUpdate(tp.symbol, WitnessSkolemType(apply(info), tp))
               case info => range(defn.NothingType, apply(info))
             }
           case tp: TypeRef if toAvoid(tp) =>

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5011,6 +5011,29 @@ object Types extends TypeUtils {
     def apply(info: Type): QualSkolemType = new QualSkolemType(info)
   }
 
+
+  /** A skolem type that keeps the `SingletonType` it was created from as a witness.
+   *
+   *  Type avoidance uses it when a stable local singleton must be hidden from
+   *  the resulting type. The skolem replaces the local singleton, while `witness`
+   *  records the original `SingletonType` so type comparison can still relate
+   *  the hidden skolem back to the original singleton.
+   *
+   *  For example, `inline def async[F[_]](am: Mon[F]) = new Wrap[F, am.Context]`
+   *  can inline to a local-proxy type `Wrap[F, am$proxy.Context]`.
+   *  Avoidance must hide `am$proxy`, but widening it to `? <: Mon[F]` loses the
+   *  dependent member selection. A witness skolem represents this as
+   *  `Wrap[F, ?1.Context]` while retaining `am$proxy` as the witness.
+   */
+  class WitnessSkolemType(info: Type, val witness: SingletonType) extends SkolemType(info) {
+    override def derivedSkolemType(info: Type)(using Context): SkolemType =
+      if (info eq this.info) this else WitnessSkolemType(info, witness)
+  }
+  object WitnessSkolemType {
+    def apply(info: Type, witness: SingletonType): WitnessSkolemType =
+      new WitnessSkolemType(info, witness)
+  }
+
   // ------------ Type variables ----------------------------------------
 
   /** In a TypeApply tree, a TypeVar is created for each argument type to be inferred.

--- a/tests/pos/i26153.scala
+++ b/tests/pos/i26153.scala
@@ -1,0 +1,39 @@
+trait Ctx[F[_]]
+
+trait Mon[F[_]]:
+  type Context <: Ctx[F]
+
+class Wrap[F[_], C <: Ctx[F]]:
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    stage2[F, T, C](expr)
+
+transparent inline def stage2[F[_], T, C <: Ctx[F]](
+    inline expr: C ?=> T
+): F[T] = ???
+
+transparent inline def async[F[_]](using am: Mon[F]) =
+  new Wrap[F, am.Context]
+
+class TupleMon[E] extends Mon[[A] =>> (E, A)]:
+  type Context = Ctx[[A] =>> (E, A)]
+
+given pm[E]: Mon[[A] =>> (E, A)] = new TupleMon[E]
+
+object Test:
+  val outer = new Object
+
+  val r = async[[A] =>> (String, A)] { 42 }
+
+  def stableLocal[F[_]](using am: Mon[F]) =
+    val local = am
+    new Wrap[F, local.Context]
+
+  def stableLocalAscribed[F[_]](using am: Mon[F]): Wrap[F, ? <: Ctx[F]] =
+    val local = am
+    new Wrap[F, local.Context]
+
+  def singletonAlias: outer.type =
+    val local: outer.type = outer
+    local
+
+  val r2 = stableLocal[[A] =>> (String, A)] { 42 }


### PR DESCRIPTION
fix https://github.com/scala/scala3/issues/26153

originally tried in https://github.com/scala/scala3/pull/26033 and this change is based on idea https://github.com/scala/scala3/pull/26033#issuecomment-4537595110

**background**
When we have an inline method whose result type depends on an argument term:

```scala
trait Mon[F[_]]:
  type Context
class Wrap[F[_], C]
inline def async[F[_]](am: Mon[F]) =
  new Wrap[F, am.Context]
```

During inlining, the compiler represents the inline argument with a local proxy. The inlined result can therefore have a type like `Wrap[F, am$proxy.Context]`. Since that local proxy cannot be exposed as the type of the  `Inlined` tree, so `TypeOps.avoid` removes references to it.

Previously, avoiding the proxy widened it to a range such as `? <: Mon[F]`, which turned the result into something like `Wrap[F, ?]`.

Later, when typing selections on the inlined value, the actual expression term still have `am$proxy.Context`, while the expected type has already avoided to a wildcard approximation, then it leads to a type mismatch.

see https://github.com/scala/scala3/pull/26033#issuecomment-4537595110

**fix**
This commit avoids stable local term with a new type `WitnessSkolemType` instead. This type is inroduced by existential generalization, and keep the original term as witness.

Now, `Wrap[F, am$proxy.Context]` would be avoided to `Wrap[F, ?1.Context]` where `?1` hides the local `am$proxy`.
Type comparison relate `?1` back to `am$proxy.Context` comparison, without leaking the local symbol outside the `Inlined` tree. In the end, that skolem type will be deskolemized when it goes outside.


## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by human review

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)

