### PR TITLE
REPL: attempt to detect user overridden toString for Product

### DIFF
--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -1,8 +1,6 @@
 package dotty.tools
 package repl
 
-import scala.language.unsafeNulls
-
 import dotc.*, core.*
 import Contexts.*, Decorators.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*
 import printing.ReplPrinter
@@ -65,19 +63,21 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
      * after return
      */
     private trait BorrowContext {
-      private var borrowed: Context = uninitialized
+      private var borrowed: Context | Null = null
 
       def useContext[T](op: Context ?=> T): T = synchronized {
-        require(borrowed != null, "BorrowContext.access called without a borrowed context")
-        op(using borrowed)
+        val localCtx = borrowed
+        assert(localCtx != null, "BorrowContext.access called without a borrowed context")
+        op(using localCtx)
       }
 
       def borrow[T](ctx: Context)(op: => T): T = synchronized {
-        if borrowed == null then
+        val oldCtx = borrowed
+        try
           borrowed = ctx
-          try op
-          finally borrowed = null
-        else op
+          op
+        finally
+          borrowed = oldCtx
       }
     }
 
@@ -112,69 +112,15 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       catch case NonFatal(_) => None
 
     private def hasRuntimeUserDefinedToString(declaringClass: Class[?]): Boolean =
-      try
-        // Some classpath-local products do not resolve back to their TASTy symbol.
-        // Reject synthesized case-class toString by cracking its bytecode.
-        !isScalaRunTimeProductToString(declaringClass)
-      catch case NonFatal(_) => false
-
-    private def isScalaRunTimeProductToString(clazz: Class[?]): Boolean =
-      def classBytes: Array[Byte] | Null =
-        val resourceName = clazz.getName.replace('.', '/') + ".class"
-        val loader = clazz.getClassLoader
-        val stream =
-          if loader == null then ClassLoader.getSystemResourceAsStream(resourceName)
-          else loader.getResourceAsStream(resourceName)
-        if stream == null then null
-        else
-          try stream.readAllBytes()
-          finally stream.close()
-
-      def isScalaRunTimeModule(insn: AbstractInsnNode): Boolean = insn match
-        case insn: FieldInsnNode =>
-          insn.getOpcode == GETSTATIC
-            && insn.owner == "scala/runtime/ScalaRunTime$"
-            && insn.name == "MODULE$"
-        case _ => false
-
-      def isLoadThis(insn: AbstractInsnNode): Boolean = insn match
-        case insn: VarInsnNode => insn.getOpcode == ALOAD && insn.`var` == 0
-        case _ => false
-
-      def isScalaRunTimeToString(insn: AbstractInsnNode): Boolean = insn match
-        case insn: MethodInsnNode =>
-          (insn.getOpcode == INVOKEVIRTUAL || insn.getOpcode == INVOKESTATIC)
-            && (insn.owner == "scala/runtime/ScalaRunTime$" || insn.owner == "scala/runtime/ScalaRunTime")
-            && insn.name == "_toString"
-            && insn.desc == "(Lscala/Product;)Ljava/lang/String;"
-        case _ => false
-
-      def isReturn(insn: AbstractInsnNode): Boolean =
-        insn.getOpcode == ARETURN
-
-      def isSynthesizedToString(method: MethodNode): Boolean =
-        method.instructions.iterator.asScala.filter(_.getOpcode >= 0).toList match
-          case List(module, loadThis, call, ret) =>
-            isScalaRunTimeModule(module) && isLoadThis(loadThis) && isScalaRunTimeToString(call) && isReturn(ret)
-          case List(loadThis, call, ret) =>
-            isLoadThis(loadThis) && isScalaRunTimeToString(call) && isReturn(ret)
-          case _ => false
-
-      val bytes = classBytes
-      if bytes == null then false
-      else
-        val classNode = ClassNode()
-        ClassReader(bytes).accept(classNode, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES)
-        classNode.methods.asScala.exists: method =>
-          method.name == "toString"
-            && method.desc == "()Ljava/lang/String;"
-            && isSynthesizedToString(method)
+      // Some classpath-local products do not resolve back to their TASTy symbol.
+      // Reject synthesized case-class toString by cracking its bytecode.
+      !ReplBytecodeAnalysis.isScalaRunTimeProductToString(declaringClass)
 
     private def runtimeClassSymbol(clazz: Class[?])(using Context): Symbol = {
       def getClassFromName(className: String | Null): Symbol =
         if className == null then NoSymbol
         else
-          val name = className.nn.toTypeName
+          val name = className.toTypeName
           val direct = getClassIfDefined(name)
           if direct.exists then direct
           else getClassIfDefined(name.unmangleClassName)

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -43,18 +43,22 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
 
   private object ProductToStringProbe {
 
-    def predicate(using Context): Predicate[Any] = (value: Any) => {
-      value != null && {
-        val clazz = value.getClass
-        val toStringDeclaringClass = userToStringDeclaringClass(clazz)
-        val testWithContext = fromSymbol.borrow(ctx) {
-          fromSymbol.cache.get(clazz).orElse(
-            toStringDeclaringClass.filter(_ != clazz).flatMap(fromSymbol.cache.get)
-          )
-        }
+    def predicate(using Context): Any => Boolean = Predicate()
 
-        testWithContext.getOrElse(toStringDeclaringClass.exists(bytecodeCache.get))
-      }
+    /** Should be a concrete class so we can reflectively load its apply method. */
+    private class Predicate(using Context) extends (Any => Boolean) {
+      def apply(value: Any): Boolean =
+        value != null && {
+          val clazz = value.getClass
+          val toStringDeclaringClass = userToStringDeclaringClass(clazz)
+          val testWithContext = fromSymbol.borrow(ctx) {
+            fromSymbol.cache.get(clazz).orElse(
+              toStringDeclaringClass.filter(_ != clazz).flatMap(fromSymbol.cache.get)
+            )
+          }
+
+          testWithContext.getOrElse(toStringDeclaringClass.exists(bytecodeCache.get))
+        }
     }
 
     /** provides access to a Context for a closure that by contract should not retain
@@ -232,6 +236,16 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       val pprintCls = Class.forName("dotty.vendored.pprint.PPrinter$Color$", false, cl)
       val fansiStrCls = Class.forName("dotty.vendored.fansi.Str", false, cl)
       val Color = pprintCls.getField("MODULE$").get(null)
+      val Function1Cls = Class.forName("scala.Function1", false, cl)
+      val reflectivePredicate = locally {
+        // cant pass our predicate directly,
+        // so we have to reflectively invoke it from within the repl classloader.
+        val ReflectiveFunctionsCls = Class.forName("dotty.vendored.pprint.ReflectiveFunctions$", false, cl)
+        val ReflectiveFunctions = ReflectiveFunctionsCls.getField("MODULE$").get(null)
+        val factory = ReflectiveFunctionsCls.getMethod("reflectivePredicate", classOf[Any])
+
+        factory.invoke(ReflectiveFunctions, useProductToString)
+      }
       val Color_apply = pprintCls.getMethod("applyWithProductToString",
         classOf[Any],     // value
         classOf[Int],     // width
@@ -240,11 +254,11 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
         classOf[Int],     // initialOffset
         classOf[Boolean], // escape Unicode
         classOf[Boolean], // show field names
-        classOf[Predicate[?]], // use product toString
+        Function1Cls, // use product toString
       )
       val FansiStr_render = fansiStrCls.getMethod("render")
       val fansiStr = Color_apply.invoke(
-        Color, value, width, height, 2, initialOffset, false, true, useProductToString
+        Color, value, width, height, 2, initialOffset, false, true, reflectivePredicate
       )
       FansiStr_render.invoke(fansiStr).asInstanceOf[String]
     catch

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -11,6 +11,10 @@ import reporting.Diagnostic
 import StackTraceOps.*
 
 import scala.compiletime.uninitialized
+import scala.jdk.CollectionConverters.*
+import scala.tools.asm.*
+import scala.tools.asm.Opcodes.*
+import scala.tools.asm.tree.*
 import scala.util.control.NonFatal
 import java.util.function.Predicate
 
@@ -37,65 +41,167 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
     "scala.xml.Elem" // is a Seq that contains itself, https://github.com/scala/scala3/issues/25691
   )
 
-  private def productToStringPredicate(using Context): Predicate[Any] = {
-    val cache = classValue(hasUserDefinedProductToString(_))
+  private object ProductToStringProbe {
 
-    new Predicate[Any] {
-      def test(value: Any): Boolean = value != null && cache.get(value.getClass)
+    def predicate(using Context): Predicate[Any] = (value: Any) => {
+      value != null && {
+        val clazz = value.getClass
+        val toStringDeclaringClass = userToStringDeclaringClass(clazz)
+        val testWithContext = fromSymbol.borrow(ctx) {
+          fromSymbol.cache.get(clazz).orElse(
+            toStringDeclaringClass.filter(_ != clazz).flatMap(fromSymbol.cache.get)
+          )
+        }
+
+        testWithContext.getOrElse(toStringDeclaringClass.exists(bytecodeCache.get))
+      }
     }
-  }
 
-  private def classValue[T](op: Class[?] => T): ClassValue[T] =
-    new ClassValue[T] {
-      def computeValue(clazz: Class[?]): T = op(clazz)
+    /** provides access to a Context for a closure that by contract should not retain
+     * after return
+     */
+    private trait BorrowContext {
+      private var borrowed: Context = uninitialized
+
+      def useContext[T](op: Context ?=> T): T = synchronized {
+        require(borrowed != null, "BorrowContext.access called without a borrowed context")
+        op(using borrowed)
+      }
+
+      def borrow[T](ctx: Context)(op: => T): T = synchronized {
+        if borrowed == null then
+          borrowed = ctx
+          try op
+          finally borrowed = null
+        else op
+      }
     }
 
-  private def hasUserDefinedProductToString(clazz: Class[?])(using Context): Boolean = {
-    val classSym = runtimeClassSymbol(clazz)
-    if !classSym.exists || !classSym.isClass || !classSym.derivesFrom(defn.ProductClass) then false
-    else
-      val toStringSym = defn.Any_toString.matchingMember(classSym.asClass.thisType)
-      toStringSym.exists
-        && toStringSym != defn.Any_toString
-        && !toStringSym.is(Deferred)
-        && !toStringSym.is(Synthetic)
-  }
+    private object fromSymbol extends BorrowContext {
+      val cache = classValue { clazz =>
+        useContext(classHasUserDefinedToString(clazz))
+      }
+    }
 
-  private def runtimeClassSymbol(clazz: Class[?])(using Context): Symbol = {
-    def getClassFromName(className: String | Null): Symbol =
-      if className == null then NoSymbol
+    private val bytecodeCache = classValue(hasRuntimeUserDefinedToString(_))
+
+    private def classValue[T](op: Class[?] => T): ClassValue[T] =
+      new ClassValue[T] {
+        def computeValue(clazz: Class[?]): T = op(clazz)
+      }
+
+    private def classHasUserDefinedToString(clazz: Class[?])(using Context): Option[Boolean] =
+      val classSym = runtimeClassSymbol(clazz)
+      if !classSym.exists || !classSym.isClass then None
       else
-        val name = className.nn.toTypeName
-        val direct = getClassIfDefined(name)
-        if direct.exists then direct
-        else getClassIfDefined(name.unmangleClassName)
+        val toStringSym = defn.Any_toString.matchingMember(classSym.asClass.thisType)
+        if !toStringSym.exists then None
+        else
+          Some(toStringSym != defn.Any_toString
+            && !toStringSym.is(Deferred)
+            && !toStringSym.is(Synthetic))
 
-    def getMemberClass: Symbol =
-      val enclosingClass = clazz.getEnclosingClass
-      if enclosingClass == null then NoSymbol
+    private def userToStringDeclaringClass(clazz: Class[?]): Option[Class[?]] =
+      try
+        val declaringClass = clazz.getMethod("toString").getDeclaringClass
+        if declaringClass == classOf[Object] then None else Some(declaringClass)
+      catch case NonFatal(_) => None
+
+    private def hasRuntimeUserDefinedToString(declaringClass: Class[?]): Boolean =
+      try
+        // Some classpath-local products do not resolve back to their TASTy symbol.
+        // Reject synthesized case-class toString by cracking its bytecode.
+        !isScalaRunTimeProductToString(declaringClass)
+      catch case NonFatal(_) => false
+
+    private def isScalaRunTimeProductToString(clazz: Class[?]): Boolean =
+      def classBytes: Array[Byte] | Null =
+        val resourceName = clazz.getName.replace('.', '/') + ".class"
+        val loader = clazz.getClassLoader
+        val stream =
+          if loader == null then ClassLoader.getSystemResourceAsStream(resourceName)
+          else loader.getResourceAsStream(resourceName)
+        if stream == null then null
+        else
+          try stream.readAllBytes()
+          finally stream.close()
+
+      def isScalaRunTimeModule(insn: AbstractInsnNode): Boolean = insn match
+        case insn: FieldInsnNode =>
+          insn.getOpcode == GETSTATIC
+            && insn.owner == "scala/runtime/ScalaRunTime$"
+            && insn.name == "MODULE$"
+        case _ => false
+
+      def isLoadThis(insn: AbstractInsnNode): Boolean = insn match
+        case insn: VarInsnNode => insn.getOpcode == ALOAD && insn.`var` == 0
+        case _ => false
+
+      def isScalaRunTimeToString(insn: AbstractInsnNode): Boolean = insn match
+        case insn: MethodInsnNode =>
+          (insn.getOpcode == INVOKEVIRTUAL || insn.getOpcode == INVOKESTATIC)
+            && (insn.owner == "scala/runtime/ScalaRunTime$" || insn.owner == "scala/runtime/ScalaRunTime")
+            && insn.name == "_toString"
+            && insn.desc == "(Lscala/Product;)Ljava/lang/String;"
+        case _ => false
+
+      def isReturn(insn: AbstractInsnNode): Boolean =
+        insn.getOpcode == ARETURN
+
+      def isSynthesizedToString(method: MethodNode): Boolean =
+        method.instructions.iterator.asScala.filter(_.getOpcode >= 0).toList match
+          case List(module, loadThis, call, ret) =>
+            isScalaRunTimeModule(module) && isLoadThis(loadThis) && isScalaRunTimeToString(call) && isReturn(ret)
+          case List(loadThis, call, ret) =>
+            isLoadThis(loadThis) && isScalaRunTimeToString(call) && isReturn(ret)
+          case _ => false
+
+      val bytes = classBytes
+      if bytes == null then false
       else
-        val owner = runtimeClassSymbol(enclosingClass)
-        val name = clazz.getSimpleName.toTypeName.unmangleClassName
-        def lookup(owner: Symbol): Symbol =
-          if owner.exists then owner.info.member(name).symbol else NoSymbol
+        val classNode = ClassNode()
+        ClassReader(bytes).accept(classNode, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES)
+        classNode.methods.asScala.exists: method =>
+          method.name == "toString"
+            && method.desc == "()Ljava/lang/String;"
+            && isSynthesizedToString(method)
 
-        val direct = lookup(owner)
-        if direct.exists then direct
-        else if owner.exists then lookup(owner.linkedClass)
-        else NoSymbol
+    private def runtimeClassSymbol(clazz: Class[?])(using Context): Symbol = {
+      def getClassFromName(className: String | Null): Symbol =
+        if className == null then NoSymbol
+        else
+          val name = className.nn.toTypeName
+          val direct = getClassIfDefined(name)
+          if direct.exists then direct
+          else getClassIfDefined(name.unmangleClassName)
 
-    if clazz.isPrimitive || clazz.isArray then NoSymbol
-    else
-      val fromCanonicalName = getClassFromName(clazz.getCanonicalName)
-      if fromCanonicalName.exists then fromCanonicalName
+      def getMemberClass: Symbol =
+        val enclosingClass = clazz.getEnclosingClass
+        if enclosingClass == null then NoSymbol
+        else
+          val owner = runtimeClassSymbol(enclosingClass)
+          val name = clazz.getSimpleName.toTypeName.unmangleClassName
+          def lookup(owner: Symbol): Symbol =
+            if owner.exists then owner.info.member(name).symbol else NoSymbol
+
+          val direct = lookup(owner)
+          if direct.exists then direct
+          else if owner.exists then lookup(owner.linkedClass)
+          else NoSymbol
+
+      if clazz.isPrimitive || clazz.isArray then NoSymbol
       else
-        val fromRuntimeName = getClassFromName(clazz.getName)
-        if fromRuntimeName.exists then fromRuntimeName
-        else getMemberClass
+        val fromCanonicalName = getClassFromName(clazz.getCanonicalName)
+        if fromCanonicalName.exists then fromCanonicalName
+        else
+          val fromMemberClass = getMemberClass
+          if fromMemberClass.exists then fromMemberClass
+          else getClassFromName(clazz.getName)
+    }
   }
 
   private def pprintRender(value: Any, width: Int, height: Int, initialOffset: Int)(using Context): String = {
-    val useProductToString = productToStringPredicate
+    val useProductToString = ProductToStringProbe.predicate
 
     def fallback() =
       dotty.vendored.pprint.PPrinter.Color

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -4,7 +4,7 @@ package repl
 import scala.language.unsafeNulls
 
 import dotc.*, core.*
-import Contexts.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*
+import Contexts.*, Decorators.*, Denotations.*, Flags.*, NameOps.*, StdNames.*, Symbols.*
 import printing.ReplPrinter
 import printing.SyntaxHighlighting
 import reporting.Diagnostic
@@ -12,6 +12,7 @@ import StackTraceOps.*
 
 import scala.compiletime.uninitialized
 import scala.util.control.NonFatal
+import java.util.function.Predicate
 
 import dotty.vendored.fansi
 
@@ -36,10 +37,78 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
     "scala.xml.Elem" // is a Seq that contains itself, https://github.com/scala/scala3/issues/25691
   )
 
+  private def productToStringPredicate(using Context): Predicate[Any] = {
+    val cache = classValue(hasUserDefinedProductToString(_))
+
+    new Predicate[Any] {
+      def test(value: Any): Boolean = value != null && cache.get(value.getClass)
+    }
+  }
+
+  private def classValue[T](op: Class[?] => T): ClassValue[T] =
+    new ClassValue[T] {
+      def computeValue(clazz: Class[?]): T = op(clazz)
+    }
+
+  private def hasUserDefinedProductToString(clazz: Class[?])(using Context): Boolean = {
+    val classSym = runtimeClassSymbol(clazz)
+    if !classSym.exists || !classSym.isClass || !classSym.derivesFrom(defn.ProductClass) then false
+    else
+      val toStringSym = defn.Any_toString.matchingMember(classSym.asClass.thisType)
+      toStringSym.exists
+        && toStringSym != defn.Any_toString
+        && !toStringSym.is(Deferred)
+        && !toStringSym.is(Synthetic)
+  }
+
+  private def runtimeClassSymbol(clazz: Class[?])(using Context): Symbol = {
+    def getClassFromName(className: String | Null): Symbol =
+      if className == null then NoSymbol
+      else
+        val name = className.nn.toTypeName
+        val direct = getClassIfDefined(name)
+        if direct.exists then direct
+        else getClassIfDefined(name.unmangleClassName)
+
+    def getMemberClass: Symbol =
+      val enclosingClass = clazz.getEnclosingClass
+      if enclosingClass == null then NoSymbol
+      else
+        val owner = runtimeClassSymbol(enclosingClass)
+        val name = clazz.getSimpleName.toTypeName.unmangleClassName
+        def lookup(owner: Symbol): Symbol =
+          if owner.exists then owner.info.member(name).symbol else NoSymbol
+
+        val direct = lookup(owner)
+        if direct.exists then direct
+        else if owner.exists then lookup(owner.linkedClass)
+        else NoSymbol
+
+    if clazz.isPrimitive || clazz.isArray then NoSymbol
+    else
+      val fromCanonicalName = getClassFromName(clazz.getCanonicalName)
+      if fromCanonicalName.exists then fromCanonicalName
+      else
+        val fromRuntimeName = getClassFromName(clazz.getName)
+        if fromRuntimeName.exists then fromRuntimeName
+        else getMemberClass
+  }
+
   private def pprintRender(value: Any, width: Int, height: Int, initialOffset: Int)(using Context): String = {
+    val useProductToString = productToStringPredicate
+
     def fallback() =
       dotty.vendored.pprint.PPrinter.Color
-        .apply(value, width = width, height = height, initialOffset = initialOffset)
+        .applyWithProductToString(
+          value,
+          width = width,
+          height = height,
+          indent = 2,
+          initialOffset = initialOffset,
+          escapeUnicode = false,
+          showFieldNames = true,
+          useProductToString = useProductToString
+        )
         .plainText
     try
       if value != null && forcedToStringClasses(value.getClass.getName) then return value.toString
@@ -57,7 +126,7 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
       val pprintCls = Class.forName("dotty.vendored.pprint.PPrinter$Color$", false, cl)
       val fansiStrCls = Class.forName("dotty.vendored.fansi.Str", false, cl)
       val Color = pprintCls.getField("MODULE$").get(null)
-      val Color_apply = pprintCls.getMethod("apply",
+      val Color_apply = pprintCls.getMethod("applyWithProductToString",
         classOf[Any],     // value
         classOf[Int],     // width
         classOf[Int],     // height
@@ -65,10 +134,11 @@ private[repl] class Rendering(parentClassLoader: Option[ClassLoader] = None):
         classOf[Int],     // initialOffset
         classOf[Boolean], // escape Unicode
         classOf[Boolean], // show field names
+        classOf[Predicate[?]], // use product toString
       )
       val FansiStr_render = fansiStrCls.getMethod("render")
       val fansiStr = Color_apply.invoke(
-        Color, value, width, height, 2, initialOffset, false, true
+        Color, value, width, height, 2, initialOffset, false, true, useProductToString
       )
       FansiStr_render.invoke(fansiStr).asInstanceOf[String]
     catch

--- a/repl/src/dotty/tools/repl/ReplBytecodeAnalysis.scala
+++ b/repl/src/dotty/tools/repl/ReplBytecodeAnalysis.scala
@@ -1,0 +1,68 @@
+package dotty.tools
+package repl
+
+import scala.jdk.CollectionConverters.*
+import scala.language.unsafeNulls
+import scala.tools.asm.*
+import scala.tools.asm.Opcodes.*
+import scala.tools.asm.tree.*
+import scala.util.control.NonFatal
+
+object ReplBytecodeAnalysis:
+
+  def classBytes(clazz: Class[?]): Array[Byte] | Null =
+    val resourceName = clazz.getName.replace('.', '/') + ".class"
+    val loader = clazz.getClassLoader
+    val stream =
+      if loader == null then ClassLoader.getSystemResourceAsStream(resourceName)
+      else loader.getResourceAsStream(resourceName)
+    if stream == null then null
+    else
+      try stream.readAllBytes()
+      finally stream.close()
+
+  def isScalaRunTimeProductToString(clazz: Class[?]): Boolean =
+
+    def isScalaRunTimeModule(insn: AbstractInsnNode): Boolean = insn match
+      case insn: FieldInsnNode =>
+        insn.getOpcode == GETSTATIC
+          && insn.owner == "scala/runtime/ScalaRunTime$"
+          && insn.name == "MODULE$"
+      case _ => false
+
+    def isLoadThis(insn: AbstractInsnNode): Boolean = insn match
+      case insn: VarInsnNode => insn.getOpcode == ALOAD && insn.`var` == 0
+      case _ => false
+
+    def isScalaRunTimeToString(insn: AbstractInsnNode): Boolean = insn match
+      case insn: MethodInsnNode =>
+        (insn.getOpcode == INVOKEVIRTUAL || insn.getOpcode == INVOKESTATIC)
+          && (insn.owner == "scala/runtime/ScalaRunTime$" || insn.owner == "scala/runtime/ScalaRunTime")
+          && insn.name == "_toString"
+          && insn.desc == "(Lscala/Product;)Ljava/lang/String;"
+      case _ => false
+
+    def isReturn(insn: AbstractInsnNode): Boolean =
+      insn.getOpcode == ARETURN
+
+    def isSynthesizedToString(method: MethodNode): Boolean =
+      method.instructions.iterator.asScala.filter(_.getOpcode >= 0).toList match
+        case List(module, loadThis, call, ret) =>
+          isScalaRunTimeModule(module) && isLoadThis(loadThis) && isScalaRunTimeToString(call) && isReturn(ret)
+        case List(loadThis, call, ret) =>
+          isLoadThis(loadThis) && isScalaRunTimeToString(call) && isReturn(ret)
+        case _ => false
+
+    try
+      val bytes = classBytes(clazz)
+      if bytes == null then false
+      else
+        val classNode = ClassNode()
+        ClassReader(bytes).accept(classNode, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES)
+        classNode.methods.asScala.exists: method =>
+          method.name == "toString"
+            && method.desc == "()Ljava/lang/String;"
+            && isSynthesizedToString(method)
+    catch case NonFatal(_) => false
+
+end ReplBytecodeAnalysis

--- a/repl/src/pprint/PPrinter.scala
+++ b/repl/src/pprint/PPrinter.scala
@@ -2,6 +2,7 @@ package dotty.vendored
 package pprint
 
 import java.io.PrintStream
+import java.util.function.Predicate
 
 /**
   *
@@ -113,15 +114,36 @@ case class PPrinter(defaultWidth: Int = 100,
             initialOffset: Int = 0,
             escapeUnicode: Boolean = defaultEscapeUnicode,
             showFieldNames: Boolean = defaultShowFieldNames): fansi.Str = {
+    applyWithProductToString(
+      x,
+      width,
+      height,
+      indent,
+      initialOffset,
+      escapeUnicode,
+      showFieldNames,
+      ProductSupport.neverUseProductToString
+    )
+  }
+
+  def applyWithProductToString(x: Any,
+                               width: Int,
+                               height: Int,
+                               indent: Int,
+                               initialOffset: Int,
+                               escapeUnicode: Boolean,
+                               showFieldNames: Boolean,
+                               useProductToString: Predicate[Any]): fansi.Str = {
     fansi.Str.join(
-      this.tokenize(
+      this.tokenizeWithProductToString(
         x,
         width,
         height,
         indent,
         initialOffset,
         escapeUnicode = escapeUnicode,
-        showFieldNames = showFieldNames
+        showFieldNames = showFieldNames,
+        useProductToString = useProductToString
       ).toSeq
     )
   }
@@ -159,11 +181,30 @@ case class PPrinter(defaultWidth: Int = 100,
                initialOffset: Int = 0,
                escapeUnicode: Boolean = defaultEscapeUnicode,
                showFieldNames: Boolean = defaultShowFieldNames): Iterator[fansi.Str] = {
+    tokenizeWithProductToString(
+      x,
+      width,
+      height,
+      indent,
+      initialOffset,
+      escapeUnicode,
+      showFieldNames,
+      ProductSupport.neverUseProductToString
+    )
+  }
 
+  def tokenizeWithProductToString(x: Any,
+                                  width: Int,
+                                  height: Int,
+                                  indent: Int,
+                                  initialOffset: Int,
+                                  escapeUnicode: Boolean,
+                                  showFieldNames: Boolean,
+                                  useProductToString: Predicate[Any]): Iterator[fansi.Str] = {
     // The three stages within the pretty-printing process:
 
     // Convert the Any into a lazy Tree of `Apply`, `Infix` and `Lazy`/`Strict` literals
-    val tree = this.treeify(x, escapeUnicode, showFieldNames)
+    val tree = this.treeify(x, escapeUnicode, showFieldNames, useProductToString)
     // Render the `Any` into a stream of tokens, properly indented and wrapped
     // at the given width
     val renderer = new Renderer(width, colorApplyPrefix, colorLiteral, indent)

--- a/repl/src/pprint/PPrinter.scala
+++ b/repl/src/pprint/PPrinter.scala
@@ -63,7 +63,7 @@ case class PPrinter(defaultWidth: Int = 100,
   }
 
   /**
-    * A base version of `pprint.log` or `pprint.err.log` that lets you specify where 
+    * A base version of `pprint.log` or `pprint.err.log` that lets you specify where
     * you want to log the debug message to
     */
   def logTo[T](x: sourcecode.Text[T],
@@ -133,7 +133,7 @@ case class PPrinter(defaultWidth: Int = 100,
                                initialOffset: Int,
                                escapeUnicode: Boolean,
                                showFieldNames: Boolean,
-                               useProductToString: Predicate[Any]): fansi.Str = {
+                               useProductToString: Any => Boolean): fansi.Str = {
     fansi.Str.join(
       this.tokenizeWithProductToString(
         x,
@@ -200,7 +200,7 @@ case class PPrinter(defaultWidth: Int = 100,
                                   initialOffset: Int,
                                   escapeUnicode: Boolean,
                                   showFieldNames: Boolean,
-                                  useProductToString: Predicate[Any]): Iterator[fansi.Str] = {
+                                  useProductToString: Any => Boolean): Iterator[fansi.Str] = {
     // The three stages within the pretty-printing process:
 
     // Convert the Any into a lazy Tree of `Apply`, `Infix` and `Lazy`/`Strict` literals

--- a/repl/src/pprint/ProductSupport.scala
+++ b/repl/src/pprint/ProductSupport.scala
@@ -5,9 +5,7 @@ import java.util.function.Predicate
 
 object ProductSupport {
 
-  private[pprint] val neverUseProductToString: Predicate[Any] = new Predicate[Any] {
-    def test(value: Any): Boolean = false
-  }
+  private[pprint] val neverUseProductToString: Any => Boolean = Function.const(false)
 
   private def isIdentifier(name: String) = {
     def isStart(c: Char) = (c == '_') || (c == '$') || Character.isUnicodeIdentifierStart(c)
@@ -24,7 +22,7 @@ object ProductSupport {
                              walker: Walker,
                              escapeUnicode: Boolean,
                              showFieldNames: Boolean,
-                             useProductToString: Predicate[Any]): Iterator[Tree] = {
+                             useProductToString: Any => Boolean): Iterator[Tree] = {
     if (!showFieldNames || x.productArity < 2) {
       x.productIterator.map(x => walker.treeify(x, escapeUnicode, showFieldNames, useProductToString))
     }
@@ -32,7 +30,7 @@ object ProductSupport {
       .zipWithIndex
       .map {
         case (name, i) =>
-          val key = 
+          val key =
             if(!isIdentifier(name)) {
               s"`$name`"
           } else {

--- a/repl/src/pprint/ProductSupport.scala
+++ b/repl/src/pprint/ProductSupport.scala
@@ -1,7 +1,13 @@
 package dotty.vendored
 package pprint
 
+import java.util.function.Predicate
+
 object ProductSupport {
+
+  private[pprint] val neverUseProductToString: Predicate[Any] = new Predicate[Any] {
+    def test(value: Any): Boolean = false
+  }
 
   private def isIdentifier(name: String) = {
     def isStart(c: Char) = (c == '_') || (c == '$') || Character.isUnicodeIdentifierStart(c)
@@ -17,9 +23,10 @@ object ProductSupport {
   def treeifyProductElements(x: Product,
                              walker: Walker,
                              escapeUnicode: Boolean,
-                             showFieldNames: Boolean): Iterator[Tree] = {
+                             showFieldNames: Boolean,
+                             useProductToString: Predicate[Any]): Iterator[Tree] = {
     if (!showFieldNames || x.productArity < 2) {
-      x.productIterator.map(x => walker.treeify(x, escapeUnicode, showFieldNames))
+      x.productIterator.map(x => walker.treeify(x, escapeUnicode, showFieldNames, useProductToString))
     }
     else x.productElementNames
       .zipWithIndex
@@ -28,11 +35,11 @@ object ProductSupport {
           val key = 
             if(!isIdentifier(name)) {
               s"`$name`"
-            } else {
-              name
-            }
+          } else {
+            name
+          }
           val elem = x.productElement(i)
-          Tree.KeyValue(key, walker.treeify(elem, escapeUnicode, showFieldNames))
+          Tree.KeyValue(key, walker.treeify(elem, escapeUnicode, showFieldNames, useProductToString))
       }
   }
 

--- a/repl/src/pprint/ProductSupportExtras.scala
+++ b/repl/src/pprint/ProductSupportExtras.scala
@@ -1,0 +1,20 @@
+package dotty.vendored
+package pprint
+
+import java.util.function.Predicate
+
+// FIXME: this would stay local to REPL extra libraries and never upstreamed.
+// TODO: move to a separate module as this is not pprint specific?
+object ReflectiveFunctions {
+
+  /** create a predicate from a function shaped object.
+   * @note e.g. if a hook is required to be injected accross a reflective boundary where
+   * two classloaders have a separate copy of the `scala.Function1` class.
+   */
+  def reflectivePredicate(fn: Any): Any => Boolean = {
+    val cls = fn.getClass
+    val method = cls.getMethod("apply", classOf[Any])
+    (x: Any) => method.invoke(fn, x.asInstanceOf[AnyRef]).asInstanceOf[Boolean]
+  }
+
+}

--- a/repl/src/pprint/README.md
+++ b/repl/src/pprint/README.md
@@ -9,3 +9,4 @@ Changes:
 - added an unsafe cast for `null` since the original builds without explicit nulls
 - added a cast to `String | Null` for `toString` since the original builds without explicit nulls
 - Commented out an unreachable match case in `TPrintImpl` (line 116)
+- Added a REPL hook to honor user-defined `Product.toString` implementations

--- a/repl/src/pprint/Walker.scala
+++ b/repl/src/pprint/Walker.scala
@@ -60,7 +60,7 @@ abstract class Walker{
   def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean): Tree =
     treeify(x, escapeUnicode, showFieldNames, ProductSupport.neverUseProductToString)
 
-  def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean, useProductToString: Predicate[Any]): Tree = additionalHandlers.lift(x).getOrElse{
+  def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean, useProductToString: Any => Boolean): Tree = additionalHandlers.lift(x).getOrElse{
     def toStringTree(x: Any) = Tree.Lazy(ctx =>
       Iterator(
         x.toString.asInstanceOf[String | Null] match{
@@ -138,7 +138,7 @@ abstract class Walker{
       case x: Product =>
         val className = x.getClass.getName
         if (x.productArity == 0) Tree.Lazy(ctx => Iterator(x.toString))
-        else if (!className.startsWith(tuplePrefix) && useProductToString.test(x)) toStringTree(x)
+        else if (!className.startsWith(tuplePrefix) && useProductToString(x)) toStringTree(x)
         else if(x.productArity == 2 && Util.isOperator(x.productPrefix)){
           Tree.Infix(
             treeify(x.productElement(0), escapeUnicode, showFieldNames, useProductToString),

--- a/repl/src/pprint/Walker.scala
+++ b/repl/src/pprint/Walker.scala
@@ -3,6 +3,7 @@ package pprint
 import scala.collection.mutable.ArraySeq
 import scala.collection.immutable.HashMap
 import scala.collection.immutable.HashSet
+import java.util.function.Predicate
 
 /**
   * A lazy AST representing pretty-printable text. Models `foo(a, b)`
@@ -56,7 +57,19 @@ abstract class Walker{
   )
 
   def additionalHandlers: PartialFunction[Any, Tree]
-  def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean): Tree = additionalHandlers.lift(x).getOrElse{
+  def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean): Tree =
+    treeify(x, escapeUnicode, showFieldNames, ProductSupport.neverUseProductToString)
+
+  def treeify(x: Any, escapeUnicode: Boolean, showFieldNames: Boolean, useProductToString: Predicate[Any]): Tree = additionalHandlers.lift(x).getOrElse{
+    def toStringTree(x: Any) = Tree.Lazy(ctx =>
+      Iterator(
+        x.toString.asInstanceOf[String | Null] match{
+          case null => "null"
+          case s => s
+        }
+      )
+    )
+
     x match{
 
       case null => Tree.Literal("null")
@@ -78,7 +91,7 @@ abstract class Walker{
         if (x.exists(c => c == '\n' || c == '\r')) Tree.Literal("\"\"\"" + x + "\"\"\"")
         else Tree.Literal(Util.literalize(x, escapeUnicode))
 
-      case x: StringBuilder => treeify(x.toString, escapeUnicode, showFieldNames)
+      case x: StringBuilder => treeify(x.toString, escapeUnicode, showFieldNames, useProductToString)
 
       case x: Symbol => Tree.Literal("'" + x.name)
 
@@ -91,7 +104,7 @@ abstract class Walker{
             case _ => StringPrefix(x)
           },
           x.iterator.flatMap { case (k, v) =>
-            Seq(Tree.Infix(treeify(k, escapeUnicode, showFieldNames), "->", treeify(v, escapeUnicode, showFieldNames)))
+            Seq(Tree.Infix(treeify(k, escapeUnicode, showFieldNames, useProductToString), "->", treeify(v, escapeUnicode, showFieldNames, useProductToString)))
           }
         )
 
@@ -108,7 +121,7 @@ abstract class Walker{
             case _: HashSet[_] => "Set"
             case _ => StringPrefix(x)
           },
-          x.iterator.map(x => treeify(x, escapeUnicode, showFieldNames))
+          x.iterator.map(x => treeify(x, escapeUnicode, showFieldNames, useProductToString))
         )
 
       case None => Tree.Literal("None")
@@ -120,37 +133,31 @@ abstract class Walker{
         else
           Tree.Literal("non-empty iterator")
 
-      case x: Array[_] => Tree.Apply("Array", x.iterator.map(x => treeify(x, escapeUnicode, showFieldNames)))
+      case x: Array[_] => Tree.Apply("Array", x.iterator.map(x => treeify(x, escapeUnicode, showFieldNames, useProductToString)))
 
       case x: Product =>
         val className = x.getClass.getName
         if (x.productArity == 0) Tree.Lazy(ctx => Iterator(x.toString))
+        else if (!className.startsWith(tuplePrefix) && useProductToString.test(x)) toStringTree(x)
         else if(x.productArity == 2 && Util.isOperator(x.productPrefix)){
           Tree.Infix(
-            treeify(x.productElement(0), escapeUnicode, showFieldNames),
+            treeify(x.productElement(0), escapeUnicode, showFieldNames, useProductToString),
 
             x.productPrefix,
-            treeify(x.productElement(1), escapeUnicode, showFieldNames)
+            treeify(x.productElement(1), escapeUnicode, showFieldNames, useProductToString)
           )
         } else (className.startsWith(tuplePrefix), className.lift(tuplePrefix.length)) match{
           // leave out tuple1, so it gets printed as Tuple1(foo) instead of (foo)
           // Don't check the whole suffix, because of specialization there may be
           // funny characters after the digit
           case (true, Some('2' | '3' | '4' | '5' | '6' | '7' | '8' | '9')) =>
-            Tree.Apply("", x.productIterator.map(x => treeify(x, escapeUnicode, showFieldNames)))
+            Tree.Apply("", x.productIterator.map(x => treeify(x, escapeUnicode, showFieldNames, useProductToString)))
 
           case _ =>
-            Tree.Apply(x.productPrefix, ProductSupport.treeifyProductElements(x, this, escapeUnicode, showFieldNames))
+            Tree.Apply(x.productPrefix, ProductSupport.treeifyProductElements(x, this, escapeUnicode, showFieldNames, useProductToString))
         }
 
-      case x => Tree.Lazy(ctx =>
-        Iterator(
-          x.toString.asInstanceOf[String | Null] match{
-            case null => "null"
-            case s =>s
-          }
-        )
-      )
+      case x => toStringTree(x)
     }
   }
 

--- a/repl/test-resources/repl/renderProductToString
+++ b/repl/test-resources/repl/renderProductToString
@@ -1,0 +1,26 @@
+scala> case class Plain(i: Int, s: String)
+// defined case class Plain
+scala> Plain(1, "x")
+val res0: Plain = Plain(i = 1, s = "x")
+scala> (1, "x")
+val res1: (Int, String) = (1, "x")
+scala> case class Fancy(i: Int, s: String) { override def toString = s"Fancy($i)" }
+// defined case class Fancy
+scala> Fancy(1, "x")
+val res2: Fancy = Fancy(1)
+scala> val widened: Product = Fancy(2, "y")
+val widened: Product = Fancy(2)
+scala> case class Box(value: Product)
+// defined case class Box
+scala> Box(Fancy(3, "z"))
+val res3: Box = Box(Fancy(3))
+scala> class CustomProduct(val x: Int) extends Product { def canEqual(that: Any) = that.isInstanceOf[CustomProduct]; def productArity = 1; def productElement(n: Int): Any = if n == 0 then x else throw new IndexOutOfBoundsException(n.toString); override def productPrefix = "CustomProduct"; override def toString = s"custom($x)" }
+// defined class CustomProduct
+scala> new CustomProduct(4)
+val res4: CustomProduct = custom(4)
+scala> trait BaseProductString { override def toString = "from-base" }
+// defined trait BaseProductString
+scala> case class InheritedString(i: Int) extends BaseProductString
+// defined case class InheritedString
+scala> InheritedString(5)
+val res5: InheritedString = from-base

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -73,3 +73,16 @@ class ReplDependencyMacroTests extends ReplTest:
       val second = storedOutput()
       assertNoMacroFailure(second)
       assertTrue(second, second.contains("// defined case class FooSummon"))
+
+  @Test def `product toString from dependency after :dep`: Unit =
+    initially:
+      run(":dep com.lihaoyi::ujson:4.4.3")
+      val depOutput = storedOutput()
+      assertTrue(depOutput, depOutput.contains("Resolved 1 dependencies"))
+      assertNoMacroFailure(depOutput)
+
+      run("ujson.Num(3.5)")
+      val output = storedOutput()
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("val res0: ujson.Num = 3.5"))
+      assertFalse(output, output.contains("Num(3.5)"))

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -78,7 +78,7 @@ class ReplDependencyMacroTests extends ReplTest:
     initially:
       run(":dep com.lihaoyi::ujson:4.4.3")
       val depOutput = storedOutput()
-      assertTrue(depOutput, depOutput.contains("Resolved 1 dependencies"))
+      assertTrue(depOutput, depOutput.contains("Resolved a dependency"))
       assertNoMacroFailure(depOutput)
 
       run("ujson.Num(3.5)")

--- a/repl/test/dotty/tools/repl/ReplProductToStringClasspathTests.scala
+++ b/repl/test/dotty/tools/repl/ReplProductToStringClasspathTests.scala
@@ -38,6 +38,9 @@ object ReplProductToStringClasspathTests:
          |abstract class BaseToString:
          |  override def toString: String = "external-base"
          |
+         |abstract class BaseSymbolOnlyToString extends Product:
+         |  override def toString: String = scala.runtime.ScalaRunTime._toString(this)
+         |
          |case class Direct(i: Int):
          |  override def toString: String = "external-direct(" + i + ")"
          |
@@ -45,7 +48,97 @@ object ReplProductToStringClasspathTests:
          |
          |case class FromBase(i: Int) extends BaseToString
          |
-         |case class Plain(i: Int)
+         |case class Plain(i: Int, s: String)
+         |
+         |case class ProductPair(first: Product, second: Product)
+         |
+         |case class SymbolOnlyToString(i: Int, s: String):
+         |  override def toString: String = scala.runtime.ScalaRunTime._toString(this)
+         |
+         |object Factory:
+         |  def localDirect: Product =
+         |    case class LocalDirect(i: Int):
+         |      override def toString: String = "external-local-direct(" + i + ")"
+         |    LocalDirect(5)
+         |
+         |  def localInherited: Product =
+         |    case class LocalInherited(i: Int) extends TraitToString
+         |    LocalInherited(6)
+         |
+         |  def localInheritedSymbolOnly: Product =
+         |    case class LocalInheritedSymbolOnly(i: Int, s: String) extends BaseSymbolOnlyToString
+         |    LocalInheritedSymbolOnly(15, "declaring")
+         |
+         |  def localPlain: Product =
+         |    case class LocalPlain(i: Int, s: String)
+         |    LocalPlain(7, "local")
+         |
+         |  def localDefaultShaped: Product =
+         |    case class LocalDefaultShaped(i: Int, s: String):
+         |      override def toString: String = "LocalDefaultShaped(" + i + "," + s + ")"
+         |    LocalDefaultShaped(13, "same")
+         |
+         |  def anonymousDirect: Product =
+         |    new Product:
+         |      def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+         |      def productArity: Int = 1
+         |      def productElement(n: Int): Any =
+         |        if n == 0 then 8 else throw new IndexOutOfBoundsException(n.toString)
+         |      override def productPrefix: String = "ExternalAnonymousDirect"
+         |      override def toString: String = "external-anonymous-direct"
+         |
+         |  def anonymousInherited: Product =
+         |    new Product with TraitToString:
+         |      def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+         |      def productArity: Int = 1
+         |      def productElement(n: Int): Any =
+         |        if n == 0 then 9 else throw new IndexOutOfBoundsException(n.toString)
+         |      override def productPrefix: String = "ExternalAnonymousInherited"
+         |
+         |  def anonymousInheritedSymbolOnly: Product =
+         |    new BaseSymbolOnlyToString:
+         |      def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+         |      def productArity: Int = 2
+         |      def productElement(n: Int): Any =
+         |        if n == 0 then 16
+         |        else if n == 1 then "anonymous"
+         |        else throw new IndexOutOfBoundsException(n.toString)
+         |      override def productElementName(n: Int): String =
+         |        if n == 0 then "i"
+         |        else if n == 1 then "s"
+         |        else throw new IndexOutOfBoundsException(n.toString)
+         |      override def productPrefix: String = "ExternalAnonymousSymbolOnly"
+         |
+         |  def anonymousInheritedSymbolOnlyAgain: Product =
+         |    new BaseSymbolOnlyToString:
+         |      def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+         |      def productArity: Int = 2
+         |      def productElement(n: Int): Any =
+         |        if n == 0 then 17
+         |        else if n == 1 then "again"
+         |        else throw new IndexOutOfBoundsException(n.toString)
+         |      override def productElementName(n: Int): String =
+         |        if n == 0 then "i"
+         |        else if n == 1 then "s"
+         |        else throw new IndexOutOfBoundsException(n.toString)
+         |      override def productPrefix: String = "ExternalAnonymousSymbolOnlyAgain"
+         |
+         |  def anonymousInheritedSymbolOnlyPair: ProductPair =
+         |    ProductPair(anonymousInheritedSymbolOnly, anonymousInheritedSymbolOnlyAgain)
+         |
+         |  def anonymousPlain: Product =
+         |    new Product:
+         |      def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+         |      def productArity: Int = 1
+         |      def productElement(n: Int): Any =
+         |        if n == 0 then 10 else throw new IndexOutOfBoundsException(n.toString)
+         |      override def productPrefix: String = "ExternalAnonymousPlain"
+         |
+         |class Outer:
+         |  case class InnerDirect(i: Int):
+         |    override def toString: String = "external-inner-direct(" + i + ")"
+         |
+         |  case class InnerPlain(i: Int, s: String)
          |""".stripMargin,
       StandardCharsets.UTF_8
     )
@@ -84,6 +177,95 @@ class ReplProductToStringClasspathTests extends ReplTest(options = ReplProductTo
       val afterBase = run("externalproduct.FromBase(3)")(using afterTrait)
       assertRenderedAs(storedOutput(), "val res2: externalproduct.FromBase = external-base", "FromBase(3)")
 
-      run("externalproduct.Plain(4)")(using afterBase)
+      val afterPlain = run("""externalproduct.Plain(4, "plain")""")(using afterBase)
       val plain = storedOutput()
-      assertTrue(plain, plain.contains("val res3: externalproduct.Plain = Plain(4)"))
+      assertTrue(plain, plain.contains("""val res3: externalproduct.Plain = Plain(i = 4, s = "plain")"""))
+      assertFalse(plain, plain.contains("Plain(4,plain)"))
+
+      val afterLocalDirect = run("externalproduct.Factory.localDirect")(using afterPlain)
+      assertRenderedAs(storedOutput(), "val res4: Product = external-local-direct(5)", "LocalDirect(5)")
+
+      val afterLocalInherited = run("externalproduct.Factory.localInherited")(using afterLocalDirect)
+      assertRenderedAs(storedOutput(), "val res5: Product = external-trait", "LocalInherited(6)")
+
+      // The local product class is unresolved, and bytecode fallback would reject
+      // the inherited method body. This passes via the declaring-class symbol.
+      val afterLocalInheritedSymbolOnly = run("externalproduct.Factory.localInheritedSymbolOnly")(using afterLocalInherited)
+      assertRenderedAs(
+        storedOutput(),
+        "val res6: Product = LocalInheritedSymbolOnly(15,declaring)",
+        """LocalInheritedSymbolOnly(i = 15, s = "declaring")"""
+      )
+
+      val afterLocalPlain = run("externalproduct.Factory.localPlain")(using afterLocalInheritedSymbolOnly)
+      val localPlain = storedOutput()
+      assertTrue(localPlain, localPlain.contains("""val res7: Product = LocalPlain(i = 7, s = "local")"""))
+      assertFalse(localPlain, localPlain.contains("LocalPlain(7,local)"))
+
+      val afterLocalDefaultShaped = run("externalproduct.Factory.localDefaultShaped")(using afterLocalPlain)
+      assertRenderedAs(
+        storedOutput(),
+        "val res8: Product = LocalDefaultShaped(13,same)",
+        """LocalDefaultShaped(i = 13, s = "same")"""
+      )
+
+      val afterOuter = run("val externalOuter = new externalproduct.Outer")(using afterLocalDefaultShaped)
+      storedOutput()
+
+      val afterInnerDirect = run("externalOuter.InnerDirect(11)")(using afterOuter)
+      assertRenderedAs(storedOutput(), "val res9: externalOuter.InnerDirect = external-inner-direct(11)", "InnerDirect(11)")
+
+      val afterInnerPlain = run("""externalOuter.InnerPlain(12, "inner")""")(using afterInnerDirect)
+      val innerPlain = storedOutput()
+      assertTrue(innerPlain, innerPlain.contains("""val res10: externalOuter.InnerPlain = InnerPlain(i = 12, s = "inner")"""))
+      assertFalse(innerPlain, innerPlain.contains("InnerPlain(12,inner)"))
+
+      val afterAnonymousDirect = run("externalproduct.Factory.anonymousDirect")(using afterInnerPlain)
+      assertRenderedAs(storedOutput(), "val res11: Product = external-anonymous-direct", "ExternalAnonymousDirect(8)")
+
+      val afterAnonymousInherited = run("externalproduct.Factory.anonymousInherited")(using afterAnonymousDirect)
+      assertRenderedAs(storedOutput(), "val res12: Product = external-trait", "ExternalAnonymousInherited(9)")
+
+      // Same declaring-class symbol path, but for an anonymous product class.
+      val afterAnonymousInheritedSymbolOnly = run("externalproduct.Factory.anonymousInheritedSymbolOnly")(using afterAnonymousInherited)
+      assertRenderedAs(
+        storedOutput(),
+        "val res13: Product = ExternalAnonymousSymbolOnly(16,anonymous)",
+        """ExternalAnonymousSymbolOnly(i = 16, s = "anonymous")"""
+      )
+
+      val afterAnonymousInheritedSymbolOnlyAgain =
+        run("externalproduct.Factory.anonymousInheritedSymbolOnlyAgain")(using afterAnonymousInheritedSymbolOnly)
+      assertRenderedAs(
+        storedOutput(),
+        "val res14: Product = ExternalAnonymousSymbolOnlyAgain(17,again)",
+        """ExternalAnonymousSymbolOnlyAgain(i = 17, s = "again")"""
+      )
+
+      val afterAnonymousInheritedSymbolOnlyPair =
+        run("externalproduct.Factory.anonymousInheritedSymbolOnlyPair")(using afterAnonymousInheritedSymbolOnlyAgain)
+      val anonymousInheritedSymbolOnlyPair = storedOutput()
+      assertTrue(anonymousInheritedSymbolOnlyPair, anonymousInheritedSymbolOnlyPair.contains("val res15: externalproduct.ProductPair ="))
+      assertTrue(anonymousInheritedSymbolOnlyPair, anonymousInheritedSymbolOnlyPair.contains("ExternalAnonymousSymbolOnly(16,anonymous)"))
+      assertTrue(anonymousInheritedSymbolOnlyPair, anonymousInheritedSymbolOnlyPair.contains("ExternalAnonymousSymbolOnlyAgain(17,again)"))
+      assertFalse(
+        anonymousInheritedSymbolOnlyPair,
+        anonymousInheritedSymbolOnlyPair.contains("""ExternalAnonymousSymbolOnly(i = 16, s = "anonymous")""")
+      )
+      assertFalse(
+        anonymousInheritedSymbolOnlyPair,
+        anonymousInheritedSymbolOnlyPair.contains("""ExternalAnonymousSymbolOnlyAgain(i = 17, s = "again")""")
+      )
+
+      val afterAnonymousPlain = run("externalproduct.Factory.anonymousPlain")(using afterAnonymousInheritedSymbolOnlyPair)
+      val anonymousPlain = storedOutput()
+      assertTrue(anonymousPlain, anonymousPlain.contains("val res16: Product = ExternalAnonymousPlain(10)"))
+
+      // This body has the same bytecode shape as synthesized case-class toString.
+      // It only renders via toString if the compiler-symbol path wins.
+      run("""externalproduct.SymbolOnlyToString(14, "symbol")""")(using afterAnonymousPlain)
+      assertRenderedAs(
+        storedOutput(),
+        "val res17: externalproduct.SymbolOnlyToString = SymbolOnlyToString(14,symbol)",
+        """SymbolOnlyToString(i = 14, s = "symbol")"""
+      )

--- a/repl/test/dotty/tools/repl/ReplProductToStringClasspathTests.scala
+++ b/repl/test/dotty/tools/repl/ReplProductToStringClasspathTests.scala
@@ -1,0 +1,89 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import dotc.Driver
+import dotc.interfaces.Diagnostic.ERROR
+import dotc.reporting.TestReporter
+import vulpix.{TestConfiguration, TestFlags}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path}
+import java.util.Comparator
+
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.{AfterClass, Test}
+
+object ReplProductToStringClasspathTests:
+  private var tempDir: Path = null
+
+  private lazy val fixtureJar: Path =
+    tempDir = Files.createTempDirectory("repl-product-tostring-classpath")
+    createFixtureJar(tempDir)
+
+  def options: Array[String] =
+    ReplTest.createOptions(fixtureJar.toAbsolutePath.toString)
+
+  private def createFixtureJar(root: Path): Path =
+    val srcDir = Files.createDirectories(root.resolve("src"))
+    val source = srcDir.resolve("ExternalProducts.scala")
+    Files.writeString(
+      source,
+      """|package externalproduct
+         |
+         |trait TraitToString:
+         |  override def toString: String = "external-trait"
+         |
+         |abstract class BaseToString:
+         |  override def toString: String = "external-base"
+         |
+         |case class Direct(i: Int):
+         |  override def toString: String = "external-direct(" + i + ")"
+         |
+         |case class FromTrait(i: Int) extends TraitToString
+         |
+         |case class FromBase(i: Int) extends BaseToString
+         |
+         |case class Plain(i: Int)
+         |""".stripMargin,
+      StandardCharsets.UTF_8
+    )
+
+    val jar = root.resolve("external-products.jar")
+    val flags =
+      TestFlags(TestConfiguration.basicClasspath, TestConfiguration.noCheckOptions)
+        .and("-d", jar.toString)
+    val reporter = TestReporter.reporter(System.out, logLevel = ERROR)
+    new Driver().process(flags.all :+ source.toString, reporter)
+    assertFalse(s"compilation of $source failed", reporter.hasErrors)
+    assertTrue(s"compiler did not create $jar", Files.isRegularFile(jar))
+    jar
+
+  @AfterClass def tearDownFixture: Unit =
+    if tempDir != null then
+      Files.walk(tempDir)
+        .sorted(Comparator.reverseOrder)
+        .forEach(Files.delete)
+      tempDir = null
+
+class ReplProductToStringClasspathTests extends ReplTest(options = ReplProductToStringClasspathTests.options):
+
+  private def assertRenderedAs(output: String, expected: String, structuralPrefix: String): Unit =
+    assertTrue(output, output.contains(expected))
+    assertFalse(output, output.contains(structuralPrefix))
+
+  @Test def `product toString from startup classpath`: Unit =
+    initially:
+      val afterDirect = run("externalproduct.Direct(1)")
+      assertRenderedAs(storedOutput(), "val res0: externalproduct.Direct = external-direct(1)", "Direct(1)")
+
+      val afterTrait = run("externalproduct.FromTrait(2)")(using afterDirect)
+      assertRenderedAs(storedOutput(), "val res1: externalproduct.FromTrait = external-trait", "FromTrait(2)")
+
+      val afterBase = run("externalproduct.FromBase(3)")(using afterTrait)
+      assertRenderedAs(storedOutput(), "val res2: externalproduct.FromBase = external-base", "FromBase(3)")
+
+      run("externalproduct.Plain(4)")(using afterBase)
+      val plain = storedOutput()
+      assertTrue(plain, plain.contains("val res3: externalproduct.Plain = Plain(4)"))

--- a/repl/test/dotty/tools/repl/ReplProductToStringShapeTests.scala
+++ b/repl/test/dotty/tools/repl/ReplProductToStringShapeTests.scala
@@ -1,0 +1,149 @@
+package dotty.tools
+package repl
+
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Test
+
+class ReplProductToStringShapeTests extends ReplTest:
+
+  private def assertRenderedAs(output: String, expected: String, structuralPrefix: String): Unit =
+    assertTrue(output, output.contains(expected))
+    assertFalse(output, output.contains(structuralPrefix))
+    assertFalse(output, output.contains("-- Error:"))
+
+  private def renderAfterDefinition(definition: String, expression: String)(using State): String =
+    val afterDefinition = run(definition)
+    storedOutput()
+    run(expression)(using afterDefinition)
+    storedOutput()
+
+  @Test def `local case class with direct toString`: Unit =
+    initially:
+      val output = renderAfterDefinition(
+        """|def makeLocalDirect: Product =
+           |  case class LocalDirect(i: Int):
+           |    override def toString: String = "local-direct(" + i + ")"
+           |  LocalDirect(1)
+           |""".stripMargin,
+        "makeLocalDirect"
+      )
+      assertRenderedAs(output, "val res0: Product = local-direct(1)", "LocalDirect(1)")
+
+  @Test def `local case class with inherited toString`: Unit =
+    initially:
+      val output = renderAfterDefinition(
+        """|def makeLocalInherited: Product =
+           |  trait LocalBase:
+           |    override def toString: String = "local-inherited"
+           |  case class LocalInherited(i: Int) extends LocalBase
+           |  LocalInherited(2)
+           |""".stripMargin,
+        "makeLocalInherited"
+      )
+      assertRenderedAs(output, "val res0: Product = local-inherited", "LocalInherited(2)")
+
+  @Test def `local case class without user toString remains structural`: Unit =
+    initially:
+      val output = renderAfterDefinition(
+        """|def makeLocalPlain: Product =
+           |  case class LocalPlain(i: Int, s: String)
+           |  LocalPlain(3, "plain")
+           |""".stripMargin,
+        "makeLocalPlain"
+      )
+      assertRenderedAs(output, """val res0: Product = LocalPlain(i = 3, s = "plain")""", "LocalPlain(3,plain)")
+
+  @Test def `block local case class with direct toString`: Unit =
+    initially:
+      run(
+        """|val blockLocal: Product =
+           |  case class BlockLocal(i: Int):
+           |    override def toString: String = "block-local(" + i + ")"
+           |  BlockLocal(4)
+           |""".stripMargin
+      )
+      val output = storedOutput()
+      assertRenderedAs(output, "val blockLocal: Product = block-local(4)", "BlockLocal(4)")
+
+  @Test def `inner case class with direct toString`: Unit =
+    initially:
+      val afterClass = run(
+        """|class OuterDirect:
+           |  case class Inner(i: Int):
+           |    override def toString: String = "inner-direct(" + i + ")"
+           |""".stripMargin
+      )
+      storedOutput()
+
+      val afterOuter = run("val outerDirect = new OuterDirect")(using afterClass)
+      storedOutput()
+
+      run("outerDirect.Inner(4)")(using afterOuter)
+      val output = storedOutput()
+      assertRenderedAs(output, " = inner-direct(4)", "Inner(4)")
+
+  @Test def `inner case class without user toString remains structural`: Unit =
+    initially:
+      val afterClass = run(
+        """|class OuterPlain:
+           |  case class Inner(i: Int, s: String)
+           |""".stripMargin
+      )
+      storedOutput()
+
+      val afterOuter = run("val outerPlain = new OuterPlain")(using afterClass)
+      storedOutput()
+
+      run("""outerPlain.Inner(5, "inner")""")(using afterOuter)
+      val output = storedOutput()
+      assertRenderedAs(output, """Inner(i = 5, s = "inner")""", "Inner(5,inner)")
+
+  @Test def `anonymous product with direct toString`: Unit =
+    initially:
+      run(
+        """|new Product:
+           |  def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+           |  def productArity: Int = 1
+           |  def productElement(n: Int): Any =
+           |    if n == 0 then 6 else throw new IndexOutOfBoundsException(n.toString)
+           |  override def productPrefix: String = "AnonymousProduct"
+           |  override def toString: String = "anonymous-product"
+           |""".stripMargin
+      )
+      val output = storedOutput()
+      assertRenderedAs(output, " = anonymous-product", "AnonymousProduct(6)")
+
+  @Test def `anonymous product with inherited toString`: Unit =
+    initially:
+      val afterTrait = run(
+        """|trait AnonymousBase:
+           |  override def toString: String = "anonymous-inherited"
+           |""".stripMargin
+      )
+      storedOutput()
+
+      run(
+        """|new Product with AnonymousBase:
+           |  def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+           |  def productArity: Int = 1
+           |  def productElement(n: Int): Any =
+           |    if n == 0 then 7 else throw new IndexOutOfBoundsException(n.toString)
+           |  override def productPrefix: String = "AnonymousInherited"
+           |""".stripMargin
+      )(using afterTrait)
+      val output = storedOutput()
+      assertRenderedAs(output, " = anonymous-inherited", "AnonymousInherited(7)")
+
+  @Test def `anonymous product without user toString remains structural`: Unit =
+    initially:
+      run(
+        """|new Product:
+           |  def canEqual(that: Any): Boolean = that.isInstanceOf[Product]
+           |  def productArity: Int = 1
+           |  def productElement(n: Int): Any =
+           |    if n == 0 then 8 else throw new IndexOutOfBoundsException(n.toString)
+           |  override def productPrefix: String = "AnonymousPlain"
+           |""".stripMargin
+      )
+      val output = storedOutput()
+      assertRenderedAs(output, "AnonymousPlain(8)", "anonymous-plain")


### PR DESCRIPTION
Adds a hook into the vendored pprint that is called on every value extending `scala.Product` - first attempt to resolve the runtime class to a compiler symbol and check for if the resolved `toString` is synthetic. If that does not work then inspect the bytecode for the exact pattern `scala.runtime.ScalaRuntime._toString(this)`.

Fixes https://github.com/scala/scala3/issues/26329

alternative to https://github.com/scala/scala3/pull/26435

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by analysing the code, and trying to think of edge cases.

### Tradeoff:
Anonymous/local classes can't be resolved from the runtime class to a (non-stubbed) symbol. So will always fallback to the bytecode inspection. So if they override `toString` as exactly `scala.runtime.ScalaRuntime._toString(this)`, (and does not inherit a `toString` override from a normal class) then the REPL will assume its a synthetic override from the shape, so will fallback to `pprint` (so adding the structural field names). [Edit: `scala.runtime` package is internal API, so we could say this is no problem.]

If we want to fix this tradeoff for such a rare case then basically you would have to call `.toString` and `pprint(...)` and compare results. We could do it but I guess that feels wrong to actually execute the code rather than static analysis.

A second alternative - how much overhead would it be to actually book-keep anonymous/local classes so that they can be queried deterministically? (ok not as a member of a scope, but still "attached" to a method)

A third alternative I considered (but i guess not working for scala 2 (and kotlin/java?) code) is to crack the Tasty of the class that defines anonymous/local classes and attempt to reconcile that to the class name, but is that deterministic?

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)