### PR TITLE
Print right-associative operators as selections

### DIFF
--- a/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/RefinedPrinter.scala
@@ -505,13 +505,12 @@ class RefinedPrinter(_ctx: Context) extends PlainPrinter(_ctx) {
         optDotPrefix(tree) ~ keywordStr("this") ~ idText(tree)
       case Super(qual: This, mix) =>
         optDotPrefix(qual) ~ keywordStr("super") ~ optText(mix)("[" ~ _ ~ "]")
+      case BinaryOp(l, op, r) if isInfix(op) && op.name.endsWith(":") =>
+        toTextLocal(l) ~ "." ~ toText(op.name) ~ "(" ~ toText(r) ~ ")"
       case BinaryOp(l, op, r) if isInfix(op) =>
-        val isRightAssoc = op.name.endsWith(":")
         val opPrec = parsing.precedence(op.name)
-        val leftPrec = if isRightAssoc then opPrec + 1 else opPrec
-        val rightPrec = if !isRightAssoc then opPrec + 1 else opPrec
         changePrec(opPrec):
-          atPrec(leftPrec)(toText(l))  ~ " " ~ toText(op.name) ~ " " ~ atPrec(rightPrec)(toText(r))
+          atPrec(opPrec)(toText(l)) ~ " " ~ toText(op.name) ~ " " ~ atPrec(opPrec + 1)(toText(r))
       case app @ Apply(fun, args) =>
         if (fun.hasType && fun.symbol == defn.throwMethod)
           changePrec (GlobalPrec) {

--- a/compiler/test/dotty/tools/dotc/printing/PrinterTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrinterTests.scala
@@ -72,5 +72,3 @@ class PrinterTests extends DottyTest {
     }
   }
 }
-
-

--- a/compiler/test/dotty/tools/dotc/printing/PrinterTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrinterTests.scala
@@ -42,4 +42,35 @@ class PrinterTests extends DottyTest {
       assertEquals("Int & (Boolean | String)", bar.tpt.show)
     }
   }
+
+  @Test
+  def rightAssocInfixPrintedAsSelection: Unit = {
+    val source = """
+      implicit def cv(i: Int): String = s"$i cv"
+
+      class C {
+        def f_:(s: String): String = s * 2
+        def +:(s: String): String = s * 2
+      }
+
+      @main def test =
+        val c = C()
+        println(42 f_: c)
+        println(42 +: c)
+    """
+
+    checkCompile("typer", source) { (tree, context) =>
+      given Context = context
+
+      val printed = tree.show
+
+      assertTrue(printed.contains(".f_:("))
+      assertTrue(printed.contains(".+:("))
+
+      assertFalse(printed.contains(" f_: "))
+      assertFalse(printed.contains(" +: "))
+    }
+  }
 }
+
+


### PR DESCRIPTION
Fixes #26014

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by understanding the proposed changes, implementing the fix by hand, ensuring the logic matched existing assumptions, and adding automated tests based on reproducer.

## How was the solution tested?

Added automated tests (including issue's reproducer). The tests verify that right-assoc operators are printed using selection syntax ('c.f_:(arg)') instead of infix. 
