### PR TITLE
Improvement: fallback PC symbol location position to a classfile if no source exists

### DIFF
--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -156,14 +156,14 @@ class PcDefinitionProvider(
       else
         val file = symbol.associatedFile
         if file != null then
-          file.underlyingSource match
-            case Some(jar: ZipArchive) if jar.jpath != null =>
+          file match
+            case entry: ZipArchive#Entry =>
               val classFile =
                 if file.ext.isTasty then file.resolveSiblingWithExtension(FileExtension.Class)
                 else file
               if classFile != null then
                 List(new Location(
-                  s"jar:${jar.jpath.toUri}!/${classFile.path}",
+                  s"jar:${entry.underlyingSource.jpath.toUri}!/${classFile.path}",
                   new Range(new Position(0, 0), new Position(0, 0))
                 ))
               else Nil

--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -20,9 +20,13 @@ import dotty.tools.dotc.interactive.Interactive.Include
 import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
+import dotty.tools.io.FileExtension
+import dotty.tools.io.ZipArchive
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 
 import org.eclipse.lsp4j.Location
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
 
 class PcDefinitionProvider(
     driver: InteractiveDriver,
@@ -146,7 +150,25 @@ class PcDefinitionProvider(
         case srcTree if srcTree.namePos.exists =>
           new Location(params.uri().toString(), srcTree.namePos.toLsp)
       .toList
-    else search.definition(semanticdbSymbol, uri).asScala.toList
+    else
+      val fromSearch = search.definition(semanticdbSymbol, uri).asScala.toList
+      if fromSearch.nonEmpty then fromSearch
+      else
+        val file = symbol.associatedFile
+        if file != null then
+          file.underlyingSource match
+            case Some(jar: ZipArchive) if jar.jpath != null =>
+              val classFile =
+                if file.ext.isTasty then file.resolveSiblingWithExtension(FileExtension.Class)
+                else file
+              if classFile != null then
+                List(new Location(
+                  s"jar:${jar.jpath.toUri}!/${classFile.path}",
+                  new Range(new Position(0, 0), new Position(0, 0))
+                ))
+              else Nil
+            case _ => Nil
+        else Nil
 
   def semanticSymbolsSorted(
       syms: List[Symbol]

--- a/presentation-compiler/test/dotty/tools/pc/base/BasePcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/base/BasePcDefinitionSuite.scala
@@ -53,7 +53,11 @@ abstract class BasePcDefinitionSuite extends BasePCSuite:
         )
       else
         val filename = location.getUri()
-        val comment = s"/*$filename*/"
+        // relativize jar files (reported as `jar:file:/absolute/cache/path.jar!/entry/path`)
+        val relativized = filename.lastIndexOf("!/") match
+          case -1 => filename
+          case idx => filename.substring(idx + 2)
+        val comment = s"/*$relativized*/"
         List(new TextEdit(offsetRange, comment))
     }
     val obtained = TextEdits.applyEdits(cleanedCode, edits)

--- a/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
+++ b/presentation-compiler/test/dotty/tools/pc/tests/definition/PcDefinitionSuite.scala
@@ -1,5 +1,7 @@
 package dotty.tools.pc.tests.definition
 
+import java.nio.file.Path
+
 import scala.language.unsafeNulls
 import scala.meta.internal.jdk.CollectionConverters.*
 import scala.meta.pc.OffsetParams
@@ -7,10 +9,24 @@ import scala.meta.pc.OffsetParams
 import dotty.tools.pc.base.BasePcDefinitionSuite
 import dotty.tools.pc.utils.MockEntries
 
+import coursierapi.{Dependency, Fetch}
 import org.eclipse.lsp4j.Location
 import org.junit.{Ignore, Test}
 
 class PcDefinitionSuite extends BasePcDefinitionSuite:
+
+  override protected def additionalClasspath: Seq[Path] =
+    // we purposefully don't request/attach the -sources.jar here
+    fetchJar("com.lihaoyi", "sourcecode_3", "0.4.2")
+
+  private def fetchJar(organization: String, artifact: String, version: String): Seq[Path] =
+    Fetch
+      .create()
+      .withDependencies(Dependency.of(organization, artifact, version))
+      .fetch()
+      .asScala
+      .map(_.toPath)
+      .toSeq
 
   override def mockEntries = new MockEntries:
     override def definitions = Map[String, List[Location]](
@@ -676,5 +692,14 @@ class PcDefinitionSuite extends BasePcDefinitionSuite:
       """|case class MyItem(<<name>>: String)
          |
          |def handle(item: String) = MyItem(na@@me = item)
+         |""".stripMargin
+    )
+
+  @Test def `dep-no-source-jar` =
+    check(
+      """|import sourcecode.Name
+         |object Main {
+         |  def foo: /*sourcecode/Name.class*/@@Name = ???
+         |}
          |""".stripMargin
     )


### PR DESCRIPTION
The goal here is to make both Scala 2 and Scala 3 PC’s more similar. Scala 2’s presentation compiler fallbacks to a .class, which metals can use. Doing this on the side of metals is difficult, because we either have to look through all jars connected to a project, or index them, but here we already have a .associatedFile value. The implementation here is nearly identical, with the exception of having to remap .associatedFile from .tasty to a .class (scala-2's: https://github.com/scalameta/metals/blob/8c8a7ef2ae4f165eaa36a2bec423d924a00b5f39/mtags/src/main/scala-2/scala/meta/internal/pc/PcDefinitionProvider.scala#L118).

## Have you relied on LLM-based tools in this contribution?

Yes, to find the right location for the change and  to find a better way to remap tasty to .class, rather than manually (I was hoping it would also remap into the right file for symbols owned by objects, alas, that's not the case, but scala-2's counterpart also doesn't seem to work this way).
I also checked the output manually and by extensive manual testing.

## How was the solution tested?

Manual tests because writing automated tests is impractical, described below (in detail):
Running the PC on an sbt project, with -source.jar caches removed, comparing the result to analogous scala 2 sbt project.
EDIT:
I also ended up adding a unit test here (which fetches a third party library)
