### PR TITLE
Minor using directives parser improvements

### DIFF
--- a/directives-parser/README.md
+++ b/directives-parser/README.md
@@ -49,12 +49,12 @@ original file where code begins.
 
 ### Prefix requirement
 
-The exact prefix `//> using` is required (with a single space after `>`):
+The prefix `//> using` is required, with zero or more whitespace characters after `>`:
 
 - `//> using scala 3` — valid
-- `//>using scala 3` — treated as code (no space after `>`)
-- `//>  using scala 3` — warning: invalid prefix; treated as code
-- `//>	using scala 3` — warning: tab after `>` is invalid; treated as code
+- `//>using scala 3` — valid
+- `//>  using scala 3` — valid
+- `//>	using scala 3` (with a tab) — valid
 - `//> notUsing foo` — treated as code
 
 ## Grammar
@@ -201,10 +201,6 @@ val x = 1
 ```scala
 package x
 //> using scala 3                   // ignored: code (package) before directive
-```
-
-```scala
-//>  using scala 3                  // invalid prefix (extra space); treated as code
 ```
 
 ### Errors

--- a/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
@@ -110,7 +110,7 @@ object CommentExtractor:
         if offset < length && content(offset) == '\n' then offset += 1
         lineNum += 1
       else if trimmed.startsWith("//>") then
-        val withoutLeading = trimmed.drop(3).dropWhile(c => c == ' ' || c == '\t')
+        val withoutLeading = trimmed.drop(3).dropWhile(c => Character.isWhitespace(c) || Character.isSpaceChar(c))
         if withoutLeading.startsWith("using") then
           val adjustedOffset = lineStart + lineContent.indexOf("//>") + bomOffset
           // Normalize the result to have exactly one space.

--- a/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
@@ -19,19 +19,12 @@ case class ExtractorResult(
 
 /** Phase 1: scans a source file and extracts `//> using` directive lines.
   *
-  * Rules:
-  *   - Lines beginning with `#!` (shebang) are allowed only as the very first line.
-  *   - Blank lines are allowed anywhere in the directive region.
-  *   - Line comments (`//` not `//> `) are allowed and skipped.
-  *   - Block comments (`/* ... */`, including multi-line) are allowed and skipped.
-  *   - The first line that is none of the above marks the start of code (`codeOffset`).
-  *   - Any `//> using` lines that appear after `codeOffset` are NOT included in the result, but a
-  *     warning diagnostic is emitted for each one.
-  *   - Directives inside block comments are NOT parsed.
+  * The accepted syntax is specified in the module README, which is the single source of truth.
+  * However, the result of extraction always has exactly one space between `//>` and `using`
   */
 object CommentExtractor:
 
-  private val UsingDirectiveRegex = """^//>\s+using(?:\s|$)""".r
+  private val UsingDirectiveRegex = """^//>\s*using(?:\s|$)""".r
 
   def extract(rawContent: IndexedSeq[Char]): ExtractorResult =
     val content =
@@ -117,23 +110,14 @@ object CommentExtractor:
         if offset < length && content(offset) == '\n' then offset += 1
         lineNum += 1
       else if trimmed.startsWith("//>") then
-        val withoutLeading = lineContent.dropWhile(c => c == ' ' || c == '\t')
-        val leadingLen     = lineContent.length - withoutLeading.length
-        if withoutLeading.startsWith("//> using") then
-          val adjustedOffset = lineStart + leadingLen + bomOffset
-          directives += DirectiveLine(withoutLeading, lineNum, adjustedOffset)
+        val withoutLeading = trimmed.drop(3).dropWhile(c => c == ' ' || c == '\t')
+        if withoutLeading.startsWith("using") then
+          val adjustedOffset = lineStart + lineContent.indexOf("//>") + bomOffset
+          // Normalize the result to have exactly one space.
+          directives += DirectiveLine("//> " + withoutLeading, lineNum, adjustedOffset)
           offset = lineStart + lineContent.length
           if offset < length && content(offset) == '\n' then offset += 1
           lineNum += 1
-        else if UsingDirectiveRegex.findFirstIn(withoutLeading).isDefined then
-          val linePos = Position(lineNum, leadingLen, lineStart + leadingLen + bomOffset)
-          val msg     =
-            s"Using directive must use the exact prefix `//> using`. Invalid prefix in: ${withoutLeading.trim}"
-          diagnostics += UsingDirectiveDiagnostic(msg, DiagnosticSeverity.Warning, linePos)
-          offset = lineStart + lineContent.length
-          if offset < length && content(offset) == '\n' then offset += 1
-          lineNum += 1
-          codeStart = offset
         else
           codeStart = lineStart
       else

--- a/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
+++ b/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
@@ -258,7 +258,7 @@ class CommentExtractorTests:
     val r = extract(src)
     assertEquals(1, r.directiveLines.length)
     val dl = r.directiveLines.head
-    assertEquals(dl.content, "//> using scala 3")
+    assertEquals("//> using scala 3", dl.content)
     assertEquals(2, dl.lineStartOffset)
     assertEquals(0, r.diagnostics.length)
   }
@@ -269,7 +269,7 @@ class CommentExtractorTests:
         |""".stripMargin
     val r = extract(src)
     assertEquals(1, r.directiveLines.length)
-    assertEquals(r.directiveLines.head.content, "//> using scala 3")
+    assertEquals("//> using scala 3", r.directiveLines.head.content)
     assertEquals(0, r.diagnostics.length)
   }
 
@@ -310,7 +310,7 @@ class CommentExtractorTests:
     val src = "//> using scala 3\r\nval x = 1\r\n"
     val r   = extract(src)
     assertEquals(1, r.directiveLines.length)
-    assertEquals(r.directiveLines.head.content, "//> using scala 3\r")
+    assertEquals("//> using scala 3\r", r.directiveLines.head.content)
     assertEquals(19, r.codeOffset) // includes \r\n
   }
 

--- a/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
+++ b/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
@@ -295,9 +295,20 @@ class CommentExtractorTests:
     assertEquals(19, r.codeOffset)
   }
 
-  @Test def tab_after_emits_a_warning(): Unit = {
+  @Test def tab_after_is_accepted(): Unit = {
     val src =
       """//>	using scala 3
+        |val x = 1
+        |""".stripMargin
+    val r = extract(src)
+    assertEquals(1, r.directiveLines.length)
+    assertEquals(0, r.directiveLines.head.lineNum)
+    assertEquals(18, r.codeOffset)
+  }
+
+  @Test def nbsp_after_is_accepted(): Unit = {
+    val src =
+      """//> using scala 3
         |val x = 1
         |""".stripMargin
     val r = extract(src)

--- a/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
+++ b/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
@@ -273,27 +273,26 @@ class CommentExtractorTests:
     assertEquals(0, r.diagnostics.length)
   }
 
-  @Test def using_without_space_is_treated_as_code(): Unit = {
+  @Test def using_without_space_is_accepted(): Unit = {
     val src =
       """//>using scala 3
         |val x = 1
         |""".stripMargin
     val r = extract(src)
-    assertEquals(0, r.directiveLines.length)
-    assertEquals(0, r.codeOffset)
+    assertEquals(1, r.directiveLines.length)
+    assertEquals(0, r.directiveLines.head.lineNum)
+    assertEquals(17, r.codeOffset)
   }
 
-  @Test def multiple_spaces_after_emits_a_warning(): Unit = {
+  @Test def multiple_spaces_after_is_accepted(): Unit = {
     val src =
       """//>  using scala 3
         |val x = 1
         |""".stripMargin
     val r = extract(src)
-    assertEquals(0, r.directiveLines.length)
-    val ws = r.diagnostics.filter(_.severity == DiagnosticSeverity.Warning)
-    assertEquals(1, ws.length)
-    assertTrue(ws.head.message.contains("exact prefix"))
-    assertTrue(ws.head.message.contains("//>  using scala 3"))
+    assertEquals(1, r.directiveLines.length)
+    assertEquals(0, r.directiveLines.head.lineNum)
+    assertEquals(19, r.codeOffset)
   }
 
   @Test def tab_after_emits_a_warning(): Unit = {
@@ -302,10 +301,9 @@ class CommentExtractorTests:
         |val x = 1
         |""".stripMargin
     val r = extract(src)
-    assertEquals(0, r.directiveLines.length)
-    val ws = r.diagnostics.filter(_.severity == DiagnosticSeverity.Warning)
-    assertEquals(1, ws.length)
-    assertTrue(ws.head.message.contains("exact prefix"))
+    assertEquals(1, r.directiveLines.length)
+    assertEquals(0, r.directiveLines.head.lineNum)
+    assertEquals(18, r.codeOffset)
   }
 
   @Test def CRLF_line_endings_parse_correctly(): Unit = {


### PR DESCRIPTION
* Support any amount of whitespace between `//>` and `using`
* Fix some expected/actual inversions in tests

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
Covered by existing tests (this is a refactoring)
