### PR TITLE
Backport "Do not warn on dollars in Java names" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Namer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Namer.scala
@@ -200,7 +200,8 @@ class Namer { typer: Typer =>
       || flags.isOneOf(Synthetic | Accessor | CaseAccessor) // check the case param not the accessor
       || flags.is(Param) && ctx.owner.is(Synthetic)
       || isDollars
-    if !exempt && (isModule || !name.toTermName.isInstanceOf[DerivedName]) then
+    // no point in warning about $ in Java, there are no backticks to insert nor other ways to suppress such a warning
+    if !flags.is(JavaDefined) && !exempt && (isModule || !name.toTermName.isInstanceOf[DerivedName]) then
       val simple = name.toSimpleName
       val max = if isModule then simple.length - 1 else simple.length
       val last = simple.lastIndexOf('$', start = max - 1)

--- a/tests/warn/dollar-java/JavaDefined$Evil.java
+++ b/tests/warn/dollar-java/JavaDefined$Evil.java
@@ -1,0 +1,4 @@
+package javadefined;
+
+public class JavaDefined$Evil {
+}


### PR DESCRIPTION
Backports #26303 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]