### PR TITLE
Backport "Don't skip generic signature for constructors with generic `using` parameters" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -40,7 +40,7 @@ object GenericSignatures {
   private def mayNeedSignature(sym0: Symbol, info: Type)(using Context) = {
     def mayNeedSignature(t: Type): Boolean = t match
       case ExprType(e) => mayNeedSignature(e)
-      case MethodTpe(_, ps, res) => (!sym0.isConstructor && mayNeedSignature(res)) || ps.exists(mayNeedSignature)
+      case MethodTpe(_, ps, res) => mayNeedSignature(res) || ps.exists(mayNeedSignature)
       case _: TypeRef => !t.isAny && !t.isAnyRef && !t.isRef(defn.StringClass, skipRefined = false) && !t.isPrimitiveValueType
       case _ => true
 

--- a/tests/generic-java-signatures/higherkind-with-raw.check
+++ b/tests/generic-java-signatures/higherkind-with-raw.check
@@ -1,0 +1,6 @@
+public A1(F<scala.collection.immutable.List>)
+public F<scala.collection.immutable.List> A1.a()
+---
+public A2(F<scala.collection.immutable.List>)
+public F<scala.collection.immutable.List> A2.a()
+---

--- a/tests/generic-java-signatures/higherkind-with-raw.scala
+++ b/tests/generic-java-signatures/higherkind-with-raw.scala
@@ -1,0 +1,16 @@
+trait F[G[_]]
+
+class A1(val a: F[List])
+class A2()(using val a: F[List])
+
+object Test:
+  def main(args: Array[String]): Unit =
+    List(classOf[A1], classOf[A2]).foreach(c =>
+      c.getConstructors.foreach(m =>
+        println(m.toGenericString)
+      )
+      c.getMethods.filter(_.getName == "a").foreach(m =>
+        println(m.toGenericString)
+      )
+      println("---")
+    )


### PR DESCRIPTION
Backports #26302 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]