### PR TITLE
Backport "Build: Centralize dependency versions" to 3.9.0

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -168,7 +168,7 @@ object Build {
     // Prevent sbt from rewriting our dependencies
     scalaModuleInfo ~= (_.map(_.withOverrideScalaVersion(false))),
 
-    libraryDependencies += "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+    libraryDependencies += Dependencies.sbtJunitInterface % Test,
 
     // If someone puts a source file at the root (e.g., for manual testing),
     // don't pick it up as part of any project.
@@ -610,8 +610,8 @@ object Build {
       Compile / resourceDirectory := baseDirectory.value / "resources",
       // Add all the project's external dependencies
       libraryDependencies ++= Seq(
-        ("org.scala-sbt" %% "zinc-apiinfo" % "1.12.0" % Test).cross(CrossVersion.for3Use2_13),
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+        (Dependencies.sbtZincApiInfo % Test).cross(CrossVersion.for3Use2_13),
+        Dependencies.sbtJunitInterface % Test,
       ),
       // Exclude the transitive dependencies from `zinc-apiinfo` that causes issues at the moment
       excludeDependencies ++= Seq(
@@ -791,8 +791,8 @@ object Build {
       Compile / resourceDirectory := baseDirectory.value / "resources",
       // Add all the project's external dependencies
       libraryDependencies ++= Seq(
-        ("org.scala-sbt" %% "zinc-apiinfo" % "1.12.0" % Test).cross(CrossVersion.for3Use2_13),
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+        (Dependencies.sbtZincApiInfo % Test).cross(CrossVersion.for3Use2_13),
+        Dependencies.sbtJunitInterface % Test,
         ),
       // Packaging configuration of `scala3-sbt-bridge`
       Compile / packageBin / publishArtifact := true,
@@ -894,15 +894,15 @@ object Build {
       Test    / publishArtifact := false,
       publish / skip := false,
       libraryDependencies ++= Seq(
-        "org.jline" % "jline-reader" % "4.0.14",
-        "org.jline" % "jline-terminal" % "4.0.14",
-        "org.jline" % "jline-terminal-jni" % "4.0.14",
-        "com.lihaoyi" %% "pprint"     % "0.9.3",
-        "com.lihaoyi" %% "fansi"      % "0.5.1",
-        "com.lihaoyi" %% "sourcecode" % "0.4.4",
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-        "io.get-coursier" % "interface" % "1.0.29-M4", // used by the REPL for dependency resolution
-        "org.virtuslab" % "using_directives" % "1.1.4", // used by the REPL for parsing magic comments
+        Dependencies.jlineReader,
+        Dependencies.jlineTerminal,
+        Dependencies.jlineTerminalJni,
+        Dependencies.pprint,
+        Dependencies.fansi,
+        Dependencies.sourcecode,
+        Dependencies.sbtJunitInterface % Test,
+        Dependencies.coursierInterface, // used by the REPL for dependency resolution
+        Dependencies.usingDirectives, // used by the REPL for parsing magic comments
       ),
       // Configure to use the non-bootstrapped compiler
       bootstrappedScalaInstanceSettings,
@@ -1025,8 +1025,8 @@ object Build {
       Test / unmanagedSourceDirectories   := Seq(baseDirectory.value / "test"),
       Test / unmanagedResourceDirectories := Seq(baseDirectory.value / "test-resources"),
       libraryDependencies ++= Seq(
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-        "org.scalacheck" %% "scalacheck" % "1.19.0" % Test
+        Dependencies.sbtJunitInterface % Test,
+        Dependencies.scalaCheck % Test
       ),
       // We do not want to list any dependency for the stdlib
       pomPostProcess := { (node: XmlNode) =>
@@ -1115,8 +1115,8 @@ object Build {
       Test / unmanagedSourceDirectories   := Seq(baseDirectory.value / "test"),
       Test / unmanagedResourceDirectories := Seq(baseDirectory.value / "test-resources"),
       libraryDependencies ++= Seq(
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-        "org.scalacheck" %% "scalacheck" % "1.19.0" % Test
+        Dependencies.sbtJunitInterface % Test,
+        Dependencies.scalaCheck % Test
       ),
       // We do not want to list any dependency for the stdlib
       pomPostProcess := { (node: XmlNode) =>
@@ -1230,8 +1230,8 @@ object Build {
           || file._2.endsWith("UnitOps.tasty")         || file._2.endsWith("UnitOps.class") || file._2.endsWith("UnitOps$.class")
           || file._2.endsWith("AnonFunctionXXL.tasty") || file._2.endsWith("AnonFunctionXXL.class"))
       },
-      libraryDependencies += ("org.scala-js" %% "scalajs-library" % scalaJSVersion % Provided).cross(CrossVersion.for3Use2_13),
-      libraryDependencies += ("org.scala-js" % "scalajs-javalib" % scalaJSVersion),
+      libraryDependencies += (Dependencies.scalaJsLibrary % Provided).cross(CrossVersion.for3Use2_13),
+      libraryDependencies += (Dependencies.scalaJsJavalib),
       // Project specific target folder. sbt doesn't like having two projects using the same target folder
       target := target.value / "scala-library",
       autoScalaLibrary := false,
@@ -1312,7 +1312,7 @@ object Build {
       Compile / unmanagedSourceDirectories += baseDirectory.value / "src-non-bootstrapped",
       // Add all the project's external dependencies
       libraryDependencies ++= Seq(
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+        Dependencies.sbtJunitInterface % Test,
       ),
       // Packaging configuration of the stdlib
       Compile / packageBin / publishArtifact := true,
@@ -1354,7 +1354,7 @@ object Build {
       Compile / unmanagedSourceDirectories += baseDirectory.value / "src-bootstrapped",
       // Add all the project's external dependencies
       libraryDependencies ++= Seq(
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+        Dependencies.sbtJunitInterface % Test,
       ),
       // Packaging configuration of the stdlib
       Compile / packageBin / publishArtifact := true,
@@ -1403,10 +1403,10 @@ object Build {
       Test / unmanagedResourceDirectories += baseDirectory.value / "test-resources",
       // All the dependencies needed by the compiler
       libraryDependencies ++= Seq(
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-        "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1",
-        Dependencies.compilerInterface,
-        ("io.get-coursier" %% "coursier" % "2.1.24" % Test).cross(CrossVersion.for3Use2_13),
+        Dependencies.sbtJunitInterface % Test,
+        Dependencies.asm,
+        Dependencies.sbtCompilerInterface,
+        (Dependencies.coursier % Test).cross(CrossVersion.for3Use2_13),
       ),
       // Specify the default entry point of the compiler
       Compile / mainClass := Some("dotty.tools.dotc.Main"),
@@ -1446,7 +1446,7 @@ object Build {
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       libraryDependencies +=
-        ("org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps").cross(CrossVersion.for3Use2_13),
+        (Dependencies.scalaJsIr % "sourcedeps").cross(CrossVersion.for3Use2_13),
       // Silence `using` clause warnings in the scalajs-ir sources
       Compile / compile / scalacOptions +=
         "-Wconf:src=scalajs-ir-src/.*&msg=Implicit parameters should be provided with a `using` clause:s",
@@ -1539,10 +1539,10 @@ object Build {
       Test / unmanagedResourceDirectories += baseDirectory.value / "test-resources",
       // All the dependencies needed by the compiler
       libraryDependencies ++= Seq(
-        "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1",
-        Dependencies.compilerInterface,
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
-        ("io.get-coursier" %% "coursier" % "2.1.24" % Test).cross(CrossVersion.for3Use2_13),
+        Dependencies.asm,
+        Dependencies.sbtCompilerInterface,
+        Dependencies.sbtJunitInterface % Test,
+        (Dependencies.coursier % Test).cross(CrossVersion.for3Use2_13),
       ),
       // Specify the default entry point of the compiler
       Compile / mainClass := Some("dotty.tools.dotc.Main"),
@@ -1570,7 +1570,7 @@ object Build {
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       libraryDependencies +=
-        ("org.scala-js" %% "scalajs-ir" % scalaJSVersion % "sourcedeps").cross(CrossVersion.for3Use2_13),
+        (Dependencies.scalaJsIr % "sourcedeps").cross(CrossVersion.for3Use2_13),
       // Silence `using` clause warnings in the scalajs-ir sources
       Compile / compile / scalacOptions +=
         "-Wconf:src=scalajs-ir-src/.*&msg=Implicit parameters should be provided with a `using` clause:s",
@@ -1673,10 +1673,10 @@ object Build {
       Test / unmanagedSourceDirectories := Seq(baseDirectory.value / "test"),
       // All the dependencies needed by the doctool
       libraryDependencies ++= Dependencies.flexmarkDeps ++ Seq(
-        "nl.big-o" % "liqp" % "0.9.2.3",
-        "org.jsoup" % "jsoup" % "1.22.2", // Needed to process .html files for static site
-        Dependencies.`jackson-dataformat-yaml`,
-        "com.github.sbt" % "junit-interface" % "0.13.3" % Test,
+        Dependencies.liqp,
+        Dependencies.jsoup, // Needed to process .html files for static site
+        Dependencies.jacksonDataformatYaml,
+        Dependencies.sbtJunitInterface % Test,
       ),
       Compile / scalacOptions += "-experimental",
       // Packaging configuration of the stdlib
@@ -1948,12 +1948,12 @@ object Build {
   lazy val presentationCompilerSettings = {
     Seq(
       libraryDependencies ++= Seq(
-        "org.lz4" % "lz4-java" % "1.8.1",
-        "io.get-coursier" % "interface" % "1.0.29-M4",
-        "org.scalameta" % "mtags-interfaces" % mtagsVersion,
-        "com.google.guava" % "guava" % "33.6.0-jre",
+        Dependencies.lz4,
+        Dependencies.coursierInterface,
+        Dependencies.mtagsInterfaces,
+        Dependencies.guava,
       ),
-      libraryDependencies += ("org.scalameta" % s"mtags-shared_${Versions.scala2Version}" % mtagsVersion % SourceDeps),
+      libraryDependencies += (Dependencies.mtagsShared % SourceDeps),
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
       publishLocal := publishLocal.dependsOn( // It is best to publish all together. It is not rare to make changes in both compiler / presentation compiler and it can get misaligned
@@ -2010,8 +2010,8 @@ object Build {
     settings(commonBootstrappedSettings).
     settings(
       libraryDependencies ++= Seq(
-        "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "1.0.0",
-        Dependencies.`jackson-databind`
+        Dependencies.lsp4j,
+        Dependencies.jacksonDatabind
       ),
       // Exclude the dependency that is resolved transively, the stdlib
       // is a project dependency instead
@@ -2122,7 +2122,7 @@ object Build {
 
       // We need JUnit in the Compile configuration
       libraryDependencies +=
-        ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion).cross(CrossVersion.for3Use2_13),
+        (Dependencies.scalaJsJunitTestRuntime).cross(CrossVersion.for3Use2_13),
 
       (Compile / sourceGenerators) += Def.task {
         import org.scalajs.linker.interface.CheckedBehavior
@@ -2290,8 +2290,8 @@ object Build {
       (Test / resourceDirectory)       := baseDirectory.value / "test-resources",
       scalaVersion := (`scala3-compiler-bootstrapped` / scalaVersion).value,
       libraryDependencies ++= Seq(
-        "org.scala-js" %% "scalajs-linker" % scalaJSVersion % Test cross CrossVersion.for3Use2_13,
-        "org.scala-js" %% "scalajs-env-nodejs" % "1.6.0" % Test cross CrossVersion.for3Use2_13,
+        Dependencies.scalaJsLinker % Test cross CrossVersion.for3Use2_13,
+        Dependencies.scalaJsEnvNodeJs % Test cross CrossVersion.for3Use2_13,
       ),
 
       // Change the baseDirectory when running the tests
@@ -2373,7 +2373,7 @@ object Build {
     dependsOn(`scala3-library-sjs`).
     settings(
       commonBootstrappedSettings,
-      libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "2.8.1"))
+      libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % Dependencies.scalaJsDomVersion))
 
   lazy val `scaladoc-js-main` = project.in(file("scaladoc-js/main")).
     enablePlugins(DottyJSPlugin).
@@ -2392,7 +2392,7 @@ object Build {
       commonBootstrappedSettings,
       Test / fork := false,
       scalaJSUseMainModuleInitializer := true,
-      libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "2.8.1")
+      libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % Dependencies.scalaJsDomVersion)
     )
 
   def generateDocumentation(configTask: Def.Initialize[Task[GenerationConfig]]) =

--- a/project/ConstantHolderGenerator.scala
+++ b/project/ConstantHolderGenerator.scala
@@ -2,8 +2,6 @@ import scala.annotation.tailrec
 
 import sbt._
 
-import org.scalajs.ir.ScalaJSVersions
-
 object ConstantHolderGenerator {
   /** Generate a *.scala file that contains the given values as literals. */
   def generate(dir: File, fqn: String, values: (String, Any)*): Seq[File] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,17 +1,22 @@
-import sbt._
+import sbt.*
+import dotty.tools.sbtplugin.Versions
 
-/** A dependency shared between multiple projects should be put here
- *  to ensure the same version of the dependency is used in all projects
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+
+/**
+ * All dependencies should be put here to ensure the same version of the dependency is used in all projects.
+ * PLEASE KEEP ALPHABETIZED!
  */
 object Dependencies {
-  private val jacksonVersion = "3.1.2"
-  val `jackson-databind` =
-    "tools.jackson.core" % "jackson-databind" % jacksonVersion
-  val `jackson-dataformat-yaml` =
-    "tools.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
+  val asm = "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1"
+
+  val coursier = "io.get-coursier" %% "coursier" % "2.1.24"
+  val coursierInterface = "io.get-coursier" % "interface" % "1.0.29-M4"
+
+  val fansi = "com.lihaoyi" %% "fansi" % "0.5.1"
 
   private val flexmarkVersion = "0.64.8"
-
   val flexmarkDeps = Seq(
     "com.vladsch.flexmark" % "flexmark" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-util-ast" % flexmarkVersion,
@@ -27,5 +32,46 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-yaml-front-matter" % flexmarkVersion,
   )
 
-  val compilerInterface = "org.scala-sbt" % "compiler-interface" % "1.12.0"
+  val guava = "com.google.guava" % "guava" % "33.6.0-jre"
+
+  private val jacksonVersion = "3.1.2"
+  val jacksonDatabind = "tools.jackson.core" % "jackson-databind" % jacksonVersion
+  val jacksonDataformatYaml = "tools.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
+
+  private val jlineVersion = "4.0.14"
+  val jlineReader = "org.jline" % "jline-reader" % jlineVersion
+  val jlineTerminal = "org.jline" % "jline-terminal" % jlineVersion
+  val jlineTerminalJni = "org.jline" % "jline-terminal-jni" % jlineVersion
+
+  val jsoup = "org.jsoup" % "jsoup" % "1.22.2"
+
+  val liqp = "nl.big-o" % "liqp" % "0.9.2.3"
+
+  val lsp4j = "org.eclipse.lsp4j" % "org.eclipse.lsp4j" % "1.0.0"
+
+  val lz4 = "org.lz4" % "lz4-java" % "1.8.1"
+
+  private val mtagsVersion = "1.6.7"
+  val mtagsInterfaces = "org.scalameta" % "mtags-interfaces" % mtagsVersion
+  val mtagsShared = "org.scalameta" % s"mtags-shared_${Versions.scala2Version}" % mtagsVersion
+
+  val pprint = "com.lihaoyi" %% "pprint" % "0.9.3"
+
+  val sbtCompilerInterface = "org.scala-sbt" % "compiler-interface" % "1.12.0"
+  val sbtJunitInterface = "com.github.sbt" % "junit-interface" % "0.13.3"
+  val sbtZincApiInfo = "org.scala-sbt" %% "zinc-apiinfo" % "1.12.0"
+
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.19.0"
+
+  val scalaJsDomVersion = "2.8.1" // needs %%% which isn't usable within a val here
+  val scalaJsEnvNodeJs = "org.scala-js" %% "scalajs-env-nodejs" % "1.6.0"
+  val scalaJsIr = "org.scala-js" %% "scalajs-ir" % scalaJSVersion
+  val scalaJsJavalib = "org.scala-js" % "scalajs-javalib" % scalaJSVersion
+  val scalaJsJunitTestRuntime = "org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion
+  val scalaJsLibrary = "org.scala-js" %% "scalajs-library" % scalaJSVersion
+  val scalaJsLinker = "org.scala-js" %% "scalajs-linker" % scalaJSVersion
+
+  val sourcecode = "com.lihaoyi" %% "sourcecode" % "0.4.4"
+
+  val usingDirectives = "org.virtuslab" % "using_directives" % "1.1.4"
 }

--- a/project/PublishBinPlugin.scala
+++ b/project/PublishBinPlugin.scala
@@ -1,11 +1,9 @@
 package sbt
 
-import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.{ FileAlreadyExistsException, Files }
 
-import org.apache.ivy.core.module.id.ModuleRevisionId
 import sbt.Keys._
-import sbt.internal.librarymanagement.{ IvySbt, IvyXml }
+import sbt.internal.librarymanagement.IvyXml
 
 /** This local plugin provides ways of publishing just the binary jar. */
 object PublishBinPlugin extends AutoPlugin {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -94,8 +94,6 @@ object Versions {
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M25"
 
-  val mtagsVersion = "1.6.7"
-
   /* Tests TASTy version invariants during NIGHLY, RC or Stable releases */
   def checkReleasedTastyVersion(): Unit = {
     case class ScalaVersion(minor: Int, patch: Int, isRC: Boolean)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -2,8 +2,6 @@
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "7.3.0.202506031305-r"
 libraryDependencies += "org.ow2.asm" % "asm" % "9.9"
 
-libraryDependencies += Dependencies.`jackson-databind`
-
 // Used for manipulating YAML files in sidebar generation script
 libraryDependencies += "org.yaml" % "snakeyaml" % "2.4"
 

--- a/project/project/build.sbt
+++ b/project/project/build.sbt
@@ -1,2 +1,0 @@
-// Some dependencies are shared between the regular build and the meta-build
-Compile / sources += baseDirectory.value / "../Dependencies.scala"


### PR DESCRIPTION
Backports #26336 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]