### PR TITLE
Backport "Upgrade to Scala.js 1.22.0." to 3.9.0

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -306,7 +306,7 @@ jobs:
       - name: Scala.js JUnit tests with latest ES version
         run: ./project/scripts/sbt ";sjsJUnitTests/clean ;set sjsJUnitTests/scalaJSLinkerConfig ~= switchToLatestESVersion ;sjsJUnitTests/test"
       - name: Scala.js JUnit tests with WebAssembly
-        run: ./project/scripts/sbt ";sjsJUnitTests/clean ;set sjsJUnitTests/scalaJSLinkerConfig ~= switchToLatestESVersion ;set Global/enableWebAssembly := true; sjsJUnitTests/test"
+        run: ./project/scripts/sbt ";sjsJUnitTests/clean ;set Global/enableWebAssembly := true; sjsJUnitTests/test"
   # TODO Scala.js on Windows
 
   test-repl:

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -2543,7 +2543,7 @@ class JSCodeGen()(using genCtx: Context) {
       val fieldsObjValue = {
         js.JSObjectConstr(privateFieldDefs.toList.map { fdef =>
           implicit val pos = fdef.pos
-          js.StringLiteral(fdef.name.name.nameString) -> jstpe.zeroOf(fdef.ftpe)
+          anonJSClassFieldIdentToStringLiteral(fdef.name) -> jstpe.zeroOf(fdef.ftpe)
         })
       }
       val definePrivateFieldsObj = {
@@ -4800,7 +4800,7 @@ class JSCodeGen()(using genCtx: Context) {
       } else if (sym.owner.isAnonymousClass) {
         js.JSSelect(
             js.JSSelect(qual, genPrivateFieldsSymbol()),
-            encodeFieldSymAsStringLiteral(sym))
+            encodeAnonJSClassFieldSymAsStringLiteral(sym))
       } else {
         js.JSPrivateSelect(qual, encodeFieldSym(sym))
       }

--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -137,7 +137,7 @@ class JSCodeGen()(using genCtx: Context) {
 
   def currentThisType: jstpe.Type = {
     currentThisTypeNullable match {
-      case tpe @ jstpe.ClassType(cls, _) =>
+      case tpe @ jstpe.ClassType(cls, _, _) =>
         jswkn.BoxedClassToPrimType.getOrElse(cls, tpe.toNonNullable)
       case tpe @ jstpe.AnyType =>
         // We are in a JS class, in which even `this` is nullable
@@ -1020,7 +1020,7 @@ class JSCodeGen()(using genCtx: Context) {
          * In dotc this is usually not an issue, because it unboxes `null` to
          * the zero of the underlying type, unlike scalac which throws an NPE.
          */
-        jstpe.ClassType(encodeClassName(tpe.tycon.typeSymbol), nullable = true)
+        jstpe.ClassType(encodeClassName(tpe.tycon.typeSymbol), nullable = true, exact = false)
 
       case _ =>
         // Other types are not boxed, so we can initialized them to their true zero.
@@ -2367,7 +2367,7 @@ class JSCodeGen()(using genCtx: Context) {
     val newMethodIdent = js.MethodIdent(newName)
 
     js.ApplyStatic(js.ApplyFlags.empty, className, newMethodIdent, args)(
-        jstpe.ClassType(className, nullable = true))
+        jstpe.ClassType(className, nullable = true, exact = false))
   }
 
   /** Gen JS code for a new of a JS class (subclass of `js.Any`). */
@@ -3485,7 +3485,7 @@ class JSCodeGen()(using genCtx: Context) {
 
     // Sanity check: we can handle Ints and Strings (including `null`s), but nothing else
     genSelector.tpe match {
-      case jstpe.IntType | jstpe.ClassType(jswkn.BoxedStringClass, _) | jstpe.NullType | jstpe.NothingType =>
+      case jstpe.IntType | jstpe.ClassType(jswkn.BoxedStringClass, _, _) | jstpe.NullType | jstpe.NothingType =>
         // ok
       case _ =>
         abortMatch(s"Invalid selector type ${genSelector.tpe}")
@@ -3669,7 +3669,7 @@ class JSCodeGen()(using genCtx: Context) {
       val formalAndActualParams = formalParamNames.lazyZip(formalParamTypes).lazyZip(formalParamRepeateds).map {
         (name, tpe, repeated) =>
           val formalTpe =
-            if (isFunctionXXL) jstpe.ArrayType(ObjectArrayTypeRef, nullable = true)
+            if (isFunctionXXL) jstpe.ArrayType(ObjectArrayTypeRef, nullable = true, exact = false)
             else jstpe.AnyType
           val formalParam = js.ParamDef(freshLocalIdent(name),
               OriginalName(name.toString), formalTpe, mutable = false)
@@ -3747,7 +3747,7 @@ class JSCodeGen()(using genCtx: Context) {
           superClass = jswkn.ObjectClass,
           interfaces = List(encodeClassName(defn.FunctionXXLClass)),
           methodName = MethodName(applySimpleMethodName, List(ObjectArrayTypeRef), jswkn.ObjectRef),
-          paramTypes = List(jstpe.ArrayType(ObjectArrayTypeRef, nullable = true)),
+          paramTypes = List(jstpe.ArrayType(ObjectArrayTypeRef, nullable = true, exact = false)),
           resultType = jstpe.AnyType
         )
         js.NewLambda(descriptor, closure)(encodeClassType(funInterfaceSym).toNonNullable)
@@ -4203,7 +4203,7 @@ class JSCodeGen()(using genCtx: Context) {
           case arg: js.JSGlobalRef => js.JSTypeOfGlobalRef(arg)
           case _                   => js.JSUnaryOp(js.JSUnaryOp.typeof, arg)
         }
-        js.AsInstanceOf(typeofExpr, jstpe.ClassType(jswkn.BoxedStringClass, nullable = true))
+        js.AsInstanceOf(typeofExpr, jstpe.ClassType(jswkn.BoxedStringClass, nullable = true, exact = false))
 
       case STRICT_EQ =>
         // js.special.strictEquals(arg1, arg2)
@@ -4615,7 +4615,7 @@ class JSCodeGen()(using genCtx: Context) {
                 js.LoadModule(ScalaJSRuntimeModClassName),
                 js.MethodIdent(WrapArray.wrapArraySymToToVarArgsName(wrapArray.symbol)),
                 List(genExpr(arrayValue))
-              )(jstpe.ClassType(encodeClassName(defn.SeqClass), nullable = true))
+              )(jstpe.ClassType(encodeClassName(defn.SeqClass), nullable = true, exact = false))
 
             case _ =>
               genExpr(arg)

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -264,7 +264,7 @@ object JSEncoding {
     else {
       assert(sym != defn.ArrayClass,
           "encodeClassType() cannot be called with ArrayClass")
-      jstpe.ClassType(encodeClassName(sym), nullable = true)
+      jstpe.ClassType(encodeClassName(sym), nullable = true, exact = false)
     }
   }
 
@@ -327,10 +327,10 @@ object JSEncoding {
         else if (sym == defn.NullClass)
           jstpe.NullType
         else
-          jstpe.ClassType(typeRef.className, nullable = true)
+          jstpe.ClassType(typeRef.className, nullable = true, exact = false)
 
       case typeRef: jstpe.ArrayTypeRef =>
-        jstpe.ArrayType(typeRef, nullable = true)
+        jstpe.ArrayType(typeRef, nullable = true, exact = false)
 
       case typeRef: jstpe.TransientTypeRef =>
         throw AssertionError(s"Unexpected transient type ref $typeRef for ${typeRefInternal._2}")

--- a/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSEncoding.scala
@@ -167,7 +167,16 @@ object JSEncoding {
   def encodeFieldSym(sym: Symbol)(implicit ctx: Context, pos: ir.Position): js.FieldIdent =
     js.FieldIdent(FieldName(encodeClassName(sym.owner), SimpleFieldName(encodeFieldSymAsString(sym))))
 
-  def encodeFieldSymAsStringLiteral(sym: Symbol)(implicit ctx: Context, pos: ir.Position): js.StringLiteral =
+  /** Turns a FieldIdent for a private field an anon JS class into a string literal.
+   *
+   *  Since we only do that for anon JS classes, which cannot be extended, we
+   *  can ignore the `className` qualifier of the field ident.
+   */
+  def anonJSClassFieldIdentToStringLiteral(ident: js.FieldIdent): js.StringLiteral =
+    js.StringLiteral(ident.name.simpleName.nameString)(using ident.pos)
+
+  /** Shortcut for `anonJSClassFieldIdentToStringLiteral(encodeFieldSym(sym))`. */
+  def encodeAnonJSClassFieldSymAsStringLiteral(sym: Symbol)(using ctx: Context, pos: ir.Position): js.StringLiteral =
     js.StringLiteral(encodeFieldSymAsString(sym))
 
   private def encodeFieldSymAsString(sym: Symbol)(using Context): String = {

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -944,11 +944,11 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
           case jstpe.FloatType   => PrimitiveTypeTest(jstpe.FloatType, 7)
           case jstpe.DoubleType  => PrimitiveTypeTest(jstpe.DoubleType, 8)
 
-          case jstpe.ClassType(jswkn.BoxedUnitClass, _)   => PrimitiveTypeTest(jstpe.UndefType, 0)
-          case jstpe.ClassType(jswkn.BoxedStringClass, _) => PrimitiveTypeTest(jstpe.StringType, 9)
-          case jstpe.ClassType(_, _)                      => InstanceOfTypeTest(tpe)
+          case jstpe.ClassType(jswkn.BoxedUnitClass, _, _)   => PrimitiveTypeTest(jstpe.UndefType, 0)
+          case jstpe.ClassType(jswkn.BoxedStringClass, _, _) => PrimitiveTypeTest(jstpe.StringType, 9)
+          case jstpe.ClassType(_, _, _)                      => InstanceOfTypeTest(tpe)
 
-          case jstpe.ArrayType(_, _) => InstanceOfTypeTest(tpe)
+          case jstpe.ArrayType(_, _, _) => InstanceOfTypeTest(tpe)
         }
     }
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1445,11 +1445,13 @@ object Build {
        */
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
-      libraryDependencies +=
-        (Dependencies.scalaJsIr % "sourcedeps").cross(CrossVersion.for3Use2_13),
+      libraryDependencies += Dependencies.scalaJsIr % "sourcedeps",
       // Silence `using` clause warnings in the scalajs-ir sources
       Compile / compile / scalacOptions +=
         "-Wconf:src=scalajs-ir-src/.*&msg=Implicit parameters should be provided with a `using` clause:s",
+      // Silence `= _` warnings in the scalajs-ir sources
+      Compile / compile / scalacOptions +=
+        "-Wconf:src=scalajs-ir-src/.*&msg=uninitialized` instead:s",
       // Silence AnyRefMap deprecation warnings in the scalajs-ir sources
       Compile / compile / scalacOptions +=
         "-Wconf:src=scalajs-ir-src/.*&msg=object AnyRefMap in package scala\\.collection\\.mutable is deprecated:s",
@@ -1480,7 +1482,7 @@ object Build {
             val linesWithPackage = Shading.replacePackage(lines) {
               case "org.scalajs.ir" => "dotty.tools.sjs.ir"
             }
-            IO.writeLines(f, Shading.insertUnsafeNullsImport(linesWithPackage))
+            IO.writeLines(f, linesWithPackage)
           })
           sjsSources
         } (Set(scalaJSIRSourcesJar)).toSeq
@@ -1569,11 +1571,13 @@ object Build {
        */
       ivyConfigurations += SourceDeps.hide,
       transitiveClassifiers := Seq("sources"),
-      libraryDependencies +=
-        (Dependencies.scalaJsIr % "sourcedeps").cross(CrossVersion.for3Use2_13),
+      libraryDependencies += Dependencies.scalaJsIr % "sourcedeps",
       // Silence `using` clause warnings in the scalajs-ir sources
       Compile / compile / scalacOptions +=
         "-Wconf:src=scalajs-ir-src/.*&msg=Implicit parameters should be provided with a `using` clause:s",
+      // Silence `= _` warnings in the scalajs-ir sources
+      Compile / compile / scalacOptions +=
+        "-Wconf:src=scalajs-ir-src/.*&msg=uninitialized` instead:s",
       // Silence AnyRefMap deprecation warnings in the scalajs-ir sources
       Compile / compile / scalacOptions +=
         "-Wconf:src=scalajs-ir-src/.*&msg=object AnyRefMap in package scala\\.collection\\.mutable is deprecated:s",
@@ -1604,7 +1608,7 @@ object Build {
             val linesWithPackage = Shading.replacePackage(lines) {
               case "org.scalajs.ir" => "dotty.tools.sjs.ir"
             }
-            IO.writeLines(f, Shading.insertUnsafeNullsImport(linesWithPackage))
+            IO.writeLines(f, linesWithPackage)
           })
           sjsSources
         } (Set(scalaJSIRSourcesJar)).toSeq
@@ -2157,7 +2161,7 @@ object Build {
             "productionMode" -> sems.productionMode,
             "esVersion" -> linkerConfig.esFeatures.esVersion.edition,
             "useECMAScript2015Semantics" -> linkerConfig.esFeatures.useECMAScript2015Semantics,
-            "isWebAssembly" -> linkerConfig.experimentalUseWebAssembly,
+            "isWebAssembly" -> linkerConfig.esFeatures.useWebAssembly,
         )
       }.taskValue,
 
@@ -2181,7 +2185,7 @@ object Build {
           case FullOptStage => (Test / fullLinkJS / scalaJSLinkerConfig).value
         }
 
-        val isWebAssembly = linkerConfig.experimentalUseWebAssembly
+        val isWebAssembly = linkerConfig.esFeatures.useWebAssembly
 
         val b = List.newBuilder[File]
 
@@ -2217,7 +2221,7 @@ object Build {
         val moduleKind = linkerConfig.moduleKind
         val hasModules = moduleKind != ModuleKind.NoModule
         val hasAsyncAwait = linkerConfig.esFeatures.esVersion >= ESVersion.ES2017
-        val isWebAssembly = linkerConfig.experimentalUseWebAssembly
+        val isWebAssembly = linkerConfig.esFeatures.useWebAssembly
 
         def conditionally(cond: Boolean, subdir: String): Seq[File] =
           if (!cond) Nil
@@ -2238,6 +2242,7 @@ object Build {
           ++ (dir / "js/src/test/scala" ** (("*.scala": FileFilter)
             -- "StackTraceTest.scala" // would require `npm install source-map-support`
             -- "UnionTypeTest.scala" // requires the Scala 2 macro defined in Typechecking*.scala
+            -- "OptimizerTest.scala" // something crashes the optimizer, TODO investigate
             )).get
 
           ++ (dir / "js/src/test/require-2.12" ** "*.scala").get

--- a/project/DottyJSPlugin.scala
+++ b/project/DottyJSPlugin.scala
@@ -17,7 +17,7 @@ object DottyJSPlugin extends AutoPlugin {
       config => config.withModuleKind(ModuleKind.ESModule)
 
     val switchToLatestESVersion: StandardConfig => StandardConfig =
-      config => config.withESFeatures(_.withESVersion(ESVersion.ES2021))
+      config => config.withESFeatures(_.withESVersion(ESVersion.ES2026))
 
     val enableWebAssembly: SettingKey[Boolean] =
       settingKey("enable all the configuration items required for WebAssembly")
@@ -60,7 +60,8 @@ object DottyJSPlugin extends AutoPlugin {
       if (enableWebAssembly.value) {
         prev
           .withModuleKind(ModuleKind.ESModule)
-          .withExperimentalUseWebAssembly(true)
+          .withESFeatures(_.withESVersion(ESVersion.ES2022).withUseWebAssembly(true))
+          .withWasmFeatures(_.withUseJSPI(true))
       } else {
         prev
       }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@
 libraryDependencySchemes +=
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.20.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 

--- a/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
+++ b/tests/sjs-junit/test/org/scalajs/testsuite/compiler/RegressionTestScala3.scala
@@ -11,11 +11,31 @@ import scala.scalajs.js.annotation._
 
 import org.scalajs.junit.async._
 
-import org.scalajs.testsuite.jsinterop.ExportLoopback
 import org.scalajs.testsuite.utils.Platform._
 
 class RegressionTestScala3 {
   import RegressionTestScala3.*
+
+  /** The namespace in which top-level exports are stored. */
+  private lazy val exportsNamespace: Future[js.Dynamic] = {
+    import scala.scalajs.LinkingInfo._
+
+    linkTimeIf[Future[js.Dynamic]](moduleKind == ModuleKind.NoModule) {
+      throw new AssertionError("attempted to get exportsNamsepace in NoModule mode")
+    } {
+      linkTimeIf[Future[js.Dynamic]](moduleKind == ModuleKind.ESModule) {
+        js.`import`("./main.js").toFuture
+      } {
+        linkTimeIf[Future[js.Dynamic]](moduleKind == ModuleKind.CommonJSModule) {
+          js.Promise.resolve[Unit](())
+            .`then`[js.Dynamic](_ => js.Dynamic.global.require("./main.js"))
+            .toFuture
+        } {
+          throw new AssertionError(s"unknown module kind: ${moduleKind}")
+        }
+      }
+    }
+  }
 
   @Test def testRegressionDoubleDefinitionOfOuterPointerIssue10177(): Unit = {
     assertEquals(6, new OuterClassIssue10177().foo(5))
@@ -124,7 +144,7 @@ class RegressionTestScala3 {
         assertEquals((), global.RegressionTestScala3_Issue14168_unitField)
       }
     } else {
-      for (exports <- ExportLoopback.exportsNamespace) yield {
+      for (exports <- exportsNamespace) yield {
         assertEquals("string", exports.RegressionTestScala3_Issue14168_stringField)
         assertEquals(null, exports.RegressionTestScala3_Issue14168_nullField)
         assertEquals((), exports.RegressionTestScala3_Issue14168_unitField)


### PR DESCRIPTION
Backports #26389 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]