### PR TITLE
Backport "reset dirty unimported state after findRef" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -185,7 +185,7 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
    */
   val scope: MutableScope = newScope(nestingLevel)
 
-  /** A temporary data item valid for a single typed ident:
+  /** A temporary data item valid for a single `findRef`:
    *  The set of all root import symbols that have been
    *  encountered as a qualifier of an import so far.
    *  Note: It would be more proper to move importedFromRoot into typedIdent.
@@ -584,7 +584,11 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
       loop(NoContext)
     }
 
-    findRefRecur(NoType, BindingPrec.NothingBound, NoContext)
+    // Root imports hidden during this lookup should not affect later lookups.
+    val savedUnimported = unimported
+    unimported = Set.empty
+    try findRefRecur(NoType, BindingPrec.NothingBound, NoContext)
+    finally unimported = savedUnimported
   }
 
   /** If `tree`'s type is a `TermRef` identified by flow typing to be non-null, then

--- a/tests/pos/predef-runtimechecked-import.scala
+++ b/tests/pos/predef-runtimechecked-import.scala
@@ -1,0 +1,9 @@
+package example
+
+import scala.Predef.{assert => _, *}
+
+class PredefRuntimeCheckedImport:
+  def f: Any = {
+    for (_ <- 1 to 1) ()
+    Map(1.runtimeChecked -> "")
+  }


### PR DESCRIPTION
Backports #26412 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]