### PR TITLE
Backport "Fix #25866: match-alias subtyping and wildcard appliedTo" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeApplications.scala
@@ -18,6 +18,42 @@ object TypeApplications {
 
   type TypeParamInfo = ParamInfo.Of[TypeName]
 
+  /** If `tr` is an alias that expands - possibly through further alias
+   *  applications - to a match type, the underlying match-alias `TypeRef`;
+   *  otherwise `NoType`. E.g. `Decode` -> `Decode`,
+   *  `type DecodeAlias = Decode[S]` -> `Decode`,
+   *  `type IAnyType[T] = Tuple.Fold[T, Any, F]` -> `Tuple.Fold`.
+   */
+  private def underlyingMatchAlias(tr: TypeRef)(using Context): Type =
+    tr.info match
+      case ab: AliasingBounds if ab.isMatchAlias =>
+        tr
+      case ab: AliasingBounds =>
+        val body = ab.alias match
+          case alias: HKTypeLambda => alias.resType
+          case alias => alias
+        body match
+          case AppliedType(tycon: TypeRef, _) => underlyingMatchAlias(tycon)
+          case _ => NoType
+      case _ =>
+        NoType
+
+  /** True if `tr` expands to a match alias whose body does not refer back to it,
+   *  so keeping `tr`'s application in `AppliedType` form is sound and terminating.
+   *  Preserves the alias tycon for structural subtyping, including
+   *  indirections like `type DecodeAlias = Decode`. Recursive match aliases
+   *  (`Tuple.Fold`, `type IAnyType = Tuple.Fold[...]`) are excluded so their
+   *  reduced applied form hash-conses and subtyping terminates.
+   */
+  def isNonRecursiveMatchAlias(tr: TypeRef)(using Context): Boolean =
+    underlyingMatchAlias(tr) match
+      case underlying: TypeRef =>
+        underlying.info match
+          case ab: AliasingBounds => !ab.alias.existsPart(_.typeSymbol eq underlying.symbol)
+          case _ => false
+      case _ =>
+        false
+
   /** Assert type is not a TypeBounds instance and return it unchanged */
   def noBounds(tp: Type): Type = tp match {
     case tp: TypeBounds => throw new AssertionError("no TypeBounds allowed")
@@ -407,19 +443,22 @@ class TypeApplications(val self: Type) extends AnyVal {
 
             else AppliedType(self, args)
           }
-          else dealiased.resType match {
-            case AppliedType(tycon, args1) if tycon.safeDealias ne tycon =>
-              // In this case we should always dealias since we cannot handle
-              // higher-kinded applications to wildcard arguments.
-              dealiased
-                .derivedLambdaType(resType = tycon.safeDealias.appliedTo(args1))
-                .appliedTo(args)
+          else stripped match
+            case tr: TypeRef if tr.info.isMatchAlias =>
+              AppliedType(stripped, args)
+            case tr: TypeRef if isNonRecursiveMatchAlias(tr) =>
+              dealiased.instantiate(args).normalized
             case _ =>
-              val reducer = new Reducer(dealiased, args)
-              val reduced = reducer(dealiased.resType)
-              if (reducer.allReplaced) reduced
-              else AppliedType(dealiased, args)
-          }
+              dealiased.resType match
+                case AppliedType(tycon, args1) if tycon.safeDealias ne tycon =>
+                  dealiased
+                    .derivedLambdaType(resType = tycon.safeDealias.appliedTo(args1))
+                    .appliedTo(args)
+                case _ =>
+                  val reducer = new Reducer(dealiased, args)
+                  val reduced = reducer(dealiased.resType)
+                  if reducer.allReplaced then reduced
+                  else AppliedType(dealiased, args)
         tryReduce
       case dealiased: PolyType =>
         dealiased.instantiate(args)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -1448,7 +1448,14 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
        *    tp1 <:< app2   using isSubType (this might instantiate params in tp2)
        */
       def compareLower(tycon2bounds: TypeBounds, tyconIsTypeRef: Boolean): Boolean =
-        if ((tycon2bounds.lo `eq` tycon2bounds.hi) && !tycon2bounds.isMatchAlias)
+        val tyconKeepsMatchAlias =
+          if tyconIsTypeRef then
+            tycon2 match
+              case tycon2ref: TypeRef => TypeApplications.isNonRecursiveMatchAlias(tycon2ref)
+              case _ => false
+          else
+            tycon2bounds.isMatchAlias
+        if ((tycon2bounds.lo `eq` tycon2bounds.hi) && !tyconKeepsMatchAlias)
           if (tyconIsTypeRef) recur(tp1, tp2.superTypeNormalized) && recordGadtUsageIf(MatchType.thatReducesUsingGadt(tp2))
           else isSubApproxHi(tp1, tycon2bounds.lo.applyIfParameterized(args2))
         else

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -5835,7 +5835,8 @@ object Types extends TypeUtils {
    *  If we assumed full substitutivity, we would have to reject all recursive match
    *  aliases (or else take the jump and allow full recursive types).
    */
-  class MatchAlias(alias: Type) extends AliasingBounds(alias)
+  class MatchAlias(alias: Type) extends AliasingBounds(alias):
+    override def isMatchAlias(using Context): Boolean = true
 
   object TypeBounds {
     def apply(lo: Type, hi: Type)(using Context): TypeBounds =

--- a/tests/pos/i25866.scala
+++ b/tests/pos/i25866.scala
@@ -1,0 +1,11 @@
+type Decode[S <: String] = S match
+  case "S" => String
+  case "B" => Boolean
+
+case class Collection[S <: String, T <: Decode[S]](
+  ts: List[T],
+)
+
+class ClassyCollection[S <: String, T <: Decode[S]](
+  val ts: List[T],
+)

--- a/tests/pos/i25866b.scala
+++ b/tests/pos/i25866b.scala
@@ -1,0 +1,6 @@
+type Decode[S <: String] = S match
+  case "S" => String
+  case "B" => Boolean
+
+class Collection[S <: String, T <: Decode[S]](val ts: List[T]):
+  val foo: List[? <: Decode[? <: String]] = ts

--- a/tests/pos/i25866c.scala
+++ b/tests/pos/i25866c.scala
@@ -1,0 +1,14 @@
+type Decode[S <: String] = S match
+  case "S" => String
+  case "B" => Boolean
+
+type DecodeAlias[S <: String] = Decode[S]
+type DecodeAlias2[S <: String] = DecodeAlias[S]   // double indirection
+
+class C[S <: String, T <: DecodeAlias[S]](val ts: List[T]):
+  val foo: List[? <: DecodeAlias[? <: String]] = ts
+
+case class Coll[S <: String, T <: DecodeAlias[S]](ts: List[T])
+
+class D[S <: String, T <: DecodeAlias2[S]](val ts: List[T]):
+  val foo: List[? <: DecodeAlias2[? <: String]] = ts

--- a/tests/pos/i25866d.scala
+++ b/tests/pos/i25866d.scala
@@ -1,0 +1,7 @@
+type Decode[S <: String] = S match
+  case "S" => String
+
+type DecodeAlias[S <: String] = Decode[S]
+
+class C[S <: String, T <: DecodeAlias[S]](val ts: List[T]):
+  val foo: List[? <: DecodeAlias[? <: String]] = ts


### PR DESCRIPTION
Backports #25981 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]