### PR TITLE
Backport "Bump Scala CLI to 1.15.0 (was 1.14.0) and `coursier` to 2.1.25-M26 (was 2.1.25-M25)" to 3.9.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,5 +276,18 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
-      - run: scala-cli format --check
+      - uses: VirtusLab/scala-cli-setup@v1.15
+      - name: Check formatting
+        run: |
+          if ! scala-cli format --check; then
+            echo ""
+            echo "========================================"
+            echo "Formatting check failed!"
+            echo "To fix this, run the following command in the root of the project:"
+            echo ""
+            echo "  scala-cli format"
+            echo ""
+            echo "Then commit the changes."
+            echo "========================================"
+            exit 1
+          fi

--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
+      - uses: VirtusLab/scala-cli-setup@v1.15
       - run: scala-cli ./project/scripts/addToBackportingProject.scala -- ${{ github.sha }}
         env:
           GRAPHQL_API_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v6
 
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
+      - uses: VirtusLab/scala-cli-setup@v1.15
 
       - name: Validate docs sidebars
         run: scala-cli ./project/scripts/checkSidebarDocs.scala
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: coursier/cache-action@v8
-      - uses: VirtusLab/scala-cli-setup@v1.14
+      - uses: VirtusLab/scala-cli-setup@v1.15
         with:
           jvm: temurin:17
           apps: sbt

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -92,7 +92,7 @@ object Versions {
   /** Version of Scala CLI to download */
   val scalaCliLauncherVersion = "1.15.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
-  val coursierJarVersion = "2.1.25-M25"
+  val coursierJarVersion = "2.1.25-M26"
 
   /* Tests TASTy version invariants during NIGHLY, RC or Stable releases */
   def checkReleasedTastyVersion(): Unit = {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -90,7 +90,7 @@ object Versions {
   val mimaPreviousDottyVersion = "3.8.0"
 
   /** Version of Scala CLI to download */
-  val scalaCliLauncherVersion = "1.14.0"
+  val scalaCliLauncherVersion = "1.15.0"
   /** Version of Coursier to download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M25"
 


### PR DESCRIPTION
Backports #26432 to the 3.9.0-RC1.

PR submitted by the release tooling.
[skip ci]