### PR TITLE
Simplify JarArchive.underlyingSource

### DIFF
--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -137,11 +137,7 @@ object FileWriters {
   object FileWriter {
     def apply(file: AbstractFile, jarManifest: Seq[(Attributes.Name, String)], jarCompressionLevel: Int = Deflater.DEFAULT_COMPRESSION): FileWriter = file match
       case jar: JarArchive =>
-        // Writing to non-empty JAR might be an undefined behaviour, e.g. in case if other files where
-        // created using `AbstractFile.bufferedOutputStream` instead of JarWriter
-        val jarFile = jar.underlyingSource.getOrElse {
-          throw new IllegalStateException("No underlying source for jar")
-        }
+        val jarFile = jar.underlyingSource
         assert(jar.iterator.isEmpty, s"Unsafe writing to non-empty JAR: $jarFile")
         new JarEntryWriter(jarFile, jarManifest, jarCompressionLevel)
       case _ if file.isVirtual => new VirtualFileWriter(file)

--- a/compiler/src/dotty/tools/io/JarArchive.scala
+++ b/compiler/src/dotty/tools/io/JarArchive.scala
@@ -9,34 +9,13 @@ import scala.jdk.CollectionConverters.*
  * This class implements an [[AbstractFile]] backed by a jar
  * that be can used as the compiler's output directory.
  */
-class JarArchive private (val jarPath: Path, root: Directory) extends PlainDirectory(root) {
+class JarArchive private (val jarPath: Path, root: Directory, path: Path) extends PlainDirectory(root) {
   def close(): Unit = this.synchronized(jpath.getFileSystem().close())
 
   override def exists: Boolean = jpath.getFileSystem().isOpen() && super.exists
 
-  def underlyingSource: Option[AbstractFile] = {
-    val fileSystem = jpath.getFileSystem
-    fileSystem.provider().getScheme match {
-      case "jar" =>
-        val fileStores = fileSystem.getFileStores.iterator()
-        if (fileStores.hasNext) {
-          val jarPath = fileStores.next().name
-          try {
-            Some(new PlainFile(new Path(Paths.get(jarPath.stripSuffix(fileSystem.getSeparator)))))
-          } catch {
-            case _: InvalidPathException =>
-              None
-          }
-        } else None
-      case "jrt" =>
-        if (jpath.getNameCount > 2 && jpath.startsWith("/modules")) {
-          // TODO limit this to OpenJDK based JVMs?
-          val moduleName = jpath.getName(1)
-          Some(new PlainFile(new Path(Paths.get(System.getProperty("java.home"), "jmods", moduleName.toString + ".jmod"))))
-        } else None
-      case _ => None
-    }
-  }
+  def underlyingSource: AbstractFile =
+    new PlainFile(path)
 
   override def toString: String = jarPath.toString
 }
@@ -64,7 +43,7 @@ object JarArchive {
       }
     }
     val root = fs.getRootDirectories().iterator.next()
-    new JarArchive(path, Directory(root))
+    new JarArchive(path, Directory(root), path)
   }
 
   // See http://download.java.net/jdk7/docs/api/java/nio/file/Path.html

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -534,9 +534,13 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       def scalacOptions = toolArgs.getOrElse(ToolName.Scalac, Nil)
       def javacOptions  = toolArgs.getOrElse(ToolName.Javac, Nil)
 
-      var flags = flags0
+      // Allow tests to override -d, e.g., for testing in the Playground
+      val flags1 =
+        if flags0.options.contains("-d") then flags0
+        else flags0.and("-d", targetDir.getPath)
+
+      var flags = flags1
         .and(scalacOptions*)
-        .and("-d", targetDir.getPath)
         .withClasspath(targetDir.getPath)
 
       // We must set -sourceroot for SemanticDB extraction to work properly inside an IDE,


### PR DESCRIPTION
We were doing a lot of complicated stuff just to get the path we had when creating the JAR in the first place.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
