### PR TITLE
feat: -deprecation and -feature by default in the REPL

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/Settings.scala
+++ b/compiler/src/dotty/tools/dotc/config/Settings.scala
@@ -345,6 +345,7 @@ object Settings:
       def valueSetByUser(using Context): Option[T] = Option(setting.value).filter(_ != setting.default)
       def update(x: T)(using Context): SettingsState = setting.updateIn(ctx.settingsState, x)
       def isDefault(using Context): Boolean = setting.isDefaultIn(ctx.settingsState)
+      def wasSetByUser(using Context): Boolean = ctx.settingsState.wasChanged(setting.idx)
 
     /**
      * A choice with help description.

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -116,8 +116,16 @@ class ReplDriver(settings: Array[String],
       case Some((files, ictx)) => inContext(ictx) {
         shouldStart = true
         if files.nonEmpty then out.println(i"Ignoring spurious arguments: $files%, %")
-        ictx.base.initialize()
-        ictx
+        val finalCtx =
+          // If the user hasn't configured warnings, enable -deprecation and -feature by default
+          if !ctx.settings.Wconf.wasSetByUser && !ctx.settings.Wall.wasSetByUser then
+            val c = ictx.fresh
+            if !ctx.settings.deprecation.wasSetByUser then c.setSetting(c.settings.deprecation, true)
+            if !ctx.settings.feature.wasSetByUser then c.setSetting(c.settings.feature, true)
+            c
+          else ictx
+        finalCtx.base.initialize()
+        finalCtx
       }
       case None =>
         shouldStart = false

--- a/repl/test-resources/repl/reset-command
+++ b/repl/test-resources/repl/reset-command
@@ -1,18 +1,18 @@
 scala> def f(thread: Thread) = thread.stop()
-there was 1 deprecation warning; re-run with -deprecation for details
-1 warning found
-def f(thread: Thread): Unit
-
-scala>:reset -deprecation
-Resetting REPL state with the following settings:
-  -deprecation
-
-scala> def f(thread: Thread) = thread.stop()
 1 warning found
 -- Deprecation Warning: --------------------------------------------------------
 1 | def f(thread: Thread) = thread.stop()
   |                         ^^^^^^^^^^^
   |method stop in class Thread is deprecated: see corresponding Javadoc for more information.
+def f(thread: Thread): Unit
+
+scala>:reset -deprecation:false
+Resetting REPL state with the following settings:
+  -deprecation:false
+
+scala> def f(thread: Thread) = thread.stop()
+there was 1 deprecation warning; re-run with -deprecation for details
+1 warning found
 def f(thread: Thread): Unit
 
 scala> def resetNoArgsStillWorks = 1

--- a/repl/test-resources/repl/settings-command
+++ b/repl/test-resources/repl/settings-command
@@ -1,17 +1,17 @@
 scala> def f(thread: Thread) = thread.stop()
-there was 1 deprecation warning; re-run with -deprecation for details
-1 warning found
-def f(thread: Thread): Unit
-
-scala>:settings -deprecation foo.scala
-Ignoring spurious arguments: foo.scala
-
-scala> def f(thread: Thread) = thread.stop()
 1 warning found
 -- Deprecation Warning: --------------------------------------------------------
 1 | def f(thread: Thread) = thread.stop()
   |                         ^^^^^^^^^^^
   |method stop in class Thread is deprecated: see corresponding Javadoc for more information.
+def f(thread: Thread): Unit
+
+scala>:settings -deprecation:false foo.scala
+Ignoring spurious arguments: foo.scala
+
+scala> def f(thread: Thread) = thread.stop()
+there was 1 deprecation warning; re-run with -deprecation for details
+1 warning found
 def f(thread: Thread): Unit
 
 scala>


### PR DESCRIPTION
Fixes #15953

Enable `-deprecation` and `-feature` if the user hasn't configured `Wall` and `Wconf`.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Manually + covered by existing tests
