### PR TITLE
Encapsulate and simplify IO package further

### DIFF
--- a/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ClassPathFactory.scala
@@ -3,13 +3,15 @@
  */
 package dotty.tools.dotc.classpath
 
-import dotty.tools.io.{AbstractFile, ClassPath, JarArchive, VirtualDirectory}
+import dotty.tools.io.{AbstractFile, ClassPath, Directory, File, Path, VirtualDirectory}
 import dotty.tools.dotc.classpath.FileUtils.isClassContainer
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interactive.LogicalSourcePath
 import dotty.tools.dotc.interactive.LogicalPackage
 
+import java.net.{MalformedURLException, URI, URISyntaxException, URL}
 import java.nio.file.Files
+import java.util.jar.{Attributes, JarInputStream}
 
 /**
  * Provides factory methods for classpath. When creating classpath instances for a given path,
@@ -68,7 +70,7 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
       if scala.util.Properties.propOrFalse("scala.expandjavacp") then
         for
           file <- files
-          a <- JarArchive.expandManifestPath(file.path)
+          a <- expandManifestPath(file.path)
           path = java.nio.file.Paths.get(a.toURI())
           if Files.exists(path)
         yield
@@ -79,6 +81,38 @@ class ClassPathFactory(precomputedSourcePackages: Option[LogicalPackage] = None)
     files.map(ClassPathFactory.newClassPath) ++ expanded
 
   end classesInPathImpl
+
+
+  /** Expand manifest jar classpath entries: these are either urls, or paths
+   *  relative to the location of the jar.
+   */
+  private def expandManifestPath(jarPath: String): List[URL] =
+    def specToURL(spec: String, basedir: Directory): Option[URL] =
+      try
+        val uri = new URI(spec)
+        if uri.isAbsolute then Some(uri.toURL)
+        else Some(basedir.resolve(Path(spec)).toURL)
+      catch
+        case _: MalformedURLException | _: URISyntaxException => None
+
+    val file = File(jarPath)
+    if !file.isFile then
+      return Nil
+
+    val baseDir = file.parent
+    val in = new JarInputStream(file.inputStream())
+    val manifest =
+      try Option(in.getManifest)
+      finally in.close()
+
+    manifest match
+      case None => Nil
+      case Some(m) =>
+        val attrs = m.getMainAttributes.asInstanceOf[java.util.Map[Attributes.Name, String]]
+        attrs.get(Attributes.Name.CLASS_PATH) match
+          case cp: String if cp.trim().nonEmpty =>
+            cp.split("\\s+").toList.map(elem => specToURL(elem, baseDir).getOrElse((baseDir / elem).toURL))
+          case _ => Nil
 }
 
 object ClassPathFactory {

--- a/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
+++ b/compiler/src/dotty/tools/dotc/classpath/ZipArchiveFileLookup.scala
@@ -22,7 +22,7 @@ trait ZipArchiveFileLookup[FileEntryType] extends ClassPath {
 
   override def asURLs: Seq[URL] = Seq(zipFile.toURI.toURL)
 
-  private val archive = new FileZipArchive(zipFile.toPath, Some(release))
+  private val archive = AbstractFile.getDirectory(zipFile.toPath, release).nn
 
   override def packages(inPackage: String): Seq[PackageEntry] =
     findDirEntry(inPackage) match {

--- a/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
+++ b/compiler/src/dotty/tools/dotc/plugins/Plugin.scala
@@ -150,7 +150,7 @@ object Plugin {
     // List[(jar, Try(descriptor))] in dir
     def scan(d: Directory) =
       d.files.toList
-        .filter(JarArchive.isJarOrZip(_))
+        .filter(_.ext.isJarOrZip)
         .sortBy(_.name)
         .map(j => (j, loadDescriptionFromJar(j)))
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -18,7 +18,7 @@ import NameOps.*
 import inlines.Inlines
 import transform.ValueClasses
 import transform.Pickler
-import dotty.tools.io.{File, FileExtension, JarArchive}
+import dotty.tools.io.{File, FileExtension}
 import util.{Property, SourceFile}
 import java.io.PrintWriter
 
@@ -94,16 +94,15 @@ class ExtractAPI extends Phase {
     def registerProductNames(fullClassName: String, binaryClassName: String) =
       val pathToClassFile = s"${binaryClassName.replace('.', java.io.File.separatorChar)}.class"
 
+      val outDir = ctx.settings.outputDir.value
       val classFile = {
-        ctx.settings.outputDir.value match {
-          case jar: JarArchive =>
+        if outDir.ext.isJar then
             // important detail here, even on Windows, Zinc expects the separator within the jar
             // to be the system default, (even if in the actual jar file the entry always uses '/').
             // see https://github.com/sbt/zinc/blob/dcddc1f9cfe542d738582c43f4840e17c053ce81/internal/compiler-bridge/src/main/scala/xsbt/JarUtils.scala#L47
-            new java.io.File(s"$jar!$pathToClassFile")
-          case outputDir =>
-            new java.io.File(outputDir.file, pathToClassFile)
-        }
+            new java.io.File(s"${outDir.path}!$pathToClassFile")
+        else
+            new java.io.File(outDir.file, pathToClassFile)
       }
 
       cb.generatedNonLocalClass(sourceFile, classFile.toPath(), binaryClassName, fullClassName)

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractDependencies.scala
@@ -18,7 +18,7 @@ import dotty.tools.dotc.core.Types.*
 import dotty.tools.dotc.typer.Applications.*
 import dotty.tools.dotc.util.{NoSourcePosition, SrcPos}
 import dotty.tools.io
-import dotty.tools.io.{AbstractFile, FileExtension, PlainFile, ZipArchive}
+import dotty.tools.io.AbstractFile
 import xsbti.UseScope
 import xsbti.api.DependencyContext
 import xsbti.api.DependencyContext.*
@@ -546,9 +546,9 @@ class DependencyRecorder {
      * FIXME: we still need a way to resolve the correct classfile when we split tasty and classes between
      * different outputs (e.g. scala2-library-bootstrapped).
      */
-    def cachedSiblingClass(pf: PlainFile): Path =
+    def cachedSiblingClass(pf: AbstractFile): Path =
       siblingClassfiles.getOrElseUpdate(pf, {
-        val jpath = pf.jpath
+        val jpath = pf.jpath.nn
         jpath.getParent.resolve(jpath.getFileName.toString.stripSuffix(".tasty") + ".class")
       })
 
@@ -564,17 +564,13 @@ class DependencyRecorder {
 
       def processExternalDependency() = {
         val binaryClassName = depClass.binaryClassName
-        depFile match {
-          case ze: ZipArchive#Entry => // The dependency comes from a JAR
-            ze.underlyingSource match
-              case zip if zip.jpath != null =>
-                binaryDependency(zip.jpath, binaryClassName)
-              case _ =>
-          case pf: PlainFile => // The dependency comes from a class file, Zinc handles JRT filesystem
-            binaryDependency(if isTastyOrSig then cachedSiblingClass(pf) else pf.jpath, binaryClassName)
+        depFile.enclosing match
+          case Some(archive) if archive.jpath != null => // The dependency comes from a JAR
+            binaryDependency(archive.jpath.nn, binaryClassName)
+          case _ if depFile.jpath != null =>
+            binaryDependency(if isTastyOrSig then cachedSiblingClass(depFile) else depFile.jpath.nn, binaryClassName)
           case _ =>
-            internalError(s"Ignoring dependency $depFile of unknown class ${depFile.getClass}}", fromClass.srcPos)
-        }
+            internalError(s"Ignoring dependency $depFile of unknown class ${depFile.getClass}", fromClass.srcPos)
       }
 
       if isTastyOrSig || depFile.ext.isClass then

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -24,7 +24,7 @@ import scala.PartialFunction.condOpt
 import typer.ImportInfo.withRootImports
 
 import dotty.tools.dotc.{semanticdb => s}
-import dotty.tools.io.{AbstractFile, JarArchive}
+import dotty.tools.io.AbstractFile
 import dotty.tools.dotc.semanticdb.DiagnosticOps.*
 import scala.util.{Using, Failure, Success}
 import java.nio.file.Path
@@ -53,7 +53,7 @@ private[semanticdb] class ExtractSemanticDB private (phaseMode: ExtractSemanticD
 
   override def isRunnable(using Context) =
     import ExtractSemanticDB.{semanticdbTarget, outputDirectory}
-    def writesToOutputJar = semanticdbTarget.isEmpty && outputDirectory.isInstanceOf[JarArchive]
+    def writesToOutputJar = semanticdbTarget.isEmpty && outputDirectory.ext.isJar
     (super.isRunnable || ctx.isBestEffort) && ctx.settings.Xsemanticdb.value && !writesToOutputJar
 
   // Check not needed since it does not transform trees

--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -40,7 +40,7 @@ object AbstractFile {
    */
   private def getDirectory(path: Path, jarVersion: String): AbstractFile | Null =
     if (path.isDirectory) new PlainFile(path)
-    else if (path.isFile && path.ext.isJarOrZip) new FileZipArchive(path.jpath, Some(jarVersion))
+    else if (path.isFile && path.ext.isJarOrZip) new FileZipArchive(path.jpath, jarVersion)
     else null
 }
 
@@ -76,6 +76,9 @@ abstract class AbstractFile extends dotty.tools.dotc.interfaces.AbstractFile {
 
   /** Returns the containing directory of this abstract file, if any */
   def container: Option[AbstractFile] = None
+
+  /** Gets the file that encloses this file, such as an archive, if this file is enclosed. */
+  def enclosing: Option[AbstractFile] = None
 
   /** Returns the underlying File if any and null otherwise. */
   def file: JFile | Null = try {

--- a/compiler/src/dotty/tools/io/ClassPath.scala
+++ b/compiler/src/dotty/tools/io/ClassPath.scala
@@ -43,7 +43,7 @@ object ClassPath {
 
     /* Get all subdirectories, jars, zips out of a directory. */
     def lsDir(dir: Directory, filt: String => Boolean = _ => true) =
-      dir.list.filter(x => filt(x.name) && (x.isDirectory || JarArchive.isJarOrZip(x))).map(_.path).toList
+      dir.list.filter(x => filt(x.name) && (x.isDirectory || x.ext.isJarOrZip)).map(_.path).toList
 
     if (pattern == "*") lsDir(Directory("."))
     // On Windows the JDK supports forward slash or backslash in classpath entries

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -137,11 +137,7 @@ object FileWriters {
   object FileWriter {
     def apply(file: AbstractFile, jarManifest: Seq[(Attributes.Name, String)], jarCompressionLevel: Int = Deflater.DEFAULT_COMPRESSION): FileWriter = file match
       case jar: JarArchive =>
-        // Writing to non-empty JAR might be an undefined behaviour, e.g. in case if other files where
-        // created using `AbstractFile.bufferedOutputStream` instead of JarWriter
-        val jarFile = jar.underlyingSource.getOrElse {
-          throw new IllegalStateException("No underlying source for jar")
-        }
+        val jarFile = jar.underlyingSource
         assert(jar.iterator.isEmpty, s"Unsafe writing to non-empty JAR: $jarFile")
         new JarEntryWriter(jarFile, jarManifest, jarCompressionLevel)
       case _ if file.isVirtual => new VirtualFileWriter(file)

--- a/compiler/src/dotty/tools/io/JarArchive.scala
+++ b/compiler/src/dotty/tools/io/JarArchive.scala
@@ -9,36 +9,16 @@ import scala.jdk.CollectionConverters.*
  * This class implements an [[AbstractFile]] backed by a jar
  * that be can used as the compiler's output directory.
  */
-class JarArchive private (val jarPath: Path, root: Directory) extends PlainDirectory(root) {
+class JarArchive private (underlying: Path, root: Directory) extends PlainDirectory(root) {
   def close(): Unit = this.synchronized(jpath.getFileSystem().close())
+
+  override val path: String = underlying.path
+  override def ext: FileExtension = underlying.ext
 
   override def exists: Boolean = jpath.getFileSystem().isOpen() && super.exists
 
-  def underlyingSource: Option[AbstractFile] = {
-    val fileSystem = jpath.getFileSystem
-    fileSystem.provider().getScheme match {
-      case "jar" =>
-        val fileStores = fileSystem.getFileStores.iterator()
-        if (fileStores.hasNext) {
-          val jarPath = fileStores.next().name
-          try {
-            Some(new PlainFile(new Path(Paths.get(jarPath.stripSuffix(fileSystem.getSeparator)))))
-          } catch {
-            case _: InvalidPathException =>
-              None
-          }
-        } else None
-      case "jrt" =>
-        if (jpath.getNameCount > 2 && jpath.startsWith("/modules")) {
-          // TODO limit this to OpenJDK based JVMs?
-          val moduleName = jpath.getName(1)
-          Some(new PlainFile(new Path(Paths.get(System.getProperty("java.home"), "jmods", moduleName.toString + ".jmod"))))
-        } else None
-      case _ => None
-    }
-  }
-
-  override def toString: String = jarPath.toString
+  def underlyingSource: AbstractFile =
+    new PlainFile(underlying)
 }
 
 object JarArchive {
@@ -49,8 +29,12 @@ object JarArchive {
     open(path, create = true)
   }
 
-  /** Create a jar file. */
-  def open(path: Path, create: Boolean = false): JarArchive = {
+  /** Opens a jar file. */
+  def open(path: Path): JarArchive =
+    open(path, create = false)
+
+  /** Opens or creates a jar file. */
+  private def open(path: Path, create: Boolean): JarArchive = {
     require(path.ext.isJar)
 
     // creating a new zip file system by using the JAR URL syntax:
@@ -66,50 +50,4 @@ object JarArchive {
     val root = fs.getRootDirectories().iterator.next()
     new JarArchive(path, Directory(root))
   }
-
-  // See http://download.java.net/jdk7/docs/api/java/nio/file/Path.html
-  // for some ideas.
-  private val ZipMagicNumber = List[Byte](80, 75, 3, 4)
-  private def magicNumberIsZip(f: Path) = f.isFile && {
-    val in = f.toFile.inputStream()
-    try
-      val first4 = in.readNBytes(4)
-      first4.toList == ZipMagicNumber
-    finally
-      in.close()
-  }
-
-  def isJarOrZip(f: Path): Boolean =
-    f.ext.isJarOrZip || magicNumberIsZip(f)
-
-  /** Expand manifest jar classpath entries: these are either urls, or paths
-   *  relative to the location of the jar.
-   */
-  def expandManifestPath(jarPath: String): List[URL] =
-    def specToURL(spec: String, basedir: Directory): Option[URL] =
-      try
-        val uri = new URI(spec)
-        if uri.isAbsolute then Some(uri.toURL)
-        else Some(basedir.resolve(Path(spec)).toURL)
-      catch
-        case _: MalformedURLException | _: URISyntaxException => None
-
-    val file = File(jarPath)
-    if !file.isFile then
-      return Nil
-
-    val baseDir = file.parent
-    val in = new JarInputStream(file.inputStream())
-    val manifest =
-      try Option(in.getManifest)
-      finally in.close()
-
-    manifest match
-      case None => Nil
-      case Some(m) =>
-        val attrs = m.getMainAttributes.asInstanceOf[java.util.Map[Attributes.Name, String]]
-        attrs.get(Attributes.Name.CLASS_PATH) match
-          case cp: String if cp.trim().nonEmpty =>
-            cp.split("\\s+").toList.map(elem => specToURL(elem, baseDir).getOrElse((baseDir / elem).toURL))
-          case _ => Nil
 }

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable
  *
  *  ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
-object ZipArchive {
+private[io] object ZipArchive {
   private[io] val closeZipFile: Boolean = sys.props.get("scala.classpath.closeZip").exists(_.toBoolean)
 
   private def dirName(path: String)  = splitPath(path, front = true)
@@ -42,7 +42,7 @@ object ZipArchive {
 }
 import ZipArchive.*
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
-abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with Equals {
+private[io] abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with Equals {
   self =>
 
   override def isDirectory: Boolean = true
@@ -53,7 +53,7 @@ abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with E
   sealed abstract class Entry(path: String, parent: Entry | Null) extends VirtualFile(path, Array.emptyByteArray) {
     // have to keep this name for compat with sbt's compiler-interface
     def getArchive: ZipFile | Null = null
-    def underlyingSource: ZipArchive = self
+    override def enclosing: Option[AbstractFile] = Some(self)
     override def container: Option[AbstractFile] = Option(parent)
     override def toString: String = self.path + "(" + path + ")"
   }
@@ -96,14 +96,12 @@ abstract class ZipArchive(override val jpath: JPath) extends AbstractFile with E
   def close(): Unit
 }
 /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */
-final class FileZipArchive(jpath: JPath, release: Option[String] = None) extends ZipArchive(jpath) {
+private[io] final class FileZipArchive(jpath: JPath, release: String) extends ZipArchive(jpath) {
   private def openZipFile(): ZipFile = try {
-    release match {
-      case Some(r) if file.nn.getName.endsWith(".jar") =>
-        new JarFile(file, true, ZipFile.OPEN_READ, if r == "" then Runtime.version() else Runtime.Version.parse(r))
-      case _ =>
-        new ZipFile(file)
-    }
+    if file.nn.getName.endsWith(".jar") then
+      new JarFile(file, true, ZipFile.OPEN_READ, if release == "" then Runtime.version() else Runtime.Version.parse(release))
+    else
+      new ZipFile(file)
   } catch {
     case ioe: IOException => throw new IOException("Error accessing " + file.nn.getPath, ioe)
   }
@@ -150,7 +148,7 @@ final class FileZipArchive(jpath: JPath, release: Option[String] = None) extends
       while (entries.hasMoreElements) {
         val zipEntry = entries.nextElement
         if (!zipEntry.getName.startsWith("META-INF/versions/")) {
-          val zipEntryVersioned = if (release.isDefined) {
+          val zipEntryVersioned = if (release != "") {
             // JARFile will return the entry for the corresponding release-dependent version here under META-INF/versions
             zipFile.getEntry(zipEntry.getName)
           } else zipEntry

--- a/compiler/src/dotty/tools/scripting/Main.scala
+++ b/compiler/src/dotty/tools/scripting/Main.scala
@@ -71,7 +71,7 @@ object Main:
       (Name.MAIN_CLASS, mainClassName),
       (Name.CLASS_PATH, cpString),
     )
-    val jarArchive = JarArchive.open(dotty.tools.io.Path(jarPath), create = true)
+    val jarArchive = JarArchive.create(dotty.tools.io.Path(jarPath))
     val writer = FileWriters.FileWriter(jarArchive, manifestAttributes)
     try
       dotty.tools.io.AbstractFile.getDirectory(outDir, "").nn.deepIterator.foreach(f => {

--- a/compiler/test/dotty/tools/dotc/core/tasty/PathPicklingTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/PathPicklingTest.scala
@@ -36,7 +36,7 @@ class PathPicklingTest {
 
     val printedTasty =
       val sb = new StringBuffer
-      val jar = JarArchive.open(Path(s"$out/out.jar"), create = false)
+      val jar = JarArchive.open(Path(s"$out/out.jar"))
       try
         for file <- jar.iterator if file.name.endsWith(".tasty") do
           sb.append(TastyPrinter.showContents(file.toByteArray, noColor = true, isBestEffortTasty = false))

--- a/compiler/test/dotty/tools/io/ZipArchiveTest.scala
+++ b/compiler/test/dotty/tools/io/ZipArchiveTest.scala
@@ -17,7 +17,7 @@ class ZipArchiveTest {
   @Test
   def corruptZip(): Unit = {
     val f = Files.createTempFile("test", ".jar")
-    val fza = new FileZipArchive(f)
+    val fza = new FileZipArchive(f, "17")
     try {
       fza.iterator
       assert(false)
@@ -33,7 +33,7 @@ class ZipArchiveTest {
   @Test
   def missingFile(): Unit = {
     val f = Paths.get("xxx.does.not.exist")
-    val fza = new FileZipArchive(f)
+    val fza = new FileZipArchive(f, "17")
     try {
       fza.iterator
       assert(false)

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -534,9 +534,13 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       def scalacOptions = toolArgs.getOrElse(ToolName.Scalac, Nil)
       def javacOptions  = toolArgs.getOrElse(ToolName.Javac, Nil)
 
-      var flags = flags0
+      // Allow tests to override -d, e.g., for testing in the Playground
+      val flags1 =
+        if flags0.options.contains("-d") then flags0
+        else flags0.and("-d", targetDir.getPath)
+
+      var flags = flags1
         .and(scalacOptions*)
-        .and("-d", targetDir.getPath)
         .withClasspath(targetDir.getPath)
 
       // We must set -sourceroot for SemanticDB extraction to work properly inside an IDE,


### PR DESCRIPTION
More prep for #26232
Part of #26492

ZIP files are now fully encapsulated, JAR stuff still has some uses outside but is simpler.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
