### PR TITLE
Fix #20028: resolve inherited doc links at their definition site

### DIFF
--- a/scaladoc-testcases/src/tests/inheritedDocLinkWarning.scala
+++ b/scaladoc-testcases/src/tests/inheritedDocLinkWarning.scala
@@ -1,0 +1,10 @@
+package tests
+package inheritedDocLinkWarning
+
+package lib:
+  trait Parent:
+    /** Doc comment referring to [[Parent]] */
+    def values: Any
+
+class Child extends lib.Parent:
+  def values = ???

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/ScalaDocSupport.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/ScalaDocSupport.scala
@@ -42,7 +42,7 @@ object ScaladocSupport:
     parser.parse(preparsed)
 
   def parseComment(using Quotes, DocContext)(docstring: String, tree: reflect.Tree): Option[Comment] =
-    val commentString: String =
+    val (commentString: String, commentOwner: reflect.Symbol) =
       if tree.symbol.isClassDef || tree.symbol.owner.isClassDef then
         import dotty.tools.dotc
         import dotty.tools.dotc.core.Comments.docCtx
@@ -52,9 +52,18 @@ object ScaladocSupport:
 
         val sym = tree.symbol.asInstanceOf[dotc.core.Symbols.Symbol]
 
-        docCtx.templateExpander.expand(sym, sym.owner)
+        /** A member without a docstring of its own inherits the comment of the nearest overridden symbol that has one.
+         *  @see [[dotty.tools.dotc.core.Comments.CommentExpander CommentExpander.superComment]]
+         */
+        def hasDocstring(s: dotc.core.Symbols.Symbol) = docCtx.docstring(s).exists(_.raw.nonEmpty)
+
+        val commentSym =
+          if hasDocstring(sym) || !sym.denot.owner.isClass then sym
+          else sym.denot.allOverriddenSymbols.find(hasDocstring).getOrElse(sym)
+
+        (docCtx.templateExpander.expand(sym, sym.owner), commentSym.asInstanceOf[reflect.Symbol])
       else
-        docstring
+        (docstring, tree.symbol)
     if commentString == ""
     then None
-    else Some(parseCommentString(commentString, tree.symbol, Some(tree.pos)))
+    else Some(parseCommentString(commentString, commentOwner, Some(tree.pos)))

--- a/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/InheritedDocLinkWarningTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/InheritedDocLinkWarningTest.scala
@@ -1,0 +1,27 @@
+package dotty.tools.scaladoc
+package noLinkWarnings
+
+import org.junit.Assert.assertEquals
+
+/** Inherited doc links must resolve at their definition site, not in the inheriting class's scope.
+ *  @see https://github.com/scala/scala3/issues/20028
+ */
+class InheritedDocLinkWarningTest extends ScaladocTest("inheritedDocLinkWarning"):
+
+  override def args = Scaladoc.Args(
+    name = "test",
+    tastyFiles = tastyFiles(name),
+    output = getTempDir().getRoot,
+    projectVersion = Some("1.0")
+  )
+
+  override def runTest = afterRendering {
+    val diagnostics = summon[DocContext].compilerContext.reportedDiagnostics
+    val linkWarnings = diagnostics.warningMsgs.filter(_.contains("link query"))
+    assertEquals(
+      "The inherited `[[Parent]]` link should currently produce exactly one spurious warning (see #20028)",
+      List("Couldn't resolve a member for the given link query: Parent"),
+      linkWarnings
+    )
+    assertNoErrors(diagnostics)
+  }

--- a/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/InheritedDocLinkWarningTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/InheritedDocLinkWarningTest.scala
@@ -1,8 +1,6 @@
 package dotty.tools.scaladoc
 package noLinkWarnings
 
-import org.junit.Assert.assertEquals
-
 /** Inherited doc links must resolve at their definition site, not in the inheriting class's scope.
  *  @see https://github.com/scala/scala3/issues/20028
  */
@@ -17,11 +15,6 @@ class InheritedDocLinkWarningTest extends ScaladocTest("inheritedDocLinkWarning"
 
   override def runTest = afterRendering {
     val diagnostics = summon[DocContext].compilerContext.reportedDiagnostics
-    val linkWarnings = diagnostics.warningMsgs.filter(_.contains("link query"))
-    assertEquals(
-      "The inherited `[[Parent]]` link should currently produce exactly one spurious warning (see #20028)",
-      List("Couldn't resolve a member for the given link query: Parent"),
-      linkWarnings
-    )
+    assertNoWarning(diagnostics)
     assertNoErrors(diagnostics)
   }


### PR DESCRIPTION
Fixes #20028

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by reading it and making changes manually.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
~Covered by existing tests (this is a refactoring)~
~Non-code change, no tests needed~
~Manual tests because writing automated tests is impractical, described below (in detail)~