### PR TITLE
Remove `unsafeNulls` from compiler unit tests, simplify class file lookups

### DIFF
--- a/compiler/test/dotty/AsmConverters.scala
+++ b/compiler/test/dotty/AsmConverters.scala
@@ -1,7 +1,6 @@
 package dotty
 
 import scala.jdk.CollectionConverters.*
-import scala.language.unsafeNulls
 import scala.tools.asm
 import scala.tools.asm.*
 import scala.tools.asm.tree.*

--- a/compiler/test/dotty/AsmNode.scala
+++ b/compiler/test/dotty/AsmNode.scala
@@ -2,7 +2,6 @@ package dotty
 
 import java.lang.reflect.Modifier
 import scala.jdk.CollectionConverters.*
-import scala.language.unsafeNulls
 import scala.tools.asm
 import scala.tools.asm.*
 import scala.tools.asm.tree.*

--- a/compiler/test/dotty/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/DottyBytecodeTest.scala
@@ -89,6 +89,9 @@ trait DottyBytecodeTest {
     files(outDir)
   }
 
+  protected def lookupClass(dir: AbstractFile, name: String): InputStream =
+    dir.lookupName(name, directory = false).nn.input
+
   protected def loadClassNode(input: InputStream, skipDebugInfo: Boolean = true): ClassNode = {
     val cr = new ClassReader(input)
     val cn = new ClassNode()
@@ -98,7 +101,7 @@ trait DottyBytecodeTest {
 
   /** Finds a class with `cls` as name in `dir`, throws if it can't find it */
   def findClass(cls: String, dir: AbstractFile) = {
-    val clsIn = dir.lookupName(s"$cls.class", directory = false).input
+    val clsIn = lookupClass(dir, s"$cls.class")
     val clsNode = loadClassNode(clsIn)
     assert(clsNode.name == cls, s"inspecting wrong class: ${clsNode.name}")
     clsNode

--- a/compiler/test/dotty/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/DottyBytecodeTest.scala
@@ -1,14 +1,8 @@
 package dotty
 
-import scala.language.unsafeNulls
-import dotty.tools.dotc.core.Contexts.{Context, ContextBase, ctx}
-import dotty.tools.dotc.core.Comments.{ContextDoc, ContextDocstrings}
-import dotty.tools.dotc.core.Phases.Phase
-import dotty.tools.dotc.Compiler
 import dotty.tools.dotc.Compiler
 import dotty.tools.dotc.core.Comments.{ContextDoc, ContextDocstrings}
 import dotty.tools.dotc.core.Contexts.{Context, ContextBase, ctx}
-import dotty.tools.io.{AbstractFile, VirtualDirectory, VirtualDirectory as Directory}
 import dotty.tools.vulpix.TestConfiguration
 
 import scala.tools.asm
@@ -18,7 +12,7 @@ import dotty.tools.io
 import dotty.tools.io.AbstractFile
 
 import scala.jdk.CollectionConverters.*
-import java.io.{InputStream, File as JFile}
+import java.io.InputStream
 import org.junit.Assert.*
 
 trait DottyBytecodeTest {

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -1,7 +1,5 @@
 package dotty
 
-import scala.language.unsafeNulls
-
 import java.nio.file.*
 
 /** Runtime properties from defines or environmnent */
@@ -58,25 +56,25 @@ object Properties {
   def dottyCompilerManagedSources: Path = Paths.get(sys.props("dotty.tests.dottyCompilerManagedSources"))
 
   /** dotty-interfaces jar */
-  def dottyInterfaces: String = sys.props("dotty.tests.classes.dottyInterfaces")
+  def dottyInterfaces: String = sys.props("dotty.tests.classes.dottyInterfaces").nn
 
   /** dotty-compiler jar */
-  def dottyCompiler: String = sys.props("dotty.tests.classes.dottyCompiler")
+  def dottyCompiler: String = sys.props("dotty.tests.classes.dottyCompiler").nn
 
   /** dotty-staging jar */
-  def dottyStaging: String = sys.props("dotty.tests.classes.dottyStaging")
+  def dottyStaging: String = sys.props("dotty.tests.classes.dottyStaging").nn
 
   /** dotty-tasty-inspector jar */
-  def dottyTastyInspector: String = sys.props("dotty.tests.classes.dottyTastyInspector")
+  def dottyTastyInspector: String = sys.props("dotty.tests.classes.dottyTastyInspector").nn
 
   /** tasty-core jar */
-  def tastyCore: String = sys.props("dotty.tests.classes.tastyCore")
+  def tastyCore: String = sys.props("dotty.tests.classes.tastyCore").nn
 
   /** compiler-interface jar */
-  def compilerInterface: String = sys.props("dotty.tests.classes.compilerInterface")
+  def compilerInterface: String = sys.props("dotty.tests.classes.compilerInterface").nn
 
   /** scala-library jar */
-  def scalaLibrary: String = sys.props("dotty.tests.classes.scalaLibrary")
+  def scalaLibrary: String = sys.props("dotty.tests.classes.scalaLibrary").nn
 
   // TODO: Remove this once we migrate the test suite
   def usingScalaLibraryCCTasty: Boolean = true
@@ -85,20 +83,20 @@ object Properties {
   def usingScalaLibraryTasty: Boolean = true
 
   /** scala-asm jar */
-  def scalaAsm: String = sys.props("dotty.tests.classes.scalaAsm")
+  def scalaAsm: String = sys.props("dotty.tests.classes.scalaAsm").nn
 
   /** jline-terminal jar */
-  def jlineTerminal: String = sys.props("dotty.tests.classes.jlineTerminal")
+  def jlineTerminal: String = sys.props("dotty.tests.classes.jlineTerminal").nn
 
   /** jline-reader jar */
-  def jlineReader: String = sys.props("dotty.tests.classes.jlineReader")
+  def jlineReader: String = sys.props("dotty.tests.classes.jlineReader").nn
 
   /** scalajs-javalib jar */
-  def scalaJSJavalib: String = sys.props("dotty.tests.classes.scalaJSJavalib")
+  def scalaJSJavalib: String = sys.props("dotty.tests.classes.scalaJSJavalib").nn
 
   /** scalajs-scalalib jar */
-  def scalaJSScalalib: String = sys.props("dotty.tests.classes.scalaJSScalalib")
+  def scalaJSScalalib: String = sys.props("dotty.tests.classes.scalaJSScalalib").nn
 
   /** scalajs-library jar */
-  def scalaJSLibrary: String = sys.props("dotty.tests.classes.scalaJSLibrary")
+  def scalaJSLibrary: String = sys.props("dotty.tests.classes.scalaJSLibrary").nn
 }

--- a/compiler/test/dotty/tools/DottyTest.scala
+++ b/compiler/test/dotty/tools/DottyTest.scala
@@ -1,15 +1,12 @@
 package dotty
 package tools
 
-import scala.language.unsafeNulls
-
 import vulpix.TestConfiguration
 
 import dotc.core.*
 import dotc.core.Comments.{ContextDoc, ContextDocstrings}
 import dotc.core.Contexts.*
-import dotc.core.Symbols.*
-import Types.*, Symbols.*, Decorators.*
+import Types.*, Symbols.*
 import dotc.core.Decorators.*
 import dotc.ast.tpd
 import dotc.Compiler
@@ -34,7 +31,7 @@ trait DottyTest extends ContextEscapeDetection {
 
   override def getCtx: Context = ctx
   override def clearCtx() = {
-    ctx = null
+    ctx = NoContext
   }
 
   protected def initializeCtx(fc: FreshContext): Unit = {

--- a/compiler/test/dotty/tools/DottyTypeStealer.scala
+++ b/compiler/test/dotty/tools/DottyTypeStealer.scala
@@ -1,7 +1,5 @@
 package dotty.tools
 
-import scala.language.unsafeNulls
-
 import dotc.ast.tpd
 import dotc.ast.tpd.*
 import dotc.core.Contexts.{Context, atPhase}
@@ -79,8 +77,8 @@ object DottyTypeStealer extends DottyTest {
     val dummyName = "x_x_x"
     val vals = typeStrings.zipWithIndex.map{case (s, x) => kind.format(dummyName + x, s) }.mkString("\n")
     val gatheredSource = s" ${source}\n object A$dummyName {$vals}"
-    var scontext : Context = null
-    var members: List[Symbol] = null
+    var scontext: Context | Null = null
+    var members: List[Symbol] | Null = null
     checkCompile(lastPhase, gatheredSource) {
       (tree, context) =>
         given Context = context
@@ -95,6 +93,6 @@ object DottyTypeStealer extends DottyTest {
         members = d.map(_.symbol).reverse
         scontext = context
     }
-    (scontext, members)
+    (scontext.nn, members.nn)
   }
 }

--- a/compiler/test/dotty/tools/TestSources.scala
+++ b/compiler/test/dotty/tools/TestSources.scala
@@ -1,8 +1,5 @@
 package dotty.tools
 
-import scala.language.unsafeNulls
-
-import java.io.File
 import java.nio.file.*
 
 import scala.jdk.CollectionConverters.*

--- a/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
@@ -152,7 +152,7 @@ class ArrayApplyOptTest extends DottyBytecodeTest {
        """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Foo.class")
       val clsNode = loadClassNode(clsIn)
       val meth   = getMethod(clsNode, "test")
 
@@ -333,7 +333,7 @@ class ArrayApplyOptTest extends DottyBytecodeTest {
 
   def checkApplyAvoidsIntermediateArray(name: String)(source: String): Unit = {
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Foo.class")
       val clsNode = loadClassNode(clsIn)
       val meth1   = getMethod(clsNode, "meth1")
       val meth2   = getMethod(clsNode, "meth2")

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -26,7 +26,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
       val methodNode = getMethod(clsNode, "foo")
       correctNumberOfNullChecks(2, methodNode.instructions)
@@ -41,7 +41,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
       val methodNode: MethodNode = getMethod(clsNode, "byNameParam")
 
@@ -63,8 +63,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  |}""".stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -85,8 +85,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  |}""".stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -106,8 +106,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -128,8 +128,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -150,8 +150,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -171,8 +171,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -192,8 +192,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -214,8 +214,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -242,8 +242,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -270,8 +270,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
       assert(verifySwitch(methodNode))
     }
@@ -288,8 +288,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("Test.class", directory = false).nn
-      val clsNode = loadClassNode(clsIn.input)
+      val clsIn = lookupClass(dir, "Test.class")
+      val clsNode = loadClassNode(clsIn)
       val method = getMethod(clsNode, "test")
       val throwMatchError = instructionsFromMethod(method).exists {
         case Op(Opcodes.ATHROW) => true
@@ -309,8 +309,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  |  }
                  |}""".stripMargin
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Foo$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Foo$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val methodNode = getMethod(moduleNode, "foo")
 
       assert(verifySwitch(methodNode, shouldFail = true))
@@ -326,8 +326,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  |  def arr = Array.ofDim[Int](2, 1)
                  |}""".stripMargin
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Arr$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Arr$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val method     = getMethod(moduleNode, "arr")
 
       val hadCorrectInstr =
@@ -353,8 +353,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  |  def arr4 = Array.ofDim[Map[String, String]](2)
                  |}""".stripMargin
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Arr$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Arr$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val arr1       = getMethod(moduleNode, "arr1")
       val arr2       = getMethod(moduleNode, "arr2")
       val arr3       = getMethod(moduleNode, "arr3")
@@ -405,8 +405,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  |}""".stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn   = dir.lookupName("Arr$.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn   = lookupClass(dir, "Arr$.class")
+      val moduleNode = loadClassNode(moduleIn)
       val arr1       = getMethod(moduleNode, "arr1")
       val arr2       = getMethod(moduleNode, "arr2")
 
@@ -433,8 +433,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn = dir.lookupName("Test.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn = lookupClass(dir, "Test.class")
+      val moduleNode = loadClassNode(moduleIn)
       val method = getMethod(moduleNode, "test")
 
       val arrayWrapped = instructionsFromMethod(method).exists {
@@ -459,8 +459,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn = dir.lookupName("Test.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn = lookupClass(dir, "Test.class")
+      val moduleNode = loadClassNode(moduleIn)
       val method = getMethod(moduleNode, "test")
 
       val hasInstanceof = instructionsFromMethod(method).exists {
@@ -481,8 +481,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
 
     checkBCode(source) { dir =>
       for ((clsName, methodName) <- List(("Case", "equals"), ("Value$", "equals$extension"))) {
-        val moduleIn = dir.lookupName(s"$clsName.class", directory = false).nn
-        val moduleNode = loadClassNode(moduleIn.input)
+        val moduleIn = lookupClass(dir, s"$clsName.class")
+        val moduleNode = loadClassNode(moduleIn)
         val equalsMethod = getMethod(moduleNode, methodName)
 
         val callsEquals = instructionsFromMethod(equalsMethod).exists {
@@ -506,7 +506,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
 
     checkBCode(source) { dir =>
       // We check the method call signature to make sure we don't call a Java bridge
-      val clsIn = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val testMethod = getMethod(clsNode, "test")
       val instructions = instructionsFromMethod(testMethod)
@@ -529,7 +529,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
     checkBCode(source) { dir =>
       // We test that the anonymous class generated for the partial function
       // holds the method implementations and does not use forwarders
-      val clsIn = dir.lookupName("Foo$$anon$1.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Foo$$anon$1.class")
       val clsNode = loadClassNode(clsIn)
       val applyOrElse = getMethod(clsNode, "applyOrElse")
       val instructions = instructionsFromMethod(applyOrElse)
@@ -553,8 +553,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn = dir.lookupName("Test.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn = lookupClass(dir, "Test.class")
+      val moduleNode = loadClassNode(moduleIn)
       val method = getMethod(moduleNode, "test")
 
       val fooInvoke = instructionsFromMethod(method).exists {
@@ -578,8 +578,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val moduleIn = dir.lookupName("Test.class", directory = false).nn
-      val moduleNode = loadClassNode(moduleIn.input)
+      val moduleIn = lookupClass(dir, "Test.class")
+      val moduleNode = loadClassNode(moduleIn)
       val method = getMethod(moduleNode, "test")
 
       val instructions = instructionsFromMethod(method)
@@ -603,7 +603,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val test    = getMethod(clsNode, "test")
       val ref     = getMethod(clsNode, "ref")
@@ -629,7 +629,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "test")
 
@@ -658,7 +658,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "x$lzyINIT1$1")
       assertEquals(32, instructionsFromMethod(method).size)
@@ -674,7 +674,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "test")
 
@@ -706,14 +706,14 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(sourceUnsafe) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "test")
       assertEquals(14, instructionsFromMethod(method).size)
     }
 
     checkBCode(sourceSafe) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "test")
       assertEquals(23, instructionsFromMethod(method).size)
@@ -724,8 +724,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
 
   private def checkReleaseFence(releaseFenceExpected: Boolean, outputClassName: String, source: String): Unit = {
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName(outputClassName, directory = false).nn
-      val clsNode = loadClassNode(clsIn.input)
+      val clsIn = lookupClass(dir, outputClassName)
+      val clsNode = loadClassNode(clsIn)
       val method = getMethod(clsNode, "<init>")
 
       val hasReleaseFence = instructionsFromMethod(method).exists {
@@ -812,8 +812,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
   private def checkFinalClass(outputClassName: String, source: String) = {
     checkBCode(source) {
       dir =>
-        val moduleIn   = dir.lookupName(outputClassName, directory = false).nn
-        val moduleNode = loadClassNode(moduleIn.input)
+        val moduleIn   = lookupClass(dir, outputClassName)
+        val moduleNode = loadClassNode(moduleIn)
         assert((moduleNode.access & Opcodes.ACC_FINAL) != 0)
     }
   }
@@ -877,7 +877,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "test")
 
@@ -905,7 +905,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "test")
 
@@ -947,7 +947,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Base.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Base.class")
       val clsNode = loadClassNode(clsIn)
       val f = getMethod(clsNode, "f")
       val x = getField(clsNode, "x")
@@ -975,7 +975,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Base.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Base.class")
       val clsNode = loadClassNode(clsIn)
       val f = getMethod(clsNode, "f")
       val x = getField(clsNode, "x")
@@ -1008,8 +1008,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(List(sourceA, sourceB)) { dir =>
-      val clsNodeA = loadClassNode(dir.lookupName("A.class", directory = false).nn.input, skipDebugInfo = false)
-      val clsNodeB = loadClassNode(dir.lookupName("B.class", directory = false).nn.input, skipDebugInfo = false)
+      val clsNodeA = loadClassNode(lookupClass(dir, "A.class"), skipDebugInfo = false)
+      val clsNodeB = loadClassNode(lookupClass(dir, "B.class"), skipDebugInfo = false)
       val a1 = getMethod(clsNodeA, "a1")
       val a2 = getMethod(clsNodeA, "a2")
       val b1 = getMethod(clsNodeB, "b1")
@@ -1047,7 +1047,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         |}
       """.stripMargin
     checkBCode(code) { dir =>
-      val c = loadClassNode(dir.lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val c = loadClassNode(lookupClass(dir, "C.class"), skipDebugInfo = false)
       val t = getMethod(c, "t")
       val instructions = instructionsFromMethod(t)
       val isFrameLine = (x: Instruction) => x.isInstanceOf[FrameEntry] || x.isInstanceOf[LineNumber]
@@ -1086,7 +1086,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
     checkBCode(source) { dir =>
       // The mutable local vars for n and acc reuse the slots of the params n and acc
 
-      val fooClass = loadClassNode(dir.lookupName("Foo.class", directory = false).nn.input)
+      val fooClass = loadClassNode(lookupClass(dir, "Foo.class"))
       val factMeth = getMethod(fooClass, "fact")
 
       assertSameCode(factMeth, List(
@@ -1114,7 +1114,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
 
       // The mutable local vars for this and acc reuse the slots of `this` and of the param acc
 
-      val intListClass = loadClassNode(dir.lookupName("IntList.class", directory = false).nn.input)
+      val intListClass = loadClassNode(lookupClass(dir, "IntList.class"))
       val sumMeth = getMethod(intListClass, "sum")
 
       assertSameCode(sumMeth, List(
@@ -1161,7 +1161,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val fooClass = loadClassNode(dir.lookupName("Foo.class", directory = false).nn.input)
+      val fooClass = loadClassNode(lookupClass(dir, "Foo.class"))
 
       // ---------------
 
@@ -1274,7 +1274,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val fooClass = loadClassNode(dir.lookupName("Foo.class", directory = false).nn.input)
+      val fooClass = loadClassNode(lookupClass(dir, "Foo.class"))
 
       // ---------------
 
@@ -1389,7 +1389,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val sourceMapWriterClass = loadClassNode(dir.lookupName("SourceMapWriter.class", directory = false).nn.input)
+      val sourceMapWriterClass = loadClassNode(lookupClass(dir, "SourceMapWriter.class"))
 
       // ---------------
 
@@ -1482,7 +1482,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
       val before1    = instructionsFromMethod(getMethod(clsNode, "before1"))
       val before2    = instructionsFromMethod(getMethod(clsNode, "before2"))
@@ -1502,8 +1502,8 @@ class DottyBytecodeTests extends DottyBytecodeTest {
     import Opcodes.*
 
     checkBCode(List(invocationReceiversTestCode.definitions("Object"))) { dir =>
-      val c1 = loadClassNode(dir.lookupName("C1.class", directory = false).nn.input)
-      val c2 = loadClassNode(dir.lookupName("C2.class", directory = false).nn.input)
+      val c1 = loadClassNode(lookupClass(dir, "C1.class"))
+      val c2 = loadClassNode(lookupClass(dir, "C2.class"))
       assertSameCode(getMethod(c1, "clone"), List(VarOp(ALOAD, 0), Invoke(INVOKESTATIC, "T", "clone$", "(LT;)Ljava/lang/Object;", true), Op(ARETURN)))
       assertInvoke(getMethod(c1, "f1"), "T", "clone")
       assertInvoke(getMethod(c1, "f2"), "T", "clone")
@@ -1513,10 +1513,10 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       assertInvoke(getMethod(c2, "f3"), "C1", "clone")
     }
     checkBCode(List(invocationReceiversTestCode.definitions("String"))) { dir =>
-      val c1b = loadClassNode(dir.lookupName("C1.class", directory = false).nn.input)
-      val c2b = loadClassNode(dir.lookupName("C2.class", directory = false).nn.input)
-      val tb = loadClassNode(dir.lookupName("T.class", directory = false).nn.input)
-      val ub = loadClassNode(dir.lookupName("U.class", directory = false).nn.input)
+      val c1b = loadClassNode(lookupClass(dir, "C1.class"))
+      val c2b = loadClassNode(lookupClass(dir, "C2.class"))
+      val tb = loadClassNode(lookupClass(dir, "T.class"))
+      val ub = loadClassNode(lookupClass(dir, "U.class"))
 
       def ms(c: ClassNode, n: String) = c.methods.asScala.toList.filter(_.name == n)
       assert(ms(tb, "clone").length == 1)
@@ -1566,7 +1566,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(scalaSources = List(cC), javaSources = List(aC, bC, iC, jC)) { dir =>
-      val clsIn   = dir.subdirectoryNamed("b").lookupName("C.class", directory = false).nn.input
+      val clsIn = lookupClass(dir.subdirectoryNamed("b"), "C.class")
       val c = loadClassNode(clsIn)
 
       assertInvoke(getMethod(c, "f1"), "a/B", "f") // receiver needs to be B (A is not accessible in class C, package b)
@@ -1586,7 +1586,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         |}
       """.stripMargin
     checkBCode(code) { dir =>
-      val c = loadClassNode(dir.lookupName("C.class", directory = false).nn.input)
+      val c = loadClassNode(lookupClass(dir, "C.class"))
 
       assertInvoke(getMethod(c, "f1"), "[Ljava/lang/String;", "clone") // array descriptor as receiver
       assertInvoke(getMethod(c, "f2"), "java/lang/Object", "hashCode") // object receiver
@@ -1605,7 +1605,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         |}
       """.stripMargin
     checkBCode(code) { dir =>
-      val c = loadClassNode(dir.lookupName("C.class", directory = false).nn.input)
+      val c = loadClassNode(lookupClass(dir, "C.class"))
       val f1 = getMethod(c, "f1")
       assertNoInvoke(f1, "scala/Tuple2$", "apply") // no Tuple2.apply call
       // no `new` instruction
@@ -1634,7 +1634,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(code) { dir =>
-      val c = loadClassNode(dir.lookupName("Test.class", directory = false).nn.input)
+      val c = loadClassNode(lookupClass(dir, "Test.class"))
       assert((c.access & Opcodes.ACC_DEPRECATED) != 0)
       assert((getMethod(c, "f").access & Opcodes.ACC_DEPRECATED) != 0)
 
@@ -1659,7 +1659,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
       val meth1      = getMethod(clsNode, "meth1")
       val meth2      = getMethod(clsNode, "meth2")
@@ -1696,7 +1696,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         |}
         |""".stripMargin
     checkBCode(source){dir =>
-      val clsIn      = dir.lookupName("A.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "A.class")
       val clsNode    = loadClassNode(clsIn)
       def isFinal(access: Int) = (access & Opcodes.ACC_FINAL) != 0
 
@@ -1721,7 +1721,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
       def testSig(methodName: String, expectedDescriptor: String) = {
         val descriptor = clsNode.methods.asScala.filter(_.name == methodName).map(_.desc)
@@ -1747,7 +1747,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Main$.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Main$.class")
       val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
       val method  = getMethod(clsNode, "m")
       val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
@@ -1788,7 +1788,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Main$.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Main$.class")
       val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
       val method  = getMethod(clsNode, "m")
       val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
@@ -1823,7 +1823,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         |}
         |""".stripMargin
     checkBCode(c1) {dir =>
-      val clsIn = dir.lookupName("C.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "C.class")
       val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
       val method = getMethod(clsNode, "m")
       val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
@@ -1851,7 +1851,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("A$.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "A$.class")
       val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
       val method  = getMethod(clsNode, "m2$1")
       val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
@@ -1876,7 +1876,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
       val meth1      = getMethod(clsNode, "meth1")
       val meth2      = getMethod(clsNode, "meth2")
@@ -1902,7 +1902,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
       val meth1      = getMethod(clsNode, "meth1")
       val meth2      = getMethod(clsNode, "meth2")
@@ -1930,7 +1930,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Main$.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Main$.class")
       val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
       val method  = getMethod(clsNode, "main")
       val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
@@ -1959,7 +1959,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Main$.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Main$.class")
       val clsNode = loadClassNode(clsIn, skipDebugInfo = false)
       val method  = getMethod(clsNode, "main")
       val instructions = instructionsFromMethod(method).filter(_.isInstanceOf[LineNumber])
@@ -1990,7 +1990,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
       |    super.receive()
       |    super.timers()""".stripMargin
     checkBCode(scalaSources = List(source), javaSources = List(javaSource)) { dir =>
-      val clsIn   = dir.lookupName("PersistentShardCoordinator.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "PersistentShardCoordinator.class")
       val clsNode = loadClassNode(clsIn)
 
       val expected = List("Actor", "Timers")
@@ -2016,7 +2016,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
         |""".stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
 
       // Get instructions for both methods
@@ -2053,7 +2053,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
     checkBCode(source) { dir =>
       // The main verification is that it compiles.
       // We can also check that `test` method exists.
-      val clsIn = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       assert(clsNode.methods.asScala.exists(_.name == "test"))
     }
@@ -2075,7 +2075,7 @@ class DottyBytecodeTests extends DottyBytecodeTest {
          |  @scala.annotation.varargs def v(x: String*): String = x(0)
          |""".stripMargin
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("Test$.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Test$.class")
       val clsNode = loadClassNode(clsIn)
       for noMeth <- clsNode.methods.asScala if noMeth.name.startsWith("no") do
         assert(noMeth.signature == null, s"${noMeth.name} should not have a signature but does: ${noMeth.signature}")

--- a/compiler/test/dotty/tools/backend/jvm/IincTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/IincTest.scala
@@ -59,7 +59,7 @@ class IincTest extends DottyBytecodeTest {
        """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Increment.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Increment.class")
       val clsNode = loadClassNode(clsIn)
       val meth   = getMethod(clsNode, "test")
 

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -23,7 +23,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
       val meth1      = getMethod(clsNode, "meth1")
       val meth2      = getMethod(clsNode, "meth2")
@@ -59,7 +59,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
     )
     for (source <- sources)
       checkBCode(source) { dir =>
-        val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+        val clsIn      = lookupClass(dir, "Foo.class")
         val clsNode    = loadClassNode(clsIn)
         val meth1      = getMethod(clsNode, "meth1")
         val meth2      = getMethod(clsNode, "meth2")
@@ -93,7 +93,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn, skipDebugInfo = false)
 
       val track = clsNode.methods.asScala.find(_.name == "track")
@@ -154,7 +154,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn, skipDebugInfo = false)
 
       val track = clsNode.methods.asScala.find(_.name == "track")
@@ -213,7 +213,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn, skipDebugInfo = false)
 
       val track = clsNode.methods.asScala.find(_.name == "track")
@@ -273,7 +273,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn, skipDebugInfo = false)
 
       val track = clsNode.methods.asScala.find(_.name == "track")
@@ -327,7 +327,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -355,7 +355,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -382,7 +382,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -403,7 +403,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -427,7 +427,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -446,7 +446,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -469,7 +469,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -496,7 +496,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -524,7 +524,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -553,7 +553,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -585,7 +585,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Foo.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -637,7 +637,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       for cls <- List("Boolean", "Byte", "Short", "Int", "Long", "Float", "Double", "Char", "Unit") do
@@ -689,7 +689,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       for cls <- List("Boolean", "Byte", "Short", "Int", "Long", "Float", "Double", "Char", "Unit") do
@@ -711,7 +711,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")
@@ -737,7 +737,7 @@ class InlineBytecodeTests extends DottyBytecodeTest {
                  """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn      = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn      = lookupClass(dir, "Test.class")
       val clsNode    = loadClassNode(clsIn)
 
       val fun = getMethod(clsNode, "test")

--- a/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
@@ -149,7 +149,7 @@ class LabelBytecodeTests extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val method  = getMethod(clsNode, "test")
 

--- a/compiler/test/dotty/tools/backend/jvm/MixinBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/MixinBytecodeTests.scala
@@ -17,7 +17,7 @@ class MixinBytecodeTestsNoForwarders extends DottyBytecodeTest {
   }
 
   private def getClass(dir: AbstractFile, name: String) =
-    loadClassNode(dir.lookupName(name + ".class", directory = false).nn.input)
+    loadClassNode(lookupClass(dir, name + ".class"))
 
   private def checkForwarder(clazz: ClassNode, target: String) = {
     val f = getMethod(clazz, "f")
@@ -36,7 +36,7 @@ class MixinBytecodeTestsNoForwarders extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(code) { dir =>
-      val clsIn = dir.lookupName("AbstractSet2.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "AbstractSet2.class")
       val clsNode = loadClassNode(clsIn)
       assertEquals(clsNode.methods.asScala.map(_.name).toList, List("<init>")) // no bridge for apply (there's already one in AbstractSet)
     }
@@ -95,7 +95,7 @@ class MixinBytecodeTestsNoForwarders extends DottyBytecodeTest {
 
     checkBCode(code) { dir =>
       val noForwarder = List("C1", "C2", "C3", "C4", "C10", "C11", "C12", "C13", "C16", "C17")
-      val noForwarderClasses = noForwarder.map(cn => loadClassNode(dir.lookupName(cn + ".class", directory = false).nn.input))
+      val noForwarderClasses = noForwarder.map(cn => loadClassNode(lookupClass(dir, cn + ".class")))
       for cn <- noForwarderClasses do
         val meth = cn.methods.asScala.find(_.name == "f")
         assert(meth.isEmpty, s"failed for ${cn.name}")
@@ -304,7 +304,7 @@ class MixinBytecodeTestsNoForwarders extends DottyBytecodeTest {
 
 class MixinBytecodeTestsWithForwarders extends DottyBytecodeTest {
   private def getClass(dir: AbstractFile, name: String) =
-    loadClassNode(dir.lookupName(name + ".class", directory = false).nn.input)
+    loadClassNode(lookupClass(dir, name + ".class"))
 
   @Test
   def sd224(): Unit = {

--- a/compiler/test/dotty/tools/backend/jvm/OptimizationBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/OptimizationBytecodeTests.scala
@@ -47,7 +47,7 @@ class OptimizationBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val meth1 = getMethod(clsNode, "actual")
       val meth2 = getMethod(clsNode, "expected")
@@ -72,7 +72,7 @@ class OptimizationBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
       val meth = getMethod(clsNode, "test")
       val instructions = instructionsFromMethod(meth)
@@ -565,7 +565,7 @@ class OptimizationBytecodeTests extends DottyBytecodeTest {
         |}
       """.stripMargin
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("C.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "C.class")
       val clsNode = loadClassNode(clsIn)
       val meth1a = getMethod(clsNode, "t1a")
       val meth1b = getMethod(clsNode, "t1b")
@@ -752,7 +752,7 @@ class OptimizationBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Foo.class")
       val clsNode = loadClassNode(clsIn)
       val meth1 = getMethod(clsNode, "foo")
 
@@ -774,7 +774,7 @@ class OptimizationBytecodeTests extends DottyBytecodeTest {
          """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn = dir.lookupName("Test.class", directory = false).nn.input
+      val clsIn = lookupClass(dir, "Test.class")
       val clsNode = loadClassNode(clsIn)
 
       for m <- List(getMethod(clsNode, "bad")) do

--- a/compiler/test/dotty/tools/backend/jvm/PublicInBinaryTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/PublicInBinaryTests.scala
@@ -50,7 +50,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  def testInlined = inlined
       """.stripMargin
     checkBCode(code) { dir =>
-      val cClass = loadClassNode(dir.lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val cClass = loadClassNode(lookupClass(dir, "C.class"), skipDebugInfo = false)
 
       checkPublicMethod(cClass, "packagePrivateMethod", "()I")
       checkPublicMethod(cClass, "protectedMethod", "()I")
@@ -78,7 +78,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  def testInlined = inlined
       """.stripMargin
     checkBCode(code) { dir =>
-      val cClass = loadClassNode(dir.lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val cClass = loadClassNode(lookupClass(dir, "C.class"), skipDebugInfo = false)
 
       checkPublicMethod(cClass, "packagePrivateVal", "()I")
       checkPublicMethod(cClass, "protectedVal", "()I")
@@ -112,7 +112,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  def testInlined = inlined
       """.stripMargin
     checkBCode(code) { dir =>
-      val cClass = loadClassNode(dir.lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val cClass = loadClassNode(lookupClass(dir, "C.class"), skipDebugInfo = false)
 
       checkPublicMethod(cClass, "packagePrivateVar", "()I")
       checkPublicMethod(cClass, "packagePrivateVar_$eq", "(I)V")
@@ -145,7 +145,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  def testInlined = inlined
       """.stripMargin
     checkBCode(code) { dir =>
-      val cClass = loadClassNode(dir.lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val cClass = loadClassNode(lookupClass(dir, "C.class"), skipDebugInfo = false)
       checkPublicMethod(cClass, "packagePrivateGiven1", "()I")
       checkPublicMethod(cClass, "protectedGiven1", "()I")
 
@@ -178,7 +178,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |}
       """.stripMargin
     checkBCode(code) { dir =>
-      val cClass = loadClassNode(dir.lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val cClass = loadClassNode(lookupClass(dir, "C.class"), skipDebugInfo = false)
       checkPublicMethod(cClass, "packagePrivateVal", "()I")
       checkPublicMethod(cClass, "protectedVal", "()I")
 
@@ -202,15 +202,15 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |@publicInBinary protected object ProtectedObject
       """.stripMargin
     checkBCode(code) { dir =>
-      val privateObject = loadClassNode(dir.subdirectoryNamed("foo").lookupName("PrivateObject$.class", directory = false).nn.input, skipDebugInfo = false)
+      val privateObject = loadClassNode(lookupClass(dir.subdirectoryNamed("foo"), "PrivateObject$.class"), skipDebugInfo = false)
       checkPublicClass(privateObject)
       checkPublicField(privateObject, "MODULE$")
 
-      val packagePrivateObject = loadClassNode(dir.subdirectoryNamed("foo").lookupName("PackagePrivateObject$.class", directory = false).nn.input, skipDebugInfo = false)
+      val packagePrivateObject = loadClassNode(lookupClass(dir.subdirectoryNamed("foo"), "PackagePrivateObject$.class"), skipDebugInfo = false)
       checkPublicClass(packagePrivateObject)
       checkPublicField(packagePrivateObject, "MODULE$")
 
-      val protectedObject = loadClassNode(dir.subdirectoryNamed("foo").lookupName("ProtectedObject$.class", directory = false).nn.input, skipDebugInfo = false)
+      val protectedObject = loadClassNode(lookupClass(dir.subdirectoryNamed("foo"), "ProtectedObject$.class"), skipDebugInfo = false)
       checkPublicClass(protectedObject)
       checkPublicField(protectedObject, "MODULE$")
     }
@@ -243,7 +243,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  def testInlined = inlined
       """.stripMargin
     checkBCode(code) { dir =>
-      val cTrait = loadClassNode(dir.lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val cTrait = loadClassNode(lookupClass(dir, "C.class"), skipDebugInfo = false)
 
       checkPublicMethod(cTrait, "packagePrivateVal", "()I")
       checkPublicMethod(cTrait, "protectedVal", "()I")
@@ -285,7 +285,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  @publicInBinary private[foo] object Baz
       """.stripMargin
     checkBCode(code) { dir =>
-      val barClass = loadClassNode(dir.subdirectoryNamed("foo").lookupName("Bar.class", directory = false).nn.input, skipDebugInfo = false)
+      val barClass = loadClassNode(lookupClass(dir.subdirectoryNamed("foo"), "Bar.class"), skipDebugInfo = false)
       checkPublicMethod(barClass, "testInlined", "()Lfoo/Baz$;")
     }
   }
@@ -301,7 +301,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  @publicInBinary private object Baz
       """.stripMargin
     checkBCode(code) { dir =>
-      val barClass = loadClassNode(dir.subdirectoryNamed("foo").lookupName("Bar.class", directory = false).nn.input, skipDebugInfo = false)
+      val barClass = loadClassNode(lookupClass(dir.subdirectoryNamed("foo"), "Bar.class"), skipDebugInfo = false)
       checkPublicMethod(barClass, "testInlined", "()Lfoo/Baz$;")
     }
   }
@@ -318,7 +318,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  @publicInBinary private[Macro] def fooImpl = {}
       """.stripMargin
     checkBCode(code) { dir =>
-      val macroClass = loadClassNode(dir.lookupName("Macro.class", directory = false).nn.input, skipDebugInfo = false)
+      val macroClass = loadClassNode(lookupClass(dir, "Macro.class"), skipDebugInfo = false)
       val testMethod = getMethod(macroClass, "test")
       val testInstructions = instructionsFromMethod(testMethod).filter(_.isInstanceOf[Invoke])
       assertSameCode(testInstructions, List(
@@ -338,7 +338,7 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |  @publicInBinary private[foo] def bazImpl = {}
       """.stripMargin
     checkBCode(code) { dir =>
-      val barClass = loadClassNode(dir.subdirectoryNamed("foo").lookupName("C.class", directory = false).nn.input, skipDebugInfo = false)
+      val barClass = loadClassNode(lookupClass(dir.subdirectoryNamed("foo"), "C.class"), skipDebugInfo = false)
       val testMethod = getMethod(barClass, "test")
       val testInstructions = instructionsFromMethod(testMethod).filter(_.isInstanceOf[Invoke])
       assertSameCode(testInstructions, List(
@@ -366,11 +366,11 @@ class PublicInBinaryTests extends DottyBytecodeTest {
         |}
       """.stripMargin
     checkBCode(code) { dir =>
-      val bClass = loadClassNode(dir.subdirectoryNamed("q").lookupName("B.class", directory = false).nn.input, skipDebugInfo = false)
+      val bClass = loadClassNode(lookupClass(dir.subdirectoryNamed("q"), "B.class"), skipDebugInfo = false)
       assert(bClass.methods.asScala.exists(_.name == "protected$a"))
       assert(bClass.methods.asScala.forall(_.name != "protected$b"))
 
-      val bInnerClass = loadClassNode(dir.subdirectoryNamed("q").lookupName("B$BInner.class", directory = false).nn.input, skipDebugInfo = false)
+      val bInnerClass = loadClassNode(lookupClass(dir.subdirectoryNamed("q"), "B$BInner.class"), skipDebugInfo = false)
 
       val test1Method = getMethod(bInnerClass, "test1")
       val test1Instructions = instructionsFromMethod(test1Method).filter(_.isInstanceOf[Invoke])

--- a/compiler/test/dotty/tools/backend/jvm/SourcePositionsTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/SourcePositionsTest.scala
@@ -26,7 +26,7 @@ class SourcePositionsTest extends DottyBytecodeTest:
       |}""".stripMargin
 
     checkBCode(code) { dir =>
-      val testClass = loadClassNode(dir.lookupName("Test.class", directory = false).nn.input, skipDebugInfo = false)
+      val testClass = loadClassNode(lookupClass(dir, "Test.class"), skipDebugInfo = false)
       val testMethod = getMethod(testClass, "test")
       val lineNumbers = instructionsFromMethod(testMethod).collect{case ln: LineNumber => ln}
       val expected = List(
@@ -62,7 +62,7 @@ class SourcePositionsTest extends DottyBytecodeTest:
       |}""".stripMargin
 
     checkBCode(code) { dir =>
-      val testClass = loadClassNode(dir.lookupName("Test.class", directory = false).nn.input, skipDebugInfo = false)
+      val testClass = loadClassNode(lookupClass(dir, "Test.class"), skipDebugInfo = false)
       val testMethod = getMethod(testClass, "test")
       val lineNumbers = instructionsFromMethod(testMethod).collect{case ln: LineNumber => ln}
       val expected = List(
@@ -98,7 +98,7 @@ class SourcePositionsTest extends DottyBytecodeTest:
       |}""".stripMargin
 
     checkBCode(code) { dir =>
-      val testClass = loadClassNode(dir.lookupName("Test.class", directory = false).nn.input, skipDebugInfo = false)
+      val testClass = loadClassNode(lookupClass(dir, "Test.class"), skipDebugInfo = false)
       val testMethod = getMethod(testClass, "test")
       val lineNumbers = instructionsFromMethod(testMethod).collect{case ln: LineNumber => ln}
       val expected = List(
@@ -127,7 +127,7 @@ class SourcePositionsTest extends DottyBytecodeTest:
       |
       """.stripMargin
     checkBCode(code): dir =>
-      val testClass = loadClassNode(dir.lookupName("Test.class", directory = false).nn.input, skipDebugInfo = false)
+      val testClass = loadClassNode(lookupClass(dir, "Test.class"), skipDebugInfo = false)
       val testMethod = getMethod(testClass, "$init$")
       val lineNumbers = instructionsFromMethod(testMethod).collect {case ln: LineNumber => ln}
       val expected = List(

--- a/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
@@ -51,7 +51,7 @@ class StringConcatTest extends DottyBytecodeTest {
 
     checkBCode(code) { dir =>
       def instructions(meth: String): List[Instruction] = {
-        val clsIn = dir.lookupName("C.class", directory = false).nn.input
+        val clsIn = lookupClass(dir, "C.class")
         val clsNode = loadClassNode(clsIn)
         instructionsFromMethod(getMethod(clsNode, meth))
       }

--- a/compiler/test/dotty/tools/backend/jvm/StringInterpolatorOptTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/StringInterpolatorOptTest.scala
@@ -21,7 +21,7 @@ class StringInterpolatorOptTest extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Foo.class")
       val clsNode = loadClassNode(clsIn)
       val meth1   = getMethod(clsNode, "meth1")
       val meth2   = getMethod(clsNode, "meth2")
@@ -49,7 +49,7 @@ class StringInterpolatorOptTest extends DottyBytecodeTest {
       """.stripMargin
 
     checkBCode(source) { dir =>
-      val clsIn   = dir.lookupName("Foo.class", directory = false).nn.input
+      val clsIn   = lookupClass(dir, "Foo.class")
       val clsNode = loadClassNode(clsIn)
       val meth1   = getMethod(clsNode, "meth1")
       val meth2   = getMethod(clsNode, "meth2")

--- a/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
+++ b/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
@@ -6,7 +6,6 @@ import dotty.tools.vulpix.*
 import reporting.TestReporter
 
 import scala.concurrent.duration.*
-import scala.language.unsafeNulls
 
 import java.io.{File => JFile}
 import org.junit.{AfterClass, Test}

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -2,8 +2,6 @@ package dotty
 package tools
 package dotc
 
-import scala.language.unsafeNulls
-
 import org.junit.{AfterClass, Ignore, Test}
 import org.junit.experimental.categories.Category
 

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -2,8 +2,6 @@ package dotty
 package tools
 package dotc
 
-import scala.language.unsafeNulls
-
 import org.junit.{Test, AfterClass}
 import org.junit.Assume.*
 

--- a/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
+++ b/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
@@ -2,7 +2,6 @@ package dotty.tools.dotc
 
 import dotty.DottyBytecodeTest
 
-import scala.language.unsafeNulls
 import org.junit.Assert.*
 import org.junit.Test
 import dotty.tools.dotc.config.CompilerCommand

--- a/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
+++ b/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
@@ -62,7 +62,7 @@ class ConstantFoldingTests extends DottyBytecodeTest {
     import dotty.AsmConverters.*
 
     checkBCode(conditionSrc) { dir =>
-      val clsIn   = dir.lookupName(s"Test.class", directory = false).input
+      val clsIn   = lookupClass(dir, "Test.class")
       val methods = loadClassNode(clsIn).methods.asScala
 
       val whenTrue = methods.find(_.name == "whenTrue").get

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -2,8 +2,6 @@ package dotty
 package tools
 package dotc
 
-import scala.language.unsafeNulls
-
 import org.junit.{AfterClass, Test}
 import reporting.TestReporter
 import vulpix.*

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -2,12 +2,8 @@ package dotty
 package tools
 package dotc
 
-import scala.language.unsafeNulls
-
 import java.io.{File => JFile}
-import java.nio.file.{Files, Path, Paths}
 
-import org.junit.Assume.assumeTrue
 import org.junit.{AfterClass, Test}
 import org.junit.experimental.categories.Category
 

--- a/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
+++ b/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
@@ -2,18 +2,11 @@ package dotty
 package tools
 package dotc
 
-import scala.language.unsafeNulls
-
-import org.junit.{ Test, Ignore, BeforeClass, AfterClass }
+import org.junit.{ Test, Ignore, AfterClass }
 import org.junit.Assert.*
-import org.junit.Assume.*
-import org.junit.experimental.categories.Category
 
 import java.io.File
 import java.nio.file.*
-import java.util.stream.{ Stream => JStream }
-import scala.jdk.CollectionConverters.*
-import scala.util.matching.Regex
 import scala.concurrent.duration.*
 import TestSources.sources
 import vulpix.*

--- a/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/MultiReleaseJarTest.scala
@@ -2,7 +2,6 @@ package dotty.tools.dotc.classpath
 
 import dotty.DottyBytecodeTest
 
-import scala.language.unsafeNulls
 import dotty.tools.dotc.core.Contexts.Context
 
 import java.io.{ByteArrayOutputStream, IOException}
@@ -13,7 +12,6 @@ import org.junit.Assert.*
 import org.junit.Test
 
 import scala.jdk.CollectionConverters.*
-import scala.util.Properties
 
 class MultiReleaseJarTest extends DottyBytecodeTest {
 

--- a/compiler/test/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactoryTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/ZipAndJarFileLookupFactoryTest.scala
@@ -1,7 +1,5 @@
 package dotty.tools.dotc.classpath
 
-import scala.language.unsafeNulls
-
 import org.junit.Test
 import java.nio.file.*
 import java.nio.file.attribute.FileTime
@@ -21,7 +19,7 @@ class ZipAndJarFileLookupFactoryTest {
     given Context = new ContextBase().initialCtx
     assert(!ctx.settings.YdisableFlatCpCaching.value) // we're testing with our JAR metadata caching enabled.
 
-    def createCp = ZipAndJarClassPathFactory.create(AbstractFile.getFile(f))
+    def createCp = ZipAndJarClassPathFactory.create(AbstractFile.getFile(f).nn)
     try {
       createZip(f, Array(), "p1/C.class")
       createZip(f, Array(), "p2/X.class")

--- a/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
+++ b/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
@@ -13,7 +13,6 @@ import dotty.tools.dotc.reporting.TestReporter
 import java.nio.file.{FileSystems, Files, Path, Paths, StandardCopyOption}
 import scala.jdk.CollectionConverters.*
 import scala.util.Properties.userDir
-import scala.language.unsafeNulls
 import scala.collection.mutable.Buffer
 
 import java.nio.charset.StandardCharsets

--- a/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
+++ b/compiler/test/dotty/tools/dotc/printing/PrintingTest.scala
@@ -3,8 +3,6 @@ package tools
 package dotc
 package printing
 
-import scala.language.unsafeNulls
-
 import vulpix.FileDiff
 import vulpix.TestConfiguration
 import vulpix.ParallelTesting

--- a/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
+++ b/compiler/test/dotty/tools/dotc/printing/SyntaxHighlightingTests.scala
@@ -1,7 +1,5 @@
 package dotty.tools.dotc.printing
 
-import scala.language.unsafeNulls
-
 import dotty.tools.DottyTest
 import org.junit.Assert.*
 import org.junit.{Ignore, Test}

--- a/compiler/test/dotty/tools/dotc/semanticdb/SemanticdbTests.scala
+++ b/compiler/test/dotty/tools/dotc/semanticdb/SemanticdbTests.scala
@@ -1,9 +1,7 @@
 package dotty.tools.dotc.semanticdb
 
-import scala.language.unsafeNulls
-import java.net.URLClassLoader
 import java.util.regex.Pattern
-import java.io.{ByteArrayOutputStream, File}
+import java.io.ByteArrayOutputStream
 import java.nio.file.*
 import java.nio.charset.StandardCharsets
 import java.util.stream.Collectors

--- a/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
+++ b/compiler/test/dotty/tools/dotc/transform/PatmatExhaustivityTest.scala
@@ -3,8 +3,6 @@ package tools
 package dotc
 package transform
 
-import scala.language.unsafeNulls
-
 import vulpix.FileDiff
 import vulpix.TestConfiguration
 import reporting.TestReporter

--- a/compiler/test/dotty/tools/dotc/transform/SpecializeFunctionsTests.scala
+++ b/compiler/test/dotty/tools/dotc/transform/SpecializeFunctionsTests.scala
@@ -2,8 +2,6 @@ package dotty.tools
 package dotc
 package transform
 
-import scala.language.unsafeNulls
-
 import org.junit.Test
 
 import dotty.DottyBytecodeTest

--- a/compiler/test/dotty/tools/dotc/typer/NamerRecompileTest.scala
+++ b/compiler/test/dotty/tools/dotc/typer/NamerRecompileTest.scala
@@ -1,7 +1,5 @@
 package dotty.tools.dotc.typer
 
-import scala.language.unsafeNulls
-
 import dotty.tools.dotc.Main
 import dotty.tools.dotc.interfaces.Diagnostic.ERROR
 import dotty.tools.dotc.reporting.TestReporter

--- a/compiler/test/dotty/tools/io/AbstractFileTest.scala
+++ b/compiler/test/dotty/tools/io/AbstractFileTest.scala
@@ -1,7 +1,5 @@
 package dotty.tools.io
 
-import scala.language.unsafeNulls
-
 import org.junit.Test
 
 import dotty.tools.io.AbstractFile
@@ -25,7 +23,7 @@ class AbstractFileTest {
       val target = createTempDirectory(temp.jpath, "real", attributes)
       val link   = temp.jpath.resolve("link")
       createSymbolicLink(link, target)     // may bail early if unsupported
-      AbstractFile.getDirectory(link, "")
+      AbstractFile.getDirectory(link, "").nn
     }
 
     val file = base.fileNamed("foo")
@@ -36,7 +34,7 @@ class AbstractFileTest {
     val leaf = dir.fileNamed("basement")
     assert(leaf.exists && !leaf.isDirectory)
 
-    val nested = AbstractFile.getDirectory(createSymbolicLink(dir.jpath.resolve("link"), dir.subdirectoryNamed("nested").jpath), "")
+    val nested = AbstractFile.getDirectory(createSymbolicLink(dir.jpath.nn.resolve("link"), dir.subdirectoryNamed("nested").jpath), "").nn
     val doubly = nested.fileNamed("doubly")
     assert(nested.exists && nested.isDirectory)  // /tmp/link/bar/link
     assert(doubly.exists && !doubly.isDirectory) // /tmp/link/bar/link/doubly

--- a/compiler/test/dotty/tools/io/ClasspathTest.scala
+++ b/compiler/test/dotty/tools/io/ClasspathTest.scala
@@ -1,7 +1,5 @@
 package dotty.tools.io
 
-import scala.language.unsafeNulls
-
 import org.junit.Test
 
 import java.io.File

--- a/compiler/test/dotty/tools/io/ZipArchiveTest.scala
+++ b/compiler/test/dotty/tools/io/ZipArchiveTest.scala
@@ -1,7 +1,5 @@
 package dotty.tools.io
 
-import scala.language.unsafeNulls
-
 import java.io.IOException
 import java.net.{URI, URL, URLClassLoader}
 import java.nio.file.{Files, Path, Paths}

--- a/compiler/test/dotty/tools/utils.scala
+++ b/compiler/test/dotty/tools/utils.scala
@@ -1,8 +1,6 @@
 package dotty
 package tools
 
-import scala.language.unsafeNulls
-
 import java.io.File
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets.UTF_8
@@ -167,7 +165,7 @@ def toolArgsParse(lines: List[String], content: String, filename: Option[String]
   lines.flatMap {
     case toolArg("scalac", _) => sys.error(s"`// scalac: args` not supported. Please use `//> using options args`${filename.fold("")(f => s" in file $f")}")
     case toolArg("javac", _) => sys.error(s"`// javac: args` not supported. Please use `//> using javacOpt args`${filename.fold("")(f => s" in file $f")}")
-    case toolArg(name, args) => List((name, args))
+    case toolArg(name, args) => List((name.nn, args.nn))
     case _ => Nil
   } ++ directiveToolArgs(content, filename)
 

--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -1,7 +1,6 @@
 package dotty.tools.vulpix
 
 import scala.jdk.CollectionConverters.*
-import scala.language.unsafeNulls
 import scala.util.Properties.{javaSpecVersion, versionNumberString}
 
 import java.io.File

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -2,8 +2,6 @@ package dotty
 package tools
 package vulpix
 
-import scala.language.unsafeNulls
-
 import java.io.{File as JFile, PrintStream}
 import java.lang.management.ManagementFactory
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
@@ -16,8 +14,6 @@ import scala.collection.mutable, mutable.ArrayBuffer, mutable.ListBuffer
 import scala.io.{Codec, Source}
 import scala.jdk.CollectionConverters.*
 import scala.util.{Random, Try, Using}
-import scala.util.control.NonFatal
-import scala.util.matching.Regex
 import scala.util.Properties.{isJavaAtLeast, javaSpecVersion}
 
 import dotc.{Compiler, Driver}
@@ -209,8 +205,8 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       def groupFor(file: JFile): Group =
         val groupSuffix = file.getName.dropWhile(_ != '_').stripSuffix(".scala").stripSuffix(".java")
         val groupSuffixParts = groupSuffix.split("_")
-        val ordinal = groupSuffixParts.collectFirst { case GroupOrdinal(n) => n.toInt }.getOrElse(Int.MinValue)
-        val compiler = groupSuffixParts.collectFirst { case CompilerVersion(c) => c }.getOrElse("")
+        val ordinal = groupSuffixParts.collectFirst { case GroupOrdinal(n) => n.nn.toInt }.getOrElse(Int.MinValue)
+        val compiler = groupSuffixParts.collectFirst { case CompilerVersion(c) => c.nn }.getOrElse("")
         Group(ordinal, compiler)
 
       dir.listFiles
@@ -269,7 +265,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
               if testSource.sourceFiles.length == 1 then
                 testSource.sourceFiles(0).getName match
                   case SeparateCompilationSource.HasCompilerVersion(version) =>
-                    val compiler = version.stripSuffix(".")
+                    val compiler = version.nn.stripSuffix(".")
                     compileWithOtherCompiler(compiler, testSource.sourceFiles, flags, outDir)
                   case _ => compile(testSource.sourceFiles, flags, outDir)
               else
@@ -527,7 +523,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       val spec = raw"(\d+)(\+)?".r
       val testIsFiltered = toolArgs.get(ToolName.Test) match
         case Some("-jvm" :: spec(n, more) :: Nil) =>
-          if more == "+" then isJavaAtLeast(n) else javaSpecVersion == n
+          if more == "+" then isJavaAtLeast(n.nn) else javaSpecVersion == n
         case Some(args) => throw new IllegalStateException(args.mkString("unknown test option: ", ", ", ""))
         case None => true
 
@@ -629,9 +625,9 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
             inError = false
           case error @ errorPattern(filePath, line, column) =>
             inError = true
-            val lineNum = line.toInt
-            val columnNum = column.toInt
-            val abstractFile = AbstractFile.getFile(filePath)
+            val lineNum = line.nn.toInt
+            val columnNum = column.nn.toInt
+            val abstractFile = AbstractFile.getFile(filePath.nn).nn
             val sourceFile = SourceFile(abstractFile, Codec.UTF8)
             val offset = sourceFile.lineToOffset(lineNum - 1) + columnNum - 1
             val span = Spans.Span(offset)
@@ -913,7 +909,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       reporterWarnings.foreach(sawDiagnostic)
 
       val splitter = raw"(?:[^:]*):(\d+)".r
-      val unfulfilled = expected.asScala.keys.toList.sortBy { case splitter(n) => n.toInt case _ => -1 }
+      val unfulfilled = expected.asScala.keys.toList.sortBy { case splitter(n) => n.nn.toInt case _ => -1 }
       (unfulfilled, unexpected.toList)
     end getMissingExpectedWarnings
   end WarnTest
@@ -1040,7 +1036,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
           source.getLines().zipWithIndex.foreach: (line, lineNbr) =>
             comment.findAllMatchIn(line).foreach: m =>
               m.group(2) match
-              case prefix if m.group(1).isEmpty =>
+              case prefix if m.group(1).nn.isEmpty =>
                 val what = Option(prefix).getOrElse("")
                 echo(s"Warning: ${file.getCanonicalPath}:${lineNbr}: found `//${what}error` but expected `// ${what}error`, skipping comment")
               case "nopos-" => bump("nopos")

--- a/compiler/test/dotty/tools/vulpix/SummaryReport.scala
+++ b/compiler/test/dotty/tools/vulpix/SummaryReport.scala
@@ -2,8 +2,6 @@ package dotty
 package tools
 package vulpix
 
-import scala.language.unsafeNulls
-import scala.collection.mutable
 import dotc.reporting.TestReporter
 import java.util.concurrent.ConcurrentLinkedDeque
 

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -2,7 +2,6 @@ package dotty
 package tools
 package vulpix
 
-import scala.language.unsafeNulls
 import scala.util.Properties.javaSpecVersion
 
 import java.io.File

--- a/compiler/test/dotty/tools/vulpix/TestFlags.scala
+++ b/compiler/test/dotty/tools/vulpix/TestFlags.scala
@@ -1,7 +1,5 @@
 package dotty.tools.vulpix
 
-import scala.language.unsafeNulls
-
 import java.io.{File => JFile}
 
 final case class TestFlags(


### PR DESCRIPTION
Part of #26492

- Centralizes the "lookup a class file for bytecode unit tests" logic so that "find all refs" of AbstractFile methods doesn't return 100+ results that are all the same, and a future refactor of the AbstractFile API can be much simpler.
- Remove imports of `unsafeNulls` from compiler unit tests

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
