### PR TITLE
Switch some callers of Path to AbstractFile

### DIFF
--- a/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSCodeGen.scala
@@ -325,7 +325,7 @@ class JSCodeGen()(using genCtx: Context) {
 
   private def genIRFile(cunit: CompilationUnit, tree: ir.Trees.ClassDef): Unit = {
     val outfile = getFileFor(cunit, tree.name.name, ".sjsir")
-    val output = new BufferedOutputStream(outfile.output)
+    val output = new BufferedOutputStream(outfile.output())
     try {
       ir.Serializers.serialize(output, tree)
     } finally {

--- a/compiler/src/dotty/tools/debug/ExpressionCompilerBridge.scala
+++ b/compiler/src/dotty/tools/debug/ExpressionCompilerBridge.scala
@@ -4,6 +4,8 @@ import java.nio.file.Path
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.Driver
 
+// IMPORTANT: This is a public class used externally, e.g., scala-debug-adapter instantiates it
+//            and calls `run` via reflection!
 class ExpressionCompilerBridge:
   def run(
       outputDir: Path,

--- a/compiler/src/dotty/tools/debug/InsertExpression.scala
+++ b/compiler/src/dotty/tools/debug/InsertExpression.scala
@@ -7,14 +7,8 @@ import dotty.tools.dotc.core.Names.*
 import dotty.tools.dotc.core.Phases.Phase
 import dotty.tools.dotc.parsing.Parsers
 import dotty.tools.dotc.report
-import dotty.tools.dotc.util.NoSourcePosition
 import dotty.tools.dotc.util.SourceFile
-import dotty.tools.dotc.util.SourcePosition
-import dotty.tools.dotc.util.Spans.Span
 import dotty.tools.dotc.util.SrcPos
-import dotty.tools.io.VirtualFile
-
-import java.nio.charset.StandardCharsets
 
 /**
   * This phase inserts the expression being evaluated at the line of the breakpoint

--- a/compiler/src/dotty/tools/dotc/core/tasty/BestEffortTastyWriter.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/BestEffortTastyWriter.scala
@@ -2,10 +2,9 @@ package dotty.tools.dotc
 package core
 package tasty
 
-import java.nio.file.{Path as JPath, Files as JFiles}
+import java.nio.file.{Files as JFiles, Path as JPath}
 import java.nio.channels.ClosedByInterruptException
-import java.io.DataOutputStream
-import dotty.tools.io.{File, PlainFile}
+import dotty.tools.io.{Path, PlainFile}
 import dotty.tools.dotc.core.Contexts.Context
 
 object BestEffortTastyWriter:
@@ -17,11 +16,11 @@ object BestEffortTastyWriter:
       unit.pickled.foreach { (clz, binary) =>
         val parts = clz.fullName.mangledString.split('.')
         val outPath = outputPath(parts.toList, dir)
-        val outTastyFile = new File(outPath)
-        val outstream = new PlainFile(outTastyFile).output
+        val outTastyFile = PlainFile(Path(outPath))
+        val outstream = outTastyFile.output()
         try outstream.write(binary())
         catch case ex: ClosedByInterruptException =>
-          outTastyFile.delete() // don't leave an empty or half-written tastyfile around after an interrupt
+          JFiles.delete(outPath) // don't leave an empty or half-written tastyfile around after an interrupt
           throw ex
         finally outstream.close()
       }

--- a/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/decompiler/DecompilationPrinter.scala
@@ -4,11 +4,8 @@ package decompiler
 import java.io.{OutputStream, PrintStream}
 import java.nio.charset.StandardCharsets
 
-import scala.io.Codec
-
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Phases.Phase
-import dotty.tools.io.File
 
 import scala.quoted.runtime.impl.QuotesImpl
 
@@ -27,7 +24,7 @@ class DecompilationPrinter extends Phase {
       var os: OutputStream|Null = null
       var ps: PrintStream|Null = null
       try {
-        os = File(outputDir.fileNamed("decompiled.scala").path)(using Codec.UTF8).outputStream(append = true)
+        os = outputDir.fileNamed("decompiled.scala").output(append = true)
         ps = new PrintStream(os, /* autoFlush = */ false, StandardCharsets.UTF_8.name)
         printToOutput(ps)
       }

--- a/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
+++ b/compiler/src/dotty/tools/dotc/rewrites/Rewrites.scala
@@ -73,7 +73,7 @@ object Rewrites {
 
     def writeBack(): Unit =
       val chars = apply(source.content)
-      val osw = OutputStreamWriter(source.file.output, UTF_8)
+      val osw = OutputStreamWriter(source.file.output(), UTF_8)
       try osw.write(chars, 0, chars.length)
       finally osw.close()
   }

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -20,13 +20,15 @@ import transform.ValueClasses
 import transform.Pickler
 import dotty.tools.io.{File, FileExtension}
 import util.{Property, SourceFile}
-import java.io.PrintWriter
 
+import java.io.PrintWriter
 import ExtractAPI.NonLocalClassSymbolsInCurrentUnits
 
 import scala.collection.mutable
 import scala.util.hashing.MurmurHash3
 import dotty.tools.dotc.util.chaining.*
+
+import java.nio.charset.StandardCharsets
 
 /** This phase sends a representation of the API of classes to sbt via callbacks.
  *
@@ -134,13 +136,10 @@ class ExtractAPI extends Phase {
 
     if (ctx.settings.YdumpSbtInc.value) {
       // Append to existing file that should have been created by ExtractDependencies
-      val sourceFileJPath = sourceFile.file.jpath
-      assert(sourceFileJPath != null, s"unexpected null jpath for $sourceFile")
-      val pw = new PrintWriter(File(sourceFileJPath).changeExtension(FileExtension.Inc).toFile
-        .bufferedWriter(append = true), true)
-      try {
-        classes.foreach(source => pw.println(DefaultShowAPI(source)))
-      } finally pw.close()
+      val container = sourceFile.file.container.getOrElse(throw new AssertionError(s"unexpected lack of parent for $sourceFile"))
+      val pw = new PrintWriter(container.fileNamed(sourceFile.file.nameWithoutExtension + FileExtension.Inc.withDot).output(append = true), true, StandardCharsets.UTF_8)
+      try classes.foreach(source => pw.println(DefaultShowAPI(source)))
+      finally pw.close()
     }
 
     ctx.withIncCallback: cb =>

--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -3,7 +3,6 @@ package transform
 
 
 import java.util.Arrays
-
 import dotty.tools.io
 import ast.tpd
 import ast.Trees.*
@@ -19,10 +18,12 @@ import DenotTransformers.IdentityDenotTransformer
 import MacroAnnotations.hasMacroAnnotation
 import inlines.Inlines
 import quoted.*
-import sbt.{ AbstractExtractDependenciesCollector, DependencyRecorder }
+import sbt.{AbstractExtractDependenciesCollector, DependencyRecorder}
 import staging.StagingLevel
 import util.Property
 
+import java.io.PrintWriter
+import java.nio.charset.StandardCharsets
 import scala.collection.mutable
 import scala.io.Codec
 
@@ -60,7 +61,9 @@ class Inlining extends MacroTransform, IdentityDenotTransformer {
 
       unit.source.file.jpath match
         case jpath: io.JPath =>
-          val pw = io.File(jpath)(using Codec.UTF8).changeExtension(io.FileExtension.Inc).toFile.printWriter()
+          val file = io.AbstractFile.getFile(jpath).nn
+          val container = file.container.getOrElse(throw new AssertionError(s"Unexpected lack of parent for $jpath"))
+          val pw = new PrintWriter(container.fileNamed(file.nameWithoutExtension + io.FileExtension.Inc.withDot).output(), true, StandardCharsets.UTF_8)
           // val pw = Console.out
           try
             pw.println("Used Names:")

--- a/compiler/src/dotty/tools/io/AbstractFile.scala
+++ b/compiler/src/dotty/tools/io/AbstractFile.scala
@@ -68,6 +68,13 @@ abstract class AbstractFile extends dotty.tools.dotc.interfaces.AbstractFile {
   /** Returns the name of this abstract file. */
   def name: String
 
+  /** strip anything after and including trailing the extension */
+  def nameWithoutExtension: String = {
+    val i = name.lastIndexOf('.')
+    if (i < 0) name
+    else name.substring(0, i)
+  }
+
   /** Returns the path of this abstract file. */
   def path: String
 
@@ -114,7 +121,7 @@ abstract class AbstractFile extends dotty.tools.dotc.interfaces.AbstractFile {
   def input: InputStream
 
   /** Returns an output stream for writing the file */
-  def output: OutputStream
+  def output(append: Boolean = false): OutputStream
 
   /** size of this file if available. */
   def sizeOption: Option[Int] = None
@@ -179,7 +186,7 @@ abstract class AbstractFile extends dotty.tools.dotc.interfaces.AbstractFile {
     container.map(_.lookupName(name, directory = false)).orNull
 
   final def resolveSiblingWithExtension(extension: FileExtension): AbstractFile | Null =
-    resolveSibling(Path.fileName(name) + "." + extension)
+    resolveSibling(nameWithoutExtension + "." + extension)
 
   private def fileOrSubdirectoryNamed(name: String, isDir: Boolean): AbstractFile =
     lookupName(name, isDir) match {

--- a/compiler/src/dotty/tools/io/Directory.scala
+++ b/compiler/src/dotty/tools/io/Directory.scala
@@ -15,12 +15,6 @@ import java.nio.file.{Files, Paths}
  * ''Note:  This library is considered experimental and should not be used unless you know what you are doing.''
  */
 object Directory {
-  def inTempDirectory[T](fn: Directory => T): T = {
-    val temp = Directory(Files.createTempDirectory("temp"))
-    try fn(temp)
-    finally temp.deleteRecursively()
-  }
-
   def apply(path: String): Directory = apply(Paths.get(path))
   def apply(path: JPath): Directory = new Directory(path)
 }

--- a/compiler/src/dotty/tools/io/File.scala
+++ b/compiler/src/dotty/tools/io/File.scala
@@ -48,30 +48,7 @@ class File(jpath: JPath)(implicit constructorCodec: Codec) extends Path(jpath) {
   def inputStream(): InputStream = Files.newInputStream(jpath)
 
   /** Obtains a OutputStream. */
-  def outputStream(append: Boolean = false): OutputStream =
+  private[io] def outputStream(append: Boolean = false): OutputStream =
     if (append) Files.newOutputStream(jpath, CREATE, APPEND)
     else Files.newOutputStream(jpath, CREATE, TRUNCATE_EXISTING)
-
-  /** Obtains an OutputStreamWriter wrapped around a FileOutputStream.
-   *  This should behave like a less broken version of java.io.FileWriter,
-   *  in that unlike the java version you can specify the encoding.
-   */
-  private def writer(append: Boolean, codec: Codec): OutputStreamWriter =
-    new OutputStreamWriter(outputStream(append), codec.charSet)
-
-  /** Wraps a BufferedWriter around the result of writer().
-   */
-  def bufferedWriter(): BufferedWriter = bufferedWriter(append = false)
-  def bufferedWriter(append: Boolean): BufferedWriter = bufferedWriter(append, constructorCodec)
-  def bufferedWriter(append: Boolean, codec: Codec): BufferedWriter =
-    new BufferedWriter(writer(append, codec))
-
-  def printWriter(): PrintWriter = new PrintWriter(bufferedWriter(), true)
-
-  /** Creates a new file and writes all the Strings to it. */
-  def writeAll(strings: String*): Unit = {
-    val out = bufferedWriter()
-    try strings.foreach(out.write(_))
-    finally out.close()
-  }
 }

--- a/compiler/src/dotty/tools/io/FileWriters.scala
+++ b/compiler/src/dotty/tools/io/FileWriters.scala
@@ -287,7 +287,7 @@ object FileWriters {
     }
 
     private def writeBytes(outFile: AbstractFile, bytes: Array[Byte]): Unit = {
-      val out = outFile.output
+      val out = outFile.output()
       try out.write(bytes, 0, bytes.length)
       finally out.close()
     }

--- a/compiler/src/dotty/tools/io/NoAbstractFile.scala
+++ b/compiler/src/dotty/tools/io/NoAbstractFile.scala
@@ -22,7 +22,7 @@ object NoAbstractFile extends AbstractFile {
   override def lastModified: Long = 0L
   override def lookupName(name: String, directory: Boolean): AbstractFile | Null = null
   override def name: String = ""
-  override def output: java.io.OutputStream = throw UnsupportedOperationException("NoAbstractFile.output")
+  override def output(append: Boolean = false): java.io.OutputStream = throw UnsupportedOperationException("NoAbstractFile.output")
   override def path: String = ""
   override def toURL: Option[URL] = None
   override def toString(): String = "<no file>"

--- a/compiler/src/dotty/tools/io/Path.scala
+++ b/compiler/src/dotty/tools/io/Path.scala
@@ -34,13 +34,6 @@ object Path {
     else FileExtension.from(name.substring(i + 1))
   }
 
-  /** strip anything after and including trailing the extension */
-  def fileName(name: String): String = {
-    val i = name.lastIndexOf('.')
-    if (i < 0) name
-    else name.substring(0, i)
-  }
-
   def apply(path: String): Path = apply(new java.io.File(path).toPath)
   def apply(jpath: JPath): Path = try {
     if (Files.isRegularFile(jpath)) new File(jpath)
@@ -137,22 +130,6 @@ class Path private[io] (val jpath: JPath) {
   }
 
   def ext: FileExtension = Path.fileExtension(name)
-
-  // returns the Path with the extension.
-  def addExtension(ext: String): Path = new Path(jpath.resolveSibling(name + ext))
-
-  // changes the existing extension out for a new one, or adds it
-  // if the current path has none.
-  def changeExtension(ext: FileExtension): Path =
-    changeExtension(ext.toLowerCase)
-
-  // changes the existing extension out for a new one, or adds it
-  // if the current path has none.
-  def changeExtension(ext: String): Path =
-    val name0 = name
-    val dropExtension = Path.fileName(name0)
-    if dropExtension eq name0 then addExtension(ext)
-    else new Path(jpath.resolveSibling(dropExtension + "." + ext))
 
   // Boolean tests
   def exists: Boolean = try Files.exists(jpath)  catch { case ex: SecurityException => false }

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -32,7 +32,7 @@ class PlainFile(givenPath: Path) extends AbstractFile {
 
   override def container: Option[AbstractFile] = Some(new PlainFile(givenPath.parent))
   override def input: InputStream = givenPath.toFile.inputStream()
-  override def output: OutputStream = givenPath.toFile.outputStream()
+  override def output(append: Boolean = false): OutputStream = givenPath.toFile.outputStream(append)
   override def sizeOption: Option[Int] = Some(givenPath.length.toInt)
   override def toURL: Option[URL] = Some(jpath.toUri.toURL)
 

--- a/compiler/src/dotty/tools/io/VirtualDirectory.scala
+++ b/compiler/src/dotty/tools/io/VirtualDirectory.scala
@@ -29,7 +29,7 @@ class VirtualDirectory private[io] (val name: String, maybeContainer: Option[Vir
   override def jpath: JPath | Null = null
   override def toURL: Option[URL] = None
   override def input: InputStream = sys.error("directories cannot be read")
-  override def output: OutputStream = sys.error("directories cannot be written")
+  override def output(append: Boolean = false): OutputStream = sys.error("directories cannot be written")
 
   private val files = mutable.Map.empty[String, AbstractFile]
 

--- a/compiler/src/dotty/tools/io/VirtualFile.scala
+++ b/compiler/src/dotty/tools/io/VirtualFile.scala
@@ -40,11 +40,12 @@ class VirtualFile(override val path: String, initialContents: Array[Byte]) exten
 
   override def input: InputStream = new ByteArrayInputStream(content)
 
-  override def output: OutputStream =
+  override def output(append: Boolean = false): OutputStream =
     new ByteArrayOutputStream() {
       override def close(): Unit = {
         super.close()
-        content = toByteArray()
+        val written = toByteArray
+        content = if append then content ++ written else written
       }
     }
 

--- a/compiler/src/dotty/tools/io/ZipArchive.scala
+++ b/compiler/src/dotty/tools/io/ZipArchive.scala
@@ -46,7 +46,7 @@ private[io] abstract class ZipArchive(override val jpath: JPath) extends Abstrac
   self =>
 
   override def isDirectory: Boolean = true
-  override def output: OutputStream    = unsupported()
+  override def output(append: Boolean = false): OutputStream    = unsupported()
   override def toURL: Option[URL] = Some(jpath.toUri.toURL)
 
   /** ''Note:  This library is considered experimental and should not be used unless you know what you are doing.'' */

--- a/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/tasty/CommentPicklingTest.scala
@@ -9,13 +9,14 @@ import dotty.tools.dotc.core.Decorators.{toTermName, toTypeName}
 import dotty.tools.dotc.core.Names.Name
 import dotty.tools.dotc.interfaces.Diagnostic.ERROR
 import dotty.tools.dotc.reporting.TestReporter
+import dotty.tools.inTempDirectory
 import dotty.tools.io.{Directory, File, Path}
-
 import dotty.tools.vulpix.TestConfiguration
-
 import org.junit.Test
 import org.junit.Assert.{assertEquals, assertFalse, fail}
 import dotty.tools.io.AbstractFile
+
+import java.nio.charset.StandardCharsets
 
 class CommentPicklingTest {
 
@@ -79,25 +80,26 @@ class CommentPicklingTest {
   }
 
   private def compileAndUnpickle[T](sources: List[String])(fn: (List[tpd.Tree], Context) => T) = {
-    Directory.inTempDirectory { tmp =>
+    inTempDirectory { tmp =>
       val sourceFiles = sources.zipWithIndex.map {
         case (src, id) =>
-          val path = tmp./(File(s"Src$id.scala")).toAbsolute
-          path.writeAll(src)
-          path.toString
+          val file = tmp.fileNamed(s"Src$id.scala")
+          val output = file.output()
+          try output.write(src.getBytes(StandardCharsets.UTF_8))
+          finally output.close()
+          file.path
       }
 
-      val out = tmp./("out")
-      out.createDirectory()
+      val out = tmp.subdirectoryNamed("out")
 
-      val options = compileOptions.and("-d", out.toAbsolute.toString).and(sourceFiles*)
+      val options = compileOptions.and("-d", out.path).and(sourceFiles*)
       val reporter = TestReporter.reporter(System.out, logLevel = ERROR)
       Main.process(options.all, reporter)
       assertFalse("Compilation failed.", reporter.hasErrors)
 
-      val tastyFiles = out.walkFilter(f => f.isFile && f.ext.isTasty).map(_.toFile).toList
+      val tastyFiles = out.iterator.toList.filter(_.ext.isTasty)
       val unpicklingOptions = unpickleOptions
-        .withClasspath(out.toAbsolute.toString)
+        .withClasspath(out.path)
         .and("dummy") // Need to pass a dummy source file name
       val unpicklingDriver = new UnpicklingDriver
       unpicklingDriver.unpickle(unpicklingOptions.all, tastyFiles)(fn)
@@ -110,11 +112,11 @@ class CommentPicklingTest {
       ctx.setSetting(ctx.settings.XreadComments, true)
       ctx
 
-    def unpickle[T](args: Array[String], files: List[File])(fn: (List[tpd.Tree], Context) => T): T = {
+    def unpickle[T](args: Array[String], files: List[AbstractFile])(fn: (List[tpd.Tree], Context) => T): T = {
       implicit val ctx: Context = setup(args, initCtx).map(_._2).getOrElse(initCtx)
       ctx.initialize()
       val trees = files.flatMap { f =>
-        val unpickler = new DottyUnpickler(AbstractFile.getFile(f.jpath).nn, isBestEffortTasty = false)
+        val unpickler = new DottyUnpickler(f, isBestEffortTasty = false)
         unpickler.enter(roots = Set.empty)
         unpickler.rootTrees(using ctx)
       }

--- a/compiler/test/dotty/tools/dotc/typer/NamerRecompileTest.scala
+++ b/compiler/test/dotty/tools/dotc/typer/NamerRecompileTest.scala
@@ -3,11 +3,13 @@ package dotty.tools.dotc.typer
 import dotty.tools.dotc.Main
 import dotty.tools.dotc.interfaces.Diagnostic.ERROR
 import dotty.tools.dotc.reporting.TestReporter
+import dotty.tools.inTempDirectory
 import dotty.tools.io.{Directory, File}
 import dotty.tools.vulpix.TestConfiguration
-
 import org.junit.Test
 import org.junit.Assert.{assertFalse, assertTrue}
+
+import java.nio.charset.StandardCharsets
 
 /** Regression test for https://github.com/scala/scala3/issues/23043
   *
@@ -33,21 +35,22 @@ import org.junit.Assert.{assertFalse, assertTrue}
 class NamerRecompileTest:
 
   @Test def spuriousPackageDirectoryDoesNotConflictWithObject(): Unit =
-    Directory.inTempDirectory { tmp =>
-      val srcFile = tmp./(File("Test.scala")).toAbsolute
-      srcFile.writeAll(
-        """package testpkg
-          |
-          |object Scope:
-          |  enum MyEnum:
-          |    case A
-          |    case B(x: Int)
-          |""".stripMargin
-      )
+    inTempDirectory { tmp =>
+      val srcFile = tmp.fileNamed("Test.scala")
+      val srcOut = srcFile.output()
+      try srcOut.write(
+            """package testpkg
+              |
+              |object Scope:
+              |  enum MyEnum:
+              |    case A
+              |    case B(x: Int)
+              |""".stripMargin.getBytes(StandardCharsets.UTF_8)
+          )
+      finally srcOut.close()
 
-      val out = tmp./("out")
-      out.createDirectory()
-      val outPath = out.toAbsolute.toString
+      val out = tmp.subdirectoryNamed("out")
+      val outPath = out.path
 
       val baseOptions = TestConfiguration.defaultOptions
         .and("-d", outPath)
@@ -64,10 +67,11 @@ class NamerRecompileTest:
       //   val dir   = parts.init.foldLeft(out)(_.subdirectoryNamed(_))
       //   dir.fileNamed(parts.last + ".sir")
       // will create  testpkg/Scope/  which the classpath scanner sees as a package.
-      val pluginDir = out./("testpkg")./("Scope")
-      pluginDir.createDirectory()
-      val pluginFile = pluginDir./(File("MyEnum.sir")).toAbsolute
-      pluginFile.writeAll("plugin data")
+      val pluginDir = out.subdirectoryNamed("testpkg").subdirectoryNamed("Scope")
+      val pluginFile = pluginDir.fileNamed("MyEnum.sir")
+      val pluginFileOut = pluginFile.output()
+      try pluginFileOut.write("plugin data".getBytes(StandardCharsets.UTF_8))
+      finally pluginFileOut.close()
       assertTrue("Plugin directory should exist", pluginDir.isDirectory)
 
       // Second compilation with output on classpath (as sbt does):

--- a/compiler/test/dotty/tools/io/AbstractFileTest.scala
+++ b/compiler/test/dotty/tools/io/AbstractFileTest.scala
@@ -1,8 +1,10 @@
 package dotty.tools.io
 
-import org.junit.Test
+import dotty.tools.inTempDirectory
 
+import org.junit.Test
 import dotty.tools.io.AbstractFile
+
 import java.nio.file.Files.*
 import java.nio.file.attribute.PosixFilePermissions
 
@@ -14,14 +16,14 @@ class AbstractFileTest {
   // but d.fileNamed and d.subdirectoryNamed also Files.createDirectories
   // for prefixes, which may optionally fail on an existing symbolic link.
   //
-  private def exerciseSymbolicLinks(temp: Directory): Unit = {
+  private def exerciseSymbolicLinks(temp: AbstractFile): Unit = {
     val base = {
       val permissions = PosixFilePermissions.fromString("rwxrwxrwx")
       val attributes = PosixFilePermissions.asFileAttribute(permissions)
       // Specifying the 'attributes' parameter on Windows prevents a
       // FileSystemException "A required privilege is not held by the client".
       val target = createTempDirectory(temp.jpath, "real", attributes)
-      val link   = temp.jpath.resolve("link")
+      val link   = temp.jpath.nn.resolve("link")
       createSymbolicLink(link, target)     // may bail early if unsupported
       AbstractFile.getDirectory(link, "").nn
     }
@@ -41,7 +43,7 @@ class AbstractFileTest {
     assert(dir.subdirectoryNamed("link").exists)
   }
   @Test def t6450(): Unit =
-    try Directory.inTempDirectory(exerciseSymbolicLinks)
+    try inTempDirectory(exerciseSymbolicLinks)
     catch { case _: UnsupportedOperationException => () }
 }
 

--- a/compiler/test/dotty/tools/utils.scala
+++ b/compiler/test/dotty/tools/utils.scala
@@ -15,6 +15,7 @@ import scala.util.control.{ControlThrowable, NonFatal}
 
 import dotc.config.CommandLineParser
 import dotty.tools.directives.{DirectiveValue, UsingDirectivesParser}
+import dotty.tools.io.AbstractFile
 
 object Dummy
 
@@ -30,6 +31,13 @@ def scriptsDir(path: String): File = {
   val dir = new File(Dummy.getClass.getResource(path).getPath)
   assert(dir.exists && dir.isDirectory, "Couldn't load scripts dir")
   dir
+}
+
+def inTempDirectory[T](fn: AbstractFile => T): T = {
+  val underlying = Files.createTempDirectory("temp")
+  val temp = AbstractFile.getDirectory(underlying, "").nn
+  try fn(temp)
+  finally dotty.tools.io.Path(underlying).deleteRecursively()
 }
 
 extension (f: File) def absPath: String =

--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -67,8 +67,10 @@ object FileDiff {
   }
 
   def dump(path: String, content: Seq[String]): Unit = {
-    val outFile = dotty.tools.io.File(path)
-    outFile.writeAll(content.mkString("", EOL, EOL))
+    val outFile = dotty.tools.io.AbstractFile.getFile(path).nn
+    val output = outFile.output()
+    try output.write(content.mkString("", EOL, EOL).getBytes(StandardCharsets.UTF_8))
+    finally output.close()
   }
 
   def checkAndDumpOrUpdate(sourceTitle: String, actualLines: Seq[String], checkFilePath: String): Boolean = {

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -1620,7 +1620,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
   def compileTastyInDir(f: String, flags0: TestFlags, fromTastyFilter: FileFilter)(implicit testGroup: TestGroup): TastyCompilationTest = {
     val outDir = new JFile(defaultOutputDir, testGroup.name)
     val flags = flags0 `and` "-Yretain-trees"
-    val sourceDir = new JFile(f)
+    val sourceDir = TestSources.getPath(f).toFile
     checkRequirements(f, sourceDir, outDir)
 
     val (dirs, files) = compilationTargets(sourceDir, fromTastyFilter)
@@ -1773,7 +1773,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
     val bestEffortFlag = "-Ybest-effort"
     val semanticDbFlag = "-Xsemanticdb"
     val withBetastyFlag = "-Ywith-best-effort-tasty"
-    val sourceDir = new JFile(f)
+    val sourceDir = TestSources.getPath(f).toFile
     val dirs = sourceDir.listFiles.toList
     assert(dirs.forall(_.isDirectory), s"All files in $f have to be directories.")
 
@@ -1871,7 +1871,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
    */
   def compileShallowFilesInDir(f: String, flags: TestFlags)(implicit testGroup: TestGroup): CompilationTest = {
     val outDir = new JFile(defaultOutputDir, testGroup.name)
-    val sourceDir = new JFile(f)
+    val sourceDir = TestSources.getPath(f).toFile
     checkRequirements(f, sourceDir, outDir)
 
     val (_, files) = compilationTargets(sourceDir)

--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -21,7 +21,6 @@ import dotty.tools.dotc.interactive.InteractiveDriver
 import dotty.tools.dotc.util.SourceFile
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.io.FileExtension
-import dotty.tools.io.ZipArchive
 import dotty.tools.pc.utils.InteractiveEnrichments.*
 
 import org.eclipse.lsp4j.Location
@@ -156,14 +155,14 @@ class PcDefinitionProvider(
       else
         val file = symbol.associatedFile
         if file != null then
-          file match
-            case entry: ZipArchive#Entry =>
+          file.enclosing match
+            case Some(underlyingSource) =>
               val classFile =
                 if file.ext.isTasty then file.resolveSiblingWithExtension(FileExtension.Class)
                 else file
               if classFile != null then
                 List(new Location(
-                  s"jar:${entry.underlyingSource.jpath.toUri}!/${classFile.path}",
+                  s"jar:${underlyingSource.jpath.toUri}!/${classFile.path}",
                   new Range(new Position(0, 0), new Position(0, 0))
                 ))
               else Nil

--- a/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/PcDefinitionProvider.scala
@@ -162,7 +162,7 @@ class PcDefinitionProvider(
                 else file
               if classFile != null then
                 List(new Location(
-                  s"jar:${underlyingSource.jpath.toUri}!/${classFile.path}",
+                  s"jar:${underlyingSource.jpath.nn.toUri}!/${classFile.path}",
                   new Range(new Position(0, 0), new Position(0, 0))
                 ))
               else Nil

--- a/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
+++ b/repl/test/dotty/tools/repl/AbstractFileClassLoaderTest.scala
@@ -19,7 +19,7 @@ class AbstractFileClassLoaderTest:
 
   def closing[T <: Closeable, U](stream: T)(f: T => U): U = try f(stream) finally stream.close()
 
-  extension (f: AbstractFile) def writeContent(s: String): Unit = closing(new BufferedOutputStream(f.output))(_.write(s.getBytes(UTF8.charSet)))
+  extension (f: AbstractFile) def writeContent(s: String): Unit = closing(new BufferedOutputStream(f.output()))(_.write(s.getBytes(UTF8.charSet)))
   def slurp(inputStream: => InputStream)(implicit codec: Codec): String = closing(Source.fromInputStream(inputStream)(using codec))(_.mkString)
   def slurp(url: URL)(implicit codec: Codec): String = slurp(url.openStream())
 


### PR DESCRIPTION
Part of #26492

We have two abstractions right now, this moves some callers of the less powerful one to the more powerful one.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
