### PR TITLE
feat: add :save command to the REPL

### DIFF
--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -10,6 +10,8 @@ import dotc.parsing.Tokens
 import dotc.reporting.{Diagnostic, StoreReporter}
 import dotc.util.SourceFile
 
+import java.util.regex.Pattern
+
 import scala.annotation.internal.sharable
 
 /** A parsing result from string input */
@@ -47,6 +49,34 @@ object Dep {
 }
 /** An ambiguous prefix that matches multiple commands */
 case class AmbiguousCommand(cmd: String, matchingCommands: List[String]) extends Command
+
+case class Save(path: String) extends Command
+
+object Save {
+  val command: String = ":save"
+
+  /** `:load` treats a file as a session only when it starts with this header.
+   * any other file is a plain source loaded as one compilation unit.
+   */
+  val sessionHeader: String = "/* Scala REPL session */"
+
+  /** Written before each saved entry so that `:load` can replay every entry as
+   *  a single compilation unit.
+   */
+  val entrySeparator: String = "/* ---- entry ---- */"
+
+  private val separatorLikeLine = Pattern.quote(entrySeparator)
+
+  def escapeEntry(entry: String): String =
+    entry.linesIterator
+      .map(line => if line.matches("""\\*""" + separatorLikeLine) then "\\" + line else line)
+      .mkString("\n")
+
+  def unescapeEntry(entry: String): String =
+    entry.linesIterator
+      .map(line => if line.matches("""\\+""" + separatorLikeLine) then line.stripPrefix("\\") else line)
+      .mkString("\n")
+}
 
 /** `:load <path>` interprets a scala file as if entered line-by-line into
  *  the REPL
@@ -141,6 +171,7 @@ case object Help extends Command {
     """The REPL has several commands available:
       |
       |:help                    print this summary
+      |:save <path>             save replayable session to a file
       |:load <path>             interpret lines in a file
       |:quit                    exit the interpreter
       |:type <expression>       evaluate the type of the given expression
@@ -174,6 +205,7 @@ object ParseResult {
     Imports.command -> (_  => Imports),
     JarCmd.command -> (arg => JarCmd(arg)),
     KindOf.command -> (arg => KindOf(arg)),
+    Save.command -> (arg => Save(arg)),
     Load.command -> (arg => Load(arg)),
     Require.command -> (arg => Require(arg)),
     Dep.command -> (arg => Dep(arg)),
@@ -215,6 +247,11 @@ object ParseResult {
   def apply(sourceCode: String)(using state: State): ParseResult =
     apply(SourceFile.virtual(str.REPL_SESSION_LINE + (state.objectIndex + 1), sourceCode))
 
+  def isCommand(line: String): Boolean =
+    line match
+      case CommandExtract(_, _) => true
+      case _ => false
+
   /** Check if the input is incomplete.
    *
    *  This can be used in order to check if a newline can be inserted without
@@ -222,7 +259,7 @@ object ParseResult {
    */
   def isIncomplete(sourceCode: String)(using Context): Boolean =
     sourceCode match {
-      case CommandExtract(_) | "" => false
+      case CommandExtract(_, _) | "" => false
       case _ => {
         val reporter = newStoreReporter
         val source   = SourceFile.virtual("<incomplete-handler>", sourceCode)

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -53,7 +53,7 @@ case class AmbiguousCommand(cmd: String, matchingCommands: List[String]) extends
   override def replayLine = None
 
 case class Save(path: String) extends Command:
-  override def replayLine = Some(s"${Save.command} $path")
+  override def replayLine = None
 
 object Save {
   val command: String = ":save"
@@ -162,7 +162,7 @@ case object Silent extends Command:
 
 /** `:quit` exits the repl */
 case object Quit extends Command {
-  override def replayLine = Some(command)
+  override def replayLine = None
   val command: String = ":quit"
   val alias: String = ":exit"
 }

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -38,19 +38,24 @@ case object SigKill extends ParseResult
  *  ```
  *  The `Command` trait denotes these commands
  */
-sealed trait Command extends ParseResult
+sealed trait Command extends ParseResult:
+  def replayLine: Option[String]
 
 /** An unknown command that will not be handled by the REPL */
-case class UnknownCommand(cmd: String) extends Command
+case class UnknownCommand(cmd: String) extends Command:
+  override def replayLine = None
 
-case class Dep(dep: String) extends Command
+case class Dep(dep: String) extends Command:
+  override def replayLine = Some(s"${Dep.command} $dep")
 object Dep {
   val command: String = ":dep"
 }
 /** An ambiguous prefix that matches multiple commands */
-case class AmbiguousCommand(cmd: String, matchingCommands: List[String]) extends Command
+case class AmbiguousCommand(cmd: String, matchingCommands: List[String]) extends Command:
+  override def replayLine = None
 
-case class Save(path: String) extends Command
+case class Save(path: String) extends Command:
+  override def replayLine = Some(s"${Save.command} $path")
 
 object Save {
   val command: String = ":save"
@@ -81,28 +86,32 @@ object Save {
 /** `:load <path>` interprets a scala file as if entered line-by-line into
  *  the REPL
  */
-case class Load(path: String) extends Command
+case class Load(path: String) extends Command:
+  override def replayLine = Some(s"${Load.command} $path")
 object Load {
   val command: String = ":load"
 }
 
 /** `:require` is a deprecated alias for :jar`
  */
-case class Require(path: String) extends Command
+case class Require(path: String) extends Command:
+  override def replayLine = Some(s"${Require.command} $path")
 object Require {
   val command: String = ":require"
 }
 
 /** `:jar <path>` adds a jar to the classpath
  */
-case class JarCmd(path: String) extends Command
+case class JarCmd(path: String) extends Command:
+  override def replayLine = Some(s"${JarCmd.command} $path")
 object JarCmd {
   val command: String = ":jar"
 }
 
 /** `:kind <type>` display the kind of a type. see also :help kind
  */
-case class KindOf(expr: String) extends Command
+case class KindOf(expr: String) extends Command:
+  override def replayLine = Some(s"${KindOf.command} $expr")
 object KindOf {
   val command: String = ":kind"
 }
@@ -114,7 +123,8 @@ object KindOf {
  * String
  * ```
  */
-case class TypeOf(expr: String) extends Command
+case class TypeOf(expr: String) extends Command:
+  override def replayLine = Some(s"${TypeOf.command} $expr")
 object TypeOf {
   val command: String = ":type"
 }
@@ -123,7 +133,8 @@ object TypeOf {
  * A command that is used to display the documentation associated with
  * the given expression.
  */
-case class DocOf(expr: String) extends Command
+case class DocOf(expr: String) extends Command:
+  override def replayLine = Some(s"${DocOf.command} $expr")
 object DocOf {
   val command: String = ":doc"
 }
@@ -132,10 +143,12 @@ object DocOf {
  *  session
  */
 case object Imports extends Command {
+  override def replayLine = Some(command)
   val command: String = ":imports"
 }
 
-case class Settings(arg: String) extends Command
+case class Settings(arg: String) extends Command:
+  override def replayLine = Some(s"${Settings.command} $arg")
 object Settings {
   val command: String = ":settings"
 }
@@ -143,29 +156,34 @@ object Settings {
 /** Reset the session to the initial state from when the repl program was
  *  started
  */
-case class Reset(arg: String) extends Command
+case class Reset(arg: String) extends Command:
+  override def replayLine = Some(s"${Reset.command} $arg")
 object Reset {
   val command: String = ":reset"
 }
 
 /** `:sh <command line>` run a shell command (result is implicitly => List[String]) */
-case class Sh(expr: String) extends Command
+case class Sh(expr: String) extends Command:
+  override def replayLine = Some(s"${Sh.command} $expr")
 object Sh {
   val command: String = ":sh"
 }
 
 /** Toggle automatic printing of results */
 case object Silent extends Command:
+  override def replayLine = Some(command)
   val command: String = ":silent"
 
 /** `:quit` exits the repl */
 case object Quit extends Command {
+  override def replayLine = Some(command)
   val command: String = ":quit"
   val alias: String = ":exit"
 }
 
 /** `:help` shows the different commands implemented by the Dotty repl */
 case object Help extends Command {
+  override def replayLine = Some(command)
   val command: String = ":help"
   val text: String =
     """The REPL has several commands available:

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -10,8 +10,6 @@ import dotc.parsing.Tokens
 import dotc.reporting.{Diagnostic, StoreReporter}
 import dotc.util.SourceFile
 
-import java.util.regex.Pattern
-
 import scala.annotation.internal.sharable
 
 /** A parsing result from string input */
@@ -69,18 +67,6 @@ object Save {
    *  a single compilation unit.
    */
   val entrySeparator: String = "/* ---- entry ---- */"
-
-  private val separatorLikeLine = Pattern.quote(entrySeparator)
-
-  def escapeEntry(entry: String): String =
-    entry.linesIterator
-      .map(line => if line.matches("""\\*""" + separatorLikeLine) then "\\" + line else line)
-      .mkString("\n")
-
-  def unescapeEntry(entry: String): String =
-    entry.linesIterator
-      .map(line => if line.matches("""\\+""" + separatorLikeLine) then line.stripPrefix("\\") else line)
-      .mkString("\n")
 }
 
 /** `:load <path>` interprets a scala file as if entered line-by-line into

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -82,7 +82,7 @@ case class State(objectIndex: Int,
                  pastInputs: List[String] = Nil):
   def validObjectIndexes = (1 to objectIndex).filterNot(invalidObjectIndexes.contains(_))
 
-  def recordInput(input: String): State = copy(pastInputs = pastInputs :+ input)
+  def recordInput(input: String): State = copy(pastInputs = input :: pastInputs)
 
 /** Main REPL instance, orchestrating input, compilation and presentation */
 class ReplDriver(settings: Array[String],
@@ -610,7 +610,7 @@ class ReplDriver(settings: Array[String],
         out.println("Nothing to save.")
       else
         try
-          val body = state.pastInputs.map(entry => s"${Save.entrySeparator}\n${Save.escapeEntry(entry)}").mkString("\n")
+          val body = state.pastInputs.reverse.map(entry => s"${Save.entrySeparator}\n${Save.escapeEntry(entry)}").mkString("\n")
           val content = s"${Save.sessionHeader}\n$body"
           Files.writeString(new JFile(path).toPath, content, StandardCharsets.UTF_8)
         catch case NonFatal(e) =>

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -6,6 +6,8 @@ import scala.util.control.NonFatal
 
 import java.io.{File => JFile, PrintStream}
 import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.regex.Pattern
 
 import dotc.ast.Trees.*
 import dotc.ast.{tpd, untpd}
@@ -76,8 +78,11 @@ case class State(objectIndex: Int,
                  imports: Map[Int, List[tpd.Import]],
                  invalidObjectIndexes: Set[Int],
                  quiet: Boolean,
-                 context: Context):
+                 context: Context,
+                 pastInputs: List[String] = Nil):
   def validObjectIndexes = (1 to objectIndex).filterNot(invalidObjectIndexes.contains(_))
+
+  def recordInput(input: String): State = copy(pastInputs = pastInputs :+ input)
 
 /** Main REPL instance, orchestrating input, compilation and presentation */
 class ReplDriver(settings: Array[String],
@@ -139,7 +144,7 @@ class ReplDriver(settings: Array[String],
     val combinedScript = initScript.trim() match
       case "" => extraPredef
       case script => s"$extraPredef\n$script"
-    run(combinedScript)(using emptyState)
+    run(combinedScript)(using emptyState).copy(pastInputs = Nil)
 
   /** Reset state of repl to the initial state
    *
@@ -453,7 +458,8 @@ class ReplDriver(settings: Array[String],
                 .sorted
                 .foreach(printDiagnostic)
 
-              updatedState
+              if updatedState.invalidObjectIndexes.contains(updatedState.objectIndex) then updatedState
+              else updatedState.recordInput(parsed.source.content().mkString)
             }
         }
       )
@@ -552,6 +558,16 @@ class ReplDriver(settings: Array[String],
     }
   }
 
+  /** Replay a file saved by `:save`: each entry runs as its own compilation unit. */
+  private def loadSavedEntries(contents: String, state: State): State =
+    val separatorLine = s"(?m)^${Pattern.quote(Save.entrySeparator)}$$"
+    val entries = contents.stripPrefix(Save.sessionHeader).split(separatorLine).toList
+      .map(_.strip).filter(_.nonEmpty).map(Save.unescapeEntry)
+    entries.foldLeft(state) { (st, entry) =>
+      if ParseResult.isCommand(entry) then interpret(ParseResult(entry)(using st))(using st)
+      else run(entry)(using st)
+    }
+
   /** Interpret `cmd` to action and propagate potentially new `state` */
   private def interpretCommand(cmd: Command)(using state: State): State = cmd match {
     case UnknownCommand(cmd) =>
@@ -586,11 +602,28 @@ class ReplDriver(settings: Array[String],
       } out.println(imp.show(using state.context))
       state
 
+    case Save(path) =>
+      if path.isEmpty then
+        out.println("File name is required.")
+      else if state.pastInputs.isEmpty then
+        out.println("Nothing to save.")
+      else
+        try
+          val body = state.pastInputs.map(entry => s"${Save.entrySeparator}\n${Save.escapeEntry(entry)}").mkString("\n")
+          val content = s"${Save.sessionHeader}\n$body"
+          Files.writeString(new JFile(path).toPath, content, StandardCharsets.UTF_8)
+        catch case NonFatal(e) =>
+          out.println(s"""Couldn't save session to "$path": ${e.getMessage}""")
+      state
+
     case Load(path) =>
       val file = new JFile(path)
       if (file.exists) {
         val contents = Using(scala.io.Source.fromFile(file, StandardCharsets.UTF_8.name))(_.mkString).get
-        run(contents)
+        val loaded =
+          if contents.linesIterator.nextOption().contains(Save.sessionHeader) then loadSavedEntries(contents, state)
+          else run(contents)(using state)
+        loaded.copy(pastInputs = state.pastInputs :+ s"${Load.command} $path")
       }
       else {
         out.println(s"""Couldn't find file "${file.getCanonicalPath}"""")
@@ -625,36 +658,41 @@ class ReplDriver(settings: Array[String],
           }
         }
 
-        try {
-          val entries = flatten(jarFile)
+        val isSuccess: Boolean =
+          try {
+            val entries = flatten(jarFile)
 
-          val existingClass = entries.filter(_.ext.isClass).find(tryClassLoad(_).isDefined)
-          if (existingClass.nonEmpty)
-            out.println(s"The path '$path' cannot be loaded, it contains a classfile that already exists on the classpath: ${existingClass.get}")
-          else inContext(state.context):
-            val jarClassPath = ClassPathFactory.newClassPath(jarFile)
-            val prevOutputDir = ctx.settings.outputDir.value
+            val existingClass = entries.filter(_.ext.isClass).find(tryClassLoad(_).isDefined)
+            if (existingClass.nonEmpty)
+              out.println(s"The path '$path' cannot be loaded, it contains a classfile that already exists on the classpath: ${existingClass.get}")
+              false
+            else inContext(state.context):
+              val jarClassPath = ClassPathFactory.newClassPath(jarFile)
+              val prevOutputDir = ctx.settings.outputDir.value
 
-            // add to compiler class path
-            ctx.platform.addToClassPath(jarClassPath)
-            SymbolLoaders.mergeNewEntries(defn.RootClass, ClassPath.RootPackage, jarClassPath, ctx.platform.classPath)
+              // add to compiler class path
+              ctx.platform.addToClassPath(jarClassPath)
+              SymbolLoaders.mergeNewEntries(defn.RootClass, ClassPath.RootPackage, jarClassPath, ctx.platform.classPath)
 
-            // new class loader with previous output dir and specified jar
-            val prevClassLoader = rendering.classLoader()
-            val jarClassLoader = fromURLsParallelCapable(
-              jarClassPath.asURLs, prevClassLoader)
-            rendering.myClassLoader = new AbstractFileClassLoader(
-              prevOutputDir,
-              jarClassLoader,
-              AbstractFileClassLoader.InterruptInstrumentation.fromString(ctx.settings.XreplInterruptInstrumentation.value)
-            )
+              // new class loader with previous output dir and specified jar
+              val prevClassLoader = rendering.classLoader()
+              val jarClassLoader = fromURLsParallelCapable(
+                jarClassPath.asURLs, prevClassLoader)
+              rendering.myClassLoader = new AbstractFileClassLoader(
+                prevOutputDir,
+                jarClassLoader,
+                AbstractFileClassLoader.InterruptInstrumentation.fromString(ctx.settings.XreplInterruptInstrumentation.value)
+              )
 
-            out.println(s"Added '$path' to classpath.")
-        } catch {
-          case e: Throwable =>
-            out.println(s"Failed to load '$path' to classpath: ${e.getMessage}")
-        }
-        state
+              out.println(s"Added '$path' to classpath.")
+              true
+          } catch {
+            case e: Throwable =>
+              out.println(s"Failed to load '$path' to classpath: ${e.getMessage}")
+              false
+          }
+
+        if isSuccess then state.recordInput(s"${JarCmd.command} $path") else state
 
     case KindOf(expr) =>
       out.println(s"""The :kind command is not currently supported.""")
@@ -699,30 +737,39 @@ class ReplDriver(settings: Array[String],
         state
       case _  =>
         rootCtx = setupRootCtx(tokenize(arg).toArray, rootCtx)
-        state.copy(context = rootCtx)
+        state.copy(context = rootCtx).recordInput(s"${Settings.command} $arg")
 
     case Silent => state.copy(quiet = !state.quiet)
     case Dep(dep) =>
-      val depStrings = List(dep)
-      if depStrings.nonEmpty then
-        val deps = depStrings.flatMap(DependencyResolver.parseDependency)
-        if deps.nonEmpty then
-          DependencyResolver.resolveDependencies(deps) match
-            case Right(files) =>
-              if files.nonEmpty then
-                inContext(state.context):
-                  // Update both compiler classpath and classloader
-                  val prevOutputDir = ctx.settings.outputDir.value
-                  val prevClassLoader = rendering.classLoader()
-                  rendering.myClassLoader = DependencyResolver.addToCompilerClasspath(
-                    files,
-                    prevClassLoader,
-                    prevOutputDir
-                  )
-                  out.println(s"Resolved ${deps.size} dependencies (${files.size} JARs)")
-            case Left(error) =>
-              out.println(s"Error resolving dependencies: $error")
-      state
+      def jarCount(fileSize: Int): String =
+        if fileSize == 1 then "1 JAR" else s"$fileSize JARs"
+
+      val isSuccess: Boolean =
+        if dep.nonEmpty then
+          DependencyResolver.parseDependency(dep) match
+            case Some(d) =>
+              DependencyResolver.resolveDependencies(List(d)) match
+                case Right(files) if files.nonEmpty =>
+                  inContext(state.context):
+                    // Update both compiler classpath and classloader
+                    val prevOutputDir = ctx.settings.outputDir.value
+                    val prevClassLoader = rendering.classLoader()
+                    rendering.myClassLoader = DependencyResolver.addToCompilerClasspath(
+                      files,
+                      prevClassLoader,
+                      prevOutputDir
+                    )
+                    out.println(s"Resolved a dependency (${jarCount(files.size)})")
+                    true
+                case Right(_) => false
+                case Left(error) =>
+                  out.println(s"Error resolving a dependency: $error")
+                  false
+            case None => false
+        else
+          out.println("No dependency specified.")
+          false
+      if isSuccess then state.recordInput(s"${Dep.command} $dep") else state
 
     case Quit =>
       // end of the world!

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -563,7 +563,7 @@ class ReplDriver(settings: Array[String],
   private def loadSavedEntries(contents: String, state: State): State =
     val separatorLine = s"(?m)^${Pattern.quote(Save.entrySeparator)}$$"
     val entries = contents.stripPrefix(Save.sessionHeader).split(separatorLine).toList
-      .map(_.strip).filter(_.nonEmpty).map(Save.unescapeEntry)
+      .map(_.strip).filter(_.nonEmpty)
     entries.foldLeft(state) { (st, entry) =>
       if ParseResult.isCommand(entry) then interpret(ParseResult(entry)(using st))(using st)
       else run(entry)(using st)
@@ -610,7 +610,7 @@ class ReplDriver(settings: Array[String],
         out.println("Nothing to save.")
       else
         try
-          val body = state.pastInputs.reverse.map(entry => s"${Save.entrySeparator}\n${Save.escapeEntry(entry)}").mkString("\n")
+          val body = state.pastInputs.reverse.map(entry => s"${Save.entrySeparator}\n$entry").mkString("\n")
           val content = s"${Save.sessionHeader}\n$body"
           Files.writeString(new JFile(path).toPath, content, StandardCharsets.UTF_8)
         catch case NonFatal(e) =>

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -392,7 +392,8 @@ class ReplDriver(settings: Array[String],
         displayErrors(errs, state)
 
       case cmd: Command =>
-        interpretCommand(cmd)
+        val next = interpretCommand(cmd)
+        cmd.replayLine.fold(next)(line => next.recordInput(line.strip))
 
       case SigKill => // TODO
         state
@@ -623,7 +624,7 @@ class ReplDriver(settings: Array[String],
         val loaded =
           if contents.linesIterator.nextOption().contains(Save.sessionHeader) then loadSavedEntries(contents, state)
           else run(contents)(using state)
-        loaded.copy(pastInputs = state.pastInputs :+ s"${Load.command} $path")
+        loaded.copy(pastInputs = state.pastInputs)
       }
       else {
         out.println(s"""Couldn't find file "${file.getCanonicalPath}"""")
@@ -658,41 +659,36 @@ class ReplDriver(settings: Array[String],
           }
         }
 
-        val isSuccess: Boolean =
-          try {
-            val entries = flatten(jarFile)
+        try {
+          val entries = flatten(jarFile)
 
-            val existingClass = entries.filter(_.ext.isClass).find(tryClassLoad(_).isDefined)
-            if (existingClass.nonEmpty)
-              out.println(s"The path '$path' cannot be loaded, it contains a classfile that already exists on the classpath: ${existingClass.get}")
-              false
-            else inContext(state.context):
-              val jarClassPath = ClassPathFactory.newClassPath(jarFile)
-              val prevOutputDir = ctx.settings.outputDir.value
+          val existingClass = entries.filter(_.ext.isClass).find(tryClassLoad(_).isDefined)
+          if (existingClass.nonEmpty)
+            out.println(s"The path '$path' cannot be loaded, it contains a classfile that already exists on the classpath: ${existingClass.get}")
+          else inContext(state.context):
+            val jarClassPath = ClassPathFactory.newClassPath(jarFile)
+            val prevOutputDir = ctx.settings.outputDir.value
 
-              // add to compiler class path
-              ctx.platform.addToClassPath(jarClassPath)
-              SymbolLoaders.mergeNewEntries(defn.RootClass, ClassPath.RootPackage, jarClassPath, ctx.platform.classPath)
+            // add to compiler class path
+            ctx.platform.addToClassPath(jarClassPath)
+            SymbolLoaders.mergeNewEntries(defn.RootClass, ClassPath.RootPackage, jarClassPath, ctx.platform.classPath)
 
-              // new class loader with previous output dir and specified jar
-              val prevClassLoader = rendering.classLoader()
-              val jarClassLoader = fromURLsParallelCapable(
-                jarClassPath.asURLs, prevClassLoader)
-              rendering.myClassLoader = new AbstractFileClassLoader(
-                prevOutputDir,
-                jarClassLoader,
-                AbstractFileClassLoader.InterruptInstrumentation.fromString(ctx.settings.XreplInterruptInstrumentation.value)
-              )
+            // new class loader with previous output dir and specified jar
+            val prevClassLoader = rendering.classLoader()
+            val jarClassLoader = fromURLsParallelCapable(
+              jarClassPath.asURLs, prevClassLoader)
+            rendering.myClassLoader = new AbstractFileClassLoader(
+              prevOutputDir,
+              jarClassLoader,
+              AbstractFileClassLoader.InterruptInstrumentation.fromString(ctx.settings.XreplInterruptInstrumentation.value)
+            )
 
-              out.println(s"Added '$path' to classpath.")
-              true
-          } catch {
-            case e: Throwable =>
-              out.println(s"Failed to load '$path' to classpath: ${e.getMessage}")
-              false
-          }
-
-        if isSuccess then state.recordInput(s"${JarCmd.command} $path") else state
+            out.println(s"Added '$path' to classpath.")
+        } catch {
+          case e: Throwable =>
+            out.println(s"Failed to load '$path' to classpath: ${e.getMessage}")
+        }
+        state
 
     case KindOf(expr) =>
       out.println(s"""The :kind command is not currently supported.""")
@@ -737,39 +733,35 @@ class ReplDriver(settings: Array[String],
         state
       case _  =>
         rootCtx = setupRootCtx(tokenize(arg).toArray, rootCtx)
-        state.copy(context = rootCtx).recordInput(s"${Settings.command} $arg")
+        state.copy(context = rootCtx)
 
     case Silent => state.copy(quiet = !state.quiet)
     case Dep(dep) =>
       def jarCount(fileSize: Int): String =
         if fileSize == 1 then "1 JAR" else s"$fileSize JARs"
 
-      val isSuccess: Boolean =
-        if dep.nonEmpty then
-          DependencyResolver.parseDependency(dep) match
-            case Some(d) =>
-              DependencyResolver.resolveDependencies(List(d)) match
-                case Right(files) if files.nonEmpty =>
-                  inContext(state.context):
-                    // Update both compiler classpath and classloader
-                    val prevOutputDir = ctx.settings.outputDir.value
-                    val prevClassLoader = rendering.classLoader()
-                    rendering.myClassLoader = DependencyResolver.addToCompilerClasspath(
-                      files,
-                      prevClassLoader,
-                      prevOutputDir
-                    )
-                    out.println(s"Resolved a dependency (${jarCount(files.size)})")
-                    true
-                case Right(_) => false
-                case Left(error) =>
-                  out.println(s"Error resolving a dependency: $error")
-                  false
-            case None => false
-        else
-          out.println("No dependency specified.")
-          false
-      if isSuccess then state.recordInput(s"${Dep.command} $dep") else state
+      if dep.nonEmpty then
+        DependencyResolver.parseDependency(dep) match
+          case Some(d) =>
+            DependencyResolver.resolveDependencies(List(d)) match
+              case Right(files) if files.nonEmpty =>
+                inContext(state.context):
+                  // Update both compiler classpath and classloader
+                  val prevOutputDir = ctx.settings.outputDir.value
+                  val prevClassLoader = rendering.classLoader()
+                  rendering.myClassLoader = DependencyResolver.addToCompilerClasspath(
+                    files,
+                    prevClassLoader,
+                    prevOutputDir
+                  )
+                  out.println(s"Resolved a dependency (${jarCount(files.size)})")
+              case Right(_) =>
+              case Left(error) =>
+                out.println(s"Error resolving a dependency: $error")
+          case None =>
+      else
+        out.println("No dependency specified.")
+      state
 
     case Quit =>
       // end of the world!

--- a/repl/test/dotty/tools/repl/LoadTests.scala
+++ b/repl/test/dotty/tools/repl/LoadTests.scala
@@ -61,6 +61,31 @@ class LoadTests extends ReplTest {
                  |""".stripMargin
   )
 
+  @Test def mutuallyRecursiveDefsResolve = loadTest(
+    file    = """|def isEven(n: Int): Boolean = if n == 0 then true else isOdd(n - 1)
+                 |def isOdd(n: Int): Boolean = if n == 0 then false else isEven(n - 1)
+                 |""".stripMargin,
+    defs    = """|def isEven(n: Int): Boolean
+                 |def isOdd(n: Int): Boolean
+                 |""".stripMargin,
+    runCode = "isEven(10)",
+    output  = """|val res0: Boolean = true
+                 |""".stripMargin
+  )
+
+  @Test def separatorCommentInPlainFileIsNotABoundary = loadTest(
+    file    = s"""|def isEven(n: Int): Boolean = if n == 0 then true else isOdd(n - 1)
+                  |${Save.entrySeparator}
+                  |def isOdd(n: Int): Boolean = if n == 0 then false else isEven(n - 1)
+                  |""".stripMargin,
+    defs    = """|def isEven(n: Int): Boolean
+                 |def isOdd(n: Int): Boolean
+                 |""".stripMargin,
+    runCode = "isEven(10)",
+    output  = """|val res0: Boolean = true
+                 |""".stripMargin
+  )
+
   def loadTest(file: String, defs: String, runCode: String, output: String) =
     eval(s":load ${writeFile(file)}") andThen {
       assertMultiLineEquals(defs, storedOutput())

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -15,7 +15,7 @@ class ReplDependencyMacroTests extends ReplTest:
   private def resolveUpickle()(using State): Unit =
     run(":dep com.lihaoyi::upickle:4.4.3")
     val output = storedOutput()
-    assertTrue(output, output.contains("Resolved 1 dependencies"))
+    assertTrue(output, output.contains("Resolved a dependency"))
     assertNoMacroFailure(output)
 
   private def addUpickleViaJar()(using State): Unit =

--- a/repl/test/dotty/tools/repl/SaveTests.scala
+++ b/repl/test/dotty/tools/repl/SaveTests.scala
@@ -64,7 +64,7 @@ class SaveTests extends ReplTest {
       )
     }
 
-  @Test def skipsCommands =
+  @Test def recordsCommands =
     val target = tempFile()
     initially {
       run("val x = 1")
@@ -77,7 +77,11 @@ class SaveTests extends ReplTest {
       assertEquals(
         s"""|$header
             |$sep
-            |val x = 1""".stripMargin,
+            |val x = 1
+            |$sep
+            |:type x
+            |$sep
+            |:imports""".stripMargin,
         contentOf(target)
       )
     }
@@ -125,16 +129,6 @@ class SaveTests extends ReplTest {
             |:jar $jar""".stripMargin,
         contentOf(target)
       )
-    }
-
-  @Test def skipsFailedJar =
-    val target = tempFile()
-    initially {
-      run(":jar /does/not/exist.jar")
-    } andThen {
-      storedOutput()
-      run(s":save $target")
-      assertEquals("Nothing to save.", storedOutput().trim)
     }
 
   @Test def roundTripsCommandViaLoad =

--- a/repl/test/dotty/tools/repl/SaveTests.scala
+++ b/repl/test/dotty/tools/repl/SaveTests.scala
@@ -213,23 +213,6 @@ class SaveTests extends ReplTest {
       assertEquals(List(s"""val res0: String = "$sep""""), lines())
     }
 
-  @Test def roundTripsSeparatorLineInStringViaLoad =
-    val target = tempFile()
-    initially {
-      run(s"val s = \"\"\"\n$sep\n\"\"\"")
-    } andThen {
-      run(s":save $target")
-    }
-    resetToInitial()
-    initially {
-      storedOutput()
-      run(s":load $target")
-    } andThen {
-      storedOutput()
-      run("s.trim")
-      assertEquals(List(s"""val res0: String = "$sep""""), lines())
-    }
-
   @Test def skipsThrowingVal =
     val target = tempFile()
     initially {

--- a/repl/test/dotty/tools/repl/SaveTests.scala
+++ b/repl/test/dotty/tools/repl/SaveTests.scala
@@ -213,6 +213,27 @@ class SaveTests extends ReplTest {
       assertEquals(List(s"""val res0: String = "$sep""""), lines())
     }
 
+  @Test def roundTripsWithCaptureChecking =
+    val target = tempFile()
+    initially {
+      run("import language.experimental.captureChecking")
+    } andThen {
+      run("import caps.*")
+    } andThen {
+      run("class File extends SharedCapability")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("class Logger(f: File^) extends SharedCapability")
+      assertEquals("// defined class Logger", storedOutput().trim)
+    }
+
   @Test def skipsThrowingVal =
     val target = tempFile()
     initially {

--- a/repl/test/dotty/tools/repl/SaveTests.scala
+++ b/repl/test/dotty/tools/repl/SaveTests.scala
@@ -1,0 +1,288 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import java.io.FileOutputStream
+import java.nio.file.{Path, Files}
+import java.util.jar.JarOutputStream
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class SaveTests extends ReplTest {
+
+  private def tempFile(suffix: String = ".scala"): Path =
+    val file = Files.createTempFile("repl_save", suffix)
+    file.toFile.deleteOnExit()
+    file
+
+  private def emptyJar(): Path =
+    val jar = tempFile(".jar")
+    new JarOutputStream(new FileOutputStream(jar.toFile)).close()
+    jar
+
+  private def contentOf(f: Path): String = Files.readString(f)
+
+  private def lines() =
+      storedOutput().trim.linesIterator.toList
+
+  private val header = Save.sessionHeader
+  private val sep = Save.entrySeparator
+
+  @Test def savesSuccessfulInputs =
+    val target = tempFile()
+    initially {
+      run("val x = 1")
+    } andThen {
+      run("def double(n: Int) = n * 2")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |val x = 1
+            |$sep
+            |def double(n: Int) = n * 2""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def skipsErroredInputs =
+    val target = tempFile()
+    initially {
+      run("val x = 1")
+    } andThen {
+      run("val y = notDefined")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |val x = 1""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def skipsCommands =
+    val target = tempFile()
+    initially {
+      run("val x = 1")
+    } andThen {
+      run(":type x")
+    } andThen {
+      run(":imports")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |val x = 1""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def roundTripsViaLoad =
+    val target = tempFile()
+    initially {
+      run("val x = 21")
+    } andThen {
+      run("def double(n: Int) = n * 2")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("double(x)")
+      assertEquals("val res0: Int = 42", storedOutput().trim)
+    }
+
+  @Test def emptyPath = initially {
+    run(":save")
+    assertEquals("File name is required.", storedOutput().trim)
+  }
+
+  @Test def emptySession =
+    val target = tempFile()
+    initially {
+      run(s":save $target")
+      assertEquals("Nothing to save.", storedOutput().trim)
+    }
+
+  @Test def recordsSuccessfulJar =
+    val jar = emptyJar()
+    val target = tempFile()
+    initially {
+      run(s":jar $jar")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |:jar $jar""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def skipsFailedJar =
+    val target = tempFile()
+    initially {
+      run(":jar /does/not/exist.jar")
+    } andThen {
+      storedOutput()
+      run(s":save $target")
+      assertEquals("Nothing to save.", storedOutput().trim)
+    }
+
+  @Test def roundTripsCommandViaLoad =
+    val jar = emptyJar()
+    val target = tempFile()
+    initially {
+      run(s":jar $jar")
+    } andThen {
+      run("val x = 42")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      assertEquals(
+        List(
+          s"Added '$jar' to classpath.",
+          "val x: Int = 42"
+        ),
+        lines()
+      )
+      run("x")
+      assertEquals(
+        List("val res0: Int = 42"),
+        lines()
+      )
+    }
+
+  @Test def roundTripsRedefinitionViaLoad =
+    val target = tempFile()
+    initially {
+      run("val x = 1")
+    } andThen {
+      run("val x = 2")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("x")
+      assertEquals(List("val res0: Int = 2"), lines())
+    }
+
+  @Test def roundTripsCommandInStringViaLoad =
+    val target = tempFile()
+    initially {
+      run("val s = \"\"\"\n:help\n\"\"\"")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("s.trim")
+      assertEquals(List("val res0: String = \":help\""), lines())
+    }
+
+  @Test def roundTripsSeparatorInStringViaLoad =
+    val target = tempFile()
+    initially {
+      run(s"""val s = "$sep"""")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("s")
+      assertEquals(List(s"""val res0: String = "$sep""""), lines())
+    }
+
+  @Test def roundTripsSeparatorLineInStringViaLoad =
+    val target = tempFile()
+    initially {
+      run(s"val s = \"\"\"\n$sep\n\"\"\"")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("s.trim")
+      assertEquals(List(s"""val res0: String = "$sep""""), lines())
+    }
+
+  @Test def skipsThrowingVal =
+    val target = tempFile()
+    initially {
+      run("val x = 1")
+    } andThen {
+      run("""val boom = throw new RuntimeException("boom")""")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |val x = 1""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def recordsLoadAsCommand =
+    val script = tempFile()
+    Files.writeString(script, "val a = 1\nval b = 2\n")
+    val target = tempFile()
+    initially {
+      run(s":load $script")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |:load $script""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def roundTripsMutuallyRecursiveDefs =
+    val target = tempFile()
+    initially {
+      run("""|def isEven(n: Int): Boolean = if n == 0 then true else isOdd(n - 1)
+             |def isOdd(n: Int): Boolean = if n == 0 then false else isEven(n - 1)""".stripMargin)
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("isEven(10)")
+      assertEquals(List("val res0: Boolean = true"), lines())
+    }
+}

--- a/repl/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/repl/test/dotty/tools/repl/TabcompleteTests.scala
@@ -220,6 +220,7 @@ class TabcompleteTests extends ReplTest {
         ":quit",
         ":require",
         ":reset",
+        ":save",
         ":settings",
         ":sh",
         ":silent",


### PR DESCRIPTION
Fixes #21656

Implements `:save` command in the REPL.
Example of the format it saves:
```scala
/* Scala REPL session */
/* ---- entry ---- */
def test1(n: Int): Boolean = if n == 0 then true else test2(n-1)
def test2(n: Int): Boolean = if n == 0 then true else test1(n-1)
/* ---- entry ---- */
:load /tmp/test12.scala
/* ---- entry ---- */
x
/* ---- entry ---- */
test1(x)
```

If the header `/* Scala REPL session */` is present then it compiles the code block-by-block, and if not - it compiles the file as a whole. `/* ---- entry ---- */` delimiter is needed, cause we need it to successfully compile blocks like this:
```scala
def test1(n: Int): Boolean = if n == 0 then true else test2(n-1)
def test2(n: Int): Boolean = if n == 0 then true else test1(n-1)
```

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by veryfing the code and updating it where changes were needed.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
&
Manually
