### PR TITLE
Add support for member selection on generic tuples with abstract type bounds

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -90,7 +90,9 @@ class TypeUtils:
             else if normalize then recur(tp.widen, bound)
             else None
           case tp: TypeProxy if !tp.typeSymbol.isClass =>
-            if normalize && (tp.superType ne tp) then recur(tp.superType, bound)
+            if normalize then
+              val st = tp.superType
+              if st ne tp then recur(st, bound) else None
             else None
           case _ =>
             if defn.isTupleClass(tp.typeSymbol) && !normalize then Some(tp.dealias.argInfos)

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -89,6 +89,9 @@ class TypeUtils:
             if tp.termSymbol == defn.EmptyTupleModule then Some(Nil)
             else if normalize then recur(tp.widen, bound)
             else None
+          case tp: TypeProxy if !tp.typeSymbol.isClass =>
+            if normalize && (tp.superType ne tp) then recur(tp.superType, bound)
+            else None
           case _ =>
             if defn.isTupleClass(tp.typeSymbol) && !normalize then Some(tp.dealias.argInfos)
             else None

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -78,6 +78,9 @@ class TypeUtils:
             if tp.termSymbol == defn.EmptyTupleModule then Some(Nil)
             else if normalize then recur(tp.widen, bound)
             else None
+          case tp: TypeProxy if !tp.typeSymbol.isClass =>
+            if normalize && (tp.superType ne tp) then recur(tp.superType, bound)
+            else None
           case _ =>
             if defn.isTupleClass(tp.typeSymbol) && !normalize then Some(tp.dealias.argInfos)
             else None

--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -79,7 +79,9 @@ class TypeUtils:
             else if normalize then recur(tp.widen, bound)
             else None
           case tp: TypeProxy if !tp.typeSymbol.isClass =>
-            if normalize && (tp.superType ne tp) then recur(tp.superType, bound)
+            if normalize then
+              val st = tp.superType
+              if st ne tp then recur(st, bound) else None
             else None
           case _ =>
             if defn.isTupleClass(tp.typeSymbol) && !normalize then Some(tp.dealias.argInfos)

--- a/tests/run/genericTupleMembers.scala
+++ b/tests/run/genericTupleMembers.scala
@@ -1,4 +1,31 @@
 
+// Member selection on a generic tuple hidden behind an abstract type bound
+// (an abstract type member, or a type parameter), where the bound itself
+// resolves to a generic `*:` tuple rather than a literal TupleN. See i26099.
+trait Container:
+  type A <: (Int *: String *: EmptyTuple)
+  def get: A
+
+class ContainerImpl extends Container:
+  type A = Int *: String *: EmptyTuple
+  def get: A = 1 *: "s" *: EmptyTuple
+
+trait ContainerG[T <: Tuple]:
+  type A <: T
+  def get: A
+
+class ContainerGImpl extends ContainerG[Int *: String *: EmptyTuple]:
+  type A = Int *: String *: EmptyTuple
+  def get: A = 1 *: "s" *: EmptyTuple
+
+def testAbstractTupleBound(c: Container): Unit =
+  assert(c.get._1 == 1)
+  assert(c.get._2 == "s")
+
+def testAbstractTupleBoundGeneric(c: ContainerG[Int *: String *: EmptyTuple]): Unit =
+  assert(c.get._1 == 1)
+  assert(c.get._2 == "s")
+
 @main def Test: Unit =
   val tup1 = 1 *: EmptyTuple
   val tup2 = 1 *: 2 *: EmptyTuple
@@ -44,3 +71,6 @@
   tup22._20
   tup22._21
   tup22._22
+
+  testAbstractTupleBound(ContainerImpl())
+  testAbstractTupleBoundGeneric(ContainerGImpl())

--- a/tests/run/i26099.scala
+++ b/tests/run/i26099.scala
@@ -1,0 +1,18 @@
+object types {
+  opaque type TupleGiven[T <: Tuple] <: T = T
+
+  object TupleGiven {
+    given emptyTuple: TupleGiven[EmptyTuple] = EmptyTuple
+    given tupleN[H, T <: Tuple](using h: H, t: TupleGiven[T]): TupleGiven[H *: T] = h *: t
+  }
+}
+
+given i: Int = 1
+given s: String = "s"
+
+val t = summon[types.TupleGiven[(Int, String)]]
+
+@main def Test =
+  assert(t._1 == 1)
+  assert(t._2 == "s")
+  assert((t: (Int, String))._1 == 1)


### PR DESCRIPTION
Fixes #26099
The fix covers not only opaque types, but also abstract types in general.

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by self-review and new tests.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer)


