### PR TITLE
Add deprecated :paste command to the REPL

### DIFF
--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -157,6 +157,7 @@ object Sh {
 
 /** `:paste` is deprecated; JLine supports multiline editing so it is not needed */
 case object Paste extends Command:
+  override def replayLine = Some(command)
   val command: String = ":paste"
 
 /** Toggle automatic printing of results */

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -155,6 +155,10 @@ object Sh {
   val command: String = ":sh"
 }
 
+/** `:paste` is deprecated; JLine supports multiline editing so it is not needed */
+case object Paste extends Command:
+  val command: String = ":paste"
+
 /** Toggle automatic printing of results */
 case object Silent extends Command:
   override def replayLine = Some(command)
@@ -217,6 +221,7 @@ object ParseResult {
     DocOf.command -> (arg => DocOf(arg)),
     Settings.command -> (arg => Settings(arg)),
     Sh.command -> (arg => Sh(arg)),
+    Paste.command -> (_ => Paste),
     Silent.command -> (_ => Silent),
   )
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -725,6 +725,10 @@ class ReplDriver(settings: Array[String],
       out.println(s"""The :sh command is deprecated. Use `import scala.sys.process._` and `"command".!` instead.""")
       state
 
+    case Paste =>
+      out.println("The :paste command is deprecated. It is no longer needed, since the REPL supports multiline editing.")
+      state
+
     case Settings(arg) => arg match
       case "" =>
         given ctx: Context = state.context

--- a/repl/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/repl/test/dotty/tools/repl/TabcompleteTests.scala
@@ -217,6 +217,7 @@ class TabcompleteTests extends ReplTest {
         ":jar",
         ":kind",
         ":load",
+        ":paste",
         ":quit",
         ":require",
         ":reset",


### PR DESCRIPTION
Fixes #21660

Adds `:paste` to the REPL as a deprecated command.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Manually
