### PR TITLE
Regression tests for #19384

### DIFF
--- a/tests/run/19384-min.scala
+++ b/tests/run/19384-min.scala
@@ -1,0 +1,7 @@
+@main def Test: Unit =
+  f{ x =>
+    { (y: Int) => y } match
+      case _ => ()
+  }
+
+def f(pf: PartialFunction[Unit, Unit]): Unit = ()

--- a/tests/run/19384.scala
+++ b/tests/run/19384.scala
@@ -1,0 +1,20 @@
+object Test {
+
+  def main(args: Array[String]): Unit = {
+    Left(()).recoverWith { _ =>
+      List.empty[Int].find(_ == 1) match {
+        case None    => Left(())
+        case Some(_) => Right(())
+      }
+    }
+  }
+}
+
+implicit final def catsSyntaxEither[A, B](eab: Either[A, B]): EitherOps[A, B] = new EitherOps(eab)
+final class EitherOps[A, B](private val eab: Either[A, B]) extends AnyVal {
+  def recoverWith[AA >: A, BB >: B](pf: PartialFunction[A, Either[AA, BB]]): Either[AA, BB] =
+    eab match {
+      case Left(a) if pf.isDefinedAt(a) => pf(a)
+      case _                            => eab
+    }
+}


### PR DESCRIPTION
Closes #19384

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
