### PR TITLE
Backport "Refactor `directives-parser`" to 3.9.0

### DIFF
--- a/directives-parser/README.md
+++ b/directives-parser/README.md
@@ -160,7 +160,7 @@ Two accessors reconstruct the text:
 
 ## Diagnostics
 
-Diagnostics are returned as `UsingDirectiveDiagnostic(message, severity, position?)`.
+Diagnostics are returned as `UsingDirectiveDiagnostic(message, severity, position)`.
 
 | Severity    | When                                                                   |
 |-------------|------------------------------------------------------------------------|

--- a/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
@@ -126,7 +126,7 @@ object CommentExtractor:
           if offset < length && content(offset) == '\n' then offset += 1
           lineNum += 1
         else if UsingDirectiveRegex.findFirstIn(withoutLeading).isDefined then
-          val linePos = Some(Position(lineNum, leadingLen, lineStart + leadingLen + bomOffset))
+          val linePos = Position(lineNum, leadingLen, lineStart + leadingLen + bomOffset)
           val msg     =
             s"Using directive must use the exact prefix `//> using`. Invalid prefix in: ${withoutLeading.trim}"
           diagnostics += UsingDirectiveDiagnostic(msg, DiagnosticSeverity.Warning, linePos)
@@ -163,7 +163,7 @@ object CommentExtractor:
           if offset < length && content(offset) == '\n' then offset += 1
           ln += 1
         else
-          val linePos = Some(Position(ln, 0, lineStart + bomOffset))
+          val linePos = Position(ln, 0, lineStart + bomOffset)
           if trimmed.startsWith("//> using") then
             val msg = s"Ignoring using directive found after Scala code: ${trimmed.trim}"
             diagnostics += UsingDirectiveDiagnostic(msg, DiagnosticSeverity.Warning, linePos)

--- a/directives-parser/src/main/scala/dotty/tools/directives/Diagnostics.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/Diagnostics.scala
@@ -6,5 +6,5 @@ enum DiagnosticSeverity:
 case class UsingDirectiveDiagnostic(
   message: String,
   severity: DiagnosticSeverity,
-  position: Option[Position] = None
+  position: Position
 )

--- a/directives-parser/src/main/scala/dotty/tools/directives/DirectiveValue.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/DirectiveValue.scala
@@ -1,6 +1,9 @@
 package dotty.tools.directives
 
 enum DirectiveValue:
+  /** Position of this value in the source file. */
+  def position: Position
+
   /** A string value, either quoted (`"hello"`) or bare (`hello`). */
   case StringVal(value: String, isQuoted: Boolean, position: Position)
 
@@ -10,28 +13,20 @@ enum DirectiveValue:
   /** No value was provided after the key (treated as `true` downstream). */
   case EmptyVal(position: Position)
 
-object DirectiveValue:
-  extension (dv: DirectiveValue)
+  /** Raw source text representation (e.g. `"hello"` with quotes for quoted strings). */
+  def rawText: String = this match
+    case StringVal(v, true, _)  => s""""$v""""
+    case StringVal(v, false, _) => v
+    case BoolVal(v, _)          => v.toString
+    case EmptyVal(_)            => ""
 
-    def pos: Position = dv match
-      case StringVal(_, _, p) => p
-      case BoolVal(_, p)      => p
-      case EmptyVal(p)        => p
+  /** The string content of the value (without quotes), or boolean/empty as string. */
+  def stringValue: String = this match
+    case StringVal(v, _, _) => v
+    case BoolVal(v, _)      => v.toString
+    case EmptyVal(_)        => ""
 
-    /** Raw source text representation (e.g. `"hello"` with quotes for quoted strings). */
-    def rawText: String = dv match
-      case StringVal(v, true, _)  => s""""$v""""
-      case StringVal(v, false, _) => v
-      case BoolVal(v, _)          => v.toString
-      case EmptyVal(_)            => ""
-
-    /** The string content of the value (without quotes), or boolean/empty as string. */
-    def stringValue: String = dv match
-      case StringVal(v, _, _) => v
-      case BoolVal(v, _)      => v.toString
-      case EmptyVal(_)        => ""
-
-    /** Whether this value is a quoted string literal. */
-    def isQuotedString: Boolean = dv match
-      case StringVal(_, true, _) => true
-      case _                     => false
+  /** Whether this value is a quoted string literal. */
+  def isQuotedString: Boolean = this match
+    case StringVal(_, true, _) => true
+    case _                     => false

--- a/directives-parser/src/main/scala/dotty/tools/directives/Lexer.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/Lexer.scala
@@ -137,36 +137,8 @@ object Lexer:
             case "true"  => buf += Token.BoolLit(true, pos(startCol))
             case "false" => buf += Token.BoolLit(false, pos(startCol))
             case _       =>
-              // Check if this looks like a dotted key segment (may have internal dots)
-              // We emit Dot tokens for '.' characters between identifiers in key position;
-              // the Parser handles the distinction between key and value contexts.
-              // For simplicity, emit the whole bare token as Ident — the Parser splits on dots.
+              // Bare tokens (including dotted keys like `test.dep`) are emitted as a single Ident.
               buf += Token.Ident(text, pos(startCol))
 
     buf += Token.Newline(pos(length))
     buf.toSeq
-
-  /** Tokenize a directive line and split dotted key parts into separate Ident + Dot tokens.
-    *
-    * This is used by the [[Parser]] to handle keys like `test.dep` where each segment is a separate
-    * Ident token joined by Dot tokens, while keeping values (which may contain `.`) as single Ident
-    * tokens.
-    *
-    * This method re-tokenizes an Ident that appears immediately after `using` (or after another
-    * Ident+Dot sequence) into its dotted components.
-    */
-  def splitDottedIdent(ident: String, startPos: Position): Seq[Token] =
-    val parts = ident.split('.').toSeq
-    if parts.length <= 1 then Seq(Token.Ident(ident, startPos))
-    else
-      val buf    = scala.collection.mutable.ArrayBuffer.empty[Token]
-      var offset = 0
-      parts.zipWithIndex.foreach: (part, i) =>
-        val partPos = Position(startPos.line, startPos.column + offset, startPos.offset + offset)
-        buf += Token.Ident(part, partPos)
-        offset += part.length
-        if i < parts.length - 1 then
-          buf +=
-            Token.Dot(Position(startPos.line, startPos.column + offset, startPos.offset + offset))
-          offset += 1
-      buf.toSeq

--- a/directives-parser/src/main/scala/dotty/tools/directives/Parser.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/Parser.scala
@@ -16,18 +16,6 @@ import scala.annotation.tailrec
   */
 object Parser:
 
-  private def tokenKindName(t: Token): String =
-    t match
-      case _: Token.Using     => "Using"
-      case _: Token.Ident     => "Ident"
-      case _: Token.StringLit => "StringLit"
-      case _: Token.BoolLit   => "BoolLit"
-      case _: Token.Dot       => "Dot"
-      case _: Token.Comma     => "Comma"
-      case _: Token.Newline   => "Newline"
-      case _: Token.Eof       => "Eof"
-      case _: Token.LexError  => "LexError"
-
   def parse(tokens: Seq[Token]): (Seq[UsingDirective], Seq[UsingDirectiveDiagnostic]) =
     val diagnostics = scala.collection.mutable.ArrayBuffer.empty[UsingDirectiveDiagnostic]
     val directives  = scala.collection.mutable.ArrayBuffer.empty[UsingDirective]
@@ -52,10 +40,10 @@ object Parser:
         case _                => ()
 
     def error(msg: String, p: Position): Unit =
-      diagnostics += UsingDirectiveDiagnostic(msg, DiagnosticSeverity.Error, Some(p))
+      diagnostics += UsingDirectiveDiagnostic(msg, DiagnosticSeverity.Error, p)
 
     def warn(msg: String, p: Position): Unit =
-      diagnostics += UsingDirectiveDiagnostic(msg, DiagnosticSeverity.Warning, Some(p))
+      diagnostics += UsingDirectiveDiagnostic(msg, DiagnosticSeverity.Warning, p)
 
     def parseValues(): Seq[DirectiveValue] =
       val values = scala.collection.mutable.ArrayBuffer.empty[DirectiveValue]
@@ -102,10 +90,6 @@ object Parser:
             error(s"Lexer error: $msg", p)
             advance()
             loop()
-          case t =>
-            error(s"Unexpected token in directive values: ${tokenKindName(t)}", t.pos)
-            skipToNewline()
-            values.toSeq
 
       loop()
 
@@ -149,7 +133,7 @@ object Parser:
               parseDirectives()
 
             case t =>
-              error(s"Expected a key after `using`, found: ${tokenKindName(t)}", t.pos)
+              error(s"Expected a key after `using`, found: ${t.productPrefix}", t.pos)
               skipToNewline()
               parseDirectives()
 
@@ -159,7 +143,7 @@ object Parser:
           parseDirectives()
 
         case t =>
-          error(s"Unexpected token: ${tokenKindName(t)}", t.pos)
+          error(s"Unexpected token: ${t.productPrefix}", t.pos)
           skipToNewline()
           parseDirectives()
 

--- a/directives-parser/src/main/scala/dotty/tools/directives/Token.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/Token.scala
@@ -1,6 +1,9 @@
 package dotty.tools.directives
 
 enum Token:
+  /** Absolute position of this token in the source file. */
+  def pos: Position
+
   /** The `using` keyword. */
   case Using(pos: Position)
 
@@ -13,9 +16,6 @@ enum Token:
   /** Boolean literal `true` or `false`. */
   case BoolLit(value: Boolean, pos: Position)
 
-  /** Dot separator in dotted keys. */
-  case Dot(pos: Position)
-
   /** Comma – accepted as a deprecated value separator. */
   case Comma(pos: Position)
 
@@ -27,16 +27,3 @@ enum Token:
 
   /** A lexer error. */
   case LexError(message: String, pos: Position)
-
-object Token:
-  extension (t: Token)
-    def pos: Position = t match
-      case Using(p)        => p
-      case Ident(_, p)     => p
-      case StringLit(_, p) => p
-      case BoolLit(_, p)   => p
-      case Dot(p)          => p
-      case Comma(p)        => p
-      case Newline(p)      => p
-      case Eof(p)          => p
-      case LexError(_, p)  => p

--- a/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
+++ b/directives-parser/src/test/scala/dotty/tools/directives/CommentExtractorTests.scala
@@ -233,8 +233,8 @@ class CommentExtractorTests:
         |""".stripMargin
     val r = extract(src)
     val w = r.diagnostics.head
-    assertEquals(Some(1), w.position.map(_.line))
-    assertEquals(Some(10), w.position.map(_.offset))
+    assertEquals(1, w.position.line)
+    assertEquals(10, w.position.offset)
   }
 
   @Test def mix_of_valid_directives_and_post_code_directives(): Unit = {

--- a/directives-parser/src/test/scala/dotty/tools/directives/LexerTests.scala
+++ b/directives-parser/src/test/scala/dotty/tools/directives/LexerTests.scala
@@ -156,11 +156,3 @@ class LexerTests:
     val err = tokens.collectFirst { case Token.LexError(msg, _) => msg }.get
     assertTrue(s"error message: $err", err.contains("Whitespace is required"))
   }
-
-  @Test def splitDottedIdent_splits_key_segments(): Unit = {
-    val pos = Position(0, 10, 10)
-    val tokens = Lexer.splitDottedIdent("test.dep", pos)
-    val idents = tokens.collect { case Token.Ident(v, _) => v }
-    assertEquals(Seq("test", "dep"), idents)
-    assertEquals(1, tokens.collect { case _: Token.Dot => () }.length)
-  }

--- a/directives-parser/src/test/scala/dotty/tools/directives/ParserTests.scala
+++ b/directives-parser/src/test/scala/dotty/tools/directives/ParserTests.scala
@@ -160,7 +160,7 @@ class ParserTests:
     assertEquals(0, kp.line)
     assertEquals(10, kp.column)
     assertEquals(10, kp.offset)
-    val vp = ds.head.values.head.pos
+    val vp = ds.head.values.head.position
     assertEquals(16, vp.column)
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1392,6 +1392,7 @@ object Build {
       ),
       publish / skip := true,
       target := target.value / "scala3-directives-parser-nonbootstrapped",
+      Compile / compile / scalacOptions += "-Wunused:all",
       fetchedScalaInstanceSettings,
       bspEnabled := true,
     )
@@ -1419,6 +1420,7 @@ object Build {
       Test    / publishArtifact := false,
       publish / skip := false,
       target := target.value / "scala3-directives-parser",
+      Compile / compile / scalacOptions += "-Wunused:all",
       bootstrappedScalaInstanceSettings,
       bspEnabled := enableBspAllProjects,
     )


### PR DESCRIPTION
Backports #26461 to the 3.9.0-RC2.

PR submitted by the release tooling.
[skip ci]