### PR TITLE
Add :replay command to the REPL

### DIFF
--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -148,6 +148,12 @@ object Reset {
   val command: String = ":reset"
 }
 
+case class Replay(arg: String) extends Command:
+  override def replayLine = None
+object Replay {
+  val command: String = ":replay"
+}
+
 /** `:sh <command line>` run a shell command (result is implicitly => List[String]) */
 case class Sh(expr: String) extends Command:
   override def replayLine = Some(s"${Sh.command} $expr")
@@ -186,7 +192,8 @@ case object Help extends Command {
       |:type <expression>       evaluate the type of the given expression
       |:doc <expression>        print the documentation for the given expression
       |:imports                 show import history
-      |:reset [options]         reset the repl to its initial state, forgetting all session entries
+      |:reset [options]         reset the REPL to its initial state, forgetting all session entries
+      |:replay [options]        reset the REPL and replay all previous commands
       |:settings <options>      update compiler options, if possible
       |:silent                  disable/enable automatic printing of results
       |:dep <group>::<artifact>:<version>     Resolve a dependency and make it available in the REPL
@@ -211,6 +218,7 @@ object ParseResult {
     Quit.alias -> (_ => Quit),
     Help.command -> (_  => Help),
     Reset.command -> (arg  => Reset(arg)),
+    Replay.command -> (arg => Replay(arg)),
     Imports.command -> (_  => Imports),
     JarCmd.command -> (arg => JarCmd(arg)),
     KindOf.command -> (arg => KindOf(arg)),

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -192,8 +192,8 @@ case object Help extends Command {
       |:type <expression>       evaluate the type of the given expression
       |:doc <expression>        print the documentation for the given expression
       |:imports                 show import history
-      |:reset [options]         reset the REPL to its initial state, forgetting all session entries
-      |:replay [options]        reset the REPL and replay all previous commands
+      |:reset [options]         clear the session and start fresh with the given compiler options
+      |:replay [options]        reset, then re-run the session with the given compiler options
       |:settings <options>      update compiler options, if possible
       |:silent                  disable/enable automatic printing of results
       |:dep <group>::<artifact>:<version>     Resolve a dependency and make it available in the REPL

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -72,6 +72,7 @@ import scala.util.Using
  *  @param invalidObjectIndexes the set of object indexes that failed to initialize
  *  @param quiet       whether we print evaluation results
  *  @param context     the latest compiler context
+ *  @param pastInputs  the replayable inputs of the session, most recent first
  */
 case class State(objectIndex: Int,
                  valIndex: Int,
@@ -564,6 +565,9 @@ class ReplDriver(settings: Array[String],
     val separatorLine = s"(?m)^${Pattern.quote(Save.entrySeparator)}$$"
     val entries = contents.stripPrefix(Save.sessionHeader).split(separatorLine).toList
       .map(_.strip).filter(_.nonEmpty)
+    replayEntries(entries, state)
+
+  private def replayEntries(entries: List[String], state: State): State =
     entries.foldLeft(state) { (st, entry) =>
       if ParseResult.isCommand(entry) then interpret(ParseResult(entry)(using st))(using st)
       else run(entry)(using st)
@@ -595,6 +599,19 @@ class ReplDriver(settings: Array[String],
 
       resetToInitial(tokens)
       initialState
+
+    case Replay(arg) =>
+      val tokens = tokenize(arg)
+
+      if tokens.nonEmpty then
+        out.println(s"""|Replaying REPL session with the following settings:
+                        |  ${tokens.mkString("\n  ")}
+                        |""".stripMargin)
+      else
+        out.println("Replaying REPL session.")
+
+      resetToInitial(tokens)
+      replayEntries(state.pastInputs.reverse, initialState)
 
     case Imports =>
       for {

--- a/repl/test/dotty/tools/repl/ReplayTests.scala
+++ b/repl/test/dotty/tools/repl/ReplayTests.scala
@@ -1,0 +1,111 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class ReplayTests extends ReplTest, SessionFileHelpers {
+
+  @Test def replaysDefinitions =
+    initially {
+      run("val x = 21")
+    } andThen {
+      run("def double(n: Int) = n * 2")
+    } andThen {
+      run(":replay")
+    } andThen {
+      storedOutput()
+      run("double(x)")
+      assertEquals("val res0: Int = 42", storedOutput().trim)
+    }
+
+  @Test def replaysRedefinitionInOrder =
+    initially {
+      run("val x = 1")
+    } andThen {
+      run("val x = 2")
+    } andThen {
+      run(":replay")
+    } andThen {
+      storedOutput()
+      run("x")
+      assertEquals("val res0: Int = 2", storedOutput().trim)
+    }
+
+  @Test def replaysMutuallyRecursiveDefsAsOneUnit =
+    initially {
+      run("""|def isEven(n: Int): Boolean = if n == 0 then true else isOdd(n - 1)
+             |def isOdd(n: Int): Boolean = if n == 0 then false else isEven(n - 1)""".stripMargin)
+    } andThen {
+      run(":replay")
+    } andThen {
+      storedOutput()
+      run("isEven(10)")
+      assertEquals("val res0: Boolean = true", storedOutput().trim)
+    }
+
+  @Test def replaysRecordedCommand =
+    val jar = emptyJar()
+    initially {
+      run(s":jar $jar")
+    } andThen {
+      storedOutput()
+      run(":replay")
+      assertEquals(
+        s"""|Replaying REPL session.
+            |Added '$jar' to classpath.""".stripMargin,
+        storedOutput().trim
+      )
+    }
+
+  @Test def replayIsNotRecorded =
+    val target = tempFile()
+    initially {
+      run("val a = 1")
+    } andThen {
+      run(":replay")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |val a = 1""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def announcesSettings = initially {
+    run(":replay -source:future")
+    assertEquals(
+      """|Replaying REPL session with the following settings:
+         |  -source:future""".stripMargin,
+      storedOutput().trim
+    )
+  }
+
+  @Test def replayLeavesOptionHistoryIntact =
+    val target = tempFile()
+    initially {
+      run("val x = 1")
+    } andThen {
+      run(":settings -source:future")
+    } andThen {
+      run("val y = 2")
+    } andThen {
+      run(":replay -deprecation")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |val x = 1
+            |$sep
+            |:settings -source:future
+            |$sep
+            |val y = 2""".stripMargin,
+        contentOf(target)
+      )
+    }
+}

--- a/repl/test/dotty/tools/repl/SaveTests.scala
+++ b/repl/test/dotty/tools/repl/SaveTests.scala
@@ -3,32 +3,15 @@ package repl
 
 import scala.language.unsafeNulls
 
-import java.io.FileOutputStream
-import java.nio.file.{Path, Files}
-import java.util.jar.JarOutputStream
+import java.nio.file.Files
 
 import org.junit.Test
 import org.junit.Assert.assertEquals
 
-class SaveTests extends ReplTest {
-
-  private def tempFile(suffix: String = ".scala"): Path =
-    val file = Files.createTempFile("repl_save", suffix)
-    file.toFile.deleteOnExit()
-    file
-
-  private def emptyJar(): Path =
-    val jar = tempFile(".jar")
-    new JarOutputStream(new FileOutputStream(jar.toFile)).close()
-    jar
-
-  private def contentOf(f: Path): String = Files.readString(f)
+class SaveTests extends ReplTest, SessionFileHelpers {
 
   private def lines() =
       storedOutput().trim.linesIterator.toList
-
-  private val header = Save.sessionHeader
-  private val sep = Save.entrySeparator
 
   @Test def savesSuccessfulInputs =
     val target = tempFile()

--- a/repl/test/dotty/tools/repl/SessionFileHelpers.scala
+++ b/repl/test/dotty/tools/repl/SessionFileHelpers.scala
@@ -1,0 +1,25 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import java.io.FileOutputStream
+import java.nio.file.{Path, Files}
+import java.util.jar.JarOutputStream
+
+trait SessionFileHelpers:
+
+  protected def tempFile(suffix: String = ".scala"): Path =
+    val file = Files.createTempFile("repl_session", suffix)
+    file.toFile.deleteOnExit()
+    file
+
+  protected def emptyJar(): Path =
+    val jar = tempFile(".jar")
+    new JarOutputStream(new FileOutputStream(jar.toFile)).close()
+    jar
+
+  protected def contentOf(f: Path): String = Files.readString(f)
+
+  protected val header: String = Save.sessionHeader
+  protected val sep: String = Save.entrySeparator

--- a/repl/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/repl/test/dotty/tools/repl/TabcompleteTests.scala
@@ -219,6 +219,7 @@ class TabcompleteTests extends ReplTest {
         ":load",
         ":paste",
         ":quit",
+        ":replay",
         ":require",
         ":reset",
         ":save",


### PR DESCRIPTION
Fixes #21663

Implements `:replay` command in the REPL.
```scala
Welcome to Scala 3.10.0-RC1-bin-SNAPSHOT-git-652f699 (25.0.1, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                  
scala> 42 + "D"
1 warning found
-- Deprecation Warning: --------------------------------------------------------
1 |42 + "D"
  |^^^^
  |method + in class Int is deprecated since 2.13.0: Adding a number and a String is deprecated. Use the string interpolation `s"$num$str"`
val res0: String = "42D"
                                                                                                                                  
scala> :replay -deprecation:false
Replaying REPL session with the following settings:
  -deprecation:false

there was 1 deprecation warning; re-run with -deprecation for details
1 warning found
val res0: String = "42D"
```

It's also excluded from being recorded in `pastInputs` to avoid something like this:
println("test1")
:replay - test1 x1
:replay - replays a replay, which replays println
etc.


## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by veryfing the code and updating it where changes were needed.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
