### PR TITLE
Add support for `//> using dep` directives in the REPL (along with trailing code)

### DIFF
--- a/repl/src/dotty/tools/repl/DependencyResolver.scala
+++ b/repl/src/dotty/tools/repl/DependencyResolver.scala
@@ -15,6 +15,12 @@ import dotty.tools.directives.{DirectiveValue, UsingDirectivesParser}
 /** Handles dependency resolution using Coursier for the REPL */
 object DependencyResolver:
 
+  /** Result of classifying `//> using` directives in REPL input. */
+  case class ClassifiedDirectives(deps: List[String], unsupportedKeys: List[String])
+
+  /** Directive keys the REPL knows how to handle. Extend as more directives gain REPL support. */
+  lazy val supportedDirectives: Set[String] = Set("dep")
+
   /** Parse a dependency string of the form `org::artifact:version` or `org:artifact:version`
    *  and return the (organization, artifact, version) triple if successful.
    *
@@ -30,23 +36,19 @@ object DependencyResolver:
         System.err.println("Unable to parse dependency \"" + dep + "\"")
         None
 
-  /** Extract all dependencies from using directives in source code */
-  def extractDependencies(sourceCode: String): List[String] =
+  /** Classify `//> using` directives in REPL input into dependency coordinates and unsupported keys. */
+  def classifyDirectives(sourceCode: String): ClassifiedDirectives =
     try
       val result = UsingDirectivesParser.parse(sourceCode)
-      result.directives.flatMap: directive =>
-        if directive.key == "dep" then
-          directive.values.flatMap:
-            case DirectiveValue.StringVal(value, _, _) => List(value)
-            case value =>
-              System.err.println("Unrecognized directive value " + value)
-              Nil
-        else
-          System.err.println("Unrecognized directive " + directive.key)
-          Nil
-      .toList
+      val (supported, unsupported) = result.directives.partition(d => supportedDirectives.contains(d.key))
+      val deps =
+        supported
+          .flatMap(_.values.collect { case DirectiveValue.StringVal(value, _, _) => value })
+          .toList
+      val unsupportedKeys = unsupported.map(_.key).distinct.toList
+      ClassifiedDirectives(deps, unsupportedKeys)
     catch
-      case NonFatal(_) => Nil // If parsing fails, fall back to empty list
+      case NonFatal(_) => ClassifiedDirectives(Nil, Nil)
 
   /** Resolve dependencies using Coursier Interface and return the classpath as a list of File objects */
   def resolveDependencies(dependencies: List[(String, String, String)]): Either[String, List[File]] =

--- a/repl/src/dotty/tools/repl/DependencyResolver.scala
+++ b/repl/src/dotty/tools/repl/DependencyResolver.scala
@@ -19,7 +19,7 @@ object DependencyResolver:
   case class ClassifiedDirectives(deps: List[String], unsupportedKeys: List[String])
 
   /** Directive keys the REPL knows how to handle. Extend as more directives gain REPL support. */
-  lazy val supportedDirectives: Set[String] = Set("dep")
+  val supportedDirectives: Set[String] = Set("dep")
 
   /** Parse a dependency string of the form `org::artifact:version` or `org:artifact:version`
    *  and return the (organization, artifact, version) triple if successful.

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -267,9 +267,16 @@ class JLineTerminal(providedTerminal: org.jline.terminal.Terminal | Null = null)
         null
       }
 
+      // A lone directive/command must defer (and assemble) when pasted code is already
+      // arriving, but submit on one ENTER when typed.
+      // A short bounded peek waits just long enough for the pump to surface
+      // already-arriving paste bytes; the wait only applies when submitting a bare
+      // directive/command line.
+      def hasPendingInput: Boolean = terminal.reader().peek(5) >= 0
+
       def acceptLine = {
         val onLastLine = !input.substring(cursor).contains(System.lineSeparator)
-        onLastLine && !ParseResult.isIncomplete(input)
+        onLastLine && ParseResult.shouldAcceptLine(input, hasPendingInput)
       }
 
       context match {

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -321,6 +321,17 @@ object ParseResult {
   private def onlyCommandSoFar(sourceCode: String): Boolean =
     !sourceCode.contains('\n') && CommandExtract.matches(sourceCode)
 
+  /** A lone leading directive block or a single `:command` line with no trailing
+   *  code yet. During a paste we keep reading so following code joins this input;
+   *  on a single interactive ENTER (nothing pending) it is submitted as-is. */
+  private[repl] def awaitsTrailingCode(sourceCode: String): Boolean =
+    !sourceCode.endsWith("\n") && (onlyDirectivesSoFar(sourceCode) || onlyCommandSoFar(sourceCode))
+
+  /** Whether JLine should accept the current buffer as a complete submission. */
+  private[repl] def shouldAcceptLine(sourceCode: String, hasPendingInput: Boolean)(using Context): Boolean =
+    if awaitsTrailingCode(sourceCode) then !hasPendingInput
+    else !isIncomplete(sourceCode)
+
   /** Check if the input is incomplete.
    *
    *  This can be used in order to check if a newline can be inserted without
@@ -329,10 +340,6 @@ object ParseResult {
   def isIncomplete(sourceCode: String)(using Context): Boolean =
     sourceCode match {
       case "" => false
-      // A lone directive or command line defers until the following pasted code arrives,
-      // so the whole block is submitted (and evaluated) as a single input. The trailing
-      // newline of the paste, or a second Enter, completes a directive/command on its own.
-      case _ if (onlyDirectivesSoFar(sourceCode) || onlyCommandSoFar(sourceCode)) && !sourceCode.endsWith("\n") => true
       case CommandExtract(_, _) => false
       case _ => {
         val reporter = newStoreReporter

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -332,6 +332,16 @@ object ParseResult {
     if awaitsTrailingCode(sourceCode) then !hasPendingInput
     else !isIncomplete(sourceCode)
 
+  /** The trailing code after any leading `:command` lines. Only this part decides
+   *  whether the whole input is complete: a `:command` is complete on its own, and
+   *  parsing its line as Scala would raise a spurious error (`:` is illegal) that
+   *  would otherwise make unfinished trailing code look complete and submit early.
+   */
+  private def codeAfterLeadingCommands(sourceCode: String): String =
+    leadingCommand(sourceCode) match
+      case Some((_, _, rest)) => codeAfterLeadingCommands(rest)
+      case None => sourceCode
+
   /** Check if the input is incomplete.
    *
    *  This can be used in order to check if a newline can be inserted without
@@ -341,18 +351,20 @@ object ParseResult {
     sourceCode match {
       case "" => false
       case CommandExtract(_, _) => false
-      case _ => {
-        val reporter = newStoreReporter
-        val source   = SourceFile.virtual("<incomplete-handler>", sourceCode)
-        val unit     = CompilationUnit(source, mustExist = false)
-        val localCtx = ctx.fresh
-                          .setCompilationUnit(unit)
-                          .setReporter(reporter)
-        var needsMore = false
-        reporter.withIncompleteHandler((_, _) => needsMore = true) {
-          parseStats(using localCtx)
+      case _ =>
+        val code = codeAfterLeadingCommands(sourceCode)
+        code.nonEmpty && {
+          val reporter = newStoreReporter
+          val source   = SourceFile.virtual("<incomplete-handler>", code)
+          val unit     = CompilationUnit(source, mustExist = false)
+          val localCtx = ctx.fresh
+                            .setCompilationUnit(unit)
+                            .setReporter(reporter)
+          var needsMore = false
+          reporter.withIncompleteHandler((_, _) => needsMore = true) {
+            parseStats(using localCtx)
+          }
+          !reporter.hasErrors && needsMore
         }
-        !reporter.hasErrors && needsMore
-      }
     }
 }

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -40,6 +40,15 @@ case object SigKill extends ParseResult
 sealed trait Command extends ParseResult:
   def replayLine: Option[String]
 
+/** A command on the first line followed by Scala code, e.g.
+ *  ```none
+ *  :dep <coords>
+ *  println("Hello")
+ *  ```
+ *  The command is interpreted first, then code is evaluated.
+ */
+case class CommandThenCode(command: Command, code: ParseResult) extends ParseResult
+
 /** An unknown command that will not be handled by the REPL */
 case class UnknownCommand(cmd: String) extends Command:
   override def replayLine = None
@@ -240,30 +249,57 @@ object ParseResult {
     Silent.command -> (_ => Silent),
   )
 
+  /** Resolve a `:command` name (which may be a prefix) and its argument into a `Command`. */
+  private def command(cmd: String, arg: String): Command =
+    commands.filter((command, _) => command.startsWith(cmd)) match {
+      case Nil => UnknownCommand(cmd)
+      case (_, f) :: Nil =>
+        f(arg) match {
+          case matched: Command => matched
+          case _ => UnknownCommand(cmd)
+        }
+      case multiple => AmbiguousCommand(cmd, multiple.map(_._1))
+    }
+
+  /** If `sourceCode`'s first line is a `:command`, split it into
+   *  `(commandName, commandArg, remainingText)`. `remainingText` may be blank.
+   */
+  private def leadingCommand(sourceCode: String): Option[(String, String, String)] =
+    sourceCode.indexOf('\n') match {
+      case -1 => None // single-line commands are handled by the CommandExtract fast path
+      case nl =>
+        val firstLineRaw = sourceCode.substring(0, nl)
+        val firstLine = if firstLineRaw.endsWith("\r") then firstLineRaw.dropRight(1) else firstLineRaw
+        val rest = sourceCode.substring(nl + 1)
+        firstLine match {
+          case CommandExtract(cmd: String, arg: String) => Some((cmd, arg, rest))
+          case _ => None
+        }
+    }
+
   def apply(source: SourceFile)(using state: State): ParseResult = {
     val sourceCode = source.content().mkString
     sourceCode match {
       case "" => Newline
-      case CommandExtract(cmd: String, arg: String) => {
-        val matchingCommands = commands.filter((command, _) => command.startsWith(cmd))
-        matchingCommands match {
-          case Nil => UnknownCommand(cmd)
-          case (_, f) :: Nil => f(arg)
-          case multiple => AmbiguousCommand(cmd, multiple.map(_._1))
-        }
-      }
+      case CommandExtract(cmd: String, arg: String) => command(cmd, arg)
       case _ =>
-        inContext(state.context) {
-          val reporter = newStoreReporter
-          val stats = parseStats(using state.context.fresh.setReporter(reporter).withSource(source))
+        leadingCommand(sourceCode) match {
+          case Some((cmd, arg, rest)) =>
+            if rest.exists(!_.isWhitespace) then CommandThenCode(command(cmd, arg), apply(rest))
+            else command(cmd, arg)
+          case None =>
+            inContext(state.context) {
+              val reporter = newStoreReporter
+              val stats = parseStats(using state.context.fresh.setReporter(reporter).withSource(source))
 
-          if (reporter.hasErrors)
-            SyntaxErrors(
-              sourceCode,
-              reporter.removeBufferedMessages,
-              stats)
-          else
-            Parsed(source, stats, reporter)
+              if (reporter.hasErrors)
+                SyntaxErrors(
+                  sourceCode,
+                  reporter.removeBufferedMessages,
+                  stats)
+              else
+                Parsed(source, stats, reporter)
+            }
         }
     }
   }
@@ -281,6 +317,10 @@ object ParseResult {
     val extracted = UsingDirectivesParser.extractLines(sourceCode.toIndexedSeq)
     extracted.directiveLines.nonEmpty && extracted.codeOffset >= sourceCode.length
 
+  /** True if `sourceCode` is a single `:command` line and no code yet. */
+  private def onlyCommandSoFar(sourceCode: String): Boolean =
+    !sourceCode.contains('\n') && CommandExtract.matches(sourceCode)
+
   /** Check if the input is incomplete.
    *
    *  This can be used in order to check if a newline can be inserted without
@@ -288,8 +328,12 @@ object ParseResult {
    */
   def isIncomplete(sourceCode: String)(using Context): Boolean =
     sourceCode match {
-      case CommandExtract(_, _) | "" => false
-      case _ if onlyDirectivesSoFar(sourceCode) && !sourceCode.endsWith("\n") => true
+      case "" => false
+      // A lone directive or command line defers until the following pasted code arrives,
+      // so the whole block is submitted (and evaluated) as a single input. The trailing
+      // newline of the paste, or a second Enter, completes a directive/command on its own.
+      case _ if (onlyDirectivesSoFar(sourceCode) || onlyCommandSoFar(sourceCode)) && !sourceCode.endsWith("\n") => true
+      case CommandExtract(_, _) => false
       case _ => {
         val reporter = newStoreReporter
         val source   = SourceFile.virtual("<incomplete-handler>", sourceCode)

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -198,6 +198,11 @@ case object Help extends Command {
       |:settings <options>      update compiler options, if possible
       |:silent                  disable/enable automatic printing of results
       |:dep <group>::<artifact>:<version>     Resolve a dependency and make it available in the REPL
+      |
+      |Scala CLI `//> using dep` directives are also supported and behave like `:dep`, e.g.:
+      |  //> using dep <group>::<artifact>:<version>
+      |Directives must appear before any Scala code in the input; code on following lines is
+      |evaluated as usual. Other `//> using` directives are not (yet) supported in the REPL.
     """.stripMargin
 }
 

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -9,6 +9,7 @@ import dotc.parsing.Parsers.Parser
 import dotc.parsing.Tokens
 import dotc.reporting.{Diagnostic, StoreReporter}
 import dotc.util.SourceFile
+import dotty.tools.directives.UsingDirectivesParser
 
 import scala.annotation.internal.sharable
 
@@ -270,6 +271,11 @@ object ParseResult {
       case CommandExtract(_, _) => true
       case _ => false
 
+  /** True if `sourceCode` contains one or more leading `//> using` directives and no code yet. */
+  private def onlyDirectivesSoFar(sourceCode: String): Boolean =
+    val extracted = UsingDirectivesParser.extractLines(sourceCode.toIndexedSeq)
+    extracted.directiveLines.nonEmpty && extracted.codeOffset >= sourceCode.length
+
   /** Check if the input is incomplete.
    *
    *  This can be used in order to check if a newline can be inserted without
@@ -278,6 +284,7 @@ object ParseResult {
   def isIncomplete(sourceCode: String)(using Context): Boolean =
     sourceCode match {
       case CommandExtract(_, _) | "" => false
+      case _ if onlyDirectivesSoFar(sourceCode) && !sourceCode.endsWith("\n") => true
       case _ => {
         val reporter = newStoreReporter
         val source   = SourceFile.virtual("<incomplete-handler>", sourceCode)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -774,8 +774,8 @@ class ReplDriver(settings: Array[String],
     val classified = DependencyResolver.classifyDirectives(sourceCode)
     classified.unsupportedKeys.foreach: key =>
       out.println(
-        s"[warn] The `using $key` directive is not supported in the REPL. " +
-        "To use it, re-run with the `scala` command and pass the directive inside an input."
+        s"""[warn] The `using $key` directive is not supported in the REPL.
+           |To use it, re-run with the `scala` command and pass the directive inside an input.""".stripMargin
       )
     resolveAndAddDeps(classified.deps)
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -381,11 +381,12 @@ class ReplDriver(settings: Array[String],
   protected def interpret(res: ParseResult)(using state: State): State = {
     res match {
       case parsed: Parsed if parsed.source.content().mkString.startsWith("//>") =>
-        val stateAfterDirectives = interpretDirectives(parsed.source.content().mkString)
+        val directiveSource = parsed.source.content().mkString
+        val stateAfterDirectives = interpretDirectives(directiveSource)
         if parsed.trees.nonEmpty then
           propagateLanguageImports(parsed.trees)
           compile(parsed, stateAfterDirectives)
-        else stateAfterDirectives
+        else stateAfterDirectives.recordInput(directiveSource.strip)
 
       case parsed: Parsed if parsed.trees.nonEmpty =>
         propagateLanguageImports(parsed.trees)
@@ -396,7 +397,8 @@ class ReplDriver(settings: Array[String],
 
       case CommandThenCode(cmd, code) =>
         val stateAfterCommand = interpretCommand(cmd)
-        interpret(code)(using stateAfterCommand)
+        val recorded = cmd.replayLine.fold(stateAfterCommand)(line => stateAfterCommand.recordInput(line.strip))
+        interpret(code)(using recorded)
 
       case cmd: Command =>
         val next = interpretCommand(cmd)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -394,6 +394,10 @@ class ReplDriver(settings: Array[String],
       case SyntaxErrors(_, errs, _) =>
         displayErrors(errs, state)
 
+      case CommandThenCode(cmd, code) =>
+        val stateAfterCommand = interpretCommand(cmd)
+        interpret(code)(using stateAfterCommand)
+
       case cmd: Command =>
         val next = interpretCommand(cmd)
         cmd.replayLine.fold(next)(line => next.recordInput(line.strip))

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -381,7 +381,11 @@ class ReplDriver(settings: Array[String],
   protected def interpret(res: ParseResult)(using state: State): State = {
     res match {
       case parsed: Parsed if parsed.source.content().mkString.startsWith("//>") =>
-        interpretDirectives(parsed.source.content().mkString)
+        val stateAfterDirectives = interpretDirectives(parsed.source.content().mkString)
+        if parsed.trees.nonEmpty then
+          propagateLanguageImports(parsed.trees)
+          compile(parsed, stateAfterDirectives)
+        else stateAfterDirectives
 
       case parsed: Parsed if parsed.trees.nonEmpty =>
         propagateLanguageImports(parsed.trees)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -381,9 +381,7 @@ class ReplDriver(settings: Array[String],
   protected def interpret(res: ParseResult)(using state: State): State = {
     res match {
       case parsed: Parsed if parsed.source.content().mkString.startsWith("//>") =>
-        // Check for magic comments specifying dependencies
-        println("Please use `:dep com.example::artifact:version` to add dependencies in the REPL")
-        state
+        interpretDirectives(parsed.source.content().mkString)
 
       case parsed: Parsed if parsed.trees.nonEmpty =>
         propagateLanguageImports(parsed.trees)
@@ -757,37 +755,43 @@ class ReplDriver(settings: Array[String],
         state.copy(context = rootCtx)
 
     case Silent => state.copy(quiet = !state.quiet)
-    case Dep(dep) =>
-      def jarCount(fileSize: Int): String =
-        if fileSize == 1 then "1 JAR" else s"$fileSize JARs"
-
-      if dep.nonEmpty then
-        DependencyResolver.parseDependency(dep) match
-          case Some(d) =>
-            DependencyResolver.resolveDependencies(List(d)) match
-              case Right(files) if files.nonEmpty =>
-                inContext(state.context):
-                  // Update both compiler classpath and classloader
-                  val prevOutputDir = ctx.settings.outputDir.value
-                  val prevClassLoader = rendering.classLoader()
-                  rendering.myClassLoader = DependencyResolver.addToCompilerClasspath(
-                    files,
-                    prevClassLoader,
-                    prevOutputDir
-                  )
-                  out.println(s"Resolved a dependency (${jarCount(files.size)})")
-              case Right(_) =>
-              case Left(error) =>
-                out.println(s"Error resolving a dependency: $error")
-          case None =>
-      else
-        out.println("No dependency specified.")
-      state
+    case Dep(dep) => resolveAndAddDeps(List(dep))
 
     case Quit =>
       // end of the world!
       state
   }
+
+  private def interpretDirectives(sourceCode: String)(using state: State): State =
+    val classified = DependencyResolver.classifyDirectives(sourceCode)
+    classified.unsupportedKeys.foreach: key =>
+      out.println(
+        s"[warn] The `using $key` directive is not supported in the REPL. " +
+        "To use it, re-run with the `scala` command and pass the directive inside an input."
+      )
+    resolveAndAddDeps(classified.deps)
+
+  private def resolveAndAddDeps(depStrings: List[String])(using state: State): State =
+    if depStrings.isEmpty then state
+    else
+      val deps = depStrings.flatMap(DependencyResolver.parseDependency)
+      if deps.isEmpty then state
+      else
+        DependencyResolver.resolveDependencies(deps) match
+          case Right(files) =>
+            if files.nonEmpty then
+              inContext(state.context):
+                val prevOutputDir = ctx.settings.outputDir.value
+                val prevClassLoader = rendering.classLoader()
+                rendering.myClassLoader = DependencyResolver.addToCompilerClasspath(
+                  files,
+                  prevClassLoader,
+                  prevOutputDir
+                )
+                out.println(s"Resolved ${deps.size} dependencies (${files.size} JARs)")
+          case Left(error) =>
+            out.println(s"Error resolving dependencies: $error")
+        state
 
   /** shows all errors nicely formatted */
   private def displayErrors(errs: Seq[Diagnostic], state: State): State = {

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -52,6 +52,32 @@ class ReplDependencyMacroTests extends ReplTest:
     initially:
       resolveUpickleViaDirective()
 
+  @Test def `i21654 using dep directive before code resolves and compiles`: Unit =
+    initially:
+      run("//> using dep com.lihaoyi::upickle:4.4.3\ncase class FooCombined(x: Int) derives upickle.default.ReadWriter")
+      val output = storedOutput()
+      assertTrue(output, output.contains("Resolved 1 dependencies"))
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("// defined case class FooCombined"))
+
+  @Test def `i21654 multiple dep directives before code resolve together`: Unit =
+    initially:
+      run("""//> using dep com.lihaoyi::upickle:4.4.3
+            |//> using dep com.lihaoyi::os-lib:0.11.3
+            |val combined = (upickle.default.write(1), os.pwd.toString)""".stripMargin)
+      val output = storedOutput()
+      assertTrue(output, output.contains("Resolved 2 dependencies"))
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("val combined:"))
+
+  @Test def `i21654 os-lib directive before code resolves and evaluates`: Unit =
+    initially:
+      run("//> using dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd.toString")
+      val output = storedOutput()
+      assertTrue(output, output.contains("Resolved 1 dependencies"))
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("val p: String ="))
+
   @Test def `i25291 derives ReadWriter after :dep`: Unit =
     initially:
       resolveUpickle()

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -15,7 +15,7 @@ class ReplDependencyMacroTests extends ReplTest:
   private def resolveUpickle()(using State): Unit =
     run(":dep com.lihaoyi::upickle:4.4.3")
     val output = storedOutput()
-    assertTrue(output, output.contains("Resolved a dependency"))
+    assertTrue(output, output.contains("Resolved 1 dependencies"))
     assertNoMacroFailure(output)
 
   private def addUpickleViaJar()(using State): Unit =
@@ -41,6 +41,16 @@ class ReplDependencyMacroTests extends ReplTest:
       val output = storedOutput()
       assertTrue(output, output.contains("Added"))
       assertNoMacroFailure(output)
+
+  private def resolveUpickleViaDirective()(using State): Unit =
+    run("//> using dep com.lihaoyi::upickle:4.4.3")
+    val output = storedOutput()
+    assertTrue(output, output.contains("Resolved 1 dependencies"))
+    assertNoMacroFailure(output)
+
+  @Test def `i21654 using dep directive resolves like :dep`: Unit =
+    initially:
+      resolveUpickleViaDirective()
 
   @Test def `i25291 derives ReadWriter after :dep`: Unit =
     initially:

--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -78,6 +78,26 @@ class ReplDependencyMacroTests extends ReplTest:
       assertNoMacroFailure(output)
       assertTrue(output, output.contains("val p: String ="))
 
+  @Test def `i21654 dep command before code resolves and evaluates`: Unit =
+    initially:
+      run(":dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd.toString")
+      val output = storedOutput()
+      assertTrue(output, output.contains("Resolved 1 dependencies"))
+      assertNoMacroFailure(output)
+      assertTrue(output, output.contains("val p: String ="))
+
+  @Test def `i21654 repeated dep commands with trailing newline resolve`: Unit =
+    initially:
+      run(":dep com.lihaoyi::os-lib:0.11.3\n")
+      val first = storedOutput()
+      assertTrue(first, first.contains("Resolved 1 dependencies"))
+      assertNoMacroFailure(first)
+      run(":dep com.lihaoyi::upickle:4.4.3\n")
+      val second = storedOutput()
+      assertTrue(second, second.contains("Resolved 1 dependencies"))
+      assertNoMacroFailure(second)
+      assertFalse(second, second.contains("Illegal start of statement"))
+
   @Test def `i25291 derives ReadWriter after :dep`: Unit =
     initially:
       resolveUpickle()

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -6,6 +6,29 @@ import org.junit.Test
 
 class ReplDirectiveTests extends ReplTest:
 
+  @Test def `lone dep directive is incomplete until code follows`: Unit = contextually:
+    assertTrue(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.3"))
+
+  @Test def `dep directive with code is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
+
+  @Test def `lone dep directive with trailing newline is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.3\n"))
+
+  @Test def `multiple dep directives without code are incomplete`: Unit = contextually:
+    assertTrue(ParseResult.isIncomplete(
+      "//> using dep com.lihaoyi::upickle:4.4.3\n//> using dep com.lihaoyi::os-lib:0.11.3"))
+
+  @Test def `multiple dep directives with code are complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete(
+      "//> using dep com.lihaoyi::upickle:4.4.3\n//> using dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
+
+  @Test def `unsupported directive with code is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete("//> using options -Werror\nval x = 1"))
+
+  @Test def `plain comment is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete("// just a comment"))
+
   @Test def `unsupported options directive warns`: Unit =
     initially:
       run("//> using options -Werror")
@@ -26,3 +49,33 @@ class ReplDirectiveTests extends ReplTest:
       run("//> using dep some.bogus.coords")
       val output = storedOutput()
       assertFalse(output, output.contains("not supported in the REPL"))
+
+  @Test def `unsupported directive before code still evaluates code`: Unit =
+    initially:
+      run("//> using options -Werror\nval x = 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertTrue(output, output.contains("val x: Int = 1"))
+
+  @Test def `unsupported directive before expression still evaluates expression`: Unit =
+    initially:
+      run("//> using scala 3.3.1\n1 + 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertTrue(output, output.contains("val res0: Int = 2"))
+
+  @Test def `directive after code is not treated as command`: Unit =
+    initially:
+      run("val y = 2\n//> using dep some.bogus.coords")
+      val output = storedOutput()
+      assertTrue(output, output.contains("val y: Int = 2"))
+      assertFalse(output, output.contains("not supported in the REPL"))
+
+  @Test def `multiple unsupported directives before code warn and evaluate code`: Unit =
+    initially:
+      run("//> using options -Werror\n//> using scala 3.3.1\nval z = 3")
+      val output = storedOutput()
+      assertTrue(output, output.contains("using options"))
+      assertTrue(output, output.contains("using scala"))
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertTrue(output, output.contains("val z: Int = 3"))

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -50,6 +50,22 @@ class ReplDirectiveTests extends ReplTest:
     assertFalse(ParseResult.awaitsTrailingCode(":dep com.lihaoyi::os-lib:0.11.3\n"))
     assertFalse(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3\n"))
 
+  @Test def `command with incomplete trailing code is incomplete`: Unit = contextually:
+    assertTrue(ParseResult.isIncomplete(":settings -deprecation\nif true then"))
+    assertFalse(ParseResult.shouldAcceptLine(":settings -deprecation\nif true then", hasPendingInput = false))
+
+  @Test def `command with complete trailing code is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete(":settings -deprecation\nif true then ()"))
+    assertTrue(ParseResult.shouldAcceptLine(":settings -deprecation\nif true then ()", hasPendingInput = false))
+
+  @Test def `code with incomplete trailing expression is incomplete`: Unit = contextually:
+    assertTrue(ParseResult.isIncomplete("val x = 5\nif x == 5 then"))
+    assertFalse(ParseResult.shouldAcceptLine("val x = 5\nif x == 5 then", hasPendingInput = false))
+
+  @Test def `code with complete trailing expression is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete("val x = 5\nif x == 5 then 1"))
+    assertTrue(ParseResult.shouldAcceptLine("val x = 5\nif x == 5 then 1", hasPendingInput = false))
+
   @Test def `command with trailing code parses as CommandThenCode`: Unit = initially:
     ParseResult(":type \"hello\"\nval x = 5") match
       case CommandThenCode(TypeOf("\"hello\""), _: Parsed) => // expected

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -7,35 +7,47 @@ import org.junit.Test
 class ReplDirectiveTests extends ReplTest:
 
   @Test def `lone dep directive is incomplete until code follows`: Unit = contextually:
-    assertTrue(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.3"))
+    assertTrue(ParseResult.awaitsTrailingCode("//> using dep com.lihaoyi::os-lib:0.11.3"))
+    assertFalse(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.3"))
 
   @Test def `dep directive with code is complete`: Unit = contextually:
+    assertFalse(ParseResult.awaitsTrailingCode("//> using dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
     assertFalse(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
 
   @Test def `lone dep directive with trailing newline is complete`: Unit = contextually:
+    assertFalse(ParseResult.awaitsTrailingCode("//> using dep com.lihaoyi::os-lib:0.11.3\n"))
     assertFalse(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.3\n"))
 
   @Test def `multiple dep directives without code are incomplete`: Unit = contextually:
-    assertTrue(ParseResult.isIncomplete(
+    assertTrue(ParseResult.awaitsTrailingCode(
+      "//> using dep com.lihaoyi::upickle:4.4.3\n//> using dep com.lihaoyi::os-lib:0.11.3"))
+    assertFalse(ParseResult.isIncomplete(
       "//> using dep com.lihaoyi::upickle:4.4.3\n//> using dep com.lihaoyi::os-lib:0.11.3"))
 
   @Test def `multiple dep directives with code are complete`: Unit = contextually:
+    assertFalse(ParseResult.awaitsTrailingCode(
+      "//> using dep com.lihaoyi::upickle:4.4.3\n//> using dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
     assertFalse(ParseResult.isIncomplete(
       "//> using dep com.lihaoyi::upickle:4.4.3\n//> using dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
 
   @Test def `unsupported directive with code is complete`: Unit = contextually:
+    assertFalse(ParseResult.awaitsTrailingCode("//> using options -Werror\nval x = 1"))
     assertFalse(ParseResult.isIncomplete("//> using options -Werror\nval x = 1"))
 
   @Test def `plain comment is complete`: Unit = contextually:
+    assertFalse(ParseResult.awaitsTrailingCode("// just a comment"))
     assertFalse(ParseResult.isIncomplete("// just a comment"))
 
   @Test def `lone command is incomplete until code follows`: Unit = contextually:
-    assertTrue(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3"))
+    assertTrue(ParseResult.awaitsTrailingCode(":dep com.lihaoyi::os-lib:0.11.3"))
+    assertFalse(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3"))
 
   @Test def `command with code is complete`: Unit = contextually:
+    assertFalse(ParseResult.awaitsTrailingCode(":dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
     assertFalse(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
 
   @Test def `lone command with trailing newline is complete`: Unit = contextually:
+    assertFalse(ParseResult.awaitsTrailingCode(":dep com.lihaoyi::os-lib:0.11.3\n"))
     assertFalse(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3\n"))
 
   @Test def `command with trailing code parses as CommandThenCode`: Unit = initially:

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -1,0 +1,28 @@
+package dotty.tools
+package repl
+
+import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Test
+
+class ReplDirectiveTests extends ReplTest:
+
+  @Test def `unsupported options directive warns`: Unit =
+    initially:
+      run("//> using options -Werror")
+      val output = storedOutput()
+      assertTrue(output, output.contains("using options"))
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertFalse(output, output.contains("Resolved"))
+
+  @Test def `unsupported scala directive warns`: Unit =
+    initially:
+      run("//> using scala 3.3.1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("using scala"))
+      assertTrue(output, output.contains("not supported in the REPL"))
+
+  @Test def `dep directive is treated as :dep alias`: Unit =
+    initially:
+      run("//> using dep some.bogus.coords")
+      val output = storedOutput()
+      assertFalse(output, output.contains("not supported in the REPL"))

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -29,6 +29,43 @@ class ReplDirectiveTests extends ReplTest:
   @Test def `plain comment is complete`: Unit = contextually:
     assertFalse(ParseResult.isIncomplete("// just a comment"))
 
+  @Test def `lone command is incomplete until code follows`: Unit = contextually:
+    assertTrue(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3"))
+
+  @Test def `command with code is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3\nval p = os.pwd"))
+
+  @Test def `lone command with trailing newline is complete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.3\n"))
+
+  @Test def `command with trailing code parses as CommandThenCode`: Unit = initially:
+    ParseResult(":type \"hello\"\nval x = 5") match
+      case CommandThenCode(TypeOf("\"hello\""), _: Parsed) => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `command with trailing code evaluates both`: Unit =
+    initially:
+      run(":type \"hello\"\nval x = 5")
+      val output = storedOutput()
+      assertTrue(output, output.contains("String"))
+      assertTrue(output, output.contains("val x: Int = 5"))
+
+  @Test def `lone command with trailing newline parses as command`: Unit = initially:
+    ParseResult(":type 1\n") match
+      case TypeOf("1") => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `repeated lone commands with trailing newline work`: Unit =
+    initially:
+      run(":type 1\n")
+      val first = storedOutput()
+      assertTrue(first, first.contains("Int"))
+      assertFalse(first, first.contains("Illegal start of statement"))
+      run(":type 2\n")
+      val second = storedOutput()
+      assertTrue(second, second.contains("Int"))
+      assertFalse(second, second.contains("Illegal start of statement"))
+
   @Test def `unsupported options directive warns`: Unit =
     initially:
       run("//> using options -Werror")

--- a/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
@@ -97,3 +97,40 @@ class ReplInteractiveTests:
     assertEquals(
       "//> using dep com.lihaoyi::os-lib:0.11.8\nval x = 1",
       readPastedLine("//> using dep com.lihaoyi::os-lib:0.11.8\nval x = 1\n"))
+
+  /** What a single `readLine` submits for `input`, or `waitsForMore` if it keeps
+   *  reading (the input was treated as incomplete). On timeout the piped input is
+   *  closed so the blocked reader unwinds cleanly and never wedges the suite.
+   */
+  private val waitsForMore = "<waits-for-more>"
+  private def submittedOrWaiting(input: String, timeoutMs: Long = 4000L): String =
+    val pos = new PipedOutputStream
+    val pis = new PipedInputStream(pos)
+    val sink = new ByteArrayOutputStream
+    val terminal =
+      TerminalBuilder.builder().system(false).streams(pis, sink).dumb(true).build()
+    val jlt = new JLineTerminal(terminal)
+    val executor = Executors.newSingleThreadExecutor: r =>
+      val t = new Thread(r, "repl-interactive-test")
+      t.setDaemon(true)
+      t
+    try
+      val future = executor.submit(() => jlt.readLine(noopCompleter)(using context))
+      pos.write(input.getBytes(StandardCharsets.UTF_8))
+      pos.flush()
+      try future.get(timeoutMs, TimeUnit.MILLISECONDS)
+      catch case _: TimeoutException =>
+        pos.close() // EOF lets the blocked reader finish so cleanup does not hang
+        try future.get(2000, TimeUnit.MILLISECONDS) catch case _: Exception => ()
+        waitsForMore
+    finally
+      executor.shutdownNow()
+      try jlt.close() catch case _: Throwable => ()
+
+  @Test def `command then incomplete code is not submitted as one line`(): Unit =
+    val incomplete = ":settings -deprecation\nif true then"
+    assertNotEquals(incomplete, submittedOrWaiting(incomplete + "\n"))
+
+  @Test def `code with incomplete trailing expression is not submitted as one line`(): Unit =
+    val incomplete = "val x = 5\nif x == 5 then"
+    assertNotEquals(incomplete, submittedOrWaiting(incomplete + "\n"))

--- a/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
@@ -1,0 +1,99 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import java.io.{ByteArrayOutputStream, PipedInputStream, PipedOutputStream}
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.{Executors, TimeUnit, TimeoutException}
+
+import dotc.core.Contexts.Context
+import org.junit.Assert.*
+import org.junit.Test
+import org.jline.reader.{Candidate, Completer, LineReader, ParsedLine}
+import org.jline.terminal.TerminalBuilder
+
+/** Interactive-mode accept-line behaviour for lone directives/commands and pastes. */
+class ReplInteractiveTests:
+
+  private lazy val context: Context = new ReplTest().initialState.context
+
+  private def contextually[A](op: Context ?=> A): A = op(using context)
+
+  @Test def `lone dep command is not incomplete`(): Unit = contextually:
+    assertFalse(ParseResult.isIncomplete(":dep com.lihaoyi::os-lib:0.11.8"))
+
+  @Test def `lone using directive is not incomplete`(): Unit = contextually:
+    assertFalse(ParseResult.isIncomplete("//> using dep com.lihaoyi::os-lib:0.11.8"))
+
+  @Test def `single-line dep accepts when nothing is pending`(): Unit = contextually:
+    val input = ":dep com.lihaoyi::os-lib:0.11.8"
+    assertTrue(ParseResult.shouldAcceptLine(input, hasPendingInput = false))
+
+  @Test def `single-line directive accepts when nothing is pending`(): Unit = contextually:
+    val input = "//> using dep com.lihaoyi::os-lib:0.11.8"
+    assertTrue(ParseResult.awaitsTrailingCode(input))
+    assertTrue(ParseResult.shouldAcceptLine(input, hasPendingInput = false))
+
+  @Test def `lone directive defers when pasted code is already buffered`(): Unit = contextually:
+    val input = "//> using dep com.lihaoyi::os-lib:0.11.8"
+    assertFalse(ParseResult.shouldAcceptLine(input, hasPendingInput = true))
+
+  @Test def `lone dep defers when pasted code is already buffered`(): Unit = contextually:
+    val input = ":dep com.lihaoyi::os-lib:0.11.8"
+    assertFalse(ParseResult.shouldAcceptLine(input, hasPendingInput = true))
+
+  @Test def `directive with code accepts when nothing is pending`(): Unit = contextually:
+    val input = "//> using dep com.lihaoyi::os-lib:0.11.8\nval x = 1"
+    assertFalse(ParseResult.awaitsTrailingCode(input))
+    assertTrue(ParseResult.shouldAcceptLine(input, hasPendingInput = false))
+
+  private val noopCompleter = new Completer:
+    def complete(reader: LineReader, line: ParsedLine, candidates: java.util.List[Candidate]): Unit = ()
+
+  private def withTestTerminal[A](test: (JLineTerminal, PipedOutputStream) => A): A =
+    val pos = new PipedOutputStream
+    val pis = new PipedInputStream(pos)
+    val sink = new ByteArrayOutputStream
+    val terminal =
+      TerminalBuilder.builder()
+        .system(false)
+        .streams(pis, sink)
+        .dumb(true)
+        .build()
+    val jlt = new JLineTerminal(terminal)
+    try test(jlt, pos)
+    finally jlt.close()
+
+  /** Feed `input` and assert `readLine` returns within `timeoutMs` (i.e. a single
+   *  ENTER submitted it). Dumb terminals bind accept-line to LF, so ENTER is `\n`.
+   */
+  private def readPastedLine(input: String, timeoutMs: Long = 5000L): String =
+    withTestTerminal: (term, pos) =>
+      val executor = Executors.newSingleThreadExecutor: r =>
+        val t = new Thread(r, "repl-interactive-test")
+        t.setDaemon(true)
+        t
+      try
+        val future = executor.submit(() => term.readLine(noopCompleter)(using context))
+        pos.write(input.getBytes(StandardCharsets.UTF_8))
+        pos.flush()
+        try future.get(timeoutMs, TimeUnit.MILLISECONDS)
+        catch
+          case _: TimeoutException =>
+            future.cancel(true)
+            throw new AssertionError(
+              s"readLine blocked awaiting a second ENTER on: ${input.replace("\n", "\\n")}")
+      finally
+        executor.shutdownNow()
+
+  @Test def `single-line dep command submits on one ENTER`(): Unit =
+    assertEquals(":dep com.lihaoyi::os-lib:0.11.8", readPastedLine(":dep com.lihaoyi::os-lib:0.11.8\n"))
+
+  @Test def `single-line directive submits on one ENTER`(): Unit =
+    assertEquals("//> using dep com.lihaoyi::os-lib:0.11.8", readPastedLine("//> using dep com.lihaoyi::os-lib:0.11.8\n"))
+
+  @Test def `directive and code paste assembles into one submission`(): Unit =
+    assertEquals(
+      "//> using dep com.lihaoyi::os-lib:0.11.8\nval x = 1",
+      readPastedLine("//> using dep com.lihaoyi::os-lib:0.11.8\nval x = 1\n"))

--- a/repl/test/dotty/tools/repl/SaveTests.scala
+++ b/repl/test/dotty/tools/repl/SaveTests.scala
@@ -266,4 +266,100 @@ class SaveTests extends ReplTest, SessionFileHelpers {
       run("isEven(10)")
       assertEquals(List("val res0: Boolean = true"), lines())
     }
+
+  @Test def savesCommandThenCode =
+    val target = tempFile()
+    initially {
+      run(":type \"hi\"\nval x = 5")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |:type "hi"
+            |$sep
+            |val x = 5""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def roundTripsCommandThenCodeViaLoad =
+    val target = tempFile()
+    initially {
+      run(":type \"hi\"\nval x = 5")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("x")
+      assertEquals(List("val res0: Int = 5"), lines())
+    }
+
+  @Test def savesLoneDirective =
+    val target = tempFile()
+    initially {
+      run("//> using options -Werror")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |//> using options -Werror""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def savesDirectiveThenCode =
+    val target = tempFile()
+    initially {
+      run("//> using options -Werror\nval x = 1")
+    } andThen {
+      run(s":save $target")
+      assertEquals(
+        s"""|$header
+            |$sep
+            |//> using options -Werror
+            |val x = 1""".stripMargin,
+        contentOf(target)
+      )
+    }
+
+  @Test def roundTripsMultipleDirectivesThenCodeViaLoad =
+    val target = tempFile()
+    initially {
+      run("//> using options -Werror\n//> using scala 3.3.1\nval z = 3")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("z")
+      assertEquals(List("val res0: Int = 3"), lines())
+    }
+
+  @Test def roundTripsDepDirectiveViaLoad =
+    val target = tempFile()
+    initially {
+      run("//> using dep com.lihaoyi::os-lib:0.11.8\nval p = os.pwd.toString.nonEmpty")
+    } andThen {
+      run(s":save $target")
+    }
+    resetToInitial()
+    initially {
+      storedOutput()
+      run(s":load $target")
+    } andThen {
+      storedOutput()
+      run("os.pwd.toString.nonEmpty")
+      assertEquals(List("val res0: Boolean = true"), lines())
+    }
 }


### PR DESCRIPTION
This does a bunch of things:
- allow to use `//> using dep <dependency>` directives in the REPL
  - `//> using dep` is essentially a synonym for `:dep`
- add proper warnings for other, unsupported directives
- add support for pasting multiple directives along with trailing code and handling that in the REPL
  ```scala
  //> dep com.lihaoyi::upickle:4.4.3
  //> dep com.lihaoyi::os-lib:0.11.3
  val combined = (upickle.default.write(1), os.pwd.toString)
  ```
  
https://github.com/user-attachments/assets/8240a1bb-a9d4-4dc6-aaf7-060956eaa28d

- multiple commands with trailing code are handled similarly, so one can also paste
  ```scala
  :dep com.lihaoyi::upickle:4.4.3
  :dep com.lihaoyi::os-lib:0.11.3
  val combined = (upickle.default.write(1), os.pwd.toString)
  ```
https://github.com/user-attachments/assets/522846b9-bbe7-4fe4-869f-4a38c52df847

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by investigating the code and testing manually, while clinging to my dear sanity, as it's been tricky to make this whole thing work

## How was the solution tested?
New automated tests + a whole bunch of manual testing
It is worth noting that `sbt scala3-repl/run` is not a good way to test multi-line directives with trailing code (as the JLine terminal spawned by SBT plays by its own rules, known only to itself), and it's better to test it by:
```bash
sbt clean
sbt scala3-repl/compile
bin/replQ
```