### PR TITLE
fix: reliably decide whether to generate static forwarders

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -678,7 +678,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
            */
           val sym = dd.symbol
           val needsStaticImplMethod =
-            claszSymbol.is(Trait) && !dd.rhs.isEmpty && !sym.isPrivate && !sym.isStaticMember
+            claszSymbol.is(Trait) && !dd.rhs.isEmpty && !sym.is(Private) && !sym.isStaticMember
           if needsStaticImplMethod then
             if sym.name == nme.TRAIT_CONSTRUCTOR then
               genTraitConstructorDefDef(dd)


### PR DESCRIPTION
I observed surprising static forwarder methods being nondeterministically generated for anonymous and inner functions in Pekko HTTP. These should not be generated, since these methods are private and static forwards methods should only be generated for functions that are not private.

Looking at this conditional, it used `!sym.isPrivate` which is implemented as `lastDenot.flagsUNSAFE.is(Private)`. `flagsUNSAFE` has scaladoc `Should be used only for printing`.

I changed `isPrivate` to `is(Private)` and could confirm this indeed makes Pekko HTTP consistently not generate these methods. I did notice `isPrivate` is used in a few more places, so those may have the same problem, but I figured I'd make the most conservative change that fixes the problem I actually saw.

Fixes #18248

If possible I think it would be valuable to backport this fix, since on 3.3.8 this bug is nondeterministically triggered, so it breaks [reproducible builds](https://reproducible-builds.org/).

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Manual tests because writing automated tests is impractical, described below (in detail)

Sadly I did not manage to reproduce the issue in a minimal test, but the use of `flagsUNSAFE` seems obviously bad.

I've tested this change both on top of 3.3.8 and on top of 5d6ed42a24a1346e07523eac3e2cdff25211487e. I'd `publishLocal`/`scala3-bootstrapped/publishLocal` the new compiler code and rebuild Pekko HTTP at 07bd95574aed641bc7d3c326f3072185060c6c94 with the updated compiler. Notably `javap ./http/target/*/classes/org/apache/pekko/http/scaladsl/server/directives/RangeDirectives.class | grep withRange` would show `withRangeSupport$$anonfun$1$` (on 3.3.8 nondeterministically, on 5d6ed42a24a1346e07523eac3e2cdff25211487e deterministically). After applying the patch `withRangeSupport$$anonfun$1$` correctly no longer shows up.