### PR TITLE
Allow for directives in the REPL to be preceded/interjected by comments or empty lines

### DIFF
--- a/repl/src/dotty/tools/repl/DependencyResolver.scala
+++ b/repl/src/dotty/tools/repl/DependencyResolver.scala
@@ -16,7 +16,7 @@ import dotty.tools.directives.{DirectiveValue, UsingDirectivesParser}
 object DependencyResolver:
 
   /** Result of classifying `//> using` directives in REPL input. */
-  case class ClassifiedDirectives(deps: List[String], unsupportedKeys: List[String])
+  case class ClassifiedDirectives(deps: List[String], unsupportedKeys: List[String], hasDirectives: Boolean)
 
   /** Directive keys the REPL knows how to handle. Extend as more directives gain REPL support. */
   val supportedDirectives: Set[String] = Set("dep")
@@ -46,9 +46,9 @@ object DependencyResolver:
           .flatMap(_.values.collect { case DirectiveValue.StringVal(value, _, _) => value })
           .toList
       val unsupportedKeys = unsupported.map(_.key).distinct.toList
-      ClassifiedDirectives(deps, unsupportedKeys)
+      ClassifiedDirectives(deps, unsupportedKeys, result.directives.nonEmpty)
     catch
-      case NonFatal(_) => ClassifiedDirectives(Nil, Nil)
+      case NonFatal(_) => ClassifiedDirectives(Nil, Nil, false)
 
   /** Resolve dependencies using Coursier Interface and return the classpath as a list of File objects */
   def resolveDependencies(dependencies: List[(String, String, String)]): Either[String, List[File]] =

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -9,7 +9,7 @@ import dotc.parsing.Parsers.Parser
 import dotc.parsing.Tokens
 import dotc.reporting.{Diagnostic, StoreReporter}
 import dotc.util.SourceFile
-import dotty.tools.directives.UsingDirectivesParser
+import dotty.tools.directives.{ExtractorResult, UsingDirectivesParser}
 
 import scala.annotation.internal.sharable
 
@@ -261,21 +261,27 @@ object ParseResult {
       case multiple => AmbiguousCommand(cmd, multiple.map(_._1))
     }
 
-  /** If `sourceCode`'s first line is a `:command`, split it into
-   *  `(commandName, commandArg, remainingText)`. `remainingText` may be blank.
+  private def extractDirectives(sourceCode: String): ExtractorResult =
+    UsingDirectivesParser.extractLines(sourceCode.toIndexedSeq)
+
+  /** If `sourceCode`'s first significant line (after comments/blank lines) is a
+   *  `:command`, split it into `(commandName, commandArg, remainingText)`.
+   *  `remainingText` may be blank.
    */
-  private def leadingCommand(sourceCode: String): Option[(String, String, String)] =
-    sourceCode.indexOf('\n') match {
-      case -1 => None // single-line commands are handled by the CommandExtract fast path
-      case nl =>
-        val firstLineRaw = sourceCode.substring(0, nl)
+  private def leadingCommand(sourceCode: String, extractedDirectives: ExtractorResult): Option[(String, String, String)] =
+    if extractedDirectives.directiveLines.nonEmpty then None // directive blocks are handled as Parsed input
+    else
+      val start = extractedDirectives.codeOffset
+      if start >= sourceCode.length then None
+      else
+        val significant = sourceCode.substring(start)
+        val (firstLineRaw, rest) = significant.indexOf('\n') match
+          case -1 => (significant, "")
+          case nl => (significant.substring(0, nl), significant.substring(nl + 1))
         val firstLine = if firstLineRaw.endsWith("\r") then firstLineRaw.dropRight(1) else firstLineRaw
-        val rest = sourceCode.substring(nl + 1)
-        firstLine match {
+        firstLine match
           case CommandExtract(cmd: String, arg: String) => Some((cmd, arg, rest))
           case _ => None
-        }
-    }
 
   def apply(source: SourceFile)(using state: State): ParseResult = {
     val sourceCode = source.content().mkString
@@ -283,7 +289,7 @@ object ParseResult {
       case "" => Newline
       case CommandExtract(cmd: String, arg: String) => command(cmd, arg)
       case _ =>
-        leadingCommand(sourceCode) match {
+        leadingCommand(sourceCode, extractDirectives(sourceCode)) match {
           case Some((cmd, arg, rest)) =>
             if rest.exists(!_.isWhitespace) then CommandThenCode(command(cmd, arg), apply(rest))
             else command(cmd, arg)
@@ -313,33 +319,38 @@ object ParseResult {
       case _ => false
 
   /** True if `sourceCode` contains one or more leading `//> using` directives and no code yet. */
-  private def onlyDirectivesSoFar(sourceCode: String): Boolean =
-    val extracted = UsingDirectivesParser.extractLines(sourceCode.toIndexedSeq)
-    extracted.directiveLines.nonEmpty && extracted.codeOffset >= sourceCode.length
+  private def onlyDirectivesSoFar(sourceCode: String, extractedDirectives: ExtractorResult): Boolean =
+    extractedDirectives.directiveLines.nonEmpty && extractedDirectives.codeOffset >= sourceCode.length
 
   /** True if `sourceCode` is a single `:command` line and no code yet. */
-  private def onlyCommandSoFar(sourceCode: String): Boolean =
-    !sourceCode.contains('\n') && CommandExtract.matches(sourceCode)
+  private def onlyCommandSoFar(sourceCode: String, extractedDirectives: ExtractorResult): Boolean =
+    leadingCommand(sourceCode, extractedDirectives) match
+      case Some((_, _, rest)) => rest.forall(_.isWhitespace)
+      case None => false
 
   /** A lone leading directive block or a single `:command` line with no trailing
    *  code yet. During a paste we keep reading so following code joins this input;
    *  on a single interactive ENTER (nothing pending) it is submitted as-is. */
   private[repl] def awaitsTrailingCode(sourceCode: String): Boolean =
-    !sourceCode.endsWith("\n") && (onlyDirectivesSoFar(sourceCode) || onlyCommandSoFar(sourceCode))
+    awaitsTrailingCode(sourceCode, extractDirectives(sourceCode))
+
+  private def awaitsTrailingCode(sourceCode: String, extractedDirectives: ExtractorResult): Boolean =
+    !sourceCode.endsWith("\n") && (onlyDirectivesSoFar(sourceCode, extractedDirectives) || onlyCommandSoFar(sourceCode, extractedDirectives))
 
   /** Whether JLine should accept the current buffer as a complete submission. */
   private[repl] def shouldAcceptLine(sourceCode: String, hasPendingInput: Boolean)(using Context): Boolean =
-    if awaitsTrailingCode(sourceCode) then !hasPendingInput
-    else !isIncomplete(sourceCode)
+    val extractedDirectives = extractDirectives(sourceCode)
+    if awaitsTrailingCode(sourceCode, extractedDirectives) then !hasPendingInput
+    else !isIncomplete(sourceCode, extractedDirectives)
 
   /** The trailing code after any leading `:command` lines. Only this part decides
    *  whether the whole input is complete: a `:command` is complete on its own, and
    *  parsing its line as Scala would raise a spurious error (`:` is illegal) that
    *  would otherwise make unfinished trailing code look complete and submit early.
    */
-  private def codeAfterLeadingCommands(sourceCode: String): String =
-    leadingCommand(sourceCode) match
-      case Some((_, _, rest)) => codeAfterLeadingCommands(rest)
+  private def codeAfterLeadingCommands(sourceCode: String, extractedDirectives: ExtractorResult): String =
+    leadingCommand(sourceCode, extractedDirectives) match
+      case Some((_, _, rest)) => codeAfterLeadingCommands(rest, extractDirectives(rest))
       case None => sourceCode
 
   /** Check if the input is incomplete.
@@ -348,11 +359,14 @@ object ParseResult {
    *  having to evaluate the expression.
    */
   def isIncomplete(sourceCode: String)(using Context): Boolean =
+    isIncomplete(sourceCode, extractDirectives(sourceCode))
+
+  private def isIncomplete(sourceCode: String, extractedDirectives: ExtractorResult)(using Context): Boolean =
     sourceCode match {
       case "" => false
       case CommandExtract(_, _) => false
       case _ =>
-        val code = codeAfterLeadingCommands(sourceCode)
+        val code = codeAfterLeadingCommands(sourceCode, extractedDirectives)
         code.nonEmpty && {
           val reporter = newStoreReporter
           val source   = SourceFile.virtual("<incomplete-handler>", code)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -380,17 +380,19 @@ class ReplDriver(settings: Array[String],
 
   protected def interpret(res: ParseResult)(using state: State): State = {
     res match {
-      case parsed: Parsed if parsed.source.content().mkString.startsWith("//>") =>
-        val directiveSource = parsed.source.content().mkString
-        val stateAfterDirectives = interpretDirectives(directiveSource)
-        if parsed.trees.nonEmpty then
+      case parsed: Parsed =>
+        val src = parsed.source.content().mkString
+        val classified = DependencyResolver.classifyDirectives(src)
+        if classified.hasDirectives then
+          val stateAfterDirectives = interpretDirectives(classified)
+          if parsed.trees.nonEmpty then
+            propagateLanguageImports(parsed.trees)
+            compile(parsed, stateAfterDirectives)
+          else stateAfterDirectives.recordInput(src.strip)
+        else if parsed.trees.nonEmpty then
           propagateLanguageImports(parsed.trees)
-          compile(parsed, stateAfterDirectives)
-        else stateAfterDirectives.recordInput(directiveSource.strip)
-
-      case parsed: Parsed if parsed.trees.nonEmpty =>
-        propagateLanguageImports(parsed.trees)
-        compile(parsed, state)
+          compile(parsed, state)
+        else state
 
       case SyntaxErrors(_, errs, _) =>
         displayErrors(errs, state)
@@ -772,8 +774,7 @@ class ReplDriver(settings: Array[String],
       state
   }
 
-  private def interpretDirectives(sourceCode: String)(using state: State): State =
-    val classified = DependencyResolver.classifyDirectives(sourceCode)
+  private def interpretDirectives(classified: DependencyResolver.ClassifiedDirectives)(using state: State): State =
     classified.unsupportedKeys.foreach: key =>
       out.println(
         s"""[warn] The `using $key` directive is not supported in the REPL.

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -144,3 +144,75 @@ class ReplDirectiveTests extends ReplTest:
       assertTrue(output, output.contains("using scala"))
       assertTrue(output, output.contains("not supported in the REPL"))
       assertTrue(output, output.contains("val z: Int = 3"))
+
+  @Test def `line comment before directive warns and evaluates code`: Unit =
+    initially:
+      run("// a comment\n//> using scala 3.3.1\nval x = 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("using scala"))
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertTrue(output, output.contains("val x: Int = 1"))
+
+  @Test def `block comment before directive warns and evaluates code`: Unit =
+    initially:
+      run("/* block */\n//> using options -Werror\nval x = 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("using options"))
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertTrue(output, output.contains("val x: Int = 1"))
+
+  @Test def `blank lines before directive warn and evaluate code`: Unit =
+    initially:
+      run("\n\n//> using options -Werror\nval x = 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("using options"))
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertTrue(output, output.contains("val x: Int = 1"))
+
+  @Test def `comment between directives warns and evaluates code`: Unit =
+    initially:
+      run("//> using options -Werror\n// c\n//> using scala 3.3.1\nval z = 3")
+      val output = storedOutput()
+      assertTrue(output, output.contains("using options"))
+      assertTrue(output, output.contains("using scala"))
+      assertTrue(output, output.contains("not supported in the REPL"))
+      assertTrue(output, output.contains("val z: Int = 3"))
+
+  @Test def `line comment before command evaluates both`: Unit =
+    initially:
+      run("// c\n:type \"hi\"\nval x = 5")
+      val output = storedOutput()
+      assertTrue(output, output.contains("String"))
+      assertTrue(output, output.contains("val x: Int = 5"))
+
+  @Test def `block comment before command evaluates both`: Unit =
+    initially:
+      run("/* c */\n:type \"hi\"\nval x = 5")
+      val output = storedOutput()
+      assertTrue(output, output.contains("String"))
+      assertTrue(output, output.contains("val x: Int = 5"))
+
+  @Test def `comment between commands evaluates all`: Unit =
+    initially:
+      run(":type \"hi\"\n// c\n:type 42\nval y = 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("String"))
+      assertTrue(output, output.contains("Int"))
+      assertTrue(output, output.contains("val y: Int = 1"))
+
+  @Test def `command after comment with incomplete code is incomplete`: Unit = contextually:
+    assertTrue(ParseResult.isIncomplete("// c\n:settings -deprecation\nif true then"))
+    assertFalse(ParseResult.shouldAcceptLine("// c\n:settings -deprecation\nif true then", hasPendingInput = false))
+
+  @Test def `lone command after comment awaits trailing code`: Unit = contextually:
+    assertTrue(ParseResult.awaitsTrailingCode("// c\n:dep x"))
+    assertFalse(ParseResult.awaitsTrailingCode("// c\n:dep x\n"))
+
+  @Test def `lone directive after block comment awaits trailing code`: Unit = contextually:
+    assertTrue(ParseResult.awaitsTrailingCode("/* c */\n//> using dep x"))
+    assertFalse(ParseResult.awaitsTrailingCode("/* c */\n//> using dep x\n"))
+
+  @Test def `comment between commands parses as nested CommandThenCode`: Unit = initially:
+    ParseResult(":type 1\n// c\n:type 2\nval x = 5") match
+      case CommandThenCode(TypeOf("1"), CommandThenCode(TypeOf("2"), _: Parsed)) => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")


### PR DESCRIPTION
A follow-up to https://github.com/scala/scala3/pull/26507#discussion_r3550526100

This basically allows for there to be empty lines or comments preceding or in-between `using` directives pasted into the REPL (with code or not)

https://github.com/user-attachments/assets/15881c53-4535-4897-ae41-b4f0a60a7a54

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by testing manually with `bin/replQ` & running the (included and existing) automated tests

## How was the solution tested?
New automated tests