### PR TITLE
[CI] Add missing directives-parser artifacts to the released artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,6 +210,7 @@ jobs:
             all \
               scala-library-bootstrapped/publishSigned \
               scala3-compiler-bootstrapped/publishSigned \
+              scala3-directives-parser-bootstrapped/publishSigned \
               scala3-interfaces/publishSigned \
               scala3-language-server/publishSigned \
               scala3-library-bootstrapped/publishSigned \


### PR DESCRIPTION
Fixes releases - the 3.9.0-RC2 was initially released without new module published 

Note: We're using this manual list of artifacts becouse of having artifacts from 2 different namespaces in Maven: `org-scala.js` and `org.scala-lang` - Sonatypes Central does not allow to have artifacts for 2 different namespaces/organization in the same published bundle 