### PR TITLE
Fix empty capture set handling in CC Setup

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -1069,9 +1069,13 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             && !ref.coreType.derivesFromCapSet
         then
           if ref.captureSetOfInfo.elems.isEmpty then
-            // an empty projection of a tracked ref denotes {}; only an untracked core is vacuous
-            if !ref.core.isTracked then
-              report.error(em"$ref cannot be tracked since its capture set is empty", pos)
+            ref match
+              case ref: DerivedCapability if ref.core.isTracked =>
+                // an empty projection (`.only[C]`/`.except[C]`) of a tracked ref denotes {}
+              case _ =>
+                // a plain reference with an empty capture set, or a projection
+                // of an untracked core, is vacuous
+                report.error(em"$ref cannot be tracked since its capture set is empty", pos)
           else
             check(parent.captureSet, parent)
 


### PR DESCRIPTION
The combination of the exclusion PR https://github.com/scala/scala3/pull/26383 which was merged shortly before https://github.com/scala/scala3/pull/26423 (without rebasing) broke the CI, since the latter's neg test errored less often than is should have. 

The problem is that classifiers change the conditions for the `"cannot be tracked since its capture set is empty"` error, since some classifier expressions denote empty capture sets.

This fix refines the check so that empty `DerivedCapability`s with a tracked core are exempt, and otherwise errors.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests
