### PR TITLE
Skip unresolved annotation trees (during TASTy loading)

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -27,6 +27,7 @@ object MacroAnnotations:
   extension (annot: Annotation)
     /** Is this an annotation that implements `scala.annation.MacroAnnotation` */
     def isMacroAnnotation(using Context): Boolean =
+      annot.symbol.exists &&
       annot.tree.symbol.maybeOwner.derivesFrom(defn.MacroAnnotationClass)
   end extension
 

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -2991,7 +2991,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def annotations: List[Term] =
           self.denot.annotations.flatMap {
             case _: dotc.core.Annotations.BodyAnnotation => Nil
-            case annot => annot.tree :: Nil
+            case annot if annot.symbol.exists => annot.tree :: Nil
+            case _ => Nil
           }
 
         def isDefinedInCurrentRun: Boolean =

--- a/scaladoc/src/test/resources/missing-annotation/annotation.scala.txt
+++ b/scaladoc/src/test/resources/missing-annotation/annotation.scala.txt
@@ -1,0 +1,3 @@
+package ann
+
+class myannotation extends scala.annotation.StaticAnnotation

--- a/scaladoc/src/test/resources/missing-annotation/foo.scala.txt
+++ b/scaladoc/src/test/resources/missing-annotation/foo.scala.txt
@@ -1,0 +1,6 @@
+package foo
+
+@ann.myannotation
+class Foo:
+  @ann.myannotation
+  def value: String = "value"

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/MissingAnnotationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/MissingAnnotationTest.scala
@@ -1,0 +1,56 @@
+package dotty.tools.scaladoc
+package tasty
+
+import java.nio.file.{Files, Path, Paths}
+import org.junit.{Assert, Test}
+import dotty.tools.scaladoc.util.IO
+
+class MissingAnnotationTest:
+
+  private val javaClasspath = System.getProperty("java.class.path")
+
+  private def source(root: Path, name: String): Path =
+    val resource = getClass.getResource(s"/missing-annotation/$name.txt")
+    val source = root.resolve("sources").resolve(name)
+    Files.createDirectories(source.getParent)
+    Files.copy(Paths.get(resource.toURI), source)
+    source
+
+  private def compileStage(output: Path, classpath: Seq[Path], sources: Path*): Unit =
+    Files.createDirectories(output)
+    val compilerClasspath =
+      (classpath.map(_.toString) :+ javaClasspath).mkString(java.io.File.pathSeparator)
+    val reporter = new TestReporter
+    val result = dotty.tools.dotc.Main.process(
+      Array("-classpath", compilerClasspath, "-d", output.toString) ++ sources.map(_.toString),
+      reporter
+    )
+    Assert.assertFalse(
+      s"Compilation failed:\n${reporter.errors.result().map(_.msg.message).mkString("\n")}",
+      result.hasErrors
+    )
+
+  @Test
+  def ignoresUndocumentedAnnotationsMissingFromDocClasspath =
+    val root = Files.createTempDirectory("scaladoc-missing-annotation")
+    try
+      val annotationOutput = root.resolve("annotation")
+      compileStage(annotationOutput, Nil, source(root, "annotation.scala"))
+
+      val fooOutput = root.resolve("foo")
+      compileStage(fooOutput, Seq(annotationOutput), source(root, "foo.scala"))
+
+      // Run Scaladoc without annotation tasty
+      val ctx = testContext
+      val docOutput = root.resolve("doc").toFile
+      Scaladoc.run(
+        testArgs(Seq(fooOutput.resolve("foo/Foo.tasty").toFile), docOutput).copy(
+          classpath = Seq(fooOutput.toString, javaClasspath)
+            .mkString(java.io.File.pathSeparator)
+        )
+      )(using ctx)
+
+      val diagnostics = ctx.reportedDiagnostics
+      assertNoErrors(diagnostics)
+      assertNoWarning(diagnostics)
+    finally IO.delete(root.toFile)


### PR DESCRIPTION
Fixes #18487
Fixes #22447

While normal compilation loads only the symbols and signatures needed from dependency TASTy. Scaladoc reads dependency TASTy and eagerly decodes attached annotation trees https://github.com/scala/scala3/blob/3718b0cf7e4df79b340d7403c1d3127bbbe71279/scaladoc/src/scala/tasty/inspector/TastyInspector.scala#L107-L118 https://github.com/scala/scala3/blob/5a728abb6e76d56774b494398539980ecea83a88/compiler/src/dotty/tools/dotc/fromtasty/ReadTasty.scala#L57

Therefore, it fails when it hits compile-time-only annotations are absent from the downstream classpath.

This commit fixes the issue by checking that annotation symbols can be resolved before decoding their trees (at least that reaches from `ReadTasty`).


<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, for write regression test, and understanding the difference between normal compilation path and scaladoc path, and I checked the output by extensive review.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

- New automated tests (including the issue's reproducer, if applicable)
- Checking this change fixes the workaround in scala-js https://github.com/scala-js/scala-js/blob/21fdca99521a4fe2a2b18e924d720e1b51da172f/project/Build.scala#L1483-L1494
- manually testing https://github.com/scala/scala3/issues/22447 and https://github.com/scala/scala3/issues/18487