### PR TITLE
Skip explicit reference deduction for consumed qualifiers

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
+++ b/compiler/src/dotty/tools/dotc/cc/SepCheck.scala
@@ -689,7 +689,12 @@ class SepCheck(checker: CheckCaptures.CheckerAPI) extends tpd.TreeTraverser:
   def checkConsumedRefs(refsToCheck: Refs, tpe: Type, role: TypeRole, descr: => String, pos: SrcPos)(using Context) =
     val badParams = mutable.ListBuffer[Symbol]()
     def currentOwner = role.dclSym.orElse(ctx.owner)
-    for hiddenRef <- refsToCheck.deduct(explicitRefs(tpe)) do
+    val refsToCheck1 = role match
+      case _: TypeRole.Qualifier =>
+        // When this is a consume method call on a receiver, no need to exclude explicit captures
+        refsToCheck
+      case _ => refsToCheck.deduct(explicitRefs(tpe))
+    for hiddenRef <- refsToCheck1 do
       if !hiddenRef.stripReadOnly.isKnownClassifiedAs(defn.Caps_SharedCapability) then
         hiddenRef.pathRoot match
           case ref: TermRef if ref.symbol != role.dclSym =>

--- a/tests/neg-custom-args/captures/consume-borrow.check
+++ b/tests/neg-custom-args/captures/consume-borrow.check
@@ -1,0 +1,15 @@
+-- Error: tests/neg-custom-args/captures/consume-borrow.scala:8:2 ------------------------------------------------------
+8 |  a.forget() // error
+  |  ^
+  |  Separation failure: call prefix of consume method forget refers to parameter a.
+  |  The parameter needs to be annotated with consume to allow this.
+-- Error: tests/neg-custom-args/captures/consume-borrow.scala:12:2 -----------------------------------------------------
+12 |  b.forget() // error
+   |  ^
+   |  Separation failure: call prefix of consume method forget refers to parameter a.
+   |  The parameter needs to be annotated with consume to allow this.
+-- Error: tests/neg-custom-args/captures/consume-borrow.scala:14:24 ----------------------------------------------------
+14 |def badResult(a: Ref^): Ref^ = a // error
+   |                        ^^^^
+   |                        Separation failure: method badResult's result type Ref^ hides parameter a.
+   |                        The parameter needs to be annotated with consume to allow this.

--- a/tests/neg-custom-args/captures/consume-borrow.scala
+++ b/tests/neg-custom-args/captures/consume-borrow.scala
@@ -1,0 +1,19 @@
+import language.experimental.separationChecking
+import caps.*
+
+class Ref extends Mutable:
+  consume def forget(): Ref^ = this
+
+def badQualifier(a: Ref^): Ref^ =
+  a.forget() // error
+
+def badAliasedQualifier(a: Ref^): Ref^ =
+  val b = a
+  b.forget() // error
+
+def badResult(a: Ref^): Ref^ = a // error
+
+def goodQualifier(consume a: Ref^): Ref^ =
+  a.forget()
+
+def goodResult(a: Ref^): a.type = a


### PR DESCRIPTION
Fixes the following issue:

Before this fix, the following program compiles without error:
```scala
import language.experimental.separationChecking
import caps.*
class Ref extends Mutable:
  consume def forget(): Ref^ = this
def boom(a: Ref^): Ref^ =
  a.forget()  // should be error, but ok
```

This was because in `checkConsumedRefs`, explicit references are deducted from the consumed references. But in the case of calling consume method, the consumed set is `{a}` and its type is `Ref^{a}`, so after deduction it will be empty. When calling a consume method on a receiver, we are in fact implicitly widening the receiver's type to `Ref^`, but the deduction logic does not see this.

The fix is to skip explicit reference deduction for qualifiers.


## Have you relied on LLM-based tools in this contribution?

Yes, it is used to diagnose the issue, but it is surprising incompetent on proposing a "proper" fix.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
