### PR TITLE
Backport "Fix REPL build break" to 3.9.0

### DIFF
--- a/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDependencyMacroTests.scala
@@ -15,8 +15,7 @@ class ReplDependencyMacroTests extends ReplTest:
   private def resolveUpickle()(using State): Unit =
     run(":dep com.lihaoyi::upickle:4.4.3")
     val output = storedOutput()
-    println(s"[debug][i25291] :dep output:\n$output")
-    assertTrue(output, output.contains("Resolved 1 dependencies"))
+    assertTrue(output, output.contains("Resolved a dependency"))
     assertNoMacroFailure(output)
 
   private def addUpickleViaJar()(using State): Unit =


### PR DESCRIPTION
Backports #26514 to the 3.9.0-RC3.

PR submitted by the release tooling.