### PR TITLE
Ignore classifiers when casting in a pattern match

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CCState.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CCState.scala
@@ -102,6 +102,11 @@ class CCState:
 
   private var discardUses: Boolean = false
 
+  /** A switch allowing to ignore classifiers in subsumption checks for
+   *  asInstanceOf applications created by pattern-matches.
+   */
+  var ignoreClassifiers = false
+
   // ------- Caches for symbols --------------------------------------------------
 
   /* A cache for CaptureOps.useSet */
@@ -181,6 +186,7 @@ object CCState:
 
   /** Should uses not be recorded in markFree? */
   def discardUses(using Context): Boolean = ccState.discardUses
+
 
   /** Perform `op` unless operation has been tried on `c` before.
    *  This is needed to prevent infinite recursions in methods like

--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -720,6 +720,8 @@ object Capabilities:
           ref1.tryClassifyAs(cls)
         case Maybe(ref1) =>
           ref1.tryClassifyAs(cls)
+        case self: TermRef if self.symbol.is(Case) && ccState.ignoreClassifiers =>
+          true
         case self: CoreCapability =>
           if self.derivesFromCapability then self.derivesFrom(cls)
           else captureSetOfInfo.tryClassifyAs(cls)

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -1657,10 +1657,17 @@ class CheckCaptures extends Recheck, SymTransformer:
      *  where local capture roots are instantiated to root variables.
      */
     override def checkConformsExpr(actual: Type, expected: Type, tree: Tree, notes: List[Note])(using Context): Type =
-      try testAdapted(actual, expected, tree, notes)(err.typeMismatch)
+      val saved = ccState.ignoreClassifiers
+      try
+        tree match
+          case tree: TypeApply if tree.symbol == defn.Any_typeCast => ccState.ignoreClassifiers = true
+          case _ =>
+        testAdapted(actual, expected, tree, notes)(err.typeMismatch)
       catch case ex: AssertionError =>
         println(i"error while checking $tree: $actual against $expected")
         throw ex
+      finally
+        ccState.ignoreClassifiers = saved
 
     @annotation.tailrec
     private def findImpureUpperBound(tp: Type)(using Context): Type = tp match

--- a/tests/pos-custom-args/captures/patmat-classified.scala
+++ b/tests/pos-custom-args/captures/patmat-classified.scala
@@ -1,0 +1,51 @@
+import caps.*
+trait Iterator[+A] extends IterableOnce[A]{ self: Iterator[A]^ =>
+  def hasNext: Boolean
+  def next(): A
+}
+
+/** Iterator can be used only once */
+trait IterableOnce[+A] {
+  this: IterableOnce[A]^ =>
+  def iterator: Iterator[A]^{this}
+}
+
+/** Base trait for generic collections */
+trait Iterable[+A] extends IterableOnce[A] {
+  this: Iterable[A]^ =>
+  type C[X] <: Iterable[X]^
+  protected def coll: Iterable[A]^{this} = this
+  def knownLength: Int = -1
+}
+
+/** Base trait for sequence collections */
+trait Seq[+A] extends Iterable[A] {
+  this: Seq[A]^ =>
+  type C[X] <: Seq[X]^
+  def apply(i: Int): A
+  def length: Int
+}
+
+/** Base trait for collection builders */
+trait Builder[-A, +To] extends Mutable {
+  update def +=(x: A): this.type
+  def result: To
+}
+
+abstract class ArrayBuffer[A] extends IterableOnce[A], Builder[A, ArrayBuffer[A]]:
+  def ++[B >: A](xs: IterableOnce[B]^): ArrayBuffer[B]^ = xs match
+    case xs: ArrayBuffer[B] @unchecked =>
+      xs.asInstanceOf[ArrayBuffer[B]^]
+
+trait FromIterable {
+  type C[X] <: Iterable[X]^
+  def fromIterable[B](it: Iterable[B]^): C[B]^{it, any}
+}
+
+/** Base trait for companion objects of collections */
+trait IterableFactory extends FromIterable
+
+trait SeqFactory extends IterableFactory {
+  type C[X] <: Seq[X]^
+  def fromIterable[B](it: Iterable[B]^{this, any}): C[B]
+}


### PR DESCRIPTION
Fixes #26525

