### PR TITLE
Tweak `bisect.sc` to handle mixed Java/Scala compilations with the use of Bloop

### DIFF
--- a/.github/workflows/stdlib.yaml
+++ b/.github/workflows/stdlib.yaml
@@ -430,6 +430,17 @@ jobs:
       - name: Run SBT scripted tests
         run: ./project/scripts/sbt scala3-bootstrapped/scripted
 
+  test-bisect-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: coursier/cache-action@v8
+      - uses: VirtusLab/scala-cli-setup@v1.15
+        with:
+          jvm: temurin:17
+      - name: Run bisect script tests
+        run: scala-cli test project/scripts/bisect.test.scala
+
   community_build_a:
     runs-on: ubuntu-latest
     steps:

--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -50,6 +50,13 @@ val usageMessage = """
   |* --should-fail
   |    Expect the validation command to fail rather that succeed. This can be used e.g. to find out when some illegal code started to compile.
   |
+  |* --with-bloop
+  |    Use Bloop/build server for scala-cli reproduction scripts (omit --server=false).
+  |    Implies --with-cleaning, because incremental compilation may interfere with bisection.
+  |
+  |* --with-cleaning
+  |    Run `scala-cli clean <input>` before each validation invocation.
+  |
   |Warning: The bisect script should not be run multiple times in parallel because of a potential race condition while publishing artifacts locally.
 
 """.stripMargin
@@ -61,7 +68,10 @@ val usageMessage = """
       case _ =>
         sys.error(s"Wrong script parameters.\n${usageMessage}")
 
-  val validationScript = scriptOptions.validationCommand.validationScript
+  val validationScript = scriptOptions.validationCommand.validationScript(
+    withBloop = scriptOptions.withBloop,
+    withCleaning = scriptOptions.withCleaning
+  )
   val releases = Releases.fromRange(scriptOptions.releasesRange)
   val releaseBisect = ReleaseBisect(validationScript, shouldFail = scriptOptions.shouldFail, releases)
 
@@ -77,7 +87,15 @@ val usageMessage = """
     commitBisect.bisect()
 
 
-case class ScriptOptions(validationCommand: ValidationCommand, dryRun: Boolean, bootstrapped: Boolean, releasesRange: ReleasesRange, shouldFail: Boolean)
+case class ScriptOptions(
+    validationCommand: ValidationCommand,
+    dryRun: Boolean,
+    bootstrapped: Boolean,
+    releasesRange: ReleasesRange,
+    shouldFail: Boolean,
+    withBloop: Boolean,
+    withCleaning: Boolean
+)
 object ScriptOptions:
   def fromArgs(args: Seq[String]) =
     val defaultOptions = ScriptOptions(
@@ -85,9 +103,15 @@ object ScriptOptions:
       dryRun = false,
       bootstrapped = false,
       ReleasesRange(first = None, last = None),
-      shouldFail = false
+      shouldFail = false,
+      withBloop = false,
+      withCleaning = false
     )
-    parseArgs(args, defaultOptions)
+    val options = parseArgs(args, defaultOptions)
+    if options.withBloop && !options.withCleaning then
+      println("--with-bloop implies --with-cleaning: enabling cleaning because incremental compilation may interfere with bisection")
+      options.copy(withCleaning = true)
+    else options
 
   private def parseArgs(args: Seq[String], options: ScriptOptions): ScriptOptions =
     args match
@@ -97,6 +121,8 @@ object ScriptOptions:
         val range = ReleasesRange.tryParse(argsRest.head).get
         parseArgs(argsRest.tail, options.copy(releasesRange = range))
       case "--should-fail" :: argsRest => parseArgs(argsRest, options.copy(shouldFail = true))
+      case "--with-bloop" :: argsRest => parseArgs(argsRest, options.copy(withBloop = true))
+      case "--with-cleaning" :: argsRest => parseArgs(argsRest, options.copy(withCleaning = true))
       case _ =>
         val command = ValidationCommand.fromArgs(args)
         options.copy(validationCommand = command)
@@ -107,15 +133,11 @@ enum ValidationCommand:
   case Test(args: Seq[String])
   case CustomValidationScript(scriptFile: File)
 
-  def validationScript: File = this match
-    case Compile(args) =>
-      ValidationScript.tmpScalaCliScript(command = "compile", args)
-    case Run(args) =>
-      ValidationScript.tmpScalaCliScript(command = "run", args)
-    case Test(args) =>
-      ValidationScript.tmpScalaCliScript(command = "test", args)
-    case CustomValidationScript(scriptFile) =>
-      ValidationScript.copiedFrom(scriptFile)
+  def validationScript(withBloop: Boolean, withCleaning: Boolean): File = this match
+    case Compile(args) => ValidationScript.tmpScalaCliScript(command = "compile", args, withBloop, withCleaning)
+    case Run(args) => ValidationScript.tmpScalaCliScript(command = "run", args, withBloop, withCleaning)
+    case Test(args) => ValidationScript.tmpScalaCliScript(command = "test", args, withBloop, withCleaning)
+    case CustomValidationScript(scriptFile) => ValidationScript.copiedFrom(scriptFile)
 
 object ValidationCommand:
   def fromArgs(args: Seq[String]) = args match
@@ -130,12 +152,17 @@ object ValidationScript:
     val fileContent = scala.io.Source.fromFile(file).mkString
     tmpScript(fileContent)
 
-  def tmpScalaCliScript(command: String, args: Seq[String]): File = tmpScript(s"""
-    |#!/usr/bin/env bash
-    |export JAVA_HOME=${sys.props("java.home")}
-    |scala-cli ${command} -S "$$1" --server=false ${args.mkString(" ")}
-    |""".stripMargin
-  )
+  def tmpScalaCliScript(command: String, args: Seq[String], withBloop: Boolean, withCleaning: Boolean): File =
+    val argsString = args.mkString(" ")
+    val serverModifier = if withBloop then "" else "--server=false "
+    val cleanCommand = if withCleaning then s"scala-cli clean ${argsString}" else ""
+    tmpScript(s"""
+      |#!/usr/bin/env bash
+      |export JAVA_HOME=${sys.props("java.home")}
+      |${cleanCommand}
+      |scala-cli ${command} -S "$$1" ${serverModifier}${argsString}
+      |""".stripMargin
+    )
 
   private def tmpScript(content: String): File =
     val executableAttr = PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x"))

--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -33,7 +33,9 @@ val usageMessage = """
   |If you want to use one of the example scripts - use a copy of the file instead of modifying it in place because that might mess up the checkout.
   |
   |The optional <bisect-options> may be any combination of:
-  |* --dry-run
+  |Boolean flags accept an optional =true|false value; the bare form means true.
+  |
+  |* --dry-run[=true|false]
   |    Don't try to bisect - just make sure the validation command works correctly
   |
   |* --releases <releases-range>
@@ -44,18 +46,19 @@ val usageMessage = """
   |    * ...3.3.0-RC1-bin-20221124-e25362d-NIGHTLY
   |    The ranges are treated as inclusive.
   |
-  |* --bootstrapped
+  |* --bootstrapped[=true|false]
   |    Publish locally and test a bootstrapped compiler rather than a nonbootstrapped one.
   |
-  |* --should-fail
+  |* --should-fail[=true|false]
   |    Expect the validation command to fail rather that succeed. This can be used e.g. to find out when some illegal code started to compile.
   |
-  |* --with-bloop
+  |* --with-bloop[=true|false]
   |    Use Bloop/build server for scala-cli reproduction scripts (omit --server=false).
   |    Implies --with-cleaning, because incremental compilation may interfere with bisection.
   |
-  |* --with-cleaning
+  |* --with-cleaning[=true|false]
   |    Run `scala-cli clean <input>` before each validation invocation.
+  |    Enabled by default when --with-bloop is set; pass --with-cleaning=false to disable it even with --with-bloop.
   |
   |Warning: The bisect script should not be run multiple times in parallel because of a potential race condition while publishing artifacts locally.
 
@@ -94,9 +97,19 @@ case class ScriptOptions(
     releasesRange: ReleasesRange,
     shouldFail: Boolean,
     withBloop: Boolean,
-    withCleaning: Boolean
+    withCleaning: Boolean,
+    withCleaningExplicit: Option[Boolean] = None
 )
 object ScriptOptions:
+  private object BooleanFlag:
+    def unapply(arg: String): Option[(String, Boolean)] =
+      arg match
+        case name @ ("--dry-run" | "--bootstrapped" | "--should-fail" | "--with-bloop" | "--with-cleaning") =>
+          Some((name, true))
+        case s"$name=$value" if name == "--dry-run" || name == "--bootstrapped" || name == "--should-fail" || name == "--with-bloop" || name == "--with-cleaning" =>
+          Some((name, value.toBooleanOption.getOrElse(sys.error(s"Invalid boolean value for $name: $value"))))
+        case _ => None
+
   def fromArgs(args: Seq[String]) =
     val defaultOptions = ScriptOptions(
       validationCommand = null,
@@ -108,24 +121,39 @@ object ScriptOptions:
       withCleaning = false
     )
     val options = parseArgs(args, defaultOptions)
-    if options.withBloop && !options.withCleaning then
-      println("--with-bloop implies --with-cleaning: enabling cleaning because incremental compilation may interfere with bisection")
-      options.copy(withCleaning = true)
-    else options
+    val resolvedCleaning = options.withCleaningExplicit match
+      case Some(value) => value
+      case None =>
+        if options.withBloop then
+          println("--with-bloop implies --with-cleaning: enabling cleaning because incremental compilation may interfere with bisection")
+          true
+        else false
+    options.copy(withCleaning = resolvedCleaning)
 
   private def parseArgs(args: Seq[String], options: ScriptOptions): ScriptOptions =
-    args match
-      case "--dry-run" :: argsRest => parseArgs(argsRest, options.copy(dryRun = true))
-      case "--bootstrapped" :: argsRest => parseArgs(argsRest, options.copy(bootstrapped = true))
-      case "--releases" :: argsRest =>
-        val range = ReleasesRange.tryParse(argsRest.head).get
-        parseArgs(argsRest.tail, options.copy(releasesRange = range))
-      case "--should-fail" :: argsRest => parseArgs(argsRest, options.copy(shouldFail = true))
-      case "--with-bloop" :: argsRest => parseArgs(argsRest, options.copy(withBloop = true))
-      case "--with-cleaning" :: argsRest => parseArgs(argsRest, options.copy(withCleaning = true))
-      case _ =>
-        val command = ValidationCommand.fromArgs(args)
-        options.copy(validationCommand = command)
+    args.toList match
+      case arg :: argsRest =>
+        BooleanFlag.unapply(arg) match
+          case Some((name, value)) =>
+            name match
+              case "--dry-run" => parseArgs(argsRest, options.copy(dryRun = value))
+              case "--bootstrapped" => parseArgs(argsRest, options.copy(bootstrapped = value))
+              case "--should-fail" => parseArgs(argsRest, options.copy(shouldFail = value))
+              case "--with-bloop" => parseArgs(argsRest, options.copy(withBloop = value))
+              case "--with-cleaning" => parseArgs(argsRest, options.copy(withCleaningExplicit = Some(value)))
+              case other => sys.error(s"Unexpected boolean flag: $other")
+          case None =>
+            arg match
+              case "--releases" =>
+                val range = ReleasesRange.tryParse(argsRest.head).get
+                parseArgs(argsRest.tail, options.copy(releasesRange = range))
+              case _ if options.validationCommand == null =>
+                val command = ValidationCommand.fromArgs(args)
+                options.copy(validationCommand = command)
+              case _ =>
+                options
+      case Nil =>
+        options
 
 enum ValidationCommand:
   case Compile(args: Seq[String])

--- a/project/scripts/bisect.test.scala
+++ b/project/scripts/bisect.test.scala
@@ -1,0 +1,150 @@
+//> using file bisect.scala
+//> using dep org.scalameta::munit::1.3.4
+
+import java.io.File
+
+class BisectOptionsTest extends munit.FunSuite:
+  import ValidationCommand.*
+
+  def parse(args: String*): ScriptOptions =
+    ScriptOptions.fromArgs(args.toSeq)
+
+  def scriptBody(cmd: ValidationCommand, withBloop: Boolean, withCleaning: Boolean): String =
+    val f = cmd.validationScript(withBloop, withCleaning)
+    scala.io.Source.fromFile(f).mkString
+
+  test("defaults") {
+    val o = parse("compile", "foo.scala")
+    assertEquals(o.dryRun, false)
+    assertEquals(o.bootstrapped, false)
+    assertEquals(o.shouldFail, false)
+    assertEquals(o.withBloop, false)
+    assertEquals(o.withCleaning, false)
+    assertEquals(o.withCleaningExplicit, None)
+    assertEquals(o.validationCommand, Compile(Seq("foo.scala")))
+  }
+
+  test("bare --dry-run") {
+    assertEquals(parse("--dry-run", "compile", "foo.scala").dryRun, true)
+  }
+
+  test("--dry-run=false") {
+    assertEquals(parse("--dry-run=false", "compile", "foo.scala").dryRun, false)
+  }
+
+  test("--dry-run=TRUE") {
+    assertEquals(parse("--dry-run=TRUE", "compile", "foo.scala").dryRun, true)
+  }
+
+  test("bare --bootstrapped") {
+    assertEquals(parse("--bootstrapped", "compile", "foo.scala").bootstrapped, true)
+  }
+
+  test("--bootstrapped=false") {
+    assertEquals(parse("--bootstrapped=false", "compile", "foo.scala").bootstrapped, false)
+  }
+
+  test("bare --should-fail") {
+    assertEquals(parse("--should-fail", "compile", "foo.scala").shouldFail, true)
+  }
+
+  test("--should-fail=false") {
+    assertEquals(parse("--should-fail=false", "compile", "foo.scala").shouldFail, false)
+  }
+
+  test("bare --with-bloop implies cleaning") {
+    val o = parse("--with-bloop", "compile", "foo.scala")
+    assertEquals(o.withBloop, true)
+    assertEquals(o.withCleaning, true)
+    assertEquals(o.withCleaningExplicit, None)
+  }
+
+  test("--with-bloop=false") {
+    val o = parse("--with-bloop=false", "compile", "foo.scala")
+    assertEquals(o.withBloop, false)
+    assertEquals(o.withCleaning, false)
+  }
+
+  test("bare --with-cleaning") {
+    val o = parse("--with-cleaning", "compile", "foo.scala")
+    assertEquals(o.withCleaning, true)
+    assertEquals(o.withCleaningExplicit, Some(true))
+  }
+
+  test("--with-cleaning=false") {
+    val o = parse("--with-cleaning=false", "compile", "foo.scala")
+    assertEquals(o.withCleaning, false)
+    assertEquals(o.withCleaningExplicit, Some(false))
+  }
+
+  test("--with-bloop + --with-cleaning=false") {
+    val o = parse("--with-bloop", "--with-cleaning=false", "compile", "foo.scala")
+    assertEquals(o.withBloop, true)
+    assertEquals(o.withCleaning, false)
+    assertEquals(o.withCleaningExplicit, Some(false))
+  }
+
+  test("--with-bloop=false + --with-cleaning=true") {
+    val o = parse("--with-bloop=false", "--with-cleaning=true", "compile", "foo.scala")
+    assertEquals(o.withBloop, false)
+    assertEquals(o.withCleaning, true)
+    assertEquals(o.withCleaningExplicit, Some(true))
+  }
+
+  test("combined flags") {
+    val o = parse("--dry-run", "--bootstrapped=true", "--should-fail=false", "--with-bloop", "compile", "foo.scala")
+    assertEquals(o.dryRun, true)
+    assertEquals(o.bootstrapped, true)
+    assertEquals(o.shouldFail, false)
+    assertEquals(o.withBloop, true)
+    assertEquals(o.withCleaning, true)
+  }
+
+  test("--releases range") {
+    val o = parse("--releases", "3.1.0...3.2.0", "compile", "foo.scala")
+    assertEquals(o.releasesRange, ReleasesRange(Some("3.1.0"), Some("3.2.0")))
+  }
+
+  test("invalid boolean value throws") {
+    intercept[Throwable] {
+      parse("--dry-run=maybe", "compile", "foo.scala")
+    }
+  }
+
+  test("ValidationCommand.fromArgs maps compile") {
+    assertEquals(ValidationCommand.fromArgs(Seq("compile", "foo.scala")), Compile(Seq("foo.scala")))
+  }
+
+  test("ValidationCommand.fromArgs maps run") {
+    assertEquals(ValidationCommand.fromArgs(Seq("run", "foo.scala")), Run(Seq("foo.scala")))
+  }
+
+  test("ValidationCommand.fromArgs maps test") {
+    assertEquals(ValidationCommand.fromArgs(Seq("test", "foo.scala")), Test(Seq("foo.scala")))
+  }
+
+  test("ValidationCommand.fromArgs maps custom script path") {
+    assertEquals(
+      ValidationCommand.fromArgs(Seq("my-script.sh")),
+      CustomValidationScript(new File("my-script.sh"))
+    )
+  }
+
+  test("default reproduction script uses --server=false and no clean") {
+    val body = scriptBody(Compile(Seq("foo.scala")), withBloop = false, withCleaning = false)
+    assert(body.contains("--server=false"))
+    assert(!body.contains("scala-cli clean"))
+  }
+
+  test("withBloop reproduction script omits --server=false") {
+    val body = scriptBody(Compile(Seq("foo.scala")), withBloop = true, withCleaning = false)
+    assert(!body.contains("--server=false"))
+  }
+
+  test("withCleaning reproduction script runs clean before compile") {
+    val body = scriptBody(Compile(Seq("foo.scala")), withBloop = false, withCleaning = true)
+    assert(body.contains("scala-cli clean foo.scala"))
+    val cleanIdx = body.indexOf("scala-cli clean foo.scala")
+    val compileIdx = body.indexOf("scala-cli compile")
+    assert(cleanIdx >= 0 && compileIdx > cleanIdx)
+  }


### PR DESCRIPTION
This allows to use the `bisect.sc` script together with Bloop, with the necessary cleanup between validation script re-runs at different Scala versions.

This includes:
- a `--with-bloop` bisect option, which gets rid of `--server=false` from the validation script whenever we run Scala CLI
- a `--with-cleaning` bisect option (implicit with `--with-bloop`, as you need this unless incremental compilation is part of the experiment)
  - this comes down to running `scala-cli clean <same-inputs` at the beginning of the validation script 
- support for `[=true|false]` on bisect flags, compiler style syntax, so that one can disable `--with-cleaning` explicitly, if one really wants
- some sanity tests for the `bisect.sc` script

As Scala CLI with `--server=false` does not handle mixed Java/Scala compilations (we need Zinc for that, and the runner uses Zinc through Bloop), a convenient toggle for bisecting such cases comes handy.

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by using the modified `bisect.sc` script to bisect the new generic signatures regressions https://github.com/scala/scala3/issues/26533 using `--with-bloop`

## How was the solution tested?
- practically, bisecting issues with mixed Scala/Java compilation.
- I included some automated sanity checks for the bisect script, so that there is any verification for the script on the CI.
