### PR TITLE
fix: rollback REPL state after compilation error

### DIFF
--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -69,7 +69,7 @@ import scala.util.Using
  *  @param objectIndex the index of the next wrapper
  *  @param valIndex    the index of next value binding for free expressions
  *  @param imports     a map from object index to the list of user defined imports
- *  @param invalidObjectIndexes the set of object indexes that failed to initialize
+ *  @param invalidObjectIndexes the set of object indexes that failed to compile or initialize
  *  @param quiet       whether we print evaluation results
  *  @param context     the latest compiler context
  *  @param pastInputs  the replayable inputs of the session, most recent first
@@ -84,6 +84,12 @@ case class State(objectIndex: Int,
   def validObjectIndexes = (1 to objectIndex).filterNot(invalidObjectIndexes.contains(_))
 
   def recordInput(input: String): State = copy(pastInputs = input :: pastInputs)
+
+  def invalidateCurrentObject: State =
+    copy(invalidObjectIndexes = invalidObjectIndexes + objectIndex)
+
+  def afterFailedCompilation(failedObjectIndex: Int): State =
+    copy(objectIndex = failedObjectIndex).invalidateCurrentObject
 
 /** Main REPL instance, orchestrating input, compilation and presentation */
 class ReplDriver(settings: Array[String],
@@ -437,7 +443,10 @@ class ReplDriver(settings: Array[String],
     compiler
       .compile(parsed)
       .fold(
-        displayErrors,
+        (errs, errState) =>
+          displayErrors(errs, errState)
+          istate.afterFailedCompilation(errState.objectIndex)
+        ,
         {
           case (unit: CompilationUnit, newState: State) =>
             val newestWrapper = extractNewestWrapper(unit.untpdTree)
@@ -528,7 +537,7 @@ class ReplDriver(settings: Array[String],
         // We limit the returned diagnostics here to `renderedVals`, which will contain the rendered error
         // for the val which failed to initialize. Since any other defs, aliases, imports, etc. from this
         // input line will be inaccessible, we avoid rendering those so as not to confuse the user.
-        (state.copy(invalidObjectIndexes = state.invalidObjectIndexes + state.objectIndex), renderedVals)
+        (state.invalidateCurrentObject, renderedVals)
       else
         val formattedMembers =
           typeAliases.map(rendering.renderTypeAlias)

--- a/repl/test-resources/repl/errmsgs
+++ b/repl/test-resources/repl/errmsgs
@@ -90,11 +90,10 @@ scala> val x: List[Int] = "foo" :: List(1)
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> while (((  foo ))) {}
--- [E007] Type Mismatch Error: -------------------------------------------------
+-- [E006] Not Found Error: -----------------------------------------------------
 1 | while (((  foo ))) {}
   |            ^^^
-  |            Found:    (foo : Foo)
-  |            Required: Boolean
+  |            Not found: foo
   |
   | longer explanation available when compiling with `-explain`
 1 error found

--- a/repl/test-resources/repl/i6474
+++ b/repl/test-resources/repl/i6474
@@ -15,10 +15,10 @@ scala> (1, 2): Foo3.T[Int][Int]
   |         Missing type parameter for Foo3.T[Int][Int]
 1 error found
 scala> ((1, 2): Foo3.T[Int][Int][Int]): Foo3.T[Any][Int][Int]
-val res3: Foo3.T[Any][Int][Int] = (1, 2)
+val res2: Foo3.T[Any][Int][Int] = (1, 2)
 scala> object Foo3 { type T[A] = [B] =>> [C] =>> (A, B) }
 // defined object Foo3
 scala> ((1, 2): Foo3.T[Int][Int][Int])
-val res4: Foo3.T[Int][Int][Int] = (1, 2)
+val res3: Foo3.T[Int][Int][Int] = (1, 2)
 scala> ((1, 2): Foo3.T[Int][Int][Int])
-val res5: Foo3.T[Int][Int][Int] = (1, 2)
+val res4: Foo3.T[Int][Int][Int] = (1, 2)

--- a/repl/test-resources/repl/importFromObj
+++ b/repl/test-resources/repl/importFromObj
@@ -14,7 +14,7 @@ scala> buf += xs
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> buf ++= xs
-val res1: mutable.ListBuffer[Int] = ListBuffer(1, 2, 3)
+val res0: mutable.ListBuffer[Int] = ListBuffer(1, 2, 3)
 scala> import util.foobar
 -- [E008] Not Found Error: -----------------------------------------------------
 1 | import util.foobar

--- a/repl/test-resources/repl/silent
+++ b/repl/test-resources/repl/silent
@@ -22,4 +22,4 @@ scala> Option[Int](2) match { case Some(x) => x }
   | longer explanation available when compiling with `-explain`
 scala>:silent
 scala> 1 + 2
-val res3: Int = 3
+val res2: Int = 3

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -342,7 +342,7 @@ class ReplCompilerTests extends ReplTest:
     state
   } andThen {
     run("a")   // `a` should retain its original binding
-    assertEquals("val res2: Int = 1234", storedOutput().trim)
+    assertEquals("val res0: Int = 1234", storedOutput().trim)
   }
 
   @Test def i4416_imports = initially {

--- a/repl/test/dotty/tools/repl/ShadowingTests.scala
+++ b/repl/test/dotty/tools/repl/ShadowingTests.scala
@@ -98,13 +98,13 @@ class ShadowingTests extends ReplTest(options = ShadowingTests.options):
          |1 error found
          |
          |scala> new C(13).c
-         |val res1: Int = 13
+         |val res0: Int = 13
          |
          |scala> class C { val c = 42 }
          |// defined class C
          |
          |scala> new C().c
-         |val res2: Int = 42
+         |val res1: Int = 42
          |""".stripMargin
   )
 


### PR DESCRIPTION
Fixes #25514

This fix, on a compile error, rollbacks the input to the pre-input state (with the exception of advancing the objectIndex and marking it as invalid). As a result:

### Before

```scala
Welcome to Scala 3.8.4 (23.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                           
scala> 1
val res0: Int = 1
                                                                                                                                                           
scala> 42 + java.lang.Integer.TYPE
-- [E134] Type Error: ----------------------------------------------------------
1 |42 + java.lang.Integer.TYPE
  |^^^^
  |None of the overloaded alternatives of method + in class Int with types
  | (x: Double): Double
  | (x: Float): Float
  | (x: Long): Long
  | (x: Int): Int
  | (x: Char): Int
  | (x: Short): Int
  | (x: Byte): Int
  | (x: String): String
  |match arguments ((Integer.TYPE : Class[Integer]))
1 error found
                                                                                                                                                           
scala> 2
val res2: Int = 2
                                                                                                                                                           
scala> res1
-- [E134] Type Error: ----------------------------------------------------------
1 |res1
  |^^^^
  |None of the overloaded alternatives of method + in class Int with types
  | (x: Double): Double
  | (x: Float): Float
  | (x: Long): Long
  | (x: Int): Int
  | (x: Char): Int
  | (x: Short): Int
  | (x: Byte): Int
  | (x: String): String
  |match arguments ((Integer.TYPE : Class[Integer]))
1 error found
```

### After

```scala
Welcome to Scala 3.10.0-RC1-bin-SNAPSHOT-git-eb75505 (23.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.

scala> 1
val res0: Int = 1
                                                                                                                                                           
scala> 42 + java.lang.Integer.TYPE
-- [E134] Type Error: ----------------------------------------------------------
1 |42 + java.lang.Integer.TYPE
  |^^^^
  |None of the overloaded alternatives of method + in class Int with types
  | (x: Double): Double
  | (x: Float): Float
  | (x: Long): Long
  | (x: Int): Int
  | (x: Char): Int
  | (x: Short): Int
  | (x: Byte): Int
  | (x: String): String
  |match arguments ((Integer.TYPE : Class[Integer]))
1 error found
                                                                                                                                                           
scala> 2
val res1: Int = 2
```

## Have you relied on LLM-based tools in this contribution?

Yes, I used it to get a general idea about the approach.

## How was the solution tested?

Covered by existing tests (this is a refactoring)
&
Manually
