### PR TITLE
fix: emit -Winfer-union warning in the REPL

### DIFF
--- a/repl/src/dotty/tools/repl/ReplCompiler.scala
+++ b/repl/src/dotty/tools/repl/ReplCompiler.scala
@@ -17,7 +17,7 @@ import dotc.config.Feature
 import dotc.core.StdNames.*
 import dotc.core.Symbols.*
 import dotc.reporting.Diagnostic
-import dotc.transform.{CheckUnused, CheckShadowing, PostTyper, UnrollDefinitions}
+import dotc.transform.{CheckUnused, CheckShadowing, PostTyper, UnrollDefinitions, WInferUnion}
 import dotc.typer.ImportInfo.{withRootImports, RootRef}
 import dotc.typer.TyperPhase
 import dotc.util.Spans.*
@@ -41,7 +41,7 @@ class ReplCompiler extends Compiler:
     List(Parser()),
     List(ReplPhase()),
     List(TyperPhase(addRootImports = false)),
-    List(CheckUnused.PostTyper(), CheckShadowing()),
+    List(WInferUnion(), CheckUnused.PostTyper(), CheckShadowing()),
     List(CollectTopLevelImports()),
     List(PostTyper()),
     List(UnrollDefinitions()),

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -936,6 +936,19 @@ class ReplUnrollTests extends ReplTest(ReplTest.defaultOptions ++ Seq("-preview"
         normalizedOutput.contains(normalizedDefn)
       )
 
+class ReplInferUnionTests extends ReplTest(ReplTest.defaultOptions :+ "-Wall"):
+  @Test def i25991: Unit = initially:
+    run("""Some(42).contains("answer")""")
+    val expected =
+      """#1 warning found
+         #-- [E225] Type Warning: --------------------------------------------------------
+         #1 |Some(42).contains("answer")
+         #  |^^^^^^^^^^^^^^^^^
+         #  |A type argument was inferred to be union type Int | String
+         #  |This may indicate a programming error.
+         #val res0: Boolean = false""".stripMargin('#')
+    assertEquals(expected, storedOutput().trim())
+
 class ReplPrintDimentionsTests extends ReplTest(ReplTest.defaultOptions) {
   private def runTest(settings: List[String], expected: String): Unit =
     resetToInitial(settings)


### PR DESCRIPTION
Fixes #25991

REPL was overriding frontendPhases without including WInferUnion, so I added it to the list.

```scala
Welcome to Scala 3.10.0-RC1-bin-SNAPSHOT-git-8433159 (23.0.2, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                           
scala> Some(42).contains("answer")
1 warning found
-- [E225] Type Warning: --------------------------------------------------------
1 |Some(42).contains("answer")
  |^^^^^^^^^^^^^^^^^
  |A type argument was inferred to be union type Int | String
  |This may indicate a programming error.
val res0: Boolean = false
```

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
