### PR TITLE
SLC: Extend `typeChecks`/`typeCheckErrors` to run compiler-plugin phases

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -266,8 +266,15 @@ class Definitions {
     @tu lazy val Compiletime_summonInline : Symbol = CompiletimePackageClass.requiredMethod("summonInline")
     @tu lazy val Compiletime_summonAll    : Symbol = CompiletimePackageClass.requiredMethod("summonAll")
   @tu lazy val CompiletimeTestingPackage: Symbol = requiredPackage("scala.compiletime.testing")
-    @tu lazy val CompiletimeTesting_typeChecks: Symbol = CompiletimeTestingPackage.requiredMethod("typeChecks")
-    @tu lazy val CompiletimeTesting_typeCheckErrors: Symbol = CompiletimeTestingPackage.requiredMethod("typeCheckErrors")
+    @tu lazy val CompiletimeTestingPackageClass: Symbol = CompiletimeTestingPackage.moduleClass
+    @tu lazy val CompiletimeTesting_typeChecks: Symbol =
+      CompiletimeTestingPackageClass.requiredMethod("typeChecks", List(StringType))
+    @tu lazy val CompiletimeTesting_typeChecksStopAfter: Symbol =
+      CompiletimeTestingPackageClass.requiredMethod("typeChecks", List(StringType, StringType))
+    @tu lazy val CompiletimeTesting_typeCheckErrors: Symbol =
+      CompiletimeTestingPackageClass.requiredMethod("typeCheckErrors", List(StringType))
+    @tu lazy val CompiletimeTesting_typeCheckErrorsStopAfter: Symbol =
+      CompiletimeTestingPackageClass.requiredMethod("typeCheckErrors", List(StringType, StringType))
     @tu lazy val CompiletimeTesting_ErrorClass: ClassSymbol = requiredClass("scala.compiletime.testing.Error")
     @tu lazy val CompiletimeTesting_Error: Symbol = requiredModule("scala.compiletime.testing.Error")
       @tu lazy val CompiletimeTesting_Error_apply = CompiletimeTesting_Error.requiredMethod(nme.apply)

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -127,8 +127,10 @@ object Inlines:
     if tree0.symbol.denot.exists
       && tree0.symbol.effectiveOwner == defn.CompiletimeTestingPackage.moduleClass
     then
-      if (tree0.symbol == defn.CompiletimeTesting_typeChecks) return Intrinsics.typeChecks(tree0)
-      if (tree0.symbol == defn.CompiletimeTesting_typeCheckErrors) return Intrinsics.typeCheckErrors(tree0)
+      if (tree0.symbol == defn.CompiletimeTesting_typeChecks
+          || tree0.symbol == defn.CompiletimeTesting_typeChecksStopAfter) return Intrinsics.typeChecks(tree0)
+      if (tree0.symbol == defn.CompiletimeTesting_typeCheckErrors
+          || tree0.symbol == defn.CompiletimeTesting_typeCheckErrorsStopAfter) return Intrinsics.typeCheckErrors(tree0)
 
     if ctx.isAfterTyper then
       // During typer we wait with cross version checks until PostTyper, in order
@@ -365,7 +367,11 @@ object Inlines:
       case Parser, Typer
 
     private def compileForErrors(tree: Tree)(using Context): List[(ErrorKind, Error)] =
-      assert(tree.symbol == defn.CompiletimeTesting_typeChecks || tree.symbol == defn.CompiletimeTesting_typeCheckErrors)
+      assert(
+        tree.symbol == defn.CompiletimeTesting_typeChecks
+        || tree.symbol == defn.CompiletimeTesting_typeChecksStopAfter
+        || tree.symbol == defn.CompiletimeTesting_typeCheckErrors
+        || tree.symbol == defn.CompiletimeTesting_typeCheckErrorsStopAfter)
       def stripTyped(t: Tree): Tree = t match {
         case Typed(t2, _) => stripTyped(t2)
         case Block(Nil, t2) => stripTyped(t2)
@@ -373,7 +379,15 @@ object Inlines:
         case _ => t
       }
 
-      val Apply(_, codeArg :: Nil) = tree: @unchecked
+      // The two-argument overloads additionally carry the name of the compiler
+      // phase up to (and including) which the code should be checked.
+      val (codeArg, stopAfterPhase) = (tree: @unchecked) match
+        case Apply(_, codeArg :: stopAfterArg :: Nil) =>
+          val stopAfterName = ConstFold(stripTyped(stopAfterArg.underlying)).tpe.widenTermRefExpr match
+            case ConstantType(Constant(phase: String)) if phase.nonEmpty => Some(phase)
+            case _ => None
+          (codeArg, stopAfterName)
+        case Apply(_, codeArg :: Nil) => (codeArg, None)
       val codeArg1 = stripTyped(codeArg.underlying)
       val underlyingCodeArg =
         if Inlines.isInlineable(codeArg1.symbol) then stripTyped(Inlines.inlineCall(codeArg1))
@@ -418,6 +432,30 @@ object Inlines:
           else Some(MegaPhaseWithCustomPhaseId(newMegaPhasePhases.toArray, phaseIds.head, phaseIds.last))
         )
 
+      // When a `stopAfterPhase` is requested, additionally reconstruct the enabled
+      // compiler-plugin phases (`PluginPhase`s registered via `-Xplugin`) that are
+      // scheduled at or before that phase, so that diagnostics they emit are surfaced.
+      // Plugins are re-initialized here to obtain fresh phase instances (as required by
+      // the `StandardPlugin` contract), which are wrapped in single-phase MegaPhases and
+      // run after the reconstructed transform phases above. Each plugin phase is run at
+      // its real phase id so denotation lookups match the actual pipeline.
+      lazy val reconstructedPluginPhases: List[MegaPhaseWithCustomPhaseId] =
+        stopAfterPhase match
+          case None => Nil
+          case Some(stopName) =>
+            val pluginPlan = ctx.base.addPluginPhases(ctx.base.phasePlan).flatten
+            // Only run plugin phases when the requested phase actually exists in the
+            // (plugin-augmented) plan; an unknown name runs nothing rather than silently
+            // running every plugin phase.
+            val cutoff = pluginPlan.indexWhere(_.phaseName == stopName)
+            pluginPlan.iterator.zipWithIndex.collect {
+              case (p: dotty.tools.dotc.plugins.PluginPhase, i) if i <= cutoff => p
+            }.flatMap { pluginPhase =>
+              ctx.base.phases
+                .find(phase => phase.phaseName == pluginPhase.phaseName)
+                .map(realPhase => MegaPhaseWithCustomPhaseId(Array(pluginPhase), realPhase.id, realPhase.id))
+            }.toList
+
       ConstFold(underlyingCodeArg).tpe.widenTermRefExpr match {
         case ConstantType(Constant(code: String)) =>
           val unitName = "tasty-reflect"
@@ -456,9 +494,10 @@ object Inlines:
                       ctx.base.inliningPhase match
                         case inlining: Inlining if noErrors =>
                           val tpdTree4 = atPhase(inlining) { inlining.newTransformer.transform(tpdTree3) }
-                          if noErrors && reconstructedTransformPhases.nonEmpty then
+                          val transformPhasesToRun = reconstructedTransformPhases ::: reconstructedPluginPhases
+                          if noErrors && transformPhasesToRun.nonEmpty then
                             var transformTree = tpdTree4
-                            for phase <- reconstructedTransformPhases do
+                            for phase <- transformPhasesToRun do
                               if noErrors then
                                 transformTree = atPhase(phase.end + 1)(phase.transformUnit(transformTree))
                         case _ =>

--- a/library/src/scala/compiletime/testing/package.scala
+++ b/library/src/scala/compiletime/testing/package.scala
@@ -16,6 +16,29 @@ transparent inline def typeChecks(inline code: String): Boolean =
   // implemented in package dotty.tools.dotc.typer.Inliner.Intrinsics
   error("Compiler bug: `typeChecks` was not checked by the compiler")
 
+/** Whether the code type checks in the current context, running the
+ *  compilation up to and including the given compiler phase?
+ *
+ *  This overload behaves like `typeChecks(code)`, but in addition it runs the
+ *  enabled compiler-plugin phases (`scala.tools.dotc.plugins.PluginPhase`,
+ *  registered via `-Xplugin`) that are scheduled at or before `stopAfterPhase`.
+ *  This makes it possible to test diagnostics emitted by compiler plugins, which
+ *  the single-argument `typeChecks` does not run.
+ *
+ *  An inline definition with a call to `typeChecks` should be transparent.
+ *
+ *  @param code a string literal containing the Scala code to type-check at compile time
+ *  @param stopAfterPhase the name of the compiler phase up to (and including) which the
+ *                        code should be checked; plugin phases scheduled at or before it are run
+ *  @return `true` if the code type-checks successfully, `false` if the code has a syntax or
+ *          type error, or an error reported by a plugin phase, in the current context.
+ *
+ *  The code should be a sequence of expressions or statements that may appear in a block.
+ */
+transparent inline def typeChecks(inline code: String, inline stopAfterPhase: String): Boolean =
+  // implemented in package dotty.tools.dotc.typer.Inliner.Intrinsics
+  error("Compiler bug: `typeChecks` was not checked by the compiler")
+
 /** Whether the code type checks in the current context? If not,
  *  returns a list of errors encountered on compilation.
  *  IMPORTANT: No stability guarantees are provided on the format of these
@@ -31,5 +54,34 @@ transparent inline def typeChecks(inline code: String): Boolean =
  *  The code should be a sequence of expressions or statements that may appear in a block.
  */
 transparent inline def typeCheckErrors(inline code: String): List[Error] =
+  // implemented in package dotty.tools.dotc.typer.Inliner.Intrinsics
+  error("Compiler bug: `typeCheckErrors` was not checked by the compiler")
+
+/** Whether the code type checks in the current context, running the compilation
+ *  up to and including the given compiler phase? If not, returns a list of errors
+ *  encountered on compilation.
+ *  IMPORTANT: No stability guarantees are provided on the format of these
+ *  errors. This means the format and the API may change from
+ *  version to version. This API is to be used for testing purposes
+ *  only.
+ *
+ *  This overload behaves like `typeCheckErrors(code)`, but in addition it runs the
+ *  enabled compiler-plugin phases (`scala.tools.dotc.plugins.PluginPhase`,
+ *  registered via `-Xplugin`) that are scheduled at or before `stopAfterPhase`.
+ *  This makes it possible to test diagnostics emitted by compiler plugins, which
+ *  the single-argument `typeCheckErrors` does not run.
+ *
+ *  An inline definition with a call to `typeCheckErrors` should be transparent.
+ *
+ *  @param code a string literal containing the Scala code to type-check at compile time
+ *  @param stopAfterPhase the name of the compiler phase up to (and including) which the
+ *                        code should be checked; plugin phases scheduled at or before it are run
+ *  @return an empty list if the code type-checks successfully, or a list of `Error` values
+ *          describing the errors encountered during parsing, type-checking and the run
+ *          plugin phases.
+ *
+ *  The code should be a sequence of expressions or statements that may appear in a block.
+ */
+transparent inline def typeCheckErrors(inline code: String, inline stopAfterPhase: String): List[Error] =
   // implemented in package dotty.tools.dotc.typer.Inliner.Intrinsics
   error("Compiler bug: `typeCheckErrors` was not checked by the compiler")

--- a/tests/plugins/run/typeCheckErrorsPhase/DivideZeroPlugin_1.scala
+++ b/tests/plugins/run/typeCheckErrorsPhase/DivideZeroPlugin_1.scala
@@ -1,0 +1,45 @@
+import dotty.tools.dotc.*
+import core.*
+import Contexts.Context
+import plugins.*
+import ast.tpd
+import Decorators.*
+import Symbols.{Symbol, requiredClass}
+import Constants.Constant
+import transform.{Pickler, PickleQuotes}
+import StdNames.*
+
+// A minimal compiler plugin used to exercise the two-argument
+// `typeCheckErrors`/`typeChecks` overloads, which run plugin phases up to a
+// requested phase. The plugin reports an error on any `_ / 0` on a numeric type.
+//
+// `DivideZeroPlugin` follows the `StandardPlugin` contract by returning a
+// freshly constructed phase from `initialize`.
+class DivideZeroPlugin extends StandardPlugin {
+  val name: String = "divideZeroCheck"
+  override val description: String = "divide by zero check"
+
+  override def initialize(options: List[String])(using Context): List[PluginPhase] =
+    new DivideZeroPhase :: Nil
+}
+
+class DivideZeroPhase extends PluginPhase {
+  val phaseName = "divideZeroCheck"
+
+  override val runsAfter = Set(Pickler.name)
+  override val runsBefore = Set(PickleQuotes.name)
+
+  private def isNumericDivide(sym: Symbol)(using Context): Boolean = {
+    def test(tpe: String): Boolean =
+      (sym.owner eq requiredClass(tpe)) && sym.name == nme.DIV
+    test("scala.Int") || test("scala.Long") || test("scala.Short") || test("scala.Float") || test("scala.Double")
+  }
+
+  override def transformApply(tree: tpd.Apply)(using Context): tpd.Tree = tree match {
+    case tpd.Apply(fun, tpd.Literal(Constant(v)) :: Nil) if isNumericDivide(fun.symbol) && v == 0 =>
+      report.error("divide by zero", tree.srcPos)
+      tree
+    case _ =>
+      tree
+  }
+}

--- a/tests/plugins/run/typeCheckErrorsPhase/Test_2.scala
+++ b/tests/plugins/run/typeCheckErrorsPhase/Test_2.scala
@@ -1,0 +1,25 @@
+import scala.compiletime.testing.*
+
+// The `DivideZeroPlugin` phase `divideZeroCheck` runs after `pickler`, which is
+// past the phases that the single-argument `typeCheckErrors`/`typeChecks` run.
+// The two-argument overloads additionally run enabled plugin phases up to (and
+// including) the named phase, so the plugin's diagnostic is observed.
+@main def Test: Unit =
+  // Without a stop-after phase, plugin phases are not run: the code type-checks.
+  val withoutPhase = typeCheckErrors("5 / 0")
+  assert(withoutPhase.isEmpty, s"expected no errors without a phase, got: $withoutPhase")
+  assert(typeChecks("5 / 0"), "expected `typeChecks` to succeed without a phase")
+
+  // Requesting the plugin phase surfaces the plugin's error.
+  val withPhase = typeCheckErrors("5 / 0", "divideZeroCheck")
+  assert(withPhase.nonEmpty, "expected the plugin phase to report an error")
+  assert(
+    withPhase.exists(e => e.message == "divide by zero" && e.kind == ErrorKind.Typer),
+    s"expected a `divide by zero` error, got: ${withPhase.map(e => (e.message, e.kind))}"
+  )
+  assert(!typeChecks("5 / 0", "divideZeroCheck"), "expected `typeChecks` to fail once the plugin phase runs")
+
+  // Ordinary type/parse errors are still reported by the two-argument overload,
+  // and a genuinely fine snippet still type-checks with the plugin phase run.
+  assert(typeCheckErrors("val x: Int = \"\"", "divideZeroCheck").nonEmpty, "expected a type error to be reported")
+  assert(typeChecks("5 / 2", "divideZeroCheck"), "expected a valid snippet to type-check with the plugin phase")

--- a/tests/plugins/run/typeCheckErrorsPhase/plugin.properties
+++ b/tests/plugins/run/typeCheckErrorsPhase/plugin.properties
@@ -1,0 +1,1 @@
+pluginClass=DivideZeroPlugin


### PR DESCRIPTION
**Currently in draft until discussion on contributors**
https://contributors.scala-lang.org/t/slc-extend-typechecks-typecheckerrors-to-run-compiler-plugin-phases/7501
`compiletime.testing.typeChecks`/`typeCheckErrors` only run the compilation up to a fixed set of reconstructed transform phases (InlineVals, ElimRepeated, RefChecks; see scala/scala3#21185). Diagnostics emitted by compiler plugins, whose phases run later in the pipeline, are therefore never surfaced, so plugin authors cannot unit-test their errors with these methods.

Add two-argument overloads `typeChecks(code, stopAfterPhase)` and `typeCheckErrors(code, stopAfterPhase)`. When a phase name is supplied, the intrinsic additionally re-initializes the enabled `-Xplugin` `PluginPhase`s (fresh instances, per the `StandardPlugin` contract), selects those scheduled at or before the named phase, and runs each on the isolated tree so their `report.error` calls are collected. An unknown phase name runs no extra phases.

The single-argument methods are unchanged: without a phase argument the set of reconstructed plugin phases is empty, so existing behaviour is identical. The four intrinsics are now resolved by argument types so the overloads disambiguate.

Adds tests/plugins/run/typeCheckErrorsPhase exercising a plugin phase that runs after `pickler`: with the phase argument the plugin's error is reported, without it the code type-checks.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by running the implementation against my own compiler-plugin dependent library.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
