### PR TITLE
Don't merge some nested capture sets when comparing capturing types.

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -145,13 +145,29 @@ extension (tp: Type)
     *     just the reference, provided the underlying capture set of their info is not empty.
     *   - For other capabilities: The capture set of their info
     *   - For all other types: The result of CaptureSet.ofType
+    * The separated variant does not merge nested capture sets in some cases.
+    * See explanation of `separated` parameter in `CaptureSet.ofType`.
     */
-  final def captureSet(using Context): CaptureSet = tp match
+  final def captureSet(using Context): CaptureSet = captureSet(separated = false)
+  final def separatedCaptureSet(using Context): CaptureSet = captureSet(separated = true)
+
+  final def captureSet(separated: Boolean)(using Context) = tp match
     case tp: CoreCapability if tp.isTrackableRef =>
       val cs = tp.captureSetOfInfo
       if cs.isAlwaysEmpty then cs else tp.singletonCaptureSet
     case tp: ObjectCapability => tp.captureSetOfInfo
-    case _ => CaptureSet.ofType(tp, followResult = false)
+    case _ => CaptureSet.ofType(tp, followResult = false, separated)
+
+  /** Does this type have a "split capture set", which means the type is of the form
+   *  `{T^cs1}^cs2` where `cs1` is a capset variable and `cs2` contains terminal capabilities.
+   */
+  def hasSplitCaptureSet(using Context): Boolean = tp.dealiasKeepAnnots match
+    case CapturingOrRetainsType(parent, refs) =>
+      !parent.captureSet.isConst && refs.containsTerminalCapability
+    case tp: TypeProxy =>
+      tp.superType.hasSplitCaptureSet
+    case _ =>
+      false
 
   /** Compute a captureset by traversing parts of this type. This is by default the union of all
    *  covariant capture sets embedded in the widened type, as computed by

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1169,7 +1169,6 @@ object CaptureSet:
 
     if debugVars && id == debugTarget then
       println(i"variable $id is derived from $source")
-      assert(false)
 
     override def tryInclude(elem: Capability, origin: CaptureSet)(using Context, VarState): Boolean =
       if origin eq source then
@@ -1781,12 +1780,15 @@ object CaptureSet:
     case c: TermRef if isAssumedPure(c.symbol) =>
       CaptureSet.empty
     case c: CoreCapability =>
-      ofType(c.underlying, followResult = ccConfig.useSpanCapset)
+      ofType(c.underlying, followResult = ccConfig.useSpanCapset, separated = false)
 
   /** Capture set of a type
    *  @param followResult  If true, also include capture sets of function results.
+   *  @param separated     If true, given a capturring type (P^cs1)^cs2 don't merge
+   *                       cs1 and cs2 if cs1 is a capset variable and cs2 contains
+   *                       terminal capabilities. This is needed to fix #26539.
    */
-  def ofType(tp: Type, followResult: Boolean)(using Context): CaptureSet =
+  def ofType(tp: Type, followResult: Boolean, separated: Boolean)(using Context): CaptureSet =
     def recur(tp: Type): CaptureSet = trace(i"ofType $tp, ${tp.getClass} $followResult", show = true):
       tp.dealiasKeepAnnots match
         case tp: TermRef =>
@@ -1797,9 +1799,11 @@ object CaptureSet:
           if tp.derivesFromCapSet then tp.captureSet
           else empty
         case CapturingOrRetainsType(parent, refs) =>
-          recur(parent) ++ refs
+          val pcs = recur(parent)
+          if separated && !pcs.isConst && refs.containsTerminalCapability then refs
+          else pcs ++ refs
         case tpd @ defn.RefinedFunctionOf(rinfo: MethodOrPoly) if followResult =>
-          ofType(tpd.parent, followResult = false)            // pick up capture set from parent type
+          ofType(tpd.parent, followResult = false, separated)            // pick up capture set from parent type
           ++ recur(rinfo.resType).freeInResult(rinfo)         // add capture set of result
         case tpd @ AppliedType(tycon, args) =>
           if followResult && defn.isNonRefinedFunction(tpd) then

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -546,9 +546,20 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         res
 
       case tp1 @ CapturingType(parent1, refs1) =>
+        // If `tp2` has a split capture set, i.e. is of the form `(A^s)^` then its normal
+        // capture set will be a cs variable with `any` in it. Then, if we add elements
+        // we avoid the `any` and add them to the variable instead. But that risks adding
+        // to much. See i26539.scala for an example. So we try a different strategy in this
+        // case: Add capabilities from tp1 to the hidden set of the outer `^`, so that the
+        // capset variable stays small. Only if that fails try to add them to the variable.
+        def compCaptures =
+          if tp2.hasSplitCaptureSet then
+            compareCaptures(tp1, refs1, tp2, tp2.separatedCaptureSet)
+            || compareCaptures(tp1, refs1, tp2, tp2.captureSet)
+          else compareCaptures(tp1, refs1, tp2, tp2.captureSet)
         def compareCapturing =
           if tp2.isAny then true
-          else if compareCaptures(tp1, refs1, tp2, tp2.captureSet)
+          else if compCaptures
             || !ctx.mode.is(Mode.CheckBoundsOrSelfType) && tp1.isAlwaysPure
             || parent1.isSingleton && refs1.elems.forall(parent1 eq _)
           then

--- a/compiler/src/dotty/tools/dotc/core/Types.scala
+++ b/compiler/src/dotty/tools/dotc/core/Types.scala
@@ -6402,7 +6402,7 @@ object Types extends TypeUtils {
         if ref1 != null then ref1
         else
           val isLiteral = tp1.typeSymbol == defn.Caps_CapSet
-          val cs = CaptureSet.ofType(tp1, followResult = false)
+          val cs = CaptureSet.ofType(tp1, followResult = false, separated = false)
           (cs, isLiteral)
 
     /** Utility method. Maps the supertype of a type proxy. Returns the

--- a/tests/pos-custom-args/captures/i26539.scala
+++ b/tests/pos-custom-args/captures/i26539.scala
@@ -1,0 +1,7 @@
+class Ref
+
+class Abs[A](val fst: A^, val snd: A^)
+
+def mkAbs[A](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y) // ok
+
+def mkAbs2[A](consume x: A^, consume y: A^): Abs[A]^ = Abs(x, y) // !!! error, because A^{x, y} is inferred as type parameter for `Abs`


### PR DESCRIPTION
When comparing types `T1 <: (T2^cs1)^cs2`, don't merge `cs1` and `cs2` if `cs1` is a capset variable and `cs2` contains a terminal capability. Rather compare with `cs2` only. This makes capabilities in `T1`'s capset flow into the hidden set of `cs2` instead of the capset variable `cs1`, Only if that fails fall back to a merged capset.

Fixes #26539

