### PR TITLE
Treat consume capabilities specially when including in unions

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1169,7 +1169,6 @@ object CaptureSet:
 
     if debugVars && id == debugTarget then
       println(i"variable $id is derived from $source")
-      assert(false)
 
     override def tryInclude(elem: Capability, origin: CaptureSet)(using Context, VarState): Boolean =
       if origin eq source then
@@ -1242,23 +1241,44 @@ object CaptureSet:
     addAsDependentTo(cs2)
     mutability = cs1.mutability | cs2.mutability
 
+    // If we have a union of a constant capture set C that contains a terminal
+    // capability `cap` and a variable capture set V, there is no uniformly best
+    // strategy for including a new element `elem`. By default, if the variable
+    // state admits additions to capset variables (i.e. vs.isOpen is true), `elem`
+    // goes into `V`. But it could also go into the hidden set of `cap`. The default
+    // can add too much to `V`, as was seen in #26539. We now use a finer distinction:
+    // If `elem` is a `consume` capability it now goes into the hidden set of `cap`
+    // instead of `V`. This makes i26539.scala compile.
+    private def subsumesConsuming(cs: CaptureSet, elem: Capability)(using Context, VarState): Boolean =
+      elem match
+        case elem: TermRef =>
+          elem.symbol.isConsume
+          && varState.isOpen
+          && cs.isConst
+          && cs.elems.exists(_.maxSubsumes(elem, canAddHidden = true))
+        case _ =>
+          false
+
     override def tryInclude(elem: Capability, origin: CaptureSet)(using Context, VarState): Boolean =
       if accountsFor(elem) then true
       else
         TypeComparer.atomicOp:
-          val res = super.tryInclude(elem, origin)
-          // If this is the union of a constant and a variable,
-          // propagate `elem` to the variable part to avoid slack
-          // between the operands and the union.
-          if res && (origin ne cs1) && (origin ne cs2) then
-            try
-              if cs1.isConst then cs2.tryInclude(elem, origin)
-              else if cs2.isConst then cs1.tryInclude(elem, origin)
-              else res
-            catch case ex: AssertionError =>
-              println(i"err while tryinclude $elem in $cs1 | $cs2, ${cs1.isConst}, ${cs2.isConst}")
-              throw ex
-          else res
+          if subsumesConsuming(cs1, elem) || subsumesConsuming(cs2, elem) then
+            true
+          else
+            val res = super.tryInclude(elem, origin)
+            // If this is the union of a constant and a variable,
+            // propagate `elem` to the variable part to avoid slack
+            // between the operands and the union.
+            if res && (origin ne cs1) && (origin ne cs2) then
+              try
+                if cs1.isConst then cs2.tryInclude(elem, origin)
+                else if cs2.isConst then cs1.tryInclude(elem, origin)
+                else res
+              catch case ex: AssertionError =>
+                println(i"err while tryinclude $elem in $cs1 | $cs2, ${cs1.isConst}, ${cs2.isConst}")
+                throw ex
+            else res
 
     override def mutableToReader(origin: CaptureSet)(using Context): Boolean =
       super.mutableToReader(origin)

--- a/tests/neg-custom-args/captures/splits.check
+++ b/tests/neg-custom-args/captures/splits.check
@@ -1,0 +1,44 @@
+-- Error: tests/neg-custom-args/captures/splits.scala:34:24 ------------------------------------------------------------
+34 |    val elem2: Ref^ = x.snd  // error separation because fst and snd cannot be shown to be separate
+   |                      ^^^^^
+   |Separation failure: Illegal access to {r2} which is hidden by the previous definition
+   |of value elem1 with type M.Ref^.
+   |This type hides capabilities  {any, r2, any²}
+   |
+   |where:    ^    refers to a root capability in the type of value elem1
+   |          any  is a root capability in the type of variable r1
+   |          any² is a root capability created in variable r1 when instantiating method Ref's type (): M.Ref^{fresh}
+-- Error: tests/neg-custom-args/captures/splits.scala:39:19 ------------------------------------------------------------
+39 |    val z = mkConc(r5, r5)  // error separation, as expected
+   |                   ^^
+   |Separation failure: argument of type  (r5 : M.Ref^)
+   |to method mkConc: (consume x: M.Ref^, consume y: M.Ref^): M.Conc^{fresh}
+   |corresponds to capture-polymorphic formal parameter x of type  M.Ref^²
+   |and hides capabilities  {r5}.
+   |Some of these overlap with the captures of the second argument with type  (r5 : M.Ref^).
+   |
+   |  Hidden set of current argument        : {r5}
+   |  Hidden footprint of current argument  : {r5}
+   |  Capture set of second argument        : {r5}
+   |  Footprint set of second argument      : {r5}
+   |  The two sets overlap at               : {r5}
+   |
+   |where:    ^  refers to a root capability in the type of value r5
+   |          ^² refers to a root capability created in value z when checking argument to parameter x of method mkConc
+-- Error: tests/neg-custom-args/captures/splits.scala:41:20 ------------------------------------------------------------
+41 |    val z1 = mkConc(r5a, r5a)  // error separation, as expected
+   |                    ^^^
+   |Separation failure: argument of type  (r5a : M.Ref^)
+   |to method mkConc: (consume x: M.Ref^, consume y: M.Ref^): M.Conc^{fresh}
+   |corresponds to capture-polymorphic formal parameter x of type  M.Ref^²
+   |and hides capabilities  {r5a}.
+   |Some of these overlap with the captures of the second argument with type  (r5a : M.Ref^).
+   |
+   |  Hidden set of current argument        : {r5a}
+   |  Hidden footprint of current argument  : {r5a}
+   |  Capture set of second argument        : {r5a}
+   |  Footprint set of second argument      : {r5a}
+   |  The two sets overlap at               : {r5a}
+   |
+   |where:    ^  refers to a root capability in the type of value r5a
+   |          ^² refers to a root capability created in value z1 when checking argument to parameter x of method mkConc

--- a/tests/neg-custom-args/captures/splits.scala
+++ b/tests/neg-custom-args/captures/splits.scala
@@ -1,0 +1,54 @@
+import caps.Mutable
+import caps.any
+
+object M {
+  class Ref /*extends Mutable:
+    var x = 0
+    def get: Int = x
+    update def put(y: Int): Unit = x = y
+*/
+  def Ref(): Ref^ = new Ref()
+
+  class Conc(val fst: Ref^, val snd: Ref^)
+
+  class Node[A](val fst: A, val snd: A)
+
+  class Abs[A](val fst: A^, val snd: A^)
+
+  def mkNode[A](consume x: A, consume y: A): Node[A] = ???
+
+  def mkConc(consume x: Ref^, consume y: Ref^): Conc^ = Conc(x, y)
+
+  def mkAbs[A](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y)
+
+  def mkAbs2[A](consume x: A^, consume y: A^): Abs[A]^ = Abs(x, y)
+
+  class C
+
+  def Test(c: C^): Unit =
+    mkNode(c, c)
+    var r1 = Ref()
+    val r2 = Ref()
+    val x = mkNode(r1, r2)  // ok, but can't pull out elements
+    val elem1: Ref^ = x.fst
+    val elem2: Ref^ = x.snd  // error separation because fst and snd cannot be shown to be separate
+    val r3 = Ref()
+    val r4 = Ref()
+    val y = mkConc(r3, r4) // ok for concrete element types
+    val r5: Ref^ = Ref()
+    val z = mkConc(r5, r5)  // error separation, as expected
+    val r5a = Ref()
+    val z1 = mkConc(r5a, r5a)  // error separation, as expected
+
+    val elem3: Ref^ = y.fst
+    val elem4: Ref^ = y.snd
+    val y1 = mkConc(elem3, elem4) // ok, can split & join for concrete element types
+
+    val r6 = Ref()
+    val r7 = Ref()
+    val z2 = mkAbs[Ref](r6, r7)
+
+    val elem5: Ref^ = z2.fst
+    val elem6: Ref^ = z2.snd
+    val z3 = mkAbs[Ref](elem5, elem6)   // ok, can spit and join for polymorphic as well.
+}

--- a/tests/pos-custom-args/captures/i26539.scala
+++ b/tests/pos-custom-args/captures/i26539.scala
@@ -1,0 +1,7 @@
+class Ref
+
+class Abs[A](val fst: A^, val snd: A^)
+
+def mkAbs[A](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y) // ok
+
+def mkAbs2[A](consume x: A^, consume y: A^): Abs[A]^ = Abs(x, y) // !!! error, because A^{x, y} is inferred as type parameter for `Abs`


### PR DESCRIPTION
If we have a union of a constant capture set C that contains a terminal capability `cap` and a variable capture set V, there is no uniformly best strategy for including a new element `elem`. By default, if the variable state admits additions to capset variables (i.e. vs.isOpen is true), `elem` goes into `V`. But it could also go into the hidden set of `cap`. The default can add too much to `V`, as was seen in #26539. We now use a finer distinction: If `elem` is a `consume` capability it now goes into the hidden set of `cap` instead of `V`. This makes i26539.scala compile.

Fixes #26539

Supersedes #26540 