### PR TITLE
Better handling of nested capture sets

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -186,7 +186,9 @@ extension (tp: Type)
    *  the two capture sets are combined.
    */
   def capturing(cs: CaptureSet)(using Context): Type =
-    if (cs.isAlwaysEmpty || cs.isConst && cs.subCaptures(tp.captureSet, VarState.Separate))
+    if (cs.isAlwaysEmpty && !tp.isAny
+        || cs.isConst && cs.subCaptures(tp.captureSet, VarState.Separate)
+        )
         && !cs.keepAlways
     then tp
     else tp match

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1244,21 +1244,12 @@ object CaptureSet:
 
     override def tryInclude(elem: Capability, origin: CaptureSet)(using Context, VarState): Boolean =
       if accountsFor(elem) then true
+      else if (origin eq cs1) || (origin eq cs2) then
+        super.tryInclude(elem, origin)
       else
-        TypeComparer.atomicOp:
-          val res = super.tryInclude(elem, origin)
-          // If this is the union of a constant and a variable,
-          // propagate `elem` to the variable part to avoid slack
-          // between the operands and the union.
-          if res && (origin ne cs1) && (origin ne cs2) then
-            try
-              if cs1.isConst then cs2.tryInclude(elem, origin)
-              else if cs2.isConst then cs1.tryInclude(elem, origin)
-              else res
-            catch case ex: AssertionError =>
-              println(i"err while tryinclude $elem in $cs1 | $cs2, ${cs1.isConst}, ${cs2.isConst}")
-              throw ex
-          else res
+           !cs1.isConst && cs1.tryInclude(elem, origin)
+        || !cs2.isConst && cs2.tryInclude(elem, origin)
+        || addIfHiddenOrFail(elem)
 
     override def mutableToReader(origin: CaptureSet)(using Context): Boolean =
       super.mutableToReader(origin)

--- a/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CapturingType.scala
@@ -27,14 +27,14 @@ import Decorators.i
 object CapturingType:
 
   /** Smart constructor that
-   *   - drops empty capture sets
+   *   - drops empty capture sets, except on Any
    *   - fuses compatible capturing types.
    *  An outer type capturing type A can be fused with an inner capturing type B if their
    *  boxing status is the same or if A is boxed.
    */
   def apply(parent: Type, refs: CaptureSet, boxed: Boolean = false)(using Context): Type =
     assert(!boxed || !parent.derivesFromCapSet)
-    if refs.isAlwaysEmpty && !refs.keepAlways && !parent.derivesFromCapability then
+    if refs.isAlwaysEmpty && !parent.isAny && !refs.keepAlways && !parent.derivesFromCapability then
       parent
     else parent match
       case parent @ CapturingType(parent1, refs1) if refs == CaptureSet.Fluid =>

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -995,6 +995,31 @@ class CheckCaptures extends Recheck, SymTransformer:
       res
     }
 
+    /** Check that capture set of type argument subcaptures capture set of bounds.
+     *  We don't check if
+     *   - the bound is excatly any since that is capture polymorphic top, or
+     *   - the bound is singleton, since that's not a "real" bound, or
+     *   - the bound capture set has terminal capabilities, since we don't
+     *     want to upper-bound capsets by GlobalAny, or
+     *   - the bound refers to parameters in the same clause, since we can't
+     *     properly check F-bounded occurrences.
+     */
+    override def recheckTypeArg(arg: Tree, formal: Type, binder: PolyType)(using Context): Type =
+      val argType = super.recheckTypeArg(arg, formal, binder)
+      val argRefs = argType.captureSet
+      val hiBound = formal.bounds.hi
+      val boundRefs = hiBound.captureSet
+      val canCheck =
+        !hiBound.isExactlyAny && !hiBound.isRef(defn.SingletonClass)
+        && !boundRefs.elems.exists:
+          case ref: TypeParamRef => ref.binder == binder // F-bounded
+          case ref => ref.isTerminalCapability // GlobalCaps cannot constrain arguments
+      if canCheck then
+        capt.println(i"constrain $arg: ${argType} with $hiBound: $boundRefs")
+        checkSubset(argRefs, boundRefs, arg.srcPos,
+          provenance = i"\nof the type parameter bound ${formal.bounds.hi}")
+      argType
+
     /** Faced with a tree of form `caps.contansImpl[CS, r.type]`, check that `R` is a tracked
      *  capability and assert that `{r} <: CS`.
      */
@@ -1469,7 +1494,6 @@ class CheckCaptures extends Recheck, SymTransformer:
       for parent <- impl.parents do // (1)
         checkSubset(parent.tpe.classSymbol.useSet, localSet, parent.srcPos,
           provenance = i"\nof the references allowed to be captured by $cls")
-
 
       val saved = curEnv
       curEnv = Env(cls, EnvKind.Regular, localSet, curEnv)

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -997,7 +997,7 @@ class CheckCaptures extends Recheck, SymTransformer:
 
     /** Check that capture set of type argument subcaptures capture set of bounds.
      *  We don't check if
-     *   - the bound is excatly any since that is capture polymorphic top, or
+     *   - the bound is exactly any since that is capture polymorphic top, or
      *   - the bound is singleton, since that's not a "real" bound, or
      *   - the bound capture set has terminal capabilities, since we don't
      *     want to upper-bound capsets by GlobalAny, or

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2968,8 +2968,21 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
           errorNotes = (level, CaptureSet.MutAdaptFailure(cs, tp1, tp2)) :: rest
         case _ =>
     subc
-    && (tp1.isBoxedCapturing == tp2.isBoxedCapturing
-        || refs1.subCaptures(CaptureSet.EmptyOfBoxed(tp1, tp2), makeVarState()))
+    && (tp1.isBoxCompatibleWith(tp2) || healBoxDifference(tp1, tp2))
+
+  /** Try to heal a box difference of `tp1` with another type `tp2` by forcing all capture
+   *  capture sets in `tp1` with a box difference to `tp2` to be empty.
+   */
+  private def healBoxDifference(tp1: Type, tp2: Type)(using Context): Boolean = tp1.dealias match
+    case tp1 @ CapturingType(parent, refs) =>
+      (  tp1.isBoxed == tp2.isBoxedCapturing
+      || refs.subCaptures(CaptureSet.EmptyOfBoxed(tp1, tp2), makeVarState())
+      || { capt.println(i"box mismatch for $tp1 <:< $tp2, ${tp1.isBoxedCapturing}")
+           false
+         }
+      ) && healBoxDifference(parent, tp2)
+    case _ =>
+      true
 
   protected def logUndoAction(action: () => Unit) =
     undoLog += action

--- a/compiler/src/dotty/tools/dotc/transform/Recheck.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Recheck.scala
@@ -382,8 +382,12 @@ abstract class Recheck extends Phase, SymTransformer:
       funtpe.widen match
         case fntpe: PolyType =>
           assert(fntpe.paramInfos.hasSameLengthAs(tree.args))
-          val argTypes = tree.args.map(recheck(_))
+          val argTypes = tree.args.lazyZip(fntpe.paramInfos).map:
+            recheckTypeArg(_, _, fntpe)
           constFold(tree, fntpe.instantiate(argTypes))
+
+    def recheckTypeArg(arg: Tree, formal: Type, binder: PolyType)(using Context): Type =
+      recheck(arg)
 
     def recheckTyped(tree: Typed)(using Context): Type =
       val tptType = recheck(tree.tpt)

--- a/tests/neg-custom-args/captures/capset-bounds.check
+++ b/tests/neg-custom-args/captures/capset-bounds.check
@@ -1,0 +1,12 @@
+-- [E223] CaptureChecking Error: tests/neg-custom-args/captures/capset-bounds.scala:15:19 ------------------------------
+15 |    val z2 = mkAbs[Ref^{r6}](r6, r7)  // error
+   |                   ^^^^^^^^
+   |                   Reference `r6` is not included in the allowed capture set {}
+   |                   of the type parameter bound Any^{}.
+-- [E223] CaptureChecking Error: tests/neg-custom-args/captures/capset-bounds.scala:16:19 ------------------------------
+16 |    val z3 = mkAbs[Ref](r6, r7)     // error
+   |                   ^^^
+   |                   Reference `any.rd` is not included in the allowed capture set {}
+   |                   of the type parameter bound Any^{}.
+   |
+   |                   where:    any is a root capability classified as Unscoped created in value z3

--- a/tests/neg-custom-args/captures/capset-bounds.scala
+++ b/tests/neg-custom-args/captures/capset-bounds.scala
@@ -1,0 +1,17 @@
+import caps.*
+
+class Ref extends Mutable:
+    var x = 0
+    def get: Int = x
+    update def put(y: Int): Unit = x = y
+
+class Abs[A](val fst: A^, val snd: A^)
+
+def mkAbs[A <: Any^{}](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y)
+
+def Test =
+    val r6 = Ref()
+    val r7 = Ref()
+    val z2 = mkAbs[Ref^{r6}](r6, r7)  // error
+    val z3 = mkAbs[Ref](r6, r7)     // error
+

--- a/tests/neg-custom-args/captures/lexical-control.scala
+++ b/tests/neg-custom-args/captures/lexical-control.scala
@@ -15,7 +15,7 @@ def test =
       val z = 3
       val w = suspend(outer) {() => z} // ok
       val v = suspend(inner) {() => y} // ok
-      val u = suspend(inner): () =>
+      val u = suspend(inner): () =>  // error, was OK (???)
         suspend(outer) {() => y} // ok
         suspend(outer) {() => y} // ok
         y

--- a/tests/neg-custom-args/captures/splits-mutable.check
+++ b/tests/neg-custom-args/captures/splits-mutable.check
@@ -1,0 +1,44 @@
+-- Error: tests/neg-custom-args/captures/splits-mutable.scala:32:24 ----------------------------------------------------
+32 |    val elem2: Ref^ = x.snd  // error separation because fst and snd cannot be shown to be separate
+   |                      ^^^^^
+   |Separation failure: Illegal access to {r2} which is hidden by the previous definition
+   |of value elem1 with type M.Ref^.
+   |This type hides capabilities  {any, r2, any²}
+   |
+   |where:    ^    refers to a root capability classified as Unscoped in the type of value elem1
+   |          any  is a root capability classified as Unscoped in the type of variable r1
+   |          any² is a root capability classified as Unscoped created in variable r1 when constructing instance M.Ref
+-- Error: tests/neg-custom-args/captures/splits-mutable.scala:37:19 ----------------------------------------------------
+37 |    val z = mkConc(r5, r5)  // error separation, as expected
+   |                   ^^
+   |Separation failure: argument of type  (r5 : M.Ref^)
+   |to method mkConc: (consume x: M.Ref^, consume y: M.Ref^): M.Conc^{fresh}
+   |corresponds to capture-polymorphic formal parameter x of type  M.Ref^²
+   |and hides capabilities  {r5}.
+   |Some of these overlap with the captures of the second argument with type  (r5 : M.Ref^).
+   |
+   |  Hidden set of current argument        : {r5}
+   |  Hidden footprint of current argument  : {r5}
+   |  Capture set of second argument        : {r5}
+   |  Footprint set of second argument      : {r5}
+   |  The two sets overlap at               : {r5}
+   |
+   |where:    ^  refers to a root capability classified as Unscoped in the type of value r5
+   |          ^² refers to a root capability classified as Unscoped created in value z when checking argument to parameter x of method mkConc
+-- Error: tests/neg-custom-args/captures/splits-mutable.scala:39:20 ----------------------------------------------------
+39 |    val z1 = mkConc(r5a, r5a)  // error separation, as expected
+   |                    ^^^
+   |Separation failure: argument of type  (r5a : M.Ref^)
+   |to method mkConc: (consume x: M.Ref^, consume y: M.Ref^): M.Conc^{fresh}
+   |corresponds to capture-polymorphic formal parameter x of type  M.Ref^²
+   |and hides capabilities  {r5a}.
+   |Some of these overlap with the captures of the second argument with type  (r5a : M.Ref^).
+   |
+   |  Hidden set of current argument        : {r5a}
+   |  Hidden footprint of current argument  : {r5a}
+   |  Capture set of second argument        : {r5a}
+   |  Footprint set of second argument      : {r5a}
+   |  The two sets overlap at               : {r5a}
+   |
+   |where:    ^  refers to a root capability classified as Unscoped in the type of value r5a
+   |          ^² refers to a root capability classified as Unscoped created in value z1 when checking argument to parameter x of method mkConc

--- a/tests/neg-custom-args/captures/splits-mutable.scala
+++ b/tests/neg-custom-args/captures/splits-mutable.scala
@@ -1,0 +1,52 @@
+import caps.Mutable
+import caps.any
+
+object M {
+  class Ref extends Mutable:
+    var x = 0
+    def get: Int = x
+    update def put(y: Int): Unit = x = y
+
+  class Conc(val fst: Ref^, val snd: Ref^)
+
+  class Node[A](val fst: A, val snd: A)
+
+  class Abs[A](val fst: A^, val snd: A^)
+
+  def mkNode[A](consume x: A, consume y: A): Node[A] = ???
+
+  def mkConc(consume x: Ref^, consume y: Ref^): Conc^ = Conc(x, y)
+
+  def mkAbs[A <: Any^{}](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y)
+
+  def mkAbs2[A <: Any^{}](consume x: A^, consume y: A^): Abs[A]^ = Abs(x, y)
+
+  class C
+
+  def Test(c: C^): Unit =
+    mkNode(c, c)
+    var r1 = Ref()
+    val r2 = Ref()
+    val x = mkNode(r1, r2)  // ok, but can't pull out elements
+    val elem1: Ref^ = x.fst
+    val elem2: Ref^ = x.snd  // error separation because fst and snd cannot be shown to be separate
+    val r3 = Ref()
+    val r4 = Ref()
+    val y = mkConc(r3, r4) // ok for concrete element types
+    val r5: Ref^ = Ref()
+    val z = mkConc(r5, r5)  // error separation, as expected
+    val r5a = Ref()
+    val z1 = mkConc(r5a, r5a)  // error separation, as expected
+
+    val elem3: Ref^ = y.fst
+    val elem4: Ref^ = y.snd
+    val y1 = mkConc(elem3, elem4) // ok, can split & join for concrete element types
+
+    val r6 = Ref()
+    val r7 = Ref()
+    val z2 = mkAbs[Ref^{}](r6, r7)
+
+    val elem5: Ref^ = z2.fst
+    val elem6: Ref^ = z2.snd
+    val z3 = mkAbs(elem5, elem6)   // ok, can spit and join for polymorphic as well.
+}

--- a/tests/neg-custom-args/captures/splits.check
+++ b/tests/neg-custom-args/captures/splits.check
@@ -1,0 +1,44 @@
+-- Error: tests/neg-custom-args/captures/splits.scala:34:24 ------------------------------------------------------------
+34 |    val elem2: Ref^ = x.snd  // error separation because fst and snd cannot be shown to be separate
+   |                      ^^^^^
+   |Separation failure: Illegal access to {r2} which is hidden by the previous definition
+   |of value elem1 with type M.Ref^.
+   |This type hides capabilities  {any, r2, any²}
+   |
+   |where:    ^    refers to a root capability classified as Unscoped in the type of value elem1
+   |          any  is a root capability classified as Unscoped in the type of variable r1
+   |          any² is a root capability classified as Unscoped created in variable r1 when instantiating method Ref's type (): M.Ref^{fresh}
+-- Error: tests/neg-custom-args/captures/splits.scala:39:19 ------------------------------------------------------------
+39 |    val z = mkConc(r5, r5)  // error separation, as expected
+   |                   ^^
+   |Separation failure: argument of type  (r5 : M.Ref^)
+   |to method mkConc: (consume x: M.Ref^, consume y: M.Ref^): M.Conc^{fresh}
+   |corresponds to capture-polymorphic formal parameter x of type  M.Ref^²
+   |and hides capabilities  {r5}.
+   |Some of these overlap with the captures of the second argument with type  (r5 : M.Ref^).
+   |
+   |  Hidden set of current argument        : {r5}
+   |  Hidden footprint of current argument  : {r5}
+   |  Capture set of second argument        : {r5}
+   |  Footprint set of second argument      : {r5}
+   |  The two sets overlap at               : {r5}
+   |
+   |where:    ^  refers to a root capability classified as Unscoped in the type of value r5
+   |          ^² refers to a root capability classified as Unscoped created in value z when checking argument to parameter x of method mkConc
+-- Error: tests/neg-custom-args/captures/splits.scala:41:20 ------------------------------------------------------------
+41 |    val z1 = mkConc(r5a, r5a)  // error separation, as expected
+   |                    ^^^
+   |Separation failure: argument of type  (r5a : M.Ref^)
+   |to method mkConc: (consume x: M.Ref^, consume y: M.Ref^): M.Conc^{fresh}
+   |corresponds to capture-polymorphic formal parameter x of type  M.Ref^²
+   |and hides capabilities  {r5a}.
+   |Some of these overlap with the captures of the second argument with type  (r5a : M.Ref^).
+   |
+   |  Hidden set of current argument        : {r5a}
+   |  Hidden footprint of current argument  : {r5a}
+   |  Capture set of second argument        : {r5a}
+   |  Footprint set of second argument      : {r5a}
+   |  The two sets overlap at               : {r5a}
+   |
+   |where:    ^  refers to a root capability classified as Unscoped in the type of value r5a
+   |          ^² refers to a root capability classified as Unscoped created in value z1 when checking argument to parameter x of method mkConc

--- a/tests/neg-custom-args/captures/splits.scala
+++ b/tests/neg-custom-args/captures/splits.scala
@@ -1,0 +1,54 @@
+import caps.Mutable
+import caps.any
+
+object M {
+  class Ref extends Mutable:
+    var x = 0
+    def get: Int = x
+    update def put(y: Int): Unit = x = y
+
+  def Ref(): Ref^ = new Ref()
+
+  class Conc(val fst: Ref^, val snd: Ref^)
+
+  class Node[A](val fst: A, val snd: A)
+
+  class Abs[A](val fst: A^, val snd: A^)
+
+  def mkNode[A](consume x: A, consume y: A): Node[A] = ???
+
+  def mkConc(consume x: Ref^, consume y: Ref^): Conc^ = Conc(x, y)
+
+  def mkAbs[A <: Any^{}](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y)
+
+  def mkAbs2[A <: Any^{}](consume x: A^, consume y: A^): Abs[A]^ = Abs(x, y)
+
+  class C
+
+  def Test(c: C^): Unit =
+    mkNode(c, c)
+    var r1 = Ref()
+    val r2 = Ref()
+    val x = mkNode(r1, r2)  // ok, but can't pull out elements
+    val elem1: Ref^ = x.fst
+    val elem2: Ref^ = x.snd  // error separation because fst and snd cannot be shown to be separate
+    val r3 = Ref()
+    val r4 = Ref()
+    val y = mkConc(r3, r4) // ok for concrete element types
+    val r5: Ref^ = Ref()
+    val z = mkConc(r5, r5)  // error separation, as expected
+    val r5a = Ref()
+    val z1 = mkConc(r5a, r5a)  // error separation, as expected
+
+    val elem3: Ref^ = y.fst
+    val elem4: Ref^ = y.snd
+    val y1 = mkConc(elem3, elem4) // ok, can split & join for concrete element types
+
+    val r6 = Ref()
+    val r7 = Ref()
+    val z2 = mkAbs[Ref^{}](r6, r7)
+
+    val elem5: Ref^ = z2.fst
+    val elem6: Ref^ = z2.snd
+    val z3 = mkAbs(elem5, elem6)   // ok, can spit and join for polymorphic as well.
+}


### PR DESCRIPTION
Several measures to improve handling of nested capture sets, of the form they appear in functions like
```scala
  def mkAbs[A <: Any^{}](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y)
```
Here, it is important that references don't get included in the capset variable `A`, but get instead included in the hidden set of the `^` occurrences. To get there, this PR combines several improvements:

 - Don't "forget" empty capture sets on `Any` when mapping types.
 - Constrain capset variables of type arguments by the bounds of type parameters. Previously, this was done only as a post check after capture checking completed.
 - Improve the tryInclude algorithms for Union capsets. 
 - Imrpove healing of capsets when comparinf types with different box status.