### PR TITLE
Split `stdlib.yaml` down into multiple workflow files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,9 +50,29 @@ env:
 # text on stderr and so can break tests which check the output of a program).
 
 jobs:
-  # Run stdlib tests before publishing a release
+  # Run tests before publishing a release
   stdlib-tests:
     uses: ./.github/workflows/stdlib.yaml
+    if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')"
+    secrets: inherit
+
+  mima-tests:
+    uses: ./.github/workflows/mima.yaml
+    if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')"
+    secrets: inherit
+
+  compiler-tests:
+    uses: ./.github/workflows/compiler-tests.yaml
+    if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')"
+    secrets: inherit
+
+  community-build-tests:
+    uses: ./.github/workflows/community-build.yaml
+    if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')"
+    secrets: inherit
+
+  misc-tests:
+    uses: ./.github/workflows/misc-tests.yaml
     if: "github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')"
     secrets: inherit
 
@@ -84,7 +104,7 @@ jobs:
     permissions:
       contents: write  # for GH CLI to create a release
     runs-on: [self-hosted, Linux]
-    needs: [stdlib-tests]
+    needs: [stdlib-tests, mima-tests, compiler-tests, community-build-tests, misc-tests]
     container:
       image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096

--- a/.github/workflows/community-build.yaml
+++ b/.github/workflows/community-build.yaml
@@ -1,4 +1,4 @@
-name: Compile Full Standard Library
+name: Community Build
 
 on:
   push:
@@ -15,48 +15,59 @@ env:
 
 jobs:
 
-  test-scala-library-nonbootstrapped:
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
-    name: Non-Bootstrapped Library Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - run: ./project/scripts/sbt scala-library-nonbootstrapped/test
-
-  test-scala-library-bootstrapped:
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
-    name: Bootstrapped Library Unit Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - run: ./project/scripts/sbt scala-library-bootstrapped/test
-
-  scala-library-docs:
+  community_build_a:
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
     runs-on: ubuntu-latest
     steps:
-      - name: Git Checkout
+      - name: Checkout cleanup script
         uses: actions/checkout@v7
-
+        with:
+          submodules: true
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 17
           cache: 'sbt'
-
       - uses: sbt/setup-sbt@v1
-      - name: Generate Documentation of the Standard Library
-        run: ./project/scripts/sbt scala-library-bootstrapped/doc
+      - name: Run Community Build A
+        run: |
+          ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestA"
+
+  community_build_b:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run Community Build B
+        run: |
+          ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestB"
+
+  community_build_c:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout cleanup script
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run Community Build C
+        run: |
+          ./project/scripts/sbt "community-build/testOnly dotty.communitybuild.CommunityBuildTestC"

--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -1,0 +1,272 @@
+name: Compiler Tests
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  DOTTY_CI_RUN: true
+
+jobs:
+
+  test-scala3-compiler-nonbootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Test `scala3-compiler-nonbootstrapped`
+        run: ./project/scripts/sbt scala3-compiler-nonbootstrapped/test
+
+      - name: Cmd Tests
+        run: |
+          ./project/scripts/sbt scala3-nonbootstrapped/publishLocal
+          ./project/scripts/cmdTests
+
+  test-scala3-compiler-bootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+
+      - name: Test `scala3-compiler-bootstrapped`
+        run: ./project/scripts/sbt scala3-compiler-bootstrapped/test
+
+      - name: Cmd Tests
+        run: |
+          ./project/scripts/sbt scala3-bootstrapped/publishLocal
+          ./project/scripts/bootstrappedOnlyCmdTests
+
+  test-scala3-sbt-bridge-nonbootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test `scala3-sbt-bridge-nonbootstrapped`
+        run: ./project/scripts/sbt scala3-sbt-bridge-nonbootstrapped/test
+
+  test-scala3-sbt-bridge-bootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test `scala3-sbt-bridge-bootstrapped`
+        run: ./project/scripts/sbt scala3-sbt-bridge-bootstrapped/test
+
+  test-tasty-core-nonbootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test `tasty-core-nonbootstrapped`
+        run: ./project/scripts/sbt tasty-core-nonbootstrapped/test
+
+  test-tasty-core-bootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test `tasty-core-bootstrapped`
+        run: ./project/scripts/sbt tasty-core-bootstrapped/test
+
+  test-scala3-directives-parser-nonbootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test `scala3-directives-parser-nonbootstrapped`
+        run: ./project/scripts/sbt scala3-directives-parser-nonbootstrapped/test
+
+  test-scala3-directives-parser-bootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test `scala3-directives-parser-bootstrapped`
+        run: ./project/scripts/sbt scala3-directives-parser-bootstrapped/test
+
+  test-scala-js:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+      - uses: sbt/setup-sbt@v1
+      - name: Scala.js compiler tests
+        run: ./project/scripts/sbt "sjsCompilerTests/test"
+      - name: Scala.js sandbox
+        run: ./project/scripts/sbt ";sjsSandbox/run ;sjsSandbox/test"
+      - name: Scala.js JUnit tests
+        run: ./project/scripts/sbt ";sjsJUnitTests/test ;set sjsJUnitTests/scalaJSLinkerConfig ~= switchToESModules ;sjsJUnitTests/test"
+      - name: Scala.js JUnit tests with latest ES version
+        run: ./project/scripts/sbt ";sjsJUnitTests/clean ;set sjsJUnitTests/scalaJSLinkerConfig ~= switchToLatestESVersion ;sjsJUnitTests/test"
+      - name: Scala.js JUnit tests with WebAssembly
+        run: ./project/scripts/sbt ";sjsJUnitTests/clean ;set Global/enableWebAssembly := true; sjsJUnitTests/test"
+  # TODO Scala.js on Windows
+
+  test-repl:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test REPL
+        run: ./project/scripts/sbt scala3-repl/test
+
+  test-repl-jdk:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [25, 26]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+      - name: Set up JDK ${{ matrix.jdk }} (REPL subprocess)
+        id: jdk
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.jdk }}
+      - name: Set up JDK 17 (build, default)
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test REPL lazy vals warning and shading on JDK ${{ matrix.jdk }}
+        env:
+          DOTTY_REPL_TEST_JAVA_HOME: ${{ steps.jdk.outputs.path }}
+        run: ./project/scripts/sbt "scala3-repl/testOnly *LazyValsWarningTest *ShadingTest"
+
+  test-presentation-compiler:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test Presentation Compiler
+        run: ./project/scripts/sbt scala3-presentation-compiler/test
+
+  test-language-server:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Test Language Server
+        run: ./project/scripts/sbt scala3-language-server/test

--- a/.github/workflows/mima.yaml
+++ b/.github/workflows/mima.yaml
@@ -1,0 +1,127 @@
+name: MiMa Binary Compatibility Checks
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  DOTTY_CI_RUN: true
+
+jobs:
+
+  mima-scala-library-nonbootstrapped:
+    runs-on: ubuntu-latest
+    if: false
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Report MiMa issues in `scala-library-nonbootstrapped`
+        run: ./project/scripts/sbt scala-library-nonbootstrapped/mimaReportBinaryIssues
+
+  mima-scala3-interfaces:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Report MiMa issues in `scala3-interfaces`
+        run: ./project/scripts/sbt scala3-interfaces/mimaReportBinaryIssues
+
+  mima-tasty-core-nonbootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Report MiMa issues in `tasty-core-nonbootstrapped`
+        run: ./project/scripts/sbt tasty-core-nonbootstrapped/mimaReportBinaryIssues
+
+  static-analysis-scala-library-bootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Report MiMa issues in `scala-library-bootstrapped`
+        run: ./project/scripts/sbt scala-library-bootstrapped/mimaReportBinaryIssues
+
+      - name: Report missingLink checks
+        run: ./project/scripts/sbt scala-library-bootstrapped/missinglinkCheck
+
+  mima-tasty-core-bootstrapped:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Report MiMa issues in `tasty-core-bootstrapped`
+        run: ./project/scripts/sbt tasty-core-bootstrapped/mimaReportBinaryIssues
+
+  mima-scala-library-sjs:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+
+      - uses: sbt/setup-sbt@v1
+      - name: Report MiMa issues in `scala-library-sjs`
+        run: ./project/scripts/sbt scala-library-sjs/mimaReportBinaryIssues

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -1,0 +1,44 @@
+name: Miscellaneous Tests
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  DOTTY_CI_RUN: true
+
+jobs:
+
+  scripted-tests:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run SBT scripted tests
+        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+
+  test-bisect-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: coursier/cache-action@v8
+      - uses: VirtusLab/scala-cli-setup@v1.15
+        with:
+          jvm: temurin:17
+      - name: Run bisect script tests
+        run: scala-cli test project/scripts/bisect.test.scala

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,9 +11,25 @@ jobs:
     uses: ./.github/workflows/stdlib.yaml
     secrets: inherit
 
+  mima-tests:
+    uses: ./.github/workflows/mima.yaml
+    secrets: inherit
+
+  compiler-tests:
+    uses: ./.github/workflows/compiler-tests.yaml
+    secrets: inherit
+
+  community-build-tests:
+    uses: ./.github/workflows/community-build.yaml
+    secrets: inherit
+
+  misc-tests:
+    uses: ./.github/workflows/misc-tests.yaml
+    secrets: inherit
+
   release-maven-artifacts:
     uses: ./.github/workflows/release-maven-artifacts.yml
-    needs: [stdlib-tests]
+    needs: [stdlib-tests, mima-tests, compiler-tests, community-build-tests, misc-tests]
     with:
       environment: release-nightly
     secrets: inherit


### PR DESCRIPTION
It's a bit confusing how we keep everything in `stdlib.yaml`. Refactored into a more managable hierarchy.

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by running the workflows on the CI

## How was the solution tested?
Covered by existing tests (this is a refactoring)
