### PR TITLE
Fix generic signatures for inherited inner classes

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -235,7 +235,16 @@ object GenericSignatures {
               boxedSig(tp.widenDealias.widenNullaryMethod)
         }
 
-      pre.widenDealias match {
+      // when generating a java generic signature that includes
+      // a selection of an inner class p.I, (p = `pre`, I = `cls`) must
+      // rewrite to p'.I, where p' refers to the class that directly defines
+      // the nested class I. see:
+      // https://github.com/scala/scala3/issues/26532
+      // https://github.com/scala/bug/issues/2585
+      val reboundPre =
+        if pre.exists then pre.baseType(sym.owner)
+        else pre
+      reboundPre.widenDealias match {
         // If the class is an inner class of a generic class, we must emit the outer generic class with its parameters
         // (see test `inner-of-generic` for an example of Java compatibility)
         case RefOrAppliedType(preSym: ClassSymbol, prePre, preArgs) if preArgs.nonEmpty =>

--- a/tests/generic-java-signatures/i26532.check
+++ b/tests/generic-java-signatures/i26532.check
@@ -1,0 +1,1 @@
+public final i26532.Base<S, D>$Helper i26532.Impl.helper()

--- a/tests/generic-java-signatures/i26532/Definitions_1.scala
+++ b/tests/generic-java-signatures/i26532/Definitions_1.scala
@@ -1,0 +1,9 @@
+package i26532
+
+trait Base[S, D]:
+  final class Helper:
+    def identity(value: S): S = value
+
+  final def helper(): Helper = new Helper
+
+abstract class Impl[S, D] extends Base[S, D]

--- a/tests/generic-java-signatures/i26532/Test_3.scala
+++ b/tests/generic-java-signatures/i26532/Test_3.scala
@@ -1,0 +1,6 @@
+import i26532.Impl
+
+object Test:
+  def main(args: Array[String]): Unit =
+    val helper = classOf[Impl[?, ?]].getDeclaredMethod("helper")
+    println(helper.toGenericString)

--- a/tests/generic-java-signatures/i26532/Use_2.java
+++ b/tests/generic-java-signatures/i26532/Use_2.java
@@ -1,0 +1,7 @@
+package i26532;
+
+final class Use_2 {
+    void test(Impl<String, Integer> impl) {
+        String value = impl.helper().identity("ok");
+    }
+}


### PR DESCRIPTION
Rebind inner-class prefixes to their declaring owner so mixin forwarders cannot reference nonexistent subclass-owned classes.

This is a fix for regression by https://github.com/scala/scala3/pull/25880 It accidently removed `pre.baseType(sym.owner)` with `needsJavaSig` check, but we shouldn't remove rebinding `pre`,
that is an old scala/bug fix for https://github.com/scala/bug/issues/2585

Fixes #26532

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
