### PR TITLE
Macro/inlining performance boost via inline finder dedup

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Inlining.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Inlining.scala
@@ -112,12 +112,21 @@ class Inlining extends MacroTransform, IdentityDenotTransformer {
      */
     private val newTopClasses = MutableSymbolMap[mutable.ListBuffer[Tree]]()
 
+    /** `Inlined` nodes already handed to `collector`, deduplicated by identity.
+     *  `transform` runs `inlineFinder` on every node's result, so an `Inlined`
+     *  subtree is otherwise re-collected once per non-`Inlined` ancestor on the
+     *  path up to it - O(depth) redundant traversals of the (often very large)
+     *  inlined types. Dependency recording is idempotent (it feeds sets), so
+     *  collecting each `Inlined` exactly once is equivalent and far cheaper.
+     */
+    private val collectedInlined = util.EqHashSet[Tree]()
+
     val inlineFinder = new tpd.TreeTraverser:
       override def traverse(tree: Tree)(using Context): Unit =
         try
           tree match
             case tree: Inlined =>
-              collector.traverse(tree)
+              if collectedInlined.add(tree) then collector.traverse(tree)
             case vd: ValDef if vd.symbol.is(ModuleVal) =>
               // Don't visit module val
             case t: Template if t.symbol.owner.is(ModuleClass) =>


### PR DESCRIPTION
The `Inlining` phase records incremental-compilation dependencies from inlined code by running `inlineFinder` on the result of every `transform` call. `inlineFinder` hands each `Inlined` node it reaches to `collector`, which traverses that node's (often very large) inlined types. Because `transform` runs per node, an `Inlined` subtree is re-collected once for every non-`Inlined` ancestor on the path up to it, i.e. O(depth) redundant traversals of the same types.

Dependency recording is idempotent (it feeds name/dependency sets), so collecting each `Inlined` exactly once is equivalent. Guard the collector call with an identity set of already-collected `Inlined` nodes.

On a macro/inline-heavy workload (the DFHDL compiler_stages test sources) dependency extraction dropped from ~23% of compiler execution samples to ~6%, cutting total samples ~19%, with identical output.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output against my own inline-heavy library.

## How was the solution tested?

Existing tests. Could be worth testing with the Open Community Build before merging.
