### PR TITLE
Macro/inlining performance boost via QuotesCache mod

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -21,6 +21,7 @@ import reporting.{Suppression, Action, Profile, ActiveProfile, MessageFilter, No
 import reporting.Diagnostic, Diagnostic.Warning
 import rewrites.Rewrites
 import profile.Profiler
+import quoted.QuotesCache
 import printing.XprintMode
 import typer.ImplicitRunInfo
 import config.Feature
@@ -611,6 +612,11 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
     if ctx.settings.YexplicitNulls.value && !Feature.enabledBySetting(nme.unsafeNulls) then
       start = start.addMode(Mode.SafeNulls)
     ctx.initialize()(using start) // re-initialize the base context with start
+
+    // Cache unpickled quote templates for the whole run (keyed by the pickled TASTY
+    // bytes, stable per quote-site), so a macro that expands many times unpickles
+    // each of its quotes once per run rather than once per expansion.
+    QuotesCache.init(start)
 
     // `this` must be unchecked for safe initialization because by being passed to setRun during
     // initialization, it is not yet considered fully initialized by the initialization checker

--- a/compiler/src/dotty/tools/dotc/quoted/MacroExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/MacroExpansion.scala
@@ -13,6 +13,6 @@ object MacroExpansion {
     ctx.property(MacroExpansionPosition)
 
   def context(inlinedFrom: tpd.Tree)(using Context): Context =
-    QuotesCache.init(ctx.fresh).setProperty(MacroExpansionPosition, inlinedFrom.sourcePos).setTypeAssigner(new Typer(ctx.nestingLevel + 1)).withSource(inlinedFrom.source)
+    ctx.fresh.setProperty(MacroExpansionPosition, inlinedFrom.sourcePos).setTypeAssigner(new Typer(ctx.nestingLevel + 1)).withSource(inlinedFrom.source)
 }
 


### PR DESCRIPTION
QuotesCache was initialized in MacroExpansion.context, i.e. freshly per macro expansion, so a macro that expands many times (heavy in inline/typeclass-macro code such as DFHDL) re-unpickled the same quote templates from TASTY on every expansion. The cache is keyed by the pickled bytes (stable per quote-site), holes are spliced after unpickling, and the cache-hit path re-owns templates via TreeTypeMap/changeNonLocalOwners - so a cached template is expansion-independent.

Initialize the cache once per run (Run.compileUnits) so all macro-expansion contexts inherit and share it, converting repeated full unpickles into cheap cache hits. getTree/update now tolerate a missing cache (behave as miss/no-op) so any quote-unpickle path outside a run context degrades gracefully instead of throwing.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by profiling against my own macro-heavy library

## How was the solution tested?

Covered by existing tests (this is a refactoring)