### PR TITLE
Fix regression #26153 (in dotty-cps-async) use typer skolems as inline proxy's type

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -229,6 +229,36 @@ class Inliner(val call: tpd.Tree)(using Context):
   private val inlineCallPrefix =
      qualifier(methPart).orElse(This(inlinedMethod.enclosingClass.asClass))
 
+  /** Skolems created from typing this call tree.
+   *
+   *  ```
+   *  trait Ctx[F[_]]
+   *  trait Mon[F[_]]:
+   *    type Context <: Ctx[F]
+   *  inline def async[F[_]](using am: Mon[F]): Wrap[F, am.Context] = ???
+   *  ```
+   *
+   *  When TypeAssigner types `async(...)`, it skolemizes unstable `am` in the
+   *  dependent result type, and the call tree is typed as `Wrap[F, ?1.Context]`.
+   *  Then the inliner expands the method body and replace `am` by a proxy `am$proxy`.
+   *  Then `new Wrap[F, am.Context]` becomes `new Wrap[F, am$proxy.Context]`.
+   *
+   *  In `paramBindingDef`, we type `am$proxy` as $1, so that both expanded tree and
+   *  call tree is typed `Wrap[F, ?1.Context]`. Otherwise, call tree and expanded tree
+   *  has different types `?1.Context` vs `am$proxy.Context` and compile fails.
+   *  See #26153 and #26031.
+   */
+  private val callValueSkolemss: List[List[Option[SkolemType]]] =
+    def loop(tree: Tree, skolemss: List[List[Option[SkolemType]]]): List[List[Option[SkolemType]]] = tree match
+      case app @ Apply(fn, args) =>
+        val mapping = app.getAttachment(TypeAssigner.SkolemizedArgs).getOrElse(Map.empty)
+        loop(fn, args.map(mapping.get) :: skolemss)
+      case TypeApply(fn, _) =>
+        loop(fn, skolemss)
+      case _ =>
+        skolemss
+    loop(call, Nil)
+
   // Make sure all type arguments to the call are fully determined,
   // but continue if that's not achievable (or else i7459.scala would crash).
   for arg <- callTypeArgs do
@@ -279,9 +309,11 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  @param formal      the type of the parameter
    *  @param arg0        the argument corresponding to the parameter
    *  @param buf         the buffer to which the definition should be appended
+   *  @param skolem      optional skolem from the call's dependent result type.
+   *                     If present, use it as the proxy type.
    */
   private[inlines] def paramBindingDef(name: Name, formal: Type, arg0: Tree,
-                              buf: DefBuffer)(using Context): ValOrDefDef = {
+                              buf: DefBuffer, skolem: Option[SkolemType] = None)(using Context): ValOrDefDef = {
     val isByName = formal.dealias.isInstanceOf[ExprType]
     val arg =
       def dropNameArg(arg: Tree): Tree = arg match
@@ -297,10 +329,17 @@ class Inliner(val call: tpd.Tree)(using Context):
           dropNameArg(arg0)
     val argtpe = arg.tpe.dealiasKeepAnnots.translateFromRepeated(toArray = false)
     val argIsBottom = argtpe.isBottomTypeAfterErasure
-    val bindingType =
+    val baseBindingType =
       if argIsBottom then formal
       else if isByName then ExprType(argtpe.widen)
       else argtpe.widen
+    // If the call result type used a skolem for this argument, use the same skolem
+    // as the proxy type. `?1` has `argtpe.widen` as its underlying type.
+    val proxySkolem = if argIsBottom then None else skolem
+    val bindingType = proxySkolem match
+      case Some(sk) => if isByName then ExprType(sk) else sk
+      case None => baseBindingType
+
     var bindingFlags: FlagSet = InlineProxy
     if formal.widenExpr.hasAnnotation(defn.InlineParamAnnot) then
       bindingFlags |= Inline
@@ -313,6 +352,10 @@ class Inliner(val call: tpd.Tree)(using Context):
       var newArg = arg.changeOwner(ctx.owner, boundSym)
       if bindingFlags.is(Inline) && argIsBottom then
         newArg = Typed(newArg, TypeTree(formal.widenExpr)) // type ascribe RHS to avoid type errors in expansion. See i8612.scala
+      else proxySkolem match
+        case Some(sk) =>
+          newArg = newArg.cast(sk) // adapt the rhs to the skolem-typed proxy
+        case None => ()
       if isByName then DefDef(boundSym, newArg)
       else ValDef(boundSym, newArg, inferred = true)
     }.withSpan(boundSym.span)
@@ -328,6 +371,7 @@ class Inliner(val call: tpd.Tree)(using Context):
   private def computeParamBindings(
       tp: Type, targs: List[Tree],
       argss: List[List[Tree]], formalss: List[List[Type]],
+      skolemss: List[List[Option[SkolemType]]],
       buf: DefBuffer): Boolean =
     tp match
       case tp: PolyType =>
@@ -335,24 +379,27 @@ class Inliner(val call: tpd.Tree)(using Context):
           paramSpan(name) = arg.span
           paramBinding(name) = arg.tpe.stripTypeVar
         }
-        computeParamBindings(tp.resultType, targs.drop(tp.paramNames.length), argss, formalss, buf)
+        computeParamBindings(tp.resultType, targs.drop(tp.paramNames.length), argss, formalss, skolemss, buf)
       case tp: MethodType =>
         if argss.isEmpty then
           report.error(em"missing arguments for inline method $inlinedMethod", call.srcPos)
           false
         else
-          tp.paramNames.lazyZip(formalss.head).lazyZip(argss.head).foreach { (name, formal, arg) =>
+          val skolems = skolemss.headOption.getOrElse(List.fill(argss.head.length)(None))
+          tp.paramNames.lazyZip(formalss.head).lazyZip(argss.head).lazyZip(skolems).foreach {
+            (name, formal, arg, skolem) =>
             paramSpan(name) = arg.span
             paramBinding(name) = arg.tpe.dealias match
               case _: SingletonType if isIdempotentPath(arg) =>
                 arg.tpe
               case _ =>
-                paramBindingDef(name, formal, arg, buf).symbol.termRef
+                paramBindingDef(name, formal, arg, buf, skolem).symbol.termRef
           }
-          computeParamBindings(tp.resultType, targs, argss.tail, formalss.tail, buf)
+          computeParamBindings(tp.resultType, targs, argss.tail, formalss.tail, skolemss.tail, buf)
       case _ =>
         assert(targs.isEmpty)
         assert(argss.isEmpty)
+        assert(skolemss.isEmpty)
         true
 
   /** The number of enclosing classes of this class, plus one */
@@ -666,6 +713,7 @@ class Inliner(val call: tpd.Tree)(using Context):
       if !computeParamBindings(
           inlinedMethod.info, callTypeArgs,
           mappedCallValueArgss, paramTypess(call, Nil),
+          callValueSkolemss,
           paramBindingsBuf)
       then
         return (Nil, EmptyTree)

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -598,7 +598,7 @@ object Inlines:
 
       // Take care that only argument bindings go into `bindings`, since positions are
       // different for bindings from arguments and bindings from body.
-      val inlined = tpd.Inlined(call, bindings, expansion)
+      val inlined0 = tpd.Inlined(call, bindings, expansion)
 
       val hasOpaquesInResultFromCallWithTransparentContext =
         val owners = call.symbol.ownersIterator.toSet
@@ -625,6 +625,24 @@ object Inlines:
                   TermRef(apply(prefix), tref.symbol.companionModule)
                 case _ => mapOver(t)
         ).typeMap(tpe)
+
+      /** Argument proxies may be typed with skolems from the call tree (see
+       *  Inliner#callValueSkolemss). However, TASTy pickles skolems as their underlying
+       *  types, so the expansion's type may change after unpickling, which break the TASTy
+       *  roundtrip checked by `-Ytest-pickler`.
+       *
+       *  To avoid this, insert the expansion with a no-op cast. This makes the pickled
+       *  underlying type to prevent `TypeOps.avoid` from generating a different
+       *  result type after unpickling.
+       */
+      val inlined =
+        val proxySkolems = bindings.map(_.symbol.info.widenExpr).collect { case sk: SkolemType => sk }
+        if proxySkolems.nonEmpty && inlined0.tpe.existsPart(proxySkolems.contains) then
+          val sealedExpansion =
+            inContext(ctx.withSource(expansion.source)):
+              expansion.cast(inlined0.tpe).withSpan(expansion.span)
+          tpd.Inlined(call, bindings, sealedExpansion)
+        else inlined0
 
       if !hasOpaqueProxies && !hasOpaquesInResultFromCallWithTransparentContext then inlined
       else

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -885,4 +885,3 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def coloredText(text: Text, color: String): Text =
     if (ctx.useColors) color ~ text ~ SyntaxHighlighting.NoColor else text
 }
-

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -616,8 +616,10 @@ object TypeAssigner extends TypeAssigner:
 
   /** An attachment on an application indicating a map from arguments to the skolem types
    *  that were created in safeSubstParams.
+   *  We use StickyKey so the Inlining phase can reuse the
+   *  same skolems for path-dependent types in the expansion (see #26153).
    */
-  private[typer] val SkolemizedArgs = new Property.Key[Map[tpd.Tree, SkolemType]]
+  private[dotc] val SkolemizedArgs = new Property.StickyKey[Map[tpd.Tree, SkolemType]]
 
   def seqLitType(tree: untpd.SeqLiteral, elemType: Type)(using Context) = tree match
     case tree: untpd.JavaSeqLiteral => defn.ArrayOf(elemType)

--- a/tests/pos/i26031.scala
+++ b/tests/pos/i26031.scala
@@ -1,0 +1,29 @@
+trait Ctx[F[_]]
+
+trait Mon[F[_]]:
+  type Context <: Ctx[F]
+
+object Mon:
+  type Aux[F[_], C <: Ctx[F]] = Mon[F] { type Context = C }
+
+class Wrap[F[_], C <: Ctx[F]](using val am: Mon.Aux[F, C]):
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    inner[F, T, C](am, expr)
+
+transparent inline def inner[F[_], T, C <: Ctx[F]](
+    inline am: Mon.Aux[F, C],
+    inline expr: C ?=> T
+): F[T] = ???
+
+transparent inline def doIt[F[_]](using am: Mon[F]) =
+  new Wrap(using am)
+
+class Pair[A, B]
+class PairCtx[E] extends Ctx[[A] =>> Pair[E, A]]
+class PairMon[E] extends Mon[[A] =>> Pair[E, A]]:
+  type Context = PairCtx[E]
+
+given pm[E]: Mon[[A] =>> Pair[E, A]] = new PairMon[E]
+
+object Test:
+  val r = doIt[[A] =>> Pair[String, A]] { 42 }

--- a/tests/pos/i26153.scala
+++ b/tests/pos/i26153.scala
@@ -1,0 +1,23 @@
+trait Ctx[F[_]]
+
+trait Mon[F[_]]:
+  type Context <: Ctx[F]
+
+class Wrap[F[_], C <: Ctx[F]]:
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    stage2[F, T, C](expr)
+
+transparent inline def stage2[F[_], T, C <: Ctx[F]](
+    inline expr: C ?=> T
+): F[T] = ???
+
+transparent inline def async[F[_]](using am: Mon[F]) =
+  new Wrap[F, am.Context]
+
+class TupleMon[E] extends Mon[[A] =>> (E, A)]:
+  type Context = Ctx[[A] =>> (E, A)]
+
+given pm[E]: Mon[[A] =>> (E, A)] = new TupleMon[E]
+
+object Test:
+  val r = async[[A] =>> (String, A)] { 42 }

--- a/tests/pos/i26624-dotty-cps-async.scala
+++ b/tests/pos/i26624-dotty-cps-async.scala
@@ -1,0 +1,35 @@
+trait Ctx[F[_]]
+trait TryCtx[F[_]] extends Ctx[F]
+
+trait Monad[F[_]]:
+  type Context <: Ctx[F]
+  def pure[T](t: T): F[T]
+  def apply[T](op: Context => F[T]): F[T]
+
+object Monad:
+  type Aux[F[_], C <: Ctx[F]] = Monad[F] { type Context = C }
+
+trait TryMonad[F[_]] extends Monad[F]:
+  type Context <: TryCtx[F]
+
+class TryBody[F[_]] extends TryCtx[F]
+
+trait TryInstance[F[_]] extends TryMonad[F]:
+  type Context = TryBody[F]
+  def apply[T](op: Context => F[T]): F[T] = op(TryBody())
+
+class InferAsyncArg[F[_], C <: Ctx[F]](using val am: Monad.Aux[F, C]):
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    am.apply(ctx => am.pure(expr(using ctx)))
+
+transparent inline def async[F[_]](using am: Monad[F]) =
+  new InferAsyncArg(using am)
+
+case class IO[A](value: A)
+
+implicit def ioTryMonad: TryMonad[IO] = new TryMonad[IO] with TryInstance[IO]:
+  def pure[T](t: T) = IO(t)
+
+def program: IO[Int] = async[IO] {
+  1 + 1
+}


### PR DESCRIPTION
~This PR is based on https://github.com/scala/scala3/pull/26579, actual change is in second commit~ done

- last good commit: https://github.com/scala/scala3/commit/897f0988b292d8b33e61c5eb55fe3283d3c4ad2d
- first bad commit: https://github.com/scala/scala3/commit/32a04c840523d8326a9e64b63f0ed0f5ec290956

TBH, not very sure why this change result in this regression 🤔 Previous to the commit, `sameTypes(Nil, <nonEmpty>)` always (wrongly) returned `true`. Maybe the issues come to surface because of fixing the bug of `sameTypes`?

---

Fixes #26153
Fixes #26031
Fixes #26624

**problem**
When an inline expansion has a type that depends on one of the inline method arguments, and that argument is not stable, there's a type mismatch error on inline function call.

For example,

```scala
trait Mon[F[_]] { type Arg }
class Wrap[F[_], A]:
  inline def apply[T](inline f: A => T): F[T] = ...

inline def async[F[_]](using am: Mon[F]) =
  new Wrap[F, am.Arg]

object Test:
  val r = async[[A] =>> (String, A)](_ => 42)

// given TupleMon[E] extends Mon[[A] ==> (E, A)]
```

The result of `async` depends on the argument `am`: `Wrap[F, am.Arg]`. At the call site, the given argument for `am` is not a stable path. When `TypeAssigner` computes the dependent result type, it skolemizes that argument. So the inline call is typed as something like:
`Wrap[[A] =>> (String, A), ?1.Arg]` where:
`?1` is some value of type `Mon[[A] =>> (String, A)]`.

On the other hand, `Inlining` creates a runtime proxy for the same arugment: `am$proxy` = <actual given>.
When the proxy is typed as `am$proxy: Mon[[A] ==> (String, A)]`, then types in the expanded tree is like `am$proxy.Arg`. While the call tree was typed as `?1.Arg`.

As a result, compile fails:

```scala
val r = async[[A] =>> (String, A)](_ => 42)
                                   ^^^^^^^
     Found:    ?1.Arg => Int
     Required: am$proxy1.Arg => Int

     where:    ?1 is an unknown value of type Mon[[A] =>> (String, A)]
```

The same root issue also causes regression #26031

```scala
trait Ctx[F[_]]
trait Mon[F[_]]:
  type Context <: Ctx[F]
object Mon:
  type Aux[F[_], C <: Ctx[F]] = Mon[F] { type Context = C }
class Wrap[F[_], C <: Ctx[F]](using val am: Mon.Aux[F, C])
transparent inline def doIt[F[_]](using am: Mon[F]) =
  new Wrap(using am)
```

The call tree fixes `C = ?1.Context`, so the expansion needs an argument of type `Mon.Aux[F, ?1.Context]`. A proxy typed only as `Mon[F]` does not prove that its `Context` member is `?1.Context`.

**Fix**

The idea is Use the skolem created by typer as the type of the inline proxy. `val am$proxy: ?1 = <actual given>.asInstanceOf[?1]`. The runtime value is still the proxy, but its type-level prefix is now the same skolem generated by typer.

This fixes the mismatch in #26153, and also fixes #26031 because the proxy term itself now has the skolem type.

The idea is from:
> I was wondering it would be great if we can use something like `Wrap[F, m.Arg] forSome { val m: Mon[F] }` instead of `?`, which is too coarse. And ... I realized that typer already uses skolem type `?1.Arg` when the result type is dependent.
> https://github.com/scala/scala3/pull/26033#issuecomment-4537595110


**note**
Original PR https://github.com/scala/scala3/pull/26033 was to special-case `selectionType` for an `Inlined` receiver. if the saved type of the `Inlined` tree was avoided to `?`, use the expansion's type instead.
That can fix the immediate receiver mismatch, but it just recovers `am$proxy.Arg` after avoidance, which I don't feel right ?

Another fix I tried was to rewrite only type positions: `am$proxy.Arg` =>  `?1.Arg`
This helps #26153, where the mismatch is in the expanded type. But it does not fix #26031. A term with type `Mon[F]` still does not conform, it's required refinements.


<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by comprehending by myself

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
