### PR TITLE
Fix regression #26550: revert isPrimitiveValueType change

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -20,19 +20,8 @@ class TypeUtils:
     def isErasedValueType(using Context): Boolean =
       self.isInstanceOf[ErasedValueType]
 
-    def isPrimitiveValueType(using Context): Boolean = self match
-      case tp: TypeRef =>
-        val sym = tp.symbol
-        if sym.isClass then sym.isPrimitiveValueClass
-        else tp.superType.isPrimitiveValueType
-      case tp: TypeProxy =>
-        tp.superType.isPrimitiveValueType
-      case tp: ClassInfo =>
-        tp.cls.isPrimitiveValueClass
-      case _ =>
-        // anything else definitely can't be one (e.g., AndType),
-        // so let's not waste time constructing a ClassSymbol
-        false
+    def isPrimitiveValueType(using Context): Boolean =
+      self.classSymbol.isPrimitiveValueClass
 
     /** Is this type a checked exception? This is the case if the type
      *  derives from Exception but not from RuntimeException. According to

--- a/tests/pos/i26550.scala
+++ b/tests/pos/i26550.scala
@@ -1,0 +1,2 @@
+class BitNumWrapper(val value: 0 | 1) extends AnyVal
+def positive(w: BitNumWrapper): Boolean = w.value > 0


### PR DESCRIPTION
Fixes #26550

In #25880 it changes the logic of `isPrimitiveValueType` for perf https://github.com/scala/scala3/pull/25880/changes/9132538e629577d3d9217f216ea2d30cc73266fb

However, it looks introduces a regression, revert for now. FYI @SolalPirelli 
(Thanks @Gedochao for bisecting!)

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->


No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)

