### PR TITLE
docs: update CLA links to cla.scala-lang.org

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Fixes #XYZ
 <!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
      do not paste LLM output here, describe the PR in your own words;
      if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
-     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->
+     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->
 
 ## Have you relied on LLM-based tools in this contribution?
 

--- a/docs/_docs/contributing/getting-started.md
+++ b/docs/_docs/contributing/getting-started.md
@@ -145,6 +145,6 @@ The main development discussion channels are:
 [java11]: https://www.oracle.com/java/technologies/javase-jdk11-downloads.html
 [adopt]: https://adoptopenjdk.net/
 [compat]: https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html
-[scala-cla]: https://contribute.akka.io/contribute/cla/scala
+[scala-cla]: https://cla.scala-lang.org/scala/scala3
 [dotty-issue]: https://github.com/scala/scala3/issues
 [dotty-discussion]: https://github.com/scala/scala3/discussions

--- a/docs/_docs/contributing/sending-in-a-pr.md
+++ b/docs/_docs/contributing/sending-in-a-pr.md
@@ -159,7 +159,7 @@ you're PR will be merged in!
 
 [pull-request]: https://docs.github.com/en?query=pull+requests
 [lampepfl/dotty]: https://github.com/lampepfl/dotty
-[cla]: https://contribute.akka.io/contribute/cla/scala
+[cla]: https://cla.scala-lang.org/scala/scala3
 [issues]: https://github.com/scala/scala3/issues
 [full-list]: https://github.com/scala/scala3/blob/master/CONTRIBUTING.md
 [discord]: https://discord.gg/TSmY9zkHar


### PR DESCRIPTION
Follow-up to https://github.com/scala/scala3/pull/26562

Updates docs with new CLA link.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
