### PR TITLE
Remove all uses of `String.format` from the standard library.

### DIFF
--- a/library/src/scala/collection/IndexedSeq.scala
+++ b/library/src/scala/collection/IndexedSeq.scala
@@ -103,7 +103,7 @@ transparent trait IndexedSeqOps[+A, +CC[_], +C] extends Any with SeqOps[A, CC, C
   override def slice(from: Int, until: Int): C^{this} = fromSpecific(new IndexedSeqView.Slice(this, from, until))
 
   override def sliding(size: Int, step: Int): Iterator[C^{this}]^{this} = {
-    require(size >= 1 && step >= 1, f"size=$size%d and step=$step%d, but both must be positive")
+    require(size >= 1 && step >= 1, s"size=$size and step=$step, but both must be positive")
     val it = new IndexedSeqSlidingIterator[A, CC, C](this, size, step)
     it.asInstanceOf[Iterator[Nothing]] // TODO: seems like CC cannot figure this out yet
   }

--- a/library/src/scala/collection/Iterator.scala
+++ b/library/src/scala/collection/Iterator.scala
@@ -167,7 +167,7 @@ trait Iterator[+A] extends IterableOnce[A] with IterableOnceOps[A, Iterator, Ite
    */
   class GroupedIterator[B >: A](self: Iterator[B]^, size: Int, step: Int) extends AbstractIterator[immutable.Seq[B]] {
 
-    require(size >= 1 && step >= 1, f"size=$size%d and step=$step%d, but both must be positive")
+    require(size >= 1 && step >= 1, s"size=$size and step=$step, but both must be positive")
 
     private var buffer: Array[B] | Null = null          // current result
     private var prev: Array[B] | Null = null            // if sliding, overlap from previous result

--- a/library/src/scala/collection/concurrent/TrieMap.scala
+++ b/library/src/scala/collection/concurrent/TrieMap.scala
@@ -434,13 +434,17 @@ private[collection] final class INode[K, V](bn: MainNode[K, V] | Null, g: Gen, e
     GCAS_READ(ct).nn.knownSize()
 
   /* this is a quiescent method! */
-  def string(lev: Int): String = "%sINode -> %s".format("  " * lev, mainnode match {
-    case null => "<null>"
-    case tn: TNode[?, ?] => "TNode(%s, %s, %d, !)".format(tn.k, tn.v, tn.hc)
-    case cn: CNode[?, ?] => cn.string(lev)
-    case ln: LNode[?, ?] => ln.string(lev)
-    case x => "<elem: %s>".format(x)
-  })
+  def string(lev: Int): String = {
+    val spaces = "  " * lev
+    val rhs = mainnode match {
+      case null => "<null>"
+      case tn: TNode[?, ?] => s"TNode(${tn.k}, ${tn.v}, ${tn.hc}, !)"
+      case cn: CNode[?, ?] => cn.string(lev)
+      case ln: LNode[?, ?] => ln.string(lev)
+      case x => s"<elem: $x>"
+    }
+    s"${spaces}INode -> $rhs"
+  }
 
 }
 
@@ -470,7 +474,7 @@ private[concurrent] final class FailedNode[K, V](p: MainNode[K, V]) extends Main
 
   def knownSize: Int = throw new UnsupportedOperationException
 
-  override def toString(): String = "FailedNode(%s)".format(p)
+  override def toString(): String = s"FailedNode($p)"
 }
 
 
@@ -485,7 +489,7 @@ private[collection] final class SNode[K, V](final val k: K, final val v: V, fina
   def copyTombed = new TNode(k, v, hc)
   def copyUntombed = new SNode(k, v, hc)
   def kvPair = (k, v)
-  def string(lev: Int): String = ("  " * lev) + "SNode(%s, %s, %x)".format(k, v, hc)
+  def string(lev: Int): String = ("  " * lev) + s"SNode($k, $v, ${hc.toHexString})"
 }
 
 // Tomb Node, used to ensure proper ordering during removals
@@ -497,7 +501,7 @@ private[collection] final class TNode[K, V](final val k: K, final val v: V, fina
   def kvPair = (k, v)
   def cachedSize(ct: AnyRef): Int = 1
   def knownSize: Int = 1
-  def string(lev: Int): String = ("  " * lev) + "TNode(%s, %s, %x, !)".format(k, v, hc)
+  def string(lev: Int): String = ("  " * lev) + s"TNode($k, $v, ${hc.toHexString}, !)"
 }
 
 // List Node, leaf node that handles hash collisions
@@ -538,7 +542,7 @@ private[collection] final class LNode[K, V](val entries: List[(K, V)], equiv: Eq
 
   def knownSize: Int = -1 // shouldn't ever be empty, and the size of a list is not known
 
-  def string(lev: Int): String = (" " * lev) + "LNode(%s)".format(entries.mkString(", "))
+  def string(lev: Int): String = (" " * lev) + s"LNode(${entries.mkString(", ")})"
 
 }
 
@@ -668,7 +672,7 @@ private[collection] final class CNode[K, V](val bitmap: Int, val array: Array[Ba
     new CNode[K, V](bmp, tmparray, gen).toContracted(lev)
   }
 
-  def string(lev: Int): String = "CNode %x\n%s".format(bitmap, array.map(_.string(lev + 1)).mkString("\n"))
+  def string(lev: Int): String = s"CNode ${bitmap.toHexString}\n" + array.map(_.string(lev + 1)).mkString("\n")
 
   override def toString() = {
     def elems: Seq[String] = array.flatMap {
@@ -676,7 +680,7 @@ private[collection] final class CNode[K, V](val bitmap: Int, val array: Array[Ba
       case in: INode[K, V] @uc => Iterable.single(augmentString(in.toString).drop(14) + "(" + in.gen + ")")
       case basicNode           => throw new MatchError(basicNode)
     }
-    f"CNode(sz: ${elems.size}%d; ${elems.sorted.mkString(", ")})"
+    s"CNode(sz: ${elems.size}; ${elems.sorted.mkString(", ")})"
   }
 }
 

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -1438,7 +1438,8 @@ private final class BitmapIndexedSetNode[A](
   override def hashCode(): Int =
     throw new UnsupportedOperationException("Trie nodes do not support hashing.")
 
-  override def toString(): String = f"BitmapIndexedSetNode(size=$size, dataMap=$dataMap%x, nodeMap=$nodeMap%x)" // content=${scala.runtime.ScalaRunTime.stringOf(content)}
+  override def toString(): String =
+    s"BitmapIndexedSetNode(size=$size, dataMap=${dataMap.toHexString}, nodeMap=${nodeMap.toHexString})" // content=${scala.runtime.ScalaRunTime.stringOf(content)}
 
   override def copy(): BitmapIndexedSetNode[A] = {
     val contentClone = content.clone()
@@ -1986,7 +1987,7 @@ private[collection] final class HashSetBuilder[A] extends ReusableBuilder[A, Has
 
   /** The last given out HashSet as a return value of `result()`, if any, otherwise null.
    *  Indicates that on next add, the elements should be copied to an identical structure, before continuing
-   *  mutations. 
+   *  mutations.
    */
   @annotation.stableNull
   private var aliased: HashSet[A] | Null = null

--- a/library/src/scala/collection/immutable/Range.scala
+++ b/library/src/scala/collection/immutable/Range.scala
@@ -239,7 +239,7 @@ sealed abstract class Range(
     if (numRangeElements <= 0 && !isEmpty)
       fail()
   }
-  private def description = "%d %s %d by %s".format(start, if (isInclusive) "to" else "until", end, step)
+  private def description = s"$start ${if (isInclusive) "to" else "until"} $end by $step"
   private def fail() = throw new IllegalArgumentException(description + ": seqs cannot contain more than Int.MaxValue elements.")
 
   @throws[IndexOutOfBoundsException]
@@ -559,7 +559,7 @@ sealed abstract class Range(
   override def distinct: Range = this
 
   override def grouped(size: Int): Iterator[Range] = {
-    require(size >= 1, f"size=$size%d, but size must be positive")
+    require(size >= 1, s"size=$size, but size must be positive")
     if (isEmpty) {
       Iterator.empty
     } else {

--- a/library/src/scala/collection/mutable/UnrolledBuffer.scala
+++ b/library/src/scala/collection/mutable/UnrolledBuffer.scala
@@ -439,7 +439,7 @@ object UnrolledBuffer extends StrictOptimizedClassTagSeqFactory[UnrolledBuffer] 
     }
 
     override def toString(): String =
-      array.take(size).mkString("Unrolled@%08x".format(System.identityHashCode(this)) + "[" + size + "/" + array.length + "](", ", ", ")") + " -> " + (if (next ne null) next.toString else "")
+      array.take(size).mkString(s"Unrolled@${System.identityHashCode(this).toHexString}[$size/${array.length}](", ", ", ")") + " -> " + (if (next ne null) next.toString else "")
   }
 }
 

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -384,7 +384,7 @@ abstract class Source extends Iterator[Char] with Closeable {
     val line  = Position line pos
     val col   = Position column pos
 
-    out.println("%s:%d:%d: %s%s%s^".format(descr, line, col, msg, lineNum(line), spaces(col - 1)))
+    out.println(s"$descr:$line:$col: $msg${lineNum(line)}${spaces(col - 1)}^")
   }
 
   /**

--- a/library/src/scala/reflect/NameTransformer.scala
+++ b/library/src/scala/reflect/NameTransformer.scala
@@ -87,7 +87,8 @@ object NameTransformer {
           buf = new StringBuilder()
           buf.append(name.substring(0, i))
         }
-        buf.append("$u%04X".format(c.toInt))
+        buf.append("$u")
+        appendHex4(buf, c)
       }
       else if (buf ne null) {
         buf.append(c)
@@ -95,6 +96,21 @@ object NameTransformer {
       i += 1
     }
     if (buf eq null) name else buf.toString()
+  }
+
+  /** Append a 4-uppercase-hex-digit representation of `c` to the given `buf`.
+   *
+   *  The result is '0'-padded if necessary.
+   */
+  private def appendHex4(buf: StringBuilder, c: Char): Unit = {
+    var x = c.toInt
+    var j = 0
+    while (j != 4) {
+      val d = (x >>> 12) & 0xf
+      buf.append((d + (if (d < 10) '0' else ('A' - 10))).toChar)
+      x <<= 4
+      j += 1
+    }
   }
 
   /** Replaces `\$opname` by corresponding operator symbol.

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -48,7 +48,7 @@ private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends P
   protected def underlying: mutable.Map[String, String | Null] = scala.sys.props
   protected def zero: T = null.asInstanceOf[T]
   private def getString = if (isSet) "currently: " + get else "unset"
-  override def toString() = "%s (%s)".format(key, getString)
+  override def toString() = s"$key ($getString)"
 }
 
 private[sys] abstract class CreatorImpl[+T](f: String => T) extends Prop.Creator[T] {


### PR DESCRIPTION
`String.format`, and the `f""` interpolator, are overkill when all we want is combine strings and numbers. It is slower than a straightforward `s""` interpolator.

More importantly, `String.format` brings all of `java.util.Formatter` to the generated code when compiling to non-JVM platforms, which has a significant cost.

The only non-trivial replacement was in `NameTransformer`, which actually wants 0-padding of a hex string. Even that is not too hard to do manually, and much more efficient this way.

Forward port of https://github.com/scala/scala/pull/11250/changes/af61c6d2c29e8e4ad036c6bccda94e7fde4b9d0f

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)