### PR TITLE
Don't merge capture sets if parent is boxed but child is not

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
@@ -474,7 +474,7 @@ trait BCodeIdiomatic(callGraph: Option[CallGraph]) {
 
     // can-multi-thread
     final def checkCast(tk: RefBType): Unit = {
-      // TODO ICode also requires: but that's too much, right? assert(!isBoxedType(tk),     "checkcast on boxed type: " + tk)
+      // TODO ICode also requires: but that's too much, right? assert(!isBoxed(tk),     "checkcast on boxed type: " + tk)
       jmethod.visitTypeInsn(Opcodes.CHECKCAST, tk.classOrArrayType)
     }
 

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -162,7 +162,7 @@ extension (tp: Type)
    *  @param includeBoxed     if true, include capture sets found in boxed parts of this type
    */
   def computeDeepCaptureSet(includeTypevars: Boolean, includeBoxed: Boolean = true)(using Context): CaptureSet =
-    tp.captureSet ++ CaptureSet.ofTypeDeeply(tp.widen.stripCapturing, includeTypevars, includeBoxed)
+    tp.captureSet ++ CaptureSet.ofTypeDeeply(tp.widen.stripOneCapturing, includeTypevars, includeBoxed)
 
   /** The deep capture set of a type. This is by default the union of all
    *  covariant capture sets embedded in the widened type, as computed by
@@ -319,10 +319,21 @@ extension (tp: Type)
    *  via dealising are also stripped.
    */
   def stripCapturing(using Context): Type = tp.dealiasKeepAnnots match
-    case CapturingType(parent, _) =>
+    case tp @ CapturingType(parent, _) =>
       parent.stripCapturing
     case atd @ AnnotatedType(parent, annot) =>
       atd.derivedAnnotatedType(parent.stripCapturing, annot)
+    case _ =>
+      tp
+
+  /** Strip capture set of type, leaving possible boxed nested capture sets in place.
+   */
+  def stripOneCapturing(using Context): Type = tp.dealiasKeepAnnots match
+    case tp @ CapturingType(parent, _) =>
+      if parent.isBoxedCapturing && !tp.isBoxed then parent
+      else parent.stripOneCapturing
+    case atd @ AnnotatedType(parent, annot) =>
+      atd.derivedAnnotatedType(parent.stripOneCapturing, annot)
     case _ =>
       tp
 

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -263,11 +263,25 @@ extension (tp: Type)
       case tp: MethodOrPoly => tp // don't box results of methods outside refinements
       case _ => recur(tp)
 
+  /** Is this type boxed (i.e its outmost capturing type is boxed,
+   *  skipping any capturing types with empty capsets)?
+   */
+  def isBoxed(using Context): Boolean = tp match
+    case tp @ CapturingType(parent, refs) =>
+      tp.annot match
+        case annot: CaptureAnnotation =>
+          annot.boxed && (!refs.isAlwaysEmpty || parent.isBoxed)
+        case _ =>
+          false
+    case tp: TypeRef if tp.symbol.isAbstractOrParamType => false
+    case tp: TypeProxy => tp.superType.isBoxed
+    case tp: AndType => tp.tp1.isBoxed && tp.tp2.isBoxed
+    case tp: OrType => tp.tp1.isBoxed || tp.tp2.isBoxed
+    case _ => false
+
   /** The capture set consisting of all top-level captures of `tp` that appear under a box.
    *  Unlike for `boxed` this also considers parents of capture types, unions and
    *  intersections, and type proxies other than abstract types.
-   *  Furthermore, if the original type is a capability `x`, it replaces boxed universal sets
-   *  on the fly with x*.
    */
   def boxedCaptureSet(using Context): CaptureSet =
     def getBoxed(tp: Type, pre: Type): CaptureSet = tp match
@@ -282,22 +296,25 @@ extension (tp: Type)
       case _ => CaptureSet.empty
     getBoxed(tp, NoType)
 
-  /** Is the boxedCaptureSet of this type nonempty? */
-  def isBoxedCapturing(using Context): Boolean =
+  /** Is the boxedCaptureSet of this type nonempty?
+   *  Unlike for `isBoxed` that also includes types with a boxed
+   *  capset wrapped in an unboxed capturing type.
+   */
+  def hasBoxedCapset(using Context): Boolean =
     tp match
       case tp @ CapturingType(parent, refs) =>
-        tp.isBoxed && !refs.isAlwaysEmpty || parent.isBoxedCapturing
+        tp.isBoxed && !refs.isAlwaysEmpty || parent.hasBoxedCapset
       case tp: TypeRef if tp.symbol.isAbstractOrParamType => false
-      case tp: TypeProxy => tp.superType.isBoxedCapturing
-      case tp: AndType => tp.tp1.isBoxedCapturing && tp.tp2.isBoxedCapturing
-      case tp: OrType => tp.tp1.isBoxedCapturing || tp.tp2.isBoxedCapturing
+      case tp: TypeProxy => tp.superType.hasBoxedCapset
+      case tp: AndType => tp.tp1.hasBoxedCapset && tp.tp2.hasBoxedCapset
+      case tp: OrType => tp.tp1.hasBoxedCapset || tp.tp2.hasBoxedCapset
       case _ => false
 
   /** Is the box status of `tp` and `tp2` compatible? I.e. they are
    *  both boxed, or both unboxed, or one of them has an empty capture set.
    */
   def isBoxCompatibleWith(tp2: Type)(using Context): Boolean =
-    isBoxedCapturing == tp2.isBoxedCapturing
+    isBoxed == tp2.isBoxed
     || tp.captureSet.isAlwaysEmpty
     || tp2.captureSet.isAlwaysEmpty
 
@@ -330,7 +347,7 @@ extension (tp: Type)
    */
   def stripOneCapturing(using Context): Type = tp.dealiasKeepAnnots match
     case tp @ CapturingType(parent, _) =>
-      if parent.isBoxedCapturing && !tp.isBoxed then parent
+      if parent.isBoxed && !tp.isBoxed then parent
       else parent.stripOneCapturing
     case atd @ AnnotatedType(parent, annot) =>
       atd.derivedAnnotatedType(parent.stripOneCapturing, annot)
@@ -864,13 +881,6 @@ extension (sym: Symbol) {
         || sym.is(Method, butNot = Flags.Accessor)
     then sym
     else sym.owner.widenOwner(skipModules)
-}
-
-extension (tp: AnnotatedType) {
-  /** Is this a boxed capturing type? */
-  def isBoxed(using Context): Boolean = tp.annot match
-    case ann: CaptureAnnotation => ann.boxed
-    case _ => false
 }
 
 extension (clss: List[ClassSymbol])

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1169,7 +1169,6 @@ object CaptureSet:
 
     if debugVars && id == debugTarget then
       println(i"variable $id is derived from $source")
-      assert(false)
 
     override def tryInclude(elem: Capability, origin: CaptureSet)(using Context, VarState): Boolean =
       if origin eq source then
@@ -1787,8 +1786,9 @@ object CaptureSet:
         case tp: (TypeRef | TypeParamRef) =>
           if tp.derivesFromCapSet then tp.captureSet
           else empty
-        case CapturingOrRetainsType(parent, refs) =>
-          recur(parent) ++ refs
+        case tp @ CapturingOrRetainsType(parent, refs) =>
+          if parent.isBoxedCapturing && !tp.isBoxed then refs
+          else recur(parent) ++ refs
         case tpd @ defn.RefinedFunctionOf(rinfo: MethodOrPoly) if followResult =>
           ofType(tpd.parent, followResult = false)            // pick up capture set from parent type
           ++ recur(rinfo.resType).freeInResult(rinfo)         // add capture set of result

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1475,7 +1475,7 @@ object CaptureSet:
         case cs: EmptyOfBoxed =>
           trailing:
             val (boxed, unboxed) =
-              if cs.tp1.isBoxedCapturing then (cs.tp1, cs.tp2) else (cs.tp2, cs.tp1)
+              if cs.tp1.isBoxed then (cs.tp1, cs.tp2) else (cs.tp2, cs.tp1)
             i"${cs.tp1} does not conform to ${cs.tp2} because $boxed is boxed but $unboxed is not"
         case _ =>
           def why =
@@ -1787,7 +1787,7 @@ object CaptureSet:
           if tp.derivesFromCapSet then tp.captureSet
           else empty
         case tp @ CapturingOrRetainsType(parent, refs) =>
-          if parent.isBoxedCapturing && !tp.isBoxed then refs
+          if parent.isBoxed && !tp.isBoxed then refs
           else recur(parent) ++ refs
         case tpd @ defn.RefinedFunctionOf(rinfo: MethodOrPoly) if followResult =>
           ofType(tpd.parent, followResult = false)            // pick up capture set from parent type

--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -737,9 +737,9 @@ class CheckCaptures extends Recheck, SymTransformer:
       //   - if the selection is of a parameterless method capturing a ResultCap
       if noWiden(selType, pt)
           || tree.hasAttachment(NoWiden)
-          || qualType.isBoxedCapturing
-          || selType.isBoxedCapturing
-          || selWiden.isBoxedCapturing
+          || qualType.hasBoxedCapset
+          || selType.hasBoxedCapset
+          || selWiden.hasBoxedCapset
           || selType.isTrackableRef
           || selWiden.captureSet.isAlwaysEmpty
           || capturesResult
@@ -842,7 +842,7 @@ class CheckCaptures extends Recheck, SymTransformer:
             case (nuType @ CapturingType(_, _), arg: Tree)
             if arg.tpe.isStable            // stable --> there might be path dependent types with arg as prefix
                && arg.tpe.isTrackableRef   // isTrackableRef --> we can get back original capture set by adaptation
-               && !nuType.isBoxedCapturing // !isBoxed --> no risk of losing uses when unboxing in result
+               && !nuType.hasBoxedCapset // !isBoxed --> no risk of losing uses when unboxing in result
               => arg.tpe
             case (nuType, _) => nuType
           if argTypes1 ne argTypes then
@@ -856,8 +856,8 @@ class CheckCaptures extends Recheck, SymTransformer:
       appType match
         case appType @ CapturingType(appType1, refs)
         if qualType.exists
-            && !qualType.isBoxedCapturing
-            && !resultType.isBoxedCapturing
+            && !qualType.hasBoxedCapset
+            && !resultType.hasBoxedCapset
             && !tree.fun.symbol.isConstructor
             && !resultType.captureSet.containsResultCapability
 
@@ -1617,7 +1617,7 @@ class CheckCaptures extends Recheck, SymTransformer:
     override def recheck(tree: Tree, pt: Type = WildcardType)(using Context): Type =
       val saved = curEnv
       tree match
-        case _: RefTree | closureDef(_) if pt.isBoxedCapturing =>
+        case _: RefTree | closureDef(_) if pt.isBoxed =>
           curEnv = Env(curEnv.owner, EnvKind.Boxed,
             CaptureSet.Var(curEnv.owner), curEnv)
         case _ =>
@@ -1632,7 +1632,7 @@ class CheckCaptures extends Recheck, SymTransformer:
           println(i"error while rechecking $tree against $pt")
           throw ex
         finally curEnv = saved
-      if tree.isTerm && !pt.isBoxedCapturing && pt != LhsProto then
+      if tree.isTerm && !pt.isBoxed && pt != LhsProto then
         markFree(res.boxedCaptureSet, tree)
       res
     end recheck
@@ -1698,7 +1698,7 @@ class CheckCaptures extends Recheck, SymTransformer:
       case _: SingletonType => findImpureUpperBound(tp.widen)
       case tp: TypeRef if tp.symbol.isAbstractOrParamType =>
         tp.info match
-          case TypeBounds(_, hi) if hi.isBoxedCapturing => hi
+          case TypeBounds(_, hi) if hi.isBoxed => hi
           case TypeBounds(_, hi) => findImpureUpperBound(hi)
           case _ => NoType
       case _ => NoType
@@ -1956,10 +1956,14 @@ class CheckCaptures extends Recheck, SymTransformer:
 
         // Decompose the actual type into the inner shape type, the capture set and the box status
         val actualShape = if actual.isFromJavaObject then actual else actual.stripCapturing
-        val actualIsBoxed = actual.isBoxedCapturing
+        val actualIsBoxed = actual.hasBoxedCapset
+          // We also need to do adapation if acual has nested boxed capture sets
+          // See neg-custom-args/captures/box-adapt-cov.scala for a test case where
+          // there would be a spurious 3rd error if we only adapt if the toplevel capset of
+          // actual is boxed.
 
         // A box/unbox should be inserted, if the actual box status mismatches with the expectation
-        val needsAdaptation = actualIsBoxed != expected.isBoxedCapturing
+        val needsAdaptation = actualIsBoxed != expected.isBoxed
         // Whether to insert a box or an unbox?
         val insertBox = needsAdaptation && covariant != actualIsBoxed
 
@@ -2085,7 +2089,7 @@ class CheckCaptures extends Recheck, SymTransformer:
               case TypeAlias(_) =>
                 otherTp match
                   case otherTp: RealTypeBounds =>
-                    if otherTp.hi.isBoxedCapturing || otherTp.lo.isBoxedCapturing then
+                    if otherTp.hi.isBoxed || otherTp.lo.isBoxed then
                       Some((memberTp, otherTp.unboxed))
                     else otherTp.hi match
                       case hi @ CapturingType(parent: TypeRef, refs)
@@ -2402,7 +2406,7 @@ class CheckCaptures extends Recheck, SymTransformer:
               case tl: PolyType =>
                 val normArgs = args.lazyZip(tl.paramInfos).map: (arg, bounds) =>
                   arg.withType(arg.nuType.forceBoxStatus(
-                    bounds.hi.isBoxedCapturing | bounds.lo.isBoxedCapturing))
+                    bounds.hi.isBoxed | bounds.lo.isBoxed))
                 withCollapsedLocalCaps: // OK? We need this since bounds use GlobalAny instead of LocalCap
                   // TODO Do bounds still contain GlobalAny?
                   checkBounds(normArgs, tl)

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -433,7 +433,7 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
      */
     def stripImpliedCaptureSet(tp: Type): Type = tp match
       case tp @ CapturingType(parent, refs)
-      if refs.isInstanceOf[CaptureSet.CSImpliedByCapability] && !tp.isBoxedCapturing =>
+      if refs.isInstanceOf[CaptureSet.CSImpliedByCapability] && !tp.isBoxed =>
         parent
       case tp: AliasingBounds =>
         tp.derivedAlias(stripImpliedCaptureSet(tp.alias))

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -548,19 +548,19 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
       case tp1 @ CapturingType(parent1, refs1) =>
         def compareCapturing =
           if tp2.isAny then true
-          else if compareCaptures(tp1, refs1, tp2, tp2.captureSet)
+          else if compareCaptures(tp1, refs1, tp2)
             || !ctx.mode.is(Mode.CheckBoundsOrSelfType) && tp1.isAlwaysPure
             || parent1.isSingleton && refs1.elems.forall(parent1 eq _)
           then
-            def remainsBoxed1 = parent1.isBoxedCapturing || parent1.dealias.match
+            def remainsBoxed1 = parent1.hasBoxedCapset || parent1.dealias.match
               case parent1: TypeRef =>
-                parent1.superType.isBoxedCapturing
+                parent1.superType.hasBoxedCapset
                 // When comparing a type parameter with boxed upper bound on the left
                 // we should not strip the box on the right. See i24543.scala.
               case _ =>
                 false
             val tp2a =
-              if tp1.isBoxedCapturing && !remainsBoxed1 then tp2.unboxed else tp2
+              if tp1.hasBoxedCapset && !remainsBoxed1 then tp2.unboxed else tp2
             recur(parent1, tp2a)
           else thirdTry
         compareCapturing
@@ -682,12 +682,12 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                   && isSubInfo(info1.resultType, info2.resultType.subst(info2, info1))
                 case (info1 @ CapturingType(parent1, refs1), info2: Type)
                 if info2.stripCapturing.isInstanceOf[MethodOrPoly] =>
-                  compareCaptures(info1, refs1, info2, info2.captureSet)
+                  compareCaptures(info1, refs1, info2)
                     && isSubInfo(parent1, info2)
-                case (info1: Type, CapturingType(parent2, refs2))
+                case (info1: Type, CapturingType(parent2, _))
                 if info1.stripCapturing.isInstanceOf[MethodOrPoly] =>
                   val refs1 = info1.captureSet
-                  (refs1.isAlwaysEmpty || compareCaptures(info1, refs1, info2, refs2))
+                  (refs1.isAlwaysEmpty || compareCaptures(info1, refs1, info2))
                     && isSubInfo(info1, parent2)
                 case _ =>
                   isSubType(info1, info2)
@@ -896,7 +896,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                   case _ =>
                     false
                 singletonOK
-                || compareCaptures(tp1, refs1, tp2, refs2)
+                || compareCaptures(tp1, refs1, tp2)
                     && (recur(tp1.widen.stripOneCapturing, parent2)
                       || tp1.isInstanceOf[SingletonType] && recur(tp1, parent2)
                           // this alternative is needed in case the right hand side is a
@@ -2956,12 +2956,12 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    *    whether the capture set `refs1` of `tp1` is subcapture of the empty set?
    *    In the latter case, boxing status does not matter.
    */
-  protected def compareCaptures(tp1: Type, refs1: CaptureSet, tp2: Type, refs2: CaptureSet): Boolean =
+  protected def compareCaptures(tp1: Type, refs1: CaptureSet, tp2: Type): Boolean =
     val refs1Adapted =
       if tp1.derivesFromStateful && !tp2.derivesFromStateful
       then refs1.readOnly
       else refs1
-    val subc = subCaptures(refs1Adapted, refs2)
+    val subc = subCaptures(refs1Adapted, tp2.captureSet)
     if !subc then
       errorNotes match
         case (level, CaptureSet.MutAdaptFailure(cs, NoType, NoType)) :: rest =>
@@ -2974,9 +2974,9 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
    */
   private def healBoxDifference(tp1: Type, tp2: Type)(using Context): Boolean = tp1.dealias match
     case tp1 @ CapturingType(parent, refs) =>
-      (  !tp1.isBoxed || tp2.isBoxedCapturing
+      (  !tp1.isBoxed || tp2.isBoxed
       || refs.subCaptures(CaptureSet.EmptyOfBoxed(tp1, tp2), makeVarState())
-      || { capt.println(i"box mismatch for $tp1 <:< $tp2, ${tp1.isBoxedCapturing}")
+      || { capt.println(i"box mismatch for $tp1 <:< $tp2, ${tp1.hasBoxedCapset}")
            false
          }
       ) && healBoxDifference(parent, tp2)

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -897,7 +897,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                     false
                 singletonOK
                 || compareCaptures(tp1, refs1, tp2, refs2)
-                    && (recur(tp1.widen.stripCapturing, parent2)
+                    && (recur(tp1.widen.stripOneCapturing, parent2)
                       || tp1.isInstanceOf[SingletonType] && recur(tp1, parent2)
                           // this alternative is needed in case the right hand side is a
                           // capturing type that contains the lhs as an alternative of a union type.
@@ -1931,7 +1931,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
                   // to the argument type. If subCapturesRange returns true we know that arg1's'
                   // capture set can be unified with arg2's capture set, so it only remains to
                   // check the underlying types with `isSubArg`.
-                  && isSubArg(arg1.hi.stripCapturing, arg2.stripCapturing)
+                  && isSubArg(arg1.hi.stripOneCapturing, arg2.stripOneCapturing)
                 || compareCaptured(arg1, arg2)
               case ExprType(arg1res)
               if ctx.phaseId > elimByNamePhase.id && !ctx.erasedTypes
@@ -2967,8 +2967,7 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         case (level, CaptureSet.MutAdaptFailure(cs, NoType, NoType)) :: rest =>
           errorNotes = (level, CaptureSet.MutAdaptFailure(cs, tp1, tp2)) :: rest
         case _ =>
-    subc
-    && (tp1.isBoxCompatibleWith(tp2) || healBoxDifference(tp1, tp2))
+    subc && (tp1.isBoxCompatibleWith(tp2) || healBoxDifference(tp1, tp2))
 
   /** Try to heal a box difference of `tp1` with another type `tp2` by forcing all capture
    *  capture sets in `tp1` with a box difference to `tp2` to be empty.

--- a/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeComparer.scala
@@ -2969,12 +2969,12 @@ class TypeComparer(@constructorOnly initctx: Context) extends ConstraintHandling
         case _ =>
     subc && (tp1.isBoxCompatibleWith(tp2) || healBoxDifference(tp1, tp2))
 
-  /** Try to heal a box difference of `tp1` with another type `tp2` by forcing all capture
-   *  capture sets in `tp1` with a box difference to `tp2` to be empty.
+  /** Try to heal a box difference of `tp1` with another unboxed type `tp2` by forcing
+   *  all boxed capture capture sets in `tp1` to be empty.
    */
   private def healBoxDifference(tp1: Type, tp2: Type)(using Context): Boolean = tp1.dealias match
     case tp1 @ CapturingType(parent, refs) =>
-      (  tp1.isBoxed == tp2.isBoxedCapturing
+      (  !tp1.isBoxed || tp2.isBoxedCapturing
       || refs.subCaptures(CaptureSet.EmptyOfBoxed(tp1, tp2), makeVarState())
       || { capt.println(i"box mismatch for $tp1 <:< $tp2, ${tp1.isBoxedCapturing}")
            false

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -19,7 +19,7 @@ import typer.Inferencing.*
 import typer.IfBottom
 import reporting.TestingReporter
 import Annotations.Annotation
-import cc.{CapturingType, derivedCapturingType, CaptureSet, captureSet, isBoxed, isBoxedCapturing}
+import cc.{CapturingType, derivedCapturingType, CaptureSet, captureSet, isBoxed}
 import CaptureSet.{IdentityCaptRefMap, VarState}
 
 import scala.annotation.internal.sharable
@@ -165,7 +165,7 @@ object TypeOps:
       case tp @ CapturingType(parent, refs) =>
         if !ctx.mode.is(Mode.Type)
             && refs.subCaptures(parent.captureSet, VarState.Separate)
-            && (tp.isBoxed || !parent.isBoxedCapturing)
+            && (tp.isBoxed || !parent.isBoxed)
               // fuse types with same boxed status and outer boxed with any type
         then
           simplify(parent, theMap)

--- a/tests/neg-custom-args/captures/lexical-control.check
+++ b/tests/neg-custom-args/captures/lexical-control.check
@@ -1,0 +1,36 @@
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lexical-control.scala:18:30 ------------------------------
+18 |      val u = suspend(inner): () =>  // error, was OK (???)
+   |                              ^
+   |                              Found:    () ->{outer} Int
+   |                              Required: () ->'s1 Int
+   |
+   |                              Note that capability `outer` cannot flow into capture set {inner.Fv}.
+   |
+19 |        suspend(outer) {() => y} // ok
+20 |        suspend(outer) {() => y} // ok
+21 |        y
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lexical-control.scala:22:23 ------------------------------
+22 |      suspend(outer) { () => // error
+   |                       ^
+   |                       Found:    () ->{outer} Int
+   |                       Required: () ->'s2 Int
+   |
+   |                       Note that capability `outer` cannot flow into capture set {outer.Fv}.
+   |
+23 |        suspend(outer) {() => y }
+   |
+   | longer explanation available when compiling with `-explain`
+-- [E007] Type Mismatch Error: tests/neg-custom-args/captures/lexical-control.scala:25:22 ------------------------------
+25 |      suspend(outer): () => // error  (leaks the inner label)
+   |                      ^
+   |                      Found:    () ->{inner} Int
+   |                      Required: () ->'s3 Int
+   |
+   |                      Note that capability `inner` cannot flow into capture set {outer.Fv}.
+   |
+26 |        println(inner)
+27 |        x + y + z
+   |
+   | longer explanation available when compiling with `-explain`

--- a/tests/pos-custom-args/captures/splits.scala
+++ b/tests/pos-custom-args/captures/splits.scala
@@ -1,0 +1,19 @@
+import caps.*
+
+class Ref extends Mutable:
+    var x = 0
+    def get: Int = x
+    update def put(y: Int): Unit = x = y
+
+class Abs[A](val fst: A^, val snd: A^)
+
+def mkAbs[A](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y)
+def mkAbs2[A <: Any{}](consume x: A^, consume y: A^): Abs[A]^ = Abs[A](x, y)
+
+def Test =
+    val r6 = Ref()
+    val r7 = Ref()
+    val z = mkAbs(r6, r7)
+    val elem5 = z.fst
+    val elem6: Ref^ = z.snd
+    val z3 = mkAbs2(elem5, elem6)   // ok, can spit and join for polymorphic as well.


### PR DESCRIPTION

We already don't do that when forming CapturingTypes. We now also do not merge capture sets in `CaptureSet.typeIOf` (which is called by `.captures`) if the carrier type is of the form

     (Box T^C1)^C2

There is a also new variant stripOneCapturing that strips only C2 in this case.

This now supports the pos test splits.scala without resorting to the `[A <: Any^{}]` trick
that forces type variables to be shape types.

We also distinguish more precisely between kinds of boxed status. Two possibilities:

 - `hasBoxedCapsets`: contains boxed capsets (even under unboxed ones)
 - `isBoxed`: has a boxed toplevel capset, or a boxed capset that is only wrapped by empty unboxed capsets


