### PR TITLE
Fix coverage capture for lifted constructor args

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -12,13 +12,14 @@ import core.Comments.Comment
 import core.Flags.*
 import core.Contexts.{Context, ctx, inContext}
 import core.DenotTransformers.IdentityDenotTransformer
-import core.Symbols.{defn, Symbol}
+import core.Symbols.{defn, Symbol, TermSymbol}
 import core.Constants.Constant
 import core.NameKinds.DefaultGetterName
 import core.NameOps.isContextFunction
 import core.StdNames.nme
 import core.Types.*
 import core.Decorators.*
+import cc.CapturingOrRetainsType
 import coverage.*
 import typer.LiftImpure
 import util.{Property, SourcePosition, SourceFile}
@@ -78,6 +79,15 @@ object LiftCoverage extends LiftImpure:
 
   override protected def onLiftedDef(tree: tpd.Tree)(using Context): Unit =
     tree.putAttachment(CoverageLiftedTemp, ())
+
+  override protected def liftedRef(lifted: TermSymbol, liftedType: Type, expr: tpd.Tree)(using Context): tpd.Tree =
+    val liftedRef = tpd.ref(lifted.termRef)
+    val hasCaptures =
+      liftedType.existsPart:
+        case CapturingOrRetainsType(_, refs) => !refs.isAlwaysEmpty
+        case _ => false
+    if liftingArgs && hasCaptures then tpd.Typed(liftedRef, tpd.TypeTree(liftedType, inferred = true))
+    else liftedRef
 
   override def noLift(expr: tpd.Tree)(using Context) =
     if liftingArgs then noLiftArg(expr)

--- a/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
+++ b/compiler/src/dotty/tools/dotc/typer/EtaExpansion.scala
@@ -55,6 +55,9 @@ abstract class Lifter {
   /** Hook for lifters that need to record or mark freshly created lifted defs. */
   protected def onLiftedDef(tree: Tree)(using Context): Unit = ()
 
+  protected def liftedRef(lifted: TermSymbol, liftedType: Type, expr: Tree)(using Context): Tree =
+    ref(lifted.termRef)
+
   private def lift(defs: mutable.ListBuffer[Tree], expr: Tree, prefix: TermName = EmptyTermName)(using Context): Tree =
     if (noLift(expr)) expr
     else {
@@ -72,7 +75,7 @@ abstract class Lifter {
         .setDefTree
       onLiftedDef(liftedTree)
       defs += liftedTree
-      ref(lifted.termRef).withSpan(expr.span.focus)
+      liftedRef(lifted, liftedType, expr).withSpan(expr.span.focus)
     }
 
   /** Lift out common part of lhs tree taking part in an operator assignment such as

--- a/tests/pos/coverage-constructor-underlying-leak.scala
+++ b/tests/pos/coverage-constructor-underlying-leak.scala
@@ -1,0 +1,34 @@
+package scala.collection
+
+import scala.language.experimental.captureChecking
+
+trait SeqView[+A]:
+  def iterator: Iterator[A]^{this}
+  def sorted[B >: A](implicit ord: Ordering[B]): SeqView[A]^{this} = this
+
+object SeqView:
+  private type SomeSeqOps[+A] = SeqOps[A, AnyConstr, ?]
+
+  final class Sorted[A, B >: A] private (
+    underlying_ : SomeSeqOps[A]^,
+    private val len: Int,
+    private val ord: Ordering[B]
+  ) extends SeqView[A]:
+    outer: Sorted[A, B]^ =>
+
+    private var underlying = underlying_
+
+    def this(underlying: SomeSeqOps[A]^, ord: Ordering[B]) =
+      this(underlying, underlying.length, ord)
+
+    def iterator: Iterator[A]^{this} = underlying.iterator
+
+    private def elems: SomeSeqOps[A]^{this} = underlying
+
+    private final class ReverseSorted extends SeqView[A]:
+      def iterator: Iterator[A]^{this} = underlying.iterator
+
+      override def sorted[B1 >: A](implicit ord1: Ordering[B1]): SeqView[A]^{this} =
+        if ord1 == Sorted.this.ord then outer
+        else if ord1.isReverseOf(Sorted.this.ord) then this
+        else new Sorted(elems, len, ord1)


### PR DESCRIPTION
Fixes #26570

## Problem

Consider this `SeqView.Sorted` shape:

```scala
else new Sorted(elems, len, ord1)
```

Coverage instrumentation lifts the `elems` argument into a stable synthetic local:

```scala
val underlying_$1: SomeSeqOps[A]^{Sorted.this} =
  { Invoker.invoked(...); Sorted.this.elems }

new Sorted(underlying_$1, Sorted.this.len, ord1)
```

The constructor is capture-polymorphic over the `underlying` argument, so capture checking treats the constructed wrapper as capturing the synthetic `underlying_$1` capability:

Without coverage:

```scala
def elems: SomeSeqOps[A]^{Sorted.this}
new Sorted(elems, ...)
```

With coverage:

```scala
val underlying_$1: SomeSeqOps[A]^{Sorted.this} = ...
new Sorted(underlying_$1, ...)
```

When tracking the captures of values passed in the constructor, `def`s and `val`s are treated differently. Here is what gets tracked after the constructor call typecheck:

```scala
elems: SomeSeqOps[A]^{Sorted.this}  // from the def
underlying_$1: SomeSeqOps[A]^{underlying_$1}  // from the val
```

That compiler-created local then fails against the declared result capture `{ReverseSorted.this}`.

## Solution

When coverage lifting substitutes an application argument whose widened value type carries a non-empty capture or retains annotation, specify the type explicitly as containing the correct capture set of the original argument.:

```scala
new Sorted(
  (underlying_$1: SomeSeqOps[A]^{Sorted.this}),
  Sorted.this.len,
  ord1)
```

This prevents the lifted value's singleton path from becoming the user-visible capture of the constructed value.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by review and regression tests.

## How was the solution tested?

New automated test. Added `tests/pos/coverage-constructor-underlying-leak.scala`, which matches the minimized reproducer.

```bash
sbt --client -no-colors "scala3-bootstrapped/testCompilation --enable-coverage-phase coverage-constructor-underlying-leak"
sbt --client -no-colors "scala3-bootstrapped/testCompilation coverage-constructor-underlying-leak"
sbt --client -no-colors "scala3-bootstrapped/testCompilation --enable-coverage-phase"
```

[test_coverage]