### PR TITLE
Fix #26552: emit InnerClasses entries for signature-only class references

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -603,9 +603,28 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
       // value types. This is needed to fix #7416.
       null
     } else {
-      val jsOpt = GenericSignatures.javaSig(sym, memberTpe)
-      if (jsOpt != null && ctx.settings.XverifySignatures.value) {
-        verifySignature(sym, jsOpt.toString)
+      val referencedNestedClasses = mutable.ListBuffer.empty[ClassSymbol]
+      // Collect only nested classes: top-level ones need no InnerClasses entry,
+      // and special classes like AnyKind have no ClassBType at all. The test
+      // must run at erasurePhase explicitly: the closure captures the caller's
+      // context, and getStaticForwarderGenericSignature calls this helper at
+      // genBCode phase, where Flatten has re-owned nested classes to packages.
+      val jsOpt = GenericSignatures.javaSig(sym, memberTpe,
+        cls => if (!atPhase(erasurePhase)(cls.isTopLevelClass)) referencedNestedClasses += cls)
+      if (jsOpt != null) {
+        // PostProcessor computes the InnerClasses attribute by resolving names
+        // in the emitted signature strings against the run's ClassBType cache,
+        // so a class referenced only from a generic signature must be
+        // registered here or its entry is lost (issue #26552). This must run
+        // at flattenPhase.next, where classSig computes the names it writes;
+        // the caller is inside atPhase(erasurePhase), where nested classes
+        // still have unflattened binary names.
+        atPhase(flattenPhase.next) {
+          referencedNestedClasses.foreach(bTypeLoader.classBTypeFromSymbol(_))
+        }
+        if (ctx.settings.XverifySignatures.value) {
+          verifySignature(sym, jsOpt.toString)
+        }
       }
       jsOpt
     }

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -135,8 +135,11 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
         previouslyConstructedClassBType(internalName).get.info.nestedClasses
 
       def getClassIfNested(internalName: InternalName): Option[ClassBType] = {
-        val c = previouslyConstructedClassBType(internalName).get
-        Option.when(c.isNestedClass)(c)
+        // A miss must not throw: the exception would be swallowed by the
+        // signature parser's `raiseError` below, dropping this entry and
+        // truncating the scan. Codegen registers a ClassBType for every class
+        // it references, including signature-only ones (see getGenericSignatureHelper).
+        previouslyConstructedClassBType(internalName).filter(_.isNestedClass)
       }
 
       def raiseError(msg: String, sig: String, e: Option[Throwable]): Unit = {

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -29,12 +29,15 @@ object GenericSignatures {
   /** Generate the signature for `sym0`, with type `info`, as defined in
    *  the Java Virtual Machine Specification, §4.3.4
    *
-   *  @param sym0 The symbol for which to define the signature
-   *  @param info The type of the symbol
+   *  @param sym0       The symbol for which to define the signature
+   *  @param info       The type of the symbol
+   *  @param onClassRef Invoked for every class whose name is written into the
+   *                    signature, so that nested ones can be registered in the
+   *                    ClassBType cache for the InnerClasses attribute (#26552).
    *  @return The signature if it could be generated, `null` otherwise.
    */
-  def javaSig(sym0: Symbol, info: Type)(using Context): StringBuilder | Null =
-    if mayNeedSignature(sym0, info) then atPhase(erasurePhase)(javaSig0(sym0, info))
+  def javaSig(sym0: Symbol, info: Type, onClassRef: ClassSymbol => Unit)(using Context): StringBuilder | Null =
+    if mayNeedSignature(sym0, info) then atPhase(erasurePhase)(javaSig0(sym0, info, onClassRef))
     else null
 
   private def mayNeedSignature(sym0: Symbol, info: Type)(using Context) = {
@@ -49,7 +52,7 @@ object GenericSignatures {
     else mayNeedSignature(info)
   }
 
-  private def javaSig0(sym0: Symbol, info: Type)(using Context): StringBuilder | Null = {
+  private def javaSig0(sym0: Symbol, info: Type, onClassRef: ClassSymbol => Unit)(using Context): StringBuilder | Null = {
     // This works as long as mangled names are always valid Java identifiers (see git history of this method).
     def sanitizeName(name: Name): String = name.mangledString
 
@@ -195,6 +198,7 @@ object GenericSignatures {
     }
 
     def classSig(sym: ClassSymbol, pre: Type = NoType, args: List[Type] = Nil): Unit = {
+      onClassRef(sym)
       def argSig(tp: Type): Unit =
         tp.dealias match {
           case bounds: TypeBounds =>

--- a/compiler/test/dotty/tools/dotc/DeterminismTest.scala
+++ b/compiler/test/dotty/tools/dotc/DeterminismTest.scala
@@ -268,8 +268,6 @@ class DeterminismTest {
     test(List(code))
   }
 
-  // TODO: fix compiler determinism for this to pass
-  @Ignore("classfile member order and InnerClasses attribute differ under separate compilation, see scala/scala3#26552")
   @Test def testReferenceToInnerClassMadeNonPrivate(): Unit = {
     def code = List(
       source("t.scala",
@@ -331,6 +329,47 @@ class DeterminismTest {
           |object B {
           |  val m = summon[scala.deriving.Mirror.Of[CC]]
           |}
+          |""".stripMargin)
+    )
+    test(List(code))
+  }
+
+  /** A nested class referenced only from a generic signature must get its
+   *  InnerClasses entry regardless of separate compilation and file order (#26552).
+   */
+  @Test def testInnerClassesSignatureOnly(): Unit = {
+    def code = List(
+      source("a.scala",
+        """class A {
+          |  class B
+          |}
+          |""".stripMargin),
+      source("d.scala",
+        """class D {
+          |  def g: Option[A#B] = None
+          |}
+          |""".stripMargin)
+    )
+    test(List(code))
+  }
+
+  /** A static forwarder in a mirror class can carry the only signature
+   *  reference to a nested class in the run (#26552).
+   */
+  @Test def testInnerClassesStaticForwarder(): Unit = {
+    def code = List(
+      source("a.scala",
+        """class A {
+          |  class B
+          |}
+          |""".stripMargin),
+      source("base.scala",
+        """class Base {
+          |  def g: Option[A#B] = None
+          |}
+          |""".stripMargin),
+      source("o.scala",
+        """object O extends Base
           |""".stripMargin)
     )
     test(List(code))


### PR DESCRIPTION
Fixes #26552

## Compiler version
  
3.7.1 +

## Snippet

  `a.scala`:
  ```scala
  class A {
    class B
  }
  ```
  
  `d.scala`:
  ```scala
  class D {
    def g: Option[A#B] = None
  }
  ```

## Reproduction

  Separate compilation (entry lost):
  ```bash
  scalac -d out a.scala
  scalac -classpath out -d out d.scala
  javap -v -p out/D.class | grep -A2 InnerClasses   # no entry for A$B
  ```

  Joint compilation, file order flips the result:
  ```bash
  scalac -d out1 a.scala d.scala
  scalac -d out2 d.scala a.scala
  javap -v -p out1/D.class | grep -A2 InnerClasses  # public #x= #y of #z  // B=class A$B of class A
  javap -v -p out2/D.class | grep -A2 InnerClasses  # entry missing
  cmp out1/D.class out2/D.class                     # differ
  ```

### Fix: Register ClassBTypes for classes referenced only from generic signatures.

Re-enables testReferenceToInnerClassMadeNonPrivate; adds testInnerClassesSignatureOnly.
## Have you relied on LLM-based tools in this contribution?
  No for the code gen, 
  yes for the code review 
  ( an automated LLM code-review (claudecode/fable5 pass was run),
  and its findings were applied manually)
  
## How was the solution tested?
  New automated tests (including the issue's reproducer).
