### PR TITLE
Preserve qualifier purity through compiler-generated casts

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -484,6 +484,7 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
    */
   private def defKind(tree: Tree)(using Context): FlagSet = unsplice(tree) match {
     case EmptyTree | _: Import => NoInitsInterface
+    case _: ModuleDef => NoInits
     case tree: TypeDef =>
       if tree.isClassDef then
         if Feature.shouldBehaveAsScala2 then EmptyFlags
@@ -608,11 +609,14 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     case TypeApply(fn, _) =>
       val sym = fn.symbol
       if tree.tpe.isInstanceOf[MethodOrPoly] then exprPurity(fn)
+      else if sym == defn.Any_typeCast then
+        fn match
+          case Select(qual, _) => exprPurity(qual) `min` Pure
+          case _ => Impure
       else if sym == defn.QuotedTypeModule_of
           || sym == defn.Predef_classOf
           || sym == defn.Compiletime_erasedValue && tree.tpe.dealias.isInstanceOf[ConstantType]
           || defn.capsErasedValueMethods.contains(sym)
-          || sym == defn.Any_typeCast
       then Pure
       else Impure
     case Apply(fn, args) =>

--- a/tests/neg/nested-module-no-inits.scala
+++ b/tests/neg/nested-module-no-inits.scala
@@ -1,0 +1,8 @@
+//> using options -language:experimental.erasedDefinitions
+
+object Outer:
+  object Inner:
+    println("effect")
+
+erased val pureOuter: Outer.type = Outer
+erased val impureInner: Outer.Inner.type = Outer.Inner // error

--- a/tests/neg/type-cast-purity.scala
+++ b/tests/neg/type-cast-purity.scala
@@ -1,0 +1,17 @@
+//> using options -language:experimental.erasedDefinitions
+
+object O:
+  opaque type T = String
+
+  transparent inline def make: T =
+    println("effect")
+    "value"
+
+// shouldn't emit E129: Pure Expression In Statement Position
+object Statement:
+  O.make
+
+def consume(erased value: O.T): Unit = ()
+
+def test(): Unit =
+  consume(O.make) // error

--- a/tests/neg/type-cast-purity.scala
+++ b/tests/neg/type-cast-purity.scala
@@ -7,10 +7,6 @@ object O:
     println("effect")
     "value"
 
-// shouldn't emit E129: Pure Expression In Statement Position
-object Statement:
-  O.make
-
 def consume(erased value: O.T): Unit = ()
 
 def test(): Unit =

--- a/tests/pos/type-cast-purity.scala
+++ b/tests/pos/type-cast-purity.scala
@@ -1,0 +1,12 @@
+//> using options -Werror
+
+object O:
+  opaque type T = String
+
+  transparent inline def make: T =
+    println("effect")
+    "value"
+
+// shouldn't emit E129: Pure Expression In Statement Position
+object Statement:
+  O.make

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3879,7 +3879,7 @@ Text => empty
 Language => Scala
 Symbols => 13 entries
 Occurrences => 35 entries
-Diagnostics => 4 entries
+Diagnostics => 1 entries
 Synthetics => 4 entries
 
 Symbols:
@@ -3935,12 +3935,9 @@ Occurrences:
 [23:4..23:19): StructuralTypes -> example/StructuralTypes.
 
 Diagnostics:
-[15:2..15:11): [warning] A pure expression does nothing in statement position
-[16:2..16:10): [warning] A pure expression does nothing in statement position
 [17:20..17:23): [warning] Alphanumeric method foo is not declared infix; it should not be used as infix operator.
 Instead, use method syntax .foo(...) or backticked identifier `foo`.
 The latter can be rewritten automatically under -rewrite -source 3.4-migration.
-[22:2..22:13): [warning] A pure expression does nothing in statement position
 
 Synthetics:
 [15:2..15:6):user => reflectiveSelectable(*)


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26578
FYI @mrdziuban 

**Problem**
https://github.com/scala/scala3/pull/25126 made expressions containing a synthetic cast always `pure`, but this should actually depend on the purity of the expression being cast. Otherwise, an `<impure expression>.$asInstanceOf` will always pure, but it should be impure.

PR #25126 intended to fix #24990, but what should really be fixed is that, in:

```scala
object test {
  opaque type Foo = Int

  class Bar[A] extends compiletime.Erased
  object Bar { inline given inst[A]: Bar[A] = new Bar[A] }
}
def takesBar[A](a: A)(using b: test.Bar[A]): A = a
val _ = takesBar(1)

// which generates

val $proxy1: test.type{type Foo = Int} =
  test.$asInstanceOf[test.type{type Foo = Int}]
```

`test` should be `pure`, and `$asInstanceOf` should simply inherit the purity of its qualifier (`test`).

The actual root cause seems that an `object` (`test`) that contains a nested `object` (`object Bar`) was not being marked `NoInit`. As a result, `test` ended up being treated as an `IdempotentPath`.

https://github.com/scala/scala3/blob/b17ee7ab1a56a1658c17ed3f8d476e0698e2bc79/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala#L699-L700

**Fix**

This commit changes `TreeInfo` so that
- `NoInit` is preserved even when there is a nested `object`
- Synthetic cast `Any_typeCast` inherits it's qualifier's purity

In fact, in the `TreeUnpickler`, an `object` is desugared into `lazy val = new ...`, and when the tree is reconstructed, `NoInit` is preserved in that case.

https://github.com/scala/scala3/blob/b17ee7ab1a56a1658c17ed3f8d476e0698e2bc79/compiler/src/dotty/tools/dotc/ast/Desugar.scala#L1154-L1163

https://github.com/scala/scala3/blob/b17ee7ab1a56a1658c17ed3f8d476e0698e2bc79/compiler/src/dotty/tools/dotc/core/tasty/TreeUnpickler.scala#L828-L835


<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://contribute.akka.io/contribute/cla/scala -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by comprehending the changes

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

- New automated tests (including the issue's reproducer, if applicable)
- Covered by existing tests  `tests/pos/i24990.scala`
