### PR TITLE
Do Not Map Capture Variables in GlobalCapToLocal

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/Capability.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Capability.scala
@@ -1179,7 +1179,11 @@ object Capabilities:
   // ---------- Maps between different kinds of root capabilities -----------------
 
   /** Map each occurrence of `caps.any` to a different LocalCap instance
-   *  Exception: CapSet^ stays as it is.
+   *  Exception: Capture set references like an `X` with `type X^ = {caps.any}`
+   *  are kept as they are. The `caps.any` in the alias is freshened once when
+   *  the alias definition itself is set up, so all uses of `X` refer to that
+   *  same instance. Following the alias in `mapCapability` instead would map
+   *  `X` to a capture set, which cannot be an element of a mapped set (i26180).
    */
   class GlobalCapToLocal(origin: Origin)(using Context) extends BiTypeMap, FollowAliasesMap:
     thisMap =>
@@ -1212,6 +1216,7 @@ object Capabilities:
         // `cap` to reach capabilities, so invariant occurrences were never
         // connected to their environment.
         LocalCap(origin, atInvariantPos = variance == 0)
+      case c: TypeRef if c.derivesFromCapSet => c
       case _ => super.mapCapability(c)
 
     override def fuse(next: BiTypeMap)(using Context) = next match
@@ -1227,6 +1232,7 @@ object Capabilities:
 
       override def mapCapability(c: Capability): Capability = c match
         case c: LocalCap if globalizes(c) => GlobalAny
+        case c: TypeRef if c.derivesFromCapSet => c
         case _ => super.mapCapability(c)
 
       def inverse = thisMap

--- a/tests/neg-custom-args/captures/i26180.scala
+++ b/tests/neg-custom-args/captures/i26180.scala
@@ -1,0 +1,15 @@
+import scala.language.experimental.captureChecking
+
+class IO
+
+object Obj:
+  type C^ = {caps.any}
+  def bar(a: IO^{C}): IO^{C} = a
+
+object Abs:
+  type C^ <: {caps.any}
+  def bar(a: IO^{C}): IO^{C} = a
+
+def test(io: IO^): Unit =
+  val x = Obj.bar(io) // error: local capability io cannot flow into the fixed set Obj.C
+  val y = Abs.bar(io) // error: same for an abstract capture-set member

--- a/tests/pos-custom-args/captures/i26180.scala
+++ b/tests/pos-custom-args/captures/i26180.scala
@@ -1,0 +1,24 @@
+import scala.language.experimental.captureChecking
+
+class IO
+
+object Obj:
+  type C^ = {caps.any}
+  def foo(a: Any^{C}): Unit = ()            // was: crash in GlobalCapToLocal
+  def bar(): Any^{C} = ???                  // result position
+  val v: Any^{C} = ???                      // val type
+  def baz(f: (Any^{C}) -> Unit): Unit = ()  // was: crash in GlobalCapToLocal.Inverse
+  def qux(xs: List[Any^{C}]): Unit = ()     // boxed position
+
+object Mixed:
+  val x: IO^ = ???
+  type C^ = {caps.any, x}
+  def foo(a: Any^{C}): Unit = ()
+
+class Cls:
+  type C^ = {caps.any}
+  def foo(a: Any^{C}): Unit = ()
+  def bar(a: Any^{this.C}): Unit = ()
+
+def test(io: IO^): Unit =
+  Obj.foo(io)


### PR DESCRIPTION
Fixes #26180

`GlobalCapToLocal` followed aliases when mapping capture-set members like `type C^ = {caps.any}` occurring as elements of a capture set, so `Obj.C` mapped to a capture set rather than a capability. But a `BiTypeMap` must map capabilities to capabilities, hence the assertion failure. Fix: `mapCapability` now keeps `TypeRef`s deriving from `CapSet` unchanged (the `caps.any` in the alias RHS is still mapped to a `LocalCap`, once, in the member's own info), which makes such aliases behave exactly like `CapSet`-bounded abstract type members.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by carefully reviewing it.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)