### PR TITLE
fix: Fixes unsound A =:= Unit inference for ???

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4591,6 +4591,26 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
     def adaptNoArgsImplicitMethod(wtp: MethodType): Tree = {
       assert(wtp.isImplicitMethod)
       val tvarsToInstantiate = tvarsInParams(tree, locked).distinct
+
+      // Pin type vars fixed by a bottom-typed argument (e.g. `???`) to Nothing,
+      // so the implicit search below can't unify them with something else.
+      def bottomBoundTVars(t: Tree): List[TypeVar] =
+        if ctx.reporter.hasErrors then Nil
+        else t match
+          case Apply(fn, args) =>
+            val fromArgs = fn.tpe.widen match
+              case mt: MethodType =>
+                mt.paramInfos.lazyZip(args).flatMap: (formal, arg) =>
+                  if arg.tpe.widen.isBottomType then
+                    tvarsToInstantiate.filter(tv => formal.existsPart(_ eq tv))
+                  else Nil
+              case _ => Nil
+            fromArgs ++ bottomBoundTVars(fn)
+          case _ => Nil
+
+      for tvar <- bottomBoundTVars(tree) do
+        if !tvar.isInstantiated then tvar.instantiate(fromBelow = true)
+
       def instantiate(tp: Type): Unit = {
         instantiateSelected(tp, tvarsToInstantiate)
         replaceSingletons(tp)

--- a/tests/run/i10393.scala
+++ b/tests/run/i10393.scala
@@ -1,0 +1,10 @@
+// Regression test for scala/bug#10393: the compiler must not prove `Nothing =:= Unit`.
+
+object Test:
+  def isUnit[A](code: => A)(using ev: A =:= Unit = null) =
+    ev != null
+
+  def main(args: Array[String]): Unit =
+    assert(isUnit(()), "isUnit(()) should be true")
+    assert(!isUnit(???), "isUnit(???) should be false: Nothing =:= Unit must not be proven")
+end Test


### PR DESCRIPTION
Fixes https://github.com/scala/bug/issues/10393

The above is a bug originally reported against Scala 2.x in 2017. Let me know if you want me to reopen one for Scala 3.

## Problem
Type variable `A` in `def isUnit[A](code: => A)(using ev: A =:= Unit = null)` is left uninstantiated after typing bottom-typed argument. This ends up unifying `ev` to `Unit` incorrectly.

## Solution
Pin the type variables that are bottom-typed to `Nothing` prior to implicit search.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by reading the code, and running tests. 

## How was the solution tested?

`sbt --client testCompilation i10393`
