### PR TITLE
Prohibit capset applications with postfix hat

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CheckCaptures.scala
@@ -106,9 +106,20 @@ object CheckCaptures:
   }
 
   /** Check that a @retains annotation only mentions references that can be tracked.
-   *  This check is performed at Typer.
+   *  Also reject a postfix `^` on a capture-set variable (`CS^`, where `CS` is a
+   *  capture-set parameter or member): `^` adds the root capability `caps.any`,
+   *  which is most likely unintended -- `CS` already stands for a capture set.
+   *  See issue #24088. This check is performed at Typer.
    */
   def checkWellformedRetains(parent: Tree, ann: Tree)(using Context): Unit =
+    if ann.symbol.maybeOwner == defn.RetainsCapAnnot
+        && parent.tpe.derivesFromCapSet
+        && parent.tpe.dealias.typeSymbol != defn.Caps_CapSet
+    then
+      report.error(
+        em"""Postfix `^` is not allowed on the capture-set variable ${parent.tpe};
+            |it adds the root capability `caps.any`. Write `${parent.tpe}` or `{${parent.tpe}}` to refer to its capture set.""",
+        parent.srcPos)
     def check(elem: Type): Unit = elem match
       case ref: TypeRef =>
         val refSym = ref.symbol

--- a/tests/neg-custom-args/captures/i24088.check
+++ b/tests/neg-custom-args/captures/i24088.check
@@ -1,0 +1,17 @@
+-- Error: tests/neg-custom-args/captures/i24088.scala:4:10 -------------------------------------------------------------
+4 |  self: A[CS^]^{CS} => // error: `^` on capture-set argument; meant A[{CS}] or A[CS]
+  |          ^^
+  |          Postfix `^` is not allowed on the capture-set variable CS;
+  |          it adds the root capability `caps.any`. Write `CS` or `{CS}` to refer to its capture set.
+-- Error: tests/neg-custom-args/captures/i24088.scala:9:24 -------------------------------------------------------------
+9 |def f[C^](b: B[{C}]): B[C^] = ??? // error
+  |                        ^
+  |                        Postfix `^` is not allowed on the capture-set variable C;
+  |                        it adds the root capability `caps.any`. Write `C` or `{C}` to refer to its capture set.
+-- Error: tests/neg-custom-args/captures/i24088.scala:12:22 ------------------------------------------------------------
+12 |def h[C^](): Unit = g[C^]() // error
+   |                      ^
+   |                    Postfix `^` is not allowed on the capture-set variable C;
+   |                    it adds the root capability `caps.any`. Write `C` or `{C}` to refer to its capture set.
+   |
+   |                    where:    C is a type in method h with bounds >: scala.caps.CapSet and <: scala.caps.CapSet^

--- a/tests/neg-custom-args/captures/i24088.scala
+++ b/tests/neg-custom-args/captures/i24088.scala
@@ -1,0 +1,12 @@
+import language.experimental.captureChecking
+
+class A[CS^]:
+  self: A[CS^]^{CS} => // error: `^` on capture-set argument; meant A[{CS}] or A[CS]
+
+class B[CS^]:
+  self: B[{CS}]^{CS} => // ok: this is what was meant
+
+def f[C^](b: B[{C}]): B[C^] = ??? // error
+
+def g[D^](): Unit = ()
+def h[C^](): Unit = g[C^]() // error

--- a/tests/pos-custom-args/captures/i24088.scala
+++ b/tests/pos-custom-args/captures/i24088.scala
@@ -1,0 +1,17 @@
+import language.experimental.captureChecking
+
+// An explicit self capture set bounds what an implementing class or object may
+// capture (the internal view); it is not observed by outside clients. So a bare
+// `A[{o}]` instance that captures nothing is pure. See the discussion on #24088.
+class A[C^]:
+  self: A[{C}]^{C} =>
+
+def test(o: Object^, x: Object^, y: Object^): Unit =
+  val a_pure: A[{o}] = A[{o}]                                     // captures nothing => pure
+  val a_good = new A[{o}] { def foo() = println(o) }              // ok: {o} within bound {o}
+  val b_good = new A[{o, x}] { def foo() = { println(o); println(x) } } // ok
+  val c_good: A[{o, x}]^{o, x} = new A[{o, x}] { def foo() = println(x) } // ok: uses x
+
+// A bare `^` on CapSet itself is legal legacy syntax, also through an alias.
+type CS0 = caps.CapSet
+def viaAlias[C >: CS0 <: CS0^](): Unit = ()


### PR DESCRIPTION
Fixes #24088

In a capture-set application `Foo[C^]`, `C^` expands to `Foo[{C, any}]`, but `Foo[C]` or `Foo[{C}]` stand for `Foo` applied to the capture-set represented by `C`. Mighty confusing & if we follow the rationale that declaring a binder `C^` is analogous to declaring a higher-kinded `F[_]` parameter, then `C^` in an application position is just as non-sensical as `F[_]` would be.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by reviewing it carefully.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)