### PR TITLE
Prevent mixing of `:` commands and `//> using` directives in a single REPL input & raise directives parser diagnostics

### DIFF
--- a/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
+++ b/directives-parser/src/main/scala/dotty/tools/directives/CommentExtractor.scala
@@ -17,6 +17,9 @@ case class ExtractorResult(
   diagnostics: Seq[UsingDirectiveDiagnostic]
 )
 
+object ExtractorResult:
+  val empty: ExtractorResult = ExtractorResult(Nil, 0, Nil)
+
 /** Phase 1: scans a source file and extracts `//> using` directive lines.
   *
   * The accepted syntax is specified in the module README, which is the single source of truth.

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -275,6 +275,20 @@ object ParseResult {
 
   private val UsingDirectivePrefix = """^//>\s*using(?:\s|$)""".r
 
+  /** Extract line bounds and trimmed content starting at offset.
+   *  Returns `(lineEnd, line, trimmed)` where:
+   *  - `lineEnd`: index of `'\n'` or `src.length`
+   *  - `line`: the raw line content (without newline)
+   *  - `trimmed`: `line` with leading whitespace stripped
+   */
+  private def extractLine(src: String, offset: Int): (Int, String, String) =
+    val lineEnd = src.indexOf('\n', offset) match
+      case -1 => src.length
+      case nl => nl
+    val line = src.substring(offset, lineEnd)
+    val trimmed = line.stripLeading()
+    (lineEnd, line, trimmed)
+
   /** Skip a block comment (with nesting). Returns offset after closing star-slash. */
   private def skipBlockComment(src: String, start: Int): Int =
     @tailrec
@@ -291,11 +305,7 @@ object ParseResult {
     def scan(offset: Int): Int =
       if offset >= src.length then offset
       else
-        val lineEnd = src.indexOf('\n', offset) match
-          case -1 => src.length
-          case nl => nl
-        val line = src.substring(offset, lineEnd)
-        val trimmed = line.stripLeading()
+        val (lineEnd, line, trimmed) = extractLine(src, offset)
 
         if trimmed.isEmpty then
           scan(lineEnd + 1)
@@ -308,21 +318,20 @@ object ParseResult {
     scan(0)
 
   /** Detect if the leading prefix (before Scala code) contains both `:` commands
-   *  and `//> using` directives. Skips blank lines, line comments, and block comments
-   *  (with nesting support matching the Scala compiler).
+   *  and `//> using` directives. Skips blank lines, a leading shebang, line comments,
+   *  and block comments (with nesting support matching the Scala compiler).
    */
   private def mixesCommandsAndDirectives(sourceCode: String): Boolean =
     @tailrec
     def scan(offset: Int, hasCommand: Boolean, hasDirective: Boolean): Boolean =
       if offset >= sourceCode.length then hasCommand && hasDirective
       else
-        val lineEnd = sourceCode.indexOf('\n', offset) match
-          case -1 => sourceCode.length
-          case nl => nl
-        val line = sourceCode.substring(offset, lineEnd)
-        val trimmed = line.stripLeading()
+        val (lineEnd, line, trimmed) = extractLine(sourceCode, offset)
 
         if trimmed.isEmpty then
+          scan(lineEnd + 1, hasCommand, hasDirective)
+        else if offset == 0 && trimmed.startsWith("#!") then
+          // Shebang: skip only on the very first line (matches CommentExtractor)
           scan(lineEnd + 1, hasCommand, hasDirective)
         else if trimmed.startsWith("/*") then
           val afterBlock = skipBlockComment(sourceCode, offset + line.indexOf("/*"))

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -285,6 +285,28 @@ object ParseResult {
       else loop(off + 1, depth)
     loop(start + 2, 1)
 
+  /** Find offset of first significant content (past blank lines, line comments, block comments). */
+  private def skipLeadingCommentsAndBlanks(src: String): Int =
+    @tailrec
+    def scan(offset: Int): Int =
+      if offset >= src.length then offset
+      else
+        val lineEnd = src.indexOf('\n', offset) match
+          case -1 => src.length
+          case nl => nl
+        val line = src.substring(offset, lineEnd)
+        val trimmed = line.stripLeading()
+
+        if trimmed.isEmpty then
+          scan(lineEnd + 1)
+        else if trimmed.startsWith("/*") then
+          scan(skipBlockComment(src, offset + line.indexOf("/*")))
+        else if trimmed.startsWith("//") then
+          scan(lineEnd + 1)
+        else
+          offset + line.indexOf(trimmed.head)
+    scan(0)
+
   /** Detect if the leading prefix (before Scala code) contains both `:` commands
    *  and `//> using` directives. Skips blank lines, line comments, and block comments
    *  (with nesting support matching the Scala compiler).
@@ -407,9 +429,17 @@ object ParseResult {
    *  would otherwise make unfinished trailing code look complete and submit early.
    */
   private def codeAfterLeadingCommands(sourceCode: String, extractedDirectives: ExtractorResult): String =
-    leadingCommand(sourceCode, extractedDirectives) match
-      case Some((_, _, rest)) => codeAfterLeadingCommands(rest, extractDirectives(rest))
-      case None => sourceCode
+    // After the first command there are no directives (would have been detected earlier),
+    // so subsequent steps skip comments/blanks without re-running extractDirectives.
+    @tailrec
+    def skipCommands(src: String, extracted: ExtractorResult): String =
+      leadingCommand(src, extracted) match
+        case Some((_, _, rest)) =>
+          val offset = skipLeadingCommentsAndBlanks(rest)
+          val significant = if offset < rest.length then rest.substring(offset) else ""
+          skipCommands(significant, ExtractorResult.empty)
+        case None => src
+    skipCommands(sourceCode, extractedDirectives)
 
   /** Check if the input is incomplete.
    *

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -9,7 +9,7 @@ import dotc.parsing.Parsers.Parser
 import dotc.parsing.Tokens
 import dotc.reporting.{Diagnostic, StoreReporter}
 import dotc.util.SourceFile
-import dotty.tools.directives.{ExtractorResult, UsingDirectivesParser}
+import dotty.tools.directives.{ExtractorResult, UsingDirectiveDiagnostic, UsingDirectivesParser}
 
 import scala.annotation.internal.sharable
 import scala.annotation.tailrec
@@ -18,7 +18,12 @@ import scala.annotation.tailrec
 sealed trait ParseResult
 
 /** An error free parsing resulting in a list of untyped trees */
-case class Parsed(source: SourceFile, trees: List[untpd.Tree], reporter: StoreReporter) extends ParseResult
+case class Parsed(
+  source: SourceFile,
+  trees: List[untpd.Tree],
+  reporter: StoreReporter,
+  directiveDiagnostics: Seq[UsingDirectiveDiagnostic] = Nil
+) extends ParseResult
 
 /** A parsing result containing syntax `errors` */
 case class SyntaxErrors(sourceCode: String,
@@ -341,7 +346,8 @@ object ParseResult {
       case _ if mixesCommandsAndDirectives(sourceCode) => MixedCommandsAndDirectives
       case CommandExtract(cmd: String, arg: String) => command(cmd, arg)
       case _ =>
-        leadingCommand(sourceCode, extractDirectives(sourceCode)) match {
+        val extracted = extractDirectives(sourceCode)
+        leadingCommand(sourceCode, extracted) match {
           case Some((cmd, arg, rest)) =>
             if rest.exists(!_.isWhitespace) then CommandThenCode(command(cmd, arg), apply(rest))
             else command(cmd, arg)
@@ -356,7 +362,7 @@ object ParseResult {
                   reporter.removeBufferedMessages,
                   stats)
               else
-                Parsed(source, stats, reporter)
+                Parsed(source, stats, reporter, extracted.diagnostics)
             }
         }
     }

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -12,6 +12,7 @@ import dotc.util.SourceFile
 import dotty.tools.directives.{ExtractorResult, UsingDirectivesParser}
 
 import scala.annotation.internal.sharable
+import scala.annotation.tailrec
 
 /** A parsing result from string input */
 sealed trait ParseResult
@@ -48,6 +49,9 @@ sealed trait Command extends ParseResult:
  *  The command is interpreted first, then code is evaluated.
  */
 case class CommandThenCode(command: Command, code: ParseResult) extends ParseResult
+
+/** Input that mixes `:` commands and `//> using` directives in a single block */
+case object MixedCommandsAndDirectives extends ParseResult
 
 /** An unknown command that will not be handled by the REPL */
 case class UnknownCommand(cmd: String) extends Command:
@@ -264,6 +268,53 @@ object ParseResult {
   private def extractDirectives(sourceCode: String): ExtractorResult =
     UsingDirectivesParser.extractLines(sourceCode.toIndexedSeq)
 
+  private val UsingDirectivePrefix = """^//>\s*using(?:\s|$)""".r
+
+  /** Skip a block comment (with nesting). Returns offset after closing star-slash. */
+  private def skipBlockComment(src: String, start: Int): Int =
+    @tailrec
+    def loop(off: Int, depth: Int): Int =
+      if off >= src.length - 1 || depth == 0 then off
+      else if src(off) == '/' && src(off + 1) == '*' then loop(off + 2, depth + 1)
+      else if src(off) == '*' && src(off + 1) == '/' then loop(off + 2, depth - 1)
+      else loop(off + 1, depth)
+    loop(start + 2, 1)
+
+  /** Detect if the leading prefix (before Scala code) contains both `:` commands
+   *  and `//> using` directives. Skips blank lines, line comments, and block comments
+   *  (with nesting support matching the Scala compiler).
+   */
+  private def mixesCommandsAndDirectives(sourceCode: String): Boolean =
+    @tailrec
+    def scan(offset: Int, hasCommand: Boolean, hasDirective: Boolean): Boolean =
+      if offset >= sourceCode.length then hasCommand && hasDirective
+      else
+        val lineEnd = sourceCode.indexOf('\n', offset) match
+          case -1 => sourceCode.length
+          case nl => nl
+        val line = sourceCode.substring(offset, lineEnd)
+        val trimmed = line.stripLeading()
+
+        if trimmed.isEmpty then
+          scan(lineEnd + 1, hasCommand, hasDirective)
+        else if trimmed.startsWith("/*") then
+          val afterBlock = skipBlockComment(sourceCode, offset + line.indexOf("/*"))
+          scan(afterBlock, hasCommand, hasDirective)
+        else if trimmed.startsWith("//") then
+          if UsingDirectivePrefix.findFirstIn(trimmed).isDefined then
+            if hasCommand then true else scan(lineEnd + 1, hasCommand, hasDirective = true)
+          else
+            scan(lineEnd + 1, hasCommand, hasDirective)
+        else trimmed match
+          case CommandExtract(_, _) =>
+            if hasDirective then true else scan(lineEnd + 1, hasCommand = true, hasDirective)
+          case _ =>
+            hasCommand && hasDirective
+    end scan
+
+    scan(0, hasCommand = false, hasDirective = false)
+  end mixesCommandsAndDirectives
+
   /** If `sourceCode`'s first significant line (after comments/blank lines) is a
    *  `:command`, split it into `(commandName, commandArg, remainingText)`.
    *  `remainingText` may be blank.
@@ -287,6 +338,7 @@ object ParseResult {
     val sourceCode = source.content().mkString
     sourceCode match {
       case "" => Newline
+      case _ if mixesCommandsAndDirectives(sourceCode) => MixedCommandsAndDirectives
       case CommandExtract(cmd: String, arg: String) => command(cmd, arg)
       case _ =>
         leadingCommand(sourceCode, extractDirectives(sourceCode)) match {

--- a/repl/src/dotty/tools/repl/ReplCompiler.scala
+++ b/repl/src/dotty/tools/repl/ReplCompiler.scala
@@ -220,7 +220,7 @@ class ReplCompiler extends Compiler:
       }
 
       ParseResult(sourceFile) match {
-        case Parsed(_, trees, _) =>
+        case Parsed(_, trees, _, _) =>
           Right(wrap(trees))
         case SyntaxErrors(_, reported, trees) =>
           if (errorsAllowed) Right(wrap(trees))

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -387,6 +387,8 @@ class ReplDriver(settings: Array[String],
   protected def interpret(res: ParseResult)(using state: State): State = {
     res match {
       case parsed: Parsed =>
+        for diag <- parsed.directiveDiagnostics do
+          out.println(s"[warn] ${diag.message}")
         val src = parsed.source.content().mkString
         val classified = DependencyResolver.classifyDirectives(src)
         if classified.hasDirectives then

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -408,6 +408,12 @@ class ReplDriver(settings: Array[String],
         val recorded = cmd.replayLine.fold(stateAfterCommand)(line => stateAfterCommand.recordInput(line.strip))
         interpret(code)(using recorded)
 
+      case MixedCommandsAndDirectives =>
+        out.println(
+          """Cannot mix `:` commands and `//> using` directives in the same REPL input.
+            |Submit them as separate inputs.""".stripMargin)
+        state
+
       case cmd: Command =>
         val next = interpretCommand(cmd)
         cmd.replayLine.fold(next)(line => next.recordInput(line.strip))

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -305,3 +305,18 @@ class ReplDirectiveTests extends ReplTest:
     ParseResult("//> using scala 3.3.1\n:type 1") match
       case MixedCommandsAndDirectives => // expected
       case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `post-code directive warning printed exactly once`: Unit =
+    initially:
+      run("val x = 1\n//> using dep foo::bar:1.0")
+      val output = storedOutput()
+      val count = "Ignoring using directive".r.findAllIn(output).length
+      org.junit.Assert.assertEquals("warning should appear exactly once", 1, count)
+      assertTrue(output, output.contains("val x: Int = 1"))
+
+  @Test def `post-code directive diagnostic is surfaced`: Unit =
+    initially:
+      run("val y = 2\n//> using options -Werror")
+      val output = storedOutput()
+      assertTrue(output, output.contains("Ignoring using directive"))
+      assertTrue(output, output.contains("val y: Int = 2"))

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -320,3 +320,23 @@ class ReplDirectiveTests extends ReplTest:
       val output = storedOutput()
       assertTrue(output, output.contains("Ignoring using directive"))
       assertTrue(output, output.contains("val y: Int = 2"))
+
+  @Test def `shebang with command then directive parses as mixed`: Unit = initially:
+    ParseResult("#!/usr/bin/env scala\n:dep a::b:1\n//> using dep c::d:2") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `shebang with directive then command parses as mixed`: Unit = initially:
+    ParseResult("#!/usr/bin/env scala\n//> using dep c::d:2\n:dep a::b:1") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `shebang with command only parses as command`: Unit = initially:
+    ParseResult("#!/usr/bin/env scala\n:type 1\nval x = 5") match
+      case CommandThenCode(TypeOf("1"), _: Parsed) => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `shebang with directive only evaluates normally`: Unit = initially:
+    ParseResult("#!/usr/bin/env scala\n//> using dep x::y:1\nval x = 1") match
+      case _: Parsed => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -216,3 +216,92 @@ class ReplDirectiveTests extends ReplTest:
     ParseResult(":type 1\n// c\n:type 2\nval x = 5") match
       case CommandThenCode(TypeOf("1"), CommandThenCode(TypeOf("2"), _: Parsed)) => // expected
       case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `command then directive parses as mixed`: Unit = initially:
+    ParseResult(":dep a::b:1\n//> using dep c::d:2\nval x = 1") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `directive then command parses as mixed`: Unit = initially:
+    ParseResult("//> using dep c::d:2\n:dep a::b:1\nval x = 1") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `command then directive without trailing code parses as mixed`: Unit = initially:
+    ParseResult(":dep a::b:1\n//> using dep c::d:2") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `multiple commands then directive parses as mixed`: Unit = initially:
+    ParseResult(":type 1\n:type 2\n//> using dep c::d:2\nval x = 1") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `command then directive with interspersed comment parses as mixed`: Unit = initially:
+    ParseResult(":dep a::b:1\n// c\n//> using dep c::d:2") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `directive then command with blank line parses as mixed`: Unit = initially:
+    ParseResult("//> using dep c::d:2\n\n:dep a::b:1") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `mixing commands and directives is rejected without executing`: Unit =
+    initially:
+      run(":dep some.bogus::coords:1\n//> using dep other.bogus::coords:2\nval x = 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("Cannot mix"))
+      assertFalse(output, output.contains("Resolved"))
+      assertFalse(output, output.contains("val x: Int = 1"))
+
+  @Test def `command with directive-like string is not mixed`: Unit = initially:
+    ParseResult(":type 1\nval s = \"//> using dep x\"") match
+      case CommandThenCode(TypeOf("1"), _: Parsed) => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `block comment between commands parses as nested CommandThenCode`: Unit = initially:
+    ParseResult(":type 1\n/* c */\n:type 2\nval x = 5") match
+      case CommandThenCode(TypeOf("1"), CommandThenCode(TypeOf("2"), _: Parsed)) => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `multiline block comment between commands parses as nested CommandThenCode`: Unit = initially:
+    ParseResult(":type 1\n/* multi\n line\n comment */\n:type 2\nval x = 5") match
+      case CommandThenCode(TypeOf("1"), CommandThenCode(TypeOf("2"), _: Parsed)) => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `block comment between command and directive parses as mixed`: Unit = initially:
+    ParseResult(":dep a::b:1\n/* c */\n//> using dep c::d:2") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `multiline block comment between command and directive parses as mixed`: Unit = initially:
+    ParseResult(":dep a::b:1\n/* multi\n line */\n//> using dep c::d:2") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `mixed input is not incomplete`: Unit = contextually:
+    assertFalse(ParseResult.isIncomplete(":dep a::b:1\n//> using dep c::d:2\nval x = 1"))
+    assertFalse(ParseResult.isIncomplete("//> using dep c::d:2\n:dep a::b:1\nval x = 1"))
+
+  @Test def `mixed input accepts line`: Unit = contextually:
+    assertTrue(ParseResult.shouldAcceptLine(":dep a::b:1\n//> using dep c::d:2\nval x = 1", hasPendingInput = false))
+    assertTrue(ParseResult.shouldAcceptLine("//> using dep c::d:2\n:dep a::b:1\nval x = 1", hasPendingInput = false))
+
+  @Test def `directive first mixing is rejected without executing`: Unit =
+    initially:
+      run("//> using dep other.bogus::coords:2\n:dep some.bogus::coords:1\nval x = 1")
+      val output = storedOutput()
+      assertTrue(output, output.contains("Cannot mix"))
+      assertFalse(output, output.contains("Resolved"))
+      assertFalse(output, output.contains("val x: Int = 1"))
+
+  @Test def `unsupported directive with command parses as mixed`: Unit = initially:
+    ParseResult(":dep a::b:1\n//> using options -Werror") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")
+
+  @Test def `unsupported directive then command parses as mixed`: Unit = initially:
+    ParseResult("//> using scala 3.3.1\n:type 1") match
+      case MixedCommandsAndDirectives => // expected
+      case other => org.junit.Assert.fail(s"unexpected parse result: $other")


### PR DESCRIPTION
A follow-up to https://github.com/scala/scala3/pull/26511#issuecomment-4925721664

We don't want to allow `:` commands and `//> using` directives to mix in the REPL, so we return an error when they do.

```scala 
scala> :dep foo::bar:1.0
       //> using dep foo::bar:1.1
       println("Hello")
Cannot mix `:` commands and `//> using` directives in the same REPL input.
Submit them as separate inputs.
```

Additionally, I added propagating of diagnostics from the directives parser to the REPL:

```scala
scala> println("Hello")
       //> using dep foo::bar:1.1
[warn] Ignoring using directive found after Scala code: //> using dep foo::bar:1.1
Hello
```

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output with included automated tests and by running `bin/replQ` manually.

## How was the solution tested?
New automated tests (including the issue's reproducer, if applicable)
