### PR TITLE
Make release process forkable

### DIFF
--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -111,5 +111,5 @@ jobs:
       - name: Compute SHA256 of the uploaded artifact (win x86-64)
         id  : win-x86_64-digest
         run : |
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -o artifact.zip -L https://api.github.com/repos/scala/scala3/actions/artifacts/${{ steps.win-x86_64.outputs.artifact-id }}/zip
+          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -o artifact.zip -L https://api.github.com/repos/${{ github.repository }}/actions/artifacts/${{ steps.win-x86_64.outputs.artifact-id }}/zip
           echo "digest=$(sha256sum artifact.zip | cut -d " " -f 1)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,8 +103,9 @@ jobs:
   publish_release:
     permissions:
       contents: write  # for GH CLI to create a release
-    runs-on: [self-hosted, Linux]
-    needs: [stdlib-tests, mima-tests, compiler-tests, community-build-tests, misc-tests]
+    # Forks have no self-hosted runners, so the release runs on a normal GitHub runner
+    runs-on: ${{ github.repository == 'scala/scala3' && fromJSON('["self-hosted", "Linux"]') || 'ubuntu-latest' }}
+    needs: [stdlib-tests, mima-tests, compiler-tests, community-build-tests, misc-tests, build-msi-package]
     container:
       image: lampepfl/dotty:2024-10-18
       options: --cpu-shares 4096
@@ -116,6 +117,16 @@ jobs:
 
     env:
       RELEASEBUILD: yes
+      # IS_ORIGIN routes how we publish:
+      #
+      # - External channels like Maven Central are only used on scala/scala3.
+      # - On forks all the artifacts are built, signed and staged, but are only
+      #   published to fork-local targets (GitHub releases, workflow artifacts).
+      #
+      # Setting the FORK_SIMULATE_ORIGIN repo variable lets a fork walk the
+      # origin code path to test that the external-publish guards fire.
+      IS_ORIGIN: ${{ github.repository == 'scala/scala3' || vars.FORK_SIMULATE_ORIGIN == 'true' }}
+      HAS_SIGNING_KEY: ${{ secrets.PGP_SECRET != '' }}
       PGP_PW: ${{ secrets.PGP_PW }}  # PGP passphrase
       PGP_SECRET: ${{ secrets.PGP_SECRET }}  # Export your private and public PGP key to an *.asc file, take the file's contents as a string
       SONATYPE_PW: ${{ secrets.SONATYPE_PW_ORGSCALALANG }}
@@ -142,6 +153,8 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Add SBT proxy repositories
+        # The proxies are EPFL-internal Artifactory, forks resolve from Maven Central
+        if: env.IS_ORIGIN == 'true'
         run: cp -vf .github/workflows/repositories /root/.sbt/ ; true
 
       # Extract the release tag
@@ -155,7 +168,10 @@ jobs:
           echo "This build version: ${version}"
           if [ "${version}" != "${{ env.RELEASE_TAG }}" ]; then
             echo "Compiler version for this build '${version}', does not match tag: ${{ env.RELEASE_TAG }}"
-            exit 1
+            if [ "${IS_ORIGIN}" = "true" ]; then
+              exit 1
+            fi
+            echo "::warning::Continuing build, fork test tags may not match the built version"
           fi
 
       - name: Prepare the SDKs
@@ -210,10 +226,16 @@ jobs:
           # We need to config safe.directory in every step that might reference git
           # It is not persisted between steps
           git config --global --add safe.directory $GITHUB_WORKSPACE
+          notesFile="./changelogs/${{ env.RELEASE_TAG }}.md"
+          notesArgs=(--notes-file "${notesFile}")
+          if [ "${IS_ORIGIN}" != "true" ] && [ ! -f "${notesFile}" ]; then
+            # Fork test tags have no changelog entry
+            notesArgs=(--generate-notes)
+          fi
           gh release create \
           --draft \
           --title "${{ env.RELEASE_TAG }}" \
-          --notes-file ./changelogs/${{ env.RELEASE_TAG }}.md \
+          "${notesArgs[@]}" \
           --latest=${{ !contains(env.RELEASE_TAG, '-RC') }} \
           --prerelease=${{ contains(env.RELEASE_TAG, '-RC') }} \
           --verify-tag ${{ env.RELEASE_TAG }} \
@@ -223,10 +245,14 @@ jobs:
           scala3-${{ env.RELEASE_TAG }}.msi
 
       # Each namespace needs to be published separately
+      # On forks, the artifacts are signed and staged (target/sona-staging) but the
+      # upload to Maven Central is skipped and the staged bundle is archived instead.
+      # A fork without a signing key configured skips these steps entirely.
       - name: Publish Release (org.scala-lang)
+        if: env.IS_ORIGIN == 'true' || env.HAS_SIGNING_KEY == 'true'
         run: |
           rm -rf ./target/sona-staging/
-          ./project/scripts/sbtPublish " \
+          publishCommand=" \
             all \
               scala-library-bootstrapped/publishSigned \
               scala3-compiler-bootstrapped/publishSigned \
@@ -242,13 +268,36 @@ jobs:
               scala3-tasty-inspector/publishSigned \
               scaladoc/publishSigned \
               tasty-core-bootstrapped/publishSigned \
-            ;sonaUpload"
+            "
+          if [ "${IS_ORIGIN}" = "true" ]; then
+            publishCommand="${publishCommand} ;sonaUpload"
+          fi
+          ./project/scripts/sbtPublish "${publishCommand}"
+
+      - name: Upload staged bundle (org.scala-lang, fork only)
+        if: env.IS_ORIGIN != 'true' && env.HAS_SIGNING_KEY == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sona-staging-org-scala-lang
+          path: target/sona-staging/
 
       - name: Publish Release (org.scala-js)
+        if: env.IS_ORIGIN == 'true' || env.HAS_SIGNING_KEY == 'true'
         run: |
           # Ensure the staging does not contain any stale artifacts
           rm -rf ./target/sona-staging/
-          ./project/scripts/sbtPublish "scala-library-sjs/publishSigned ;sonaUpload"
+          publishCommand="scala-library-sjs/publishSigned"
+          if [ "${IS_ORIGIN}" = "true" ]; then
+            publishCommand="${publishCommand} ;sonaUpload"
+          fi
+          ./project/scripts/sbtPublish "${publishCommand}"
+
+      - name: Upload staged bundle (org.scala-js, fork only)
+        if: env.IS_ORIGIN != 'true' && env.HAS_SIGNING_KEY == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: sona-staging-org-scala-js
+          path: target/sona-staging/
 
   build-msi-package:
    uses: ./.github/workflows/build-msi.yml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
   test_windows_full:
     runs-on: [self-hosted, Windows]
     if: "github.event_name == 'schedule' && github.repository == 'scala/scala3'
-         || github.event_name == 'push'
+         || github.event_name == 'push' && github.repository == 'scala/scala3'
          || (
            github.event_name == 'pull_request'
            && !contains(github.event.pull_request.body, '[skip ci]')

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,6 +166,7 @@ jobs:
         run : |
           version=$(./project/scripts/sbt "print scala3-compiler-bootstrapped/version" | tail -n1)
           echo "This build version: ${version}"
+          echo "BUILD_VERSION=${version}" >> $GITHUB_ENV
           if [ "${version}" != "${{ env.RELEASE_TAG }}" ]; then
             echo "Compiler version for this build '${version}', does not match tag: ${{ env.RELEASE_TAG }}"
             if [ "${IS_ORIGIN}" = "true" ]; then
@@ -186,11 +187,15 @@ jobs:
             ./project/scripts/sbt "all ${sbtProject}/Universal/packageBin ${sbtProject}/Universal/packageZipTarball"
 
             artifactName="scala3-${{ env.RELEASE_TAG }}${distroSuffix}"
+            # sbt names the archives after the built version. On scala/scala3 the
+            # version check guarantees it equals the tag; on forks a test tag may
+            # differ, so rename the archives to the tag the release will use.
+            builtName="scala3-${{ env.BUILD_VERSION }}${distroSuffix}"
 
             # Caluclate SHA for each of archive files
-            for file in "${artifactName}.zip" "${artifactName}.tar.gz"; do
-              mv ${distDir}/target/universal/$file $file
-              sha256sum "${file}" > "${file}.sha256"
+            for ext in "zip" "tar.gz"; do
+              mv "${distDir}/target/universal/${builtName}.${ext}" "${artifactName}.${ext}"
+              sha256sum "${artifactName}.${ext}" > "${artifactName}.${ext}.sha256"
             done
           }
           prepareSDK ""                      "dist"               "./dist/"

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -27,7 +27,9 @@ on:
         required: true
 
 jobs:
+  # Never push to Chocolatey from a fork, regardless of how this workflow is called
   publish:
+    if: github.repository == 'scala/scala3'
     runs-on: windows-latest
     steps:
       - name: Fetch the Chocolatey package from GitHub

--- a/.github/workflows/publish-sdkman.yml
+++ b/.github/workflows/publish-sdkman.yml
@@ -27,10 +27,14 @@ on:
         required: true
 
 env:
-  RELEASE-URL: 'https://github.com/scala/scala3/releases/download/${{ inputs.version }}'
+  # The download URLs handed to sdkman point at the releases of the repository
+  # that ran the workflow. Only the scala/scala3 releases are real sdkman targets.
+  RELEASE-URL: 'https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}'
 
 jobs:
+  # Never push to SDKMAN! from a fork, regardless of how this workflow is called
   publish:
+    if: github.repository == 'scala/scala3'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -56,6 +60,7 @@ jobs:
           PLATFORM       : ${{ matrix.platform }}
 
   default:
+    if: github.repository == 'scala/scala3'
     runs-on: ubuntu-latest
     needs: publish
     steps:

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -23,7 +23,9 @@ on:
         required: true
 
 jobs:
+  # Never push to WinGet from a fork, regardless of how this workflow is called
   publish:
+    if: github.repository == 'scala/scala3'
     runs-on: windows-latest
     steps:
       - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -22,8 +22,12 @@ on:
 
 jobs:
   # TODO: ADD JOB TO SWITCH THE GITHUB RELEASE FROM DRAFT TO LATEST
+  # The publish-* jobs push to external package managers and channels so we only
+  # run then on scala/scala3. Forks running this workflow still build and test
+  # the packages.
   publish-sdkman:
     uses:  ./.github/workflows/publish-sdkman.yml
+    if: github.repository == 'scala/scala3'
     with:
       version: ${{ inputs.version }}
     secrets:
@@ -32,7 +36,7 @@ jobs:
 
   publish-winget:
     uses: ./.github/workflows/publish-winget.yml
-    if: false # TODO: Requires setting up initial WinGet package
+    if: false && github.repository == 'scala/scala3' # TODO: Requires setting up initial WinGet package (keep the repository guard when enabling)
     with:
       version: ${{ inputs.version }}
     secrets:
@@ -48,7 +52,8 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          curl -o artifact.zip -L "https://github.com/scala/scala3/releases/download/$VERSION/scala3-$VERSION-x86_64-pc-win32.zip"
+          # TODO(puerco): Verify provenance of this artifact
+          curl -o artifact.zip -L "https://github.com/${{ github.repository }}/releases/download/$VERSION/scala3-$VERSION-x86_64-pc-win32.zip"
           echo "digest=$(sha256sum artifact.zip | cut -d " " -f 1)" >> "$GITHUB_OUTPUT"
 
   build-chocolatey:
@@ -56,7 +61,7 @@ jobs:
     needs: compute-digest
     with:
       version: ${{ inputs.version }}
-      url    : 'https://github.com/scala/scala3/releases/download/${{ inputs.version }}/scala3-${{ inputs.version }}-x86_64-pc-win32.zip'
+      url    : 'https://github.com/${{ github.repository }}/releases/download/${{ inputs.version }}/scala3-${{ inputs.version }}-x86_64-pc-win32.zip'
       digest : ${{ needs.compute-digest.outputs.digest }}
   test-chocolatey:
     uses: ./.github/workflows/test-chocolatey.yml
@@ -66,6 +71,7 @@ jobs:
       java-version: 17
   publish-chocolatey:
     uses: ./.github/workflows/publish-chocolatey.yml
+    if: github.repository == 'scala/scala3'
     needs: [ build-chocolatey, test-chocolatey ]
     with:
       version: ${{ inputs.version }}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2638,6 +2638,12 @@ object Build {
     )
     .settings(
       Windows / name := "scala",
+      // Windows/packageName feeds the WiX core-feature id: WindowsPlugin truncates
+      // the sanitized id to its last 38 chars, and with the default long name
+      // (e.g. scala3-3.10.0-RC1-x86_64-pc-win32) the truncation can leave an id
+      // starting with a digit, which WiX rejects (error CNDL0014). A short stable
+      // name keeps the id legal and version-independent.
+      Windows / packageName := "scala3",
       // Windows/version is used to create ProductInfo - it requires a version without any -RC suffixes
       // If not explicitly overridden it would try to use `dottyVersion` assigned to `dist-win-x86_64/version`
       Windows / version    := developedVersion,

--- a/project/scripts/sbtPublish
+++ b/project/scripts/sbtPublish
@@ -8,8 +8,13 @@ set -e
 RELEASE_CMD="${1:?Missing publish command}"
 
 # Make sure required environment variable are set
-: "${SONATYPE_USER:?not set}"
-: "${SONATYPE_PW:?not set}"
+# Sonatype credentials are only used by sonaUpload. If run by itself, publishSigned
+# only stages locally so runs that only sign and don't push (like when you run in
+# a fork) don't need the Sonatype account creds.
+if [[ "$RELEASE_CMD" == *sonaUpload* ]]; then
+  : "${SONATYPE_USER:?not set}"
+  : "${SONATYPE_PW:?not set}"
+fi
 : "${PGP_PW:?not set}"
 : "${PGP_SECRET:?is not set}"
 


### PR DESCRIPTION
This PR updates the release process workflows to make them runnable on a user's fork.  Most of the changes center on three areas:

__1. Skip pushing to external channels (sonatype, etc)__
We introduce gates to check when the workflows are running on scala/scala3 and otherwise stop the execution of the publishing jobs.


__2. Running on GitHub runners when executed on a fork__
When running a user fork, the build runs on GitHUb public runners on the user's accoutn

__3. Not failing when official secrets and credentials are not present.__
If not running on `scala/scala3`, we now don't require secrets to be set.

It also introduces two small changes relevant to naming, in particular please check e8fb73b553bf47a80c96b8cf7bbd2d0a9450bad5 as this adds a small change in the scala code that computes the name of the windows package. I think it's right, but I would appreciate a second pair of eyes on it.


Next step after this will be [pinning all workflows](https://github.com/scala/scala3/issues/26594).

Fixes #26593

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

This is a refactor, but not of the scala code itself. 

This PR should does not modify the behavior of the workflows on scala/scala3, it only modifies the workflows to gate the publishing jobs and stops when the draft release is created. Here is a preview of the built artifacts:

https://github.com/puerco/scala3/releases/tag/untagged-e783dac20c87c0e81434
