### PR TITLE
Merge `test-repl-jdk` and `test-repl` CI workflows

### DIFF
--- a/.github/workflows/compiler-tests.yaml
+++ b/.github/workflows/compiler-tests.yaml
@@ -195,27 +195,10 @@ jobs:
   test-repl:
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
     runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 17
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Test REPL
-        run: ./project/scripts/sbt scala3-repl/test
-
-  test-repl-jdk:
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        jdk: [25, 26]
+        jdk: [17, 25, 26]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v7
@@ -232,10 +215,10 @@ jobs:
           java-version: 17
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
-      - name: Test REPL lazy vals warning and shading on JDK ${{ matrix.jdk }}
+      - name: Test REPL on JDK ${{ matrix.jdk }}
         env:
           DOTTY_REPL_TEST_JAVA_HOME: ${{ steps.jdk.outputs.path }}
-        run: ./project/scripts/sbt "scala3-repl/testOnly *LazyValsWarningTest *ShadingTest"
+        run: ./project/scripts/sbt scala3-repl/test
 
   test-presentation-compiler:
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')


### PR DESCRIPTION
There's actually no need to have separate `test-repl` and `test-repl-jdk` jobs.

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by running it on the CI here (how else?)

## How was the solution tested?
Covered by existing tests (this is a refactoring)
