### PR TITLE
fix: REPL crash on :dep after compiler queries

### DIFF
--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -738,32 +738,36 @@ class ReplDriver(settings: Array[String],
       out.println(s"""The :kind command is not currently supported.""")
       state
     case TypeOf(expr) =>
-      expr match {
-        case "" => out.println(s":type <expression>")
+      expr match
+        case "" =>
+          out.println(s":type <expression>")
+          state
         case _  =>
+          val queryState = newRun(state)
           try
-            compiler.typeOf(expr)(using newRun(state)).fold(
-              errs => displayErrors(errs, state),
+            compiler.typeOf(expr)(using queryState).fold(
+              errs => displayErrors(errs, queryState),
               res => out.println(res)  // result has some highlights
             )
           catch case NonFatal(ex) =>
             out.println(s"Error: ${ex.getMessage}")
-      }
-      state
+          queryState
 
     case DocOf(expr) =>
-      expr match {
-        case "" => out.println(s":doc <expression>")
+      expr match
+        case "" =>
+          out.println(s":doc <expression>")
+          state
         case _  =>
+          val queryState = newRun(state)
           try
-            compiler.docOf(expr)(using newRun(state)).fold(
-              errs => displayErrors(errs, state),
+            compiler.docOf(expr)(using queryState).fold(
+              errs => displayErrors(errs, queryState),
               res => out.println(res)
             )
           catch case NonFatal(ex) =>
             out.println(s"Error: ${ex.getMessage}")
-      }
-      state
+          queryState
 
     case Sh(expr) =>
       out.println(s"""The :sh command is deprecated. Use `import scala.sys.process._` and `"command".!` instead.""")
@@ -808,7 +812,8 @@ class ReplDriver(settings: Array[String],
         DependencyResolver.resolveDependencies(deps) match
           case Right(files) =>
             if files.nonEmpty then
-              inContext(state.context):
+              val classpathState = newRun(state)
+              inContext(classpathState.context):
                 val prevOutputDir = ctx.settings.outputDir.value
                 val prevClassLoader = rendering.classLoader()
                 rendering.myClassLoader = DependencyResolver.addToCompilerClasspath(
@@ -818,9 +823,11 @@ class ReplDriver(settings: Array[String],
                 )
                 val depsDescription = if deps.size == 1 then "a dependency" else s"${deps.size} dependencies"
                 out.println(s"Resolved $depsDescription (${files.size} JARs)")
+              classpathState
+            else state
           case Left(error) =>
             out.println(s"Error resolving dependencies: $error")
-        state
+            state
 
   /** shows all errors nicely formatted */
   private def displayErrors(errs: Seq[Diagnostic], state: State): State = {

--- a/repl/test/dotty/tools/repl/ReplClasspathUpdateTests.scala
+++ b/repl/test/dotty/tools/repl/ReplClasspathUpdateTests.scala
@@ -1,0 +1,29 @@
+package dotty.tools
+package repl
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class ReplClasspathUpdateTests extends ReplTest:
+  private def resolveOsLib()(using State): Unit =
+    run(":dep com.lihaoyi::os-lib:0.11.8")
+    assertEquals("Resolved a dependency (5 JARs)", storedOutput().trim)
+
+  @Test def `i26598 dep after type query does not crash`: Unit =
+    initially:
+      val stateAfterTypeQuery = run(":type 1")
+      storedOutput()
+      stateAfterTypeQuery.andThen:
+        resolveOsLib()
+
+  @Test def `i26598 dep after doc query does not crash`: Unit =
+    initially:
+      val stateAfterDocQuery = run(":doc 1")
+      storedOutput()
+      stateAfterDocQuery.andThen:
+        resolveOsLib()
+
+  @Test def `i26598 dep after tab completion does not crash`: Unit =
+    initially:
+      assertEquals(List("toString"), tabComplete("1.toStr"))
+      resolveOsLib()


### PR DESCRIPTION
Fixes #26598

`:type`, `:doc`, and tab completion created new compiler runs, but REPL kept a State from an older run. Then `:dep` tried to modify the classpath using the stale context, and that caused:
`Exception in thread "main" java.lang.AssertionError: assertion failed: denotation class TypeTest invalid in run 2. ValidFor: Period(3.1-5)`

The fix is to make `:type` and `:doc` return the new State, and `:dep` to create a fresh run before modifying the classpath.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by running included tests & testing manually with bin/replQ

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
