### PR TITLE
Fix coverage lifting across unsafeDiscardUses

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -851,6 +851,7 @@ class InstrumentCoverage extends MacroTransform with IdentityDenotTransformer:
       val sym = tree.symbol
       !sym.isOneOf(ExcludeMethodFlags)
       && !isCompilerIntrinsicMethod(sym)
+      && sym != defn.Caps_unsafeDiscardUses
       && !(sym.isClassConstructor && isSecondaryCtorDelegateCall(tree.fun))
       && !sym.name.is(DefaultGetterName) // https://github.com/scala/scala3/issues/20255
       && (tree.typeOpt match

--- a/tests/pos-custom-args/captures/coverage-mapops-contains-this.scala
+++ b/tests/pos-custom-args/captures/coverage-mapops-contains-this.scala
@@ -1,0 +1,32 @@
+//> using options -Yexplicit-nulls -Wsafe-init
+
+import scala.annotation.retains
+import scala.collection.{AbstractSet, IterableFactory, IterableOps, Set, View}
+import scala.language.experimental.captureChecking
+
+transparent trait MiniMapOps[K, +V, +C]
+extends IterableOps[(K, V), Iterable, C]
+  with PartialFunction[K, V]:
+  self: MiniMapOps[K, V, C]^ =>
+
+  override def view: View[(K, V)]^{this} = View.from(this)
+
+  def iterator: Iterator[(K, V)] = Iterator.empty
+  def iterableFactory: IterableFactory[Iterable] = Iterable
+  def get(key: K): Option[V]
+
+  def apply(key: K): V = get(key).get
+
+  protected trait GenKeySet @retains[MiniMapOps.this.type]():
+    this: Set[K] =>
+    def contains(key: K): Boolean =
+      scala.caps.unsafe.unsafeDiscardUses(MiniMapOps.this).contains(key)
+
+  def keySet: Set[K] = new AbstractSet[K] with GenKeySet:
+    def iterator: Iterator[K] = Iterator.empty
+    def diff(that: Set[K]): Set[K] = this
+
+  def contains(key: K): Boolean =
+    scala.caps.unsafe.unsafeDiscardUses(this.get(key)).isDefined
+
+  def isDefinedAt(key: K): Boolean = contains(key)


### PR DESCRIPTION
Fixes #26600

## Problem

`unsafeDiscardUses` is a method that discards the capture tracking of its argument.

Example usage (from the issue and test):

```scala
unsafeDiscardUses(this.get(key)).isDefined
```

With coverage, instrumentation lifts the argument of `unsafeDiscardUses`:

```scala
val op$1 = { Invoker.invoked(...); this.get(key) }
Invoker.invoked(...)
unsafeDiscardUses(op$1).isDefined
```

This moves `this.get(key)` outside the discarded-uses scope, thereby breaking the intended capture tracking contract.

## Solution

Do not instrument applications of the exact `defn.Caps_unsafeDiscardUses` symbol.
The argument is still recursively instrumented, but remains inside the intrinsic:

```scala
unsafeDiscardUses {
  Invoker.invoked(...)
  this.get(key)
}.isDefined
```

The tradeoff is to discard generating coverage data for `unsafeDiscardUses` itself, but that is acceptable since it does not containt business logic and is needed only to establish capture tracking contract.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by review and regression tests.

## How was the solution tested?

Added `tests/pos-custom-args/captures/coverage-mapops-contains-this.scala`, matching
the minimized reproducer.

```bash
sbt --client "testCompilation coverage-mapops-contains-this"
sbt --client "testCompilation --enable-coverage-phase coverage-mapops-contains-this"
sbt --client "testCompilation --enable-coverage-phase tests/pos-custom-args/captures"
```

The standard-library coverage compile no longer reports the `MapOps.contains` E223.

[test_coverage]