### PR TITLE
Backport "Fix generic signatures for inherited inner classes" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -237,7 +237,16 @@ object GenericSignatures {
               boxedSig(tp.widenDealias.widenNullaryMethod)
         }
 
-      pre.widenDealias match {
+      // when generating a java generic signature that includes
+      // a selection of an inner class p.I, (p = `pre`, I = `cls`) must
+      // rewrite to p'.I, where p' refers to the class that directly defines
+      // the nested class I. see:
+      // https://github.com/scala/scala3/issues/26532
+      // https://github.com/scala/bug/issues/2585
+      val reboundPre =
+        if pre.exists then pre.baseType(sym.owner)
+        else pre
+      reboundPre.widenDealias match {
         // If the class is an inner class of a generic class, we must emit the outer generic class with its parameters
         // (see test `inner-of-generic` for an example of Java compatibility)
         case RefOrAppliedType(preSym: ClassSymbol, prePre, preArgs) if preArgs.nonEmpty =>

--- a/tests/generic-java-signatures/i26532.check
+++ b/tests/generic-java-signatures/i26532.check
@@ -1,0 +1,1 @@
+public final i26532.Base<S, D>$Helper i26532.Impl.helper()

--- a/tests/generic-java-signatures/i26532/Definitions_1.scala
+++ b/tests/generic-java-signatures/i26532/Definitions_1.scala
@@ -1,0 +1,9 @@
+package i26532
+
+trait Base[S, D]:
+  final class Helper:
+    def identity(value: S): S = value
+
+  final def helper(): Helper = new Helper
+
+abstract class Impl[S, D] extends Base[S, D]

--- a/tests/generic-java-signatures/i26532/Test_3.scala
+++ b/tests/generic-java-signatures/i26532/Test_3.scala
@@ -1,0 +1,6 @@
+import i26532.Impl
+
+object Test:
+  def main(args: Array[String]): Unit =
+    val helper = classOf[Impl[?, ?]].getDeclaredMethod("helper")
+    println(helper.toGenericString)

--- a/tests/generic-java-signatures/i26532/Use_2.java
+++ b/tests/generic-java-signatures/i26532/Use_2.java
@@ -1,0 +1,7 @@
+package i26532;
+
+final class Use_2 {
+    void test(Impl<String, Integer> impl) {
+        String value = impl.helper().identity("ok");
+    }
+}


### PR DESCRIPTION
Backports #26549 to the 3.9.0-RC4.

PR submitted by the release tooling.
[skip ci]