### PR TITLE
Backport "Fix regression #26550: revert isPrimitiveValueType change" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeUtils.scala
@@ -20,19 +20,8 @@ class TypeUtils:
     def isErasedValueType(using Context): Boolean =
       self.isInstanceOf[ErasedValueType]
 
-    def isPrimitiveValueType(using Context): Boolean = self match
-      case tp: TypeRef =>
-        val sym = tp.symbol
-        if sym.isClass then sym.isPrimitiveValueClass
-        else tp.superType.isPrimitiveValueType
-      case tp: TypeProxy =>
-        tp.superType.isPrimitiveValueType
-      case tp: ClassInfo =>
-        tp.cls.isPrimitiveValueClass
-      case _ =>
-        // anything else definitely can't be one (e.g., AndType),
-        // so let's not waste time constructing a ClassSymbol
-        false
+    def isPrimitiveValueType(using Context): Boolean =
+      self.classSymbol.isPrimitiveValueClass
 
     /** Is this type a checked exception? This is the case if the type
      *  derives from Exception but not from RuntimeException. According to

--- a/tests/pos/i26550.scala
+++ b/tests/pos/i26550.scala
@@ -1,0 +1,2 @@
+class BitNumWrapper(val value: 0 | 1) extends AnyVal
+def positive(w: BitNumWrapper): Boolean = w.value > 0


### PR DESCRIPTION
Backports #26565 to the 3.9.0-RC4.

PR submitted by the release tooling.
[skip ci]