### PR TITLE
Backport "Skip unresolved annotation trees (during TASTy loading)" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
+++ b/compiler/src/dotty/tools/dotc/transform/MacroAnnotations.scala
@@ -27,6 +27,7 @@ object MacroAnnotations:
   extension (annot: Annotation)
     /** Is this an annotation that implements `scala.annation.MacroAnnotation` */
     def isMacroAnnotation(using Context): Boolean =
+      annot.symbol.exists &&
       annot.tree.symbol.maybeOwner.derivesFrom(defn.MacroAnnotationClass)
   end extension
 

--- a/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
+++ b/compiler/src/scala/quoted/runtime/impl/QuotesImpl.scala
@@ -3005,7 +3005,8 @@ class QuotesImpl private (using val ctx: Context) extends Quotes, QuoteUnpickler
         def annotations: List[Term] =
           self.denot.annotations.flatMap {
             case _: dotc.core.Annotations.BodyAnnotation => Nil
-            case annot => annot.tree :: Nil
+            case annot if annot.symbol.exists => annot.tree :: Nil
+            case _ => Nil
           }
 
         def isDefinedInCurrentRun: Boolean =

--- a/scaladoc/src/test/resources/missing-annotation/annotation.scala.txt
+++ b/scaladoc/src/test/resources/missing-annotation/annotation.scala.txt
@@ -1,0 +1,3 @@
+package ann
+
+class myannotation extends scala.annotation.StaticAnnotation

--- a/scaladoc/src/test/resources/missing-annotation/foo.scala.txt
+++ b/scaladoc/src/test/resources/missing-annotation/foo.scala.txt
@@ -1,0 +1,6 @@
+package foo
+
+@ann.myannotation
+class Foo:
+  @ann.myannotation
+  def value: String = "value"

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/MissingAnnotationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/MissingAnnotationTest.scala
@@ -1,0 +1,56 @@
+package dotty.tools.scaladoc
+package tasty
+
+import java.nio.file.{Files, Path, Paths}
+import org.junit.{Assert, Test}
+import dotty.tools.scaladoc.util.IO
+
+class MissingAnnotationTest:
+
+  private val javaClasspath = System.getProperty("java.class.path")
+
+  private def source(root: Path, name: String): Path =
+    val resource = getClass.getResource(s"/missing-annotation/$name.txt")
+    val source = root.resolve("sources").resolve(name)
+    Files.createDirectories(source.getParent)
+    Files.copy(Paths.get(resource.toURI), source)
+    source
+
+  private def compileStage(output: Path, classpath: Seq[Path], sources: Path*): Unit =
+    Files.createDirectories(output)
+    val compilerClasspath =
+      (classpath.map(_.toString) :+ javaClasspath).mkString(java.io.File.pathSeparator)
+    val reporter = new TestReporter
+    val result = dotty.tools.dotc.Main.process(
+      Array("-classpath", compilerClasspath, "-d", output.toString) ++ sources.map(_.toString),
+      reporter
+    )
+    Assert.assertFalse(
+      s"Compilation failed:\n${reporter.errors.result().map(_.msg.message).mkString("\n")}",
+      result.hasErrors
+    )
+
+  @Test
+  def ignoresUndocumentedAnnotationsMissingFromDocClasspath =
+    val root = Files.createTempDirectory("scaladoc-missing-annotation")
+    try
+      val annotationOutput = root.resolve("annotation")
+      compileStage(annotationOutput, Nil, source(root, "annotation.scala"))
+
+      val fooOutput = root.resolve("foo")
+      compileStage(fooOutput, Seq(annotationOutput), source(root, "foo.scala"))
+
+      // Run Scaladoc without annotation tasty
+      val ctx = testContext
+      val docOutput = root.resolve("doc").toFile
+      Scaladoc.run(
+        testArgs(Seq(fooOutput.resolve("foo/Foo.tasty").toFile), docOutput).copy(
+          classpath = Seq(fooOutput.toString, javaClasspath)
+            .mkString(java.io.File.pathSeparator)
+        )
+      )(using ctx)
+
+      val diagnostics = ctx.reportedDiagnostics
+      assertNoErrors(diagnostics)
+      assertNoWarning(diagnostics)
+    finally IO.delete(root.toFile)


### PR DESCRIPTION
Backports #26520 to the 3.9.0-RC4.

PR submitted by the release tooling.