### PR TITLE
[CI] Run scaladoc workflow only on modifications to docs or scaladoc

### DIFF
--- a/.github/workflows/scaladoc.yaml
+++ b/.github/workflows/scaladoc.yaml
@@ -8,6 +8,14 @@ on:
   pull_request:
     branches-ignore:
       - 'language-reference-stable'
+    paths:
+      - 'docs/**'
+      - 'scaladoc*/**'
+      - 'compiler/src/dotty/tools/dotc/reporting/**' # When error codes or messages are updated, we need to update the documentation
+      - 'project/scripts/checkSidebarDocs.scala'
+      - 'project/scripts/validateScaladocLinks.sh'
+      - 'project/scripts/checkErrorCodeSnippets*.scala'
+      - '.github/workflows/scaladoc.yaml'
   merge_group:
 permissions:
   contents: read


### PR DESCRIPTION
Limits execution of scaladoc workflow (validation of outputs, generation of reference docs, etc) - now we do execute that only if there are any changes to `docs`. 
We do also run it when there's are updates to reporting which mostly affects messages and error message ids, so we can force new error codes are up to date 

The scaladoc is still used by default in CI, mostly in stdlib docs build - that's the most important area to ensure that API docs are up to date, other jobs like building reference documentation are redundant