### PR TITLE
Fix coverage lifting of skolem-prefixed types

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -85,7 +85,7 @@ object LiftCoverage extends LiftImpure:
 
   /** Preserve precision for lifted coverage temps when widening would break later checks:
    *  compile-time constants and stable singleton types need their singleton precision,
-   *  and capture-converted types need their local TypeBox#CAP references.
+   *  and capture-converted or skolem-prefixed type selections need their local references.
    */
   override protected def liftedExprType(expr: tpd.Tree)(using Context): Type =
     val dealiased = expr.tpe.dealias
@@ -99,6 +99,10 @@ object LiftCoverage extends LiftImpure:
       case _: ConstantType => deskolemized
       case _ if dealiased.isInstanceOf[SingletonType] && dealiased.isStable => dealiased
       case _ if valueType.existsPart(_.typeSymbol == defn.TypeBox_CAP) => valueType
+      case _ if valueType.existsPart {
+        case ref: TypeRef => ref.prefix.isInstanceOf[SkolemType]
+        case _ => false
+      } => valueType
       case _ => super.liftedExprType(expr)
 
   private def markSelectedReceiverDef(

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -83,23 +83,10 @@ object LiftCoverage extends LiftImpure:
     if liftingArgs then noLiftArg(expr)
     else isUnsafeAssumeSeparate(expr) || super.noLift(expr)
 
-  /** Coverage lifting runs after type checking, so preserve the already valid type of
-   *  ordinary values. Methodic types and unstable singleton types still require the
-   *  usual lifting adaptation.
-   */
+  /** Coverage runs post-typer, so skip deskolemization and preserve valid skolems. */
   override protected def liftedExprType(expr: tpd.Tree)(using Context): Type =
-    val dealiased = expr.tpe.dealias
-    val valueType = dealiased match
-      case ref: TermRef if ref.prefix.exists && ref.underlying.isInstanceOf[ExprType] =>
-        ref.prefix.memberInfo(ref.symbol).widenExpr
-      case singleton: SingletonType if singleton.isStable =>
-        singleton
-      case _: SingletonType =>
-        NoType
-      case _ =>
-        expr.tpe
-    if valueType.isValueType then valueType
-    else super.liftedExprType(expr)
+    val tp = expr.tpe
+    if tp.isStable then tp else tp.widen
 
   private def markSelectedReceiverDef(
     defs: mutable.ListBuffer[tpd.Tree],

--- a/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InstrumentCoverage.scala
@@ -83,27 +83,23 @@ object LiftCoverage extends LiftImpure:
     if liftingArgs then noLiftArg(expr)
     else isUnsafeAssumeSeparate(expr) || super.noLift(expr)
 
-  /** Preserve precision for lifted coverage temps when widening would break later checks:
-   *  compile-time constants and stable singleton types need their singleton precision,
-   *  and capture-converted or skolem-prefixed type selections need their local references.
+  /** Coverage lifting runs after type checking, so preserve the already valid type of
+   *  ordinary values. Methodic types and unstable singleton types still require the
+   *  usual lifting adaptation.
    */
   override protected def liftedExprType(expr: tpd.Tree)(using Context): Type =
     val dealiased = expr.tpe.dealias
-    val deskolemized = dealiased.deskolemized
     val valueType = dealiased match
       case ref: TermRef if ref.prefix.exists && ref.underlying.isInstanceOf[ExprType] =>
         ref.prefix.memberInfo(ref.symbol).widenExpr
+      case singleton: SingletonType if singleton.isStable =>
+        singleton
+      case _: SingletonType =>
+        NoType
       case _ =>
-        dealiased
-    valueType.widenTermRefExpr.normalized.simplified match
-      case _: ConstantType => deskolemized
-      case _ if dealiased.isInstanceOf[SingletonType] && dealiased.isStable => dealiased
-      case _ if valueType.existsPart(_.typeSymbol == defn.TypeBox_CAP) => valueType
-      case _ if valueType.existsPart {
-        case ref: TypeRef => ref.prefix.isInstanceOf[SkolemType]
-        case _ => false
-      } => valueType
-      case _ => super.liftedExprType(expr)
+        expr.tpe
+    if valueType.isValueType then valueType
+    else super.liftedExprType(expr)
 
   private def markSelectedReceiverDef(
     defs: mutable.ListBuffer[tpd.Tree],

--- a/tests/pos-custom-args/captures/coverage-array-clone-skolem-type.scala
+++ b/tests/pos-custom-args/captures/coverage-array-clone-skolem-type.scala
@@ -1,0 +1,11 @@
+//> using options -Yexplicit-nulls -Wsafe-init -language:experimental.captureChecking
+
+abstract class ArrayCloneSeq[A]:
+  def array: Array[?]
+
+  def cloneArray: ArrayCloneSeq[A] =
+    ArrayCloneSeq.unsafeWrapArray(array.clone()).asInstanceOf[ArrayCloneSeq[A]]
+
+object ArrayCloneSeq:
+  def unsafeWrapArray[T](array: Array[T]): ArrayCloneSeq[T] =
+    null.asInstanceOf[ArrayCloneSeq[T]]


### PR DESCRIPTION
Fixes #26612

## Problem

Consider:

```scala
def array: Array[?]
ArrayCloneSeq.unsafeWrapArray(array.clone())
```

`array.clone()` has type `Array[?]`. With capture checking, on typechecking, the compiler resolves the unknown type via a skolem to: `Array[?1.T^'s1]`, where `?1` is a skolem of the unknown type of `array`, and `^'s1` refers to the unknown capture set that the unknown type carries.

Coverage instrumentation lifts that clone into a synthetic local variable:

```scala
val array$1: Array[?] = array.clone()
```

The type of that synthetic variable is computed incorrectly to `Array[?]^{}`, whereas `Array[?1.T^'s1]` is required, as precomputed by the typechecker, and therefor the typecheck of the lifted version fails:

```text
Found:    (array$1 : Array[?]^{})
Required: Array[?1.T^'s1]
```

## Solution

Preserve the precise type as computed by typing on coverage lifting when any part of that type involves a skolem at a prefix position of a `TypeRef`, i.e. of shape like `?1.T`.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by review and regression tests.

## How was the solution tested?

Added a new regression test `tests/pos-custom-args/captures/coverage-array-clone-skolem-type.scala`.

```bash
sbt --client "testCompilation coverage-array-clone-skolem-type"
sbt --client "testCompilation --enable-coverage-phase coverage-array-clone-skolem-type"
sbt --client "testCompilation --enable-coverage-phase tests/pos-custom-args/captures"
```

[test_coverage]