### PR TITLE
[chore] Use Scala 3.9.0-RC4 for reference version

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -12,7 +12,7 @@ object Versions {
    *
    *  Warning: Change of this variable needs to be consulted with `expectedTastyVersion`
    */
-  val referenceVersion = "3.9.0-RC3"
+  val referenceVersion = "3.9.0-RC4"
 
   /** Version of the Scala compiler targeted in the current release cycle
    *  Contains a version without RC/SNAPSHOT/NIGHTLY specific suffixes


### PR DESCRIPTION
Updates the reference version as part of release procedure