### PR TITLE
fix: ignore CDN preconnect in link checks

### DIFF
--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -1,5 +1,5 @@
 <link rel="dns-prefetch" href="//fonts.googleapis.com">
-<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin data-proofer-ignore>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="{{site.baseurl}}/css/dottydoc.css">
 


### PR DESCRIPTION
For some unknown reasons https://cdnjs.cloudflare.com/ started to respond with 301 instead of 200 (it applies only to the main page, e.g.: https://cdnjs.cloudflare.com/?v=6 works).

Since preconnect does not fetch any resources, in my opinion, we can exclude it from the link validation.

This change fixes failing `validate-generated-docs` test.

## Have you relied on LLM-based tools in this contribution?

Yes, to help identify the root cause.

## How was the solution tested?

Non-code change, no tests needed
