### PR TITLE
Add JDK 27 to supported versions

### DIFF
--- a/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
@@ -6,7 +6,7 @@ import Settings.Setting.ChoiceWithHelp
 object ScalaSettingsProperties:
 
   private val minTargetVersion = 17
-  private val maxTargetVersion = 26
+  private val maxTargetVersion = 27
   private val minReleaseVersion = 17
 
   def supportedTargetVersions: List[String] =


### PR DESCRIPTION
Support for the new [JDK 27](https://openjdk.org/projects/jdk/27/).

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
