### PR TITLE
Ignore 500- error status codes when validating links in docs, to filter out upstream failures

### DIFF
--- a/project/scripts/validateScaladocLinks.sh
+++ b/project/scripts/validateScaladocLinks.sh
@@ -41,8 +41,9 @@ IGNORE_URLS="${IGNORE_URLS},/dl.acm.org/"
 # nightlyOf links to potentially not yet existing pages
 IGNORE_URLS="${IGNORE_URLS},/docs.scala-lang.org\/scala3\/reference\//"
 
-# Status code 0 = timeouts, connection refused, DNS errors; ignore so CI does not flake
-IGNORE_STATUS_CODES="0"
+# Status code 0 = timeouts, connection refused, DNS errors; ignore so CI does not flake.
+# 502/503 = transient upstream errors (valid pages that occasionally fail under load).
+IGNORE_STATUS_CODES="0,502,503"
 
 # Takes too much time (~30 min) to validate all subdirs in api/scala; only package scala is checked
 IGNORE_FILES='/api\/scala\/[^/]+\//'


### PR DESCRIPTION
This is meant to fix some intermittent failures when we validate docs on the CI

Relevant failure at https://github.com/scala/scala3/pull/26580:
https://github.com/scala/scala3/actions/runs/30151034044/job/89667791748

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by running the flaky tests

## How was the solution tested?
Covered by existing tests
