### PR TITLE
Emit a super init call for primitives on the JVM

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -850,7 +850,13 @@ trait BCodeSkelBuilder extends BCodeHelpers {
         // we failed to emit the method header, no point in continuing
         return
 
-      if (!isAbstractMethod && !isNative) {
+      if mnode.name == BCodeUtils.INSTANCE_CONSTRUCTOR_NAME && claszSymbol.isPrimitiveValueClass then
+        // The JVM requires all classes' constructors to call a superclass constructor (or another of the class's constructors),
+        // which doesn't match our view of primitive value classes as special
+        mnode.visitVarInsn(asm.Opcodes.ALOAD, 0)
+        bc.invokespecial(ClassBType.javaLangObjectInternalName, mnode.name, mnode.desc, itf = false, dd)
+        bc.emitRETURN(UNIT)
+      else if !isAbstractMethod && !isNative then {
         // #14773 Reuse locals slots for tailrec-generated mutable vars
         val trimmedRhs: Tree =
           @tailrec def loop(stats: List[Tree]): List[Tree] =

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -774,7 +774,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
       if filteredSources.nonEmpty then
         val pool = JExecutors.newWorkStealingPool(threadLimit.getOrElse(Runtime.getRuntime.availableProcessors()))
         val timer = new Timer()
-        val logProgress = isInteractive && !suppressAllOutput
+        val logProgress = sourceCount > 1 && isInteractive && !suppressAllOutput
         val start = System.currentTimeMillis()
         if logProgress then
           timer.schedule((() => updateProgressMonitor(start)): TimerTask, 100/*ms*/, 200/*ms*/)

--- a/tests/run-bootstrapped/int.scala
+++ b/tests/run-bootstrapped/int.scala
@@ -1,0 +1,3 @@
+object Test:
+  def main(args: Array[String]): Unit =
+    Class.forName("scala.Int")


### PR DESCRIPTION
Fixes #26576

Since this is a JVM-specific requirement, I did it in the JVM backend. We could also change `Mixin.transformTemplate` to remove the special-casing of primitive value classes, but this would require other changes, and it seems wrong to, e.g., tell Scala.js to include a call to scala.AnyVal or j.l.Object's init in scala.Int's init.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
