### PR TITLE
Stop hiding errors in `GenericSignatureVisitor`

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -603,7 +603,13 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
       // value types. This is needed to fix #7416.
       null
     } else {
-      val jsOpt = GenericSignatures.javaSig(sym, memberTpe)
+      // We must ensure all classes used in generic signatures are known to the loader so they can later be resolved
+      // if necessary; and to do so, we must have a context with flattened names, because the callback is called with an erasure-time context.
+      // The one exception is `scala.Array`, which can end up in a signature like `class C extends T[Array]` with `trait T[C[_]]`.
+      val loadingCtx = ctx.withPhase(flattenPhase.next)
+      val jsOpt = GenericSignatures.javaSig(sym, memberTpe, c => {
+        if c != defn.ArrayClass then bTypeLoader.classBTypeFromSymbol(c)(using loadingCtx)
+      })
       if (jsOpt != null && ctx.settings.XverifySignatures.value) {
         verifySignature(sym, jsOpt.toString)
       }

--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -606,7 +606,7 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
       // We must ensure all classes used in generic signatures are known to the loader so they can later be resolved
       // if necessary; and to do so, we must have a context with flattened names, because the callback is called with an erasure-time context.
       // The one exception is `scala.Array`, which can end up in a signature like `class C extends T[Array]` with `trait T[C[_]]`.
-      val loadingCtx = ctx.withPhase(flattenPhase.next)
+      lazy val loadingCtx = ctx.withPhase(flattenPhase.next)
       val jsOpt = GenericSignatures.javaSig(sym, memberTpe, c => {
         if c != defn.ArrayClass then bTypeLoader.classBTypeFromSymbol(c)(using loadingCtx)
       })

--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -597,24 +597,17 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
   } // end of class JMirrorBuilder
 
   private def getGenericSignatureHelper(sym: Symbol, owner: Symbol, memberTpe: Type)(using Context): java.lang.StringBuilder | Null = {
-    val erasedTypeSym = TypeErasure.fullErasure(sym.denot.info).typeSymbol
-    if (erasedTypeSym.isPrimitiveValueClass) {
-      // Suppress signatures for symbols whose types erase in the end to primitive
-      // value types. This is needed to fix #7416.
-      null
-    } else {
-      // We must ensure all classes used in generic signatures are known to the loader so they can later be resolved
-      // if necessary; and to do so, we must have a context with flattened names, because the callback is called with an erasure-time context.
-      // The one exception is `scala.Array`, which can end up in a signature like `class C extends T[Array]` with `trait T[C[_]]`.
-      lazy val loadingCtx = ctx.withPhase(flattenPhase.next)
-      val jsOpt = GenericSignatures.javaSig(sym, memberTpe, c => {
-        if c != defn.ArrayClass then bTypeLoader.classBTypeFromSymbol(c)(using loadingCtx)
-      })
-      if (jsOpt != null && ctx.settings.XverifySignatures.value) {
-        verifySignature(sym, jsOpt.toString)
-      }
-      jsOpt
+    // We must ensure all classes used in generic signatures are known to the loader so they can later be resolved
+    // if necessary; and to do so, we must have a context with flattened names, because the callback is called with an erasure-time context.
+    // The one exception is `scala.Array`, which can end up in a signature like `class C extends T[Array]` with `trait T[C[_]]`.
+    lazy val loadingCtx = ctx.withPhase(flattenPhase.next)
+    val jsOpt = GenericSignatures.javaSig(sym, memberTpe, c => {
+      if c != defn.ArrayClass then bTypeLoader.classBTypeFromSymbol(c)(using loadingCtx)
+    })
+    if (jsOpt != null && ctx.settings.XverifySignatures.value) {
+      verifySignature(sym, jsOpt.toString)
     }
+    jsOpt
   }
 
   private def verifySignature(sym: Symbol, sig: String)(using Context): Unit = {

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -76,7 +76,7 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
     assert(
       classSym != defn.NothingClass && classSym != defn.NullClass,
       s"Cannot create ClassBType for special class symbol ${classSym.showFullName}")
-    assert(classSym != defn.ArrayClass || compilingArray, classSym)
+    assert(classSym != defn.ArrayClass || compilingArray, s"Found $classSym while compiling ${ctx.compilationUnit.source.file.name}")
     assert(!classSym.isPrimitiveValueClass || compilingPrimitive, s"Found $classSym while compiling ${ctx.compilationUnit.source.file.name}")
 
     classBType(classSym.javaBinaryName)(ct => createClassInfo(ct, classSym.asClass))
@@ -158,7 +158,7 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
       else t
     }
     assert(
-      if (classSym == defn.ObjectClass)
+      if (classSym == defn.ObjectClass || classSym == defn.AnyKindClass)
         superClassSym == NoSymbol
       else if (classSym.is(Trait))
         superClassSym == defn.ObjectClass
@@ -176,20 +176,6 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
     // if `C` inherits from `non-sealed A` which itself inherits from `sealed B permits A`, then having `C` inherit from `B` directly is illegal.
     val allBaseClasses = classSym.directlyInheritedTraits.iterator.flatMap(_.asClass.baseClasses.drop(1)).toSet
     val interfaces = classSym.directlyInheritedTraits.filter(!allBaseClasses(_)).map(classBTypeFromSymbol)
-
-    // We need to make sure the symbol->BType cache contains all classes, including unused type parameters that are only emitted in signatures,
-    // otherwise we won't be able to parse our own signatures when emitting inner class attributes.
-    // This bit of code could be removed if we collected inner class attributes as we emit code rather than at the end,
-    // and thus didn't need to parse the signatures we emit, but that adds its own complications.
-    def force(tp: Type) =
-      val argSym = tp.classSymbol
-      if argSym != NoSymbol && !argSym.isPrimitiveValueClass && !defn.NotRuntimeClasses.contains(argSym) && argSym != defn.ArrayClass then
-        classBTypeFromSymbol(argSym)
-    val unerasedParents = atPhase(erasurePhase) { classSym.info.parents }
-    unerasedParents.foreach {
-      case a @ AppliedType(_, args) => args.foreach(force)
-      case t => ()
-    }
 
     val flags = BCodeUtils.javaFlags(classSym)
 

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -10,10 +10,11 @@ import dotty.tools.dotc.core.Symbols.{ClassSymbol, NoSymbol, Symbol, defn}
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.toTermName
 import dotty.tools.dotc.core.Flags.{Final, JavaDefined, Method, ModuleClass, ModuleVal, PackageClass, Private, Trait}
-import dotty.tools.dotc.core.Phases.{Phase, erasurePhase, flattenPhase, lambdaLiftPhase, picklerPhase}
+import dotty.tools.dotc.core.Phases.{Phase, flattenPhase, lambdaLiftPhase, picklerPhase}
 import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.{StdNames, Types}
-import dotty.tools.dotc.core.Types.{AppliedType, JavaArrayType, Type, TypeRef, abstractTermNameFilter}
+import dotty.tools.dotc.core.Types.{JavaArrayType, Type, TypeRef, abstractTermNameFilter}
+import dotty.tools.dotc.util.EqHashMap
 
 import scala.annotation.tailrec
 import scala.tools.asm
@@ -23,6 +24,12 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
   // Concurrent map because stack map frames are computed when in the class writer, which
   // might run on multiple classes concurrently.
   private val classBTypeCache = new ConcurrentHashMap[InternalName, ClassBType]
+
+  // Cache only for `classBTypeFromSymbol`, since it is heavily called.
+  // Its values are all also values of the main cache.
+  // Does not need to be concurrent because that method takes a Context,
+  // and thus can only be called from the main thread anyway.
+  private val classBTypeCacheBySymbol = new EqHashMap[Symbol, ClassBType]
 
   /** Maps special symbols, including primitive types, to their corresponding BType. */
   // It's OK to cache this because all Contexts that go through here share their defns.
@@ -63,23 +70,27 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
   /**
    * The ClassBType for a class symbol `sym`.
    */
-  def classBTypeFromSymbol(classSym0: Symbol)(using Context): ClassBType = {
-    // For each java class, the scala compiler creates a class and a module (thus a module class).
-    // If the symbol is a java module class, we use the java class instead. This ensures that the
-    // ClassBType is created from the main class (instead of the module class).
-    // The two symbols have the same name, so the resulting internalName is the same.
-    val classSym = if classSym0.isAllOf(JavaDefined | ModuleClass, butNot = PackageClass)
-                   then classSym0.linkedClass
-                   else classSym0
+  def classBTypeFromSymbol(classSym0: Symbol)(using Context): ClassBType = classBTypeCacheBySymbol.get(classSym0) match {
+    case Some(t) => t
+    case None =>
+      // For each java class, the scala compiler creates a class and a module (thus a module class).
+      // If the symbol is a java module class, we use the java class instead. This ensures that the
+      // ClassBType is created from the main class (instead of the module class).
+      // The two symbols have the same name, so the resulting internalName is the same.
+      val classSym = if classSym0.isAllOf(JavaDefined | ModuleClass, butNot = PackageClass)
+                     then classSym0.linkedClass
+                     else classSym0
 
-    assert(classSym.isClass, s"Cannot create ClassBType from non-class symbol $classSym") // also covers the NoSymbol case
-    assert(
-      classSym != defn.NothingClass && classSym != defn.NullClass,
-      s"Cannot create ClassBType for special class symbol ${classSym.showFullName}")
-    assert(classSym != defn.ArrayClass || compilingArray, s"Found $classSym while compiling ${ctx.compilationUnit.source.file.name}")
-    assert(!classSym.isPrimitiveValueClass || compilingPrimitive, s"Found $classSym while compiling ${ctx.compilationUnit.source.file.name}")
+      assert(classSym.isClass, s"Cannot create ClassBType from non-class symbol $classSym") // also covers the NoSymbol case
+      assert(
+        classSym != defn.NothingClass && classSym != defn.NullClass,
+        s"Cannot create ClassBType for special class symbol ${classSym.showFullName}")
+      assert(classSym != defn.ArrayClass || compilingArray, s"Found $classSym while compiling ${ctx.compilationUnit.source.file.name}")
+      assert(!classSym.isPrimitiveValueClass || compilingPrimitive, s"Found $classSym while compiling ${ctx.compilationUnit.source.file.name}")
 
-    classBType(classSym.javaBinaryName)(ct => createClassInfo(ct, classSym.asClass))
+      val result = classBType(classSym.javaBinaryName)(ct => createClassInfo(ct, classSym.asClass))
+      classBTypeCacheBySymbol.update(classSym0, result)
+      result
   }
 
   def mirrorClassBTypeFromSymbol(moduleClassSym: Symbol)(using Context): ClassBType = {

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -135,8 +135,7 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
         previouslyConstructedClassBType(internalName).get.info.nestedClasses
 
       def getClassIfNested(internalName: InternalName): Option[ClassBType] = {
-        val c = previouslyConstructedClassBType(internalName).get
-        Option.when(c.isNestedClass)(c)
+        previouslyConstructedClassBType(internalName).filter(_.isNestedClass)
       }
 
       def raiseError(msg: String, sig: String, e: Option[Throwable]): Unit = {

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -135,10 +135,11 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
         previouslyConstructedClassBType(internalName).get.info.nestedClasses
 
       def getClassIfNested(internalName: InternalName): Option[ClassBType] =
-        // It's important to call `.get` here instead of using `.filter`,
-        // since a missing ClassBType means we did something wrong!
-        val c = previouslyConstructedClassBType(internalName).get
-        Option.when(c.isNestedClass)(c)
+        // A missing ClassBType here means we did something wrong!
+        previouslyConstructedClassBType(internalName) match
+          case Some(c) => if c.isNestedClass then Some(c) else None
+          case None =>
+            throw new AssertionError("Unknown name while collecting nested classes: " + internalName)
     }
     c.visit(classNode)
     (c.declaredInnerClasses, c.referredInnerClasses)
@@ -180,14 +181,14 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
     // otherwise we won't be able to parse our own signatures when emitting inner class attributes.
     // This bit of code could be removed if we collected inner class attributes as we emit code rather than at the end,
     // and thus didn't need to parse the signatures we emit, but that adds its own complications.
+    def force(tp: Type) =
+      val argSym = tp.classSymbol
+      if argSym != NoSymbol && !argSym.isPrimitiveValueClass && !defn.NotRuntimeClasses.contains(argSym) && argSym != defn.ArrayClass then
+        classBTypeFromSymbol(argSym)
     val unerasedParents = atPhase(erasurePhase) { classSym.info.parents }
     unerasedParents.foreach {
-      case AppliedType(_, args) => args.foreach(tp =>
-        val argSym = tp.classSymbol
-        if argSym != NoSymbol && !argSym.isPrimitiveValueClass && !defn.NotRuntimeClasses.contains(argSym) && argSym != defn.ArrayClass then
-          classBTypeFromSymbol(argSym)
-      )
-      case _ => ()
+      case a @ AppliedType(_, args) => args.foreach(force)
+      case t => ()
     }
 
     val flags = BCodeUtils.javaFlags(classSym)

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -134,13 +134,8 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
       def declaredNestedClasses(internalName: InternalName): List[ClassBType] =
         previouslyConstructedClassBType(internalName).get.info.nestedClasses
 
-      def getClassIfNested(internalName: InternalName): Option[ClassBType] = {
+      def getClassIfNested(internalName: InternalName): Option[ClassBType] =
         previouslyConstructedClassBType(internalName).filter(_.isNestedClass)
-      }
-
-      def raiseError(msg: String, sig: String, e: Option[Throwable]): Unit = {
-        // don't crash on invalid generic signatures
-      }
     }
     c.visit(classNode)
     (c.declaredInnerClasses, c.referredInnerClasses)

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -10,10 +10,10 @@ import dotty.tools.dotc.core.Symbols.{ClassSymbol, NoSymbol, Symbol, defn}
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.toTermName
 import dotty.tools.dotc.core.Flags.{Final, JavaDefined, Method, ModuleClass, ModuleVal, PackageClass, Private, Trait}
-import dotty.tools.dotc.core.Phases.{Phase, flattenPhase, lambdaLiftPhase, picklerPhase}
+import dotty.tools.dotc.core.Phases.{Phase, erasurePhase, flattenPhase, lambdaLiftPhase, picklerPhase}
 import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.{StdNames, Types}
-import dotty.tools.dotc.core.Types.{JavaArrayType, Type, TypeRef, abstractTermNameFilter}
+import dotty.tools.dotc.core.Types.{AppliedType, JavaArrayType, Type, TypeRef, abstractTermNameFilter}
 
 import scala.annotation.tailrec
 import scala.tools.asm
@@ -135,7 +135,10 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
         previouslyConstructedClassBType(internalName).get.info.nestedClasses
 
       def getClassIfNested(internalName: InternalName): Option[ClassBType] =
-        previouslyConstructedClassBType(internalName).filter(_.isNestedClass)
+        // It's important to call `.get` here instead of using `.filter`,
+        // since a missing ClassBType means we did something wrong!
+        val c = previouslyConstructedClassBType(internalName).get
+        Option.when(c.isNestedClass)(c)
     }
     c.visit(classNode)
     (c.declaredInnerClasses, c.referredInnerClasses)
@@ -172,6 +175,20 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
     // if `C` inherits from `non-sealed A` which itself inherits from `sealed B permits A`, then having `C` inherit from `B` directly is illegal.
     val allBaseClasses = classSym.directlyInheritedTraits.iterator.flatMap(_.asClass.baseClasses.drop(1)).toSet
     val interfaces = classSym.directlyInheritedTraits.filter(!allBaseClasses(_)).map(classBTypeFromSymbol)
+
+    // We need to make sure the symbol->BType cache contains all classes, including unused type parameters that are only emitted in signatures,
+    // otherwise we won't be able to parse our own signatures when emitting inner class attributes.
+    // This bit of code could be removed if we collected inner class attributes as we emit code rather than at the end,
+    // and thus didn't need to parse the signatures we emit, but that adds its own complications.
+    val unerasedParents = atPhase(erasurePhase) { classSym.info.parents }
+    unerasedParents.foreach {
+      case AppliedType(_, args) => args.foreach(tp =>
+        val argSym = tp.classSymbol
+        if argSym != NoSymbol && !argSym.isPrimitiveValueClass && !defn.NotRuntimeClasses.contains(argSym) && argSym != defn.ArrayClass then
+          classBTypeFromSymbol(argSym)
+      )
+      case _ => ()
+    }
 
     val flags = BCodeUtils.javaFlags(classSym)
 

--- a/compiler/src/dotty/tools/backend/jvm/BTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypes.scala
@@ -680,7 +680,7 @@ final case class ClassBType private(internalName: String) extends RefBType {
 
     assert(!ClassBType.isInternalPhantomType(internalName), s"Cannot create ClassBType for phantom type $this")
     assert(
-      if (info.superClass.isEmpty) { isJLO(this) || ClassBType.hasNoSuper(internalName) }
+      if (info.superClass.isEmpty) ClassBType.hasNoSuper(internalName)
       else if (isInterface) isJLO(info.superClass.get)
       else !isJLO(this) && ifInit(info.superClass.get)(!_.isInterface),
       s"Invalid superClass in $this: ${info.superClass}"
@@ -854,9 +854,9 @@ object ClassBType {
     }
   }
 
-  // Primitive classes have no super class. A ClassBType for those is only created when
-  // they are actually being compiled (e.g., when compiling scala/Boolean.scala).
   private val hasNoSuper = Set(
+    // Primitive classes have no super class. A ClassBType for those is only created when
+    // they are actually being compiled (e.g., when compiling scala/Boolean.scala).
     "scala/Unit",
     "scala/Boolean",
     "scala/Char",
@@ -865,7 +865,10 @@ object ClassBType {
     "scala/Int",
     "scala/Float",
     "scala/Long",
-    "scala/Double"
+    "scala/Double",
+    // java.lang.Object and scala.AnyKind have no super either
+    javaLangObjectInternalName,
+    "scala/AnyKind"
   )
 
   private val isInternalPhantomType = Set(

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -105,7 +105,6 @@ abstract class GenericSignatureVisitor(nestedOnly: Boolean) {
 
         while (current == '.') {
           skip()
-          assert(!names.isEmpty)
           names.append('$')
           appendUntil(names, isClassNameEnd)
           visitInternalName(names.toString)

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -90,7 +90,7 @@ abstract class GenericSignatureVisitor(nestedOnly: Boolean) {
           index += 1
         }
 
-        // OPT: avoid allocations when only a top-level class is encountered
+        // OPT: avoid allocations when collecting only nested classes and only a top-level class is encountered
         val topLevelIndex = index
         lazy val names = {
           val n = new java.lang.StringBuilder(32)

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -4,7 +4,6 @@ import scala.tools.asm.{Type, Handle}
 import scala.tools.asm.tree.*
 
 import scala.collection.mutable
-import scala.util.control.NoStackTrace
 import scala.annotation.*
 import scala.jdk.CollectionConverters.*
 import BTypes.InternalName
@@ -18,21 +17,19 @@ abstract class GenericSignatureVisitor(nestedOnly: Boolean) {
   final def visitInternalName(internalName: String): Unit = visitInternalName(internalName, 0, if (internalName eq null) 0 else internalName.length)
   def visitInternalName(internalName: String, offset: Int, length: Int): Unit
 
-  def raiseError(msg: String, sig: String, e: Option[Throwable] = None): Unit
-
   def visitClassSignature(sig: String): Unit = if (sig != null) {
     val p = new Parser(sig, nestedOnly)
-    p.safely { p.classSignature() }
+    p.classSignature()
   }
 
   def visitMethodSignature(sig: String): Unit = if (sig != null) {
     val p = new Parser(sig, nestedOnly)
-    p.safely { p.methodSignature() }
+    p.methodSignature()
   }
 
   def visitFieldSignature(sig: String): Unit = if (sig != null) {
     val p = new Parser(sig, nestedOnly)
-    p.safely { p.fieldSignature() }
+    p.fieldSignature()
   }
 
   private final class Parser(sig: String, nestedOnly: Boolean) {
@@ -40,27 +37,11 @@ abstract class GenericSignatureVisitor(nestedOnly: Boolean) {
     private var index = 0
     private val end = sig.length
 
-    private val Aborted: Throwable = new NoStackTrace { }
-    private def abort(): Nothing = throw Aborted
-
-    @inline def safely(f: => Unit): Unit = try f catch {
-      case Aborted =>
-      case e: Exception => raiseError(s"Exception thrown during signature parsing", sig, Some(e))
-    }
-
-    private def current = {
-      if (index >= end) {
-        raiseError(s"Out of bounds, $index >= $end", sig)
-        abort() // Don't continue, even if `notifyInvalidSignature` returns
-      }
+    private def current =
       sig.charAt(index)
-    }
 
     private def accept(c: Char): Unit = {
-      if (current != c) {
-        raiseError(s"Expected $c at $index, found $current", sig)
-        abort()
-      }
+      assert(current == c, s"Expected $c at $index, found $current, in $sig")
       index += 1
     }
 
@@ -71,13 +52,9 @@ abstract class GenericSignatureVisitor(nestedOnly: Boolean) {
       while (!isDelimiter(current)) { index += 1 }
     }
     private def skipUntilDelimiter(delimiter: Char): Unit = {
-      sig.indexOf(delimiter, index) match {
-        case -1 =>
-          raiseError(s"Out of bounds", sig)
-          abort() // Don't continue, even if `notifyInvalidSignature` returns
-        case i =>
-          index = i
-      }
+      val idx = sig.indexOf(delimiter, index)
+      assert(idx >= 0, s"Out of bounds finding $delimiter from $index in $sig")
+      index = idx
     }
 
     private def appendUntil(builder: java.lang.StringBuilder, isDelimiter: CharBooleanFunction): Unit = {
@@ -182,9 +159,8 @@ abstract class GenericSignatureVisitor(nestedOnly: Boolean) {
       }
     }
 
-    def fieldSignature(): Unit = if (sig != null) safely {
-      referenceTypeSignature()
-    }
+    def fieldSignature(): Unit =
+      if sig != null then referenceTypeSignature()
   }
 }
 

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -106,26 +106,31 @@ abstract class GenericSignatureVisitor(nestedOnly: Boolean) {
 
     @tailrec private def referenceTypeSignature(): Unit = getCurrentAndSkip() match {
       case 'L' =>
-        var names: java.lang.StringBuilder | Null = null
-
         val start = index
         var seenDollar = false
         while (!isClassNameEnd(current)) {
           seenDollar ||= current == '$'
           index += 1
         }
+
+        // OPT: avoid allocations when only a top-level class is encountered
+        val topLevelIndex = index
+        lazy val names = {
+          val n = new java.lang.StringBuilder(32)
+          n.append(sig, start, topLevelIndex)
+          n
+        }
+
         if ((current == '.' || seenDollar) || !nestedOnly) {
-          // OPT: avoid allocations when only a top-level class is encountered
-          names = new java.lang.StringBuilder(32)
-          names.append(sig, start, index)
           visitInternalName(names.toString)
         }
         typeArguments()
 
         while (current == '.') {
           skip()
-          names.nn.append('$')
-          appendUntil(names.nn, isClassNameEnd)
+          assert(!names.isEmpty)
+          names.append('$')
+          appendUntil(names, isClassNameEnd)
           visitInternalName(names.toString)
           typeArguments()
         }

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -31,10 +31,11 @@ object GenericSignatures {
    *
    *  @param sym0 The symbol for which to define the signature
    *  @param info The type of the symbol
+   *  @param onClassRef Invoked for every class whose name is written into the signature
    *  @return The signature if it could be generated, `null` otherwise.
    */
-  def javaSig(sym0: Symbol, info: Type)(using Context): StringBuilder | Null =
-    if mayNeedSignature(sym0, info) then atPhase(erasurePhase)(javaSig0(sym0, info))
+  def javaSig(sym0: Symbol, info: Type, onClassRef: ClassSymbol => Unit)(using Context): StringBuilder | Null =
+    if mayNeedSignature(sym0, info) then atPhase(erasurePhase)(javaSig0(sym0, info, onClassRef))
     else null
 
   private def mayNeedSignature(sym0: Symbol, info: Type)(using Context) = {
@@ -49,7 +50,7 @@ object GenericSignatures {
     else mayNeedSignature(info)
   }
 
-  private def javaSig0(sym0: Symbol, info: Type)(using Context): StringBuilder | Null = {
+  private def javaSig0(sym0: Symbol, info: Type, onClassRef: ClassSymbol => Unit)(using Context): StringBuilder | Null = {
     // This works as long as mangled names are always valid Java identifiers (see git history of this method).
     def sanitizeName(name: Name): String = name.mangledString
 
@@ -230,6 +231,8 @@ object GenericSignatures {
               // `tp` might be a singleton type referring to a getter.
               // Hence the widenNullaryMethod.
         }
+
+      onClassRef(sym)
 
       // when generating a java generic signature that includes
       // a selection of an inner class p.I, (p = `pre`, I = `cls`) must

--- a/compiler/test/dotty/tools/dotc/DeterminismTest.scala
+++ b/compiler/test/dotty/tools/dotc/DeterminismTest.scala
@@ -268,8 +268,6 @@ class DeterminismTest {
     test(List(code))
   }
 
-  // TODO: fix compiler determinism for this to pass
-  @Ignore("classfile member order and InnerClasses attribute differ under separate compilation, see scala/scala3#26552")
   @Test def testReferenceToInnerClassMadeNonPrivate(): Unit = {
     def code = List(
       source("t.scala",
@@ -331,6 +329,47 @@ class DeterminismTest {
           |object B {
           |  val m = summon[scala.deriving.Mirror.Of[CC]]
           |}
+          |""".stripMargin)
+    )
+    test(List(code))
+  }
+
+  /** A nested class referenced only from a generic signature must get its
+   *  InnerClasses entry regardless of separate compilation and file order (#26552).
+   */
+  @Test def testInnerClassesSignatureOnly(): Unit = {
+    def code = List(
+      source("a.scala",
+        """class A {
+          |  class B
+          |}
+          |""".stripMargin),
+      source("d.scala",
+        """class D {
+          |  def g: Option[A#B] = None
+          |}
+          |""".stripMargin)
+    )
+    test(List(code))
+  }
+
+  /** A static forwarder in a mirror class can carry the only signature
+   *  reference to a nested class in the run (#26552).
+   */
+  @Test def testInnerClassesStaticForwarder(): Unit = {
+    def code = List(
+      source("a.scala",
+        """class A {
+          |  class B
+          |}
+          |""".stripMargin),
+      source("base.scala",
+        """class Base {
+          |  def g: Option[A#B] = None
+          |}
+          |""".stripMargin),
+      source("o.scala",
+        """object O extends Base
           |""".stripMargin)
     )
     test(List(code))

--- a/tests/generic-java-signatures/t6344.check
+++ b/tests/generic-java-signatures/t6344.check
@@ -4,7 +4,7 @@ public <A> int C0.v1(int)
 public scala.collection.immutable.List C0.v2()
 public <A> scala.collection.immutable.List<Val<A>> C0.v2()
 public int C0.v3()
-public int C0.v3()
+public <A> int C0.v3()
 public int C0.v4(int,scala.collection.immutable.List)
 public <A extends java.lang.String> int C0.v4(int,scala.collection.immutable.List<Val<A>>)
 


### PR DESCRIPTION
Fixes #26575
Fixes #26618

scala/scala#5925 introduced this, with the reasonable expectation that there would be a fair number of bugs and preventing regressions was important.

Nearly a decade later, these concerns are less important since bugs have been flushed out, but hiding potential problems is a bigger deal. So let's remove it, and if something breaks in a rare edge case, we'll learn about it quickly.

Indeed, this fixes 2 separate bugs that were hidden by swallowing errors.

(Also, we still have the catch-all in the backend, so this won't crash the compiler either, just "Error while emitting...")

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
