### PR TITLE
Add more status codes to ignore when verifying links

### DIFF
--- a/project/scripts/validateScaladocLinks.sh
+++ b/project/scripts/validateScaladocLinks.sh
@@ -41,9 +41,8 @@ IGNORE_URLS="${IGNORE_URLS},/dl.acm.org/"
 # nightlyOf links to potentially not yet existing pages
 IGNORE_URLS="${IGNORE_URLS},/docs.scala-lang.org\/scala3\/reference\//"
 
-# Status code 0 = timeouts, connection refused, DNS errors; ignore so CI does not flake.
-# 502/503 = transient upstream errors (valid pages that occasionally fail under load).
-IGNORE_STATUS_CODES="0,502,503"
+# Status codes = timeouts, connection refused, DNS errors, transient upstream errors; ignore so CI does not flake.
+IGNORE_STATUS_CODES="0,301,502,503,520,521,522,523,524,530"
 
 # Takes too much time (~30 min) to validate all subdirs in api/scala; only package scala is checked
 IGNORE_FILES='/api\/scala\/[^/]+\//'


### PR DESCRIPTION
Some people like to timeout with a 301, apparently. 🤡 
Being paranoid here, as we'd like doc link validation to stop failing on flakes.
cc @odersky 

## Have you relied on LLM-based tools in this contribution?
No

## How was the solution tested?
Covered by existing tests
