### PR TITLE
Fix outline compilation with string interpolation

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Parsers.scala
@@ -109,7 +109,10 @@ object Parsers {
      *  If `t` does not have a span yet, set its span to the given one.
      */
     def atSpan[T <: Positioned](span: Span)(t: T): T =
-      if (t.span.isSourceDerived) t else t.withSpan(span.union(t.span))
+      if t.span.isSourceDerived then t
+      else t match
+        case tree: Tree if tree.isEmpty => t
+        case _ => t.withSpan(span.union(t.span))
 
     def atSpan[T <: Positioned](start: Offset, point: Offset, end: Offset)(t: T): T =
       atSpan(Span(start, end, point))(t)

--- a/compiler/test/dotty/tools/dotc/parsing/OutlineParserTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/OutlineParserTest.scala
@@ -20,14 +20,11 @@ class OutlineParserTest extends DottyTest {
   }
 
   @Test def `outline parser handles simple string interpolation`: Unit = {
-    // Simple $name works because it's just an identifier, not a block expression
     val code = """val x = s"hello $name""""
     parseOutline(code)
   }
 
   @Test def `outline parser handles string interpolation with block expression`: Unit = {
-    // This fails because ${...} is parsed as a block expression,
-    // and OutlineParser.blockExpr() returns EmptyTree
     val code = """val x = s"hello ${name.toString}""""
     parseOutline(code)
   }

--- a/compiler/test/dotty/tools/dotc/parsing/OutlineParserTest.scala
+++ b/compiler/test/dotty/tools/dotc/parsing/OutlineParserTest.scala
@@ -1,0 +1,51 @@
+package dotty.tools
+package dotc
+package parsing
+
+import ast.untpd.*
+import util.SourceFile
+import org.junit.Test
+
+class OutlineParserTest extends DottyTest {
+
+  def parseOutline(code: String): Tree = {
+    val source = SourceFile.virtual("<code>", code)
+    val parser = new Parsers.OutlineParser(source)
+    parser.parse()
+  }
+
+  @Test def `outline parser handles simple val`: Unit = {
+    val code = "val x = 42"
+    parseOutline(code)
+  }
+
+  @Test def `outline parser handles simple string interpolation`: Unit = {
+    // Simple $name works because it's just an identifier, not a block expression
+    val code = """val x = s"hello $name""""
+    parseOutline(code)
+  }
+
+  @Test def `outline parser handles string interpolation with block expression`: Unit = {
+    // This fails because ${...} is parsed as a block expression,
+    // and OutlineParser.blockExpr() returns EmptyTree
+    val code = """val x = s"hello ${name.toString}""""
+    parseOutline(code)
+  }
+
+  @Test def `outline parser handles raw string interpolation with complex expression`: Unit = {
+    // This is the actual failing case from compiler/test/dotty/tools/utils.scala
+    val code = """val toolArg = raw"(?://|/\*| \*) ?(?i:(${ToolName.values.mkString("|")})):((?:[^*]|\*(?!/))*)".r.unanchored"""
+    parseOutline(code)
+  }
+
+  @Test def `outline parser handles multiline string interpolation`: Unit = {
+    val tq = "\"\"\""
+    val code = s"""val x = s${tq}hello $${name.toString}${tq}"""
+    parseOutline(code)
+  }
+
+  @Test def `outline parser handles string interpolation with nested braces`: Unit = {
+    val code = """val x = s"result: ${list.map { x => x + 1 }.mkString}""""
+    parseOutline(code)
+  }
+}


### PR DESCRIPTION
Fixes issue previously tried with https://github.com/scala/scala3/pull/26348

The problem is that we got an empty tree with braces in outline compilation and we can't set any span there.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by running the tests. It's also very similar to my previous manual fix.

## How was the solution tested?

New automated tests 
