### PR TITLE
Remove misleading `Symbol.isPrivate`

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -9,7 +9,7 @@ import dotty.tools.backend.jvm.SymbolUtils.symExtensions
 import dotty.tools.dotc.core.Symbols.{ClassSymbol, NoSymbol, Symbol, defn}
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.toTermName
-import dotty.tools.dotc.core.Flags.{Final, JavaDefined, Method, ModuleClass, ModuleVal, PackageClass, Trait}
+import dotty.tools.dotc.core.Flags.{Final, JavaDefined, Method, ModuleClass, ModuleVal, PackageClass, Private, Trait}
 import dotty.tools.dotc.core.Phases.{Phase, flattenPhase, lambdaLiftPhase, picklerPhase}
 import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.{StdNames, Types}
@@ -353,7 +353,7 @@ final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Opt
     else
       val staticForwarders = if classSym.is(Trait) then
         // !!! This logic duplicates PlainSkelBuilder::makeStaticForwarder, copy changes there !!!
-        classSym.info.decls.filter(s => s.isTerm && !s.isPrivate && !s.isStaticMember && s.name != nme.TRAIT_CONSTRUCTOR).map(s => {
+        classSym.info.decls.filter(s => s.isTerm && !s.is(Private) && !s.isStaticMember && s.name != nme.TRAIT_CONSTRUCTOR).map(s => {
           SymbolUtils.makeStatifiedDefSymbol(s.asTerm, SymbolUtils.traitSuperAccessorName(s).toTermName)
         })
       else Nil

--- a/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
+++ b/compiler/src/dotty/tools/backend/sjs/JSExportsGen.scala
@@ -826,7 +826,7 @@ final class JSExportsGen(jsCodeGen: JSCodeGen)(using Context) {
     } else {
       if (sym.isClassConstructor)
         js.New(encodeClassName(currentClass), encodeMethodSym(sym), args)
-      else if (sym.isPrivate)
+      else if (sym.is(Private))
         boxIfNeeded(genApplyMethodStatically(receiver, sym, args))
       else
         boxIfNeeded(genApplyMethod(receiver, sym, args))

--- a/compiler/src/dotty/tools/debug/ExtractExpression.scala
+++ b/compiler/src/dotty/tools/debug/ExtractExpression.scala
@@ -335,7 +335,7 @@ private class ExtractExpression(
   private def isAccessibleMember(tree: Tree)(using Context): Boolean =
     val symbol = tree.symbol
     symbol.owner.isType &&
-    !symbol.isPrivate &&
+    !symbol.is(Private) &&
     !symbol.is(Protected) &&
     isTypeAccessible(widenDealiasQualifierType(tree))
 

--- a/compiler/src/dotty/tools/debug/ResolveReflectEval.scala
+++ b/compiler/src/dotty/tools/debug/ResolveReflectEval.scala
@@ -218,7 +218,7 @@ private class ResolveReflectEval(config: ExpressionCompilerConfig, expressionSto
         .filter(term => term.isField)
         .find { field =>
           field.name match
-            case DerivedName(underlying, _) if field.isPrivate =>
+            case DerivedName(underlying, _) if field.is(Private) =>
               underlying == originalName
             case DerivedName(DerivedName(_, info: QualifiedInfo), _) =>
               info.name == originalName

--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -197,13 +197,6 @@ object Symbols extends SymUtils {
     final def isClass: Boolean = isInstanceOf[ClassSymbol]
     final def asClass: ClassSymbol = asInstanceOf[ClassSymbol]
 
-    /** Test whether symbol is private. This
-     *  conservatively returns `false` if symbol does not yet have a denotation, or denotation
-     *  is a class that is not yet read.
-     */
-    final def isPrivate(using Context): Boolean =
-      lastDenot.flagsUNSAFE.is(Private)
-
     /** Is the symbol a pattern bound symbol?
      */
     final def isPatternBound(using Context): Boolean =
@@ -244,7 +237,7 @@ object Symbols extends SymUtils {
             if (this.is(Module)) this.moduleClass.validFor |= InitialPeriod
           }
           else owner.ensureFreshScopeAfter(phase)
-          assert(isPrivate || phase.changesMembers, i"$this entered in $owner at undeclared phase $phase")
+          assert(this.is(Private) || phase.changesMembers, i"$this entered in $owner at undeclared phase $phase")
           entered
         case _ => this
       }
@@ -265,7 +258,7 @@ object Symbols extends SymUtils {
       else {
         assert (!this.owner.is(Package))
         this.owner.asClass.ensureFreshScopeAfter(phase)
-        assert(isPrivate || phase.changesMembers, i"$this deleted in ${this.owner} at undeclared phase $phase")
+        assert(this.is(Private) || phase.changesMembers, i"$this deleted in ${this.owner} at undeclared phase $phase")
         drop()
       }
 

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -606,7 +606,7 @@ private[semanticdb] object ExtractSemanticDB:
         body.collect({
           case tree: ValDef
           if ctorParams.contains(tree.name)
-          && !tree.symbol.isPrivate =>
+          && !tree.symbol.is(Private) =>
             tree.name -> tree
         }).toMap
     end findGetters

--- a/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckShadowing.scala
@@ -221,7 +221,7 @@ object CheckShadowing:
       )
 
     private def lookForShadowedField(symDecl: Symbol)(using Context): Option[Symbol] =
-      if symDecl.isPrivate then
+      if symDecl.is(Private) then
         val symDeclType = symDecl.info
         val bClasses = symDecl.owner.info.baseClasses
         bClasses match


### PR DESCRIPTION
Follow-up to #26510

This method is too easy to misuse.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
