### PR TITLE
feat: support Java 25 main class discovery

### DIFF
--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -18,36 +18,23 @@ jobs:
   scripted-tests:
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [17, 25]
     steps:
       - name: Git Checkout
         uses: actions/checkout@v7
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.jdk }}
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: ${{ matrix.jdk }}
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Run SBT scripted tests
         run: ./project/scripts/sbt scala3-bootstrapped/scripted
-
-  main-discovery-tests-java-25:
-    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Git Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: 25
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Run main discovery tests
-        run: ./project/scripts/sbt "scala3-bootstrapped/scripted sbt-bridge/main-discovery sbt-bridge/main-discovery-scalajs"
 
   test-bisect-script:
     runs-on: ubuntu-latest

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -32,6 +32,23 @@ jobs:
       - name: Run SBT scripted tests
         run: ./project/scripts/sbt scala3-bootstrapped/scripted
 
+  main-discovery-tests-java-25:
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 25
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Run main discovery tests
+        run: ./project/scripts/sbt "scala3-bootstrapped/scripted sbt-bridge/main-discovery sbt-bridge/main-discovery-scalajs"
+
   test-bisect-script:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/misc-tests.yaml
+++ b/.github/workflows/misc-tests.yaml
@@ -16,12 +16,17 @@ env:
 jobs:
 
   scripted-tests:
+    name: scripted-tests (${{ matrix.jdk }})
     if: github.event_name != 'pull_request' || !contains(github.event.pull_request.body, '[skip ci]')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        jdk: [17, 25]
+        include:
+          - jdk: 17
+            command: scala3-bootstrapped/scripted
+          - jdk: 25
+            command: scala3-bootstrapped/scripted sbt-bridge/main-discovery sbt-bridge/main-discovery-scalajs
     steps:
       - name: Git Checkout
         uses: actions/checkout@v7
@@ -34,7 +39,7 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Run SBT scripted tests
-        run: ./project/scripts/sbt scala3-bootstrapped/scripted
+        run: ./project/scripts/sbt "${{ matrix.command }}"
 
   test-bisect-script:
     runs-on: ubuntu-latest

--- a/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/JavaPlatform.scala
@@ -10,6 +10,8 @@ import Flags.*
 import interactive.LogicalPackage
 import transform.ExplicitOuter
 
+import scala.util.Properties.isJavaAtLeast
+
 class JavaPlatform(precomputedSourcePackages: Option[LogicalPackage] = None) extends Platform {
 
   private var currentClassPath: Option[ClassPath] = None
@@ -23,10 +25,45 @@ class JavaPlatform(precomputedSourcePackages: Option[LogicalPackage] = None) ext
 
   // The given symbol is a method with the right name and signature to be a runnable java program.
   def isMainMethod(sym: Symbol)(using Context): Boolean =
-    (sym.name == nme.main) && (sym.info match {
-      case MethodTpe(_, defn.ArrayOf(el) :: Nil, restpe) => el =:= defn.StringType && restpe.isRef(defn.UnitClass)
+    sym.name == nme.main && isMainMethodType(sym.info, allowNoArgs = false)
+
+  private def isMainMethodType(info: Type, allowNoArgs: Boolean)(using Context): Boolean =
+    info match
+      case MethodTpe(_, parameters, resultType) if resultType.isRef(defn.UnitClass) =>
+        parameters match
+          case defn.ArrayOf(elementType) :: Nil => elementType =:= defn.StringType
+          case Nil => allowNoArgs
+          case _ => false
+      case ExprType(resultType) =>
+        allowNoArgs && resultType.isRef(defn.UnitClass)
       case _ => false
-    })
+
+  protected def supportsJava25MainClassDiscovery: Boolean = true
+
+  override def isMainClass(sym: ClassSymbol)(using Context): Boolean =
+    if supportsJava25MainClassDiscovery && isJavaAtLeast(25) then
+      sym.isStatic && !sym.isOneOf(AbstractOrTrait) && hasJava25Main(sym)
+    else super.isMainClass(sym)
+
+  private def hasJava25Main(sym: ClassSymbol)(using Context): Boolean =
+    sym.info.member(nme.main).hasAltWith: d =>
+      val main = d.symbol
+      !main.is(Private)
+        && isMainMethodType(main.info, allowNoArgs = true)
+        && isInvocableJava25Main(sym, main)
+
+  private def isInvocableJava25Main(owner: ClassSymbol, main: Symbol)(using Context): Boolean =
+    if isEmittedAsStaticMethod(main) then true
+    else if owner.is(Module) then main.isPublic
+    else hasInvocableNoArgConstructor(owner)
+
+  private def isEmittedAsStaticMethod(sym: Symbol)(using Context): Boolean =
+    sym.is(JavaStatic) || sym.isScalaStatic
+
+  private def hasInvocableNoArgConstructor(sym: ClassSymbol)(using Context): Boolean =
+    sym.info.member(nme.CONSTRUCTOR).hasAltWith: d =>
+      val constructor = d.symbol
+      !constructor.is(Private) && !constructor.info.takesParams
 
   def addToClassPath(cPath: ClassPath)(using Context): Unit = classPath match {
     case AggregateClassPath(entries) =>

--- a/compiler/src/dotty/tools/dotc/config/Platform.scala
+++ b/compiler/src/dotty/tools/dotc/config/Platform.scala
@@ -6,7 +6,7 @@ import io.{ClassPath, AbstractFile}
 import core.Contexts.*, core.Symbols.*
 import core.SymbolLoader
 import core.StdNames.nme
-import core.Flags.Module
+import core.Flags.{Module, Trait}
 
 /** The platform dependent pieces of Global.
  */
@@ -54,6 +54,10 @@ abstract class Platform {
   final def hasMainMethod(sym: Symbol)(using Context): Boolean =
     sym.info.member(nme.main).hasAltWith(d =>
       isMainMethod(d.symbol) && (sym.is(Module) || d.symbol.isStatic))
+
+  /** Is the given class symbol eligible to be reported as a main class? */
+  def isMainClass(sym: ClassSymbol)(using Context): Boolean =
+    sym.isStatic && !sym.is(Trait) && hasMainMethod(sym)
 
   /**
    * Whether instances of the class represented by the class symbol `c` **might** be a subtype of

--- a/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
+++ b/compiler/src/dotty/tools/dotc/config/SJSPlatform.scala
@@ -18,6 +18,8 @@ class SJSPlatform(precomputedSourcePackages: Option[LogicalPackage] = None) exte
   /** Scala.js-specific definitions. */
   val jsDefinitions: JSDefinitions = new JSDefinitions()
 
+  override protected def supportsJava25MainClassDiscovery: Boolean = false
+
   override def init()(using Context): Unit =
     jsDefinitions.init()
 

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -319,10 +319,8 @@ private class ExtractAPICollector(nonLocalClassSymbols: mutable.HashSet[Symbol])
     if !sym.isLocal then
       nonLocalClassSymbols += sym
 
-    if (sym.isStatic && !sym.is(Trait) && ctx.platform.hasMainMethod(sym)) {
-       // If sym is an object, all main methods count, otherwise only @static ones count.
+    if ctx.platform.isMainClass(sym) then
       _mainClasses += name
-    }
 
     api.ClassLikeDef.of(name, acc, modifiers, anns, tparams, defType)
   }

--- a/sbt-test/sbt-bridge/main-discovery-scalajs/build.sbt
+++ b/sbt-test/sbt-bridge/main-discovery-scalajs/build.sbt
@@ -1,0 +1,12 @@
+enablePlugins(ScalaJSPlugin)
+
+scalaVersion := sys.props("plugin.scalaVersion")
+
+val checkMainClasses = taskKey[Unit]("Checks the main classes discovered by the compiler bridge")
+
+checkMainClasses := {
+  val actual = (Compile / discoveredMainClasses).value.toSet
+  val expected = Set("runscala.MainScala")
+
+  assert(actual == expected, s"Expected $expected main classes, got $actual")
+}

--- a/sbt-test/sbt-bridge/main-discovery-scalajs/project/plugins.sbt
+++ b/sbt-test/sbt-bridge/main-discovery-scalajs/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.scalaJSVersion"))

--- a/sbt-test/sbt-bridge/main-discovery-scalajs/src/main/scala/Hello.scala
+++ b/sbt-test/sbt-bridge/main-discovery-scalajs/src/main/scala/Hello.scala
@@ -1,0 +1,10 @@
+package runscala
+
+object MainScala:
+  def main(args: Array[String]): Unit = ()
+
+class InstanceWithArgs:
+  def main(args: Array[String]): Unit = ()
+
+class InstanceNoArgs:
+  def main(): Unit = ()

--- a/sbt-test/sbt-bridge/main-discovery-scalajs/test
+++ b/sbt-test/sbt-bridge/main-discovery-scalajs/test
@@ -1,0 +1,1 @@
+> checkMainClasses

--- a/sbt-test/sbt-bridge/main-discovery/build.sbt
+++ b/sbt-test/sbt-bridge/main-discovery/build.sbt
@@ -1,0 +1,26 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+val checkMainClasses = taskKey[Unit]("Checks the main classes discovered by the compiler bridge")
+
+checkMainClasses := {
+  val actual = (Compile / discoveredMainClasses).value.toSet
+  val alwaysExpected = Set(
+    "runscala.MainScala",
+    "runscala.foo"
+  )
+  val fromJava25 = Set(
+    "runscala.InheritTrait",
+    "runscala.NoArgs",
+    "runscala.NoStatic",
+    "runscala.Parameterless",
+    "runscala.Protected",
+    "runscala.ProtectedStatic",
+    "runscala.SecondaryNoArgs",
+    "runscala.StaticNoArgs"
+  )
+  val expected =
+    if (scala.util.Properties.isJavaAtLeast("25")) alwaysExpected ++ fromJava25
+    else alwaysExpected
+
+  assert(actual == expected, s"Expected $expected main classes, got $actual")
+}

--- a/sbt-test/sbt-bridge/main-discovery/src/main/scala/Hello.scala
+++ b/sbt-test/sbt-bridge/main-discovery/src/main/scala/Hello.scala
@@ -1,0 +1,62 @@
+package runscala
+
+import scala.annotation.static
+
+@main def foo(): Unit = ()
+
+object MainScala:
+  def main(args: Array[String]): Unit = ()
+
+object StaticNoArgs:
+  def main(): Unit = ()
+
+object ProtectedObject:
+  protected def main(): Unit = ()
+
+class ProtectedStatic
+
+object ProtectedStatic:
+  @static protected def main(): Unit = ()
+
+class NoStatic:
+  def main(args: Array[String]): Unit = ()
+
+class NoArgs:
+  def main(): Unit = ()
+
+class Parameterless:
+  def main: Unit = ()
+
+class ConstructorArgument(message: String):
+  def main(): Unit = ()
+
+class PrivateConstructor private ():
+  def main(): Unit = ()
+
+class SecondaryNoArgs(message: String):
+  def this() = this("")
+  def main(): Unit = ()
+
+class Protected:
+  protected def main(): Unit = ()
+
+class Private:
+  private def main(): Unit = ()
+
+class Outer:
+  class Inner:
+    def main(): Unit = ()
+
+trait Tr:
+  def main(): Unit = ()
+
+class InheritTrait extends Tr
+
+abstract class Abstract:
+  def main(): Unit = ()
+
+class NonUnit:
+  def main(): Int = 1
+
+class ParameterlessNonUnit:
+  def main: Int = 1

--- a/sbt-test/sbt-bridge/main-discovery/test
+++ b/sbt-test/sbt-bridge/main-discovery/test
@@ -1,0 +1,1 @@
+> checkMainClasses


### PR DESCRIPTION
Fixes #25301

Forward port https://github.com/scala/scala/pull/11137 with a few minor changes/improvements:
- disabled new discovery for Scala.js (new main classses didn't work with scala.js)
- handles parameterless `def main: Unit`
- rejects main classes whose constructors require arguments
- rejects non-public object mains

### One known limitation for Scala Native (it also applies to 2.13.18):
cc @WojciechMazur 

```scala
class Session {
  def main(): Unit = {
    println("test")
  }
}
```
```
[error] Found 1 unreachable symbols!
[error] Unknown static method Session.main(java.lang.String[]): scala.runtime.BoxedUnit, referenced from:
[error] 
[info] Total (665 ms)
[error] Unreachable symbols found after classloading run. It can happen when using dependencies not cross-compiled for Scala Native or not yet ported JDK definitions.
[error] (Compile / nativeLink) Unreachable symbols found after classloading run. It can happen when using dependencies not cross-compiled for Scala Native or not yet ported JDK definitions.
```

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by reviewing and understanding every code change.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
