### PR TITLE
Add regression test for #10339

### DIFF
--- a/scaladoc-testcases/src/tests/functionDRI.scala
+++ b/scaladoc-testcases/src/tests/functionDRI.scala
@@ -17,9 +17,8 @@ def b(b: B) = 3
 // @targetName("c_a") def c(p: Seq[A]) = 6
 // @targetName("c_b") def c(p: Seq[B]) = 7
 
-// scala3 doc right now is not differentiating between fields and nested classlikes
-// class C(val b: Int):
-//   trait b
+class C(val b: Int):
+  trait b
 
 class D:
   trait b:

--- a/scaladoc/test/dotty/tools/scaladoc/linking/DriTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/linking/DriTest.scala
@@ -10,7 +10,7 @@ abstract class DriTest(testName: String) extends ScaladocTest(testName):
   def assertOnDRIs(dris: Seq[DRI]): Unit = ()
 
   override def runTest = withModule { module =>
-    val dris = module.members.keys.toSeq
+    val dris = collectFrom(module.rootPackage).map(_.dri)
 
     val grouping = dris.groupMapReduce(identity)(const(1))(_+_)
     val duplicates = grouping.filter { (_, v )=> v > 1 }


### PR DESCRIPTION
Fixes #10339

Enables the existing test for this issue, as the DRI clash no longer occurs.
Change from `module.members.keys.toSeq` to `collectFrom(module.rootPackage).map(_.dri)` was needed, because duplicates would be discarded while constructing the map. Thus the test would pass regardless of whether the issue was properly fixed.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
