### PR TITLE
Fix crash when `unapply` returns a Boolean-deriving opaque type

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -402,7 +402,7 @@ object PatternMatcher {
             if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(_, ref(scrutinee)))
             else caseAccessors.map(tupleSel)
           matchArgsPlan(components, args, onSuccess)
-        else if unappType.isRef(defn.BooleanClass) then
+        else if unappType.derivesFrom(defn.BooleanClass) then
           TestPlan(GuardTest, unapp, unapp.span, onSuccess)
         else
           letAbstract(unapp) { unappResult =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -185,7 +185,7 @@ object Applications {
     (0 until argsNum).map(i => if (i < arity - 1) selectorTypes(i) else elemTp).toList
   end seqSelectors
 
-  /** A utility class that matches results of unapplys with patterns. Two queriable members:
+  /** A utility class that matches results of unapplys with patterns. Two queryable members:
    *     val argTypes: List[Type]
    *     def typedPatterns(qual: untpd.Tree, typer: Typer): List[Tree]
    *  TODO: Move into Applications trait. No need to keep it outside. But it's a large
@@ -263,7 +263,7 @@ object Applications {
             case _ => None
         case _ => None
 
-    /** The computed argument types which will be the scutinees of the sub-patterns. */
+    /** The computed argument types which will be the scrutinees of the sub-patterns. */
     val argTypes: List[Type] =
       if unapplyName == nme.unapplySeq then
         unapplySeq(unapplyResult):

--- a/tests/pos/opaque-bool-as-unapply-result.scala
+++ b/tests/pos/opaque-bool-as-unapply-result.scala
@@ -1,0 +1,11 @@
+object Internal:
+  opaque type Foo <: Boolean = Boolean
+
+import Internal.*
+
+object Bar:
+  def unapply(arg: Int): Foo = ???
+
+@main def main =
+  1 match
+    case Bar() =>


### PR DESCRIPTION
Fixes #26655

The fixed line now matches the check at 
https://github.com/scala/scala3/blob/98a8f43de1e6b4ff78fbc550680092d94a764922/compiler/src/dotty/tools/dotc/typer/Applications.scala#L277
that determines whether to emit an error at that point or not.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
