### PR TITLE
Fix `Boolean` scaladoc to match other primitives re: extensions

### DIFF
--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -18,8 +18,7 @@ import scala.language.`2.13`
  *  subtype of [[scala.AnyVal]]. Instances of `Boolean` are not
  *  represented by an object in the underlying runtime system.
  *
- *  There is an implicit conversion from [[scala.Boolean]] => [[scala.runtime.RichBoolean]]
- *  which provides useful non-primitive operations.
+ *  The companion object provides useful non-primitive operations as extension methods.
  */
 final abstract class Boolean private extends AnyVal {
   /** Negates a Boolean expression.


### PR DESCRIPTION
Follow-up to #23872, noticed while doing something else.

The text now matches the doc of other primitives.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
