### PR TITLE
Disable `parboiled2` in community build

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -87,6 +87,7 @@ final case class SbtCommunityProject(
     sbtDocCommand: String = null,
     scalacOptions: List[String] = SbtCommunityProject.scalacOptions,
     override val environment: Map[String, String] = Map.empty,
+    sbtVersionOverride: Option[String] = None
   ) extends CommunityProject:
   override val binaryName: String = "sbt"
 
@@ -115,7 +116,7 @@ final case class SbtCommunityProject(
     val sbtProps = Option(System.getProperty("sbt.ivy.home")) match
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
-    extraSbtArgs ++ sbtProps ++ List("-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
+    extraSbtArgs ++ sbtProps ++ List("-sbt-version", sbtVersionOverride.getOrElse("1.12.1"), "-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
 
 object SbtCommunityProject:
   def scalacOptions = List(
@@ -690,6 +691,7 @@ object projects:
     sbtTestCommand = "parboiledCoreJVM3/test; parboiledJVM3/test",
     sbtPublishCommand = "publishLocal",
     scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Xcheck-macros"),
+    sbtVersionOverride = Some("2.0.4")
   )
 
 end projects

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -117,7 +117,7 @@ final case class SbtCommunityProject(
     val sbtProps = Option(System.getProperty("sbt.ivy.home")) match
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
-    extraSbtArgs ++ sbtProps ++ List("-Dsbt.supershell=false")
+    extraSbtArgs ++ sbtProps ++ List("-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
 
 object SbtCommunityProject:
   def scalacOptions = List(

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -11,8 +11,6 @@ lazy val compilerVersion: String =
   new String(Files.readAllBytes(file), UTF_8)
 
 lazy val sbtPluginFilePath: String =
-  // Workaround for https://github.com/sbt/sbt/issues/4395
-  new File(sys.props("user.home") + "/.sbt/1.0/plugins").mkdirs()
   communitybuildDir.resolve("sbt-injected-plugins").toAbsolutePath().toString()
 
 def log(msg: String) = println(Console.GREEN + msg + Console.RESET)

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -11,6 +11,8 @@ lazy val compilerVersion: String =
   new String(Files.readAllBytes(file), UTF_8)
 
 lazy val sbtPluginFilePath: String =
+  // Workaround for https://github.com/sbt/sbt/issues/4395
+  new File(sys.props("user.home") + "/.sbt/1.0/plugins").mkdirs()
   communitybuildDir.resolve("sbt-injected-plugins").toAbsolutePath().toString()
 
 def log(msg: String) = println(Console.GREEN + msg + Console.RESET)
@@ -87,7 +89,6 @@ final case class SbtCommunityProject(
     sbtDocCommand: String = null,
     scalacOptions: List[String] = SbtCommunityProject.scalacOptions,
     override val environment: Map[String, String] = Map.empty,
-    sbtVersionOverride: Option[String] = None
   ) extends CommunityProject:
   override val binaryName: String = "sbt"
 
@@ -116,7 +117,7 @@ final case class SbtCommunityProject(
     val sbtProps = Option(System.getProperty("sbt.ivy.home")) match
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
-    extraSbtArgs ++ sbtProps ++ List("-sbt-version", sbtVersionOverride.getOrElse("1.12.1"), "-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
+    extraSbtArgs ++ sbtProps ++ List("-sbt-version", "1.12.1", "-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
 
 object SbtCommunityProject:
   def scalacOptions = List(
@@ -686,13 +687,13 @@ object projects:
     scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Wsafe-init"),
   )
 
-  lazy val parboiled2 = SbtCommunityProject(
+  // Disabled because it requires SBT 2
+  /*lazy val parboiled2 = SbtCommunityProject(
     project = "parboiled2",
     sbtTestCommand = "parboiledCoreJVM3/test; parboiledJVM3/test",
     sbtPublishCommand = "publishLocal",
     scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Xcheck-macros"),
-    sbtVersionOverride = Some("2.0.4")
-  )
+  )*/
 
 end projects
 
@@ -773,7 +774,7 @@ def allProjects = List(
   projects.specs2,
   projects.spire,
   projects.http4s,
-  projects.parboiled2,
+  //projects.parboiled2,
 )
 
 lazy val projectMap = allProjects.groupBy(_.project)

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -117,7 +117,7 @@ final case class SbtCommunityProject(
     val sbtProps = Option(System.getProperty("sbt.ivy.home")) match
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
-    extraSbtArgs ++ sbtProps ++ List("-sbt-version", "1.12.1", "-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
+    extraSbtArgs ++ sbtProps ++ List("-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
 
 object SbtCommunityProject:
   def scalacOptions = List(

--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -117,7 +117,7 @@ final case class SbtCommunityProject(
     val sbtProps = Option(System.getProperty("sbt.ivy.home")) match
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
-    extraSbtArgs ++ sbtProps ++ List("-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
+    extraSbtArgs ++ sbtProps ++ List("-Dsbt.supershell=false")
 
 object SbtCommunityProject:
   def scalacOptions = List(

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -75,7 +75,7 @@ class CommunityBuildTestC:
   //@Test def onnxScala = projects.onnxScala.run()
   @Test def oslib = projects.oslib.run()
   // @Test def oslibWatch = projects.oslibWatch.run()
-  @Test def parboiled2 = projects.parboiled2.run()
+  //@Test def parboiled2 = projects.parboiled2.run()
   // Disabled because `javax.xml.bind` is not available since java 11
   // @Test def playJson = projects.playJson.run()
   @Test def pprint = projects.pprint.run()


### PR DESCRIPTION
CI is currently broken because parboiled2 expects SBT 2.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)