### PR TITLE
When bisecting, get nightlies both from Scala artifactory and from Maven Central

### DIFF
--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -15,6 +15,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import scala.util.Using
 
 val usageMessage = """
   |Usage:
@@ -231,13 +232,23 @@ object ReleasesRange:
 class Releases(val releases: Vector[Release])
 
 object Releases:
+  /* Nightlies used to be published to Maven Central and are published to the Artifactory nightlies
+   * repository since 2025-08. Neither repository holds the full history on its own, so both are queried. */
+  private val metadataUrls = Seq(
+    "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/maven-metadata.xml",
+    "https://repo.scala-lang.org/artifactory/maven-nightlies/org/scala-lang/scala3-compiler_3/maven-metadata.xml"
+  )
+
   lazy val allReleases: Vector[Release] =
     val re = raw"<version>(.+-bin-\d{8}-\w{7}-NIGHTLY)</version>".r
-    val xml = io.Source.fromURL(
-      "https://repo.scala-lang.org/artifactory/maven-nightlies/org/scala-lang/scala3-compiler_3/maven-metadata.xml"
-    )
-    re.findAllMatchIn(xml.mkString)
-      .flatMap{ m => Option(m.group(1)).map(Release.apply) }
+    metadataUrls
+      .flatMap: url =>
+        val xml =
+          try Using.resource(Source.fromURL(url))(_.mkString)
+          catch case ex: Exception => sys.error(s"Could not fetch the list of nightly releases from ${url}: ${ex}")
+        re.findAllMatchIn(xml).map(_.group(1))
+      .distinct
+      .map(Release.apply)
       .toVector
       .sortBy: release =>
         (release.semanticVersion, release.date)

--- a/project/scripts/bisect.test.scala
+++ b/project/scripts/bisect.test.scala
@@ -148,3 +148,21 @@ class BisectOptionsTest extends munit.FunSuite:
     val compileIdx = body.indexOf("scala-cli compile")
     assert(cleanIdx >= 0 && compileIdx > cleanIdx)
   }
+
+class BisectReleasesTest extends munit.FunSuite:
+  // Maven Central holds older nightlies; Artifactory nightlies has builds since ~2025-08.
+  // Both must be queried so ranges spanning the migration remain usable.
+  private val mavenCentralNightly = "3.4.1-RC1-bin-20240125-453658b-NIGHTLY"
+  private val artifactoryNightly = "3.10.0-RC1-bin-20260729-8526f78-NIGHTLY"
+
+  test("nightly releases include Maven Central and Artifactory nightlies") {
+    val versions = Releases.allReleases.map(_.version).toSet
+    assert(versions.contains(mavenCentralNightly), s"missing Maven Central nightly: $mavenCentralNightly")
+    assert(versions.contains(artifactoryNightly), s"missing Artifactory nightly: $artifactoryNightly")
+  }
+
+  test("releases range spanning Maven Central and Artifactory nightlies") {
+    val releases = Releases.fromRange(ReleasesRange(Some(mavenCentralNightly), Some(artifactoryNightly)))
+    assertEquals(releases.head.version, mavenCentralNightly)
+    assertEquals(releases.last.version, artifactoryNightly)
+  }


### PR DESCRIPTION
Theoretically, repo.scala-lang.org serves as a proxy to Maven Central for old Scala nightlies.
However, it seems that at times I can't get all the nightly versions this way.
As the `bisect.sc` script is the main consumer of pre-3.8 nightlies anyway, I think it's fine to just fetch from both here to make it more reliable.

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by running the bisect script on an actual issue reproduction

## How was the solution tested?
New automated tests + testing it out on an old regression
