### PR TITLE
Disable bogus Scaladoc warnings

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/SiteRenderer.scala
@@ -77,7 +77,9 @@ trait SiteRenderer(using DocContext) extends Locations:
         .orElse(asStaticSite)
         .orElse(asAsset)
         .getOrElse {
-          if (!summon[DocContext].args.noLinkAssetWarnings){
+          // Disabled. This feature is currently so broken as to be effectively useless,
+          // For instance, it fails as soon as there is a slash, or a link to a redirect.
+          if (false && !summon[DocContext].args.noLinkAssetWarnings){
             val msg = s"Unable to resolve link '$str'"
             report.warn(msg, content.template.templateFile.file)
           }

--- a/scaladoc/src/dotty/tools/scaladoc/site/StaticSiteLoader.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/StaticSiteLoader.scala
@@ -44,8 +44,9 @@ class StaticSiteLoader(val root: File, val args: Scaladoc.Args)(using StaticSite
       .filter(_.exists)
       .fold(emptyTemplate(rootDest, "index")) { f =>
         val loaded = loadTemplateFile(f)
-        if loaded.title.name != "index"
-        then report.warn("Property `title` will be overridden by project name", f)
+        // This does not work for pages that are set as index from the sidebar...
+        //if loaded.title.name != "index"
+        //then report.warn("Property `title` will be overridden by project name", f)
         loaded
       }.copy(title = TemplateName.FilenameDefined(args.name))
 


### PR DESCRIPTION
Fixes #22960

Better to disable broken functionality than emit nonsensical warnings. Ideally we'd make it work but that would require a lot of restructuring; the link checking needs a proper representation of files, and the "title attribute will be overridden" one requires more info than is available at that point...

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Ran `scaladoc/publishLocal` in SBT and saw only one warning left about redefining the classpath; I'm not sure why we do that but I don't have time to look deeply into it.
