### PR TITLE
Fix capture checker crash when mapping a Var capture set

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -393,8 +393,9 @@ sealed abstract class CaptureSet extends Showable:
    *      the same transformation is applied to all future additions of new elements.
    *      We try to fuse with previous maps to avoid long paths of BiTypeMapped sets.
    *    - If the map is a BiTypeMap, and CCState.mapVars is false,
-   *      we return the original capture set. In this case any elements that are
-   *      already in the set must be invariant under the mapping. This mode is
+   *      return the original capture set if all current elements are invariant
+   *      under the mapping; otherwise freeze the set (i.e. make it provisionally
+   *      solved) and return the mapped elements as a constant set,  This mode is
    *      necessary for bootstrap when we create capset variables the first time.
    *    - If the map is some other map that maps the current set of elements
    *      to itself, return the current var. We implicitly assume that the map
@@ -424,9 +425,13 @@ sealed abstract class CaptureSet extends Showable:
               case Some(fused: BiTypeMap) => BiMapped(self.source, fused, mappedElems)
               case _ => unfused
             case _ => unfused
+        else if mappedElems == elems then this
         else
-          assert(mappedElems == elems)
-          this
+          // The map changes existing elements but cannot be installed for future
+          // additions (mapVars == false). Freeze the set and return the mapped
+          // elements as a constant set.
+          asVar.markSolved(provisional = true)
+          Const(mappedElems)
       case tm: IdentityCaptRefMap =>
         this
       case tm: AvoidMap if this.isInstanceOf[HiddenSet] =>

--- a/tests/neg-custom-args/captures/sep-dependent-any.scala
+++ b/tests/neg-custom-args/captures/sep-dependent-any.scala
@@ -1,0 +1,24 @@
+import language.experimental.captureChecking
+import language.experimental.separationChecking
+import caps.*
+
+// Neg variant of the `sep-dependent-any` regression test: instantiating the
+// dependent capture set `{any, f}` with an argument whose capture set is still
+// a variable must not crash; the underlying separation errors should be
+// reported gracefully.
+
+class Ref extends Mutable:
+  private var data: Int = 0
+  def get: Int = data
+  update def set(x: Int): Unit = data = x
+
+def seq(f: () => Unit, g: () ->{any, f} Unit): Unit = ()
+
+def test1(a: Ref) =
+  seq(() => a.set(1), () => ()) // error: cannot call update method on read-only `a`
+
+def test2(a: Ref) =
+  seq(() => (), () => a.set(1)) // error: same, in the dependent position
+
+def test3(a: Ref) =
+  seq(() => a.set(1), () => a.set(2)) // error // error

--- a/tests/pos-custom-args/captures/sep-dependent-any.scala
+++ b/tests/pos-custom-args/captures/sep-dependent-any.scala
@@ -1,0 +1,37 @@
+import language.experimental.captureChecking
+import language.experimental.separationChecking
+import caps.*
+
+// Regression test: a dependent capture set containing `any`, like the
+// `{any, f}` below, used to crash CheckCaptures. When the call was rechecked,
+// the dependent parameter `f` was substituted by the first argument's capture
+// set, which was still a variable. The substitution produced a `Union`
+// variable containing `any`, and mapping it with `GlobalCapToLocal` (under
+// `withNoVarsMapped`) tripped an assertion in `CaptureSet.map`.
+
+class Ref extends Mutable:
+  private var data: Int = 0
+  def get: Int = data
+  update def set(x: Int): Unit = data = x
+
+def seq(f: () => Unit, g: () ->{any, f} Unit): Unit = ()
+
+def test1() =
+  val a = Ref()
+  seq(() => a.set(10), () => println(s"value: ${a.get}"))
+
+def test2() =
+  val a = Ref()
+  seq(() => a.set(10), () => a.set(20)) // both closures capture the same ref
+
+def test3() =
+  val a = Ref()
+  val b = Ref()
+  seq(() => a.set(1), () => b.set(2)) // each closure captures its own ref
+  seq(() => (), () => a.set(3))       // first closure captures nothing
+
+def seq3(f: () => Unit, g: () => Unit, h: () ->{any, f, g} Unit): Unit = ()
+
+def test4() =
+  val a = Ref()
+  seq3(() => a.set(1), () => (), () => a.set(2)) // set depending on two parameters


### PR DESCRIPTION
A dependent capture set such as `{any, f}` becomes a `Union` variable containing `any` when `f` is instantiated with an argument whose capture set is still a variable. When such a var is later mapped by a BiTypeMap under `withNoVarsMapped` (e.g. `GlobalCapToLocal` in `CheckCaptures.recheckArg`), the map changes existing elements, which tripped the assertion in `CaptureSet.map` that required the map to be element-identity in this mode.

Fixes #26649.

## Have you relied on LLM-based tools in this contribution?

Yes, the crash was investigated and fixed by Kimi K3. I checked the changes with my brain. It looks reasonable to me, but I am no way an expert in capture inference.

## How was the solution tested?

New automated tests
