### PR TITLE
Avoid saying Dotty in user-facing contexts

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/Typer.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Typer.scala
@@ -4915,14 +4915,14 @@ class Typer(@constructorOnly nestingLevel: Int = 0) extends Namer
                 tree.symbol != defn.StringContext_f &&
                 tree.symbol != defn.StringContext_s)
           if (ctx.settings.XignoreScala2Macros.value) {
-            report.warning("Scala 2 macro cannot be used in Dotty, this call will crash at runtime. See https://docs.scala-lang.org/scala3/reference/dropped-features/macros.html", tree.srcPos.startPos)
+            report.warning("Scala 2 macro cannot be used in Scala 3, this call will crash at runtime. See https://docs.scala-lang.org/scala3/reference/dropped-features/macros.html", tree.srcPos.startPos)
             Throw(New(defn.MatchErrorClass.typeRef, Literal(Constant(s"Reached unexpanded Scala 2 macro call to ${tree.symbol.showFullName} compiled with -Xignore-scala2-macros.")) :: Nil))
               .withType(tree.tpe)
               .withSpan(tree.span)
           }
           else {
             report.error(
-              em"""Scala 2 macro cannot be used in Dotty. See https://docs.scala-lang.org/scala3/reference/dropped-features/macros.html
+              em"""Scala 2 macro cannot be used in Scala 3. See https://docs.scala-lang.org/scala3/reference/dropped-features/macros.html
                   |To turn this error into a warning, pass -Xignore-scala2-macros to the compiler""",
               tree.srcPos.startPos)
             tree

--- a/docs/_docs/reference/metaprogramming/macros.md
+++ b/docs/_docs/reference/metaprogramming/macros.md
@@ -325,7 +325,7 @@ The result will reference a variable that is defined in the next stage.
 ```
 
 To catch both scope extrusion scenarios, our system restricts the use of quotes by only allowing a quote to be spliced if it was not extruded from a splice scope.
-Unlike level consistency, this is checked at run-time[^4] rather than compile-time to avoid making the static type system too complicated.
+Unlike level consistency, this is checked at run-time[^3] rather than compile-time to avoid making the static type system too complicated.
 
 Each `Quotes` instance contains a unique scope identifier and refers to its parent scope, forming a stack of identifiers.
 The parent of the scope of a `Quotes` is the scope of the `Quotes` used to create the enclosing quote.
@@ -631,5 +631,4 @@ def setForExpr[T: Type]()(using Quotes): Expr[Set[T]] =
 
 [^1]: [Scalable Metaprogramming in Scala 3](https://infoscience.epfl.ch/record/299370)
 [^2]: [Semantics-preserving inlining for metaprogramming](https://dl.acm.org/doi/10.1145/3426426.3428486)
-[^3]: Implemented in the Scala 3 Dotty project https://github.com/lampepfl/dotty. sbt library dependency `"org.scala-lang" %% "scala3-staging" % scalaVersion.value`
-[^4]: Using the `-Xcheck-macros` compiler flag
+[^3]: Using the `-Xcheck-macros` compiler flag


### PR DESCRIPTION
Just a couple lingering "Dotty"s I happened to notice...

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed