### PR TITLE
Fix Enumeration.ValueSet.iteratorFrom for negative IDs

### DIFF
--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -315,7 +315,13 @@ abstract class Enumeration (initial: Int) extends Serializable {
     def incl (value: Value): ValueSet = new ValueSet(nnIds + (value.id - bottomId))
     def excl (value: Value): ValueSet = new ValueSet(nnIds - (value.id - bottomId))
     def iterator: Iterator[Value] = nnIds.iterator map (id => thisenum.apply(bottomId + id))
-    override def iteratorFrom(start: Value): Iterator[Value] = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
+    /** Returns an iterator over the values in this set whose ids are greater than or equal to
+     *  that of `start`, in increasing order of their ids.
+     *
+     *  @param start the inclusive lower bound for the values to return
+     */
+    override def iteratorFrom(start: Value): Iterator[Value] =
+      nnIds.iteratorFrom(start.id - bottomId).map(id => thisenum.apply(bottomId + id))
     override def className: String = s"$thisenum.ValueSet"
     /** Creates a bit mask for the zero-adjusted ids in this set as a
      *  new array of longs 

--- a/library/test/scala/EnumerationTest.scala
+++ b/library/test/scala/EnumerationTest.scala
@@ -23,4 +23,11 @@ class EnumerationTest {
     }
     assertSame(Ordering[MyEnum.Value], MyEnum.ValueOrdering)
   }
+
+  @Test def iteratorFromWithNegativeValueIds(): Unit = {
+    object NegativeIds extends Enumeration(-2) {
+      val first, second, third = Value
+    }
+    assertEquals(List(NegativeIds.second, NegativeIds.third), NegativeIds.values.iteratorFrom(NegativeIds.second).toList)
+  }
 }


### PR DESCRIPTION
## Summary

Fix `Enumeration.ValueSet.iteratorFrom` for enumerations with negative value IDs.

`ValueSet` stores IDs offset by the enumeration’s lowest ID. `iteratorFrom` previously passed the raw ID to the underlying bit set, which could include values below the requested start value. The implementation now applies the same offset used when storing IDs.

Adds Scaladoc for `iteratorFrom` and a regression test covering an enumeration starting at `-2`.

## Testing

- `sbt --client "scala-library-nonbootstrapped/testOnly scala.collection.EnumerationTest"`

## AI assistance

I used an LLM to help analyze the issue and draft the change. I reviewed the implementation and test, reproduced the failure before the fix, and verified that the focused test passes after it.