### PR TITLE
bisect: do smarter handling for broken builds, and other tweaks

### DIFF
--- a/project/scripts/bisect.scala
+++ b/project/scripts/bisect.scala
@@ -315,37 +315,123 @@ class ReleaseBisect(validationScript: File, shouldFail: Boolean, allReleases: Ve
       isGood
     })
 
-class CommitBisect(validationScript: File, shouldFail: Boolean, bootstrapped: Boolean, lastGoodHash: String, firstBadHash: String):
-  def bisect(): Unit =
-    println(s"Starting bisecting commits $lastGoodHash..$firstBadHash\n")
-    val scala3CompilerProject = if bootstrapped then "scala3-compiler-bootstrapped" else "scala3-compiler"
+/** What the build-and-validate script should do when the compiler cannot be built. */
+enum BuildFailureAction(val exitCode: Int):
+  /** Tell `git bisect run` that this commit cannot be tested. */
+  case SkipCommit extends BuildFailureAction(CommitBisectScripts.skipExitCode)
+  /** Abort, because there is no bisection in progress that could skip the commit. */
+  case AbortBisect extends BuildFailureAction(CommitBisectScripts.abortExitCode)
+
+object CommitBisectScripts:
+  /** `git bisect run` treats this status as "this commit cannot be tested". */
+  val skipExitCode = 125
+  /** `git bisect run` aborts on statuses of 128 and above instead of recording a verdict. */
+  val abortExitCode = 128
+
+  def sbtPublishRecipe(bootstrapped: Boolean): String =
     val scala3Project = if bootstrapped then "scala3-bootstrapped" else "scala3"
-    val validationCommandStatusModifier = if shouldFail then "! " else "" // invert the process status if failure was expected
-    val sbtPublishRecipe = Seq(
+    Seq(
       "clean",
       """set every doc := new File("unused")""",
       s"set scaladoc/Compile/resourceGenerators := (`$scala3Project`/Compile/resourceGenerators).value",
       s"$scala3Project/publishLocal",
     ).mkString("; ")
 
-    val bisectRunScript = raw"""
-      |scalaVersion=$$(sbt "print ${scala3CompilerProject}/version" | tail -n1)
+  /** A script that publishes the compiler built from the currently checked out commit
+   *  and validates it, exiting with a status that `git bisect run` understands.
+   */
+  def buildAndValidateScript(
+      validationScriptPath: String,
+      shouldFail: Boolean,
+      bootstrapped: Boolean,
+      onBuildFailure: BuildFailureAction
+  ): String =
+    val scala3CompilerProject = if bootstrapped then "scala3-compiler-bootstrapped" else "scala3-compiler"
+    val validationCommandStatusModifier = if shouldFail then "! " else "" // invert the process status if failure was expected
+    val publishRecipe = sbtPublishRecipe(bootstrapped)
+    raw"""
+      |commit=$$(git rev-parse --short HEAD)
+      |echo "Testing commit $$commit"
+      |scalaVersion=$$(sbt "print ${scala3CompilerProject}/version" | tr -d '\r' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
+      |if [ -z "$$scalaVersion" ]; then
+      |  echo "Could not read the ${scala3CompilerProject} version at $$commit, aborting the bisection"
+      |  exit ${abortExitCode}
+      |fi
+      |echo "Compiler version at $$commit: $$scalaVersion"
       |rm -rf out
       |export JAVA_HOME=${sys.props("java.home")}
       |sbt_build_log=$$(mktemp)
-      |echo 'Running sbt publish recipe: sbt "$sbtPublishRecipe"'
-      |if sbt '$sbtPublishRecipe' >"$$sbt_build_log" 2>&1; then
+      |echo 'Running sbt publish recipe: sbt "$publishRecipe"'
+      |if sbt '$publishRecipe' >"$$sbt_build_log" 2>&1; then
       |  rm -f "$$sbt_build_log"
-      |  ${validationCommandStatusModifier}${validationScript.getAbsolutePath} "$$scalaVersion"
+      |  ${validationCommandStatusModifier}${validationScriptPath} "$$scalaVersion"
       |else
-      |  echo "Failed to build compiler, skip $$scalaVersion"
+      |  echo "Failed to build the compiler at $$commit"
       |  cat "$$sbt_build_log"
       |  rm -f "$$sbt_build_log"
-      |  git bisect skip
+      |  exit ${onBuildFailure.exitCode}
       |fi
     """.stripMargin
+
+class CommitBisect(validationScript: File, shouldFail: Boolean, bootstrapped: Boolean, lastGoodHash: String, firstBadHash: String):
+  def bisect(): Unit =
+    println(s"Starting bisecting commits $lastGoodHash..$firstBadHash\n")
+    verifyEdgeCommits()
+
+    val bisectRunScript = buildAndValidateScript(BuildFailureAction.SkipCommit)
     "git bisect start".!
     s"git bisect bad $firstBadHash".!
     s"git bisect good $lastGoodHash".!
     Seq("git", "bisect", "run", "sh", "-c", bisectRunScript).!
     s"git bisect reset".!
+
+  private def buildAndValidateScript(onBuildFailure: BuildFailureAction): String =
+    CommitBisectScripts.buildAndValidateScript(
+      validationScript.getAbsolutePath,
+      shouldFail = shouldFail,
+      bootstrapped = bootstrapped,
+      onBuildFailure = onBuildFailure
+    )
+
+  /** Build and validate both ends of the bisected range before bisecting it.
+   *  The release bisection already established that the compiler changed its behaviour
+   *  between them, so a verdict that disagrees means the validation is not measuring the
+   *  locally built compiler, and bisecting would report an arbitrary commit as the culprit.
+   */
+  private def verifyEdgeCommits(): Unit =
+    val originalRef = currentRef()
+    try
+      verifyEdgeCommit(lastGoodHash, expectedGood = true)
+      verifyEdgeCommit(firstBadHash, expectedGood = false)
+      println("Both edge commits behave as expected\n")
+    finally
+      println(s"Checking out $originalRef again")
+      Seq("git", "checkout", originalRef).!
+
+  private def verifyEdgeCommit(hash: String, expectedGood: Boolean): Unit =
+    val expected = if expectedGood then "good" else "bad"
+    println(s"Verifying the '$expected' commit $hash by building it and validating the result")
+    if Seq("git", "checkout", "--detach", hash).! != 0 then
+      sys.error(s"Could not check out $hash. Make sure the working tree is clean before bisecting.")
+
+    val status = Seq("sh", "-c", buildAndValidateScript(BuildFailureAction.AbortBisect)).!
+    if status == CommitBisectScripts.abortExitCode then
+      sys.error(s"Could not build and validate the compiler at $hash, see the output above.")
+
+    val actual = if status == 0 then "good" else "bad"
+    println(s"Test result: $hash is a $actual commit\n")
+    if actual != expected then
+      sys.error(
+        s"""|The validation command reported that $hash is a '$actual' commit,
+            |but the release bisection determined that it is a '$expected' one. The validation command
+            |is not measuring the compiler that was just built from that commit. Common causes are:
+            |* the reproduction files are not present in the working tree after `git checkout`
+            |  (keep them outside of the repository or in a gitignored directory like `local/`),
+            |* the validation command fails for a reason unrelated to the compiler,
+            |* the locally published compiler is not the one picked up by the validation command.
+            |Run the validation command manually at $hash to see what happens.""".stripMargin
+      )
+
+  private def currentRef(): String =
+    val branch = scala.util.Try(Process(Seq("git", "symbolic-ref", "--quiet", "--short", "HEAD")).!!.trim).toOption
+    branch.filter(_.nonEmpty).getOrElse(Process(Seq("git", "rev-parse", "HEAD")).!!.trim)

--- a/project/scripts/bisect.test.scala
+++ b/project/scripts/bisect.test.scala
@@ -149,6 +149,74 @@ class BisectOptionsTest extends munit.FunSuite:
     assert(cleanIdx >= 0 && compileIdx > cleanIdx)
   }
 
+class CommitBisectScriptTest extends munit.FunSuite:
+  import BuildFailureAction.*
+
+  private val validationScriptPath = "/tmp/validate-bisect.sh"
+
+  def script(
+      shouldFail: Boolean = false,
+      bootstrapped: Boolean = false,
+      onBuildFailure: BuildFailureAction = SkipCommit
+  ): String =
+    CommitBisectScripts.buildAndValidateScript(validationScriptPath, shouldFail, bootstrapped, onBuildFailure)
+
+  test("build failure skips the commit instead of running git bisect skip") {
+    val body = script(onBuildFailure = SkipCommit)
+    // `git bisect skip` nested in `git bisect run` moves HEAD and makes the run script exit with
+    // the status of the skip itself, which git bisect then records as a verdict for the wrong commit
+    assert(!body.contains("git bisect skip"), body)
+    assert(body.contains("exit 125"), body)
+  }
+
+  test("build failure during edge verification aborts instead of skipping") {
+    val body = script(onBuildFailure = AbortBisect)
+    assert(body.contains("exit 128"), body)
+    assert(!body.contains("exit 125"), body)
+  }
+
+  test("aborts when the compiler version cannot be captured") {
+    for onBuildFailure <- BuildFailureAction.values do
+      val body = script(onBuildFailure = onBuildFailure)
+      val guardIdx = body.indexOf("""if [ -z "$scalaVersion" ]""")
+      assert(guardIdx >= 0, body)
+      assert(body.indexOf("exit 128", guardIdx) >= 0, body)
+      assert(guardIdx < body.indexOf(validationScriptPath), body)
+  }
+
+  test("version capture filters the sbt output") {
+    val body = script()
+    val grepIdx = body.indexOf("""grep -E '^[0-9]+\.[0-9]+\.[0-9]+'""")
+    assert(grepIdx >= 0, body)
+    assert(grepIdx < body.indexOf("tail -n1"), body)
+  }
+
+  test("logs the commit under test") {
+    val body = script()
+    assert(body.contains("git rev-parse --short HEAD"), body)
+    assert(body.contains("""echo "Testing commit $commit""""), body)
+  }
+
+  test("prints the version of the project matching the bootstrapping") {
+    assert(script(bootstrapped = false).contains("print scala3-compiler/version"))
+    assert(script(bootstrapped = true).contains("print scala3-compiler-bootstrapped/version"))
+  }
+
+  test("shouldFail inverts the validation command status") {
+    assert(script(shouldFail = true).contains(s"! $validationScriptPath"))
+    val body = script(shouldFail = false)
+    assert(!body.contains(s"! $validationScriptPath"), body)
+    assert(body.contains(s"""$validationScriptPath "$$scalaVersion""""), body)
+  }
+
+  test("publish recipe targets the project matching the bootstrapping") {
+    val nonbootstrapped = CommitBisectScripts.sbtPublishRecipe(bootstrapped = false)
+    assert(nonbootstrapped.contains("scala3/publishLocal"), nonbootstrapped)
+    assert(!nonbootstrapped.contains("scala3-bootstrapped"), nonbootstrapped)
+    val bootstrapped = CommitBisectScripts.sbtPublishRecipe(bootstrapped = true)
+    assert(bootstrapped.contains("scala3-bootstrapped/publishLocal"), bootstrapped)
+  }
+
 class BisectReleasesTest extends munit.FunSuite:
   // Maven Central holds older nightlies; Artifactory nightlies has builds since ~2025-08.
   // Both must be queried so ranges spanning the migration remain usable.


### PR DESCRIPTION
A number of fixes around the bisect script.

1. We now do validation on the commit hashes established by the nightlies pair, to confirm the range is correct. If it is not, the script will just quit with `exit 128` (I'm doing sanity checks here, at the cost of extra 2 builds).
2. In case of a failure, rather than explicitly calling `git bisect skip` (which we shouldn't, as we can then miss a commit), we now do `exit 125`. In git bisect terms, this means the commit could not be built and we want to skip it, as it doesn't have a valid build (and we have a lot of those in the compiler, since we don't squash). More reading on this at https://git-scm.com/docs/git-bisect#_bisect_run

Plus some more minor stuff.

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by running git bisect in different configurations a lot

## How was the solution tested?
I included some more automatic tests, but the real one is:

While bisecting https://github.com/scala/scala3/issues/26656:
- pre-change, it bisected (wrongly) to https://github.com/scala/scala3/commit/d96bf104318ac486fd5e198479933865cb49e177
- post-change, it now bisects to https://github.com/scala/scala3/commit/c6245ed4e00839f78abe2da9f7c367f09ceb98ed, as it should
