### PR TITLE
Fix regression: more frequently cast the result of transparent inline

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -650,14 +650,17 @@ object Inlines:
           if inlinedMethod.is(Transparent) then
             val unpacked = unpackProxiesFromResultType(inlined)
             val withAdjustedThisTypes = if call.symbol.is(Macro) then fixThisTypeModuleClassReferences(unpacked) else unpacked
-            (call.tpe & withAdjustedThisTypes, withAdjustedThisTypes != unpacked)
+            (call.tpe & withAdjustedThisTypes, withAdjustedThisTypes != inlined.tpe)
           else (call.tpe, false)
         // `target` might contain a method reference, which is an invalid cast target. Use its return type instead.
         // see https://github.com/scala/scala3/issues/25091
         val resultType = target.widenIfUnstable
         if forceCast then
-          // we need to force the cast for issues with ThisTypes, as ensureConforms will just
-          // check subtyping and then choose not to cast, leaving the previous, incorrect type
+          // We might need to force the cast for various issues, as a subtype check/ensureConform
+          // will leave out the previous type which might not be correct, e.g.:
+          //  * fixes for nonsense ThisTypes that expose opaque types would fall through any subtype check
+          //  * RefinedTypes are skipped when looking for implicits, so we want to avoid
+          //    the ones with generated RefinedType prefixes if we can
           inlined.cast(resultType)
         else if !(inlined.tpe <:< target) then
           // Make sure that the sealing with the declared type

--- a/tests/pos/i26656.scala
+++ b/tests/pos/i26656.scala
@@ -1,0 +1,21 @@
+
+object ParsingIntra {
+    val ImmutLexerFlow: ImmutLexerFlowModule = new AnyRef with ImmutLexerFlowModule
+    trait ImmutLexerFlowModule {
+
+        opaque type NvriImpl >: String <: String = String
+
+        transparent inline def Parser: Parser1.type = Parser1
+
+        object Parser1
+
+        extension (C: Parser1.type) {
+            def gc(): Unit = { }
+        }
+    }
+}
+
+object Parsing {
+    def gcRules() = locally[Unit]:
+        ParsingIntra.ImmutLexerFlow.Parser.gc()
+}


### PR DESCRIPTION
Fixes #26656
In the issue minimisation (that I included in the PR in a slightly adjusted form, for readability), the `Parser` method would expand into:
```scala
{
  val $proxy1:
    
      (ParsingIntra.ImmutLexerFlow : ParsingIntra.ImmutLexerFlowModule){
        type NvriImpl = String}
    
   =
    ParsingIntra.ImmutLexerFlow.$asInstanceOf[
      
        (ParsingIntra.ImmutLexerFlow : ParsingIntra.ImmutLexerFlowModule){
          type NvriImpl = String}
      
    ]
  val ImmutLexerFlowModule_this:
    
      ($proxy1 :
        (ParsingIntra.ImmutLexerFlow : ParsingIntra.ImmutLexerFlowModule){
          type NvriImpl = String}
      )
    
   = $proxy1
  ImmutLexerFlowModule_this.Parser1:ImmutLexerFlowModule_this.Parser1.type
}
```
of type 
```scala
(ParsingIntra.ImmutLexerFlow : ParsingIntra.ImmutLexerFlowModule){type NvriImpl = String}#Parser1
```
This passed the check `(ParsingIntra.ImmutLexerFlow : ParsingIntra.ImmutLexerFlowModule){type NvriImpl = String}#Parser1 <:<  (ParsingIntra.ImmutLexerFlow.Parser :=> ParsingIntra.ImmutLexerFlow.Parser1.type)`, which later caused problems with implicit resolution as due to the more complex prefix with a RefinedType, the extension method would not be found. Since we already reconstruct the alias-less result type (like used in the check above), we now forcefully cast to it more frequently, skipping the subtype check also more frequently (in favor of type shape equality check).

Worth noting - since we now return `{...}.asInstanceOf(...) `more frequently I somewhat expect there to be issues with libraries with macros that rely on transparent inline defs returning certain shape. Ultimately, I can't think of any better solution, so affected libraries might need to update, and that's something we also did in the past so I think it's fine.


## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
