### PR TITLE
Fixes #26683: Do not answer IsConst for a stuck match type

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeEval.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeEval.scala
@@ -49,14 +49,10 @@ object TypeEval:
       // Returns Some(false) if the type is not a constant.
       // Returns None if there is not enough information to determine if the type is a constant.
       // The type is a constant if it is a constant type or a type operation composition of constant types.
-      // If we get a type reference for an argument, then the result is not yet known.
+      // A type that is not concrete yet may still be instantiated to a constant, so it stays unknown.
       def isConst(tp: Type): Option[Boolean] = tp.dealias match
         // known to be constant
         case ConstantType(_) => Some(true)
-        // currently not a concrete known type
-        case TypeRef(NoPrefix,_) => None
-        // currently not a concrete known type
-        case _: TypeParamRef => None
         // constant if the term is constant
         case t: TermRef =>
           if t.denot.symbol.flagsUNSAFE.is(Flags.Param) then
@@ -69,8 +65,15 @@ object TypeEval:
           val argsConst = applied.args.map(isConst)
           if (argsConst.exists(_.isEmpty)) None
           else Some(argsConst.forall(_.get))
-        // all other types are considered not to be constant
-        case _ => Some(false)
+        case tp1 =>
+          // a type that still reduces is as constant as its reduction
+          val reduced = tp1.tryNormalize
+          if reduced.exists then isConst(reduced)
+          // only a concrete type is known not to be a constant; anything else
+          // (an abstract type, an application of an abstract type constructor,
+          // a stuck match type) may still become one
+          else if MatchTypes.isConcrete(tp1) then Some(false)
+          else None
 
       def expectArgsNum(expectedNum: Int): Unit =
       // We can use assert instead of a compiler type error because this error should not

--- a/tests/neg/i26683.scala
+++ b/tests/neg/i26683.scala
@@ -1,0 +1,63 @@
+// https://github.com/scala/scala3/issues/26683
+// `IsConst` must stay unevaluated wherever the other `compiletime.ops` do,
+// rather than answering `false` for a type that is merely not known yet.
+import scala.compiletime.ops.any.IsConst
+import scala.compiletime.ops.int.+
+
+// A match type that is stuck for an argument whose bound cannot decide the first
+// case: `X <: Int` is neither provable nor refutable for an unbounded `X`.
+// Non-recursive, so an application is instantiated into a bare `MatchType`.
+type Pick[T] <: Int = T match
+  case Int => 1
+  case _   => 2
+
+// Recursive, so an application stays an `AppliedType` over a match alias.
+type Len[T <: Tuple] <: Int = T match
+  case EmptyTuple => 0
+  case _ *: t     => 1 + Len[t]
+
+type Probe[T] = IsConst[T] match
+  case true  => "const"
+  case false => "not-const"
+
+object P:
+  // with the arguments known, the match types reduce and `IsConst` answers `true`
+  summon[Pick[5] =:= 1]
+  summon[Probe[Pick[5]] =:= "const"]
+  summon[Len[(1, 2, 3)] =:= 3]
+  summon[Probe[Len[(1, 2, 3)]] =:= "const"]
+
+  // with the arguments unknown the match types are stuck, so `IsConst` is
+  // undetermined and `Probe` cannot reduce either way
+  def stuck1[X]: Unit = summon[Probe[Pick[X]] =:= "not-const"] // error
+  def stuck2[X]: Unit = summon[Probe[Pick[X]] =:= "const"] // error
+  def stuck3[T <: Tuple]: Unit = summon[Probe[Len[T]] =:= "not-const"] // error
+  def stuck4[T <: Tuple]: Unit = summon[Probe[Len[T]] =:= "const"] // error
+
+  // once the scrutinee is known again, reduction resumes
+  def known[X <: 5]: Unit = summon[Probe[Pick[X]] =:= "const"]
+end P
+
+// The same applies to every other type that is not concrete yet: `IsConst` must
+// be undetermined exactly where an operation such as `+` is.
+trait AbstractMember:
+  type T <: Int
+  def op: Unit = summon[(T + 1) =:= 2] // error
+  def isConst1: Unit = summon[IsConst[T] =:= false] // error
+  def isConst2: Unit = summon[IsConst[T] =:= true] // error
+
+trait AbstractConstructor[F[_ <: Int] <: Int]:
+  def op[X <: Int]: Unit = summon[(F[X] + 1) =:= 2] // error
+  def isConst1[X <: Int]: Unit = summon[IsConst[F[X]] =:= false] // error
+  def isConst2[X <: Int]: Unit = summon[IsConst[F[X]] =:= true] // error
+
+// Concrete types are still decided, and an abstract member becomes decidable
+// again as soon as a prefix pins it down.
+object Concrete:
+  summon[IsConst[Int] =:= false]
+  summon[IsConst[Any] =:= false]
+  summon[IsConst[List[Int]] =:= false]
+  def poly[X]: Unit = summon[IsConst[List[X]] =:= false]
+  val pinned: AbstractMember { type T = 5 } = ???
+  summon[IsConst[pinned.T] =:= true]
+end Concrete


### PR DESCRIPTION
Use the match type concreteness check to avoid returning an answer for `IsConst` if the match type is not concrete. In general, this makes `IsConst` behave just like all `compiletime.ops`.

Note: this is a change of behavior on top of what is described on the original issue, since `IsConst[T]` for abstract `T` used to return false, even without the match type issue. I would say this was also a bug as to what `IsConst` was intended for.

Fixes #26683

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by inspecting the code myself. I added `IsConst` at the time, so this bug is my fault 😮‍💨 

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
