### PR TITLE
Stop interning all PlainFile paths

### DIFF
--- a/compiler/src/dotty/tools/io/JarArchive.scala
+++ b/compiler/src/dotty/tools/io/JarArchive.scala
@@ -12,7 +12,7 @@ import scala.jdk.CollectionConverters.*
 class JarArchive private (underlying: Path, root: Directory) extends PlainDirectory(root) {
   def close(): Unit = this.synchronized(jpath.getFileSystem().close())
 
-  override lazy val path: String = underlying.path
+  override val path: String = underlying.path
   override def ext: FileExtension = underlying.ext
 
   override def exists: Boolean = jpath.getFileSystem().isOpen() && super.exists

--- a/compiler/src/dotty/tools/io/JarArchive.scala
+++ b/compiler/src/dotty/tools/io/JarArchive.scala
@@ -12,7 +12,7 @@ import scala.jdk.CollectionConverters.*
 class JarArchive private (underlying: Path, root: Directory) extends PlainDirectory(root) {
   def close(): Unit = this.synchronized(jpath.getFileSystem().close())
 
-  override val path: String = underlying.path
+  override lazy val path: String = underlying.path
   override def ext: FileExtension = underlying.ext
 
   override def exists: Boolean = jpath.getFileSystem().isOpen() && super.exists

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -27,19 +27,18 @@ class PlainFile(givenPath: Path) extends AbstractFile {
 
   override def name: String = givenPath.name
 
-  // Interned for fast hashcode and equals
-  override val path: String = givenPath.normalize.path.intern
+  override lazy val path: String = givenPath.normalize.path
 
   override def container: Option[AbstractFile] = Some(new PlainFile(givenPath.parent))
   override def input: InputStream = givenPath.toFile.inputStream()
   override def output: OutputStream = givenPath.toFile.outputStream()
   override def toURL: Option[URL] = Some(jpath.toUri.toURL)
 
-  override def hashCode(): Int = System.identityHashCode(path)
-  override def equals(that: Any): Boolean = that match {
+  override def hashCode(): Int = path.hashCode
+  override def equals(that: Any): Boolean = (this `eq` that.asInstanceOf[Object]) || (that match {
     case x: PlainFile => path `eq` x.path
     case _            => false
-  }
+  })
 
   /** Is this abstract file a directory? */
   override val isDirectory: Boolean = givenPath.isDirectory // cached for performance on Windows

--- a/compiler/src/dotty/tools/io/PlainFile.scala
+++ b/compiler/src/dotty/tools/io/PlainFile.scala
@@ -27,7 +27,7 @@ class PlainFile(givenPath: Path) extends AbstractFile {
 
   override def name: String = givenPath.name
 
-  override lazy val path: String = givenPath.normalize.path
+  override val path: String = givenPath.normalize.path
 
   override def container: Option[AbstractFile] = Some(new PlainFile(givenPath.parent))
   override def input: InputStream = givenPath.toFile.inputStream()


### PR DESCRIPTION
The `intern` call shows up in profiles. Benchmarks say it doesn't actually help later.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
