### PR TITLE
Backport "Fix Scaladoc top package order to be alphabetical" to 3.9.0

### DIFF
--- a/scaladoc-testcases/src/packageorderingalpha.scala
+++ b/scaladoc-testcases/src/packageorderingalpha.scala
@@ -1,0 +1,3 @@
+package packageorderingalpha
+
+class PackageOrderingAlpha

--- a/scaladoc-testcases/src/packageorderingalphaaardvark.scala
+++ b/scaladoc-testcases/src/packageorderingalphaaardvark.scala
@@ -1,0 +1,3 @@
+package packageorderingalpha.aardvark
+
+class PackageOrderingAlphaAardvark

--- a/scaladoc-testcases/src/packageorderingalphazebra.scala
+++ b/scaladoc-testcases/src/packageorderingalphazebra.scala
@@ -1,0 +1,3 @@
+package packageorderingalpha.zebra
+
+class PackageOrderingAlphaZebra

--- a/scaladoc-testcases/src/packageorderingbeta.scala
+++ b/scaladoc-testcases/src/packageorderingbeta.scala
@@ -1,0 +1,3 @@
+package packageorderingbeta
+
+class PackageOrderingBeta

--- a/scaladoc/src/dotty/tools/scaladoc/ScalaModuleProvider.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScalaModuleProvider.scala
@@ -37,7 +37,7 @@ object ScalaModuleProvider:
                   members = ms,
                 )
         }.toList.sortBy(_.name)
-      groupMembers(nonemptyPackages).reverse
+      groupMembers(nonemptyPackages)
 
     val packageMembers = groupedMembers ++ emptyPackages.flatMap(_.members)
 

--- a/scaladoc/test/dotty/tools/scaladoc/PackageOrderingTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/PackageOrderingTest.scala
@@ -1,0 +1,28 @@
+package dotty.tools.scaladoc
+
+import org.junit.Assert.assertEquals
+
+class PackageOrderingTest extends ScaladocTest(""):
+  override def moduleDocContext =
+    testDocContext(
+      tastyFiles("", rootPck = "packageorderingalpha") ++
+        tastyFiles("", rootPck = "packageorderingbeta")
+    )
+
+  override def runTest: Unit = withModule { module =>
+    val packages = module.rootPackage.members
+      .filter(_.name.startsWith("packageordering"))
+      .map(_.name)
+    assertEquals(List("packageorderingalpha", "packageorderingbeta"), packages)
+
+    val subpackages = module.rootPackage.members
+      .find(_.name == "packageorderingalpha")
+      .toList
+      .flatMap(_.members)
+      .filter(_.name.startsWith("packageorderingalpha."))
+      .map(_.name)
+    assertEquals(
+      List("packageorderingalpha.aardvark", "packageorderingalpha.zebra"),
+      subpackages
+    )
+  }


### PR DESCRIPTION
Backports #26653 to the 3.9.0-RC5.

PR submitted by the release tooling.
[skip ci]