### PR TITLE
Backport "Fix crash when `unapply` returns a Boolean-deriving opaque type" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PatternMatcher.scala
@@ -403,7 +403,7 @@ object PatternMatcher {
             if isGenericTuple then caseAccessors.indices.toList.map(tupleApp(_, ref(scrutinee)))
             else caseAccessors.map(tupleSel)
           matchArgsPlan(components, args, onSuccess)
-        else if unappType.isRef(defn.BooleanClass) then
+        else if unappType.derivesFrom(defn.BooleanClass) then
           TestPlan(GuardTest, unapp, unapp.span, onSuccess)
         else
           letAbstract(unapp) { unappResult =>

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -185,7 +185,7 @@ object Applications {
     (0 until argsNum).map(i => if (i < arity - 1) selectorTypes(i) else elemTp).toList
   end seqSelectors
 
-  /** A utility class that matches results of unapplys with patterns. Two queriable members:
+  /** A utility class that matches results of unapplys with patterns. Two queryable members:
    *     val argTypes: List[Type]
    *     def typedPatterns(qual: untpd.Tree, typer: Typer): List[Tree]
    *  TODO: Move into Applications trait. No need to keep it outside. But it's a large
@@ -263,7 +263,7 @@ object Applications {
             case _ => None
         case _ => None
 
-    /** The computed argument types which will be the scutinees of the sub-patterns. */
+    /** The computed argument types which will be the scrutinees of the sub-patterns. */
     val argTypes: List[Type] =
       if unapplyName == nme.unapplySeq then
         unapplySeq(unapplyResult):

--- a/tests/pos/opaque-bool-as-unapply-result.scala
+++ b/tests/pos/opaque-bool-as-unapply-result.scala
@@ -1,0 +1,11 @@
+object Internal:
+  opaque type Foo <: Boolean = Boolean
+
+import Internal.*
+
+object Bar:
+  def unapply(arg: Int): Foo = ???
+
+@main def main =
+  1 match
+    case Bar() =>


### PR DESCRIPTION
Backports #26658 to the 3.9.0-RC5.

PR submitted by the release tooling.
[skip ci]