### PR TITLE
Backport "Fix regression #26153 (in dotty-cps-async) use typer skolems as inline proxy's type" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -484,6 +484,7 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
    */
   private def defKind(tree: Tree)(using Context): FlagSet = unsplice(tree) match {
     case EmptyTree | _: Import => NoInitsInterface
+    case _: ModuleDef => NoInits
     case tree: TypeDef =>
       if tree.isClassDef then
         if Feature.shouldBehaveAsScala2 then EmptyFlags
@@ -608,11 +609,14 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     case TypeApply(fn, _) =>
       val sym = fn.symbol
       if tree.tpe.isInstanceOf[MethodOrPoly] then exprPurity(fn)
+      else if sym == defn.Any_typeCast then
+        fn match
+          case Select(qual, _) => exprPurity(qual) `min` Pure
+          case _ => Impure
       else if sym == defn.QuotedTypeModule_of
           || sym == defn.Predef_classOf
           || sym == defn.Compiletime_erasedValue && tree.tpe.dealias.isInstanceOf[ConstantType]
           || defn.capsErasedValueMethods.contains(sym)
-          || sym == defn.Any_typeCast
       then Pure
       else Impure
     case Apply(fn, args) =>

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -207,6 +207,36 @@ class Inliner(val call: tpd.Tree)(using Context):
   private val inlineCallPrefix =
      qualifier(methPart).orElse(This(inlinedMethod.enclosingClass.asClass))
 
+  /** Skolems created from typing this call tree.
+   *
+   *  ```
+   *  trait Ctx[F[_]]
+   *  trait Mon[F[_]]:
+   *    type Context <: Ctx[F]
+   *  inline def async[F[_]](using am: Mon[F]): Wrap[F, am.Context] = ???
+   *  ```
+   *
+   *  When TypeAssigner types `async(...)`, it skolemizes unstable `am` in the
+   *  dependent result type, and the call tree is typed as `Wrap[F, ?1.Context]`.
+   *  Then the inliner expands the method body and replace `am` by a proxy `am$proxy`.
+   *  Then `new Wrap[F, am.Context]` becomes `new Wrap[F, am$proxy.Context]`.
+   *
+   *  In `paramBindingDef`, we type `am$proxy` as $1, so that both expanded tree and
+   *  call tree is typed `Wrap[F, ?1.Context]`. Otherwise, call tree and expanded tree
+   *  has different types `?1.Context` vs `am$proxy.Context` and compile fails.
+   *  See #26153 and #26031.
+   */
+  private val callValueSkolemss: List[List[Option[SkolemType]]] =
+    def loop(tree: Tree, skolemss: List[List[Option[SkolemType]]]): List[List[Option[SkolemType]]] = tree match
+      case app @ Apply(fn, args) =>
+        val mapping = app.getAttachment(TypeAssigner.SkolemizedArgs).getOrElse(Map.empty)
+        loop(fn, args.map(mapping.get) :: skolemss)
+      case TypeApply(fn, _) =>
+        loop(fn, skolemss)
+      case _ =>
+        skolemss
+    loop(call, Nil)
+
   // Make sure all type arguments to the call are fully determined,
   // but continue if that's not achievable (or else i7459.scala would crash).
   for arg <- callTypeArgs do
@@ -257,9 +287,11 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  @param formal      the type of the parameter
    *  @param arg0        the argument corresponding to the parameter
    *  @param buf         the buffer to which the definition should be appended
+   *  @param skolem      optional skolem from the call's dependent result type.
+   *                     If present, use it as the proxy type.
    */
   private[inlines] def paramBindingDef(name: Name, formal: Type, arg0: Tree,
-                              buf: DefBuffer)(using Context): ValOrDefDef = {
+                              buf: DefBuffer, skolem: Option[SkolemType] = None)(using Context): ValOrDefDef = {
     val isByName = formal.dealias.isInstanceOf[ExprType]
     val arg =
       def dropNameArg(arg: Tree): Tree = arg match
@@ -275,10 +307,17 @@ class Inliner(val call: tpd.Tree)(using Context):
           dropNameArg(arg0)
     val argtpe = arg.tpe.dealiasKeepAnnots.translateFromRepeated(toArray = false)
     val argIsBottom = argtpe.isBottomTypeAfterErasure
-    val bindingType =
+    val baseBindingType =
       if argIsBottom then formal
       else if isByName then ExprType(argtpe.widen)
       else argtpe.widen
+    // If the call result type used a skolem for this argument, use the same skolem
+    // as the proxy type. `?1` has `argtpe.widen` as its underlying type.
+    val proxySkolem = if argIsBottom then None else skolem
+    val bindingType = proxySkolem match
+      case Some(sk) => if isByName then ExprType(sk) else sk
+      case None => baseBindingType
+
     var bindingFlags: FlagSet = InlineProxy
     if formal.widenExpr.hasAnnotation(defn.InlineParamAnnot) then
       bindingFlags |= Inline
@@ -291,6 +330,10 @@ class Inliner(val call: tpd.Tree)(using Context):
       var newArg = arg.changeOwner(ctx.owner, boundSym)
       if bindingFlags.is(Inline) && argIsBottom then
         newArg = Typed(newArg, TypeTree(formal.widenExpr)) // type ascribe RHS to avoid type errors in expansion. See i8612.scala
+      else proxySkolem match
+        case Some(sk) =>
+          newArg = newArg.cast(sk) // adapt the rhs to the skolem-typed proxy
+        case None => ()
       if isByName then DefDef(boundSym, newArg)
       else ValDef(boundSym, newArg, inferred = true)
     }.withSpan(boundSym.span)
@@ -306,6 +349,7 @@ class Inliner(val call: tpd.Tree)(using Context):
   private def computeParamBindings(
       tp: Type, targs: List[Tree],
       argss: List[List[Tree]], formalss: List[List[Type]],
+      skolemss: List[List[Option[SkolemType]]],
       buf: DefBuffer): Boolean =
     tp match
       case tp: PolyType =>
@@ -313,24 +357,27 @@ class Inliner(val call: tpd.Tree)(using Context):
           paramSpan(name) = arg.span
           paramBinding(name) = arg.tpe.stripTypeVar
         }
-        computeParamBindings(tp.resultType, targs.drop(tp.paramNames.length), argss, formalss, buf)
+        computeParamBindings(tp.resultType, targs.drop(tp.paramNames.length), argss, formalss, skolemss, buf)
       case tp: MethodType =>
         if argss.isEmpty then
           report.error(em"missing arguments for inline method $inlinedMethod", call.srcPos)
           false
         else
-          tp.paramNames.lazyZip(formalss.head).lazyZip(argss.head).foreach { (name, formal, arg) =>
+          val skolems = skolemss.headOption.getOrElse(List.fill(argss.head.length)(None))
+          tp.paramNames.lazyZip(formalss.head).lazyZip(argss.head).lazyZip(skolems).foreach {
+            (name, formal, arg, skolem) =>
             paramSpan(name) = arg.span
             paramBinding(name) = arg.tpe.dealias match
               case _: SingletonType if isIdempotentPath(arg) =>
                 arg.tpe
               case _ =>
-                paramBindingDef(name, formal, arg, buf).symbol.termRef
+                paramBindingDef(name, formal, arg, buf, skolem).symbol.termRef
           }
-          computeParamBindings(tp.resultType, targs, argss.tail, formalss.tail, buf)
+          computeParamBindings(tp.resultType, targs, argss.tail, formalss.tail, skolemss.tail, buf)
       case _ =>
         assert(targs.isEmpty)
         assert(argss.isEmpty)
+        assert(skolemss.isEmpty)
         true
 
   /** The number of enclosing classes of this class, plus one */
@@ -644,6 +691,7 @@ class Inliner(val call: tpd.Tree)(using Context):
       if !computeParamBindings(
           inlinedMethod.info, callTypeArgs,
           mappedCallValueArgss, paramTypess(call, Nil),
+          callValueSkolemss,
           paramBindingsBuf)
       then
         return (Nil, EmptyTree)

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -586,7 +586,7 @@ object Inlines:
 
       // Take care that only argument bindings go into `bindings`, since positions are
       // different for bindings from arguments and bindings from body.
-      val inlined = tpd.Inlined(call, bindings, expansion)
+      val inlined0 = tpd.Inlined(call, bindings, expansion)
 
       val hasOpaquesInResultFromCallWithTransparentContext =
         val owners = call.symbol.ownersIterator.toSet
@@ -613,6 +613,24 @@ object Inlines:
                   TermRef(apply(prefix), tref.symbol.companionModule)
                 case _ => mapOver(t)
         ).typeMap(tpe)
+
+      /** Argument proxies may be typed with skolems from the call tree (see
+       *  Inliner#callValueSkolemss). However, TASTy pickles skolems as their underlying
+       *  types, so the expansion's type may change after unpickling, which break the TASTy
+       *  roundtrip checked by `-Ytest-pickler`.
+       *
+       *  To avoid this, insert the expansion with a no-op cast. This makes the pickled
+       *  underlying type to prevent `TypeOps.avoid` from generating a different
+       *  result type after unpickling.
+       */
+      val inlined =
+        val proxySkolems = bindings.map(_.symbol.info.widenExpr).collect { case sk: SkolemType => sk }
+        if proxySkolems.nonEmpty && inlined0.tpe.existsPart(proxySkolems.contains) then
+          val sealedExpansion =
+            inContext(ctx.withSource(expansion.source)):
+              expansion.cast(inlined0.tpe).withSpan(expansion.span)
+          tpd.Inlined(call, bindings, sealedExpansion)
+        else inlined0
 
       if !hasOpaqueProxies && !hasOpaquesInResultFromCallWithTransparentContext then inlined
       else

--- a/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
+++ b/compiler/src/dotty/tools/dotc/printing/PlainPrinter.scala
@@ -885,4 +885,3 @@ class PlainPrinter(_ctx: Context) extends Printer {
   protected def coloredText(text: Text, color: String): Text =
     if (ctx.useColors) color ~ text ~ SyntaxHighlighting.NoColor else text
 }
-

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -590,8 +590,10 @@ object TypeAssigner extends TypeAssigner:
 
   /** An attachment on an application indicating a map from arguments to the skolem types
    *  that were created in safeSubstParams.
+   *  We use StickyKey so the Inlining phase can reuse the
+   *  same skolems for path-dependent types in the expansion (see #26153).
    */
-  private[typer] val SkolemizedArgs = new Property.Key[Map[tpd.Tree, SkolemType]]
+  private[dotc] val SkolemizedArgs = new Property.StickyKey[Map[tpd.Tree, SkolemType]]
 
   def seqLitType(tree: untpd.SeqLiteral, elemType: Type)(using Context) = tree match
     case tree: untpd.JavaSeqLiteral => defn.ArrayOf(elemType)

--- a/tests/neg/nested-module-no-inits.scala
+++ b/tests/neg/nested-module-no-inits.scala
@@ -1,0 +1,8 @@
+//> using options -language:experimental.erasedDefinitions
+
+object Outer:
+  object Inner:
+    println("effect")
+
+erased val pureOuter: Outer.type = Outer
+erased val impureInner: Outer.Inner.type = Outer.Inner // error

--- a/tests/neg/type-cast-purity.scala
+++ b/tests/neg/type-cast-purity.scala
@@ -1,0 +1,13 @@
+//> using options -language:experimental.erasedDefinitions
+
+object O:
+  opaque type T = String
+
+  transparent inline def make: T =
+    println("effect")
+    "value"
+
+def consume(erased value: O.T): Unit = ()
+
+def test(): Unit =
+  consume(O.make) // error

--- a/tests/pos/i26031.scala
+++ b/tests/pos/i26031.scala
@@ -1,0 +1,29 @@
+trait Ctx[F[_]]
+
+trait Mon[F[_]]:
+  type Context <: Ctx[F]
+
+object Mon:
+  type Aux[F[_], C <: Ctx[F]] = Mon[F] { type Context = C }
+
+class Wrap[F[_], C <: Ctx[F]](using val am: Mon.Aux[F, C]):
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    inner[F, T, C](am, expr)
+
+transparent inline def inner[F[_], T, C <: Ctx[F]](
+    inline am: Mon.Aux[F, C],
+    inline expr: C ?=> T
+): F[T] = ???
+
+transparent inline def doIt[F[_]](using am: Mon[F]) =
+  new Wrap(using am)
+
+class Pair[A, B]
+class PairCtx[E] extends Ctx[[A] =>> Pair[E, A]]
+class PairMon[E] extends Mon[[A] =>> Pair[E, A]]:
+  type Context = PairCtx[E]
+
+given pm[E]: Mon[[A] =>> Pair[E, A]] = new PairMon[E]
+
+object Test:
+  val r = doIt[[A] =>> Pair[String, A]] { 42 }

--- a/tests/pos/i26153.scala
+++ b/tests/pos/i26153.scala
@@ -1,0 +1,23 @@
+trait Ctx[F[_]]
+
+trait Mon[F[_]]:
+  type Context <: Ctx[F]
+
+class Wrap[F[_], C <: Ctx[F]]:
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    stage2[F, T, C](expr)
+
+transparent inline def stage2[F[_], T, C <: Ctx[F]](
+    inline expr: C ?=> T
+): F[T] = ???
+
+transparent inline def async[F[_]](using am: Mon[F]) =
+  new Wrap[F, am.Context]
+
+class TupleMon[E] extends Mon[[A] =>> (E, A)]:
+  type Context = Ctx[[A] =>> (E, A)]
+
+given pm[E]: Mon[[A] =>> (E, A)] = new TupleMon[E]
+
+object Test:
+  val r = async[[A] =>> (String, A)] { 42 }

--- a/tests/pos/i26624-dotty-cps-async.scala
+++ b/tests/pos/i26624-dotty-cps-async.scala
@@ -1,0 +1,35 @@
+trait Ctx[F[_]]
+trait TryCtx[F[_]] extends Ctx[F]
+
+trait Monad[F[_]]:
+  type Context <: Ctx[F]
+  def pure[T](t: T): F[T]
+  def apply[T](op: Context => F[T]): F[T]
+
+object Monad:
+  type Aux[F[_], C <: Ctx[F]] = Monad[F] { type Context = C }
+
+trait TryMonad[F[_]] extends Monad[F]:
+  type Context <: TryCtx[F]
+
+class TryBody[F[_]] extends TryCtx[F]
+
+trait TryInstance[F[_]] extends TryMonad[F]:
+  type Context = TryBody[F]
+  def apply[T](op: Context => F[T]): F[T] = op(TryBody())
+
+class InferAsyncArg[F[_], C <: Ctx[F]](using val am: Monad.Aux[F, C]):
+  transparent inline def apply[T](inline expr: C ?=> T): F[T] =
+    am.apply(ctx => am.pure(expr(using ctx)))
+
+transparent inline def async[F[_]](using am: Monad[F]) =
+  new InferAsyncArg(using am)
+
+case class IO[A](value: A)
+
+implicit def ioTryMonad: TryMonad[IO] = new TryMonad[IO] with TryInstance[IO]:
+  def pure[T](t: T) = IO(t)
+
+def program: IO[Int] = async[IO] {
+  1 + 1
+}

--- a/tests/pos/type-cast-purity.scala
+++ b/tests/pos/type-cast-purity.scala
@@ -1,0 +1,12 @@
+//> using options -Werror
+
+object O:
+  opaque type T = String
+
+  transparent inline def make: T =
+    println("effect")
+    "value"
+
+// shouldn't emit E129: Pure Expression In Statement Position
+object Statement:
+  O.make

--- a/tests/semanticdb/metac.expect
+++ b/tests/semanticdb/metac.expect
@@ -3764,7 +3764,7 @@ Text => empty
 Language => Scala
 Symbols => 13 entries
 Occurrences => 35 entries
-Diagnostics => 4 entries
+Diagnostics => 1 entries
 Synthetics => 4 entries
 
 Symbols:
@@ -3820,12 +3820,9 @@ Occurrences:
 [23:4..23:19): StructuralTypes -> example/StructuralTypes.
 
 Diagnostics:
-[15:2..15:11): [warning] A pure expression does nothing in statement position
-[16:2..16:10): [warning] A pure expression does nothing in statement position
 [17:20..17:23): [warning] Alphanumeric method foo is not declared infix; it should not be used as infix operator.
 Instead, use method syntax .foo(...) or backticked identifier `foo`.
 The latter can be rewritten automatically under -rewrite -source 3.4-migration.
-[22:2..22:13): [warning] A pure expression does nothing in statement position
 
 Synthetics:
 [15:2..15:6):user => reflectiveSelectable(*)


### PR DESCRIPTION
Backports #26563 to the 3.9.0-RC5.

PR submitted by the release tooling.
[skip ci]