### PR TITLE
Least privilege permissions

### DIFF
--- a/.github/workflows/build-chocolatey.yml
+++ b/.github/workflows/build-chocolatey.yml
@@ -23,6 +23,9 @@ on:
         required: true
         type    : string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build-msi.yml
+++ b/.github/workflows/build-msi.yml
@@ -17,6 +17,9 @@ on:
         description: 'The developed Scala version (major.minor.patch) extracted from project/Build.scala'
         value: ${{ jobs.build.outputs.version }}
 
+permissions:
+  contents: read
+
 env:
   # Release only happends when triggering CI by pushing tag
   RELEASEBUILD: ${{ startsWith(github.event.ref, 'refs/tags/') && 'yes' || 'no' }}

--- a/.github/workflows/build-sdk.yml
+++ b/.github/workflows/build-sdk.yml
@@ -40,6 +40,9 @@ on:
         description: The SHA256 of the uploaded artifact (`win x86-64`)
         value      : ${{ jobs.build.outputs.win-x86_64-digest }}
 
+permissions:
+  contents: read
+  actions: read  # To read back the win-x86_64 artifact through the Actions API
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,11 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Default token permissions for all jobs: read-only. Jobs that need more must
+# declare their own permissions block.
+permissions:
+  contents: read
+
 # Cancels any in-progress runs within the same group identified by workflow name and GH reference (branch or tag)
 # For example it would:
 # - terminate previous PR CI execution after pushing more changes to the same PR branch
@@ -319,6 +324,9 @@ jobs:
 
   build-sdk-package:
    uses: ./.github/workflows/build-sdk.yml
+   permissions:
+     contents: read
+     actions: read  # to read back the win-x86_64 artifact through the Actions API
    if:
      (github.event_name == 'pull_request' && !contains(github.event.pull_request.body, '[skip ci]')) ||
      (github.event_name == 'workflow_dispatch' && github.repository == 'scala/scala3') ||
@@ -338,6 +346,8 @@ jobs:
 
   test-chocolatey-package:
    uses: ./.github/workflows/test-chocolatey.yml
+   permissions:
+     actions: read  # downloads the launcher artifact through the Actions API
    with:
      version     : 3.6.0-SNAPSHOT # Fake version, used only for choco tests
      java-version: 17

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main # default branch of the project
+
+permissions:
+  contents: write  # To submit the dependency graph (in sbt-dependency-submission)
+
 jobs:
   dependency-graph:
     name: Update Dependency Graph

--- a/.github/workflows/language-reference.yaml
+++ b/.github/workflows/language-reference.yaml
@@ -15,8 +15,6 @@ permissions:
 jobs:
   build-and-push:
     name: Build reference documentation and push it
-    permissions:
-      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     steps:
       - name: Get current date

--- a/.github/workflows/lts-backport.yaml
+++ b/.github/workflows/lts-backport.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# The backporting project is updated via the API with a GitHub App token, the
+# workflow GITHUB_TOKEN is only used to check out the repository.
+permissions:
+  contents: read
+
 jobs:
   add-to-backporting-project:
     if: "!contains(github.event.push.head_commit.message, '[Next only]') &&

--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -26,6 +26,9 @@ on:
       API-KEY:
         required: true
 
+# Pushes to Chocolatey with an API key, no GITHUB_TOKEN use
+permissions: {}
+
 jobs:
   # Never push to Chocolatey from a fork, regardless of how this workflow is called
   publish:

--- a/.github/workflows/publish-sdkman.yml
+++ b/.github/workflows/publish-sdkman.yml
@@ -26,6 +26,9 @@ on:
       CONSUMER-TOKEN:
         required: true
 
+# Publishes to SDKMAN! with vendor credentials no GITHUB_TOKEN use
+permissions: {}
+
 env:
   # The download URLs handed to sdkman point at the releases of the repository
   # that ran the workflow. Only the scala/scala3 releases are real sdkman targets.

--- a/.github/workflows/release-maven-artifacts.yml
+++ b/.github/workflows/release-maven-artifacts.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   release-maven-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: '0 3 * * *'  # Every day at 3 AM
 
+# The nightly documentation is pushed to scala/nightly.scala-lang.org with a
+# GitHub App token, and Maven artifacts with the project's Sonatype credentials,
+# so read-only access for the token is enough for every job.
+permissions:
+  contents: read
+
 jobs:
   stdlib-tests:
     uses: ./.github/workflows/stdlib.yaml

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -20,6 +20,11 @@ on:
         required: true
         type: string
 
+# Publishing uses credentials from secrets for each repository (SDKMAN,
+# Chocolatey, etc), the GITHUB_TOKEN is only needed by the jobs that declare
+# their own permissions.
+permissions: {}
+
 jobs:
   # TODO: ADD JOB TO SWITCH THE GITHUB RELEASE FROM DRAFT TO LATEST
   # The publish-* jobs push to external package managers and channels so we only
@@ -58,6 +63,8 @@ jobs:
 
   build-chocolatey:
     uses: ./.github/workflows/build-chocolatey.yml
+    permissions:
+      contents: read
     needs: compute-digest
     with:
       version: ${{ inputs.version }}
@@ -65,6 +72,8 @@ jobs:
       digest : ${{ needs.compute-digest.outputs.digest }}
   test-chocolatey:
     uses: ./.github/workflows/test-chocolatey.yml
+    permissions:
+      actions: read  # Granted because the called workflow declares it, unused for stable versions
     needs: build-chocolatey
     with:
       version     : ${{ inputs.version }}

--- a/.github/workflows/scoverage.yaml
+++ b/.github/workflows/scoverage.yaml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 # This workflow compiles a subset of the Scala 3 projects with
 # scoverage enabled to test robustness of scoverage.
 #

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -10,6 +10,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOTTY_CI_RUN: true
 

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -19,6 +19,9 @@ on:
         required: true
         type    : string
 
+permissions:
+  actions: read # downloads the launcher artifact through the Actions API
+
 env:
   CHOCOLATEY-REPOSITORY: chocolatey-pkgs
   # Controls behaviour of chocolatey{Install,Uninstall}.ps1 scripts
@@ -51,4 +54,3 @@ jobs:
         run  : scaladoc --version
       - name : Uninstall the `scala` package
         run  : choco uninstall scala
-        

--- a/.github/workflows/test-launchers.yml
+++ b/.github/workflows/test-launchers.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   linux-x86_64:
     name: Deploy and Test on Linux x64 architecture

--- a/.github/workflows/test-msi.yml
+++ b/.github/workflows/test-msi.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+# The scala.msi artifact comes from the same run no GITHUB_TOKEN required
+permissions: {}
+
 jobs:
   test:
     runs-on: windows-latest
@@ -37,7 +40,7 @@ jobs:
           path: .
 
       # Run the MSI installer
-      # During normal installation msiexec would modify the PATH automatically. 
+      # During normal installation msiexec would modify the PATH automatically.
       # However, it seems not to work in GH Actions. Append the PATH manually instead.
       - name: Install Scala Runner
         shell: pwsh


### PR DESCRIPTION
This commit updates all the repository workflows to drop all privileges (or to a bare minimum) and only enables additional capabilities for the token when required, following the least privilege principle.

Fixes https://github.com/scala/scala3/issues/26686

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

- [x] Covered by existing tests (this is a refactoring)

I've run a test release run (the testable parts at least) here, https://github.com/puerco/scala3/actions/runs/30780742171