### PR TITLE
Shade JLine

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,6 +259,7 @@ jobs:
           rm -rf ./target/sona-staging/
           publishCommand=" \
             all \
+              scala3-jline-shaded/publishSigned \
               scala-library-bootstrapped/publishSigned \
               scala3-compiler-bootstrapped/publishSigned \
               scala3-directives-parser-bootstrapped/publishSigned \

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ val `scala3-compiler-nonbootstrapped` = Build.`scala3-compiler-nonbootstrapped`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
 
 val `scala3-repl` = Build.`scala3-repl`
+val `jline-shaded` = Build.`jline-shaded`
 
 // The Standard Library
 val `scala2-library` = Build.`scala2-library`

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val `scala3-compiler-nonbootstrapped` = Build.`scala3-compiler-nonbootstrapped`
 val `scala3-compiler-bootstrapped` = Build.`scala3-compiler-bootstrapped`
 
 val `scala3-repl` = Build.`scala3-repl`
-val `jline-shaded` = Build.`jline-shaded`
+val `scala3-jline-shaded` = Build.`scala3-jline-shaded`
 
 // The Standard Library
 val `scala2-library` = Build.`scala2-library`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -614,7 +614,7 @@ object Build {
     `scala3-directives-parser-bootstrapped`,
     `scala3-staging`,
     `scala3-tasty-inspector`,
-    `jline-shaded`,
+    `scala3-jline-shaded`,
     `scala3-repl`,
     `scala2-library`,
     scaladoc,
@@ -735,7 +735,7 @@ object Build {
     .aggregate(`scala3-interfaces`, `scala3-library-bootstrapped` , `scala-library-bootstrapped`,
       `tasty-core-bootstrapped`, `scala3-directives-parser-bootstrapped`, `scala3-compiler-bootstrapped`, `scala3-sbt-bridge-bootstrapped`,
       `scala3-staging`, `scala3-tasty-inspector`, `scala-library-sjs`, `scala3-library-sjs`,
-      scaladoc, `scala3-repl`, `scala3-presentation-compiler`, `scala3-language-server`)
+      scaladoc, `scala3-jline-shaded`, `scala3-repl`, `scala3-presentation-compiler`, `scala3-language-server`)
     .settings(
       name          := "scala3-bootstrapped",
       moduleName    := "scala3-bootstrapped",
@@ -786,6 +786,7 @@ object Build {
         (`scala3-staging` / publishLocalBin),
         (`scala3-tasty-inspector` / publishLocalBin),
         (scaladoc / publishLocalBin),
+        (`scala3-jline-shaded` / publishLocalBin),
         (`scala3-repl` / publishLocalBin),
         publishLocalBin,
       ).evaluated,
@@ -894,10 +895,7 @@ object Build {
    *  alone (its JNI symbols are name-based and cannot be renamed).
    */
   private def shadeJlineResourceText(text: String): String =
-    text
-      .replace("org.jline.nativ.", "\u0000ORG_JLINE_NATIV.\u0000")
-      .replace("org.jline.", "dotty.shaded.org.jline.")
-      .replace("\u0000ORG_JLINE_NATIV.\u0000", "org.jline.nativ.")
+    text.replaceAll("""org\.jline\.(?!nativ\b)""", "dotty.shaded.org.jline.")
 
   private def shadeJlineResourceEntries(
       conflicts: Vector[sbtassembly.Assembly.Dependency],
@@ -911,30 +909,59 @@ object Build {
 
   /* Shade JLine under `dotty.shaded.org.jline.**` so sbt 1's JLineLoader cannot
    * intercept half of it when `sbt console` runs the REPL in-process.
-   * See scala/scala3#26678. `org.jline.nativ` stays unshaded (JNI symbol names).
+   * See scala/scala3#26678. `org.jline.nativ` stays unshaded (JNI symbol names)
+   * and is published as a normal dependency of this artifact.
    */
-  lazy val `jline-shaded` = project.in(file("repl/jline-shaded"))
+  lazy val `scala3-jline-shaded` = project.in(file("repl/scala3-jline-shaded"))
+    .settings(publishSettings)
     .settings(
-      name := "jline-shaded",
+      // Artifact id must contain "jline": Scala CLI filters REPL artifacts by
+      // that substring when building the JDK 24+ module path (ReplArtifacts).
+      name := "scala3-jline-shaded",
+      moduleName := "scala3-jline-shaded",
+      version := dottyVersion,
+      versionScheme := Some("semver-spec"),
       autoScalaLibrary := false,
       crossPaths := false,
-      publish / skip := true,
-      bspEnabled := false,
+      publish / skip := false,
+      Compile / packageBin / publishArtifact := true,
+      Compile / packageDoc / publishArtifact := false,
+      Compile / packageSrc / publishArtifact := false,
+      Test / publishArtifact := false,
+      bspEnabled := true,
       libraryDependencies ++= Seq(
-        Dependencies.jlineReader,
-        Dependencies.jlineTerminal,
-        Dependencies.jlineTerminalJni,
+        // Shaded into the published jar; Provided so they are not runtime
+        // transitive deps. Stripped from the POM below so coursier cannot put
+        // unshaded `org.jline.terminal` jars on Scala CLI's module path next
+        // to this artifact (same JPMS module name = conflict).
+        Dependencies.jlineReader % Provided,
+        Dependencies.jlineTerminal % Provided,
+        Dependencies.jlineTerminalJni % Provided,
+        // Unshaded: JNI symbols are name-based (`Java_org_jline_nativ_*`).
+        // Must appear in the POM so Scala CLI / coursier put it on the module
+        // path next to this jar for `--enable-native-access=org.jline.nativ`.
+        Dependencies.jlineNative,
       ),
-      // Keep `jline-native` out of the shaded jar: its JNI symbols are
-      // name-based (`Java_org_jline_nativ_*`) and cannot be relocated.
-      // `scala3-repl` depends on it as a normal published dependency.
-      excludeDependencies += "org.jline" % "jline-native",
+      // Drop Provided deps from the published POM (they are baked into the jar).
+      pomPostProcess := { (node: XmlNode) =>
+        new RuleTransformer(new RewriteRule {
+          override def transform(n: XmlNode): XmlNodeSeq = n match {
+            case e: Elem if e.label == "dependency" &&
+                (e \ "scope").text == "provided" => XmlNodeSeq.Empty
+            case other => other
+          }
+        }).transform(node).head
+      },
+      // Dependency classpath only (managed Provided JLine jars + jline-native).
+      // Avoid Compile/fullClasspath so packageBin (which depends on assembly)
+      // cannot appear on the assembly classpath.
+      assembly / fullClasspath := (Compile / dependencyClasspath).value,
       assemblyExcludedJars := {
         (assembly / fullClasspath).value.filter { atr =>
           atr.data.getName.startsWith("jline-native")
         }
       },
-      assembly / assemblyJarName := "jline-shaded.jar",
+      assembly / assemblyJarName := "scala3-jline-shaded.jar",
       assembly / test := {},
       assemblyPackageScala / assembleArtifact := false,
       assemblyShadeRules := Seq(
@@ -971,19 +998,30 @@ object Build {
           val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
           oldStrategy(x)
       },
-      // JarJar also rewrites string constants that look like class names,
-      // which corrupts JLine system-property keys. Restore any shaded dotted
-      // string that does not name a class present in the jar.
+      // Restore JarJar-corrupted string constants and inject module-info.class.
       shadedJlineJar := {
         val assembled = assembly.value
-        val fixed = streams.value.cacheDirectory / "jline-shaded-fixed.jar"
-        JLineShade.restoreNonClassStringConstants(assembled, fixed)
+        val fixed = streams.value.cacheDirectory / "scala3-jline-shaded-fixed.jar"
+        JLineShade.finalizeShadedJar(assembled, fixed)
         fixed
+      },
+      // Publish the post-processed shaded jar (with module-info). Copy to the
+      // standard packageBin path rather than returning the streams cache file
+      // directly, so Ivy/coursier publish and exportJars see a stable artifact.
+      Compile / packageBin := {
+        val shaded = shadedJlineJar.value
+        val dest = (Compile / packageBin / artifactPath).value
+        IO.copyFile(shaded, dest)
+        dest
       },
     )
 
   lazy val `scala3-repl` = project.in(file("repl"))
-    .dependsOn(`scala3-compiler-bootstrapped` % "compile->compile;test->test", `scala3-directives-parser-bootstrapped`)
+    .dependsOn(
+      `scala3-compiler-bootstrapped` % "compile->compile;test->test",
+      `scala3-directives-parser-bootstrapped`,
+      `scala3-jline-shaded`,
+    )
     .settings(publishSettings)
     .settings(
       name          := "scala3-repl",
@@ -1005,28 +1043,16 @@ object Build {
       // Only publish compilation artifacts, no test artifacts
       Test    / publishArtifact := false,
       publish / skip := false,
-      // JLine is shaded into this jar under `dotty.shaded.org.jline.**` (see
-      // `jline-shaded`) so sbt 1's JLineLoader cannot mix versions (#26678).
-      // `jline-native` stays a normal dependency: its JNI symbols are name-based
-      // and cannot be relocated.
+      // Shaded JLine comes from `scala3-jline-shaded`;
+      // `jline-native` is transitive via that dependency (#26678).
+      // unmanagedJars is required because scala3-jline-shaded cannot use exportJars
+      // (sbt-assembly forbids it when shading), so dependsOn alone would put
+      // an empty classDirectory on the classpath.
       libraryDependencies ++= Seq(
-        Dependencies.jlineNative,
         Dependencies.sbtJunitInterface % Test,
         Dependencies.coursierInterface, // used by the REPL for dependency resolution
       ),
-      Compile / unmanagedJars += (`jline-shaded` / shadedJlineJar).value,
-      Compile / packageBin / mappings ++= {
-        val shadedJar = (`jline-shaded` / shadedJlineJar).value
-        val out = target.value / "jline-shaded-unpacked"
-        IO.delete(out)
-        IO.unzip(shadedJar, out)
-        sbt.io.Path.allSubpaths(out).toSeq.filterNot { case (_, rel) =>
-          rel == "META-INF/MANIFEST.MF"
-        }
-      },
-      // Dependents must see the packaged jar (which embeds shaded JLine), not
-      // just the classDirectory (which does not).
-      exportJars := true,
+      Compile / unmanagedJars += (`scala3-jline-shaded` / shadedJlineJar).value,
       // Configure to use the non-bootstrapped compiler
       bootstrappedScalaInstanceSettings,
       // Needed for the JSR223 tests which are "run" tests
@@ -2616,6 +2642,7 @@ object Build {
         (`scala-library-bootstrapped` / publishLocalBin).value
         (`scala3-tasty-inspector` / publishLocalBin).value
         (scaladoc / publishLocalBin).value
+        (`scala3-jline-shaded` / publishLocalBin).value
         (`scala3-repl` / publishLocalBin).value
         (`scala3-directives-parser-bootstrapped` / publishLocalBin).value
         (`scala3-compiler-bootstrapped` / publishLocalBin).value
@@ -2820,6 +2847,7 @@ object Build {
         `scala3-compiler-bootstrapped`,
         `scala3-interfaces`,
         `scala3-library-bootstrapped`,
+        `scala3-jline-shaded`,
         `scala3-repl`,
         `scala3-sbt-bridge-bootstrapped`, // for scala-cli
         `scala3-staging`,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,6 +36,11 @@ import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 import sbt.dsl.LinterLevel.Ignore
 
+import sbtassembly.{AssemblyPlugin, CustomMergeStrategy, MergeStrategy, PathList}
+import sbtassembly.AssemblyPlugin.autoImport.*
+import sbtassembly.Assembly.JarEntry
+import com.eed3si9n.jarjarabrams.ShadeRule
+
 import Constants._
 
 object Build {
@@ -47,6 +52,9 @@ object Build {
 
   // Used to compile files similar to ./bin/scalac script
   val scalac = inputKey[Unit]("run the compiler using the correct classpath, or the user supplied classpath")
+
+  /** Shaded JLine jar with system-property string constants restored. */
+  val shadedJlineJar = taskKey[File]("JLine jar shaded under dotty.shaded.org.jline with property strings fixed")
 
   // Used to run binaries similar to ./bin/scala script
   val scala = inputKey[Unit]("run compiled binary using the correct classpath, or the user supplied classpath")
@@ -606,6 +614,7 @@ object Build {
     `scala3-directives-parser-bootstrapped`,
     `scala3-staging`,
     `scala3-tasty-inspector`,
+    `jline-shaded`,
     `scala3-repl`,
     `scala2-library`,
     scaladoc,
@@ -881,6 +890,98 @@ object Build {
       bspEnabled := false,
     )
 
+  /** Relocate JLine package names in resource file contents, leaving `org.jline.nativ`
+   *  alone (its JNI symbols are name-based and cannot be renamed).
+   */
+  private def shadeJlineResourceText(text: String): String =
+    text
+      .replace("org.jline.nativ.", "\u0000ORG_JLINE_NATIV.\u0000")
+      .replace("org.jline.", "dotty.shaded.org.jline.")
+      .replace("\u0000ORG_JLINE_NATIV.\u0000", "org.jline.nativ.")
+
+  private def shadeJlineResourceEntries(
+      conflicts: Vector[sbtassembly.Assembly.Dependency],
+      retarget: String => String = identity,
+  ): Either[String, Vector[JarEntry]] =
+    Right(conflicts.map { dep =>
+      val text = shadeJlineResourceText(IO.readStream(dep.stream()))
+      val bytes = text.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+      JarEntry(retarget(dep.target), () => new java.io.ByteArrayInputStream(bytes))
+    })
+
+  /* Shade JLine under `dotty.shaded.org.jline.**` so sbt 1's JLineLoader cannot
+   * intercept half of it when `sbt console` runs the REPL in-process.
+   * See scala/scala3#26678. `org.jline.nativ` stays unshaded (JNI symbol names).
+   */
+  lazy val `jline-shaded` = project.in(file("repl/jline-shaded"))
+    .settings(
+      name := "jline-shaded",
+      autoScalaLibrary := false,
+      crossPaths := false,
+      publish / skip := true,
+      bspEnabled := false,
+      libraryDependencies ++= Seq(
+        Dependencies.jlineReader,
+        Dependencies.jlineTerminal,
+        Dependencies.jlineTerminalJni,
+      ),
+      // Keep `jline-native` out of the shaded jar: its JNI symbols are
+      // name-based (`Java_org_jline_nativ_*`) and cannot be relocated.
+      // `scala3-repl` depends on it as a normal published dependency.
+      excludeDependencies += "org.jline" % "jline-native",
+      assemblyExcludedJars := {
+        (assembly / fullClasspath).value.filter { atr =>
+          atr.data.getName.startsWith("jline-native")
+        }
+      },
+      assembly / assemblyJarName := "jline-shaded.jar",
+      assembly / test := {},
+      assemblyPackageScala / assembleArtifact := false,
+      assemblyShadeRules := Seq(
+        // First match wins: keep any residual `org.jline.nativ` references
+        // under their real name so shaded JNI classes link against the
+        // separately shipped `jline-native` jar.
+        ShadeRule.rename("org.jline.nativ.**" -> "org.jline.nativ.@1").inAll,
+        ShadeRule.rename("org.jline.**" -> "dotty.shaded.org.jline.@1").inAll,
+      ),
+      assemblyMergeStrategy := {
+        case PathList("META-INF", "jline", "providers", _*) =>
+          CustomMergeStrategy("shade-jline-providers")(shadeJlineResourceEntries(_))
+        case PathList("META-INF", "services", "org.jline.terminal.spi.TerminalProvider") =>
+          CustomMergeStrategy("shade-jline-spi") { conflicts =>
+            val combined = conflicts
+              .map(dep => shadeJlineResourceText(IO.readStream(dep.stream())))
+              .mkString
+            val bytes = combined.getBytes(java.nio.charset.StandardCharsets.UTF_8)
+            Right(Vector(JarEntry(
+              "META-INF/services/dotty.shaded.org.jline.terminal.spi.TerminalProvider",
+              () => new java.io.ByteArrayInputStream(bytes),
+            )))
+          }
+        case PathList("META-INF", "native-image", "org.jline", _*) =>
+          CustomMergeStrategy("shade-jline-native-image")(
+            shadeJlineResourceEntries(_, _.replace(
+              "META-INF/native-image/org.jline/",
+              "META-INF/native-image/dotty.shaded.org.jline/",
+            ))
+          )
+        case PathList("module-info.class") => MergeStrategy.discard
+        case PathList("META-INF", "versions", _*) => MergeStrategy.discard
+        case x =>
+          val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
+          oldStrategy(x)
+      },
+      // JarJar also rewrites string constants that look like class names,
+      // which corrupts JLine system-property keys. Restore any shaded dotted
+      // string that does not name a class present in the jar.
+      shadedJlineJar := {
+        val assembled = assembly.value
+        val fixed = streams.value.cacheDirectory / "jline-shaded-fixed.jar"
+        JLineShade.restoreNonClassStringConstants(assembled, fixed)
+        fixed
+      },
+    )
+
   lazy val `scala3-repl` = project.in(file("repl"))
     .dependsOn(`scala3-compiler-bootstrapped` % "compile->compile;test->test", `scala3-directives-parser-bootstrapped`)
     .settings(publishSettings)
@@ -904,13 +1005,28 @@ object Build {
       // Only publish compilation artifacts, no test artifacts
       Test    / publishArtifact := false,
       publish / skip := false,
+      // JLine is shaded into this jar under `dotty.shaded.org.jline.**` (see
+      // `jline-shaded`) so sbt 1's JLineLoader cannot mix versions (#26678).
+      // `jline-native` stays a normal dependency: its JNI symbols are name-based
+      // and cannot be relocated.
       libraryDependencies ++= Seq(
-        Dependencies.jlineReader,
-        Dependencies.jlineTerminal,
-        Dependencies.jlineTerminalJni,
+        Dependencies.jlineNative,
         Dependencies.sbtJunitInterface % Test,
         Dependencies.coursierInterface, // used by the REPL for dependency resolution
       ),
+      Compile / unmanagedJars += (`jline-shaded` / shadedJlineJar).value,
+      Compile / packageBin / mappings ++= {
+        val shadedJar = (`jline-shaded` / shadedJlineJar).value
+        val out = target.value / "jline-shaded-unpacked"
+        IO.delete(out)
+        IO.unzip(shadedJar, out)
+        sbt.io.Path.allSubpaths(out).toSeq.filterNot { case (_, rel) =>
+          rel == "META-INF/MANIFEST.MF"
+        }
+      },
+      // Dependents must see the packaged jar (which embeds shaded JLine), not
+      // just the classDirectory (which does not).
+      exportJars := true,
       // Configure to use the non-bootstrapped compiler
       bootstrappedScalaInstanceSettings,
       // Needed for the JSR223 tests which are "run" tests

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,6 +39,7 @@ object Dependencies {
   val jacksonDataformatYaml = "tools.jackson.dataformat" % "jackson-dataformat-yaml" % jacksonVersion
 
   private val jlineVersion = "4.3.1"
+  val jlineNative = "org.jline" % "jline-native" % jlineVersion
   val jlineReader = "org.jline" % "jline-reader" % jlineVersion
   val jlineTerminal = "org.jline" % "jline-terminal" % jlineVersion
   val jlineTerminalJni = "org.jline" % "jline-terminal-jni" % jlineVersion

--- a/project/JLineShade.scala
+++ b/project/JLineShade.scala
@@ -1,0 +1,97 @@
+import java.io.{ByteArrayOutputStream, File, InputStream}
+import java.util.jar.{JarEntry, JarFile, JarOutputStream}
+import java.nio.file.Files
+
+import org.objectweb.asm.{ClassReader, ClassWriter}
+import org.objectweb.asm.commons.{ClassRemapper, Remapper}
+
+/** Helpers for the JLine shading pipeline used by `jline-shaded`. */
+object JLineShade {
+
+  private val ShadedPrefix = "dotty.shaded.org.jline."
+  private val UnshadedPrefix = "org.jline."
+
+  /**
+   * JarJar rename rules also rewrite string constants that *look* like class
+   * names. That corrupts JLine's system-property keys (e.g.
+   * `org.jline.terminal.provider`). Restore any shaded dotted string that does
+   * not correspond to a class actually present in the jar.
+   */
+  def restoreNonClassStringConstants(inJar: File, outJar: File): Unit = {
+    val classNames = collectDottedClassNames(inJar)
+    val remapper = new Remapper {
+      override def map(internalName: String): String = internalName
+      override def mapValue(value: AnyRef): AnyRef = value match {
+        case s: String => restoreIfNotAClass(s, classNames)
+        case other     => other
+      }
+    }
+
+    val buffer = new ByteArrayOutputStream(Math.max(32 * 1024, inJar.length().toInt))
+    val jos = new JarOutputStream(buffer)
+    val jf = new JarFile(inJar)
+    try {
+      val entries = jf.entries()
+      while (entries.hasMoreElements) {
+        val entry = entries.nextElement()
+        val bytes = readAll(jf.getInputStream(entry))
+        val outBytes =
+          if (entry.getName.endsWith(".class") && !entry.isDirectory)
+            rewriteClass(bytes, remapper)
+          else bytes
+        val outEntry = new JarEntry(entry.getName)
+        outEntry.setTime(entry.getTime)
+        jos.putNextEntry(outEntry)
+        jos.write(outBytes)
+        jos.closeEntry()
+      }
+    } finally {
+      jf.close()
+      jos.close()
+    }
+    Files.write(outJar.toPath, buffer.toByteArray)
+  }
+
+  private def collectDottedClassNames(jar: File): Set[String] = {
+    val jf = new JarFile(jar)
+    try {
+      val b = Set.newBuilder[String]
+      val entries = jf.entries()
+      while (entries.hasMoreElements) {
+        val name = entries.nextElement().getName
+        if (name.endsWith(".class") && !name.contains("module-info"))
+          b += name.stripSuffix(".class").replace('/', '.')
+      }
+      b.result()
+    } finally jf.close()
+  }
+
+  private def restoreIfNotAClass(s: String, classNames: Set[String]): String =
+    if (!s.startsWith(ShadedPrefix)) s
+    else if (isPresentClass(s, classNames)) s
+    else UnshadedPrefix + s.substring(ShadedPrefix.length)
+
+  /** True if `dotted` names a class (or outer class of an inner class) in the jar. */
+  private def isPresentClass(dotted: String, classNames: Set[String]): Boolean =
+    classNames.contains(dotted) ||
+      classNames.exists(c => c.startsWith(dotted + "$$") || c.startsWith(dotted + "$"))
+
+  private def rewriteClass(bytes: Array[Byte], remapper: Remapper): Array[Byte] = {
+    val cr = new ClassReader(bytes)
+    val cw = new ClassWriter(0)
+    cr.accept(new ClassRemapper(cw, remapper), 0)
+    cw.toByteArray
+  }
+
+  private def readAll(in: InputStream): Array[Byte] = {
+    try {
+      val buf = new ByteArrayOutputStream()
+      val tmp = new Array[Byte](8192)
+      Iterator
+        .continually(in.read(tmp))
+        .takeWhile(_ != -1)
+        .foreach(n => buf.write(tmp, 0, n))
+      buf.toByteArray
+    } finally in.close()
+  }
+}

--- a/project/JLineShade.scala
+++ b/project/JLineShade.scala
@@ -2,23 +2,42 @@ import java.io.{ByteArrayOutputStream, File, InputStream}
 import java.util.jar.{JarEntry, JarFile, JarOutputStream}
 import java.nio.file.Files
 
-import org.objectweb.asm.{ClassReader, ClassWriter}
+import org.objectweb.asm.{ClassReader, ClassWriter, Opcodes}
 import org.objectweb.asm.commons.{ClassRemapper, Remapper}
 
-/** Helpers for the JLine shading pipeline used by `jline-shaded`. */
+/** Helpers for the JLine shading pipeline used by `scala3-jline-shaded`. */
 object JLineShade {
 
   private val ShadedPrefix = "dotty.shaded.org.jline."
   private val UnshadedPrefix = "org.jline."
 
   /**
+   * Module name must stay `org.jline.terminal`: Scala CLI hardcodes
+   * `--add-modules org.jline.terminal` for JDK 24+ (see VirtusLab/scala-cli
+   * `ReplArtifacts`). The jar still exports `dotty.shaded.org.jline.**`.
+   */
+  val ModuleName = "org.jline.terminal"
+
+  private val TerminalProvider =
+    "dotty.shaded.org.jline.terminal.spi.TerminalProvider"
+  private val JniTerminalProvider =
+    "dotty.shaded.org.jline.terminal.impl.jni.JniTerminalProvider"
+  private val TerminalGraphics =
+    "dotty.shaded.org.jline.terminal.impl.TerminalGraphics"
+
+  /**
    * JarJar rename rules also rewrite string constants that *look* like class
    * names. That corrupts JLine's system-property keys (e.g.
    * `org.jline.terminal.provider`). Restore any shaded dotted string that does
-   * not correspond to a class actually present in the jar.
+   * not correspond to a class actually present in the jar, then inject a
+   * `module-info.class`.
    */
-  def restoreNonClassStringConstants(inJar: File, outJar: File): Unit = {
+  def finalizeShadedJar(inJar: File, outJar: File): Unit = {
     val classNames = collectDottedClassNames(inJar)
+    requireClass(classNames, TerminalProvider)
+    requireClass(classNames, JniTerminalProvider)
+    requireClass(classNames, TerminalGraphics)
+
     val remapper = new Remapper {
       override def map(internalName: String): String = internalName
       override def mapValue(value: AnyRef): AnyRef = value match {
@@ -27,6 +46,9 @@ object JLineShade {
       }
     }
 
+    val packages = classNames.flatMap(packageOf)
+    val moduleInfo = moduleInfoBytes(packages)
+
     val buffer = new ByteArrayOutputStream(Math.max(32 * 1024, inJar.length().toInt))
     val jos = new JarOutputStream(buffer)
     val jf = new JarFile(inJar)
@@ -34,22 +56,74 @@ object JLineShade {
       val entries = jf.entries()
       while (entries.hasMoreElements) {
         val entry = entries.nextElement()
-        val bytes = readAll(jf.getInputStream(entry))
-        val outBytes =
-          if (entry.getName.endsWith(".class") && !entry.isDirectory)
-            rewriteClass(bytes, remapper)
-          else bytes
-        val outEntry = new JarEntry(entry.getName)
-        outEntry.setTime(entry.getTime)
-        jos.putNextEntry(outEntry)
-        jos.write(outBytes)
-        jos.closeEntry()
+        // Discard any upstream / stale module descriptor; we inject our own.
+        if (entry.getName != "module-info.class") {
+          val bytes = readAll(jf.getInputStream(entry))
+          val outBytes =
+            if (entry.getName.endsWith(".class") && !entry.isDirectory)
+              rewriteClass(bytes, remapper)
+            else bytes
+          val outEntry = new JarEntry(entry.getName)
+          outEntry.setTime(entry.getTime)
+          jos.putNextEntry(outEntry)
+          jos.write(outBytes)
+          jos.closeEntry()
+        }
       }
+      val mi = new JarEntry("module-info.class")
+      jos.putNextEntry(mi)
+      jos.write(moduleInfo)
+      jos.closeEntry()
     } finally {
       jf.close()
       jos.close()
     }
     Files.write(outJar.toPath, buffer.toByteArray)
+  }
+
+  /**
+   * Build `module-info.class` for an open module named [[ModuleName]].
+   * Exports every package found in the shaded jar; requires `org.jline.nativ`
+   * transitively so `--enable-native-access=org.jline.nativ` names a resolved
+   * module when Scala CLI puts both jars on the module path.
+   */
+  def moduleInfoBytes(packages: Set[String]): Array[Byte] = {
+    val cw = new ClassWriter(0)
+    cw.visit(
+      Opcodes.V9,
+      Opcodes.ACC_MODULE,
+      "module-info",
+      null,
+      null,
+      null,
+    )
+    val mv = cw.visitModule(ModuleName, Opcodes.ACC_OPEN, null)
+    mv.visitRequire("java.base", Opcodes.ACC_MANDATED, null)
+    mv.visitRequire("org.jline.nativ", Opcodes.ACC_TRANSITIVE, null)
+    mv.visitRequire("java.desktop", Opcodes.ACC_STATIC_PHASE, null)
+    packages.toSeq.sorted.foreach(pkg => mv.visitExport(pkg.replace('.', '/'), 0))
+    mv.visitUse(TerminalProvider.replace('.', '/'))
+    mv.visitUse(TerminalGraphics.replace('.', '/'))
+    mv.visitProvide(
+      TerminalProvider.replace('.', '/'),
+      JniTerminalProvider.replace('.', '/'),
+    )
+    mv.visitEnd()
+    cw.visitEnd()
+    cw.toByteArray
+  }
+
+  private def requireClass(classNames: Set[String], dotted: String): Unit =
+    if (!classNames.contains(dotted))
+      throw new IllegalStateException(
+        s"""shaded JLine jar is missing required class $dotted;
+           |a JLine upgrade may have renamed it""".stripMargin
+      )
+
+  private def packageOf(dottedClass: String): Option[String] = {
+    val i = dottedClass.lastIndexOf('.')
+    if (i <= 0) None
+    else Some(dottedClass.substring(0, i))
   }
 
   private def collectDottedClassNames(jar: File): Set[String] = {
@@ -83,7 +157,7 @@ object JLineShade {
     cw.toByteArray
   }
 
-  private def readAll(in: InputStream): Array[Byte] = {
+  private def readAll(in: InputStream): Array[Byte] =
     try {
       val buf = new ByteArrayOutputStream()
       val tmp = new Array[Byte](8192)
@@ -93,5 +167,4 @@ object JLineShade {
         .foreach(n => buf.write(tmp, 0, n))
       buf.toByteArray
     } finally in.close()
-  }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,3 +24,6 @@ addSbtPlugin("com.github.sbt" % "sbt-jdi-tools" % "1.2.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-missinglink" % "0.3.6")
 libraryDependencies += "com.spotify" % "missinglink-core" % "0.2.11"
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
+libraryDependencies += "org.ow2.asm" % "asm-commons" % "9.9.1"

--- a/project/scripts/native-integration/bashTests
+++ b/project/scripts/native-integration/bashTests
@@ -99,10 +99,21 @@ echo "testing REPL does not emit legacy lazy vals warnings on JDK 25 (scala/scal
 # The vendored pprint/fansi/sourcecode must be compiled with the new lazy vals
 # scheme, otherwise scala.runtime.LazyVals$ calls sun.misc.Unsafe::objectFieldOffset,
 # which the JVM reports as a terminally deprecated method starting with JDK 24+
+#
+# Also guards scala/scala3#22756.
 std_output=$("$PROG_HOME/bin/scala" --jvm 25 --server=false -repl-init-script 'val replCheck = 1 + 1' -repl-quit-after-init 2>&1)
 echo "$std_output" | grep -q "replCheck" || die "REPL init script did not run on JDK 25, output: $std_output"
 if echo "$std_output" | grep "has been called by scala.runtime.LazyVals" | grep -qv "scala-cli"; then
   die "REPL emitted a legacy lazy vals warning on JDK 25, output: $std_output"
+fi
+if echo "$std_output" | grep -q "A restricted method in java.lang.System has been called"; then
+  die "REPL emitted a restricted-method warning on JDK 25 (JLine native access misconfigured), output: $std_output"
+fi
+if echo "$std_output" | grep -q "Unknown module"; then
+  die "REPL reported Unknown module on JDK 25 (JLine module path misconfigured), output: $std_output"
+fi
+if echo "$std_output" | grep -q "FindException"; then
+  die "REPL failed to resolve a JPMS module on JDK 25, output: $std_output"
 fi
 clear_cli_dotfiles "$ROOT"
 

--- a/repl/src/dotty/tools/repl/JLineTerminal.scala
+++ b/repl/src/dotty/tools/repl/JLineTerminal.scala
@@ -11,26 +11,26 @@ import dotc.parsing.Tokens.*
 import dotc.printing.SyntaxHighlighting
 import dotc.reporting.Reporter
 import dotc.util.SourceFile
-import org.jline.reader
-import org.jline.reader.Parser.ParseContext
-import org.jline.reader.*
-import org.jline.reader.impl.LineReaderImpl
-import org.jline.reader.impl.history.DefaultHistory
-import org.jline.terminal.Attributes
-import org.jline.terminal.Attributes.ControlChar
-import org.jline.terminal.TerminalBuilder
-import org.jline.terminal.Terminal.Signal
-import org.jline.utils.AttributedString
-import org.jline.utils.NonBlockingReader
+import dotty.shaded.org.jline.reader
+import dotty.shaded.org.jline.reader.Parser.ParseContext
+import dotty.shaded.org.jline.reader.*
+import dotty.shaded.org.jline.reader.impl.LineReaderImpl
+import dotty.shaded.org.jline.reader.impl.history.DefaultHistory
+import dotty.shaded.org.jline.terminal.Attributes
+import dotty.shaded.org.jline.terminal.Attributes.ControlChar
+import dotty.shaded.org.jline.terminal.TerminalBuilder
+import dotty.shaded.org.jline.terminal.Terminal.Signal
+import dotty.shaded.org.jline.utils.AttributedString
+import dotty.shaded.org.jline.utils.NonBlockingReader
 
 // `stdin` alternates between a background Ctrl-C monitor and the foreground
 // wrapped `System.in` reader. These states track which side currently owns it.
 private enum InputState:
   case Monitoring, ForegroundRead, Closed
 
-class JLineTerminal(providedTerminal: org.jline.terminal.Terminal | Null = null) extends java.io.Closeable {
+class JLineTerminal(providedTerminal: dotty.shaded.org.jline.terminal.Terminal | Null = null) extends java.io.Closeable {
   def this() = this(null)
-  private val terminal: org.jline.terminal.Terminal =
+  private val terminal: dotty.shaded.org.jline.terminal.Terminal =
     if providedTerminal != null then providedTerminal
     else
       val builder = TerminalBuilder.builder()

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -41,7 +41,7 @@ import dotty.tools.io.{AbstractFileClassLoader => _, *}
 import dotty.tools.dotc.classpath.FileUtils.isClassContainer
 import dotty.tools.repl.ScalaClassLoader.*
 
-import org.jline.reader.*
+import dotty.shaded.org.jline.reader.*
 
 import Rendering.showUser
 

--- a/repl/test/dotty/tools/repl/JLineTerminalTests.scala
+++ b/repl/test/dotty/tools/repl/JLineTerminalTests.scala
@@ -7,8 +7,8 @@ import java.io.{ByteArrayOutputStream, PipedInputStream, PipedOutputStream}
 
 import org.junit.Assert.*
 import org.junit.{Ignore, Test}
-import org.jline.terminal.TerminalBuilder
-import org.jline.utils.NonBlockingReader
+import dotty.shaded.org.jline.terminal.TerminalBuilder
+import dotty.shaded.org.jline.utils.NonBlockingReader
 
 class JLineTerminalTests:
 

--- a/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplInteractiveTests.scala
@@ -10,8 +10,8 @@ import java.util.concurrent.{Executors, TimeUnit, TimeoutException}
 import dotc.core.Contexts.Context
 import org.junit.Assert.*
 import org.junit.Test
-import org.jline.reader.{Candidate, Completer, LineReader, ParsedLine}
-import org.jline.terminal.TerminalBuilder
+import dotty.shaded.org.jline.reader.{Candidate, Completer, LineReader, ParsedLine}
+import dotty.shaded.org.jline.terminal.TerminalBuilder
 
 /** Interactive-mode accept-line behaviour for lone directives/commands and pastes. */
 class ReplInteractiveTests:

--- a/sbt-test/sbt-dotty/repl-jline/build.sbt
+++ b/sbt-test/sbt-dotty/repl-jline/build.sbt
@@ -1,0 +1,8 @@
+scalaVersion := sys.props("plugin.scalaVersion")
+
+// Make `console` non-interactive so it cannot hang CI: the init script runs
+// and the REPL quits immediately.
+Compile / console / scalacOptions ++= Seq(
+  "--repl-init-script", """println("REPL_JLINE_OK")""",
+  "--repl-quit-after-init",
+)

--- a/sbt-test/sbt-dotty/repl-jline/src/main/scala/Main.scala
+++ b/sbt-test/sbt-dotty/repl-jline/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+@main def main(): Unit = ()

--- a/sbt-test/sbt-dotty/repl-jline/test
+++ b/sbt-test/sbt-dotty/repl-jline/test
@@ -1,0 +1,2 @@
+> compile
+> console


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26678

This shades the JLine dependency of the REPL behind `dotty.shaded.*`

## Have you relied on LLM-based tools in this contribution?
Yes, and I checked the output by verifying it and running tests

## How was the solution tested?
New automated tests
