### PR TITLE
refactor(repl): using directive handling

### DIFF
--- a/repl/src/dotty/tools/repl/DependencyResolver.scala
+++ b/repl/src/dotty/tools/repl/DependencyResolver.scala
@@ -10,16 +10,9 @@ import scala.util.control.NonFatal
 import dotty.tools.repl.AbstractFileClassLoader
 
 import coursierapi.{Dependency, MavenRepository}
-import dotty.tools.directives.{DirectiveValue, UsingDirectivesParser}
 
 /** Handles dependency resolution using Coursier for the REPL */
 object DependencyResolver:
-
-  /** Result of classifying `//> using` directives in REPL input. */
-  case class ClassifiedDirectives(deps: List[String], unsupportedKeys: List[String], hasDirectives: Boolean)
-
-  /** Directive keys the REPL knows how to handle. Extend as more directives gain REPL support. */
-  val supportedDirectives: Set[String] = Set("dep")
 
   /** Parse a dependency string of the form `org::artifact:version` or `org:artifact:version`
    *  and return the (organization, artifact, version) triple if successful.
@@ -35,20 +28,6 @@ object DependencyResolver:
       case _ =>
         System.err.println("Unable to parse dependency \"" + dep + "\"")
         None
-
-  /** Classify `//> using` directives in REPL input into dependency coordinates and unsupported keys. */
-  def classifyDirectives(sourceCode: String): ClassifiedDirectives =
-    try
-      val result = UsingDirectivesParser.parse(sourceCode)
-      val (supported, unsupported) = result.directives.partition(d => supportedDirectives.contains(d.key))
-      val deps =
-        supported
-          .flatMap(_.values.collect { case DirectiveValue.StringVal(value, _, _) => value })
-          .toList
-      val unsupportedKeys = unsupported.map(_.key).distinct.toList
-      ClassifiedDirectives(deps, unsupportedKeys, result.directives.nonEmpty)
-    catch
-      case NonFatal(_) => ClassifiedDirectives(Nil, Nil, false)
 
   /** Resolve dependencies using Coursier Interface and return the classpath as a list of File objects */
   def resolveDependencies(dependencies: List[(String, String, String)]): Either[String, List[File]] =

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -204,26 +204,23 @@ case object Help extends Command {
   override def replayLine = Some(command)
   val command: String = ":help"
   val text: String =
-    """The REPL has several commands available:
-      |
-      |:help                    print this summary
-      |:save <path>             save replayable session to a file
-      |:load <path>             interpret lines in a file
-      |:quit                    exit the interpreter
-      |:type <expression>       evaluate the type of the given expression
-      |:doc <expression>        print the documentation for the given expression
-      |:imports                 show import history
-      |:reset [options]         clear the session and start fresh with the given compiler options
-      |:replay [options]        reset, then re-run the session with the given compiler options
-      |:settings <options>      update compiler options, if possible
-      |:silent                  disable/enable automatic printing of results
-      |:dep <group>::<artifact>:<version>     Resolve a dependency and make it available in the REPL
-      |
-      |Scala CLI `//> using dep` directives are also supported and behave like `:dep`, e.g.:
-      |  //> using dep <group>::<artifact>:<version>
-      |Directives must appear before any Scala code in the input; code on following lines is
-      |evaluated as usual. Other `//> using` directives are not (yet) supported in the REPL.
-    """.stripMargin
+    s"""|The REPL has several commands available:
+        |
+        |:help                    print this summary
+        |:save <path>             save replayable session to a file
+        |:load <path>             interpret lines in a file
+        |:quit                    exit the interpreter
+        |:type <expression>       evaluate the type of the given expression
+        |:doc <expression>        print the documentation for the given expression
+        |:imports                 show import history
+        |:reset [options]         clear the session and start fresh with the given compiler options
+        |:replay [options]        reset, then re-run the session with the given compiler options
+        |:settings <options>      update compiler options, if possible
+        |:silent                  disable/enable automatic printing of results
+        |:dep <group>::<artifact>:<version>     Resolve a dependency and make it available in the REPL
+        |
+        |${ReplDirectives.helpText}
+      """.stripMargin
 }
 
 object ParseResult {

--- a/repl/src/dotty/tools/repl/ReplDirectives.scala
+++ b/repl/src/dotty/tools/repl/ReplDirectives.scala
@@ -1,0 +1,67 @@
+package dotty.tools.repl
+
+import scala.util.control.NonFatal
+
+import dotty.tools.directives.{DirectiveValue, UsingDirectivesParser}
+
+private[repl] object ReplDirectives:
+
+  case class DirectiveEffects(dependencies: List[String] = Nil):
+    def ++(other: DirectiveEffects): DirectiveEffects =
+      DirectiveEffects(dependencies ++ other.dependencies)
+
+  case class ClassifiedDirectives(
+    effects: DirectiveEffects,
+    unsupportedKeys: List[String],
+    hasDirectives: Boolean
+  )
+
+  private trait DirectiveHandler:
+    def keys: List[String]
+    def usage: String
+    def description: String
+    def process(values: Seq[DirectiveValue]): DirectiveEffects
+
+    final def helpText: String =
+      val aliasText = keys.drop(1) match
+        case Nil => Nil
+        case aliases => List(s"  Aliases: ${aliases.mkString(", ")}")
+      (List(usage, s"  $description") ++ aliasText).mkString("\n")
+
+  private object DependencyDirective extends DirectiveHandler:
+    val keys = List("dep")
+    val usage = "//> using dep <group>::<artifact>:<version> ..."
+    val description = "Resolve dependencies and make them available in the REPL."
+
+    def process(values: Seq[DirectiveValue]): DirectiveEffects =
+      val dependencies = values.collect:
+        case DirectiveValue.StringVal(value, _, _) => value
+      DirectiveEffects(dependencies.toList)
+
+  private val handlers = List(DependencyDirective)
+  private val handlersByKey = handlers.flatMap(handler => handler.keys.map(_ -> handler)).toMap
+
+  require(
+    handlersByKey.size == handlers.map(_.keys.size).sum,
+    "REPL directive keys must be unique"
+  )
+
+  val helpText: String =
+    s"""Supported `//> using` directives:
+       |
+       |${handlers.map(_.helpText).mkString("\n\n")}
+       |
+       |Directives must appear before any Scala code in the input; code on following lines is
+       |evaluated as usual. Other `//> using` directives are not (yet) supported in the REPL.
+       |""".stripMargin
+
+  def classify(sourceCode: String): ClassifiedDirectives =
+    try
+      val result = UsingDirectivesParser.parse(sourceCode)
+      val (supported, unsupported) = result.directives.partition(directive => handlersByKey.contains(directive.key))
+      val effects = supported.foldLeft(DirectiveEffects()): (acc, directive) =>
+        acc ++ handlersByKey(directive.key).process(directive.values)
+      val unsupportedKeys = unsupported.map(_.key).distinct.toList
+      ClassifiedDirectives(effects, unsupportedKeys, result.directives.nonEmpty)
+    catch
+      case NonFatal(_) => ClassifiedDirectives(DirectiveEffects(), Nil, false)

--- a/repl/src/dotty/tools/repl/ReplDirectives.scala
+++ b/repl/src/dotty/tools/repl/ReplDirectives.scala
@@ -6,12 +6,10 @@ import dotty.tools.directives.{DirectiveValue, UsingDirectivesParser}
 
 private[repl] object ReplDirectives:
 
-  case class DirectiveEffects(dependencies: List[String] = Nil):
-    def ++(other: DirectiveEffects): DirectiveEffects =
-      DirectiveEffects(dependencies ++ other.dependencies)
+  type Dependencies = List[String]
 
-  case class ClassifiedDirectives(
-    effects: DirectiveEffects,
+  case class DirectiveClassification(
+    dependencies: Dependencies,
     unsupportedKeys: List[String],
     hasDirectives: Boolean
   )
@@ -20,7 +18,7 @@ private[repl] object ReplDirectives:
     def keys: List[String]
     def usage: String
     def description: String
-    def process(values: Seq[DirectiveValue]): DirectiveEffects
+    def process(values: Seq[DirectiveValue]): Dependencies
 
     final def helpText: String =
       val aliasText = keys.drop(1) match
@@ -33,10 +31,10 @@ private[repl] object ReplDirectives:
     val usage = "//> using dep <group>::<artifact>:<version> ..."
     val description = "Resolve dependencies and make them available in the REPL."
 
-    def process(values: Seq[DirectiveValue]): DirectiveEffects =
-      val dependencies = values.collect:
-        case DirectiveValue.StringVal(value, _, _) => value
-      DirectiveEffects(dependencies.toList)
+    def process(values: Seq[DirectiveValue]): Dependencies =
+      values.collect:
+          case DirectiveValue.StringVal(value, _, _) => value
+        .toList
 
   private val handlers = List(DependencyDirective)
   private val handlersByKey = handlers.flatMap(handler => handler.keys.map(_ -> handler)).toMap
@@ -55,13 +53,14 @@ private[repl] object ReplDirectives:
        |evaluated as usual. Other `//> using` directives are not (yet) supported in the REPL.
        |""".stripMargin
 
-  def classify(sourceCode: String): ClassifiedDirectives =
+  def classify(sourceCode: String): DirectiveClassification =
     try
       val result = UsingDirectivesParser.parse(sourceCode)
       val (supported, unsupported) = result.directives.partition(directive => handlersByKey.contains(directive.key))
-      val effects = supported.foldLeft(DirectiveEffects()): (acc, directive) =>
-        acc ++ handlersByKey(directive.key).process(directive.values)
+      val dependencies = supported
+        .flatMap(directive => handlersByKey(directive.key).process(directive.values))
+        .toList
       val unsupportedKeys = unsupported.map(_.key).distinct.toList
-      ClassifiedDirectives(effects, unsupportedKeys, result.directives.nonEmpty)
+      DirectiveClassification(dependencies, unsupportedKeys, result.directives.nonEmpty)
     catch
-      case NonFatal(_) => ClassifiedDirectives(DirectiveEffects(), Nil, false)
+      case NonFatal(_) => DirectiveClassification(Nil, Nil, false)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -795,13 +795,13 @@ class ReplDriver(settings: Array[String],
       state
   }
 
-  private def interpretDirectives(classified: ReplDirectives.ClassifiedDirectives)(using state: State): State =
+  private def interpretDirectives(classified: ReplDirectives.DirectiveClassification)(using state: State): State =
     classified.unsupportedKeys.foreach: key =>
       out.println(
         s"""[warn] The `using $key` directive is not supported in the REPL.
            |To use it, re-run with the `scala` command and pass the directive inside an input.""".stripMargin
       )
-    resolveAndAddDeps(classified.effects.dependencies)
+    resolveAndAddDeps(classified.dependencies)
 
   private def resolveAndAddDeps(depStrings: List[String])(using state: State): State =
     if depStrings.isEmpty then state

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -390,7 +390,7 @@ class ReplDriver(settings: Array[String],
         for diag <- parsed.directiveDiagnostics do
           out.println(s"[warn] ${diag.message}")
         val src = parsed.source.content().mkString
-        val classified = DependencyResolver.classifyDirectives(src)
+        val classified = ReplDirectives.classify(src)
         if classified.hasDirectives then
           val stateAfterDirectives = interpretDirectives(classified)
           if parsed.trees.nonEmpty then
@@ -795,13 +795,13 @@ class ReplDriver(settings: Array[String],
       state
   }
 
-  private def interpretDirectives(classified: DependencyResolver.ClassifiedDirectives)(using state: State): State =
+  private def interpretDirectives(classified: ReplDirectives.ClassifiedDirectives)(using state: State): State =
     classified.unsupportedKeys.foreach: key =>
       out.println(
         s"""[warn] The `using $key` directive is not supported in the REPL.
            |To use it, re-run with the `scala` command and pass the directive inside an input.""".stripMargin
       )
-    resolveAndAddDeps(classified.deps)
+    resolveAndAddDeps(classified.effects.dependencies)
 
   private def resolveAndAddDeps(depStrings: List[String])(using state: State): State =
     if depStrings.isEmpty then state


### PR DESCRIPTION
Refactors directive handling in the REPL to make it easier to support additional directives in the future, such as `//> using options`.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by testing manually with bin/replQ

## How was the solution tested?

Covered by existing tests (this is a refactoring)
