### PR TITLE
Ignore coverage probes in unused update analysis

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -353,7 +353,7 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
     def mightObserve(rhs: Tree): Boolean =
       rhs.existsSubTree: t =>
         t.srcPos.sourcePos.contains(pos.sourcePos) && t.match
-          case t: GenericApply => !isKnownPureOp(funPart(t).symbol)
+          case t: GenericApply => !InstrumentCoverage.isCoverageProbe(t) && !isKnownPureOp(funPart(t).symbol)
           case _: DefDef => true
           case _ => false
     enclosingAssigns.exists: assign =>


### PR DESCRIPTION
Fixes recent nighly CI breakage: https://github.com/scala/scala3/actions/runs/30876607715

Will unblock https://github.com/scala/scala3/pull/26571

The problem is that unused warnings phase treated Scoverage probes as valid instances of using a variable, therefore, preventing warnings from being emitted for such variables.

The solution is to teach unused warnings phase to ignore scoverage probes and not count them as instances of variable usage.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by review and testing.

## How was the solution tested?

Covered by existing tests (this is a regression fix)

[test_coverage]