### PR TITLE
Fix stale `baseTypeCache` after synthetic Product.Mirror parents added

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -668,6 +668,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       val newClassInfo = oldClassInfo.derivedClassInfo(
         declaredParents = oldClassInfo.declaredParents :+ parent)
       clazz.copySymDenotation(info = newClassInfo).installAfter(thisPhase)
+      parent.classSymbol.asClass.invalidateBaseTypeCache()
     }
     def addMethod(name: TermName, info: Type, cls: Symbol, body: (Symbol, Tree) => Context ?=> Tree): Unit = {
       val meth = newSymbol(clazz, name, Synthetic | Method, info, coord = clazz.coord)

--- a/tests/pos/i26611/App_2.scala
+++ b/tests/pos/i26611/App_2.scala
@@ -1,0 +1,10 @@
+package app
+
+import lib.*
+
+case class Local(y: Int)
+object Local extends HasOptions { val options = 1 }
+
+trait Cli {
+  Seq(Local, A, B, C, D, E)
+}

--- a/tests/pos/i26611/Lib_1.scala
+++ b/tests/pos/i26611/Lib_1.scala
@@ -1,0 +1,18 @@
+package lib
+
+trait HasOptions { def options: Int }
+
+case class A(x: String)
+object A extends HasOptions { val options = 1 }
+
+case class B(x: String)
+object B extends HasOptions { val options = 1 }
+
+case class C(x: String)
+object C extends HasOptions { val options = 1 }
+
+case class D(x: String)
+object D extends HasOptions { val options = 1 }
+
+case class E(x: String)
+object E extends HasOptions { val options = 1 }

--- a/tests/pos/i26611b.scala
+++ b/tests/pos/i26611b.scala
@@ -1,0 +1,10 @@
+import scala.deriving.Mirror
+
+case class Local(y: Int)
+object Local
+
+// `| Any` is for make typer pass
+// Run Local <:< Mirror.Product check at typer (baseTypeCache for `Mirror.Product` on `Local$` <- NoType)
+// PostTyper adds `MirrorPrpduct` as a parent of `Local$`, we should invalidate baseTypeCache for `Local$`
+// otherwise, Recheck fails `Local$ <:< Mirror.Product`.
+val x: Mirror.Product | Any = Local


### PR DESCRIPTION
Fixes #26611

- Case class companions get `Mirror.Product` added in `PostTyper`.
- If at Typer phase did subtype checking `Companion$ <:< Mirror.Product`. It caches `NoType` on `Mirror.Product.baseTypeCache(Companion$)`. (because at this point, `Mirror.Product` haven't yet added as parent).
- Later, `RefChecks` validate `Companion$ <:< Mirror.Product`, and wrongly rejects that by reading the stale cache.

We should invalidate the baseTypeCache when we add `Mirror.Product` as parent in PostTyper.

The original reproduction in https://github.com/scala/scala3/issues/26611 is same. `Seq(Local, A, B, C, D, E)` where A-E are separately compiled, does subtype check `Local <:< Mirror.Product` and cache `NoType` during type inference.

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No (Used AI for debugging though)

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)

