### PR TITLE
More helpful implicit not found message for `ClassTag[T]`

### DIFF
--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -42,7 +42,7 @@ import scala.runtime.ClassValueCompat
  *  [[scala.reflect.TypeTest]] and [[scala.reflect.Typeable]].
  */
 @nowarn("""cat=deprecation&origin=scala\.reflect\.ClassManifestDeprecatedApis""")
-@implicitNotFound(msg = "No ClassTag available for ${T}. You can fix this by changing [${T}] to [${T}: ClassTag].")
+@implicitNotFound(msg = "No reflect.ClassTag available for ${T}. You can fix this by changing [${T}] to [${T}: reflect.ClassTag].")
 trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serializable {
   // please, don't add any APIs here, like it was with `newWrappedArray` and `newArrayBuilder`
   // class tags, and all tags in general, should be as minimalistic as possible

--- a/library/src/scala/reflect/ClassTag.scala
+++ b/library/src/scala/reflect/ClassTag.scala
@@ -42,7 +42,7 @@ import scala.runtime.ClassValueCompat
  *  [[scala.reflect.TypeTest]] and [[scala.reflect.Typeable]].
  */
 @nowarn("""cat=deprecation&origin=scala\.reflect\.ClassManifestDeprecatedApis""")
-@implicitNotFound(msg = "No ClassTag available for ${T}")
+@implicitNotFound(msg = "No ClassTag available for ${T}. You can fix this by changing [${T}] to [${T}: ClassTag].")
 trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serializable {
   // please, don't add any APIs here, like it was with `newWrappedArray` and `newArrayBuilder`
   // class tags, and all tags in general, should be as minimalistic as possible

--- a/tests/neg/i15618.check
+++ b/tests/neg/i15618.check
@@ -1,24 +1,24 @@
 -- [E172] Type Error: tests/neg/i15618.scala:17:44 ---------------------------------------------------------------------
 17 |  def toArray: Array[ScalaType[T]] = Array() // error
    |                                            ^
-   |                                            No ClassTag available for ScalaType[T]
+   |No ClassTag available for ScalaType[T]. You can fix this by changing [ScalaType[T]] to [ScalaType[T]: ClassTag].
    |
-   |                                            where:    T is a type in class Tensor with bounds <: DType
+   |where:    T is a type in class Tensor with bounds <: DType
    |
    |
-   |                                            Note: a match type could not be fully reduced:
+   |Note: a match type could not be fully reduced:
    |
-   |                                              trying to reduce  ScalaType[T]
-   |                                              failed since selector T
-   |                                              does not match  case Float16 => Float
-   |                                              and cannot be shown to be disjoint from it either.
-   |                                              Therefore, reduction cannot advance to the remaining cases
+   |  trying to reduce  ScalaType[T]
+   |  failed since selector T
+   |  does not match  case Float16 => Float
+   |  and cannot be shown to be disjoint from it either.
+   |  Therefore, reduction cannot advance to the remaining cases
    |
-   |                                                case Float32 => Float
-   |                                                case Int32 => Int
+   |    case Float32 => Float
+   |    case Int32 => Int
 -- [E172] Type Error: tests/neg/i15618.scala:21:33 ---------------------------------------------------------------------
 21 |  def toArray: Array[T] = Array() // error
    |                                 ^
-   |                                 No ClassTag available for T
+   |                                 No ClassTag available for T. You can fix this by changing [T] to [T: ClassTag].
    |
    |                                 where:    T is a type in class Tensor2 with bounds <: Int | Float

--- a/tests/neg/i15618.check
+++ b/tests/neg/i15618.check
@@ -1,7 +1,7 @@
 -- [E172] Type Error: tests/neg/i15618.scala:17:44 ---------------------------------------------------------------------
 17 |  def toArray: Array[ScalaType[T]] = Array() // error
    |                                            ^
-   |No ClassTag available for ScalaType[T]. You can fix this by changing [ScalaType[T]] to [ScalaType[T]: ClassTag].
+   |No reflect.ClassTag available for ScalaType[T]. You can fix this by changing [ScalaType[T]] to [ScalaType[T]: reflect.ClassTag].
    |
    |where:    T is a type in class Tensor with bounds <: DType
    |
@@ -19,6 +19,6 @@
 -- [E172] Type Error: tests/neg/i15618.scala:21:33 ---------------------------------------------------------------------
 21 |  def toArray: Array[T] = Array() // error
    |                                 ^
-   |                                 No ClassTag available for T. You can fix this by changing [T] to [T: ClassTag].
+   |                 No reflect.ClassTag available for T. You can fix this by changing [T] to [T: reflect.ClassTag].
    |
-   |                                 where:    T is a type in class Tensor2 with bounds <: Int | Float
+   |                 where:    T is a type in class Tensor2 with bounds <: Int | Float


### PR DESCRIPTION
Fixes #24506

This should be better overall, though it may be a little confusing if you do weird things like `Array[Int & Nothing]()`, but presumably those are not common.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)