### PR TITLE
Scaladoc: do not warn on unused scalacOptions by default

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Scaladoc.scala
@@ -127,7 +127,7 @@ object Scaladoc:
       .partition(commonScalaSettings.contains)
     shared.foreach(setInGlobal)
 
-    if !other.isEmpty then report.echo(s"Skipping unused scalacOptions: ${other.map(_.name).mkString(", ")}")
+    if warnOnUnusedOptions.get && other.nonEmpty then report.warning(s"Skipping unused scalacOptions: ${other.map(_.name).mkString(", ")}")
 
     def parseTastyRoots(roots: String) =
       roots.split(File.pathSeparatorChar).toList.map(new File(_))

--- a/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScaladocSettings.scala
@@ -123,6 +123,9 @@ class ScaladocSettings extends SettingGroup with AllScalaSettings:
   val generateApi: Setting[Boolean] =
     BooleanSetting(RootSetting, "Ygenerate-api", "Controls whether API documentation should be generated. If disabled, only documentation pages will be generated", true)
 
+  val warnOnUnusedOptions: Setting[Boolean] =
+    BooleanSetting(RootSetting, "warn-on-unused-options", "Controls whether a warning is emitted when scaladoc receives scalac options that have no effect.", false)
+
   val scastieConfiguration: Setting[String] =
     StringSetting(RootSetting, "scastie-configuration", "Scastie configuration", "Additional configuration passed to Scastie in code snippets", "")
 

--- a/scaladoc/test/dotty/tools/scaladoc/DiagnosticsTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/DiagnosticsTests.scala
@@ -1,0 +1,38 @@
+package dotty.tools.scaladoc
+
+import org.junit.Test
+import org.junit.Assert.*
+
+class DiagnosticsTests:
+  @Test
+  def standardWarnings(): Unit =
+    val ctx = testContext
+    Scaladoc.run(Array("-no-indent", "doesnotexist.tasty"), ctx)
+    assertEquals("", ctx.reportedDiagnostics.errorMsgs.mkString("\n"))
+    assertEquals(
+      "scaladoc will ignore following non-existent paths: doesnotexist.tasty\n"
+       + "Destination is not provided, please provide '-d' parameter pointing to directory where docs should be created",
+      ctx.reportedDiagnostics.warningMsgs.mkString("\n")
+    )
+    assertEquals("", ctx.reportedDiagnostics.infoMsgs.mkString("\n"))
+
+  @Test
+  def warnOnUnusedOptions(): Unit =
+    val ctx = testContext
+    Scaladoc.run(Array("-no-indent", "-warn-on-unused-options", "doesnotexist.tasty"), ctx)
+    assertEquals("", ctx.reportedDiagnostics.errorMsgs.mkString("\n"))
+    assertEquals(
+      "Skipping unused scalacOptions: -no-indent\n"
+      + "scaladoc will ignore following non-existent paths: doesnotexist.tasty\n"
+      + "Destination is not provided, please provide '-d' parameter pointing to directory where docs should be created",
+      ctx.reportedDiagnostics.warningMsgs.mkString("\n")
+    )
+    assertEquals("", ctx.reportedDiagnostics.infoMsgs.mkString("\n"))
+
+  @Test
+  def noArgsDisplaysHelp(): Unit =
+    val ctx = testContext
+    Scaladoc.run(Array(), ctx)
+    assertEquals("", ctx.reportedDiagnostics.errorMsgs.mkString("\n"))
+    assertEquals("", ctx.reportedDiagnostics.warningMsgs.mkString("\n"))
+    assertTrue(ctx.reportedDiagnostics.infoMsgs.mkString("\n").contains("Usage: "))

--- a/scaladoc/test/dotty/tools/scaladoc/ExternalLocationProviderIntegrationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/ExternalLocationProviderIntegrationTest.scala
@@ -5,6 +5,7 @@ import dotty.tools.scaladoc.test.BuildInfo
 import java.nio.file.Path;
 import org.jsoup.Jsoup
 import util.IO
+import org.junit.Test
 
 class JavadocExternalLocationProviderIntegrationTest extends ExternalLocationProviderIntegrationTest(
   "externalJavadoc",
@@ -74,7 +75,8 @@ abstract class ExternalLocationProviderIntegrationTest(
       ).toList
   )
 
-  override def runTest = afterRendering {
+  @Test
+  def runTest(): Unit = afterRendering {
     val output = summon[DocContext].args.output.nn.toPath
     val linksBuilder = List.newBuilder[String]
 

--- a/scaladoc/test/dotty/tools/scaladoc/PackageDocumentationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/PackageDocumentationTest.scala
@@ -4,10 +4,11 @@ import org.junit.Assert._
 import com.vladsch.flexmark.util.{ast => mdu, sequence}
 import com.vladsch.flexmark.{ast => mda}
 import scala.jdk.CollectionConverters._
-
+import org.junit.Test
 
 class PackageDocumentationTest extends ScaladocTest("packageobjdocs"):
-  override def runTest: Unit = withModule { module =>
+  @Test
+  def runTest(): Unit = withModule { module =>
     module.members.values.find {
       case member if member.kind == Kind.Package => true
       case _ => false

--- a/scaladoc/test/dotty/tools/scaladoc/PackageOrderingTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/PackageOrderingTest.scala
@@ -1,6 +1,7 @@
 package dotty.tools.scaladoc
 
 import org.junit.Assert.assertEquals
+import org.junit.Test
 
 class PackageOrderingTest extends ScaladocTest(""):
   override def moduleDocContext =
@@ -9,7 +10,8 @@ class PackageOrderingTest extends ScaladocTest(""):
         tastyFiles("", rootPck = "packageorderingbeta")
     )
 
-  override def runTest: Unit = withModule { module =>
+  @Test
+  def runTest(): Unit = withModule { module =>
     val packages = module.rootPackage.members
       .filter(_.name.startsWith("packageordering"))
       .map(_.name)

--- a/scaladoc/test/dotty/tools/scaladoc/ScaladocTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/ScaladocTest.scala
@@ -1,7 +1,7 @@
 package dotty.tools.scaladoc
 
 import scala.jdk.CollectionConverters.{ListHasAsScala, SeqHasAsJava}
-import org.junit.{Test, Rule}
+import org.junit.Rule
 import org.junit.rules.{TemporaryFolder, ErrorCollector}
 import java.io.File
 
@@ -29,10 +29,6 @@ abstract class ScaladocTest(val name: String):
       projectVersion = Some("1.0"),
       sourceLinks = List("github://scala/scala3/master")
     )
-
-  @Test
-  def runTest: Unit
-
 
   @Rule
   def collector = _collector

--- a/scaladoc/test/dotty/tools/scaladoc/diagram/HierarchyTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/diagram/HierarchyTest.scala
@@ -4,9 +4,11 @@ package diagram
 import dotty.tools.scaladoc.ScaladocTest
 import scala.jdk.CollectionConverters.{ListHasAsScala, SeqHasAsJava}
 import org.junit.Assert.{assertSame, assertTrue, assertEquals}
+import org.junit.Test
 
 class HierarchyTest extends ScaladocTest("hierarchy"):
-  override def runTest = withModule(_.visitMembers(checkMember))
+  @Test
+  def runTest(): Unit = withModule(_.visitMembers(checkMember))
 
   def checkMember(x: Member) = x.name match
     case "C1" =>

--- a/scaladoc/test/dotty/tools/scaladoc/diagram/SealedHierarchyTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/diagram/SealedHierarchyTest.scala
@@ -4,9 +4,11 @@ package diagram
 import dotty.tools.scaladoc.ScaladocTest
 import scala.jdk.CollectionConverters.{ListHasAsScala, SeqHasAsJava}
 import org.junit.Assert.{assertSame, assertTrue, assertEquals}
+import org.junit.Test
 
 class SealedHierarchyTest extends ScaladocTest("sealedClasses"):
-  override def runTest = withModule(_.visitMembers(checkMember))
+  @Test
+  def runTest(): Unit = withModule(_.visitMembers(checkMember))
 
   def checkMember(x: Member) = x.name match
     case "A" =>

--- a/scaladoc/test/dotty/tools/scaladoc/linking/DriTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/linking/DriTest.scala
@@ -4,12 +4,14 @@ package linking
 import scala.jdk.CollectionConverters._
 import scala.Function.const
 import dotty.tools.scaladoc.ScaladocTest
+import org.junit.Test
 
 abstract class DriTest(testName: String) extends ScaladocTest(testName):
   // override for additional assertions
   def assertOnDRIs(dris: Seq[DRI]): Unit = ()
 
-  override def runTest = withModule { module =>
+  @Test
+  def runTest(): Unit = withModule { module =>
     val dris = collectFrom(module.rootPackage).map(_.dri)
 
     val grouping = dris.groupMapReduce(identity)(const(1))(_+_)

--- a/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/LinkWarningTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/LinkWarningTest.scala
@@ -2,6 +2,7 @@ package dotty.tools.scaladoc
 package noLinkWarnings
 
 import org.junit.Assert.assertEquals
+import org.junit.Test
 
 class LinkWarningsTest extends ScaladocTest("noLinkWarnings"):
 
@@ -12,7 +13,8 @@ class LinkWarningsTest extends ScaladocTest("noLinkWarnings"):
     projectVersion = Some("1.0")
   )
 
-  override def runTest = afterRendering {
+  @Test
+  def runTest(): Unit = afterRendering {
     val diagnostics = summon[DocContext].compilerContext.reportedDiagnostics
     val filteredWarnings = diagnostics.warningMsgs.filter(_ != "1 warning found")
     assertEquals("There should be exactly one warning", 1, filteredWarnings.size)

--- a/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/NoLinkWarningsTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/no-link-warnings/NoLinkWarningsTest.scala
@@ -1,6 +1,8 @@
 package dotty.tools.scaladoc
 package noLinkWarnings
 
+import org.junit.Test
+
 class NoLinkWarningsTest extends ScaladocTest("noLinkWarnings"):
 
   override def args = Scaladoc.Args(
@@ -11,7 +13,8 @@ class NoLinkWarningsTest extends ScaladocTest("noLinkWarnings"):
     noLinkWarnings = true
   )
 
-  override def runTest = afterRendering {
+  @Test
+  def runTest(): Unit = afterRendering {
     val diagnostics = summon[DocContext].compilerContext.reportedDiagnostics
     assertNoWarning(diagnostics)
     assertNoErrors(diagnostics)

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/AbstractMemberSignaturesTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/AbstractMemberSignaturesTest.scala
@@ -12,10 +12,12 @@ import dotty.tools.scaladoc.test.BuildInfo
 import org.jsoup.Jsoup
 import util.IO
 import org.junit.Assert.assertTrue
+import org.junit.Test
 
 class AbstractMembers extends ScaladocTest("abstractmembersignatures"):
 
-  def runTest = {
+  @Test
+  def runTest(): Unit = {
     afterRendering {
       val actualSignatures = signaturesFromDocumentation()
       actualSignatures.foreach { (k, v) => k match

--- a/scaladoc/test/dotty/tools/scaladoc/signatures/SignatureTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/signatures/SignatureTest.scala
@@ -8,6 +8,7 @@ import dotty.tools.scaladoc.test.BuildInfo
 import java.nio.file.Path;
 import org.jsoup.Jsoup
 import util.IO
+import org.junit.Test
 
 private enum SignatureRes:
   case Expected(name: String, signature: String)
@@ -22,7 +23,8 @@ abstract class SignatureTest(
   filterFunc: (Path) => Boolean = _ => true
 ) extends ScaladocTest(testName):
 
-  def runTest = { org.junit.Assume.assumeTrue("Running on Windows", java.io.File.separatorChar == '/'); afterRendering {
+  @Test
+  def runTest(): Unit = { org.junit.Assume.assumeTrue("Running on Windows", java.io.File.separatorChar == '/'); afterRendering {
     val sources = sourceFiles match
       case Nil => testName :: Nil
       case s => s

--- a/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/snippets/SnippetsE2eTest.scala
@@ -14,6 +14,7 @@ import com.vladsch.flexmark.util.{ast => mdu, sequence}
 import com.vladsch.flexmark.{ast => mda}
 import com.vladsch.flexmark.formatter.Formatter
 import scala.jdk.CollectionConverters._
+import org.junit.Test
 
 import dotty.tools.scaladoc.tasty.comments.markdown.ExtendedFencedCodeBlock
 
@@ -135,7 +136,8 @@ abstract class SnippetsE2eTest(testName: String, flag: SCFlags) extends Scaladoc
     }
   }
 
-  def runTest = {
+  @Test
+  def runTest(): Unit = {
     org.junit.Assume.assumeTrue("Running on Windows", java.io.File.separatorChar == '/')
     withModule(moduleTestingFunc)
   }

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/comments/MemberGroupingTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/comments/MemberGroupingTests.scala
@@ -8,6 +8,7 @@ import com.vladsch.flexmark.util.{ast => mdu, sequence}
 import com.vladsch.flexmark.{ast => mda}
 
 import wiki.WikiDocElement
+import org.junit.Test
 
 abstract class MemberGroupingTests(syntax: String) extends ScaladocTest("groups") {
   import MemberGroupingTests._
@@ -31,7 +32,8 @@ abstract class MemberGroupingTests(syntax: String) extends ScaladocTest("groups"
     "bazz" -> 10
   )
 
-  override def runTest = withModule { module =>
+  @Test
+  def runTest(): Unit = withModule { module =>
     val memberGroups = module.members.values.flatMap { member =>
       member.docs.flatMap(_.group).map(g => member.name -> g)
     }.toMap


### PR DESCRIPTION
Fixes #26459

Adds an argument to do that (and formally makes it a warning).

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)