### PR TITLE
Encapsulate `SourceFile` more

### DIFF
--- a/compiler/src/dotty/tools/dotc/CompilationUnit.scala
+++ b/compiler/src/dotty/tools/dotc/CompilationUnit.scala
@@ -17,6 +17,7 @@ import config.{SourceVersion, Feature}
 import scala.annotation.internal.sharable
 import scala.util.control.NoStackTrace
 import transform.MacroAnnotations.isMacroAnnotation
+import scala.io.Codec
 
 class CompilationUnit protected (val source: SourceFile, val info: CompilationUnitInfo | Null) {
 
@@ -149,7 +150,7 @@ object CompilationUnit {
   def apply(clsd: ClassDenotation, unpickled: Tree, forceTrees: Boolean)(using Context): CompilationUnit =
     val compilationUnitInfo = clsd.symbol.compilationUnitInfo.nn
     val file = compilationUnitInfo.associatedFile
-    apply(SourceFile(file, Array.emptyCharArray), unpickled, forceTrees, compilationUnitInfo)
+    apply(SourceFile(file, Codec(ctx.settings.encoding.value)), unpickled, forceTrees, compilationUnitInfo)
 
   /** Make a compilation unit, given picked bytes and unpickled tree */
   def apply(source: SourceFile, unpickled: Tree, forceTrees: Boolean, info: CompilationUnitInfo)(using Context): CompilationUnit = {

--- a/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/LogicalPackagesProvider.scala
@@ -11,6 +11,8 @@ import dotty.tools.io.ClassPath
 import dotty.tools.io.FileExtension
 import dotty.tools.io.Path
 
+import scala.io.Codec
+
 /**
  * A compiler component that adds support for parsing Scala and Java source files and finding out
  * the logical package structure of the whole source path.
@@ -20,8 +22,9 @@ class LogicalPackagesProvider(sourcePath: String){
   // We only use it for parser
   private given Context = new ContextBase().initialCtx
 
+  // TODO: Forward the compiler's encoding argument here instead of always using UTF8
   private lazy val sourceRoots: Seq[SourceFile] =
-    allSources(sourcePath).map(f => SourceFile(f, f.toCharArray))
+    allSources(sourcePath).map(f => SourceFile(f, Codec.UTF8))
 
   lazy val root: LogicalPackage = parseSourcePath()
 

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -60,15 +60,18 @@ object WrappedSourceFile:
         result
       case result => result
 
-class SourceFile private[util] (val file: AbstractFile | Null, computeContent: => Array[Char]) extends interfaces.SourceFile {
+class SourceFile (val file: AbstractFile | Null, codec: Codec) extends interfaces.SourceFile {
   private var myContent: Array[Char] | Null = null
 
   /** The contents of the original source file. Note that this can be empty, for example when
    * the source is read from Tasty. */
-  def content(): Array[Char] = {
-    if (myContent == null) myContent = computeContent
-    myContent.nn
-  }
+  def content(): Array[Char] =
+    if file == null then Array.emptyCharArray
+    else
+      initialize(myContent, myContent = _,
+        try new String(file.toByteArray, codec.charSet).toCharArray
+        catch case _: FileSystemException => Array.empty[Char]
+      )
 
   override def name: String =
     if file eq null then "" else file.name
@@ -198,15 +201,13 @@ class SourceFile private[util] (val file: AbstractFile | Null, computeContent: =
     if file eq null then "<no file>" else file.toString
 }
 object SourceFile {
-  implicit def eqSource: CanEqual[SourceFile, SourceFile] = CanEqual.derived
-
   implicit def fromContext(using Context): SourceFile = ctx.source
 
   /** A source file with an underlying virtual file. The path is taken as a file system path
    *  with the local separator converted to "/". The last element of the path will be the simple name of the file.
    */
   def virtual(name: String, content: String) =
-    new SourceFile(new VirtualFile(name.replace(separator, "/"), content.getBytes(StandardCharsets.UTF_8)), content.toCharArray)
+    new SourceFile(new VirtualFile(name.replace(separator, "/"), content.getBytes(StandardCharsets.UTF_8)), Codec.UTF8)
 
   /** A helper method to create a virtual source file for given URI.
    */
@@ -248,19 +249,9 @@ object SourceFile {
       else
         jpath.toString
   }
-
-  def apply(file: AbstractFile, codec: Codec): SourceFile =
-    def chars =
-      try new String(file.toByteArray, codec.charSet).toCharArray
-      catch case _: FileSystemException => Array.empty[Char]
-
-    new SourceFile(file, chars)
-
-  def apply(file: AbstractFile | Null, contents: => Array[Char]): SourceFile =
-    new SourceFile(file, contents)
 }
 
-@sharable object NoSource extends SourceFile(null, Array[Char]()) {
+@sharable object NoSource extends SourceFile(null, Codec.UTF8) {
   override def exists: Boolean = false
   override def atSpan(span: Span): SourcePosition = NoSourcePosition
 }

--- a/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
+++ b/compiler/test/dotty/tools/dotc/config/ScalaSettingsTests.scala
@@ -16,6 +16,7 @@ import dotty.tools.io.{Path, PlainFile}
 import java.net.URI
 import java.nio.file.Files
 import scala.util.Using
+import scala.io.Codec
 
 import scala.annotation.nowarn
 
@@ -199,7 +200,7 @@ class ScalaSettingsTests:
         warning = reporting.Diagnostic.Warning(
           "A warning".toMessage,
           util.SourcePosition(
-            source = util.SourceFile(new PlainFile(Path(file)), "UTF-8"),
+            source = util.SourceFile(new PlainFile(Path(file)), Codec.UTF8),
             span = util.Spans.Span(1L)
           )
         )
@@ -214,7 +215,7 @@ class ScalaSettingsTests:
         warning = reporting.Diagnostic.Warning(
           "A warning".toMessage,
           util.SourcePosition(
-            source = util.SourceFile(new PlainFile(Path(file)), "UTF-8"),
+            source = util.SourceFile(new PlainFile(Path(file)), Codec.UTF8),
             span = util.Spans.Span(1L)
           )
         )

--- a/scaladoc/src/dotty/tools/scaladoc/site/templates.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/templates.scala
@@ -78,7 +78,7 @@ case class TemplateFile(
     lazy val snippetCheckingFunc: SnippetChecker.SnippetCheckingFunc =
       val path = Some(Paths.get(file.getAbsolutePath))
       val pathBasedArg = ssctx.snippetCompilerArgs.get(path)
-      val sourceFile = dotty.tools.dotc.util.SourceFile(dotty.tools.io.AbstractFile.getFile(path.get).nn, scala.io.Codec.UTF8)
+      val sourceFile = dotty.tools.dotc.util.SourceFile(dotty.tools.io.AbstractFile.getFile(path.get), scala.io.Codec.UTF8)
       (snippet: SnippetSource, argOverride: Option[SnippetCompilerArg]) =>
         val arg = argOverride.fold(pathBasedArg)(pathBasedArg.merge(_))
         val compilerData = SnippetCompilerData("staticsitesnippet", SnippetCompilerData.Position(configOffset - 1, 0))

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -89,7 +89,7 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
   private given qctx.type = qctx
 
   lazy val srcPos = if owner == qctx.reflect.defn.RootClass then {
-    val sourceFile = dctx.args.rootDocPath.map(p => dotty.tools.dotc.util.SourceFile(dotty.tools.io.AbstractFile.getFile(p).nn, scala.io.Codec.UTF8))
+    val sourceFile = dctx.args.rootDocPath.map(p => dotty.tools.dotc.util.SourceFile(dotty.tools.io.AbstractFile.getFile(p), scala.io.Codec.UTF8))
     sourceFile.fold(dotty.tools.dotc.util.NoSourcePosition)(sf => dotty.tools.dotc.util.SourcePosition(sf, dotty.tools.dotc.util.Spans.NoSpan))
   } else owner.pos.get.asInstanceOf[dotty.tools.dotc.util.SrcPos]
 


### PR DESCRIPTION
The concept of creating a source file with contents that aren't the file contents makes no sense. Also, it made it easy to forget to pass a codec.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
