### PR TITLE
feat(repl): support dependency directive aliases

### DIFF
--- a/repl/src/dotty/tools/repl/ReplDirectives.scala
+++ b/repl/src/dotty/tools/repl/ReplDirectives.scala
@@ -8,8 +8,12 @@ private[repl] object ReplDirectives:
 
   type Dependencies = List[String]
 
+  enum Warning:
+    case NoSeparateTestScope
+
   case class DirectiveClassification(
     dependencies: Dependencies,
+    warnings: List[Warning],
     unsupportedKeys: List[String],
     hasDirectives: Boolean
   )
@@ -19,6 +23,7 @@ private[repl] object ReplDirectives:
     def usage: String
     def description: String
     def process(values: Seq[DirectiveValue]): Dependencies
+    def warnings: List[Warning] = Nil
 
     final def helpText: String =
       val aliasText = keys.drop(1) match
@@ -36,7 +41,16 @@ private[repl] object ReplDirectives:
           case DirectiveValue.StringVal(value, _, _) => value
         .toList
 
-  private val handlers = List(DependencyDirective)
+  private object TestDependencyDirective extends DirectiveHandler:
+    val keys = List("test.dep", "test.deps", "test.dependency", "test.dependencies")
+    val usage = "//> using test.dep <group>::<artifact>:<version> ..."
+    val description = "Resolve dependencies and make them available in the REPL."
+    override val warnings = List(Warning.NoSeparateTestScope)
+
+    def process(values: Seq[DirectiveValue]): Dependencies =
+      DependencyDirective.process(values)
+
+  private val handlers = List(DependencyDirective, TestDependencyDirective)
   private val handlersByKey = handlers.flatMap(handler => handler.keys.map(_ -> handler)).toMap
 
   require(
@@ -60,7 +74,11 @@ private[repl] object ReplDirectives:
       val dependencies = supported
         .flatMap(directive => handlersByKey(directive.key).process(directive.values))
         .toList
+      val warnings = supported
+        .flatMap(directive => handlersByKey(directive.key).warnings)
+        .distinct
+        .toList
       val unsupportedKeys = unsupported.map(_.key).distinct.toList
-      DirectiveClassification(dependencies, unsupportedKeys, result.directives.nonEmpty)
+      DirectiveClassification(dependencies, warnings, unsupportedKeys, result.directives.nonEmpty)
     catch
-      case NonFatal(_) => DirectiveClassification(Nil, Nil, false)
+      case NonFatal(_) => DirectiveClassification(Nil, Nil, Nil, false)

--- a/repl/src/dotty/tools/repl/ReplDirectives.scala
+++ b/repl/src/dotty/tools/repl/ReplDirectives.scala
@@ -10,11 +10,19 @@ private[repl] object ReplDirectives:
 
   enum Warning:
     case NoSeparateTestScope
+    case UnsupportedDirective(key: String)
+
+    override def toString: String = this match
+      case NoSeparateTestScope =>
+        """[warn] The REPL does not have a separate test scope. Dependencies declared with a
+          |`using test.*` directive are added to the current REPL session.""".stripMargin
+      case UnsupportedDirective(key) =>
+        s"""[warn] The `using $key` directive is not supported in the REPL.
+           |To use it, re-run with the `scala` command and pass the directive inside an input.""".stripMargin
 
   case class DirectiveClassification(
     dependencies: Dependencies,
     warnings: List[Warning],
-    unsupportedKeys: List[String],
     hasDirectives: Boolean
   )
 
@@ -74,11 +82,10 @@ private[repl] object ReplDirectives:
       val dependencies = supported
         .flatMap(directive => handlersByKey(directive.key).process(directive.values))
         .toList
-      val warnings = supported
-        .flatMap(directive => handlersByKey(directive.key).warnings)
+      val warnings = (supported.flatMap(directive => handlersByKey(directive.key).warnings) ++
+        unsupported.map(directive => Warning.UnsupportedDirective(directive.key)))
         .distinct
         .toList
-      val unsupportedKeys = unsupported.map(_.key).distinct.toList
-      DirectiveClassification(dependencies, warnings, unsupportedKeys, result.directives.nonEmpty)
+      DirectiveClassification(dependencies, warnings, result.directives.nonEmpty)
     catch
-      case NonFatal(_) => DirectiveClassification(Nil, Nil, Nil, false)
+      case NonFatal(_) => DirectiveClassification(Nil, Nil, false)

--- a/repl/src/dotty/tools/repl/ReplDirectives.scala
+++ b/repl/src/dotty/tools/repl/ReplDirectives.scala
@@ -27,7 +27,7 @@ private[repl] object ReplDirectives:
       (List(usage, s"  $description") ++ aliasText).mkString("\n")
 
   private object DependencyDirective extends DirectiveHandler:
-    val keys = List("dep")
+    val keys = List("dep", "deps", "dependency", "dependencies")
     val usage = "//> using dep <group>::<artifact>:<version> ..."
     val description = "Resolve dependencies and make them available in the REPL."
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -795,6 +795,12 @@ class ReplDriver(settings: Array[String],
   }
 
   private def interpretDirectives(classified: ReplDirectives.DirectiveClassification)(using state: State): State =
+    classified.warnings.foreach:
+      case ReplDirectives.Warning.NoSeparateTestScope =>
+        out.println(
+          """[warn] The REPL does not have a separate test scope. Dependencies declared with a
+            |`using test.*` directive are added to the current REPL session.""".stripMargin
+        )
     classified.unsupportedKeys.foreach: key =>
       out.println(
         s"""[warn] The `using $key` directive is not supported in the REPL.

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -795,17 +795,7 @@ class ReplDriver(settings: Array[String],
   }
 
   private def interpretDirectives(classified: ReplDirectives.DirectiveClassification)(using state: State): State =
-    classified.warnings.foreach:
-      case ReplDirectives.Warning.NoSeparateTestScope =>
-        out.println(
-          """[warn] The REPL does not have a separate test scope. Dependencies declared with a
-            |`using test.*` directive are added to the current REPL session.""".stripMargin
-        )
-    classified.unsupportedKeys.foreach: key =>
-      out.println(
-        s"""[warn] The `using $key` directive is not supported in the REPL.
-           |To use it, re-run with the `scala` command and pass the directive inside an input.""".stripMargin
-      )
+    classified.warnings.foreach(warning => out.println(warning.toString))
     resolveAndAddDeps(classified.dependencies)
 
   private def resolveAndAddDeps(depStrings: List[String])(using state: State): State =

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -13,7 +13,6 @@ class ReplDirectiveTests extends ReplTest:
       val result = ReplDirectives.classify(s"//> using $alias $dependency")
       assertEquals(List(dependency), result.dependencies)
       assertEquals(Nil, result.warnings)
-      assertEquals(Nil, result.unsupportedKeys)
     assertTrue(ReplDirectives.helpText.contains("Aliases: deps, dependency, dependencies"))
 
   @Test def `test dependency directive aliases are supported with a warning`: Unit =
@@ -23,7 +22,6 @@ class ReplDirectiveTests extends ReplTest:
       val result = ReplDirectives.classify(s"//> using $alias ${dependencies.mkString(" ")}")
       assertEquals(dependencies, result.dependencies)
       assertEquals(List(ReplDirectives.Warning.NoSeparateTestScope), result.warnings)
-      assertEquals(Nil, result.unsupportedKeys)
     assertTrue(ReplDirectives.helpText.contains("Aliases: test.deps, test.dependency, test.dependencies"))
 
   @Test def `test dependency directive warns about the shared REPL scope`: Unit =

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -28,7 +28,7 @@ class ReplDirectiveTests extends ReplTest:
 
   @Test def `test dependency directive warns about the shared REPL scope`: Unit =
     initially:
-      run("//> using test.dep one.weird.dep")
+      run("//> using test.dep")
       assertEquals(
         """[warn] The REPL does not have a separate test scope. Dependencies declared with a
           |`using test.*` directive are added to the current REPL session.""".stripMargin,

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -1,10 +1,19 @@
 package dotty.tools
 package repl
 
-import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.Test
 
 class ReplDirectiveTests extends ReplTest:
+
+  @Test def `dependency directive aliases are supported`: Unit =
+    val dependency = "com.lihaoyi::os-lib:0.11.3"
+    val aliases = List("dep", "deps", "dependency", "dependencies")
+    aliases.foreach: alias =>
+      val result = ReplDirectives.classify(s"//> using $alias $dependency")
+      assertEquals(List(dependency), result.dependencies)
+      assertEquals(Nil, result.unsupportedKeys)
+    assertTrue(ReplDirectives.helpText.contains("Aliases: deps, dependency, dependencies"))
 
   @Test def `lone dep directive is incomplete until code follows`: Unit = contextually:
     assertTrue(ParseResult.onlyPreambleSoFar("//> using dep com.lihaoyi::os-lib:0.11.3"))

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -12,8 +12,28 @@ class ReplDirectiveTests extends ReplTest:
     aliases.foreach: alias =>
       val result = ReplDirectives.classify(s"//> using $alias $dependency")
       assertEquals(List(dependency), result.dependencies)
+      assertEquals(Nil, result.warnings)
       assertEquals(Nil, result.unsupportedKeys)
     assertTrue(ReplDirectives.helpText.contains("Aliases: deps, dependency, dependencies"))
+
+  @Test def `test dependency directive aliases are supported with a warning`: Unit =
+    val dependencies = List("org.scalameta::munit:1.1.1", "org.typelevel::cats-effect:3.6.3")
+    val aliases = List("test.dep", "test.deps", "test.dependency", "test.dependencies")
+    aliases.foreach: alias =>
+      val result = ReplDirectives.classify(s"//> using $alias ${dependencies.mkString(" ")}")
+      assertEquals(dependencies, result.dependencies)
+      assertEquals(List(ReplDirectives.Warning.NoSeparateTestScope), result.warnings)
+      assertEquals(Nil, result.unsupportedKeys)
+    assertTrue(ReplDirectives.helpText.contains("Aliases: test.deps, test.dependency, test.dependencies"))
+
+  @Test def `test dependency directive warns about the shared REPL scope`: Unit =
+    initially:
+      run("//> using test.dep one.weird.dep")
+      assertEquals(
+        """[warn] The REPL does not have a separate test scope. Dependencies declared with a
+          |`using test.*` directive are added to the current REPL session.""".stripMargin,
+        storedOutput().trim
+      )
 
   @Test def `lone dep directive is incomplete until code follows`: Unit = contextually:
     assertTrue(ParseResult.onlyPreambleSoFar("//> using dep com.lihaoyi::os-lib:0.11.3"))


### PR DESCRIPTION
Adds `//> using dep` aliases and `//> using test.*` directives.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by testing manually with bin/replQ

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
