### PR TITLE
Experiment: Don't add packages (without package objects) as import-suggestion roots

### DIFF
--- a/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
+++ b/compiler/src/dotty/tools/dotc/typer/ImportSuggestions.scala
@@ -54,6 +54,9 @@ trait ImportSuggestions:
    *     that should not be used for suggestions.
    *   - Any members of the java or java.lang packages. These are
    *     skipped as an optimization, since they won't contain implicits anyway.
+   *   - Package symbols that have no package object.
+   *     Givens/extensions accessible as members of a package is only in those objects
+   *
    */
   private def suggestionRoots(using Context) =
     val seen = mutable.Set[TermRef]()
@@ -103,12 +106,21 @@ trait ImportSuggestions:
           .flatMap(rootsIn(_, newParentSymbols))
           .toList
 
+    def hasPackageObject(pkg: Symbol)(using Context): Boolean =
+      pkg.moduleClass.denot match
+        case pcd: PackageClassDenotation => pcd.packageObjs.nonEmpty
+        case _ => false
+
     def rootsIn(ref: TermRef, parentSymbols: Set[Symbol] = Set())(using Context): List[TermRef] =
       if seen.contains(ref) then Nil
       else
-        implicitsDetailed.println(i"search for suggestions in ${ref.symbol.fullName}")
         seen += ref
-        ref :: rootsStrictlyIn(ref, parentSymbols)
+        // put in the root if the symbol is not a package (except package object)
+        if !ref.symbol.is(Package) || hasPackageObject(ref.symbol) then
+          implicitsDetailed.println(i"search for suggestions in ${ref.symbol.fullName}")
+          ref :: rootsStrictlyIn(ref, parentSymbols)
+        else
+          rootsStrictlyIn(ref, parentSymbols)
 
     def rootsOnPath(tp: Type)(using Context): List[TermRef] = tp match
       case ref: TermRef => rootsIn(ref) ::: rootsOnPath(ref.prefix)


### PR DESCRIPTION
Fixes #XYZ <- I haven't yet opened an issue, it's an experiment :bow:

When I was working on #26622, noticed that import suggetsion treat Java packages as import suggestion search roots. And walks package decls and runs `lookInside` on each member (and Java classes should be skipped here).

This is because, currently every package is added as a root including Java packages. For example in #26622 `import javax.swing.JFrame` adds `javax` and `javax.swing` as search roots.

While `lookInside` calls `root.is(ModuleVal, butNot = JavaDefined)`, and it doesn't look inside of Java defined classes, `.is(...)` eventually calls `ensureCompleted` and complete the incomplete Java defined symbols. This means, import suggestion parses all classfiles defined under `javax` and `javax.swing` in `import javax.swing.JFrame` case.

This commit tries optimizing import suggestion by stop adding a package as a search root unless it has a `package object`. If I understand correctly, we can't define extension methods, implicit class, and given can't be defined directly under package. (toplevel givens are desugared to be warpped by synthetic package object). (Am I right...?)

Since Java doesn't have `package object`, we should be able to skip Java packages adding to search roots.

---

Edit: Oops, I misunderstood, we're still complete symbols by `rootStrictlyIn`




---

I'm wondering how can we becnhmark this change 🤔 Does https://lampepfl.github.io/scala3-benchmarks/ contains compilation fail scenarios?

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, specifically for how to check the package symbol has package object, it seems legit.

```scala
    def hasPackageObject(pkg: Symbol)(using Context): Boolean =
      pkg.moduleClass.denot match
        case pcd: PackageClassDenotation => pcd.packageObjs.nonEmpty
        case _ => false
```

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

Covered by existing tests (this is a refactoring), but haven't yet how much it speeds up

