### PR TITLE
feat(repl): support the jar directive

### DIFF
--- a/repl/src/dotty/tools/repl/ReplDirectives.scala
+++ b/repl/src/dotty/tools/repl/ReplDirectives.scala
@@ -6,8 +6,6 @@ import dotty.tools.directives.{DirectiveValue, UsingDirectivesParser}
 
 private[repl] object ReplDirectives:
 
-  type Dependencies = List[String]
-
   enum Warning:
     case NoSeparateTestScope
     case UnsupportedDirective(key: String)
@@ -20,18 +18,49 @@ private[repl] object ReplDirectives:
         s"""[warn] The `using $key` directive is not supported in the REPL.
            |To use it, re-run with the `scala` command and pass the directive inside an input.""".stripMargin
 
+  enum ReplDirective:
+    case Dependency(coordinate: String)
+    case Jar(path: String)
+
   case class DirectiveClassification(
-    dependencies: Dependencies,
+    directives: List[ReplDirective],
     warnings: List[Warning],
     hasDirectives: Boolean
   )
 
-  private trait DirectiveHandler:
-    def keys: List[String]
-    def usage: String
-    def description: String
-    def process(values: Seq[DirectiveValue]): Dependencies
-    def warnings: List[Warning] = Nil
+  private enum DirectiveHandler(
+    val keys: List[String],
+    val usage: String,
+    val description: String,
+    toDirective: String => ReplDirective,
+    val warnings: List[Warning] = Nil
+  ):
+    case Dependency extends DirectiveHandler(
+      keys = List("dep", "deps", "dependency", "dependencies"),
+      usage = "//> using dep <group>::<artifact>:<version> ...",
+      description = "Resolve dependencies and make them available in the REPL.",
+      toDirective = ReplDirective.Dependency(_)
+    )
+
+    case TestDependency extends DirectiveHandler(
+      keys = List("test.dep", "test.deps", "test.dependency", "test.dependencies"),
+      usage = "//> using test.dep <group>::<artifact>:<version> ...",
+      description = "Resolve dependencies and make them available in the REPL.",
+      toDirective = ReplDirective.Dependency(_),
+      warnings = List(Warning.NoSeparateTestScope)
+    )
+
+    case Jar extends DirectiveHandler(
+      keys = List("jar", "jars"),
+      usage = "//> using jar <path> ...",
+      description = "Add JARs to the REPL classpath.",
+      toDirective = ReplDirective.Jar(_)
+    )
+
+    def process(values: Seq[DirectiveValue]): List[ReplDirective] =
+      values.collect:
+          case DirectiveValue.StringVal(value, _, _) => toDirective(value)
+        .toList
 
     final def helpText: String =
       val aliasText = keys.drop(1) match
@@ -39,26 +68,7 @@ private[repl] object ReplDirectives:
         case aliases => List(s"  Aliases: ${aliases.mkString(", ")}")
       (List(usage, s"  $description") ++ aliasText).mkString("\n")
 
-  private object DependencyDirective extends DirectiveHandler:
-    val keys = List("dep", "deps", "dependency", "dependencies")
-    val usage = "//> using dep <group>::<artifact>:<version> ..."
-    val description = "Resolve dependencies and make them available in the REPL."
-
-    def process(values: Seq[DirectiveValue]): Dependencies =
-      values.collect:
-          case DirectiveValue.StringVal(value, _, _) => value
-        .toList
-
-  private object TestDependencyDirective extends DirectiveHandler:
-    val keys = List("test.dep", "test.deps", "test.dependency", "test.dependencies")
-    val usage = "//> using test.dep <group>::<artifact>:<version> ..."
-    val description = "Resolve dependencies and make them available in the REPL."
-    override val warnings = List(Warning.NoSeparateTestScope)
-
-    def process(values: Seq[DirectiveValue]): Dependencies =
-      DependencyDirective.process(values)
-
-  private val handlers = List(DependencyDirective, TestDependencyDirective)
+  private val handlers = DirectiveHandler.values.toList
   private val handlersByKey = handlers.flatMap(handler => handler.keys.map(_ -> handler)).toMap
 
   require(
@@ -79,13 +89,13 @@ private[repl] object ReplDirectives:
     try
       val result = UsingDirectivesParser.parse(sourceCode)
       val (supported, unsupported) = result.directives.partition(directive => handlersByKey.contains(directive.key))
-      val dependencies = supported
+      val directives = supported
         .flatMap(directive => handlersByKey(directive.key).process(directive.values))
         .toList
       val warnings = (supported.flatMap(directive => handlersByKey(directive.key).warnings) ++
         unsupported.map(directive => Warning.UnsupportedDirective(directive.key)))
         .distinct
         .toList
-      DirectiveClassification(dependencies, warnings, result.directives.nonEmpty)
+      DirectiveClassification(directives, warnings, result.directives.nonEmpty)
     catch
       case NonFatal(_) => DirectiveClassification(Nil, Nil, false)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -795,8 +795,16 @@ class ReplDriver(settings: Array[String],
   }
 
   private def interpretDirectives(classified: ReplDirectives.DirectiveClassification)(using state: State): State =
+    import ReplDirectives.ReplDirective.*
+
     classified.warnings.foreach(warning => out.println(warning.toString))
-    resolveAndAddDeps(classified.dependencies)
+    val dependencies = classified.directives.collect:
+      case Dependency(coordinate) => coordinate
+    val jars = classified.directives.collect:
+      case Jar(path) => path
+    val stateWithDependencies = resolveAndAddDeps(dependencies)
+    jars.foldLeft(stateWithDependencies): (currentState, path) =>
+      interpretCommand(JarCmd(path))(using currentState)
 
   private def resolveAndAddDeps(depStrings: List[String])(using state: State): State =
     if depStrings.isEmpty then state

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -4,14 +4,17 @@ package repl
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.Test
 
-class ReplDirectiveTests extends ReplTest:
+import ReplDirectives.ReplDirective.{Dependency, Jar}
+import ReplDirectives.Warning
+
+class ReplDirectiveTests extends ReplTest, SessionFileHelpers:
 
   @Test def `dependency directive aliases are supported`: Unit =
     val dependency = "com.lihaoyi::os-lib:0.11.3"
     val aliases = List("dep", "deps", "dependency", "dependencies")
     aliases.foreach: alias =>
       val result = ReplDirectives.classify(s"//> using $alias $dependency")
-      assertEquals(List(dependency), result.dependencies)
+      assertEquals(List(Dependency(dependency)), result.directives)
       assertEquals(Nil, result.warnings)
     assertTrue(ReplDirectives.helpText.contains("Aliases: deps, dependency, dependencies"))
 
@@ -20,9 +23,28 @@ class ReplDirectiveTests extends ReplTest:
     val aliases = List("test.dep", "test.deps", "test.dependency", "test.dependencies")
     aliases.foreach: alias =>
       val result = ReplDirectives.classify(s"//> using $alias ${dependencies.mkString(" ")}")
-      assertEquals(dependencies, result.dependencies)
-      assertEquals(List(ReplDirectives.Warning.NoSeparateTestScope), result.warnings)
+      assertEquals(dependencies.map(Dependency(_)), result.directives)
+      assertEquals(List(Warning.NoSeparateTestScope), result.warnings)
     assertTrue(ReplDirectives.helpText.contains("Aliases: test.deps, test.dependency, test.dependencies"))
+
+  @Test def `jar directive aliases are supported`: Unit =
+    val jars = List("lib/first.jar", "lib/second.jar")
+    List("jar", "jars").foreach: alias =>
+      val result = ReplDirectives.classify(s"//> using $alias ${jars.mkString(" ")}")
+      assertEquals(jars.map(Jar(_)), result.directives)
+      assertEquals(Nil, result.warnings)
+    assertTrue(ReplDirectives.helpText.contains("Aliases: jars"))
+
+  @Test def `jars directive adds all JARs to the classpath`: Unit =
+    val firstJar = emptyJar()
+    val secondJar = emptyJar()
+    initially:
+      run(s"//> using jars $firstJar $secondJar")
+      assertEquals(
+        s"""Added '$firstJar' to classpath.
+           |Added '$secondJar' to classpath.""".stripMargin,
+        storedOutput().trim
+      )
 
   @Test def `test dependency directive warns about the shared REPL scope`: Unit =
     initially:


### PR DESCRIPTION
Adds a support for `//> using jar` directive to the REPL.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by testing manually with bin/replQ

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
