### PR TITLE
More progress on capture-checking stdlib

### DIFF
--- a/library/src/scala/AnyVal.scala
+++ b/library/src/scala/AnyVal.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `AnyVal` is the root class of all *value types*, which describe values

--- a/library/src/scala/AnyValCompanion.scala
+++ b/library/src/scala/AnyValCompanion.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A common supertype for companion classes of primitive types.

--- a/library/src/scala/Boolean.scala
+++ b/library/src/scala/Boolean.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Boolean` (equivalent to Java's `boolean` primitive type) is a

--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Byte`, a 8-bit signed integer (equivalent to Java's `byte` primitive type) is a

--- a/library/src/scala/Char.scala
+++ b/library/src/scala/Char.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.collection.immutable.NumericRange

--- a/library/src/scala/Console.scala
+++ b/library/src/scala/Console.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import java.io.{ BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream, Reader }

--- a/library/src/scala/Double.scala
+++ b/library/src/scala/Double.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Double`, a 64-bit IEEE-754 floating point number (equivalent to Java's `double` primitive type) is a

--- a/library/src/scala/DummyImplicit.scala
+++ b/library/src/scala/DummyImplicit.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A type for which there is always an implicit value. */

--- a/library/src/scala/Dynamic.scala
+++ b/library/src/scala/Dynamic.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A marker trait that enables dynamic invocations. Instances `x` of this

--- a/library/src/scala/Enumeration.scala
+++ b/library/src/scala/Enumeration.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.collection.{SpecificIterableFactory, StrictOptimizedIterableOps, View, immutable, mutable}
@@ -87,7 +88,7 @@ import scala.util.matching.Regex
  *                 identifies values at run-time.
  */
 @SerialVersionUID(8476000850333817230L)
-abstract class Enumeration (initial: Int) extends Serializable {
+abstract class Enumeration (initial: Int) extends Serializable, caps.Pure {
   thisenum =>
 
   def this() = this(0)
@@ -232,7 +233,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
 
   /** The type of the enumerated values. */
   @SerialVersionUID(7091335633555234129L)
-  abstract class Value extends Ordered[Value] with Serializable {
+  abstract class Value extends Ordered[Value] with Serializable with caps.Pure {
     /** The id and bit location of this enumeration value. */
     def id: Int
     /** A marker so we can tell whose values belong to whom come reflective-naming time. */
@@ -328,7 +329,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
      */
     def toBitMask: Array[Long] = nnIds.toBitMask
 
-    override protected def fromSpecific(coll: IterableOnce[Value]): ValueSet = ValueSet.fromSpecific(coll)
+    override protected def fromSpecific(coll: IterableOnce[Value]^): ValueSet = ValueSet.fromSpecific(coll)
     override protected def newSpecificBuilder = ValueSet.newBuilder
 
     def map(f: Value => Value): ValueSet = fromSpecific(new View.Map(this, f))
@@ -337,11 +338,11 @@ abstract class Enumeration (initial: Int) extends Serializable {
     // necessary for disambiguation:
     override def map[B](f: Value => B)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
       super[SortedSet].map[B](f)
-    override def flatMap[B](f: Value => IterableOnce[B])(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
+    override def flatMap[B](f: Value => IterableOnce[B]^)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
       super[SortedSet].flatMap[B](f)
-    override def zip[B](that: IterableOnce[B])(implicit @implicitNotFound(ValueSet.zipOrdMsg) ev: Ordering[(Value, B)]): immutable.SortedSet[(Value, B)] =
+    override def zip[B](that: IterableOnce[B]^)(implicit @implicitNotFound(ValueSet.zipOrdMsg) ev: Ordering[(Value, B)]): immutable.SortedSet[(Value, B)] =
       super[SortedSet].zip[B](that)
-    override def collect[B](pf: PartialFunction[Value, B])(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
+    override def collect[B](pf: PartialFunction[Value, B]^)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =
       super[SortedSet].collect[B](pf)
 
     @transient private[Enumeration] lazy val byName: Map[String, Value] = iterator.map( v => v.toString -> v).toMap
@@ -368,7 +369,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
       def clear() = b.clear()
       def result() = new ValueSet(b.toImmutable)
     }
-    def fromSpecific(it: IterableOnce[Value]): ValueSet =
+    def fromSpecific(it: IterableOnce[Value]^): ValueSet =
       newBuilder.addAll(it).result()
   }
 }

--- a/library/src/scala/Equals.scala
+++ b/library/src/scala/Equals.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An interface containing operations for equality.

--- a/library/src/scala/Float.scala
+++ b/library/src/scala/Float.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Float`, a 32-bit IEEE-754 floating point number (equivalent to Java's `float` primitive type) is a

--- a/library/src/scala/IArray.scala
+++ b/library/src/scala/IArray.scala
@@ -368,7 +368,7 @@ object IArray:
    *  @param f the transformation function mapping elements to their sort keys
    *  @return a new array consisting of the elements of this array sorted by the value `f` produces for each
    */
-  extension [T](arr: IArray[T]) def sortBy[U](f: T => U)(using math.Ordering[U]): IArray[T] =
+  extension [T](arr: IArray[T]) def sortBy[U](f: T -> U)(using math.Ordering[U]): IArray[T] =
     genericArrayOps(arr).sortBy(f)
 
   /** Sorts this array according to a comparison function.
@@ -376,13 +376,13 @@ object IArray:
    *  @param f the comparison function returning true if its first argument should come first
    *  @return a new array consisting of the elements of this array sorted according to `f`
    */
-  extension [T](arr: IArray[T]) def sortWith(f: (T, T) => Boolean): IArray[T] =
+  extension [T](arr: IArray[T]) def sortWith(f: (T, T) -> Boolean): IArray[T] =
     genericArrayOps(arr).sortWith(f)
 
   /** Sorts this array according to an Ordering.
    *
      */
-  extension [T](arr: IArray[T]) def sorted(using math.Ordering[T]^): IArray[T] =
+  extension [T](arr: IArray[T]) def sorted(using math.Ordering[T]): IArray[T] =
     genericArrayOps(arr).sorted
 
   /** Splits this array into a prefix/suffix pair according to a predicate.

--- a/library/src/scala/Int.scala
+++ b/library/src/scala/Int.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Int`, a 32-bit signed integer (equivalent to Java's `int` primitive type) is a

--- a/library/src/scala/Long.scala
+++ b/library/src/scala/Long.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.collection.immutable.NumericRange

--- a/library/src/scala/MatchError.scala
+++ b/library/src/scala/MatchError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class implements errors which are thrown whenever an

--- a/library/src/scala/NotImplementedError.scala
+++ b/library/src/scala/NotImplementedError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Throwing this exception can be a temporary replacement for a method

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 object Option {
@@ -402,7 +403,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  @param p the predicate used to test elements
    *  @return a `WithFilter` that applies `p` to this option before subsequent `map`, `flatMap`, `foreach`, or `withFilter` operations
    */
-  @inline final def withFilter(p: A => Boolean): WithFilter = new WithFilter(p)
+  @inline final def withFilter(p: A -> Boolean): WithFilter = new WithFilter(p)
 
   /** We need a whole WithFilter class to honor the "doesn't create a new
    *  collection" contract even though it seems unlikely to matter much in a
@@ -414,7 +415,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
     def map[B](f: A => B): Option[B] = self filter p map f
     def flatMap[B](f: A => Option[B]): Option[B] = self filter p flatMap f
     def foreach[U](f: A => U): Unit = self filter p foreach f
-    def withFilter(q: A => Boolean): WithFilter = new WithFilter(x => p(x) && q(x))
+    def withFilter(q: A => Boolean): WithFilter^{this, q} = new WithFilter(x => p(x) && q(x))
   }
 
   /** Tests whether the option contains a given value as an element.
@@ -520,7 +521,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *
    *  @tparam B the result type of the partial function
    */
-  @inline final def collect[B](pf: PartialFunction[A, B]): Option[B] =
+  @inline final def collect[B](pf: PartialFunction[A, B]^): Option[B] =
     if (!isEmpty) pf.lift(this.get) else None
 
   /** Returns this $option if it is nonempty,

--- a/library/src/scala/Product.scala
+++ b/library/src/scala/Product.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import language.experimental.captureChecking
 

--- a/library/src/scala/Product1.scala
+++ b/library/src/scala/Product1.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 object Product1 {

--- a/library/src/scala/ScalaReflectionException.scala
+++ b/library/src/scala/ScalaReflectionException.scala
@@ -1,5 +1,6 @@
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An exception that indicates an error during Scala reflection.

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Short`, a 16-bit signed integer (equivalent to Java's `short` primitive type) is a

--- a/library/src/scala/Specializable.scala
+++ b/library/src/scala/Specializable.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A common supertype for companions of specializable types.

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.{ StringBuilder => JLSBuilder }
 import scala.annotation.tailrec

--- a/library/src/scala/Symbol.scala
+++ b/library/src/scala/Symbol.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class provides a simple way to get unique objects for equal strings.

--- a/library/src/scala/UninitializedError.scala
+++ b/library/src/scala/UninitializedError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class represents uninitialized variable/value errors.

--- a/library/src/scala/UninitializedFieldError.scala
+++ b/library/src/scala/UninitializedFieldError.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This class implements errors which are thrown whenever a

--- a/library/src/scala/Unit.scala
+++ b/library/src/scala/Unit.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** `Unit` is a subtype of [[scala.AnyVal]]. There is only one value of type

--- a/library/src/scala/ValueOf.scala
+++ b/library/src/scala/ValueOf.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/Annotation.scala
+++ b/library/src/scala/annotation/Annotation.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/ConstantAnnotation.scala
+++ b/library/src/scala/annotation/ConstantAnnotation.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/StaticAnnotation.scala
+++ b/library/src/scala/annotation/StaticAnnotation.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/TypeConstraint.scala
+++ b/library/src/scala/annotation/TypeConstraint.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A marker for annotations that, when applied to a type, should be treated

--- a/library/src/scala/annotation/compileTimeOnly.scala
+++ b/library/src/scala/annotation/compileTimeOnly.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/annotation/implicitAmbiguous.scala
+++ b/library/src/scala/annotation/implicitAmbiguous.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** To customize the error message that's emitted when an implicit search finds

--- a/library/src/scala/annotation/implicitNotFound.scala
+++ b/library/src/scala/annotation/implicitNotFound.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** To customize the error message that's emitted when an implicit of type

--- a/library/src/scala/annotation/internal/$into.scala
+++ b/library/src/scala/annotation/internal/$into.scala
@@ -1,5 +1,7 @@
 package scala.annotation.internal
 
+import language.experimental.captureChecking
+
 /** An internal annotation on (part of) a parameter type that serves as a marker where
  *  the original type was of the form `into[T]`. These annotated types are mapped back
  *  to `into[T]` types when forming a method types from the parameter types. The idea is

--- a/library/src/scala/annotation/internal/onlyCapability.scala
+++ b/library/src/scala/annotation/internal/onlyCapability.scala
@@ -1,6 +1,8 @@
 package scala.annotation
 package internal
 
+import language.experimental.captureChecking
+
 /** An annotation that represents a capability  `c.only[T]`,
  *  encoded as `x.type @onlyCapability[T]`
  *

--- a/library/src/scala/annotation/meta/beanGetter.scala
+++ b/library/src/scala/annotation/meta/beanGetter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/beanSetter.scala
+++ b/library/src/scala/annotation/meta/beanSetter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/companionClass.scala
+++ b/library/src/scala/annotation/meta/companionClass.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/companionMethod.scala
+++ b/library/src/scala/annotation/meta/companionMethod.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/companionObject.scala
+++ b/library/src/scala/annotation/meta/companionObject.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/defaultArg.scala
+++ b/library/src/scala/annotation/meta/defaultArg.scala
@@ -13,6 +13,7 @@
 package scala.annotation
 package meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This internal meta annotation is used by the compiler to support default annotation arguments.

--- a/library/src/scala/annotation/meta/field.scala
+++ b/library/src/scala/annotation/meta/field.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/getter.scala
+++ b/library/src/scala/annotation/meta/getter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/languageFeature.scala
+++ b/library/src/scala/annotation/meta/languageFeature.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation giving particulars for a language feature in object `scala.language`.

--- a/library/src/scala/annotation/meta/package.scala
+++ b/library/src/scala/annotation/meta/package.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/param.scala
+++ b/library/src/scala/annotation/meta/param.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/setter.scala
+++ b/library/src/scala/annotation/meta/setter.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/meta/superArg.scala
+++ b/library/src/scala/annotation/meta/superArg.scala
@@ -13,6 +13,7 @@
 package scala.annotation
 package meta
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** This internal annotation encodes arguments passed to annotation superclasses. Example:

--- a/library/src/scala/annotation/migration.scala
+++ b/library/src/scala/annotation/migration.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/nowarn.scala
+++ b/library/src/scala/annotation/nowarn.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation for local warning suppression.

--- a/library/src/scala/annotation/showAsInfix.scala
+++ b/library/src/scala/annotation/showAsInfix.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/annotation/stableNull.scala
+++ b/library/src/scala/annotation/stableNull.scala
@@ -1,5 +1,7 @@
 package scala.annotation
 
+import language.experimental.captureChecking
+
 /** An annotation that can be used to mark a mutable field as trackable for nullability.
  *  With explicit nulls, a normal mutable field cannot be tracked for nullability by flow typing,
  *  since it can be updated to a null value at the same time.

--- a/library/src/scala/annotation/strictfp.scala
+++ b/library/src/scala/annotation/strictfp.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** If this annotation is present on a method or its enclosing class,

--- a/library/src/scala/annotation/switch.scala
+++ b/library/src/scala/annotation/switch.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation to be applied to a match expression.  If present,

--- a/library/src/scala/annotation/tailrec.scala
+++ b/library/src/scala/annotation/tailrec.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A method annotation which verifies that the method will be compiled

--- a/library/src/scala/annotation/unchecked/uncheckedOverride.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedOverride.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.unchecked
 
+import language.experimental.captureChecking
 import scala.annotation.StaticAnnotation
 import scala.language.`2.13`
 

--- a/library/src/scala/annotation/unchecked/uncheckedStable.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedStable.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.unchecked
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta.{field, getter}
 

--- a/library/src/scala/annotation/unchecked/uncheckedVariance.scala
+++ b/library/src/scala/annotation/unchecked/uncheckedVariance.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation.unchecked
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation for type arguments for which one wants to suppress variance checking.

--- a/library/src/scala/annotation/unspecialized.scala
+++ b/library/src/scala/annotation/unspecialized.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A method annotation which suppresses the creation of

--- a/library/src/scala/annotation/unused.scala
+++ b/library/src/scala/annotation/unused.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Mark an element unused for a given context.

--- a/library/src/scala/annotation/varargs.scala
+++ b/library/src/scala/annotation/varargs.scala
@@ -12,6 +12,7 @@
 
 package scala.annotation
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A method annotation which instructs the compiler to generate a

--- a/library/src/scala/beans/BeanProperty.scala
+++ b/library/src/scala/beans/BeanProperty.scala
@@ -12,6 +12,7 @@
 
 package scala.beans
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.annotation.meta.{beanGetter, beanSetter, field}

--- a/library/src/scala/beans/BooleanBeanProperty.scala
+++ b/library/src/scala/beans/BooleanBeanProperty.scala
@@ -12,6 +12,7 @@
 
 package scala.beans
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta.{beanGetter, beanSetter, field}
 

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -628,7 +628,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @return     an array consisting of the elements of this array
    *              sorted according to the ordering `ord`.
    */
-  def sorted[B >: A](implicit ord: Ordering[B]^): Array[A] = {
+  def sorted[B >: A](implicit ord: Ordering[B]): Array[A] = {
     val len = xs.length
     def boxed = if(len < ArrayOps.MaxStableSortLength) {
       val a = xs.clone()
@@ -676,7 +676,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *  @return     an array consisting of the elements of this array
    *              sorted according to the comparison function `lt`.
    */
-  def sortWith(lt: (A, A) => Boolean): Array[A] = sorted(using Ordering.fromLessThan(lt))
+  def sortWith(lt: (A, A) -> Boolean): Array[A] = sorted(using Ordering.fromLessThan(lt))
 
   /** Sorts this array according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -691,7 +691,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
    *           sorted according to the ordering where `x < y` if
    *           `ord.lt(f(x), f(y))`.
    */
-  def sortBy[B](f: A => B)(implicit ord: Ordering[B]): Array[A] = sorted(using ord.on(f))
+  def sortBy[B](f: A -> B)(implicit ord: Ordering[B]): Array[A] = sorted(using ord.on(f))
 
   /** Creates a non-strict filter of this array.
    *

--- a/library/src/scala/collection/Seq.scala
+++ b/library/src/scala/collection/Seq.scala
@@ -723,7 +723,10 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *  @return     a $coll consisting of the elements of this $coll
    *              sorted according to the ordering `ord`.
    */
-  def sorted[B >: A](implicit ord: Ordering[B]): C^{this} = {
+  def sorted[B >: A](implicit ord: Ordering[B]): C^{this} = sortedImpl
+
+  // The actual sort implementation. `sorted` needs a more lenient capture set because of lazy seqs.
+  private[collection] def sortedImpl[B >: A](implicit ord: Ordering[B]): C^{this} = {
     val len = this.length
     val b = newSpecificBuilder
     if (len == 1) b += head
@@ -760,7 +763,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *    // List("Bobby", "Bob", "John", "Steve", "Tom")
    *  ```
    */
-  def sortWith(lt: (A, A) => Boolean): C^{this} = sorted(using Ordering.fromLessThan(lt))
+  def sortWith(lt: (A, A) -> Boolean): C^{this} = sorted(using Ordering.fromLessThan(lt))
 
   /** Sorts this $coll according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -787,7 +790,7 @@ transparent trait SeqOps[+A, +CC[_], +C] extends Any
    *    // sorted: Array[String] = Array(The, dog, fox, the, lazy, over, brown, quick, jumped)
    *  ```
    */
-  def sortBy[B](f: A => B)(implicit ord: Ordering[B]): C^{this} = sorted(using ord.on(f))
+  def sortBy[B](f: A -> B)(implicit ord: Ordering[B]): C^{this} = sorted(using ord.on(f))
 
   /** Produces the range of all indices of this sequence.
    *  $willForceEvaluation

--- a/library/src/scala/collection/SeqView.scala
+++ b/library/src/scala/collection/SeqView.scala
@@ -161,7 +161,7 @@ object SeqView {
       override def sorted[B1 >: A](implicit ord1: Ordering[B1]): SeqView[A]^{this} =
         if (ord1 == Sorted.this.ord) outer
         else if (ord1.isReverseOf(Sorted.this.ord)) this
-        else new Sorted(elems, len, ord1)
+        else new Sorted(outer.elems, len, ord1)
     }
 
     @volatile private var evaluated = false

--- a/library/src/scala/collection/StringOps.scala
+++ b/library/src/scala/collection/StringOps.scala
@@ -1735,7 +1735,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *              sorted according to the comparison function `lt`.
    *  @note       $unicodeunaware
    */
-  def sortWith(lt: (Char, Char) => Boolean): String = new WrappedString(s).sortWith(lt).unwrap
+  def sortWith(lt: (Char, Char) -> Boolean): String = new WrappedString(s).sortWith(lt).unwrap
 
   /** Sorts this string according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -1754,7 +1754,7 @@ final class StringOps(private val s: String) extends AnyVal { self =>
    *           `ord.lt(f(x), f(y))`.
    *  @note    $unicodeunaware
    */
-  def sortBy[B](f: Char => B)(implicit ord: Ordering[B]): String = new WrappedString(s).sortBy(f)(using ord).unwrap
+  def sortBy[B](f: Char -> B)(implicit ord: Ordering[B]): String = new WrappedString(s).sortBy(f)(using ord).unwrap
 
   /** Partitions this string into a map of strings according to some discriminator function.
    *

--- a/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
+++ b/library/src/scala/collection/immutable/StrictOptimizedSeqOps.scala
@@ -86,6 +86,6 @@ transparent trait StrictOptimizedSeqOps[+A, +CC[B] <: caps.Pure, +C]
     b.result()
   }
 
-  override def sorted[B >: A](implicit ord: Ordering[B]): C = super.sorted(using ord)
+  override def sorted[B >: A](implicit ord: Ordering[B]): C = sortedImpl(using ord)
 
 }

--- a/library/src/scala/collection/mutable/IndexedSeq.scala
+++ b/library/src/scala/collection/mutable/IndexedSeq.scala
@@ -78,7 +78,7 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @param lt the less-than comparison function; should return `true` if the first argument strictly precedes the second in the desired ordering
    *  @return this $coll sorted in place according to the comparison function `lt`
    */
-  def sortInPlaceWith(lt: (A, A) => Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
+  def sortInPlaceWith(lt: (A, A) -> Boolean): this.type = sortInPlace()(using Ordering.fromLessThan(lt))
 
   /** Sorts this $coll in place according to the Ordering which results from transforming
    *  an implicitly given Ordering with a transformation function.
@@ -90,6 +90,6 @@ transparent trait IndexedSeqOps[A, +CC[_] <: caps.Pure, +C <: AnyRef]
    *  @param ord the implicit ordering on type `B` used to compare transformed elements
    *  @return this $coll sorted in place according to the ordering induced by applying `f` and comparing with `ord`
    */
-  def sortInPlaceBy[B](f: A => B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
+  def sortInPlaceBy[B](f: A -> B)(implicit ord: Ordering[B]): this.type = sortInPlace()(using ord.on(f))
 
 }

--- a/library/src/scala/compiletime/Erased.scala
+++ b/library/src/scala/compiletime/Erased.scala
@@ -1,6 +1,8 @@
 package scala.compiletime
 import annotation.experimental
 
+import language.experimental.captureChecking
+
 /** A marker trait for erased values. vals or parameters whose type extends
  *  `Erased` get an implicit `erased` modifier.
  */

--- a/library/src/scala/concurrent/Awaitable.scala
+++ b/library/src/scala/concurrent/Awaitable.scala
@@ -13,6 +13,7 @@
 package scala.concurrent
 
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.concurrent.duration.Duration
 

--- a/library/src/scala/deprecated.scala
+++ b/library/src/scala/deprecated.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/deprecatedInheritance.scala
+++ b/library/src/scala/deprecatedInheritance.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/deprecatedName.scala
+++ b/library/src/scala/deprecatedName.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/deprecatedOverriding.scala
+++ b/library/src/scala/deprecatedOverriding.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/inline.scala
+++ b/library/src/scala/inline.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/io/AnsiColor.scala
+++ b/library/src/scala/io/AnsiColor.scala
@@ -13,6 +13,7 @@
 package scala
 package io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** ANSI escape codes providing control over text formatting and color on supporting text terminals.

--- a/library/src/scala/io/BufferedSource.scala
+++ b/library/src/scala/io/BufferedSource.scala
@@ -12,6 +12,7 @@
 
 package scala.io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.io.{ InputStream, BufferedReader, InputStreamReader, PushbackReader }
 import Source.DefaultBufSize
@@ -41,7 +42,7 @@ class BufferedSource(inputStream: InputStream, bufferSize: Int)(implicit val cod
     bufferedReader()
   }
 
-  override val iter = (
+  override val iter: Iterator[Char]^{this} = (
     Iterator
     continually (codec wrap charReader.read())
     takeWhile (_ != -1)

--- a/library/src/scala/io/Codec.scala
+++ b/library/src/scala/io/Codec.scala
@@ -13,6 +13,7 @@
 package scala
 package io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.nio.charset.{CharacterCodingException, Charset, CharsetDecoder, CharsetEncoder, CodingErrorAction => Action}
 import java.nio.charset.StandardCharsets.{ISO_8859_1, UTF_8}
@@ -35,8 +36,8 @@ import scala.language.implicitConversions
  *  @param charSet the character set used for encoding and decoding operations
  */
 class Codec(val charSet: Charset) {
-  type Configure[T] = (T => T, Boolean)
-  type Handler      = CharacterCodingException => Int
+  type Configure[T] = (T -> T, Boolean)
+  type Handler      = CharacterCodingException -> Int
 
   // these variables allow configuring the Codec object, and then
   // all decoders and encoders retrieved from it will use these settings.

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -316,7 +316,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   def next(): Char = positioner.next()
 
   @nowarn("cat=deprecation")
-  class Positioner(encoder: Position) uses Source.this.iter uses_init Source.this {
+  class Positioner(encoder: Position) uses Source.this.iter, Source.this initially {
     def this() = this(RelaxedPosition)
     /** the last character returned by next. */
     var ch: Char = compiletime.uninitialized

--- a/library/src/scala/io/Source.scala
+++ b/library/src/scala/io/Source.scala
@@ -17,6 +17,7 @@ import scala.collection.{AbstractIterator, BufferedIterator}
 import java.io.{Closeable, FileInputStream, FileNotFoundException, InputStream, PrintStream, File => JFile}
 import java.net.{URI, URL}
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.nowarn
 
@@ -217,8 +218,8 @@ object Source {
   def createBufferedSource(
     inputStream: InputStream,
     bufferSize: Int = DefaultBufSize,
-    reset: (() => Source) | Null = null,
-    close: (() => Unit) | Null = null
+    reset: (() -> Source) | Null = null,
+    close: (() -> Unit) | Null = null
   )(implicit codec: Codec): BufferedSource = {
     // workaround for default arguments being unable to refer to other parameters
     val resetFn = if (reset == null) () => createBufferedSource(inputStream, bufferSize, reset, close)(using codec) else reset
@@ -264,7 +265,7 @@ object Source {
  */
 abstract class Source extends Iterator[Char] with Closeable {
   /** The actual iterator. */
-  protected val iter: Iterator[Char]
+  protected val iter: Iterator[Char]^{this}
 
   // ------ public values
 
@@ -275,10 +276,10 @@ abstract class Source extends Iterator[Char] with Closeable {
 
   private def lineNum(line: Int): String = (getLines() drop (line - 1) take 1).mkString
 
-  class LineIterator extends AbstractIterator[String] with Iterator[String] {
+  class LineIterator extends AbstractIterator[String] with Iterator[String] uses Source.this.iter {
     private val sb = new StringBuilder
 
-    lazy val iter: BufferedIterator[Char] = Source.this.iter.buffered
+    lazy val iter: BufferedIterator[Char]^{Source.this.iter} = Source.this.iter.buffered
     def isNewline(ch: Char): Boolean = ch == '\r' || ch == '\n'
     def getc(): Boolean = iter.hasNext && {
       val ch = iter.next()
@@ -306,7 +307,7 @@ abstract class Source extends Iterator[Char] with Closeable {
    *  It will treat any of \r\n, \r, or \n as a line separator (longest match) - if
    *  you need more refined behavior you can subclass Source#LineIterator directly.
    */
-  def getLines(): Iterator[String] = new LineIterator()
+  def getLines(): Iterator[String]^{this} = new LineIterator()
 
   /** Returns `**true**` if this source has more characters. */
   def hasNext: Boolean = iter.hasNext
@@ -315,7 +316,7 @@ abstract class Source extends Iterator[Char] with Closeable {
   def next(): Char = positioner.next()
 
   @nowarn("cat=deprecation")
-  class Positioner(encoder: Position) {
+  class Positioner(encoder: Position) uses Source.this.iter uses_init Source.this {
     def this() = this(RelaxedPosition)
     /** the last character returned by next. */
     var ch: Char = compiletime.uninitialized
@@ -352,8 +353,8 @@ abstract class Source extends Iterator[Char] with Closeable {
   object RelaxedPosition extends Position {
     def checkInput(line: Int, column: Int): Unit = ()
   }
-  object RelaxedPositioner extends Positioner(RelaxedPosition) { }
-  object NoPositioner extends Positioner(Position) {
+  object RelaxedPositioner extends Positioner(RelaxedPosition) uses Source.this { }
+  object NoPositioner extends Positioner(Position) uses Source.this {
     override def next(): Char = iter.next()
   }
   def ch: Char = positioner.ch
@@ -402,16 +403,16 @@ abstract class Source extends Iterator[Char] with Closeable {
   }
 
   @annotation.stableNull
-  private var resetFunction: (() => Source) | Null = null
+  private var resetFunction: (() -> Source) | Null = null
   @annotation.stableNull
-  private var closeFunction: (() => Unit) | Null = null
-  private var positioner: Positioner = RelaxedPositioner
+  private var closeFunction: (() -> Unit) | Null = null
+  private var positioner: Positioner^{this} = RelaxedPositioner
 
-  def withReset(f: (() => Source) | Null): this.type = {
+  def withReset(f: (() -> Source) | Null): this.type = {
     resetFunction = f
     this
   }
-  def withClose(f: (() => Unit) | Null): this.type = {
+  def withClose(f: (() -> Unit) | Null): this.type = {
     closeFunction = f
     this
   }

--- a/library/src/scala/io/StdIn.scala
+++ b/library/src/scala/io/StdIn.scala
@@ -13,6 +13,7 @@
 package scala
 package io
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.text.MessageFormat
 

--- a/library/src/scala/language.scala
+++ b/library/src/scala/language.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import scala.annotation.compileTimeOnly

--- a/library/src/scala/languageFeature.scala
+++ b/library/src/scala/languageFeature.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta
 

--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -15,6 +15,7 @@ package math
 
 import java.math.BigInteger
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.nowarn
 import scala.language.implicitConversions

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.util.Comparator
 import scala.annotation.migration
@@ -65,10 +66,10 @@ object Equiv extends LowPriorityEquiv {
   def fromComparator[T](cmp: Comparator[T]): Equiv[T] = {
     (x, y) => cmp.compare(x, y) == 0
   }
-  def fromFunction[T](cmp: (T, T) => Boolean): Equiv[T] = {
+  def fromFunction[T](cmp: (T, T) -> Boolean): Equiv[T] = {
     (x, y) => cmp(x, y)
   }
-  def by[T, S: Equiv](f: T => S): Equiv[T] =
+  def by[T, S: Equiv](f: T -> S): Equiv[T] =
     ((x, y) => implicitly[Equiv[S]].equiv(f(x), f(y)))
 
   @inline def apply[T: Equiv]: Equiv[T] = implicitly[Equiv[T]]
@@ -78,7 +79,7 @@ object Equiv extends LowPriorityEquiv {
   private final val optionSeed   = 43
   private final val iterableSeed = 47
 
-  private final class IterableEquiv[CC[X] <: Iterable[X], T](private val eqv: Equiv[T]) extends Equiv[CC[T]] {
+  private final class IterableEquiv[CC[X] <: Iterable[X]^, T](private val eqv: Equiv[T]) extends Equiv[CC[T]] {
     def equiv(x: CC[T], y: CC[T]): Boolean = {
       val xe = x.iterator
       val ye = y.iterator

--- a/library/src/scala/math/Fractional.scala
+++ b/library/src/scala/math/Fractional.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/math/Integral.scala
+++ b/library/src/scala/math/Integral.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.StringParsers
 import scala.language.implicitConversions

--- a/library/src/scala/math/Ordered.scala
+++ b/library/src/scala/math/Ordered.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.util.Comparator
 
@@ -81,7 +82,7 @@ import scala.annotation.unchecked.uncheckedOverride
  *  @tparam T the type of objects that this ordering can compare
  */
 trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializable {
-  outer =>
+  outer: Ordering[T] =>
 
   /** Returns whether a comparison between `x` and `y` is defined, and if so
    *  the result of `compare(x, y)`.
@@ -194,7 +195,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param f the function to extract a `T` value from a `U` value
    *  @return an `Ordering[U]` that orders values by applying `f` and comparing the results using this ordering
    */
-  def on[U](f: U => T): Ordering[U] = new Ordering[U] {
+  def on[U](f: U -> T): Ordering[U] = new Ordering[U] {
     def compare(x: U, y: U) = outer.compare(f(x), f(y))
   }
 
@@ -242,7 +243,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param ord the implicit ordering for the extracted key type `S`
    *  @return an `Ordering[T]` that uses this ordering first, falling back to comparing by `f` when values are equal
    */
-  def orElseBy[S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] = (x, y) => {
+  def orElseBy[S](f: T -> S)(implicit ord: Ordering[S]): Ordering[T] = (x, y) => {
     val res1 = outer.compare(x, y)
     if (res1 != 0) res1 else ord.compare(f(x), f(y))
   }
@@ -254,7 +255,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *
    *  @param lhs the left-hand side value for infix comparison operations
    */
-  class OrderingOps(lhs: T) {
+  class OrderingOps(lhs: T) uses Ordering.this {
     def <(rhs: T): Boolean = lt(lhs, rhs)
     def <=(rhs: T): Boolean = lteq(lhs, rhs)
     def >(rhs: T): Boolean = gt(lhs, rhs)
@@ -275,7 +276,7 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
 
 trait LowPriorityOrderingImplicits {
 
-  type AsComparable[A] = A => Comparable[? >: A]
+  type AsComparable[A] = A -> Comparable[? >: A]
 
   /** This would conflict with all the nice implicit Orderings
    *  available, but thanks to the magic of prioritized implicits
@@ -323,8 +324,9 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  @tparam T the type of objects that this ordering can compare
    *  @param outer the original ordering to be reversed
    */
+  /** A reverse ordering. */
   private final class Reverse[T](private[Ordering] val outer: Ordering[T]) extends Ordering[T] {
-    override def reverse: Ordering[T]                   = outer
+    override def reverse: Ordering[T]                     = outer
     override def isReverseOf(other: Ordering[?]): Boolean = other == outer
 
     def compare(x: T, y: T): Int            = outer.compare(y, x)
@@ -407,7 +409,7 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  @param cmp a function that returns `true` if the first argument is less than the second
    *  @return an `Ordering[T]` whose comparison is derived from `cmp`
    */
-  def fromLessThan[T](cmp: (T, T) => Boolean): Ordering[T] = new Ordering[T] {
+  def fromLessThan[T](cmp: (T, T) -> Boolean): Ordering[T] = new Ordering[T] {
     def compare(x: T, y: T) = if (cmp(x, y)) -1 else if (cmp(y, x)) 1 else 0
     // overrides to avoid multiple comparisons
     override def lt(x: T, y: T): Boolean = cmp(x, y)
@@ -432,7 +434,7 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  @param ord the implicit ordering for the extracted key type `S`
    *  @return an `Ordering[T]` that orders values by applying `f` and comparing the results
    */
-  def by[T, S](f: T => S)(implicit ord: Ordering[S]): Ordering[T] = new Ordering[T] {
+  def by[T, S](f: T -> S)(implicit ord: Ordering[S]): Ordering[T] = new Ordering[T] {
     def compare(x: T, y: T) = ord.compare(f(x), f(y))
     override def lt(x: T, y: T): Boolean = ord.lt(f(x), f(y))
     override def gt(x: T, y: T): Boolean = ord.gt(f(x), f(y))

--- a/library/src/scala/math/PartialOrdering.scala
+++ b/library/src/scala/math/PartialOrdering.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A trait for representing partial orderings.  It is important to
@@ -43,7 +44,7 @@ import scala.language.`2.13`
  */
 
 trait PartialOrdering[T] extends Equiv[T] {
-  outer =>
+  outer: PartialOrdering[T] =>
 
   /** Result of comparing `x` with operand `y`.
    *  Returns `None` if operands are not comparable.

--- a/library/src/scala/math/PartiallyOrdered.scala
+++ b/library/src/scala/math/PartiallyOrdered.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A class for partially ordered data.

--- a/library/src/scala/math/ScalaNumericConversions.scala
+++ b/library/src/scala/math/ScalaNumericConversions.scala
@@ -13,6 +13,7 @@
 package scala
 package math
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A slightly more specific conversion trait for classes which

--- a/library/src/scala/math/package.scala
+++ b/library/src/scala/math/package.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** The package object `scala.math` contains methods for performing basic

--- a/library/src/scala/native.scala
+++ b/library/src/scala/native.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Marker for native methods.

--- a/library/src/scala/noinline.scala
+++ b/library/src/scala/noinline.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/package.scala
+++ b/library/src/scala/package.scala
@@ -10,6 +10,7 @@
  * additional information regarding copyright ownership.
  */
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.migration
 

--- a/library/src/scala/ref/PhantomReference.scala
+++ b/library/src/scala/ref/PhantomReference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 class PhantomReference[+T <: AnyRef](value: T, queue: ReferenceQueue[T]) extends ReferenceWrapper[T] {

--- a/library/src/scala/ref/Reference.scala
+++ b/library/src/scala/ref/Reference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/ref/ReferenceQueue.scala
+++ b/library/src/scala/ref/ReferenceQueue.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 class ReferenceQueue[+T <: AnyRef] {

--- a/library/src/scala/ref/ReferenceWrapper.scala
+++ b/library/src/scala/ref/ReferenceWrapper.scala
@@ -12,11 +12,12 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.nowarn
 
 @nowarn("cat=deprecation")
-trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy {
+trait ReferenceWrapper[+T <: AnyRef] extends Reference[T] with Proxy with caps.Pure {
   val underlying: java.lang.ref.Reference[? <: T]
   override def get = Option(underlying.get)
   def apply() = {

--- a/library/src/scala/ref/SoftReference.scala
+++ b/library/src/scala/ref/SoftReference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 class SoftReference[+T <: AnyRef](value : T, queue : ReferenceQueue[T] | Null) extends ReferenceWrapper[T] {

--- a/library/src/scala/ref/WeakReference.scala
+++ b/library/src/scala/ref/WeakReference.scala
@@ -12,6 +12,7 @@
 
 package scala.ref
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A wrapper class for java.lang.ref.WeakReference

--- a/library/src/scala/runtime/ArrayCharSequence.scala
+++ b/library/src/scala/runtime/ArrayCharSequence.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 // Still need this one since the implicit class ArrayCharSequence only converts

--- a/library/src/scala/runtime/ClassValueCompat.scala
+++ b/library/src/scala/runtime/ClassValueCompat.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.runtime.ClassValueCompat._
 

--- a/library/src/scala/runtime/ClassValueCompat.scala
+++ b/library/src/scala/runtime/ClassValueCompat.scala
@@ -16,7 +16,7 @@ import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.runtime.ClassValueCompat._
 
-private[scala] abstract class ClassValueCompat[T] extends ClassValueInterface[T] { self =>
+private[scala] abstract class ClassValueCompat[T] extends ClassValueInterface[T] { self: ClassValueCompat[T] =>
   private val instance: ClassValueInterface[T] =
     if (classValueAvailable) new JavaClassValue()
     else new FallbackClassValue()

--- a/library/src/scala/runtime/LambdaDeserialize.scala
+++ b/library/src/scala/runtime/LambdaDeserialize.scala
@@ -18,6 +18,7 @@ import java.util
 import scala.annotation.varargs
 import scala.collection.immutable
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 final class LambdaDeserialize private (lookup: MethodHandles.Lookup, targetMethods: Array[MethodHandle]) {

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.invoke._
 

--- a/library/src/scala/runtime/LazyRef.scala
+++ b/library/src/scala/runtime/LazyRef.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Classes used as holders for lazy vals defined in methods. */

--- a/library/src/scala/runtime/MethodCache.scala
+++ b/library/src/scala/runtime/MethodCache.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.reflect.{ Method => JMethod }
 import java.lang.{ Class => JClass }

--- a/library/src/scala/runtime/ModuleSerializationProxy.scala
+++ b/library/src/scala/runtime/ModuleSerializationProxy.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.io.Serializable
 import java.security.PrivilegedActionException

--- a/library/src/scala/runtime/NonLocalReturnControl.scala
+++ b/library/src/scala/runtime/NonLocalReturnControl.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.util.control.ControlThrowable
 

--- a/library/src/scala/runtime/Nothing$.scala
+++ b/library/src/scala/runtime/Nothing$.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/runtime/Null$.scala
+++ b/library/src/scala/runtime/Null$.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /**

--- a/library/src/scala/runtime/PStatics.scala
+++ b/library/src/scala/runtime/PStatics.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 // things that should be in `Statics`, but can't be yet for bincompat reasons

--- a/library/src/scala/runtime/RichBoolean.scala
+++ b/library/src/scala/runtime/RichBoolean.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")

--- a/library/src/scala/runtime/RichByte.scala
+++ b/library/src/scala/runtime/RichByte.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")

--- a/library/src/scala/runtime/RichChar.scala
+++ b/library/src/scala/runtime/RichChar.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")

--- a/library/src/scala/runtime/RichDouble.scala
+++ b/library/src/scala/runtime/RichDouble.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")

--- a/library/src/scala/runtime/RichFloat.scala
+++ b/library/src/scala/runtime/RichFloat.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.immutable.Range
 

--- a/library/src/scala/runtime/RichLong.scala
+++ b/library/src/scala/runtime/RichLong.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")

--- a/library/src/scala/runtime/RichShort.scala
+++ b/library/src/scala/runtime/RichShort.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")

--- a/library/src/scala/runtime/ScalaNumberProxy.scala
+++ b/library/src/scala/runtime/ScalaNumberProxy.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.immutable
 import scala.math.ScalaNumericAnyConversions
@@ -82,7 +83,7 @@ trait FractionalProxy[T] extends Any with ScalaNumberProxy[T] {
 
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 trait OrderedProxy[T] extends Any with Ordered[T] with Proxy.Typed[T] {
-  protected def ord: Ordering[T]
+  protected def ord: Ordering[T]^
 
   def compare(y: T) = ord.compare(self, y)
 }

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -13,6 +13,7 @@
 package scala
 package runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.{AbstractIterator, AnyConstr, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View}
 import scala.collection.generic.IsIterable
@@ -66,7 +67,7 @@ object ScalaRunTime {
    *  @param idx the index of the element to retrieve
    *  @return the element at position `idx` in the array
    */
-  def array_apply(xs: AnyRef, idx: Int): Any = {
+  def array_apply(xs: AnyRef^, idx: Int): Any = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
       case x: Array[Int]     => x(idx).asInstanceOf[Any]
@@ -87,7 +88,7 @@ object ScalaRunTime {
    *  @param idx the index of the element to set
    *  @param value the value to store at the given index
    */
-  def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
+  def array_update(xs: AnyRef^, idx: Int, value: Any): Unit = {
     (xs: @unchecked) match {
       case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
       case x: Array[Int]     => x(idx) = value.asInstanceOf[Int]
@@ -107,11 +108,11 @@ object ScalaRunTime {
    *  @param xs the array to measure, as an `AnyRef`
    *  @return the number of elements in the array
    */
-  @inline def array_length(xs: AnyRef): Int = java.lang.reflect.Array.getLength(xs)
+  @inline def array_length(xs: AnyRef^): Int = java.lang.reflect.Array.getLength(xs)
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
   // the type switch. See Array_clone comment in BCodeBodyBuilder.
-  def array_clone(xs: AnyRef): AnyRef = (xs: @unchecked) match {
+  def array_clone(xs: AnyRef^): AnyRef = (xs: @unchecked) match {
     case x: Array[AnyRef]  => x.clone()
     case x: Array[Int]     => x.clone()
     case x: Array[Double]  => x.clone()
@@ -131,7 +132,7 @@ object ScalaRunTime {
    *  @param src the source array to convert, which may be a primitive array
    *  @return an `Array[Object]` containing the (boxed) elements of `src`
    */
-  def toObjectArray(src: AnyRef): Array[Object] = {
+  def toObjectArray(src: AnyRef^): Array[Object] = {
     def copy[@specialized T <: AnyVal](src: Array[T]): Array[Object] = {
       val length = src.length
       if (length == 0) Array.emptyObjectArray

--- a/library/src/scala/runtime/StructuralCallSite.scala
+++ b/library/src/scala/runtime/StructuralCallSite.scala
@@ -12,6 +12,7 @@
 
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.invoke._
 import java.lang.ref.SoftReference

--- a/library/src/scala/runtime/VarArgsBuilder.scala
+++ b/library/src/scala/runtime/VarArgsBuilder.scala
@@ -1,5 +1,6 @@
 package scala.runtime
 
+import language.experimental.captureChecking
 import scala.collection.immutable.ArraySeq
 import scala.reflect.ClassTag
 

--- a/library/src/scala/specialized.scala
+++ b/library/src/scala/specialized.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 import Specializable._

--- a/library/src/scala/sys/BooleanProp.scala
+++ b/library/src/scala/sys/BooleanProp.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 

--- a/library/src/scala/sys/Prop.scala
+++ b/library/src/scala/sys/Prop.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A lightweight interface wrapping a property contained in some
@@ -95,7 +96,7 @@ object Prop {
      *  @param key the property name used for lookup
      *  @return a new `Prop[T]` backed by the given key
      */
-    def apply(key: String): Prop[T]
+    def apply(key: String): Prop[T]^{this}
   }
 
   implicit object FileProp extends CreatorImpl[java.io.File](s => new java.io.File(s))

--- a/library/src/scala/sys/PropImpl.scala
+++ b/library/src/scala/sys/PropImpl.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.mutable
 
@@ -52,5 +53,5 @@ private[sys] class PropImpl[+T](val key: String, valueFn: String => T) extends P
 }
 
 private[sys] abstract class CreatorImpl[+T](f: String => T) extends Prop.Creator[T] {
-  def apply(key: String): Prop[T] = new PropImpl[T](key, f)
+  def apply(key: String): Prop[T]^{f} = new PropImpl[T](key, f)
 }

--- a/library/src/scala/sys/ShutdownHookThread.scala
+++ b/library/src/scala/sys/ShutdownHookThread.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A minimal Thread wrapper to enhance shutdown hooks.  It knows
@@ -34,7 +35,8 @@ object ShutdownHookThread {
    *  @param body the code to execute when the JVM shuts down
    *  @return the newly created and registered `ShutdownHookThread`
    */
-  def apply(body: => Unit): ShutdownHookThread = {
+  def apply(body: -> Unit): ShutdownHookThread = {
+    // CC note: shutdown hooks capture until the end of the program, so they have to be pure.
     val t = new ShutdownHookThread(() => body, hookName())
     Runtime.getRuntime.addShutdownHook(t)
     t

--- a/library/src/scala/sys/SystemProperties.scala
+++ b/library/src/scala/sys/SystemProperties.scala
@@ -13,6 +13,7 @@
 package scala
 package sys
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.{mutable, Iterator}
 import scala.jdk.CollectionConverters._

--- a/library/src/scala/sys/package.scala
+++ b/library/src/scala/sys/package.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters._
@@ -73,6 +74,7 @@ package object sys {
     s
   }
 
+  // CC note: shutdown hooks capture until the end of the program, so they must be pure.
   /** Registers a shutdown hook to be run when the VM exits.
    *  The hook is automatically registered: the returned value can be ignored,
    *  but is available in case the Thread requires further modification.
@@ -84,7 +86,7 @@ package object sys {
    *  @return   the `ShutdownHookThread` which will run the shutdown hook
    *  @see      [[scala.sys.ShutdownHookThread]]
    */
-  def addShutdownHook(body: => Unit): ShutdownHookThread = ShutdownHookThread(body)
+  def addShutdownHook(body: -> Unit): ShutdownHookThread = ShutdownHookThread(body)
 
   /** Returns all active thread in the current thread's thread group and subgroups.
    *

--- a/library/src/scala/throws.scala
+++ b/library/src/scala/throws.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Annotation for specifying the exceptions thrown by a method.

--- a/library/src/scala/transient.scala
+++ b/library/src/scala/transient.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 

--- a/library/src/scala/typeConstraints.scala
+++ b/library/src/scala/typeConstraints.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.implicitNotFound
 
@@ -116,8 +117,8 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     substituteCo[Id](f)
   }
 
-  override def compose[C](r: C => From): C => To = {
-    type G[+T] = C => T
+  override def compose[C](r: C => From): C ->{r} To = {
+    type G[+T] = C ->{r} T
     substituteCo[G](r)
   }
   /** If `From <: To` and `C <: From`, then `C <: To` (subtyping is transitive).
@@ -129,8 +130,8 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     type G[+T] = C <:< T
     substituteCo[G](r)
   }
-  override def andThen[C](r: To => C): From => C = {
-    type G[-T] = T => C
+  override def andThen[C](r: To => C): From ->{r} C = {
+    type G[-T] = T ->{r} C
     substituteContra[G](r)
   }
   /** If `From <: To` and `To <: C`, then `From <: C` (subtyping is transitive).
@@ -169,10 +170,10 @@ object <:< {
     override def substituteContra[F[_]](ff: F[Any]) = ff
     override def apply(x: Any) = x
     override def flip: Any =:= Any = this
-    override def compose[C](r: C =>  Any) = r
+    override def compose[C](r: C =>  Any): C ->{r} Any = r
     override def compose[C](r: C <:< Any) = r
     override def compose[C](r: C =:= Any) = r
-    override def andThen[C](r: Any =>  C) = r
+    override def andThen[C](r: Any =>  C): Any ->{r} C = r
     override def andThen[C](r: Any <:< C) = r
     override def andThen[C](r: Any =:= C) = r
     override def liftCo    [F[_]] = asInstanceOf[F[Any] =:= F[Any]]

--- a/library/src/scala/typeConstraints.scala
+++ b/library/src/scala/typeConstraints.scala
@@ -12,7 +12,7 @@
 
 package scala
 
-import language.experimental.captureChecking
+// import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.implicitNotFound
 
@@ -117,8 +117,8 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     substituteCo[Id](f)
   }
 
-  override def compose[C](r: C => From): C ->{r} To = {
-    type G[+T] = C ->{r} T
+  override def compose[C](r: C => From): C => To = {
+    type G[+T] = C => T
     substituteCo[G](r)
   }
   /** If `From <: To` and `C <: From`, then `C <: To` (subtyping is transitive).
@@ -130,8 +130,8 @@ sealed abstract class <:<[-From, +To] extends (From => To) with Serializable {
     type G[+T] = C <:< T
     substituteCo[G](r)
   }
-  override def andThen[C](r: To => C): From ->{r} C = {
-    type G[-T] = T ->{r} C
+  override def andThen[C](r: To => C): From => C = {
+    type G[-T] = T => C
     substituteContra[G](r)
   }
   /** If `From <: To` and `To <: C`, then `From <: C` (subtyping is transitive).
@@ -170,10 +170,10 @@ object <:< {
     override def substituteContra[F[_]](ff: F[Any]) = ff
     override def apply(x: Any) = x
     override def flip: Any =:= Any = this
-    override def compose[C](r: C =>  Any): C ->{r} Any = r
+    override def compose[C](r: C =>  Any): C => Any = r
     override def compose[C](r: C <:< Any) = r
     override def compose[C](r: C =:= Any) = r
-    override def andThen[C](r: Any =>  C): Any ->{r} C = r
+    override def andThen[C](r: Any =>  C): Any => C = r
     override def andThen[C](r: Any <:< C) = r
     override def andThen[C](r: Any =:= C) = r
     override def liftCo    [F[_]] = asInstanceOf[F[Any] =:= F[Any]]

--- a/library/src/scala/unchecked.scala
+++ b/library/src/scala/unchecked.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** An annotation to designate that the annotated entity

--- a/library/src/scala/util/ChainingOps.scala
+++ b/library/src/scala/util/ChainingOps.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.language.implicitConversions
 import language.experimental.captureChecking

--- a/library/src/scala/util/DynamicVariable.scala
+++ b/library/src/scala/util/DynamicVariable.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.lang.InheritableThreadLocal
 

--- a/library/src/scala/util/Either.scala
+++ b/library/src/scala/util/Either.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import language.experimental.captureChecking
 

--- a/library/src/scala/util/Properties.scala
+++ b/library/src/scala/util/Properties.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import java.io.{IOException, PrintWriter}
 import java.util.jar.Attributes.{Name => AttributeName}

--- a/library/src/scala/util/Random.scala
+++ b/library/src/scala/util/Random.scala
@@ -13,6 +13,7 @@
 package scala
 package util
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.{migration, tailrec}
 import scala.collection.mutable.ArrayBuffer
@@ -262,7 +263,7 @@ class Random(val self: java.util.Random^) extends AnyRef with Serializable {
    *  @param bf the implicit `BuildFrom` instance used to build the result collection
    *  @return         the shuffled collection
    */
-  def shuffle[T, C](xs: IterableOnce[T])(implicit bf: BuildFrom[xs.type, T, C]): C = {
+  def shuffle[T, C](xs: IterableOnce[T]^)(implicit bf: BuildFrom[xs.type, T, C]): C = {
     val buf = new ArrayBuffer[T] ++= xs
 
     def swap(i1: Int, i2: Int): Unit = {

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -13,6 +13,8 @@
 package scala
 package util
 
+// Context bounds cannot carry a capture set
+// import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.reflect.ClassTag
 import scala.math.Ordering

--- a/library/src/scala/util/Sorting.scala
+++ b/library/src/scala/util/Sorting.scala
@@ -289,7 +289,7 @@ object Sorting {
    *  @param a the array to sort in place
    *  @param f a function that returns `true` if its first argument is less than its second
    */
-  @`inline` def stableSort[K](a: Array[K], f: (K, K) => Boolean): Unit = stableSort(a, f, 0, a.length)
+  @`inline` def stableSort[K](a: Array[K], f: (K, K) -> Boolean): Unit = stableSort(a, f, 0, a.length)
 
   // TODO: make this fast for primitive K (could be specialized if it didn't go through Ordering)
   /** Sorts array `a` or a part of it using function `f` that computes the less-than relation for each element.
@@ -301,7 +301,7 @@ object Sorting {
    *  @param from the first index in the array to sort
    *  @param until the last index (exclusive) in the array to sort
    */
-  def stableSort[K](a: Array[K], f: (K, K) => Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
+  def stableSort[K](a: Array[K], f: (K, K) -> Boolean, from: Int, until: Int): Unit = sort(a, from, until, Ordering fromLessThan f)
 
   /** A sorted Array, using the Ordering for the elements in the sequence `a`.  Uses `java.util.Arrays.sort` unless `K` is a primitive type.
    *
@@ -323,7 +323,7 @@ object Sorting {
    *  @param f a function that returns `true` if its first argument is less than its second
    *  @return a new array containing the elements of `a` sorted according to the less-than relation `f`
    */
-  def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) => Boolean): Array[K] = {
+  def stableSort[K: ClassTag](a: scala.collection.Seq[K], f: (K, K) -> Boolean): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering fromLessThan f)
     ret
@@ -337,7 +337,7 @@ object Sorting {
    *  @param f a function that extracts a comparable key from each element
    *  @return a new array containing the elements of `a` sorted by comparing the keys produced by `f`
    */
-  def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K => M): Array[K] = {
+  def stableSort[K: ClassTag, M: Ordering](a: scala.collection.Seq[K], f: K -> M): Array[K] = {
     val ret = a.toArray
     sort(ret, 0, ret.length, Ordering[M] on f)
     ret

--- a/library/src/scala/util/control/Exception.scala
+++ b/library/src/scala/util/control/Exception.scala
@@ -14,6 +14,7 @@ package scala
 package util
 package control
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.tailrec
 import scala.reflect.{ClassTag, classTag}
@@ -174,7 +175,7 @@ import scala.language.implicitConversions
 object Exception {
   type Catcher[+T] = PartialFunction[Throwable, T]
 
-  def mkCatcher[Ex <: Throwable: ClassTag, T](isDef: Ex => Boolean, f: Ex => T): PartialFunction[Throwable, T] = new Catcher[T] {
+  def mkCatcher[Ex <: Throwable: ClassTag, T](isDef: Ex => Boolean, f: Ex => T): PartialFunction[Throwable, T]^{isDef, f} = new Catcher[T] {
     private def downcast(x: Throwable): Option[Ex] =
       if (classTag[Ex].runtimeClass.isAssignableFrom(x.getClass)) Some(x.asInstanceOf[Ex])
       else None
@@ -183,9 +184,9 @@ object Exception {
     def apply(x: Throwable): T = f(downcast(x).get)
   }
 
-  def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T): PartialFunction[Throwable, T] = mkCatcher[Throwable, T](isDef, f)
+  def mkThrowableCatcher[T](isDef: Throwable => Boolean, f: Throwable => T): PartialFunction[Throwable, T]^{isDef, f} = mkCatcher[Throwable, T](isDef, f)
 
-  implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]): Catcher[T] =
+  implicit def throwableSubtypeToCatcher[Ex <: Throwable: ClassTag, T](pf: PartialFunction[Ex, T]^): Catcher[T]^{pf} =
     mkCatcher(pf.isDefinedAt, pf.apply)
 
   /** !!! Not at all sure of every factor which goes into this,
@@ -233,7 +234,7 @@ object Exception {
    *  @group logic-container
    */
   class Catch[+T](
-    val pf: Catcher[T],
+    val pf: Catcher[T]^,
     val fin: Option[Finally] = None,
     val rethrow: Throwable => Boolean = shouldRethrow)
   extends Described {
@@ -246,8 +247,8 @@ object Exception {
      *  @param pf2 the additional exception handler to combine with the existing one
      *  @return a new `Catch` that tries this catch's handler first, falling back to `pf2`
      */
-    def or[U >: T](pf2: Catcher[U]): Catch[U] = new Catch(pf orElse pf2, fin, rethrow)
-    def or[U >: T](other: Catch[U]): Catch[U] = or(other.pf)
+    def or[U >: T](pf2: Catcher[U]^): Catch[U]^{this, pf2} = new Catch(pf orElse pf2, fin, rethrow)
+    def or[U >: T](other: Catch[U]^): Catch[U]^{this, other} = or(other.pf)
 
     /** Applies this catch logic to the supplied body.
      *
@@ -268,7 +269,7 @@ object Exception {
      *  @param body the additional logic to apply after all existing finally bodies
      *  @return a new `Catch` with the same catch logic and `body` appended to the finally logic
      */
-    def andFinally(body: => Unit): Catch[T] = {
+    def andFinally(body: => Unit): Catch[T]^{this, body} = {
       val appendedFin = fin map(_ and body) getOrElse new Finally(body)
       new Catch(pf, Some(appendedFin), rethrow)
     }
@@ -308,7 +309,7 @@ object Exception {
      *  @param f the function to apply to caught exceptions instead of the current handler
      *  @return a new `Catch` that handles the same exceptions but produces results by applying `f`
      */
-    def withApply[U](f: Throwable => U): Catch[U] = {
+    def withApply[U](f: Throwable => U): Catch[U]^{this, f} = {
       val pf2 = new Catcher[U] {
         def isDefinedAt(x: Throwable): Boolean = pf isDefinedAt x
         def apply(x: Throwable): U = f(x)
@@ -317,9 +318,9 @@ object Exception {
     }
 
     /** Convenience methods. */
-    def toOption: Catch[Option[T]] = withApply(_ => None)
-    def toEither: Catch[Either[Throwable, T]] = withApply(Left(_))
-    def toTry: Catch[scala.util.Try[T]] = withApply(x => Failure(x))
+    def toOption: Catch[Option[T]]^{this} = withApply(_ => None)
+    def toEither: Catch[Either[Throwable, T]]^{this} = withApply(Left(_))
+    def toTry: Catch[scala.util.Try[T]]^{this} = withApply(x => Failure(x))
   }
 
   final val nothingCatcher: Catcher[Nothing]  = mkThrowableCatcher(_ => false, throw _)
@@ -405,7 +406,7 @@ object Exception {
    *  @param value the default value to return when one of the specified exceptions is caught
    *  @return a `Catch[T]` that returns `value` when any of the specified exceptions is caught
    */
-  def failAsValue[T](exceptions: Class[?]*)(value: => T): Catch[T] =
+  def failAsValue[T](exceptions: Class[?]*)(value: => T): Catch[T]^{value} =
     catching(exceptions*) withApply (_ => value)
 
   class By[T,R](f: T => R) {
@@ -428,9 +429,9 @@ object Exception {
    *
    *  @return a `By` builder whose `by` method takes a handler function and returns a configured `Catch[T]`
    */
-  def handling[T](exceptions: Class[?]*): By[Throwable => T, Catch[T]] = {
-    def fun(f: Throwable => T): Catch[T] = catching(exceptions*) withApply f
-    new By[Throwable => T, Catch[T]](fun)
+  def handling[T](exceptions: Class[?]*): By[Throwable -> T, Catch[T]] = { /* CC note: By is invariant. :( */
+    def fun(f: Throwable -> T): Catch[T] = catching(exceptions*) withApply f
+    new By[Throwable -> T, Catch[T]](fun)
   }
 
   /** Returns a `Catch` object with no catch logic and the argument as the finally logic.
@@ -439,7 +440,7 @@ object Exception {
    *  @tparam T the result type of the `Catch` body
    *  @param body the finally logic to execute after the `Catch` body completes
    */
-  def ultimately[T](body: => Unit): Catch[T] = noCatch andFinally body
+  def ultimately[T](body: => Unit): Catch[T]^{body} = noCatch andFinally body
 
   /** Creates a `Catch` object which unwraps any of the supplied exceptions.
    *  @group composition-catch

--- a/library/src/scala/util/control/NoStackTrace.scala
+++ b/library/src/scala/util/control/NoStackTrace.scala
@@ -13,6 +13,7 @@
 package scala
 package util.control
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** A trait for exceptions which, for efficiency reasons, do not

--- a/library/src/scala/util/control/NonFatal.scala
+++ b/library/src/scala/util/control/NonFatal.scala
@@ -13,6 +13,7 @@
 package scala
 package util.control
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 
 /** Extractor of non-fatal Throwables. Will not match fatal errors like `VirtualMachineError`

--- a/library/src/scala/volatile.scala
+++ b/library/src/scala/volatile.scala
@@ -12,6 +12,7 @@
 
 package scala
 
+import language.experimental.captureChecking
 import scala.language.`2.13`
 import scala.annotation.meta._
 


### PR DESCRIPTION
Continuation of #25526

## MiMA changes

- A new `private[collection]` static method `sortedImpl` that contains the generic `sorted` implementation. This implementation actually does _not_ retain the original collection (i.e. its return type is capturing less than the generic interface). 
- `StrictOptimizedSeqOps` use this above implementation and requires the interface to return a strict Seq. The default implementation calls `sortedImpl` instead of `super.sorted`, so the `super.sorted` reference goes away. 

## Have you relied on LLM-based tools in this contribution?

Claude was used for debugging the failing CI tests. I manually checked all changes.

## How was the solution tested?

Covered by existing tests 
