### PR TITLE
Mark erased as always used

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -689,7 +689,7 @@ object CheckUnused:
         || m.hasAnnotation(defn.UnusedAnnot) // param of unused method
         || sym.info.isSingleton
         || m.isConstructor && m.owner.thisType.baseClasses.contains(defn.AnnotationClass)
-        || sym.isErased // erased param is unused by design
+        || sym.isErased // erased param may be unused by design
       def checkExplicit(): Unit =
         // A class param is unused if its param accessor is unused.
         // (The class param is not assigned to a field until constructors.)

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -689,6 +689,7 @@ object CheckUnused:
         || m.hasAnnotation(defn.UnusedAnnot) // param of unused method
         || sym.info.isSingleton
         || m.isConstructor && m.owner.thisType.baseClasses.contains(defn.AnnotationClass)
+        || sym.isErased // erased param is unused by design
       def checkExplicit(): Unit =
         // A class param is unused if its param accessor is unused.
         // (The class param is not assigned to a field until constructors.)
@@ -755,6 +756,7 @@ object CheckUnused:
              tps.hasAnnotation(dd.LanguageFeatureMetaAnnot)
         || sym.info.isSingleton // DSL friendly
         || sym.info.dealias.isInstanceOf[RefinedType] // can't be expressed as a context bound
+        || sym.isErased // erased param is unused by design
       if ctx.settings.WunusedHas.implicits
         && !infos.skip(m)
         && !m.isEffectivelyOverride

--- a/tests/warn/unused-erased.scala
+++ b/tests/warn/unused-erased.scala
@@ -1,0 +1,14 @@
+//> using options -Wunused:all -language:experimental.erasedDefinitions
+
+trait Ev:
+  def foo: Int
+
+def answer: Int = 42
+
+def f(using erased ev: Ev): Int = answer     // no warn, erased using param is unused by design
+
+def g(erased x: Int): Int = answer           // no warn, erased explicit param is unused by design
+
+def h(using ev: Ev): Int = answer            // warn, non-erased using param is still checked
+
+def i(x: Int): Int = answer                  // warn, non-erased explicit param is still checked

--- a/tests/warn/unused-erased.scala
+++ b/tests/warn/unused-erased.scala
@@ -1,14 +1,34 @@
 //> using options -Wunused:all -language:experimental.erasedDefinitions
 
 trait Ev:
-  def foo: Int
+  def foo: Unit = () // avoid Ev being treated as a marker trait
+
+object Ev:
+  def f(using erased ev: Ev): Int = answer     // no warn, erased using param is unused by design
+
+  def g(erased x: Int): Int = answer           // no warn, erased explicit param is unused by design
+
+  def h(using ev: Ev): Int = answer            // warn, non-erased using param is still checked
+
+  def i(x: Int): Int = answer                  // warn, non-erased explicit param is still checked
+
+trait EvErased extends compiletime.Erased:
+  def foo: Unit = () // avoid Ev being treated as a marker trait
+
+
+object EvErased:
+  def f(using erased ev: EvErased): Int = answer     // no warn, explicitly erased
+
+  def g(erased x: EvErased): Int = answer            // no warn, explicitly erased
+
+  def h(using ev: EvErased): Int = answer            // no warn, type derives from Erased so param is implicitly erased
+
+  def i(x: EvErased): Int = answer                   // no warn, type derives from Erased so param is implicitly erased
+
+
+def localScope =
+  val x = new Ev {}                           // warn, non-erased val is still checked
+  erased val y = new Ev {}                    // warn, not affected
+  val z = new EvErased {}                     // warn, not affected
 
 def answer: Int = 42
-
-def f(using erased ev: Ev): Int = answer     // no warn, erased using param is unused by design
-
-def g(erased x: Int): Int = answer           // no warn, erased explicit param is unused by design
-
-def h(using ev: Ev): Int = answer            // warn, non-erased using param is still checked
-
-def i(x: Int): Int = answer                  // warn, non-erased explicit param is still checked


### PR DESCRIPTION
Erased parameters should be marked as used, since they are unused by design. 

For example

```scala
//> using options -Wunused:all

type Ev

def meth(using erased ev: Ev) = ???
```


<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests 
