### PR TITLE
Missing close code block backticks

### DIFF
--- a/docs/_docs/reference/experimental/erased-defs.md
+++ b/docs/_docs/reference/experimental/erased-defs.md
@@ -129,6 +129,7 @@ inline def g(x: Int): Int =
 methodWithErasedInt2(5)  // ok
 methodWithErasedInt2(f(5))  // error, f(22) is not a pure expression
 methodWithErasedInt2(g(5))  // ok since `g` is `inline`.
+```
 
 Besides parameters, `val` definitions can also be marked with `erased`.
 These will also only be usable as arguments to `erased` parameters or


### PR DESCRIPTION
Add backticks to doc page at end of "details" section.

https://www.scala-lang.org/files/archive/api/current/docs/experimental/erased-defs.html

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
