### PR TITLE
Backport "Scaladoc: add fallback lookup from nearest package" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -352,7 +352,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   def ClassDefWithParents(cls: ClassSymbol, constr: DefDef, parents: List[Tree], body: List[Tree])(using Context): TypeDef = {
     val selfType =
-      if (cls.classInfo.selfInfo ne NoType) ValDef(newSelfSym(cls))
+      if (cls.info ne NoType) && (cls.classInfo.selfInfo ne NoType) then ValDef(newSelfSym(cls))
       else EmptyValDef
     def isOwnTypeParam(stat: Tree) =
       stat.symbol.is(TypeParam) && stat.symbol.owner == cls

--- a/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
+++ b/scaladoc-js/main/src/searchbar/SearchbarComponent.scala
@@ -205,7 +205,7 @@ class SearchbarComponent(engine: PageSearchEngine, inkuireEngine: InkuireJSSearc
         span(cls := "search-error")(s)
       )
 
-  var timeoutHandle: SetTimeoutHandle = null
+  private var timeoutHandle: SetTimeoutHandle = null
   def handleNewQuery(query: String) =
     resultsDiv.scrollTop = 0
     resultsDiv.onscroll = (event: Event) => { }

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MemberLookup.scala
@@ -73,6 +73,7 @@ trait MemberLookup {
                 val ql = query.asList
                 toplevelLookup(ql)
                 .orElse(relativeLookup(ql, nearest))
+                .orElse(downwardLookup(ql, nearestPkg))
                 .map(memberLookupResult(_, query.join, _))
             }
 

--- a/scaladoc/src/test/resources/i26627/lazyFuture.scala.txt
+++ b/scaladoc/src/test/resources/i26627/lazyFuture.scala.txt
@@ -1,0 +1,14 @@
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Try, Success}
+
+abstract class Lazy[+T](body: => T) extends Future[T] {
+  lazy val await = body
+  def value = Some(Success(await))
+  def isCompleted = true
+
+  def onComplete[U](func: Try[T] => U)(using executor: ExecutionContext) = ???
+  def transform[S](f: Try[T] => Try[S])(using executor: ExecutionContext): Future[S] = ???
+  def transformWith[S](f: Try[T] => Future[S])(using executor: ExecutionContext): Future[S] = ???
+}
+
+class Helper { def foo: Int = 0 }

--- a/scaladoc/test-source-links/dotty/tools/scaladoc/source-links/RemoteLinksTest.scala
+++ b/scaladoc/test-source-links/dotty/tools/scaladoc/source-links/RemoteLinksTest.scala
@@ -94,4 +94,4 @@ class RemoteLinksTest:
             }
         }
     IO.foreachFileIn(output, processFile)
-    mtsl.result
+    mtsl.result()

--- a/scaladoc/test/dotty/tools/scaladoc/e2e/EndToEndTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/e2e/EndToEndTests.scala
@@ -1,0 +1,40 @@
+package dotty.tools.scaladoc
+package e2e
+
+import java.nio.file.Files
+import org.junit.Test
+import dotty.tools.scaladoc.util.IO
+
+/** End-to-end Scaladoc runs that compile sources at test time and assert on diagnostics. */
+class EndToEndTests:
+
+  @Test
+  def i26627 =
+    val root = Files.createTempDirectory("scaladoc-i26627")
+    try
+      val output = root.resolve("classes")
+      compileStage(output, Nil, copyTestResource(root, "i26627", "lazyFuture.scala"))
+
+      val ctx = testContext
+      val docOutput = root.resolve("doc").toFile
+      val tasty = collectTastyFiles(output)
+      assert(tasty.nonEmpty, s"Expected .tasty files under $output")
+      Scaladoc.run(
+        testArgs(tasty, docOutput).copy(
+          classpath = Seq(output.toString, javaClasspath)
+            .mkString(java.io.File.pathSeparator)
+        )
+      )(using ctx)
+
+      val diagnostics = ctx.reportedDiagnostics
+      val linkWarnings = diagnostics.warningMsgs.filter(msg =>
+        msg.contains("Couldn't resolve a member for the given link query")
+          || msg.contains("Unable to find a link for")
+      )
+      org.junit.Assert.assertEquals(
+        s"Unexpected unresolved link warnings:\n${linkWarnings.mkString("\n")}",
+        Nil,
+        linkWarnings
+      )
+      assertNoErrors(diagnostics)
+    finally IO.delete(root.toFile)

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/MissingAnnotationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/MissingAnnotationTest.scala
@@ -1,44 +1,21 @@
 package dotty.tools.scaladoc
 package tasty
 
-import java.nio.file.{Files, Path, Paths}
-import org.junit.{Assert, Test}
+import java.nio.file.Files
+import org.junit.Test
 import dotty.tools.scaladoc.util.IO
 
 class MissingAnnotationTest:
-
-  private val javaClasspath = System.getProperty("java.class.path")
-
-  private def source(root: Path, name: String): Path =
-    val resource = getClass.getResource(s"/missing-annotation/$name.txt")
-    val source = root.resolve("sources").resolve(name)
-    Files.createDirectories(source.getParent)
-    Files.copy(Paths.get(resource.toURI), source)
-    source
-
-  private def compileStage(output: Path, classpath: Seq[Path], sources: Path*): Unit =
-    Files.createDirectories(output)
-    val compilerClasspath =
-      (classpath.map(_.toString) :+ javaClasspath).mkString(java.io.File.pathSeparator)
-    val reporter = new TestReporter
-    val result = dotty.tools.dotc.Main.process(
-      Array("-classpath", compilerClasspath, "-d", output.toString) ++ sources.map(_.toString),
-      reporter
-    )
-    Assert.assertFalse(
-      s"Compilation failed:\n${reporter.errors.result().map(_.msg.message).mkString("\n")}",
-      result.hasErrors
-    )
 
   @Test
   def ignoresUndocumentedAnnotationsMissingFromDocClasspath =
     val root = Files.createTempDirectory("scaladoc-missing-annotation")
     try
       val annotationOutput = root.resolve("annotation")
-      compileStage(annotationOutput, Nil, source(root, "annotation.scala"))
+      compileStage(annotationOutput, Nil, copyTestResource(root, "missing-annotation", "annotation.scala"))
 
       val fooOutput = root.resolve("foo")
-      compileStage(fooOutput, Seq(annotationOutput), source(root, "foo.scala"))
+      compileStage(fooOutput, Seq(annotationOutput), copyTestResource(root, "missing-annotation", "foo.scala"))
 
       // Run Scaladoc without annotation tasty
       val ctx = testContext

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/comments/MemberLookupTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/comments/MemberLookupTests.scala
@@ -16,6 +16,7 @@ class LookupTestCases[Q <: Quotes](val q: Quotes) {
     testOwnerlessLookupOfInherited()
     testOwnerlessLookupOfClassWithinPackageWithPackageObject()
     testOwnedLookup()
+    testLookupFromNearestPackage()
     testStrictMemberLookup()
     testOverloadedMethodLookup()
   }
@@ -159,6 +160,20 @@ class LookupTestCases[Q <: Quotes](val q: Quotes) {
       cls("tests.D") -> "bar" -> cls("tests.tests$package$").fld("bar"),
       cls("tests.inner.A$") -> "foo" -> cls("tests.package$").fld("foo"),
       cls("tests.inner.A$") -> "bar" -> cls("tests.tests$package$").fld("bar"),
+    )
+
+    cases.foreach { case ((Sym(owner), query), Sym(target)) =>
+      val Some((lookedUp, _, _)) = MemberLookup.lookup(parseQuery(query), owner): @unchecked
+      assertSame(s"$owner / $query", target, lookedUp)
+    }
+  }
+
+  def testLookupFromNearestPackage(): Unit = {
+    val cases = List[((Sym, String), Sym)](
+      cls("scala.concurrent.Awaitable").fun("ready") -> "Await.ready" ->
+        cls("scala.concurrent.Await$").fun("ready"),
+      cls("scala.concurrent.Awaitable").fun("result") -> "Await.result" ->
+        cls("scala.concurrent.Await$").fun("result"),
     )
 
     cases.foreach { case ((Sym(owner), query), Sym(target)) =>

--- a/scaladoc/test/dotty/tools/scaladoc/testUtils.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/testUtils.scala
@@ -7,7 +7,7 @@ import dotty.tools.dotc.interfaces.Diagnostic.{ERROR, INFO, WARNING}
 import dotty.tools.scaladoc.test.BuildInfo
 import org.junit.Assert._
 import java.io.File
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 
 
 case class ReportedDiagnostics(errors: List[Diagnostic], warnings: List[Diagnostic], infos: List[Diagnostic]):
@@ -80,3 +80,40 @@ def tastyFiles(name: String, allowEmpty: Boolean = false, rootPck: String = "tes
   files.toSeq
 
 def testDocPath: Path = Paths.get(BuildInfo.testDocumentationRoot)
+
+/** JVM classpath of the test runner; used when compiling sources or running Scaladoc at test time. */
+def javaClasspath: String = System.getProperty("java.class.path")
+
+/** Copy a test resource `<resourceDir>/<name>.txt` into `root/sources/<name>` and return that path.
+ *  Why .txt? So that the files don't conflict with other tests that load all .scala files... not great. */
+def copyTestResource(root: Path, resourceDir: String, name: String): Path =
+  val resource = classOf[TestReporter].getResource(s"/$resourceDir/$name.txt")
+  assertNotNull(s"Test resource not found: /$resourceDir/$name.txt", resource)
+  val source = root.resolve("sources").resolve(name)
+  Files.createDirectories(source.getParent)
+  Files.copy(Paths.get(resource.toURI), source)
+  source
+
+/** Compile `sources` with the current compiler into `output`, using `classpath` ahead of the JVM classpath. */
+def compileStage(output: Path, classpath: Seq[Path], sources: Path*): Unit =
+  Files.createDirectories(output)
+  val compilerClasspath =
+    (classpath.map(_.toString) :+ javaClasspath).mkString(java.io.File.pathSeparator)
+  val reporter = new TestReporter
+  val result = dotty.tools.dotc.Main.process(
+    Array("-classpath", compilerClasspath, "-d", output.toString) ++ sources.map(_.toString),
+    reporter
+  )
+  assertFalse(
+    s"Compilation failed:\n${reporter.errors.result().map(_.msg.message).mkString("\n")}",
+    result.hasErrors
+  )
+
+/** Recursively collect `.tasty` files under `dir`. */
+def collectTastyFiles(dir: Path): Seq[File] =
+  def collect(f: File): List[File] = Option(f.listFiles).toList.flatten.flatMap {
+    case d if d.isDirectory => collect(d)
+    case t if t.getName.endsWith(".tasty") => t :: Nil
+    case _ => Nil
+  }
+  collect(dir.toFile)


### PR DESCRIPTION
Backports #26661 to the 3.9.0-RC5.

PR submitted by the release tooling.
[skip ci]