### PR TITLE
Backport "Fix stale `baseTypeCache` after synthetic Product.Mirror parents added" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -668,6 +668,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       val newClassInfo = oldClassInfo.derivedClassInfo(
         declaredParents = oldClassInfo.declaredParents :+ parent)
       clazz.copySymDenotation(info = newClassInfo).installAfter(thisPhase)
+      parent.classSymbol.asClass.invalidateBaseTypeCache()
     }
     def addMethod(name: TermName, info: Type, cls: Symbol, body: (Symbol, Tree) => Context ?=> Tree): Unit = {
       val meth = newSymbol(clazz, name, Synthetic | Method, info, coord = clazz.coord)

--- a/tests/pos/i26611/App_2.scala
+++ b/tests/pos/i26611/App_2.scala
@@ -1,0 +1,10 @@
+package app
+
+import lib.*
+
+case class Local(y: Int)
+object Local extends HasOptions { val options = 1 }
+
+trait Cli {
+  Seq(Local, A, B, C, D, E)
+}

--- a/tests/pos/i26611/Lib_1.scala
+++ b/tests/pos/i26611/Lib_1.scala
@@ -1,0 +1,18 @@
+package lib
+
+trait HasOptions { def options: Int }
+
+case class A(x: String)
+object A extends HasOptions { val options = 1 }
+
+case class B(x: String)
+object B extends HasOptions { val options = 1 }
+
+case class C(x: String)
+object C extends HasOptions { val options = 1 }
+
+case class D(x: String)
+object D extends HasOptions { val options = 1 }
+
+case class E(x: String)
+object E extends HasOptions { val options = 1 }

--- a/tests/pos/i26611b.scala
+++ b/tests/pos/i26611b.scala
@@ -1,0 +1,10 @@
+import scala.deriving.Mirror
+
+case class Local(y: Int)
+object Local
+
+// `| Any` is for make typer pass
+// Run Local <:< Mirror.Product check at typer (baseTypeCache for `Mirror.Product` on `Local$` <- NoType)
+// PostTyper adds `MirrorPrpduct` as a parent of `Local$`, we should invalidate baseTypeCache for `Local$`
+// otherwise, Recheck fails `Local$ <:< Mirror.Product`.
+val x: Mirror.Product | Any = Local


### PR DESCRIPTION
Backports #26714 to the 3.9.0-RC5.

PR submitted by the release tooling.