### PR TITLE
Scaladoc: Do not allow resolving warnings to hide each other

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/Comments.scala
@@ -1,21 +1,24 @@
 package dotty.tools.scaladoc
 package tasty.comments
 
+import scala.collection.mutable
 import scala.collection.immutable.SortedMap
 import scala.util.Try
-
-import com.vladsch.flexmark.util.{ast => mdu, sequence}
-import com.vladsch.flexmark.{ast => mda}
+import com.vladsch.flexmark.util.{sequence, ast as mdu}
+import com.vladsch.flexmark.ast as mda
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.util.sequence.BasedSequence
+import dotty.tools.dotc.core.Contexts
+import dotty.tools.dotc.util.{SrcPos, SourcePosition, Spans}
 
-import scala.quoted._
+import scala.quoted.*
 import dotty.tools.scaladoc.tasty.comments.markdown.ExtendedFencedCodeBlock
 import dotty.tools.scaladoc.tasty.comments.wiki.Paragraph
 import dotty.tools.scaladoc.DocPart
-import dotty.tools.scaladoc.tasty.{ SymOpsWithLinkCache, SymOps }
-import scala.jdk.CollectionConverters._
-import dotty.tools.scaladoc.snippets._
+import dotty.tools.scaladoc.tasty.{SymOps, SymOpsWithLinkCache}
+
+import scala.jdk.CollectionConverters.*
+import dotty.tools.scaladoc.snippets.*
 
 class Repr(val qctx: Quotes)(val sym: qctx.reflect.Symbol)
 
@@ -73,6 +76,8 @@ case class PreparsedComment(
 case class DokkaCommentBody(summary: Option[DocPart], body: DocPart)
 
 abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
+  private val existingWarningPositions: mutable.Set[SrcPos] = mutable.Set.empty
+
   protected def stringToMarkup(str: String): T
   protected def markupToDokka(t: T): DocPart
   protected def markupToString(t: T): String
@@ -88,7 +93,7 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
     if repr == null then null.asInstanceOf[qctx.reflect.Symbol] else repr.sym
   private given qctx.type = qctx
 
-  lazy val srcPos = if owner == qctx.reflect.defn.RootClass then {
+  private lazy val srcPos = if owner == qctx.reflect.defn.RootClass then {
     val sourceFile = dctx.args.rootDocPath.map(p => dotty.tools.dotc.util.SourceFile(dotty.tools.io.AbstractFile.getFile(p), scala.io.Codec.UTF8))
     sourceFile.fold(dotty.tools.dotc.util.NoSourcePosition)(sf => dotty.tools.dotc.util.SourcePosition(sf, dotty.tools.dotc.util.Spans.NoSpan))
   } else owner.pos.get.asInstanceOf[dotty.tools.dotc.util.SrcPos]
@@ -115,8 +120,21 @@ abstract class MarkupConversion[T](val repr: Repr)(using dctx: DocContext) {
             DocLink.ToDRI(dri, targetText)
           case None =>
             val txt = s"Couldn't resolve a member for the given link query"
+            // We do not have the actual position of the link,
+            // and to get it, we need to refactor the entire Scaladoc codebase to track positions when parsing.
+            // For now, we at least don't want warnings to hide other warnings, so shift the position by 1
+            // if we've already reported a warning at that position.
+            var pos = srcPos
+            while !existingWarningPositions.add(pos) do
+              val oldPos = pos
+              pos = new SrcPos {
+                def sourcePos(using ctx: Contexts.Context): SourcePosition =
+                  SourcePosition(oldPos.sourcePos.source, oldPos.sourcePos.span.shift(1), oldPos.sourcePos.outer)
+                def span: Spans.Span =
+                  oldPos.span.shift(1)
+              }
             if !summon[DocContext].args.noLinkWarnings then
-              report.warning(s"$txt: $queryStr", srcPos)
+              report.warning(s"$txt: $queryStr", pos)
             DocLink.UnresolvedDRI(queryStr, txt)
 
   private val SchemeUri = """[a-z]+:.*""".r

--- a/scaladoc/test-resources/warningPosition/warningPosition.scala
+++ b/scaladoc/test-resources/warningPosition/warningPosition.scala
@@ -1,0 +1,4 @@
+/**
+ * See [[nofoo.Foo]] or [[foo.noFoo]] neither of which exist
+ */
+def bar = ()

--- a/scaladoc/test/dotty/tools/scaladoc/e2e/EndToEndTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/e2e/EndToEndTests.scala
@@ -160,3 +160,12 @@ class EndToEndTests:
     ensureContains(out, "pkg", "Midrange.html", "parameterless method 1", "method with empty parameter list 1", "method with one parameter 1")
     ensureContains(out, "pkg", "Treble.html", "parameterless method 2", "method with empty parameter list 2", "method with one parameter 2")
   }
+
+  @Test
+  def warningPosition(): Unit = run("warningPosition", "warningPosition.scala") { (_, reporter) =>
+    assertEquals(
+      reporter.allWarnings.mkString("\n"),
+      2,
+      reporter.allWarnings.count(m => m.message.contains("Couldn't resolve"))
+    )
+  }


### PR DESCRIPTION
Fixes #17550

This is terrible but it's less terrible than having warnings hide each other.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
