### PR TITLE
chore: add CLA to the CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,7 @@ Principal areas of the compiler and internal team members responsible for their 
 - Vulpix: @SolalPirelli
 - Benchmarks: @mbovel
 - Releases: @WojciechMazur (Scala 3 Next), @tgodzik (Scala 3.3 LTS)
+- CLA Checker: @warcholjakub, @sjrd
 
 **Misc**
 - Issue tracker: @Gedochao


### PR DESCRIPTION
Since old [CLA Checker](https://github.com/scala/cla-checker) has been archived and the migration requires CLA Assistant administrator privileges, add information about whom to contact.

Related: https://github.com/scala/cla-checker/blob/main/README.md

cc @sjrd - not sure if you want to be listed, so just checking

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Non-code change, no tests needed
