### PR TITLE
chore(compiler): add top-level object dependency regression test

### DIFF
--- a/sbt-bridge/test/xsbt/DependencySpecification.scala
+++ b/sbt-bridge/test/xsbt/DependencySpecification.scala
@@ -107,6 +107,30 @@ class DependencySpecification {
   }
 
   @Test
+  def binaryDependencyOnTopLevelObjectUsesModuleClassFile = {
+    val upstream =
+      """|package example
+         |object Api {
+         |  val value = 1
+         |}""".stripMargin
+    val downstream =
+      """|package example
+         |object Usage {
+         |  val value = Api.value
+         |}""".stripMargin
+
+    val compilerForTesting = new ScalaCompilerForUnitTesting
+    val output = compilerForTesting.compileSrcs(List(List(upstream), List(downstream)))
+    val downstreamSource = output.srcFiles.last
+    val dependencyClassFiles = output.analysis.binaryDependencies.collect {
+      case (classFile, "example.Api$", _, source, _) if source == downstreamSource =>
+        classFile.getFileName.toString
+    }
+
+    assertEquals(Seq("Api$.class"), dependencyClassFiles.toSeq)
+  }
+
+  @Test
   def extractedTopLevelImportDependencies = {
     val srcA =
       """


### PR DESCRIPTION
This adds a regression test for binary dependencies loaded from TASTy.

For a top-level object, the compiler reports binary name `example.Api$` with `Api.class`; the defining file is `Api$.class`. Zinc can therefore detect a false classpath change and recompile downstream sources.

The new test intentionally fails with `expected: Api$.class, actual: Api.class`.

## Have you relied on LLM-based tools in this contribution?

Yes, extensively. I first noticed the problem while using Mill: changing one source file caused incremental compilation to recompile five files. I asked Codex GPT-5.6 Sol (Extra High) and Claude Fable 5 (High) to investigate.

Both reached the same diagnosis and agreed on this regression test. I verified their work by reproducing the behavior locally, reviewing the dependency callback output, and running the focused test.

## How was the solution tested?

This PR does not include a fix. It adds a minimal regression test that reproduces the bug and intentionally fails on `main`; CI should confirm the failure.

I do not have sufficient expertise in this compiler area to propose a reliable fix. Instead of opening an issue with a separate reproducer, I am submitting the reproducer directly as a test so maintainers can investigate and use it to validate the eventual fix.

If the project prefers an issue before proceeding with this PR, I am happy to file one.
