### PR TITLE
Backport "[library] Make Option.orNull public in binary" to 3.9.0

### DIFF
--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -13,6 +13,7 @@
 package scala
 
 import scala.language.`2.13`
+import scala.annotation.publicInBinary
 
 object Option {
 
@@ -249,8 +250,9 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
    *  @return the option's value if nonempty, or `null` if empty
    */
   @inline final def orNull[A1 >: A | Null]: A1 = this.getOrElse(null)
-  
-  // for binary and TASTy backwards compatibility 
+
+  // for binary and TASTy backwards compatibility
+  @publicInBinary
   @deprecated @inline protected final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
 
   /** Returns a $some containing the result of applying $f to this $option's

--- a/library/src/scala/Option.scala
+++ b/library/src/scala/Option.scala
@@ -253,7 +253,7 @@ sealed abstract class Option[+A] extends IterableOnce[A] with Product with Seria
 
   // for binary and TASTy backwards compatibility
   @publicInBinary
-  @deprecated @inline protected final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
+  @deprecated @inline private[Option] final def orNull[A1 >: A](implicit ev: Null <:< A1): A1 = this getOrElse ev(null)
 
   /** Returns a $some containing the result of applying $f to this $option's
    *  value if this $option is nonempty.

--- a/tests/run-macros/i26626/Macro_1_c3.8.4.scala
+++ b/tests/run-macros/i26626/Macro_1_c3.8.4.scala
@@ -1,0 +1,20 @@
+// Compiles with published Scala 3.8.4 (via Vulpix `_c` suffix / Coursier).
+// Repro for https://github.com/scala/scala3/issues/26626:
+// macros that expand to Option.orNull must remain usable on newer compilers.
+
+package sangria
+
+import scala.quoted.*
+import scala.compiletime.testing.typeChecks
+
+object Macros:
+  final val LegacyOrNullSnippet = "Option.empty[String].orNull[String | Null](using summon[Null <:< (String | Null)])"
+
+  // To confirms it's Scala 3.8
+  assert(typeChecks(LegacyOrNullSnippet))
+
+  inline def useOrNull[T](inline o: Option[T]): T =
+    ${ useOrNullImpl('o) }
+
+  def useOrNullImpl[T: Type](o: Expr[Option[T]])(using Quotes): Expr[T] =
+    '{ $o.orNull.asInstanceOf[T] }

--- a/tests/run-macros/i26626/Test_2.scala
+++ b/tests/run-macros/i26626/Test_2.scala
@@ -1,0 +1,14 @@
+//> using options -Yexplicit-nulls
+import scala.compiletime.testing.typeChecks
+
+object AstVisitor:
+  def visit(o: Option[String]): String = sangria.Macros.useOrNull(o)
+
+@main def Test =
+  assert(AstVisitor.visit(Some("ok")) == "ok")
+  assert(AstVisitor.visit(None) == null)
+
+  // protected/private[scala] def orNull[A1 >: A](implicit ev: Null <:< A1): A1
+  // typechecks under 3.8, tested in Macro
+  assert(!typeChecks(sangria.Macros.LegacyOrNullSnippet))
+  val _: String | Null = Option.empty[String].orNull


### PR DESCRIPTION
Backports #26751 to the 3.9.0-RC5.

PR submitted by the release tooling.