### PR TITLE
3.9: Do not crash when receiving a dir instead of a file to compile

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -256,7 +256,11 @@ object Contexts {
     /** Sourcefile corresponding to given abstract file, memoized */
     def getSource(file: AbstractFile, codec: => Codec = Codec(settings.encoding.value)) = {
       util.Stats.record("Context.getSource")
-      base.sources.getOrElseUpdate(file, SourceFile(file, codec))
+      if file.isDirectory then
+        report.error(s"expected file, received directory '${file.path}'")
+        NoSource
+      else
+        base.sources.getOrElseUpdate(file, SourceFile(file, codec))
     }
 
     /** SourceFile with given path name, memoized */

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -158,6 +158,7 @@ class CompilationTests {
         defaultOptions),
       compileFile("tests/neg/i7575.scala", defaultOptions.withoutLanguageFeatures),
       compileFile("tests/neg-custom-args/i20491/Test.scala", defaultOptions.withClasspath("tests/neg-custom-args/i20491/cp")),
+      compileFile("tests/neg-custom-args/empty-compiled-with-dir.scala", defaultOptions.and("tests"))
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/empty-compiled-with-dir.check
+++ b/tests/neg-custom-args/empty-compiled-with-dir.check
@@ -1,0 +1,1 @@
+expected file, received directory 'tests'

--- a/tests/neg-custom-args/empty-compiled-with-dir.scala
+++ b/tests/neg-custom-args/empty-compiled-with-dir.scala
@@ -1,0 +1,1 @@
+// nopos-error


### PR DESCRIPTION
**This targets 3.9 not main**; I'll make a separate PR with just the regression test for main

Fixes #25882 (already fixed in main)

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
