### PR TITLE
Regression test for #25882

### DIFF
--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -161,6 +161,7 @@ class CompilationTests {
           defaultOptions.withClasspath("tests/neg-custom-args/missing-java-outer-dependency/cp")),
       compileFile("tests/neg-custom-args/missing-java-outer-dependency/TestImportSuggestion.scala",
           defaultOptions.withClasspath("tests/neg-custom-args/missing-java-outer-dependency/cp")),
+      compileFile("tests/neg-custom-args/empty-compiled-with-dir.scala", defaultOptions.and("tests"))
     ).checkExpectedErrors()
   }
 

--- a/tests/neg-custom-args/empty-compiled-with-dir.check
+++ b/tests/neg-custom-args/empty-compiled-with-dir.check
@@ -1,0 +1,1 @@
+expected file, received directory 'tests'

--- a/tests/neg-custom-args/empty-compiled-with-dir.scala
+++ b/tests/neg-custom-args/empty-compiled-with-dir.scala
@@ -1,0 +1,1 @@
+// nopos-error


### PR DESCRIPTION
`main` version of #26764 where we only need a regression test because I accidentally fixed this

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
