### PR TITLE
Scaladoc: Do not crash on class+module in API package

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/ScalaModuleProvider.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/ScalaModuleProvider.scala
@@ -21,12 +21,13 @@ object ScalaModuleProvider:
 
     val groupedMembers =
       def groupMembers(ms: List[Member], n: Int = 0): List[Member] =
-        ms.groupBy(_.name.split('.')(n)).values.map {
+        ms.groupBy(_.name.split('.')(n)).values.flatMap {
           case m :: ms if m.name.count(_ == '.') == n =>
-            m.withMembers(groupMembers(ms, n + 1) ++ m.members)
+            val (nested, rest) = ms.partition(mm => mm.name.count(_ == '.') > n)
+            m.withMembers(groupMembers(nested, n + 1) ++ m.members) :: rest
           case ms =>
             groupMembers(ms, n + 1) match
-              case m :: Nil => m
+              case m :: Nil => m :: Nil
               case ms =>
                 val name = ms.head.name.split('.').take(n + 1).mkString(".")
                 Member(
@@ -35,7 +36,7 @@ object ScalaModuleProvider:
                   dri = DRI(location = name),
                   kind = Kind.Package,
                   members = ms,
-                )
+                ) :: Nil
         }.toList.sortBy(_.name)
       groupMembers(nonemptyPackages)
 

--- a/scaladoc/test-resources/24438/24438.scala
+++ b/scaladoc/test-resources/24438/24438.scala
@@ -1,0 +1,9 @@
+package API
+
+class C() {
+  def g = 3
+}
+
+object C {
+  def f = 2
+}

--- a/scaladoc/test/dotty/tools/scaladoc/e2e/EndToEndTests.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/e2e/EndToEndTests.scala
@@ -169,3 +169,9 @@ class EndToEndTests:
       reporter.allWarnings.count(m => m.message.contains("Couldn't resolve"))
     )
   }
+
+  @Test
+  def i24438(): Unit = run("24438", "24438.scala") { (_, reporter) =>
+    // this used to crash
+    assertTrue(reporter.allErrors.mkString("\n"), reporter.allErrors.isEmpty)
+  }


### PR DESCRIPTION
Fixes #24438

I have no idea what the code is trying to do but I can at least make it not crash.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
