### PR TITLE
Safe universal methods under -Yexplicit-nulls.

### DIFF
--- a/compiler/src/dotty/tools/dotc/Compiler.scala
+++ b/compiler/src/dotty/tools/dotc/Compiler.scala
@@ -99,7 +99,7 @@ class Compiler {
          new InlinePatterns,         // Remove placeholders of inlined patterns
          new VCInlineMethods,        // Inlines calls to value class methods
          new SeqLiterals,            // Express vararg arguments as arrays
-         new InterceptedMethods,     // Special handling of `==`, `|=`, `getClass` methods
+         new InterceptedMethods,     // Special handling of `!=`, `##`, `toString()` and `getClass()` methods
          new Getters,                // Replace non-private vals and vars with getter defs (fields are added later)
          new SpecializeFunctions,    // Specialized Function{0,1,2} by replacing super with specialized super
          new SpecializeTuples,       // Specializes Tuples by replacing tuple construction and selection trees

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -535,6 +535,7 @@ class Definitions {
     @tu lazy val ScalaRuntime__hashCode: Symbol = ScalaRuntimeModule.requiredMethod(nme._hashCode_)
     @tu lazy val ScalaRuntime_toArray: Symbol = ScalaRuntimeModule.requiredMethod(nme.toArray)
     @tu lazy val ScalaRuntime_toObjectArray: Symbol = ScalaRuntimeModule.requiredMethod(nme.toObjectArray)
+    @tu lazy val ScalaRuntime_anyClass: Symbol = ScalaRuntimeModule.requiredMethod(nme.anyClass)
 
   @tu lazy val MurmurHash3Module: Symbol = requiredModule("scala.util.hashing.MurmurHash3")
     @tu lazy val MurmurHash3_productHash = MurmurHash3Module.info.member(termName("productHash")).suchThat(_.info.firstParamTypes.size == 3).symbol
@@ -758,6 +759,8 @@ class Definitions {
     JavaUtilObjectsClass.info.member(nme.hashCode_).suchThat(_.info.firstParamTypes.length == 1).symbol
   def Objects_equals(using Context): Symbol =
     JavaUtilObjectsClass.info.member(nme.equals_).suchThat(_.info.firstParamTypes.length == 2).symbol
+  def Objects_toString(using Context): Symbol =
+    JavaUtilObjectsClass.info.member(nme.toString_).suchThat(_.info.firstParamTypes.length == 1).symbol
 
   @tu lazy val JavaEnumClass: ClassSymbol = {
     val cls = requiredClass("java.lang.Enum")

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -304,12 +304,21 @@ class Definitions {
   def MatchableType: TypeRef = MatchableClass.typeRef
   @tu lazy val AnyValClass: ClassSymbol = requiredClass("scala.AnyVal")
 
+  extension (sym: TermSymbol) private def deprecatedUniversalMethod(replacement: String): TermSymbol =
+    if ctx.explicitNulls then
+      import dotty.tools.dotc.ast.tpd, Constants.Constant, Annotations.Annotation
+      val message = s"Any.${sym.name} does not handle `null` nor equality of primitive numbers; use $replacement instead"
+      sym.addAnnotation(Annotation.deferredSymAndTree(DeprecatedAnnot)(
+        tpd.New(DeprecatedAnnot.typeRef, tpd.Literal(Constant(message)) :: tpd.Literal(Constant("3.10.0")) :: Nil)
+      ))
+    sym
+
   def AnyValType: TypeRef = AnyValClass.typeRef
 
     @tu lazy val Any_== : TermSymbol          = enterMethod(AnyClass, nme.EQ, methOfAny(BooleanType), Final)
     @tu lazy val Any_!= : TermSymbol          = enterMethod(AnyClass, nme.NE, methOfAny(BooleanType), Final)
-    @tu lazy val Any_equals: TermSymbol       = enterMethod(AnyClass, nme.equals_, methOfAny(BooleanType))
-    @tu lazy val Any_hashCode: TermSymbol     = enterMethod(AnyClass, nme.hashCode_, MethodType(Nil, IntType))
+    @tu lazy val Any_equals: TermSymbol       = enterMethod(AnyClass, nme.equals_, methOfAny(BooleanType)).deprecatedUniversalMethod("==")
+    @tu lazy val Any_hashCode: TermSymbol     = enterMethod(AnyClass, nme.hashCode_, MethodType(Nil, IntType)).deprecatedUniversalMethod("##")
     @tu lazy val Any_toString: TermSymbol     = enterMethod(AnyClass, nme.toString_, MethodType(Nil, StringType))
     @tu lazy val Any_## : TermSymbol          = enterMethod(AnyClass, nme.HASHHASH, ExprType(IntType), Final)
     @tu lazy val Any_isInstanceOf: TermSymbol = enterT1ParameterlessMethod(AnyClass, nme.isInstanceOf_, _ => BooleanType, Final)
@@ -454,8 +463,13 @@ class Definitions {
     @tu lazy val Object_waitL: TermSymbol = enterMethod(ObjectClass, nme.wait_, MethodType(LongType :: Nil, UnitType), Final)
     @tu lazy val Object_waitLI: TermSymbol = enterMethod(ObjectClass, nme.wait_, MethodType(LongType :: IntType :: Nil, UnitType), Final)
 
+    // Non-deprecated overrides from Any
+    @tu lazy val Object_equals: TermSymbol = enterMethod(ObjectClass, nme.equals_, methOfAny(BooleanType), Override)
+    @tu lazy val Object_hashCode: TermSymbol = enterMethod(ObjectClass, nme.hashCode_, MethodType(Nil, IntType), Override)
+
     def ObjectMethods: List[TermSymbol] = List(Object_eq, Object_ne, Object_synchronized, Object_clone,
-        Object_finalize, Object_notify, Object_notifyAll, Object_wait, Object_waitL, Object_waitLI)
+        Object_finalize, Object_notify, Object_notifyAll, Object_wait, Object_waitL, Object_waitLI,
+        Object_equals, Object_hashCode)
 
   /** Methods in Object and Any that do not have a side effect */
   @tu lazy val pureMethods: List[TermSymbol] = List(Any_==, Any_!=, Any_equals, Any_hashCode,

--- a/compiler/src/dotty/tools/dotc/core/Hashable.scala
+++ b/compiler/src/dotty/tools/dotc/core/Hashable.scala
@@ -85,13 +85,13 @@ trait Hashable {
   }
 
 
-  protected final def doHash(x: Any): Int =
+  protected final def doHash(x: AnyRef): Int =
     finishHash(hashing.mix(hashSeed, x.hashCode), 1)
 
   protected final def doHash(bs: Binders, tp: Type): Int =
     finishHash(bs, hashSeed, 0, tp)
 
-  protected final def doHash(bs: Binders, x1: Any, tp2: Type): Int =
+  protected final def doHash(bs: Binders, x1: AnyRef, tp2: Type): Int =
     finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2)
 
   protected final def doHash(bs: Binders, x1: Int, tp2: Type): Int =
@@ -103,13 +103,13 @@ trait Hashable {
   protected final def doHash(bs: Binders, tp1: Type, tp2: Type): Int =
     finishHash(bs, hashSeed, 0, tp1, tp2)
 
-  protected final def doHash(bs: Binders, x1: Any, tp2: Type, tp3: Type): Int =
+  protected final def doHash(bs: Binders, x1: AnyRef, tp2: Type, tp3: Type): Int =
     finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2, tp3)
 
   protected final def doHash(bs: Binders, tp1: Type, tps2: List[Type]): Int =
     finishHash(bs, hashSeed, 0, tp1, tps2)
 
-  protected final def doHash(bs: Binders, x1: Any, tp2: Type, tps3: List[Type]): Int =
+  protected final def doHash(bs: Binders, x1: AnyRef, tp2: Type, tps3: List[Type]): Int =
     finishHash(bs, hashing.mix(hashSeed, x1.hashCode), 1, tp2, tps3)
 
   protected final def doHash(x1: Int, x2: Int): Int =

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -406,6 +406,7 @@ object StdNames {
     val annotation: N           = "annotation"
     val any: N                  = "any"
     val any2stringadd: N        = "any2stringadd"
+    val anyClass: N             = "anyClass"
     val anyHash: N              = "anyHash"
     val anyValClass: N          = "anyValClass"
     val append: N               = "append"

--- a/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
+++ b/compiler/src/dotty/tools/dotc/sbt/ExtractAPI.scala
@@ -798,7 +798,7 @@ private class ExtractAPICollector(nonLocalClassSymbols: mutable.HashSet[Symbol])
           // representation.
           h = MurmurHash3.mix(h, apiType(c.typeValue).hashCode)
         case _ =>
-          h = MurmurHash3.mix(h, c.value.hashCode)
+          h = MurmurHash3.mix(h, java.util.Objects.hashCode(c.value))
       h
     end constantHash
 

--- a/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
+++ b/compiler/src/dotty/tools/dotc/transform/InterceptedMethods.scala
@@ -12,7 +12,7 @@ import dotty.tools.dotc.transform.MegaPhase.MiniPhase
 
 object InterceptedMethods {
   val name: String = "intercepted"
-  val description: String = "rewrite universal `!=`, `##` methods"
+  val description: String = "rewrite universal `!=`, `##`, `toString()` and `getClass()` methods"
 }
 
 /** Replace member references as follows:
@@ -21,6 +21,12 @@ object InterceptedMethods {
   * - `x.##` for ## in NullClass becomes `0`
   * - `x.##` for ## in Any becomes calls to ScalaRunTime.hash,
   *     using the most precise overload available
+  *
+  * Under -Yexplicit-nulls:
+  *
+  * - `x.toString()` for `toString()` in class Any becomes `java.util.Objects.toString(x)`
+  * - `x.getClass()` for `x: T` where `T <: AnyRef` is not true becomes `Scala3Runtime.anyGetClass(x)`
+  *   (for primitives, getClass() has already been replaced when we get here)
   */
 class InterceptedMethods extends MiniPhase {
   import tpd.*
@@ -63,7 +69,7 @@ class InterceptedMethods extends MiniPhase {
   }
 
   override def transformApply(tree: Apply)(using Context): Tree = {
-    lazy val qual = tree.fun match {
+    def qualOf(fun: Tree): Tree = fun match {
       case Select(qual, _) => qual
       case ident: Ident =>
         ident.tpe match {
@@ -72,10 +78,22 @@ class InterceptedMethods extends MiniPhase {
           case TermRef(prefix: ThisType, _) =>
             tpd.This(prefix.cls)
         }
+      case TypeApply(inner, _) => qualOf(inner)
     }
 
-    if tree.fun.symbol == defn.Any_!= then
+    lazy val qual = qualOf(tree.fun)
+
+    val sym = tree.fun.symbol
+
+    if sym == defn.Any_!= then
       qual.select(defn.Any_==).appliedToTermArgs(tree.args).select(defn.Boolean_!).withSpan(tree.span)
+    else if ctx.explicitNulls then
+      if sym == defn.Any_toString && !qual.tpe.isNotNull then
+        ref(defn.Objects_toString).appliedTo(qual)
+      else if sym == defn.Any_getClass && !qual.tpe.isNotNull then
+        ref(defn.ScalaRuntime_anyClass).appliedToType(qual.tpe).appliedTo(qual)
+      else
+        tree
     else
       tree
   }

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -322,23 +322,16 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
      *  class C(x: T) extends AnyVal
      *  ```
      *
-     *  gets the `hashCode` method. If the value is primitive:
-     *  ```
-     *  def hashCode: Int = x.hashCode()
-     *  ```
-     *  otherwise, the null-safe variant:
+     *  gets the `hashCode` method
      *  ```
      *  def hashCode: Int = java.util.Objects.hashCode(x)
      *  ```
+     *
+     *  If the value is primitive, we precompute the dispatch so that we do not need to box.
      */
     def valueHashCodeBody(using Context): Tree = {
       assert(accessors.nonEmpty)
-      val accessor = accessors.head
-      val tp = accessor.info.finalResultType
-      if (tp.classSymbol.isPrimitiveValueClass)
-        ref(accessor).select(nme.hashCode_).ensureApplied
-      else
-        ref(defn.Objects_hashCode).appliedTo(ref(accessor))
+      hashImpl(accessors.head, scalaHashHash = false)
     }
 
     /**
@@ -397,22 +390,28 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       val mixPrefix = Assign(ref(acc),
         ref(defn.staticsMethod("mix")).appliedTo(ref(acc), Literal(Constant(ownName.hashCode))))
       val mixes = for (accessor <- accessors) yield
-        Assign(ref(acc), ref(defn.staticsMethod("mix")).appliedTo(ref(acc), hashImpl(accessor)))
+        Assign(ref(acc), ref(defn.staticsMethod("mix")).appliedTo(ref(acc), hashImpl(accessor, scalaHashHash = true)))
       val finish = ref(defn.staticsMethod("finalizeHash")).appliedTo(ref(acc), Literal(Constant(accessors.size)))
       Block(accDef :: mixPrefix :: mixes, finish)
     }
 
     /** The `hashCode` implementation for given symbol `sym`. */
-    def hashImpl(sym: Symbol)(using Context): Tree =
+    def hashImpl(sym: Symbol, scalaHashHash: Boolean)(using Context): Tree =
+      def hashHashDependent(staticsMethodName: String, javaBoxedClass: ClassSymbol): Tree =
+        val implMethod =
+          if scalaHashHash then defn.staticsMethod(staticsMethodName)
+          else javaBoxedClass.companionModule.moduleClass.asClass.info.member(nme.hashCode_).suchThat(_.info.firstParamTypes.length == 1).symbol
+        ref(implMethod).appliedTo(ref(sym))
+
       defn.scalaClassName(sym.info.finalResultType) match {
         case tpnme.Unit | tpnme.Null               => Literal(Constant(0))
         case tpnme.Boolean                         => If(ref(sym), Literal(Constant(1231)), Literal(Constant(1237)))
         case tpnme.Int                             => ref(sym)
         case tpnme.Short | tpnme.Byte | tpnme.Char => ref(sym).select(nme.toInt)
-        case tpnme.Long                            => ref(defn.staticsMethod("longHash")).appliedTo(ref(sym))
-        case tpnme.Double                          => ref(defn.staticsMethod("doubleHash")).appliedTo(ref(sym))
-        case tpnme.Float                           => ref(defn.staticsMethod("floatHash")).appliedTo(ref(sym))
-        case _                                     => ref(defn.staticsMethod("anyHash")).appliedTo(ref(sym))
+        case tpnme.Long                            => hashHashDependent("longHash", defn.BoxedLongClass)
+        case tpnme.Double                          => hashHashDependent("doubleHash", defn.BoxedDoubleClass)
+        case tpnme.Float                           => hashHashDependent("floatHash", defn.BoxedFloatClass)
+        case _                                     => hashHashDependent("anyHash", defn.JavaUtilObjectsClass)
       }
 
     /** The class

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -82,7 +82,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
     val existing = sym.matchingMember(clazz.thisType)
     if Feature.shouldBehaveAsScala2 && clazz.isValueClass && (sym == defn.Any_equals || sym == defn.Any_hashCode) then
       NoSymbol
-    else if existing != sym && !existing.is(Deferred) then
+    else if existing != sym && !existing.is(Deferred) && existing != defn.Object_equals && existing != defn.Object_hashCode then
       existing
     else
       NoSymbol

--- a/compiler/src/dotty/tools/dotc/util/HashMap.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashMap.scala
@@ -11,13 +11,13 @@ extends GenericHashMap[Key, Value](initialCapacity, capacityMultiple):
    *  when taking the index.
    */
   final def hash(key: Key): Int =
-    val h = key.hashCode
+    val h = java.util.Objects.hashCode(key)
     // Part of the MurmurHash3 32 bit finalizer
     val i = (h ^ (h >>> 16)) * 0x85EBCA6B
     val j = (i ^ (i >>> 13)) & 0x7FFFFFFF
     (if j==0 then 0x41081989 else j) << 1
 
-  final def isEqual(x: Key, y: Key): Boolean = x.equals(y)
+  final def isEqual(x: Key, y: Key): Boolean = java.util.Objects.equals(x, y)
 
   // The following methods are duplicated from GenericHashMap
   // to avoid polymorphic dispatches

--- a/compiler/src/dotty/tools/dotc/util/HashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/HashSet.scala
@@ -24,14 +24,14 @@ class HashSet[T](initialCapacity: Int = 8, capacityMultiple: Int = 2) extends Ge
 
   /** Hashcode, by default a processed `x.hashCode`, can be overridden */
   protected def hash(key: T): Int =
-    val h = key.hashCode
+    val h = java.util.Objects.hashCode(key)
     // Part of the MurmurHash3 32 bit finalizer
     val i = (h ^ (h >>> 16)) * 0x85EBCA6B
     val j = (i ^ (i >>> 13)) & 0x7FFFFFFF
     if j==0 then 0x41081989 else j
 
   /** Hashcode, by default `equals`, can be overridden */
-  protected def isEqual(x: T, y: T): Boolean = x.equals(y)
+  protected def isEqual(x: T, y: T): Boolean = java.util.Objects.equals(x, y)
 
   /** Turn hashcode `x` into a table index */
   protected def index(x: Int): Int = x & (table.length - 1)

--- a/compiler/src/dotty/tools/dotc/util/PerfectHashing.scala
+++ b/compiler/src/dotty/tools/dotc/util/PerfectHashing.scala
@@ -56,14 +56,14 @@ class PerfectHashing[Key](initialCapacity: Int = 8, capacityMultiple: Int = 2):
    *  can be overridden
    */
   protected def hash(k: Key): Int =
-    val h = k.hashCode
+    val h = java.util.Objects.hashCode(k)
     // Part of the MurmurHash3 32 bit finalizer
     val i = (h ^ (h >>> 16)) * 0x85EBCA6B
     val j = (i ^ (i >>> 13)) & 0x7FFFFFFF
     if (j==0) 0x41081989 else j
 
   /** Equality test, by default `equals`, can be overridden */
-  protected def isEqual(x: Key, y: Key): Boolean = x.equals(y)
+  protected def isEqual(x: Key, y: Key): Boolean = java.util.Objects.equals(x, y)
 
   private def matches(entry: Int, k: Key) = isEqual(key(entry), k)
 

--- a/library-js/src/scala/runtime/ScalaRunTime.scala
+++ b/library-js/src/scala/runtime/ScalaRunTime.scala
@@ -61,6 +61,14 @@ object ScalaRunTime {
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
+  /** Runtime code for `(x: T).getClass()` where `T` is not a subtype of `AnyRef`.
+   *
+   *  It returns `classOf[Null]` when `x == null`.
+   */
+  def anyClass[T](x: T): Class[? <: T] =
+    if x == null then classOf[Null].asInstanceOf[Class[? <: T]]
+    else x.asInstanceOf[AnyRef & T].getClass()
+
   /** Retrieves generic array element.
    *
    *  @param xs the array to access, typed as `AnyRef` to support both reference and primitive arrays

--- a/library/src/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/library/src/scala/collection/convert/JavaCollectionWrappers.scala
@@ -286,10 +286,8 @@ private[collection] object JavaCollectionWrappers extends Serializable {
             // specified in the javadocs of java.util.Map.Entry.hashCode
             //
             // See https://github.com/scala/bug/issues/10663
-            override def hashCode() = {
-              (if (k == null) 0 else k.hashCode()) ^
-              (if (v == null) 0 else v.hashCode())
-            }
+            override def hashCode() =
+              java.util.Objects.hashCode(k) ^ java.util.Objects.hashCode(v)
 
             override def equals(other: Any) = other match {
               case e: ju.Map.Entry[?, ?] => k == e.getKey && v == e.getValue

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -66,7 +66,9 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
   override def size: Int = contentSize
 
   @inline private final def computeHash(o: K): Int = {
-    val h = if(o.asInstanceOf[AnyRef] eq null) 0 else o.hashCode
+    // Objects.hashCode is consistent with the requirements, namely:
+    // > Universal equality of numeric types is not supported (similar to `AnyRefMap`).
+    val h = java.util.Objects.hashCode(o)
     h ^ (h >>> 16)
   }
 

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -95,7 +95,7 @@ object Equiv extends LowPriorityEquiv {
       case that: IterableEquiv[?, ?]     => this.eqv == that.eqv
       case _                             => false
     }
-    override def hashCode(): Int = eqv.hashCode() * iterableSeed
+    override def hashCode(): Int = eqv.## * iterableSeed
   }
 
   trait ExtraImplicits {
@@ -275,7 +275,7 @@ object Equiv extends LowPriorityEquiv {
       case that: OptionEquiv[?]         => this.eqv == that.eqv
       case _                            => false
     }
-    override def hashCode(): Int = eqv.hashCode() * optionSeed
+    override def hashCode(): Int = eqv.## * optionSeed
   }
 
   implicit def Tuple2[T1, T2](implicit eqv1: Equiv[T1], eqv2: Equiv[T2]): Equiv[(T1, T2)] =

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -60,6 +60,14 @@ object ScalaRunTime {
   def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
+  /** Runtime code for `(x: T).getClass()` where `T` is not a subtype of `AnyRef`.
+   *
+   *  It returns `classOf[Null]` when `x == null`.
+   */
+  def anyClass[T](x: T): Class[? <: T] =
+    if x == null then classOf[Null].asInstanceOf[Class[? <: T]]
+    else x.asInstanceOf[AnyRef & T].getClass()
+
   /** Retrieves generic array element.
    *
    *  @param xs the array to read from (typed as `AnyRef` to support both reference and primitive arrays)

--- a/library/test/scala/collection/immutable/ImmutableChampHashMapProperties.scala
+++ b/library/test/scala/collection/immutable/ImmutableChampHashMapProperties.scala
@@ -215,7 +215,7 @@ object ImmutableChampHashMapProperties extends Properties("HashMap") {
 
   property("rootnode hashCode should be sum of key improved hashcodes") = forAll { (seq: Seq[(K, V)]) =>
     val distinct = seq.distinctBy(_._1)
-    val expectedHash = distinct.map(_._1.hashCode).map(Hashing.improve).sum
+    val expectedHash = distinct.map(_._1.##).map(Hashing.improve).sum
     val b = HashMap.newBuilder[K, V]
     distinct.foreach(b.addOne)
     b.result().rootNode.cachedJavaKeySetHashCode == expectedHash
@@ -242,7 +242,7 @@ object ImmutableChampHashMapProperties extends Properties("HashMap") {
         var timesHashed = 0
         override def hashCode(): Int = {
           timesHashed += 1
-          inner.hashCode()
+          inner.##
         }
       }
 

--- a/library/test/scala/math/NumericTest.scala
+++ b/library/test/scala/math/NumericTest.scala
@@ -8,8 +8,8 @@ class NumericTest {
   /* Test for scala/bug#8102 */
   @Test
   def testAbs(): Unit = {
-    assertTrue((-0.0).abs.equals(0.0))
-    assertTrue((-0.0f).abs.equals(0.0f))
+    assertTrue(java.lang.Double.compare((-0.0).abs, 0.0) == 0)
+    assertTrue(java.lang.Float.compare((-0.0f).abs, 0.0f) == 0)
   }
 
   /* Test for scala/bug#9348 */
@@ -19,4 +19,3 @@ class NumericTest {
     assertTrue(num.quot(BigDecimal(2.5), BigDecimal(0.5)) equals BigDecimal(5.0))
     assertTrue(num.quot(BigDecimal(5.0), BigDecimal(2.0)) equals BigDecimal(2.0))
   }}
-

--- a/library/test/scala/util/RandomUtilTest.scala
+++ b/library/test/scala/util/RandomUtilTest.scala
@@ -6,9 +6,9 @@ import tools.AssertUtil.assertThrows
 class RandomUtilTest {
   @Test def testBetween(): Unit = {
     val rand = new Random()
-    Assert.assertTrue("Random between Int must be inclusive-exclusive", rand.between(0, 1).equals(0))
-    Assert.assertTrue("Random between Long must be inclusive-exclusive", rand.between(0L, 1L).equals(0L))
-    Assert.assertTrue("Random nextLong must be inclusive-exclusive", rand.nextLong(1L).equals(0L))
+    Assert.assertTrue("Random between Int must be inclusive-exclusive", rand.between(0, 1) == 0)
+    Assert.assertTrue("Random between Long must be inclusive-exclusive", rand.between(0L, 1L) == 0L)
+    Assert.assertTrue("Random nextLong must be inclusive-exclusive", rand.nextLong(1L) == 0L)
     val float: Float = rand.between(0.0f, 1.0f)
     Assert.assertTrue("Float Random should be inclusive-exclusive", 0.0f <= float && float < 1.0f)
     val double: Double = rand.between(0.0f.toDouble, 1.0f.toDouble)

--- a/scaladoc/src/dotty/tools/scaladoc/Inkuire.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/Inkuire.scala
@@ -182,7 +182,7 @@ object Inkuire {
     vars:        Set[String],
     constraints: Map[String, Seq[TypeLike]]
   ) {
-    override def hashCode: Int = vars.size.hashCode
+    override def hashCode: Int = vars.size.##
 
     override def equals(obj: Any): Boolean =
       obj match {

--- a/tests/explicit-nulls/run/safe-universal-methods.scala
+++ b/tests/explicit-nulls/run/safe-universal-methods.scala
@@ -1,0 +1,88 @@
+
+object Test {
+  def toString1(x: Any): String = x.toString()
+  def toString2(x: AnyVal): String = x.toString()
+  def toString3(x: Matchable): String = x.toString()
+  def toString4(x: Int | Null): String = x.toString()
+  def toString5(x: List[String] | Null): String = x.toString()
+  def toString6(x: Null): String = x.toString()
+
+  def toStringGen1[T <: Any](x: T): String = x.toString()
+  def toStringGen2[T <: AnyVal](x: T): String = x.toString()
+  def toStringGen3[T <: Matchable](x: T): String = x.toString()
+  def toStringGen4[T <: Int | Null](x: T): String = x.toString()
+  def toStringGen5[T <: List[String] | Null](x: T): String = x.toString()
+  def toStringGen6[T <: Null](x: T): String = x.toString()
+
+  def getClass1(x: Any): Class[?] = x.getClass()
+  def getClass2(x: AnyVal): Class[?] = x.getClass()
+  def getClass3(x: Matchable): Class[?] = x.getClass()
+  def getClass4(x: Int | Null): Class[?] = x.getClass()
+  def getClass5(x: List[String] | Null): Class[?] = x.getClass()
+  def getClass6(x: Null): Class[?] = x.getClass()
+
+  def getClassGen1[T <: Any](x: T): Class[?] = x.getClass()
+  def getClassGen2[T <: AnyVal](x: T): Class[?] = x.getClass()
+  def getClassGen3[T <: Matchable](x: T): Class[?] = x.getClass()
+  def getClassGen4[T <: Int | Null](x: T): Class[?] = x.getClass()
+  def getClassGen5[T <: List[String] | Null](x: T): Class[?] = x.getClass()
+  def getClassGen6[T <: Null](x: T): Class[?] = x.getClass()
+
+  def main(args: Array[String]): Unit = {
+    assertEquals("List(foo)", toString1(List("foo")))
+    assertEquals("5", toString2(5))
+    assertEquals("List(foo)", toString3(List("foo")))
+    assertEquals("5", toString4(5))
+    assertEquals("List(foo)", toString5(List("foo")))
+
+    assertEquals("null", toString1(null))
+    assertEquals("null", toString2(null))
+    assertEquals("null", toString3(null))
+    assertEquals("null", toString4(null))
+    assertEquals("null", toString5(null))
+    assertEquals("null", toString6(null))
+
+    assertEquals("List(foo)", toStringGen1(List("foo")))
+    assertEquals("5", toStringGen2(5))
+    assertEquals("List(foo)", toStringGen3(List("foo")))
+    assertEquals("5", toStringGen4(5))
+    assertEquals("List(foo)", toStringGen5(List("foo")))
+
+    assertEquals("null", toStringGen1(null))
+    assertEquals("null", toStringGen2(null))
+    assertEquals("null", toStringGen3(null))
+    assertEquals("null", toStringGen4(null))
+    assertEquals("null", toStringGen5(null))
+    assertEquals("null", toStringGen6(null))
+
+    assertEquals(classOf[::[?]], getClass1(List("foo")))
+    assertEquals(classOf[Integer], getClass2(5))
+    assertEquals(classOf[::[?]], getClass3(List("foo")))
+    assertEquals(classOf[Integer], getClass4(5))
+    assertEquals(classOf[::[?]], getClass5(List("foo")))
+
+    assertEquals(classOf[Null], getClass1(null))
+    assertEquals(classOf[Null], getClass2(null))
+    assertEquals(classOf[Null], getClass3(null))
+    assertEquals(classOf[Null], getClass4(null))
+    assertEquals(classOf[Null], getClass5(null))
+    assertEquals(classOf[Null], getClass6(null))
+
+    assertEquals(classOf[::[?]], getClassGen1(List("foo")))
+    assertEquals(classOf[Integer], getClassGen2(5))
+    assertEquals(classOf[::[?]], getClassGen3(List("foo")))
+    assertEquals(classOf[Integer], getClassGen4(5))
+    assertEquals(classOf[::[?]], getClassGen5(List("foo")))
+
+    assertEquals(classOf[Null], getClassGen1(null))
+    assertEquals(classOf[Null], getClassGen2(null))
+    assertEquals(classOf[Null], getClassGen3(null))
+    assertEquals(classOf[Null], getClassGen4(null))
+    assertEquals(classOf[Null], getClassGen5(null))
+    assertEquals(classOf[Null], getClassGen6(null))
+  }
+
+  def assertEquals(expected: Any, actual: Any): Unit =
+    if actual != expected then
+      throw AssertionError(s"expected '$expected' but got '$actual'")
+}

--- a/tests/explicit-nulls/warn/unsafe-universal-methods.scala
+++ b/tests/explicit-nulls/warn/unsafe-universal-methods.scala
@@ -1,0 +1,109 @@
+//> using options -deprecation
+
+class CustomAnyRef // definition ok
+
+class CustomAnyVal(x: Double) extends AnyVal // definition ok
+
+case class CaseClass(x: Double, y: String) // definition ok
+
+object Test {
+  // --- hashCode -- concrete classes ---
+
+  // must warn
+  def hashCode1(x: Any): Int = x.hashCode() // warn
+  def hashCode2(x: AnyVal): Int = x.hashCode() // warn
+  def hashCode3(x: Matchable): Int = x.hashCode() // warn
+  def hashCode4(x: Int | Null): Int = x.hashCode() // warn
+  def hashCode5(x: List[String] | Null): Int = x.hashCode() // warn
+  def hashCode6(x: Float): Int = x.hashCode() // warn
+  def hashCode7(x: Double): Int = x.hashCode() // warn
+
+  // these could become 'ok' one day; only Float and Double are problematic
+  def hashCode8(x: Boolean): Int = x.hashCode() // warn
+  def hashCode9(x: Int): Int = x.hashCode() // warn
+  def hashCode10(x: Char): Int = x.hashCode() // warn
+
+  // slightly undesirable, but no big deal; changing to 'ok' would be a progression
+  def hashCode11(x: CustomAnyVal): Int = x.hashCode() // warn
+
+  // must be ok
+  def hashCodeOK1(x: AnyRef): Int = x.hashCode() // ok
+  def hashCodeOK2(x: String): Int = x.hashCode() // ok
+  def hashCodeOK3(x: CustomAnyRef): Int = x.hashCode() // ok
+  def hashCodeOK4(x: CaseClass): Int = x.hashCode() // ok
+
+  // --- hashCode -- type parameter bound ---
+
+  // must warn
+  def hashCodeGen1[T <: Any](x: T): Int = x.hashCode() // warn
+  def hashCodeGen2[T <: AnyVal](x: T): Int = x.hashCode() // warn
+  def hashCodeGen3[T <: Matchable](x: T): Int = x.hashCode() // warn
+  def hashCodeGen4[T <: Int | Null](x: T): Int = x.hashCode() // warn
+  def hashCodeGen5[T <: List[String] | Null](x: T): Int = x.hashCode() // warn
+  def hashCodeGen6[T <: Float](x: T): Int = x.hashCode() // warn
+  def hashCodeGen7[T <: Double](x: T): Int = x.hashCode() // warn
+
+  // these could become 'ok' one day; only Float and Double are problematic
+  def hashCodeGen8[T <: Boolean](x: T): Int = x.hashCode() // warn
+  def hashCodeGen9[T <: Int](x: T): Int = x.hashCode() // warn
+  def hashCodeGen10[T <: Char](x: T): Int = x.hashCode() // warn
+
+  // slightly undesirable, but no big deal; changing to 'ok' would be a progression
+  def hashCodeGen11[T <: CustomAnyVal](x: T): Int = x.hashCode() // warn
+
+  // must be ok
+  def hashCodeGenOK1[T <: AnyRef](x: T): Int = x.hashCode() // ok
+  def hashCodeGenOK2[T <: String](x: T): Int = x.hashCode() // ok
+  def hashCodeGenOK3[T <: CustomAnyRef](x: T): Int = x.hashCode() // ok
+  def hashCodeGenOK4[T <: CaseClass](x: T): Int = x.hashCode() // ok
+
+  // --- equals -- concrete classes ---
+
+  // must warn
+  def equals1(x: Any): Boolean = x.equals(42) // warn
+  def equals2(x: AnyVal): Boolean = x.equals(42) // warn
+  def equals3(x: Matchable): Boolean = x.equals(42) // warn
+  def equals4(x: Int | Null): Boolean = x.equals(42) // warn
+  def equals5(x: List[String] | Null): Boolean = x.equals(42) // warn
+  def equals6(x: Float): Boolean = x.equals(42) // warn
+  def equals7(x: Double): Boolean = x.equals(42) // warn
+
+  // these could become 'ok' one day; only Float and Double are problematic
+  def equals8(x: Boolean): Boolean = x.equals(42) // warn
+  def equals9(x: Int): Boolean = x.equals(42) // warn
+  def equals10(x: Char): Boolean = x.equals(42) // warn
+
+  // slightly undesirable, but no big deal; changing to 'ok' would be a progression
+  def equals11(x: CustomAnyVal): Boolean = x.equals(42) // warn
+
+  // must be ok
+  def equalsOK1(x: AnyRef): Boolean = x.equals(42) // ok
+  def equalsOK2(x: String): Boolean = x.equals(42) // ok
+  def equalsOK3(x: CustomAnyRef): Boolean = x.equals(42) // ok
+  def equalsOK4(x: CaseClass): Boolean = x.equals(42) // ok
+
+  // --- equals -- type parameter bound ---
+
+  // must warn
+  def equalsGen1[T <: Any](x: T): Boolean = x.equals(42) // warn
+  def equalsGen2[T <: AnyVal](x: T): Boolean = x.equals(42) // warn
+  def equalsGen3[T <: Matchable](x: T): Boolean = x.equals(42) // warn
+  def equalsGen4[T <: Int | Null](x: T): Boolean = x.equals(42) // warn
+  def equalsGen5[T <: List[String] | Null](x: T): Boolean = x.equals(42) // warn
+  def equalsGen6[T <: Float](x: T): Boolean = x.equals(42) // warn
+  def equalsGen7[T <: Double](x: T): Boolean = x.equals(42) // warn
+
+  // these could become 'ok' one day; only Float and Double are problematic
+  def equalsGen8[T <: Boolean](x: T): Boolean = x.equals(42) // warn
+  def equalsGen9[T <: Int](x: T): Boolean = x.equals(42) // warn
+  def equalsGen10[T <: Char](x: T): Boolean = x.equals(42) // warn
+
+  // slightly undesirable, but no big deal; changing to 'ok' would be a progression
+  def equalsGen11[T <: CustomAnyVal](x: T): Boolean = x.equals(42) // warn
+
+  // must be ok
+  def equalsGenOK1[T <: AnyRef](x: T): Boolean = x.equals(42) // ok
+  def equalsGenOK2[T <: String](x: T): Boolean = x.equals(42) // ok
+  def equalsGenOK3[T <: CustomAnyRef](x: T): Boolean = x.equals(42) // ok
+  def equalsGenOK4[T <: CaseClass](x: T): Boolean = x.equals(42) // ok
+}

--- a/tests/neg/i7359-f.check
+++ b/tests/neg/i7359-f.check
@@ -3,7 +3,7 @@
   |      ^
   |      Name clash between inherited members:
   |      def equals[T >: Boolean <: Boolean](obj: Any): T in trait SAMTrait at line 3 and
-  |      def equals(x$0: Any): Boolean in class Any
+  |      override def equals(x$0: Any): Boolean in class Object
   |      have the same type (x$0: Object): Boolean after erasure.
   |
   |      Consider adding a @targetName annotation to one of the conflicting definitions

--- a/tests/printing/posttyper/i22533.check
+++ b/tests/printing/posttyper/i22533.check
@@ -5,7 +5,7 @@ package <empty> {
     override def hashCode(): Int = ???
   }
   final class Foo(u: Int) extends AnyVal(), A {
-    override def hashCode(): Int = Foo.this.u.hashCode()
+    override def hashCode(): Int = Foo.this.u
     override def equals(x$0: Any): Boolean =
       x$0 match
         {


### PR DESCRIPTION
https://contributors.scala-lang.org/t/proposal-fixing-null-methodofany-under-explicit-nulls/7504

~~WiP: based on #25393, and still need to deprecated `Any.hashCode()` and `Any.equals()`.~~