### PR TITLE
For bytecode generation, use stock ASM (not our old scala-asm fork)

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeBodyBuilder.scala
@@ -4,8 +4,8 @@ package jvm
 
 import scala.annotation.{switch, tailrec}
 import scala.collection.mutable.SortedMap
-import scala.tools.asm
-import scala.tools.asm.{Handle, Opcodes}
+import org.objectweb.asm
+import org.objectweb.asm.{Handle, Opcodes}
 import BCodeHelpers.InvokeStyle
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.core.Constants.*

--- a/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeHelpers.scala
@@ -2,8 +2,8 @@ package dotty.tools
 package backend
 package jvm
 
-import scala.tools.asm
-import scala.tools.asm.{AnnotationVisitor, ClassWriter, Opcodes}
+import org.objectweb.asm
+import org.objectweb.asm.{AnnotationVisitor, ClassWriter, Opcodes}
 import scala.collection.mutable
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.Trees
@@ -611,7 +611,7 @@ trait BCodeHelpers(val bTypeLoader: BTypeLoader) extends BCodeIdiomatic {
   }
 
   private def verifySignature(sym: Symbol, sig: String)(using Context): Unit = {
-    import scala.tools.asm.util.CheckClassAdapter
+    import org.objectweb.asm.util.CheckClassAdapter
     def wrap(body: => Unit): Unit = {
       try body
       catch case ex: Exception =>

--- a/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeIdiomatic.scala
@@ -3,9 +3,9 @@ package backend
 package jvm
 
 import dotty.tools.backend.jvm.opt.CallGraph
-import scala.tools.asm
+import org.objectweb.asm
 import scala.annotation.tailrec
-import scala.tools.asm.tree.MethodInsnNode
+import org.objectweb.asm.tree.MethodInsnNode
 import dotty.tools.dotc.ast.Positioned
 import dotty.tools.dotc.core.Contexts.Context
 import dotty.tools.dotc.util.NoSourcePosition

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -4,7 +4,7 @@ package jvm
 
 import scala.annotation.tailrec
 import scala.collection.{immutable, mutable}
-import scala.tools.asm
+import org.objectweb.asm
 import dotty.tools.dotc.ast.tpd
 import dotty.tools.dotc.ast.TreeTypeMap
 import dotty.tools.dotc.ast.Trees.SyntheticUnit

--- a/compiler/src/dotty/tools/backend/jvm/BCodeSyncAndTry.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSyncAndTry.scala
@@ -3,7 +3,7 @@ package backend
 package jvm
 
 import scala.collection.immutable
-import scala.tools.asm
+import org.objectweb.asm
 import dotty.tools.dotc.core.StdNames.nme
 import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.ast.tpd

--- a/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeUtils.scala
@@ -22,12 +22,12 @@ import dotty.tools.dotc.report
 import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.commons.CodeSizeEvaluator
-import scala.tools.asm.tree.*
-import scala.tools.asm.tree.analysis.*
-import scala.tools.asm.{Label, Type}
+import org.objectweb.asm
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.commons.CodeSizeEvaluator
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.analysis.*
+import org.objectweb.asm.{Label, Type}
 
 object BCodeUtils {
   val CLASS_CONSTRUCTOR_NAME    = "<clinit>"

--- a/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypeLoader.scala
@@ -17,8 +17,8 @@ import dotty.tools.dotc.core.Types.{JavaArrayType, Type, TypeRef, abstractTermNa
 import dotty.tools.dotc.util.EqHashMap
 
 import scala.annotation.tailrec
-import scala.tools.asm
-import scala.tools.asm.tree.ClassNode
+import org.objectweb.asm
+import org.objectweb.asm.tree.ClassNode
 
 final class BTypeLoader(primitives: ScalaPrimitives, inlineInfoLoader: () => Option[InlineInfoLoader]) {
   // Concurrent map because stack map frames are computed when in the class writer, which

--- a/compiler/src/dotty/tools/backend/jvm/BTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypes.scala
@@ -3,14 +3,14 @@ package backend
 package jvm
 
 import java.util.concurrent.ConcurrentHashMap
-import scala.tools.asm
+import org.objectweb.asm
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.ClassBType.runtimeNullInternalName
 import dotty.tools.backend.jvm.opt.{InlineInfoAttribute, OptimizerWarning}
 import dotty.tools.dotc.core.Definitions
 
 import scala.collection.SortedMap
-import scala.tools.asm.Opcodes
+import org.objectweb.asm.Opcodes
 
 
 /**

--- a/compiler/src/dotty/tools/backend/jvm/ClassNode1.java
+++ b/compiler/src/dotty/tools/backend/jvm/ClassNode1.java
@@ -12,10 +12,10 @@
 
 package dotty.tools.backend.jvm;
 
-import scala.tools.asm.MethodVisitor;
-import scala.tools.asm.Opcodes;
-import scala.tools.asm.tree.ClassNode;
-import scala.tools.asm.tree.MethodNode;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
 
 /**
  * A subclass of {@link ClassNode} to customize the representation of

--- a/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
+++ b/compiler/src/dotty/tools/backend/jvm/CodeGen.scala
@@ -15,7 +15,7 @@ import StdNames.nme
 import dotty.tools.tasty.{TastyBuffer, TastyHeaderUnpickler}
 import dotty.tools.dotc.core.tasty.TastyUnpickler
 
-import scala.tools.asm.tree.*
+import org.objectweb.asm.tree.*
 import tpd.*
 import dotty.tools.io.AbstractFile
 import dotty.tools.dotc.ast.Positioned

--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatureVisitor.scala
@@ -1,7 +1,7 @@
 package dotty.tools.backend.jvm
 
-import scala.tools.asm.{Type, Handle}
-import scala.tools.asm.tree.*
+import org.objectweb.asm.{Type, Handle}
+import org.objectweb.asm.tree.*
 
 import scala.collection.mutable
 import scala.annotation.*

--- a/compiler/src/dotty/tools/backend/jvm/KnownBTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/KnownBTypes.scala
@@ -2,7 +2,7 @@ package dotty.tools.backend.jvm
 
 import dotty.tools.dotc.core.Symbols.*
 
-import scala.tools.asm.{Handle, Opcodes}
+import org.objectweb.asm.{Handle, Opcodes}
 import dotty.tools.dotc.core.Contexts.Context
 
 import scala.annotation.constructorOnly

--- a/compiler/src/dotty/tools/backend/jvm/LabelNode1.java
+++ b/compiler/src/dotty/tools/backend/jvm/LabelNode1.java
@@ -12,9 +12,9 @@
 
 package dotty.tools.backend.jvm;
 
-import scala.tools.asm.Label;
-import scala.tools.asm.tree.ClassNode;
-import scala.tools.asm.tree.LabelNode;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.LabelNode;
 
 /**
  * A subclass of {@link LabelNode} to add user-definable flags.

--- a/compiler/src/dotty/tools/backend/jvm/MethodNode1.java
+++ b/compiler/src/dotty/tools/backend/jvm/MethodNode1.java
@@ -12,10 +12,10 @@
 
 package dotty.tools.backend.jvm;
 
-import scala.tools.asm.Label;
-import scala.tools.asm.Opcodes;
-import scala.tools.asm.tree.LabelNode;
-import scala.tools.asm.tree.MethodNode;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.MethodNode;
 /**
  * A subclass of {@link MethodNode} to customize the representation of
  * label nodes with {@link LabelNode1},

--- a/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
+++ b/compiler/src/dotty/tools/backend/jvm/PostProcessor.scala
@@ -7,8 +7,8 @@ import dotty.tools.io.FileWriters
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Decorators.em
 
-import scala.tools.asm.{ClassWriter, Handle}
-import scala.tools.asm.tree.{ClassNode, InvokeDynamicInsnNode}
+import org.objectweb.asm.{ClassWriter, Handle}
+import org.objectweb.asm.tree.{ClassNode, InvokeDynamicInsnNode}
 import dotty.tools.backend.jvm.opt.*
 import dotty.tools.dotc.report
 import dotty.tools.io.PlainFile.toPlainFile
@@ -16,7 +16,7 @@ import dotty.tools.io.PlainFile.toPlainFile
 import java.nio.file.{Files, Paths}
 import scala.jdk.CollectionConverters.*
 import scala.collection.mutable
-import scala.tools.asm
+import org.objectweb.asm
 import scala.util.chaining.scalaUtilChainingOps
 
 /**
@@ -184,7 +184,7 @@ class PostProcessor(bTypeLoader: BTypeLoader, bTypes: KnownBTypes)(using Context
     val groups: Array[Array[Handle]] = implMethodsArray.grouped(targetMethodGroupLimit).toArray
     val numGroups = groups.length
 
-    import scala.tools.asm.Label
+    import org.objectweb.asm.Label
     val initialLabels = Array.fill(numGroups - 1)(new Label())
     val terminalLabel = new Label
     def nextLabel(i: Int) = if (i == numGroups - 2) terminalLabel else initialLabels(i + 1)

--- a/compiler/src/dotty/tools/backend/jvm/TestOp.scala
+++ b/compiler/src/dotty/tools/backend/jvm/TestOp.scala
@@ -16,17 +16,17 @@ enum TestOp:
     case GT => LE
 
   def opcodeIF(): Int = this match
-    case EQ => scala.tools.asm.Opcodes.IFEQ
-    case NE => scala.tools.asm.Opcodes.IFNE
-    case LT => scala.tools.asm.Opcodes.IFLT
-    case GE => scala.tools.asm.Opcodes.IFGE
-    case LE => scala.tools.asm.Opcodes.IFLE
-    case GT => scala.tools.asm.Opcodes.IFGT
+    case EQ => org.objectweb.asm.Opcodes.IFEQ
+    case NE => org.objectweb.asm.Opcodes.IFNE
+    case LT => org.objectweb.asm.Opcodes.IFLT
+    case GE => org.objectweb.asm.Opcodes.IFGE
+    case LE => org.objectweb.asm.Opcodes.IFLE
+    case GT => org.objectweb.asm.Opcodes.IFGT
 
   def opcodeIFICMP(): Int = this match
-    case EQ => scala.tools.asm.Opcodes.IF_ICMPEQ
-    case NE => scala.tools.asm.Opcodes.IF_ICMPNE
-    case LT => scala.tools.asm.Opcodes.IF_ICMPLT
-    case GE => scala.tools.asm.Opcodes.IF_ICMPGE
-    case LE => scala.tools.asm.Opcodes.IF_ICMPLE
-    case GT => scala.tools.asm.Opcodes.IF_ICMPGT
+    case EQ => org.objectweb.asm.Opcodes.IF_ICMPEQ
+    case NE => org.objectweb.asm.Opcodes.IF_ICMPNE
+    case LT => org.objectweb.asm.Opcodes.IF_ICMPLT
+    case GE => org.objectweb.asm.Opcodes.IF_ICMPGE
+    case LE => org.objectweb.asm.Opcodes.IF_ICMPLE
+    case GT => org.objectweb.asm.Opcodes.IF_ICMPGT

--- a/compiler/src/dotty/tools/backend/jvm/TraceUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/TraceUtils.scala
@@ -2,9 +2,9 @@ package dotty.tools
 package backend
 package jvm
 
-import scala.tools.asm.util.{Textifier, TraceClassVisitor, TraceMethodVisitor}
-import scala.tools.asm.ClassReader
-import scala.tools.asm.tree.*
+import org.objectweb.asm.util.{Textifier, TraceClassVisitor, TraceMethodVisitor}
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.tree.*
 import java.io.{PrintWriter, StringWriter}
 
 object TraceUtils {

--- a/compiler/src/dotty/tools/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -17,9 +17,9 @@ package analysis
 import scala.annotation.switch
 import scala.collection.AbstractIterator
 import scala.collection.mutable
-import scala.tools.asm.Opcodes
-import scala.tools.asm.tree.*
-import scala.tools.asm.tree.analysis.*
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.analysis.*
 import dotty.tools.backend.jvm.BCodeUtils.FrameExtensions
 
 /**

--- a/compiler/src/dotty/tools/backend/jvm/analysis/AnalysisUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/AnalysisUtils.scala
@@ -3,9 +3,9 @@ package dotty.tools.backend.jvm.analysis
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.{BCodeUtils, ClassBType}
 
-import scala.tools.asm
-import scala.tools.asm.{Handle, Opcodes}
-import scala.tools.asm.tree.{AbstractInsnNode, FieldInsnNode, InvokeDynamicInsnNode, MethodInsnNode, MethodNode}
+import org.objectweb.asm
+import org.objectweb.asm.{Handle, Opcodes}
+import org.objectweb.asm.tree.{AbstractInsnNode, FieldInsnNode, InvokeDynamicInsnNode, MethodInsnNode, MethodNode}
 
 object AnalysisUtils {
 

--- a/compiler/src/dotty/tools/backend/jvm/analysis/AsmAnalyzer.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/AsmAnalyzer.scala
@@ -14,8 +14,8 @@ package dotty.tools
 package backend.jvm
 package analysis
 
-import scala.tools.asm.tree.analysis.*
-import scala.tools.asm.tree.{AbstractInsnNode, MethodNode}
+import org.objectweb.asm.tree.analysis.*
+import org.objectweb.asm.tree.{AbstractInsnNode, MethodNode}
 import dotty.tools.backend.jvm.BCodeUtils.AnalyzerExtensions
 
 

--- a/compiler/src/dotty/tools/backend/jvm/analysis/InstructionStackEffect.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/InstructionStackEffect.scala
@@ -15,10 +15,10 @@ package backend.jvm
 package analysis
 
 import scala.annotation.switch
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.Type
-import scala.tools.asm.tree.*
-import scala.tools.asm.tree.analysis.{Frame, Value}
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.analysis.{Frame, Value}
 import dotty.tools.backend.jvm.BCodeUtils.FrameExtensions
 
 object InstructionStackEffect {

--- a/compiler/src/dotty/tools/backend/jvm/analysis/NullnessAnalyzer.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/NullnessAnalyzer.scala
@@ -16,9 +16,9 @@ package analysis
 
 import java.util
 import scala.annotation.switch
-import scala.tools.asm.tree.analysis.*
-import scala.tools.asm.tree.*
-import scala.tools.asm.{Opcodes, Type}
+import org.objectweb.asm.tree.analysis.*
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.{Opcodes, Type}
 import dotty.tools.backend.jvm.BCodeUtils.FrameExtensions
 
 /**

--- a/compiler/src/dotty/tools/backend/jvm/analysis/ProdConsAnalyzer.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/ProdConsAnalyzer.scala
@@ -7,10 +7,10 @@ import java.util
 import scala.annotation.switch
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.tree.*
-import scala.tools.asm.tree.analysis.*
-import scala.tools.asm.{MethodVisitor, Type}
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.analysis.*
+import org.objectweb.asm.{MethodVisitor, Type}
 import dotty.tools.backend.jvm.BCodeUtils.{FrameExtensions, isLoad, isStore, isLoadOrStore}
 
 /**
@@ -446,7 +446,7 @@ case class ParameterProducer(local: Int)                                        
 case class UninitializedLocalProducer(local: Int)                                       extends InitialProducer
 case class ExceptionProducer[V <: Value](handlerLabel: LabelNode, handlerStackTop: Int) extends InitialProducer
 
-class InitialProducerSourceInterpreter extends SourceInterpreter(scala.tools.asm.Opcodes.ASM7) {
+class InitialProducerSourceInterpreter extends SourceInterpreter(org.objectweb.asm.Opcodes.ASM7) {
   override def newParameterValue(isInstanceMethod: Boolean, local: Int, tp: Type): SourceValue = {
     new SourceValue(tp.getSize, ParameterProducer(local))
   }

--- a/compiler/src/dotty/tools/backend/jvm/analysis/TypeFlowAnalyzer.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/TypeFlowAnalyzer.scala
@@ -15,12 +15,12 @@ package backend.jvm
 package analysis
 
 import scala.annotation.tailrec
-import scala.tools.asm.{Opcodes, Type}
-import scala.tools.asm.tree.{AbstractInsnNode, InsnNode, MethodNode}
-import scala.tools.asm.tree.analysis.{Analyzer, BasicInterpreter, BasicValue}
+import org.objectweb.asm.{Opcodes, Type}
+import org.objectweb.asm.tree.{AbstractInsnNode, InsnNode, MethodNode}
+import org.objectweb.asm.tree.analysis.{Analyzer, BasicInterpreter, BasicValue}
 import dotty.tools.backend.jvm.BCodeUtils.FrameExtensions
 
-abstract class TypeFlowInterpreter extends BasicInterpreter(scala.tools.asm.Opcodes.ASM7) {
+abstract class TypeFlowInterpreter extends BasicInterpreter(org.objectweb.asm.Opcodes.ASM7) {
   import TypeFlowInterpreter.*
 
   override def newParameterValue(isInstanceMethod: Boolean, local: Int, tpe: Type): BasicValue =

--- a/compiler/src/dotty/tools/backend/jvm/analysis/package.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/package.scala
@@ -90,7 +90,7 @@ package dotty.tools.backend.jvm
  *   import backend.jvm.*
  *   import backend.jvm.opt.ByteCodeUtils.*
  *   import scala.collection.convert.decorateAsScala.*
- *   import scala.tools.asm.tree.analysis.*
+ *   import org.objectweb.asm.tree.analysis.*
  *
  *   val cn = AsmUtils.readClass("/Users/luc/scala/scala/sandbox/A.class")
  *   val m = cn.methods.iterator.asScala.find(_.name == "f").head
@@ -371,7 +371,7 @@ object Test {
     // analysis runs 3.5x faster. Most likely because the call to Interpreter.merge inside
     // Frame.merge is no longer megamorphic.
 
-    import scala.tools.asm.tree.analysis._
+    import org.objectweb.asm.tree.analysis._
     val ba = new Analyzer(new BasicInterpreter)
     ba.analyze(cn.name, m) // warm up
 

--- a/compiler/src/dotty/tools/backend/jvm/opt/BCodeRepository.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/BCodeRepository.scala
@@ -23,9 +23,9 @@ import dotty.tools.io.ClassPath
 
 import scala.collection.{concurrent, mutable}
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm
-import scala.tools.asm.tree.*
-import scala.tools.asm.{Attribute, ClassReader, Type}
+import org.objectweb.asm
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.{Attribute, ClassReader, Type}
 
 /**
  * The BCodeRepository provides utilities to read the bytecode of classfiles from the compilation

--- a/compiler/src/dotty/tools/backend/jvm/opt/BTypesFromClassfile.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/BTypesFromClassfile.scala
@@ -20,8 +20,8 @@ import dotty.tools.dotc.core.StdNames.nme
 import scala.annotation.{switch, unused}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Opcodes
-import scala.tools.asm.tree.{ClassNode, InnerClassNode, ModuleNode}
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.{ClassNode, InnerClassNode, ModuleNode}
 
 class BTypesFromClassfile(byteCodeRepository: BCodeRepository, bTypeLoader: BTypeLoader) extends InlineInfoLoader {
 

--- a/compiler/src/dotty/tools/backend/jvm/opt/BoxUnbox.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/BoxUnbox.scala
@@ -18,9 +18,9 @@ import scala.annotation.tailrec
 import scala.collection.AbstractIterator
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.Type
-import scala.tools.asm.tree.*
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.analysis.{AsmAnalyzer, ProdConsAnalyzer}
 import dotty.tools.backend.jvm.BCodeUtils.*

--- a/compiler/src/dotty/tools/backend/jvm/opt/CallGraph.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/CallGraph.scala
@@ -18,8 +18,8 @@ import scala.collection.concurrent.TrieMap
 import scala.collection.immutable.IntMap
 import scala.collection.{concurrent, mutable}
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.tree.*
-import scala.tools.asm.{Opcodes, Type}
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.{Opcodes, Type}
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.analysis.TypeFlowInterpreter.{LMFValue, ParamValue}
 import dotty.tools.backend.jvm.analysis.{AnalysisUtils, *}

--- a/compiler/src/dotty/tools/backend/jvm/opt/ClosureOptimizer.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/ClosureOptimizer.scala
@@ -18,9 +18,9 @@ import scala.annotation.switch
 import scala.collection.immutable.IntMap
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.Type
-import scala.tools.asm.tree.*
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
 import dotty.tools.dotc.util.NoSourcePosition
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.analysis.{AnalysisUtils, AsmAnalyzer, ProdConsAnalyzer}
@@ -549,7 +549,7 @@ class ClosureOptimizer(optimizerUtils: OptimizerUtils,
    * Stores a local variable index the opcode offset required for operating on that variable.
    *
    * The xLOAD / xSTORE opcodes are in the following sequence: I, L, F, D, A, so the offset for
-   * a local variable holding a reference (`A`) is 4. See also method `getOpcode` in [[scala.tools.asm.Type]].
+   * a local variable holding a reference (`A`) is 4. See also method `getOpcode` in [[org.objectweb.asm.Type]].
    */
   private case class Local(local: Int, opcodeOffset: Int) {
     def size = if (loadOpcode == LLOAD || loadOpcode == DLOAD) 2  else 1

--- a/compiler/src/dotty/tools/backend/jvm/opt/CopyProp.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/CopyProp.scala
@@ -17,14 +17,14 @@ package opt
 import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.{Opcodes, Type}
-import scala.tools.asm.tree.*
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.{Opcodes, Type}
+import org.objectweb.asm.tree.*
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.analysis.*
 import BCodeUtils.*
 
-import scala.tools.asm
+import org.objectweb.asm
 
 class CopyProp(optimizerUtils: OptimizerUtils, callGraph: CallGraph, inliner: Inliner, ts: OptimizerKnownBTypes, settings: OptimizerSettings) {
 

--- a/compiler/src/dotty/tools/backend/jvm/opt/InlineInfoAttribute.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/InlineInfoAttribute.scala
@@ -15,7 +15,7 @@ package backend.jvm
 package opt
 
 import scala.collection.mutable
-import scala.tools.asm.*
+import org.objectweb.asm.*
 
 /**
  * This attribute stores the InlineInfo for a ClassBType as an independent classfile attribute.

--- a/compiler/src/dotty/tools/backend/jvm/opt/Inliner.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/Inliner.scala
@@ -17,11 +17,11 @@ package opt
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.Type
-import scala.tools.asm.tree.*
-import scala.tools.asm.tree.analysis.Value
+import org.objectweb.asm
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.analysis.Value
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.analysis.*
 import AnalysisUtils.LambdaMetaFactoryCall

--- a/compiler/src/dotty/tools/backend/jvm/opt/InlinerHeuristics.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/InlinerHeuristics.scala
@@ -18,8 +18,8 @@ import java.util.regex.Pattern
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Type
-import scala.tools.asm.tree.MethodNode
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.MethodNode
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.opt.InlinerHeuristics.*
 import dotty.tools.backend.jvm.BCodeUtils.{isStrictfpMethod, isSynchronizedMethod}

--- a/compiler/src/dotty/tools/backend/jvm/opt/Limits.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/Limits.scala
@@ -1,6 +1,6 @@
 package dotty.tools.backend.jvm.opt
 
-import scala.tools.asm.tree.MethodNode
+import org.objectweb.asm.tree.MethodNode
 
 /**
  * See the doc comment on package object `analysis` for a discussion on performance.

--- a/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
@@ -17,10 +17,10 @@ package opt
 import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.Type
-import scala.tools.asm.tree.*
-import scala.tools.asm.tree.analysis.Frame
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.Type
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.tree.analysis.Frame
 import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.backend.jvm.analysis.*
 import BCodeUtils.*

--- a/compiler/src/dotty/tools/backend/jvm/opt/LogUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/LogUtils.scala
@@ -4,8 +4,8 @@ import dotty.tools.backend.jvm.analysis.InitialProducer
 
 import scala.jdk.CollectionConverters.*
 import java.io.{PrintWriter, StringWriter}
-import scala.tools.asm.tree.{AbstractInsnNode, ClassNode, InsnList, MethodNode}
-import scala.tools.asm.util.{ASMifier, Textifier, TraceClassVisitor, TraceMethodVisitor}
+import org.objectweb.asm.tree.{AbstractInsnNode, ClassNode, InsnList, MethodNode}
+import org.objectweb.asm.util.{ASMifier, Textifier, TraceClassVisitor, TraceMethodVisitor}
 
 object LogUtils {
   /**

--- a/compiler/src/dotty/tools/backend/jvm/opt/MethodMax.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/MethodMax.scala
@@ -3,8 +3,8 @@ package dotty.tools.backend.jvm.opt
 import dotty.tools.backend.jvm.BCodeUtils
 import dotty.tools.backend.jvm.analysis.InstructionStackEffect
 
-import scala.tools.asm.Opcodes
-import scala.tools.asm.tree.{AbstractInsnNode, IincInsnNode, JumpInsnNode, LookupSwitchInsnNode, MethodNode, TableSwitchInsnNode, VarInsnNode}
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.{AbstractInsnNode, IincInsnNode, JumpInsnNode, LookupSwitchInsnNode, MethodNode, TableSwitchInsnNode, VarInsnNode}
 
 object MethodMax {
 

--- a/compiler/src/dotty/tools/backend/jvm/opt/OptimizerUtils.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/OptimizerUtils.scala
@@ -9,9 +9,9 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.switch
 import scala.collection.{BitSet, mutable}
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm
-import scala.tools.asm.tree.*
-import scala.tools.asm.{Handle, Opcodes, Type}
+import org.objectweb.asm
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.{Handle, Opcodes, Type}
 
 /**
  * This component hosts tools and utilities used in the optimizer that require access to an `OptimizerKnownBTypes` instance.

--- a/compiler/src/dotty/tools/backend/jvm/opt/OptimizerWarning.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/OptimizerWarning.scala
@@ -4,7 +4,7 @@ import dotty.tools.backend.jvm.BTypes.InternalName
 import dotty.tools.dotc.reporting.Message
 import dotty.tools.dotc.util.{SourcePosition, SrcPos}
 
-import scala.tools.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.AbstractInsnNode
 
 final class OptimizerIssue(val msg: String, val site: String, val pos: SrcPos)
 

--- a/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
+++ b/compiler/src/dotty/tools/dotc/config/ScalaSettingsProperties.scala
@@ -6,7 +6,7 @@ import Settings.Setting.ChoiceWithHelp
 object ScalaSettingsProperties:
 
   private val minTargetVersion = 17
-  private val maxTargetVersion = 26
+  private val maxTargetVersion = 27
   private val minReleaseVersion = 17
 
   def supportedTargetVersions: List[String] =

--- a/compiler/test/dotty/AsmConverters.scala
+++ b/compiler/test/dotty/AsmConverters.scala
@@ -1,9 +1,9 @@
 package dotty
 
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm
-import scala.tools.asm.*
-import scala.tools.asm.tree.*
+import org.objectweb.asm
+import org.objectweb.asm.*
+import org.objectweb.asm.tree.*
 
 /** Makes using ASM from tests more convenient.
  *
@@ -11,7 +11,7 @@ import scala.tools.asm.tree.*
  * for the purpose of bytecode diffing and pretty printing.
  */
 object AsmConverters {
-  import scala.tools.asm.tree as t
+  import org.objectweb.asm.tree as t
 
   /**
    * Transform the instructions of an ASM Method into a list of [[Instruction]]s.
@@ -60,7 +60,7 @@ object AsmConverters {
   }
 
   def opcodeToString(op: Int, default: Any = "?"): String = {
-    import scala.tools.asm.util.Printer.OPCODES
+    import org.objectweb.asm.util.Printer.OPCODES
     if (OPCODES.isDefinedAt(op)) OPCODES(op) else default.toString
   }
 

--- a/compiler/test/dotty/AsmNode.scala
+++ b/compiler/test/dotty/AsmNode.scala
@@ -2,9 +2,9 @@ package dotty
 
 import java.lang.reflect.Modifier
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm
-import scala.tools.asm.*
-import scala.tools.asm.tree.*
+import org.objectweb.asm
+import org.objectweb.asm.*
+import org.objectweb.asm.tree.*
 
 sealed trait AsmNode[+T] {
   def node: T

--- a/compiler/test/dotty/DottyBytecodeTest.scala
+++ b/compiler/test/dotty/DottyBytecodeTest.scala
@@ -5,9 +5,9 @@ import dotty.tools.dotc.core.Comments.{ContextDoc, ContextDocstrings}
 import dotty.tools.dotc.core.Contexts.{Context, ContextBase, ctx}
 import dotty.tools.vulpix.TestConfiguration
 
-import scala.tools.asm
-import scala.tools.asm.*
-import scala.tools.asm.tree.*
+import org.objectweb.asm
+import org.objectweb.asm.*
+import org.objectweb.asm.tree.*
 import dotty.tools.io
 import dotty.tools.io.AbstractFile
 

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -82,8 +82,15 @@ object Properties {
   // TODO: Remove this once we migrate the test suite
   def usingScalaLibraryTasty: Boolean = true
 
-  /** scala-asm jar */
-  def scalaAsm: String = sys.props("dotty.tests.classes.scalaAsm").nn
+  /** main ASM jar */
+  def asm: String = sys.props("dotty.tests.classes.asm").nn
+
+  /** all the ASM jars */
+  def asmAll: Seq[String] =
+    Seq("", "-tree", "-util", "-commons", "-analysis")
+      .map(suffix =>
+        asm.replaceAll("asm", "asm" + suffix)
+          .replaceFirst("/asm" + suffix + "/", "/asm/"))
 
   /** jline-terminal jar */
   def jlineTerminal: String = sys.props("dotty.tests.classes.jlineTerminal").nn

--- a/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/ArrayApplyOptTest.scala
@@ -5,7 +5,7 @@ import dotty.DottyBytecodeTest
 import org.junit.Test
 import org.junit.Assert.*
 
-import scala.tools.asm.Opcodes.*
+import org.objectweb.asm.Opcodes.*
 
 class ArrayApplyOptTest extends DottyBytecodeTest {
   import dotty.AsmConverters.*

--- a/compiler/test/dotty/tools/backend/jvm/ClassfileParserTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/ClassfileParserTest.scala
@@ -20,7 +20,7 @@ class ClassfileParserTest {
       "CONSTANT_NAME_AND_TYPE" -> "CONSTANT_NAMEANDTYPE",
     ).withDefault(x => x)
 
-    val asmConsts = constNames(Class.forName("scala.tools.asm.Symbol").getDeclaredFields.toList)
+    val asmConsts = constNames(Class.forName("org.objectweb.asm.Symbol").getDeclaredFields.toList)
       .map(_.stripSuffix("_TAG"))
       .map(toDotc)
       .::("CONSTANT_UNICODE")

--- a/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/DottyBytecodeTests.scala
@@ -5,11 +5,11 @@ import dotty.DottyBytecodeTest
 import org.junit.Assert.*
 import org.junit.Test
 
-import scala.tools.asm
-import scala.tools.asm.*
-import scala.tools.asm.tree.*
-import scala.tools.asm.Opcodes
-import scala.tools.asm.Opcodes.*
+import org.objectweb.asm
+import org.objectweb.asm.*
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Opcodes.*
 import scala.jdk.CollectionConverters.*
 
 class DottyBytecodeTests extends DottyBytecodeTest {

--- a/compiler/test/dotty/tools/backend/jvm/IincTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/IincTest.scala
@@ -4,7 +4,7 @@ import dotty.DottyBytecodeTest
 import org.junit.Test
 import org.junit.Assert.*
 
-import scala.tools.asm.Opcodes.*
+import org.objectweb.asm.Opcodes.*
 
 class IincTest extends DottyBytecodeTest {
   import dotty.AsmConverters.*

--- a/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/InlineBytecodeTests.scala
@@ -4,7 +4,7 @@ import dotty.DottyBytecodeTest
 
 import org.junit.Test
 
-import scala.tools.asm.Opcodes.*
+import org.objectweb.asm.Opcodes.*
 import scala.jdk.CollectionConverters.*
 
 class InlineBytecodeTests extends DottyBytecodeTest {

--- a/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/LabelBytecodeTests.scala
@@ -4,7 +4,7 @@ import dotty.DottyBytecodeTest
 
 import org.junit.Test
 
-import scala.tools.asm.Opcodes
+import org.objectweb.asm.Opcodes
 import Opcodes.*
 
 class LabelBytecodeTests extends DottyBytecodeTest {

--- a/compiler/test/dotty/tools/backend/jvm/MixinBytecodeTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/MixinBytecodeTests.scala
@@ -5,8 +5,8 @@ import org.junit.Assert.*
 import org.junit.Test
 
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.tree.ClassNode
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.tree.ClassNode
 import dotty.AsmConverters.*
 import dotty.DottyBytecodeTest
 

--- a/compiler/test/dotty/tools/backend/jvm/PublicInBinaryTests.scala
+++ b/compiler/test/dotty/tools/backend/jvm/PublicInBinaryTests.scala
@@ -4,9 +4,9 @@ import dotty.DottyBytecodeTest
 
 import org.junit.Test
 
-import scala.tools.asm.*
-import scala.tools.asm.tree.*
-import scala.tools.asm.Opcodes.*
+import org.objectweb.asm.*
+import org.objectweb.asm.tree.*
+import org.objectweb.asm.Opcodes.*
 import scala.jdk.CollectionConverters.*
 
 class PublicInBinaryTests extends DottyBytecodeTest {

--- a/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
+++ b/compiler/test/dotty/tools/backend/jvm/StringConcatTest.scala
@@ -4,7 +4,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.junit.Test
 
-import scala.tools.asm.Opcodes.*
+import org.objectweb.asm.Opcodes.*
 import org.junit.Assert.*
 import dotty.AsmConverters.*
 import dotty.DottyBytecodeTest

--- a/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
+++ b/compiler/test/dotty/tools/dotc/ConstantFoldingTests.scala
@@ -7,7 +7,7 @@ import org.junit.Test
 import dotty.tools.dotc.config.CompilerCommand
 import dotty.tools.dotc.core.Contexts.FreshContext
 
-import scala.tools.asm.tree.MethodNode
+import org.objectweb.asm.tree.MethodNode
 import scala.jdk.CollectionConverters.*
 
 class ConstantFoldingTests extends DottyBytecodeTest {

--- a/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
+++ b/compiler/test/dotty/tools/dotc/TastyBootstrapTests.scala
@@ -41,7 +41,7 @@ class TastyBootstrapTests {
         // as well as bootstrapped compiler:
         Paths.get(defaultOutputDir.getAbsolutePath, dotty1Group.name, "dotty1").toString,
         // and the other compiler dependencies:
-        Properties.compilerInterface, Properties.scalaLibrary, Properties.scalaAsm,
+        Properties.compilerInterface, Properties.scalaLibrary, Properties.asm,
         Properties.dottyInterfaces, Properties.jlineTerminal, Properties.jlineReader,
       ).mkString(File.pathSeparator),
       Array("-Ycheck-reentrant", "-language:postfixOps", "-Xsemanticdb")

--- a/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala
+++ b/compiler/test/dotty/tools/dotc/classpath/JrtClassPathTest.scala
@@ -13,8 +13,8 @@ import dotty.tools.dotc.config.PathResolver
 import dotty.tools.dotc.core.Contexts.{Context, ContextBase}
 import dotty.tools.dotc.classpath.ClassPathFactory
 
-import scala.tools.asm.ClassReader
-import scala.tools.asm.tree.ClassNode
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.tree.ClassNode
 
 @RunWith(classOf[JUnit4])
 class JrtClassPathTest {

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -35,9 +35,8 @@ object TestConfiguration {
 
   val basicClasspath = mkClasspath(List(Properties.scalaLibrary))
 
-  lazy val withCompilerClasspath = mkClasspath(List(
+  lazy val withCompilerClasspath = mkClasspath(Properties.asmAll ++ List(
     Properties.scalaLibrary,
-    Properties.scalaAsm,
     Properties.compilerInterface,
     Properties.dottyInterfaces,
     Properties.tastyCore,
@@ -56,7 +55,7 @@ object TestConfiguration {
     Properties.scalaJSLibrary,
   ))
 
-  def mkClasspath(classpaths: List[String]): String =
+  def mkClasspath(classpaths: Iterable[String]): String =
     classpaths.map({ p =>
       val file = new java.io.File(p)
       assert(file.exists, s"File $p couldn't be found.")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -488,9 +488,11 @@ object Build {
     val dottyStaging = (`scala3-staging` / Compile / packageBin).value.getAbsolutePath
     val dottyTastyInspector = (`scala3-tasty-inspector` / Compile / packageBin).value.getAbsolutePath
     val tastyCore = (`tasty-core-bootstrapped` / Compile / packageBin).value.getAbsolutePath
-    val asm = findArtifactPath(externalDeps, "scala-asm")
+    val asm =
+      Seq("asm", "asm-util", "asm-commons", "asm-analysis", "asm-tree")
+        .map(name => findArtifactPath(externalDeps, name))
     val compilerInterface = findArtifactPath(externalDeps, "compiler-interface")
-    Seq(dottyCompiler, dottyInterfaces, asm, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface)
+    asm ++ Seq(dottyCompiler, dottyInterfaces, dottyStaging, dottyTastyInspector, tastyCore, compilerInterface)
   }
 
   /** Build the `scala` input task for an aggregate project.
@@ -1435,7 +1437,8 @@ object Build {
       // All the dependencies needed by the compiler
       libraryDependencies ++= Seq(
         Dependencies.sbtJunitInterface % Test,
-        Dependencies.asm,
+        Dependencies.asmUtil,
+        Dependencies.asmCommons,
         Dependencies.sbtCompilerInterface,
         (Dependencies.coursier % Test).cross(CrossVersion.for3Use2_13),
       ),
@@ -1544,7 +1547,7 @@ object Build {
           s"-Ddotty.tests.classes.tastyCore=${(`tasty-core-nonbootstrapped` / Compile / packageBin).value}",
           s"-Ddotty.tests.classes.compilerInterface=${findArtifactPath(externalDeps, "compiler-interface")}",
           s"-Ddotty.tests.classes.scalaLibrary=${(`scala-library-nonbootstrapped` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.scalaAsm=${findArtifactPath(externalDeps, "scala-asm")}",
+          s"-Ddotty.tests.classes.asm=${findArtifactPath(externalDeps, "asm")}",
           s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
         )
       },
@@ -1572,7 +1575,8 @@ object Build {
       Test / unmanagedResourceDirectories += baseDirectory.value / "test-resources",
       // All the dependencies needed by the compiler
       libraryDependencies ++= Seq(
-        Dependencies.asm,
+        Dependencies.asmUtil,
+        Dependencies.asmCommons,
         Dependencies.sbtCompilerInterface,
         Dependencies.sbtJunitInterface % Test,
         (Dependencies.coursier % Test).cross(CrossVersion.for3Use2_13),
@@ -1671,7 +1675,7 @@ object Build {
           s"-Ddotty.tests.classes.compilerInterface=${findArtifactPath(externalDeps, "compiler-interface")}",
           s"-Ddotty.tests.classes.scalaLibrary=${(`scala-library-bootstrapped` / Compile / packageBin).value}",
           s"-Ddotty.tests.classes.scalaJSScalalib=${(`scala-library-sjs` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.scalaAsm=${findArtifactPath(externalDeps, "scala-asm")}",
+          s"-Ddotty.tests.classes.asm=${findArtifactPath(externalDeps, "asm")}",
           s"-Ddotty.tests.classes.dottyStaging=${(LocalProject("scala3-staging") / Compile / packageBin).value}",
           s"-Ddotty.tests.classes.dottyTastyInspector=${(LocalProject("scala3-tasty-inspector") / Compile / packageBin).value}",
           s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
@@ -2369,7 +2373,7 @@ object Build {
           s"-Ddotty.tests.classes.tastyCore=${(`tasty-core-bootstrapped` / Compile / packageBin).value}",
           s"-Ddotty.tests.classes.compilerInterface=${findArtifactPath(externalDeps, "compiler-interface")}",
           s"-Ddotty.tests.classes.scalaLibrary=${(`scala-library-bootstrapped` / Compile / packageBin).value}",
-          s"-Ddotty.tests.classes.scalaAsm=${findArtifactPath(externalDeps, "scala-asm")}",
+          s"-Ddotty.tests.classes.asm=${findArtifactPath(externalDeps, "asm")}",
           s"-Ddotty.tools.dotc.semanticdb.test=${(ThisBuild / baseDirectory).value/"tests"/"semanticdb"}",
           "-Ddotty.tests.classes.scalaJSScalalib=" + (`scala-library-sjs` / Compile / packageBin).value,
           "-Ddotty.tests.classes.scalaJSJavalib=" + findArtifactPath(externalJSDeps, "scalajs-javalib"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,8 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
  * PLEASE KEEP ALPHABETIZED!
  */
 object Dependencies {
-  val asmUtil = "org.ow2.asm" % "asm-util" % "9.9.1"
-  val asmCommons = "org.ow2.asm" % "asm-commons" % "9.9.1"
+  val asmUtil = "org.ow2.asm" % "asm-util" % "9.10.1"
+  val asmCommons = "org.ow2.asm" % "asm-commons" % "9.10.1"
 
   /** Version of Coursier to use + download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M26"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,8 @@ import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
  * PLEASE KEEP ALPHABETIZED!
  */
 object Dependencies {
-  val asm = "org.scala-lang.modules" % "scala-asm" % "9.9.0-scala-1"
+  val asmUtil = "org.ow2.asm" % "asm-util" % "9.9.1"
+  val asmCommons = "org.ow2.asm" % "asm-commons" % "9.9.1"
 
   /** Version of Coursier to use + download for initializing the local maven repo of Scala command */
   val coursierJarVersion = "2.1.25-M26"

--- a/repl/src/dotty/tools/repl/Rendering.scala
+++ b/repl/src/dotty/tools/repl/Rendering.scala
@@ -10,9 +10,9 @@ import StackTraceOps.*
 
 import scala.compiletime.uninitialized
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.tree.*
+import org.objectweb.asm.*
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.tree.*
 import scala.util.control.NonFatal
 import java.util.function.Predicate
 

--- a/repl/src/dotty/tools/repl/ReplBytecodeAnalysis.scala
+++ b/repl/src/dotty/tools/repl/ReplBytecodeAnalysis.scala
@@ -3,9 +3,9 @@ package repl
 
 import scala.jdk.CollectionConverters.*
 import scala.language.unsafeNulls
-import scala.tools.asm.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.tree.*
+import org.objectweb.asm.*
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.tree.*
 import scala.util.control.NonFatal
 
 object ReplBytecodeAnalysis:

--- a/repl/src/dotty/tools/repl/ReplBytecodeInstrumentation.scala
+++ b/repl/src/dotty/tools/repl/ReplBytecodeInstrumentation.scala
@@ -3,9 +3,9 @@ package repl
 
 import scala.language.unsafeNulls
 
-import scala.tools.asm.*
-import scala.tools.asm.Opcodes.*
-import scala.tools.asm.tree.*
+import org.objectweb.asm.*
+import org.objectweb.asm.Opcodes.*
+import org.objectweb.asm.tree.*
 import scala.jdk.CollectionConverters.*
 import java.util.concurrent.atomic.AtomicBoolean
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -49,7 +49,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.compiletime.uninitialized
 import scala.jdk.CollectionConverters.*
-import scala.tools.asm.ClassReader
+import org.objectweb.asm.ClassReader
 import scala.util.Using
 
 /** The state of the REPL contains necessary bindings instead of having to have

--- a/tests/disabled/partest/run/classfile-format-51.scala
+++ b/tests/disabled/partest/run/classfile-format-51.scala
@@ -2,7 +2,7 @@ import java.io.{File, FileOutputStream}
 
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.partest._
-import scala.tools.asm
+import org.objectweb.asm
 import asm.{AnnotationVisitor, ClassWriter, FieldVisitor, Handle, MethodVisitor, Opcodes}
 import Opcodes._
 

--- a/tests/disabled/partest/run/classfile-format-52.scala
+++ b/tests/disabled/partest/run/classfile-format-52.scala
@@ -2,7 +2,7 @@ import java.io.{File, FileOutputStream}
 
 import scala.tools.nsc.settings.ScalaVersion
 import scala.tools.partest._
-import scala.tools.asm
+import org.objectweb.asm
 import asm.{AnnotationVisitor, ClassWriter, FieldVisitor, Handle, MethodVisitor, Opcodes}
 import Opcodes._
 

--- a/tests/disabled/partest/run/icode-reader-dead-code.scala
+++ b/tests/disabled/partest/run/icode-reader-dead-code.scala
@@ -1,7 +1,7 @@
 import java.io.{FileOutputStream, FileInputStream}
 
-import scala.tools.asm.{ClassWriter, Opcodes, ClassReader}
-import scala.tools.asm.tree.{InsnNode, ClassNode}
+import org.objectweb.asm.{ClassWriter, Opcodes, ClassReader}
+import org.objectweb.asm.tree.{InsnNode, ClassNode}
 import scala.tools.nsc.backend.jvm.AsmUtils
 import scala.tools.partest.DirectTest
 import scala.jdk.CollectionConverters._

--- a/tests/disabled/partest/run/t7852.scala
+++ b/tests/disabled/partest/run/t7852.scala
@@ -1,6 +1,6 @@
 import scala.tools.partest.BytecodeTest
-import scala.tools.asm
-import scala.tools.asm.util._
+import org.objectweb.asm
+import org.objectweb.asm.util._
 import scala.tools.nsc.util.stringFromWriter
 import scala.jdk.CollectionConverters._
 

--- a/tests/disabled/partest/run/t8601-closure-elim.scala
+++ b/tests/disabled/partest/run/t8601-closure-elim.scala
@@ -1,6 +1,6 @@
 import scala.tools.partest.BytecodeTest
-import scala.tools.asm
-import scala.tools.asm.util._
+import org.objectweb.asm
+import org.objectweb.asm.util._
 import scala.jdk.CollectionConverters._
 
 object Test extends BytecodeTest {

--- a/tests/disabled/reflect/run/t2464/Test.scala
+++ b/tests/disabled/reflect/run/t2464/Test.scala
@@ -1,6 +1,6 @@
 import scala.reflect.io.Streamable
-import scala.tools.asm.{ClassWriter, ClassReader}
-import scala.tools.asm.tree.ClassNode
+import org.objectweb.asm.{ClassWriter, ClassReader}
+import org.objectweb.asm.tree.ClassNode
 import scala.tools.partest._
 import scala.tools.partest.BytecodeTest.modifyClassFile
 import java.io.{FileOutputStream, FileInputStream, File}

--- a/tests/disabled/reflect/run/t7974/Test.scala
+++ b/tests/disabled/reflect/run/t7974/Test.scala
@@ -1,7 +1,7 @@
 import java.io.PrintWriter;
 
 import scala.tools.partest.BytecodeTest
-import scala.tools.asm.util._
+import org.objectweb.asm.util._
 import scala.tools.nsc.util.stringFromWriter
 
 object Test extends BytecodeTest {


### PR DESCRIPTION
Supersedes #25989
Supersedes #26621

**Review commit by commit**

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
