### PR TITLE
Fix issue with reading legal java cyclic signatures

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -652,7 +652,23 @@ final class ClassfileParser(
           while (sig(index) == '.') {
             accept('.')
             val name = subName(c => c == ';' || c == '<' || c == '.').toTypeName
-            val tp = tpe.select(name)
+            // Java allows for certain cyclic signatures, so we must too.
+            // If we are already in a class, we manually lookup instead of
+            // tpe.select to avoid cyclic errors. See #26646
+            val tp =
+              if tpe.typeSymbol eq classRoot.symbol then
+                // classRoot is being completed - we have to use classRoot's instanceScope
+                // e.g. case: `class CyclicSignature<S extends CyclicSignature<S>.Nested>`
+                val member = instanceScope.lookup(name)
+                if member.exists then TypeRef(tpe, member) else tpe.select(name)
+              else if tpe.typeSymbol.isContainedIn(classRoot.symbol) then
+                // classRoot is completed - using .info is safe
+                // e.g. case: `class CyclicSignature<S extends CyclicSignature<S>.Nested.Deeper>`
+                val member = tpe.typeSymbol.info.decls.lookup(name)
+                if member.exists then TypeRef(tpe, member) else tpe.select(name)
+              else
+                // non-cyclic case
+                tpe.select(name)
             tpe = processTypeArgs(tp)
           }
           accept(';')

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -361,7 +361,11 @@ object Checking {
 
           if isInteresting(pre) then
             CyclicReference.trace(i"explore ${tp.symbol} for cyclic references"):
-              val pre1 = atVariance(variance max 0)(this(pre, false, false))
+              val nestedCycleOkInPrefix =
+                // generated symbols like primary constructor may not have JavaDefined,
+                // even when the corresponding file is java - also check the owner
+                if sym.is(JavaDefined) || sym.maybeOwner.is(JavaDefined) then nestedCycleOK else false
+              val pre1 = atVariance(variance max 0)(this(pre, false, nestedCycleOkInPrefix))
               if locked.contains(tp)
                   || tp.symbol.infoOrCompleter.isInstanceOf[NoCompleter]
                   && tp.symbol == sym

--- a/tests/pos/i26646-a-joint/CyclicSignature.java
+++ b/tests/pos/i26646-a-joint/CyclicSignature.java
@@ -1,0 +1,7 @@
+class CyclicSignature<S extends CyclicSignature<S>.Nested> {
+    class Nested {}
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-a-joint/Test.scala
+++ b/tests/pos/i26646-a-joint/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-a-separate/CyclicSignature_JAVA_ONLY_1.java
+++ b/tests/pos/i26646-a-separate/CyclicSignature_JAVA_ONLY_1.java
@@ -1,0 +1,7 @@
+public class CyclicSignature_JAVA_ONLY_1<S extends CyclicSignature_JAVA_ONLY_1<S>.Nested> {
+    class Nested {}
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-a-separate/Test_2.scala
+++ b/tests/pos/i26646-a-separate/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature_JAVA_ONLY_1[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-b-joint/CyclicSignature.java
+++ b/tests/pos/i26646-b-joint/CyclicSignature.java
@@ -1,0 +1,9 @@
+class CyclicSignature<S extends CyclicSignature<S>.Nested.Deeper> {
+    class Nested {
+        class Deeper {}
+    }
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-b-joint/Test.scala
+++ b/tests/pos/i26646-b-joint/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-b-separate/CyclicSignature_JAVA_ONLY_1.java
+++ b/tests/pos/i26646-b-separate/CyclicSignature_JAVA_ONLY_1.java
@@ -1,0 +1,9 @@
+public class CyclicSignature_JAVA_ONLY_1<S extends CyclicSignature_JAVA_ONLY_1<S>.Nested.Deeper> {
+    class Nested {
+        class Deeper {}
+    }
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-b-separate/Test_2.scala
+++ b/tests/pos/i26646-b-separate/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature_JAVA_ONLY_1[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-c-joint/CyclicSignature.java
+++ b/tests/pos/i26646-c-joint/CyclicSignature.java
@@ -1,0 +1,12 @@
+public class CyclicSignature {
+    static class Actual<S extends Actual<S>.Nested.Deeper> {
+        class Nested {
+            class Deeper {}
+        }
+
+        public S test() {
+            return null;
+        }
+    }
+
+}

--- a/tests/pos/i26646-c-joint/Test.scala
+++ b/tests/pos/i26646-c-joint/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature.Actual[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-c-separate/CyclicSignature_JAVA_ONLY_1.java
+++ b/tests/pos/i26646-c-separate/CyclicSignature_JAVA_ONLY_1.java
@@ -1,0 +1,12 @@
+public class CyclicSignature_JAVA_ONLY_1 {
+    static class Actual<S extends Actual<S>.Nested.Deeper> {
+        class Nested {
+            class Deeper {}
+        }
+
+        public S test() {
+            return null;
+        }
+    }
+
+}

--- a/tests/pos/i26646-c-separate/Test_2.scala
+++ b/tests/pos/i26646-c-separate/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature_JAVA_ONLY_1.Actual[Nothing] = ???
+  def x() = a.test()
+}


### PR DESCRIPTION
This includes things like:
* `class CyclicSignature<S extends CyclicSignature<S>.Nested>`
* `class CyclicSignature<S extends CyclicSignature<S>.Nested.Deeper>` Type parameters with self referential prefixes in bounds like these are impossible to define in scala, but can appear in java, with a reference to `java.lang.invoke.ClassSpecializer` in stdlib's MethodHandle specifically causing issues.

This is fixed both in JavaParser (the fix is in Checking.scala file) and ClassfileParser. The behavior for analogous scala code is unchanged (it will still error out). Interestingly, this wasn't an issue in scala 2, however both parsers are quite different there, so moving solutions from scala 2 wasn't possible.

Both java and scala 2 is able to read even more java signatures, like `class Foo<T extends List<Foo<T>.Inner>>`, as both seem to omit having any cyclicity checks this early.
However, as far as I'm aware, actually defining an instance of such type seems impossible (even in java), so perhaps failing early is fine, and we hopefully shouldn't find such java code in the wild, since this would be more difficult to support.

Fixes #26646

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by reading and comprehending the code (comments are mine)

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (<s>including the issue's reproducer, if applicable</s>)
Unfortunately, the reproducer is different, since the original requires a newer idk that we don't use for compilation tests yet. Hovewer, the underlying issue is still tested, and I manually checked that the original reproducer also successfully compiles now.
