### PR TITLE
Cache asSeenFrom results per context

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -14,7 +14,7 @@ import Uniques.*
 import ast.Trees.*
 import Flags.ParamAccessor
 import ast.untpd
-import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, WrappedSourceFile, GenericHashMap}
+import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, WrappedSourceFile, HashMap}
 import typer.{Implicits, ImportInfo, SearchHistory, SearchRoot, TypeAssigner, Typer, Nullables}
 import inlines.Inliner
 import Nullables.*
@@ -125,6 +125,18 @@ object Contexts {
    *      of all class fields of type context; allow them only in allowlisted
    *      classes (which should be short-lived).
    */
+
+  /** Identity-based key for the per-context `asSeenFrom` cache. */
+  private[dotc] final class AsfKey(val tp: Type, val pre: Type, val cls: Symbol):
+    override def hashCode: Int =
+      ((System.identityHashCode(tp) * 31
+        + System.identityHashCode(pre)) * 31
+        + System.identityHashCode(cls))
+    override def equals(other: Any): Boolean = other match
+      case that: AsfKey =>
+        (tp eq that.tp) && (pre eq that.pre) && (cls eq that.cls)
+      case _ => false
+
   abstract class Context(val base: ContextBase) { thiscontext =>
 
     protected given Context = this
@@ -275,24 +287,11 @@ object Contexts {
           None
     )
 
-    /** A hash map whose composite keys compare each component by identity. */
-    private[dotc] class AsSeenFromCache
-        extends GenericHashMap[(Type, Type, Symbol), Type](8, 2) { // same as EqHashSet
-      protected def hash(key: (Type, Type, Symbol)): Int = {
-        (System.identityHashCode(key._1) * 31
-          + System.identityHashCode(key._2)) * 31
-          + System.identityHashCode(key._3)
-      }
-
-      protected def isEqual(x: (Type, Type, Symbol), y: (Type, Type, Symbol)): Boolean =
-        (x._1 eq y._1) && (x._2 eq y._2) && (x._3 eq y._3)
-    }
-
     /** Cache for `TypeOps.asSeenFrom` results computed in this context. */
-    private var asSeenFromCacheMap: AsSeenFromCache | Null = null
-    private[dotc] def asSeenFromCache: AsSeenFromCache =
+    private var asSeenFromCacheMap: HashMap[AsfKey, Type] | Null = null
+    private[dotc] def asSeenFromCache: HashMap[AsfKey, Type] =
       if asSeenFromCacheMap == null then
-        asSeenFromCacheMap = new AsSeenFromCache
+        asSeenFromCacheMap = HashMap()
       asSeenFromCacheMap.nn
 
     private var related: SimpleIdentityMap[Phase | SourceFile, Context] | Null = null

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -14,7 +14,7 @@ import Uniques.*
 import ast.Trees.*
 import Flags.ParamAccessor
 import ast.untpd
-import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, WrappedSourceFile}
+import util.{NoSource, SimpleIdentityMap, SourceFile, HashSet, WrappedSourceFile, GenericHashMap}
 import typer.{Implicits, ImportInfo, SearchHistory, SearchRoot, TypeAssigner, Typer, Nullables}
 import inlines.Inliner
 import Nullables.*
@@ -274,6 +274,26 @@ object Contexts {
           report.error(em"invalid file path: ${ex.getMessage}")
           None
     )
+
+    /** A hash map whose composite keys compare each component by identity. */
+    private[dotc] class AsSeenFromCache
+        extends GenericHashMap[(Type, Type, Symbol), Type](8, 2) { // same as EqHashSet
+      protected def hash(key: (Type, Type, Symbol)): Int = {
+        (System.identityHashCode(key._1) * 31
+          + System.identityHashCode(key._2)) * 31
+          + System.identityHashCode(key._3)
+      }
+
+      protected def isEqual(x: (Type, Type, Symbol), y: (Type, Type, Symbol)): Boolean =
+        (x._1 eq y._1) && (x._2 eq y._2) && (x._3 eq y._3)
+    }
+
+    /** Cache for `TypeOps.asSeenFrom` results computed in this context. */
+    private var asSeenFromCacheMap: AsSeenFromCache | Null = null
+    private[dotc] def asSeenFromCache: AsSeenFromCache =
+      if asSeenFromCacheMap == null then
+        asSeenFromCacheMap = new AsSeenFromCache
+      asSeenFromCacheMap.nn
 
     private var related: SimpleIdentityMap[Phase | SourceFile, Context] | Null = null
 
@@ -551,6 +571,7 @@ object Contexts {
     protected def resetCaches(): Unit =
       implicitsCache = null
       related = null
+      asSeenFromCacheMap = null
 
     /** Reuse this context as a fresh context nested inside `outer`
      *  But keep the typerstate, this one has to be set explicitly if needed.

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -53,7 +53,20 @@ object TypeOps:
       case _ =>
     }
 
-    new AsSeenFromMap(pre, cls).apply(tp)
+    if tp.isProvisional || pre.isProvisional then
+      new AsSeenFromMap(pre, cls).apply(tp)
+    else
+      val cache = ctx.asSeenFromCache
+      val key = (tp, pre, cls)
+      val cached = cache.lookup(key)
+      if cached != null then
+        Stats.record("asSeenFrom cache hit")
+        cached
+      else
+        Stats.record("asSeenFrom cache miss")
+        val res = new AsSeenFromMap(pre, cls).apply(tp)
+        cache.update(key, res)
+        res
   }
 
   /** The TypeMap handling the asSeenFrom */

--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -56,17 +56,13 @@ object TypeOps:
     if tp.isProvisional || pre.isProvisional then
       new AsSeenFromMap(pre, cls).apply(tp)
     else
-      val cache = ctx.asSeenFromCache
-      val key = (tp, pre, cls)
-      val cached = cache.lookup(key)
-      if cached != null then
-        Stats.record("asSeenFrom cache hit")
-        cached
-      else
-        Stats.record("asSeenFrom cache miss")
-        val res = new AsSeenFromMap(pre, cls).apply(tp)
-        cache.update(key, res)
-        res
+      var hit = true
+      val res = ctx.asSeenFromCache.getOrElseUpdate(AsfKey(tp, pre, cls), {
+        hit = false
+        new AsSeenFromMap(pre, cls).apply(tp)
+      })
+      Stats.record(if hit then "asSeenFrom cache hit" else "asSeenFrom cache miss")
+      res
   }
 
   /** The TypeMap handling the asSeenFrom */


### PR DESCRIPTION
Fixes https://github.com/scala/scala3/issues/26777

Cache `TypeOps$.asSeenFrom`. Described details on https://github.com/scala/scala3/issues/26777

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, mostly for discussing how to cache `TypeOps$.asSeenFrom` safely, and ended up storing cache in `Context` and using `GenericHashMap` for it's keys (but I'm doubting about this 🤔 )

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->


Covered by existing tests (this is a refactoring)

