### PR TITLE
Fix Windows build after ASM change

### DIFF
--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -87,10 +87,11 @@ object Properties {
 
   /** all the ASM jars */
   def asmAll: Seq[String] =
+    val sep = java.io.File.separator
     Seq("", "-tree", "-util", "-commons", "-analysis")
       .map(suffix =>
         asm.replaceAll("asm", "asm" + suffix)
-          .replaceFirst("/asm" + suffix + "/", "/asm/"))
+          .replaceFirst(sep + "asm" + suffix + sep, sep + "asm" + sep))
 
   /** jline-terminal jar */
   def jlineTerminal: String = sys.props("dotty.tests.classes.jlineTerminal").nn

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -1,7 +1,7 @@
 package dotty
 
 import java.nio.file.*
-import java.util.regex.Pattern
+import java.util.regex.{Matcher, Pattern}
 
 /** Runtime properties from defines or environmnent */
 object Properties {
@@ -92,7 +92,7 @@ object Properties {
     Seq("", "-tree", "-util", "-commons", "-analysis")
       .map(suffix =>
         asm.replaceAll("asm", "asm" + suffix)
-          .replaceFirst(Pattern.quote(sep + "asm" + suffix + sep), sep + "asm" + sep))
+          .replaceFirst(Pattern.quote(sep + "asm" + suffix + sep), Matcher.quoteReplacement(sep + "asm" + sep)))
 
   /** jline-terminal jar */
   def jlineTerminal: String = sys.props("dotty.tests.classes.jlineTerminal").nn

--- a/compiler/test/dotty/Properties.scala
+++ b/compiler/test/dotty/Properties.scala
@@ -1,6 +1,7 @@
 package dotty
 
 import java.nio.file.*
+import java.util.regex.Pattern
 
 /** Runtime properties from defines or environmnent */
 object Properties {
@@ -91,7 +92,7 @@ object Properties {
     Seq("", "-tree", "-util", "-commons", "-analysis")
       .map(suffix =>
         asm.replaceAll("asm", "asm" + suffix)
-          .replaceFirst(sep + "asm" + suffix + sep, sep + "asm" + sep))
+          .replaceFirst(Pattern.quote(sep + "asm" + suffix + sep), sep + "asm" + sep))
 
   /** jline-terminal jar */
   def jlineTerminal: String = sys.props("dotty.tests.classes.jlineTerminal").nn


### PR DESCRIPTION
[test_windows_full]

One more reason to not treat paths as strings...

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
