### PR TITLE
Check entry.hash before deref WeakReference in WeakHashSet impl

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Uniques.scala
+++ b/compiler/src/dotty/tools/dotc/core/Uniques.scala
@@ -58,8 +58,10 @@ object Uniques:
         def linkedListLoop(entry: Entry[NamedType] | Null): NamedType = entry match
           case null                    => addEntryAt(bucket, newType, h, oldHead)
           case _                       =>
-            val e = entry.get
-            if e != null && (e.prefix eq prefix) && (e.designator eq designator) && (e.isTerm == isTerm) then e
+            if entry.hash == h then
+              val e = entry.get
+              if e != null && (e.prefix eq prefix) && (e.designator eq designator) && (e.isTerm == isTerm) then e
+              else linkedListLoop(entry.tail)
             else linkedListLoop(entry.tail)
 
         linkedListLoop(oldHead)
@@ -93,8 +95,10 @@ object Uniques:
         def linkedListLoop(entry: Entry[AppliedType] | Null): AppliedType = entry match
           case null                    => addEntryAt(bucket, newType, h, oldHead)
           case _                       =>
-            val e = entry.get
-            if e != null && (e.tycon eq tycon) && e.args.eqElements(args) then e
+            if entry.hash == h then
+              val e = entry.get
+              if e != null && (e.tycon eq tycon) && e.args.eqElements(args) then e
+              else linkedListLoop(entry.tail)
             else linkedListLoop(entry.tail)
 
         linkedListLoop(oldHead)

--- a/compiler/src/dotty/tools/dotc/util/WeakHashSet.scala
+++ b/compiler/src/dotty/tools/dotc/util/WeakHashSet.scala
@@ -136,14 +136,17 @@ abstract class WeakHashSet[A <: AnyRef](initialCapacity: Int = 8, loadFactor: Do
   def lookup(elem: A): A | Null =
     Stats.record(statsItem("lookup"))
     removeStaleEntries()
-    val bucket = index(hash(elem))
+    val h = hash(elem)
+    val bucket = index(h)
 
     @tailrec
     def linkedListLoop(entry: Entry[A] | Null): A | Null = entry match {
       case null                    => null
       case _                       =>
-        val entryElem = entry.get
-        if entryElem != null && isEqual(elem, entryElem) then entryElem
+        if entry.hash == h then
+          val entryElem = entry.get
+          if entryElem != null && isEqual(elem, entryElem) then entryElem
+          else linkedListLoop(entry.tail)
         else linkedListLoop(entry.tail)
     }
 
@@ -168,8 +171,10 @@ abstract class WeakHashSet[A <: AnyRef](initialCapacity: Int = 8, loadFactor: Do
     def linkedListLoop(entry: Entry[A] | Null): A = entry match {
       case null                    => addEntryAt(bucket, elem, h, oldHead)
       case _                       =>
-        val entryElem = entry.get
-        if entryElem != null && isEqual(elem, entryElem) then entryElem
+        if entry.hash == h then
+          val entryElem = entry.get
+          if entryElem != null && isEqual(elem, entryElem) then entryElem
+          else linkedListLoop(entry.tail)
         else linkedListLoop(entry.tail)
     }
 
@@ -180,13 +185,16 @@ abstract class WeakHashSet[A <: AnyRef](initialCapacity: Int = 8, loadFactor: Do
   def -=(elem: A): Unit =
     Stats.record(statsItem("-="))
     removeStaleEntries()
-    val bucket = index(hash(elem))
+    val h = hash(elem)
+    val bucket = index(h)
 
     @tailrec
     def linkedListLoop(prevEntry: Entry[A] | Null, entry: Entry[A] | Null): Unit =
       if entry != null then
-        val entryElem = entry.get
-        if entryElem != null && isEqual(elem, entryElem) then remove(bucket, prevEntry, entry)
+        if entry.hash == h then
+          val entryElem = entry.get
+          if entryElem != null && isEqual(elem, entryElem) then remove(bucket, prevEntry, entry)
+          else linkedListLoop(entry, entry.tail)
         else linkedListLoop(entry, entry.tail)
 
     linkedListLoop(null, table(bucket))


### PR DESCRIPTION
Scala 3's internal WeakHashSet is implemented using separate chaining. Previously, when traversing the chain, each entry would (unconditionally) dereference its
WeakReference to check whether it matches with the entry we're looking up. However, if we first check whether the hash match, we can skip dereference in the first place.

I temporarily added counter (Record) to measure how many entries in the `linkedListLoop` could be skipped thanks to hash mismatches, and found that in `scalaz` / `AppliedUniques`, about 38% could skip the deref.

Unfortunately, when I run `scala3-benchmark` locally, I couldn't see the noticeable performance change overall because `linkedListLoop` in scalaz accounts for around 4%). While the number is pretty small, I think this is safe micro-opt and there shouldn't be any risks (of performance regression or memory usage).

Fixes https://github.com/scala/scala3/issues/26790

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

Covered by existing tests (this is a refactoring)
