### PR TITLE
Resurrect parboiled2 in community build

### DIFF
--- a/community-build/src/scala/dotty/communitybuild/projects.scala
+++ b/community-build/src/scala/dotty/communitybuild/projects.scala
@@ -81,6 +81,9 @@ sealed case class MillCommunityProject(
   override val runCommandsArgs = List("-i", "-D", s"dottyVersion=$compilerVersion")
   override val environment = Map.empty
 
+val sbt1Version = "1.12.1"
+val sbt2Version = "2.0.3"
+
 final case class SbtCommunityProject(
     project: String,
     sbtTestCommand: String,
@@ -89,6 +92,7 @@ final case class SbtCommunityProject(
     sbtDocCommand: String = null,
     scalacOptions: List[String] = SbtCommunityProject.scalacOptions,
     override val environment: Map[String, String] = Map.empty,
+    sbtVersion: String = sbt1Version
   ) extends CommunityProject:
   override val binaryName: String = "sbt"
 
@@ -117,7 +121,7 @@ final case class SbtCommunityProject(
     val sbtProps = Option(System.getProperty("sbt.ivy.home")) match
       case Some(ivyHome) => List(s"-Dsbt.ivy.home=$ivyHome")
       case _ => Nil
-    extraSbtArgs ++ sbtProps ++ List("-sbt-version", "1.12.1", "-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
+    extraSbtArgs ++ sbtProps ++ List(s"-Dsbt.version=$sbtVersion", "-Dsbt.supershell=false", s"--addPluginSbtFile=$sbtPluginFilePath")
 
 object SbtCommunityProject:
   def scalacOptions = List(
@@ -687,13 +691,13 @@ object projects:
     scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Wsafe-init"),
   )
 
-  // Disabled because it requires SBT 2
-  /*lazy val parboiled2 = SbtCommunityProject(
+  lazy val parboiled2 = SbtCommunityProject(
     project = "parboiled2",
-    sbtTestCommand = "parboiledCoreJVM3/test; parboiledJVM3/test",
+    sbtTestCommand = "parboiledCoreJVM3/testFull; parboiledJVM3/testFull",
     sbtPublishCommand = "publishLocal",
     scalacOptions = SbtCommunityProject.scalacOptions.filter(_ != "-Xcheck-macros"),
-  )*/
+    sbtVersion = sbt2Version,
+  )
 
 end projects
 
@@ -774,7 +778,7 @@ def allProjects = List(
   projects.specs2,
   projects.spire,
   projects.http4s,
-  //projects.parboiled2,
+  projects.parboiled2,
 )
 
 lazy val projectMap = allProjects.groupBy(_.project)

--- a/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
+++ b/community-build/test/scala/dotty/communitybuild/CommunityBuildTest.scala
@@ -75,7 +75,7 @@ class CommunityBuildTestC:
   //@Test def onnxScala = projects.onnxScala.run()
   @Test def oslib = projects.oslib.run()
   // @Test def oslibWatch = projects.oslibWatch.run()
-  //@Test def parboiled2 = projects.parboiled2.run()
+  @Test def parboiled2 = projects.parboiled2.run()
   // Disabled because `javax.xml.bind` is not available since java 11
   // @Test def playJson = projects.playJson.run()
   @Test def pprint = projects.pprint.run()


### PR DESCRIPTION
Ref https://github.com/scala/scala3/pull/26660

This brings back Parboiled2, which uses sbt 2.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

```bash
sbt --client 'community-build/testOnly -- *parboiled2'
```

ran their tests.

## Test

https://github.com/scala/scala3/actions/runs/31726209244/job/94535098618?pr=26797

<details>

<summary>
[info] Test dotty.communitybuild.CommunityBuildTestC.parboiled2 started
Building parboiled2 with dotty-bootstrapped 3.10.0-RC1-bin-SNAPSHOT...
....
</summary>

```bash
[info] Test dotty.communitybuild.CommunityBuildTestC.parboiled2 started
Building parboiled2 with dotty-bootstrapped 3.10.0-RC1-bin-SNAPSHOT...
sbt -Dsbt.version=2.0.3 -Dsbt.supershell=false --addPluginSbtFile=/home/runner/work/scala3/scala3/community-build/sbt-injected-plugins set Global/testOptions += Tests.Argument(TestFramework("munit.Framework"), "+l"); clean; set Global/logLevel := Level.Error; set Global/updateOptions ~= (_.withLatestSnapshots(false)); set Global/scalacOptions ++= List("-Wsafe-init","-Yexplicit-nulls","-language:unsafeNulls");++3.10.0-RC1-bin-SNAPSHOT!; parboiledCoreJVM3/testFull; parboiledJVM3/testFull
[info] entering thin client - BEEP WHIRR
[info] starting sbt server in the background
[info] use 'sbt shutdown' to shutdown the server
[info]  
[info] welcome to sbt 2.0.3 (Eclipse Adoptium Java 17.0.20)
[info] loading project definition from /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/project
[info] compiling 1 Scala source to /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/target/out/jvm/scala-3.8.4/parboiled2-build/classes ...
[info] done compiling
[info] resolving key references (37998 settings) ...
[info] looking for workflow definition in /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/.github/workflows
[warn] unable to find or parse workflow YAML definition
[warn] assuming the empty map for `githubWorkflowDefinition`
[info] set current project to parboiled2-root (in build file:/home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/)
[info] Defining Global / testOptions
[info] The new value will be used by Test / test / testOptionDigests, Test / test / testOptions and 245 others.
[info] 	Run `last` for details.
[info] Reapplying settings...
[info] looking for workflow definition in /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/.github/workflows
[warn] unable to find or parse workflow YAML definition
[warn] assuming the empty map for `githubWorkflowDefinition`
[info] set current project to parboiled2-root (in build file:/home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/)
[info] Defining Global / logLevel
[info] The new value will be used by Test / test / testListeners, Test / testOnly / testListeners and 261 others.
[info] 	Run `last` for details.
[info] Reapplying settings...
[info] looking for workflow definition in /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/.github/workflows
[warn] unable to find or parse workflow YAML definition
[warn] assuming the empty map for `githubWorkflowDefinition`
[info] set current project to parboiled2-root (in build file:/home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/)
[info] Defining Global / updateOptions
[info] The new value will be used by dependencyTreeIgnoreMissingUpdate / updateOptions, examples2_12 / dependencyTreeIgnoreMissingUpdate / updateOptions and 53 others.
[info] 	Run `last` for details.
[info] Reapplying settings...
[info] looking for workflow definition in /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/.github/workflows
[warn] unable to find or parse workflow YAML definition
[warn] assuming the empty map for `githubWorkflowDefinition`
[info] set current project to parboiled2-root (in build file:/home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/)
[info] Defining Global / scalacOptions
[info] The new value will be used by examples2_12 / scalacOptions, examples2_13 / scalacOptions and 25 others.
[info] 	Run `last` for details.
[info] Reapplying settings...
[info] looking for workflow definition in /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/.github/workflows
[warn] unable to find or parse workflow YAML definition
[warn] assuming the empty map for `githubWorkflowDefinition`
[info] set current project to parboiled2-root (in build file:/home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/)
[info] Forcing Scala version to 3.10.0-RC1-bin-SNAPSHOT on all projects.
[info] Reapplying settings...
[info] looking for workflow definition in /home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/.github/workflows
[warn] unable to find or parse workflow YAML definition
[warn] assuming the empty map for `githubWorkflowDefinition`
[info] set current project to parboiled2-root (in build file:/home/runner/work/scala3/scala3/community-build/community-projects/parboiled2/)
[info] Running in CI, enabling Scala2 optimizer
[info] Running in CI, enabling Scala2 optimizer
[info] Running in CI, enabling Scala2 optimizer
-------------------------------- Running Tests --------------------------------
-------------------------------- Running Tests --------------------------------
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.enable parsing of RFC2045 Strings 56ms  
+ org.parboiled2.DynamicRuleDispatchSpec.DynamicRuleDispatch.work as expected when selecting from 0 rules 17ms  
+ org.parboiled2.DynamicRuleDispatchSpec.DynamicRuleDispatch.work as expected when selecting from 1 rule 0ms  
+ org.parboiled2.DynamicRuleDispatchSpec.DynamicRuleDispatch.work as expected when selecting from 2 rules 1ms  
+ org.parboiled2.DynamicRuleDispatchSpec.DynamicRuleDispatch.work as expected when selecting from 3 rules 1ms  
+ org.parboiled2.DynamicRuleDispatchSpec.DynamicRuleDispatch.work as expected when selecting from 4 rules 1ms  
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.enable parsing of RFC2045 Blocks 8ms  
+ org.parboiled2.DynamicRuleDispatchSpec.DynamicRuleDispatch.work as expected when selecting from 5 rules 2ms  
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.enable parsing of custom-Base64 Strings 4ms  
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.enable parsing of custom-Base64 Blocks 4ms  
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.reject RFC2045 Strings with trailing garbage 27ms  
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.reject RFC2045 Blocks with trailing garbage 11ms  
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.reject custom-Base64 Strings with trailing garbage 8ms  
+ org.parboiled2.Base64ParsingSpec.Base64Parsing.reject custom-Base64 Blocks with trailing garbage 7ms  
[success] elapsed time: 32 s
```

</details>

