### PR TITLE
Drop REPL parse warnings on parse error

### DIFF
--- a/compiler/src/dotty/tools/dotc/Run.scala
+++ b/compiler/src/dotty/tools/dotc/Run.scala
@@ -82,9 +82,10 @@ extends ImplicitRunInfo, ConstraintRunInfo, cc.CaptureRunInfo {
     // When the REPL creates a new run (ReplDriver.compile), parsing is already done in the old context, with the
     // previous Run. Parser warnings were suspended in the old run and need to be copied over so they are not lost.
     // Same as scala/scala/commit/79ca1408c7.
-    def initSuspendedMessages(oldRun: Run | Null) = if oldRun != null then
+    def initSuspendedMessages(oldRun: Run | Null) =
       mySuspendedMessages.clear()
-      mySuspendedMessages ++= oldRun.mySuspendedMessages
+      if oldRun != null then
+        mySuspendedMessages ++= oldRun.mySuspendedMessages
 
     def suppressionsComplete(source: SourceFile) = source == NoSource || mySuppressionsComplete(source)
 

--- a/repl/src/dotty/tools/repl/ReplCompiler.scala
+++ b/repl/src/dotty/tools/repl/ReplCompiler.scala
@@ -48,7 +48,7 @@ class ReplCompiler extends Compiler:
   )
 
   def newRun(initCtx: Context, state: State): Run =
-    val run = new Run(this, initCtx) {
+    new Run(this, initCtx):
       /** Import previous runs and user defined imports */
       override protected def rootContext(using Context): Context = {
         def importContext(imp: tpd.Import)(using Context) =
@@ -74,9 +74,7 @@ class ReplCompiler extends Compiler:
         (state.validObjectIndexes).foldLeft(rootCtx)((ctx, id) =>
           importPreviousRun(id)(using ctx))
       }
-    }
-    run.suppressions.initSuspendedMessages(state.context.run)
-    run
+    .tap(_.suppressions.initSuspendedMessages(state.context.run))
   end newRun
 
   private def packaged(stats: List[untpd.Tree])(using Context): untpd.PackageDef =

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -454,42 +454,39 @@ class ReplDriver(settings: Array[String],
           displayErrors(errs, errState)
           istate.afterFailedCompilation(errState.objectIndex)
         ,
-        {
-          case (unit: CompilationUnit, newState: State) =>
-            val newestWrapper = extractNewestWrapper(unit.untpdTree)
-            val newImports = extractTopLevelImports(newState.context)
-            var allImports = newState.imports
-            if (newImports.nonEmpty)
-              allImports += (newState.objectIndex -> newImports)
-            val newStateWithImports = newState.copy(
-              imports = allImports,
-              context = contextWithNewImports(newState.context, newImports)
-            )
+        (unit, newState) =>
+          val newestWrapper = extractNewestWrapper(unit.untpdTree)
+          val newImports = extractTopLevelImports(newState.context)
+          var allImports = newState.imports
+          if (newImports.nonEmpty)
+            allImports += (newState.objectIndex -> newImports)
+          val newStateWithImports = newState.copy(
+            imports = allImports,
+            context = contextWithNewImports(newState.context, newImports)
+          )
 
-            val warnings = newState.context.reporter
-              .removeBufferedMessages(using newState.context)
+          val warnings = newState.context.reporter
+            .removeBufferedMessages(using newState.context)
 
-            inContext(newState.context) {
-              val (updatedState, definitions) =
-                if (!ctx.settings.XreplDisableDisplay.value)
-                  renderDefinitions(unit.tpdTree, newestWrapper)(using newStateWithImports)
-                else
-                  (newStateWithImports, Seq.empty)
+          inContext(newState.context):
+            val (updatedState, definitions) =
+              if (!ctx.settings.XreplDisableDisplay.value)
+                renderDefinitions(unit.tpdTree, newestWrapper)(using newStateWithImports)
+              else
+                (newStateWithImports, Seq.empty)
 
-              // output is printed in the order it was put in. warnings should be
-              // shown before infos (eg. typedefs) for the same line. column
-              // ordering is mostly to make tests deterministic
-              given Ordering[Diagnostic] =
-                Ordering[(Int, Int, Int)].on(d => (d.pos.line, -d.level, d.pos.column))
+            // output is printed in the order it was put in. warnings should be
+            // shown before infos (e.g. typedefs) for the same line.
+            // column ordering is mostly to make tests deterministic
+            given Ordering[Diagnostic] =
+              Ordering[(Int, Int, Int)].on(d => (d.pos.line, -d.level, d.pos.column))
 
-              (if istate.quiet then warnings else definitions ++ warnings)
-                .sorted
-                .foreach(printDiagnostic)
+            (if istate.quiet then warnings else definitions ++ warnings)
+              .sorted
+              .foreach(printDiagnostic)
 
-              if updatedState.invalidObjectIndexes.contains(updatedState.objectIndex) then updatedState
-              else updatedState.recordInput(parsed.source.content().mkString)
-            }
-        }
+            if updatedState.invalidObjectIndexes.contains(updatedState.objectIndex) then updatedState
+            else updatedState.recordInput(parsed.source.content().mkString)
       )
   }
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -402,7 +402,9 @@ class ReplDriver(settings: Array[String],
         else state
 
       case SyntaxErrors(_, errs, _) =>
-        state.context.run.suppressions.initSuspendedMessages(oldRun = null)
+        // if there is a Run that is tracking suspended parse warnings, ignore (drop) them when erroring
+        if state.context.run != null then
+          state.context.run.suppressions.initSuspendedMessages(oldRun = null)
         displayErrors(errs, state)
 
       case CommandThenCode(cmd, code) =>

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -402,6 +402,7 @@ class ReplDriver(settings: Array[String],
         else state
 
       case SyntaxErrors(_, errs, _) =>
+        state.context.run.suppressions.initSuspendedMessages(oldRun = null)
         displayErrors(errs, state)
 
       case CommandThenCode(cmd, code) =>

--- a/repl/src/dotty/tools/repl/package.scala
+++ b/repl/src/dotty/tools/repl/package.scala
@@ -4,6 +4,6 @@ package repl
 import dotc.reporting.{HideNonSensicalMessages, StoreReporter, UniqueMessagePositions}
 
 /** Create empty outer store reporter */
-private[repl] def newStoreReporter: StoreReporter =
-  new StoreReporter(null)
-  with UniqueMessagePositions with HideNonSensicalMessages
+private[repl] def newStoreReporter: StoreReporter = ReplReporter()
+
+private[repl] class ReplReporter extends StoreReporter(null), UniqueMessagePositions, HideNonSensicalMessages

--- a/repl/test-resources/repl/10886
+++ b/repl/test-resources/repl/10886
@@ -6,5 +6,5 @@ scala> type SelChannel[C <: Tuple] = C match { case x *: xs => x | SelChannel[xs
 scala> lazy val a: SelChannel[("A", "B", "C")] = "A"
 lazy val a: "A" | ("B" | ("C" | Nothing))
 
-scala>:type a
+scala> :type a
 ("A" : String) | (("B" : String) | (("C" : String) | Nothing))

--- a/repl/test-resources/repl/1379
+++ b/repl/test-resources/repl/1379
@@ -1,6 +1,6 @@
-scala>  object Foo { val bar = new Object { def baz = 1 }; bar.baz }
+scala> object Foo { val bar = new Object { def baz = 1 }; bar.baz }
 -- [E008] Not Found Error: -----------------------------------------------------
-1 |  object Foo { val bar = new Object { def baz = 1 }; bar.baz }
-  |                                                     ^^^^^^^
+1 |object Foo { val bar = new Object { def baz = 1 }; bar.baz }
+  |                                                   ^^^^^^^
   |                                       value baz is not a member of Object
 1 error found

--- a/repl/test-resources/repl/commandPrefixes
+++ b/repl/test-resources/repl/commandPrefixes
@@ -1,6 +1,6 @@
-scala>:ty 123
+scala> :ty 123
 Int
-scala>:type 123
+scala> :type 123
 Int
-scala>:typee 123
+scala> :typee 123
 Unknown command: ":typee", run ":help" for a list of commands

--- a/repl/test-resources/repl/errmsgs
+++ b/repl/test-resources/repl/errmsgs
@@ -2,33 +2,33 @@ scala> class Inv[T](x: T)
 // defined class Inv
 scala> val x: List[String] = List(1)
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val x: List[String] = List(1)
-  |                            ^
-  |                            Found:    (1 : Int)
-  |                            Required: String
+1 |val x: List[String] = List(1)
+  |                           ^
+  |                           Found:    (1 : Int)
+  |                           Required: String
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> val y: List[List[String]] = List(List(1))
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val y: List[List[String]] = List(List(1))
-  |                                       ^
-  |                                       Found:    (1 : Int)
-  |                                       Required: String
+1 |val y: List[List[String]] = List(List(1))
+  |                                      ^
+  |                                      Found:    (1 : Int)
+  |                                      Required: String
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> val z: (List[String], List[Int]) = (List(1), List("a"))
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val z: (List[String], List[Int]) = (List(1), List("a"))
-  |                                          ^
-  |                                          Found:    (1 : Int)
-  |                                          Required: String
+1 |val z: (List[String], List[Int]) = (List(1), List("a"))
+  |                                         ^
+  |                                         Found:    (1 : Int)
+  |                                         Required: String
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val z: (List[String], List[Int]) = (List(1), List("a"))
-  |                                                   ^^^
+1 |val z: (List[String], List[Int]) = (List(1), List("a"))
+  |                                                  ^^^
   |                                                  Found:    ("a" : String)
   |                                                  Required: Int
   |
@@ -36,26 +36,26 @@ scala> val z: (List[String], List[Int]) = (List(1), List("a"))
 2 errors found
 scala> val a: Inv[String] = new Inv(new Inv(1))
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val a: Inv[String] = new Inv(new Inv(1))
-  |                              ^^^^^^^^^^
-  |                              Found:    Inv[Int]
-  |                              Required: String
+1 |val a: Inv[String] = new Inv(new Inv(1))
+  |                             ^^^^^^^^^^
+  |                             Found:    Inv[Int]
+  |                             Required: String
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> val b: Inv[String] = new Inv(1)
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val b: Inv[String] = new Inv(1)
-  |                              ^
-  |                              Found:    (1 : Int)
-  |                              Required: String
+1 |val b: Inv[String] = new Inv(1)
+  |                             ^
+  |                             Found:    (1 : Int)
+  |                             Required: String
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
-  |                                                                                  ^
+1 |abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
+  |                                                                                 ^
   |Found:    (C.this.x : C.this.T)
   |Required: T²
   |
@@ -64,8 +64,8 @@ scala> abstract class C { type T; val x: T; val s: Unit = { type T = String; var
   |
   | longer explanation available when compiling with `-explain`
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
-  |                                                                                                                                    ^
+1 |abstract class C { type T; val x: T; val s: Unit = { type T = String; var y: T = x; locally { def f() = { type T = Int; val z: T = y }; f() } }; }
+  |                                                                                                                                   ^
   |Found:    (y : T)
   |Required: T²
   |
@@ -76,47 +76,47 @@ scala> abstract class C { type T; val x: T; val s: Unit = { type T = String; var
 2 errors found
 scala> class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
 -- [E008] Not Found Error: -----------------------------------------------------
-1 | class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
-  |                                                        ^^^^^^^^
+1 |class Foo() { def bar: Int = 1 }; val foo = new Foo(); foo.barr
+  |                                                       ^^^^^^^^
   |                 value barr is not a member of Foo - did you mean foo.bar?
 1 error found
 scala> val x: List[Int] = "foo" :: List(1)
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val x: List[Int] = "foo" :: List(1)
-  |                    ^^^^^
-  |                    Found:    ("foo" : String)
-  |                    Required: Int
+1 |val x: List[Int] = "foo" :: List(1)
+  |                   ^^^^^
+  |                   Found:    ("foo" : String)
+  |                   Required: Int
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> while (((  foo ))) {}
 -- [E006] Not Found Error: -----------------------------------------------------
-1 | while (((  foo ))) {}
-  |            ^^^
-  |            Not found: foo
+1 |while (((  foo ))) {}
+  |           ^^^
+  |           Not found: foo
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> val a: iDontExist = 1
 -- [E006] Not Found Error: -----------------------------------------------------
-1 | val a: iDontExist = 1
-  |        ^^^^^^^^^^
-  |        Not found: type iDontExist
+1 |val a: iDontExist = 1
+  |       ^^^^^^^^^^
+  |       Not found: type iDontExist
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> def foo1(x: => Int) = x _
 -- [E099] Syntax Error: --------------------------------------------------------
-1 | def foo1(x: => Int) = x _
-  |                       ^^^
+1 |def foo1(x: => Int) = x _
+  |                      ^^^
   |Only function types can be followed by _ but the current expression has type Int
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> def foo2(x: => Int): () => Int = x _
 -- [E099] Syntax Error: --------------------------------------------------------
-1 | def foo2(x: => Int): () => Int = x _
-  |                                  ^^^
+1 |def foo2(x: => Int): () => Int = x _
+  |                                 ^^^
   |Only function types can be followed by _ but the current expression has type Int
   |
   | longer explanation available when compiling with `-explain`

--- a/repl/test-resources/repl/i13208.default.scala
+++ b/repl/test-resources/repl/i13208.default.scala
@@ -1,10 +1,10 @@
 scala> try 1
 1 warning found
 -- [E002] Syntax Warning: ------------------------------------------------------
-1 | try 1
-  | ^^^^^
-  | A try without catch or finally is equivalent to putting
-  | its body in a block; no exceptions are handled.
+1 |try 1
+  |^^^^^
+  |A try without catch or finally is equivalent to putting
+  |its body in a block; no exceptions are handled.
   |
   | longer explanation available when compiling with `-explain`
 val res0: Int = 1

--- a/repl/test-resources/repl/i1370
+++ b/repl/test-resources/repl/i1370
@@ -1,7 +1,7 @@
 scala> object Lives { class Private { def foo1: Any = new Private.C1; def foo2: Any = new Private.C2 };  object Private { class C1 private {}; private class C2 {} } }
 -- [E173] Reference Error: -----------------------------------------------------
-1 | object Lives { class Private { def foo1: Any = new Private.C1; def foo2: Any = new Private.C2 };  object Private { class C1 private {}; private class C2 {} } }
-  |                                                    ^^^^^^^^^^
+1 |object Lives { class Private { def foo1: Any = new Private.C1; def foo2: Any = new Private.C2 };  object Private { class C1 private {}; private class C2 {} } }
+  |                                                   ^^^^^^^^^^
   |constructor C1 cannot be accessed as a member of Lives.Private.C1 from class Private.
   |  private constructor C1 can only be accessed from class C1 in object Private.
 1 error found

--- a/repl/test-resources/repl/i18383
+++ b/repl/test-resources/repl/i18383
@@ -1,13 +1,13 @@
-scala>:settings -Wunused:all
+scala> :settings -Wunused:all
 
 scala> import scala.collection.*
 
 scala> class Foo { import scala.util.*; println("foo") }
 1 warning found
 -- [E198] Unused Symbol Warning: -----------------------------------------------
-1 | class Foo { import scala.util.*; println("foo") }
-  |                               ^
-  |                               unused import
+1 |class Foo { import scala.util.*; println("foo") }
+  |                              ^
+  |                              unused import
 // defined class Foo
 
 scala> { import scala.util.*; "foo" }

--- a/repl/test-resources/repl/i2063
+++ b/repl/test-resources/repl/i2063
@@ -1,23 +1,23 @@
 scala> 	class Foo extends Bar // with one tab
 -- [E006] Not Found Error: -----------------------------------------------------
-1 | 	class Foo extends Bar // with one tab
-  | 	                  ^^^
-  | 	                  Not found: type Bar
+1 |	class Foo extends Bar // with one tab
+  |	                  ^^^
+  |	                  Not found: type Bar
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala>                                                                               class Foo extends Bar // with spaces
 -- [E006] Not Found Error: -----------------------------------------------------
-1 |                                                                               class Foo extends Bar // with spaces
-  |                                                                                                 ^^^
+1 |                                                                              class Foo extends Bar // with spaces
+  |                                                                                                ^^^
   |                                                       Not found: type Bar
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala>                                                                                  class Foo extends Bar // with tabs
 -- [E006] Not Found Error: -----------------------------------------------------
-1 |                                                                                  class Foo extends Bar // with tabs
-  |                                                                                                    ^^^
+1 |                                                                                 class Foo extends Bar // with tabs
+  |                                                                                                   ^^^
   |                                                       Not found: type Bar
   |
   | longer explanation available when compiling with `-explain`

--- a/repl/test-resources/repl/i21655
+++ b/repl/test-resources/repl/i21655
@@ -1,2 +1,2 @@
-scala>:kind
+scala> :kind
 The :kind command is not currently supported.

--- a/repl/test-resources/repl/i21657
+++ b/repl/test-resources/repl/i21657
@@ -1,2 +1,2 @@
-scala>:sh
+scala> :sh
 The :sh command is deprecated. Use `import scala.sys.process._` and `"command".!` instead.

--- a/repl/test-resources/repl/i2213
+++ b/repl/test-resources/repl/i2213
@@ -1,13 +1,13 @@
 scala> def x
 -- [E019] Syntax Error: --------------------------------------------------------
-1 | def x
-  |      ^
-  |      Missing return type
+1 |def x
+  |     ^
+  |     Missing return type
   |
   | longer explanation available when compiling with `-explain`
 scala> def x: Int
 -- [E067] Syntax Error: --------------------------------------------------------
-1 | def x: Int
-  |     ^
+1 |def x: Int
+  |    ^
   |Declaration of method x not allowed here: only classes can have declared but undefined members
 1 error found

--- a/repl/test-resources/repl/i25055
+++ b/repl/test-resources/repl/i25055
@@ -1,0 +1,10 @@
+scala> try:
+-- [E018] Syntax Error: --------------------------------------------------------
+1 |try:
+  |   ^
+  |   expression expected but : found
+  |
+  | longer explanation available when compiling with `-explain`
+
+scala> 42
+val res0: Int = 42

--- a/repl/test-resources/repl/i2631
+++ b/repl/test-resources/repl/i2631
@@ -1,6 +1,6 @@
 scala> class Foo(x : Any) { val foo : Integer = 0; def this() = { this(foo) } }
 -- Error: ----------------------------------------------------------------------
-1 | class Foo(x : Any) { val foo : Integer = 0; def this() = { this(foo) } }
-  |                                                                 ^^^
+1 |class Foo(x : Any) { val foo : Integer = 0; def this() = { this(foo) } }
+  |                                                                ^^^
   |                          foo is not accessible from constructor arguments
 1 error found

--- a/repl/test-resources/repl/i4184
+++ b/repl/test-resources/repl/i4184
@@ -6,8 +6,8 @@ scala> implicit def eqFoo: CanEqual[foo.Foo, foo.Foo] = CanEqual.derived
 def eqFoo: CanEqual[foo.Foo, foo.Foo]
 scala> object Bar { new foo.Foo == new bar.Foo }
 -- [E172] Type Error: ----------------------------------------------------------
-1 | object Bar { new foo.Foo == new bar.Foo }
-  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+1 |object Bar { new foo.Foo == new bar.Foo }
+  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     Values of types foo.Foo and bar.Foo² cannot be compared with == or !=
   |
   |     where:    Foo  is a class in object foo

--- a/repl/test-resources/repl/i4217
+++ b/repl/test-resources/repl/i4217
@@ -1,11 +1,11 @@
 scala> def foo(x: Option[Int]) = x match { case None => }
 1 warning found
 -- [E029] Pattern Match Exhaustivity Warning: ----------------------------------
-1 | def foo(x: Option[Int]) = x match { case None => }
-  |                           ^
-  |                           match may not be exhaustive.
+1 |def foo(x: Option[Int]) = x match { case None => }
+  |                          ^
+  |                          match may not be exhaustive.
   |
-  |                           It would fail on pattern case: Some(_)
+  |                          It would fail on pattern case: Some(_)
   |
   | longer explanation available when compiling with `-explain`
 def foo(x: Option[Int]): Unit

--- a/repl/test-resources/repl/i4566
+++ b/repl/test-resources/repl/i4566
@@ -1,7 +1,7 @@
 scala> object test { type ::[A, B]; def a: Int :: Int = ???; def b: Int = a }
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | object test { type ::[A, B]; def a: Int :: Int = ???; def b: Int = a }
-  |                                                                    ^
+1 |object test { type ::[A, B]; def a: Int :: Int = ???; def b: Int = a }
+  |                                                                   ^
   |                                                      Found:    Int :: Int
   |                                                      Required: Int
   |

--- a/repl/test-resources/repl/i5733
+++ b/repl/test-resources/repl/i5733
@@ -3,7 +3,7 @@ scala> abstract class F { def f(arg: Any): Unit; override def toString = "F" }
 scala> val f: F = println
 1 warning found
 -- Warning: --------------------------------------------------------------------
-1 | val f: F = println
-  |            ^^^^^^^
+1 |val f: F = println
+  |           ^^^^^^^
   |method println is eta-expanded even though F does not have the @FunctionalInterface annotation.
 val f: F = F

--- a/repl/test-resources/repl/i5890
+++ b/repl/test-resources/repl/i5890
@@ -1,4 +1,4 @@
-scala>
+scala> 
 
 scala> {}
 

--- a/repl/test-resources/repl/i6474
+++ b/repl/test-resources/repl/i6474
@@ -10,9 +10,9 @@ scala> ((1, 2): Foo2.T[Int][Int]): Foo2.T[Any][Int]
 val res1: Foo2.T[Any][Int] = (1, 2)
 scala> (1, 2): Foo3.T[Int][Int]
 -- [E056] Syntax Error: --------------------------------------------------------
-1 | (1, 2): Foo3.T[Int][Int]
-  |         ^^^^^^^^^^^^^^^^
-  |         Missing type parameter for Foo3.T[Int][Int]
+1 |(1, 2): Foo3.T[Int][Int]
+  |        ^^^^^^^^^^^^^^^^
+  |        Missing type parameter for Foo3.T[Int][Int]
 1 error found
 scala> ((1, 2): Foo3.T[Int][Int][Int]): Foo3.T[Any][Int][Int]
 val res2: Foo3.T[Any][Int][Int] = (1, 2)

--- a/repl/test-resources/repl/i6643
+++ b/repl/test-resources/repl/i6643
@@ -1,5 +1,5 @@
 scala> import scala.collection._
-scala>:type 1
+scala> :type 1
 Int
 scala> object IterableTest { def g[CC[_] <: Iterable[?] & IterableOps[?, ?, ?]](from: CC[Int]): IterableFactory[CC] = ??? }
 // defined object IterableTest

--- a/repl/test-resources/repl/i6676
+++ b/repl/test-resources/repl/i6676
@@ -1,25 +1,25 @@
 scala> xml"
 -- Error: ----------------------------------------------------------------------
-1 | xml"
-  |    ^
-  |    unclosed string literal
+1 |xml"
+  |   ^
+  |   unclosed string literal
 scala> xml""
 -- [E008] Not Found Error: -----------------------------------------------------
-1 | xml""
-  | ^^^^^
-  | value xml is not a member of StringContext
+1 |xml""
+  |^^^^^
+  |value xml is not a member of StringContext
 1 error found
 scala> xml"""
 -- Error: ----------------------------------------------------------------------
-1 | xml"""
-  |    ^
-  |    unclosed multi-line string literal
+1 |xml"""
+  |   ^
+  |   unclosed multi-line string literal
 -- Error: ----------------------------------------------------------------------
-1 | xml"""
-  |       ^
-  |       unclosed multi-line string literal
+1 |xml"""
+  |      ^
+  |      unclosed multi-line string literal
 scala> s"
 -- Error: ----------------------------------------------------------------------
-1 | s"
-  |  ^
-  |  unclosed string literal
+1 |s"
+  | ^
+  | unclosed string literal

--- a/repl/test-resources/repl/i7644
+++ b/repl/test-resources/repl/i7644
@@ -1,16 +1,16 @@
 scala> class T extends CanEqual
 -- [E112] Syntax Error: --------------------------------------------------------
-1 | class T extends CanEqual
-  |       ^
-  |       Cannot extend sealed trait CanEqual in a different source file
+1 |class T extends CanEqual
+  |      ^
+  |      Cannot extend sealed trait CanEqual in a different source file
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> class T extends CanEqual
 -- [E112] Syntax Error: --------------------------------------------------------
-1 | class T extends CanEqual
-  |       ^
-  |       Cannot extend sealed trait CanEqual in a different source file
+1 |class T extends CanEqual
+  |      ^
+  |      Cannot extend sealed trait CanEqual in a different source file
   |
   | longer explanation available when compiling with `-explain`
 1 error found

--- a/repl/test-resources/repl/i9227
+++ b/repl/test-resources/repl/i9227
@@ -1,6 +1,6 @@
 scala> import scala.quoted._; inline def myMacro[T]: Unit = ${ myMacroImpl[T] }; def myMacroImpl[T](using Quotes): Expr[Unit] = '{}; println(myMacro[Int])
 -- Error: ----------------------------------------------------------------------
-1 | import scala.quoted._; inline def myMacro[T]: Unit = ${ myMacroImpl[T] }; def myMacroImpl[T](using Quotes): Expr[Unit] = '{}; println(myMacro[Int])
-  |                                                                                                                                       ^^^^^^^^^^^^
+1 |import scala.quoted._; inline def myMacro[T]: Unit = ${ myMacroImpl[T] }; def myMacroImpl[T](using Quotes): Expr[Unit] = '{}; println(myMacro[Int])
+  |                                                                                                                                      ^^^^^^^^^^^^
   |      Cannot call macro method myMacroImpl defined in the same source file
 1 error found

--- a/repl/test-resources/repl/i9538
+++ b/repl/test-resources/repl/i9538
@@ -1,5 +1,5 @@
-scala>:type
+scala> :type
 :type <expression>
 
-scala>:doc
+scala> :doc
 :doc <expression>

--- a/repl/test-resources/repl/importFromObj
+++ b/repl/test-resources/repl/importFromObj
@@ -6,10 +6,10 @@ scala> object o { val xs = List(1, 2, 3) }
 scala> import o._
 scala> buf += xs
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | buf += xs
-  |        ^^
-  |        Found:    (o.xs : List[Int])
-  |        Required: Int
+1 |buf += xs
+  |       ^^
+  |       Found:    (o.xs : List[Int])
+  |       Required: Int
   |
   | longer explanation available when compiling with `-explain`
 1 error found
@@ -17,13 +17,13 @@ scala> buf ++= xs
 val res0: mutable.ListBuffer[Int] = ListBuffer(1, 2, 3)
 scala> import util.foobar
 -- [E008] Not Found Error: -----------------------------------------------------
-1 | import util.foobar
-  |             ^^^^^^
-  |             value foobar is not a member of util
+1 |import util.foobar
+  |            ^^^^^^
+  |            value foobar is not a member of util
 1 error found
 scala> import util.foobar.bar
 -- [E008] Not Found Error: -----------------------------------------------------
-1 | import util.foobar.bar
-  |        ^^^^^^^^^^^
-  |        value foobar is not a member of util
+1 |import util.foobar.bar
+  |       ^^^^^^^^^^^
+  |       value foobar is not a member of util
 1 error found

--- a/repl/test-resources/repl/init-script-flag
+++ b/repl/test-resources/repl/init-script-flag
@@ -1,4 +1,4 @@
-scala>:reset --repl-init-script:'println("Hello from init script!")'
+scala> :reset --repl-init-script:'println("Hello from init script!")'
 Resetting REPL state with the following settings:
   --repl-init-script:println("Hello from init script!")
 

--- a/repl/test-resources/repl/jar-command
+++ b/repl/test-resources/repl/jar-command
@@ -1,7 +1,7 @@
 scala> val z = 1
 val z: Int = 1
 
-scala>:jar ../sbt-test/source-dependencies/canon/actual/a.jar
+scala> :jar ../sbt-test/source-dependencies/canon/actual/a.jar
 Added '../sbt-test/source-dependencies/canon/actual/a.jar' to classpath.
 
 scala> import A.x

--- a/repl/test-resources/repl/jar-errors
+++ b/repl/test-resources/repl/jar-errors
@@ -1,11 +1,11 @@
-scala>:jar path/does/not/exist
+scala> :jar path/does/not/exist
 Cannot add "path/does/not/exist" to classpath.
 
-scala>:jar ../sbt-test/source-dependencies/canon/actual/a.jar
+scala> :jar ../sbt-test/source-dependencies/canon/actual/a.jar
 Added '../sbt-test/source-dependencies/canon/actual/a.jar' to classpath.
 
-scala>:jar ../sbt-test/source-dependencies/canon/actual/a.jar
+scala> :jar ../sbt-test/source-dependencies/canon/actual/a.jar
 The path '../sbt-test/source-dependencies/canon/actual/a.jar' cannot be loaded, it contains a classfile that already exists on the classpath: ../sbt-test/source-dependencies/canon/actual/a.jar(A.class)
 
-scala>:require ../sbt-test/source-dependencies/canon/actual/a.jar
+scala> :require ../sbt-test/source-dependencies/canon/actual/a.jar
 :require is no longer supported, but has been replaced with :jar. Please use :jar

--- a/repl/test-resources/repl/jar-multiple
+++ b/repl/test-resources/repl/jar-multiple
@@ -1,7 +1,7 @@
 scala> val z = 1
 val z: Int = 1
 
-scala>:jar ../compiler/test-resources/jars/mylibrary.jar
+scala> :jar ../compiler/test-resources/jars/mylibrary.jar
 Added '../compiler/test-resources/jars/mylibrary.jar' to classpath.
 
 scala> import mylibrary.Utils
@@ -9,7 +9,7 @@ scala> import mylibrary.Utils
 scala> Utils.greet("Alice")
 val res0: String = "Hello, Alice!"
 
-scala>:jar ../compiler/test-resources/jars/mylibrary2.jar
+scala> :jar ../compiler/test-resources/jars/mylibrary2.jar
 Added '../compiler/test-resources/jars/mylibrary2.jar' to classpath.
 
 scala> import mylibrary2.Utils2

--- a/repl/test-resources/repl/notFound
+++ b/repl/test-resources/repl/notFound
@@ -1,16 +1,16 @@
-scala>  Foo
+scala> Foo
 -- [E006] Not Found Error: -----------------------------------------------------
-1 |  Foo
-  |  ^^^
-  |  Not found: Foo
+1 |Foo
+  |^^^
+  |Not found: Foo
   |
   | longer explanation available when compiling with `-explain`
 1 error found
-scala>  Bar
+scala> Bar
 -- [E006] Not Found Error: -----------------------------------------------------
-1 |  Bar
-  |  ^^^
-  |  Not found: Bar
+1 |Bar
+  |^^^
+  |Not found: Bar
   |
   | longer explanation available when compiling with `-explain`
 1 error found

--- a/repl/test-resources/repl/nowarn.scala
+++ b/repl/test-resources/repl/nowarn.scala
@@ -1,8 +1,8 @@
 scala> @annotation.nowarn def f = try 1 // @nowarn doesn't work on first line, ctx.run is null in issueIfNotSuppressed
 1 warning found
 -- [E002] Syntax Warning: ------------------------------------------------------
-1 | @annotation.nowarn def f = try 1 // @nowarn doesn't work on first line, ctx.run is null in issueIfNotSuppressed
-  |                            ^^^^^
+1 |@annotation.nowarn def f = try 1 // @nowarn doesn't work on first line, ctx.run is null in issueIfNotSuppressed
+  |                           ^^^^^
   |                   A try without catch or finally is equivalent to putting
   |                   its body in a block; no exceptions are handled.
   |
@@ -13,10 +13,10 @@ def f: Int
 scala> def f = try 1
 1 warning found
 -- [E002] Syntax Warning: ------------------------------------------------------
-1 | def f = try 1
-  |         ^^^^^
-  |         A try without catch or finally is equivalent to putting
-  |         its body in a block; no exceptions are handled.
+1 |def f = try 1
+  |        ^^^^^
+  |        A try without catch or finally is equivalent to putting
+  |        its body in a block; no exceptions are handled.
   |
   | longer explanation available when compiling with `-explain`
 def f: Int
@@ -25,9 +25,9 @@ def f: Int
 scala> def f = { 1; 2 }
 1 warning found
 -- [E129] Potential Issue Warning: ---------------------------------------------
-1 | def f = { 1; 2 }
-  |           ^
-  |           A pure expression does nothing in statement position
+1 |def f = { 1; 2 }
+  |          ^
+  |          A pure expression does nothing in statement position
   |
   | longer explanation available when compiling with `-explain`
 def f: Int

--- a/repl/test-resources/repl/overrides
+++ b/repl/test-resources/repl/overrides
@@ -1,8 +1,8 @@
 scala> class B { override def foo(i: Int): Unit = {}; }
 -- [E037] Declaration Error: ---------------------------------------------------
-1 | class B { override def foo(i: Int): Unit = {}; }
-  |                        ^
-  |                        method foo overrides nothing
+1 |class B { override def foo(i: Int): Unit = {}; }
+  |                       ^
+  |                       method foo overrides nothing
   |
   | longer explanation available when compiling with `-explain`
 1 error found
@@ -10,8 +10,8 @@ scala> class A { def foo: Unit = {}; }
 // defined class A
 scala> class B extends A { override def foo(i: Int): Unit = {}; }
 -- [E038] Declaration Error: ---------------------------------------------------
-1 | class B extends A { override def foo(i: Int): Unit = {}; }
-  |                                  ^
+1 |class B extends A { override def foo(i: Int): Unit = {}; }
+  |                                 ^
   |      method foo has a different signature than the overridden declaration
   |
   | longer explanation available when compiling with `-explain`

--- a/repl/test-resources/repl/parsing
+++ b/repl/test-resources/repl/parsing
@@ -10,6 +10,6 @@ val res3: Int = 1
 val res4: Int = 2
 scala> }
 -- [E040] Syntax Error: --------------------------------------------------------
-1 | }
-  | ^
-  | eof expected, but '}' found
+1 |}
+  |^
+  |eof expected, but '}' found

--- a/repl/test-resources/repl/reset-command
+++ b/repl/test-resources/repl/reset-command
@@ -1,12 +1,12 @@
 scala> def f(thread: Thread) = thread.stop()
 1 warning found
 -- Deprecation Warning: --------------------------------------------------------
-1 | def f(thread: Thread) = thread.stop()
-  |                         ^^^^^^^^^^^
+1 |def f(thread: Thread) = thread.stop()
+  |                        ^^^^^^^^^^^
   |method stop in class Thread is deprecated: see corresponding Javadoc for more information.
 def f(thread: Thread): Unit
 
-scala>:reset -deprecation:false
+scala> :reset -deprecation:false
 Resetting REPL state with the following settings:
   -deprecation:false
 
@@ -18,16 +18,16 @@ def f(thread: Thread): Unit
 scala> def resetNoArgsStillWorks = 1
 def resetNoArgsStillWorks: Int
 
-scala>:reset
+scala> :reset
 Resetting REPL state.
 
 scala> resetNoArgsStillWorks
 -- [E006] Not Found Error: -----------------------------------------------------
-1 | resetNoArgsStillWorks
-  | ^^^^^^^^^^^^^^^^^^^^^
-  | Not found: resetNoArgsStillWorks
+1 |resetNoArgsStillWorks
+  |^^^^^^^^^^^^^^^^^^^^^
+  |Not found: resetNoArgsStillWorks
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 
-scala>:settings "-Dfoo=bar baz"
+scala> :settings "-Dfoo=bar baz"

--- a/repl/test-resources/repl/rewrite-messages
+++ b/repl/test-resources/repl/rewrite-messages
@@ -1,8 +1,8 @@
 //> using options -source:future-migration -deprecation -Werror
 scala> import scala.util._
 -- Migration Warning: ----------------------------------------------------------
-1 | import scala.util._
-  |                   ^
+1 |import scala.util._
+  |                  ^
   |         `_` is no longer supported for a wildcard import; use `*` instead
 No warnings can be incurred under -Werror
 1 warning found
@@ -11,8 +11,8 @@ scala> extension (x: Int) def foo(y: Int) = x + y
 def foo(x: Int)(y: Int): Int
 scala> 2 foo 4
 -- Migration Warning: ----------------------------------------------------------
-1 | 2 foo 4
-  |   ^^^
+1 |2 foo 4
+  |  ^^^
   |Alphanumeric method foo is not declared infix; it should not be used as infix operator.
   |Instead, use method syntax .foo(...) or backticked identifier `foo`.
 No warnings can be incurred under -Werror

--- a/repl/test-resources/repl/settings-command
+++ b/repl/test-resources/repl/settings-command
@@ -1,17 +1,15 @@
 scala> def f(thread: Thread) = thread.stop()
 1 warning found
 -- Deprecation Warning: --------------------------------------------------------
-1 | def f(thread: Thread) = thread.stop()
-  |                         ^^^^^^^^^^^
+1 |def f(thread: Thread) = thread.stop()
+  |                        ^^^^^^^^^^^
   |method stop in class Thread is deprecated: see corresponding Javadoc for more information.
 def f(thread: Thread): Unit
 
-scala>:settings -deprecation:false foo.scala
+scala> :settings -deprecation:false foo.scala
 Ignoring spurious arguments: foo.scala
 
 scala> def f(thread: Thread) = thread.stop()
 there was 1 deprecation warning; re-run with -deprecation for details
 1 warning found
 def f(thread: Thread): Unit
-
-scala>

--- a/repl/test-resources/repl/settings-outputDir
+++ b/repl/test-resources/repl/settings-outputDir
@@ -4,7 +4,7 @@ val res0: Boolean = true
 scala> val x = 1
 val x: Int = 1
 
-scala>:settings -d target/test-repl-settings-outDir
+scala> :settings -d target/test-repl-settings-outDir
 
 scala> val y = 2
 val y: Int = 2

--- a/repl/test-resources/repl/settings-repl-disable-display
+++ b/repl/test-resources/repl/settings-repl-disable-display
@@ -1,11 +1,11 @@
 scala> 1
 val res0: Int = 1
 
-scala>:settings -Xrepl-disable-display
+scala> :settings -Xrepl-disable-display
 
 scala> 2
 
-scala>:reset
+scala> :reset
 Resetting REPL state.
 
 scala> 3

--- a/repl/test-resources/repl/silent
+++ b/repl/test-resources/repl/silent
@@ -1,25 +1,25 @@
-scala>:silent
+scala> :silent
 scala> 1+1
 scala> case class A(x: Int)
 scala> A("string")
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | A("string")
-  |   ^^^^^^^^
-  |   Found:    ("string" : String)
-  |   Required: Int
+1 |A("string")
+  |  ^^^^^^^^
+  |  Found:    ("string" : String)
+  |  Required: Int
   |
   | longer explanation available when compiling with `-explain`
 1 error found
 scala> Option[Int](2) match { case Some(x) => x }
 1 warning found
 -- [E029] Pattern Match Exhaustivity Warning: ----------------------------------
-1 | Option[Int](2) match { case Some(x) => x }
-  | ^^^^^^^^^^^^^^
-  | match may not be exhaustive.
+1 |Option[Int](2) match { case Some(x) => x }
+  |^^^^^^^^^^^^^^
+  |match may not be exhaustive.
   |
-  | It would fail on pattern case: None
+  |It would fail on pattern case: None
   |
   | longer explanation available when compiling with `-explain`
-scala>:silent
+scala> :silent
 scala> 1 + 2
 val res2: Int = 3

--- a/repl/test-resources/type-printer/type-mismatch
+++ b/repl/test-resources/type-printer/type-mismatch
@@ -4,10 +4,10 @@ scala> Foo(1)
 val res0: Foo[Int] = Foo(1)
 scala> val x: Foo[String] = res0
 -- [E007] Type Mismatch Error: -------------------------------------------------
-1 | val x: Foo[String] = res0
-  |                      ^^^^
-  |                      Found:    (res0 : Foo[Int])
-  |                      Required: Foo[String]
+1 |val x: Foo[String] = res0
+  |                     ^^^^
+  |                     Found:    (res0 : Foo[Int])
+  |                     Required: Foo[String]
   |
   | longer explanation available when compiling with `-explain`
 1 error found

--- a/repl/test/dotty/tools/repl/ReplTest.scala
+++ b/repl/test/dotty/tools/repl/ReplTest.scala
@@ -63,7 +63,7 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
 
   /** Returns failures: None if all is well, Some for an error */
   private def testScript(name: => String, lines: List[String], scriptFile: Option[JFile] = None): Option[String] = {
-    val prompt = "scala>"
+    val prompt = "scala> "
 
     def evaluate(state: State, input: String) =
       try {
@@ -91,7 +91,7 @@ extends ReplDriver(options, new PrintStream(out, true, StandardCharsets.UTF_8.na
       resetToInitial(opts)
 
       assert(inputLines.head.startsWith(prompt),
-        s"""Each script must start with the prompt: "$prompt"""")
+        s"""[$name]: Each script must start with the prompt: "$prompt"""")
       val inputRes = inputLines.filter(_.startsWith(prompt))
 
       val buf = new ArrayBuffer[String]

--- a/repl/test/dotty/tools/repl/ShadowingTests.scala
+++ b/repl/test/dotty/tools/repl/ShadowingTests.scala
@@ -92,9 +92,9 @@ class ShadowingTests extends ReplTest(options = ShadowingTests.options):
     script =
       """|scala> new C().c
          |-- [E171] Type Error: ----------------------------------------------------------
-         |1 | new C().c
-         |  | ^^^^^^^
-         |  | missing argument for parameter c of constructor C in class C: (c: Int): C
+         |1 |new C().c
+         |  |^^^^^^^
+         |  |missing argument for parameter c of constructor C in class C: (c: Int): C
          |1 error found
          |
          |scala> new C(13).c
@@ -141,9 +141,9 @@ class ShadowingTests extends ReplTest(options = ShadowingTests.options):
     testScript(name = "<shadow-subdir-util>",
       """|scala> import util.Try
          |-- [E008] Not Found Error: -----------------------------------------------------
-         |1 | import util.Try
-         |  |             ^^^
-         |  |             value Try is not a member of util
+         |1 |import util.Try
+         |  |            ^^^
+         |  |            value Try is not a member of util
          |1 error found
          |
          |scala> object util { class Try { override def toString = "you've gotta try!" }  }


### PR DESCRIPTION
Fixes #25055

As explained in the comment in Run, REPL does a parse (which may produce diagnostics) and then a compile (which may produce more diagnostics); the parse warnings will be suspended and then moved to the new Run. However, this commit drops those warnings if the parse is erroneous. The errors are issued, and as usual errors have precedence over warnings. Moreover, the warnings are not relevant because the source text must be amended to pass compilation.

The REPL tests are adjusted so that the test text looks the same as a real REPL transcript, where there is a "trailing space" in the prompt but no "leading space" in the diagnostic text. The adjustment makes it easier to paste a transcript to a test.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
