### PR TITLE
Ignore @throws annotation on non-methods

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -439,7 +439,7 @@ object GenericSignatures {
     jsig(info, toplevel = true)
     for annot <- sym0.annotations do
       annot match
-        case ThrownException(e) =>
+        case ThrownException(e) if sym0.is(Method) => // ThrowsSignature is only valid in MethodSignature
           builder.append('^')
           jsig(e, toplevel = true)
         case _ => ()

--- a/tests/run/throws-annot.scala
+++ b/tests/run/throws-annot.scala
@@ -68,6 +68,15 @@ object TL {
   def readNoEx(): Int = 0
 }
 
+// @throws on class/object/field must be ignored/compiler shouldn't crash.
+@throws(classOf[IOException])
+class ThrowsOnClass
+
+@throws(classOf[IOException])
+object ThrowsOnObject:
+  @throws(classOf[IOException])
+  val field: Int = 0
+
 object Test {
   def main(args: Array[String]): Unit = {
     TestThrows.run(classOf[TestThrows.Foo])


### PR DESCRIPTION
According to JVMS 4.7.9.1
https://docs.oracle.com/javase/specs/jvms/se24/html/jvms-4.html#jvms-4.7.9.1

`ThrowsSignature` is only valid in `MethodSignature`s. Previously, we add `^...` ThrowsSignature no matter the symbol is method or not. We should just ignore `@throws` annotation on invalid locations.

Fixes comment by @WojciechMazur https://github.com/scala/scala3/pull/26787#issuecomment-5287133824 (in `usql`)

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->


No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)

