### PR TITLE
Simplify `ArrayApply.isSeqApply`

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
+++ b/compiler/src/dotty/tools/dotc/transform/ArrayApply.scala
@@ -53,19 +53,13 @@ class ArrayApply extends MiniPhase {
     sym.name == nme.apply
     && (sym.owner == defn.ArrayModuleClass || (sym.owner == defn.IArrayModuleClass && !sym.is(Extension)))
 
-  private def isListApply(tree: Tree)(using Context): Boolean =
-    (tree.symbol == defn.ListModule_apply || tree.symbol.name == nme.apply) && appliedCore(tree).match
+  private def isSeqApply(tree: Tree)(using Context): Boolean =
+    tree.symbol.name == nme.apply && appliedCore(tree).match
       case Select(qual, _) =>
         val sym = qual.symbol
         sym == defn.ListModule
         || sym == defn.ListModuleAlias
-      case _ => false
-
-  private def isSeqApply(tree: Tree)(using Context): Boolean =
-    isListApply(tree) || tree.symbol == defn.SeqModule_apply && appliedCore(tree).match
-      case Select(qual, _) =>
-        val sym = qual.symbol
-        sym == defn.SeqModule
+        || sym == defn.SeqModule
         || sym == defn.SeqModuleAlias
         || sym == defn.CollectionSeqType.symbol.companionModule
       case _ => false


### PR DESCRIPTION
Noticed on a flame graph; we do a redundant comparison and explore the same tree twice. A surprisingly big chunk of `HelloWorld` because loading the `List.apply` symbol we don't actually need takes time.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
