### PR TITLE
fix(repl): restore SourceFile.maybeIncomplete

### DIFF
--- a/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/Scanners.scala
@@ -792,8 +792,10 @@ object Scanners {
           if lastToken == IDENTIFIER && lastName != null && isIdentifierStart(lastName.head)
               || colonEOLPredecessors.contains(lastToken)
           then token = COLONfollow
-        case RBRACE | RPAREN | RBRACKET | EOF =>
+        case RBRACE | RPAREN | RBRACKET =>
           closeIndented()
+        case EOF =>
+          if !source.maybeIncomplete then closeIndented()
         case _ =>
       }
     }

--- a/compiler/src/dotty/tools/dotc/util/SourceFile.scala
+++ b/compiler/src/dotty/tools/dotc/util/SourceFile.scala
@@ -13,6 +13,8 @@ import Chars.*
 import scala.annotation.internal.sharable
 import scala.collection.mutable.ArrayBuffer
 import scala.compiletime.uninitialized
+import dotty.tools.dotc.util.chaining.*
+
 import java.io.File.separator
 import java.net.URI
 import java.nio.charset.StandardCharsets
@@ -63,6 +65,10 @@ object WrappedSourceFile:
 
 class SourceFile (val file: AbstractFile | Null, sourceRoot: AbstractFile, codec: Codec) extends interfaces.SourceFile {
   private var myContent: Array[Char] | Null = null
+
+  private var _maybeIncomplete: Boolean = false
+
+  def maybeIncomplete: Boolean = _maybeIncomplete
 
   /** The contents of the original source file. Note that this can be empty, for example when
    * the source is read from Tasty. */
@@ -229,8 +235,9 @@ object SourceFile {
   /** A source file with an underlying virtual file. The path is taken as a file system path
    *  with the local separator converted to "/". The last element of the path will be the simple name of the file.
    */
-  def virtual(name: String, content: String) =
+  def virtual(name: String, content: String, maybeIncomplete: Boolean = false) =
     new SourceFile(new VirtualFile(name.replace(separator, "/"), content.getBytes(StandardCharsets.UTF_8)), new VirtualFile("_root_", Array.emptyByteArray), Codec.UTF8)
+      .tap(_._maybeIncomplete = maybeIncomplete)
 
   /** A helper method to create a virtual source file for given URI.
    */

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -369,7 +369,13 @@ object ParseResult {
   }
 
   def apply(sourceCode: String)(using state: State): ParseResult =
-    apply(SourceFile.virtual(str.REPL_SESSION_LINE + (state.objectIndex + 1), sourceCode))
+    maybeIncomplete(sourceCode, maybeIncomplete = true)
+
+  def complete(sourceCode: String)(using state: State): ParseResult =
+    maybeIncomplete(sourceCode, maybeIncomplete = false)
+
+  private def maybeIncomplete(sourceCode: String, maybeIncomplete: Boolean)(using state: State): ParseResult =
+    apply(SourceFile.virtual(str.REPL_SESSION_LINE + (state.objectIndex + 1), sourceCode, maybeIncomplete = maybeIncomplete))
 
   def isCommand(line: String): Boolean =
     line match
@@ -434,7 +440,7 @@ object ParseResult {
         val code = codeAfterLeadingCommands(sourceCode, extractedDirectives)
         code.nonEmpty && {
           val reporter = newStoreReporter
-          val source   = SourceFile.virtual("<incomplete-handler>", code)
+          val source   = SourceFile.virtual("<incomplete-handler>", code, maybeIncomplete = true)
           val unit     = CompilationUnit(source, mustExistIfNotNull = false)
           val localCtx = ctx.fresh
                             .setCompilationUnit(unit)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -291,7 +291,7 @@ class ReplDriver(settings: Array[String],
   }
 
   final def run(input: String)(using state: State): State = runBody {
-    interpret(ParseResult(input))
+    interpret(ParseResult.complete(input))
   }
 
   protected def runBody(body: => State): State = rendering.classLoader()(using rootCtx).asContext(withRedirectedOutput(body))
@@ -369,7 +369,7 @@ class ReplDriver(settings: Array[String],
       compiler
         .typeCheck(expr, errorsAllowed = true)
         .map { (untpdTree, tpdTree) =>
-          val file = SourceFile.virtual("<completions>", expr)
+          val file = SourceFile.virtual("<completions>", expr, maybeIncomplete = true)
           val unit = CompilationUnit(file)(using state.context)
           unit.untpdTree = untpdTree
           unit.tpdTree = tpdTree

--- a/repl/test/dotty/tools/repl/ReplCompilerTests.scala
+++ b/repl/test/dotty/tools/repl/ReplCompilerTests.scala
@@ -412,6 +412,11 @@ class ReplCompilerTests extends ReplTest:
   @Test def `i13097 expect template after colon` = contextually:
     assert(ParseResult.isIncomplete("class C:"))
 
+  @Test def `i26585 expect more members in braceless template` = contextually:
+    assert(ParseResult.isIncomplete("class C:\n  private var i = 0"))
+    assert(ParseResult.isIncomplete("class C:\n  private var i = 0\n  def get = i"))
+    assertFalse(ParseResult.isIncomplete("class C:\n  private var i = 0\n"))
+
   @Test def i15562: Unit = initially {
     val s1 = run("List(1, 2).filter(_ % 2 == 0).foreach(println)")
     assertEquals("2", storedOutput().trim)


### PR DESCRIPTION
Fixes #26585

The removal of SourceFile.maybeIncomplete in https://github.com/scala/scala3/pull/26444 caused this, so this PR just restores it.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)
