### PR TITLE
Revert #26579 and #25126 for binary compatibility

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
+++ b/compiler/src/dotty/tools/dotc/ast/TreeInfo.scala
@@ -499,7 +499,6 @@ trait UntypedTreeInfo extends TreeInfo[Untyped] { self: Trees.Instance[Untyped] 
    */
   private def defKind(tree: Tree)(using Context): FlagSet = unsplice(tree) match {
     case EmptyTree | _: Import => NoInitsInterface
-    case _: ModuleDef => NoInits
     case tree: TypeDef =>
       if tree.isClassDef then
         if Feature.shouldBehaveAsScala2 then EmptyFlags
@@ -624,10 +623,6 @@ trait TypedTreeInfo extends TreeInfo[Type] { self: Trees.Instance[Type] =>
     case TypeApply(fn, _) =>
       val sym = fn.symbol
       if tree.tpe.isInstanceOf[MethodOrPoly] then exprPurity(fn)
-      else if sym == defn.Any_typeCast then
-        fn match
-          case Select(qual, _) => exprPurity(qual) `min` Pure
-          case _ => Impure
       else if sym == defn.QuotedTypeModule_of
           || sym == defn.Predef_classOf
           || sym == defn.Compiletime_erasedValue && tree.tpe.dealias.isInstanceOf[ConstantType]

--- a/tests/neg-custom-args/captures/freshlist-explicit.check
+++ b/tests/neg-custom-args/captures/freshlist-explicit.check
@@ -38,7 +38,7 @@
 -- Error: tests/neg-custom-args/captures/freshlist-explicit.scala:55:20 ------------------------------------------------
 55 |      case FreshCons(h, t) => FreshCons(h, t) // error separation // error separation
    |                    ^
-   |Separation failure: Illegal access to (x10 : (xs : FreshList[Ref^{}]^)), which was passed as a consume parameter to method unapply
+   |Separation failure: Illegal access to (x11 : FreshCons[Any]^{x10, any}), which was passed as a consume parameter to method unapply
    |on line 49 and therefore is no longer available.
    |
-   |where:    ^ refers to a root capability in the type of value xs
+   |where:    any is a root capability in the type of value x11

--- a/tests/neg/i24990.scala
+++ b/tests/neg/i24990.scala
@@ -9,4 +9,5 @@ object test {
 
 def takesBar[A](a: A)(using b: test.Bar[A]): A = a
 
-val _ = takesBar(1)
+// TODO: this should be pure, see #26800 #24990 #26578
+val _ = takesBar(1) // error

--- a/tests/neg/nested-module-no-inits.scala
+++ b/tests/neg/nested-module-no-inits.scala
@@ -4,5 +4,6 @@ object Outer:
   object Inner:
     println("effect")
 
-erased val pureOuter: Outer.type = Outer
+// TODO: this should be pure, see #26800 #24990 #26578
+erased val impureOuter: Outer.type = Outer // error
 erased val impureInner: Outer.Inner.type = Outer.Inner // error

--- a/tests/run/i26800-trait-init-binary-compat.scala
+++ b/tests/run/i26800-trait-init-binary-compat.scala
@@ -1,0 +1,28 @@
+// scalajs: --skip
+
+trait WithNestedObject: // see #26800
+  object Nested
+
+trait WithVal:
+  val x = 1
+
+trait WithStatement:
+  println("init")
+
+trait WithDef:
+  def f = 1
+
+trait WithAbstractDef:
+  def f: Int
+
+// Traits that need initialization must emit `$init$` for binary compatibility (#26800).
+object Test:
+  def main(args: Array[String]): Unit =
+    def hasInit(cls: Class[?]) =
+      cls.getMethods.map(_.toString).exists(_.contains("$init$"))
+    assert(!hasInit(classOf[WithDef]))
+    assert(!hasInit(classOf[WithAbstractDef]))
+    // traits with object/val/statement are marked with Init
+    assert(hasInit(classOf[WithNestedObject]))
+    assert(hasInit(classOf[WithVal]))
+    assert(hasInit(classOf[WithStatement]))


### PR DESCRIPTION
Fixes #26800

reverting #26579 (and #25126, which is already reverted by 26579)

This change re-opens https://github.com/scala/scala3/issues/24990

**History**

Previsous to #25126 (fix for #24990),
compiler generated type cast makes expression impure, and therefore we couldn't pass expressions contains artificial casts to erased params.

PR #25126 workaround it by, make expression contains artificial casts pure pure expression.
However, this results to, purity analysis wrongly judge impure expressions contain artificial cats pure.

```scala
object O:
  opaque type T = String
  transparent inline def make: T = // <- this was judged as pure
    println("effect")
    "value"
```

PR #26579 fixed this by preserving purity through artificial cast instead of making impure expression with cast as pure.

Problem is, #26579 als changed `NoInits` to be preserved when there is only a nested `ModuleDef` (to keep fixing #24990), and as a result, traits/classes that have only a nested object stopped generating an empty `$init$`.

**Problem**

It's binary incompatible if `traits/class` only with nested object stopped generating an empty `$init$`.

For example, if we have a dependency like libA <- libB <- App, and

```scala
// libA (update to RC5, trait T no longer has `$init$`)
trait T { object Nested }
// libB (still on RC4, C still calls `T.$init$`)
classs C extends T
```

then libB would also need to be rebuilt with RC5.

**Fix**

Revert both #26579 and #25126 (it's fine to revert  #26579 because it's a fix for bug result of #25126)
While #24990 would be a problem again, we should fix differently, for 3.10


<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?


New automated tests (including the issue's reproducer, if applicable)
Covered by existing tests (this is a refactoring)

