### PR TITLE
Retain loading diagnostics across REPL completions

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -58,6 +58,9 @@ object Contexts {
 
   private val initialStore = store11
 
+  /** Loading failures retained after their symbols are marked absent. */
+  private[tools] object RetainedSymbolLoadingFailures extends Key[mutable.WeakHashMap[Symbol, LoadingFailure]]
+
   /** The current context */
   inline def ctx(using ctx: Context): Context = ctx
 
@@ -1101,12 +1104,6 @@ object Contexts {
      *  to avoid space leaks - the message usually captures a context.
      */
     private[core] val errorTypeMsg: mutable.Map[Types.ErrorType, Message] = mutable.Map()
-
-    /** Symbol-loading failures retained for later references to the same symbol.
-     *  These must live as long as the symbol graph: resetting per-run caches does not
-     *  restore symbols whose infos have already been replaced by `NoType`.
-     */
-    private[core] val loadingFailures: mutable.WeakHashMap[Symbol, LoadingFailure] = mutable.WeakHashMap()
 
     // Phases state
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -22,6 +22,7 @@ import Implicits.ContextualImplicits
 import config.Settings.*
 import config.Config
 import reporting.*
+import reporting.Diagnostic.LoadingFailure
 import io.{AbstractFile, PlainFile, Path}
 import scala.io.Codec
 import collection.mutable
@@ -1100,6 +1101,12 @@ object Contexts {
      *  to avoid space leaks - the message usually captures a context.
      */
     private[core] val errorTypeMsg: mutable.Map[Types.ErrorType, Message] = mutable.Map()
+
+    /** Symbol-loading failures retained for later references to the same symbol.
+     *  These must live as long as the symbol graph: resetting per-run caches does not
+     *  restore symbols whose infos have already been replaced by `NoType`.
+     */
+    private[core] val loadingFailures: mutable.WeakHashMap[Symbol, LoadingFailure] = mutable.WeakHashMap()
 
     // Phases state
 

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -55,11 +55,10 @@ object Contexts {
   private val (importInfoLoc,        store9) = store8.newLocation[ImportInfo | Null]()
   private val (typeAssignerLoc,     store10) = store9.newLocation[TypeAssigner](TypeAssigner)
   private val (progressCallbackLoc, store11) = store10.newLocation[ProgressCallback | Null]()
+  private val (retainedSymbolLoadingFailuresLoc, store12) =
+    store11.newLocation[mutable.WeakHashMap[Symbol, LoadingFailure] | Null]()
 
-  private val initialStore = store11
-
-  /** Loading failures retained after their symbols are marked absent. */
-  private[tools] object RetainedSymbolLoadingFailures extends Key[mutable.WeakHashMap[Symbol, LoadingFailure]]
+  private val initialStore = store12
 
   /** The current context */
   inline def ctx(using ctx: Context): Context = ctx
@@ -166,6 +165,12 @@ object Contexts {
      *  slightly slower than a normal field access would be.
      */
     def store: Store
+
+    /** Failures retained for symbols whose loader has installed `NoType`,
+     *  or `null` when retention is disabled.
+     */
+    private[tools] def retainedSymbolLoadingFailures: mutable.WeakHashMap[Symbol, LoadingFailure] | Null =
+      store(retainedSymbolLoadingFailuresLoc)
 
     /** The compiler callback implementation, or null if no callback will be called. */
     def compilerCallback: CompilerCallback | Null = store(compilerCallbackLoc)
@@ -772,6 +777,9 @@ object Contexts {
         case _ =>
       updateStore(importInfoLoc, importInfo)
     def setTypeAssigner(typeAssigner: TypeAssigner): this.type = updateStore(typeAssignerLoc, typeAssigner)
+    private[tools] def setRetainedSymbolLoadingFailures(
+        failures: mutable.WeakHashMap[Symbol, LoadingFailure] | Null
+    ): this.type = updateStore(retainedSymbolLoadingFailuresLoc, failures)
 
     def setProperty[T](key: Key[T], value: T): this.type =
       setMoreProperties(moreProperties.updated(key, value))

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -21,6 +21,7 @@ import util.Stats
 import java.util.WeakHashMap
 import config.Config
 import reporting.*
+import reporting.Diagnostic.LoadingFailure
 import collection.mutable
 import cc.{CapturingType, derivedCapturingType, stripCapturing}
 
@@ -609,10 +610,18 @@ object SymDenotations {
         assert(myInfo.isInstanceOf[ModuleCompleter | SymbolLoader],
           s"Illegal call to `markAbsent()` while completing $this using completer $myInfo")
       myInfo = NoType
+      if (ctx ne NoContext) && (symbol ne NoSymbol) then
+        ctx.base.loadingFailures.remove(symbol)
     }
+
+    /** Mark this symbol absent because its binary representation could not be loaded. */
+    private[core] final def markLoadFailed(failure: LoadingFailure)(using Context): Unit =
+      markAbsent()
+      ctx.base.loadingFailures(symbol) = failure
 
     /** Is symbol known to not exist?
      *  @param canForce  If this is true, the info may be forced to avoid a false-negative result
+     *                   and a retained loading failure may be reported.
      */
     @tailrec
     final def isAbsent(canForce: Boolean = true)(using Context): Boolean = myInfo match {
@@ -626,7 +635,10 @@ object SymDenotations {
         isAbsent(canForce)
       case _ =>
         // Otherwise, no completion is necessary, see the preconditions of `markAbsent()`.
-        (myInfo `eq` NoType)
+        val absent = myInfo `eq` NoType
+        if absent && canForce && (symbol ne NoSymbol) && (ctx ne NoContext) then
+          ctx.base.loadingFailures.get(symbol).foreach(report.loadingError)
+        absent
         || (is(Invisible) && !ctx.mode.is(Mode.ResolveFromTASTy)) && ctx.isTyper
         || is(ModuleVal, butNot = Package) && moduleClass.isAbsent(canForce)
     }

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -602,26 +602,31 @@ object SymDenotations {
     /** is this symbol the result of an erroneous definition? */
     def isError: Boolean = false
 
+    private def setAbsentInfo(): Unit = {
+      if (isCompleting)
+        assert(myInfo.isInstanceOf[ModuleCompleter | SymbolLoader],
+          s"Illegal attempt to mark $this absent while completing using completer $myInfo")
+      myInfo = NoType
+    }
+
     /** Make denotation not exist.
      *  @pre `isCompleting` is false, or this is a ModuleCompleter or SymbolLoader
      */
     final def markAbsent()(using Context): Unit = {
-      if (isCompleting)
-        assert(myInfo.isInstanceOf[ModuleCompleter | SymbolLoader],
-          s"Illegal call to `markAbsent()` while completing $this using completer $myInfo")
-      myInfo = NoType
-      if (ctx ne NoContext) && (symbol ne NoSymbol) then
-        ctx.base.loadingFailures.remove(symbol)
+      val wasAbsent = myInfo eq NoType
+      setAbsentInfo()
+      if !wasAbsent && (ctx ne NoContext) && (symbol ne NoSymbol) then
+        ctx.property(RetainedSymbolLoadingFailures).foreach(_.remove(symbol))
     }
 
-    /** Mark this symbol absent because its binary representation could not be loaded. */
+    /** Mark this symbol absent and retain the loading failure when retention is enabled. */
     private[core] final def markLoadFailed(failure: LoadingFailure)(using Context): Unit =
-      markAbsent()
-      ctx.base.loadingFailures(symbol) = failure
+      setAbsentInfo()
+      ctx.property(RetainedSymbolLoadingFailures).foreach(_(symbol) = failure)
 
     /** Is symbol known to not exist?
-     *  @param canForce  If this is true, the info may be forced to avoid a false-negative result
-     *                   and a retained loading failure may be reported.
+     *  @param canForce  If true, force the info to avoid a false negative. In contexts that
+     *                   retain loading failures, report the failure for an absent symbol.
      */
     @tailrec
     final def isAbsent(canForce: Boolean = true)(using Context): Boolean = myInfo match {
@@ -636,8 +641,11 @@ object SymDenotations {
       case _ =>
         // Otherwise, no completion is necessary, see the preconditions of `markAbsent()`.
         val absent = myInfo `eq` NoType
-        if absent && canForce && (symbol ne NoSymbol) && (ctx ne NoContext) then
-          ctx.base.loadingFailures.get(symbol).foreach(report.loadingError)
+        if absent && canForce && (ctx ne NoContext) && (symbol ne NoSymbol) then
+          for
+            failures <- ctx.property(RetainedSymbolLoadingFailures)
+            failure <- failures.get(symbol)
+          do report.loadingError(failure)
         absent
         || (is(Invisible) && !ctx.mode.is(Mode.ResolveFromTASTy)) && ctx.isTyper
         || is(ModuleVal, butNot = Package) && moduleClass.isAbsent(canForce)

--- a/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymDenotations.scala
@@ -616,13 +616,15 @@ object SymDenotations {
       val wasAbsent = myInfo eq NoType
       setAbsentInfo()
       if !wasAbsent && (ctx ne NoContext) && (symbol ne NoSymbol) then
-        ctx.property(RetainedSymbolLoadingFailures).foreach(_.remove(symbol))
+        val failures = ctx.retainedSymbolLoadingFailures
+        if failures != null then failures.remove(symbol)
     }
 
     /** Mark this symbol absent and retain the loading failure when retention is enabled. */
     private[core] final def markLoadFailed(failure: LoadingFailure)(using Context): Unit =
       setAbsentInfo()
-      ctx.property(RetainedSymbolLoadingFailures).foreach(_(symbol) = failure)
+      val failures = ctx.retainedSymbolLoadingFailures
+      if failures != null then failures(symbol) = failure
 
     /** Is symbol known to not exist?
      *  @param canForce  If true, force the info to avoid a false negative. In contexts that
@@ -642,10 +644,9 @@ object SymDenotations {
         // Otherwise, no completion is necessary, see the preconditions of `markAbsent()`.
         val absent = myInfo `eq` NoType
         if absent && canForce && (ctx ne NoContext) && (symbol ne NoSymbol) then
-          for
-            failures <- ctx.property(RetainedSymbolLoadingFailures)
-            failure <- failures.get(symbol)
-          do report.loadingError(failure)
+          val failures = ctx.retainedSymbolLoadingFailures
+          if failures != null then
+            failures.get(symbol).foreach(report.loadingError)
         absent
         || (is(Invisible) && !ctx.mode.is(Mode.ResolveFromTASTy)) && ctx.isTyper
         || is(ModuleVal, butNot = Package) && moduleClass.isAbsent(canForce)

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -15,7 +15,7 @@ import classfile.{ClassfileParser, ClassfileTastyUUIDParser}
 import Decorators.*
 
 import util.Stats
-import reporting.trace
+import reporting.{Message, trace}
 import reporting.Diagnostic.LoadingFailure
 
 import ast.desugar
@@ -423,14 +423,12 @@ abstract class SymbolLoader extends LazyType { self =>
   }
 
   override def complete(root: SymDenotation)(using Context): Unit = profileCompletion(root) {
-    def loadingFailure(ex: Exception): LoadingFailure = {
+    def loadingMessage(ex: IOException): Message = {
       if (ctx.debug) ex.printStackTrace()
       val msg = ex.getMessage()
-      val message =
-        if msg == null then em"i/o error while loading ${root.name}"
-        else em"""error while loading ${root.name},
-                 |$msg"""
-      LoadingFailure(message)
+      if msg == null then em"i/o error while loading ${root.name}"
+      else em"""error while loading ${root.name},
+               |$msg"""
     }
     var failure: Option[LoadingFailure] = None
     try {
@@ -444,9 +442,12 @@ abstract class SymbolLoader extends LazyType { self =>
       case ex: ClosedByInterruptException =>
         throw new InterruptedException
       case ex: IOException =>
-        val loadFailure = loadingFailure(ex)
-        failure = Some(loadFailure)
-        report.loadingError(loadFailure)
+        val message = loadingMessage(ex)
+        if ctx.property(RetainedSymbolLoadingFailures).isDefined then
+          val loadFailure = LoadingFailure(message)
+          failure = Some(loadFailure)
+          report.loadingError(loadFailure)
+        else report.error(message)
       case ex: TypeError =>
         println(s"exception caught when loading $root: ${ex.toMessage}")
         throw ex

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -16,6 +16,7 @@ import Decorators.*
 
 import util.Stats
 import reporting.trace
+import reporting.Diagnostic.LoadingFailure
 
 import ast.desugar
 
@@ -422,14 +423,16 @@ abstract class SymbolLoader extends LazyType { self =>
   }
 
   override def complete(root: SymDenotation)(using Context): Unit = profileCompletion(root) {
-    def signalError(ex: Exception): Unit = {
+    def loadingFailure(ex: Exception): LoadingFailure = {
       if (ctx.debug) ex.printStackTrace()
       val msg = ex.getMessage()
-      report.error(
+      val message =
         if msg == null then em"i/o error while loading ${root.name}"
         else em"""error while loading ${root.name},
-                 |$msg""")
+                 |$msg"""
+      LoadingFailure(message)
     }
+    var failure: Option[LoadingFailure] = None
     try {
       val start = System.currentTimeMillis
       trace.onDebug("loading") {
@@ -441,7 +444,9 @@ abstract class SymbolLoader extends LazyType { self =>
       case ex: ClosedByInterruptException =>
         throw new InterruptedException
       case ex: IOException =>
-        signalError(ex)
+        val loadFailure = loadingFailure(ex)
+        failure = Some(loadFailure)
+        report.loadingError(loadFailure)
       case ex: TypeError =>
         println(s"exception caught when loading $root: ${ex.toMessage}")
         throw ex
@@ -453,11 +458,14 @@ abstract class SymbolLoader extends LazyType { self =>
       def postProcess(denot: SymDenotation, other: Symbol) =
         if !denot.isCompleted &&
            !denot.completer.isInstanceOf[SymbolLoaders.SecondCompleter] then
-          if denot.is(ModuleClass) && NamerOps.needsConstructorProxies(other) then
-            NamerOps.makeConstructorCompanion(denot.sourceModule.asTerm, other.asClass)
-            denot.resetFlag(Touched)
-          else
-            denot.markAbsent()
+          failure match
+            case Some(failure) => denot.markLoadFailed(failure)
+            case None =>
+              if denot.is(ModuleClass) && NamerOps.needsConstructorProxies(other) then
+                NamerOps.makeConstructorCompanion(denot.sourceModule.asTerm, other.asClass)
+                denot.resetFlag(Touched)
+              else
+                denot.markAbsent()
 
       val other = if root.isRoot then NoSymbol else root.scalacLinkedClass
       postProcess(root, other)

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -443,7 +443,7 @@ abstract class SymbolLoader extends LazyType { self =>
         throw new InterruptedException
       case ex: IOException =>
         val message = loadingMessage(ex)
-        if ctx.property(RetainedSymbolLoadingFailures).isDefined then
+        if ctx.retainedSymbolLoadingFailures != null then
           val loadFailure = LoadingFailure(message)
           failure = Some(loadFailure)
           report.loadingError(loadFailure)

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -81,7 +81,7 @@ object report:
   def error(msg: => String)(using Context): Unit =
     error(msg, NoSourcePosition)
 
-  private[tools] def loadingError(failure: LoadingFailure)(using Context): Unit =
+  private[dotc] def loadingError(failure: LoadingFailure)(using Context): Unit =
     ctx.reporter.report(new LoadingError(failure))
     if ctx.settings.YdebugError.value then Thread.dumpStack()
 

--- a/compiler/src/dotty/tools/dotc/report.scala
+++ b/compiler/src/dotty/tools/dotc/report.scala
@@ -81,6 +81,10 @@ object report:
   def error(msg: => String)(using Context): Unit =
     error(msg, NoSourcePosition)
 
+  private[tools] def loadingError(failure: LoadingFailure)(using Context): Unit =
+    ctx.reporter.report(new LoadingError(failure))
+    if ctx.settings.YdebugError.value then Thread.dumpStack()
+
   def error(ex: TypeError, pos: SrcPos)(using Context): Unit =
     val fullPos = addInlineds(pos)
     ctx.reporter.report(new StickyError(ex.toMessage, fullPos))

--- a/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
@@ -16,14 +16,15 @@ import core.Decorators.toMessage
 object Diagnostic:
 
   /** A context-independent description of a failed symbol load.
-   *  One instance can be shared by linked roots that are invalidated and acts as a reporting identity.
+   *  Linked roots invalidated by the same load share one instance so a reporter can
+   *  suppress duplicate diagnostics.
    */
   private[tools] final class LoadingFailure private (val message: Message)
 
   private[tools] object LoadingFailure:
     def apply(message: Message): LoadingFailure = new LoadingFailure(message.persist)
 
-  /** An error caused by a failed symbol load. */
+  /** An error whose `failure` identifies a failed symbol load. */
   private[tools] final class LoadingError(val failure: LoadingFailure)
       extends Error(failure.message, NoSourcePosition)
 

--- a/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Diagnostic.scala
@@ -5,7 +5,7 @@ package reporting
 import dotty.tools.dotc.config.Settings.Setting
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.interfaces.Diagnostic.{ERROR, INFO, WARNING}
-import dotty.tools.dotc.util.SourcePosition
+import dotty.tools.dotc.util.{NoSourcePosition, SourcePosition}
 import dotty.tools.dotc.util.SourcePosition.inlinePosStack
 import dotty.tools.dotc.util.chaining.*
 
@@ -14,6 +14,18 @@ import scala.jdk.CollectionConverters.*
 import core.Decorators.toMessage
 
 object Diagnostic:
+
+  /** A context-independent description of a failed symbol load.
+   *  One instance can be shared by linked roots that are invalidated and acts as a reporting identity.
+   */
+  private[tools] final class LoadingFailure private (val message: Message)
+
+  private[tools] object LoadingFailure:
+    def apply(message: Message): LoadingFailure = new LoadingFailure(message.persist)
+
+  /** An error caused by a failed symbol load. */
+  private[tools] final class LoadingError(val failure: LoadingFailure)
+      extends Error(failure.message, NoSourcePosition)
 
   /** Message attached to each inline call-site exposed as related information (scalameta/metals#3214).
    *  The clickable location is carried by `position()`; the text only has to explain why the

--- a/compiler/src/dotty/tools/dotc/reporting/ExploringReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/ExploringReporter.scala
@@ -19,6 +19,8 @@ class ExploringReporter extends StoreReporter(null, fromTyperState = false):
   override def mapBufferedMessages(f: Diagnostic => Diagnostic)(using Context): Unit =
     infos.nn.mapInPlace(f)
 
-  def reset(): Unit = infos.nn.clear()
+  def reset(): Unit =
+    infos.nn.clear()
+    clearReportedLoadingFailures()
 
 end ExploringReporter

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -99,8 +99,19 @@ abstract class Reporter extends interfaces.ReporterResult {
   private var _errorCount = 0
   private var _warningCount = 0
   private var _infoCount = 0
-  // Suppress repeated reports of the same loading failure within one run.
-  private val reportedLoadingFailures = mutable.WeakHashMap.empty[LoadingFailure, Int]
+  // The last run that reported each loading failure through this reporter.
+  private var reportedLoadingFailures: mutable.WeakHashMap[LoadingFailure, Int] | Null = null
+
+  private def reportedLoadingFailuresMap: mutable.WeakHashMap[LoadingFailure, Int] =
+    val reported = reportedLoadingFailures
+    if reported != null then reported
+    else
+      val fresh = mutable.WeakHashMap.empty[LoadingFailure, Int]
+      reportedLoadingFailures = fresh
+      fresh
+
+  protected final def clearReportedLoadingFailures(): Unit =
+    reportedLoadingFailures = null
 
   /** The number of errors reported by this reporter (ignoring outer reporters) */
   def errorCount: Int = _errorCount
@@ -271,11 +282,14 @@ abstract class Reporter extends interfaces.ReporterResult {
   def isHidden(dia: Diagnostic)(using Context): Boolean =
     ctx.mode.is(Mode.Printing)
     || (dia match
-      case error: LoadingError => reportedLoadingFailures.get(error.failure).contains(ctx.runId)
+      case error: LoadingError =>
+        val reported = reportedLoadingFailures
+        reported != null && reported.get(error.failure).contains(ctx.runId)
       case _ => false)
 
   def markReported(dia: Diagnostic)(using Context): Unit = dia match
-    case error: LoadingError => reportedLoadingFailures(error.failure) = ctx.runId
+    case error: LoadingError =>
+      reportedLoadingFailuresMap(error.failure) = ctx.runId
     case _ =>
 
   /** Does this reporter contain errors that have yet to be reported by its outer reporter ?

--- a/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Reporter.scala
@@ -12,6 +12,7 @@ import dotty.tools.dotc.util.NoSourcePosition
 
 import java.io.{BufferedReader, PrintWriter}
 import scala.annotation.internal.sharable
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import core.Decorators.{em, toMessage}
 
@@ -98,6 +99,8 @@ abstract class Reporter extends interfaces.ReporterResult {
   private var _errorCount = 0
   private var _warningCount = 0
   private var _infoCount = 0
+  // Suppress repeated reports of the same loading failure within one run.
+  private val reportedLoadingFailures = mutable.WeakHashMap.empty[LoadingFailure, Int]
 
   /** The number of errors reported by this reporter (ignoring outer reporters) */
   def errorCount: Int = _errorCount
@@ -267,8 +270,13 @@ abstract class Reporter extends interfaces.ReporterResult {
   /** Should this diagnostic not be reported at all? */
   def isHidden(dia: Diagnostic)(using Context): Boolean =
     ctx.mode.is(Mode.Printing)
+    || (dia match
+      case error: LoadingError => reportedLoadingFailures.get(error.failure).contains(ctx.runId)
+      case _ => false)
 
-  def markReported(dia: Diagnostic)(using Context): Unit = ()
+  def markReported(dia: Diagnostic)(using Context): Unit = dia match
+    case error: LoadingError => reportedLoadingFailures(error.failure) = ctx.runId
+    case _ =>
 
   /** Does this reporter contain errors that have yet to be reported by its outer reporter ?
    *  Note: this is always false when there is no outer reporter.

--- a/compiler/src/dotty/tools/dotc/reporting/TestReporter.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/TestReporter.scala
@@ -9,4 +9,6 @@ import Diagnostic.*
 class TestingReporter extends StoreReporter(null, fromTyperState = false):
   infos = new mutable.ListBuffer[Diagnostic]
   override def hasUnreportedErrors: Boolean = infos.nn.exists(_.isInstanceOf[Error])
-  def reset(): Unit = infos.nn.clear()
+  def reset(): Unit =
+    infos.nn.clear()
+    clearReportedLoadingFailures()

--- a/compiler/test/dotty/tools/dotc/core/LoadingFailureTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/LoadingFailureTest.scala
@@ -72,24 +72,25 @@ class LoadingFailureTest extends DottyTest:
     errors.head
 
   private def retainingContext(reporter: StoreReporter)(using Context): Context =
-    val failures = ctx.property(RetainedSymbolLoadingFailures).getOrElse(mutable.WeakHashMap.empty)
+    val retained = ctx.retainedSymbolLoadingFailures
+    val failures = if retained == null then mutable.WeakHashMap.empty else retained
     ctx.fresh
       .setReporter(reporter)
-      .setProperty(RetainedSymbolLoadingFailures, failures)
+      .setRetainedSymbolLoadingFailures(failures)
 
-  @Test def `failed loads are not retained without the context property`(): Unit =
+  @Test def `failed loads are not retained when retention is disabled`(): Unit =
     val initialReporter = new StoreReporter(null)
     ctx = ctx.fresh
       .addMode(Mode.Interactive)
       .setReporter(initialReporter)
-      .dropProperty(RetainedSymbolLoadingFailures)
+      .setRetainedSymbolLoadingFailures(null)
     val failed = newFailedLoad("UnretainedOwner")
 
     assertTrue(failed.cls.isAbsent())
     val initialDiagnostics = initialReporter.removeBufferedMessages
     assertEquals(1, initialDiagnostics.size)
     assertFalse(initialDiagnostics.head.isInstanceOf[LoadingError])
-    assertTrue(ctx.property(RetainedSymbolLoadingFailures).isEmpty)
+    assertNull(ctx.retainedSymbolLoadingFailures)
 
     val replayReporter = new StoreReporter(null)
     ctx = retainingContext(replayReporter)
@@ -108,7 +109,7 @@ class LoadingFailureTest extends DottyTest:
     val replayReporter = new StoreReporter(null)
     ctx = ctx.fresh
       .setReporter(replayReporter)
-      .dropProperty(RetainedSymbolLoadingFailures)
+      .setRetainedSymbolLoadingFailures(null)
     assertTrue(failed.cls.isAbsent())
     assertTrue(replayReporter.removeBufferedMessages.isEmpty)
     assertEquals(1, failed.loader.attempts)

--- a/compiler/test/dotty/tools/dotc/core/LoadingFailureTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/LoadingFailureTest.scala
@@ -1,10 +1,11 @@
 package dotty.tools.dotc.core
 
 import java.io.IOException
+import scala.collection.mutable
 
 import dotty.tools.DottyTest
 import dotty.tools.dotc.reporting.Diagnostic.LoadingError
-import dotty.tools.dotc.reporting.StoreReporter
+import dotty.tools.dotc.reporting.{ExploringReporter, StoreReporter}
 
 import Contexts.*
 import Flags.*
@@ -27,6 +28,12 @@ class LoadingFailureTest extends DottyTest:
 
     def description(using Context): String = "failing test loader"
 
+  private case class FailedLoad(
+      loader: FailingLoader,
+      cls: ClassSymbol,
+      moduleClass: ClassSymbol
+  )
+
   private def newOwner(name: String)(using Context): ClassSymbol =
     newCompleteClassSymbol(
       defn.EmptyPackageClass,
@@ -46,67 +53,179 @@ class LoadingFailureTest extends DottyTest:
     val cls = owner.unforcedDecls.lookup(term.toTypeName).asClass
     (cls, cls.scalacLinkedClass.asClass)
 
-  private def loadingErrors(reporter: StoreReporter)(using Context): List[LoadingError] =
-    reporter.removeBufferedMessages.collect:
+  private def newFailedLoad(ownerName: String, message: String = "broken binary")(using Context): FailedLoad =
+    val loader = new FailingLoader(message)
+    val (cls, moduleClass) = enterClassAndCompanion(newOwner(ownerName), "Broken", loader)
+    FailedLoad(loader, cls, moduleClass)
+
+  private def takeLoadingErrors(reporter: StoreReporter)(using Context): List[LoadingError] =
+    reporter.removeBufferedMessages.map:
       case error: LoadingError => error
+      case diagnostic =>
+        throw new AssertionError(
+          s"unexpected ${diagnostic.getClass.getSimpleName}: ${diagnostic.message}"
+        )
 
-  @Test def `failed load is cached and replayed once per reporter and run`(): Unit =
-    val firstReporter = new StoreReporter(null)
-    ctx = ctx.fresh.setReporter(firstReporter)
-    val loader = new FailingLoader("broken binary")
-    val (cls, moduleClass) = enterClassAndCompanion(newOwner("FailureOwner"), "Broken", loader)
-    val sourceModule = moduleClass.sourceModule
+  private def takeSingleLoadingError(reporter: StoreReporter)(using Context): LoadingError =
+    val errors = takeLoadingErrors(reporter)
+    assertEquals(1, errors.size)
+    errors.head
 
-    assertFalse(cls.isAbsent(canForce = false))
-    assertEquals(0, loader.attempts)
-    assertTrue(loadingErrors(firstReporter).isEmpty)
+  private def retainingContext(reporter: StoreReporter)(using Context): Context =
+    val failures = ctx.property(RetainedSymbolLoadingFailures).getOrElse(mutable.WeakHashMap.empty)
+    ctx.fresh
+      .setReporter(reporter)
+      .setProperty(RetainedSymbolLoadingFailures, failures)
 
-    assertTrue(cls.isAbsent())
-    assertFalse(firstReporter.hasStickyErrors)
-    val initialErrors = loadingErrors(firstReporter)
-    assertEquals(1, loader.attempts)
-    assertEquals(1, initialErrors.size)
-    assertSame(
-      ctx.base.loadingFailures(cls),
-      ctx.base.loadingFailures(moduleClass)
-    )
+  @Test def `failed loads are not retained without the context property`(): Unit =
+    val initialReporter = new StoreReporter(null)
+    ctx = ctx.fresh
+      .addMode(Mode.Interactive)
+      .setReporter(initialReporter)
+      .dropProperty(RetainedSymbolLoadingFailures)
+    val failed = newFailedLoad("UnretainedOwner")
 
-    assertTrue(cls.isAbsent())
-    assertTrue(moduleClass.isAbsent())
-    assertTrue(loadingErrors(firstReporter).isEmpty)
+    assertTrue(failed.cls.isAbsent())
+    val initialDiagnostics = initialReporter.removeBufferedMessages
+    assertEquals(1, initialDiagnostics.size)
+    assertFalse(initialDiagnostics.head.isInstanceOf[LoadingError])
+    assertTrue(ctx.property(RetainedSymbolLoadingFailures).isEmpty)
+
+    val replayReporter = new StoreReporter(null)
+    ctx = retainingContext(replayReporter)
+    assertTrue(failed.cls.isAbsent())
+    assertTrue(replayReporter.removeBufferedMessages.isEmpty)
+    assertEquals(1, failed.loader.attempts)
+
+  @Test def `retained failure is not replayed outside the retaining context`(): Unit =
+    val initialReporter = new StoreReporter(null)
+    ctx = retainingContext(initialReporter)
+    val failed = newFailedLoad("DisabledReplayOwner")
+
+    assertTrue(failed.cls.isAbsent())
+    takeSingleLoadingError(initialReporter)
+
+    val replayReporter = new StoreReporter(null)
+    ctx = ctx.fresh
+      .setReporter(replayReporter)
+      .dropProperty(RetainedSymbolLoadingFailures)
+    assertTrue(failed.cls.isAbsent())
+    assertTrue(replayReporter.removeBufferedMessages.isEmpty)
+    assertEquals(1, failed.loader.attempts)
+
+  @Test def `forcing a failed load reports a non-sticky error`(): Unit =
+    val reporter = new StoreReporter(null)
+    ctx = retainingContext(reporter)
+    val failed = newFailedLoad("NonStickyOwner")
+
+    assertFalse(failed.cls.isAbsent(canForce = false))
+    assertEquals(0, failed.loader.attempts)
+    assertTrue(takeLoadingErrors(reporter).isEmpty)
+
+    assertTrue(failed.cls.isAbsent())
+    takeSingleLoadingError(reporter)
+    assertFalse(reporter.hasStickyErrors)
+    assertEquals(1, failed.loader.attempts)
+
+  @Test def `failed load is attempted once for a class and its companion`(): Unit =
+    val reporter = new StoreReporter(null)
+    ctx = retainingContext(reporter)
+    val failed = newFailedLoad("SingleAttemptOwner")
+
+    assertTrue(failed.cls.isAbsent())
+    takeSingleLoadingError(reporter)
+
+    assertTrue(failed.cls.isAbsent())
+    assertTrue(failed.moduleClass.isAbsent())
+    assertTrue(takeLoadingErrors(reporter).isEmpty)
+    assertEquals(1, failed.loader.attempts)
+
+  @Test def `class and companion replay the same load failure`(): Unit =
+    val classReporter = new StoreReporter(null)
+    ctx = retainingContext(classReporter)
+    val failed = newFailedLoad("CompanionOwner")
+
+    assertTrue(failed.cls.isAbsent())
+    val classError = takeSingleLoadingError(classReporter)
+
+    val companionReporter = new StoreReporter(null)
+    ctx = retainingContext(companionReporter)
+    assertTrue(failed.moduleClass.isAbsent())
+    val companionError = takeSingleLoadingError(companionReporter)
+    assertSame(classError.failure, companionError.failure)
+    assertEquals(1, failed.loader.attempts)
+
+  @Test def `failed load is reported again in a later run`(): Unit =
+    val reporter = new StoreReporter(null)
+    ctx = retainingContext(reporter)
+    val failed = newFailedLoad("LaterRunOwner")
+
+    assertTrue(failed.cls.isAbsent())
+    val initialError = takeSingleLoadingError(reporter)
 
     ctx = ctx.fresh.setPeriod(Periods.Period(ctx.runId + 1, ctx.phaseId))
-    assertTrue(cls.isAbsent())
-    val nextRunErrors = loadingErrors(firstReporter)
-    assertEquals(1, nextRunErrors.size)
-    assertSame(initialErrors.head.failure, nextRunErrors.head.failure)
+    assertTrue(failed.cls.isAbsent())
+    val nextRunError = takeSingleLoadingError(reporter)
+    assertSame(initialError.failure, nextRunError.failure)
+    assertEquals(1, failed.loader.attempts)
+
+  @Test def `failed load survives a context base reset`(): Unit =
+    val initialReporter = new StoreReporter(null)
+    ctx = retainingContext(initialReporter)
+    val failed = newFailedLoad("ResetOwner")
+
+    assertTrue(failed.cls.isAbsent())
+    val initialError = takeSingleLoadingError(initialReporter)
 
     ctx.base.reset()
     val replayReporter = new StoreReporter(null)
     ctx = ctx.fresh.setReporter(replayReporter)
-    assertTrue(sourceModule.isAbsent(canForce = false))
-    assertTrue(loadingErrors(replayReporter).isEmpty)
+    assertTrue(failed.moduleClass.isAbsent(canForce = false))
+    assertTrue(takeLoadingErrors(replayReporter).isEmpty)
 
-    assertTrue(sourceModule.isAbsent())
-    assertTrue(cls.isAbsent())
-    val replayedErrors = loadingErrors(replayReporter)
-    assertEquals(1, replayedErrors.size)
-    assertSame(initialErrors.head.failure, replayedErrors.head.failure)
-    assertEquals(1, loader.attempts)
+    assertTrue(failed.moduleClass.isAbsent())
+    val replayedError = takeSingleLoadingError(replayReporter)
+    assertSame(initialError.failure, replayedError.failure)
+    assertEquals(1, failed.loader.attempts)
+
+  @Test def `markAbsent preserves an existing load failure`(): Unit =
+    val initialReporter = new StoreReporter(null)
+    ctx = retainingContext(initialReporter)
+    val failed = newFailedLoad("AbsentOwner")
+
+    assertTrue(failed.cls.isAbsent())
+    val initialError = takeSingleLoadingError(initialReporter)
+    failed.cls.denot.markAbsent()
+
+    val replayReporter = new StoreReporter(null)
+    ctx = retainingContext(replayReporter)
+    assertTrue(failed.cls.isAbsent())
+    val replayedError = takeSingleLoadingError(replayReporter)
+    assertSame(initialError.failure, replayedError.failure)
+
+  @Test def `exploring reporter can report a failure again after reset`(): Unit =
+    val reporter = new ExploringReporter
+    ctx = retainingContext(reporter)
+    val failed = newFailedLoad("ExploringOwner")
+
+    assertTrue(failed.cls.isAbsent())
+    assertEquals(1, reporter.pendingMessages.size)
+    reporter.reset()
+
+    assertTrue(failed.cls.isAbsent())
+    takeSingleLoadingError(reporter)
+    assertEquals(1, failed.loader.attempts)
 
   @Test def `distinct same-message failures are both reported`(): Unit =
     val reporter = new StoreReporter(null)
-    ctx = ctx.fresh.setReporter(reporter)
-    val firstLoader = new FailingLoader("same failure")
-    val secondLoader = new FailingLoader("same failure")
-    val (firstClass, _) = enterClassAndCompanion(newOwner("FirstOwner"), "Broken", firstLoader)
-    val (secondClass, _) = enterClassAndCompanion(newOwner("SecondOwner"), "Broken", secondLoader)
+    ctx = retainingContext(reporter)
+    val first = newFailedLoad("FirstOwner", "same failure")
+    val second = newFailedLoad("SecondOwner", "same failure")
 
-    assertTrue(firstClass.isAbsent())
-    assertTrue(secondClass.isAbsent())
-    val errors = loadingErrors(reporter)
+    assertTrue(first.cls.isAbsent())
+    assertTrue(second.cls.isAbsent())
+    val errors = takeLoadingErrors(reporter)
     assertEquals(2, errors.size)
-    assertEquals(errors.head.message, errors.last.message)
     assertNotSame(errors.head.failure, errors.last.failure)
-    assertEquals(1, firstLoader.attempts)
-    assertEquals(1, secondLoader.attempts)
+    assertEquals(1, first.loader.attempts)
+    assertEquals(1, second.loader.attempts)

--- a/compiler/test/dotty/tools/dotc/core/LoadingFailureTest.scala
+++ b/compiler/test/dotty/tools/dotc/core/LoadingFailureTest.scala
@@ -1,0 +1,112 @@
+package dotty.tools.dotc.core
+
+import java.io.IOException
+
+import dotty.tools.DottyTest
+import dotty.tools.dotc.reporting.Diagnostic.LoadingError
+import dotty.tools.dotc.reporting.StoreReporter
+
+import Contexts.*
+import Flags.*
+import Names.*
+import Scopes.*
+import Symbols.*
+import org.junit.Assert.*
+import org.junit.Test
+
+class LoadingFailureTest extends DottyTest:
+
+  private class FailingLoader(message: String) extends SymbolLoader:
+    var attempts = 0
+
+    def doComplete(root: SymDenotations.SymDenotation)(using Context): Unit =
+      attempts += 1
+      throw new IOException(message)
+
+    def compilationUnitInfo: CompilationUnitInfo | Null = null
+
+    def description(using Context): String = "failing test loader"
+
+  private def newOwner(name: String)(using Context): ClassSymbol =
+    newCompleteClassSymbol(
+      defn.EmptyPackageClass,
+      typeName(name),
+      EmptyFlags,
+      defn.ObjectType :: Nil,
+      newScope
+    ).entered
+
+  private def enterClassAndCompanion(
+      owner: ClassSymbol,
+      name: String,
+      loader: SymbolLoader
+  )(using Context): (ClassSymbol, ClassSymbol) =
+    val term = termName(name)
+    SymbolLoaders.enterClassAndModule(owner, term, loader)
+    val cls = owner.unforcedDecls.lookup(term.toTypeName).asClass
+    (cls, cls.scalacLinkedClass.asClass)
+
+  private def loadingErrors(reporter: StoreReporter)(using Context): List[LoadingError] =
+    reporter.removeBufferedMessages.collect:
+      case error: LoadingError => error
+
+  @Test def `failed load is cached and replayed once per reporter and run`(): Unit =
+    val firstReporter = new StoreReporter(null)
+    ctx = ctx.fresh.setReporter(firstReporter)
+    val loader = new FailingLoader("broken binary")
+    val (cls, moduleClass) = enterClassAndCompanion(newOwner("FailureOwner"), "Broken", loader)
+    val sourceModule = moduleClass.sourceModule
+
+    assertFalse(cls.isAbsent(canForce = false))
+    assertEquals(0, loader.attempts)
+    assertTrue(loadingErrors(firstReporter).isEmpty)
+
+    assertTrue(cls.isAbsent())
+    assertFalse(firstReporter.hasStickyErrors)
+    val initialErrors = loadingErrors(firstReporter)
+    assertEquals(1, loader.attempts)
+    assertEquals(1, initialErrors.size)
+    assertSame(
+      ctx.base.loadingFailures(cls),
+      ctx.base.loadingFailures(moduleClass)
+    )
+
+    assertTrue(cls.isAbsent())
+    assertTrue(moduleClass.isAbsent())
+    assertTrue(loadingErrors(firstReporter).isEmpty)
+
+    ctx = ctx.fresh.setPeriod(Periods.Period(ctx.runId + 1, ctx.phaseId))
+    assertTrue(cls.isAbsent())
+    val nextRunErrors = loadingErrors(firstReporter)
+    assertEquals(1, nextRunErrors.size)
+    assertSame(initialErrors.head.failure, nextRunErrors.head.failure)
+
+    ctx.base.reset()
+    val replayReporter = new StoreReporter(null)
+    ctx = ctx.fresh.setReporter(replayReporter)
+    assertTrue(sourceModule.isAbsent(canForce = false))
+    assertTrue(loadingErrors(replayReporter).isEmpty)
+
+    assertTrue(sourceModule.isAbsent())
+    assertTrue(cls.isAbsent())
+    val replayedErrors = loadingErrors(replayReporter)
+    assertEquals(1, replayedErrors.size)
+    assertSame(initialErrors.head.failure, replayedErrors.head.failure)
+    assertEquals(1, loader.attempts)
+
+  @Test def `distinct same-message failures are both reported`(): Unit =
+    val reporter = new StoreReporter(null)
+    ctx = ctx.fresh.setReporter(reporter)
+    val firstLoader = new FailingLoader("same failure")
+    val secondLoader = new FailingLoader("same failure")
+    val (firstClass, _) = enterClassAndCompanion(newOwner("FirstOwner"), "Broken", firstLoader)
+    val (secondClass, _) = enterClassAndCompanion(newOwner("SecondOwner"), "Broken", secondLoader)
+
+    assertTrue(firstClass.isAbsent())
+    assertTrue(secondClass.isAbsent())
+    val errors = loadingErrors(reporter)
+    assertEquals(2, errors.size)
+    assertEquals(errors.head.message, errors.last.message)
+    assertNotSame(errors.head.failure, errors.last.failure)
+    assertEquals(1, firstLoader.attempts)
+    assertEquals(1, secondLoader.attempts)

--- a/repl/src/dotty/tools/repl/ReplCompiler.scala
+++ b/repl/src/dotty/tools/repl/ReplCompiler.scala
@@ -16,7 +16,7 @@ import dotc.core.Contexts.atPhase
 import dotc.config.Feature
 import dotc.core.StdNames.*
 import dotc.core.Symbols.*
-import dotc.reporting.Diagnostic
+import dotc.reporting.{Diagnostic, StoreReporter}
 import dotc.transform.{CheckUnused, CheckShadowing, PostTyper, UnrollDefinitions, WInferUnion}
 import dotc.typer.ImportInfo.{withRootImports, RootRef}
 import dotc.typer.TyperPhase
@@ -203,7 +203,14 @@ class ReplCompiler extends Compiler:
     }
   }
 
-  final def typeCheck(expr: String, errorsAllowed: Boolean = false)(using state: State): Either[List[Diagnostic], (untpd.ValDef, tpd.ValDef)] = {
+  final def typeCheck(expr: String, errorsAllowed: Boolean = false)(using state: State): Either[List[Diagnostic], (untpd.ValDef, tpd.ValDef)] =
+    typeCheck(expr, errorsAllowed, newStoreReporter)
+
+  private[repl] final def typeCheck(
+    expr: String,
+    errorsAllowed: Boolean,
+    reporter: StoreReporter
+  )(using state: State): Either[List[Diagnostic], (untpd.ValDef, tpd.ValDef)] = {
 
     def wrapped(expr: String, sourceFile: SourceFile, state: State)(using Context): Either[List[Diagnostic], untpd.PackageDef] = {
       def wrap(trees: List[untpd.Tree]): untpd.PackageDef = {
@@ -260,7 +267,7 @@ class ReplCompiler extends Compiler:
 
     val src = SourceFile.virtual("<typecheck>", expr)
     inContext(state.context.fresh
-      .setReporter(newStoreReporter)
+      .setReporter(reporter)
       .setSetting(state.context.settings.YstopAfter, List("typer"))
     ) {
       wrapped(expr, src, state).flatMap { pkg =>

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -105,6 +105,7 @@ class ReplDriver(settings: Array[String],
   /** Create a fresh and initialized context with IDE mode enabled */
   private def initialCtx(settings: List[String]) = {
     val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions | Mode.Interactive)
+    rootCtx.setProperty(RetainedSymbolLoadingFailures, mutable.WeakHashMap.empty)
     rootCtx.setSetting(rootCtx.settings.XcookComments, true)
     rootCtx.setSetting(rootCtx.settings.XreadComments, true)
     setupRootCtx(this.settings ++ settings, rootCtx)
@@ -367,7 +368,7 @@ class ReplDriver(settings: Array[String],
     cursor: Int,
     expr: String,
     state0: State,
-    reportLoadingErrors: String => Unit
+    displayLoadingErrors: String => Unit
   ): List[Completion] =
     if expr.startsWith(":") then
       ReplCommands.names.collect:
@@ -390,13 +391,14 @@ class ReplDriver(settings: Array[String],
             List(Completion("<Error while fetching completions. Please report it to the Scala 3 maintainers at https://github.com/scala/scala3/issues>", "", Nil))
         }
         .getOrElse(Nil)
-      // Candidate discovery may force unrelated symbols, so discard its diagnostics.
+      // Candidate discovery can load symbols unrelated to the qualifier. Discard its
+      // diagnostics; failed loads are retained and reported if the symbol is requested later.
       state.context.reporter.removeBufferedMessages(using state.context)
-      val errors = typecheckReporter.removeBufferedMessages(using state.context).collect:
+      val loadingErrors = typecheckReporter.removeBufferedMessages(using state.context).collect:
         case error: Diagnostic.LoadingError => error
-      if errors.nonEmpty then
+      if loadingErrors.nonEmpty then
         given Context = state.context
-        reportLoadingErrors(errors.map(ReplConsoleReporter.messageAndPos).mkString("\n"))
+        displayLoadingErrors(loadingErrors.map(ReplConsoleReporter.messageAndPos).mkString("\n"))
       result
   end completions
 

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -105,7 +105,7 @@ class ReplDriver(settings: Array[String],
   /** Create a fresh and initialized context with IDE mode enabled */
   private def initialCtx(settings: List[String]) = {
     val rootCtx = initCtx.fresh.addMode(Mode.ReadPositions | Mode.Interactive)
-    rootCtx.setProperty(RetainedSymbolLoadingFailures, mutable.WeakHashMap.empty)
+    rootCtx.setRetainedSymbolLoadingFailures(mutable.WeakHashMap.empty)
     rootCtx.setSetting(rootCtx.settings.XcookComments, true)
     rootCtx.setSetting(rootCtx.settings.XreadComments, true)
     setupRootCtx(this.settings ++ settings, rootCtx)

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -215,7 +215,7 @@ class ReplDriver(settings: Array[String],
             /* complete = */ false  // if true adds space when completing
           )
         }
-        val comps = completions(line.cursor, line.line, state)
+        val comps = completions(line.cursor, line.line, state, lineReader.printAbove(_))
         candidates.addAll(comps.map(_.label).distinct.map(makeCandidate).asJava)
         val lineWord = line.word()
         comps.filter(c => c.label == lineWord && c.symbols.nonEmpty) match
@@ -361,13 +361,22 @@ class ReplDriver(settings: Array[String],
 
   /** Extract possible completions at the index of `cursor` in `expr` */
   protected final def completions(cursor: Int, expr: String, state0: State): List[Completion] =
+    completions(cursor, expr, state0, out.println(_))
+
+  private def completions(
+    cursor: Int,
+    expr: String,
+    state0: State,
+    reportLoadingErrors: String => Unit
+  ): List[Completion] =
     if expr.startsWith(":") then
       ReplCommands.names.collect:
         case command if command.startsWith(expr) => Completion(command, "", List())
     else
+      val typecheckReporter = newStoreReporter
       given state: State = newRun(state0)
-      compiler
-        .typeCheck(expr, errorsAllowed = true)
+      val result = compiler
+        .typeCheck(expr, errorsAllowed = true, reporter = typecheckReporter)
         .map { (untpdTree, tpdTree) =>
           val file = SourceFile.virtual("<completions>", expr, maybeIncomplete = true)
           val unit = CompilationUnit(file)(using state.context)
@@ -381,6 +390,14 @@ class ReplDriver(settings: Array[String],
             List(Completion("<Error while fetching completions. Please report it to the Scala 3 maintainers at https://github.com/scala/scala3/issues>", "", Nil))
         }
         .getOrElse(Nil)
+      // Candidate discovery may force unrelated symbols, so discard its diagnostics.
+      state.context.reporter.removeBufferedMessages(using state.context)
+      val errors = typecheckReporter.removeBufferedMessages(using state.context).collect:
+        case error: Diagnostic.LoadingError => error
+      if errors.nonEmpty then
+        given Context = state.context
+        reportLoadingErrors(errors.map(ReplConsoleReporter.messageAndPos).mkString("\n"))
+      result
   end completions
 
   protected def interpret(res: ParseResult)(using state: State): State = {

--- a/repl/test/dotty/tools/repl/CompletionDiagnosticsTests.scala
+++ b/repl/test/dotty/tools/repl/CompletionDiagnosticsTests.scala
@@ -28,6 +28,7 @@ object CompletionDiagnosticsTests:
     Files.write(Files.createDirectories(classpath.resolve("scala")).resolve("CompletionPoison.class"), brokenBytes)
 
   def options: Array[String] =
+    // `-Ydebug` prints exceptions from the deliberately corrupt classfiles.
     ReplTest.createOptions(classpath.toString).filterNot(_ == "-Ydebug")
 
   @AfterClass def tearDownFixture(): Unit =
@@ -40,11 +41,11 @@ object CompletionDiagnosticsTests:
 class CompletionDiagnosticsTests extends ReplTest(options = CompletionDiagnosticsTests.options):
 
   private def assertSingleLoadingError(output: String, name: String): Unit =
-    assertTrue(output, output.contains(s"error while loading $name"))
-    assertTrue(output, output.contains("is broken"))
-    assertEquals(1, output.linesIterator.count(_.contains(s"error while loading $name")))
+    val header = s"error while loading $name"
+    assertTrue(output, output.contains(header))
+    assertEquals(output, 1, output.linesIterator.count(_.contains(header)))
 
-  @Test def `i18614 loading errors are reported for every explicit completion`: Unit =
+  @Test def `explicit completion reports a loading error on every request`: Unit =
     initially:
       tabComplete("import broken.Broken.")
       assertSingleLoadingError(storedOutput(), "Broken")
@@ -52,26 +53,28 @@ class CompletionDiagnosticsTests extends ReplTest(options = CompletionDiagnostic
       tabComplete("import broken.Broken.")
       assertSingleLoadingError(storedOutput(), "Broken")
 
-  @Test def `ordinary completion errors remain hidden`: Unit =
+  @Test def `missing member completion remains silent`: Unit =
     initially:
       tabComplete("List.doesNotExist")
       assertEquals("", storedOutput())
 
-  @Test def `incidental loading errors remain available to an explicit completion`: Unit =
+  @Test def `loading error found by completion is replayed by a later submission`: Unit =
     initially {
       val state = run("object O")
       storedOutput()
-      Files.write(CompletionDiagnosticsTests.incidentalClassfile, CompletionDiagnosticsTests.invalidClassfile(99))
       state
     } andThen {
       try
+        Files.write(CompletionDiagnosticsTests.incidentalClassfile, CompletionDiagnosticsTests.invalidClassfile(99))
+
+        // Extension completion for `O.` enumerates the default `scala.*` import,
+        // which forces `CompletionPoison` while looking for candidates.
         tabComplete("O.")
         assertEquals("", storedOutput())
 
-        // Changing the file again proves that the explicit query replays the failure found by `O.`
-        // instead of attempting the physical load for the first time.
+        // A second load would now fail on the header, not on constant-pool tag 99.
         Files.write(CompletionDiagnosticsTests.incidentalClassfile, Array[Byte](0, 0, 0, 0))
-        tabComplete("import scala.CompletionPoison.")
+        run("val poison: scala.CompletionPoison = ???")
         val output = storedOutput()
         assertSingleLoadingError(output, "CompletionPoison")
         assertTrue(output, output.contains("bad constant pool tag 99"))

--- a/repl/test/dotty/tools/repl/CompletionDiagnosticsTests.scala
+++ b/repl/test/dotty/tools/repl/CompletionDiagnosticsTests.scala
@@ -1,0 +1,80 @@
+package dotty.tools
+package repl
+
+import java.nio.file.Files
+
+import org.junit.{AfterClass, Test}
+import org.junit.Assert.{assertEquals, assertTrue}
+
+object CompletionDiagnosticsTests:
+  private val classpath = Files.createTempDirectory("repl-completion-diagnostics")
+  private def invalidClassfile(tag: Byte) = Array[Byte](
+    0xca.toByte,
+    0xfe.toByte,
+    0xba.toByte,
+    0xbe.toByte,
+    0,
+    0,
+    0,
+    52, // Java 8 classfile header
+    0,
+    2, // constant_pool_count (one entry)
+    tag // invalid tag for entry #1
+  )
+  private val brokenBytes = invalidClassfile(0)
+  private val brokenClassfile =
+    Files.write(Files.createDirectories(classpath.resolve("broken")).resolve("Broken.class"), brokenBytes)
+  private val incidentalClassfile =
+    Files.write(Files.createDirectories(classpath.resolve("scala")).resolve("CompletionPoison.class"), brokenBytes)
+
+  def options: Array[String] =
+    ReplTest.createOptions(classpath.toString).filterNot(_ == "-Ydebug")
+
+  @AfterClass def tearDownFixture(): Unit =
+    Files.delete(brokenClassfile)
+    Files.delete(incidentalClassfile)
+    Files.delete(brokenClassfile.getParent)
+    Files.delete(incidentalClassfile.getParent)
+    Files.delete(classpath)
+
+class CompletionDiagnosticsTests extends ReplTest(options = CompletionDiagnosticsTests.options):
+
+  private def assertSingleLoadingError(output: String, name: String): Unit =
+    assertTrue(output, output.contains(s"error while loading $name"))
+    assertTrue(output, output.contains("is broken"))
+    assertEquals(1, output.linesIterator.count(_.contains(s"error while loading $name")))
+
+  @Test def `i18614 loading errors are reported for every explicit completion`: Unit =
+    initially:
+      tabComplete("import broken.Broken.")
+      assertSingleLoadingError(storedOutput(), "Broken")
+
+      tabComplete("import broken.Broken.")
+      assertSingleLoadingError(storedOutput(), "Broken")
+
+  @Test def `ordinary completion errors remain hidden`: Unit =
+    initially:
+      tabComplete("List.doesNotExist")
+      assertEquals("", storedOutput())
+
+  @Test def `incidental loading errors remain available to an explicit completion`: Unit =
+    initially {
+      val state = run("object O")
+      storedOutput()
+      Files.write(CompletionDiagnosticsTests.incidentalClassfile, CompletionDiagnosticsTests.invalidClassfile(99))
+      state
+    } andThen {
+      try
+        tabComplete("O.")
+        assertEquals("", storedOutput())
+
+        // Changing the file again proves that the explicit query replays the failure found by `O.`
+        // instead of attempting the physical load for the first time.
+        Files.write(CompletionDiagnosticsTests.incidentalClassfile, Array[Byte](0, 0, 0, 0))
+        tabComplete("import scala.CompletionPoison.")
+        val output = storedOutput()
+        assertSingleLoadingError(output, "CompletionPoison")
+        assertTrue(output, output.contains("bad constant pool tag 99"))
+      finally
+        Files.write(CompletionDiagnosticsTests.incidentalClassfile, CompletionDiagnosticsTests.brokenBytes)
+    }


### PR DESCRIPTION
Fixes #18614

Keep loading errors around so later REPL completions can still report them, while unrelated completion searches stay quiet.

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by reviewing it. 

I explored a few alternatives, and this is a simple one that at least replays the error when completing again.

The more fundamental problem is that REPL completions are side-effecting operations, but it'd require a significant amount of work to make them isolated. 

And `:dep` itself is another can of worms I dare not open this time. 

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

& manual testing using `./bin/replQ`.