### PR TITLE
Simplify or avoid some data copies

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BCodeSkelBuilder.scala
@@ -44,7 +44,7 @@ trait BCodeSkelBuilder extends BCodeHelpers {
 
     def push(btype: BType): Unit =
       if size == stack.length then
-        stack = java.util.Arrays.copyOf(stack, stack.length * 2)
+        stack = Array.copyOf(stack, stack.length * 2)
       stack(size) = btype
       size += 1
 

--- a/compiler/src/dotty/tools/backend/jvm/analysis/AliasingAnalyzer.scala
+++ b/compiler/src/dotty/tools/backend/jvm/analysis/AliasingAnalyzer.scala
@@ -512,9 +512,7 @@ object AliasSet {
     else {
       var newLength = set.length
       while (index >= newLength) newLength *= 2
-      val newSet = new Array[Long](newLength)
-      Array.copy(set, 0, newSet, 0, set.length)
-      newSet
+      Array.copyOf(set, newLength)
     }
   }
 

--- a/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/LocalOpt.scala
@@ -693,9 +693,7 @@ object LocalOptImpls {
     var top = -1
     def enq(i: Int): Unit = {
       if (top == queue.length - 1) {
-        val nq = new Array[Int](queue.length * 2)
-        Array.copy(queue, 0, nq, 0, queue.length)
-        queue = nq
+        queue = Array.copyOf(queue, queue.length * 2)
       }
       top += 1
       queue(top) = i

--- a/compiler/src/dotty/tools/backend/jvm/opt/MethodMax.scala
+++ b/compiler/src/dotty/tools/backend/jvm/opt/MethodMax.scala
@@ -51,9 +51,7 @@ object MethodMax {
 
       def enq(i: Int): Unit = {
         if (top == queue.length - 1) {
-          val nq = new Array[Int](queue.length * 2)
-          Array.copy(queue, 0, nq, 0, queue.length)
-          queue = nq
+          queue = Array.copyOf(queue, queue.length * 2)
         }
         top += 1
         queue(top) = i

--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -899,7 +899,7 @@ object Trees {
     override def isTerm: Boolean = name.isTermName
 
     override def nameSpan(using Context): Span =
-      if span.exists then Span(span.start, span.start + name.toString.length) else span
+      if span.exists then Span(span.start, span.start + name.length) else span
   }
 
   /** tree_1 | ... | tree_n */

--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1393,7 +1393,7 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
 
   // convert a numeric with a toXXX method
   def primitiveConversion(tree: Tree, numericCls: Symbol)(using Context): Tree =
-    val mname      = "to".concat(numericCls.name)
+    val mname      = termName("to" + numericCls.name.toString)
     val conversion = tree.tpe.member(mname)
     if conversion.symbol.exists then
       tree.select(conversion.symbol.termRef).ensureApplied

--- a/compiler/src/dotty/tools/dotc/core/Contexts.scala
+++ b/compiler/src/dotty/tools/dotc/core/Contexts.scala
@@ -1147,16 +1147,9 @@ object Contexts {
     private[Contexts] val comparers = new mutable.ArrayBuffer[TypeComparer]
     private[Contexts] var comparersInUse: Int = 0
 
-    private var charArray = new Array[Char](256)
-
     private[dotc] var wConfCache: (List[String], WConf) = uninitialized
 
     private[dotc] val patched: Rewrites.PatchedFiles = Rewrites.newPatchedFiles()
-
-    def sharedCharArray(len: Int): Array[Char] =
-      while len > charArray.length do
-        charArray = new Array[Char](charArray.length * 2)
-      charArray
 
     def reset(): Unit =
       uniques.clear()

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -30,16 +30,6 @@ object Decorators {
         else Some((s.take(idx), s.drop(if (doDropIndex) idx + 1 else idx)))
       splitAt(s.indexWhere(f), doDropIndex)
 
-    def concat(name: Name)(using Context): SimpleName = name match
-      case name: SimpleName =>
-        val len = s.length + name.length
-        val chars = ctx.base.sharedCharArray(len)
-        s.getChars(0, s.length, chars, 0)
-        if name.length != 0 then name.getChars(0, name.length, chars, s.length)
-        termName(chars, 0, len)
-      case name: TypeName => s.concat(name.toTermName)
-      case _ => termName(s.concat(name.toString))
-
     def indented(width: Int): String =
       val padding = " " * width
       padding + s.replace("\n", "\n" + padding)

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -30,18 +30,6 @@ object Decorators {
         else Some((s.take(idx), s.drop(if (doDropIndex) idx + 1 else idx)))
       splitAt(s.indexWhere(f), doDropIndex)
 
-    /** Create a term name from a string slice, using a common buffer.
-     *  This avoids some allocation relative to `termName(s)`
-     */
-    def sliceToTermName(start: Int, end: Int)(using Context): SimpleName =
-      val len = end - start
-      val chars = ctx.base.sharedCharArray(len)
-      s.getChars(start, end, chars, 0)
-      termName(chars, 0, len)
-
-    def sliceToTypeName(start: Int, end: Int)(using Context): TypeName =
-      sliceToTermName(start, end).toTypeName
-
     def concat(name: Name)(using Context): SimpleName = name match
       case name: SimpleName =>
         val len = s.length + name.length

--- a/compiler/src/dotty/tools/dotc/core/Decorators.scala
+++ b/compiler/src/dotty/tools/dotc/core/Decorators.scala
@@ -45,7 +45,7 @@ object Decorators {
     def concat(name: Name)(using Context): SimpleName = name match
       case name: SimpleName =>
         val len = s.length + name.length
-        var chars = ctx.base.sharedCharArray(len)
+        val chars = ctx.base.sharedCharArray(len)
         s.getChars(0, s.length, chars, 0)
         if name.length != 0 then name.getChars(0, name.length, chars, s.length)
         termName(chars, 0, len)

--- a/compiler/src/dotty/tools/dotc/core/Definitions.scala
+++ b/compiler/src/dotty/tools/dotc/core/Definitions.scala
@@ -1631,9 +1631,7 @@ class Definitions {
     private var classRefs: Array[TypeRef | Null] = new Array(22)
     def apply(n: Int): TypeRef =
       while n >= classRefs.length do
-        val classRefs1 = new Array[TypeRef | Null](classRefs.length * 2)
-        Array.copy(classRefs, 0, classRefs1, 0, classRefs.length)
-        classRefs = classRefs1
+        classRefs = Array.copyOf(classRefs, classRefs.length * 2)
       if classRefs(n) == null then
         val funName = s"scala.$prefix$n"
         classRefs(n) =

--- a/compiler/src/dotty/tools/dotc/core/NameKinds.scala
+++ b/compiler/src/dotty/tools/dotc/core/NameKinds.scala
@@ -186,7 +186,7 @@ object NameKinds {
       var i = name.length
       while i > 0 && name(i - 1).isDigit do i -= 1
       if i >= separator.length && i < name.length
-          && name.slice(i - separator.length, i).toString == separator
+          && name.sliceToString(i - separator.length, i) == separator
       then i
       else -1
 

--- a/compiler/src/dotty/tools/dotc/core/Names.scala
+++ b/compiler/src/dotty/tools/dotc/core/Names.scala
@@ -65,6 +65,9 @@ object Names {
     /** Convert to string after mangling */
     def mangledString: String
 
+    /** This name's length */
+    def length: Int
+
     /** Apply rewrite rule given by `f` to some part of this name, skipping and rewrapping
      *  other decorators.
      *  Stops at DerivedNames with infos of kind QualifiedInfo.
@@ -138,9 +141,6 @@ object Names {
     /** Append `other` to the last part of this name */
     def ++ (other: Name): ThisName = ++ (other.toString)
     def ++ (other: String): ThisName = mapLast(n => termName(n.toString + other))
-
-    /** Replace all occurrences of `from` to `to` in this name */
-    def replace(from: Char, to: Char): ThisName = mapParts(_.replace(from, to))
 
     /** Is this name empty? */
     def isEmpty: Boolean
@@ -273,7 +273,7 @@ object Names {
   }
 
   /** A simple name is essentially an interned string */
-  final class SimpleName(val start: Int, val length: Int) extends TermName {
+  final class SimpleName(val start: Int, override val length: Int) extends TermName {
 
   /** The n'th character */
     def apply(n: Int): Char = chrs(start + n)
@@ -332,6 +332,10 @@ object Names {
       assert(0 <= from && from <= end && end <= length)
       Array.copy(chrs, start + from, dst, dstStart, end - from)
 
+    def toUTF8Bytes(): Array[Byte] =
+      if length == 0 then Array.emptyByteArray
+      else Codec.toUTF8(chrs, start, length)
+
     override def asSimpleName: SimpleName = this
     override def toSimpleName: SimpleName = this
     override final def mangle: SimpleName = encode
@@ -369,14 +373,6 @@ object Names {
       while i <= suffix.length && i <= length && apply(length - i) == suffix(suffix.length - i) do i += 1
       i > suffix.length
 
-    override def replace(from: Char, to: Char): SimpleName = {
-      val cs = new Array[Char](length)
-      System.arraycopy(chrs, start, cs, 0, length)
-      for (i <- 0 until length)
-        if (cs(i) == from) cs(i) = to
-      termName(cs, 0, length)
-    }
-
     override def firstPart: SimpleName = this
     override def lastPart: SimpleName = this
 
@@ -404,6 +400,7 @@ object Names {
     override def mangled: TypeName = toTermName.mangled.toTypeName
     override def mangledString: String = toTermName.mangledString
 
+    override def length: Int = toTermName.length
     override def replace(f: PartialFunction[Name, Name]): ThisName = toTermName.replace(f).toTypeName
     override def collect[T](f: PartialFunction[Name, T]): Option[T] = toTermName.collect(f)
     override def mapLast(f: SimpleName => SimpleName): TypeName = toTermName.mapLast(f).toTypeName
@@ -435,7 +432,10 @@ object Names {
     override def asSimpleName: Nothing = throw new UnsupportedOperationException(s"$debugString is not a simple name")
 
     override def toSimpleName: SimpleName = termName(toString)
-    override final def mangle: SimpleName = encode.toSimpleName
+    override def mangle: SimpleName = encode.toSimpleName
+
+    override def length: Int =
+      toString.length
 
     override def replace(f: PartialFunction[Name, Name]): ThisName =
       if (f.isDefinedAt(this)) likeSpaced(f(this))
@@ -492,7 +492,7 @@ object Names {
 
   /** Memory to store all names sequentially. */
   @sharable // because it's only mutated in synchronized block of enterIfNew
-  private[dotty] var chrs: Array[Char] = new Array[Char](InitialNameSize)
+  private var chrs: Array[Char] = new Array[Char](InitialNameSize)
 
   /** The number of characters filled. */
   @sharable // because it's only mutated in synchronized block of enterIfNew

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -220,19 +220,11 @@ object SymbolLoaders {
         val completer =
           if bin.ext.isTasty || bin.ext.isBetasty then ctx.platform.newTastyLoader(bin)
           else ctx.platform.newClassLoader(bin)
-        enterClassAndModule(owner, nameOf(classRep), completer)
+        enterClassAndModule(owner, termName(classRep.name), completer)
     }
 
   def needCompile(bin: AbstractFile, src: AbstractFile): Boolean =
     src.lastModified >= bin.lastModified
-
-  private def nameOf(classRep: ClassRepresentation)(using Context): TermName =
-    // avoid forcing `classRep.name` when we just need the length
-    val nameLength = {
-      val ix = classRep.fileName.lastIndexOf('.')
-      if (ix < 0) classRep.fileName.length else ix
-    }
-    classRep.fileName.sliceToTermName(0, nameLength)
 
   /** Load contents of a package
    */

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -200,8 +200,8 @@ object SymbolLoaders {
    *  Note: We do a name-base comparison here because the method is called before we even
    *  have ReflectPackage defined.
    */
-  def binaryOnly(owner: Symbol, name: TermName)(using Context): Boolean =
-    name == nme.PACKAGEkw &&
+  def binaryOnly(owner: Symbol, name: String)(using Context): Boolean =
+    name == nme.PACKAGE.toString &&
       (owner.name == nme.scala || owner.name == nme.reflect && owner.owner.name == nme.scala)
 
   /** Initialize toplevel class and module symbols in `owner` from class path representation `classRep`
@@ -210,7 +210,7 @@ object SymbolLoaders {
     // module-info is a special class added by JPMS (Java 9+) that cannot be parsed like a normal class
     if classRep.name != "module-info" then
       ((classRep.binary, classRep.source): @unchecked) match {
-      case (Some(bin), Some(src)) if needCompile(bin, src) && !binaryOnly(owner, nameOf(classRep)) =>
+      case (Some(bin), Some(src)) if needCompile(bin, src) && !binaryOnly(owner, classRep.name) =>
         if (ctx.settings.verbose.value) report.inform("[symloader] picked up newer source file for " + src.path)
         enterToplevelsFromSource(owner, src)
       case (None, Some(src)) =>

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -134,7 +134,7 @@ object SymbolLoaders {
    *  All entered symbols are given a source completer of `src` as info.
    */
   def enterToplevelsFromSource(
-      owner: Symbol, name: PreName, src: AbstractFile,
+      owner: Symbol, src: AbstractFile,
       scope: Scope = EmptyScope)(using Context): Unit =
     if src.exists && !src.isDirectory then
       val completer = new SourcefileLoader(src)
@@ -212,10 +212,10 @@ object SymbolLoaders {
       ((classRep.binary, classRep.source): @unchecked) match {
       case (Some(bin), Some(src)) if needCompile(bin, src) && !binaryOnly(owner, nameOf(classRep)) =>
         if (ctx.settings.verbose.value) report.inform("[symloader] picked up newer source file for " + src.path)
-        enterToplevelsFromSource(owner, nameOf(classRep), src)
+        enterToplevelsFromSource(owner, src)
       case (None, Some(src)) =>
         if (ctx.settings.verbose.value) report.inform("[symloader] no class or tasty, picked up source file for " + src.path)
-        enterToplevelsFromSource(owner, nameOf(classRep), src)
+        enterToplevelsFromSource(owner, src)
       case (Some(bin), _) =>
         val completer =
           if bin.ext.isTasty || bin.ext.isBetasty then ctx.platform.newTastyLoader(bin)

--- a/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/core/tasty/NameBuffer.scala
@@ -82,9 +82,7 @@ class NameBuffer extends TastyBuffer(10000) {
     name.toTermName match {
       case name: SimpleName =>
         writeByte(tag)
-        val bytes =
-          if (name.length == 0) new Array[Byte](0)
-          else Codec.toUTF8(chrs, name.start, name.length)
+        val bytes = name.toUTF8Bytes()
         writeNat(bytes.length)
         writeBytes(bytes, bytes.length)
       case AnyQualifiedName(prefix, name) =>

--- a/compiler/src/dotty/tools/dotc/interactive/SourceTree.scala
+++ b/compiler/src/dotty/tools/dotc/interactive/SourceTree.scala
@@ -28,8 +28,8 @@ case class SourceTree(tree: tpd.Import | tpd.NameTree, source: SourceFile) {
       else {
         // Constructors are named `<init>` in the trees, but `this` in the source.
         val nameLength = tree.name match {
-          case nme.CONSTRUCTOR => nme.this_.toString.length
-          case other => other.stripModuleClassSuffix.show.toString.length
+          case nme.CONSTRUCTOR => nme.this_.length
+          case other => other.stripModuleClassSuffix.show.length
         }
         val position = {
           // FIXME: This is incorrect in some cases, like with backquoted identifiers,

--- a/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
+++ b/compiler/src/dotty/tools/dotc/parsing/JavaParsers.scala
@@ -29,6 +29,7 @@ object JavaParsers {
   import ast.untpd.*
 
 
+  val nonName = termName("non")
   val fakeFlags = Flags.JavaDefined | Flags.PrivateLocal | Flags.Invisible
 
   class JavaParser(source: SourceFile)(using Context) extends ParserCommon(source) {
@@ -515,7 +516,7 @@ object JavaParsers {
             flags |= Flags.Sealed
             in.nextToken()
           // JEP-409: Special trick for the 'non-sealed' java keyword
-          case IDENTIFIER if in.name.toString == "non" =>
+          case IDENTIFIER if in.name == nonName =>
             val lookahead = in.LookaheadScanner()
             ({lookahead.nextToken(); lookahead.token}, {lookahead.nextToken(); lookahead.name.toString}) match
               case (MINUS, "sealed") =>

--- a/compiler/src/dotty/tools/dotc/quoted/TastyString.scala
+++ b/compiler/src/dotty/tools/dotc/quoted/TastyString.scala
@@ -1,7 +1,9 @@
 package dotty.tools.dotc.quoted
 
+import java.io.{ByteArrayInputStream, SequenceInputStream}
+import java.nio.charset.StandardCharsets
 import java.util.Base64
-import java.nio.charset.StandardCharsets.UTF_8
+import scala.jdk.CollectionConverters.*
 
 /** Utils for String representation of TASTY */
 object TastyString {
@@ -11,19 +13,22 @@ object TastyString {
 
   /** Encode TASTY bytes into a List of String */
   def pickle(bytes: Array[Byte]): List[String] = {
-    val str = new String(Base64.getEncoder().encode(bytes), UTF_8)
+    val str = Base64.getEncoder().encodeToString(bytes)
     str.toSeq.sliding(maxStringSize, maxStringSize).map(_.unwrap).toList
   }
 
   /** Decode the List of Strings into TASTY bytes */
   def unpickle(strings: List[String]): Array[Byte] = {
-    val string = new StringBuilder
-    strings.foreach(string.append)
-    Base64.getDecoder().decode(string.result().getBytes(UTF_8))
+    val stream = new SequenceInputStream(
+      strings.map(s => new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8))).iterator.asJavaEnumeration
+    )
+    val result = Base64.getDecoder().wrap(stream)
+    try result.readAllBytes()
+    finally result.close()
   }
 
   /** Decode the Strings into TASTY bytes */
   def unpickle(string: String): Array[Byte] =
-    Base64.getDecoder().decode(string.getBytes(UTF_8))
+    Base64.getDecoder().decode(string)
 
 }

--- a/compiler/src/dotty/tools/dotc/reporting/Message.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Message.scala
@@ -150,7 +150,7 @@ object Message:
 
         val suffix = alts.length match {
           case 1 => ""
-          case n => n.toString.toCharArray.map {
+          case n => n.toString.map {
             case '0' => '⁰'
             case '1' => '¹'
             case '2' => '²'
@@ -161,7 +161,7 @@ object Message:
             case '7' => '⁷'
             case '8' => '⁸'
             case '9' => '⁹'
-          }.mkString
+          }
         }
         str + suffix
       else str

--- a/compiler/src/dotty/tools/dotc/reporting/Profile.scala
+++ b/compiler/src/dotty/tools/dotc/reporting/Profile.scala
@@ -125,7 +125,7 @@ class ActiveProfile(details: Int) extends Profile:
 
     def printDetails(agg: Profile.Info): Unit =
       val sourceNameWidth = safeMax(agg.leading.map(_.meth.source.name.length))
-      val methNameWidth = safeMax(agg.leading.map(_.meth.name.toString.length))
+      val methNameWidth = safeMax(agg.leading.map(_.meth.name.length))
       report.echo("\nMost complex methods:")
       val layout = printHeader(sourceNameWidth, methNameWidth)
       for

--- a/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/ExtractSemanticDB.scala
@@ -382,7 +382,7 @@ private[semanticdb] object ExtractSemanticDB:
               case tree @ NamedArg(name, arg) =>
                 traverse(localBodies.getOrElse(arg.symbol, arg))
                 genParamSymbol(name).foreach(
-                  registerUse(_, tree.span.startPos.withEnd(tree.span.start + name.toString.length), tree.source)
+                  registerUse(_, tree.span.startPos.withEnd(tree.span.start + name.length), tree.source)
                 )
               case _ => traverse(arg)
         case tree: Assign =>

--- a/compiler/src/dotty/tools/dotc/semanticdb/internal/MD5.scala
+++ b/compiler/src/dotty/tools/dotc/semanticdb/internal/MD5.scala
@@ -6,15 +6,15 @@ import java.security.MessageDigest
 
 object MD5 {
   def compute(string: String): String = {
-    compute(ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8)))
+    compute(string.getBytes(StandardCharsets.UTF_8))
   }
-  def compute(buffer: ByteBuffer): String = {
+  def compute(buffer: Array[Byte]): String = {
     val md = MessageDigest.getInstance("MD5")
     md.update(buffer)
     bytesToHex(md.digest())
   }
-  private val hexArray = "0123456789ABCDEF".toCharArray
-  def bytesToHex(bytes: Array[Byte]): String = {
+  private val hexArray = Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F')
+  private def bytesToHex(bytes: Array[Byte]): String = {
     val hexChars = new Array[Char](bytes.length * 2)
     var j = 0
     while (j < bytes.length) {

--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -1115,7 +1115,7 @@ object CheckUnused:
     def namePos: SrcPos =
       sym.srcPos.sourcePos.withSpan:
         val span = sym.span
-        Span(span.start, span.start + sym.name.toString.length)
+        Span(span.start, span.start + sym.name.length)
 
   extension (sel: ImportSelector)
     def boundTpe: Type = sel.bound match

--- a/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Objects.scala
@@ -1304,7 +1304,7 @@ class Objects(using Context @constructorOnly):
           UnknownValue
 
       else if target.exists then
-        def isNextFieldOfColonColon: Boolean = ref.klass == defn.ConsClass && target.name.toString == "next"
+        def isNextFieldOfColonColon: Boolean = ref.klass == defn.ConsClass && target.name == nme.next
         if target.isMutableVarOrAccessor && !isNextFieldOfColonColon then
           if ref.hasVar(target) then
             if ref.owner == State.currentObject then

--- a/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
+++ b/compiler/src/dotty/tools/dotc/transform/init/Semantic.scala
@@ -783,7 +783,7 @@ object Semantic:
 
         case Fun(body, thisV, klass) =>
           // meth == NoSymbol for poly functions
-          if meth.name.toString == "tupled" then value // a call like `fun.tupled`
+          if meth.name == nme.tupled then value // a call like `fun.tupled`
           else
             promoteArgs()
             eval(body, thisV, klass, cacheResult = true)

--- a/compiler/src/dotty/tools/dotc/typer/Deriving.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Deriving.scala
@@ -42,7 +42,7 @@ trait Deriving {
      *  @param  reportErrors  Report an error if an instance with the same name exists already
      */
     private def addDerivedInstance(derived: tpd.Tree, clsName: Name, info: Type, pos: SrcPos): Unit = {
-      val instanceName = "derived$".concat(clsName)
+      val instanceName = termName("derived$" + clsName.toString)
       if (ctx.denotNamed(instanceName).exists)
         report.error(em"duplicate type class derivation for $clsName", pos)
       else

--- a/compiler/src/dotty/tools/dotc/typer/Migrations.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Migrations.scala
@@ -329,7 +329,7 @@ trait Migrations:
     private def usesAppMember(tree: tpd.Tree, allowArgs: Boolean)(using Context): Boolean =
       def isAppMember(sym: Symbol) = sym.exists && sym.maybeOwner == defn.AppClass
       tree.existsSubTree {
-        case id: tpd.Ident   => isAppMember(id.symbol) && !(allowArgs && id.symbol.name.toString == "args")
+        case id: tpd.Ident   => isAppMember(id.symbol) && !(allowArgs && id.symbol.name == nme.args)
         case sel: tpd.Select => isAppMember(sel.symbol)
         case _               => false
       }

--- a/compiler/src/dotty/tools/dotc/util/CharBuffer.scala
+++ b/compiler/src/dotty/tools/dotc/util/CharBuffer.scala
@@ -11,9 +11,7 @@ class CharBuffer(initialSize: Int = 1024):
 
   def append(ch: Char): Unit =
     if len == cs.length then
-      val cs1 = new Array[Char](len * 2)
-      Array.copy(cs, 0, cs1, 0, len)
-      cs = cs1
+      cs = Array.copyOf(cs, len * 2)
     cs(len) = ch
     len += 1
 

--- a/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
+++ b/compiler/src/scala/quoted/runtime/impl/printers/SourceCode.scala
@@ -1458,7 +1458,7 @@ object SourceCode {
         namesIndex(name0) = index + 1
         val name =
           if index == 1 then name0
-          else s"`$name0${index.toString.toCharArray.map {x => (x - '0' + '₀').toChar}.mkString}`"
+          else s"`$name0${index.toString.map {x => (x - '0' + '₀').toChar}}`"
         names(sym) = name
         Some(name)
       }


### PR DESCRIPTION
Non-controversial parts of #26427:
- Simplify some array copying operations
- Avoid other copying operations entirely

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)