### PR TITLE
Backport "Do not emit Java generic signatures for trait private val setters" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/Mixin.scala
+++ b/compiler/src/dotty/tools/dotc/transform/Mixin.scala
@@ -164,8 +164,13 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
           val setter = makeTraitSetter(decl.asTerm)
           setter.validFor = thisPhase.validFor // validity of setter = next phase up to next transformer afterwards
           decls1.enter(setter)
-          // Re-create the setter from the unerased getter so we can have its unerased form for generic signatures
-          mixinGenericInfos(setter) = atPhase(erasurePhase) { makeTraitSetter(decl.asTerm).info }
+          // Only populate generic infos for non-private decls, since private ones may refer to private types,
+          // and are anyway not useful as only Scala code can access them
+          atPhase(erasurePhase) {
+            if !decl.is(Private) then
+              // Re-create the setter from the unerased getter so we can have its unerased form for generic signatures
+              mixinGenericInfos(setter) = makeTraitSetter(decl.asTerm).info
+          }
           modified = true
       if modified then
         sym.copySymDenotation(
@@ -318,10 +323,7 @@ class Mixin extends MiniPhase with SymTransformer { thisPhase =>
         val copied = transformFollowing(DefDef(mkForwarderSym(setter.asTerm), unitLiteral.withSpan(cls.span)))
         mixinGenericInfos.get(setter) match
           case Some(gi) =>
-            mixinGenericInfos(copied.symbol) = atPhase(erasurePhase) {
-              val mixinArgs = mixin.typeParams.map(_.typeRef.asSeenFrom(cls.thisType, mixin))
-              gi.subst(mixin.typeParams, mixinArgs)
-            }
+            mixinGenericInfos(copied.symbol) = atPhase(erasurePhase) { gi.asSeenFrom(cls.thisType, mixin) }
           case None => ()
         copied
       })

--- a/tests/generic-java-signatures/26616.check
+++ b/tests/generic-java-signatures/26616.check
@@ -1,0 +1,8 @@
+public scala.PartialFunction MyAbstract.MyTrait$$handler()
+public scala.PartialFunction MyAbstract.MyTrait$$handler()
+public void MyAbstract.MyTrait$_setter_$MyTrait$$handler_$eq(scala.PartialFunction)
+public void MyAbstract.MyTrait$_setter_$MyTrait$$handler_$eq(scala.PartialFunction)
+public scala.PartialFunction MyAbstract2.MyTrait$$handler()
+public scala.PartialFunction MyAbstract2.MyTrait$$handler()
+public void MyAbstract2.MyTrait$_setter_$MyTrait$$handler_$eq(scala.PartialFunction)
+public void MyAbstract2.MyTrait$_setter_$MyTrait$$handler_$eq(scala.PartialFunction)

--- a/tests/generic-java-signatures/26616/Java_2.java
+++ b/tests/generic-java-signatures/26616/Java_2.java
@@ -1,0 +1,2 @@
+public class Java_2 extends MyAbstract<String, String> {
+}

--- a/tests/generic-java-signatures/26616/Scala_1.scala
+++ b/tests/generic-java-signatures/26616/Scala_1.scala
@@ -1,0 +1,26 @@
+object MyTrait:
+  case class Event[D](value: D)
+  case class State[S, D](name: S, data: D)
+
+trait MyTrait[S, D]:
+  import MyTrait.*
+  type StateT = State[S, D]
+  type EventT = Event[D]
+  type StateFunction = PartialFunction[EventT, StateT]
+  private val handler: StateFunction = { case e => State(null.asInstanceOf[S], e.value) }
+
+abstract class MyAbstract[S, D] extends MyTrait[S, D]
+
+abstract class MyAbstract2[A, B] extends MyTrait[A, B]
+
+object Test:
+  def main(args: Array[String]): Unit =
+    classOf[MyAbstract[String, String]].getMethods.sortBy(_.getName).filter(_.getName.contains("handler")).foreach(m => {
+      println(m)
+      println(m.toGenericString)
+    })
+    classOf[MyAbstract2[String, String]].getMethods.sortBy(_.getName).filter(_.getName.contains("handler")).foreach(m => {
+      println(m)
+      println(m.toGenericString)
+    })
+


### PR DESCRIPTION
Backports #26633 to the 3.9.0-RC6.

PR submitted by the release tooling.
[skip ci]