### PR TITLE
Backport "Bail out of patDef opt for .runtimeChecked, not only `@unchecked`" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Desugar.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Desugar.scala
@@ -1555,8 +1555,8 @@ object desugar {
           // we can simplify the match we emit to not have any variable patterns and just use the type directly.
           // In this case too, `variables` may contain wildcard names.
           // Exception:
-          // This optimization cannot be used in the presence of the `@unchecked` annotation,
-          // since given `a: List[A]` and `B <: A`, `val (x: List[B @unchecked], _) = (a, 1): @unchecked` is OK,
+          // This optimization cannot be used in the presence of `@unchecked` or `.runtimeChecked`,
+          // e.g., given `a: List[A]` and `B <: A`, `val (x: List[B @unchecked], _) = (a, 1): @unchecked` is OK,
           // but `val x: List[B @unchecked] = a: @unchecked` is not.
           // So we cannot desugar the first one into `(a, 1) match { $1 @ (_: List[B @unchecked], _) => $1 }`
           // because that loses track of the unchecked-ness.
@@ -1568,18 +1568,23 @@ object desugar {
         val (opt, variables) = pat match {
           case TuplePattern(pats, _) =>
             // We want to include wildcards for the optimizations, so we can't use `IdPattern` which excludes them
-            val allVariables = pats.map {
+            val allVariables = pats.flatMap {
               case id: Ident if isVarPattern(id) => Some(id, TypeTree())
               case Typed(id: Ident, tpt) if isVarPattern(id) => Some((id, tpt))
               case _ => None
-            }.flatten
+            }
             if allVariables.size == pats.size then
               def isMatchingTuple(t: Tree) = t match {
                 case Tuple(elems) => pats.size == elems.length && !hasNamedArg(elems)
                 case _ => false
               }
+              def mayBeUnchecked(t: Tree) = t match {
+                case _: Annotated => true // conservatively; might be @unchecked
+                case Select(_, nme.runtimeChecked) => true
+                case _ => false
+              }
               if forallResults(rhs, isMatchingTuple) then (Optimization.SimpleTuple, allVariables)
-              else if !rhs.isInstanceOf[Annotated] then (Optimization.MatchableTuple, allVariables)
+              else if !mayBeUnchecked(rhs) then (Optimization.MatchableTuple, allVariables)
               else (Optimization.None, generalGetVariables)
             else
               (Optimization.None, generalGetVariables)

--- a/compiler/src/dotty/tools/dotc/core/StdNames.scala
+++ b/compiler/src/dotty/tools/dotc/core/StdNames.scala
@@ -609,6 +609,7 @@ object StdNames {
     val run: N                  = "run"
     val runOrElse: N            = "runOrElse"
     val runtime: N              = "runtime"
+    val runtimeChecked: N       = "runtimeChecked"
     val runtimeClass: N         = "runtimeClass"
     val runtimeMirror: N        = "runtimeMirror"
     val s: N                    = "s"

--- a/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
+++ b/presentation-compiler/src/main/dotty/tools/pc/completions/Completions.scala
@@ -815,7 +815,7 @@ class Completions(
   private lazy val EnsuringClass: ClassSymbol = requiredClass("scala.Predef.Ensuring")
   private lazy val StringFormatClass: ClassSymbol = requiredClass("scala.Predef.StringFormat")
   private lazy val nnMethod: Symbol = defn.ScalaPredefModule.info.member("nn".toTermName).symbol
-  private lazy val runtimeCheckedMethod: Symbol = defn.ScalaPredefModule.info.member("runtimeChecked".toTermName).symbol
+  private lazy val runtimeCheckedMethod: Symbol = defn.ScalaPredefModule.info.member(nme.runtimeChecked).symbol
 
   private def isNotLocalForwardReference(sym: Symbol)(using Context): Boolean =
     !sym.isLocalToBlock ||

--- a/tests/pos/26773.scala
+++ b/tests/pos/26773.scala
@@ -1,0 +1,8 @@
+trait HttpHeader
+class Accept extends HttpHeader
+
+def parseLine(s: String): (Int, HttpHeader) = (0, new Accept)
+
+@main def run(): Unit =
+  val (_, accept: Accept) = parseLine("Accept: text/plain").runtimeChecked
+  println(accept)


### PR DESCRIPTION
Backports #26774 to the 3.9.0-RC6.

PR submitted by the release tooling.
[skip ci]