### PR TITLE
Backport "Fix issue with reading legal java cyclic signatures" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
+++ b/compiler/src/dotty/tools/dotc/core/classfile/ClassfileParser.scala
@@ -635,7 +635,23 @@ class ClassfileParser(
           while (sig(index) == '.') {
             accept('.')
             val name = subName(c => c == ';' || c == '<' || c == '.').toTypeName
-            val tp = tpe.select(name)
+            // Java allows for certain cyclic signatures, so we must too.
+            // If we are already in a class, we manually lookup instead of
+            // tpe.select to avoid cyclic errors. See #26646
+            val tp =
+              if tpe.typeSymbol eq classRoot.symbol then
+                // classRoot is being completed - we have to use classRoot's instanceScope
+                // e.g. case: `class CyclicSignature<S extends CyclicSignature<S>.Nested>`
+                val member = instanceScope.lookup(name)
+                if member.exists then TypeRef(tpe, member) else tpe.select(name)
+              else if tpe.typeSymbol.isContainedIn(classRoot.symbol) then
+                // classRoot is completed - using .info is safe
+                // e.g. case: `class CyclicSignature<S extends CyclicSignature<S>.Nested.Deeper>`
+                val member = tpe.typeSymbol.info.decls.lookup(name)
+                if member.exists then TypeRef(tpe, member) else tpe.select(name)
+              else
+                // non-cyclic case
+                tpe.select(name)
             tpe = processTypeArgs(tp)
           }
           accept(';')

--- a/compiler/src/dotty/tools/dotc/typer/Checking.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Checking.scala
@@ -361,7 +361,11 @@ object Checking {
 
           if isInteresting(pre) then
             CyclicReference.trace(i"explore ${tp.symbol} for cyclic references"):
-              val pre1 = atVariance(variance max 0)(this(pre, false, false))
+              val nestedCycleOkInPrefix =
+                // generated symbols like primary constructor may not have JavaDefined,
+                // even when the corresponding file is java - also check the owner
+                if sym.is(JavaDefined) || sym.maybeOwner.is(JavaDefined) then nestedCycleOK else false
+              val pre1 = atVariance(variance max 0)(this(pre, false, nestedCycleOkInPrefix))
               if locked.contains(tp)
                   || tp.symbol.infoOrCompleter.isInstanceOf[NoCompleter]
                   && tp.symbol == sym

--- a/tests/pos/i26646-a-joint/CyclicSignature.java
+++ b/tests/pos/i26646-a-joint/CyclicSignature.java
@@ -1,0 +1,7 @@
+class CyclicSignature<S extends CyclicSignature<S>.Nested> {
+    class Nested {}
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-a-joint/Test.scala
+++ b/tests/pos/i26646-a-joint/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-a-separate/CyclicSignature_JAVA_ONLY_1.java
+++ b/tests/pos/i26646-a-separate/CyclicSignature_JAVA_ONLY_1.java
@@ -1,0 +1,7 @@
+public class CyclicSignature_JAVA_ONLY_1<S extends CyclicSignature_JAVA_ONLY_1<S>.Nested> {
+    class Nested {}
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-a-separate/Test_2.scala
+++ b/tests/pos/i26646-a-separate/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature_JAVA_ONLY_1[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-b-joint/CyclicSignature.java
+++ b/tests/pos/i26646-b-joint/CyclicSignature.java
@@ -1,0 +1,9 @@
+class CyclicSignature<S extends CyclicSignature<S>.Nested.Deeper> {
+    class Nested {
+        class Deeper {}
+    }
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-b-joint/Test.scala
+++ b/tests/pos/i26646-b-joint/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-b-separate/CyclicSignature_JAVA_ONLY_1.java
+++ b/tests/pos/i26646-b-separate/CyclicSignature_JAVA_ONLY_1.java
@@ -1,0 +1,9 @@
+public class CyclicSignature_JAVA_ONLY_1<S extends CyclicSignature_JAVA_ONLY_1<S>.Nested.Deeper> {
+    class Nested {
+        class Deeper {}
+    }
+
+    public S test() {
+        return null;
+    }
+}

--- a/tests/pos/i26646-b-separate/Test_2.scala
+++ b/tests/pos/i26646-b-separate/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature_JAVA_ONLY_1[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-c-joint/CyclicSignature.java
+++ b/tests/pos/i26646-c-joint/CyclicSignature.java
@@ -1,0 +1,12 @@
+public class CyclicSignature {
+    static class Actual<S extends Actual<S>.Nested.Deeper> {
+        class Nested {
+            class Deeper {}
+        }
+
+        public S test() {
+            return null;
+        }
+    }
+
+}

--- a/tests/pos/i26646-c-joint/Test.scala
+++ b/tests/pos/i26646-c-joint/Test.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature.Actual[Nothing] = ???
+  def x() = a.test()
+}

--- a/tests/pos/i26646-c-separate/CyclicSignature_JAVA_ONLY_1.java
+++ b/tests/pos/i26646-c-separate/CyclicSignature_JAVA_ONLY_1.java
@@ -1,0 +1,12 @@
+public class CyclicSignature_JAVA_ONLY_1 {
+    static class Actual<S extends Actual<S>.Nested.Deeper> {
+        class Nested {
+            class Deeper {}
+        }
+
+        public S test() {
+            return null;
+        }
+    }
+
+}

--- a/tests/pos/i26646-c-separate/Test_2.scala
+++ b/tests/pos/i26646-c-separate/Test_2.scala
@@ -1,0 +1,4 @@
+object Test {
+  val a: CyclicSignature_JAVA_ONLY_1.Actual[Nothing] = ???
+  def x() = a.test()
+}


### PR DESCRIPTION
Backports #26775 to the 3.9.0-RC6.

PR submitted by the release tooling.
[skip ci]