### PR TITLE
Backport "Box bounded arguments of HKT result types in Java generic signatures" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -222,7 +222,7 @@ object GenericSignatures {
                     builder.append("*")
                 else
                   // For bounded arguments, we can't translate it cleanly so emit an erased type
-                  jsig(erasure(a.tycon))
+                  boxedSig(erasure(a.tycon))
               case res if res.isPrimitiveValueType =>
                 // value classes cannot appear as generic arguments
                 jsig(defn.boxedType(res))

--- a/tests/generic-java-signatures/26786.check
+++ b/tests/generic-java-signatures/26786.check
@@ -1,1 +1,1 @@
-public Check<java.lang.Boolean> X.foo()
+public Check<java.lang.Object> X.foo()

--- a/tests/generic-java-signatures/26786.check
+++ b/tests/generic-java-signatures/26786.check
@@ -1,0 +1,1 @@
+public Check<java.lang.Boolean> X.foo()

--- a/tests/generic-java-signatures/26786.scala
+++ b/tests/generic-java-signatures/26786.scala
@@ -1,0 +1,14 @@
+import compiletime.ops.int.>
+
+trait Check[Cond[T <: Int] <: Boolean]:
+  def apply(arg: Int): Unit
+
+type CondT = [t <: Int] =>> t > 0
+
+class X:
+  val foo: Check[CondT] = new Check[CondT]:
+    def apply(arg: Int): Unit = ()
+
+object Test:
+  def main(args: Array[String]): Unit =
+    classOf[X].getMethods.filter(_.getName.contains("foo")).sortBy(_.getName).foreach(m => println(m.toGenericString))


### PR DESCRIPTION
Backports #26787 to the 3.9.0-RC6.

PR submitted by the release tooling.
[skip ci]