### PR TITLE
Backport "Ignore @throws annotation on non-methods" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
+++ b/compiler/src/dotty/tools/backend/jvm/GenericSignatures.scala
@@ -441,7 +441,7 @@ object GenericSignatures {
     jsig(info, toplevel = true)
     for annot <- sym0.annotations do
       annot match
-        case ThrownException(e) =>
+        case ThrownException(e) if sym0.is(Method) => // ThrowsSignature is only valid in MethodSignature
           builder.append('^')
           jsig(e, toplevel = true)
         case _ => ()

--- a/tests/run/throws-annot.scala
+++ b/tests/run/throws-annot.scala
@@ -68,6 +68,15 @@ object TL {
   def readNoEx(): Int = 0
 }
 
+// @throws on class/object/field must be ignored/compiler shouldn't crash.
+@throws(classOf[IOException])
+class ThrowsOnClass
+
+@throws(classOf[IOException])
+object ThrowsOnObject:
+  @throws(classOf[IOException])
+  val field: Int = 0
+
 object Test {
   def main(args: Array[String]): Unit = {
     TestThrows.run(classOf[TestThrows.Foo])


### PR DESCRIPTION
Backports #26802 to the 3.9.0-RC6.

PR submitted by the release tooling.
[skip ci]