### PR TITLE
Remove unused parameter warnings in the library

### DIFF
--- a/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
+++ b/compiler/src/dotty/tools/dotc/transform/CheckUnused.scala
@@ -2,14 +2,13 @@ package dotty.tools.dotc
 package transform
 
 import ast.*, desugar.{ForArtifact, PatternVar}, tpd.*, untpd.ImportSelector
-import config.ScalaSettings
 import core.*, Contexts.*, Decorators.*, Flags.*
 import Names.{Name, SimpleName, DerivedName, TermName, termName}
-import NameKinds.{BodyRetainerName, ContextBoundParamName, ContextFunctionParamName, DefaultGetterName, WildcardParamName}
-import NameOps.{isAnonymousFunctionName, isReplWrapperName, setterName}
+import NameKinds.{BodyRetainerName, ContextFunctionParamName, DefaultGetterName, WildcardParamName}
+import NameOps.{isReplWrapperName, setterName}
 import Scopes.newScope
 import StdNames.nme
-import Symbols.{ClassSymbol, NoSymbol, Symbol, defn, isDeprecated, requiredClass, requiredModule}
+import Symbols.{NoSymbol, Symbol, defn, isDeprecated}
 import Types.*
 import reporting.{CodeAction, Diagnostic, UnusedSymbol}
 import rewrites.Rewrites.ActionPatch
@@ -17,14 +16,14 @@ import rewrites.Rewrites.ActionPatch
 import MegaPhase.MiniPhase
 import typer.{ImportInfo, Typer, TyperPhase}
 import typer.Deriving.OriginalTypeClass
-import typer.Implicits.{ContextualImplicits, RenamedImplicitRef}
+import typer.Implicits.RenamedImplicitRef
 import util.{Property, Spans, SrcPos}, Spans.Span
 import util.Chars.{isLineBreakChar, isWhitespace}
 import util.chaining.*
 
 import java.util.IdentityHashMap
 
-import scala.collection.mutable, mutable.{ArrayBuilder, ListBuffer, Stack}
+import scala.collection.mutable, mutable.ArrayBuilder
 
 import CheckUnused.*
 
@@ -485,9 +484,8 @@ class CheckUnused private (phaseMode: PhaseMode, suffix: String) extends MiniPha
    *  Avoid cached ctx.implicits because it needs the precise import context that introduces the given.
    */
   def resolveScoped(tp: Type, pos: SrcPos)(using Context): Unit =
-    var done = false
     val ctxs = ctx.outersIterator
-    while !done && ctxs.hasNext do
+    while ctxs.hasNext do
       val cur = ctxs.next()
       val importInfo = cur.importInfoIfImportContext
       val implicitRefs: List[ImplicitRef] =
@@ -689,6 +687,7 @@ object CheckUnused:
            m.isDeprecated
         || m.is(Synthetic) && !m.isAnonymousFunction
         || m.hasAnnotation(defn.UnusedAnnot) // param of unused method
+        || sym.name.startsWith("_") // convenient syntax to avoid needing @unused
         || sym.info.isSingleton
         || m.isConstructor && m.owner.thisType.baseClasses.contains(defn.AnnotationClass)
         || sym.isErased // erased param may be unused by design

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -787,7 +787,7 @@ object Array {
  *  @tparam T the element type of the array
  *  @param _length the size of the array to allocate; must be non-negative
  */
-final class Array[T](@unused _length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
+final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
 
   /** The length of the array. */
   def length: Int = throw new Error()

--- a/library/src/scala/Array.scala
+++ b/library/src/scala/Array.scala
@@ -14,6 +14,7 @@ package scala
 
 import scala.language.`2.13`
 import language.experimental.captureChecking
+import scala.annotation.unused
 
 //import scala.collection.generic._
 import scala.collection.{Factory, immutable, mutable}
@@ -54,7 +55,7 @@ object Array {
    */
   implicit def toFactory[A : ClassTag](dummy: Array.type): Factory[A, Array[A]] = new ArrayFactory(dummy)
   @SerialVersionUID(3L)
-  private class ArrayFactory[A : ClassTag](dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
+  private class ArrayFactory[A : ClassTag](@unused dummy: Array.type) extends Factory[A, Array[A]] with Serializable {
     def fromSpecific(it: IterableOnce[A]^): Array[A] = Array.from[A](it)
     def newBuilder: mutable.Builder[A, Array[A]] = Array.newBuilder[A]
   }
@@ -786,7 +787,7 @@ object Array {
  *  @tparam T the element type of the array
  *  @param _length the size of the array to allocate; must be non-negative
  */
-final class Array[T](_length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
+final class Array[T](@unused _length: Int) extends java.io.Serializable with java.lang.Cloneable { self: Array[T] =>
 
   /** The length of the array. */
   def length: Int = throw new Error()

--- a/library/src/scala/Function.scala
+++ b/library/src/scala/Function.scala
@@ -13,6 +13,7 @@
 package scala
 
 import scala.language.`2.13`
+import scala.annotation.unused
 
 /** A module defining utility methods for higher-order functional programming. */
 object Function {
@@ -33,7 +34,7 @@ object Function {
    *  @param y the argument that is ignored
    *  @return `x` regardless of the value of `y`
    */
-  def const[T, U](x: T)(y: U): T = x
+  def const[T, U](x: T)(@unused y: U): T = x
 
   /** Turns a function `A => Option[B]` into a `PartialFunction[A, B]`.
    *

--- a/library/src/scala/PartialFunction.scala
+++ b/library/src/scala/PartialFunction.scala
@@ -417,7 +417,7 @@ object PartialFunction {
     def apply(x: Any) = throw new MatchError(x)
     override def orElse[A1, B1](that: PartialFunction[A1, B1]^) = that
     override def andThen[C](k: PartialFunction[Nothing, C]^): PartialFunction[Any, C]^{k} = this
-    override val lift: Any -> None.type = (x: Any) => None
+    override val lift: Any -> None.type = (_: Any) => None
     override def runWith[U](action: Nothing => U) = constFalse
   }
 

--- a/library/src/scala/Specializable.scala
+++ b/library/src/scala/Specializable.scala
@@ -13,6 +13,7 @@
 package scala
 
 import scala.language.`2.13`
+import scala.annotation.unused
 
 /** A common supertype for companions of specializable types.
  *  Should not be extended in user code.
@@ -24,7 +25,7 @@ object Specializable {
   trait SpecializedGroup
 
   // Smuggle a list of types by way of a tuple upon which Group is parameterized.
-  class Group[T](value: T) extends SpecializedGroup
+  class Group[T](@unused value: T) extends SpecializedGroup
 
   final val Primitives:  Group[(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit)] = null.asInstanceOf[Group[(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit)]]
   final val Everything:  Group[(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit, AnyRef)] = null.asInstanceOf[Group[(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit, AnyRef)]]

--- a/library/src/scala/Unit.scala
+++ b/library/src/scala/Unit.scala
@@ -13,6 +13,7 @@
 package scala
 
 import scala.language.`2.13`
+import scala.annotation.unused
 
 /** `Unit` is a subtype of [[scala.AnyVal]]. There is only one value of type
  *  `Unit`, `()`, and it is not represented by any object in the underlying
@@ -32,7 +33,7 @@ object Unit extends AnyValCompanion {
    *  @param  x   the Unit to be boxed
    *  @return     a scala.runtime.BoxedUnit offering `x` as its underlying value.
    */
-  def box(x: Unit): scala.runtime.BoxedUnit = scala.runtime.BoxedUnit.UNIT
+  def box(@unused x: Unit): scala.runtime.BoxedUnit = scala.runtime.BoxedUnit.UNIT
 
   /** Transforms a boxed type into a value type.  Note that this
    *  method is not typesafe: it accepts any Object, but will throw

--- a/library/src/scala/collection/ArrayOps.scala
+++ b/library/src/scala/collection/ArrayOps.scala
@@ -1383,7 +1383,7 @@ final class ArrayOps[A](private val xs: Array[A]) extends AnyVal {
     if (xs.length == 0) bb.result()
     else {
       def mkRowBuilder() = ArrayBuilder.make[B](using ClassTag[B](aClass.getComponentType))
-      val bs = new ArrayOps(asArray(xs(0))).map((x: B) => mkRowBuilder())
+      val bs = new ArrayOps(asArray(xs(0))).map((_: B) => mkRowBuilder())
       for (xs <- this) {
         var i = 0
         for (x <- new ArrayOps(asArray(xs))) {

--- a/library/src/scala/collection/StrictOptimizedIterableOps.scala
+++ b/library/src/scala/collection/StrictOptimizedIterableOps.scala
@@ -150,7 +150,7 @@ transparent trait StrictOptimizedIterableOps[+A, +CC[_], +C]
     val it = iterator
     while (it.hasNext) {
       val elem = it.next()
-      val v = pf.applyOrElse(elem, ((x: A) => marker).asInstanceOf[Function[A, B]])
+      val v = pf.applyOrElse(elem, ((_: A) => marker).asInstanceOf[Function[A, B]])
       if (marker ne v.asInstanceOf[AnyRef]) b += v
     }
     b.result()

--- a/library/src/scala/collection/convert/JavaCollectionWrappers.scala
+++ b/library/src/scala/collection/convert/JavaCollectionWrappers.scala
@@ -16,6 +16,7 @@ package convert
 
 import scala.language.`2.13`
 import language.experimental.captureChecking
+import scala.annotation.unused
 
 import java.util.{concurrent => juc}
 import java.util.{NavigableMap}
@@ -395,7 +396,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
     override def update(k: K, v: V): Unit = underlying.put(k, v)
 
     override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
-      def remap(k: K, v: V): V =
+      def remap(@unused k: K, v: V): V =
         remappingFunction(Option(v)) match {
           case Some(null) => throw PutNull
           case Some(x)    => x
@@ -506,7 +507,7 @@ private[collection] object JavaCollectionWrappers extends Serializable {
       }
 
     override def updateWith(key: K)(remappingFunction: Option[V] => Option[V]): Option[V] = {
-      def remap(k: K, v: V): V =
+      def remap(@unused k: K, v: V): V =
         remappingFunction(Option(v)) match {
           case Some(null) => throw PutNull // see scala/scala#10129
           case Some(x)    => x

--- a/library/src/scala/collection/immutable/HashMap.scala
+++ b/library/src/scala/collection/immutable/HashMap.scala
@@ -779,7 +779,7 @@ private final class BitmapIndexedMapNode[K, +V](
           val value0 = this.getValue(index)
           if ((key0.asInstanceOf[AnyRef] eq key.asInstanceOf[AnyRef]) && (value0.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]))
             this
-          else copyAndSetValue(bitpos, key, value)
+          else copyAndSetValue(bitpos, value)
         } else this
       } else {
         val value0 = this.getValue(index)
@@ -979,7 +979,7 @@ private final class BitmapIndexedMapNode[K, +V](
 
   def nodeIndex(bitpos: Int) = bitCount(nodeMap & (bitpos - 1))
 
-  def copyAndSetValue[V1 >: V](bitpos: Int, newKey: K, newValue: V1): BitmapIndexedMapNode[K, V1] = {
+  def copyAndSetValue[V1 >: V](bitpos: Int, newValue: V1): BitmapIndexedMapNode[K, V1] = {
     val dataIx = dataIndex(bitpos)
     val idx = TupleLength * dataIx
 
@@ -1929,12 +1929,6 @@ private final class HashCollisionMapNode[K, +V ](
 
   override def containsKey(key: K, originalHash: Int, hash: Int, shift: Int): Boolean =
     this.hash == hash && indexOf(key) >= 0
-
-  def contains[V1 >: V](key: K, value: V1, hash: Int, shift: Int): Boolean =
-    this.hash == hash && {
-      val index = indexOf(key)
-      index >= 0 && (content(index)._2.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef])
-    }
 
   def updated[V1 >: V](key: K, value: V1, originalHash: Int, hash: Int, shift: Int, replaceValue: Boolean): MapNode[K, V1] = {
     val index = indexOf(key)

--- a/library/src/scala/collection/immutable/HashSet.scala
+++ b/library/src/scala/collection/immutable/HashSet.scala
@@ -645,7 +645,7 @@ private final class BitmapIndexedSetNode[A](
           // escalate (singleton or empty) result
           if (this.size == subNode.size) subNodeNew.asInstanceOf[BitmapIndexedSetNode[A]]
           // inline value (move to front)
-          else copyAndMigrateFromNodeToInline(bitpos, elementHash, subNode, subNodeNew)
+          else copyAndMigrateFromNodeToInline(bitpos, subNode, subNodeNew)
         case subNodeNewSize if subNodeNewSize > 1 =>
           // modify current node (set replacement node)
           copyAndSetNode(bitpos, subNode, subNodeNew)
@@ -733,7 +733,7 @@ private final class BitmapIndexedSetNode[A](
           this.cachedJavaKeySetHashCode = subNodeNew.cachedJavaKeySetHashCode
           this
         } else {
-          migrateFromNodeToInlineInPlace(bitpos, originalHash, elementHash, subNode, subNodeNew)
+          migrateFromNodeToInlineInPlace(bitpos, subNode, subNodeNew)
           this
         }
       } else {
@@ -822,20 +822,6 @@ private final class BitmapIndexedSetNode[A](
     new BitmapIndexedSetNode[A](dataMap | bitpos, nodeMap, dst, dstHashes, size + 1, cachedJavaKeySetHashCode + elementHash)
   }
 
-  def copyAndSetValue(bitpos: Int, key: A, originalHash: Int, elementHash: Int) = {
-    val dataIx = dataIndex(bitpos)
-    val idx = TupleLength * dataIx
-
-    val src = this.content
-    val dst = new Array[Any](src.length)
-
-    // copy 'src' and set 1 element(s) at position 'idx'
-    arraycopy(src, 0, dst, 0, src.length)
-    dst(idx) = key
-
-    new BitmapIndexedSetNode[A](dataMap | bitpos, nodeMap, dst, originalHashes, size, cachedJavaKeySetHashCode)
-  }
-
   def copyAndRemoveValue(bitpos: Int, elementHash: Int) = {
     val dataIx = dataIndex(bitpos)
     val idx = TupleLength * dataIx
@@ -903,7 +889,7 @@ private final class BitmapIndexedSetNode[A](
     this
   }
 
-  def copyAndMigrateFromNodeToInline(bitpos: Int, elementHash: Int, oldNode: SetNode[A], node: SetNode[A]) = {
+  def copyAndMigrateFromNodeToInline(bitpos: Int, oldNode: SetNode[A], node: SetNode[A]) = {
     val idxOld = this.content.length - 1 - nodeIndex(bitpos)
     val dataIxNew = dataIndex(bitpos)
     val idxNew = TupleLength * dataIxNew
@@ -944,7 +930,7 @@ private final class BitmapIndexedSetNode[A](
    *  @param oldNode the node currently stored at position `bitpos`
    *  @param node the node containing the single element to migrate inline
    */
-  def migrateFromNodeToInlineInPlace(bitpos: Int, originalHash: Int, elementHash: Int, oldNode: SetNode[A], node: SetNode[A]): Unit = {
+  def migrateFromNodeToInlineInPlace(bitpos: Int, oldNode: SetNode[A], node: SetNode[A]): Unit = {
     val idxOld = this.content.length - 1 - nodeIndex(bitpos)
     val dataIxNew = dataIndex(bitpos)
     val element = node.getPayload(0)

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -479,10 +479,10 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *  @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
    */
   def intersection[R](that: IntMap[R]): IntMap[T] =
-    this.intersectionWith(that, (key: Int, value: T, value2: R) => value)
+    this.intersectionWith(that, (_: Int, value: T, _: R) => value)
 
   def ++[S >: T](that: IntMap[S]) =
-    this.unionWith[S](that, (key, x, y) => y)
+    this.unionWith[S](that, (_, _, y) => y)
 
   /** The entry with the lowest key value considered in unsigned order. */
   @tailrec

--- a/library/src/scala/collection/immutable/IntMap.scala
+++ b/library/src/scala/collection/immutable/IntMap.scala
@@ -479,10 +479,10 @@ sealed abstract class IntMap[+T] extends AbstractMap[Int, T]
    *  @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
    */
   def intersection[R](that: IntMap[R]): IntMap[T] =
-    this.intersectionWith(that, (_: Int, value: T, _: R) => value)
+    this.intersectionWith(that, (_key: Int, value: T, _value2: R) => value)
 
   def ++[S >: T](that: IntMap[S]) =
-    this.unionWith[S](that, (_, _, y) => y)
+    this.unionWith[S](that, (_key, _x, y) => y)
 
   /** The entry with the lowest key value considered in unsigned order. */
   @tailrec

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -460,10 +460,10 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
    *  @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
    */
   def intersection[R](that: LongMap[R]): LongMap[T] =
-    this.intersectionWith(that, (_: Long, value: T, _: R) => value)
+    this.intersectionWith(that, (_key: Long, value: T, _value2: R) => value)
 
   def ++[S >: T](that: LongMap[S]) =
-    this.unionWith[S](that, (_, _, y) => y)
+    this.unionWith[S](that, (_key, _x, y) => y)
 
   @tailrec
   final def firstKey: Long = this match {

--- a/library/src/scala/collection/immutable/LongMap.scala
+++ b/library/src/scala/collection/immutable/LongMap.scala
@@ -460,10 +460,10 @@ sealed abstract class LongMap[+T] extends AbstractMap[Long, T]
    *  @return        A map with all the keys both in `this` and `that`, mapped to corresponding values from `this`.
    */
   def intersection[R](that: LongMap[R]): LongMap[T] =
-    this.intersectionWith(that, (key: Long, value: T, value2: R) => value)
+    this.intersectionWith(that, (_: Long, value: T, _: R) => value)
 
   def ++[S >: T](that: LongMap[S]) =
-    this.unionWith[S](that, (key, x, y) => y)
+    this.unionWith[S](that, (_, _, y) => y)
 
   @tailrec
   final def firstKey: Long = this match {

--- a/library/src/scala/collection/immutable/RedBlackTree.scala
+++ b/library/src/scala/collection/immutable/RedBlackTree.scala
@@ -219,9 +219,9 @@ private[collection] object RedBlackTree {
   def to[A: Ordering, B](tree: Tree[A, B] | Null, to: A): Tree[A, B] | Null = blacken(doTo(tree, to))
   def until[A: Ordering, B](tree: Tree[A, B] | Null, key: A): Tree[A, B] | Null = blacken(doUntil(tree, key))
 
-  def drop[A: Ordering, B](tree: Tree[A, B] | Null, n: Int): Tree[A, B] | Null = blacken(doDrop(tree, n))
-  def take[A: Ordering, B](tree: Tree[A, B] | Null, n: Int): Tree[A, B] | Null = blacken(doTake(tree, n))
-  def slice[A: Ordering, B](tree: Tree[A, B] | Null, from: Int, until: Int): Tree[A, B] | Null = blacken(doSlice(tree, from, until))
+  def drop[A, B](tree: Tree[A, B] | Null, n: Int): Tree[A, B] | Null = blacken(doDrop(tree, n))
+  def take[A, B](tree: Tree[A, B] | Null, n: Int): Tree[A, B] | Null = blacken(doTake(tree, n))
+  def slice[A, B](tree: Tree[A, B] | Null, from: Int, until: Int): Tree[A, B] | Null = blacken(doSlice(tree, from, until))
 
   def smallest[A, B](tree: Tree[A, B] | Null): Tree[A, B] = {
     if (tree eq null) throw new NoSuchElementException("empty tree")

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -15,7 +15,6 @@ package immutable
 
 import scala.language.`2.13`
 import language.experimental.captureChecking
-import scala.annotation.unused
 
 import java.lang.Math.{abs, max => mmax, min => mmin}
 import java.util.Arrays.{copyOf, copyOfRange}
@@ -2595,7 +2594,7 @@ private class LongVectorStepper(it: NewVectorIterator[Long])
 
 
 // The following definitions are needed for binary compatibility with ParVector
-private[collection] class VectorIterator[+A](@unused _startIndex: Int, private var endIndex: Int) extends AbstractIterator[A] {
+private[collection] class VectorIterator[+A](_startIndex: Int, private var endIndex: Int) extends AbstractIterator[A] {
   private[immutable] var it: NewVectorIterator[A @uncheckedVariance] = compiletime.uninitialized
   def hasNext: Boolean = it.hasNext
   def next(): A = it.next()

--- a/library/src/scala/collection/immutable/Vector.scala
+++ b/library/src/scala/collection/immutable/Vector.scala
@@ -15,6 +15,7 @@ package immutable
 
 import scala.language.`2.13`
 import language.experimental.captureChecking
+import scala.annotation.unused
 
 import java.lang.Math.{abs, max => mmax, min => mmin}
 import java.util.Arrays.{copyOf, copyOfRange}
@@ -2594,7 +2595,7 @@ private class LongVectorStepper(it: NewVectorIterator[Long])
 
 
 // The following definitions are needed for binary compatibility with ParVector
-private[collection] class VectorIterator[+A](_startIndex: Int, private var endIndex: Int) extends AbstractIterator[A] {
+private[collection] class VectorIterator[+A](@unused _startIndex: Int, private var endIndex: Int) extends AbstractIterator[A] {
   private[immutable] var it: NewVectorIterator[A @uncheckedVariance] = compiletime.uninitialized
   def hasNext: Boolean = it.hasNext
   def next(): A = it.next()

--- a/library/src/scala/collection/mutable/CollisionProofHashMap.scala
+++ b/library/src/scala/collection/mutable/CollisionProofHashMap.scala
@@ -489,7 +489,7 @@ final class CollisionProofHashMap[K, V](initialCapacity: Int, loadFactor: Double
     if(i != 0) i else ordering.compare(key, node.key)
   }
 
-  @`inline` private def compare(key: K, hash: Int, node: RBNode): Int = {
+  @`inline` private def compare(key: K, @unused hash: Int, node: RBNode): Int = {
     /*val i = hash - node.hash
     if(i != 0) i else*/ ordering.compare(key, node.key)
   }
@@ -799,7 +799,7 @@ object CollisionProofHashMap extends SortedMapFactory[CollisionProofHashMap] {
     if(i != 0) i else ord.compare(key, node.key)
   }
 
-  @`inline` private def compare[K, V](key: K, hash: Int, node: RBNode[K, V])(implicit ord: Ordering[K]): Int = {
+  @`inline` private def compare[K, V](key: K, @unused hash: Int, node: RBNode[K, V])(implicit ord: Ordering[K]): Int = {
     /*val i = hash - node.hash
     if(i != 0) i else*/ ord.compare(key, node.key)
   }

--- a/library/src/scala/collection/mutable/Map.scala
+++ b/library/src/scala/collection/mutable/Map.scala
@@ -63,7 +63,7 @@ trait Map[K, V]
    *  @param d     default value used for non-present keys
    *  @return      a wrapper of the map with a default value
    */
-  def withDefaultValue(d: V): Map[K, V] = new Map.WithDefault[K, V](this, x => d)
+  def withDefaultValue(d: V): Map[K, V] = new Map.WithDefault[K, V](this, _ => d)
 }
 
 /**

--- a/library/src/scala/concurrent/Future.scala
+++ b/library/src/scala/concurrent/Future.scala
@@ -600,7 +600,7 @@ object Future {
   private[concurrent] final val recoverWithFailedMarker: Future[Nothing] =
     scala.concurrent.Future.failed(new Throwable with NoStackTrace)
 
-  private[concurrent] final val recoverWithFailed = (t: Throwable) => recoverWithFailedMarker
+  private[concurrent] final val recoverWithFailed = (_: Throwable) => recoverWithFailedMarker
 
   private final val _zipWithTuple2: (Any, Any) => (Any, Any) = Tuple2.apply
   private[concurrent] final def zipWithTuple2Fun[T,U] = _zipWithTuple2.asInstanceOf[(T,U) => (T,U)]

--- a/library/src/scala/concurrent/duration/DurationConversions.scala
+++ b/library/src/scala/concurrent/duration/DurationConversions.scala
@@ -13,6 +13,7 @@
 package scala.concurrent.duration
 
 import scala.language.`2.13`
+import scala.annotation.unused
 import DurationConversions._
 
 // Would be nice to limit the visibility of this trait a little bit,
@@ -47,31 +48,31 @@ trait DurationConversions extends Any {
   def days: FiniteDuration         = durationIn(DAYS)
   def day: FiniteDuration          = days
 
-  def nanoseconds[C](c: C)(implicit ev: Classifier[C]): ev.R  = ev.convert(nanoseconds)
-  def nanos[C](c: C)(implicit ev: Classifier[C]): ev.R        = nanoseconds(c)
-  def nanosecond[C](c: C)(implicit ev: Classifier[C]): ev.R   = nanoseconds(c)
-  def nano[C](c: C)(implicit ev: Classifier[C]): ev.R         = nanoseconds(c)
+  def nanoseconds[C](@unused c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(nanoseconds)
+  def nanos[C](c: C)(implicit ev: Classifier[C]): ev.R               = nanoseconds(c)
+  def nanosecond[C](c: C)(implicit ev: Classifier[C]): ev.R          = nanoseconds(c)
+  def nano[C](c: C)(implicit ev: Classifier[C]): ev.R                = nanoseconds(c)
 
-  def microseconds[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(microseconds)
-  def micros[C](c: C)(implicit ev: Classifier[C]): ev.R       = microseconds(c)
-  def microsecond[C](c: C)(implicit ev: Classifier[C]): ev.R  = microseconds(c)
-  def micro[C](c: C)(implicit ev: Classifier[C]): ev.R        = microseconds(c)
+  def microseconds[C](@unused c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(microseconds)
+  def micros[C](c: C)(implicit ev: Classifier[C]): ev.R               = microseconds(c)
+  def microsecond[C](c: C)(implicit ev: Classifier[C]): ev.R          = microseconds(c)
+  def micro[C](c: C)(implicit ev: Classifier[C]): ev.R                = microseconds(c)
 
-  def milliseconds[C](c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(milliseconds)
-  def millis[C](c: C)(implicit ev: Classifier[C]): ev.R       = milliseconds(c)
-  def millisecond[C](c: C)(implicit ev: Classifier[C]): ev.R  = milliseconds(c)
-  def milli[C](c: C)(implicit ev: Classifier[C]): ev.R        = milliseconds(c)
+  def milliseconds[C](@unused c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(milliseconds)
+  def millis[C](c: C)(implicit ev: Classifier[C]): ev.R               = milliseconds(c)
+  def millisecond[C](c: C)(implicit ev: Classifier[C]): ev.R          = milliseconds(c)
+  def milli[C](c: C)(implicit ev: Classifier[C]): ev.R                = milliseconds(c)
 
-  def seconds[C](c: C)(implicit ev: Classifier[C]): ev.R      = ev.convert(seconds)
-  def second[C](c: C)(implicit ev: Classifier[C]): ev.R       = seconds(c)
+  def seconds[C](@unused c: C)(implicit ev: Classifier[C]): ev.R  = ev.convert(seconds)
+  def second[C](c: C)(implicit ev: Classifier[C]): ev.R          = seconds(c)
 
-  def minutes[C](c: C)(implicit ev: Classifier[C]): ev.R      = ev.convert(minutes)
-  def minute[C](c: C)(implicit ev: Classifier[C]): ev.R       = minutes(c)
+  def minutes[C](@unused c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(minutes)
+  def minute[C](c: C)(implicit ev: Classifier[C]): ev.R          = minutes(c)
 
-  def hours[C](c: C)(implicit ev: Classifier[C]): ev.R        = ev.convert(hours)
-  def hour[C](c: C)(implicit ev: Classifier[C]): ev.R         = hours(c)
+  def hours[C](@unused c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(hours)
+  def hour[C](c: C)(implicit ev: Classifier[C]): ev.R          = hours(c)
 
-  def days[C](c: C)(implicit ev: Classifier[C]): ev.R         = ev.convert(days)
+  def days[C](@unused c: C)(implicit ev: Classifier[C]): ev.R = ev.convert(days)
   def day[C](c: C)(implicit ev: Classifier[C]): ev.R          = days(c)
 }
 

--- a/library/src/scala/concurrent/impl/ExecutionContextImpl.scala
+++ b/library/src/scala/concurrent/impl/ExecutionContextImpl.scala
@@ -98,7 +98,7 @@ private[concurrent] object ExecutionContextImpl {
     val threadFactory = new DefaultThreadFactory(daemonic = true,
                                                  maxBlockers = getInt("scala.concurrent.context.maxExtraThreads", "256"),
                                                  prefix = "scala-execution-context-global",
-                                                 uncaught = (thread: Thread, cause: Throwable) => reporter(cause))
+                                                 uncaught = (_: Thread, cause: Throwable) => reporter(cause))
 
     new ForkJoinPool(desiredParallelism, threadFactory, threadFactory.uncaught, true) with ExecutionContextExecutorService {
       final override def reportFailure(cause: Throwable): Unit =

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -1,6 +1,7 @@
 package scala.quoted
 
 import language.experimental.captureChecking
+import scala.annotation.unused
 
 trait ExprMap:
 
@@ -130,7 +131,7 @@ trait ExprMap:
           case _ =>
             transformTermChildren(tree, tpe)(owner)
 
-      def transformTypeTree(tree: TypeTree)(owner: Symbol): TypeTree = tree
+      def transformTypeTree(tree: TypeTree)(@unused owner: Symbol): TypeTree = tree
 
       def transformCaseDef(tree: CaseDef, tpe: TypeRepr)(owner: Symbol): CaseDef =
         CaseDef.copy(tree)(tree.pattern, tree.guard.map(x => transformTerm(x, TypeRepr.of[Boolean])(owner)), transformTerm(tree.rhs, tpe)(owner))

--- a/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
+++ b/library/src/scala/reflect/ClassManifestDeprecatedApis.scala
@@ -14,6 +14,7 @@ package scala
 package reflect
 
 import scala.language.`2.13`
+import scala.annotation.unused
 import scala.collection.mutable.{ArrayBuilder, ArraySeq}
 import java.lang.{Class => jClass}
 
@@ -242,7 +243,7 @@ object ClassManifestFactory {
    *  @param clazz the runtime `Class` for the upper bound of the abstract type, used for erasure
    *  @param args the manifests for the type arguments of the abstract type (note: currently unused in the implementation)
    */
-  def abstractType[T](prefix: OptManifest[?], name: String, clazz: jClass[?], args: OptManifest[?]*): ClassManifest[T] =
+  def abstractType[T](prefix: OptManifest[?], name: String, clazz: jClass[?], @unused args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, clazz)
 
   /** ClassManifest for the abstract type `prefix # name`. `upperBound` is not
@@ -256,7 +257,7 @@ object ClassManifestFactory {
    *  @param upperbound the `ClassManifest` for the upper bound, whose `runtimeClass` is used for erasure
    *  @param args the manifests for the type arguments of the abstract type (note: currently unused in the implementation)
    */
-  def abstractType[T](prefix: OptManifest[?], name: String, upperbound: ClassManifest[?], args: OptManifest[?]*): ClassManifest[T] =
+  def abstractType[T](prefix: OptManifest[?], name: String, upperbound: ClassManifest[?], @unused args: OptManifest[?]*): ClassManifest[T] =
     new AbstractTypeClassManifest(prefix, name, upperbound.runtimeClass)
 }
 

--- a/library/src/scala/runtime/LambdaDeserialize.scala
+++ b/library/src/scala/runtime/LambdaDeserialize.scala
@@ -15,6 +15,7 @@ package scala.runtime
 import java.lang.invoke._
 import java.util
 
+import scala.annotation.unused
 import scala.annotation.varargs
 import scala.collection.immutable
 
@@ -36,7 +37,7 @@ final class LambdaDeserialize private (lookup: MethodHandles.Lookup, targetMetho
 
 object LambdaDeserialize {
   @varargs @throws[Throwable]
-  def bootstrap(lookup: MethodHandles.Lookup, invokedName: String, invokedType: MethodType, targetMethods: MethodHandle*): CallSite = {
+  def bootstrap(lookup: MethodHandles.Lookup, @unused invokedName: String, invokedType: MethodType, targetMethods: MethodHandle*): CallSite = {
     val targetMethodsArray = targetMethods.asInstanceOf[immutable.ArraySeq[?]].unsafeArray.asInstanceOf[Array[MethodHandle]]
     val exact = MethodHandleConstants.LAMBDA_DESERIALIZE_DESERIALIZE_LAMBDA.bindTo(new LambdaDeserialize(lookup, targetMethodsArray)).asType(invokedType)
     new ConstantCallSite(exact)

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -14,6 +14,7 @@ package scala
 package runtime
 
 import scala.language.`2.13`
+import scala.annotation.unused
 import scala.collection.{AbstractIterator, AnyConstr, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View}
 import scala.collection.generic.IsIterable
 import scala.collection.immutable.{ArraySeq, NumericRange}
@@ -57,7 +58,7 @@ object ScalaRunTime {
    *  @param value the boxed value whose unboxed class is returned
    *  @return the runtime `Class` representing the unboxed type `T`
    */
-  def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
+  def anyValClass[T <: AnyVal : ClassTag](@unused value: T): jClass[T] =
     classTag[T].runtimeClass.asInstanceOf[jClass[T]]
 
   /** Runtime code for `(x: T).getClass()` where `T` is not a subtype of `AnyRef`.

--- a/library/src/scala/runtime/StructuralCallSite.scala
+++ b/library/src/scala/runtime/StructuralCallSite.scala
@@ -13,6 +13,7 @@
 package scala.runtime
 
 import scala.language.`2.13`
+import scala.annotation.unused
 import java.lang.invoke._
 import java.lang.ref.SoftReference
 import java.lang.reflect.Method
@@ -40,7 +41,7 @@ final class StructuralCallSite private (callType: MethodType) {
 }
 
 object StructuralCallSite {
-  def bootstrap(lookup: MethodHandles.Lookup, invokedName: String, invokedType: MethodType, reflectiveCallType: MethodType): CallSite = {
+  def bootstrap(@unused lookup: MethodHandles.Lookup, @unused invokedName: String, @unused invokedType: MethodType, reflectiveCallType: MethodType): CallSite = {
     val structuralCallSite = new StructuralCallSite(reflectiveCallType)
     new ConstantCallSite(MethodHandles.constant(classOf[StructuralCallSite], structuralCallSite))
   }

--- a/library/src/scala/sys/process/ProcessImpl.scala
+++ b/library/src/scala/sys/process/ProcessImpl.scala
@@ -178,7 +178,7 @@ private[process] trait ProcessImpl {
     }
   }
 
-  private[process] abstract class PipeThread(isSink: Boolean, labelFn: () => String) extends Thread {
+  private[process] abstract class PipeThread(isSink: Boolean) extends Thread {
     def run(): Unit
 
     private[process] def runloop(src: InputStream, dst: OutputStream): Unit = {
@@ -192,7 +192,7 @@ private[process] trait ProcessImpl {
   }
 
   @nowarn("msg=Calling the external method .*Name") // setName+getName are safe to call in a constructor
-  private[process] class PipeSource(label: => String) extends PipeThread(isSink = false, () => label) {
+  private[process] class PipeSource(label: => String) extends PipeThread(isSink = false) {
     setName(s"PipeSource($label)-$getName")
     protected val pipe = new PipedOutputStream
     protected val source = new LinkedBlockingQueue[Option[InputStream]](1)
@@ -216,7 +216,7 @@ private[process] trait ProcessImpl {
     def done() = source.put(None)
   }
   @nowarn("msg=Calling the external method .*Name") // setName+getName are safe to call in a constructor
-  private[process] class PipeSink(label: => String) extends PipeThread(isSink = true, () => label) {
+  private[process] class PipeSink(label: => String) extends PipeThread(isSink = true) {
     setName(s"PipeSink($label)-$getName")
     protected val pipe = new PipedInputStream
     protected val sink = new LinkedBlockingQueue[Option[OutputStream]](1)

--- a/library/src/scala/util/Try.scala
+++ b/library/src/scala/util/Try.scala
@@ -278,14 +278,14 @@ final case class Failure[+T](exception: Throwable) extends Try[T] { self: Failur
   override def recover[U >: T](pf: PartialFunction[Throwable, U]^): Try[U]^{this, pf.only[Control]} = {
     val marker = Statics.pfMarker
     try {
-      val v: U | marker.type = pf.applyOrElse(exception, (x: Throwable) => marker)
+      val v: U | marker.type = pf.applyOrElse(exception, (_: Throwable) => marker)
       if (marker ne v.asInstanceOf[AnyRef]) Success(v.asInstanceOf[U]) else this
     } catch { case NonFatal(e) => Failure(e) }
   }
   override def recoverWith[U >: T](pf: PartialFunction[Throwable, Try[U]^]^): Try[U]^{this, pf} = {
     val marker = Statics.pfMarker
     try {
-      val v = pf.applyOrElse[Throwable, Any /* Should be Try[U]^{pf*} | marker.type */](exception, (x: Throwable) => marker)
+      val v = pf.applyOrElse[Throwable, Any /* Should be Try[U]^{pf*} | marker.type */](exception, (_: Throwable) => marker)
       if (marker ne v.asInstanceOf[AnyRef]) v.asInstanceOf[Try[U]] else this
     } catch { case NonFatal(e) => Failure(e) }
   }
@@ -312,7 +312,7 @@ final case class Success[+T](value: T) extends Try[T] {
   override def collect[U](pf: PartialFunction[T, U]^): Try[U]^{pf.only[Control]} = {
     val marker = Statics.pfMarker
     try {
-      val v = pf.applyOrElse(value, ((x: T) => marker).asInstanceOf[Function[T, U]])
+      val v = pf.applyOrElse(value, ((_: T) => marker).asInstanceOf[Function[T, U]])
       if (marker ne v.asInstanceOf[AnyRef]) Success(v)
       else Failure(new NoSuchElementException("Predicate does not hold for " + value))
     } catch { case NonFatal(e) => Failure(e) }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -87,6 +87,7 @@ object Build {
       // Workaround for #25897
       "-Wconf:cat=deprecation&origin=scala\\.collection\\.Iterable\\.stringPrefix:s",
       //"-Wunused:all",
+      //"-Wunused:params",
       "-encoding", "UTF8",
       "-language:implicitConversions",
       s"--java-output-version:${Versions.minimumJVMVersion}",
@@ -955,11 +956,12 @@ object Build {
       moduleName    := "scala2-library",
       scalaVersion  := Versions.scala2Version,
       version       := scalaVersion.value,
-      // Remove Scala 3 specific settings
+      // Remove Scala 3 specific settings (and the unused params one, which is an issue that should be fixed in the 2.x stdlib)
       scalacOptions --= Seq(
         "--java-output-version:17",
         "-Yexplicit-nulls",
-        "-Wsafe-init"
+        "-Wsafe-init",
+        "-Wunused:params"
       ),
       scalacOptions ++= Seq(
         "-release:17",

--- a/tests/warn/unused-params.scala
+++ b/tests/warn/unused-params.scala
@@ -29,6 +29,8 @@ trait BadAPI extends InterFace {
     a
   }
 
+  def withUnderscores(_a: Int, _b: String, c: Double): Double = c // no warn
+
   def meth(x: Int) = x
 
   override def equals(other: Any): Boolean = true  // no warn
@@ -165,3 +167,5 @@ object Optional:
 class Nested {
   @annotation.unused private def actuallyNotUsed(fresh: Int, stale: Int) = fresh // no warn if owner is unused
 }
+
+class UnusedUnderscoreParam(_x: Int) { } // no warn


### PR DESCRIPTION
I noticed while working on the compiler that we sometimes have unused parameters for which we do non-trivial work to pass arguments, or unused `Context` implicits that make it harder to tell what really needs a context for some work.

There are currently almost 500 unused params warnings in the compiler, so this isn't going to happen overnight, but at least I made `scala3-library-nonbootstrapped` clean for `-Wunused:params`.

Sometimes this involved deleting code because the entire method was private and unused.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)