### PR TITLE
support `\s` space escape also in interpolations

### DIFF
--- a/docs/_spec/13-syntax-summary.md
+++ b/docs/_spec/13-syntax-summary.md
@@ -32,7 +32,7 @@ opchar           ::=  ‘!’ | ‘#’ | ‘%’ | ‘&’ | ‘*’ | ‘+’ 
 printableChar    ::=  all characters in [\u0020, \u007E] inclusive
 UnicodeEscape    ::=  ‘\’ ‘u’ {‘u’} hexDigit hexDigit hexDigit hexDigit
 hexDigit         ::=  ‘0’ | ... | ‘9’ | ‘A’ | ... | ‘F’ | ‘a’ | ... | ‘f’
-charEscapeSeq    ::=  ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘"’ | ‘'’ | ‘\’)
+charEscapeSeq    ::=  ‘\’ (‘b’ | ‘t’ | ‘n’ | ‘f’ | ‘r’ | ‘s’ | ‘"’ | ‘'’ | ‘\’)
 escapeSeq        ::=  UnicodeEscape | charEscapeSeq
 
 op               ::=  opchar {opchar}

--- a/library/src/scala/StringContext.scala
+++ b/library/src/scala/StringContext.scala
@@ -310,7 +310,7 @@ object StringContext {
   class InvalidEscapeException(str: String, val index: Int) extends IllegalArgumentException(
     s"""invalid escape ${
       require(index >= 0 && index < str.length)
-      val ok = s"""[\\b, \\t, \\n, \\f, \\r, \\\\, \\", \\', \\uxxxx]"""
+      val ok = s"""[\\b, \\t, \\n, \\f, \\s, \\r, \\\\, \\", \\', \\uxxxx]"""
       if (index == str.length - 1) "at terminal" else s"'\\${str(index + 1)}' not one of $ok at"
     } index $index in "$str". Use \\\\ for literal \\."""
   )
@@ -350,7 +350,7 @@ object StringContext {
 
   /** Expands standard Scala escape sequences in a string.
    *  Escape sequences are:
-   *   control: `\b`, `\t`, `\n`, `\f`, `\r`
+   *   control: `\b`, `\t`, `\n`, `\f`, `\r`, `\s`
    *   escape:  `\\`, `\"`, `\'`
    *
    *  @param  str  A string that may contain escape sequences
@@ -361,7 +361,7 @@ object StringContext {
 
   /** Expands standard Scala escape sequences in a string.
    *  Escape sequences are:
-   *   control: `\b`, `\t`, `\n`, `\f`, `\r`
+   *   control: `\b`, `\t`, `\n`, `\f`, `\r`, `\s`
    *   escape:  `\\`, `\"`, `\'`
    *
    *  @param  str  A string that may contain escape sequences
@@ -397,6 +397,7 @@ object StringContext {
             case 'n'  => '\n'
             case 'f'  => '\f'
             case 'r'  => '\r'
+            case 's'  => ' '
             case '"'  => '"'
             case '\'' => '\''
             case '\\' => '\\'

--- a/tests/neg/unicodeEscapes-interpolations.check
+++ b/tests/neg/unicodeEscapes-interpolations.check
@@ -45,4 +45,4 @@
 -- Error: tests/neg/unicodeEscapes-interpolations.scala:14:29 ----------------------------------------------------------
 14 |  val badInterother = s"this \p ain't legal either" // error
    |                             ^
-   |invalid escape '\p' not one of [\b, \t, \n, \f, \r, \\, \", \', \uxxxx] at index 5 in "this \p ain't legal either". Use \\ for literal \.
+   |invalid escape '\p' not one of [\b, \t, \n, \f, \s, \r, \\, \", \', \uxxxx] at index 5 in "this \p ain't legal either". Use \\ for literal \.

--- a/tests/run/escaped-space.check
+++ b/tests/run/escaped-space.check
@@ -1,1 +1,7 @@
 a b
+a\sb
+a b
+heh  \s
+bi   \s
+heh   
+bi    

--- a/tests/run/escaped-space.scala
+++ b/tests/run/escaped-space.scala
@@ -1,3 +1,13 @@
 object Test:
   def main(args: Array[String]): Unit =
     println("a\sb")
+    println(raw"a\sb")
+    println(f"a\sb")
+    print(
+      """heh  \s
+        |bi   \s
+        |""".stripMargin)
+    print(
+      s"""heh  \s
+         |bi   \s
+         |""".stripMargin)


### PR DESCRIPTION
Follow-up for https://github.com/scala/scala3/pull/26515

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)