### PR TITLE
Provide `Byte` / `Short` `to`/ `until` `Range` extension methods

### DIFF
--- a/library/src/scala/Byte.scala
+++ b/library/src/scala/Byte.scala
@@ -14,6 +14,8 @@ package scala
 
 import scala.language.`2.13`
 
+import scala.collection.immutable.NumericRange
+
 /** `Byte`, a 8-bit signed integer (equivalent to Java's `byte` primitive type) is a
  *  subtype of [[scala.AnyVal]]. Instances of `Byte` are not
  *  represented by an object in the underlying runtime system.
@@ -707,5 +709,19 @@ object Byte extends AnyValCompanion {
       * - `0` if `this == that`
       */
     def compare(that: Byte): Int = java.lang.Byte.compare(self, that)
+
+    /** A [[scala.collection.immutable.NumericRange]] from `this` up to but not including `end`.
+      *
+      * @param end The final bound of the range to make.
+      * @param step The number to increase by for each step of the range (defaults to 1).
+      */
+    def until(end: Byte, step: Byte = 1): NumericRange.Exclusive[Byte] = NumericRange(self, end, step)
+
+    /** A [[scala.collection.immutable.NumericRange]] from `this` up to and including `end`.
+      *
+      * @param end The final bound of the range to make.
+      * @param step The number to increase by for each step of the range (defaults to 1).
+      */
+    def to(end: Byte, step: Byte = 1): NumericRange.Inclusive[Byte] = NumericRange.inclusive(self, end, step)
   }
 }

--- a/library/src/scala/Short.scala
+++ b/library/src/scala/Short.scala
@@ -14,6 +14,8 @@ package scala
 
 import scala.language.`2.13`
 
+import scala.collection.immutable.NumericRange
+
 /** `Short`, a 16-bit signed integer (equivalent to Java's `short` primitive type) is a
  *  subtype of [[scala.AnyVal]]. Instances of `Short` are not
  *  represented by an object in the underlying runtime system.
@@ -705,5 +707,19 @@ object Short extends AnyValCompanion {
       * - `0` if `this == that`
       */
     def compare(that: Short): Int = java.lang.Short.compare(self, that)
+
+    /** A [[scala.collection.immutable.NumericRange]] from `this` up to but not including `end`.
+      *
+      * @param end The final bound of the range to make.
+      * @param step The number to increase by for each step of the range (defaults to 1).
+      */
+    def until(end: Short, step: Short = 1): NumericRange.Exclusive[Short] = NumericRange(self, end, step)
+
+    /** A [[scala.collection.immutable.NumericRange]] from `this` up to and including `end`.
+      *
+      * @param end The final bound of the range to make.
+      * @param step The number to increase by for each step of the range (defaults to 1).
+      */
+    def to(end: Short, step: Short = 1): NumericRange.Inclusive[Short] = NumericRange.inclusive(self, end, step)
   }
 }

--- a/library/test/scala/lang/RicherTest.scala
+++ b/library/test/scala/lang/RicherTest.scala
@@ -78,6 +78,24 @@ class RicherTest {
     assertEqualTo(0)((10 until -2).length)
     assertEqualTo(0)((10 to -2).length)
   }
+  @Test def `Bytes are ranged`(): Unit = {
+    val start: Byte = 1
+    val end: Byte = 5
+    val step: Byte = 2
+    assertEqualTo(List[Byte](1, 2, 3, 4, 5))((start to end).toList)
+    assertEqualTo(List[Byte](1, 2, 3, 4))((start until end).toList)
+    assertEqualTo(List[Byte](1, 3, 5))(start.to(end, step).toList)
+    assertEqualTo(List[Byte](1, 3))(start.until(end, step).toList)
+  }
+  @Test def `Shorts are ranged`(): Unit = {
+    val start: Short = 10
+    val end: Short = 14
+    val step: Short = 2
+    assertEqualTo(List[Short](10, 11, 12, 13, 14))((start to end).toList)
+    assertEqualTo(List[Short](10, 11, 12, 13))((start until end).toList)
+    assertEqualTo(List[Short](10, 12, 14))(start.to(end, step).toList)
+    assertEqualTo(List[Short](10, 12))(start.until(end, step).toList)
+  }
   @Test def `Int strings`(): Unit = {
     assertEqualTo(x"1_0000")(16.toBinaryString)
     assertEqualTo("10")(16.toHexString)


### PR DESCRIPTION
Fixes issues found in 5 OpenCB projects after changes to RichInt in https://github.com/scala/scala3/pull/23872
- japgolly/nyaya
- japgolly/webapp-util
- japgolly/scalacss
- mjakubowski84/parquet4s
- netflix/atlas

All of the mentioned projects used `Byte.to(Byte)` range methods - these compile on Scala 2.13 and are available under Scala 3. It not longer works in 3.10 as we no longer perform `Byte` -> `Int` -> `RichInt` conversion  (same for Short) 

Effectively previouslly emitted ranges were constructed as `Range`, which gives as oportuninity to introduce new extensions typed as `NumericRange[Byte]` / `NumericRange[Short]` (same as BigInt and Char) 

Since these ranges are not wildly used these can use potentially slower NumericRange while keeping the original type of elements. For more performant versions explicit conversion Byte/Short -> Int can be used by users.
 

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output.

## How was the solution tested?

Manual tests