### PR TITLE
Fix regression: special case Symbol-less overloaded TermRefs in Inliner

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -1053,7 +1053,24 @@ class Inliner(val call: tpd.Tree)(using Context):
           val rhs = inlinedConstToLiteral(typed(vdef.rhs))
           sym.info = rhs.tpe
           untpd.cpy.ValDef(vdef)(vdef.name, untpd.TypeTree(rhs.tpe), untpd.TypedSplice(rhs))
-        else vdef
+        else
+          // If the declared type is a still-undisambiguated singleton reference over
+          // an overloaded member, typing the RHS below would use it as the
+          // expected type, and `typedSelect`'s raw member lookup can install an
+          // ambiguous denotation onto it as a side effect, later failing the conformance
+          // check. Settle it to the sole non-method alternative up front instead, inverting
+          // the TreePickler pickling optimisation for NotAMethod TermRefs (where, like here,
+          // they aren't assigned a Signature, and aren't tied to a Symbol, using Name
+          // designator instead).
+          vdef.tpt.typeOpt match
+            case tp: TermRef if tp.designator.isInstanceOf[Name] =>
+              tp.prefix.member(tp.name).altsWith(_.info.isParameterless) match
+                case alt :: Nil =>
+                  val fixed = TermRef(tp.prefix, tp.name, alt)
+                  sym.info = fixed
+                  untpd.cpy.ValDef(vdef)(vdef.name, untpd.TypeTree(fixed), vdef.rhs)
+                case _ => vdef
+            case _ => vdef
       super.typedValDef(vdef1, sym)
 
     override def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree =

--- a/tests/pos-macros/i26623/Macro_1.scala
+++ b/tests/pos-macros/i26623/Macro_1.scala
@@ -1,0 +1,12 @@
+trait Binder[T]
+
+object Binder:
+  def foo(s: String): Binder[Int] = new Binder[Int] {}
+  val foo: Binder[Int] = foo("x")
+
+// Named `binder =` skips the defaulted `name` parameter.
+case class Box[A](tpe: String, name: String = "", binder: Binder[A] = null)
+
+object Mapping:
+  inline def localDate: Box[Int] =
+    Box("LocalDate", binder = Binder.foo)

--- a/tests/pos-macros/i26623/Test_2.scala
+++ b/tests/pos-macros/i26623/Test_2.scala
@@ -1,0 +1,1 @@
+@main def Test = Mapping.localDate


### PR DESCRIPTION
Fixes #26623
This issue is multifaceted and somewhat difficult to explain, so please bear with me!

First, the inlining data is pickled:
```scala
    val binder$1: (Binder.foo : Binder[Int]) = Binder.foo
    val name$1: String = Box.$lessinit$greater$default$2[Int]
    Box.apply[Int]("LocalDate", name$1, binder = binder$1)
```
Take notice of the `val binder$1: (Binder.foo : Binder[Int]) = Binder.foo`. When pickling the TypeTree[TermRef(…)], when the signature of the TermRef is `Signature.NotAMethod`, then only name is pickled, without the signature (likely as optimization).
Then, when compiling the second file the inlined body is unpickled (with the symbol data/ signature expectedly missing):
```scala
    val binder$1: Binder.foo.type = Binder.foo
    val name$1: String = Box.$lessinit$greater$default$2[Int]
    Box.apply[Int]("LocalDate", name$1, binder = binder$1)
```

The true cause of the issue happens inside Inliner’s typedSelect. There, we have a selectionType call meant to change the denotation of the typed symbols (ironically commented with `Make sure that the named type has the correct denotation`), which for our case, causes the .foo to be typed with the <overloaded Binder.foo> MultiDenotation, also affecting the ValDef type, since the incorrect denotation is now cached and used for Binder.foo.type as well.

So even though we do end up correctly typing the RHS of the ValDef later, we can’t change the Binary.foo.type at that point, since the denotation for Binary.foo.type is keyed by `(prefix, name)` (because of the MultiDenotation) and any fixed denotation from the actual select tree is keyed as `(prefix, symbol)` (because we know the symbol we want). The point here is we can’t fix the issue after the selectionType poisoning, it has to be before.

For that I picked typedValDef, with explicit check for this kind of case in the ValDef’s type. I think, since we know that Pickler’s optimization means that the expected signature here is „NotAMethod”, and we also cannot define TermRefs (or typeTrees, for that matter) based on `Name`s (it has to be `Symbol`s) in macros, we are pretty precise about fixing this specific issue here. I haven’t been able to reengineer any other code that would break, and I did try for a long time, so hopefully this granular change is ok.

I did try other fixes:
* fix in tree unpickler - at that point we didn’t have information about all of the overloaded members yet, so I didn’t manage to make this work
* fix in withDenotation - we could disambiguate directly in withDenotation called by selectionType, before it gets cached, worked for this case, but I though this might be too invasive and cause issues elsewhere
* Removing/ rewriting the selectionType - I also thought might be too invasive, and blew up the code


## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by reading the code

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable) (Also spent some time trying to come up with other distinct cases causing this issue, without success)
