### PR TITLE
Avoid incorrect auto-tupling with leading using param list

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/Trees.scala
+++ b/compiler/src/dotty/tools/dotc/ast/Trees.scala
@@ -528,11 +528,15 @@ object Trees {
       putAttachment(untpd.KindOfApply, kind)
       this
 
-    /** The kind of this application. Works reliably only for untyped trees; typed trees
-     *  are under no obligation to update it correctly.
-     */
-    def applyKind: ApplyKind =
-      attachmentOrElse(untpd.KindOfApply, ApplyKind.Regular)
+    /** The kind of this application. */
+    def applyKind(using Context): ApplyKind =
+      // The attachement is only guaranteed to be set on untyped trees.
+      if hasAttachment(untpd.KindOfApply) then
+        attachment(untpd.KindOfApply)
+      else
+        val funTpe = fun.typeOpt
+        if funTpe.exists && funTpe.widen.stripPoly.isImplicitMethod then ApplyKind.Using
+        else ApplyKind.Regular
   }
 
   /** fun[args] */

--- a/compiler/src/dotty/tools/dotc/typer/Applications.scala
+++ b/compiler/src/dotty/tools/dotc/typer/Applications.scala
@@ -1649,18 +1649,21 @@ trait Applications extends Compatibility {
 
   /** Is `tp` a unary function type or an overloaded type with only unary function
    *  types as alternatives?
+   *  If `skipImplicit` is true, leading implicit parameter sections are
+   *  skipped first.
    */
-  def isUnary(tp: Type)(using Context): Boolean = tp match {
-    case tp: MethodicType =>
-      tp.firstParamTypes match {
-        case ptype :: Nil => !ptype.isRepeatedParam
-        case _ => false
-      }
+  def isUnary(tp: Type, skipImplicit: Boolean)(using Context): Boolean = tp.stripPoly match
+    case mt: MethodType =>
+      if skipImplicit && mt.isImplicitMethod then
+        isUnary(tp.resultType, skipImplicit)
+      else
+        mt.paramInfos match
+          case ptype :: Nil => !ptype.isRepeatedParam
+          case _ => false
     case tp: TermRef =>
-      tp.denot.alternatives.forall(alt => isUnary(alt.info))
+      tp.denot.alternatives.forall(alt => isUnary(alt.info, skipImplicit))
     case _ =>
       false
-  }
 
   /** Should we tuple or untuple the argument before application?
     *  If auto-tupling is enabled then
@@ -1671,14 +1674,15 @@ trait Applications extends Compatibility {
     *     does not consist only of unary alternatives.
     */
   def needsTupledDual(funType: Type, pt: FunProto)(using Context): Boolean =
+    val skipImplicit = pt.applyKind != ApplyKind.Using
     pt.args match
       case untpd.Tuple(elems) :: Nil =>
         elems.length > 1
         && pt.applyKind == ApplyKind.InfixTuple
-        && !isUnary(funType)
+        && !isUnary(funType, skipImplicit)
       case args =>
         args.lengthCompare(1) > 0
-        && isUnary(funType)
+        && isUnary(funType, skipImplicit)
         && Feature.autoTuplingEnabled
 
   /** If `tree` is a complete application of a compiler-generated `apply`

--- a/tests/neg-macros/cyclic.check
+++ b/tests/neg-macros/cyclic.check
@@ -49,14 +49,14 @@
    |    val x$1: A = ${(using contextual$3: scala.quoted.Quotes) => value}
    |    ${(using contextual$2: scala.quoted.Quotes) => createTupleAux(x - 1)}.*:[A, Tuple](x$1)
    |  }
-   |}.apply(q)
-   |  typing if x == 0 then '{EmptyTuple}.apply(q) else
+   |}.apply(using q)
+   |  typing if x == 0 then '{EmptyTuple}.apply(using q) else
    |  '{
    |    {
    |      val x$1: A = ${(using contextual$3: scala.quoted.Quotes) => value}
    |      ${(using contextual$2: scala.quoted.Quotes) => createTupleAux(x - 1)}.*:[A, Tuple](x$1)
    |    }
-   |  }.apply(q)
+   |  }.apply(using q)
    |  typing {
    |  createTupleAux(x)
    |}

--- a/tests/neg/given-ambiguous-1.check
+++ b/tests/neg/given-ambiguous-1.check
@@ -1,9 +1,9 @@
 -- [E172] Type Error: tests/neg/given-ambiguous-1.scala:12:23 ----------------------------------------------------------
 12 |def f: Unit = summon[B] // error: Ambiguous given instances
    |                       ^
-   |                No best given instance of type B was found for parameter x of method summon in object Predef.
-   |                I found:
+   |          No best given instance of type B was found for parameter x of method summon in object Predef.
+   |          I found:
    |
-   |                    given_B(/* ambiguous: both given instance a1 and given instance a2 match type A */summon[A])
+   |              given_B(using /* ambiguous: both given instance a1 and given instance a2 match type A */summon[A])
    |
-   |                But both given instance a1 and given instance a2 match type A.
+   |          But both given instance a1 and given instance a2 match type A.

--- a/tests/neg/given-ambiguous-default-1.check
+++ b/tests/neg/given-ambiguous-default-1.check
@@ -1,9 +1,9 @@
 -- [E172] Type Error: tests/neg/given-ambiguous-default-1.scala:18:23 --------------------------------------------------
 18 |def f: Unit = summon[B] // error: Ambiguous given instances
    |                       ^
-   |                No best given instance of type B was found for parameter x of method summon in object Predef.
-   |                I found:
+   |          No best given instance of type B was found for parameter x of method summon in object Predef.
+   |          I found:
    |
-   |                    given_B(/* ambiguous: both given instance a1 and given instance a2 match type A */summon[A])
+   |              given_B(using /* ambiguous: both given instance a1 and given instance a2 match type A */summon[A])
    |
-   |                But both given instance a1 and given instance a2 match type A.
+   |          But both given instance a1 and given instance a2 match type A.

--- a/tests/neg/given-ambiguous-default-2.check
+++ b/tests/neg/given-ambiguous-default-2.check
@@ -1,9 +1,9 @@
 -- [E172] Type Error: tests/neg/given-ambiguous-default-2.scala:18:23 --------------------------------------------------
 18 |def f: Unit = summon[C] // error: Ambiguous given instances
    |                       ^
-   |            No best given instance of type C was found for parameter x of method summon in object Predef.
-   |            I found:
+   |      No best given instance of type C was found for parameter x of method summon in object Predef.
+   |      I found:
    |
-   |                given_C(a = /* ambiguous: both given instance a1 and given instance a2 match type A */summon[A])
+   |          given_C(using a = /* ambiguous: both given instance a1 and given instance a2 match type A */summon[A])
    |
-   |            But both given instance a1 and given instance a2 match type A.
+   |      But both given instance a1 and given instance a2 match type A.

--- a/tests/neg/i10901.check
+++ b/tests/neg/i10901.check
@@ -40,7 +40,7 @@
    |          value foo is not a member of String.
    |          An extension method was tried, but could not be fully constructed:
    |
-   |              Test.foo("abc")(/* missing */summon[C])
+   |              Test.foo("abc")(using /* missing */summon[C])
    |
    |              failed with:
    |

--- a/tests/neg/i18670.check
+++ b/tests/neg/i18670.check
@@ -4,7 +4,7 @@
    |      No given instance of type TC[A] was found for a context parameter of constructor Payload in class Payload.
    |      I found:
    |
-   |          TC.derived[A](/* missing */summon[scala.deriving.Mirror.Of[A]])
+   |          TC.derived[A](using /* missing */summon[scala.deriving.Mirror.Of[A]])
    |
    |      But Failed to synthesize an instance of type scala.deriving.Mirror.Of[A]:
    |      	* class Nothing is not a generic product because it is not a case class

--- a/tests/neg/i19414-desugared.check
+++ b/tests/neg/i19414-desugared.check
@@ -4,7 +4,7 @@
    |No best given instance of type BodySerializer[JsObject] was found for parameter x of method summon in object Predef.
    |I found:
    |
-   |    given_BodySerializer_B[B](
+   |    given_BodySerializer_B[B](using
    |      writer =
    |        /* ambiguous: both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B] */
    |          summon[Writer[B]]

--- a/tests/neg/i19414.check
+++ b/tests/neg/i19414.check
@@ -4,7 +4,7 @@
    |No best given instance of type BodySerializer[JsObject] was found for parameter x of method summon in object Predef.
    |I found:
    |
-   |    given_BodySerializer_B[B](
+   |    given_BodySerializer_B[B](using
    |      evidence$1 =
    |        /* ambiguous: both given instance given_Writer_JsValue and given instance given_Writer_JsObject match type Writer[B] */
    |          summon[Writer[B]]

--- a/tests/neg/i8827a.check
+++ b/tests/neg/i8827a.check
@@ -4,7 +4,7 @@
    | No given instance of type pkg.Order[List[pkg.Foo]] was found for parameter x of method summon in object Predef.
    | I found:
    |
-   |     pkg.Order.orderList[pkg.Foo](/* missing */summon[pkg.Order[pkg.Foo]])
+   |     pkg.Order.orderList[pkg.Foo](using /* missing */summon[pkg.Order[pkg.Foo]])
    |
    | But no implicit values were found that match type pkg.Order[pkg.Foo].
    |

--- a/tests/neg/i8827b.check
+++ b/tests/neg/i8827b.check
@@ -4,7 +4,7 @@
    |No given instance of type pkg.Order[Option[pkg.Foo]] was found for parameter x of method summon in object Predef.
    |I found:
    |
-   |    pkg.Order.given_Order_Option[pkg.Foo](/* missing */summon[pkg.Order[pkg.Foo]])
+   |    pkg.Order.given_Order_Option[pkg.Foo](using /* missing */summon[pkg.Order[pkg.Foo]])
    |
    |But no implicit values were found that match type pkg.Order[pkg.Foo].
    |

--- a/tests/neg/i9185.check
+++ b/tests/neg/i9185.check
@@ -4,7 +4,7 @@
   |value pure is not a member of String.
   |An extension method was tried, but could not be fully constructed:
   |
-  |    M.pure[A, F]("ola")(
+  |    M.pure[A, F]("ola")(using
   |      /* ambiguous: both object listMonad in object M and object optionMonad in object M match type M[F] */summon[M[F]])
   |
   |    failed with:

--- a/tests/neg/implicitSearch.check
+++ b/tests/neg/implicitSearch.check
@@ -4,7 +4,7 @@
    |      No given instance of type Test.Ord[List[List[T]]] was found for parameter o of method sort in object Test.
    |      I found:
    |
-   |          Test.listOrd[List[T]](Test.listOrd[T](/* missing */summon[Test.Ord[T]]))
+   |          Test.listOrd[List[T]](using Test.listOrd[T](using /* missing */summon[Test.Ord[T]]))
    |
    |      But no implicit values were found that match type Test.Ord[T].
 -- [E172] Type Error: tests/neg/implicitSearch.scala:15:38 -------------------------------------------------------------

--- a/tests/neg/missing-implicit3.check
+++ b/tests/neg/missing-implicit3.check
@@ -4,7 +4,7 @@
    |     No given instance of type ord.Ord[ord.Foo] was found for a context parameter of method sort in package ord.
    |     I found:
    |
-   |         ord.Ord.ordered[ord.Foo](/* missing */summon[ord.Foo => Comparable[? >: ord.Foo]])
+   |         ord.Ord.ordered[ord.Foo](using /* missing */summon[ord.Foo => Comparable[? >: ord.Foo]])
    |
    |     But no implicit values were found that match type ord.Foo => Comparable[? >: ord.Foo].
    |

--- a/tests/neg/named-tuples-strictEquality.check
+++ b/tests/neg/named-tuples-strictEquality.check
@@ -5,7 +5,7 @@
   |I found:
   |
   |    NamedTuple.namedTupleCanEqual[(("name" : String), ("age" : String)), (("name" : String), ("birthYear" : String)), V1, V2
-  |      ](/* missing */summon[(("name" : String), ("age" : String)) =:= (("name" : String), ("birthYear" : String))])
+  |      ](using /* missing */summon[(("name" : String), ("age" : String)) =:= (("name" : String), ("birthYear" : String))])
   |
   |But no implicit values were found that match type (("name" : String), ("age" : String)) =:= (("name" : String), ("birthYear" : String)).
 -- [E172] Type Error: tests/neg/named-tuples-strictEquality.scala:15:11 ------------------------------------------------
@@ -15,6 +15,6 @@
    |I found:
    |
    |    NamedTuple.namedTupleCanEqual[(("name" : String), ("published" : String)), (("name" : String), ("age" : String)), V1, V2
-   |      ](/* missing */summon[(("name" : String), ("published" : String)) =:= (("name" : String), ("age" : String))])
+   |      ](using /* missing */summon[(("name" : String), ("published" : String)) =:= (("name" : String), ("age" : String))])
    |
    |But no implicit values were found that match type (("name" : String), ("published" : String)) =:= (("name" : String), ("age" : String)).

--- a/tests/neg/scala-uri.check
+++ b/tests/neg/scala-uri.check
@@ -4,8 +4,8 @@
    |No best given instance of type QueryKeyValue[(String, None.type)] was found for parameter x of method summon in object Predef.
    |I found:
    |
-   |    QueryKeyValue.tuple2QueryKeyValue[String, None.type](QueryKey.stringQueryKey,
-   |      QueryValue.optionQueryValue[A](
+   |    QueryKeyValue.tuple2QueryKeyValue[String, None.type](using QueryKey.stringQueryKey,
+   |      QueryValue.optionQueryValue[A](using
    |        /* ambiguous: both given instance stringQueryValue in trait QueryValueInstances1 and given instance noneQueryValue in trait QueryValueInstances1 match type QueryValue[A] */
    |          summon[QueryValue[A]]
    |      )

--- a/tests/pos/i26847.scala
+++ b/tests/pos/i26847.scala
@@ -1,0 +1,24 @@
+sealed trait A
+case object B extends A
+
+object Test:
+  def before[T <: A](using Int)(t: T): Int = 1
+  def before[T <: A](using Int)(t: T, b: Boolean): String = ""
+
+  given Int = 0
+
+  val a: Int = before(B)
+  val b: String = before(B, true) // was: type mismatch: found (B.type, Boolean), required A
+
+  // Same without the upper bound: used to compile but silently picked the
+  // unary overload by auto-tupling the arguments.
+  def g[T](using Int)(t: T): Int = 1
+  def g[T](using Int)(t: T, b: Boolean): String = ""
+
+  val c: Int = g(B)
+  val d: String = g(B, true)
+
+  // Auto-tupling still applies when all alternatives take a single
+  // explicit parameter after the using clause.
+  def h[T](using Int)(t: T): Int = 1
+  val e: Int = h(B, true)

--- a/tests/pos/i26847b/Lib_1.scala
+++ b/tests/pos/i26847b/Lib_1.scala
@@ -1,0 +1,29 @@
+import scala.util.NotGiven
+
+class C
+class D
+
+object Lib:
+  def f(using c: C, d: D)(x: Int): Int = x
+
+  given C = C()
+  given D = D()
+
+  inline def g(x: Int): Int = f(x)
+
+// An overloaded variant in the style of specs2's Debug.pp: a two-parameter
+// using clause on the extension, followed by unary explicit sections.
+trait NoDebug
+trait Output:
+  def println(m: Any): Unit
+
+object Debug:
+  extension [T](t: => T)(using not: NotGiven[NoDebug], output: Output)
+    def pp: T = t
+    def pp(condition: Boolean): T = t
+    def pp(pre: String): T = t
+
+  given Output = new Output:
+    def println(m: Any): Unit = ()
+
+  inline def use[T](t: => T): T = t.pp(condition = true)

--- a/tests/pos/i26847b/Use_2.scala
+++ b/tests/pos/i26847b/Use_2.scala
@@ -1,0 +1,8 @@
+// Inlining `g` and `use` retypes their bodies, in which the applications of
+// the leading implicit parameter sections appear as regular applications
+// since ApplyKind attachments are not pickled. The retyper must not
+// auto-tuple the implicit arguments against the following explicit
+// parameter section.
+object Use:
+  def test1: Int = Lib.g(1)
+  def test2: Int = Debug.use(1)

--- a/tests/printing/dependent-annot-default-args.check
+++ b/tests/printing/dependent-annot-default-args.check
@@ -16,7 +16,7 @@ package <empty> {
   final module class annot2() extends AnyRef() { this: annot2.type =>
     def $lessinit$greater$default$1: Any @uncheckedVariance = -1
     def $lessinit$greater$default$2: Array[Any] @uncheckedVariance =
-      Array.apply[Any](["Hello" : Any]*)(scala.reflect.ClassTag.Any)
+      Array.apply[Any](["Hello" : Any]*)(using scala.reflect.ClassTag.Any)
   }
   final lazy module val dependent-annot-default-args$package:
     dependent-annot-default-args$package =
@@ -26,7 +26,9 @@ package <empty> {
     def f(x: Any): Any @annot(x) = x
     def f2(x: Int):
       Int @annot2(
-        y = Array.apply[Any](["Hello",x : Any]*)(scala.reflect.ClassTag.Any))
+        y =
+          Array.apply[Any](["Hello",x : Any]*)(using scala.reflect.ClassTag.Any)
+        )
      = x
     def f3(x: Any, y: Any): Any @annot(x = x, y = y) = x
     def test: Unit =
@@ -35,31 +37,36 @@ package <empty> {
         val z: Any @annot(y) = f(y)
         val z2:
           Int @annot2(
-            y = Array.apply[Any](["Hello",y : Any]*)(scala.reflect.ClassTag.Any)
-            )
+            y =
+              Array.apply[Any](["Hello",y : Any]*)(using
+                scala.reflect.ClassTag.Any)
+          )
          = f2(y)
         @annot(44) val z3: Int = 45
         @annot2(
-          y = Array.apply[Any](["Hello",y : Any]*)(scala.reflect.ClassTag.Any))
-          val z4: Int = 45
+          y =
+            Array.apply[Any](["Hello",y : Any]*)(using
+              scala.reflect.ClassTag.Any)
+        ) val z4: Int = 45
         val z5: annot =
           {
             val y$1: Array[String] =
-              Array.apply[String](["World" : String]*)(
+              Array.apply[String](["World" : String]*)(using
                 scala.reflect.ClassTag.apply[String](classOf[String]))
             new annot(x = 1, y = y$1)
           }
         val z6: annot2 =
           {
             val y$2: Array[Any] =
-              Array.apply[Any](["World" : Any]*)(scala.reflect.ClassTag.Any)
+              Array.apply[Any](["World" : Any]*)(using
+                scala.reflect.ClassTag.Any)
             new annot2(x = 1, y = y$2)
           }
         @annot(x = 2,
           y =
             {
               val y$3: Array[String] =
-                Array.apply[String](["World" : String]*)(
+                Array.apply[String](["World" : String]*)(using
                   scala.reflect.ClassTag.apply[String](classOf[String]))
               new annot(x = 1, y = y$3)
             }
@@ -69,7 +76,7 @@ package <empty> {
             3:
               Int @annot(x = 1,
                 y =
-                  Array.apply[String](["World" : String]*)(
+                  Array.apply[String](["World" : String]*)(using
                     scala.reflect.ClassTag.apply[String](classOf[String]))
               )
         ) val z8: Int = 45
@@ -78,7 +85,7 @@ package <empty> {
             y =
               {
                 val y$4: Array[String] =
-                  Array.apply[String](["World" : String]*)(
+                  Array.apply[String](["World" : String]*)(using
                     scala.reflect.ClassTag.apply[String](classOf[String]))
                 new annot(x = 1, y = y$4)
               }
@@ -89,7 +96,7 @@ package <empty> {
             3:
               Int @annot(x = 1,
                 y =
-                  Array.apply[String](["World" : String]*)(
+                  Array.apply[String](["World" : String]*)(using
                     scala.reflect.ClassTag.apply[String](classOf[String]))
               )
         ) val z10: Int = 45
@@ -97,20 +104,20 @@ package <empty> {
           f(
             {
               val y$5: Array[String] =
-                Array.apply[String](["World" : String]*)(
+                Array.apply[String](["World" : String]*)(using
                   scala.reflect.ClassTag.apply[String](classOf[String]))
               new annot(x = 1, y = y$5)
             }
           )
         val z12: Any @annot(x = x, y = y) =
           f3(
-            Array.apply[String](["World" : String]*)(
+            Array.apply[String](["World" : String]*)(using
               scala.reflect.ClassTag.apply[String](classOf[String])),
           1)
         val z13: Any @annot(x = x, y = y) =
           {
             val y$6: Array[String] =
-              Array.apply[String](["World" : String]*)(
+              Array.apply[String](["World" : String]*)(using
                 scala.reflect.ClassTag.apply[String](classOf[String]))
             f3(x = 1, y = y$6)
           }


### PR DESCRIPTION
 `isUnary`, which decides whether `needsTupledDual` auto-tuples the arguments,
looks at the first parameter section of each alternative. In:

    def before[T <: A](using Int)(t: T): Unit
    def before[T <: A](using Int)(t: T, b: Boolean): Unit

    val b: String = before(B, true) // type mismatch: found (B.type, Boolean), required A

both alternatives were classified as unary based on the `using` clause, even
though the call is written without `using`. Fixed by taking applyKind into
account.

Fixes #26847.

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Fable 5 wrote the initial fix which I cleaned up.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests

