### PR TITLE
Turn Scaladoc tasty parsing error into warning

### DIFF
--- a/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/TastyParser.scala
@@ -244,7 +244,7 @@ case class TastyParser(
 
     try Traverser.traverseTree(root)(Symbol.spliceOwner)
     catch case e: Throwable =>
-      report.error(s"Problem parsing ${root.pos}, documentation may not be generated. (Error message: ${e.getMessage})")
+      report.warning(s"Problem parsing ${root.pos}, documentation may not be generated. (Error message: ${e.getMessage})")
       // e.printStackTrace()
 
     docs.result()


### PR DESCRIPTION
Unblocks #26852

We probably screw up the context somewhere. But the data flow is so messed up and we keep converting contexts and symbols between various types. This needs to be rewritten from scratch with as little Scaladoc code as possible and zero involvement of Quotes. Oh well.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
