### PR TITLE
Backport "Fix regression: special case Symbol-less overloaded TermRefs in Inliner" to 3.9.0

### DIFF
--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -983,7 +983,24 @@ class Inliner(val call: tpd.Tree)(using Context):
           val rhs = typed(vdef.rhs)
           sym.info = rhs.tpe
           untpd.cpy.ValDef(vdef)(vdef.name, untpd.TypeTree(rhs.tpe), untpd.TypedSplice(rhs))
-        else vdef
+        else
+          // If the declared type is a still-undisambiguated singleton reference over
+          // an overloaded member, typing the RHS below would use it as the
+          // expected type, and `typedSelect`'s raw member lookup can install an
+          // ambiguous denotation onto it as a side effect, later failing the conformance
+          // check. Settle it to the sole non-method alternative up front instead, inverting
+          // the TreePickler pickling optimisation for NotAMethod TermRefs (where, like here,
+          // they aren't assigned a Signature, and aren't tied to a Symbol, using Name
+          // designator instead).
+          vdef.tpt.typeOpt match
+            case tp: TermRef if tp.designator.isInstanceOf[Name] =>
+              tp.prefix.member(tp.name).altsWith(_.info.isParameterless) match
+                case alt :: Nil =>
+                  val fixed = TermRef(tp.prefix, tp.name, alt)
+                  sym.info = fixed
+                  untpd.cpy.ValDef(vdef)(vdef.name, untpd.TypeTree(fixed), vdef.rhs)
+                case _ => vdef
+            case _ => vdef
       super.typedValDef(vdef1, sym)
 
     override def typedApply(tree: untpd.Apply, pt: Type)(using Context): Tree =

--- a/tests/pos-macros/i26623/Macro_1.scala
+++ b/tests/pos-macros/i26623/Macro_1.scala
@@ -1,0 +1,12 @@
+trait Binder[T]
+
+object Binder:
+  def foo(s: String): Binder[Int] = new Binder[Int] {}
+  val foo: Binder[Int] = foo("x")
+
+// Named `binder =` skips the defaulted `name` parameter.
+case class Box[A](tpe: String, name: String = "", binder: Binder[A] = null)
+
+object Mapping:
+  inline def localDate: Box[Int] =
+    Box("LocalDate", binder = Binder.foo)

--- a/tests/pos-macros/i26623/Test_2.scala
+++ b/tests/pos-macros/i26623/Test_2.scala
@@ -1,0 +1,1 @@
+@main def Test = Mapping.localDate


### PR DESCRIPTION
Backports #26853 to the 3.9.0-RC6.

PR submitted by the release tooling.