### PR TITLE
More Vulpix simplifications

### DIFF
--- a/compiler/test/dotty/tools/debug/DebugTests.scala
+++ b/compiler/test/dotty/tools/debug/DebugTests.scala
@@ -27,12 +27,6 @@ class DebugTests:
 object DebugTests extends ParallelTesting:
   override def debugMode = true
 
-  given summaryReport: SummaryReporting = new SummaryReport
-
-  @AfterClass def tearDown(): Unit =
-    super.cleanup()
-    summaryReport.echoSummary()
-
   extension (test: CompilationTest)
     private def checkDebug()(using SummaryReporting): test.type =
       import test.*

--- a/compiler/test/dotty/tools/debug/DebugTests.scala
+++ b/compiler/test/dotty/tools/debug/DebugTests.scala
@@ -25,7 +25,6 @@ class DebugTests:
     ).checkDebug()
 
 object DebugTests extends ParallelTesting:
-  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
   override def debugMode = true
 
   given summaryReport: SummaryReporting = new SummaryReport

--- a/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
+++ b/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
@@ -40,8 +40,6 @@ class BestEffortOptionsTests {
 }
 
 object BestEffortOptionsTests extends ParallelTesting {
-  def numberOfWorkers = Runtime.getRuntime.availableProcessors()
-
   implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def tearDown(): Unit = {
     super.cleanup()

--- a/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
+++ b/compiler/test/dotty/tools/dotc/BestEffortOptionsTests.scala
@@ -13,7 +13,7 @@ import org.junit.{AfterClass, Test}
 class BestEffortOptionsTests {
   import ParallelTesting.*
   import vulpix.TestConfiguration.*
-  import BestEffortOptionsTests.*
+  import BestEffortOptionsTests.{*, given}
 
   // Since TASTy and beTASTy files are read in a lazy manner (only when referenced by the source .scala file)
   // we test by using the "-from-tasty" option. This guarantees that the tasty files will be read
@@ -39,10 +39,4 @@ class BestEffortOptionsTests {
       .noCrashWithCompilingDependencies()
 }
 
-object BestEffortOptionsTests extends ParallelTesting {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
-  @AfterClass def tearDown(): Unit = {
-    super.cleanup()
-    summaryReport.echoSummary()
-  }
-}
+object BestEffortOptionsTests extends ParallelTesting

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -208,8 +208,6 @@ class BootstrappedOnlyCompilationTests {
 }
 
 object BootstrappedOnlyCompilationTests extends ParallelTesting with CoverageSupport {
-  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
-
   implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def tearDown(): Unit = {
     super.cleanup()

--- a/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/BootstrappedOnlyCompilationTests.scala
@@ -15,7 +15,7 @@ import java.nio.file.*
 class BootstrappedOnlyCompilationTests {
   import ParallelTesting.*
   import TestConfiguration.*
-  import BootstrappedOnlyCompilationTests.*
+  import BootstrappedOnlyCompilationTests.{*, given}
   import CompilationTest.aggregateTests
 
   // Positive tests ------------------------------------------------------------
@@ -207,10 +207,4 @@ class BootstrappedOnlyCompilationTests {
   }
 }
 
-object BootstrappedOnlyCompilationTests extends ParallelTesting with CoverageSupport {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
-  @AfterClass def tearDown(): Unit = {
-    super.cleanup()
-    summaryReport.echoSummary()
-  }
-}
+object BootstrappedOnlyCompilationTests extends ParallelTesting with CoverageSupport

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -471,8 +471,6 @@ class CompilationTests {
 }
 
 object CompilationTests extends ParallelTesting with CoverageSupport {
-  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
-
   given summaryReport: SummaryReporting = new SummaryReport
 
   @AfterClass def tearDown(): Unit = {

--- a/compiler/test/dotty/tools/dotc/CompilationTests.scala
+++ b/compiler/test/dotty/tools/dotc/CompilationTests.scala
@@ -470,12 +470,4 @@ class CompilationTests {
   }
 }
 
-object CompilationTests extends ParallelTesting with CoverageSupport {
-  given summaryReport: SummaryReporting = new SummaryReport
-
-  @AfterClass def tearDown(): Unit = {
-    super.cleanup()
-    summaryReport.echoSummary()
-  }
-
-}
+object CompilationTests extends ParallelTesting with CoverageSupport

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration.*
 
 class FromTastyTests {
   import TestConfiguration.*
-  import FromTastyTests.*
+  import FromTastyTests.{*, given}
 
   @Test def posTestFromTasty: Unit = {
     // Can be reproduced with
@@ -38,10 +38,4 @@ class FromTastyTests {
   }
 }
 
-object FromTastyTests extends ParallelTesting {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
-  @AfterClass def tearDown(): Unit = {
-    super.cleanup()
-    summaryReport.echoSummary()
-  }
-}
+object FromTastyTests extends ParallelTesting

--- a/compiler/test/dotty/tools/dotc/FromTastyTests.scala
+++ b/compiler/test/dotty/tools/dotc/FromTastyTests.scala
@@ -39,8 +39,6 @@ class FromTastyTests {
 }
 
 object FromTastyTests extends ParallelTesting {
-  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
-
   implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def tearDown(): Unit = {
     super.cleanup()

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -65,8 +65,6 @@ class IdempotencyTests {
 }
 
 object IdempotencyTests extends ParallelTesting {
-  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
-
   implicit val summaryReport: SummaryReporting = new SummaryReport
   @AfterClass def tearDown(): Unit = {
     super.cleanup()

--- a/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
+++ b/compiler/test/dotty/tools/dotc/IdempotencyTests.scala
@@ -14,7 +14,7 @@ import vulpix.*
 
 class IdempotencyTests {
   import TestConfiguration.*
-  import IdempotencyTests.*
+  import IdempotencyTests.{*, given}
   import CompilationTest.aggregateTests
 
   // ignore flaky tests
@@ -64,10 +64,4 @@ class IdempotencyTests {
 
 }
 
-object IdempotencyTests extends ParallelTesting {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
-  @AfterClass def tearDown(): Unit = {
-    super.cleanup()
-    summaryReport.echoSummary()
-  }
-}
+object IdempotencyTests extends ParallelTesting

--- a/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
+++ b/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
@@ -201,8 +201,6 @@ class CoverageTests:
     }
 
 object CoverageTests extends ParallelTesting:
-  def numberOfWorkers = 1
-
   given summaryReport: SummaryReporting = SummaryReport()
   @AfterClass def tearDown(): Unit =
     super.cleanup()

--- a/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
+++ b/compiler/test/dotty/tools/dotc/coverage/CoverageTests.scala
@@ -21,6 +21,7 @@ import java.util.stream.Collectors
 @Category(Array(classOf[BootstrappedOnlyTests]))
 class CoverageTests:
   import CoverageTests.{*, given}
+  given TestGroup = TestGroup("instrumentCoverage")
 
   private val scalaFile = FileSystems.getDefault.getPathMatcher("glob:**.scala")
   private val rootSrc = Paths.get(userDir, "tests", "coverage")
@@ -200,10 +201,4 @@ class CoverageTests:
       assertEquals(Set("file2.scala"), filesWithCoverage)
     }
 
-object CoverageTests extends ParallelTesting:
-  given summaryReport: SummaryReporting = SummaryReport()
-  @AfterClass def tearDown(): Unit =
-    super.cleanup()
-    summaryReport.echoSummary()
-
-  given TestGroup = TestGroup("instrumentCoverage")
+object CoverageTests extends ParallelTesting

--- a/compiler/test/dotty/tools/vulpix/FileDiff.scala
+++ b/compiler/test/dotty/tools/vulpix/FileDiff.scala
@@ -4,7 +4,6 @@ import scala.jdk.CollectionConverters.*
 import scala.util.Properties.{javaSpecVersion, versionNumberString}
 
 import java.io.File
-import java.lang.System.{lineSeparator => EOL}
 import java.nio.file.{Files, Paths}
 
 
@@ -47,7 +46,7 @@ object FileDiff {
         None
       else
         // Do not use a """ literal here with .stripMargin since `outputLines` may begin with |
-        Some(s"Output from '$sourceTitle' did not match check file. Actual output:\n${outputLines.mkString(EOL)}\n")
+        Some(s"Output from '$sourceTitle' did not match check file. Actual output:\n${outputLines.mkString(System.lineSeparator())}\n")
     else
       assert(tolerateMissing, "Missing check file: " + path.toString)
       None
@@ -68,7 +67,7 @@ object FileDiff {
 
   def dump(path: String, content: Seq[String]): Unit = {
     val outFile = dotty.tools.io.File(path)
-    outFile.writeAll(content.mkString("", EOL, EOL))
+    outFile.writeAll(content.mkString("", System.lineSeparator(), System.lineSeparator()))
   }
 
   def checkAndDumpOrUpdate(sourceTitle: String, actualLines: Seq[String], checkFilePath: String, tolerateMissingCheckFile: Boolean = true): Boolean = {

--- a/compiler/test/dotty/tools/vulpix/FileFilter.scala
+++ b/compiler/test/dotty/tools/vulpix/FileFilter.scala
@@ -5,11 +5,6 @@ sealed trait FileFilter {
 }
 
 object FileFilter {
-  def exclude(file: String): FileFilter = exclude(file :: Nil)
-
-  def exclude(file: String, files: String*): FileFilter =
-    exclude(file :: files.toList)
-
   def exclude(files: List[String]): FileFilter = new FileFilter {
     private val excluded = files.toSet
     def accept(file: String): Boolean = !excluded.contains(file)

--- a/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
+++ b/compiler/test/dotty/tools/vulpix/ParallelTesting.scala
@@ -378,7 +378,7 @@ trait ParallelTesting extends RunnerOrchestration with CoverageSupport:
 
       final def run(): Unit = {
         checkTestSource()
-        summaryReport.echoToLog(logBuffer.iterator)
+        summaryReport.echoToLog(logBuffer)
       }
     }
 

--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -2,6 +2,7 @@ package dotty
 package tools
 package vulpix
 
+import org.junit.AfterClass
 import java.io.{BufferedReader, IOException, InputStreamReader, PrintStream, File as JFile}
 import java.nio.file.Paths
 import java.nio.charset.StandardCharsets.UTF_8
@@ -37,6 +38,7 @@ import scala.jdk.CollectionConverters.ListHasAsScala
  *  child process is destroyed and a new child is spawned.
  */
 trait RunnerOrchestration:
+  given summaryReport: SummaryReporting = SummaryReport()
 
   /** Open JDI connection for testing the debugger */
   def debugMode: Boolean = false
@@ -50,8 +52,10 @@ trait RunnerOrchestration:
     /** wait until the end of the main method */
     def exit(): Status
 
-  /** Kill all processes */
-  def cleanup() = monitor.killAll()
+  @AfterClass
+  def cleanup(): Unit =
+    monitor.killAll()
+    summaryReport.echoSummary()
 
   private val monitor = new RunnerMonitor
   export monitor.debugMain

--- a/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
+++ b/compiler/test/dotty/tools/vulpix/RunnerOrchestration.scala
@@ -17,7 +17,7 @@ import dotty.tools.debug.{Debugger, ExpressionEvaluator}
 import java.lang.management.ManagementFactory
 import scala.jdk.CollectionConverters.ListHasAsScala
 
-/** Vulpix spawns JVM subprocesses (`numberOfWorkers`) in order to run tests
+/** Vulpix spawns JVM subprocesses in order to run tests
  *  without compromising the main JVM
  *
  *  These need to be orchestrated in a safe manner with a simple protocol. This
@@ -37,9 +37,6 @@ import scala.jdk.CollectionConverters.ListHasAsScala
  *  child process is destroyed and a new child is spawned.
  */
 trait RunnerOrchestration:
-
-  /** The maximum amount of active runners, which contain a child JVM */
-  def numberOfWorkers: Int
 
   /** Open JDI connection for testing the debugger */
   def debugMode: Boolean = false
@@ -201,6 +198,7 @@ trait RunnerOrchestration:
 
     private val freeRunners = mutable.Queue.empty[Runner]
     private val busyRunners = mutable.Set.empty[Runner]
+    private val numberOfWorkers = Runtime.getRuntime.availableProcessors()
 
     private def getRunner(): Runner = synchronized {
       while freeRunners.isEmpty && busyRunners.size >= numberOfWorkers

--- a/compiler/test/dotty/tools/vulpix/SummaryReport.scala
+++ b/compiler/test/dotty/tools/vulpix/SummaryReport.scala
@@ -29,17 +29,11 @@ trait SummaryReporting {
   /** Add instructions to reproduce the error */
   def addReproduceInstruction(instr: String): Unit
 
-  /** Add a message that will be issued in the beginning of the summary */
-  def addStartingMessage(msg: String): Unit
-
   /** Echo the summary report to the appropriate locations */
   def echoSummary(): Unit
 
-  /** Echoes *immediately* to file */
-  def echoToLog(msg: String): Unit
-
   /** Echoes contents of `it` to file *immediately* then flushes */
-  def echoToLog(it: Iterator[String]): Unit
+  def echoToLog(it: Iterable[String]): Unit
 
 }
 
@@ -50,10 +44,8 @@ final class NoSummaryReport extends SummaryReporting {
   override def addFailedTest(msg: FailedTestInfo): Unit = ()
   override def addSkippedTest(msg: FailedTestInfo): Unit = ()
   override def addReproduceInstruction(instr: String): Unit = ()
-  override def addStartingMessage(msg: String): Unit = ()
   override def echoSummary(): Unit = ()
-  override def echoToLog(msg: String): Unit = ()
-  override def echoToLog(it: Iterator[String]): Unit = ()
+  override def echoToLog(it: Iterable[String]): Unit = ()
 }
 
 /** A summary report that logs to both stdout and the `TestReporter.logWriter`
@@ -62,7 +54,6 @@ final class NoSummaryReport extends SummaryReporting {
 final class SummaryReport extends SummaryReporting {
   import scala.jdk.CollectionConverters.*
 
-  private val startingMessages = new ConcurrentLinkedDeque[String]
   private val failedTests = new ConcurrentLinkedDeque[FailedTestInfo]
   private val skippedTests = new ConcurrentLinkedDeque[FailedTestInfo]
   private val reproduceInstructions = new ConcurrentLinkedDeque[String]
@@ -85,9 +76,6 @@ final class SummaryReport extends SummaryReporting {
   override def addReproduceInstruction(instr: String): Unit =
     reproduceInstructions.add(instr)
 
-  override def addStartingMessage(msg: String): Unit =
-    startingMessages.add(msg)
-
   /** Both echoes the summary to stdout and prints to file */
   override def echoSummary(): Unit = {
     val rep = new StringBuilder
@@ -100,8 +88,6 @@ final class SummaryReport extends SummaryReporting {
           |$passed suites passed, $failed failed, ${passed + failed} total
           |""".stripMargin
     )
-
-    startingMessages.asScala.foreach(rep.append)
 
     failedTests.asScala.map(x => s"    ${x.title}${x.extra}\n").foreach(rep.append)
     TestReporter.writeFailedTests(failedTests.asScala.toList.map(_.title))
@@ -133,10 +119,7 @@ final class SummaryReport extends SummaryReporting {
   private def removeColors(msg: String): String =
     msg.replaceAll("\u001b\\[.*?m", "")
 
-  override def echoToLog(msg: String): Unit =
-    TestReporter.logPrintln(removeColors(msg))
-
-  override def echoToLog(it: Iterator[String]): Unit = {
+  override def echoToLog(it: Iterable[String]): Unit = {
     it.foreach(msg => TestReporter.logPrint(removeColors(msg)))
     TestReporter.logFlush()
   }

--- a/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
+++ b/compiler/test/dotty/tools/vulpix/TestConfiguration.scala
@@ -9,8 +9,10 @@ import java.io.File
 import dotc.config.ScalaSettingsProperties.supportedReleaseVersions
 
 object TestConfiguration {
+  /** Default target of the generated class files */
+  private val defaultTarget: String = "17"
 
-  val usingBaselineJava = javaSpecVersion.startsWith(supportedReleaseVersions.headOption.getOrElse("17"))
+  val usingBaselineJava = javaSpecVersion.startsWith(supportedReleaseVersions.headOption.getOrElse(defaultTarget))
 
   val pageWidth = 120
 
@@ -94,6 +96,4 @@ object TestConfiguration {
   val oldSyntax = defaultOptions `and` "-old-syntax"
   val newSyntax = defaultOptions `and` "-new-syntax"
 
-  /** Default target of the generated class files */
-  private def defaultTarget: String = "17"
 }

--- a/compiler/test/dotty/tools/vulpix/TestFlags.scala
+++ b/compiler/test/dotty/tools/vulpix/TestFlags.scala
@@ -30,18 +30,6 @@ final case class TestFlags(
   private val languageFeatureFlag = "-language:"
   private def withoutLanguageFeaturesOptions = options.filterNot(_.startsWith(languageFeatureFlag))
 
-  def andLanguageFeature(feature: String) =
-    copy(options = options ++ Array(s"$languageFeatureFlag$feature"))
-
-  def withoutLanguageFeature(feature: String) =
-    val (languageFeatures, rest) = options.partition(_.startsWith(languageFeatureFlag))
-    val existingFeatures = languageFeatures.flatMap(_.stripPrefix(languageFeatureFlag).split(","))
-    val filteredFeatures = existingFeatures.filterNot(_ == feature)
-    val newOptions =
-      if filteredFeatures.isEmpty then rest
-      else rest ++ Array(languageFeatureFlag + filteredFeatures.mkString(","))
-    copy(options = newOptions)
-
   /** Subset of the flags that should be passed to javac. */
   def javacFlags: Array[String] = {
     val flags = all

--- a/compiler/test/dotty/tools/vulpix/TestGroup.scala
+++ b/compiler/test/dotty/tools/vulpix/TestGroup.scala
@@ -8,9 +8,4 @@ package dotty.tools.vulpix
  *    compileFilesInDir("tests/pos", defaultOptions)(TestGroup("compileStdLib")) // will output in ./out/compileStdLib/...
  *    compileFilesInDir("tests/pos", defaultOptimised)(TestGroup("optimised/testOptimised")) // will output in ./out/optimised/testOptimised/...
  */
-
-opaque type TestGroup = String
-
-object TestGroup:
-  inline def apply(inline name: String): TestGroup = name
-  extension (inline group: TestGroup) inline def name: String = group
+case class TestGroup(name: String)

--- a/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
@@ -23,9 +23,6 @@ class VulpixMetaTests {
 }
 
 object VulpixMetaTests extends ParallelTesting {
-  // Ensure maximum reproducibility.
-  def numberOfWorkers = 1
-
   @AfterClass
   def tearDown() = this.cleanup()
 }

--- a/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixMetaTests.scala
@@ -12,9 +12,8 @@ import TestConfiguration.*
  */
 @Category(Array(classOf[dotty.VulpixMetaTests]))
 class VulpixMetaTests {
-  import VulpixMetaTests.*
+  import VulpixMetaTests.{*, given}
 
-  implicit val summaryReport: SummaryReporting = new SummaryReport
   implicit def testGroup: TestGroup = TestGroup("VulpixMetaTests")
 
   @Test def compilePos: Unit = compileFilesInDir("tests/vulpix-tests/meta/pos", defaultOptions).checkCompile()
@@ -22,7 +21,4 @@ class VulpixMetaTests {
   @Test def runAll: Unit     = compileFilesInDir("tests/vulpix-tests/meta/run", defaultOptions).checkRuns()
 }
 
-object VulpixMetaTests extends ParallelTesting {
-  @AfterClass
-  def tearDown() = this.cleanup()
-}
+object VulpixMetaTests extends ParallelTesting

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -93,7 +93,5 @@ class VulpixUnitTests:
         .checkRuns()
 
 object VulpixUnitTests extends ParallelTesting:
-  def numberOfWorkers = 5
-
   @tearDown
   def tearDown() = cleanup()

--- a/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
+++ b/compiler/test/dotty/tools/vulpix/VulpixUnitTests.scala
@@ -1,90 +1,88 @@
 package dotty.tools
 package vulpix
 
-import org.junit.{Test as test, AfterClass as tearDown}
+import org.junit.Test
 
 /** Unit tests for the Vulpix test suite */
 class VulpixUnitTests:
-  import VulpixUnitTests.*
+  import VulpixUnitTests.{*, given}
   import TestConfiguration.*
-
-  given SummaryReporting = new NoSummaryReport
 
   given TestGroup = TestGroup("VulpixTests")
 
-  @test def missingFile: Unit =
+  @Test def missingFile: Unit =
     assertThrows[IllegalArgumentException](_ => true):
       compileFile("tests/vulpix-tests/unit/i-dont-exist.scala", defaultOptions).expectFailure.checkExpectedErrors()
 
-  @test def pos1Error: Unit =
+  @Test def pos1Error: Unit =
     compileFile("tests/vulpix-tests/unit/posFail1Error.scala", defaultOptions).expectFailure.checkCompile()
 
-  @test def negMissingAnnot: Unit =
+  @Test def negMissingAnnot: Unit =
     compileFile("tests/vulpix-tests/unit/negMissingAnnot.scala", defaultOptions)
       .suppressAllOutput
       .expectFailure
       .checkExpectedErrors()
 
-  @test def negAnnotWrongLine: Unit =
+  @Test def negAnnotWrongLine: Unit =
     compileFile("tests/vulpix-tests/unit/negAnnotWrongLine.scala", defaultOptions)
       .suppressAllOutput
       .expectFailure
       .checkExpectedErrors()
 
-  @test def negTooManyAnnots: Unit =
+  @Test def negTooManyAnnots: Unit =
     compileFile("tests/vulpix-tests/unit/negTooManyAnnots.scala", defaultOptions)
       .suppressAllOutput
       .expectFailure
       .checkExpectedErrors()
 
-  @test def negNoPositionAnnot: Unit =
+  @Test def negNoPositionAnnot: Unit =
     compileFile("tests/vulpix-tests/unit/negNoPositionAnnots.scala", defaultOptions)
       .suppressAllOutput
       .expectFailure
       .checkExpectedErrors()
 
-  @test def negAnyPositionAnnot: Unit =
+  @Test def negAnyPositionAnnot: Unit =
     compileFile("tests/vulpix-tests/unit/negAnyPositionAnnots.scala", defaultOptions)
       .suppressAllOutput
       .checkExpectedErrors()
 
-  @test def runCompileFail: Unit =
+  @Test def runCompileFail: Unit =
     compileFile("tests/vulpix-tests/unit/posFail1Error.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def runWrongOutput1: Unit =
+  @Test def runWrongOutput1: Unit =
     compileFile("tests/vulpix-tests/unit/runWrongOutput1.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def runWrongOutput2: Unit =
+  @Test def runWrongOutput2: Unit =
     compileFile("tests/vulpix-tests/unit/runWrongOutput2.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def runDiffOutput1: Unit =
+  @Test def runDiffOutput1: Unit =
     compileFile("tests/vulpix-tests/unit/runDiffOutput1.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def runStackOverflow: Unit =
+  @Test def runStackOverflow: Unit =
     compileFile("tests/vulpix-tests/unit/stackOverflow.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def runOutRedirects: Unit =
+  @Test def runOutRedirects: Unit =
     compileFile("tests/vulpix-tests/unit/i2147.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def infiniteNonRec: Unit =
+  @Test def infiniteNonRec: Unit =
     compileFile("tests/vulpix-tests/unit/infinite.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def infiniteTailRec: Unit =
+  @Test def infiniteTailRec: Unit =
     compileFile("tests/vulpix-tests/unit/infiniteTail.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def infiniteAlloc: Unit =
+  @Test def infiniteAlloc: Unit =
     compileFile("tests/vulpix-tests/unit/infiniteAlloc.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def deadlock: Unit =
+  @Test def deadlock: Unit =
     compileFile("tests/vulpix-tests/unit/deadlock.scala", defaultOptions).expectFailure.checkRuns()
 
-  @test def badJava: Unit =
+  @Test def badJava: Unit =
     assertThrows[AssertionError](_.getMessage.contains("java compilation failed")):
       compileFile("tests/vulpix-tests/unit/BadJava.java", defaultOptions)
         .suppressAllOutput
         .checkCompile()
 
-  @test def runTimeout: Unit =
+  @Test def runTimeout: Unit =
     val fileName = s"tests/vulpix-tests/unit/timeout.scala"
     val expect = """(?m).*test '.+' timed out.*"""
     assertThrows[AssertionError](_.getMessage.linesIterator.toList.last.matches(expect)):
@@ -92,6 +90,4 @@ class VulpixUnitTests:
         .suppressAllOutput
         .checkRuns()
 
-object VulpixUnitTests extends ParallelTesting:
-  @tearDown
-  def tearDown() = cleanup()
+object VulpixUnitTests extends ParallelTesting

--- a/repl/test/dotty/tools/repl/JSR223Tests.scala
+++ b/repl/test/dotty/tools/repl/JSR223Tests.scala
@@ -7,7 +7,6 @@ import org.junit.AfterClass
 import vulpix.*
 
 final class JSR223Tests:
-
   import JSR223Tests.{*, given}
 
   @Test def filetests: Unit =
@@ -20,13 +19,4 @@ final class JSR223Tests:
 
 end JSR223Tests
 
-object JSR223Tests extends ParallelTesting:
-
-  given report: SummaryReporting = new SummaryReport
-
-  @AfterClass def tearDown(): Unit = {
-    super.cleanup()
-    report.echoSummary()
-  }
-
-end JSR223Tests
+object JSR223Tests extends ParallelTesting

--- a/repl/test/dotty/tools/repl/JSR223Tests.scala
+++ b/repl/test/dotty/tools/repl/JSR223Tests.scala
@@ -24,8 +24,6 @@ object JSR223Tests extends ParallelTesting:
 
   given report: SummaryReporting = new SummaryReport
 
-  def numberOfWorkers = Runtime.getRuntime().availableProcessors()
-
   @AfterClass def tearDown(): Unit = {
     super.cleanup()
     report.echoSummary()

--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -14,7 +14,7 @@ import org.junit.Ignore
 class ScalaJSCompilationTests {
   import ParallelTesting._
   import TestConfiguration._
-  import ScalaJSCompilationTests._
+  import ScalaJSCompilationTests.{*, given}
   import CompilationTest.aggregateTests
 
   // Negative tests ------------------------------------------------------------

--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -35,11 +35,6 @@ class ScalaJSCompilationTests {
 }
 
 object ScalaJSCompilationTests extends ParallelTesting {
-  implicit val summaryReport: SummaryReporting = new SummaryReport
-
-  @AfterClass def tearDown(): Unit =
-    cleanup()
-    summaryReport.echoSummary()
 
   // Run tests -----------------------------------------------------------------
 

--- a/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
+++ b/sjs-compiler-tests/test/scala/dotty/tools/dotc/ScalaJSCompilationTests.scala
@@ -37,8 +37,6 @@ class ScalaJSCompilationTests {
 object ScalaJSCompilationTests extends ParallelTesting {
   implicit val summaryReport: SummaryReporting = new SummaryReport
 
-  def numberOfWorkers = 5
-
   @AfterClass def tearDown(): Unit =
     cleanup()
     summaryReport.echoSummary()


### PR DESCRIPTION
* Use the same parallelism everywhere
* Unify `@AfterClass` logic
* Delete dead code

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
