### PR TITLE
Scaladoc: lower font size of API signatures

### DIFF
--- a/scaladoc/resources/dotty_res/styles/theme/components/api-member.css
+++ b/scaladoc/resources/dotty_res/styles/theme/components/api-member.css
@@ -101,7 +101,8 @@ color: var(--text-secondary);
 .documentableElement .icon-button {
   position: absolute;
   left: calc(3.5 * var(--base-spacing) / -1);
-  top: calc(2 * var(--base-spacing));
+  /* centers the 16px icon on the signature's first line (13px padding + 20px line-height) */
+  top: 15px;
 }
 
 @media (max-width: 480px) {

--- a/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/renderers/MemberRenderer.scala
@@ -258,10 +258,10 @@ class MemberRenderer(signatureRenderer: SignatureRenderer)(using DocContext) ext
       div(cls := "documentableElement-expander")(
         Option.when(annots.nonEmpty || originInf.nonEmpty || memberInf.nonEmpty)(button(cls := "icon-button ar show-content")).toList,
         annots.map(div(_)).toList,
-        div(cls := "header monospace mono-medium")(memberSignature(member)),
+        div(cls := "header monospace mono-small-block")(memberSignature(member)),
       ),
       Option.when(originInf.nonEmpty || memberInf.nonEmpty)(
-        div(cls := "docs")(
+        div(cls := "docs body-small")(
           span(cls := "modifiers"), // just to have padding on left
           div(
             div(cls := "originInfo")(originInf*),


### PR DESCRIPTION
Scala 2:

<img width="1525" height="943" alt="image" src="https://github.com/user-attachments/assets/ac412fee-fd65-4e57-92cd-dd990fe14019" />

Scala 3, before this change:

<img width="1514" height="944" alt="image" src="https://github.com/user-attachments/assets/3978287b-6a3f-45c2-875f-f2b198d1ee86" />

Scala 3, after this change:

<img width="1527" height="943" alt="image" src="https://github.com/user-attachments/assets/d065f7aa-736b-4bc5-99f2-1b643fed7f12" />
