### PR TITLE
Recover call skolems in avoid instead of typing inline proxies as skolem

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -559,12 +559,17 @@ object TypeOps:
    *  does not update `ctx.nestingLevel` when entering a block so I'm leaving
    *  this as Future Work™.
    */
-  def avoid(tp: Type, symsToAvoid: => List[Symbol])(using Context): Type = {
+  def avoid(tp: Type, symsToAvoid: => List[Symbol],
+      replacements: Map[Symbol, Type] = Map.empty)(using Context): Type = {
     val widenMap = new AvoidMap {
       @threadUnsafe lazy val forbidden = symsToAvoid.toSet
       def toAvoid(tp: NamedType) = forbidden.contains(tp.symbol)
 
       override def apply(tp: Type): Type = tp match
+        case tp: TermRef if toAvoid(tp) =>
+          replacements.get(tp.symbol) match
+            case Some(replacement) => replacement
+            case None => super.apply(tp)
         case tp: TypeVar if mapCtx.typerState.constraint.contains(tp) =>
           val lo = TypeComparer.instanceType(
             tp.origin,

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -241,12 +241,12 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  When TypeAssigner types `async(...)`, it skolemizes unstable `am` in the
    *  dependent result type, and the call tree is typed as `Wrap[F, ?1.Context]`.
    *  Then the inliner expands the method body and replace `am` by a proxy `am$proxy`.
-   *  Then `new Wrap[F, am.Context]` becomes `new Wrap[F, am$proxy.Context]`.
    *
-   *  In `paramBindingDef`, we type `am$proxy` as $1, so that both expanded tree and
-   *  call tree is typed `Wrap[F, ?1.Context]`. Otherwise, call tree and expanded tree
-   *  has different types `?1.Context` vs `am$proxy.Context` and compile fails.
-   *  See #26153 and #26031.
+   *  Later, when the Inlined node's type avoids that proxy,
+   *  `TypeAssigner.InlineProxySkolem` on the binding recovers `?1` so the result
+   *  matches the call type `Wrap[F, ?1.Context]`
+   *  (instead of `Wrap[F, am$proxy.Context]` avoids to `Wrap[F, ?]`)
+   *  See #26153, #26031, and #26810.
    */
   private val callValueSkolemss: List[List[Option[SkolemType]]] =
     def loop(tree: Tree, skolemss: List[List[Option[SkolemType]]]): List[List[Option[SkolemType]]] = tree match
@@ -310,7 +310,6 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  @param arg0        the argument corresponding to the parameter
    *  @param buf         the buffer to which the definition should be appended
    *  @param skolem      optional skolem from the call's dependent result type.
-   *                     If present, use it as the proxy type.
    */
   private[inlines] def paramBindingDef(name: Name, formal: Type, arg0: Tree,
                               buf: DefBuffer, skolem: Option[SkolemType] = None)(using Context): ValOrDefDef = {
@@ -329,16 +328,10 @@ class Inliner(val call: tpd.Tree)(using Context):
           dropNameArg(arg0)
     val argtpe = arg.tpe.dealiasKeepAnnots.translateFromRepeated(toArray = false)
     val argIsBottom = argtpe.isBottomTypeAfterErasure
-    val baseBindingType =
+    val bindingType =
       if argIsBottom then formal
       else if isByName then ExprType(argtpe.widen)
       else argtpe.widen
-    // If the call result type used a skolem for this argument, use the same skolem
-    // as the proxy type. `?1` has `argtpe.widen` as its underlying type.
-    val proxySkolem = if argIsBottom then None else skolem
-    val bindingType = proxySkolem match
-      case Some(sk) => if isByName then ExprType(sk) else sk
-      case None => baseBindingType
 
     var bindingFlags: FlagSet = InlineProxy
     if formal.widenExpr.hasAnnotation(defn.InlineParamAnnot) then
@@ -352,13 +345,11 @@ class Inliner(val call: tpd.Tree)(using Context):
       var newArg = arg.changeOwner(ctx.owner, boundSym)
       if bindingFlags.is(Inline) && argIsBottom then
         newArg = Typed(newArg, TypeTree(formal.widenExpr)) // type ascribe RHS to avoid type errors in expansion. See i8612.scala
-      else proxySkolem match
-        case Some(sk) =>
-          newArg = newArg.cast(sk) // adapt the rhs to the skolem-typed proxy
-        case None => ()
       if isByName then DefDef(boundSym, newArg)
       else ValDef(boundSym, newArg, inferred = true)
     }.withSpan(boundSym.span)
+    if !argIsBottom then // Record typer skolem on the proxy ValDef, so the `avoidingType` can avoid proxy to skolem.
+      skolem.foreach(binding.putAttachment(TypeAssigner.InlineProxySkolem, _))
     inlining.println(i"parameter binding: $binding, $argIsBottom")
     buf += binding
     binding

--- a/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inlines.scala
@@ -636,7 +636,8 @@ object Inlines:
        *  result type after unpickling.
        */
       val inlined =
-        val proxySkolems = bindings.map(_.symbol.info.widenExpr).collect { case sk: SkolemType => sk }
+        val proxySkolems = bindings.flatMap: b =>
+          b.getAttachment(TypeAssigner.InlineProxySkolem)
         if proxySkolems.nonEmpty && inlined0.tpe.existsPart(proxySkolems.contains) then
           val sealedExpansion =
             inContext(ctx.withSource(expansion.source)):

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -45,7 +45,12 @@ trait TypeAssigner {
   }
 
   def avoidingType(expr: Tree, bindings: List[Tree])(using Context): Type =
-    TypeOps.avoid(expr.tpe, localSyms(bindings).filterConserve(_.isTerm))
+    val syms = localSyms(bindings).filterConserve(_.isTerm)
+    val replacements = bindings.flatMap { b =>
+      b.getAttachment(InlineProxySkolem).map(b.symbol -> _)
+    }
+    if replacements.isEmpty then TypeOps.avoid(expr.tpe, syms)
+    else TypeOps.avoid(expr.tpe, syms, replacements.toMap)
 
   def avoidPrivateLeaks(sym: Symbol)(using Context): Type =
     if sym.owner.isClass && !sym.isOneOf(JavaOrPrivateOrSynthetic)
@@ -620,6 +625,13 @@ object TypeAssigner extends TypeAssigner:
    *  same skolems for path-dependent types in the expansion (see #26153).
    */
   private[dotc] val SkolemizedArgs = new Property.StickyKey[Map[tpd.Tree, SkolemType]]
+
+  /** Sticky attachment on an inline argument proxy ValDef, the typer skolem
+   *  that this proxy stands for (#26153 / #26810). Proxy itself keeps a widened
+   *  type and `avoidingType` recovers the skolem when eliminating the proxy from
+   *  the Inlined result type.
+   */
+  private[dotc] val InlineProxySkolem = new Property.StickyKey[SkolemType]
 
   def seqLitType(tree: untpd.SeqLiteral, elemType: Type)(using Context) = tree match
     case tree: untpd.JavaSeqLiteral => defn.ArrayOf(elemType)

--- a/tests/pos/i26810-min/Macro_1.scala
+++ b/tests/pos/i26810-min/Macro_1.scala
@@ -1,0 +1,7 @@
+import scala.quoted.*
+
+object M:
+  transparent inline def apply(inline expr: Any): Any =
+    ${ impl('expr) }
+
+  private def impl(e: Expr[Any])(using Quotes): Expr[Any] = e

--- a/tests/pos/i26810-min/Test_2.scala
+++ b/tests/pos/i26810-min/Test_2.scala
@@ -1,0 +1,3 @@
+@main def Test(): Unit =
+  val _ = M { summon[1 <:< Int] }
+  val _ = M { summon[String <:< Any] }

--- a/tests/pos/i26810/Macro_1.scala
+++ b/tests/pos/i26810/Macro_1.scala
@@ -1,0 +1,51 @@
+import scala.quoted.*
+
+final class TestCallTree(inner: => Either[Any, IndexedSeq[TestCallTree]])
+
+object Tests:
+  transparent inline def apply(inline expr: Unit): TestCallTree =
+    ${ applyImpl('expr) }
+
+  private def applyImpl(body: Expr[Unit])(using Quotes): Expr[TestCallTree] =
+    import quotes.reflect.*
+
+    def testCallTreeExpr(setupStats: List[Statement]): Expr[TestCallTree] =
+      val inner =
+        Block(
+          setupStats.dropRight(1),
+          '{ Left(${setupStats.takeRight(1).head.asInstanceOf[Term].asExpr}) }.asTerm
+        )
+      '{ TestCallTree(${inner.asExprOf[Either[Any, IndexedSeq[TestCallTree]]]}) }
+
+    object TestMethod:
+      def unapply(tree: Tree): Option[Term] =
+        Option(tree).collect { case t: Term => t.asExpr }.collect {
+          case '{ ($name: String).-($body) } => body.asTerm
+        }
+
+    object Stats:
+      def partition(stats: List[Statement]): (List[Apply], List[Statement]) =
+        stats.partitionMap {
+          case t: Term if TestMethod.unapply(t).isDefined => Left(t.asInstanceOf[Apply])
+          case stmt                                       => Right(stmt)
+        }
+      def unapply(tree: Tree): Option[(List[Apply], List[Statement])] =
+        tree match
+          case Inlined(_, inlBindings, Stats(tests, testsBindings)) =>
+            Some((tests, inlBindings ++ testsBindings))
+          case Block(stats, expr) => Some(partition(stats :+ expr))
+          case stmt: Statement    => Some(partition(stmt :: Nil))
+          case _                  => None
+
+    body.asTerm match
+      case Stats(tests, _) =>
+        val Some(testBody) = TestMethod.unapply(tests.head): @unchecked
+        testBody match
+          case Stats(Nil, setupStats) => testCallTreeExpr(setupStats)
+          case other                  => testCallTreeExpr(List(other))
+      case other =>
+        report.errorAndAbort("bad Tests body: " + other.show)
+
+extension (name: String)
+  @annotation.compileTimeOnly("only inside Tests")
+  def -(body: => Any): Unit = ()

--- a/tests/pos/i26810/Test_2.scala
+++ b/tests/pos/i26810/Test_2.scala
@@ -1,0 +1,6 @@
+@main def Test(): Unit =
+  val _ = Tests {
+    "x" - {
+      summon[1 <:< Int]
+    }
+  }


### PR DESCRIPTION
Fixes #26810

See also the detailed problem tracing https://github.com/scala/scala3/issues/26810#issuecomment-5343809636

**Background**
When typing a call with an unstable using argument and a dependent result type, the typer skolemize that argument. For example:

```scala
transparent inline def async[F[_]](using am: Mon[F]) =
  new Wrap[F, am.Context]
async(using someMon)   // someMon unstable
// call type:  Wrap[F, ?1.Context]
// expansion:  val am$proxy = someMon; new Wrap[F, am$proxy.Context] -> avoid to new Wrap[F, ?.Context]
```

Later type avoidance conceal the local proxy `am$proxy.type` to a wildcard type `?`. In the end, issue #26153 had a problem type mismatch between `?1.Context` (skolem) vs `?.Context` (wildcard).

PR #26563 typed each inline arguments proxy (`am$proxy`) as the call's skolem and cast the RHS `val x$proxy: ?1 = evidence.$asInstanceOf[?1]`. Then the expansion tree type matches the call tree type `Wrap[F, ?1.Context]`.

---

**Problem**

```scala
// Macro_1.scala
import scala.quoted.*
object M:
  transparent inline def apply(inline expr: Any): Any =
    ${ impl('expr) }
  private def impl(e: Expr[Any])(using Quotes): Expr[Any] = e

// Test_2.scala
@main def Test(): Unit =
  val _ = M { summon[1 <:< Int] }

// Predef.scala
transparent inline def summon[T](using x: T): x.type = x
```

`summon`'s parameter `x` type would be skolemized, and the body would be transformed like `val x$proxy: ?S = evidence.$asInstanceOf[?S]`, and at this point, `?S.info` is ``=:=[TypeVar(A->Int), TypeVar(A->Int)]`.

Later, that tree is embedded into the caller/quote side as an inline argument of `M.apply`. During embedding, `TypeTreeMap` normalizes `TypeVars` in the skolem's info and then, create a new `SkolemType` per tree site.

Therefore, `val x$proxy: ?S = evidence.$asInstanceOf[?S]`, would be mapped to `val x$proxy: ($2: Int =:= Int) = evicence.$asInstanceOf[($1: Int =:= Int)]` Macro recheck fails with:

```
Found:    (?1 : Int =:= Int)
Required: (?2 : Int =:= Int)
```

**Fix**

We hit #26810 when the same `SkolemType` appears in different tree sites, and it mapped to different new skolems.

PR #26563 types the proxy as skolem `$1` and cast RHS to the skolem, and it ends up the same SkolemType appears on different tree sites.

Instead, this commit does not proxy as skolem, and avoiding the proxy type `am$proxy.type` to be the skolem `$1`. Then we don't have the skolem type twice in the inline body.

Fixes #XYZ

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, I used LLM to understand what is the problem, and discuss how should we fix, and iterate with LLM until the change makes sense + minimal to me.

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests 