### PR TITLE
Revert commit 10610cb, simplifying Symbol.isTerm/isType

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/Symbols.scala
+++ b/compiler/src/dotty/tools/dotc/core/Symbols.scala
@@ -181,16 +181,14 @@ object Symbols extends SymUtils {
         // periods check out OK. But once a package member is overridden it is not longer
         // valid. If the option would be removed, the check would be no longer needed.
 
-    final def isTerm(using Context): Boolean =
-      (if (defRunId == ctx.runId) lastDenot else denot).isTerm
-    final def isType(using Context): Boolean =
-      (if (defRunId == ctx.runId) lastDenot else denot).isType
+    final def isTerm(using Context): Boolean = lastDenot.isTerm
+    final def isType(using Context): Boolean = lastDenot.isType
     final def asTerm(using Context): TermSymbol = {
-      assert(isTerm, s"asTerm called on not-a-Term $this" );
+      assert(isTerm, s"asTerm called on not-a-Term $this")
       asInstanceOf[TermSymbol]
     }
     final def asType(using Context): TypeSymbol = {
-      assert(isType, s"asType called on not-a-Type $this");
+      assert(isType, s"asType called on not-a-Type $this")
       asInstanceOf[TypeSymbol]
     }
 


### PR DESCRIPTION
Extracted from @lihaoyi's #26366, this turns out to be a revert of a >10 year old commit. The commit suggests there was context in #544 but I don't see it.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
