### PR TITLE
Reconstruct inferred use sets from TASTy under CC

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CCState.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CCState.scala
@@ -9,7 +9,7 @@ import reporting.Message
 import Contexts.Context
 import Types.MethodType
 import Symbols.{Symbol, ClassSymbol}
-import util.{SimpleIdentitySet, EqHashMap}
+import util.{SimpleIdentitySet, EqHashMap, EqHashSet}
 import Capabilities.Capability
 
 /** Capture checking state, which is known to other capture checking components */
@@ -111,6 +111,11 @@ class CCState:
 
   /* A cache for CaptureOps.useSet */
   private[cc] val useSetCache: EqHashMap[Symbol, CaptureSet] = EqHashMap()
+
+  /** Symbols whose use sets are currently being reconstructed from TASTy, to
+   *  guard against cycles in the reconstruction.
+   */
+  private[cc] val tastyUsesInProgress: EqHashSet[Symbol] = EqHashSet()
 
   /** A cache that stores for each class the classifiers of all LocalCap instances
    *  in the types of its fields and the fields that contribute such LocalCap instances.

--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -11,6 +11,7 @@ import config.Printers.capt
 import util.Property.Key
 import tpd.*
 import Annotations.Annotation
+import scala.util.control.NonFatal
 import CaptureSet.VarState
 import Capabilities.*
 import Mutability.isStatefulType
@@ -641,6 +642,22 @@ extension (cls: ClassSymbol) {
     (impliedSet, contributing)
   }
 
+  /** Is `cls` a class read from a capture-checked TASTy file that was exempt
+   *  from explicit type and uses checks when it was compiled? No inferred
+   *  capture information is pickled for such classes, since the capture checker
+   *  runs after the pickler; their use sets are reconstructed from the pickled
+   *  member bodies instead, see `usesFromTasty`.
+   *  Exemption is decided from the symbol alone: classes in the empty package
+   *  (unless under `@assumeSafe`) and REPL wrappers. This also excludes the
+   *  standard library, whose classes all live under named packages.
+   */
+  def isBinaryExemptClass(using Context): Boolean =
+    cls.isDefinedInBinary
+    && cls.is(CaptureChecked)
+    && (cls.enclosingPackageClass.isEmptyPackage || cls.name.isReplWrapperName)
+    && !cls.ownersIterator.takeWhile(!_.is(Package))
+        .exists(_.hasAnnotation(defn.AssumeSafeAnnot))
+
   def creationCapset(using Context)(core: Type = cls.appliedRef): CaptureSet =
     if cls.derivesFromCapability
     then LocalCap(Origin.NewInstance(core, Nil)).singletonCaptureSet
@@ -667,6 +684,76 @@ extension (cls: ClassSymbol) {
         sym.is(ParamAccessor) && sym.isConsume
       .symbol
 }
+
+/** Reconstruct the use set of a class read from TASTy by walking its pickled
+ *  member bodies. Use sets are inferred by the capture checker, which runs
+ *  after the pickler, so they are not recorded in TASTy; without reconstruction
+ *  an exempt class would silently become pure under separate compilation.
+ *  Only top-level classes have a root tree, but that suffices: uses inside
+ *  nested classes are walked as part of the enclosing top-level class's body,
+ *  and accesses to nested entities from other compilation units go through a
+ *  path rooted in the top-level entity, which is charged at the use site.
+ *  Returns `None` if no reconstruction is possible or no uses were found.
+ */
+private def usesFromTasty(cls: ClassSymbol)(using Context): Option[CaptureSet] =
+  if !cls.isBinaryExemptClass
+      || ccState.tastyUsesInProgress.contains(cls) // break cycles between mutually referring classes
+  then None
+  else
+    ccState.tastyUsesInProgress += cls
+    try
+      val tree = cls.rootTree // EmptyTree if `cls` is not top-level or its tree was not retained
+      if tree.isEmpty then None
+      else
+        val uses = usesInTree(tree)
+        if uses.isEmpty then None else Some(CaptureSet(uses*))
+    catch case NonFatal(_) => None // best-effort reconstruction: never crash the checker
+    finally
+      ccState.tastyUsesInProgress -= cls
+
+/** The tracked references used in `tree`, the pickled body of a top-level
+ *  class: for each reference to a term defined outside the class, the
+ *  outermost tracked capability on its path. Paths are taken from the pickled
+ *  types, which spell out the full prefix chain even for bare `Ident`s of
+ *  imported members. References inside imports and exports are skipped, and so
+ *  are paths rooted in a non-package `this`: these refer to the class's own
+ *  members, whose capabilities are accounted for by `capturesImpliedByFields`.
+ */
+private def usesInTree(tree: tpd.Tree)(using Context): List[Capability] =
+  var refs: List[Capability] = Nil
+
+  def isSelfRooted(tp: Type): Boolean = tp match
+    case tp: TermRef => isSelfRooted(tp.prefix)
+    case tp: ThisType => !tp.cls.is(Package)
+    case _ => false
+
+  /** The outermost capability on the path `tp` that is tracked and visible
+   *  outside the compilation unit that defined it, if any.
+   */
+  def outermostTracked(tp: Type): Option[Capability] = tp match
+    case tp: TermRef =>
+      outermostTracked(tp.prefix).orElse:
+        if tp.symbol.isTerm && !tp.symbol.is(Method)
+            && !tp.symbol.isLocalToCompilationUnit
+            && tp.isTracked
+        then Some(tp)
+        else None
+    case _ => None
+
+  val traverser = new TreeTraverser:
+    def traverse(t: tpd.Tree)(using Context): Unit = t match
+      case _: Import | _: Export =>
+      case _: (Ident | Select) =>
+        t.tpe match
+          case tp: TermRef if !isSelfRooted(tp) =>
+            for ref <- outermostTracked(tp) do
+              if !refs.contains(ref) then refs = ref :: refs
+          case _ =>
+        traverseChildren(t)
+      case _ =>
+        traverseChildren(t)
+  traverser.traverse(tree)
+  refs
 
 extension (sym: Symbol) {
 
@@ -818,25 +905,39 @@ extension (sym: Symbol) {
    *  representing the captured references of the environment associated with `sym`.
    */
   def useSet(using Context): CaptureSet =
-    ccState.useSetCache.getOrElseUpdate(sym,
-      sym.getAnnotation(defn.RetainsAnnot) match
-        case Some(ann) =>
-          // If we read from Tasty, the annotation is not a RetainingAnnotation but is
-          // instead a regular annotation of type TreeUnpickler#DeferredSymAndTree.
-          // Map it to a RetainingAnnotation now.
-          try RetainingAnnotation.fromAnnotation(ann).toCaptureSet
-          catch case ex: IllegalCaptureRef =>
-            report.error(em"Illegal capture reference: ${ex.getMessage}", sym.srcPos)
-            CaptureSet.empty
-        case _ =>
-          if sym.is(Package)
-            || (sym.isClass || sym.isConstructor) && !sym.isExemptFromExplicitChecks
-            // If `sym` does not have a `uses` clause, set its capture set to the empty set,
-            // unless it is local to the current compilation unit.
-            // For local classes and constructors we infer their use set.
-          then CaptureSet.empty
-          else CaptureSet.Var(sym, nestedOK = false)
-    )
+    // Don't use `getOrElseUpdate`: `usesFromTasty` can reentrantly add other
+    // symbols' use sets to the cache while this use set is being computed.
+    val cached = ccState.useSetCache.lookup(sym)
+    if cached != null then cached
+    else
+      val computed = computeUseSet
+      ccState.useSetCache(sym) = computed
+      computed
+
+  private def computeUseSet(using Context): CaptureSet =
+    sym.getAnnotation(defn.RetainsAnnot) match
+      case Some(ann) =>
+        // If we read from Tasty, the annotation is not a RetainingAnnotation but is
+        // instead a regular annotation of type TreeUnpickler#DeferredSymAndTree.
+        // Map it to a RetainingAnnotation now.
+        try RetainingAnnotation.fromAnnotation(ann).toCaptureSet
+        catch case ex: IllegalCaptureRef =>
+          report.error(em"Illegal capture reference: ${ex.getMessage}", sym.srcPos)
+          CaptureSet.empty
+      case _ =>
+        val reconstructed = sym match
+          case cls: ClassSymbol => usesFromTasty(cls)
+          case _ => None
+        reconstructed match
+          case Some(cs) => cs
+          case None =>
+            if sym.is(Package)
+              || (sym.isClass || sym.isConstructor) && !sym.isExemptFromExplicitChecks
+              // If `sym` does not have a `uses` clause, set its capture set to the empty set,
+              // unless it is local to the current compilation unit.
+              // For local classes and constructors we infer their use set.
+            then CaptureSet.empty
+            else CaptureSet.Var(sym, nestedOK = false)
 
   def varMirror(using Context): Symbol =
     ccState.varMirrors.getOrElseUpdate(sym,

--- a/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureSet.scala
@@ -1779,7 +1779,29 @@ object CaptureSet:
     case c: TermRef if isAssumedPure(c.symbol) =>
       CaptureSet.empty
     case c: CoreCapability =>
-      ofType(c.underlying, followResult = ccConfig.useSpanCapset)
+      val cs = ofType(c.underlying, followResult = ccConfig.useSpanCapset)
+      c match
+        case c: TermRef if cs.isAlwaysEmpty && c.symbol.is(ModuleVal)
+            && c.symbol.moduleClass.isClass
+            && c.symbol.moduleClass.asClass.isBinaryExemptClass =>
+          // For module vals read from TASTy, the capture set of their type is
+          // not pickled, since the capture checker runs after the pickler.
+          // Fall back to the use set of the module class (reconstructed from
+          // the pickled member bodies) plus the capabilities implied by its
+          // fields, which are still visible. Only constant use sets are used;
+          // unresolved variables would make every module look tracked.
+          val moduleClass = c.symbol.moduleClass.asClass
+          val (fieldRefs, fields) = moduleClass.capturesImpliedByFields(moduleClass.appliedRef)
+          // Fields that are themselves module values (i.e. nested objects) do
+          // not contribute to the capture set of the enclosing module's type;
+          // they are reached through their own paths.
+          val fieldCs =
+            if fields.forall(_.is(Module)) then CaptureSet.empty
+            else fieldRefs
+          moduleClass.useSet match
+            case uses: CaptureSet.Const => uses ++ fieldCs
+            case _ => fieldCs
+        case _ => cs
 
   /** Capture set of a type
    *  @param followResult  If true, also include capture sets of function results.

--- a/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
+++ b/compiler/src/dotty/tools/dotc/core/SymbolLoaders.scala
@@ -574,6 +574,12 @@ class TastyLoader(tastyFile: AbstractFile) extends SymbolLoader {
 
   private def mayLoadTreesFromTasty(using Context): Boolean =
     ctx.settings.YretainTrees.value || ctx.settings.fromTasty.value
+      || unpickler.tastyAttributes.captureChecked
+      // Retain the unpicklers of capture-checked TASTy files, so that the
+      // capture checker can reconstruct the use sets of their classes by
+      // walking the pickled member bodies. This is keyed on the file's own
+      // attribute since a classpath symbol can be completed before any
+      // compilation unit has enabled capture checking.
 }
 
 class SourcefileLoader(srcfile: AbstractFile) extends SymbolLoader {

--- a/tests/neg-custom-args/captures/sepcomp-inferred-uses-nested/Attack_2.scala
+++ b/tests/neg-custom-args/captures/sepcomp-inferred-uses-nested/Attack_2.scala
@@ -1,0 +1,7 @@
+import language.experimental.captureChecking
+import caps.*
+
+@main def attack(): Unit =
+  val secret = Boxed("TOP-SECRET")
+  val out = secret.map(user.sneaky) // error
+  println(out.value)

--- a/tests/neg-custom-args/captures/sepcomp-inferred-uses-nested/Library_1.scala
+++ b/tests/neg-custom-args/captures/sepcomp-inferred-uses-nested/Library_1.scala
@@ -1,0 +1,19 @@
+import language.experimental.captureChecking
+import caps.*
+
+class Ex extends ExclusiveCapability
+
+class Boxed[+T](val value: T):
+  def map[B](op: T ->{any.rd} B): Boxed[B] = Boxed(op(value))
+
+object host:
+  def effect(msg: String)(using ex: Ex^): String = msg
+  def mkEx(): Ex^ = new Ex
+
+object outer:
+  object env:
+    given ex: (Ex^) = host.mkEx()
+
+object user:
+  import outer.env.given
+  def sneaky(s: String): String = host.effect("effect-on:" + s)

--- a/tests/neg-custom-args/captures/sepcomp-inferred-uses/Attack_2.scala
+++ b/tests/neg-custom-args/captures/sepcomp-inferred-uses/Attack_2.scala
@@ -1,0 +1,7 @@
+import language.experimental.captureChecking
+import caps.*
+
+@main def attack(): Unit =
+  val secret = Boxed("TOP-SECRET")
+  val out = secret.map(user.sneaky) // error
+  println(out.value)

--- a/tests/neg-custom-args/captures/sepcomp-inferred-uses/Library_1.scala
+++ b/tests/neg-custom-args/captures/sepcomp-inferred-uses/Library_1.scala
@@ -1,0 +1,18 @@
+import language.experimental.captureChecking
+import caps.*
+
+class Ex extends ExclusiveCapability
+
+class Boxed[+T](val value: T):
+  def map[B](op: T ->{any.rd} B): Boxed[B] = Boxed(op(value))
+
+object host:
+  def effect(msg: String)(using ex: Ex^): String = msg
+  def mkEx(): Ex^ = new Ex
+
+object env:
+  given ex: (Ex^) = host.mkEx()
+
+object user:
+  import env.given
+  def sneaky(s: String): String = host.effect("effect-on:" + s)

--- a/tests/pos-custom-args/captures/sepcomp-inferred-uses-import/Library_1.scala
+++ b/tests/pos-custom-args/captures/sepcomp-inferred-uses-import/Library_1.scala
@@ -1,0 +1,17 @@
+import language.experimental.captureChecking
+import caps.*
+
+class Ex extends ExclusiveCapability
+
+class Boxed[+T](val value: T):
+  def map[B](op: T ->{any.rd} B): Boxed[B] = Boxed(op(value))
+
+object host:
+  def mkEx(): Ex^ = new Ex
+
+object env:
+  given ex: (Ex^) = host.mkEx()
+
+object clean:
+  import env.given
+  def pure(s: String): String = s.toUpperCase

--- a/tests/pos-custom-args/captures/sepcomp-inferred-uses-import/Use_2.scala
+++ b/tests/pos-custom-args/captures/sepcomp-inferred-uses-import/Use_2.scala
@@ -1,0 +1,6 @@
+import language.experimental.captureChecking
+import caps.*
+
+@main def use(): Unit =
+  val out = Boxed("hello").map(clean.pure)
+  println(out.value)

--- a/tests/pos-custom-args/captures/sepcomp-inferred-uses/Library_1.scala
+++ b/tests/pos-custom-args/captures/sepcomp-inferred-uses/Library_1.scala
@@ -1,0 +1,21 @@
+import language.experimental.captureChecking
+import caps.*
+
+class Ex extends ExclusiveCapability
+
+class Boxed[+T](val value: T):
+  def map[B](op: T ->{any.rd} B): Boxed[B] = Boxed(op(value))
+
+object host:
+  def effect(msg: String)(using ex: Ex^): String = msg
+  def mkEx(): Ex^ = new Ex
+
+object env:
+  given ex: (Ex^) = host.mkEx()
+
+object user:
+  import env.given
+  def sneaky(s: String): String = host.effect("effect-on:" + s)
+
+object purehelper:
+  def up(s: String): String = s.toUpperCase

--- a/tests/pos-custom-args/captures/sepcomp-inferred-uses/Use_2.scala
+++ b/tests/pos-custom-args/captures/sepcomp-inferred-uses/Use_2.scala
@@ -1,0 +1,7 @@
+import language.experimental.captureChecking
+import caps.*
+
+@main def use(): Unit =
+  val secret = Boxed("TOP-SECRET")
+  val out = secret.map(purehelper.up)
+  println(out.value)


### PR DESCRIPTION
The capture checker runs after the pickler, so capture information it infers is never recorded in TASTy. For symbols that are exempt from explicit type and uses checks (classes in the empty package and REPL wrappers), this information exists only as inference results. Under separate compilation it is lost: an exempt class read from TASTy gets an empty use set, and a module val whose capture set was inferred looks untracked.

This PR reconstructs this information when an exempt class is read from TASTy: retain the unpicklers of capture-checked TASTy files, walk the pickled member bodies, and collect the outermost tracked capability on each referenced path. Module vals of such classes fall back to the reconstructed use set of their module class plus the captures implied by its fields.

## Have you relied on LLM-based tools in this contribution?

Yes, used to find root cause and propose fix. I verify the changes and tests.

## How was the solution tested?

New automated tests
