### PR TITLE
Scaladoc: Support Markdown Footnotes

### DIFF
--- a/docs/_docs/reference/changed-features/implicit-resolution.md
+++ b/docs/_docs/reference/changed-features/implicit-resolution.md
@@ -160,10 +160,10 @@ The new rules are as follows: An implicit `a` defined in `A` is more specific th
  - `A` extends `B`, or
  - `A` is an object and the companion class of `A` extends `B`, or
  - `A` and `B` are objects,
-    `B` does not inherit any implicit members from base classes (*),
+    `B` does not inherit any implicit members from base classes[^1],
     and the companion class of `A` extends the companion class of `B`.
 
-Condition (*) is new. It is necessary to ensure that the defined relation is transitive.
+[^1]: This condition is new. It is necessary to ensure that the defined relation is transitive.
 
 [//]: # todo: expand with precise rules
 

--- a/docs/_docs/reference/experimental/capture-checking/classes.md
+++ b/docs/_docs/reference/experimental/capture-checking/classes.md
@@ -93,10 +93,10 @@ we know that the type of `this` must be pure, since `this` is the right hand sid
 
 ### Traits and Open Classes
 
-The self-type inference behaves differently depending on whether all subclasses of a class are known. For a regular (non-open, non-abstract) class, all subclasses are known at compile time,¹ so the capture checker can precisely infer the self-type. However, for traits, abstract classes, and [`open`](../../other-new-features/open-classes.md) classes, arbitrary subclasses may exist, so the capture checker conservatively assumes that `this` may capture arbitrary capabilities
+The self-type inference behaves differently depending on whether all subclasses of a class are known. For a regular (non-open, non-abstract) class, all subclasses are known at compile time,[^1] so the capture checker can precisely infer the self-type. However, for traits, abstract classes, and [`open`](../../other-new-features/open-classes.md) classes, arbitrary subclasses may exist, so the capture checker conservatively assumes that `this` may capture arbitrary capabilities
 (i.e., it infers the universal capture set `any`).
 
-¹We ignore here the possibility that non-open classes have subclasses in other compilation units (e.g. for testing) and assume that these subclasses do not change the inferred self type.
+[^1]: We ignore here the possibility that non-open classes have subclasses in other compilation units (e.g. for testing) and assume that these subclasses do not change the inferred self type.
 
 For example (assuming all definitions are in the same file):
 ```scala sc:fail sc-compile-with:classes-cc-context

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
     "com.vladsch.flexmark" % "flexmark-ext-anchorlink" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-autolink" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-emoji" % flexmarkVersion,
+    "com.vladsch.flexmark" % "flexmark-ext-footnotes" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-gfm-strikethrough" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-gfm-tasklist" % flexmarkVersion,
     "com.vladsch.flexmark" % "flexmark-ext-wikilink" % flexmarkVersion,

--- a/scaladoc/resources/dotty_res/styles/theme/layout/content.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/content.css
@@ -273,7 +273,38 @@
 
 #content .footnotes .footnote-backref {
   margin-left: calc(0.5 * var(--base-spacing));
+  color: var(--action-primary-content-default);
   text-decoration: none;
+}
+
+#content .footnotes .footnote-backref:hover {
+  color: var(--action-primary-content-hover);
+}
+
+/* footnote references */
+#content sup:has(> a.footnote-ref),
+#content sup.footnote-ref-sep {
+  /* neutralize the default superscript metrics so references
+     do not stretch the line box */
+  vertical-align: baseline;
+  position: relative;
+  top: -0.5em;
+  font-size: 11px;
+  line-height: 1;
+}
+
+#content a.footnote-ref {
+  color: var(--action-primary-content-default);
+  text-decoration: none;
+  padding: 0 2px;
+}
+
+#content a.footnote-ref:hover {
+  color: var(--action-primary-content-hover);
+}
+
+#content sup.footnote-ref-sep {
+  color: var(--text-secondary);
 }
 
 /* content link */

--- a/scaladoc/resources/dotty_res/styles/theme/layout/content.css
+++ b/scaladoc/resources/dotty_res/styles/theme/layout/content.css
@@ -247,6 +247,35 @@
   margin-inline-end: calc(2 * var(--base-spacing));
 }
 
+/* content footnotes */
+#content .footnotes {
+  margin-block-start: calc(8 * var(--base-spacing));
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 16px;
+}
+
+#content .footnotes hr {
+  border: none;
+  border-top: 1px solid var(--border-default);
+  margin: 0 0 calc(3 * var(--base-spacing));
+}
+
+#content .footnotes ol {
+  margin-block: 0;
+  padding-inline-start: calc(3 * var(--base-spacing));
+}
+
+/* keep the back-reference arrow on the same line as the note text */
+#content .footnotes li > p:last-of-type {
+  display: inline;
+}
+
+#content .footnotes .footnote-backref {
+  margin-left: calc(0.5 * var(--base-spacing));
+  text-decoration: none;
+}
+
 /* content link */
 #content a {
   color: var(--text-primary);

--- a/scaladoc/src/dotty/tools/scaladoc/site/common.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/common.scala
@@ -7,6 +7,7 @@ import java.nio.file.Files
 import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension
 import com.vladsch.flexmark.ext.emoji.EmojiExtension
+import com.vladsch.flexmark.ext.footnotes.FootnoteExtension
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
 import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
 import com.vladsch.flexmark.ext.tables.TablesExtension
@@ -33,6 +34,7 @@ def defaultMarkdownOptions(showSnippetName: Boolean = true)(using ctx: StaticSit
       TaskListExtension.create(),
       AutolinkExtension.create(),
       EmojiExtension.create(),
+      FootnoteExtension.create(),
       YamlFrontMatterExtension.create(),
       StrikethroughExtension.create(),
       WikiLinkExtension.create(),

--- a/scaladoc/src/dotty/tools/scaladoc/site/common.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/site/common.scala
@@ -35,6 +35,7 @@ def defaultMarkdownOptions(showSnippetName: Boolean = true)(using ctx: StaticSit
       AutolinkExtension.create(),
       EmojiExtension.create(),
       FootnoteExtension.create(),
+      tasty.comments.markdown.FootnoteSeparatorExtension,
       YamlFrontMatterExtension.create(),
       StrikethroughExtension.create(),
       WikiLinkExtension.create(),

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MarkdownParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MarkdownParser.scala
@@ -34,6 +34,7 @@ object MarkdownParser {
       AnchorLinkExtension.create(),
       EmojiExtension.create(),
       FootnoteExtension.create(),
+      markdown.FootnoteSeparatorExtension,
       YamlFrontMatterExtension.create(),
       StrikethroughExtension.create()
     ) ++ additionalExtensions

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MarkdownParser.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/MarkdownParser.scala
@@ -12,6 +12,7 @@ import com.vladsch.flexmark.parser.ParserEmulationProfile
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension
 import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension
 import com.vladsch.flexmark.ext.emoji.EmojiExtension
+import com.vladsch.flexmark.ext.footnotes.FootnoteExtension
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension
 import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension
@@ -32,6 +33,7 @@ object MarkdownParser {
       AutolinkExtension.create(),
       AnchorLinkExtension.create(),
       EmojiExtension.create(),
+      FootnoteExtension.create(),
       YamlFrontMatterExtension.create(),
       StrikethroughExtension.create()
     ) ++ additionalExtensions

--- a/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/FootnoteSeparatorExtension.scala
+++ b/scaladoc/src/dotty/tools/scaladoc/tasty/comments/markdown/FootnoteSeparatorExtension.scala
@@ -1,0 +1,36 @@
+package dotty.tools.scaladoc
+package tasty.comments
+package markdown
+
+import com.vladsch.flexmark.ast.HtmlInline
+import com.vladsch.flexmark.ext.footnotes.Footnote
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.parser.block.{NodePostProcessor, NodePostProcessorFactory}
+import com.vladsch.flexmark.util.ast.{Document, Node, NodeTracker}
+import com.vladsch.flexmark.util.data.MutableDataHolder
+import com.vladsch.flexmark.util.sequence.BasedSequence
+
+/** Inserts a separator between directly adjacent footnote references
+ *  (e.g. `text[^1][^2]`), so that they do not render as a single run of
+ *  superscript digits. This cannot be done in CSS: sibling selectors ignore
+ *  the text between elements, so `sup + sup` would also match references
+ *  that are words apart within the same paragraph.
+ */
+object FootnoteSeparatorExtension extends Parser.ParserExtension:
+  val separator = """<sup class="footnote-ref-sep">,</sup>"""
+
+  class Processor extends NodePostProcessor:
+    def process(state: NodeTracker, node: Node): Unit = node match
+      case f: Footnote if f.getPrevious.isInstanceOf[Footnote] =>
+        val sep = HtmlInline(BasedSequence.of(separator))
+        f.insertBefore(sep)
+        state.nodeAdded(sep)
+      case _ => ()
+
+  object Factory extends NodePostProcessorFactory(false):
+    addNodes(classOf[Footnote])
+    override def apply(document: Document): NodePostProcessor = Processor()
+
+  def parserOptions(opt: MutableDataHolder): Unit = () // noop
+  override def extend(parserBuilder: Parser.Builder): Unit =
+    parserBuilder.postProcessorFactory(Factory)

--- a/scaladoc/test-documentations/basic/_docs/Adoc.md
+++ b/scaladoc/test-documentations/basic/_docs/Adoc.md
@@ -5,4 +5,6 @@ title: Adoc
 
 [[tests.site.SomeClass]]
 
-And a text!
+And a text with a footnote[^1]!
+
+[^1]: The footnote text.

--- a/scaladoc/test/dotty/tools/scaladoc/site/SiteGenerationTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/site/SiteGenerationTest.scala
@@ -67,7 +67,10 @@ class SiteGenerationTest extends BaseHtmlTest:
     testApiPages()
 
     withHtmlFile("docs/Adoc.html"){ content  =>
-        content.assertAttr("p a","href", "../tests/site/SomeClass.html")
+        content.assertAttr("p a","href", "../tests/site/SomeClass.html", "#fn-1")
+        content.assertAttr("p sup","id", "fnref-1")
+        content.assertAttr(".footnotes li","id", "fn-1")
+        content.assertAttr(".footnotes a.footnote-backref","href", "#fnref-1")
     }
 
     withHtmlFile("tests/site/SomeClass.html"){ content  =>

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/comments/FootnoteSupportTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/comments/FootnoteSupportTest.scala
@@ -1,0 +1,24 @@
+package dotty.tools.scaladoc
+package tasty.comments
+
+import org.junit.Test
+import org.junit.Assert.{assertFalse, assertTrue}
+
+import dotty.tools.scaladoc.tasty.comments.markdown.DocFlexmarkRenderer
+
+class FootnoteSupportTest {
+  @Test def renderMarkdownFootnotes(): Unit = {
+    val markdown =
+      """Top-level splices are restricted to inline methods[^1].
+        |
+        |[^1]: See the metaprogramming reference for details.
+        |""".stripMargin
+
+    val html = DocFlexmarkRenderer.render(MarkdownParser.parseToMarkdown(markdown))((_, _) => "")
+
+    assertTrue(s"expected a footnote reference in: $html", html.contains("footnote-ref"))
+    assertTrue(s"expected a footnote definition block in: $html", html.contains("class=\"footnotes\""))
+    assertTrue(s"expected the footnote text in: $html", html.contains("See the metaprogramming reference for details."))
+    assertFalse(s"footnote markers should not render literally in: $html", html.contains("[^1]"))
+  }
+}

--- a/scaladoc/test/dotty/tools/scaladoc/tasty/comments/FootnoteSupportTest.scala
+++ b/scaladoc/test/dotty/tools/scaladoc/tasty/comments/FootnoteSupportTest.scala
@@ -2,7 +2,7 @@ package dotty.tools.scaladoc
 package tasty.comments
 
 import org.junit.Test
-import org.junit.Assert.{assertFalse, assertTrue}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 
 import dotty.tools.scaladoc.tasty.comments.markdown.DocFlexmarkRenderer
 
@@ -20,5 +20,21 @@ class FootnoteSupportTest {
     assertTrue(s"expected a footnote definition block in: $html", html.contains("class=\"footnotes\""))
     assertTrue(s"expected the footnote text in: $html", html.contains("See the metaprogramming reference for details."))
     assertFalse(s"footnote markers should not render literally in: $html", html.contains("[^1]"))
+  }
+
+  @Test def separateAdjacentFootnoteReferences(): Unit = {
+    val markdown =
+      """Restricted to inline methods[^1][^2], but not[^1] elsewhere[^2].
+        |
+        |[^1]: First footnote.
+        |[^2]: Second footnote.
+        |""".stripMargin
+
+    val html = DocFlexmarkRenderer.render(MarkdownParser.parseToMarkdown(markdown))((_, _) => "")
+
+    val separators = "footnote-ref-sep".r.findAllIn(html).size
+    assertEquals(s"only the adjacent references should be separated in: $html", 1, separators)
+    assertTrue(s"expected the separator between adjacent references in: $html",
+      html.contains("""</sup><sup class="footnote-ref-sep">,</sup><sup"""))
   }
 }


### PR DESCRIPTION
Fixes #24757

## Have you relied on LLM-based tools in this contribution?

Yes, pair programming.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

Tested manually in the browser for `scaladoc/generateScalaDocumentation`.