### PR TITLE
Keep references to local capsets in inferred types

### DIFF
--- a/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
+++ b/compiler/src/dotty/tools/dotc/cc/CaptureOps.scala
@@ -900,18 +900,31 @@ class PathSelectionProto(val selector: Symbol, val pt: Type, val tree: Tree) ext
 /** Drop retains annotations in the inferred type if CC is not enabled
  *  or transform them into retains annotations with Nothing (i.e. empty set) as
  *   argument if CC is enabled (we need to do that to keep by-name status).
+ *  Retains annotations that refer to a type lambda binder enclosing them in
+ *  the mapped type itself are kept, since they cannot be re-inferred later.
+ *  See issue #26000.
  */
 class CleanupRetains(using Context) extends TypeMap:
   var retainsFound: Boolean = false
+
+  /** The type lambdas enclosing the currently mapped part of the type */
+  private var localBinders: List[TypeLambda] = Nil
+
   def apply(tp: Type): Type = tp match
     case tp @ AnnotatedType(parent, annot: RetainingAnnotation) =>
       if Feature.ccEnabled then
         retainsFound = true
-        if annot.symbol == defn.RetainsCapAnnot then tp
+        if annot.symbol == defn.RetainsCapAnnot || annot.refersToParamOf(localBinders) then tp
         else AnnotatedType(this(parent), RetainingAnnotation(annot.symbol.asClass, defn.NothingType))
       else this(parent)
     case tp @ AnnotatedType(parent, annot) if annot.symbol == defn.DeclaredAnnot =>
       tp
+    case tp: TypeLambda if Feature.ccEnabled =>
+      // Don't clean the parameter bounds: like the kept annotations above, they
+      // are transformed as declared types when the enclosing type is inferred.
+      localBinders = tp :: localBinders
+      try tp.derivedLambdaType(resType = this(tp.resType))
+      finally localBinders = localBinders.tail
     case _ => mapOver(tp)
 
 /** A base class for extractors that match annotated types with a specific

--- a/compiler/src/dotty/tools/dotc/cc/RetainingAnnotation.scala
+++ b/compiler/src/dotty/tools/dotc/cc/RetainingAnnotation.scala
@@ -49,6 +49,24 @@ class RetainingAnnotation(tpe: Type) extends CompactAnnotation(tpe) {
     if myCaptureSet == null then
       myCaptureSet = CaptureSet(retainedType.retainedElements*)
     myCaptureSet.nn
+
+  /** Does this annotation refer to a parameter of one of the type lambdas
+   *  in `binders`? This is used when transforming inferred types, where
+   *  capture sets referring to a type lambda binder enclosing them in the
+   *  inferred type itself must be kept: they cannot be re-inferred since
+   *  capture set variables would live outside the type lambda's binder,
+   *  so level checking would exclude the parameter from them.
+   *  The check goes through `retainedElementsRaw` since binder references
+   *  can be nested inside further retaining annotations, as in
+   *  `retains[CapSet^{C}]`, where `existsPart` alone would not see them.
+   *  See issue #26000.
+   */
+  def refersToParamOf(binders: List[TypeLambda])(using Context): Boolean =
+    binders.nonEmpty
+    && retainedType.retainedElementsRaw.exists:
+        _.existsPart:
+          case tp: TypeParamRef => binders.exists(_ eq tp.binder)
+          case _ => false
 }
 object RetainingAnnotation {
 

--- a/compiler/src/dotty/tools/dotc/cc/Setup.scala
+++ b/compiler/src/dotty/tools/dotc/cc/Setup.scala
@@ -337,7 +337,9 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
     *  4. Add capture set variables to all types that can be tracked
     *  5. Perform normalizeCaptures
     *
-    *  Polytype bounds are only cleaned using step 1, but not otherwise transformed.
+    *  Type lambda parameter bounds and retains annotations referring to a type
+    *  lambda binder in the mapped type itself are treated as explicitly declared
+    *  types; they are transformed with `transformExplicitType` instead.
     *  @param tp            the type to transform
     *  @param sym           the definition to which this type belongs
     *  @param typeArgFormal if `tp` is an an inferred type argument, the formal parameter info,
@@ -350,6 +352,9 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
       variance = initialVariance
       var refiningNames: Set[Name] = Set()
+
+      /** The type lambdas enclosing the currently mapped part of the type */
+      var localBinders: List[TypeLambda] = Nil
 
       /** Refine a possibly applied class type C where the class has tracked parameters
        *  x_1: T_1, ..., x_n: T_n to C { val x_1: T_1^{CV_1}, ..., val x_n: T_n^{CV_n} }
@@ -389,6 +394,11 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
 
       def innerApply(tp: Type) =
         tp match
+          case tp @ AnnotatedType(parent, annot: RetainingAnnotation)
+          if annot.isStrict && annot.refersToParamOf(localBinders) =>
+            // Keep retains annotations that refer to a type lambda binder that is
+            // local to the mapped type; they cannot be re-inferred. See issue #26000.
+            transformExplicitType(tp, sym, initialVariance = variance)
           case AnnotatedType(parent, annot)
           if annot.symbol.isRetains || annot.symbol == defn.InferredAnnot =>
             // Drop explicit retains and @inferred annotations
@@ -401,6 +411,16 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             refiningNames += rname
             val parent1 = try this(parent) finally refiningNames = saved
             addVar(tp.derivedRefinedType(parent1, rname, this(rinfo)), tp)
+          case tp: TypeLambda =>
+            // The parameter bounds of a type lambda embedded in an inferred type
+            // are declared types coming from the source; keep them instead of
+            // re-inferring them, which is not possible for capture set bounds
+            // such as `[C^ <: {io}]`. See issue #26000.
+            val paramInfos1 = tp.paramInfos.mapConserve: info =>
+              transformExplicitType(info, sym, initialVariance = -variance).bounds
+            localBinders = tp :: localBinders
+            val resType1 = try this(tp.resType) finally localBinders = localBinders.tail
+            tp.derivedLambdaType(paramInfos = paramInfos1, resType = resType1)
           case _ =>
             addVar(mapFollowingAliases(tp), tp)
     }
@@ -528,6 +548,10 @@ class Setup extends PreRecheck, SymTransformer, SetupAPI:
             else if ann.symbol == defn.InferredAnnot then
               transformInferredType(parent, sym, initialVariance = variance)
                 // typeArgFormal is NoType here since we are inferring inside an argument, not at the toplevel
+            else if ann.symbol == defn.DeclaredAnnot then
+              // @declared annotations only inform the transformation of inferred types;
+              // in an explicitly transformed part of a type they can be dropped.
+              this(parent)
             else
               t.derivedAnnotatedType(this(parent), ann)
           case throwsAlias(res, exc) =>

--- a/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
+++ b/compiler/src/dotty/tools/dotc/transform/PostTyper.scala
@@ -437,6 +437,11 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
      *   (3) If the definition is a closure that is a curried result of the
      *       right hand side of a defininition meeting condition (2), also make
      *       its parameter types non-inferred as specified by (2).
+     *   (4) If the definition is a closure with a capture set parameter, also
+     *       make its parameter types non-inferred as specified by (2), no
+     *       matter where the closure appears. References to the capture set
+     *       parameter in the types of subsequent parameters cannot be
+     *       re-inferred, so they have to be kept. See issue #26000.
      */
     private def explicifyTpt(tree: ValOrDefDef)(using Context): Tree = tree.tpt match
       case tpt: InferredTypeTree if Feature.ccEnabled =>
@@ -446,6 +451,7 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           case closureDef(mdef)
           if !tree.symbol.isAnonymousFunction // (2)
             || closuresNeedingExplicify.remove(tree.symbol) // (3)
+            || hasCapSetParam(tree.symbol) // (4)
           =>
             val tpe1 = makeFormalsDeclared(tpt.tpe, tree.rhs)
             if tpe1 `ne` tpt.tpe
@@ -454,6 +460,13 @@ class PostTyper extends MacroTransform with InfoTransformer { thisPhase =>
           case _ => tpt
       case tpt =>
         tpt
+
+    /** Does `sym` have a type parameter that is a capture set parameter,
+     *  as in `[C^] => ...`?
+     */
+    private def hasCapSetParam(sym: Symbol)(using Context): Boolean = sym.info match
+      case pt: PolyType => pt.paramInfos.exists(_.hi.derivesFromCapSet)
+      case _ => false
 
     /** Insert a `@caps.declared` annotation on all parameter infos
      *  of a function type `tp` corresponding to a closure `rhs` that contain

--- a/repl/test-resources/repl/i26000
+++ b/repl/test-resources/repl/i26000
@@ -1,0 +1,18 @@
+//> using options -language:experimental.captureChecking
+scala> import caps.*
+scala> class File { override def toString = "File" }
+// defined class File
+scala> class Box[A](val value: A) { override def toString = "Box" }
+// defined class Box
+scala> val f = Box([C^] => (f: File^{C}) => (h: File^{C}) => (g: File^{C}) => { println(h); (f, h) })
+val f:
+  Box[
+    [C^] => (f: File^{C}) ->
+      (h: File^{C}) -> (g: File^{C}) ->{h} (File^{C}, File^{C})^{}
+  ]^{} = Box
+scala> val x: File^ = File()
+val x: File^ = File
+scala> val bounded = Box([C^ <: {x}] => (xs: List[File^{C}]) => xs)
+val bounded: Box[[C^ <: {x}] => (xs: List[File^{C}]) -> List[File^{C}]]^{} = Box
+scala> def g = Box([C^] => (xs: List[File^{C}]) => xs)
+def g: Box[[C^ <: {fresh}] => (xs: List[File^{C}]) -> List[File^{C}]]

--- a/tests/neg-custom-args/captures/i26000-external.scala
+++ b/tests/neg-custom-args/captures/i26000-external.scala
@@ -1,0 +1,22 @@
+package i26000external
+// Symbols in the empty package are exempt from explicit-type checks,
+// so this test needs a package declaration.
+
+import language.experimental.captureChecking
+import caps.*
+
+class File
+class Box[A](val value: A)
+
+object Lib:
+  // An externally visible definition whose inferred type embeds a
+  // capture-polymorphic lambda needs an explicit type, like for a lambda
+  // that appears directly on the right-hand side of the definition.
+  // Before the fix for issue #26000 this compiled, but with all capture
+  // sets referring to `C` erased to `{}` in the externally visible type.
+  val f = Box([C^] => (x: File^{C}) => x) // error
+
+  def g = Box([C^] => (xs: List[File^{C}]) => xs) // error
+
+  val ok: Box[[C^] => (x: File^{C}) -> File^{C}] =
+    Box([C^] => (x: File^{C}) => x)

--- a/tests/neg-custom-args/captures/i26000.scala
+++ b/tests/neg-custom-args/captures/i26000.scala
@@ -1,0 +1,23 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File
+class Box[A](val value: A)
+
+@main def test =
+  val io: File^ = File()
+  val other: File^ = File()
+
+  // The preserved bound `[C^ <: {io}]` must still be enforced.
+  val bounded = Box([C^ <: {io}] => (f: File^{C}) => f)
+  val r1 = bounded.value[{other}](other) // error
+
+  // The preserved parameter and result sets must still constrain.
+  val f = Box([C^] => (x: File^{C}) => x)
+  val r2: File = f.value[{io}](io) // error
+
+  // The `fresh` upper bound of the capture set parameter in a method result
+  // must reject instantiation with an external capture set.
+  def g = Box([C^] => (xs: List[File^{C}]) => xs)
+  val files: List[File^{io}] = List(io)
+  val r3 = g.value[{io}](files) // error

--- a/tests/pos-custom-args/captures/i26000-sep/a_1.scala
+++ b/tests/pos-custom-args/captures/i26000-sep/a_1.scala
@@ -1,0 +1,12 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File
+class Box[A](val value: A)
+
+// These definitions are compiled separately from their use in b_2.scala,
+// so the capture sets and bounds referring to `C` in their inferred types
+// must survive the TASTy round trip.
+val fBoxed = Box([C^] => (x: File^{C}) => x)
+val io: File^ = File()
+val bounded = Box([C^ <: {io}] => (xs: List[File^{C}]) => xs)

--- a/tests/pos-custom-args/captures/i26000-sep/b_2.scala
+++ b/tests/pos-custom-args/captures/i26000-sep/b_2.scala
@@ -1,0 +1,10 @@
+import language.experimental.captureChecking
+import caps.*
+
+@main def sepTest =
+  val x: File^ = File()
+  val r = fBoxed.value[{x}](x)
+  val _: File^{x} = r
+  val files: List[File^{io}] = List(io)
+  val r2 = bounded.value[{io}](files)
+  val _: List[File^{io}] = r2

--- a/tests/pos-custom-args/captures/i26000.scala
+++ b/tests/pos-custom-args/captures/i26000.scala
@@ -1,0 +1,34 @@
+import language.experimental.captureChecking
+import caps.*
+
+class File
+class Box[A](val value: A)
+
+@main def test =
+  // The type of the lambda is captured in the inferred type argument of `Box`
+  // and in the inferred type of `f`. The `^{C}` capture sets and the bound of
+  // `C` must be preserved there.
+  val f = Box([C^] => (f: File^{C}) => (h: File^{C}) => (g: File^{C}) => { println(h); (f, h) })
+
+  val x: File^ = File()
+  val (r1, r2) = f.value[{x}](x)(x)(x)
+  val _: File^{x} = r1
+  val _: File^{x} = r2
+
+  // The same, one level further out: the inferred type of `g` is derived from
+  // the inferred type of a local definition. Note that `g.value` cannot be
+  // instantiated with an external capture set, since the capture set parameter's
+  // upper bound in the result type of `g` is the result's `fresh` capability;
+  // this is the same behavior as for an explicitly declared result type.
+  def g =
+    val b = Box([C^] => (xs: List[File^{C}]) => xs)
+    b
+  val files: List[File^{x}] = List(x)
+  val r3 = g.value[{}](List(File()))
+  val _: List[File] = r3
+
+  // A bounded capset parameter in an inferred type argument.
+  val io: File^ = File()
+  val bounded = Box([C^ <: {io}] => (f: File^{C}) => f)
+  val r4 = bounded.value[{io}](io)
+  val _: File^{io} = r4


### PR DESCRIPTION
Fixes #26000 

https://github.com/scala/scala3/pull/25976 preserved `^{C}` by marking closure parameters `@declared` in PostTyper, but only when the lambda is the direct RHS of a named definition.
It notably can't reach lambdas whose types end up in inferred types via arguments like `Box([C^] => ...)`. 

This fix adds a type-level rule to both cleanup passes: a retains set referencing a type-lambda binder that lives inside the inferred type itself is provably un-re-inferable, so it's kept and processed as a declared type 

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by guiding and reviewing it.

## How was the solution tested?

New automated tests (including the issue's reproducer, if applicable)

& testing in the REPL via `./bin/replQ`.