### PR TITLE
scope some synthetic cast generation under SafeNulls instead of Yexplicit-nulls

### DIFF
--- a/compiler/src/dotty/tools/dotc/ast/tpd.scala
+++ b/compiler/src/dotty/tools/dotc/ast/tpd.scala
@@ -1086,11 +1086,11 @@ object tpd extends Trees.Instance[Type] with TypedTreeInfo {
       // e.g. `null.ne(null)` doesn't type, but `(null: AnyRef).ne(null)` does.
       val receiver =
         if tree.tpe.isBottomType then
-          if ctx.explicitNulls then tree.cast(defn.AnyRefType)
+          if ctx.mode.is(Mode.SafeNulls) then tree.cast(defn.AnyRefType)
           else Typed(tree, TypeTree(defn.AnyRefType))
         else tree.ensureConforms(defn.ObjectType)
       // also need to cast the null literal to AnyRef in explicit nulls
-      val nullLit = if ctx.explicitNulls then nullLiteral.cast(defn.AnyRefType) else nullLiteral
+      val nullLit = if ctx.mode.is(Mode.SafeNulls) then nullLiteral.cast(defn.AnyRefType) else nullLiteral
       receiver.select(defn.Object_ne).appliedTo(nullLit).withSpan(tree.span)
     }
 

--- a/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
+++ b/compiler/src/dotty/tools/dotc/transform/SyntheticMembers.scala
@@ -138,7 +138,7 @@ class SyntheticMembers(thisPhase: DenotTransformer) {
       def nameRef: Tree =
         if isJavaEnumValue then
           val name = Select(This(clazz), nme.name).ensureApplied
-          if ctx.explicitNulls then name.cast(defn.StringType) else name
+          if ctx.mode.is(Mode.SafeNulls) then name.cast(defn.StringType) else name
         else
           identifierRef
 


### PR DESCRIPTION
The casts are not needed in UnsafeNulls contexts.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
