### PR TITLE
Experiment: Cache BType.toString

### DIFF
--- a/compiler/src/dotty/tools/backend/jvm/BTypes.scala
+++ b/compiler/src/dotty/tools/backend/jvm/BTypes.scala
@@ -27,19 +27,23 @@ import org.objectweb.asm.Opcodes
  * referring to BTypes.
  */
 sealed trait BType {
-  final override def toString: String = this match {
-    case UNIT   => "V"
-    case BOOL   => "Z"
-    case CHAR   => "C"
-    case BYTE   => "B"
-    case SHORT  => "S"
-    case INT    => "I"
-    case FLOAT  => "F"
-    case LONG   => "J"
-    case DOUBLE => "D"
-    case c: ClassBType            => "L" + c.internalName + ";"
-    case ArrayBType(component)    => "[" + component
-    case MethodBType(args, res)   => BTypes.methodDescriptor(args, res)
+  private var myToString: String | Null = null
+
+  final override def toString: String = {
+    initialize(myToString, myToString = _, this match
+      case UNIT   => "V"
+      case BOOL   => "Z"
+      case CHAR   => "C"
+      case BYTE   => "B"
+      case SHORT  => "S"
+      case INT    => "I"
+      case FLOAT  => "F"
+      case LONG   => "J"
+      case DOUBLE => "D"
+      case c: ClassBType          => "L" + c.internalName + ";"
+      case ArrayBType(component)  => "[" + component
+      case MethodBType(args, res) => BTypes.methodDescriptor(args, res)
+    )
   }
 
   /**


### PR DESCRIPTION
This method comes up a lot in flame graphs.

Might also be worth having an internal StringBuilder version to avoid the many concatenations; first, let's see if the caching is worth it.

## Have you relied on LLM-based tools in this contribution?

No

## How was the solution tested?

Covered by existing tests (this is a refactoring)
