### PR TITLE
Experiment: Make TypeOps avoid symbols if they widen to another avoided symbol

### DIFF
--- a/compiler/src/dotty/tools/dotc/core/TypeOps.scala
+++ b/compiler/src/dotty/tools/dotc/core/TypeOps.scala
@@ -546,8 +546,6 @@ object TypeOps:
    *  We need to approximate with ranges:
    *
    *    term references to symbols in `symsToAvoid`,
-   *    term references that have a widened type of which some part refers
-   *    to a symbol in `symsToAvoid`,
    *    type references to symbols in `symsToAvoid`,
    *
    *  Type variables that would be interpolated to a type that

--- a/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
+++ b/compiler/src/dotty/tools/dotc/inlines/Inliner.scala
@@ -611,7 +611,11 @@ class Inliner(val call: tpd.Tree)(using Context):
    *  the method will return: `Foo.OpaqueInt`
    */
   def unpackProxiesFromResultType(inlined: Inlined): Type =
-    if thisTypeProxyExists then mapBackToOpaques.typeMap(thisTypeUnpacker.typeMap(inlined.expansion.tpe))
+    if thisTypeProxyExists then
+      val unpacked = mapBackToOpaques.typeMap(thisTypeUnpacker.typeMap(inlined.expansion.tpe))
+      // base inlined.tpe always avoids bindings in it's type (behavior built-in to the
+      // Inlined(...) constructor) so we do that here too
+      TypeAssigner.avoidingType(unpacked, inlined.bindings)
     else inlined.tpe
 
   /** Populate `thisProxy` and `paramProxy` as follows:

--- a/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
+++ b/compiler/src/dotty/tools/dotc/typer/TypeAssigner.scala
@@ -45,12 +45,15 @@ trait TypeAssigner {
   }
 
   def avoidingType(expr: Tree, bindings: List[Tree])(using Context): Type =
+    avoidingType(expr.tpe, bindings)
+
+  def avoidingType(tpe: Type, bindings: List[Tree])(using Context): Type =
     val syms = localSyms(bindings).filterConserve(_.isTerm)
     val replacements = bindings.flatMap { b =>
       b.getAttachment(InlineProxySkolem).map(b.symbol -> _)
     }
-    if replacements.isEmpty then TypeOps.avoid(expr.tpe, syms)
-    else TypeOps.avoid(expr.tpe, syms, replacements.toMap)
+    if replacements.isEmpty then TypeOps.avoid(tpe, syms)
+    else TypeOps.avoid(tpe, syms, replacements.toMap)
 
   def avoidPrivateLeaks(sym: Symbol)(using Context): Type =
     if sym.owner.isClass && !sym.isOneOf(JavaOrPrivateOrSynthetic)

--- a/tests/neg/i26785-a.scala
+++ b/tests/neg/i26785-a.scala
@@ -1,0 +1,30 @@
+enum HList[+T]:
+	case HNil extends HList[Nothing]
+	case HCons[T0, E <: T0, L <: HList[T0]](h: E, t: L) extends HList[T0]
+
+import HList.*
+
+object Append:
+	//                    v This variance causes typer to crash
+	opaque type Append[T, +E <: T, L <: HList[T]] <: HList[T] = HList[T]
+	def append[T, E <: T](lst: HList[T], elem: E): Append[T, E, lst.type] = ???
+	transparent inline def apply[T, E <: T](lst: HList[T], elem: E): Append[T, E, lst.type] =
+		append[T, E](lst, elem)
+
+object Rev:
+	opaque type Rev[T, L <: HList[T]] <: HList[T] = HList[T]
+	def rev[T](lst: HList[T]): Rev[T, lst.type] = ???
+	transparent inline def apply[T](lst: HList[T]): Rev[T, lst.type] =
+		inline lst match
+			case HNil => HNil
+			case HCons(h, t) => // error
+				Append(Rev.rev(t), h)
+
+object TestMain:
+	import Rev.Rev
+	def failure[T, L <: HList[T]](lst: L): Nothing =
+		lst match
+			case base: HNil.type => ???
+			case ind @ HCons(h, t) => // error
+				val g = Rev(ind)
+		???

--- a/tests/neg/i26785-b.scala
+++ b/tests/neg/i26785-b.scala
@@ -1,0 +1,24 @@
+enum HList[+T]:
+	case HCons[T0, E <: T0, L <: HList[T0]](t: L) extends HList[T0]
+
+import HList.*
+
+object Append:
+	opaque type Append[T, L] <: HList[T] = HList[T]
+	def append[T](lst: HList[T]): Append[T, lst.type] = ???
+	transparent inline def apply[T](lst: HList[T]): Append[T, lst.type] =
+		append[T](lst)
+
+object Rev:
+	opaque type Rev[T, L <: HList[T]] <: HList[T] = HList[T]
+	def rev[T](lst: HList[T]): Rev[T, lst.type] = ???
+	transparent inline def apply[T](inline lst2: HList[T]): Rev[T, lst2.type] = // error
+		inline lst2 match
+			case HCons(t) =>
+				// This is the problematic line
+				Append(Rev.rev(t))
+
+object TestMain:
+	import Rev.Rev
+	def failure[T0, E <: T0, L <: HList[T0]](h: E, t: L): Unit =
+		Rev(HCons(t))

--- a/tests/pos/typeops-avoid-quotes-regression.scala
+++ b/tests/pos/typeops-avoid-quotes-regression.scala
@@ -1,0 +1,20 @@
+// Overeager TypeOps.avoid widening can result here in:
+//-- [E008] Not Found Error: typeops-avoid-quotes-regression.scala:15:52 ----------------------------------
+// 15 |  val code = '{ ${ Expr.ofSeq(instances.toSeq.map(_.asExprOf[T])) }.toSet }
+//    |                                                  ^^^^^^^^^^
+//    |                                value asExprOf is not a member of AnyRef
+import scala.quoted._
+
+private def wireCollInstances(using q: Quotes) =
+  import q.reflect._
+  val dependencyResolver = new DependencyResolver[q.type]
+  dependencyResolver.resolveAll()
+
+def wireSet_impl[T: Type](using q: Quotes): Unit =
+  val instances = wireCollInstances
+  val code = '{ ${ Expr.ofSeq(instances.toSeq.map(_.asExprOf[T])) }.toSet }
+  ???
+
+class DependencyResolver[Q <: Quotes](using val q: Q):
+  import q.reflect.*
+  def resolveAll(): Iterable[Tree] = ???


### PR DESCRIPTION
Brings back previously removed behavior for TypeOps.avoid. Mostly want to check CI/ community build for now. Will make a detailed description later.

Fixes #26785 

<!-- where #XYZ is the issue number; create as draft if this is not in a reviewable state yet;
     do not paste LLM output here, describe the PR in your own words;
     if in doubt about your contribution, refer to: https://github.com/scala/scala3/blob/main/CONTRIBUTING.md;
     don't forget to sign the CLA: https://cla.scala-lang.org/scala/scala3 -->

## Have you relied on LLM-based tools in this contribution?

<!-- Pick one; "running tests" is not enough; refer to https://github.com/scala/scala3/blob/main/LLM_POLICY.md for details -->

Yes, and I checked the output by ...
No

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
Covered by existing tests (this is a refactoring)
Non-code change, no tests needed
Manual tests because writing automated tests is impractical, described below (in detail)
