### PR TITLE
feat(repl): support the repository directive and :repository command

### DIFF
--- a/repl/src/dotty/tools/repl/DependencyResolver.scala
+++ b/repl/src/dotty/tools/repl/DependencyResolver.scala
@@ -9,10 +9,43 @@ import scala.util.control.NonFatal
 
 import dotty.tools.repl.AbstractFileClassLoader
 
-import coursierapi.{Dependency, MavenRepository}
+import coursierapi.{Dependency, IvyRepository, MavenRepository, Repository}
 
 /** Handles dependency resolution using Coursier for the REPL */
 object DependencyResolver:
+
+  private val defaultRepositories: List[Repository] = List(
+    MavenRepository.of("https://repo1.maven.org/maven2"),
+    MavenRepository.of("https://oss.sonatype.org/content/repositories/releases")
+  )
+
+  // TODO: support every alias coursier does, once the Coursier Interface exposes its own
+  // `parseRepository` and parsing can be delegated to it.
+  private val repositoryAliases: Map[String, Repository] =
+    val m2Local = MavenRepository.of(File(sys.props("user.home"), ".m2/repository").toURI.toString)
+    Map(
+      "central" -> Repository.central(),
+      "ivy2Local" -> Repository.ivy2Local(),
+      "ivy2local" -> Repository.ivy2Local(),
+      "m2Local" -> m2Local,
+      "m2local" -> m2Local
+    )
+
+  /** Parse a repository given as one of the [[repositoryAliases]], an `ivy:<pattern>`, a URL or a
+   *  local directory.
+   */
+  def parseRepository(repository: String): Option[Repository] =
+    repositoryAliases.get(repository).orElse:
+      repository match
+        case s"ivy:$pattern" if pattern.nonEmpty =>
+          pattern.split("\\|", 2) match
+            case Array(artifacts, metadata) => Some(IvyRepository.of(artifacts, metadata))
+            case _ => Some(IvyRepository.of(pattern))
+        case url if url.contains("://") => Some(MavenRepository.of(url))
+        case path if path.contains(File.separatorChar) && File(path).isDirectory =>
+          Some(MavenRepository.of(File(path).toURI.toString))
+        case _ => None
+
 
   /** Parse a dependency string of the form `org::artifact:version` or `org:artifact:version`
    *  and return the (organization, artifact, version) triple if successful.
@@ -30,15 +63,14 @@ object DependencyResolver:
         None
 
   /** Resolve dependencies using Coursier Interface and return the classpath as a list of File objects */
-  def resolveDependencies(dependencies: List[(String, String, String)]): Either[String, List[File]] =
+  def resolveDependencies(
+    dependencies: List[(String, String, String)],
+    repositories: List[Repository] = Nil
+  ): Either[String, List[File]] =
     if dependencies.isEmpty then Right(Nil)
     else
       try
-        // Add Maven Central and Sonatype repositories
-        val repos = Array(
-          MavenRepository.of("https://repo1.maven.org/maven2"),
-          MavenRepository.of("https://oss.sonatype.org/content/repositories/releases")
-        )
+        val repos = (repositories ++ defaultRepositories).toArray
 
         // Create dependency objects
         val deps = dependencies

--- a/repl/src/dotty/tools/repl/ParseResult.scala
+++ b/repl/src/dotty/tools/repl/ParseResult.scala
@@ -134,6 +134,14 @@ object ToolkitCmd extends ArgCommand[ToolkitCmd] {
   val command: String = ":toolkit"
 }
 
+/** `:repository <url>|<alias>` adds repositories used to resolve dependencies
+ */
+case class RepoCmd(repositories: String) extends Command:
+  override def replayLine = Some(s"${RepoCmd.command} $repositories")
+object RepoCmd extends ArgCommand[RepoCmd] {
+  val command: String = ":repository"
+}
+
 /** `:kind <type>` display the kind of a type. see also :help kind
  */
 case class KindOf(expr: String) extends Command:

--- a/repl/src/dotty/tools/repl/ReplCommands.scala
+++ b/repl/src/dotty/tools/repl/ReplCommands.scala
@@ -54,6 +54,7 @@ private[repl] object ReplCommands:
     command(JarCmd,     "add a JAR to the classpath", "<path>"),
     command(Dep,        "resolve a dependency and make it available in the REPL", "<group>::<artifact>:<version>"),
     command(ToolkitCmd, "resolve a toolkit and make it available in the REPL", "<version>|default|<flavor>:<version>"),
+    command(RepoCmd,    "add repositories used to resolve dependencies", "<url>|<alias>"),
     hidden(Sh),
     hidden(KindOf),
     hidden(Require),

--- a/repl/src/dotty/tools/repl/ReplDirectives.scala
+++ b/repl/src/dotty/tools/repl/ReplDirectives.scala
@@ -37,6 +37,7 @@ private[repl] object ReplDirectives:
   enum ReplDirective:
     case Dependency(coordinate: String)
     case Jar(path: String)
+    case Repository(repository: String)
 
   case class DirectiveClassification(
     directives: List[ReplDirective],
@@ -125,6 +126,13 @@ private[repl] object ReplDirectives:
       toDirectives = toolkitDependencies,
       warnings = List(Warning.TestToolkitSameAsToolkit),
       acceptsMultipleValues = false
+    )
+
+    case Repository extends DirectiveHandler(
+      keys = List("repository", "repositories"),
+      usage = "//> using repository <url>|<alias> ...",
+      description = "Add repositories, consulted before the default ones, to dependency resolution.",
+      toDirectives = repository => List(ReplDirective.Repository(repository))
     )
 
     def process(values: Seq[DirectiveValue]): List[ReplDirective] =

--- a/repl/src/dotty/tools/repl/ReplDriver.scala
+++ b/repl/src/dotty/tools/repl/ReplDriver.scala
@@ -73,6 +73,7 @@ import scala.util.Using
  *  @param quiet       whether we print evaluation results
  *  @param context     the latest compiler context
  *  @param pastInputs  the replayable inputs of the session, most recent first
+ *  @param repositories the repositories added to dependency resolution, in the order they were added
  */
 case class State(objectIndex: Int,
                  valIndex: Int,
@@ -80,7 +81,8 @@ case class State(objectIndex: Int,
                  invalidObjectIndexes: Set[Int],
                  quiet: Boolean,
                  context: Context,
-                 pastInputs: List[String] = Nil):
+                 pastInputs: List[String] = Nil,
+                 repositories: List[coursierapi.Repository] = Nil):
   def validObjectIndexes = (1 to objectIndex).filterNot(invalidObjectIndexes.contains(_))
 
   def recordInput(input: String): State = copy(pastInputs = input :: pastInputs)
@@ -809,6 +811,12 @@ class ReplDriver(settings: Array[String],
 
     case Dep(dep) => resolveAndAddDeps(List(dep))
 
+    case RepoCmd(repositories) => repositories.split("\\s+").filter(_.nonEmpty).toList match
+      case Nil =>
+        out.println(s"${RepoCmd.command} <url>|<alias> ...")
+        state
+      case repositoryStrings => addRepositories(repositoryStrings)
+
     case ToolkitCmd(coordinates) =>
       val singleValue = coordinates.split("\\s+").filter(_.nonEmpty).toList match
         case coords :: Nil => Some(coords)
@@ -836,9 +844,22 @@ class ReplDriver(settings: Array[String],
       case Dependency(coordinate) => coordinate
     val jars = classified.directives.collect:
       case Jar(path) => path
-    val stateWithDependencies = resolveAndAddDeps(dependencies)
+    val repositories = classified.directives.collect:
+      case Repository(repository) => repository
+    val stateWithRepositories = addRepositories(repositories)
+    val stateWithDependencies = resolveAndAddDeps(dependencies)(using stateWithRepositories)
     jars.foldLeft(stateWithDependencies): (currentState, path) =>
       interpretCommand(JarCmd(path))(using currentState)
+
+  private def addRepositories(repositoryStrings: List[String])(using state: State): State =
+    repositoryStrings.foldLeft(state): (currentState, repositoryString) =>
+      DependencyResolver.parseRepository(repositoryString) match
+        case Some(repository) =>
+          out.println(s"Added repository '$repositoryString'.")
+          currentState.copy(repositories = (currentState.repositories :+ repository).distinct)
+        case None =>
+          out.println(s"Unable to parse repository '$repositoryString'.")
+          currentState
 
   private def resolveAndAddDeps(depStrings: List[String])(using state: State): State =
     if depStrings.isEmpty then state
@@ -846,7 +867,7 @@ class ReplDriver(settings: Array[String],
       val deps = depStrings.flatMap(DependencyResolver.parseDependency)
       if deps.isEmpty then state
       else
-        DependencyResolver.resolveDependencies(deps) match
+        DependencyResolver.resolveDependencies(deps, state.repositories) match
           case Right(files) =>
             if files.nonEmpty then
               val classpathState = newRun(state)

--- a/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
+++ b/repl/test/dotty/tools/repl/ReplDirectiveTests.scala
@@ -4,7 +4,7 @@ package repl
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.Test
 
-import ReplDirectives.ReplDirective.{Dependency, Jar}
+import ReplDirectives.ReplDirective.{Dependency, Jar, Repository}
 import ReplDirectives.Warning
 
 class ReplDirectiveTests extends ReplTest, SessionFileHelpers:
@@ -35,8 +35,16 @@ class ReplDirectiveTests extends ReplTest, SessionFileHelpers:
       assertEquals(Nil, result.warnings)
     assertTrue(ReplDirectives.helpText.contains("Aliases: jars"))
 
+  @Test def `repository directive aliases are supported`: Unit =
+    val repositories = List("m2Local", "https://jitpack.io")
+    List("repository", "repositories").foreach: alias =>
+      val result = ReplDirectives.classify(s"//> using $alias ${repositories.mkString(" ")}")
+      assertEquals(repositories.map(Repository(_)), result.directives)
+      assertEquals(Nil, result.warnings)
+    assertTrue(ReplDirectives.helpText.contains("Aliases: repositories"))
+
   @Test def `directives without a value are reported and act on nothing`: Unit =
-    List("dep", "test.dep", "jar", "toolkit", "test.toolkit").foreach: key =>
+    List("dep", "test.dep", "jar", "toolkit", "test.toolkit", "repository").foreach: key =>
       val result = ReplDirectives.classify(s"//> using $key")
       assertEquals(key, Nil, result.directives)
       assertEquals(key, List(Warning.ValueMissing(key)), result.warnings)

--- a/repl/test/dotty/tools/repl/RepositoryTests.scala
+++ b/repl/test/dotty/tools/repl/RepositoryTests.scala
@@ -1,0 +1,70 @@
+package dotty.tools
+package repl
+
+import scala.language.unsafeNulls
+
+import java.io.FileOutputStream
+import java.nio.file.{Files, Path}
+import java.util.jar.JarOutputStream
+
+import org.junit.Assert.{assertEquals, assertTrue}
+import org.junit.Test
+
+class RepositoryTests extends ReplTest:
+
+  private val organization = "dotty.repl.test"
+  private val artifact = "tiny"
+  private val version = "1.0.0"
+  private val dependency = s"$organization:$artifact:$version"
+
+  private lazy val localRepositoryDirectory: Path =
+    val repository = Files.createTempDirectory("repl_repository")
+    val directory = organization.split('.').foldLeft(repository)(_.resolve(_)).resolve(artifact).resolve(version)
+    Files.createDirectories(directory)
+    Files.writeString(directory.resolve(s"$artifact-$version.pom"),
+      s"""<project>
+         |  <modelVersion>4.0.0</modelVersion>
+         |  <groupId>$organization</groupId>
+         |  <artifactId>$artifact</artifactId>
+         |  <version>$version</version>
+         |</project>""".stripMargin)
+    new JarOutputStream(new FileOutputStream(directory.resolve(s"$artifact-$version.jar").toFile)).close()
+    repository
+
+  private lazy val localRepository: String = localRepositoryDirectory.toUri.toString
+
+  @Test def `repository parses aliases, URLs, ivy patterns and local directories`: Unit =
+    List("central", "ivy2Local", "ivy2local", "m2Local", "m2local", "https://jitpack.io",
+         "file:///tmp/repo", "ivy:file:///tmp/repo/[defaultPattern]",
+         "ivy:file:///tmp/repo/[defaultPattern]|file:///tmp/repo/[module]/ivy-[revision].xml",
+         localRepositoryDirectory.toString).foreach: spec =>
+      assertTrue(spec, DependencyResolver.parseRepository(spec).isDefined)
+
+  @Test def `repository command accepts a local directory without a file URL`: Unit =
+    initially {
+      val stateAfterRepository = run(s":repository $localRepositoryDirectory")
+      assertEquals(s"Added repository '$localRepositoryDirectory'.", storedOutput().trim)
+      stateAfterRepository
+    } andThen {
+      run(s":dep $dependency")
+      assertEquals("Resolved a dependency (1 JARs)", storedOutput().trim)
+    }
+
+  @Test def `repository command reports what it cannot parse`: Unit =
+    initially:
+      run(":repository bogusrepo")
+      assertEquals("Unable to parse repository 'bogusrepo'.", storedOutput().trim)
+
+  @Test def `repository command without a value prints its usage`: Unit =
+    initially:
+      run(":repository")
+      assertEquals(":repository <url>|<alias> ...", storedOutput().trim)
+
+  @Test def `repository directive applies to dependencies of the same block`: Unit =
+    initially:
+      run(s"//> using dep $dependency\n//> using repository $localRepository")
+      assertEquals(
+        s"""Added repository '$localRepository'.
+           |Resolved a dependency (1 JARs)""".stripMargin,
+        storedOutput().trim
+      )

--- a/repl/test/dotty/tools/repl/TabcompleteTests.scala
+++ b/repl/test/dotty/tools/repl/TabcompleteTests.scala
@@ -220,6 +220,7 @@ class TabcompleteTests extends ReplTest {
         ":paste",
         ":quit",
         ":replay",
+        ":repository",
         ":require",
         ":reset",
         ":save",


### PR DESCRIPTION
Fixes #26750

As in the title. One minor note - it adds a limited support for aliases, because in `coursier-interface` there's no access to repository parser (hence, the TODO comment). When it'll become available (https://github.com/coursier/interface/pull/478 - I hope soon), then I'll change that.

[test_windows_full]

## Have you relied on LLM-based tools in this contribution?

Yes, and I checked the output by testing manually with bin/replQ

## How was the solution tested?

<!-- Pick one; exceptions must have a very good reason -->

New automated tests (including the issue's reproducer, if applicable)
