### PR TITLE
math, coll, generic (5): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/collection/concurrent/Map.scala
+++ b/library/src/scala/collection/concurrent/Map.scala
@@ -93,6 +93,19 @@ trait Map[K, V] extends scala.collection.mutable.Map[K, V] {
     */
   def replace(k: K, v: V): Option[V]
 
+  /** Returns the value associated with the given key, if present; otherwise
+   *  computes `defaultValue`, stores it under the key, and returns it.
+   *
+   *  This is not atomic. If another thread inserts a value for `key` after the
+   *  initial lookup fails but before the computed `defaultValue` is stored, that
+   *  concurrently inserted value is returned instead and the computed
+   *  `defaultValue` is discarded. If such a value is inserted and removed again
+   *  in that window, `defaultValue` is stored and returned after all.
+   *
+   *  @param key the key whose associated value is to be retrieved or updated
+   *  @param defaultValue the value to compute and store if `key` is absent;
+   *                      not evaluated if `key` is already present
+   */
   override def getOrElseUpdate(key: K, @deprecatedName("op", since="2.13.13") defaultValue: => V): V = get(key) match {
     case Some(v) => v
     case None =>

--- a/library/src/scala/collection/concurrent/TrieMap.scala
+++ b/library/src/scala/collection/concurrent/TrieMap.scala
@@ -732,10 +732,19 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   private var equalityobj = ef
   @transient
   private var rootupdater: AtomicReferenceFieldUpdater[TrieMap[K, V], AnyRef] | Null = rtupd
+  /** Returns the hashing function used to compute hash codes for keys in this TrieMap.
+   */
   def hashing = hashingobj
+  /** Returns the equivalence relation used by this TrieMap.
+   */
   def equality = equalityobj
   @volatile private var root = r
 
+  /** Initializes a new TrieMap with the specified hashing function and equivalence relation for key comparison.
+   *
+   *  @param hashf the hashing function
+   *  @param ef the equivalence relation
+   */
   def this(hashf: Hashing[K], ef: Equiv[K]) = this(
     INode.newRootNode(ef),
     AtomicReferenceFieldUpdater.newUpdater(classOf[TrieMap[K, V]], classOf[AnyRef], "root"),
@@ -743,8 +752,12 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     ef
   )
 
+  /** Initializes a new TrieMap with default universal equivalence and hashing for key comparison.
+   */
   def this() = this(Hashing.default, Equiv.universal)
 
+  /** Returns the TrieMap companion object as the factory for creating new TrieMap instances.
+   */
   override def mapFactory: MapFactory[TrieMap] = TrieMap
 
   /* internal methods */
@@ -871,12 +884,18 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   }
 
 
+  /** Returns a string representation of the trie structure rooted at this TrieMap's root node.
+   */
   def string: String = RDCSS_READ_ROOT().string(0)
 
   /* public methods */
 
+  /** Returns `true` if this TrieMap is a read-only snapshot (its root updater is `null`).
+   */
   def isReadOnly = rootupdater eq null
 
+  /** Returns `true` if this TrieMap is mutable (its root updater is not `null`).
+   */
   def nonReadOnly = rootupdater ne null
 
   /** Returns a snapshot of this TrieMap.
@@ -918,13 +937,25 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     else readOnlySnapshot()
   }
 
+  /** Atomically removes all key-value pairs from this TrieMap by swapping in
+   *  a fresh empty root node, retrying until the swap succeeds.
+   */
   @tailrec override def clear(): Unit = {
     val r = RDCSS_READ_ROOT()
     if (!RDCSS_ROOT(r, r.gcasRead(this), INode.newRootNode[K, V](equality))) clear()
   }
 
+  /** Computes the hash code for the specified key using this TrieMap's hashing function.
+   *
+   *  @param k the key to compute the hash code for
+   */
   def computeHash(k: K) = hashingobj.hash(k)
 
+  /** Looks up the value associated with the key, returning `null` if the key is not present.
+   *
+   *  @param k the key to look up
+   *  @return the value associated with the key, or `null` if the key is not present
+   */
   @deprecated("Use getOrElse(k, null) instead.", "2.13.0")
   def lookup(k: K): V = {
     val hc = computeHash(k)
@@ -933,6 +964,12 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     res.asInstanceOf[V]
   }
 
+  /** Returns the value associated with the specified key.
+   *
+   *  @param k the key to look up
+   *  @return the value associated with the key
+   *  @throws NoSuchElementException if the key is not present
+   */
   override def apply(k: K): V = {
     val hc = computeHash(k)
     val res = lookuphc(k, hc)
@@ -940,37 +977,72 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     else res.asInstanceOf[V]
   }
 
+  /** Returns the value associated with the specified key.
+   *
+   *  @param k the key to look up
+   *  @return `Some` of the value associated with the key, or `None` if the key is not present
+   */
   def get(k: K): Option[V] = {
     val hc = computeHash(k)
     val res = lookuphc(k, hc)
     if (res eq INodeBase.NO_SUCH_ELEMENT_SENTINEL) None else Some(res).asInstanceOf[Option[V]]
   }
 
+  /** Inserts or overwrites the key-value pair, returning the previous value if any.
+   *
+   *  @param key the key to insert
+   *  @param value the value to associate with the key
+   *  @return `Some` of the previous value associated with the key, or `None` if the key was not present
+   */
   override def put(key: K, value: V): Option[V] = {
     val hc = computeHash(key)
     insertifhc(key, hc, value, INode.KEY_PRESENT_OR_ABSENT, fullEquals = false /* unused */)
   }
 
+  /** Inserts or updates the value associated with the specified key.
+   *
+   *  @param k the key to update
+   *  @param v the new value to associate with the key
+   */
   override def update(k: K, v: V): Unit = {
     val hc = computeHash(k)
     inserthc(k, hc, v)
   }
 
+  /** Adds the given key-value pair to this TrieMap, returning this TrieMap.
+   *
+   *  @param kv the key-value pair to add
+   */
   def addOne(kv: (K, V)) = {
     update(kv._1, kv._2)
     this
   }
 
+  /** Removes the key-value pair with the specified key unconditionally, returning the previous value if any.
+   *
+   *  @param k the key to remove
+   *  @return `Some` of the previous value associated with the key, or `None` if the key was not present
+   */
   override def remove(k: K): Option[V] = {
     val hc = computeHash(k)
     removehc(k = k, v = null.asInstanceOf[V], RemovalPolicy.Always, hc = hc)
   }
 
+  /** Removes the entry with the specified key from this TrieMap, if present, returning this TrieMap.
+   *
+   *  @param k the key to remove
+   */
   def subtractOne(k: K) = {
     remove(k)
     this
   }
 
+  /** Inserts the key-value pair only if the key is not already present, returning the existing value if any.
+   *
+   *  @param k the key to insert
+   *  @param v the value to associate with the key
+   *  @return `Some` of the existing value, leaving this TrieMap unchanged, or `None` if the key was not present and the pair was inserted
+   */
   def putIfAbsent(k: K, v: V): Option[V] = {
     val hc = computeHash(k)
     insertifhc(k, hc, v, INode.KEY_ABSENT, fullEquals = false /* unused */)
@@ -1006,6 +1078,12 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     }
   }
 
+  /** Removes the key-value pair only if the current value matches `v`, returning true if removed.
+   *
+   *  @param k the key to remove
+   *  @param v the value to compare against the current value associated with the key
+   *  @return true if the key-value pair was removed, false otherwise
+   */
   def remove(k: K, v: V): Boolean = {
     val hc = computeHash(k)
     removehc(k, v, RemovalPolicy.FullEquals, hc).nonEmpty
@@ -1016,6 +1094,13 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     removehc(k, v, RemovalPolicy.ReferenceEq, hc).nonEmpty
   }
 
+  /** Replaces the value associated with the key only if the current value matches `oldvalue`, returning true if replaced.
+   *
+   *  @param k the key to replace
+   *  @param oldvalue the expected old value
+   *  @param newvalue the new value to associate with the key
+   *  @return true if the replacement was successful, false otherwise
+   */
   def replace(k: K, oldvalue: V, newvalue: V): Boolean = {
     val hc = computeHash(k)
     insertifhc(k, hc, newvalue, oldvalue.asInstanceOf[AnyRef], fullEquals = true).nonEmpty
@@ -1026,11 +1111,19 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
     insertifhc(k, hc, newValue, oldValue.asInstanceOf[AnyRef], fullEquals = false).nonEmpty
   }
 
+  /** Replaces the value associated with the key only if the key is present, returning the previous value if any.
+   *
+   *  @param k the key to replace
+   *  @param v the new value to associate with the key
+   *  @return `Some` of the previous value associated with the key, or `None` if the key was not present
+   */
   def replace(k: K, v: V): Option[V] = {
     val hc = computeHash(k)
     insertifhc(k, hc, v, INode.KEY_PRESENT, fullEquals = false /* unused */)
   }
 
+  /** Returns an iterator over the key-value pairs, using a read-only snapshot if the TrieMap is mutable.
+   */
   def iterator: Iterator[(K, V)] = {
     if (nonReadOnly) readOnlySnapshot().iterator
     else new TrieMapIterator(0, this)
@@ -1043,35 +1136,66 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
   // view of the data if there is a concurrent writer
   // Note that the we don't need overrides for keysIterator or valuesIterator
   // TrieMapTest validates the behaviour.
+  /** Returns an iterable over the values, using a read-only snapshot if the TrieMap is mutable.
+   */
   override def values: Iterable[V] = {
     if (nonReadOnly) readOnlySnapshot().values
     else super.values
   }
+  /** Returns a set of the keys, using a read-only snapshot if the TrieMap is mutable.
+   */
   override def keySet: Set[K] = {
     if (nonReadOnly) readOnlySnapshot().keySet
     else super.keySet
   }
 
+  /** Returns a view of this TrieMap, using a read-only snapshot if the TrieMap is mutable.
+   */
   override def view: MapView[K, V] = if (nonReadOnly) readOnlySnapshot().view else super.view
 
+  /** Returns a view of this TrieMap with keys filtered by the specified predicate.
+   *
+   *  @param p the predicate to filter keys by
+   */
   @deprecated("Use .view.filterKeys(f). A future version will include a strict version of this method (for now, .view.filterKeys(p).toMap).", "2.13.0")
   override def filterKeys(p: K => Boolean): collection.MapView[K, V]^{p} = view.filterKeys(p)
 
+  /** Returns a view of this TrieMap with values transformed by the specified function.
+   *
+   *  @tparam W the type of the transformed values
+   *  @param f the function to transform values with
+   */
   @deprecated("Use .view.mapValues(f). A future version will include a strict version of this method (for now, .view.mapValues(f).toMap).", "2.13.0")
   override def mapValues[W](f: V => W): collection.MapView[K, W]^{f} = view.mapValues(f)
   // END extra overrides
   ///////////////////////////////////////////////////////////////////
 
+  /** Returns the size of this TrieMap, using a read-only snapshot if the TrieMap is mutable.
+   */
   override def size: Int =
     if (nonReadOnly) readOnlySnapshot().size
     else RDCSS_READ_ROOT().cachedSize(this)
+  /** Returns the known size of this TrieMap, or -1 if it is not known.
+   *
+   *  The result is always -1 if this TrieMap is mutable, since it may be
+   *  modified concurrently. For a read-only snapshot it is the size cached in
+   *  the root, when the root has one. A -1 is not necessarily transient: some
+   *  root representations never cache a size, and for those the result stays
+   *  -1 however often it is asked for.
+   */
   override def knownSize: Int =
     if (nonReadOnly) -1
     else RDCSS_READ_ROOT().knownSize(this)
+  /** Returns `true` if this TrieMap contains no key-value pairs, using a read-only snapshot if the TrieMap is mutable.
+   */
   override def isEmpty: Boolean =
     (if (nonReadOnly) readOnlySnapshot() else this).sizeIs == 0 // sizeIs checks knownSize
+  /** Returns the class name of this TrieMap for use in string representation.
+   */
   override protected def className = "TrieMap"
 
+  /** Returns `Some` of the last key-value pair of this TrieMap, or `None` if this TrieMap is empty or the last pair cannot be retrieved because of a concurrent modification.
+   */
   override def lastOption: Option[(K, V)] = if (isEmpty) None else Try(last).toOption
 }
 
@@ -1079,16 +1203,46 @@ final class TrieMap[K, V] private (r: AnyRef, rtupd: AtomicReferenceFieldUpdater
 @SerialVersionUID(3L)
 object TrieMap extends MapFactory[TrieMap] {
 
+  /** Returns a new empty TrieMap with default hashing and equivalence.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @return an empty TrieMap
+   */
   def empty[K, V]: TrieMap[K, V] = new TrieMap[K, V]
 
+  /** Creates a new TrieMap populated with the key-value pairs from the specified iterable.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @param it the iterable to create the TrieMap from
+   *  @return a new TrieMap containing the key-value pairs from the iterable
+   */
   def from[K, V](it: IterableOnce[(K, V)]^): TrieMap[K, V] = new TrieMap[K, V]() ++= it
 
+  /** Returns a new builder for constructing TrieMaps from key-value pairs.
+   *
+   *  @tparam K the type of keys
+   *  @tparam V the type of values
+   *  @return a new builder for TrieMap
+   */
   def newBuilder[K, V]: mutable.GrowableBuilder[(K, V), TrieMap[K, V]] = new GrowableBuilder(empty[K, V])
 
+  /** The atomic field updater used to update the `mainnode` field of `INodeBase` instances.
+   */
   @transient
   val inodeupdater: AtomicReferenceFieldUpdater[INodeBase[?, ?], MainNode[?, ?]] = AtomicReferenceFieldUpdater.newUpdater(classOf[INodeBase[?, ?]], classOf[MainNode[?, ?]], "mainnode")
 
+  /** A hashing function that mangles the hash code of keys.
+   *
+   *  @tparam K the type of keys
+   */
   class MangledHashing[K] extends Hashing[K] {
+    /** Computes and mangles the hash code of the key for better distribution in the TrieMap.
+     *
+     *  @param k the key to compute the hash code for
+     *  @return the hash code
+     */
     def hash(k: K): Int = scala.util.hashing.byteswap32(k.##)
   }
 

--- a/library/src/scala/collection/generic/DefaultSerializationProxy.scala
+++ b/library/src/scala/collection/generic/DefaultSerializationProxy.scala
@@ -30,6 +30,11 @@ import scala.collection.mutable.Builder
 @SerialVersionUID(3L)
 final class DefaultSerializationProxy[A](factory: Factory[A, Any], @transient private val coll: Iterable[A]^) extends Serializable {
 
+  /** A transient builder used during deserialization to reconstruct the collection.
+    *
+    *  This builder is initialized in `readObject` and populated with deserialized
+    *  elements before being converted to the final collection in `readResolve`.
+    */
   @transient protected var builder: Builder[A, Any] = compiletime.uninitialized
 
   private def writeObject(out: ObjectOutputStream): Unit = {
@@ -65,6 +70,11 @@ final class DefaultSerializationProxy[A](factory: Factory[A, Any], @transient pr
     }
   }
 
+  /** Returns the reconstructed collection after deserialization.
+    *
+    *  This method is called automatically during deserialization to convert the
+    *  populated builder into the final collection instance.
+    */
   protected def readResolve(): Any = builder.result()
 }
 
@@ -78,6 +88,14 @@ private[collection] case object SerializeEnd
   * serialization scheme.
   */
 transparent trait DefaultSerializable extends Serializable { this: scala.collection.Iterable[?]^ =>
+  /** Returns a serialization proxy for this collection.
+    *
+    *  This method is called during serialization to replace the collection with
+    *  a `DefaultSerializationProxy` that handles the serialization and
+    *  deserialization process. The proxy uses the appropriate factory based on
+    *  the collection type (e.g., `iterableFactory`, `mapFactory`, etc.) to ensure
+    *  correct reconstruction during deserialization.
+    */
   protected def writeReplace(): AnyRef^{this} = {
     val f: Factory[Any, Any] = this match {
       case it: scala.collection.SortedMap[?, ?] => it.sortedMapFactory.sortedMapFactory[Any, Any](using it.ordering.asInstanceOf[Ordering[Any]]).asInstanceOf[Factory[Any, Any]]

--- a/library/src/scala/collection/generic/IsIterable.scala
+++ b/library/src/scala/collection/generic/IsIterable.scala
@@ -106,6 +106,7 @@ transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
    */
   type C
 
+  /** A function that converts a `Repr` to an `IterableOps[A, Iterable, C]`, equivalent to `apply`. */
   @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
   @untrackedCaptures
   override val conversion: Repr => IterableOps[A, Iterable, C] = apply(_)
@@ -122,6 +123,12 @@ transparent trait IsIterable[Repr] extends IsIterableOnce[Repr] {
 object IsIterable extends IsIterableLowPriority {
 
   // Straightforward case: IterableOps subclasses
+  /** Provides an `IsIterable` instance for any `IterableOps` type.
+   *
+   *  @tparam A0 the element type of the collection
+   *  @tparam CC0 the collection type constructor, which must be a subtype of `IterableOps`
+   *  @return an `IsIterable` instance for the given `IterableOps` type, with `A` set to `A0` and `C` set to `CC0[A0]`
+   */
   implicit def iterableOpsIsIterable[A0, CC0[X] <: IterableOps[X, Iterable, CC0[X]]]: IsIterable[CC0[A0]] { type A = A0; type C = CC0[A0] } =
     new IsIterable[CC0[A0]] {
       type A = A0
@@ -132,6 +139,11 @@ object IsIterable extends IsIterableLowPriority {
   // The `BitSet` type can not be unified with the `CC0` parameter of
   // the above definition because it does not take a type parameter.
   // Hence the need for a separate case:
+  /** Provides an `IsIterable` instance for `BitSet` types.
+   *
+   *  @tparam C0 the `BitSet` type, which must extend both `BitSet` and `BitSetOps`
+   *  @return an `IsIterable` instance for the given `BitSet` type, with `A` set to `Int` and `C` set to `C0`
+   */
   implicit def bitSetOpsIsIterable[C0 <: BitSet & BitSetOps[C0]]: IsIterable[C0] { type A = Int; type C = C0 } =
     new IsIterable[C0] {
       type A = Int
@@ -144,11 +156,23 @@ object IsIterable extends IsIterableLowPriority {
 transparent trait IsIterableLowPriority {
 
   // Makes `IsSeq` instances visible in `IsIterable` companion
+  /** Makes an `IsSeq` instance visible as an `IsIterable` instance.
+   *
+   *  @tparam Repr the representation type that can be converted to an `Iterable`
+   *  @param isSeqLike the `IsSeq` instance to expose as an `IsIterable`
+   *  @return `isSeqLike` itself (an `IsSeq` is an `IsIterable`), preserving its element (`A`) and collection (`C`) types
+   */
   implicit def isSeqLikeIsIterable[Repr](implicit
     isSeqLike: IsSeq[Repr]
   ): IsIterable[Repr] { type A = isSeqLike.A; type C = isSeqLike.C } = isSeqLike
 
   // Makes `IsMap` instances visible in `IsIterable` companion
+  /** Makes an `IsMap` instance visible as an `IsIterable` instance.
+   *
+   *  @tparam Repr the representation type that can be converted to an `Iterable`
+   *  @param isMapLike the `IsMap` instance to expose as an `IsIterable`
+   *  @return `isMapLike` itself (an `IsMap` is an `IsIterable`), preserving its element (`A`) and collection (`C`) types
+   */
   implicit def isMapLikeIsIterable[Repr](implicit
     isMapLike: IsMap[Repr]
   ): IsIterable[Repr] { type A = isMapLike.A; type C = isMapLike.C } = isMapLike

--- a/library/src/scala/collection/generic/IsIterableOnce.scala
+++ b/library/src/scala/collection/generic/IsIterableOnce.scala
@@ -49,6 +49,7 @@ transparent trait IsIterableOnce[Repr] {
   /** The type of elements we can traverse over (e.g. `Int`). */
   type A
 
+  /** A function that converts a `Repr` to an `IterableOnce[A]`, equivalent to `apply`. */
   @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
   @untrackedCaptures
   val conversion: Repr => IterableOnce[A] = apply(_)
@@ -65,6 +66,12 @@ transparent trait IsIterableOnce[Repr] {
 object IsIterableOnce extends IsIterableOnceLowPriority {
 
   // Straightforward case: IterableOnce subclasses
+  /** Provides an `IsIterableOnce` instance for any `IterableOnce` subclass.
+   *
+   *  @tparam CC0 the collection type constructor, which must be a subclass of `IterableOnce`
+   *  @tparam A0 the element type of the collection
+   *  @return an `IsIterableOnce` instance for `CC0[A0]`
+   */
   implicit def iterableOnceIsIterableOnce[CC0[A] <: IterableOnce[A], A0]: IsIterableOnce[CC0[A0]] { type A = A0 } =
     new IsIterableOnce[CC0[A0]] {
       type A = A0
@@ -76,6 +83,12 @@ object IsIterableOnce extends IsIterableOnceLowPriority {
 transparent trait IsIterableOnceLowPriority {
 
   // Makes `IsIterable` instance visible in `IsIterableOnce` companion
+  /** Provides an `IsIterableOnce` instance for any type that has an implicit `IsIterable` instance.
+   *
+   *  @tparam Repr the collection representation type
+   *  @param isIterableLike the implicit `IsIterable` instance for `Repr`
+   *  @return `isIterableLike` itself (an `IsIterable` is an `IsIterableOnce`), preserving its element type `A`
+   */
   implicit def isIterableLikeIsIterableOnce[Repr](implicit
     isIterableLike: IsIterable[Repr]
   ): IsIterableOnce[Repr] { type A = isIterableLike.A } = isIterableLike

--- a/library/src/scala/collection/generic/IsMap.scala
+++ b/library/src/scala/collection/generic/IsMap.scala
@@ -62,6 +62,12 @@ object IsMap {
   type Tupled[F[+_]] = { type Ap[X, Y] = F[(X, Y)] }
 
   // Map collections
+  /** Provides an `IsMap` instance for any `MapOps` collection type.
+   *
+   *  @tparam CC0 the collection type constructor, which must be a subtype of `MapOps[X, Y, Tupled[Iterable]#Ap, CC0[X, Y]]`
+   *  @tparam K0 the type of keys in the map
+   *  @tparam V0 the type of values in the map
+   */
   implicit def mapOpsIsMap[CC0[X, Y] <: MapOps[X, Y, Tupled[Iterable]#Ap, CC0[X, Y]], K0, V0]: IsMap[CC0[K0, V0]] { type K = K0; type V = V0; type C = CC0[K, V] } =
     new IsMap[CC0[K0, V0]] {
       type K = K0
@@ -71,6 +77,12 @@ object IsMap {
     }
 
   // MapView
+  /** Provides an `IsMap` instance for any `MapView` collection type.
+   *
+   *  @tparam CC0 the collection type constructor, which must be a subtype of `MapView[X, Y]`
+   *  @tparam K0 the type of keys in the map view
+   *  @tparam V0 the type of values in the map view
+   */
   implicit def mapViewIsMap[CC0[X, Y] <: MapView[X, Y], K0, V0]: IsMap[CC0[K0, V0]] { type K = K0; type V = V0; type C = View[(K0, V0)] } =
     new IsMap[CC0[K0, V0]] {
       type K = K0
@@ -80,6 +92,11 @@ object IsMap {
     }
 
   // AnyRefMap has stricter bounds than the ones used by the mapOpsIsMap definition
+  /** Provides an `IsMap` instance for `mutable.AnyRefMap` collections.
+   *
+   *  @tparam K0 the type of keys in the map, which must be a subtype of `AnyRef`
+   *  @tparam V0 the type of values in the map
+   */
   @deprecated("AnyRefMap is deprecated", "2.13.16")
   implicit def anyRefMapIsMap[K0 <: AnyRef, V0]: IsMap[mutable.AnyRefMap[K0, V0]] { type K = K0; type V = V0; type C = mutable.AnyRefMap[K0, V0] } =
     new IsMap[mutable.AnyRefMap[K0, V0]] {
@@ -90,6 +107,10 @@ object IsMap {
     }
 
   // IntMap takes one type parameter only whereas mapOpsIsMap uses a parameter CC0 with two type parameters
+  /** Provides an `IsMap` instance for `IntMap` collections.
+   *
+   *  @tparam V0 the type of values in the map (keys are `Int`)
+   */
   implicit def intMapIsMap[V0]: IsMap[IntMap[V0]] { type K = Int; type V = V0; type C = IntMap[V0] } =
     new IsMap[IntMap[V0]] {
       type K = Int
@@ -99,6 +120,10 @@ object IsMap {
     }
 
   // LongMap is in a similar situation as IntMap
+  /** Provides an `IsMap` instance for `LongMap` collections.
+   *
+   *  @tparam V0 the type of values in the map (keys are `Long`)
+   */
   implicit def longMapIsMap[V0]: IsMap[LongMap[V0]] { type K = Long; type V = V0; type C = LongMap[V0] } =
     new IsMap[LongMap[V0]] {
       type K = Long
@@ -108,6 +133,10 @@ object IsMap {
     }
 
   // mutable.LongMap is in a similar situation as LongMap and IntMap
+  /** Provides an `IsMap` instance for `mutable.LongMap` collections.
+   *
+   *  @tparam V0 the type of values in the map (keys are `Long`)
+   */
   implicit def mutableLongMapIsMap[V0]: IsMap[mutable.LongMap[V0]] { type K = Long; type V = V0; type C = mutable.LongMap[V0] } =
     new IsMap[mutable.LongMap[V0]] {
       type K = Long

--- a/library/src/scala/collection/generic/IsSeq.scala
+++ b/library/src/scala/collection/generic/IsSeq.scala
@@ -33,6 +33,7 @@ import scala.reflect.ClassTag
  */
 transparent trait IsSeq[Repr] extends IsIterable[Repr] {
 
+  /** A function that converts a `Repr` to a `SeqOps[A, Iterable, C]`, equivalent to `apply`. */
   @deprecated("'conversion' is now a method named 'apply'", "2.13.0")
   @untrackedCaptures
   override val conversion: Repr => SeqOps[A, Iterable, C] = apply(_)
@@ -58,9 +59,21 @@ object IsSeq {
       def apply(coll: Seq[Any]): SeqOps[Any, Iterable, Any] = coll
     }
 
+  /** Provides an `IsSeq` instance for any `SeqOps` subtype.
+   *
+   *  @tparam CC0 the collection type constructor, a subtype of `SeqOps`
+   *  @tparam A0 the element type of the collection
+   *  @return an `IsSeq` instance for `CC0[A0]`
+   */
   implicit def seqOpsIsSeq[CC0[X] <: SeqOps[X, Iterable, CC0[X]], A0]: IsSeq[CC0[A0]] { type A = A0; type C = CC0[A0] } =
     seqOpsIsSeqVal.asInstanceOf[IsSeq[CC0[A0]] { type A = A0; type C = CC0[A0] }]
 
+  /** Provides an `IsSeq` instance for any `SeqView` subtype.
+   *
+   *  @tparam CC0 the collection type constructor, a subtype of `SeqView`
+   *  @tparam A0 the element type of the collection
+   *  @return an `IsSeq` instance for `CC0[A0]`
+   */
   implicit def seqViewIsSeq[CC0[X] <: SeqView[X], A0]: IsSeq[CC0[A0]] { type A = A0; type C = View[A0] } =
     new IsSeq[CC0[A0]] {
       type A = A0
@@ -68,6 +81,8 @@ object IsSeq {
       def apply(coll: CC0[A0]): SeqOps[A0, View, View[A0]] = coll
     }
 
+  /** Provides an `IsSeq` instance for `String`, treating it as a sequence of characters.
+   */
   implicit val stringIsSeq: IsSeq[String] { type A = Char; type C = String } =
     new IsSeq[String] {
       type A = Char
@@ -86,6 +101,8 @@ object IsSeq {
         }
     }
 
+  /** Provides an `IsSeq` instance for `StringView`, treating it as a sequence of characters.
+   */
   implicit val stringViewIsSeq: IsSeq[StringView] { type A = Char; type C = View[Char] } =
     new IsSeq[StringView] {
       type A = Char
@@ -93,6 +110,12 @@ object IsSeq {
       def apply(coll: StringView): SeqOps[Char, View, View[Char]] = coll
     }
 
+  /** Provides an `IsSeq` instance for arrays of any element type that has an
+   *  available `ClassTag`.
+   *
+   *  @tparam A0 the element type of the array
+   *  @return an `IsSeq` instance for `Array[A0]`
+   */
   implicit def arrayIsSeq[A0 : ClassTag]: IsSeq[Array[A0]] { type A = A0; type C = Array[A0] } =
     new IsSeq[Array[A0]] {
       type A = A0
@@ -132,6 +155,11 @@ object IsSeq {
   // `Range` can not be unified with the `CC0` parameter of the
   // `seqOpsIsSeq` definition because it does not take a type parameter.
   // Hence the need for a separate case:
+  /** Provides an `IsSeq` instance for `Range` values.
+   *
+   *  @tparam C0 the specific `Range` type
+   *  @return an `IsSeq` instance for `C0`
+   */
   implicit def rangeIsSeq[C0 <: Range]: IsSeq[C0] { type A = Int; type C = immutable.IndexedSeq[Int] } =
     new IsSeq[C0] {
       type A = Int

--- a/library/src/scala/math/BigDecimal.scala
+++ b/library/src/scala/math/BigDecimal.scala
@@ -30,6 +30,7 @@ object BigDecimal {
   private final val deci2binary = 3.3219280948873626  // Ratio of log(10) to log(2)
   private val minCached = -512
   private val maxCached = 512
+  /** The default `MathContext` (34 decimal digits, `HALF_EVEN` rounding). */
   val defaultMathContext: MathContext = MathContext.DECIMAL128
 
   /** Cache only for defaultMathContext using BigDecimals in a small range. */
@@ -38,13 +39,23 @@ object BigDecimal {
   object RoundingMode extends Enumeration {
     // Annoying boilerplate to ensure consistency with java.math.RoundingMode
     type RoundingMode = Value
+    /** Rounding mode to round away from zero. */
     val UP          = Value(JRM.UP.ordinal)
+    /** Rounding mode to round towards zero. */
     val DOWN        = Value(JRM.DOWN.ordinal)
+    /** Rounding mode to round towards positive infinity. */
     val CEILING     = Value(JRM.CEILING.ordinal)
+    /** Rounding mode to round towards negative infinity. */
     val FLOOR       = Value(JRM.FLOOR.ordinal)
+    /** Rounding mode to round towards the nearest neighbor, or away from zero if equidistant. */
     val HALF_UP     = Value(JRM.HALF_UP.ordinal)
+    /** Rounding mode to round towards the nearest neighbor, or towards zero if equidistant. */
     val HALF_DOWN   = Value(JRM.HALF_DOWN.ordinal)
+    /** Rounding mode to round towards the nearest neighbor, or towards the even neighbor if equidistant. */
     val HALF_EVEN   = Value(JRM.HALF_EVEN.ordinal)
+    /** Rounding mode to assert that no rounding is necessary.
+     *  @note Operations that would require rounding throw an `ArithmeticException` under this mode.
+     */
     val UNNECESSARY = Value(JRM.UNNECESSARY.ordinal)
   }
 
@@ -106,6 +117,7 @@ object BigDecimal {
    *  @param bd the `java.math.BigDecimal` to convert
    *  @param mc the precision and rounding mode for the conversion
    *  @return a `BigDecimal` wrapping `bd` rounded per `mc`
+   *  @throws java.lang.NullPointerException if `bd` or `mc` is `null`
    */
   def decimal(bd: BigDec, mc: MathContext): BigDecimal = new BigDecimal(bd.round(mc), mc)
 
@@ -292,6 +304,7 @@ object BigDecimal {
    *
    *  @param x the character array containing the decimal representation
    *  @return a `BigDecimal` exactly equal to the value parsed from `x`
+   *  @throws java.lang.NullPointerException if `x` is `null`
    */
   def apply(x: Array[Char]): BigDecimal = exact(x)
 
@@ -310,6 +323,7 @@ object BigDecimal {
    *
    *  @param x the string representation of the decimal value
    *  @return a `BigDecimal` exactly equal to the value parsed from `x`
+   *  @throws java.lang.NullPointerException if `x` is `null`
    */
   def apply(x: String): BigDecimal = exact(x)
 
@@ -328,6 +342,7 @@ object BigDecimal {
    *
    *  @param x the specified `BigInt` value
    *  @return  the constructed `BigDecimal`
+   *  @throws java.lang.NullPointerException if `x` is `null`
    */
   def apply(x: BigInt): BigDecimal = exact(x)
 
@@ -366,6 +381,7 @@ object BigDecimal {
    *
    *  @param bd the `java.math.BigDecimal` to convert
    *  @return a `BigDecimal` wrapping `bd` with the default `MathContext`
+   *  @throws java.lang.IllegalArgumentException if `bd` is `null`
    */
   def apply(bd: BigDec): BigDecimal = new BigDecimal(bd, defaultMathContext)
 
@@ -454,6 +470,11 @@ object BigDecimal {
  */
 final class BigDecimal(val bigDecimal: BigDec, val mc: MathContext)
 extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[BigDecimal] {
+  /** Constructs a `BigDecimal` using the given `java.math.BigDecimal` and the default `MathContext`.
+   *
+   *  @param bigDecimal the `java.math.BigDecimal` to wrap
+   *  @throws java.lang.IllegalArgumentException if `bigDecimal` is `null`
+   */
   def this(bigDecimal: BigDec) = this(bigDecimal, BigDecimal.defaultMathContext)
   import BigDecimal.RoundingMode._
   import BigDecimal.{decimal, binary, exact}
@@ -517,10 +538,15 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
       }
     case _                    => isValidLong && unifiedPrimitiveEquals(that)
   }
+  /** Returns `true` if this `BigDecimal` can be converted to a `Byte` without truncation or overflow. */
   override def isValidByte  = noArithmeticException(toByteExact)
+  /** Returns `true` if this `BigDecimal` can be converted to a `Short` without truncation or overflow. */
   override def isValidShort = noArithmeticException(toShortExact)
+  /** Returns `true` if this `BigDecimal` can be converted to a `Char` without truncation or overflow. */
   override def isValidChar  = isValidInt && toIntExact >= Char.MinValue && toIntExact <= Char.MaxValue
+  /** Returns `true` if this `BigDecimal` can be converted to an `Int` without truncation or overflow. */
   override def isValidInt   = noArithmeticException(toIntExact)
+  /** Returns `true` if this `BigDecimal` can be converted to a `Long` without truncation or overflow. */
   def isValidLong  = noArithmeticException(toLongExact)
 
   /** Tests whether this `BigDecimal` holds the decimal representation of a `Double`. */
@@ -565,8 +591,10 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     catch { case _: ArithmeticException => false }
   }
 
+  /** Returns `true` if this `BigDecimal` represents a whole number (has no fractional part). */
   def isWhole = scale <= 0 || bigDecimal.stripTrailingZeros.scale <= 0
 
+  /** Returns the underlying `java.math.BigDecimal` representation. */
   def underlying: java.math.BigDecimal = bigDecimal
 
 
@@ -574,6 +602,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *
    *  @param that the `BigDecimal` to compare with
    *  @return `true` if this and `that` represent the same numeric value, `false` otherwise
+   *  @throws java.lang.NullPointerException if `that` is `null`
    */
   def equals (that: BigDecimal): Boolean = compare(that) == 0
 
@@ -581,30 +610,45 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *
    *  @param that the `BigDecimal` to compare with
    *  @return a negative number, zero, or a positive number if this is less than, equal to, or greater than `that`
+   *  @throws java.lang.NullPointerException if `that` is `null`
    */
   def compare (that: BigDecimal): Int = this.bigDecimal.compareTo(that.bigDecimal)
 
   /** Addition of BigDecimals
    *
    *  @param that the `BigDecimal` to add to this value
+   *  @throws java.lang.NullPointerException if `that` is `null`
+   *  @throws java.lang.ArithmeticException if this value's `MathContext` uses
+   *          `RoundingMode.UNNECESSARY` and the exact result needs rounding
    */
   def +  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.add(that.bigDecimal, mc), mc)
 
   /** Subtraction of BigDecimals
    *
    *  @param that the `BigDecimal` to subtract from this value
+   *  @throws java.lang.NullPointerException if `that` is `null`
+   *  @throws java.lang.ArithmeticException if this value's `MathContext` uses
+   *          `RoundingMode.UNNECESSARY` and the exact result needs rounding
    */
   def -  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.subtract(that.bigDecimal, mc), mc)
 
   /** Multiplication of BigDecimals
    *
    *  @param that the `BigDecimal` to multiply with this value
+   *  @throws java.lang.NullPointerException if `that` is `null`
+   *  @throws java.lang.ArithmeticException if this value's `MathContext` uses
+   *          `RoundingMode.UNNECESSARY` and the exact result needs rounding
    */
   def *  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.multiply(that.bigDecimal, mc), mc)
 
   /** Division of BigDecimals
    *
    *  @param that the `BigDecimal` to divide this value by
+   *  @throws java.lang.NullPointerException if `that` is `null`
+   *  @throws java.lang.ArithmeticException if `that` is zero; if this value's
+   *          `MathContext` uses `RoundingMode.UNNECESSARY` and the exact quotient
+   *          needs rounding; or if that `MathContext` has unlimited precision and
+   *          the exact quotient has a non-terminating decimal expansion
    */
   def /  (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.divide(that.bigDecimal, mc), mc)
 
@@ -612,6 +656,10 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *  divideToIntegralValue and the remainder.  The computation is exact: no rounding is applied.
    *
    *  @param that the `BigDecimal` divisor
+   *  @throws java.lang.NullPointerException if `that` is `null`
+   *  @throws java.lang.ArithmeticException if `that` is zero, or if the integer
+   *          part of the quotient needs more digits than this value's
+   *          `MathContext` permits
    */
   def /% (that: BigDecimal): (BigDecimal, BigDecimal) = {
     val qr = this.bigDecimal.divideAndRemainder(that.bigDecimal, mc)
@@ -622,6 +670,10 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *
    *  @param that the `BigDecimal` divisor
    *  @return the integer part of `this / that` as a `BigDecimal`
+   *  @throws java.lang.NullPointerException if `that` is `null`
+   *  @throws java.lang.ArithmeticException if `that` is zero, or if the integer
+   *          part of the quotient needs more digits than this value's
+   *          `MathContext` permits
    */
   def quot (that: BigDecimal): BigDecimal =
     new BigDecimal(this.bigDecimal.divideToIntegralValue(that.bigDecimal, mc), mc)
@@ -629,6 +681,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   /** Returns the minimum of this and that, or this if the two are equal
    *
    *  @param that the `BigDecimal` to compare with
+   *  @throws java.lang.NullPointerException if `that` is `null`
    */
   def min (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x <= 0 => this
@@ -638,6 +691,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
   /** Returns the maximum of this and that, or this if the two are equal
    *
    *  @param that the `BigDecimal` to compare with
+   *  @throws java.lang.NullPointerException if `that` is `null`
    */
   def max (that: BigDecimal): BigDecimal = (this compare that) match {
     case x if x >= 0 => this
@@ -648,18 +702,21 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *
    *  @param that the `BigDecimal` divisor
    *  @return the remainder of `this / that` as a `BigDecimal`
+   *  @throws java.lang.NullPointerException if `that` is `null`
    */
   def remainder (that: BigDecimal): BigDecimal = new BigDecimal(this.bigDecimal.remainder(that.bigDecimal, mc), mc)
 
   /** Remainder after dividing this by that.
    *
    *  @param that the `BigDecimal` divisor
+   *  @throws java.lang.NullPointerException if `that` is `null`
    */
   def % (that: BigDecimal): BigDecimal = this.remainder(that)
 
   /** Returns a BigDecimal whose value is this ** n.
    *
    *  @param n the exponent to raise this `BigDecimal` to
+   *  @throws java.lang.ArithmeticException if `n` is out of the supported range, or if the result is inexact and this BigDecimal's MathContext rounding mode is UNNECESSARY
    */
   def pow (n: Int): BigDecimal = new BigDecimal(this.bigDecimal.pow(n, mc), mc)
 
@@ -690,6 +747,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *  preserving its own MathContext for future operations.
    *
    *  @param mc the `MathContext` specifying the precision and rounding mode
+   *  @throws java.lang.NullPointerException if `mc` is `null`
    */
   def round(mc: MathContext): BigDecimal = {
     val r = this.bigDecimal.round(mc)
@@ -712,6 +770,7 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
    *
    *  @param mc the new `MathContext` for precision and rounding
    *  @return a `BigDecimal` rounded per `mc` and carrying `mc` as its `MathContext`
+   *  @throws java.lang.NullPointerException if `mc` is `null`
    */
   def apply(mc: MathContext): BigDecimal = new BigDecimal(this.bigDecimal.round(mc), mc)
 
@@ -724,6 +783,12 @@ extends ScalaNumber with ScalaNumericConversions with Serializable with Ordered[
     if (this.scale == scale) this
     else new BigDecimal(this.bigDecimal.setScale(scale), mc)
 
+  /** Returns a `BigDecimal` with the specified scale, using the given rounding mode.
+   *
+   *  @param scale the scale to set for this `BigDecimal`
+   *  @param mode the rounding mode to apply
+   *  @throws java.lang.ArithmeticException if `mode` is `UNNECESSARY` but rounding would be required for the requested `scale`
+   */
   def setScale(scale: Int, mode: RoundingMode): BigDecimal =
     if (this.scale == scale) this
     else new BigDecimal(this.bigDecimal.setScale(scale, JRM.valueOf(mode.id)), mc)

--- a/library/src/scala/math/BigInt.scala
+++ b/library/src/scala/math/BigInt.scala
@@ -263,6 +263,7 @@ final class BigInt private (
    */
   private def longEncoding: Boolean = _long != Long.MinValue
 
+  /** Returns the `java.math.BigInteger` representation of this `BigInt`. */
   def bigInteger: BigInteger = {
     val read = _bigInteger
     if (read ne null) read else {
@@ -287,9 +288,13 @@ final class BigInt private (
     case x                => isValidLong && unifiedPrimitiveEquals(x)
   }
 
+  /** Returns `true` if this `BigInt` can be represented as a `Byte`, `false` otherwise. */
   override def isValidByte: Boolean = _long >= Byte.MinValue && _long <= Byte.MaxValue /* && longEncoding */
+  /** Returns `true` if this `BigInt` can be represented as a `Short`, `false` otherwise. */
   override def isValidShort: Boolean = _long >= Short.MinValue && _long <= Short.MaxValue /* && longEncoding */
+  /** Returns `true` if this `BigInt` can be represented as a `Char`, `false` otherwise. */
   override def isValidChar: Boolean = _long >= Char.MinValue && _long <= Char.MaxValue /* && longEncoding */
+  /** Returns `true` if this `BigInt` can be represented as an `Int`, `false` otherwise. */
   override def isValidInt: Boolean = _long >= Int.MinValue && _long <= Int.MaxValue /* && longEncoding */
            def isValidLong: Boolean = longEncoding || _bigInteger == BigInt.longMinValueBigInteger // rhs of || tests == Long.MinValue
 
@@ -327,8 +332,10 @@ final class BigInt private (
     (shifted.signum != 0) && !(shifted.equals(BigInt.minusOne))
   }
 
+  /** Always returns `true` since a `BigInt` is always a whole number. */
   @deprecated("isWhole on an integer type is always true", "2.12.15")
   def isWhole: Boolean = true
+  /** Returns the underlying `java.math.BigInteger` representation of this `BigInt`. */
   def underlying: BigInteger = bigInteger
 
   /** Compares this BigInt with the specified BigInt for equality.

--- a/library/src/scala/math/Equiv.scala
+++ b/library/src/scala/math/Equiv.scala
@@ -43,15 +43,23 @@ trait Equiv[T] extends Any with Serializable {
   def equiv(x: T, y: T): Boolean
 }
 
+/** A trait containing low-priority implicit `Equiv` instances.
+ *
+ *  These instances are inherited into `Equiv`'s implicit scope but are
+ *  deprioritized via subclassing.
+ */
 trait LowPriorityEquiv {
   self: Equiv.type =>
 
   /** Use `Equiv.universal` explicitly instead. If you really want an implicit universal `Equiv` instance
+   *  despite the potential problems, consider `implicit def universalEquiv[T]: Equiv[T] = universal[T]`.
+   *
+   *  @tparam T the type of values to compare
+   *  @return an `Equiv[T]` that compares values using universal equality (`==`), as returned by `Equiv.universal`
+   *
    *  @deprecated This implicit universal `Equiv` instance allows accidentally
    *  comparing instances of types for which equality isn't well-defined or implemented.
    *  (For example, it does not make sense to compare two `Function1` instances.)
-   *
-   *  despite the potential problems, consider `implicit def universalEquiv[T]: Equiv[T] = universal[T]`.
    */
   @deprecated("Use explicit Equiv.universal instead. See Scaladoc entry for more information: " +
     "https://www.scala-lang.org/api/current/scala/math/Equiv$.html#universalEquiv[T]:scala.math.Equiv[T]",
@@ -60,17 +68,51 @@ trait LowPriorityEquiv {
 }
 
 object Equiv extends LowPriorityEquiv {
+  /** Returns an `Equiv` instance that uses reference equality (`eq`) for any reference type `T`.
+   *
+   *  @tparam T the reference type of values to compare, a subtype of `AnyRef`
+   *  @return an `Equiv[T]` that compares values using `eq`
+   */
   def reference[T <: AnyRef]: Equiv[T] = { _ eq _ }
+  /** Returns an `Equiv` instance that uses universal equality (`==`) for any type `T`.
+   *
+   *  @tparam T the type of values to compare
+   *  @return an `Equiv[T]` that compares values using `==`
+   */
   def universal[T]: Equiv[T] = { _ == _ }
+  /** Returns an `Equiv` instance from a `Comparator`.
+   *
+   *  @tparam T the type of values to compare
+   *  @param cmp the `Comparator` used to compare values
+   *  @return an `Equiv[T]` that uses `cmp.compare(x, y) == 0` to determine equivalence
+   */
   def fromComparator[T](cmp: Comparator[T]): Equiv[T] = {
     (x, y) => cmp.compare(x, y) == 0
   }
+  /** Creates an `Equiv` instance from a comparison function.
+   *
+   *  @tparam T the type of values to compare
+   *  @param cmp the function used to compare values
+   *  @return an `Equiv[T]` that uses `cmp(x, y)` to determine equivalence
+   */
   def fromFunction[T](cmp: (T, T) => Boolean): Equiv[T] = {
     (x, y) => cmp(x, y)
   }
+  /** Creates an `Equiv` instance that compares values of type `T` by first applying a function `f` to them.
+   *
+   *  @tparam T the type of values to compare
+   *  @tparam S the type of values returned by `f`, for which an `Equiv` instance is available
+   *  @param f the function applied to values before comparison
+   *  @return an `Equiv[T]` that compares values by applying `f` and then using the `Equiv[S]` instance
+   */
   def by[T, S: Equiv](f: T => S): Equiv[T] =
     ((x, y) => implicitly[Equiv[S]].equiv(f(x), f(y)))
 
+  /** Returns the implicit `Equiv` instance for type `T`.
+   *
+   *  @tparam T the type for which an `Equiv` instance is requested
+   *  @return the implicit `Equiv[T]` instance
+   */
   @inline def apply[T: Equiv]: Equiv[T] = implicitly[Equiv[T]]
 
   /* copied from Ordering */
@@ -79,6 +121,12 @@ object Equiv extends LowPriorityEquiv {
   private final val iterableSeed = 47
 
   private final class IterableEquiv[CC[X] <: Iterable[X], T](private val eqv: Equiv[T]) extends Equiv[CC[T]] {
+    /** Returns `true` if the two iterables `x` and `y` are equivalent.
+     *
+     *  @param x the first iterable to compare
+     *  @param y the second iterable to compare
+     *  @return `true` if `x` and `y` have the same length and all corresponding elements are equivalent in iteration order, `false` otherwise
+     */
     def equiv(x: CC[T], y: CC[T]): Boolean = {
       val xe = x.iterator
       val ye = y.iterator
@@ -90,14 +138,27 @@ object Equiv extends LowPriorityEquiv {
       xe.hasNext == ye.hasNext
     }
 
+    /** Returns `true` if this `IterableEquiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is an `IterableEquiv` whose underlying `Equiv` is equal to this one
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that  => true
       case that: IterableEquiv[?, ?]     => this.eqv == that.eqv
       case _                             => false
     }
+    /** Returns a hash code for this `IterableEquiv`.
+     *
+     *  The hash code is computed as the hash code of the underlying `Equiv` instance multiplied by a seed value.
+     */
     override def hashCode(): Int = eqv.## * iterableSeed
   }
 
+  /** A trait containing additional implicit `Equiv` instances for collections.
+   *
+   *  These instances are not in the default scope to avoid potential divergence issues.
+   */
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:
      *  For instance `implicitly[Equiv[Any]]` diverges in its presence.
@@ -124,30 +185,66 @@ object Equiv extends LowPriorityEquiv {
   object Implicits extends ExtraImplicits { }
 
   implicit object Unit extends Equiv[Unit] {
+    /** Returns `true` unconditionally, as all `Unit` values are equivalent.
+     *
+     *  @param x the first `Unit` value to compare
+     *  @param y the second `Unit` value to compare
+     *  @return `true`, always
+     */
     def equiv(x: Unit, y: Unit): Boolean = true
   }
 
   implicit object Boolean extends Equiv[Boolean] {
+    /** Returns `true` if the two `Boolean` values are equivalent.
+     *
+     *  @param x the first `Boolean` value to compare
+     *  @param y the second `Boolean` value to compare
+     */
     def equiv(x: Boolean, y: Boolean): Boolean = x == y
   }
 
   implicit object Byte extends Equiv[Byte] {
+    /** Returns `true` if the two `Byte` values are equivalent.
+     *
+     *  @param x the first `Byte` value to compare
+     *  @param y the second `Byte` value to compare
+     */
     def equiv(x: Byte, y: Byte): Boolean = x == y
   }
 
   implicit object Char extends Equiv[Char] {
+    /** Returns `true` if the two `Char` values are equivalent.
+     *
+     *  @param x the first `Char` value to compare
+     *  @param y the second `Char` value to compare
+     */
     def equiv(x: Char, y: Char): Boolean = x == y
   }
 
   implicit object Short extends Equiv[Short] {
+    /** Returns `true` if the two `Short` values are equivalent.
+     *
+     *  @param x the first `Short` value to compare
+     *  @param y the second `Short` value to compare
+     */
     def equiv(x: Short, y: Short): Boolean = x == y
   }
 
   implicit object Int extends Equiv[Int] {
+    /** Returns `true` if the two `Int` values are equivalent.
+     *
+     *  @param x the first `Int` value to compare
+     *  @param y the second `Int` value to compare
+     */
     def equiv(x: Int, y: Int): Boolean = x == y
   }
 
   implicit object Long extends Equiv[Long] {
+    /** Returns `true` if the two `Long` values are equivalent.
+     *
+     *  @param x the first `Long` value to compare
+     *  @param y the second `Long` value to compare
+     */
     def equiv(x: Long, y: Long): Boolean = x == y
   }
 
@@ -173,6 +270,14 @@ object Equiv extends LowPriorityEquiv {
      *  @see [[IeeeEquiv]]
      */
     trait StrictEquiv extends Equiv[Float] {
+      /** Returns `true` if the two `Float` values are equivalent.
+       *
+       *  This method uses `java.lang.Float.compare` to compare the values, which treats all `NaN` values as equivalent and distinguishes between `-0.0` and `0.0`.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return `true` if `x` and `y` are equivalent according to `java.lang.Float.compare`, `false` otherwise
+       */
       def equiv(x: Float, y: Float): Boolean = java.lang.Float.compare(x, y) == 0
     }
     implicit object StrictEquiv extends StrictEquiv
@@ -186,6 +291,14 @@ object Equiv extends LowPriorityEquiv {
      *  @see [[StrictEquiv]]
      */
     trait IeeeEquiv extends Equiv[Float] {
+      /** Returns `true` if the two `Float` values are equivalent.
+       *
+       *  This method uses `==` to compare the values, which is consistent with IEEE specifications but not reflexive for `NaN` values.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return `true` if `x` and `y` are equal according to `==`, `false` otherwise
+       */
       override def equiv(x: Float, y: Float): Boolean = x == y
     }
     implicit object IeeeEquiv extends IeeeEquiv
@@ -220,6 +333,14 @@ object Equiv extends LowPriorityEquiv {
      *  @see [[IeeeEquiv]]
      */
     trait StrictEquiv extends Equiv[Double] {
+      /** Returns `true` if the two `Double` values are equivalent.
+       *
+       *  This method uses `java.lang.Double.compare` to compare the values, which treats all `NaN` values as equivalent and distinguishes between `-0.0` and `0.0`.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return `true` if `x` and `y` are equivalent according to `java.lang.Double.compare`, `false` otherwise
+       */
       def equiv(x: Double, y: Double): Boolean = java.lang.Double.compare(x, y) == 0
     }
     implicit object StrictEquiv extends StrictEquiv
@@ -233,6 +354,14 @@ object Equiv extends LowPriorityEquiv {
      *  @see [[StrictEquiv]]
      */
     trait IeeeEquiv extends Equiv[Double] {
+      /** Returns `true` if the two `Double` values are equivalent.
+       *
+       *  This method uses `==` to compare the values, which is consistent with IEEE specifications but not reflexive for `NaN` values.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return `true` if `x` and `y` are equal according to `==`, `false` otherwise
+       */
       def equiv(x: Double, y: Double): Boolean = x == y
     }
     implicit object IeeeEquiv extends IeeeEquiv
@@ -245,48 +374,108 @@ object Equiv extends LowPriorityEquiv {
   implicit object DeprecatedDoubleEquiv extends Double.StrictEquiv
 
   implicit object BigInt extends Equiv[BigInt] {
+    /** Returns `true` if the two `BigInt` values are equivalent.
+     *
+     *  @param x the first `BigInt` value to compare
+     *  @param y the second `BigInt` value to compare
+     */
     def equiv(x: BigInt, y: BigInt): Boolean = x == y
   }
 
   implicit object BigDecimal extends Equiv[BigDecimal] {
+    /** Returns `true` if the two `BigDecimal` values are equivalent.
+     *
+     *  @param x the first `BigDecimal` value to compare
+     *  @param y the second `BigDecimal` value to compare
+     */
     def equiv(x: BigDecimal, y: BigDecimal): Boolean = x == y
   }
 
   implicit object String extends Equiv[String] {
+    /** Returns `true` if the two `String` values are equivalent.
+     *
+     *  @param x the first `String` value to compare
+     *  @param y the second `String` value to compare
+     */
     def equiv(x: String, y: String): Boolean = x == y
   }
 
   implicit object Symbol extends Equiv[Symbol] {
+    /** Returns `true` if the two `Symbol` values are equivalent.
+     *
+     *  @param x the first `Symbol` value to compare
+     *  @param y the second `Symbol` value to compare
+     */
     def equiv(x: Symbol, y: Symbol): Boolean = x == y
   }
 
+  /** Returns an `Equiv` instance for `Option[T]` that uses the given `Equiv[T]` instance to compare the elements.
+   *
+   *  @tparam T the type of the elements in the `Option`
+   *  @param eqv the `Equiv` instance used to compare the elements
+   *  @return an `Equiv[Option[T]]` that compares `Option` values using `eqv`
+   */
   implicit def Option[T](implicit eqv: Equiv[T]): Equiv[Option[T]] =
     new OptionEquiv[T](eqv)
 
   private final class OptionEquiv[T](private val eqv: Equiv[T]) extends Equiv[Option[T]] {
+    /** Returns `true` if the two `Option` values are equivalent.
+     *
+     *  @param x the first `Option` value to compare
+     *  @param y the second `Option` value to compare
+     *  @return `true` if both are `None` or both are `Some` with equivalent elements
+     */
     def equiv(x: Option[T], y: Option[T]): Boolean = (x, y) match {
       case (None, None)       => true
       case (Some(x), Some(y)) => eqv.equiv(x, y)
       case _                  => false
     }
 
+    /** Returns `true` if this `OptionEquiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is an `OptionEquiv` whose underlying `Equiv` is equal to this one
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: OptionEquiv[?]         => this.eqv == that.eqv
       case _                            => false
     }
+    /** Returns a hash code for this `OptionEquiv`.
+     *
+     *  The hash code is computed as the hash code of the underlying `Equiv` instance multiplied by a seed value.
+     */
     override def hashCode(): Int = eqv.## * optionSeed
   }
 
+  /** Returns an `Equiv` instance for `Tuple2[T1, T2]` that uses the given `Equiv[T1]` and `Equiv[T2]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @return an `Equiv[(T1, T2)]` that compares tuples using `eqv1` and `eqv2`
+   */
   implicit def Tuple2[T1, T2](implicit eqv1: Equiv[T1], eqv2: Equiv[T2]): Equiv[(T1, T2)] =
     new Tuple2Equiv(eqv1, eqv2)
 
   private final class Tuple2Equiv[T1, T2](private val eqv1: Equiv[T1],
                                                 private val eqv2: Equiv[T2]) extends Equiv[(T1, T2)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if both elements are equivalent
+     */
     def equiv(x: (T1, T2), y: (T1, T2)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2)
 
+    /** Returns `true` if this `Tuple2Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple2Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple2Equiv[?, ?] =>
@@ -294,20 +483,45 @@ object Equiv extends LowPriorityEquiv {
         this.eqv2 == that.eqv2
       case _ => false
     }
+    /** Returns a hash code for this `Tuple2Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2).hashCode()
   }
 
+  /** Returns an `Equiv` instance for `Tuple3[T1, T2, T3]` that uses the given `Equiv[T1]`, `Equiv[T2]`, and `Equiv[T3]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @param eqv3 the `Equiv` instance used to compare the third elements
+   *  @return an `Equiv[(T1, T2, T3)]` that compares tuples using `eqv1`, `eqv2`, and `eqv3`
+   */
   implicit def Tuple3[T1, T2, T3](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3]) : Equiv[(T1, T2, T3)] =
     new Tuple3Equiv(eqv1, eqv2, eqv3)
 
   private final class Tuple3Equiv[T1, T2, T3](private val eqv1: Equiv[T1],
                                                     private val eqv2: Equiv[T2],
                                                     private val eqv3: Equiv[T3]) extends Equiv[(T1, T2, T3)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if all three elements are equivalent
+     */
     def equiv(x: (T1, T2, T3), y: (T1, T2, T3)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
       eqv3.equiv(x._3, y._3)
 
+    /** Returns `true` if this `Tuple3Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple3Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple3Equiv[?, ?, ?] =>
@@ -316,9 +530,25 @@ object Equiv extends LowPriorityEquiv {
         this.eqv3 == that.eqv3
       case _ => false
     }
+    /** Returns a hash code for this `Tuple3Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2, eqv3).hashCode()
   }
 
+  /** Returns an `Equiv` instance for `Tuple4[T1, T2, T3, T4]` that uses the given `Equiv[T1]`, `Equiv[T2]`, `Equiv[T3]`, and `Equiv[T4]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @param eqv3 the `Equiv` instance used to compare the third elements
+   *  @param eqv4 the `Equiv` instance used to compare the fourth elements
+   *  @return an `Equiv[(T1, T2, T3, T4)]` that compares tuples using `eqv1`, `eqv2`, `eqv3`, and `eqv4`
+   */
   implicit def Tuple4[T1, T2, T3, T4](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4]) : Equiv[(T1, T2, T3, T4)] =
     new Tuple4Equiv(eqv1, eqv2, eqv3, eqv4)
 
@@ -327,12 +557,23 @@ object Equiv extends LowPriorityEquiv {
                                                         private val eqv3: Equiv[T3],
                                                         private val eqv4: Equiv[T4])
     extends Equiv[(T1, T2, T3, T4)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if all four elements are equivalent
+     */
     def equiv(x: (T1, T2, T3, T4), y: (T1, T2, T3, T4)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
       eqv3.equiv(x._3, y._3) &&
       eqv4.equiv(x._4, y._4)
 
+    /** Returns `true` if this `Tuple4Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple4Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple4Equiv[?, ?, ?, ?] =>
@@ -342,9 +583,27 @@ object Equiv extends LowPriorityEquiv {
         this.eqv4 == that.eqv4
       case _ => false
     }
+    /** Returns a hash code for this `Tuple4Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4).hashCode()
   }
 
+  /** Returns an `Equiv` instance for `Tuple5[T1, T2, T3, T4, T5]` that uses the given `Equiv[T1]`, `Equiv[T2]`, `Equiv[T3]`, `Equiv[T4]`, and `Equiv[T5]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @param eqv3 the `Equiv` instance used to compare the third elements
+   *  @param eqv4 the `Equiv` instance used to compare the fourth elements
+   *  @param eqv5 the `Equiv` instance used to compare the fifth elements
+   *  @return an `Equiv[(T1, T2, T3, T4, T5)]` that compares tuples using `eqv1`, `eqv2`, `eqv3`, `eqv4`, and `eqv5`
+   */
   implicit def Tuple5[T1, T2, T3, T4, T5](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5]): Equiv[(T1, T2, T3, T4, T5)] =
     new Tuple5Equiv(eqv1, eqv2, eqv3, eqv4, eqv5)
 
@@ -354,6 +613,12 @@ object Equiv extends LowPriorityEquiv {
                                                             private val eqv4: Equiv[T4],
                                                             private val eqv5: Equiv[T5])
     extends Equiv[(T1, T2, T3, T4, T5)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if all five elements are equivalent
+     */
     def equiv(x: (T1, T2, T3, T4, T5), y: (T1, T2, T3, T4, T5)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
@@ -361,6 +626,11 @@ object Equiv extends LowPriorityEquiv {
       eqv4.equiv(x._4, y._4) &&
       eqv5.equiv(x._5, y._5)
 
+    /** Returns `true` if this `Tuple5Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple5Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple5Equiv[?, ?, ?, ?, ?] =>
@@ -371,9 +641,29 @@ object Equiv extends LowPriorityEquiv {
         this.eqv5 == that.eqv5
       case _ => false
     }
+    /** Returns a hash code for this `Tuple5Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5).hashCode()
   }
 
+  /** Returns an `Equiv` instance for `Tuple6[T1, T2, T3, T4, T5, T6]` that uses the given `Equiv[T1]`, `Equiv[T2]`, `Equiv[T3]`, `Equiv[T4]`, `Equiv[T5]`, and `Equiv[T6]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @param eqv3 the `Equiv` instance used to compare the third elements
+   *  @param eqv4 the `Equiv` instance used to compare the fourth elements
+   *  @param eqv5 the `Equiv` instance used to compare the fifth elements
+   *  @param eqv6 the `Equiv` instance used to compare the sixth elements
+   *  @return an `Equiv[(T1, T2, T3, T4, T5, T6)]` that compares tuples using `eqv1`, `eqv2`, `eqv3`, `eqv4`, `eqv5`, and `eqv6`
+   */
   implicit def Tuple6[T1, T2, T3, T4, T5, T6](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6]): Equiv[(T1, T2, T3, T4, T5, T6)] =
     new Tuple6Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6)
 
@@ -384,6 +674,12 @@ object Equiv extends LowPriorityEquiv {
                                                                 private val eqv5: Equiv[T5],
                                                                 private val eqv6: Equiv[T6])
     extends Equiv[(T1, T2, T3, T4, T5, T6)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if all six elements are equivalent
+     */
     def equiv(x: (T1, T2, T3, T4, T5, T6), y: (T1, T2, T3, T4, T5, T6)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
@@ -392,6 +688,11 @@ object Equiv extends LowPriorityEquiv {
       eqv5.equiv(x._5, y._5) &&
       eqv6.equiv(x._6, y._6)
 
+    /** Returns `true` if this `Tuple6Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple6Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple6Equiv[?, ?, ?, ?, ?, ?] =>
@@ -403,9 +704,31 @@ object Equiv extends LowPriorityEquiv {
         this.eqv6 == that.eqv6
       case _ => false
     }
+    /** Returns a hash code for this `Tuple6Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5, eqv6).hashCode()
   }
 
+  /** Returns an `Equiv` instance for `Tuple7[T1, T2, T3, T4, T5, T6, T7]` that uses the given `Equiv[T1]`, `Equiv[T2]`, `Equiv[T3]`, `Equiv[T4]`, `Equiv[T5]`, `Equiv[T6]`, and `Equiv[T7]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @tparam T7 the type of the seventh element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @param eqv3 the `Equiv` instance used to compare the third elements
+   *  @param eqv4 the `Equiv` instance used to compare the fourth elements
+   *  @param eqv5 the `Equiv` instance used to compare the fifth elements
+   *  @param eqv6 the `Equiv` instance used to compare the sixth elements
+   *  @param eqv7 the `Equiv` instance used to compare the seventh elements
+   *  @return an `Equiv[(T1, T2, T3, T4, T5, T6, T7)]` that compares tuples using `eqv1`, `eqv2`, `eqv3`, `eqv4`, `eqv5`, `eqv6`, and `eqv7`
+   */
   implicit def Tuple7[T1, T2, T3, T4, T5, T6, T7](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6], eqv7: Equiv[T7]): Equiv[(T1, T2, T3, T4, T5, T6, T7)] =
     new Tuple7Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7)
 
@@ -417,6 +740,12 @@ object Equiv extends LowPriorityEquiv {
                                                                     private val eqv6: Equiv[T6],
                                                                     private val eqv7: Equiv[T7])
     extends Equiv[(T1, T2, T3, T4, T5, T6, T7)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if all seven elements are equivalent
+     */
     def equiv(x: (T1, T2, T3, T4, T5, T6, T7), y: (T1, T2, T3, T4, T5, T6, T7)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
@@ -426,6 +755,11 @@ object Equiv extends LowPriorityEquiv {
       eqv6.equiv(x._6, y._6) &&
       eqv7.equiv(x._7, y._7)
 
+    /** Returns `true` if this `Tuple7Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple7Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple7Equiv[?, ?, ?, ?, ?, ?, ?] =>
@@ -438,9 +772,33 @@ object Equiv extends LowPriorityEquiv {
         this.eqv7 == that.eqv7
       case _ => false
     }
+    /** Returns a hash code for this `Tuple7Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7).hashCode()
   }
 
+  /** Returns an `Equiv` instance for `Tuple8[T1, T2, T3, T4, T5, T6, T7, T8]` that uses the given `Equiv[T1]`, `Equiv[T2]`, `Equiv[T3]`, `Equiv[T4]`, `Equiv[T5]`, `Equiv[T6]`, `Equiv[T7]`, and `Equiv[T8]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @tparam T7 the type of the seventh element in the tuple
+   *  @tparam T8 the type of the eighth element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @param eqv3 the `Equiv` instance used to compare the third elements
+   *  @param eqv4 the `Equiv` instance used to compare the fourth elements
+   *  @param eqv5 the `Equiv` instance used to compare the fifth elements
+   *  @param eqv6 the `Equiv` instance used to compare the sixth elements
+   *  @param eqv7 the `Equiv` instance used to compare the seventh elements
+   *  @param eqv8 the `Equiv` instance used to compare the eighth elements
+   *  @return an `Equiv[(T1, T2, T3, T4, T5, T6, T7, T8)]` that compares tuples using `eqv1`, `eqv2`, `eqv3`, `eqv4`, `eqv5`, `eqv6`, `eqv7`, and `eqv8`
+   */
   implicit def Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6], eqv7: Equiv[T7], eqv8: Equiv[T8]): Equiv[(T1, T2, T3, T4, T5, T6, T7, T8)] =
     new Tuple8Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7, eqv8)
 
@@ -453,6 +811,12 @@ object Equiv extends LowPriorityEquiv {
                                                                         private val eqv7: Equiv[T7],
                                                                         private val eqv8: Equiv[T8])
     extends Equiv[(T1, T2, T3, T4, T5, T6, T7, T8)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if all eight elements are equivalent
+     */
     def equiv(x: (T1, T2, T3, T4, T5, T6, T7, T8), y: (T1, T2, T3, T4, T5, T6, T7, T8)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
@@ -463,6 +827,11 @@ object Equiv extends LowPriorityEquiv {
       eqv7.equiv(x._7, y._7) &&
       eqv8.equiv(x._8, y._8)
 
+    /** Returns `true` if this `Tuple8Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple8Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple8Equiv[?, ?, ?, ?, ?, ?, ?, ?] =>
@@ -476,9 +845,35 @@ object Equiv extends LowPriorityEquiv {
         this.eqv8 == that.eqv8
       case _ => false
     }
+    /** Returns a hash code for this `Tuple8Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7, eqv8).hashCode()
   }
 
+  /** Returns an `Equiv` instance for `Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]` that uses the given `Equiv[T1]`, `Equiv[T2]`, `Equiv[T3]`, `Equiv[T4]`, `Equiv[T5]`, `Equiv[T6]`, `Equiv[T7]`, `Equiv[T8]`, and `Equiv[T9]` instances to compare the elements.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @tparam T7 the type of the seventh element in the tuple
+   *  @tparam T8 the type of the eighth element in the tuple
+   *  @tparam T9 the type of the ninth element in the tuple
+   *  @param eqv1 the `Equiv` instance used to compare the first elements
+   *  @param eqv2 the `Equiv` instance used to compare the second elements
+   *  @param eqv3 the `Equiv` instance used to compare the third elements
+   *  @param eqv4 the `Equiv` instance used to compare the fourth elements
+   *  @param eqv5 the `Equiv` instance used to compare the fifth elements
+   *  @param eqv6 the `Equiv` instance used to compare the sixth elements
+   *  @param eqv7 the `Equiv` instance used to compare the seventh elements
+   *  @param eqv8 the `Equiv` instance used to compare the eighth elements
+   *  @param eqv9 the `Equiv` instance used to compare the ninth elements
+   *  @return an `Equiv[(T1, T2, T3, T4, T5, T6, T7, T8, T9)]` that compares tuples using `eqv1`, `eqv2`, `eqv3`, `eqv4`, `eqv5`, `eqv6`, `eqv7`, `eqv8`, and `eqv9`
+   */
   implicit def Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit eqv1: Equiv[T1], eqv2: Equiv[T2], eqv3: Equiv[T3], eqv4: Equiv[T4], eqv5: Equiv[T5], eqv6: Equiv[T6], eqv7: Equiv[T7], eqv8 : Equiv[T8], eqv9: Equiv[T9]): Equiv[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
     new Tuple9Equiv(eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7, eqv8, eqv9)
 
@@ -492,6 +887,12 @@ object Equiv extends LowPriorityEquiv {
                                                                             private val eqv8: Equiv[T8],
                                                                             private val eqv9: Equiv[T9])
     extends Equiv[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {
+    /** Returns `true` if the two tuples are equivalent.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return `true` if all nine elements are equivalent
+     */
     def equiv(x: (T1, T2, T3, T4, T5, T6, T7, T8, T9), y: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Boolean =
       eqv1.equiv(x._1, y._1) &&
       eqv2.equiv(x._2, y._2) &&
@@ -503,6 +904,11 @@ object Equiv extends LowPriorityEquiv {
       eqv8.equiv(x._8, y._8) &&
       eqv9.equiv(x._9, y._9)
 
+    /** Returns `true` if this `Tuple9Equiv` is equal to `obj`.
+     *
+     *  @param obj the object to compare with
+     *  @return `true` if `obj` is a `Tuple9Equiv` whose underlying `Equiv`s are equal to this one's
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple9Equiv[?, ?, ?, ?, ?, ?, ?, ?, ?] =>
@@ -517,6 +923,10 @@ object Equiv extends LowPriorityEquiv {
         this.eqv9 == that.eqv9
       case _ => false
     }
+    /** Returns a hash code for this `Tuple9Equiv`.
+     *
+     *  The hash code is computed as the hash code of the tuple of the underlying `Equiv` instances.
+     */
     override def hashCode(): Int = (eqv1, eqv2, eqv3, eqv4, eqv5, eqv6, eqv7, eqv8, eqv9).hashCode()
   }
 

--- a/library/src/scala/math/Fractional.scala
+++ b/library/src/scala/math/Fractional.scala
@@ -16,20 +16,54 @@ package math
 import scala.language.`2.13`
 import scala.language.implicitConversions
 
+/** A typeclass for fractional numeric types.
+ *
+ *  @tparam T the type of the fractional numbers
+ */
 trait Fractional[T] extends Numeric[T] {
+  /** Returns the result of dividing `x` by `y`.
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   *  @return the quotient of `x` divided by `y`
+   */
   def div(x: T, y: T): T
 
+  /** Provides fractional operations for a given value.
+   *
+   *  @param lhs the value to perform operations on
+   */
   class FractionalOps(lhs: T) extends NumericOps(lhs) {
+    /** Returns the result of dividing `lhs` by `rhs`.
+     *
+     *  @param rhs the divisor
+     */
     def /(rhs: T) = div(lhs, rhs)
   }
+  /** Returns a `FractionalOps` instance that provides fractional operations for `lhs`.
+   *
+   *  @param lhs the value to perform operations on
+   */
   override implicit def mkNumericOps(lhs: T): FractionalOps =
     new FractionalOps(lhs)
 }
 
 object Fractional {
+  /** Returns the implicit `Fractional` instance for type `T`.
+   *
+   *  @tparam T the type of the fractional numbers
+   *  @param frac the implicit `Fractional` instance for `T`
+   */
   @inline def apply[T](implicit frac: Fractional[T]): Fractional[T] = frac
 
+  /** Provides additional implicit conversions for fractional types. */
   trait ExtraImplicits {
+    /** Returns a `FractionalOps` instance that provides fractional operations for `x`.
+     *
+     *  @tparam T the type of the fractional numbers
+     *  @param x the value to perform operations on
+     *  @param num the implicit `Fractional` instance for `T`
+     */
     implicit def infixFractionalOps[T](x: T)(implicit num: Fractional[T]): Fractional[T]#FractionalOps = new num.FractionalOps(x)
   }
   object Implicits extends ExtraImplicits

--- a/library/src/scala/math/Integral.scala
+++ b/library/src/scala/math/Integral.scala
@@ -16,21 +16,61 @@ package math
 import scala.language.`2.13`
 import scala.language.implicitConversions
 
+/** A typeclass representing integral numeric types.
+ *
+ *  @tparam T the type of the integral values
+ */
 trait Integral[T] extends Numeric[T] {
+  /** Returns the quotient of `x` divided by `y`.
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def quot(x: T, y: T): T
+  /** Returns the remainder of `x` divided by `y`.
+   *
+   *  @param x the dividend
+   *  @param y the divisor
+   */
   def rem(x: T, y: T): T
 
+  /** Provides integral operations on a value of type `T`.
+   *
+   *  @param lhs the value to operate on
+   */
   class IntegralOps(lhs: T) extends NumericOps(lhs) {
+    /** Returns the quotient of this value divided by `rhs`.
+     *
+     *  @param rhs the divisor
+     */
     def /(rhs: T) = quot(lhs, rhs)
+    /** Returns the remainder of this value divided by `rhs`.
+     *
+     *  @param rhs the divisor
+     */
     def %(rhs: T) = rem(lhs, rhs)
+    /** Returns the quotient and remainder of this value divided by `rhs`, as a `(quotient, remainder)` tuple.
+     *
+     *  @param rhs the divisor
+     */
     def /%(rhs: T) = (quot(lhs, rhs), rem(lhs, rhs))
   }
+  /** Returns an `IntegralOps` instance providing integral operators on `lhs`.
+   *
+   *  @param lhs the value to wrap with integral operations
+   */
   override implicit def mkNumericOps(lhs: T): IntegralOps = new IntegralOps(lhs)
 }
 
 object Integral {
+  /** Returns the implicit `Integral` instance for type `T`.
+   *
+   *  @tparam T the type for which an `Integral` instance is requested
+   *  @param int the implicit `Integral` instance for type `T`
+   */
   @inline def apply[T](implicit int: Integral[T]): Integral[T] = int
 
+  /** Provides additional implicit conversions for integral types. */
   trait ExtraImplicits {
     /** The regrettable design of Numeric/Integral/Fractional has them all
      *  bumping into one another when searching for this implicit, so they
@@ -39,7 +79,7 @@ object Integral {
      *  @tparam T the numeric type for which an `Integral` instance exists
      *  @param x the value to wrap with integral operator syntax (`/`, `%`, `/%`)
      *  @param num the implicit `Integral` instance for type `T`
-     *  @return an `IntegralOps` instance providing integral operators on `x`
+     *  @return an `Integral[T]#IntegralOps` instance providing integral operators on `x`
      */
     implicit def infixIntegralOps[T](x: T)(implicit num: Integral[T]): Integral[T]#IntegralOps = new num.IntegralOps(x)
   }

--- a/library/src/scala/math/Numeric.scala
+++ b/library/src/scala/math/Numeric.scala
@@ -19,8 +19,15 @@ import scala.language.implicitConversions
 import scala.util.Try
 
 object Numeric {
+  /** Returns the implicit `Numeric` instance for type `T`.
+   *
+   *  @tparam T the numeric type for which an implicit `Numeric` instance is requested
+   *  @param num the implicit `Numeric` instance for type `T`
+   *  @return the `Numeric` instance for type `T`
+   */
   @inline def apply[T](implicit num: Numeric[T]): Numeric[T] = num
 
+  /** Provides additional implicit conversions for numeric types. */
   trait ExtraImplicits {
     /** These implicits create conversions from a value for which an implicit Numeric
      *  exists to the inner class which creates infix operations.  Once imported, you
@@ -40,171 +47,836 @@ object Numeric {
   }
   object Implicits extends ExtraImplicits { }
 
+  /** Provides arithmetic operations for `BigInt` values. */
   trait BigIntIsIntegral extends Integral[BigInt] {
+    /** Returns the sum of two `BigInt` values.
+     *
+     *  @param x the first `BigInt` value
+     *  @param y the second `BigInt` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: BigInt, y: BigInt): BigInt = x + y
+    /** Returns the difference between two `BigInt` values.
+     *
+     *  @param x the first `BigInt` value
+     *  @param y the second `BigInt` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: BigInt, y: BigInt): BigInt = x - y
+    /** Returns the product of two `BigInt` values.
+     *
+     *  @param x the first `BigInt` value
+     *  @param y the second `BigInt` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: BigInt, y: BigInt): BigInt = x * y
+    /** Returns the quotient of two `BigInt` values.
+     *
+     *  @param x the first `BigInt` value
+     *  @param y the second `BigInt` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def quot(x: BigInt, y: BigInt): BigInt = x / y
+    /** Returns the remainder of two `BigInt` values.
+     *
+     *  @param x the first `BigInt` value
+     *  @param y the second `BigInt` value
+     *  @return the remainder of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def rem(x: BigInt, y: BigInt): BigInt = x % y
+    /** Returns the negation of a `BigInt` value.
+     *
+     *  @param x the `BigInt` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: BigInt): BigInt = -x
+    /** Converts an `Int` to a `BigInt`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `BigInt` representation of `x`
+     */
     def fromInt(x: Int): BigInt = BigInt(x)
+    /** Parses a `String` into a `BigInt`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(BigInt)` if the string is a valid `BigInt`, `None` otherwise
+     */
     def parseString(str: String): Option[BigInt] = Try(BigInt(str)).toOption
+    /** Converts a `BigInt` to an `Int`.
+     *
+     *  @param x the `BigInt` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: BigInt): Int = x.intValue
+    /** Converts a `BigInt` to a `Long`.
+     *
+     *  @param x the `BigInt` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: BigInt): Long = x.longValue
+    /** Converts a `BigInt` to a `Float`.
+     *
+     *  @param x the `BigInt` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: BigInt): Float = x.floatValue
+    /** Converts a `BigInt` to a `Double`.
+     *
+     *  @param x the `BigInt` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: BigInt): Double = x.doubleValue
   }
   implicit object BigIntIsIntegral extends BigIntIsIntegral with Ordering.BigIntOrdering
 
+  /** Provides arithmetic operations for `Int` values. */
   trait IntIsIntegral extends Integral[Int] {
+    /** Returns the sum of two `Int` values.
+     *
+     *  @param x the first `Int` value
+     *  @param y the second `Int` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: Int, y: Int): Int = x + y
+    /** Returns the difference between two `Int` values.
+     *
+     *  @param x the first `Int` value
+     *  @param y the second `Int` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: Int, y: Int): Int = x - y
+    /** Returns the product of two `Int` values.
+     *
+     *  @param x the first `Int` value
+     *  @param y the second `Int` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: Int, y: Int): Int = x * y
+    /** Returns the quotient of two `Int` values.
+     *
+     *  @param x the first `Int` value
+     *  @param y the second `Int` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def quot(x: Int, y: Int): Int = x / y
+    /** Returns the remainder of two `Int` values.
+     *
+     *  @param x the first `Int` value
+     *  @param y the second `Int` value
+     *  @return the remainder of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def rem(x: Int, y: Int): Int = x % y
+    /** Returns the negation of an `Int` value.
+     *
+     *  @param x the `Int` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: Int): Int = -x
+    /** Returns the given `Int` value, as no conversion is needed.
+     *
+     *  @param x the `Int` value (returned unchanged)
+     *  @return the given `Int` value unchanged
+     */
     def fromInt(x: Int): Int = x
+    /** Parses a `String` into an `Int`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(Int)` if the string is a valid `Int`, `None` otherwise
+     */
     def parseString(str: String): Option[Int] = StringParsers.parseInt(str)
+    /** Returns the given `Int` value, as no conversion is needed.
+     *
+     *  @param x the `Int` value (returned unchanged)
+     *  @return the given `Int` value unchanged
+     */
     def toInt(x: Int): Int = x
+    /** Converts an `Int` to a `Long`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: Int): Long = x.toLong
+    /** Converts an `Int` to a `Float`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: Int): Float = x.toFloat
+    /** Converts an `Int` to a `Double`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: Int): Double = x.toDouble
+    /** Returns the signum of an `Int` value.
+     *
+     *  @param x the `Int` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def signum(x: Int): Int = math.signum(x)
+    /** Returns the sign of an `Int` value.
+     *
+     *  @param x the `Int` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def sign(x: Int): Int = math.signum(x)
   }
   implicit object IntIsIntegral extends IntIsIntegral with Ordering.IntOrdering
 
+  /** Provides arithmetic operations for `Short` values. */
   trait ShortIsIntegral extends Integral[Short] {
+    /** Returns the sum of two `Short` values.
+     *
+     *  @param x the first `Short` value
+     *  @param y the second `Short` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: Short, y: Short): Short = (x + y).toShort
+    /** Returns the difference between two `Short` values.
+     *
+     *  @param x the first `Short` value
+     *  @param y the second `Short` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: Short, y: Short): Short = (x - y).toShort
+    /** Returns the product of two `Short` values.
+     *
+     *  @param x the first `Short` value
+     *  @param y the second `Short` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: Short, y: Short): Short = (x * y).toShort
+    /** Returns the quotient of two `Short` values.
+     *
+     *  @param x the first `Short` value
+     *  @param y the second `Short` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def quot(x: Short, y: Short): Short = (x / y).toShort
+    /** Returns the remainder of two `Short` values.
+     *
+     *  @param x the first `Short` value
+     *  @param y the second `Short` value
+     *  @return the remainder of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def rem(x: Short, y: Short): Short = (x % y).toShort
+    /** Returns the negation of a `Short` value.
+     *
+     *  @param x the `Short` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: Short): Short = (-x).toShort
+    /** Converts an `Int` to a `Short`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Short` representation of `x`
+     */
     def fromInt(x: Int): Short = x.toShort
+    /** Parses a `String` into a `Short`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(Short)` if the string is a valid `Short`, `None` otherwise
+     */
     def parseString(str: String): Option[Short] = StringParsers.parseShort(str)
+    /** Converts a `Short` to an `Int`.
+     *
+     *  @param x the `Short` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: Short): Int = x.toInt
+    /** Converts a `Short` to a `Long`.
+     *
+     *  @param x the `Short` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: Short): Long = x.toLong
+    /** Converts a `Short` to a `Float`.
+     *
+     *  @param x the `Short` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: Short): Float = x.toFloat
+    /** Converts a `Short` to a `Double`.
+     *
+     *  @param x the `Short` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: Short): Double = x.toDouble
+    /** Returns the signum of a `Short` value.
+     *
+     *  @param x the `Short` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def signum(x: Short): Int = math.signum(x.toInt)
+    /** Returns the sign of a `Short` value.
+     *
+     *  @param x the `Short` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def sign(x: Short): Short = math.signum(x.toInt).toShort
   }
   implicit object ShortIsIntegral extends ShortIsIntegral with Ordering.ShortOrdering
 
+  /** Provides arithmetic operations for `Byte` values. */
   trait ByteIsIntegral extends Integral[Byte] {
+    /** Returns the sum of two `Byte` values.
+     *
+     *  @param x the first `Byte` value
+     *  @param y the second `Byte` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: Byte, y: Byte): Byte = (x + y).toByte
+    /** Returns the difference between two `Byte` values.
+     *
+     *  @param x the first `Byte` value
+     *  @param y the second `Byte` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: Byte, y: Byte): Byte = (x - y).toByte
+    /** Returns the product of two `Byte` values.
+     *
+     *  @param x the first `Byte` value
+     *  @param y the second `Byte` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: Byte, y: Byte): Byte = (x * y).toByte
+    /** Returns the quotient of two `Byte` values.
+     *
+     *  @param x the first `Byte` value
+     *  @param y the second `Byte` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def quot(x: Byte, y: Byte): Byte = (x / y).toByte
+    /** Returns the remainder of two `Byte` values.
+     *
+     *  @param x the first `Byte` value
+     *  @param y the second `Byte` value
+     *  @return the remainder of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def rem(x: Byte, y: Byte): Byte = (x % y).toByte
+    /** Returns the negation of a `Byte` value.
+     *
+     *  @param x the `Byte` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: Byte): Byte = (-x).toByte
+    /** Converts an `Int` to a `Byte`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Byte` representation of `x`
+     */
     def fromInt(x: Int): Byte = x.toByte
+    /** Parses a `String` into a `Byte`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(Byte)` if the string is a valid `Byte`, `None` otherwise
+     */
     def parseString(str: String): Option[Byte] = StringParsers.parseByte(str)
+    /** Converts a `Byte` to an `Int`.
+     *
+     *  @param x the `Byte` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: Byte): Int = x.toInt
+    /** Converts a `Byte` to a `Long`.
+     *
+     *  @param x the `Byte` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: Byte): Long = x.toLong
+    /** Converts a `Byte` to a `Float`.
+     *
+     *  @param x the `Byte` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: Byte): Float = x.toFloat
+    /** Converts a `Byte` to a `Double`.
+     *
+     *  @param x the `Byte` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: Byte): Double = x.toDouble
+    /** Returns the signum of a `Byte` value.
+     *
+     *  @param x the `Byte` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def signum(x: Byte): Int = math.signum(x.toInt)
+    /** Returns the sign of a `Byte` value.
+     *
+     *  @param x the `Byte` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def sign(x: Byte): Byte = math.signum(x.toInt).toByte
   }
   implicit object ByteIsIntegral extends ByteIsIntegral with Ordering.ByteOrdering
 
+  /** Provides arithmetic operations for `Char` values. */
   trait CharIsIntegral extends Integral[Char] {
+    /** Returns the sum of two `Char` values.
+     *
+     *  @param x the first `Char` value
+     *  @param y the second `Char` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: Char, y: Char): Char = (x + y).toChar
+    /** Returns the difference between two `Char` values.
+     *
+     *  @param x the first `Char` value
+     *  @param y the second `Char` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: Char, y: Char): Char = (x - y).toChar
+    /** Returns the product of two `Char` values.
+     *
+     *  @param x the first `Char` value
+     *  @param y the second `Char` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: Char, y: Char): Char = (x * y).toChar
+    /** Returns the quotient of two `Char` values.
+     *
+     *  @param x the first `Char` value
+     *  @param y the second `Char` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def quot(x: Char, y: Char): Char = (x / y).toChar
+    /** Returns the remainder of two `Char` values.
+     *
+     *  @param x the first `Char` value
+     *  @param y the second `Char` value
+     *  @return the remainder of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def rem(x: Char, y: Char): Char = (x % y).toChar
+    /** Returns the negation of a `Char` value.
+     *
+     *  @param x the `Char` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: Char): Char = (-x).toChar
+    /** Converts an `Int` to a `Char`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Char` representation of `x`
+     */
     def fromInt(x: Int): Char = x.toChar
+    /** Parses a `String` into a `Char` by interpreting it as a decimal integer and converting that integer to a `Char`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(Char)` if the string is a valid integer (any valid `Int` is truncated to a `Char` via narrowing conversion, so out-of-range integers wrap rather than failing), `None` otherwise
+     */
     def parseString(str: String): Option[Char] = Try(str.toInt.toChar).toOption
+    /** Converts a `Char` to an `Int`.
+     *
+     *  @param x the `Char` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: Char): Int = x.toInt
+    /** Converts a `Char` to a `Long`.
+     *
+     *  @param x the `Char` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: Char): Long = x.toLong
+    /** Converts a `Char` to a `Float`.
+     *
+     *  @param x the `Char` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: Char): Float = x.toFloat
+    /** Converts a `Char` to a `Double`.
+     *
+     *  @param x the `Char` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: Char): Double = x.toDouble
+    /** Returns the signum of a `Char` value.
+     *
+     *  @param x the `Char` value
+     *  @return 1 if `x` is nonzero, 0 if `x` is zero; the result is never -1 because `Char` values are unsigned
+     */
     override def signum(x: Char): Int = math.signum(x.toInt)
+    /** Returns the sign of a `Char` value.
+     *
+     *  @param x the `Char` value
+     *  @return `'\u0001'` if `x` is nonzero, `'\u0000'` if `x` is zero; `Char` values are unsigned
+     */
     override def sign(x: Char): Char = math.signum(x.toInt).toChar
   }
   implicit object CharIsIntegral extends CharIsIntegral with Ordering.CharOrdering
 
+  /** Provides arithmetic operations for `Long` values. */
   trait LongIsIntegral extends Integral[Long] {
+    /** Returns the sum of two `Long` values.
+     *
+     *  @param x the first `Long` value
+     *  @param y the second `Long` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: Long, y: Long): Long = x + y
+    /** Returns the difference between two `Long` values.
+     *
+     *  @param x the first `Long` value
+     *  @param y the second `Long` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: Long, y: Long): Long = x - y
+    /** Returns the product of two `Long` values.
+     *
+     *  @param x the first `Long` value
+     *  @param y the second `Long` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: Long, y: Long): Long = x * y
+    /** Returns the quotient of two `Long` values.
+     *
+     *  @param x the first `Long` value
+     *  @param y the second `Long` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def quot(x: Long, y: Long): Long = x / y
+    /** Returns the remainder of two `Long` values.
+     *
+     *  @param x the first `Long` value
+     *  @param y the second `Long` value
+     *  @return the remainder of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def rem(x: Long, y: Long): Long = x % y
+    /** Returns the negation of a `Long` value.
+     *
+     *  @param x the `Long` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: Long): Long = -x
+    /** Converts an `Int` to a `Long`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def fromInt(x: Int): Long = x.toLong
+    /** Parses a `String` into a `Long`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(Long)` if the string is a valid `Long`, `None` otherwise
+     */
     def parseString(str: String): Option[Long] = StringParsers.parseLong(str)
+    /** Converts a `Long` to an `Int`.
+     *
+     *  @param x the `Long` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: Long): Int = x.toInt
+    /** Returns the given `Long` value, as no conversion is needed.
+     *
+     *  @param x the `Long` value (returned unchanged)
+     *  @return the given `Long` value unchanged
+     */
     def toLong(x: Long): Long = x
+    /** Converts a `Long` to a `Float`.
+     *
+     *  @param x the `Long` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: Long): Float = x.toFloat
+    /** Converts a `Long` to a `Double`.
+     *
+     *  @param x the `Long` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: Long): Double = x.toDouble
+    /** Returns the signum of a `Long` value.
+     *
+     *  @param x the `Long` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def signum(x: Long): Int = math.signum(x).toInt
+    /** Returns the sign of a `Long` value.
+     *
+     *  @param x the `Long` value
+     *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+     */
     override def sign(x: Long): Long = math.signum(x)
   }
   implicit object LongIsIntegral extends LongIsIntegral with Ordering.LongOrdering
 
+  /** Provides arithmetic operations for `Float` values. */
   trait FloatIsFractional extends Fractional[Float] {
+    /** Returns the sum of two `Float` values.
+     *
+     *  @param x the first `Float` value
+     *  @param y the second `Float` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: Float, y: Float): Float = x + y
+    /** Returns the difference between two `Float` values.
+     *
+     *  @param x the first `Float` value
+     *  @param y the second `Float` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: Float, y: Float): Float = x - y
+    /** Returns the product of two `Float` values.
+     *
+     *  @param x the first `Float` value
+     *  @param y the second `Float` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: Float, y: Float): Float = x * y
+    /** Returns the negation of a `Float` value.
+     *
+     *  @param x the `Float` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: Float): Float = -x
+    /** Converts an `Int` to a `Float`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def fromInt(x: Int): Float = x.toFloat
+    /** Parses a `String` into a `Float`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(Float)` if the string is a valid `Float`, `None` otherwise
+     */
     def parseString(str: String): Option[Float] = StringParsers.parseFloat(str)
+    /** Converts a `Float` to an `Int`.
+     *
+     *  @param x the `Float` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: Float): Int = x.toInt
+    /** Converts a `Float` to a `Long`.
+     *
+     *  @param x the `Float` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: Float): Long = x.toLong
+    /** Returns the given `Float` value, as no conversion is needed.
+     *
+     *  @param x the `Float` value (returned unchanged)
+     *  @return the given `Float` value unchanged
+     */
     def toFloat(x: Float): Float = x
+    /** Converts a `Float` to a `Double`.
+     *
+     *  @param x the `Float` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: Float): Double = x.toDouble
+    /** Returns the quotient of two `Float` values.
+     *
+     *  This is IEEE 754 floating-point division, not integer division, so it
+     *  never throws: dividing a non-zero value by zero yields an infinity,
+     *  `0.0F / 0.0F` yields `NaN`, and any division involving `NaN` yields
+     *  `NaN`.
+     *
+     *  @param x the first `Float` value
+     *  @param y the second `Float` value
+     *  @return the quotient of `x` divided by `y`
+     */
     def div(x: Float, y: Float): Float = x / y
     // logic in Numeric base trait mishandles abs(-0.0f)
+    /** Returns the absolute value of a `Float`.
+     *
+     *  @param x the `Float` value
+     *  @return the absolute value of `x`
+     */
     override def abs(x: Float): Float = math.abs(x)
     // logic in Numeric base trait mishandles sign(-0.0f) and sign(Float.NaN)
+    /** Returns the sign of a `Float` value.
+     *
+     *  @param x the `Float` value
+     *  @return -1.0 if `x` is negative, 1.0 if `x` is positive, `x` itself if `x` is a zero (the sign of the zero is preserved), or `NaN` if `x` is `NaN`
+     */
     override def sign(x: Float): Float = math.signum(x)
   }
   implicit object FloatIsFractional extends FloatIsFractional with Ordering.Float.IeeeOrdering
 
+  /** Provides arithmetic operations for `Double` values. */
   trait DoubleIsFractional extends Fractional[Double] {
+    /** Returns the sum of two `Double` values.
+     *
+     *  @param x the first `Double` value
+     *  @param y the second `Double` value
+     *  @return the sum of `x` and `y`
+     */
     def plus(x: Double, y: Double): Double = x + y
+    /** Returns the difference between two `Double` values.
+     *
+     *  @param x the first `Double` value
+     *  @param y the second `Double` value
+     *  @return the difference between `x` and `y`
+     */
     def minus(x: Double, y: Double): Double = x - y
+    /** Returns the product of two `Double` values.
+     *
+     *  @param x the first `Double` value
+     *  @param y the second `Double` value
+     *  @return the product of `x` and `y`
+     */
     def times(x: Double, y: Double): Double = x * y
+    /** Returns the negation of a `Double` value.
+     *
+     *  @param x the `Double` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: Double): Double = -x
+    /** Converts an `Int` to a `Double`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def fromInt(x: Int): Double = x.toDouble
+    /** Parses a `String` into a `Double`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(Double)` if the string is a valid `Double`, `None` otherwise
+     */
     def parseString(str: String): Option[Double] = StringParsers.parseDouble(str)
+    /** Converts a `Double` to an `Int`.
+     *
+     *  @param x the `Double` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: Double): Int = x.toInt
+    /** Converts a `Double` to a `Long`.
+     *
+     *  @param x the `Double` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: Double): Long = x.toLong
+    /** Converts a `Double` to a `Float`.
+     *
+     *  @param x the `Double` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: Double): Float = x.toFloat
+    /** Returns the given `Double` value, as no conversion is needed.
+     *
+     *  @param x the `Double` value (returned unchanged)
+     *  @return the given `Double` value unchanged
+     */
     def toDouble(x: Double): Double = x
+    /** Returns the quotient of two `Double` values.
+     *
+     *  This is IEEE 754 floating-point division, not integer division, so it
+     *  never throws: dividing a non-zero value by zero yields an infinity,
+     *  `0.0 / 0.0` yields `NaN`, and any division involving `NaN` yields
+     *  `NaN`.
+     *
+     *  @param x the first `Double` value
+     *  @param y the second `Double` value
+     *  @return the quotient of `x` divided by `y`
+     */
     def div(x: Double, y: Double): Double = x / y
     // logic in Numeric base trait mishandles abs(-0.0)
+    /** Returns the absolute value of a `Double`.
+     *
+     *  @param x the `Double` value
+     *  @return the absolute value of `x`
+     */
     override def abs(x: Double): Double = math.abs(x)
     // logic in Numeric base trait mishandles sign(-0.0) and sign(Double.NaN)
+    /** Returns the sign of a `Double` value.
+     *
+     *  @param x the `Double` value
+     *  @return -1.0 if `x` is negative, 1.0 if `x` is positive, `x` itself if `x` is a zero (the sign of the zero is preserved), or `NaN` if `x` is `NaN`
+     */
     override def sign(x: Double): Double = math.signum(x)
   }
   implicit object DoubleIsFractional extends DoubleIsFractional with Ordering.Double.IeeeOrdering
 
+  /** Provides arithmetic operations for `BigDecimal` values. */
   trait BigDecimalIsConflicted extends Numeric[BigDecimal] {
     // works around pollution of math context by ignoring identity element
+    /** Returns the sum of two `BigDecimal` values.
+     *
+     *  @param x the first `BigDecimal` value
+     *  @param y the second `BigDecimal` value
+     *  @return the sum of `x` and `y`
+     *  @note Returns the second value directly if the first value is the cached zero instance (BigDecimal(0) under the default MathContext) to avoid math context pollution.
+     */
     def plus(x: BigDecimal, y: BigDecimal): BigDecimal = {
       import BigDecimalIsConflicted._0
       if (x eq _0) y else x + y
     }
+    /** Returns the difference between two `BigDecimal` values.
+     *
+     *  @param x the first `BigDecimal` value
+     *  @param y the second `BigDecimal` value
+     *  @return the difference between `x` and `y`
+     *  @note Returns the negation of the second value directly if the first value is the cached zero instance (BigDecimal(0) under the default MathContext) to avoid math context pollution.
+     */
     def minus(x: BigDecimal, y: BigDecimal): BigDecimal = {
       import BigDecimalIsConflicted._0
       if (x eq _0) -y else x - y
     }
     // works around pollution of math context by ignoring identity element
+    /** Returns the product of two `BigDecimal` values.
+     *
+     *  @param x the first `BigDecimal` value
+     *  @param y the second `BigDecimal` value
+     *  @return the product of `x` and `y`
+     *  @note Returns the second value directly if the first value is the cached one instance (BigDecimal(1) under the default MathContext) to avoid math context pollution.
+     */
     def times(x: BigDecimal, y: BigDecimal): BigDecimal = {
       import BigDecimalIsConflicted._1
       if (x eq _1) y else x * y
     }
+    /** Returns the negation of a `BigDecimal` value.
+     *
+     *  @param x the `BigDecimal` value to negate
+     *  @return the negation of `x`
+     */
     def negate(x: BigDecimal): BigDecimal = -x
+    /** Converts an `Int` to a `BigDecimal`.
+     *
+     *  @param x the `Int` value to convert
+     *  @return the `BigDecimal` representation of `x`
+     */
     def fromInt(x: Int): BigDecimal = BigDecimal(x)
+    /** Parses a `String` into a `BigDecimal`.
+     *
+     *  @param str the `String` to parse
+     *  @return `Some(BigDecimal)` if the string is a valid `BigDecimal`, `None` otherwise
+     */
     def parseString(str: String): Option[BigDecimal] = Try(BigDecimal(str)).toOption
+    /** Converts a `BigDecimal` to an `Int`.
+     *
+     *  @param x the `BigDecimal` value to convert
+     *  @return the `Int` representation of `x`
+     */
     def toInt(x: BigDecimal): Int = x.intValue
+    /** Converts a `BigDecimal` to a `Long`.
+     *
+     *  @param x the `BigDecimal` value to convert
+     *  @return the `Long` representation of `x`
+     */
     def toLong(x: BigDecimal): Long = x.longValue
+    /** Converts a `BigDecimal` to a `Float`.
+     *
+     *  @param x the `BigDecimal` value to convert
+     *  @return the `Float` representation of `x`
+     */
     def toFloat(x: BigDecimal): Float = x.floatValue
+    /** Converts a `BigDecimal` to a `Double`.
+     *
+     *  @param x the `BigDecimal` value to convert
+     *  @return the `Double` representation of `x`
+     */
     def toDouble(x: BigDecimal): Double = x.doubleValue
   }
   private object BigDecimalIsConflicted {
@@ -212,11 +884,34 @@ object Numeric {
     private val _1 = BigDecimal(1)   // cached one is ordinarily cached for default math context
   }
 
+  /** Provides fractional arithmetic operations for `BigDecimal` values. */
   trait BigDecimalIsFractional extends BigDecimalIsConflicted with Fractional[BigDecimal] {
+    /** Returns the quotient of two `BigDecimal` values.
+     *
+     *  @param x the first `BigDecimal` value
+     *  @param y the second `BigDecimal` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def div(x: BigDecimal, y: BigDecimal): BigDecimal = x / y
   }
+  /** Provides integral arithmetic operations for `BigDecimal` values. */
   trait BigDecimalAsIfIntegral extends BigDecimalIsConflicted with Integral[BigDecimal] {
+    /** Returns the quotient of two `BigDecimal` values.
+     *
+     *  @param x the first `BigDecimal` value
+     *  @param y the second `BigDecimal` value
+     *  @return the quotient of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def quot(x: BigDecimal, y: BigDecimal): BigDecimal = x quot y
+    /** Returns the remainder of two `BigDecimal` values.
+     *
+     *  @param x the first `BigDecimal` value
+     *  @param y the second `BigDecimal` value
+     *  @return the remainder of `x` divided by `y`
+     *  @throws java.lang.ArithmeticException if `y` is zero
+     */
     def rem(x: BigDecimal, y: BigDecimal): BigDecimal = x remainder y
   }
 
@@ -226,44 +921,158 @@ object Numeric {
   object BigDecimalAsIfIntegral extends BigDecimalAsIfIntegral with Ordering.BigDecimalOrdering
 }
 
+/** Provides arithmetic operations for a numeric type `T`.
+ *
+ *  @tparam T the numeric type
+ */
 trait Numeric[T] extends Ordering[T] {
+  /** Returns the sum of two values of type `T`.
+   *
+   *  @param x the first value
+   *  @param y the second value
+   *  @return the sum of `x` and `y`
+   */
   def plus(x: T, y: T): T
+  /** Returns the difference between two values of type `T`.
+   *
+   *  @param x the first value
+   *  @param y the second value
+   *  @return the difference between `x` and `y`
+   */
   def minus(x: T, y: T): T
+  /** Returns the product of two values of type `T`.
+   *
+   *  @param x the first value
+   *  @param y the second value
+   *  @return the product of `x` and `y`
+   */
   def times(x: T, y: T): T
+  /** Returns the negation of a value of type `T`.
+   *
+   *  @param x the value to negate
+   *  @return the negation of `x`
+   */
   def negate(x: T): T
+  /** Converts an `Int` to a value of type `T`.
+   *
+   *  @param x the `Int` value to convert
+   *  @return the `T` representation of `x`
+   */
   def fromInt(x: Int): T
+  /** Parses a `String` into a value of type `T`.
+   *
+   *  @param str the `String` to parse
+   *  @return `Some(T)` if the string is a valid `T`, `None` if it is not
+   *  @throws NullPointerException if `str` is `null`, for the built-in instances that
+   *          delegate to `StringParsers`
+   */
   def parseString(str: String): Option[T]
+  /** Converts a value of type `T` to an `Int`.
+   *
+   *  @param x the value to convert
+   *  @return the `Int` representation of `x`
+   */
   def toInt(x: T): Int
+  /** Converts a value of type `T` to a `Long`.
+   *
+   *  @param x the value to convert
+   *  @return the `Long` representation of `x`
+   */
   def toLong(x: T): Long
+  /** Converts a value of type `T` to a `Float`.
+   *
+   *  @param x the value to convert
+   *  @return the `Float` representation of `x`
+   */
   def toFloat(x: T): Float
+  /** Converts a value of type `T` to a `Double`.
+   *
+   *  @param x the value to convert
+   *  @return the `Double` representation of `x`
+   */
   def toDouble(x: T): Double
 
+  /** The additive identity element for type `T`. */
   def zero = fromInt(0)
+  /** The multiplicative identity element for type `T`. */
   def one = fromInt(1)
 
+  /** Returns the absolute value of a value of type `T`.
+   *
+   *  This negates a negative value, so for a fixed-width signed type it returns the
+   *  argument unchanged at the minimum value, which has no positive counterpart:
+   *  `IntIsIntegral.abs(Int.MinValue)` is `Int.MinValue`. The `Float` and `Double`
+   *  instances override this and do not have that behaviour.
+   *
+   *  @param x the value
+   *  @return the absolute value of `x`, except at the minimum value of a fixed-width
+   *          signed type, where it is `x` itself
+   */
   def abs(x: T): T = if (lt(x, zero)) negate(x) else x
 
+  /** Returns the signum of a value of type `T`.
+   *
+   *  @param x the value
+   *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+   */
   @deprecated("use `sign` method instead", since = "2.13.0") def signum(x: T): Int =
     if (lt(x, zero)) -1
     else if (gt(x, zero)) 1
     else 0
+  /** Returns the sign of a value of type `T`.
+   *
+   *  @param x the value
+   *  @return -1 if `x` is negative, 1 if `x` is positive, 0 if `x` is zero
+   */
   def sign(x: T): T =
     if (lt(x, zero)) negate(one)
     else if (gt(x, zero)) one
     else zero
 
+  /** Provides infix arithmetic operations for a value of type `T`.
+   *
+   *  @param lhs the value to wrap with infix arithmetic operations
+   */
   class NumericOps(lhs: T) {
+    /** Returns the sum of this value and another value of type `T`.
+     *
+     *  @param rhs the other value
+     *  @return the sum of this value and `rhs`
+     */
     def +(rhs: T) = plus(lhs, rhs)
+    /** Returns the difference between this value and another value of type `T`.
+     *
+     *  @param rhs the other value
+     *  @return the difference between this value and `rhs`
+     */
     def -(rhs: T) = minus(lhs, rhs)
+    /** Returns the product of this value and another value of type `T`.
+     *
+     *  @param rhs the other value
+     *  @return the product of this value and `rhs`
+     */
     def *(rhs: T) = times(lhs, rhs)
+    /** Returns the negation of this value. */
     def unary_- = negate(lhs)
+    /** Returns the absolute value of this value. */
     def abs: T = Numeric.this.abs(lhs)
+    /** Returns the signum of this value. */
     @deprecated("use `sign` method instead", since = "2.13.0") def signum: Int = Numeric.this.signum(lhs)
+    /** Returns the sign of this value. */
     def sign: T = Numeric.this.sign(lhs)
+    /** Converts this value to an `Int`. */
     def toInt: Int = Numeric.this.toInt(lhs)
+    /** Converts this value to a `Long`. */
     def toLong: Long = Numeric.this.toLong(lhs)
+    /** Converts this value to a `Float`. */
     def toFloat: Float = Numeric.this.toFloat(lhs)
+    /** Converts this value to a `Double`. */
     def toDouble: Double = Numeric.this.toDouble(lhs)
   }
+  /** Creates a `NumericOps` wrapper for a value of type `T`.
+   *
+   *  @param lhs the value to wrap
+   *  @return a `NumericOps` wrapper for `lhs`
+   */
   implicit def mkNumericOps(lhs: T): NumericOps = new NumericOps(lhs)
 }

--- a/library/src/scala/math/Ordering.scala
+++ b/library/src/scala/math/Ordering.scala
@@ -255,12 +255,47 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
    *  @param lhs the left-hand side value for infix comparison operations
    */
   class OrderingOps(lhs: T) {
+    /** Returns true if `lhs` is less than `rhs` in this ordering.
+     *
+     *  @param rhs the right-hand side value to compare with `lhs`
+     *  @return `true` if `lhs` < `rhs`, `false` otherwise
+     */
     def <(rhs: T): Boolean = lt(lhs, rhs)
+    /** Returns true if `lhs` is less than or equal to `rhs` in this ordering.
+     *
+     *  @param rhs the right-hand side value to compare with `lhs`
+     *  @return `true` if `lhs` <= `rhs`, `false` otherwise
+     */
     def <=(rhs: T): Boolean = lteq(lhs, rhs)
+    /** Returns true if `lhs` is greater than `rhs` in this ordering.
+     *
+     *  @param rhs the right-hand side value to compare with `lhs`
+     *  @return `true` if `lhs` > `rhs`, `false` otherwise
+     */
     def >(rhs: T): Boolean = gt(lhs, rhs)
+    /** Returns true if `lhs` is greater than or equal to `rhs` in this ordering.
+     *
+     *  @param rhs the right-hand side value to compare with `lhs`
+     *  @return `true` if `lhs` >= `rhs`, `false` otherwise
+     */
     def >=(rhs: T): Boolean = gteq(lhs, rhs)
+    /** Returns true if `lhs` is equivalent to `rhs` in this ordering.
+     *
+     *  @param rhs the right-hand side value to compare with `lhs`
+     *  @return `true` if `lhs` == `rhs` in this ordering, `false` otherwise
+     */
     def equiv(rhs: T): Boolean = Ordering.this.equiv(lhs, rhs)
+    /** Returns the greater of `lhs` and `rhs` according to this ordering.
+     *
+     *  @param rhs the right-hand side value to compare with `lhs`
+     *  @return the maximum of `lhs` and `rhs`
+     */
     def max(rhs: T): T = Ordering.this.max(lhs, rhs)
+    /** Returns the lesser of `lhs` and `rhs` according to this ordering.
+     *
+     *  @param rhs the right-hand side value to compare with `lhs`
+     *  @return the minimum of `lhs` and `rhs`
+     */
     def min(rhs: T): T = Ordering.this.min(lhs, rhs)
   }
 
@@ -273,6 +308,13 @@ trait Ordering[T] extends Comparator[T] with PartialOrdering[T] with Serializabl
   implicit def mkOrderingOps(lhs: T): OrderingOps = new OrderingOps(lhs)
 }
 
+/** A trait containing low-priority implicit `Ordering` instances.
+ *
+ *  These instances, derived from `Comparable` and `Comparator`, are inherited
+ *  into the [[Ordering]] companion object's implicit scope but are deprioritized
+ *  via subclassing, so an ordering defined directly in [[Ordering]] takes
+ *  precedence.
+ */
 trait LowPriorityOrderingImplicits {
 
   type AsComparable[A] = A => Comparable[? >: A]
@@ -291,6 +333,12 @@ trait LowPriorityOrderingImplicits {
     def compare(x: A, y: A): Int = asComparable(x).compareTo(y)
   }
 
+  /** Converts a Java `Comparator` to a Scala `Ordering`.
+   *
+   *  @tparam A the type of elements to be compared
+   *  @param cmp the Java `Comparator` to convert
+   *  @return an `Ordering[A]` that delegates to the provided `Comparator`
+   */
   implicit def comparatorToOrdering[A](implicit cmp: Comparator[A]): Ordering[A] = new Ordering[A] {
     def compare(x: A, y: A) = cmp.compare(x, y)
   }
@@ -306,6 +354,11 @@ object Ordering extends LowPriorityOrderingImplicits {
   private final val optionSeed   = 43
   private final val iterableSeed = 47
 
+  /** Returns the implicit `Ordering` instance for type `T`.
+   *
+   *  @tparam T the type for which to retrieve the ordering
+   *  @param ord the implicit `Ordering[T]` instance
+   */
   @inline def apply[T](implicit ord: Ordering[T]) = ord
 
   /** An ordering which caches the value of its reverse.
@@ -314,7 +367,16 @@ object Ordering extends LowPriorityOrderingImplicits {
    */
   sealed trait CachedReverse[T] extends Ordering[T] {
     private val _reverse = super.reverse
+    /** Returns the cached reverse ordering of this ordering. */
     override final def reverse: Ordering[T] = _reverse
+    /** Returns whether the given ordering is this ordering's cached reverse.
+     *
+     *  The check is by reference identity (`eq`), so only the very instance
+     *  returned by `reverse` qualifies.
+     *
+     *  @param other the ordering to check
+     *  @return `true` if `other` is the same object as this ordering's cached reverse, `false` otherwise
+     */
     override final def isReverseOf(other: Ordering[?]): Boolean = other eq _reverse
   }
 
@@ -324,28 +386,99 @@ object Ordering extends LowPriorityOrderingImplicits {
    *  @param outer the original ordering to be reversed
    */
   private final class Reverse[T](private[Ordering] val outer: Ordering[T]) extends Ordering[T] {
+    /** Returns the original ordering that this ordering reverses. */
     override def reverse: Ordering[T]                   = outer
+    /** Returns whether the given ordering is the original ordering that this ordering reverses.
+     *
+     *  The check is by `==`, so any ordering equal to the original qualifies,
+     *  not only the original instance itself.
+     *
+     *  @param other the ordering to check
+     *  @return `true` if `other` is equal to the original ordering that this ordering reverses, `false` otherwise
+     */
     override def isReverseOf(other: Ordering[?]): Boolean = other == outer
 
+    /** Compares two values in reverse order.
+     *
+     *  @param x the first value to compare
+     *  @param y the second value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is greater than, equal to, or less than `y`
+     */
     def compare(x: T, y: T): Int            = outer.compare(y, x)
+    /** Returns true if `x` is greater than or equal to `y` in the original ordering.
+     *
+     *  @param x the first value to compare
+     *  @param y the second value to compare
+     *  @return `true` if `x` >= `y` in the original ordering, `false` otherwise
+     */
     override def lteq(x: T, y: T): Boolean  = outer.lteq(y, x)
+    /** Returns true if `x` is less than or equal to `y` in the original ordering.
+     *
+     *  @param x the first value to compare
+     *  @param y the second value to compare
+     *  @return `true` if `x` <= `y` in the original ordering, `false` otherwise
+     */
     override def gteq(x: T, y: T): Boolean  = outer.gteq(y, x)
+    /** Returns true if `x` is greater than `y` in the original ordering.
+     *
+     *  @param x the first value to compare
+     *  @param y the second value to compare
+     *  @return `true` if `x` > `y` in the original ordering, `false` otherwise
+     */
     override def lt(x: T, y: T): Boolean    = outer.lt(y, x)
+    /** Returns true if `x` is less than `y` in the original ordering.
+     *
+     *  @param x the first value to compare
+     *  @param y the second value to compare
+     *  @return `true` if `x` < `y` in the original ordering, `false` otherwise
+     */
     override def gt(x: T, y: T): Boolean    = outer.gt(y, x)
+    /** Returns true if `x` is equivalent to `y` in the original ordering.
+     *
+     *  @param x the first value to compare
+     *  @param y the second value to compare
+     *  @return `true` if `x` == `y` in the original ordering, `false` otherwise
+     */
     override def equiv(x: T, y: T): Boolean = outer.equiv(y, x)
+    /** Returns the minimum of `x` and `y` in the original ordering.
+     *
+     *  @tparam U a subtype of `T`, used to preserve the specific type in the return value
+     *  @param x the first candidate value
+     *  @param y the second candidate value
+     *  @return the minimum of `x` and `y` in the original ordering
+     */
     override def max[U <: T](x: U, y: U): U = outer.min(x, y)
+    /** Returns the maximum of `x` and `y` in the original ordering.
+     *
+     *  @tparam U a subtype of `T`, used to preserve the specific type in the return value
+     *  @param x the first candidate value
+     *  @param y the second candidate value
+     *  @return the maximum of `x` and `y` in the original ordering
+     */
     override def min[U <: T](x: U, y: U): U = outer.max(x, y)
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Reverse[?]             => this.outer == that.outer
       case _                            => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = outer.hashCode() * reverseSeed
   }
 
   @SerialVersionUID(-2996748994664583574L)
   private final class IterableOrdering[CC[X] <: Iterable[X], T](private val ord: Ordering[T]) extends Ordering[CC[T]] {
+    /** Compares two iterables lexicographically using the element ordering.
+     *
+     *  @param x the first iterable to compare
+     *  @param y the second iterable to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: CC[T], y: CC[T]): Int = {
       val xe = x.iterator
       val ye = y.iterator
@@ -358,14 +491,21 @@ object Ordering extends LowPriorityOrderingImplicits {
       Boolean.compare(xe.hasNext, ye.hasNext)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that  => true
       case that: IterableOrdering[?, ?]  => this.ord == that.ord
       case _                             => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = ord.hashCode() * iterableSeed
   }
 
+  /** Provides additional implicit orderings that are not in the default scope. */
   trait ExtraImplicits {
     /** Not in the standard scope due to the potential for divergence:
      *  For instance `implicitly[Ordering[Any]]` diverges in its presence.
@@ -378,6 +518,13 @@ object Ordering extends LowPriorityOrderingImplicits {
     implicit def seqOrdering[CC[X] <: scala.collection.Seq[X], T](implicit ord: Ordering[T]): Ordering[CC[T]] =
       new IterableOrdering[CC, T](ord)
 
+    /** Creates an ordering for sorted sets using the element ordering.
+     *
+     *  @tparam CC the higher-kinded type constructor for the sorted set type, bounded by `scala.collection.SortedSet`
+     *  @tparam T the element type of the sorted sets being compared
+     *  @param ord the implicit `Ordering` used to compare elements of type `T`
+     *  @return an `Ordering[CC[T]]` that compares sorted sets lexicographically using `ord`
+     */
     implicit def sortedSetOrdering[CC[X] <: scala.collection.SortedSet[X], T](implicit ord: Ordering[T]): Ordering[CC[T]] =
       new IterableOrdering[CC, T](ord)
 
@@ -440,43 +587,91 @@ object Ordering extends LowPriorityOrderingImplicits {
     override def lteq(x: T, y: T): Boolean = ord.lteq(f(x), f(y))
   }
 
+  /** An ordering for `Unit` values, under which all values are equal. */
   trait UnitOrdering extends Ordering[Unit] {
+    /** Compares two `Unit` values, always returning 0 since all `Unit` values are equal.
+     *
+     *  @param x the first `Unit` value to compare
+     *  @param y the second `Unit` value to compare
+     */
     def compare(x: Unit, y: Unit) = 0
   }
   @SerialVersionUID(4089257611611206746L)
   implicit object Unit extends UnitOrdering
 
+  /** An ordering for `Boolean` values that orders `false` before `true`. */
   trait BooleanOrdering extends Ordering[Boolean] {
+    /** Compares two `Boolean` values.
+     *
+     *  @param x the first `Boolean` value to compare
+     *  @param y the second `Boolean` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: Boolean, y: Boolean): Int = java.lang.Boolean.compare(x, y)
   }
   @SerialVersionUID(-94703182178890445L)
   implicit object Boolean extends BooleanOrdering
 
+  /** An ordering for `Byte` values in numeric order. */
   trait ByteOrdering extends Ordering[Byte] {
+    /** Compares two `Byte` values.
+     *
+     *  @param x the first `Byte` value to compare
+     *  @param y the second `Byte` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: Byte, y: Byte): Int = java.lang.Byte.compare(x, y)
   }
   @SerialVersionUID(-2268545360148786406L)
   implicit object Byte extends ByteOrdering
 
+  /** An ordering for `Char` values in numeric (code unit) order. */
   trait CharOrdering extends Ordering[Char] {
+    /** Compares two `Char` values.
+     *
+     *  @param x the first `Char` value to compare
+     *  @param y the second `Char` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: Char, y: Char): Int = java.lang.Character.compare(x, y)
   }
   @SerialVersionUID(2588141633104296698L)
   implicit object Char extends CharOrdering
 
+  /** An ordering for `Short` values in numeric order. */
   trait ShortOrdering extends Ordering[Short] {
+    /** Compares two `Short` values.
+     *
+     *  @param x the first `Short` value to compare
+     *  @param y the second `Short` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: Short, y: Short): Int = java.lang.Short.compare(x, y)
   }
   @SerialVersionUID(4919657051864630912L)
   implicit object Short extends ShortOrdering
 
+  /** An ordering for `Int` values in numeric order. */
   trait IntOrdering extends Ordering[Int] {
+    /** Compares two `Int` values.
+     *
+     *  @param x the first `Int` value to compare
+     *  @param y the second `Int` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: Int, y: Int): Int = java.lang.Integer.compare(x, y)
   }
   @SerialVersionUID(-8412871093094815037L)
   implicit object Int extends IntOrdering with CachedReverse[Int]
 
+  /** An ordering for `Long` values in numeric order. */
   trait LongOrdering extends Ordering[Long] {
+    /** Compares two `Long` values.
+     *
+     *  @param x the first `Long` value to compare
+     *  @param y the second `Long` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: Long, y: Long): Int = java.lang.Long.compare(x, y)
   }
   @SerialVersionUID(-5231423581640563981L)
@@ -536,6 +731,12 @@ object Ordering extends LowPriorityOrderingImplicits {
      *  @see [[IeeeOrdering]]
      */
     trait TotalOrdering extends Ordering[Float] {
+      /** Compares two `Float` values using the total ordering.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y` in the total ordering
+       */
       def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
     }
     @SerialVersionUID(2951539161283192433L)
@@ -558,14 +759,64 @@ object Ordering extends LowPriorityOrderingImplicits {
      *  @see [[TotalOrdering]]
      */
     trait IeeeOrdering extends Ordering[Float] {
+      /** Compares two `Float` values using the total ordering.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y` in the total ordering
+       */
       def compare(x: Float, y: Float) = java.lang.Float.compare(x, y)
 
+      /** Returns true if `x` is less than or equal to `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return `true` if `x` <= `y`, `false` otherwise
+       */
       override def lteq(x: Float, y: Float): Boolean = x <= y
+      /** Returns true if `x` is greater than or equal to `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return `true` if `x` >= `y`, `false` otherwise
+       */
       override def gteq(x: Float, y: Float): Boolean = x >= y
+      /** Returns true if `x` is less than `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return `true` if `x` < `y`, `false` otherwise
+       */
       override def lt(x: Float, y: Float): Boolean = x < y
+      /** Returns true if `x` is greater than `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return `true` if `x` > `y`, `false` otherwise
+       */
       override def gt(x: Float, y: Float): Boolean = x > y
+      /** Returns true if `x` is equivalent to `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Float` value to compare
+       *  @param y the second `Float` value to compare
+       *  @return `true` if `x` == `y`, `false` otherwise
+       */
       override def equiv(x: Float, y: Float): Boolean = x == y
+      /** Returns the maximum of `x` and `y`, as computed by `math.max`.
+       *
+       *  @tparam U a subtype of `Float`, used to preserve the specific type in the return value
+       *  @param x the first candidate value
+       *  @param y the second candidate value
+       *  @return the maximum of `x` and `y`; `NaN` if either argument is `NaN`
+       */
       override def max[U <: Float](x: U, y: U): U = math.max(x, y).asInstanceOf[U]
+      /** Returns the minimum of `x` and `y`, as computed by `math.min`.
+       *
+       *  @tparam U a subtype of `Float`, used to preserve the specific type in the return value
+       *  @param x the first candidate value
+       *  @param y the second candidate value
+       *  @return the minimum of `x` and `y`; `NaN` if either argument is `NaN`
+       */
       override def min[U <: Float](x: U, y: U): U = math.min(x, y).asInstanceOf[U]
     }
     @SerialVersionUID(2142189527751553605L)
@@ -633,6 +884,12 @@ object Ordering extends LowPriorityOrderingImplicits {
      *  @see [[IeeeOrdering]]
      */
     trait TotalOrdering extends Ordering[Double] {
+      /** Compares two `Double` values using the total ordering.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y` in the total ordering
+       */
       def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
     }
     @SerialVersionUID(-831119229746134011L)
@@ -655,14 +912,64 @@ object Ordering extends LowPriorityOrderingImplicits {
      *  @see [[TotalOrdering]]
      */
     trait IeeeOrdering extends Ordering[Double] {
+      /** Compares two `Double` values using the total ordering.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y` in the total ordering
+       */
       def compare(x: Double, y: Double) = java.lang.Double.compare(x, y)
 
+      /** Returns true if `x` is less than or equal to `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return `true` if `x` <= `y`, `false` otherwise
+       */
       override def lteq(x: Double, y: Double): Boolean = x <= y
+      /** Returns true if `x` is greater than or equal to `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return `true` if `x` >= `y`, `false` otherwise
+       */
       override def gteq(x: Double, y: Double): Boolean = x >= y
+      /** Returns true if `x` is less than `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return `true` if `x` < `y`, `false` otherwise
+       */
       override def lt(x: Double, y: Double): Boolean = x < y
+      /** Returns true if `x` is greater than `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return `true` if `x` > `y`, `false` otherwise
+       */
       override def gt(x: Double, y: Double): Boolean = x > y
+      /** Returns true if `x` is equivalent to `y` using IEEE 754 semantics.
+       *
+       *  @param x the first `Double` value to compare
+       *  @param y the second `Double` value to compare
+       *  @return `true` if `x` == `y`, `false` otherwise
+       */
       override def equiv(x: Double, y: Double): Boolean = x == y
+      /** Returns the maximum of `x` and `y`, as computed by `math.max`.
+       *
+       *  @tparam U a subtype of `Double`, used to preserve the specific type in the return value
+       *  @param x the first candidate value
+       *  @param y the second candidate value
+       *  @return the maximum of `x` and `y`; `NaN` if either argument is `NaN`
+       */
       override def max[U <: Double](x: U, y: U): U = math.max(x, y).asInstanceOf[U]
+      /** Returns the minimum of `x` and `y`, as computed by `math.min`.
+       *
+       *  @tparam U a subtype of `Double`, used to preserve the specific type in the return value
+       *  @param x the first candidate value
+       *  @param y the second candidate value
+       *  @return the minimum of `x` and `y`; `NaN` if either argument is `NaN`
+       */
       override def min[U <: Double](x: U, y: U): U = math.min(x, y).asInstanceOf[U]
     }
     @SerialVersionUID(5722631152457877238L)
@@ -678,32 +985,72 @@ object Ordering extends LowPriorityOrderingImplicits {
   @SerialVersionUID(-7340686892557971538L)
   implicit object DeprecatedDoubleOrdering extends Double.TotalOrdering
 
+  /** An ordering for `BigInt` values in numeric order. */
   trait BigIntOrdering extends Ordering[BigInt] {
+    /** Compares two `BigInt` values.
+     *
+     *  @param x the first `BigInt` value to compare
+     *  @param y the second `BigInt` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: BigInt, y: BigInt) = x.compare(y)
   }
   @SerialVersionUID(-3075297647817530785L)
   implicit object BigInt extends BigIntOrdering
 
+  /** An ordering for `BigDecimal` values in numeric order. */
   trait BigDecimalOrdering extends Ordering[BigDecimal] {
+    /** Compares two `BigDecimal` values.
+     *
+     *  @param x the first `BigDecimal` value to compare
+     *  @param y the second `BigDecimal` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: BigDecimal, y: BigDecimal) = x.compare(y)
   }
   @SerialVersionUID(-833457937756812905L)
   implicit object BigDecimal extends BigDecimalOrdering
 
+  /** An ordering for `String` values, lexicographic by Unicode code unit as by `String.compareTo`. */
   trait StringOrdering extends Ordering[String] {
+    /** Compares two `String` values lexicographically.
+     *
+     *  @param x the first `String` value to compare
+     *  @param y the second `String` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: String, y: String) = x.compareTo(y)
   }
   @SerialVersionUID(1302240016074071079L)
   implicit object String extends StringOrdering
 
+  /** An ordering for `Symbol` values, ordered by their names. */
   trait SymbolOrdering extends Ordering[Symbol] {
+    /** Compares two `Symbol` values by their names.
+     *
+     *  @param x the first `Symbol` value to compare
+     *  @param y the second `Symbol` value to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: Symbol, y: Symbol): Int = x.name.compareTo(y.name)
   }
   @SerialVersionUID(1996702162912307637L)
   implicit object Symbol extends SymbolOrdering
 
+  /** An ordering for `Option` values in which `None` precedes every `Some`.
+   *
+   *  @tparam T the type of the values contained in the `Option`
+   */
   trait OptionOrdering[T] extends Ordering[Option[T]] {
+    /** The ordering used to compare the values contained in the `Option`.
+     */
     def optionOrdering: Ordering[T]
+    /** Compares two `Option` values, treating `None` as less than any `Some`; two
+     *  `Some` values are compared by their contents using `optionOrdering`.
+     *
+     *  @param x the first `Option` value to compare
+     *  @param y the second `Option` value to compare
+     */
     def compare(x: Option[T], y: Option[T]) = (x, y) match {
       case (None, None)       => 0
       case (None, _)          => -1
@@ -711,20 +1058,37 @@ object Ordering extends LowPriorityOrderingImplicits {
       case (Some(x), Some(y)) => optionOrdering.compare(x, y)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: OptionOrdering[?]      => this.optionOrdering == that.optionOrdering
       case _                            => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = optionOrdering.hashCode() * optionSeed
   }
+  /** Creates an ordering for `Option` values using the given element ordering.
+   *
+   *  @tparam T the type of the values contained in the `Option`
+   *  @param ord the implicit `Ordering` used to compare the values contained in the `Option`
+   *  @return an `Ordering[Option[T]]` that compares the contents of `Some` values using `ord`, ordering `None` before any `Some`
+   */
   implicit def Option[T](implicit ord: Ordering[T]): Ordering[Option[T]] = {
     @SerialVersionUID(6958068162830323876L)
     class O extends  OptionOrdering[T] { val optionOrdering = ord }
     new O()
   }
 
-  /**
+  /** Creates an ordering for `Iterable` values using the given element ordering.
+   *
+   *  @tparam T the type of the elements contained in the `Iterable`
+   *  @param ord the implicit `Ordering` used to compare elements of type `T`
+   *  @return an `Ordering[Iterable[T]]` that compares `Iterable` values lexicographically using `ord`
+   *
    *  @deprecated Iterables are not guaranteed to have a consistent order, so the `Ordering`
    *             returned by this method may not be stable or meaningful. If you are using a type
    *             with a consistent order (such as `Seq`), use its `Ordering` (found in the
@@ -735,18 +1099,37 @@ object Ordering extends LowPriorityOrderingImplicits {
   implicit def Iterable[T](implicit ord: Ordering[T]): Ordering[Iterable[T]] =
     new IterableOrdering[Iterable, T](ord)
 
+  /** Creates an ordering for tuples of two elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @return an `Ordering[(T1, T2)]` that compares tuples lexicographically using `ord1` and `ord2`
+   */
   implicit def Tuple2[T1, T2](implicit ord1: Ordering[T1], ord2: Ordering[T2]): Ordering[(T1, T2)] =
     new Tuple2Ordering(ord1, ord2)
 
   @SerialVersionUID(4945084135299531202L)
   private final class Tuple2Ordering[T1, T2](private val ord1: Ordering[T1],
                                                    private val ord2: Ordering[T2]) extends Ordering[(T1, T2)] {
+    /** Compares two tuples of two elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2), y: (T1, T2)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
       ord2.compare(x._2, y._2)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple2Ordering[?, ?] =>
@@ -754,9 +1137,20 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord2 == that.ord2
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2).hashCode()
   }
 
+  /** Creates an ordering for tuples of three elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @param ord3 the implicit `Ordering` used to compare the third element
+   *  @return an `Ordering[(T1, T2, T3)]` that compares tuples lexicographically using `ord1`, `ord2`, and `ord3`
+   */
   implicit def Tuple3[T1, T2, T3](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3]) : Ordering[(T1, T2, T3)] =
     new Tuple3Ordering(ord1, ord2, ord3)
 
@@ -764,6 +1158,12 @@ object Ordering extends LowPriorityOrderingImplicits {
   private final class Tuple3Ordering[T1, T2, T3](private val ord1: Ordering[T1],
                                                        private val ord2: Ordering[T2],
                                                        private val ord3: Ordering[T3]) extends Ordering[(T1, T2, T3)] {
+    /** Compares two tuples of three elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2, T3), y: (T1, T2, T3)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -772,6 +1172,11 @@ object Ordering extends LowPriorityOrderingImplicits {
       ord3.compare(x._3, y._3)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple3Ordering[?, ?, ?] =>
@@ -780,9 +1185,22 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord3 == that.ord3
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2, ord3).hashCode()
   }
 
+  /** Creates an ordering for tuples of four elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @param ord3 the implicit `Ordering` used to compare the third element
+   *  @param ord4 the implicit `Ordering` used to compare the fourth element
+   *  @return an `Ordering[(T1, T2, T3, T4)]` that compares tuples lexicographically using `ord1`, `ord2`, `ord3`, and `ord4`
+   */
   implicit def Tuple4[T1, T2, T3, T4](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4]) : Ordering[(T1, T2, T3, T4)] =
     new Tuple4Ordering(ord1, ord2, ord3, ord4)
 
@@ -792,6 +1210,12 @@ object Ordering extends LowPriorityOrderingImplicits {
                                                            private val ord3: Ordering[T3],
                                                            private val ord4: Ordering[T4])
     extends Ordering[(T1, T2, T3, T4)] {
+    /** Compares two tuples of four elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2, T3, T4), y: (T1, T2, T3, T4)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -802,6 +1226,11 @@ object Ordering extends LowPriorityOrderingImplicits {
       ord4.compare(x._4, y._4)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple4Ordering[?, ?, ?, ?] =>
@@ -811,9 +1240,24 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord4 == that.ord4
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2, ord3, ord4).hashCode()
   }
 
+  /** Creates an ordering for tuples of five elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @param ord3 the implicit `Ordering` used to compare the third element
+   *  @param ord4 the implicit `Ordering` used to compare the fourth element
+   *  @param ord5 the implicit `Ordering` used to compare the fifth element
+   *  @return an `Ordering[(T1, T2, T3, T4, T5)]` that compares tuples lexicographically using `ord1`, `ord2`, `ord3`, `ord4`, and `ord5`
+   */
   implicit def Tuple5[T1, T2, T3, T4, T5](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5]): Ordering[(T1, T2, T3, T4, T5)] =
     new Tuple5Ordering(ord1, ord2, ord3, ord4, ord5)
 
@@ -824,6 +1268,12 @@ object Ordering extends LowPriorityOrderingImplicits {
                                                                private val ord4: Ordering[T4],
                                                                private val ord5: Ordering[T5])
     extends Ordering[(T1, T2, T3, T4, T5)] {
+    /** Compares two tuples of five elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2, T3, T4, T5), y: (T1, T2, T3, T4, T5)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -836,6 +1286,11 @@ object Ordering extends LowPriorityOrderingImplicits {
       ord5.compare(x._5, y._5)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple5Ordering[?, ?, ?, ?, ?] =>
@@ -846,9 +1301,26 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord5 == that.ord5
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5).hashCode()
   }
 
+  /** Creates an ordering for tuples of six elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @param ord3 the implicit `Ordering` used to compare the third element
+   *  @param ord4 the implicit `Ordering` used to compare the fourth element
+   *  @param ord5 the implicit `Ordering` used to compare the fifth element
+   *  @param ord6 the implicit `Ordering` used to compare the sixth element
+   *  @return an `Ordering[(T1, T2, T3, T4, T5, T6)]` that compares tuples lexicographically using `ord1`, `ord2`, `ord3`, `ord4`, `ord5`, and `ord6`
+   */
   @SerialVersionUID(3045467524192969060L)
   implicit def Tuple6[T1, T2, T3, T4, T5, T6](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6]): Ordering[(T1, T2, T3, T4, T5, T6)] =
     new Tuple6Ordering(ord1, ord2, ord3, ord4, ord5, ord6)
@@ -860,6 +1332,12 @@ object Ordering extends LowPriorityOrderingImplicits {
                                                                    private val ord5: Ordering[T5],
                                                                    private val ord6: Ordering[T6])
     extends Ordering[(T1, T2, T3, T4, T5, T6)] {
+    /** Compares two tuples of six elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2, T3, T4, T5, T6), y: (T1, T2, T3, T4, T5, T6)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -874,6 +1352,11 @@ object Ordering extends LowPriorityOrderingImplicits {
       ord6.compare(x._6, y._6)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple6Ordering[?, ?, ?, ?, ?, ?] =>
@@ -885,9 +1368,28 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord6 == that.ord6
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6).hashCode()
   }
 
+  /** Creates an ordering for tuples of seven elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @tparam T7 the type of the seventh element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @param ord3 the implicit `Ordering` used to compare the third element
+   *  @param ord4 the implicit `Ordering` used to compare the fourth element
+   *  @param ord5 the implicit `Ordering` used to compare the fifth element
+   *  @param ord6 the implicit `Ordering` used to compare the sixth element
+   *  @param ord7 the implicit `Ordering` used to compare the seventh element
+   *  @return an `Ordering[(T1, T2, T3, T4, T5, T6, T7)]` that compares tuples lexicographically using `ord1`, `ord2`, `ord3`, `ord4`, `ord5`, `ord6`, and `ord7`
+   */
   implicit def Tuple7[T1, T2, T3, T4, T5, T6, T7](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7]): Ordering[(T1, T2, T3, T4, T5, T6, T7)] =
     new Tuple7Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7)
 
@@ -900,6 +1402,12 @@ object Ordering extends LowPriorityOrderingImplicits {
                                                                        private val ord6: Ordering[T6],
                                                                        private val ord7: Ordering[T7])
     extends Ordering[(T1, T2, T3, T4, T5, T6, T7)] {
+    /** Compares two tuples of seven elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2, T3, T4, T5, T6, T7), y: (T1, T2, T3, T4, T5, T6, T7)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -916,6 +1424,11 @@ object Ordering extends LowPriorityOrderingImplicits {
       ord7.compare(x._7, y._7)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple7Ordering[?, ?, ?, ?, ?, ?, ?] =>
@@ -928,9 +1441,30 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord7 == that.ord7
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7).hashCode()
   }
 
+  /** Creates an ordering for tuples of eight elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @tparam T7 the type of the seventh element in the tuple
+   *  @tparam T8 the type of the eighth element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @param ord3 the implicit `Ordering` used to compare the third element
+   *  @param ord4 the implicit `Ordering` used to compare the fourth element
+   *  @param ord5 the implicit `Ordering` used to compare the fifth element
+   *  @param ord6 the implicit `Ordering` used to compare the sixth element
+   *  @param ord7 the implicit `Ordering` used to compare the seventh element
+   *  @param ord8 the implicit `Ordering` used to compare the eighth element
+   *  @return an `Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)]` that compares tuples lexicographically using `ord1`, `ord2`, `ord3`, `ord4`, `ord5`, `ord6`, `ord7`, and `ord8`
+   */
   @SerialVersionUID(4003095353309354068L)
   implicit def Tuple8[T1, T2, T3, T4, T5, T6, T7, T8](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7], ord8: Ordering[T8]): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)] =
     new Tuple8Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8)
@@ -944,6 +1478,12 @@ object Ordering extends LowPriorityOrderingImplicits {
                                                                            private val ord7: Ordering[T7],
                                                                            private val ord8: Ordering[T8])
     extends Ordering[(T1, T2, T3, T4, T5, T6, T7, T8)] {
+    /** Compares two tuples of eight elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8), y: (T1, T2, T3, T4, T5, T6, T7, T8)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -962,6 +1502,11 @@ object Ordering extends LowPriorityOrderingImplicits {
       ord8.compare(x._8, y._8)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple8Ordering[?, ?, ?, ?, ?, ?, ?, ?] =>
@@ -975,9 +1520,32 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord8 == that.ord8
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8).hashCode()
   }
 
+  /** Creates an ordering for tuples of nine elements using the given element orderings.
+   *
+   *  @tparam T1 the type of the first element in the tuple
+   *  @tparam T2 the type of the second element in the tuple
+   *  @tparam T3 the type of the third element in the tuple
+   *  @tparam T4 the type of the fourth element in the tuple
+   *  @tparam T5 the type of the fifth element in the tuple
+   *  @tparam T6 the type of the sixth element in the tuple
+   *  @tparam T7 the type of the seventh element in the tuple
+   *  @tparam T8 the type of the eighth element in the tuple
+   *  @tparam T9 the type of the ninth element in the tuple
+   *  @param ord1 the implicit `Ordering` used to compare the first element
+   *  @param ord2 the implicit `Ordering` used to compare the second element
+   *  @param ord3 the implicit `Ordering` used to compare the third element
+   *  @param ord4 the implicit `Ordering` used to compare the fourth element
+   *  @param ord5 the implicit `Ordering` used to compare the fifth element
+   *  @param ord6 the implicit `Ordering` used to compare the sixth element
+   *  @param ord7 the implicit `Ordering` used to compare the seventh element
+   *  @param ord8 the implicit `Ordering` used to compare the eighth element
+   *  @param ord9 the implicit `Ordering` used to compare the ninth element
+   *  @return an `Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)]` that compares tuples lexicographically using `ord1`, `ord2`, `ord3`, `ord4`, `ord5`, `ord6`, `ord7`, `ord8`, and `ord9`
+   */
   @SerialVersionUID(8185342054829975001L)
   implicit def Tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9](implicit ord1: Ordering[T1], ord2: Ordering[T2], ord3: Ordering[T3], ord4: Ordering[T4], ord5: Ordering[T5], ord6: Ordering[T6], ord7: Ordering[T7], ord8 : Ordering[T8], ord9: Ordering[T9]): Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
     new Tuple9Ordering(ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9)
@@ -992,6 +1560,12 @@ object Ordering extends LowPriorityOrderingImplicits {
                                                                                private val ord8: Ordering[T8],
                                                                                private val ord9: Ordering[T9])
     extends Ordering[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {
+    /** Compares two tuples of nine elements lexicographically.
+     *
+     *  @param x the first tuple to compare
+     *  @param y the second tuple to compare
+     *  @return a negative integer, zero, or a positive integer as `x` is less than, equal to, or greater than `y`
+     */
     def compare(x: (T1, T2, T3, T4, T5, T6, T7, T8, T9), y: (T1, T2, T3, T4, T5, T6, T7, T8, T9)): Int = {
       val compare1 = ord1.compare(x._1, y._1)
       if (compare1 != 0) return compare1
@@ -1012,6 +1586,11 @@ object Ordering extends LowPriorityOrderingImplicits {
       ord9.compare(x._9, y._9)
     }
 
+    /** Returns whether the given object is equal to this ordering.
+     *
+     *  @param obj the object to compare with this ordering
+     *  @return `true` if `obj` is equal to this ordering, `false` otherwise
+     */
     override def equals(obj: scala.Any): Boolean = obj match {
       case that: AnyRef if this eq that => true
       case that: Tuple9Ordering[?, ?, ?, ?, ?, ?, ?, ?, ?] =>
@@ -1026,6 +1605,7 @@ object Ordering extends LowPriorityOrderingImplicits {
         this.ord9 == that.ord9
       case _ => false
     }
+    /** Returns a hash code for this ordering. */
     override def hashCode(): Int = (ord1, ord2, ord3, ord4, ord5, ord6, ord7, ord8, ord9).hashCode()
   }
 }

--- a/library/src/scala/math/PartialOrdering.scala
+++ b/library/src/scala/math/PartialOrdering.scala
@@ -99,6 +99,10 @@ trait PartialOrdering[T] extends Equiv[T] {
    */
   def equiv(x: T, y: T): Boolean = lteq(x,y) && lteq(y,x)
 
+  /** Returns a new `PartialOrdering` that reverses the order of this one.
+   *
+   *  The returned ordering satisfies `this.reverse.lteq(x, y) == this.lteq(y, x)`.
+   */
   def reverse : PartialOrdering[T] = new PartialOrdering[T] {
     override def reverse = outer
     def tryCompare(x: T, y: T) = outer.tryCompare(y, x)
@@ -111,5 +115,10 @@ trait PartialOrdering[T] extends Equiv[T] {
 }
 
 object PartialOrdering {
+  /** Returns the implicit `PartialOrdering` instance for type `T`.
+   *
+   *  @tparam T the type of elements being ordered
+   *  @param ev the implicit `PartialOrdering[T]` to return
+   */
   @inline def apply[T](implicit ev: PartialOrdering[T]): PartialOrdering[T] = ev
 }

--- a/library/src/scala/math/PartiallyOrdered.scala
+++ b/library/src/scala/math/PartiallyOrdered.scala
@@ -36,24 +36,48 @@ trait PartiallyOrdered[+A] extends Any {
    */
   def tryCompareTo [B >: A: AsPartiallyOrdered](that: B): Option[Int]
 
+  /** Returns `true` if this value is less than `that` according to the partial
+   *  ordering, `false` otherwise (including when the two values are not comparable).
+   *
+   *  @tparam B a supertype of `A` for which an implicit conversion to `PartiallyOrdered[B]` exists
+   *  @param that the value to compare against
+   */
   def < [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x < 0 => true
       case _ => false
     }
 
+  /** Returns `true` if this value is greater than `that` according to the partial
+   *  ordering, `false` otherwise (including when the two values are not comparable).
+   *
+   *  @tparam B a supertype of `A` for which an implicit conversion to `PartiallyOrdered[B]` exists
+   *  @param that the value to compare against
+   */
   def > [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x > 0 => true
       case _ => false
     }
 
+  /** Returns `true` if this value is less than or equal to `that` according to the partial
+   *  ordering, `false` otherwise (including when the two values are not comparable).
+   *
+   *  @tparam B a supertype of `A` for which an implicit conversion to `PartiallyOrdered[B]` exists
+   *  @param that the value to compare against
+   */
   def <= [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x <= 0 => true
       case _ => false
     }
 
+  /** Returns `true` if this value is greater than or equal to `that` according to the partial
+   *  ordering, `false` otherwise (including when the two values are not comparable).
+   *
+   *  @tparam B a supertype of `A` for which an implicit conversion to `PartiallyOrdered[B]` exists
+   *  @param that the value to compare against
+   */
   def >= [B >: A: AsPartiallyOrdered](that: B): Boolean =
     (this tryCompareTo that) match {
       case Some(x) if x >= 0 => true

--- a/library/src/scala/math/ScalaNumericConversions.scala
+++ b/library/src/scala/math/ScalaNumericConversions.scala
@@ -19,6 +19,7 @@ import scala.language.`2.13`
  *  extend ScalaNumber (which excludes value classes.)
  */
 trait ScalaNumericConversions extends ScalaNumber with ScalaNumericAnyConversions {
+  /** Returns the underlying value as a Java `Object`. */
   def underlying: Object
 }
 
@@ -31,11 +32,17 @@ trait ScalaNumericAnyConversions extends Any {
    */
   def isWhole: Boolean
 
+  /** Returns the value of this number as a [[scala.Byte]]. Any fractional part is discarded, and a value that does not fit is narrowed in an implementation-specific way: integral implementations such as [[scala.math.BigInt]] keep only the low-order 8 bits, while `Float` and `Double` first saturate at `Int.MinValue` or `Int.MaxValue`, or give `0` for `NaN`, and only then keep the low-order 8 bits of that. Either way the magnitude and sign can change. */
   def byteValue: Byte
+  /** Returns the value of this number as a [[scala.Short]]. Any fractional part is discarded, and a value that does not fit is narrowed in an implementation-specific way: integral implementations such as [[scala.math.BigInt]] keep only the low-order 16 bits, while `Float` and `Double` first saturate at `Int.MinValue` or `Int.MaxValue`, or give `0` for `NaN`, and only then keep the low-order 16 bits of that. Either way the magnitude and sign can change. */
   def shortValue: Short
+  /** Returns the value of this number as an [[scala.Int]]. Any fractional part is discarded, and a value that does not fit is narrowed in an implementation-specific way: integral implementations such as [[scala.math.BigInt]] keep only the low-order 32 bits, which can change the magnitude and sign, while `Float` and `Double` saturate at `Int.MinValue` or `Int.MaxValue`, and give `0` for `NaN`. */
   def intValue: Int
+  /** Returns the value of this number as a [[scala.Long]]. Any fractional part is discarded, and a value that does not fit is narrowed in an implementation-specific way: integral implementations such as [[scala.math.BigInt]] keep only the low-order 64 bits, which can change the magnitude and sign, while `Float` and `Double` saturate at `Long.MinValue` or `Long.MaxValue`, and give `0` for `NaN`. */
   def longValue: Long
+  /** Returns the value of this number as a [[scala.Float]]. This may involve rounding, or overflow to positive/negative infinity if the magnitude is too large to represent. */
   def floatValue: Float
+  /** Returns the value of this number as a [[scala.Double]]. This may involve rounding, or overflow to positive/negative infinity if the magnitude is too large to represent. */
   def doubleValue: Double
 
   /** Returns the value of this as a [[scala.Char]]. This may involve
@@ -93,6 +100,7 @@ trait ScalaNumericAnyConversions extends Any {
    */
   def isValidChar  = isWhole && (toInt >= Char.MinValue && toInt <= Char.MaxValue)
 
+  /** Returns a hash code based on `toLong`: the value itself, as an [[scala.Int]], if it fits in the `Int` range; otherwise the hash code of the [[scala.Long]] value. */
   protected def unifiedPrimitiveHashcode = {
     val lv = toLong
     if (lv >= Int.MinValue && lv <= Int.MaxValue) lv.toInt


### PR DESCRIPTION
This PR fills in a main doc comment plus @PARAM, @tparam, and @return tags for  scala.math, scala.collection.generic and scala.collection.concurrent APIs that are completely missing any Scaladoc documentation. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.