### PR TITLE
quoted, jdk (6): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/jdk/Accumulator.scala
+++ b/library/src/scala/jdk/Accumulator.scala
@@ -112,15 +112,37 @@ abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.
     else 1 << 24
   }
 
+  /** Returns a [[scala.collection.Stepper]] over the elements of this accumulator that supports
+   *  efficient splitting, so that it can be traversed in parallel.
+   *
+   *  @tparam S the specific stepper type, determined by `shape`
+   *  @param shape the implicit shape selecting the stepper specialized for the element type `A`
+   */
   protected def efficientStepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit
 
+  /** Returns a [[scala.collection.Stepper]] over the elements of this accumulator, refining the
+   *  inherited result type to one that always supports efficient splitting.
+   *
+   *  @tparam S the specific stepper type, determined by `shape`
+   *  @param shape the implicit shape selecting the stepper specialized for the element type `A`
+   *  @return the stepper created by [[efficientStepper]]
+   */
   final override def stepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit =
     efficientStepper(using shape)
 
+  /** Returns the number of accumulated elements as an `Int`.
+   *
+   *  @throws IllegalArgumentException if this accumulator holds `Int.MaxValue` or more elements, in
+   *          which case [[sizeLong]] has to be used instead
+   */
   final override def length: Int =
     if (sizeLong < Int.MaxValue) sizeLong.toInt
     else throw new IllegalArgumentException(s"Size too large for an Int: $sizeLong")
 
+  /** Returns the number of accumulated elements, or `-1` once this accumulator holds
+   *  `Int.MaxValue` or more of them. The bound is exclusive, so `-1` is reported at exactly
+   *  `Int.MaxValue` elements even though that count is representable.
+   */
   final override def knownSize: Int = if (sizeLong < Int.MaxValue) size else -1
 
   /** Size of the accumulated collection, as a `Long`. */
@@ -169,6 +191,15 @@ abstract class Accumulator[@specialized(Double, Int, Long) A, +CC[X] <: mutable.
  *  @define Coll `Accumulator`
  */
 object Accumulator {
+  /** Returns the [[collection.Factory]] selected by `canAccumulate`, so that the [[Accumulator]]
+   *  object can be passed wherever a factory for the element type is expected, as in
+   *  `List(1, 2, 3).to(Accumulator)`.
+   *
+   *  @tparam A the type of the ${coll}'s elements
+   *  @tparam C the (inferred) specific type of the $coll built by the returned factory
+   *  @param sa the `Accumulator` object being converted (never used)
+   *  @param canAccumulate the implicit factory shape that determines the specific accumulator type to build
+   */
   implicit def toFactory[A, C](sa: Accumulator.type)(implicit canAccumulate: AccumulatorFactoryShape[A, C]): collection.Factory[A, C] = canAccumulate.factory
 
   /** Creates a target $coll from an existing source collection
@@ -432,32 +463,54 @@ object Accumulator {
    *  @tparam C the specific accumulator type produced (e.g., `IntAccumulator`, `DoubleAccumulator`, or `AnyAccumulator[A]`)
    */
   sealed trait AccumulatorFactoryShape[A, C] {
+    /** Returns the factory that builds a `C` from elements of type `A`. */
     def factory: collection.Factory[A, C]
+    /** Returns an empty accumulator of type `C`. */
     def empty: C
   }
 
   object AccumulatorFactoryShape extends LowPriorityAccumulatorFactoryShape {
+    /** The shape that collects `Double` elements into a [[DoubleAccumulator]], without boxing them. */
     implicit val doubleAccumulatorFactoryShape: AccumulatorFactoryShape[Double, DoubleAccumulator] = new AccumulatorFactoryShape[Double, DoubleAccumulator] {
       def factory: collection.Factory[Double, DoubleAccumulator] = DoubleAccumulator
       def empty: DoubleAccumulator = DoubleAccumulator.empty
     }
 
+    /** The shape that collects `Int` elements into an [[IntAccumulator]], without boxing them. */
     implicit val intAccumulatorFactoryShape: AccumulatorFactoryShape[Int, IntAccumulator] = new AccumulatorFactoryShape[Int, IntAccumulator] {
       def factory: collection.Factory[Int, IntAccumulator] = IntAccumulator
       def empty: IntAccumulator = IntAccumulator.empty
     }
 
+    /** The shape that collects `Long` elements into a [[LongAccumulator]], without boxing them. */
     implicit val longAccumulatorFactoryShape: AccumulatorFactoryShape[Long, LongAccumulator] = new AccumulatorFactoryShape[Long, LongAccumulator] {
       def factory: collection.Factory[Long, LongAccumulator] = LongAccumulator
       def empty: LongAccumulator = LongAccumulator.empty
     }
 
+    /** The shape that collects `java.lang.Double` elements into a [[DoubleAccumulator]], which
+     *  stores them unboxed.
+     */
     implicit val jDoubleAccumulatorFactoryShape: AccumulatorFactoryShape[jl.Double, DoubleAccumulator] = doubleAccumulatorFactoryShape.asInstanceOf[AccumulatorFactoryShape[jl.Double, DoubleAccumulator]]
+    /** The shape that collects `java.lang.Integer` elements into an [[IntAccumulator]], which
+     *  stores them unboxed.
+     */
     implicit val jIntegerAccumulatorFactoryShape: AccumulatorFactoryShape[jl.Integer, IntAccumulator] = intAccumulatorFactoryShape.asInstanceOf[AccumulatorFactoryShape[jl.Integer, IntAccumulator]]
+    /** The shape that collects `java.lang.Long` elements into a [[LongAccumulator]], which stores
+     *  them unboxed.
+     */
     implicit val jLongAccumulatorFactoryShape: AccumulatorFactoryShape[jl.Long, LongAccumulator] = longAccumulatorFactoryShape.asInstanceOf[AccumulatorFactoryShape[jl.Long, LongAccumulator]]
   }
 
+  /** Provides the fallback [[Accumulator.AccumulatorFactoryShape]] used for element types that have
+   *  no unboxed specialization, so that the specialized shapes in
+   *  [[Accumulator.AccumulatorFactoryShape]] take precedence.
+   */
   sealed trait LowPriorityAccumulatorFactoryShape {
+    /** Returns the shape that collects elements of type `A` into an [[AnyAccumulator]].
+     *
+     *  @tparam A the type of the elements to accumulate
+     */
     implicit def anyAccumulatorFactoryShape[A]: AccumulatorFactoryShape[A, AnyAccumulator[A]] = anyAccumulatorFactoryShapePrototype.asInstanceOf[AccumulatorFactoryShape[A, AnyAccumulator[A]]]
 
     private val anyAccumulatorFactoryShapePrototype = new AccumulatorFactoryShape[AnyRef, AnyAccumulator[AnyRef]] {

--- a/library/src/scala/jdk/AnyAccumulator.scala
+++ b/library/src/scala/jdk/AnyAccumulator.scala
@@ -36,8 +36,17 @@ final class AnyAccumulator[A]
 
   private[jdk] def cumulative(i: Int): Long = cumul(i)
 
+  /** Returns `"AnyAccumulator"`, the prefix used by `toString`. */
   override protected def className: String = "AnyAccumulator"
 
+  /** Returns a [[scala.collection.Stepper]] over the elements of this `AnyAccumulator` that
+   *  supports efficient splitting, so that it can be traversed in parallel.
+   *
+   *  @tparam S the specific stepper type, determined by `shape`
+   *  @param shape the implicit shape selecting the stepper specialized for the element type `A`
+   *  @return a stepper of shape `S`; if `shape` selects a primitive stepper, the elements are
+   *          unboxed as they are stepped over
+   */
   def efficientStepper[S <: Stepper[?]](implicit shape: StepperShape[A, S]): S & EfficientSplit =
     shape.parUnbox(new AnyAccumulatorStepper[A](this.asInstanceOf[AnyAccumulator[A]]))
 
@@ -131,6 +140,7 @@ final class AnyAccumulator[A]
     that.clear()
   }
 
+  /** Removes all accumulated elements from this `AnyAccumulator`, releasing the arrays that held them. */
   override def clear(): Unit = {
     super.clear()
     current = AnyAccumulator.emptyAnyRefArray
@@ -158,6 +168,23 @@ final class AnyAccumulator[A]
    */
   def apply(i: Int): A = apply(i.toLong)
 
+  /** Replaces the element at index `idx` with `elem`.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the current array, in which case the write silently succeeds
+   *  without changing any element this accumulator reports. Because the offset into the current
+   *  array is computed as a `Long` and then narrowed to an `Int`, an index far enough out of range
+   *  can also wrap onto an occupied slot and silently overwrite an element this accumulator does
+   *  report. The same narrowing happens on the other branch: `seekSlot` narrows the index it is
+   *  given to an `Int` when locating a slot in `history`, so an out-of-range index can wrap onto
+   *  an occupied history slot as well. Otherwise the write throws.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the element to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if `idx` is out of range and the computed offset falls
+   *          outside the array being written, rather than into unused current-array capacity or
+   *          onto a slot reached by `Int` wraparound
+   */
   def update(idx: Long, elem: A): Unit = {
     if (totalSize - idx <= index || hIndex == 0) current((idx - (totalSize - index)).toInt) = elem.asInstanceOf[AnyRef]
     else {
@@ -166,11 +193,29 @@ final class AnyAccumulator[A]
     }
   }
 
+  /** Replaces the element at index `idx` with `elem`, using an `Int` index.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the current array, in which case the write silently succeeds
+   *  without changing any element this accumulator reports. Otherwise the write throws. An `Int`
+   *  index is widened to a `Long` without loss, so it can never wrap onto an occupied slot the
+   *  way a sufficiently large `Long` index can.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the element to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if `idx` is out of range and the computed offset falls
+   *          outside the array being written, rather than into unused current-array capacity
+   */
   def update(idx: Int, elem: A): Unit = update(idx.toLong, elem)
 
   /** Returns an `Iterator` over the contents of this `AnyAccumulator`. */
   def iterator: Iterator[A] = stepper.iterator
 
+  /** Returns the number of elements of this `AnyAccumulator` that satisfy `p`, as a `Long`, so
+   *  that accumulators holding more than `Int.MaxValue` elements are counted correctly.
+   *
+   *  @param p the predicate each element is tested against
+   */
   def countLong(p: A => Boolean): Long = {
     var r = 0L
     val s = stepper
@@ -246,6 +291,9 @@ final class AnyAccumulator[A]
     factory.fromSpecific(iterator)
   }
 
+  /** Returns the `AnyAccumulator` companion object, the factory used to build the results of
+   *  operations such as `map` and `filter`.
+   */
   override def iterableFactory: SeqFactory[AnyAccumulator] = AnyAccumulator
 
   private def writeReplace(): AnyRef = new AnyAccumulator.SerializationProxy(this)
@@ -288,15 +336,39 @@ object AnyAccumulator extends collection.SeqFactory[AnyAccumulator] {
    */
   def merger[A]: jf.BiConsumer[AnyAccumulator[A], AnyAccumulator[A]] = (a1: AnyAccumulator[A], a2: AnyAccumulator[A]) => a1 drain a2
 
+  /** Returns an `AnyAccumulator` holding the elements of `source`.
+   *
+   *  @tparam A the element type of `source` and of the resulting accumulator
+   *  @param source the `IterableOnce` whose elements are accumulated; it may be a one-shot
+   *         source, such as an `Iterator`, in which case it is consumed
+   *  @return `source` itself if it already is an `AnyAccumulator`, otherwise a new
+   *          `AnyAccumulator` with all of its elements appended in order
+   */
   def from[A](source: IterableOnce[A]): AnyAccumulator[A] = (source: @unchecked) match {
     case acc: AnyAccumulator[A] => acc
     case _ => new AnyAccumulator[A].addAll(source)
   }
 
+  /** Returns a new, empty `AnyAccumulator`.
+   *
+   *  @tparam A the element type of the accumulator
+   */
   def empty[A]: AnyAccumulator[A] = new AnyAccumulator[A]
 
+  /** Returns a builder that accumulates elements into an `AnyAccumulator`.
+   *
+   *  @tparam A the element type of the accumulator to build
+   *  @return a new, empty `AnyAccumulator[A]`, which acts as its own builder and result
+   */
   def newBuilder[A]: mutable.Builder[A, AnyAccumulator[A]] = new AnyAccumulator[A]
 
+  /** A serialization proxy that writes an `AnyAccumulator` as its size followed by its elements,
+   *  and reads it back into a freshly built accumulator.
+   *
+   *  @tparam A the element type of the accumulator being serialized
+   *  @param acc the accumulator whose elements are written; it is `@transient`, so it is only
+   *         available while serializing, not after deserialization
+   */
   class SerializationProxy[A](@transient private val acc: AnyAccumulator[A]) extends Serializable {
     @transient private var result: AnyAccumulator[AnyRef] = compiletime.uninitialized
 

--- a/library/src/scala/jdk/DoubleAccumulator.scala
+++ b/library/src/scala/jdk/DoubleAccumulator.scala
@@ -33,8 +33,18 @@ final class DoubleAccumulator
 
   private[jdk] def cumulative(i: Int) = { val x = history(i); x(x.length-1).toLong }
 
+  /** Returns `"DoubleAccumulator"`, the prefix used by `toString`. */
   override protected def className: String = "DoubleAccumulator"
 
+  /** Returns a [[scala.collection.Stepper]] over the elements of this `DoubleAccumulator` that
+   *  supports efficient splitting, so that it can be traversed in parallel.
+   *
+   *  @tparam S the specific stepper type, determined by `shape`
+   *  @param shape the implicit shape selecting the stepper specialized for the element type; it
+   *         has to select either the `Double` shape or the reference shape
+   *  @return a stepper of shape `S`; an unboxed `DoubleStepper` for the `Double` shape, and a
+   *          boxing `AnyStepper` wrapped around it for the reference shape
+   */
   def efficientStepper[S <: Stepper[?]](implicit shape: StepperShape[Double, S]): S & EfficientSplit = {
     val st = new DoubleAccumulatorStepper(this)
     val r =
@@ -138,6 +148,7 @@ final class DoubleAccumulator
     that.clear()
   }
 
+  /** Removes all accumulated elements from this `DoubleAccumulator`, releasing the arrays that held them. */
   override def clear(): Unit = {
     super.clear()
     current = DoubleAccumulator.emptyDoubleArray
@@ -164,6 +175,22 @@ final class DoubleAccumulator
    */
   def apply(i: Int): Double = apply(i.toLong)
 
+  /** Replaces the element at index `idx` with `elem`.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the array it is written to, in which case the write silently
+   *  succeeds without changing any element this accumulator reports. The offset into that array is
+   *  computed as a `Long` and then narrowed to an `Int`, both when it is computed directly for the
+   *  current array and when `seekSlot` computes it for a history array, so an index far enough out
+   *  of range can also wrap onto an occupied slot and silently overwrite an element this
+   *  accumulator does report, or onto a history block's trailing bookkeeping slot, corrupting the
+   *  accumulator's internal indexing.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the `Double` value to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if the offset computed from `idx` falls outside the
+   *          bounds of the array being written
+   */
   def update(idx: Long, elem: Double): Unit = {
     if (totalSize - idx <= index || hIndex == 0) current((idx - (totalSize - index)).toInt) = elem
     else {
@@ -172,16 +199,39 @@ final class DoubleAccumulator
     }
   }
 
+  /** Replaces the element at index `idx` with `elem`, using an `Int` index.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the current array, in which case the write silently succeeds
+   *  without changing any element this accumulator reports. Otherwise the write throws. An `Int`
+   *  index is widened to a `Long` without loss, so it can never wrap onto an occupied slot the
+   *  way a sufficiently large `Long` index can.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the `Double` value to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if `idx` is out of range and the computed offset falls
+   *          outside the array being written, rather than into unused current-array capacity
+   */
   def update(idx: Int, elem: Double): Unit = update(idx.toLong, elem)
 
   /** Returns an `Iterator` over the contents of this `DoubleAccumulator`. The `Iterator` is not specialized. */
   def iterator: Iterator[Double] = stepper.iterator
 
+  /** Applies `f` to every element of this `DoubleAccumulator`, in order.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each element
+   */
   override def foreach[U](f: Double => U): Unit = {
     val s = stepper
     while (s.hasStep) f(s.nextStep())
   }
 
+  /** Returns a new `DoubleAccumulator` holding the results of applying `f` to every element of
+   *  this one, in order.
+   *
+   *  @param f the function applied to each element
+   */
   def map(f: Double => Double): DoubleAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -190,6 +240,11 @@ final class DoubleAccumulator
     b.result()
   }
 
+  /** Returns a new `DoubleAccumulator` holding the concatenated results of applying `f` to every
+   *  element of this one, in order.
+   *
+   *  @param f the function mapping each element to the elements to append in its place
+   */
   def flatMap(f: Double => IterableOnce[Double]): DoubleAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -198,6 +253,11 @@ final class DoubleAccumulator
     b.result()
   }
 
+  /** Returns a new `DoubleAccumulator` holding the results of applying `pf` to the elements of
+   *  this one for which it is defined, in order.
+   *
+   *  @param pf the partial function applied to each element; elements outside its domain are skipped
+   */
   def collect(pf: PartialFunction[Double, Double]): DoubleAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -218,10 +278,25 @@ final class DoubleAccumulator
     b.result()
   }
 
+  /** Returns a new `DoubleAccumulator` holding the elements of this one that satisfy `pred`, in order.
+   *
+   *  @param pred the predicate each element is tested against
+   */
   override def filter(pred: Double => Boolean): DoubleAccumulator = filterAccImpl(pred, not = false)
 
+  /** Returns a new `DoubleAccumulator` holding the elements of this one that do not satisfy `pred`,
+   *  in order.
+   *
+   *  @param pred the predicate each element is tested against
+   */
   override def filterNot(pred: Double => Boolean): DoubleAccumulator = filterAccImpl(pred, not = true)
 
+  /** Tests whether `p` holds for every element of this `DoubleAccumulator`.
+   *
+   *  @param p the predicate each element is tested against
+   *  @return `true` if every element satisfies `p`, or if this accumulator is empty; `false` as
+   *          soon as an element fails the test, leaving the remaining elements untested
+   */
   override def forall(p: Double => Boolean): Boolean = {
     val s = stepper
     while (s.hasStep)
@@ -229,6 +304,12 @@ final class DoubleAccumulator
     true
   }
 
+  /** Tests whether `p` holds for at least one element of this `DoubleAccumulator`.
+   *
+   *  @param p the predicate each element is tested against
+   *  @return `true` as soon as an element satisfies `p`, leaving the remaining elements untested;
+   *          `false` if no element does, and in particular if this accumulator is empty
+   */
   override def exists(p: Double => Boolean): Boolean = {
     val s = stepper
     while (s.hasStep)
@@ -236,6 +317,12 @@ final class DoubleAccumulator
     false
   }
 
+  /** Counts the elements of this `DoubleAccumulator` that satisfy a predicate.
+   *
+   *  @param p the predicate each element is tested against
+   *  @return the number of matching elements, as an `Int`, which overflows if more than
+   *          `Int.MaxValue` elements match; use [[countLong]] for such accumulators
+   */
   override def count(p: Double => Boolean): Int = {
     var r = 0
     val s = stepper
@@ -244,6 +331,12 @@ final class DoubleAccumulator
     r
   }
 
+  /** Counts the elements of this `DoubleAccumulator` that satisfy a predicate.
+   *
+   *  @param p the predicate each element is tested against
+   *  @return the number of matching elements, as a `Long`, so that accumulators holding more
+   *          than `Int.MaxValue` elements are counted correctly
+   */
   def countLong(p: Double => Boolean): Long = {
     var r = 0L
     val s = stepper
@@ -308,10 +401,23 @@ final class DoubleAccumulator
     factory.fromSpecific(iterator)
   }
 
+  /** Returns a `DoubleAccumulator` holding the elements of `coll`, used to rebuild this
+   *  collection type from the result of a generic operation.
+   *
+   *  @param coll the elements of the resulting accumulator; a one-shot source, such as an
+   *         `Iterator`, is consumed
+   *  @return `coll` itself if it already is a `DoubleAccumulator`, otherwise a new
+   *          `DoubleAccumulator` with all of its elements appended in order
+   */
   override protected def fromSpecific(coll: IterableOnce[Double]): DoubleAccumulator = DoubleAccumulator.fromSpecific(coll)
+  /** Returns a new, empty `DoubleAccumulator`, which acts as its own builder and result. */
   override protected def newSpecificBuilder: DoubleAccumulator = DoubleAccumulator.newBuilder
+  /** Returns the [[AnyAccumulator]] companion object, the factory used to build the results of
+   *  operations that are not specialized for `Double`, such as mapping to another element type.
+   */
   override def iterableFactory: SeqFactory[AnyAccumulator] = AnyAccumulator
 
+  /** Returns a new, empty `DoubleAccumulator`. */
   override def empty: DoubleAccumulator = DoubleAccumulator.empty
 
   private def writeReplace(): AnyRef = new DoubleAccumulator.SerializationProxy(this)
@@ -321,6 +427,13 @@ object DoubleAccumulator extends collection.SpecificIterableFactory[Double, Doub
   private val emptyDoubleArray = new Array[Double](0)
   private val emptyDoubleArrayArray = new Array[Array[Double]](0)
 
+  /** Adapts the [[DoubleAccumulator]] companion object to a factory for boxed `java.lang.Double`
+   *  elements, so that it can be used where a factory of a Java-typed collection is expected.
+   *
+   *  @param ia the `DoubleAccumulator` companion object being converted (never used)
+   *  @return the `DoubleAccumulator` companion object itself, cast to a
+   *          `SpecificIterableFactory` of `java.lang.Double`; no new factory is created
+   */
   implicit def toJavaDoubleAccumulator(ia: DoubleAccumulator.type): collection.SpecificIterableFactory[jl.Double, DoubleAccumulator] = DoubleAccumulator.asInstanceOf[collection.SpecificIterableFactory[jl.Double, DoubleAccumulator]]
 
   import java.util.{function => jf}
@@ -344,6 +457,13 @@ object DoubleAccumulator extends collection.SpecificIterableFactory[Double, Doub
     r
   }
 
+  /** Returns a `DoubleAccumulator` holding the elements of `it`.
+   *
+   *  @param it the elements to accumulate; a one-shot source, such as an `Iterator`, is consumed
+   *  @return `it` itself if it already is a `DoubleAccumulator`, otherwise a new
+   *          `DoubleAccumulator` with all of its elements appended in order; an `ArraySeq` of
+   *          `Double` is copied without boxing
+   */
   override def fromSpecific(it: IterableOnce[Double]): DoubleAccumulator = it match {
     case acc: DoubleAccumulator => acc
     case as: collection.immutable.ArraySeq.ofDouble => fromArray(as.unsafeArray)
@@ -351,10 +471,19 @@ object DoubleAccumulator extends collection.SpecificIterableFactory[Double, Doub
     case _ => (new DoubleAccumulator).addAll(it)
   }
 
+  /** Returns a new, empty `DoubleAccumulator`. */
   override def empty: DoubleAccumulator = new DoubleAccumulator
 
+  /** Returns a new, empty `DoubleAccumulator`, which acts as its own builder and result. */
   override def newBuilder: DoubleAccumulator = new DoubleAccumulator
 
+  /** A serialization proxy that writes a `DoubleAccumulator` as its size followed by its
+   *  elements, and reads it back into a freshly built accumulator.
+   *
+   *  @tparam A a type parameter that is never used; the element type is always `Double`
+   *  @param acc the accumulator whose elements are written; it is `@transient`, so it is only
+   *         available while serializing, not after deserialization
+   */
   class SerializationProxy[A](@transient private val acc: DoubleAccumulator) extends Serializable {
     @transient private var result: DoubleAccumulator = compiletime.uninitialized
 

--- a/library/src/scala/jdk/DurationConverters.scala
+++ b/library/src/scala/jdk/DurationConverters.scala
@@ -23,11 +23,21 @@ import scala.concurrent.duration.FiniteDuration
   * [[javaapi.DurationConverters]] instead.
   */
 object DurationConverters {
+  /** Adds a `toScala` extension method to `java.time.Duration` for converting it to a
+   *  [[scala.concurrent.duration.FiniteDuration]].
+   *
+   *  @param duration the Java duration the extension method converts
+   */
   implicit class JavaDurationOps(private val duration: JDuration) extends AnyVal {
     /** Converts a Java duration to a Scala duration, see [[javaapi.DurationConverters.toScala]]. */
     def toScala: FiniteDuration = javaapi.DurationConverters.toScala(duration)
   }
 
+  /** Adds a `toJava` extension method to [[scala.concurrent.duration.FiniteDuration]] for
+   *  converting it to a `java.time.Duration`.
+   *
+   *  @param duration the Scala duration the extension method converts
+   */
   implicit final class ScalaDurationOps(private val duration: FiniteDuration) extends AnyVal {
     /** Converts a Scala duration to a Java duration, see [[javaapi.DurationConverters.toJava]]. */
     def toJava: JDuration = javaapi.DurationConverters.toJava(duration)

--- a/library/src/scala/jdk/FunctionExtensions.scala
+++ b/library/src/scala/jdk/FunctionExtensions.scala
@@ -18,9 +18,22 @@ package scala.jdk
 import scala.language.`2.13`
 import language.implicitConversions
 
+/** Provides the lowest-priority implicit conversion from a Scala function to a Java functional
+ *  interface wrapper. It applies only when no conversion declared in
+ *  [[Priority2FunctionExtensions]] or one of its subtraits does, so that a Scala function is
+ *  enriched with the most specific Java function type that fits it.
+ */
 trait Priority3FunctionExtensions {
   import FunctionWrappers._
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaBiFunction` methods that convert it to a `java.util.function.BiFunction`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam U the type of the second argument of `sf`
+   *  @tparam R the result type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction2AsBiFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaBiFunction[T, U, R](sf: scala.Function2[T, U, R]): RichFunction2AsBiFunction[T, U, R] = new RichFunction2AsBiFunction[T, U, R](sf)
 }
 
@@ -28,19 +41,64 @@ trait Priority3FunctionExtensions {
 
 import language.implicitConversions
 
+/** Provides implicit conversions from Scala functions to Java functional interface wrappers,
+ *  taking precedence over the conversion inherited from [[Priority3FunctionExtensions]].
+ */
 trait Priority2FunctionExtensions extends Priority3FunctionExtensions {
   import FunctionWrappers._
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaBiConsumer` methods that convert it to a `java.util.function.BiConsumer`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam U the type of the second argument of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction2AsBiConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaBiConsumer[T, U](sf: scala.Function2[T, U, Unit]): RichFunction2AsBiConsumer[T, U] = new RichFunction2AsBiConsumer[T, U](sf)
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaBiPredicate` methods that convert it to a `java.util.function.BiPredicate`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam U the type of the second argument of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction2AsBiPredicate]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaBiPredicate[T, U](sf: scala.Function2[T, U, Boolean]): RichFunction2AsBiPredicate[T, U] = new RichFunction2AsBiPredicate[T, U](sf)
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaFunction` methods that convert it to a `java.util.function.Function`.
+   *
+   *  @tparam T the argument type of `sf`
+   *  @tparam R the result type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction1AsFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaFunction[T, R](sf: scala.Function1[T, R]): RichFunction1AsFunction[T, R] = new RichFunction1AsFunction[T, R](sf)
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaToDoubleBiFunction` methods that convert it to a `java.util.function.ToDoubleBiFunction`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam U the type of the second argument of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction2AsToDoubleBiFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaToDoubleBiFunction[T, U](sf: scala.Function2[T, U, Double]): RichFunction2AsToDoubleBiFunction[T, U] = new RichFunction2AsToDoubleBiFunction[T, U](sf)
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaToIntBiFunction` methods that convert it to a `java.util.function.ToIntBiFunction`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam U the type of the second argument of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction2AsToIntBiFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaToIntBiFunction[T, U](sf: scala.Function2[T, U, Int]): RichFunction2AsToIntBiFunction[T, U] = new RichFunction2AsToIntBiFunction[T, U](sf)
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaToLongBiFunction` methods that convert it to a `java.util.function.ToLongBiFunction`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam U the type of the second argument of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction2AsToLongBiFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaToLongBiFunction[T, U](sf: scala.Function2[T, U, Long]): RichFunction2AsToLongBiFunction[T, U] = new RichFunction2AsToLongBiFunction[T, U](sf)
 }
 
@@ -48,35 +106,140 @@ trait Priority2FunctionExtensions extends Priority3FunctionExtensions {
 
 import language.implicitConversions
 
+/** Provides implicit conversions from Scala functions to Java functional interface wrappers,
+ *  taking precedence over those inherited from [[Priority2FunctionExtensions]].
+ */
 trait Priority1FunctionExtensions extends Priority2FunctionExtensions {
   import FunctionWrappers._
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaBinaryOperator` methods that convert it to a `java.util.function.BinaryOperator`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam A1 the type of the second argument of `sf`, constrained by `evA1` to be `T`
+   *  @tparam A2 the result type of `sf`, constrained by `evA2` to be `T`
+   *  @param sf the Scala function to convert
+   *  @param evA1 evidence that `A1` is `T`
+   *  @param evA2 evidence that `A2` is `T`
+   *  @return a [[FunctionWrappers.RichFunction2AsBinaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaBinaryOperator[T, A1, A2](sf: scala.Function2[T, A1, A2])(implicit evA1: =:=[A1, T], evA2: =:=[A2, T]): RichFunction2AsBinaryOperator[T] = new RichFunction2AsBinaryOperator[T](sf.asInstanceOf[scala.Function2[T, T, T]])
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaConsumer` methods that convert it to a `java.util.function.Consumer`.
+   *
+   *  @tparam T the argument type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction1AsConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaConsumer[T](sf: scala.Function1[T, Unit]): RichFunction1AsConsumer[T] = new RichFunction1AsConsumer[T](sf)
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaDoubleFunction` methods that convert it to a `java.util.function.DoubleFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Double`
+   *  @tparam R the result type of `sf`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction1AsDoubleFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoubleFunction[A0, R](sf: scala.Function1[A0, R])(implicit evA0: =:=[A0, Double]): RichFunction1AsDoubleFunction[R] = new RichFunction1AsDoubleFunction[R](sf.asInstanceOf[scala.Function1[Double, R]])
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaIntFunction` methods that convert it to a `java.util.function.IntFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Int`
+   *  @tparam R the result type of `sf`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction1AsIntFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntFunction[A0, R](sf: scala.Function1[A0, R])(implicit evA0: =:=[A0, Int]): RichFunction1AsIntFunction[R] = new RichFunction1AsIntFunction[R](sf.asInstanceOf[scala.Function1[Int, R]])
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaLongFunction` methods that convert it to a `java.util.function.LongFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Long`
+   *  @tparam R the result type of `sf`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction1AsLongFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongFunction[A0, R](sf: scala.Function1[A0, R])(implicit evA0: =:=[A0, Long]): RichFunction1AsLongFunction[R] = new RichFunction1AsLongFunction[R](sf.asInstanceOf[scala.Function1[Long, R]])
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaObjDoubleConsumer` methods that convert it to a `java.util.function.ObjDoubleConsumer`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam A1 the type of the second argument of `sf`, constrained by `evA1` to be `Double`
+   *  @param sf the Scala function to convert
+   *  @param evA1 evidence that `A1` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction2AsObjDoubleConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaObjDoubleConsumer[T, A1](sf: scala.Function2[T, A1, Unit])(implicit evA1: =:=[A1, Double]): RichFunction2AsObjDoubleConsumer[T] = new RichFunction2AsObjDoubleConsumer[T](sf.asInstanceOf[scala.Function2[T, Double, Unit]])
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaObjIntConsumer` methods that convert it to a `java.util.function.ObjIntConsumer`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam A1 the type of the second argument of `sf`, constrained by `evA1` to be `Int`
+   *  @param sf the Scala function to convert
+   *  @param evA1 evidence that `A1` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction2AsObjIntConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaObjIntConsumer[T, A1](sf: scala.Function2[T, A1, Unit])(implicit evA1: =:=[A1, Int]): RichFunction2AsObjIntConsumer[T] = new RichFunction2AsObjIntConsumer[T](sf.asInstanceOf[scala.Function2[T, Int, Unit]])
   
+  /** Enriches a Scala `Function2` with `asJava` and `asJavaObjLongConsumer` methods that convert it to a `java.util.function.ObjLongConsumer`.
+   *
+   *  @tparam T the type of the first argument of `sf`
+   *  @tparam A1 the type of the second argument of `sf`, constrained by `evA1` to be `Long`
+   *  @param sf the Scala function to convert
+   *  @param evA1 evidence that `A1` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction2AsObjLongConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaObjLongConsumer[T, A1](sf: scala.Function2[T, A1, Unit])(implicit evA1: =:=[A1, Long]): RichFunction2AsObjLongConsumer[T] = new RichFunction2AsObjLongConsumer[T](sf.asInstanceOf[scala.Function2[T, Long, Unit]])
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaPredicate` methods that convert it to a `java.util.function.Predicate`.
+   *
+   *  @tparam T the argument type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction1AsPredicate]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaPredicate[T](sf: scala.Function1[T, Boolean]): RichFunction1AsPredicate[T] = new RichFunction1AsPredicate[T](sf)
   
+  /** Enriches a Scala `Function0` with `asJava` and `asJavaSupplier` methods that convert it to a `java.util.function.Supplier`.
+   *
+   *  @tparam T the result type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction0AsSupplier]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaSupplier[T](sf: scala.Function0[T]): RichFunction0AsSupplier[T] = new RichFunction0AsSupplier[T](sf)
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaToDoubleFunction` methods that convert it to a `java.util.function.ToDoubleFunction`.
+   *
+   *  @tparam T the argument type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction1AsToDoubleFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaToDoubleFunction[T](sf: scala.Function1[T, Double]): RichFunction1AsToDoubleFunction[T] = new RichFunction1AsToDoubleFunction[T](sf)
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaToIntFunction` methods that convert it to a `java.util.function.ToIntFunction`.
+   *
+   *  @tparam T the argument type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction1AsToIntFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaToIntFunction[T](sf: scala.Function1[T, Int]): RichFunction1AsToIntFunction[T] = new RichFunction1AsToIntFunction[T](sf)
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaToLongFunction` methods that convert it to a `java.util.function.ToLongFunction`.
+   *
+   *  @tparam T the argument type of `sf`
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction1AsToLongFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaToLongFunction[T](sf: scala.Function1[T, Long]): RichFunction1AsToLongFunction[T] = new RichFunction1AsToLongFunction[T](sf)
   
+  /** Enriches a Scala `Function1` with `asJava` and `asJavaUnaryOperator` methods that convert it to a `java.util.function.UnaryOperator`.
+   *
+   *  @tparam T the argument type of `sf`
+   *  @tparam A1 the result type of `sf`, constrained by `evA1` to be `T`
+   *  @param sf the Scala function to convert
+   *  @param evA1 evidence that `A1` is `T`
+   *  @return a [[FunctionWrappers.RichFunction1AsUnaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaUnaryOperator[T, A1](sf: scala.Function1[T, A1])(implicit evA1: =:=[A1, T]): RichFunction1AsUnaryOperator[T] = new RichFunction1AsUnaryOperator[T](sf.asInstanceOf[scala.Function1[T, T]])
 }
 
@@ -84,138 +247,540 @@ trait Priority1FunctionExtensions extends Priority2FunctionExtensions {
 
 import language.implicitConversions
 
+/** Provides the highest-priority implicit conversions between Scala functions and Java functional
+ *  interfaces, taking precedence over those inherited from [[Priority1FunctionExtensions]].
+ *  Alongside the conversions to the primitive-specialized Java function types, every conversion
+ *  that enriches a Java functional interface with an `asScala` method is declared here.
+ *  [[FunctionConverters]] extends this trait to make the whole hierarchy available at once.
+ */
 trait Priority0FunctionExtensions extends Priority1FunctionExtensions {
   import FunctionWrappers._
   
+  /** Enriches a Scala `Function0` with an `asJava` method that converts it to a `java.util.function.BooleanSupplier`.
+   *
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction0AsBooleanSupplier]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaBooleanSupplier(sf: scala.Function0[Boolean]): RichFunction0AsBooleanSupplier = new RichFunction0AsBooleanSupplier(sf)
   
+  /** Enriches a Scala `Function2` with an `asJava` method that converts it to a `java.util.function.DoubleBinaryOperator`.
+   *
+   *  @tparam A0 the type of the first argument of `sf`, constrained by `evA0` to be `Double`
+   *  @tparam A1 the type of the second argument of `sf`, constrained by `evA1` to be `Double`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Double`
+   *  @param evA1 evidence that `A1` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction2AsDoubleBinaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoubleBinaryOperator[A0, A1](sf: scala.Function2[A0, A1, Double])(implicit evA0: =:=[A0, Double], evA1: =:=[A1, Double]): RichFunction2AsDoubleBinaryOperator = new RichFunction2AsDoubleBinaryOperator(sf.asInstanceOf[scala.Function2[Double, Double, Double]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.DoubleConsumer`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Double`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction1AsDoubleConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoubleConsumer[A0](sf: scala.Function1[A0, Unit])(implicit evA0: =:=[A0, Double]): RichFunction1AsDoubleConsumer = new RichFunction1AsDoubleConsumer(sf.asInstanceOf[scala.Function1[Double, Unit]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.DoublePredicate`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Double`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction1AsDoublePredicate]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoublePredicate[A0](sf: scala.Function1[A0, Boolean])(implicit evA0: =:=[A0, Double]): RichFunction1AsDoublePredicate = new RichFunction1AsDoublePredicate(sf.asInstanceOf[scala.Function1[Double, Boolean]])
   
+  /** Enriches a Scala `Function0` with an `asJava` method that converts it to a `java.util.function.DoubleSupplier`.
+   *
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction0AsDoubleSupplier]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoubleSupplier(sf: scala.Function0[Double]): RichFunction0AsDoubleSupplier = new RichFunction0AsDoubleSupplier(sf)
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.DoubleToIntFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Double`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction1AsDoubleToIntFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoubleToIntFunction[A0](sf: scala.Function1[A0, Int])(implicit evA0: =:=[A0, Double]): RichFunction1AsDoubleToIntFunction = new RichFunction1AsDoubleToIntFunction(sf.asInstanceOf[scala.Function1[Double, Int]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.DoubleToLongFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Double`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction1AsDoubleToLongFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoubleToLongFunction[A0](sf: scala.Function1[A0, Long])(implicit evA0: =:=[A0, Double]): RichFunction1AsDoubleToLongFunction = new RichFunction1AsDoubleToLongFunction(sf.asInstanceOf[scala.Function1[Double, Long]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.DoubleUnaryOperator`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Double`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Double`
+   *  @return a [[FunctionWrappers.RichFunction1AsDoubleUnaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaDoubleUnaryOperator[A0](sf: scala.Function1[A0, Double])(implicit evA0: =:=[A0, Double]): RichFunction1AsDoubleUnaryOperator = new RichFunction1AsDoubleUnaryOperator(sf.asInstanceOf[scala.Function1[Double, Double]])
   
+  /** Enriches a Scala `Function2` with an `asJava` method that converts it to a `java.util.function.IntBinaryOperator`.
+   *
+   *  @tparam A0 the type of the first argument of `sf`, constrained by `evA0` to be `Int`
+   *  @tparam A1 the type of the second argument of `sf`, constrained by `evA1` to be `Int`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Int`
+   *  @param evA1 evidence that `A1` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction2AsIntBinaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntBinaryOperator[A0, A1](sf: scala.Function2[A0, A1, Int])(implicit evA0: =:=[A0, Int], evA1: =:=[A1, Int]): RichFunction2AsIntBinaryOperator = new RichFunction2AsIntBinaryOperator(sf.asInstanceOf[scala.Function2[Int, Int, Int]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.IntConsumer`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Int`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction1AsIntConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntConsumer[A0](sf: scala.Function1[A0, Unit])(implicit evA0: =:=[A0, Int]): RichFunction1AsIntConsumer = new RichFunction1AsIntConsumer(sf.asInstanceOf[scala.Function1[Int, Unit]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.IntPredicate`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Int`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction1AsIntPredicate]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntPredicate[A0](sf: scala.Function1[A0, Boolean])(implicit evA0: =:=[A0, Int]): RichFunction1AsIntPredicate = new RichFunction1AsIntPredicate(sf.asInstanceOf[scala.Function1[Int, Boolean]])
   
+  /** Enriches a Scala `Function0` with an `asJava` method that converts it to a `java.util.function.IntSupplier`.
+   *
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction0AsIntSupplier]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntSupplier(sf: scala.Function0[Int]): RichFunction0AsIntSupplier = new RichFunction0AsIntSupplier(sf)
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.IntToDoubleFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Int`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction1AsIntToDoubleFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntToDoubleFunction[A0](sf: scala.Function1[A0, Double])(implicit evA0: =:=[A0, Int]): RichFunction1AsIntToDoubleFunction = new RichFunction1AsIntToDoubleFunction(sf.asInstanceOf[scala.Function1[Int, Double]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.IntToLongFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Int`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction1AsIntToLongFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntToLongFunction[A0](sf: scala.Function1[A0, Long])(implicit evA0: =:=[A0, Int]): RichFunction1AsIntToLongFunction = new RichFunction1AsIntToLongFunction(sf.asInstanceOf[scala.Function1[Int, Long]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.IntUnaryOperator`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Int`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Int`
+   *  @return a [[FunctionWrappers.RichFunction1AsIntUnaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaIntUnaryOperator[A0](sf: scala.Function1[A0, Int])(implicit evA0: =:=[A0, Int]): RichFunction1AsIntUnaryOperator = new RichFunction1AsIntUnaryOperator(sf.asInstanceOf[scala.Function1[Int, Int]])
   
+  /** Enriches a Scala `Function2` with an `asJava` method that converts it to a `java.util.function.LongBinaryOperator`.
+   *
+   *  @tparam A0 the type of the first argument of `sf`, constrained by `evA0` to be `Long`
+   *  @tparam A1 the type of the second argument of `sf`, constrained by `evA1` to be `Long`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Long`
+   *  @param evA1 evidence that `A1` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction2AsLongBinaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongBinaryOperator[A0, A1](sf: scala.Function2[A0, A1, Long])(implicit evA0: =:=[A0, Long], evA1: =:=[A1, Long]): RichFunction2AsLongBinaryOperator = new RichFunction2AsLongBinaryOperator(sf.asInstanceOf[scala.Function2[Long, Long, Long]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.LongConsumer`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Long`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction1AsLongConsumer]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongConsumer[A0](sf: scala.Function1[A0, Unit])(implicit evA0: =:=[A0, Long]): RichFunction1AsLongConsumer = new RichFunction1AsLongConsumer(sf.asInstanceOf[scala.Function1[Long, Unit]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.LongPredicate`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Long`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction1AsLongPredicate]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongPredicate[A0](sf: scala.Function1[A0, Boolean])(implicit evA0: =:=[A0, Long]): RichFunction1AsLongPredicate = new RichFunction1AsLongPredicate(sf.asInstanceOf[scala.Function1[Long, Boolean]])
   
+  /** Enriches a Scala `Function0` with an `asJava` method that converts it to a `java.util.function.LongSupplier`.
+   *
+   *  @param sf the Scala function to convert
+   *  @return a [[FunctionWrappers.RichFunction0AsLongSupplier]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongSupplier(sf: scala.Function0[Long]): RichFunction0AsLongSupplier = new RichFunction0AsLongSupplier(sf)
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.LongToDoubleFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Long`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction1AsLongToDoubleFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongToDoubleFunction[A0](sf: scala.Function1[A0, Double])(implicit evA0: =:=[A0, Long]): RichFunction1AsLongToDoubleFunction = new RichFunction1AsLongToDoubleFunction(sf.asInstanceOf[scala.Function1[Long, Double]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.LongToIntFunction`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Long`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction1AsLongToIntFunction]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongToIntFunction[A0](sf: scala.Function1[A0, Int])(implicit evA0: =:=[A0, Long]): RichFunction1AsLongToIntFunction = new RichFunction1AsLongToIntFunction(sf.asInstanceOf[scala.Function1[Long, Int]])
   
+  /** Enriches a Scala `Function1` with an `asJava` method that converts it to a `java.util.function.LongUnaryOperator`.
+   *
+   *  @tparam A0 the argument type of `sf`, constrained by `evA0` to be `Long`
+   *  @param sf the Scala function to convert
+   *  @param evA0 evidence that `A0` is `Long`
+   *  @return a [[FunctionWrappers.RichFunction1AsLongUnaryOperator]] value class wrapping `sf`
+   */
   @inline implicit def enrichAsJavaLongUnaryOperator[A0](sf: scala.Function1[A0, Long])(implicit evA0: =:=[A0, Long]): RichFunction1AsLongUnaryOperator = new RichFunction1AsLongUnaryOperator(sf.asInstanceOf[scala.Function1[Long, Long]])
   
   
   
+  /** Enriches a `java.util.function.BiConsumer` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @tparam U the type of the second argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichBiConsumerAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromBiConsumer[T, U](jf: java.util.function.BiConsumer[T, U]): RichBiConsumerAsFunction2[T, U] = new RichBiConsumerAsFunction2[T, U](jf)
   
+  /** Enriches a `java.util.function.BiFunction` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @tparam U the type of the second argument of `jf`
+   *  @tparam R the result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichBiFunctionAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromBiFunction[T, U, R](jf: java.util.function.BiFunction[T, U, R]): RichBiFunctionAsFunction2[T, U, R] = new RichBiFunctionAsFunction2[T, U, R](jf)
   
+  /** Enriches a `java.util.function.BiPredicate` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @tparam U the type of the second argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichBiPredicateAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromBiPredicate[T, U](jf: java.util.function.BiPredicate[T, U]): RichBiPredicateAsFunction2[T, U] = new RichBiPredicateAsFunction2[T, U](jf)
   
+  /** Enriches a `java.util.function.BinaryOperator` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the operand and result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichBinaryOperatorAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromBinaryOperator[T](jf: java.util.function.BinaryOperator[T]): RichBinaryOperatorAsFunction2[T] = new RichBinaryOperatorAsFunction2[T](jf)
   
+  /** Enriches a `java.util.function.BooleanSupplier` with an `asScala` method that converts it to a Scala `Function0`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichBooleanSupplierAsFunction0]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromBooleanSupplier(jf: java.util.function.BooleanSupplier): RichBooleanSupplierAsFunction0 = new RichBooleanSupplierAsFunction0(jf)
   
+  /** Enriches a `java.util.function.Consumer` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam T the argument type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichConsumerAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromConsumer[T](jf: java.util.function.Consumer[T]): RichConsumerAsFunction1[T] = new RichConsumerAsFunction1[T](jf)
   
+  /** Enriches a `java.util.function.DoubleBinaryOperator` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoubleBinaryOperatorAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoubleBinaryOperator(jf: java.util.function.DoubleBinaryOperator): RichDoubleBinaryOperatorAsFunction2 = new RichDoubleBinaryOperatorAsFunction2(jf)
   
+  /** Enriches a `java.util.function.DoubleConsumer` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoubleConsumerAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoubleConsumer(jf: java.util.function.DoubleConsumer): RichDoubleConsumerAsFunction1 = new RichDoubleConsumerAsFunction1(jf)
   
+  /** Enriches a `java.util.function.DoubleFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam R the result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoubleFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoubleFunction[R](jf: java.util.function.DoubleFunction[R]): RichDoubleFunctionAsFunction1[R] = new RichDoubleFunctionAsFunction1[R](jf)
   
+  /** Enriches a `java.util.function.DoublePredicate` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoublePredicateAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoublePredicate(jf: java.util.function.DoublePredicate): RichDoublePredicateAsFunction1 = new RichDoublePredicateAsFunction1(jf)
   
+  /** Enriches a `java.util.function.DoubleSupplier` with an `asScala` method that converts it to a Scala `Function0`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoubleSupplierAsFunction0]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoubleSupplier(jf: java.util.function.DoubleSupplier): RichDoubleSupplierAsFunction0 = new RichDoubleSupplierAsFunction0(jf)
   
+  /** Enriches a `java.util.function.DoubleToIntFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoubleToIntFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoubleToIntFunction(jf: java.util.function.DoubleToIntFunction): RichDoubleToIntFunctionAsFunction1 = new RichDoubleToIntFunctionAsFunction1(jf)
   
+  /** Enriches a `java.util.function.DoubleToLongFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoubleToLongFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoubleToLongFunction(jf: java.util.function.DoubleToLongFunction): RichDoubleToLongFunctionAsFunction1 = new RichDoubleToLongFunctionAsFunction1(jf)
   
+  /** Enriches a `java.util.function.DoubleUnaryOperator` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichDoubleUnaryOperatorAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromDoubleUnaryOperator(jf: java.util.function.DoubleUnaryOperator): RichDoubleUnaryOperatorAsFunction1 = new RichDoubleUnaryOperatorAsFunction1(jf)
   
+  /** Enriches a `java.util.function.Function` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam T the argument type of `jf`
+   *  @tparam R the result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromFunction[T, R](jf: java.util.function.Function[T, R]): RichFunctionAsFunction1[T, R] = new RichFunctionAsFunction1[T, R](jf)
   
+  /** Enriches a `java.util.function.IntBinaryOperator` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntBinaryOperatorAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntBinaryOperator(jf: java.util.function.IntBinaryOperator): RichIntBinaryOperatorAsFunction2 = new RichIntBinaryOperatorAsFunction2(jf)
   
+  /** Enriches a `java.util.function.IntConsumer` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntConsumerAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntConsumer(jf: java.util.function.IntConsumer): RichIntConsumerAsFunction1 = new RichIntConsumerAsFunction1(jf)
   
+  /** Enriches a `java.util.function.IntFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam R the result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntFunction[R](jf: java.util.function.IntFunction[R]): RichIntFunctionAsFunction1[R] = new RichIntFunctionAsFunction1[R](jf)
   
+  /** Enriches a `java.util.function.IntPredicate` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntPredicateAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntPredicate(jf: java.util.function.IntPredicate): RichIntPredicateAsFunction1 = new RichIntPredicateAsFunction1(jf)
   
+  /** Enriches a `java.util.function.IntSupplier` with an `asScala` method that converts it to a Scala `Function0`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntSupplierAsFunction0]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntSupplier(jf: java.util.function.IntSupplier): RichIntSupplierAsFunction0 = new RichIntSupplierAsFunction0(jf)
   
+  /** Enriches a `java.util.function.IntToDoubleFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntToDoubleFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntToDoubleFunction(jf: java.util.function.IntToDoubleFunction): RichIntToDoubleFunctionAsFunction1 = new RichIntToDoubleFunctionAsFunction1(jf)
   
+  /** Enriches a `java.util.function.IntToLongFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntToLongFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntToLongFunction(jf: java.util.function.IntToLongFunction): RichIntToLongFunctionAsFunction1 = new RichIntToLongFunctionAsFunction1(jf)
   
+  /** Enriches a `java.util.function.IntUnaryOperator` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichIntUnaryOperatorAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromIntUnaryOperator(jf: java.util.function.IntUnaryOperator): RichIntUnaryOperatorAsFunction1 = new RichIntUnaryOperatorAsFunction1(jf)
   
+  /** Enriches a `java.util.function.LongBinaryOperator` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongBinaryOperatorAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongBinaryOperator(jf: java.util.function.LongBinaryOperator): RichLongBinaryOperatorAsFunction2 = new RichLongBinaryOperatorAsFunction2(jf)
   
+  /** Enriches a `java.util.function.LongConsumer` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongConsumerAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongConsumer(jf: java.util.function.LongConsumer): RichLongConsumerAsFunction1 = new RichLongConsumerAsFunction1(jf)
   
+  /** Enriches a `java.util.function.LongFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam R the result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongFunction[R](jf: java.util.function.LongFunction[R]): RichLongFunctionAsFunction1[R] = new RichLongFunctionAsFunction1[R](jf)
   
+  /** Enriches a `java.util.function.LongPredicate` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongPredicateAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongPredicate(jf: java.util.function.LongPredicate): RichLongPredicateAsFunction1 = new RichLongPredicateAsFunction1(jf)
   
+  /** Enriches a `java.util.function.LongSupplier` with an `asScala` method that converts it to a Scala `Function0`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongSupplierAsFunction0]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongSupplier(jf: java.util.function.LongSupplier): RichLongSupplierAsFunction0 = new RichLongSupplierAsFunction0(jf)
   
+  /** Enriches a `java.util.function.LongToDoubleFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongToDoubleFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongToDoubleFunction(jf: java.util.function.LongToDoubleFunction): RichLongToDoubleFunctionAsFunction1 = new RichLongToDoubleFunctionAsFunction1(jf)
   
+  /** Enriches a `java.util.function.LongToIntFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongToIntFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongToIntFunction(jf: java.util.function.LongToIntFunction): RichLongToIntFunctionAsFunction1 = new RichLongToIntFunctionAsFunction1(jf)
   
+  /** Enriches a `java.util.function.LongUnaryOperator` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichLongUnaryOperatorAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromLongUnaryOperator(jf: java.util.function.LongUnaryOperator): RichLongUnaryOperatorAsFunction1 = new RichLongUnaryOperatorAsFunction1(jf)
   
+  /** Enriches a `java.util.function.ObjDoubleConsumer` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichObjDoubleConsumerAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromObjDoubleConsumer[T](jf: java.util.function.ObjDoubleConsumer[T]): RichObjDoubleConsumerAsFunction2[T] = new RichObjDoubleConsumerAsFunction2[T](jf)
   
+  /** Enriches a `java.util.function.ObjIntConsumer` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichObjIntConsumerAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromObjIntConsumer[T](jf: java.util.function.ObjIntConsumer[T]): RichObjIntConsumerAsFunction2[T] = new RichObjIntConsumerAsFunction2[T](jf)
   
+  /** Enriches a `java.util.function.ObjLongConsumer` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichObjLongConsumerAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromObjLongConsumer[T](jf: java.util.function.ObjLongConsumer[T]): RichObjLongConsumerAsFunction2[T] = new RichObjLongConsumerAsFunction2[T](jf)
   
+  /** Enriches a `java.util.function.Predicate` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam T the argument type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichPredicateAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromPredicate[T](jf: java.util.function.Predicate[T]): RichPredicateAsFunction1[T] = new RichPredicateAsFunction1[T](jf)
   
+  /** Enriches a `java.util.function.Supplier` with an `asScala` method that converts it to a Scala `Function0`.
+   *
+   *  @tparam T the result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichSupplierAsFunction0]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromSupplier[T](jf: java.util.function.Supplier[T]): RichSupplierAsFunction0[T] = new RichSupplierAsFunction0[T](jf)
   
+  /** Enriches a `java.util.function.ToDoubleBiFunction` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @tparam U the type of the second argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichToDoubleBiFunctionAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromToDoubleBiFunction[T, U](jf: java.util.function.ToDoubleBiFunction[T, U]): RichToDoubleBiFunctionAsFunction2[T, U] = new RichToDoubleBiFunctionAsFunction2[T, U](jf)
   
+  /** Enriches a `java.util.function.ToDoubleFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam T the argument type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichToDoubleFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromToDoubleFunction[T](jf: java.util.function.ToDoubleFunction[T]): RichToDoubleFunctionAsFunction1[T] = new RichToDoubleFunctionAsFunction1[T](jf)
   
+  /** Enriches a `java.util.function.ToIntBiFunction` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @tparam U the type of the second argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichToIntBiFunctionAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromToIntBiFunction[T, U](jf: java.util.function.ToIntBiFunction[T, U]): RichToIntBiFunctionAsFunction2[T, U] = new RichToIntBiFunctionAsFunction2[T, U](jf)
   
+  /** Enriches a `java.util.function.ToIntFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam T the argument type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichToIntFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromToIntFunction[T](jf: java.util.function.ToIntFunction[T]): RichToIntFunctionAsFunction1[T] = new RichToIntFunctionAsFunction1[T](jf)
   
+  /** Enriches a `java.util.function.ToLongBiFunction` with an `asScala` method that converts it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first argument of `jf`
+   *  @tparam U the type of the second argument of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichToLongBiFunctionAsFunction2]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromToLongBiFunction[T, U](jf: java.util.function.ToLongBiFunction[T, U]): RichToLongBiFunctionAsFunction2[T, U] = new RichToLongBiFunctionAsFunction2[T, U](jf)
   
+  /** Enriches a `java.util.function.ToLongFunction` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam T the argument type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichToLongFunctionAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromToLongFunction[T](jf: java.util.function.ToLongFunction[T]): RichToLongFunctionAsFunction1[T] = new RichToLongFunctionAsFunction1[T](jf)
   
+  /** Enriches a `java.util.function.UnaryOperator` with an `asScala` method that converts it to a Scala `Function1`.
+   *
+   *  @tparam T the operand and result type of `jf`
+   *  @param jf the Java function to convert
+   *  @return a [[FunctionWrappers.RichUnaryOperatorAsFunction1]] value class wrapping `jf`
+   */
   @inline implicit def enrichAsScalaFromUnaryOperator[T](jf: java.util.function.UnaryOperator[T]): RichUnaryOperatorAsFunction1[T] = new RichUnaryOperatorAsFunction1[T](jf)
 }

--- a/library/src/scala/jdk/FunctionWrappers.scala
+++ b/library/src/scala/jdk/FunctionWrappers.scala
@@ -18,26 +18,68 @@ package scala.jdk
 import scala.language.`2.13`
 
 object FunctionWrappers {
+  /** A Scala `Function2` that delegates to a Java `BiConsumer`.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param jf the Java `BiConsumer` to which `apply` delegates
+   */
   case class FromJavaBiConsumer[T, U](jf: java.util.function.BiConsumer[T, U]) extends scala.Function2[T, U, Unit] {
+    /** Invokes the wrapped Java `BiConsumer` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: T, x2: U) = jf.accept(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `BiConsumer`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param underlying the Java `BiConsumer` to convert
+   */
   class RichBiConsumerAsFunction2[T, U](private val underlying: java.util.function.BiConsumer[T, U]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaBiConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, U, Unit] = underlying match {
       case AsJavaBiConsumer((sf @ _)) => sf.asInstanceOf[scala.Function2[T, U, Unit]]
       case _ => new FromJavaBiConsumer[T, U](underlying)
     }
   }
   
+  /** A Java `BiConsumer` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param sf the Scala `Function2` to which `accept` delegates
+   */
   case class AsJavaBiConsumer[T, U](sf: scala.Function2[T, U, Unit]) extends java.util.function.BiConsumer[T, U] {
+    /** Invokes the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: T, x2: U) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaBiConsumer` methods to a Scala `Function2`, converting it to a Java `BiConsumer`.
+   *
+   *  @tparam T the first input type of the bi-consumer
+   *  @tparam U the second input type of the bi-consumer
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsBiConsumer[T, U](private val underlying: scala.Function2[T, U, Unit]) extends AnyVal {
+    /** Returns a Java `BiConsumer` that calls `underlying`, or, if `underlying` is a `FromJavaBiConsumer`, the Java `BiConsumer` that wrapper holds. */
     @inline def asJava: java.util.function.BiConsumer[T, U] = underlying match {
       case FromJavaBiConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.BiConsumer[T, U]]
       case _ => new AsJavaBiConsumer[T, U](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `BiConsumer` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaBiConsumer: java.util.function.BiConsumer[T, U] = underlying match {
       case FromJavaBiConsumer((sf @ _)) => sf.asInstanceOf[java.util.function.BiConsumer[T, U]]
       case _ => new AsJavaBiConsumer[T, U](underlying)
@@ -45,26 +87,70 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `BiFunction`.
+   *
+   *  @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param jf the Java `BiFunction` to which `apply` delegates
+   */
   case class FromJavaBiFunction[T, U, R](jf: java.util.function.BiFunction[T, U, R]) extends scala.Function2[T, U, R] {
+    /** Returns the result of invoking the wrapped Java `BiFunction` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: T, x2: U) = jf.apply(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `BiFunction`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param underlying the Java `BiFunction` to convert
+   */
   class RichBiFunctionAsFunction2[T, U, R](private val underlying: java.util.function.BiFunction[T, U, R]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaBiFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, U, R] = underlying match {
       case AsJavaBiFunction((sf @ _)) => sf.asInstanceOf[scala.Function2[T, U, R]]
       case _ => new FromJavaBiFunction[T, U, R](underlying)
     }
   }
   
+  /** A Java `BiFunction` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param sf the Scala `Function2` to which `apply` delegates
+   */
   case class AsJavaBiFunction[T, U, R](sf: scala.Function2[T, U, R]) extends java.util.function.BiFunction[T, U, R] {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def apply(x1: T, x2: U): R = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaBiFunction` methods to a Scala `Function2`, converting it to a Java `BiFunction`.
+   *
+   *  @tparam T the first input type of the bi-function
+   *  @tparam U the second input type of the bi-function
+   *  @tparam R the return type of the bi-function
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsBiFunction[T, U, R](private val underlying: scala.Function2[T, U, R]) extends AnyVal {
+    /** Returns a Java `BiFunction` that calls `underlying`, or, if `underlying` is a `FromJavaBiFunction`, the Java `BiFunction` that wrapper holds. */
     @inline def asJava: java.util.function.BiFunction[T, U, R] = underlying match {
       case FromJavaBiFunction((jf @ _)) => jf.asInstanceOf[java.util.function.BiFunction[T, U, R]]
       case _ => new AsJavaBiFunction[T, U, R](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `BiFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaBiFunction: java.util.function.BiFunction[T, U, R] = underlying match {
       case FromJavaBiFunction((sf @ _)) => sf.asInstanceOf[java.util.function.BiFunction[T, U, R]]
       case _ => new AsJavaBiFunction[T, U, R](underlying)
@@ -72,26 +158,66 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `BiPredicate`.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param jf the Java `BiPredicate` to which `apply` delegates
+   */
   case class FromJavaBiPredicate[T, U](jf: java.util.function.BiPredicate[T, U]) extends scala.Function2[T, U, Boolean] {
+    /** Returns the result of invoking the wrapped Java `BiPredicate` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: T, x2: U) = jf.test(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `BiPredicate`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param underlying the Java `BiPredicate` to convert
+   */
   class RichBiPredicateAsFunction2[T, U](private val underlying: java.util.function.BiPredicate[T, U]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaBiPredicate`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, U, Boolean] = underlying match {
       case AsJavaBiPredicate((sf @ _)) => sf.asInstanceOf[scala.Function2[T, U, Boolean]]
       case _ => new FromJavaBiPredicate[T, U](underlying)
     }
   }
   
+  /** A Java `BiPredicate` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param sf the Scala `Function2` to which `test` delegates
+   */
   case class AsJavaBiPredicate[T, U](sf: scala.Function2[T, U, Boolean]) extends java.util.function.BiPredicate[T, U] {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def test(x1: T, x2: U) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaBiPredicate` methods to a Scala `Function2`, converting it to a Java `BiPredicate`.
+   *
+   *  @tparam T the first input type of the bi-predicate
+   *  @tparam U the second input type of the bi-predicate
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsBiPredicate[T, U](private val underlying: scala.Function2[T, U, Boolean]) extends AnyVal {
+    /** Returns a Java `BiPredicate` that calls `underlying`, or, if `underlying` is a `FromJavaBiPredicate`, the Java `BiPredicate` that wrapper holds. */
     @inline def asJava: java.util.function.BiPredicate[T, U] = underlying match {
       case FromJavaBiPredicate((jf @ _)) => jf.asInstanceOf[java.util.function.BiPredicate[T, U]]
       case _ => new AsJavaBiPredicate[T, U](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `BiPredicate` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaBiPredicate: java.util.function.BiPredicate[T, U] = underlying match {
       case FromJavaBiPredicate((sf @ _)) => sf.asInstanceOf[java.util.function.BiPredicate[T, U]]
       case _ => new AsJavaBiPredicate[T, U](underlying)
@@ -99,26 +225,62 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `BinaryOperator`.
+   *
+   *  @tparam T the input and output type of the binary operator
+   *  @param jf the Java `BinaryOperator` to which `apply` delegates
+   */
   case class FromJavaBinaryOperator[T](jf: java.util.function.BinaryOperator[T]) extends scala.Function2[T, T, T] {
+    /** Returns the result of invoking the wrapped Java `BinaryOperator` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: T, x2: T) = jf.apply(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `BinaryOperator`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the input and output type of the binary operator
+   *  @param underlying the Java `BinaryOperator` to convert
+   */
   class RichBinaryOperatorAsFunction2[T](private val underlying: java.util.function.BinaryOperator[T]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaBinaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, T, T] = underlying match {
       case AsJavaBinaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function2[T, T, T]]
       case _ => new FromJavaBinaryOperator[T](underlying)
     }
   }
   
+  /** A Java `BinaryOperator` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the input and output type of the binary operator
+   *  @param sf the Scala `Function2` to which `apply` delegates
+   */
   case class AsJavaBinaryOperator[T](sf: scala.Function2[T, T, T]) extends java.util.function.BinaryOperator[T] {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def apply(x1: T, x2: T): T = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaBinaryOperator` methods to a Scala `Function2`, converting it to a Java `BinaryOperator`.
+   *
+   *  @tparam T the input and output type of the binary operator
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsBinaryOperator[T](private val underlying: scala.Function2[T, T, T]) extends AnyVal {
+    /** Returns a Java `BinaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaBinaryOperator`, the Java `BinaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.BinaryOperator[T] = underlying match {
       case FromJavaBinaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.BinaryOperator[T]]
       case _ => new AsJavaBinaryOperator[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `BinaryOperator` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaBinaryOperator: java.util.function.BinaryOperator[T] = underlying match {
       case FromJavaBinaryOperator((sf @ _)) => sf.asInstanceOf[java.util.function.BinaryOperator[T]]
       case _ => new AsJavaBinaryOperator[T](underlying)
@@ -126,22 +288,42 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function0` that delegates to a Java `BooleanSupplier`.
+   *
+   *  @param jf the Java `BooleanSupplier` to which `apply` delegates
+   */
   case class FromJavaBooleanSupplier(jf: java.util.function.BooleanSupplier) extends scala.Function0[Boolean] {
+    /** Returns the value produced by the wrapped Java `BooleanSupplier`. */
     def apply() = jf.getAsBoolean()
   }
   
+  /** A value class that adds an `asScala` method to a Java `BooleanSupplier`, converting it to a Scala `Function0`.
+   *
+   *  @param underlying the Java `BooleanSupplier` to convert
+   */
   class RichBooleanSupplierAsFunction0(private val underlying: java.util.function.BooleanSupplier) extends AnyVal {
+    /** Returns a Scala `Function0` that calls `underlying`, or, if `underlying` is an `AsJavaBooleanSupplier`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function0[Boolean] = underlying match {
       case AsJavaBooleanSupplier((sf @ _)) => sf.asInstanceOf[scala.Function0[Boolean]]
       case _ => new FromJavaBooleanSupplier(underlying)
     }
   }
   
+  /** A Java `BooleanSupplier` that delegates to a Scala `Function0`.
+   *
+   *  @param sf the Scala `Function0` to which `getAsBoolean` delegates
+   */
   case class AsJavaBooleanSupplier(sf: scala.Function0[Boolean]) extends java.util.function.BooleanSupplier {
+    /** Returns the value produced by the wrapped Scala `Function0`. */
     def getAsBoolean() = sf.apply()
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function0`, converting it to a Java `BooleanSupplier`.
+   *
+   *  @param underlying the Scala `Function0` to convert
+   */
   class RichFunction0AsBooleanSupplier(private val underlying: scala.Function0[Boolean]) extends AnyVal {
+    /** Returns a Java `BooleanSupplier` that calls `underlying`, or, if `underlying` is a `FromJavaBooleanSupplier`, the Java `BooleanSupplier` that wrapper holds. */
     @inline def asJava: java.util.function.BooleanSupplier = underlying match {
       case FromJavaBooleanSupplier((jf @ _)) => jf.asInstanceOf[java.util.function.BooleanSupplier]
       case _ => new AsJavaBooleanSupplier(underlying)
@@ -149,26 +331,62 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `Consumer`.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param jf the Java `Consumer` to which `apply` delegates
+   */
   case class FromJavaConsumer[T](jf: java.util.function.Consumer[T]) extends scala.Function1[T, Unit] {
+    /** Invokes the wrapped Java `Consumer` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: T) = jf.accept(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `Consumer`, converting it to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param underlying the Java `Consumer` to convert
+   */
   class RichConsumerAsFunction1[T](private val underlying: java.util.function.Consumer[T]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[T, Unit] = underlying match {
       case AsJavaConsumer((sf @ _)) => sf.asInstanceOf[scala.Function1[T, Unit]]
       case _ => new FromJavaConsumer[T](underlying)
     }
   }
   
+  /** A Java `Consumer` that delegates to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param sf the Scala `Function1` to which `accept` delegates
+   */
   case class AsJavaConsumer[T](sf: scala.Function1[T, Unit]) extends java.util.function.Consumer[T] {
+    /** Invokes the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: T) = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaConsumer` methods to a Scala `Function1`, converting it to a Java `Consumer`.
+   *
+   *  @tparam T the input type of the consumer
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsConsumer[T](private val underlying: scala.Function1[T, Unit]) extends AnyVal {
+    /** Returns a Java `Consumer` that calls `underlying`, or, if `underlying` is a `FromJavaConsumer`, the Java `Consumer` that wrapper holds. */
     @inline def asJava: java.util.function.Consumer[T] = underlying match {
       case FromJavaConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.Consumer[T]]
       case _ => new AsJavaConsumer[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `Consumer` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaConsumer: java.util.function.Consumer[T] = underlying match {
       case FromJavaConsumer((sf @ _)) => sf.asInstanceOf[java.util.function.Consumer[T]]
       case _ => new AsJavaConsumer[T](underlying)
@@ -176,22 +394,50 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `DoubleBinaryOperator`.
+   *
+   *  @param jf the Java `DoubleBinaryOperator` to which `apply` delegates
+   */
   case class FromJavaDoubleBinaryOperator(jf: java.util.function.DoubleBinaryOperator) extends scala.Function2[Double, Double, Double] {
+    /** Returns the result of invoking the wrapped Java `DoubleBinaryOperator` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: scala.Double, x2: scala.Double) = jf.applyAsDouble(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoubleBinaryOperator`, converting it to a Scala `Function2`.
+   *
+   *  @param underlying the Java `DoubleBinaryOperator` to convert
+   */
   class RichDoubleBinaryOperatorAsFunction2(private val underlying: java.util.function.DoubleBinaryOperator) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaDoubleBinaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[Double, Double, Double] = underlying match {
       case AsJavaDoubleBinaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function2[Double, Double, Double]]
       case _ => new FromJavaDoubleBinaryOperator(underlying)
     }
   }
   
+  /** A Java `DoubleBinaryOperator` that delegates to a Scala `Function2`.
+   *
+   *  @param sf the Scala `Function2` to which `applyAsDouble` delegates
+   */
   case class AsJavaDoubleBinaryOperator(sf: scala.Function2[Double, Double, Double]) extends java.util.function.DoubleBinaryOperator {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def applyAsDouble(x1: scala.Double, x2: scala.Double) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function2`, converting it to a Java `DoubleBinaryOperator`.
+   *
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsDoubleBinaryOperator(private val underlying: scala.Function2[Double, Double, Double]) extends AnyVal {
+    /** Returns a Java `DoubleBinaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaDoubleBinaryOperator`, the Java `DoubleBinaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.DoubleBinaryOperator = underlying match {
       case FromJavaDoubleBinaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.DoubleBinaryOperator]
       case _ => new AsJavaDoubleBinaryOperator(underlying)
@@ -199,22 +445,50 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `DoubleConsumer`.
+   *
+   *  @param jf the Java `DoubleConsumer` to which `apply` delegates
+   */
   case class FromJavaDoubleConsumer(jf: java.util.function.DoubleConsumer) extends scala.Function1[Double, Unit] {
+    /** Invokes the wrapped Java `DoubleConsumer` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: scala.Double) = jf.accept(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoubleConsumer`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `DoubleConsumer` to convert
+   */
   class RichDoubleConsumerAsFunction1(private val underlying: java.util.function.DoubleConsumer) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaDoubleConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Double, Unit] = underlying match {
       case AsJavaDoubleConsumer((sf @ _)) => sf.asInstanceOf[scala.Function1[Double, Unit]]
       case _ => new FromJavaDoubleConsumer(underlying)
     }
   }
   
+  /** A Java `DoubleConsumer` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `accept` delegates
+   */
   case class AsJavaDoubleConsumer(sf: scala.Function1[Double, Unit]) extends java.util.function.DoubleConsumer {
+    /** Invokes the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: scala.Double) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `DoubleConsumer`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsDoubleConsumer(private val underlying: scala.Function1[Double, Unit]) extends AnyVal {
+    /** Returns a Java `DoubleConsumer` that calls `underlying`, or, if `underlying` is a `FromJavaDoubleConsumer`, the Java `DoubleConsumer` that wrapper holds. */
     @inline def asJava: java.util.function.DoubleConsumer = underlying match {
       case FromJavaDoubleConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.DoubleConsumer]
       case _ => new AsJavaDoubleConsumer(underlying)
@@ -222,26 +496,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `DoubleFunction`.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `DoubleFunction` to which `apply` delegates
+   */
   case class FromJavaDoubleFunction[R](jf: java.util.function.DoubleFunction[R]) extends scala.Function1[Double, R] {
+    /** Returns the result of invoking the wrapped Java `DoubleFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Double) = jf.apply(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoubleFunction`, converting it to a Scala `Function1`.
+   *
+   *  @tparam R the return type of the function
+   *  @param underlying the Java `DoubleFunction` to convert
+   */
   class RichDoubleFunctionAsFunction1[R](private val underlying: java.util.function.DoubleFunction[R]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaDoubleFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Double, R] = underlying match {
       case AsJavaDoubleFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Double, R]]
       case _ => new FromJavaDoubleFunction[R](underlying)
     }
   }
   
+  /** A Java `DoubleFunction` that delegates to a Scala `Function1`.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to which `apply` delegates
+   */
   case class AsJavaDoubleFunction[R](sf: scala.Function1[Double, R]) extends java.util.function.DoubleFunction[R] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def apply(x1: scala.Double): R = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaDoubleFunction` methods to a Scala `Function1`, converting it to a Java `DoubleFunction`.
+   *
+   *  @tparam R the return type of the function
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsDoubleFunction[R](private val underlying: scala.Function1[Double, R]) extends AnyVal {
+    /** Returns a Java `DoubleFunction` that calls `underlying`, or, if `underlying` is a `FromJavaDoubleFunction`, the Java `DoubleFunction` that wrapper holds. */
     @inline def asJava: java.util.function.DoubleFunction[R] = underlying match {
       case FromJavaDoubleFunction((jf @ _)) => jf.asInstanceOf[java.util.function.DoubleFunction[R]]
       case _ => new AsJavaDoubleFunction[R](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `DoubleFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaDoubleFunction: java.util.function.DoubleFunction[R] = underlying match {
       case FromJavaDoubleFunction((sf @ _)) => sf.asInstanceOf[java.util.function.DoubleFunction[R]]
       case _ => new AsJavaDoubleFunction[R](underlying)
@@ -249,22 +557,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `DoublePredicate`.
+   *
+   *  @param jf the Java `DoublePredicate` to which `apply` delegates
+   */
   case class FromJavaDoublePredicate(jf: java.util.function.DoublePredicate) extends scala.Function1[Double, Boolean] {
+    /** Returns the result of invoking the wrapped Java `DoublePredicate` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Double) = jf.test(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoublePredicate`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `DoublePredicate` to convert
+   */
   class RichDoublePredicateAsFunction1(private val underlying: java.util.function.DoublePredicate) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaDoublePredicate`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Double, Boolean] = underlying match {
       case AsJavaDoublePredicate((sf @ _)) => sf.asInstanceOf[scala.Function1[Double, Boolean]]
       case _ => new FromJavaDoublePredicate(underlying)
     }
   }
   
+  /** A Java `DoublePredicate` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `test` delegates
+   */
   case class AsJavaDoublePredicate(sf: scala.Function1[Double, Boolean]) extends java.util.function.DoublePredicate {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def test(x1: scala.Double) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `DoublePredicate`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsDoublePredicate(private val underlying: scala.Function1[Double, Boolean]) extends AnyVal {
+    /** Returns a Java `DoublePredicate` that calls `underlying`, or, if `underlying` is a `FromJavaDoublePredicate`, the Java `DoublePredicate` that wrapper holds. */
     @inline def asJava: java.util.function.DoublePredicate = underlying match {
       case FromJavaDoublePredicate((jf @ _)) => jf.asInstanceOf[java.util.function.DoublePredicate]
       case _ => new AsJavaDoublePredicate(underlying)
@@ -272,22 +606,42 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function0` that delegates to a Java `DoubleSupplier`.
+   *
+   *  @param jf the Java `DoubleSupplier` to which `apply` delegates
+   */
   case class FromJavaDoubleSupplier(jf: java.util.function.DoubleSupplier) extends scala.Function0[Double] {
+    /** Returns the value produced by the wrapped Java `DoubleSupplier`. */
     def apply() = jf.getAsDouble()
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoubleSupplier`, converting it to a Scala `Function0`.
+   *
+   *  @param underlying the Java `DoubleSupplier` to convert
+   */
   class RichDoubleSupplierAsFunction0(private val underlying: java.util.function.DoubleSupplier) extends AnyVal {
+    /** Returns a Scala `Function0` that calls `underlying`, or, if `underlying` is an `AsJavaDoubleSupplier`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function0[Double] = underlying match {
       case AsJavaDoubleSupplier((sf @ _)) => sf.asInstanceOf[scala.Function0[Double]]
       case _ => new FromJavaDoubleSupplier(underlying)
     }
   }
   
+  /** A Java `DoubleSupplier` that delegates to a Scala `Function0`.
+   *
+   *  @param sf the Scala `Function0` to which `getAsDouble` delegates
+   */
   case class AsJavaDoubleSupplier(sf: scala.Function0[Double]) extends java.util.function.DoubleSupplier {
+    /** Returns the value produced by the wrapped Scala `Function0`. */
     def getAsDouble() = sf.apply()
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function0`, converting it to a Java `DoubleSupplier`.
+   *
+   *  @param underlying the Scala `Function0` to convert
+   */
   class RichFunction0AsDoubleSupplier(private val underlying: scala.Function0[Double]) extends AnyVal {
+    /** Returns a Java `DoubleSupplier` that calls `underlying`, or, if `underlying` is a `FromJavaDoubleSupplier`, the Java `DoubleSupplier` that wrapper holds. */
     @inline def asJava: java.util.function.DoubleSupplier = underlying match {
       case FromJavaDoubleSupplier((jf @ _)) => jf.asInstanceOf[java.util.function.DoubleSupplier]
       case _ => new AsJavaDoubleSupplier(underlying)
@@ -295,22 +649,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `DoubleToIntFunction`.
+   *
+   *  @param jf the Java `DoubleToIntFunction` to which `apply` delegates
+   */
   case class FromJavaDoubleToIntFunction(jf: java.util.function.DoubleToIntFunction) extends scala.Function1[Double, Int] {
+    /** Returns the result of invoking the wrapped Java `DoubleToIntFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Double) = jf.applyAsInt(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoubleToIntFunction`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `DoubleToIntFunction` to convert
+   */
   class RichDoubleToIntFunctionAsFunction1(private val underlying: java.util.function.DoubleToIntFunction) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaDoubleToIntFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Double, Int] = underlying match {
       case AsJavaDoubleToIntFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Double, Int]]
       case _ => new FromJavaDoubleToIntFunction(underlying)
     }
   }
   
+  /** A Java `DoubleToIntFunction` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsInt` delegates
+   */
   case class AsJavaDoubleToIntFunction(sf: scala.Function1[Double, Int]) extends java.util.function.DoubleToIntFunction {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsInt(x1: scala.Double) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `DoubleToIntFunction`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsDoubleToIntFunction(private val underlying: scala.Function1[Double, Int]) extends AnyVal {
+    /** Returns a Java `DoubleToIntFunction` that calls `underlying`, or, if `underlying` is a `FromJavaDoubleToIntFunction`, the Java `DoubleToIntFunction` that wrapper holds. */
     @inline def asJava: java.util.function.DoubleToIntFunction = underlying match {
       case FromJavaDoubleToIntFunction((jf @ _)) => jf.asInstanceOf[java.util.function.DoubleToIntFunction]
       case _ => new AsJavaDoubleToIntFunction(underlying)
@@ -318,22 +698,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `DoubleToLongFunction`.
+   *
+   *  @param jf the Java `DoubleToLongFunction` to which `apply` delegates
+   */
   case class FromJavaDoubleToLongFunction(jf: java.util.function.DoubleToLongFunction) extends scala.Function1[Double, Long] {
+    /** Returns the result of invoking the wrapped Java `DoubleToLongFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Double) = jf.applyAsLong(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoubleToLongFunction`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `DoubleToLongFunction` to convert
+   */
   class RichDoubleToLongFunctionAsFunction1(private val underlying: java.util.function.DoubleToLongFunction) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaDoubleToLongFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Double, Long] = underlying match {
       case AsJavaDoubleToLongFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Double, Long]]
       case _ => new FromJavaDoubleToLongFunction(underlying)
     }
   }
   
+  /** A Java `DoubleToLongFunction` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsLong` delegates
+   */
   case class AsJavaDoubleToLongFunction(sf: scala.Function1[Double, Long]) extends java.util.function.DoubleToLongFunction {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsLong(x1: scala.Double) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `DoubleToLongFunction`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsDoubleToLongFunction(private val underlying: scala.Function1[Double, Long]) extends AnyVal {
+    /** Returns a Java `DoubleToLongFunction` that calls `underlying`, or, if `underlying` is a `FromJavaDoubleToLongFunction`, the Java `DoubleToLongFunction` that wrapper holds. */
     @inline def asJava: java.util.function.DoubleToLongFunction = underlying match {
       case FromJavaDoubleToLongFunction((jf @ _)) => jf.asInstanceOf[java.util.function.DoubleToLongFunction]
       case _ => new AsJavaDoubleToLongFunction(underlying)
@@ -341,22 +747,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `DoubleUnaryOperator`.
+   *
+   *  @param jf the Java `DoubleUnaryOperator` to which `apply` delegates
+   */
   case class FromJavaDoubleUnaryOperator(jf: java.util.function.DoubleUnaryOperator) extends scala.Function1[Double, Double] {
+    /** Returns the result of invoking the wrapped Java `DoubleUnaryOperator` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Double) = jf.applyAsDouble(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `DoubleUnaryOperator`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `DoubleUnaryOperator` to convert
+   */
   class RichDoubleUnaryOperatorAsFunction1(private val underlying: java.util.function.DoubleUnaryOperator) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaDoubleUnaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Double, Double] = underlying match {
       case AsJavaDoubleUnaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function1[Double, Double]]
       case _ => new FromJavaDoubleUnaryOperator(underlying)
     }
   }
   
+  /** A Java `DoubleUnaryOperator` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsDouble` delegates
+   */
   case class AsJavaDoubleUnaryOperator(sf: scala.Function1[Double, Double]) extends java.util.function.DoubleUnaryOperator {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsDouble(x1: scala.Double) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `DoubleUnaryOperator`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsDoubleUnaryOperator(private val underlying: scala.Function1[Double, Double]) extends AnyVal {
+    /** Returns a Java `DoubleUnaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaDoubleUnaryOperator`, the Java `DoubleUnaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.DoubleUnaryOperator = underlying match {
       case FromJavaDoubleUnaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.DoubleUnaryOperator]
       case _ => new AsJavaDoubleUnaryOperator(underlying)
@@ -364,26 +796,64 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `Function`.
+   *
+   *  @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param jf the Java `Function` to which `apply` delegates
+   */
   case class FromJavaFunction[T, R](jf: java.util.function.Function[T, R]) extends scala.Function1[T, R] {
+    /** Returns the result of invoking the wrapped Java `Function` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: T) = jf.apply(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `Function`, converting it to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param underlying the Java `Function` to convert
+   */
   class RichFunctionAsFunction1[T, R](private val underlying: java.util.function.Function[T, R]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[T, R] = underlying match {
       case AsJavaFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[T, R]]
       case _ => new FromJavaFunction[T, R](underlying)
     }
   }
   
+  /** A Java `Function` that delegates to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to which `apply` delegates
+   */
   case class AsJavaFunction[T, R](sf: scala.Function1[T, R]) extends java.util.function.Function[T, R] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def apply(x1: T): R = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaFunction` methods to a Scala `Function1`, converting it to a Java `Function`.
+   *
+   *  @tparam T the input type of the function
+   *  @tparam R the return type of the function
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsFunction[T, R](private val underlying: scala.Function1[T, R]) extends AnyVal {
+    /** Returns a Java `Function` that calls `underlying`, or, if `underlying` is a `FromJavaFunction`, the Java `Function` that wrapper holds. */
     @inline def asJava: java.util.function.Function[T, R] = underlying match {
       case FromJavaFunction((jf @ _)) => jf.asInstanceOf[java.util.function.Function[T, R]]
       case _ => new AsJavaFunction[T, R](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `Function` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaFunction: java.util.function.Function[T, R] = underlying match {
       case FromJavaFunction((sf @ _)) => sf.asInstanceOf[java.util.function.Function[T, R]]
       case _ => new AsJavaFunction[T, R](underlying)
@@ -391,22 +861,50 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `IntBinaryOperator`.
+   *
+   *  @param jf the Java `IntBinaryOperator` to which `apply` delegates
+   */
   case class FromJavaIntBinaryOperator(jf: java.util.function.IntBinaryOperator) extends scala.Function2[Int, Int, Int] {
+    /** Returns the result of invoking the wrapped Java `IntBinaryOperator` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: scala.Int, x2: scala.Int) = jf.applyAsInt(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntBinaryOperator`, converting it to a Scala `Function2`.
+   *
+   *  @param underlying the Java `IntBinaryOperator` to convert
+   */
   class RichIntBinaryOperatorAsFunction2(private val underlying: java.util.function.IntBinaryOperator) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaIntBinaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[Int, Int, Int] = underlying match {
       case AsJavaIntBinaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function2[Int, Int, Int]]
       case _ => new FromJavaIntBinaryOperator(underlying)
     }
   }
   
+  /** A Java `IntBinaryOperator` that delegates to a Scala `Function2`.
+   *
+   *  @param sf the Scala `Function2` to which `applyAsInt` delegates
+   */
   case class AsJavaIntBinaryOperator(sf: scala.Function2[Int, Int, Int]) extends java.util.function.IntBinaryOperator {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def applyAsInt(x1: scala.Int, x2: scala.Int) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function2`, converting it to a Java `IntBinaryOperator`.
+   *
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsIntBinaryOperator(private val underlying: scala.Function2[Int, Int, Int]) extends AnyVal {
+    /** Returns a Java `IntBinaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaIntBinaryOperator`, the Java `IntBinaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.IntBinaryOperator = underlying match {
       case FromJavaIntBinaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.IntBinaryOperator]
       case _ => new AsJavaIntBinaryOperator(underlying)
@@ -414,22 +912,50 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `IntConsumer`.
+   *
+   *  @param jf the Java `IntConsumer` to which `apply` delegates
+   */
   case class FromJavaIntConsumer(jf: java.util.function.IntConsumer) extends scala.Function1[Int, Unit] {
+    /** Invokes the wrapped Java `IntConsumer` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: scala.Int) = jf.accept(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntConsumer`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `IntConsumer` to convert
+   */
   class RichIntConsumerAsFunction1(private val underlying: java.util.function.IntConsumer) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaIntConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Int, Unit] = underlying match {
       case AsJavaIntConsumer((sf @ _)) => sf.asInstanceOf[scala.Function1[Int, Unit]]
       case _ => new FromJavaIntConsumer(underlying)
     }
   }
   
+  /** A Java `IntConsumer` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `accept` delegates
+   */
   case class AsJavaIntConsumer(sf: scala.Function1[Int, Unit]) extends java.util.function.IntConsumer {
+    /** Invokes the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: scala.Int) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `IntConsumer`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsIntConsumer(private val underlying: scala.Function1[Int, Unit]) extends AnyVal {
+    /** Returns a Java `IntConsumer` that calls `underlying`, or, if `underlying` is a `FromJavaIntConsumer`, the Java `IntConsumer` that wrapper holds. */
     @inline def asJava: java.util.function.IntConsumer = underlying match {
       case FromJavaIntConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.IntConsumer]
       case _ => new AsJavaIntConsumer(underlying)
@@ -437,26 +963,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `IntFunction`.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `IntFunction` to which `apply` delegates
+   */
   case class FromJavaIntFunction[R](jf: java.util.function.IntFunction[R]) extends scala.Function1[Int, R] {
+    /** Returns the result of invoking the wrapped Java `IntFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Int) = jf.apply(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntFunction`, converting it to a Scala `Function1`.
+   *
+   *  @tparam R the return type of the function
+   *  @param underlying the Java `IntFunction` to convert
+   */
   class RichIntFunctionAsFunction1[R](private val underlying: java.util.function.IntFunction[R]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaIntFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Int, R] = underlying match {
       case AsJavaIntFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Int, R]]
       case _ => new FromJavaIntFunction[R](underlying)
     }
   }
   
+  /** A Java `IntFunction` that delegates to a Scala `Function1`.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to which `apply` delegates
+   */
   case class AsJavaIntFunction[R](sf: scala.Function1[Int, R]) extends java.util.function.IntFunction[R] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def apply(x1: scala.Int): R = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaIntFunction` methods to a Scala `Function1`, converting it to a Java `IntFunction`.
+   *
+   *  @tparam R the return type of the function
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsIntFunction[R](private val underlying: scala.Function1[Int, R]) extends AnyVal {
+    /** Returns a Java `IntFunction` that calls `underlying`, or, if `underlying` is a `FromJavaIntFunction`, the Java `IntFunction` that wrapper holds. */
     @inline def asJava: java.util.function.IntFunction[R] = underlying match {
       case FromJavaIntFunction((jf @ _)) => jf.asInstanceOf[java.util.function.IntFunction[R]]
       case _ => new AsJavaIntFunction[R](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `IntFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaIntFunction: java.util.function.IntFunction[R] = underlying match {
       case FromJavaIntFunction((sf @ _)) => sf.asInstanceOf[java.util.function.IntFunction[R]]
       case _ => new AsJavaIntFunction[R](underlying)
@@ -464,22 +1024,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `IntPredicate`.
+   *
+   *  @param jf the Java `IntPredicate` to which `apply` delegates
+   */
   case class FromJavaIntPredicate(jf: java.util.function.IntPredicate) extends scala.Function1[Int, Boolean] {
+    /** Returns the result of invoking the wrapped Java `IntPredicate` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Int) = jf.test(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntPredicate`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `IntPredicate` to convert
+   */
   class RichIntPredicateAsFunction1(private val underlying: java.util.function.IntPredicate) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaIntPredicate`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Int, Boolean] = underlying match {
       case AsJavaIntPredicate((sf @ _)) => sf.asInstanceOf[scala.Function1[Int, Boolean]]
       case _ => new FromJavaIntPredicate(underlying)
     }
   }
   
+  /** A Java `IntPredicate` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `test` delegates
+   */
   case class AsJavaIntPredicate(sf: scala.Function1[Int, Boolean]) extends java.util.function.IntPredicate {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def test(x1: scala.Int) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `IntPredicate`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsIntPredicate(private val underlying: scala.Function1[Int, Boolean]) extends AnyVal {
+    /** Returns a Java `IntPredicate` that calls `underlying`, or, if `underlying` is a `FromJavaIntPredicate`, the Java `IntPredicate` that wrapper holds. */
     @inline def asJava: java.util.function.IntPredicate = underlying match {
       case FromJavaIntPredicate((jf @ _)) => jf.asInstanceOf[java.util.function.IntPredicate]
       case _ => new AsJavaIntPredicate(underlying)
@@ -487,22 +1073,42 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function0` that delegates to a Java `IntSupplier`.
+   *
+   *  @param jf the Java `IntSupplier` to which `apply` delegates
+   */
   case class FromJavaIntSupplier(jf: java.util.function.IntSupplier) extends scala.Function0[Int] {
+    /** Returns the value produced by the wrapped Java `IntSupplier`. */
     def apply() = jf.getAsInt()
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntSupplier`, converting it to a Scala `Function0`.
+   *
+   *  @param underlying the Java `IntSupplier` to convert
+   */
   class RichIntSupplierAsFunction0(private val underlying: java.util.function.IntSupplier) extends AnyVal {
+    /** Returns a Scala `Function0` that calls `underlying`, or, if `underlying` is an `AsJavaIntSupplier`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function0[Int] = underlying match {
       case AsJavaIntSupplier((sf @ _)) => sf.asInstanceOf[scala.Function0[Int]]
       case _ => new FromJavaIntSupplier(underlying)
     }
   }
   
+  /** A Java `IntSupplier` that delegates to a Scala `Function0`.
+   *
+   *  @param sf the Scala `Function0` to which `getAsInt` delegates
+   */
   case class AsJavaIntSupplier(sf: scala.Function0[Int]) extends java.util.function.IntSupplier {
+    /** Returns the value produced by the wrapped Scala `Function0`. */
     def getAsInt() = sf.apply()
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function0`, converting it to a Java `IntSupplier`.
+   *
+   *  @param underlying the Scala `Function0` to convert
+   */
   class RichFunction0AsIntSupplier(private val underlying: scala.Function0[Int]) extends AnyVal {
+    /** Returns a Java `IntSupplier` that calls `underlying`, or, if `underlying` is a `FromJavaIntSupplier`, the Java `IntSupplier` that wrapper holds. */
     @inline def asJava: java.util.function.IntSupplier = underlying match {
       case FromJavaIntSupplier((jf @ _)) => jf.asInstanceOf[java.util.function.IntSupplier]
       case _ => new AsJavaIntSupplier(underlying)
@@ -510,22 +1116,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `IntToDoubleFunction`.
+   *
+   *  @param jf the Java `IntToDoubleFunction` to which `apply` delegates
+   */
   case class FromJavaIntToDoubleFunction(jf: java.util.function.IntToDoubleFunction) extends scala.Function1[Int, Double] {
+    /** Returns the result of invoking the wrapped Java `IntToDoubleFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Int) = jf.applyAsDouble(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntToDoubleFunction`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `IntToDoubleFunction` to convert
+   */
   class RichIntToDoubleFunctionAsFunction1(private val underlying: java.util.function.IntToDoubleFunction) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaIntToDoubleFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Int, Double] = underlying match {
       case AsJavaIntToDoubleFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Int, Double]]
       case _ => new FromJavaIntToDoubleFunction(underlying)
     }
   }
   
+  /** A Java `IntToDoubleFunction` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsDouble` delegates
+   */
   case class AsJavaIntToDoubleFunction(sf: scala.Function1[Int, Double]) extends java.util.function.IntToDoubleFunction {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsDouble(x1: scala.Int) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `IntToDoubleFunction`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsIntToDoubleFunction(private val underlying: scala.Function1[Int, Double]) extends AnyVal {
+    /** Returns a Java `IntToDoubleFunction` that calls `underlying`, or, if `underlying` is a `FromJavaIntToDoubleFunction`, the Java `IntToDoubleFunction` that wrapper holds. */
     @inline def asJava: java.util.function.IntToDoubleFunction = underlying match {
       case FromJavaIntToDoubleFunction((jf @ _)) => jf.asInstanceOf[java.util.function.IntToDoubleFunction]
       case _ => new AsJavaIntToDoubleFunction(underlying)
@@ -533,22 +1165,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `IntToLongFunction`.
+   *
+   *  @param jf the Java `IntToLongFunction` to which `apply` delegates
+   */
   case class FromJavaIntToLongFunction(jf: java.util.function.IntToLongFunction) extends scala.Function1[Int, Long] {
+    /** Returns the result of invoking the wrapped Java `IntToLongFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Int) = jf.applyAsLong(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntToLongFunction`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `IntToLongFunction` to convert
+   */
   class RichIntToLongFunctionAsFunction1(private val underlying: java.util.function.IntToLongFunction) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaIntToLongFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Int, Long] = underlying match {
       case AsJavaIntToLongFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Int, Long]]
       case _ => new FromJavaIntToLongFunction(underlying)
     }
   }
   
+  /** A Java `IntToLongFunction` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsLong` delegates
+   */
   case class AsJavaIntToLongFunction(sf: scala.Function1[Int, Long]) extends java.util.function.IntToLongFunction {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsLong(x1: scala.Int) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `IntToLongFunction`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsIntToLongFunction(private val underlying: scala.Function1[Int, Long]) extends AnyVal {
+    /** Returns a Java `IntToLongFunction` that calls `underlying`, or, if `underlying` is a `FromJavaIntToLongFunction`, the Java `IntToLongFunction` that wrapper holds. */
     @inline def asJava: java.util.function.IntToLongFunction = underlying match {
       case FromJavaIntToLongFunction((jf @ _)) => jf.asInstanceOf[java.util.function.IntToLongFunction]
       case _ => new AsJavaIntToLongFunction(underlying)
@@ -556,22 +1214,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `IntUnaryOperator`.
+   *
+   *  @param jf the Java `IntUnaryOperator` to which `apply` delegates
+   */
   case class FromJavaIntUnaryOperator(jf: java.util.function.IntUnaryOperator) extends scala.Function1[Int, Int] {
+    /** Returns the result of invoking the wrapped Java `IntUnaryOperator` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Int) = jf.applyAsInt(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `IntUnaryOperator`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `IntUnaryOperator` to convert
+   */
   class RichIntUnaryOperatorAsFunction1(private val underlying: java.util.function.IntUnaryOperator) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaIntUnaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Int, Int] = underlying match {
       case AsJavaIntUnaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function1[Int, Int]]
       case _ => new FromJavaIntUnaryOperator(underlying)
     }
   }
   
+  /** A Java `IntUnaryOperator` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsInt` delegates
+   */
   case class AsJavaIntUnaryOperator(sf: scala.Function1[Int, Int]) extends java.util.function.IntUnaryOperator {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsInt(x1: scala.Int) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `IntUnaryOperator`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsIntUnaryOperator(private val underlying: scala.Function1[Int, Int]) extends AnyVal {
+    /** Returns a Java `IntUnaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaIntUnaryOperator`, the Java `IntUnaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.IntUnaryOperator = underlying match {
       case FromJavaIntUnaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.IntUnaryOperator]
       case _ => new AsJavaIntUnaryOperator(underlying)
@@ -579,22 +1263,50 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `LongBinaryOperator`.
+   *
+   *  @param jf the Java `LongBinaryOperator` to which `apply` delegates
+   */
   case class FromJavaLongBinaryOperator(jf: java.util.function.LongBinaryOperator) extends scala.Function2[Long, Long, Long] {
+    /** Returns the result of invoking the wrapped Java `LongBinaryOperator` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: scala.Long, x2: scala.Long) = jf.applyAsLong(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongBinaryOperator`, converting it to a Scala `Function2`.
+   *
+   *  @param underlying the Java `LongBinaryOperator` to convert
+   */
   class RichLongBinaryOperatorAsFunction2(private val underlying: java.util.function.LongBinaryOperator) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaLongBinaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[Long, Long, Long] = underlying match {
       case AsJavaLongBinaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function2[Long, Long, Long]]
       case _ => new FromJavaLongBinaryOperator(underlying)
     }
   }
   
+  /** A Java `LongBinaryOperator` that delegates to a Scala `Function2`.
+   *
+   *  @param sf the Scala `Function2` to which `applyAsLong` delegates
+   */
   case class AsJavaLongBinaryOperator(sf: scala.Function2[Long, Long, Long]) extends java.util.function.LongBinaryOperator {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def applyAsLong(x1: scala.Long, x2: scala.Long) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function2`, converting it to a Java `LongBinaryOperator`.
+   *
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsLongBinaryOperator(private val underlying: scala.Function2[Long, Long, Long]) extends AnyVal {
+    /** Returns a Java `LongBinaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaLongBinaryOperator`, the Java `LongBinaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.LongBinaryOperator = underlying match {
       case FromJavaLongBinaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.LongBinaryOperator]
       case _ => new AsJavaLongBinaryOperator(underlying)
@@ -602,22 +1314,50 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `LongConsumer`.
+   *
+   *  @param jf the Java `LongConsumer` to which `apply` delegates
+   */
   case class FromJavaLongConsumer(jf: java.util.function.LongConsumer) extends scala.Function1[Long, Unit] {
+    /** Invokes the wrapped Java `LongConsumer` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: scala.Long) = jf.accept(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongConsumer`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `LongConsumer` to convert
+   */
   class RichLongConsumerAsFunction1(private val underlying: java.util.function.LongConsumer) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaLongConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Long, Unit] = underlying match {
       case AsJavaLongConsumer((sf @ _)) => sf.asInstanceOf[scala.Function1[Long, Unit]]
       case _ => new FromJavaLongConsumer(underlying)
     }
   }
   
+  /** A Java `LongConsumer` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `accept` delegates
+   */
   case class AsJavaLongConsumer(sf: scala.Function1[Long, Unit]) extends java.util.function.LongConsumer {
+    /** Invokes the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: scala.Long) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `LongConsumer`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsLongConsumer(private val underlying: scala.Function1[Long, Unit]) extends AnyVal {
+    /** Returns a Java `LongConsumer` that calls `underlying`, or, if `underlying` is a `FromJavaLongConsumer`, the Java `LongConsumer` that wrapper holds. */
     @inline def asJava: java.util.function.LongConsumer = underlying match {
       case FromJavaLongConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.LongConsumer]
       case _ => new AsJavaLongConsumer(underlying)
@@ -625,26 +1365,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `LongFunction`.
+   *
+   *  @tparam R the return type of the function
+   *  @param jf the Java `LongFunction` to which `apply` delegates
+   */
   case class FromJavaLongFunction[R](jf: java.util.function.LongFunction[R]) extends scala.Function1[Long, R] {
+    /** Returns the result of invoking the wrapped Java `LongFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Long) = jf.apply(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongFunction`, converting it to a Scala `Function1`.
+   *
+   *  @tparam R the return type of the function
+   *  @param underlying the Java `LongFunction` to convert
+   */
   class RichLongFunctionAsFunction1[R](private val underlying: java.util.function.LongFunction[R]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaLongFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Long, R] = underlying match {
       case AsJavaLongFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Long, R]]
       case _ => new FromJavaLongFunction[R](underlying)
     }
   }
   
+  /** A Java `LongFunction` that delegates to a Scala `Function1`.
+   *
+   *  @tparam R the return type of the function
+   *  @param sf the Scala `Function1` to which `apply` delegates
+   */
   case class AsJavaLongFunction[R](sf: scala.Function1[Long, R]) extends java.util.function.LongFunction[R] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def apply(x1: scala.Long): R = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaLongFunction` methods to a Scala `Function1`, converting it to a Java `LongFunction`.
+   *
+   *  @tparam R the return type of the function
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsLongFunction[R](private val underlying: scala.Function1[Long, R]) extends AnyVal {
+    /** Returns a Java `LongFunction` that calls `underlying`, or, if `underlying` is a `FromJavaLongFunction`, the Java `LongFunction` that wrapper holds. */
     @inline def asJava: java.util.function.LongFunction[R] = underlying match {
       case FromJavaLongFunction((jf @ _)) => jf.asInstanceOf[java.util.function.LongFunction[R]]
       case _ => new AsJavaLongFunction[R](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `LongFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaLongFunction: java.util.function.LongFunction[R] = underlying match {
       case FromJavaLongFunction((sf @ _)) => sf.asInstanceOf[java.util.function.LongFunction[R]]
       case _ => new AsJavaLongFunction[R](underlying)
@@ -652,22 +1426,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `LongPredicate`.
+   *
+   *  @param jf the Java `LongPredicate` to which `apply` delegates
+   */
   case class FromJavaLongPredicate(jf: java.util.function.LongPredicate) extends scala.Function1[Long, Boolean] {
+    /** Returns the result of invoking the wrapped Java `LongPredicate` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Long) = jf.test(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongPredicate`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `LongPredicate` to convert
+   */
   class RichLongPredicateAsFunction1(private val underlying: java.util.function.LongPredicate) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaLongPredicate`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Long, Boolean] = underlying match {
       case AsJavaLongPredicate((sf @ _)) => sf.asInstanceOf[scala.Function1[Long, Boolean]]
       case _ => new FromJavaLongPredicate(underlying)
     }
   }
   
+  /** A Java `LongPredicate` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `test` delegates
+   */
   case class AsJavaLongPredicate(sf: scala.Function1[Long, Boolean]) extends java.util.function.LongPredicate {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def test(x1: scala.Long) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `LongPredicate`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsLongPredicate(private val underlying: scala.Function1[Long, Boolean]) extends AnyVal {
+    /** Returns a Java `LongPredicate` that calls `underlying`, or, if `underlying` is a `FromJavaLongPredicate`, the Java `LongPredicate` that wrapper holds. */
     @inline def asJava: java.util.function.LongPredicate = underlying match {
       case FromJavaLongPredicate((jf @ _)) => jf.asInstanceOf[java.util.function.LongPredicate]
       case _ => new AsJavaLongPredicate(underlying)
@@ -675,22 +1475,42 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function0` that delegates to a Java `LongSupplier`.
+   *
+   *  @param jf the Java `LongSupplier` to which `apply` delegates
+   */
   case class FromJavaLongSupplier(jf: java.util.function.LongSupplier) extends scala.Function0[Long] {
+    /** Returns the value produced by the wrapped Java `LongSupplier`. */
     def apply() = jf.getAsLong()
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongSupplier`, converting it to a Scala `Function0`.
+   *
+   *  @param underlying the Java `LongSupplier` to convert
+   */
   class RichLongSupplierAsFunction0(private val underlying: java.util.function.LongSupplier) extends AnyVal {
+    /** Returns a Scala `Function0` that calls `underlying`, or, if `underlying` is an `AsJavaLongSupplier`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function0[Long] = underlying match {
       case AsJavaLongSupplier((sf @ _)) => sf.asInstanceOf[scala.Function0[Long]]
       case _ => new FromJavaLongSupplier(underlying)
     }
   }
   
+  /** A Java `LongSupplier` that delegates to a Scala `Function0`.
+   *
+   *  @param sf the Scala `Function0` to which `getAsLong` delegates
+   */
   case class AsJavaLongSupplier(sf: scala.Function0[Long]) extends java.util.function.LongSupplier {
+    /** Returns the value produced by the wrapped Scala `Function0`. */
     def getAsLong() = sf.apply()
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function0`, converting it to a Java `LongSupplier`.
+   *
+   *  @param underlying the Scala `Function0` to convert
+   */
   class RichFunction0AsLongSupplier(private val underlying: scala.Function0[Long]) extends AnyVal {
+    /** Returns a Java `LongSupplier` that calls `underlying`, or, if `underlying` is a `FromJavaLongSupplier`, the Java `LongSupplier` that wrapper holds. */
     @inline def asJava: java.util.function.LongSupplier = underlying match {
       case FromJavaLongSupplier((jf @ _)) => jf.asInstanceOf[java.util.function.LongSupplier]
       case _ => new AsJavaLongSupplier(underlying)
@@ -698,22 +1518,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `LongToDoubleFunction`.
+   *
+   *  @param jf the Java `LongToDoubleFunction` to which `apply` delegates
+   */
   case class FromJavaLongToDoubleFunction(jf: java.util.function.LongToDoubleFunction) extends scala.Function1[Long, Double] {
+    /** Returns the result of invoking the wrapped Java `LongToDoubleFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Long) = jf.applyAsDouble(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongToDoubleFunction`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `LongToDoubleFunction` to convert
+   */
   class RichLongToDoubleFunctionAsFunction1(private val underlying: java.util.function.LongToDoubleFunction) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaLongToDoubleFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Long, Double] = underlying match {
       case AsJavaLongToDoubleFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Long, Double]]
       case _ => new FromJavaLongToDoubleFunction(underlying)
     }
   }
   
+  /** A Java `LongToDoubleFunction` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsDouble` delegates
+   */
   case class AsJavaLongToDoubleFunction(sf: scala.Function1[Long, Double]) extends java.util.function.LongToDoubleFunction {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsDouble(x1: scala.Long) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `LongToDoubleFunction`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsLongToDoubleFunction(private val underlying: scala.Function1[Long, Double]) extends AnyVal {
+    /** Returns a Java `LongToDoubleFunction` that calls `underlying`, or, if `underlying` is a `FromJavaLongToDoubleFunction`, the Java `LongToDoubleFunction` that wrapper holds. */
     @inline def asJava: java.util.function.LongToDoubleFunction = underlying match {
       case FromJavaLongToDoubleFunction((jf @ _)) => jf.asInstanceOf[java.util.function.LongToDoubleFunction]
       case _ => new AsJavaLongToDoubleFunction(underlying)
@@ -721,22 +1567,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `LongToIntFunction`.
+   *
+   *  @param jf the Java `LongToIntFunction` to which `apply` delegates
+   */
   case class FromJavaLongToIntFunction(jf: java.util.function.LongToIntFunction) extends scala.Function1[Long, Int] {
+    /** Returns the result of invoking the wrapped Java `LongToIntFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Long) = jf.applyAsInt(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongToIntFunction`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `LongToIntFunction` to convert
+   */
   class RichLongToIntFunctionAsFunction1(private val underlying: java.util.function.LongToIntFunction) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaLongToIntFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Long, Int] = underlying match {
       case AsJavaLongToIntFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[Long, Int]]
       case _ => new FromJavaLongToIntFunction(underlying)
     }
   }
   
+  /** A Java `LongToIntFunction` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsInt` delegates
+   */
   case class AsJavaLongToIntFunction(sf: scala.Function1[Long, Int]) extends java.util.function.LongToIntFunction {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsInt(x1: scala.Long) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `LongToIntFunction`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsLongToIntFunction(private val underlying: scala.Function1[Long, Int]) extends AnyVal {
+    /** Returns a Java `LongToIntFunction` that calls `underlying`, or, if `underlying` is a `FromJavaLongToIntFunction`, the Java `LongToIntFunction` that wrapper holds. */
     @inline def asJava: java.util.function.LongToIntFunction = underlying match {
       case FromJavaLongToIntFunction((jf @ _)) => jf.asInstanceOf[java.util.function.LongToIntFunction]
       case _ => new AsJavaLongToIntFunction(underlying)
@@ -744,22 +1616,48 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `LongUnaryOperator`.
+   *
+   *  @param jf the Java `LongUnaryOperator` to which `apply` delegates
+   */
   case class FromJavaLongUnaryOperator(jf: java.util.function.LongUnaryOperator) extends scala.Function1[Long, Long] {
+    /** Returns the result of invoking the wrapped Java `LongUnaryOperator` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: scala.Long) = jf.applyAsLong(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `LongUnaryOperator`, converting it to a Scala `Function1`.
+   *
+   *  @param underlying the Java `LongUnaryOperator` to convert
+   */
   class RichLongUnaryOperatorAsFunction1(private val underlying: java.util.function.LongUnaryOperator) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaLongUnaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[Long, Long] = underlying match {
       case AsJavaLongUnaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function1[Long, Long]]
       case _ => new FromJavaLongUnaryOperator(underlying)
     }
   }
   
+  /** A Java `LongUnaryOperator` that delegates to a Scala `Function1`.
+   *
+   *  @param sf the Scala `Function1` to which `applyAsLong` delegates
+   */
   case class AsJavaLongUnaryOperator(sf: scala.Function1[Long, Long]) extends java.util.function.LongUnaryOperator {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsLong(x1: scala.Long) = sf.apply(x1)
   }
   
+  /** A value class that adds an `asJava` method to a Scala `Function1`, converting it to a Java `LongUnaryOperator`.
+   *
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsLongUnaryOperator(private val underlying: scala.Function1[Long, Long]) extends AnyVal {
+    /** Returns a Java `LongUnaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaLongUnaryOperator`, the Java `LongUnaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.LongUnaryOperator = underlying match {
       case FromJavaLongUnaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.LongUnaryOperator]
       case _ => new AsJavaLongUnaryOperator(underlying)
@@ -767,26 +1665,64 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `ObjDoubleConsumer`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param jf the Java `ObjDoubleConsumer` to which `apply` delegates
+   */
   case class FromJavaObjDoubleConsumer[T](jf: java.util.function.ObjDoubleConsumer[T]) extends scala.Function2[T, Double, Unit] {
+    /** Invokes the wrapped Java `ObjDoubleConsumer` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: T, x2: scala.Double) = jf.accept(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ObjDoubleConsumer`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param underlying the Java `ObjDoubleConsumer` to convert
+   */
   class RichObjDoubleConsumerAsFunction2[T](private val underlying: java.util.function.ObjDoubleConsumer[T]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaObjDoubleConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, Double, Unit] = underlying match {
       case AsJavaObjDoubleConsumer((sf @ _)) => sf.asInstanceOf[scala.Function2[T, Double, Unit]]
       case _ => new FromJavaObjDoubleConsumer[T](underlying)
     }
   }
   
+  /** A Java `ObjDoubleConsumer` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param sf the Scala `Function2` to which `accept` delegates
+   */
   case class AsJavaObjDoubleConsumer[T](sf: scala.Function2[T, Double, Unit]) extends java.util.function.ObjDoubleConsumer[T] {
+    /** Invokes the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: T, x2: scala.Double) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaObjDoubleConsumer` methods to a Scala `Function2`, converting it to a Java `ObjDoubleConsumer`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsObjDoubleConsumer[T](private val underlying: scala.Function2[T, Double, Unit]) extends AnyVal {
+    /** Returns a Java `ObjDoubleConsumer` that calls `underlying`, or, if `underlying` is a `FromJavaObjDoubleConsumer`, the Java `ObjDoubleConsumer` that wrapper holds. */
     @inline def asJava: java.util.function.ObjDoubleConsumer[T] = underlying match {
       case FromJavaObjDoubleConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.ObjDoubleConsumer[T]]
       case _ => new AsJavaObjDoubleConsumer[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ObjDoubleConsumer` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaObjDoubleConsumer: java.util.function.ObjDoubleConsumer[T] = underlying match {
       case FromJavaObjDoubleConsumer((sf @ _)) => sf.asInstanceOf[java.util.function.ObjDoubleConsumer[T]]
       case _ => new AsJavaObjDoubleConsumer[T](underlying)
@@ -794,26 +1730,64 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `ObjIntConsumer`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param jf the Java `ObjIntConsumer` to which `apply` delegates
+   */
   case class FromJavaObjIntConsumer[T](jf: java.util.function.ObjIntConsumer[T]) extends scala.Function2[T, Int, Unit] {
+    /** Invokes the wrapped Java `ObjIntConsumer` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: T, x2: scala.Int) = jf.accept(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ObjIntConsumer`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param underlying the Java `ObjIntConsumer` to convert
+   */
   class RichObjIntConsumerAsFunction2[T](private val underlying: java.util.function.ObjIntConsumer[T]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaObjIntConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, Int, Unit] = underlying match {
       case AsJavaObjIntConsumer((sf @ _)) => sf.asInstanceOf[scala.Function2[T, Int, Unit]]
       case _ => new FromJavaObjIntConsumer[T](underlying)
     }
   }
   
+  /** A Java `ObjIntConsumer` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param sf the Scala `Function2` to which `accept` delegates
+   */
   case class AsJavaObjIntConsumer[T](sf: scala.Function2[T, Int, Unit]) extends java.util.function.ObjIntConsumer[T] {
+    /** Invokes the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: T, x2: scala.Int) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaObjIntConsumer` methods to a Scala `Function2`, converting it to a Java `ObjIntConsumer`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsObjIntConsumer[T](private val underlying: scala.Function2[T, Int, Unit]) extends AnyVal {
+    /** Returns a Java `ObjIntConsumer` that calls `underlying`, or, if `underlying` is a `FromJavaObjIntConsumer`, the Java `ObjIntConsumer` that wrapper holds. */
     @inline def asJava: java.util.function.ObjIntConsumer[T] = underlying match {
       case FromJavaObjIntConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.ObjIntConsumer[T]]
       case _ => new AsJavaObjIntConsumer[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ObjIntConsumer` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaObjIntConsumer: java.util.function.ObjIntConsumer[T] = underlying match {
       case FromJavaObjIntConsumer((sf @ _)) => sf.asInstanceOf[java.util.function.ObjIntConsumer[T]]
       case _ => new AsJavaObjIntConsumer[T](underlying)
@@ -821,26 +1795,64 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `ObjLongConsumer`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param jf the Java `ObjLongConsumer` to which `apply` delegates
+   */
   case class FromJavaObjLongConsumer[T](jf: java.util.function.ObjLongConsumer[T]) extends scala.Function2[T, Long, Unit] {
+    /** Invokes the wrapped Java `ObjLongConsumer` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def apply(x1: T, x2: scala.Long) = jf.accept(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ObjLongConsumer`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param underlying the Java `ObjLongConsumer` to convert
+   */
   class RichObjLongConsumerAsFunction2[T](private val underlying: java.util.function.ObjLongConsumer[T]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaObjLongConsumer`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, Long, Unit] = underlying match {
       case AsJavaObjLongConsumer((sf @ _)) => sf.asInstanceOf[scala.Function2[T, Long, Unit]]
       case _ => new FromJavaObjLongConsumer[T](underlying)
     }
   }
   
+  /** A Java `ObjLongConsumer` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param sf the Scala `Function2` to which `accept` delegates
+   */
   case class AsJavaObjLongConsumer[T](sf: scala.Function2[T, Long, Unit]) extends java.util.function.ObjLongConsumer[T] {
+    /** Invokes the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     *  @return `()`, since the delegate is called only for its side effect
+     */
     def accept(x1: T, x2: scala.Long) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaObjLongConsumer` methods to a Scala `Function2`, converting it to a Java `ObjLongConsumer`.
+   *
+   *  @tparam T the type of the first (object) argument to the consumer (the second argument is a primitive)
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsObjLongConsumer[T](private val underlying: scala.Function2[T, Long, Unit]) extends AnyVal {
+    /** Returns a Java `ObjLongConsumer` that calls `underlying`, or, if `underlying` is a `FromJavaObjLongConsumer`, the Java `ObjLongConsumer` that wrapper holds. */
     @inline def asJava: java.util.function.ObjLongConsumer[T] = underlying match {
       case FromJavaObjLongConsumer((jf @ _)) => jf.asInstanceOf[java.util.function.ObjLongConsumer[T]]
       case _ => new AsJavaObjLongConsumer[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ObjLongConsumer` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaObjLongConsumer: java.util.function.ObjLongConsumer[T] = underlying match {
       case FromJavaObjLongConsumer((sf @ _)) => sf.asInstanceOf[java.util.function.ObjLongConsumer[T]]
       case _ => new AsJavaObjLongConsumer[T](underlying)
@@ -848,26 +1860,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `Predicate`.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param jf the Java `Predicate` to which `apply` delegates
+   */
   case class FromJavaPredicate[T](jf: java.util.function.Predicate[T]) extends scala.Function1[T, Boolean] {
+    /** Returns the result of invoking the wrapped Java `Predicate` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: T) = jf.test(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `Predicate`, converting it to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param underlying the Java `Predicate` to convert
+   */
   class RichPredicateAsFunction1[T](private val underlying: java.util.function.Predicate[T]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaPredicate`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[T, Boolean] = underlying match {
       case AsJavaPredicate((sf @ _)) => sf.asInstanceOf[scala.Function1[T, Boolean]]
       case _ => new FromJavaPredicate[T](underlying)
     }
   }
   
+  /** A Java `Predicate` that delegates to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param sf the Scala `Function1` to which `test` delegates
+   */
   case class AsJavaPredicate[T](sf: scala.Function1[T, Boolean]) extends java.util.function.Predicate[T] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def test(x1: T) = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaPredicate` methods to a Scala `Function1`, converting it to a Java `Predicate`.
+   *
+   *  @tparam T the input type of the predicate
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsPredicate[T](private val underlying: scala.Function1[T, Boolean]) extends AnyVal {
+    /** Returns a Java `Predicate` that calls `underlying`, or, if `underlying` is a `FromJavaPredicate`, the Java `Predicate` that wrapper holds. */
     @inline def asJava: java.util.function.Predicate[T] = underlying match {
       case FromJavaPredicate((jf @ _)) => jf.asInstanceOf[java.util.function.Predicate[T]]
       case _ => new AsJavaPredicate[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `Predicate` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaPredicate: java.util.function.Predicate[T] = underlying match {
       case FromJavaPredicate((sf @ _)) => sf.asInstanceOf[java.util.function.Predicate[T]]
       case _ => new AsJavaPredicate[T](underlying)
@@ -875,26 +1921,54 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function0` that delegates to a Java `Supplier`.
+   *
+   *  @tparam T the return type of the supplier
+   *  @param jf the Java `Supplier` to which `apply` delegates
+   */
   case class FromJavaSupplier[T](jf: java.util.function.Supplier[T]) extends scala.Function0[T] {
+    /** Returns the value produced by the wrapped Java `Supplier`. */
     def apply() = jf.get()
   }
   
+  /** A value class that adds an `asScala` method to a Java `Supplier`, converting it to a Scala `Function0`.
+   *
+   *  @tparam T the return type of the supplier
+   *  @param underlying the Java `Supplier` to convert
+   */
   class RichSupplierAsFunction0[T](private val underlying: java.util.function.Supplier[T]) extends AnyVal {
+    /** Returns a Scala `Function0` that calls `underlying`, or, if `underlying` is an `AsJavaSupplier`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function0[T] = underlying match {
       case AsJavaSupplier((sf @ _)) => sf.asInstanceOf[scala.Function0[T]]
       case _ => new FromJavaSupplier[T](underlying)
     }
   }
   
+  /** A Java `Supplier` that delegates to a Scala `Function0`.
+   *
+   *  @tparam T the return type of the supplier
+   *  @param sf the Scala `Function0` to which `get` delegates
+   */
   case class AsJavaSupplier[T](sf: scala.Function0[T]) extends java.util.function.Supplier[T] {
+    /** Returns the value produced by the wrapped Scala `Function0`. */
     def get(): T = sf.apply()
   }
   
+  /** A value class that adds `asJava` and `asJavaSupplier` methods to a Scala `Function0`, converting it to a Java `Supplier`.
+   *
+   *  @tparam T the return type of the supplier
+   *  @param underlying the Scala `Function0` to convert
+   */
   class RichFunction0AsSupplier[T](private val underlying: scala.Function0[T]) extends AnyVal {
+    /** Returns a Java `Supplier` that calls `underlying`, or, if `underlying` is a `FromJavaSupplier`, the Java `Supplier` that wrapper holds. */
     @inline def asJava: java.util.function.Supplier[T] = underlying match {
       case FromJavaSupplier((jf @ _)) => jf.asInstanceOf[java.util.function.Supplier[T]]
       case _ => new AsJavaSupplier[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `Supplier` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaSupplier: java.util.function.Supplier[T] = underlying match {
       case FromJavaSupplier((sf @ _)) => sf.asInstanceOf[java.util.function.Supplier[T]]
       case _ => new AsJavaSupplier[T](underlying)
@@ -902,26 +1976,66 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `ToDoubleBiFunction`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToDoubleBiFunction` to which `apply` delegates
+   */
   case class FromJavaToDoubleBiFunction[T, U](jf: java.util.function.ToDoubleBiFunction[T, U]) extends scala.Function2[T, U, Double] {
+    /** Returns the result of invoking the wrapped Java `ToDoubleBiFunction` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: T, x2: U) = jf.applyAsDouble(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ToDoubleBiFunction`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param underlying the Java `ToDoubleBiFunction` to convert
+   */
   class RichToDoubleBiFunctionAsFunction2[T, U](private val underlying: java.util.function.ToDoubleBiFunction[T, U]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaToDoubleBiFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, U, Double] = underlying match {
       case AsJavaToDoubleBiFunction((sf @ _)) => sf.asInstanceOf[scala.Function2[T, U, Double]]
       case _ => new FromJavaToDoubleBiFunction[T, U](underlying)
     }
   }
   
+  /** A Java `ToDoubleBiFunction` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to which `applyAsDouble` delegates
+   */
   case class AsJavaToDoubleBiFunction[T, U](sf: scala.Function2[T, U, Double]) extends java.util.function.ToDoubleBiFunction[T, U] {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def applyAsDouble(x1: T, x2: U) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaToDoubleBiFunction` methods to a Scala `Function2`, converting it to a Java `ToDoubleBiFunction`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsToDoubleBiFunction[T, U](private val underlying: scala.Function2[T, U, Double]) extends AnyVal {
+    /** Returns a Java `ToDoubleBiFunction` that calls `underlying`, or, if `underlying` is a `FromJavaToDoubleBiFunction`, the Java `ToDoubleBiFunction` that wrapper holds. */
     @inline def asJava: java.util.function.ToDoubleBiFunction[T, U] = underlying match {
       case FromJavaToDoubleBiFunction((jf @ _)) => jf.asInstanceOf[java.util.function.ToDoubleBiFunction[T, U]]
       case _ => new AsJavaToDoubleBiFunction[T, U](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ToDoubleBiFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaToDoubleBiFunction: java.util.function.ToDoubleBiFunction[T, U] = underlying match {
       case FromJavaToDoubleBiFunction((sf @ _)) => sf.asInstanceOf[java.util.function.ToDoubleBiFunction[T, U]]
       case _ => new AsJavaToDoubleBiFunction[T, U](underlying)
@@ -929,26 +2043,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `ToDoubleFunction`.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToDoubleFunction` to which `apply` delegates
+   */
   case class FromJavaToDoubleFunction[T](jf: java.util.function.ToDoubleFunction[T]) extends scala.Function1[T, Double] {
+    /** Returns the result of invoking the wrapped Java `ToDoubleFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: T) = jf.applyAsDouble(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ToDoubleFunction`, converting it to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @param underlying the Java `ToDoubleFunction` to convert
+   */
   class RichToDoubleFunctionAsFunction1[T](private val underlying: java.util.function.ToDoubleFunction[T]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaToDoubleFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[T, Double] = underlying match {
       case AsJavaToDoubleFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[T, Double]]
       case _ => new FromJavaToDoubleFunction[T](underlying)
     }
   }
   
+  /** A Java `ToDoubleFunction` that delegates to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to which `applyAsDouble` delegates
+   */
   case class AsJavaToDoubleFunction[T](sf: scala.Function1[T, Double]) extends java.util.function.ToDoubleFunction[T] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsDouble(x1: T) = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaToDoubleFunction` methods to a Scala `Function1`, converting it to a Java `ToDoubleFunction`.
+   *
+   *  @tparam T the input type of the function
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsToDoubleFunction[T](private val underlying: scala.Function1[T, Double]) extends AnyVal {
+    /** Returns a Java `ToDoubleFunction` that calls `underlying`, or, if `underlying` is a `FromJavaToDoubleFunction`, the Java `ToDoubleFunction` that wrapper holds. */
     @inline def asJava: java.util.function.ToDoubleFunction[T] = underlying match {
       case FromJavaToDoubleFunction((jf @ _)) => jf.asInstanceOf[java.util.function.ToDoubleFunction[T]]
       case _ => new AsJavaToDoubleFunction[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ToDoubleFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaToDoubleFunction: java.util.function.ToDoubleFunction[T] = underlying match {
       case FromJavaToDoubleFunction((sf @ _)) => sf.asInstanceOf[java.util.function.ToDoubleFunction[T]]
       case _ => new AsJavaToDoubleFunction[T](underlying)
@@ -956,26 +2104,66 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `ToIntBiFunction`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToIntBiFunction` to which `apply` delegates
+   */
   case class FromJavaToIntBiFunction[T, U](jf: java.util.function.ToIntBiFunction[T, U]) extends scala.Function2[T, U, Int] {
+    /** Returns the result of invoking the wrapped Java `ToIntBiFunction` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: T, x2: U) = jf.applyAsInt(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ToIntBiFunction`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param underlying the Java `ToIntBiFunction` to convert
+   */
   class RichToIntBiFunctionAsFunction2[T, U](private val underlying: java.util.function.ToIntBiFunction[T, U]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaToIntBiFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, U, Int] = underlying match {
       case AsJavaToIntBiFunction((sf @ _)) => sf.asInstanceOf[scala.Function2[T, U, Int]]
       case _ => new FromJavaToIntBiFunction[T, U](underlying)
     }
   }
   
+  /** A Java `ToIntBiFunction` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to which `applyAsInt` delegates
+   */
   case class AsJavaToIntBiFunction[T, U](sf: scala.Function2[T, U, Int]) extends java.util.function.ToIntBiFunction[T, U] {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def applyAsInt(x1: T, x2: U) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaToIntBiFunction` methods to a Scala `Function2`, converting it to a Java `ToIntBiFunction`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsToIntBiFunction[T, U](private val underlying: scala.Function2[T, U, Int]) extends AnyVal {
+    /** Returns a Java `ToIntBiFunction` that calls `underlying`, or, if `underlying` is a `FromJavaToIntBiFunction`, the Java `ToIntBiFunction` that wrapper holds. */
     @inline def asJava: java.util.function.ToIntBiFunction[T, U] = underlying match {
       case FromJavaToIntBiFunction((jf @ _)) => jf.asInstanceOf[java.util.function.ToIntBiFunction[T, U]]
       case _ => new AsJavaToIntBiFunction[T, U](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ToIntBiFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaToIntBiFunction: java.util.function.ToIntBiFunction[T, U] = underlying match {
       case FromJavaToIntBiFunction((sf @ _)) => sf.asInstanceOf[java.util.function.ToIntBiFunction[T, U]]
       case _ => new AsJavaToIntBiFunction[T, U](underlying)
@@ -983,26 +2171,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `ToIntFunction`.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToIntFunction` to which `apply` delegates
+   */
   case class FromJavaToIntFunction[T](jf: java.util.function.ToIntFunction[T]) extends scala.Function1[T, Int] {
+    /** Returns the result of invoking the wrapped Java `ToIntFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: T) = jf.applyAsInt(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ToIntFunction`, converting it to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @param underlying the Java `ToIntFunction` to convert
+   */
   class RichToIntFunctionAsFunction1[T](private val underlying: java.util.function.ToIntFunction[T]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaToIntFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[T, Int] = underlying match {
       case AsJavaToIntFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[T, Int]]
       case _ => new FromJavaToIntFunction[T](underlying)
     }
   }
   
+  /** A Java `ToIntFunction` that delegates to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to which `applyAsInt` delegates
+   */
   case class AsJavaToIntFunction[T](sf: scala.Function1[T, Int]) extends java.util.function.ToIntFunction[T] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsInt(x1: T) = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaToIntFunction` methods to a Scala `Function1`, converting it to a Java `ToIntFunction`.
+   *
+   *  @tparam T the input type of the function
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsToIntFunction[T](private val underlying: scala.Function1[T, Int]) extends AnyVal {
+    /** Returns a Java `ToIntFunction` that calls `underlying`, or, if `underlying` is a `FromJavaToIntFunction`, the Java `ToIntFunction` that wrapper holds. */
     @inline def asJava: java.util.function.ToIntFunction[T] = underlying match {
       case FromJavaToIntFunction((jf @ _)) => jf.asInstanceOf[java.util.function.ToIntFunction[T]]
       case _ => new AsJavaToIntFunction[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ToIntFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaToIntFunction: java.util.function.ToIntFunction[T] = underlying match {
       case FromJavaToIntFunction((sf @ _)) => sf.asInstanceOf[java.util.function.ToIntFunction[T]]
       case _ => new AsJavaToIntFunction[T](underlying)
@@ -1010,26 +2232,66 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function2` that delegates to a Java `ToLongBiFunction`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param jf the Java `ToLongBiFunction` to which `apply` delegates
+   */
   case class FromJavaToLongBiFunction[T, U](jf: java.util.function.ToLongBiFunction[T, U]) extends scala.Function2[T, U, Long] {
+    /** Returns the result of invoking the wrapped Java `ToLongBiFunction` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `jf`
+     *  @param x2 the second argument to pass to `jf`
+     */
     def apply(x1: T, x2: U) = jf.applyAsLong(x1, x2)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ToLongBiFunction`, converting it to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param underlying the Java `ToLongBiFunction` to convert
+   */
   class RichToLongBiFunctionAsFunction2[T, U](private val underlying: java.util.function.ToLongBiFunction[T, U]) extends AnyVal {
+    /** Returns a Scala `Function2` that calls `underlying`, or, if `underlying` is an `AsJavaToLongBiFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function2[T, U, Long] = underlying match {
       case AsJavaToLongBiFunction((sf @ _)) => sf.asInstanceOf[scala.Function2[T, U, Long]]
       case _ => new FromJavaToLongBiFunction[T, U](underlying)
     }
   }
   
+  /** A Java `ToLongBiFunction` that delegates to a Scala `Function2`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param sf the Scala `Function2` to which `applyAsLong` delegates
+   */
   case class AsJavaToLongBiFunction[T, U](sf: scala.Function2[T, U, Long]) extends java.util.function.ToLongBiFunction[T, U] {
+    /** Returns the result of invoking the wrapped Scala `Function2` with `x1` and `x2`.
+     *
+     *  @param x1 the first argument to pass to `sf`
+     *  @param x2 the second argument to pass to `sf`
+     */
     def applyAsLong(x1: T, x2: U) = sf.apply(x1, x2)
   }
   
+  /** A value class that adds `asJava` and `asJavaToLongBiFunction` methods to a Scala `Function2`, converting it to a Java `ToLongBiFunction`.
+   *
+   *  @tparam T the first input type of the function
+   *  @tparam U the second input type of the function
+   *  @param underlying the Scala `Function2` to convert
+   */
   class RichFunction2AsToLongBiFunction[T, U](private val underlying: scala.Function2[T, U, Long]) extends AnyVal {
+    /** Returns a Java `ToLongBiFunction` that calls `underlying`, or, if `underlying` is a `FromJavaToLongBiFunction`, the Java `ToLongBiFunction` that wrapper holds. */
     @inline def asJava: java.util.function.ToLongBiFunction[T, U] = underlying match {
       case FromJavaToLongBiFunction((jf @ _)) => jf.asInstanceOf[java.util.function.ToLongBiFunction[T, U]]
       case _ => new AsJavaToLongBiFunction[T, U](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ToLongBiFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaToLongBiFunction: java.util.function.ToLongBiFunction[T, U] = underlying match {
       case FromJavaToLongBiFunction((sf @ _)) => sf.asInstanceOf[java.util.function.ToLongBiFunction[T, U]]
       case _ => new AsJavaToLongBiFunction[T, U](underlying)
@@ -1037,26 +2299,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `ToLongFunction`.
+   *
+   *  @tparam T the input type of the function
+   *  @param jf the Java `ToLongFunction` to which `apply` delegates
+   */
   case class FromJavaToLongFunction[T](jf: java.util.function.ToLongFunction[T]) extends scala.Function1[T, Long] {
+    /** Returns the result of invoking the wrapped Java `ToLongFunction` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: T) = jf.applyAsLong(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `ToLongFunction`, converting it to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @param underlying the Java `ToLongFunction` to convert
+   */
   class RichToLongFunctionAsFunction1[T](private val underlying: java.util.function.ToLongFunction[T]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaToLongFunction`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[T, Long] = underlying match {
       case AsJavaToLongFunction((sf @ _)) => sf.asInstanceOf[scala.Function1[T, Long]]
       case _ => new FromJavaToLongFunction[T](underlying)
     }
   }
   
+  /** A Java `ToLongFunction` that delegates to a Scala `Function1`.
+   *
+   *  @tparam T the input type of the function
+   *  @param sf the Scala `Function1` to which `applyAsLong` delegates
+   */
   case class AsJavaToLongFunction[T](sf: scala.Function1[T, Long]) extends java.util.function.ToLongFunction[T] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def applyAsLong(x1: T) = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaToLongFunction` methods to a Scala `Function1`, converting it to a Java `ToLongFunction`.
+   *
+   *  @tparam T the input type of the function
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsToLongFunction[T](private val underlying: scala.Function1[T, Long]) extends AnyVal {
+    /** Returns a Java `ToLongFunction` that calls `underlying`, or, if `underlying` is a `FromJavaToLongFunction`, the Java `ToLongFunction` that wrapper holds. */
     @inline def asJava: java.util.function.ToLongFunction[T] = underlying match {
       case FromJavaToLongFunction((jf @ _)) => jf.asInstanceOf[java.util.function.ToLongFunction[T]]
       case _ => new AsJavaToLongFunction[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `ToLongFunction` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaToLongFunction: java.util.function.ToLongFunction[T] = underlying match {
       case FromJavaToLongFunction((sf @ _)) => sf.asInstanceOf[java.util.function.ToLongFunction[T]]
       case _ => new AsJavaToLongFunction[T](underlying)
@@ -1064,26 +2360,60 @@ object FunctionWrappers {
   }
   
   
+  /** A Scala `Function1` that delegates to a Java `UnaryOperator`.
+   *
+   *  @tparam T the input and output type of the unary operator
+   *  @param jf the Java `UnaryOperator` to which `apply` delegates
+   */
   case class FromJavaUnaryOperator[T](jf: java.util.function.UnaryOperator[T]) extends scala.Function1[T, T] {
+    /** Returns the result of invoking the wrapped Java `UnaryOperator` with `x1`.
+     *
+     *  @param x1 the argument to pass to `jf`
+     */
     def apply(x1: T): T = jf.apply(x1)
   }
   
+  /** A value class that adds an `asScala` method to a Java `UnaryOperator`, converting it to a Scala `Function1`.
+   *
+   *  @tparam T the input and output type of the unary operator
+   *  @param underlying the Java `UnaryOperator` to convert
+   */
   class RichUnaryOperatorAsFunction1[T](private val underlying: java.util.function.UnaryOperator[T]) extends AnyVal {
+    /** Returns a Scala `Function1` that calls `underlying`, or, if `underlying` is an `AsJavaUnaryOperator`, the Scala function that wrapper holds. */
     @inline def asScala: scala.Function1[T, T] = underlying match {
       case AsJavaUnaryOperator((sf @ _)) => sf.asInstanceOf[scala.Function1[T, T]]
       case _ => new FromJavaUnaryOperator[T](underlying)
     }
   }
   
+  /** A Java `UnaryOperator` that delegates to a Scala `Function1`.
+   *
+   *  @tparam T the input and output type of the unary operator
+   *  @param sf the Scala `Function1` to which `apply` delegates
+   */
   case class AsJavaUnaryOperator[T](sf: scala.Function1[T, T]) extends java.util.function.UnaryOperator[T] {
+    /** Returns the result of invoking the wrapped Scala `Function1` with `x1`.
+     *
+     *  @param x1 the argument to pass to `sf`
+     */
     def apply(x1: T): T = sf.apply(x1)
   }
   
+  /** A value class that adds `asJava` and `asJavaUnaryOperator` methods to a Scala `Function1`, converting it to a Java `UnaryOperator`.
+   *
+   *  @tparam T the input and output type of the unary operator
+   *  @param underlying the Scala `Function1` to convert
+   */
   class RichFunction1AsUnaryOperator[T](private val underlying: scala.Function1[T, T]) extends AnyVal {
+    /** Returns a Java `UnaryOperator` that calls `underlying`, or, if `underlying` is a `FromJavaUnaryOperator`, the Java `UnaryOperator` that wrapper holds. */
     @inline def asJava: java.util.function.UnaryOperator[T] = underlying match {
       case FromJavaUnaryOperator((jf @ _)) => jf.asInstanceOf[java.util.function.UnaryOperator[T]]
       case _ => new AsJavaUnaryOperator[T](underlying)
     };
+    /** An explicitly named alias for `asJava`, with identical behavior.
+     *
+     *  @return a Java `UnaryOperator` that behaves identically to the one `asJava` returns
+     */
     @inline def asJavaUnaryOperator: java.util.function.UnaryOperator[T] = underlying match {
       case FromJavaUnaryOperator((sf @ _)) => sf.asInstanceOf[java.util.function.UnaryOperator[T]]
       case _ => new AsJavaUnaryOperator[T](underlying)

--- a/library/src/scala/jdk/FutureConverters.scala
+++ b/library/src/scala/jdk/FutureConverters.scala
@@ -32,11 +32,23 @@ import scala.concurrent.Future
   * `CompletionStage`s.
   */
 object FutureConverters {
+  /** Provides the `asJava` extension method on [[scala.concurrent.Future]], which converts it to a
+   *  Java [[java.util.concurrent.CompletionStage]].
+   *
+   *  @tparam T the type of value with which the future completes
+   *  @param f the Scala future to convert
+   */
   implicit class FutureOps[T](private val f: Future[T]) extends AnyVal {
     /** Converts a Scala Future to a Java CompletionStage, see [[javaapi.FutureConverters.asJava]]. */
     def asJava: CompletionStage[T] = javaapi.FutureConverters.asJava(f)
   }
 
+  /** Provides the `asScala` extension method on [[java.util.concurrent.CompletionStage]], which
+   *  converts it to a Scala [[scala.concurrent.Future]].
+   *
+   *  @tparam T the type of value with which the completion stage completes
+   *  @param cs the Java completion stage to convert
+   */
   implicit class CompletionStageOps[T](private val cs: CompletionStage[T]) extends AnyVal {
     /** Converts a Java CompletionStage to a Scala Future, see [[javaapi.FutureConverters.asScala]]. */
     def asScala: Future[T] = javaapi.FutureConverters.asScala(cs)

--- a/library/src/scala/jdk/IntAccumulator.scala
+++ b/library/src/scala/jdk/IntAccumulator.scala
@@ -34,8 +34,18 @@ final class IntAccumulator
 
   private[jdk] def cumulative(i: Int) = { val x = history(i); x(x.length-2).toLong << 32 | (x(x.length-1)&0xFFFFFFFFL) }
 
+  /** Returns `"IntAccumulator"`, the prefix used by `toString`. */
   override protected def className: String = "IntAccumulator"
 
+  /** Returns a [[scala.collection.Stepper]] over the elements of this `IntAccumulator` that
+   *  supports efficient splitting, so that it can be traversed in parallel.
+   *
+   *  @tparam S the specific stepper type, determined by `shape`
+   *  @param shape the implicit shape selecting the stepper specialized for `Int`; only
+   *         `IntShape` and `ReferenceShape` are supported
+   *  @return a stepper of shape `S`; for `IntShape` it steps over the elements without boxing,
+   *          for `ReferenceShape` it boxes them as `java.lang.Integer`
+   */
   def efficientStepper[S <: Stepper[?]](implicit shape: StepperShape[Int, S]): S & EfficientSplit = {
     val st = new IntAccumulatorStepper(this)
     val r =
@@ -144,6 +154,7 @@ final class IntAccumulator
     that.clear()
   }
 
+  /** Removes all accumulated elements from this `IntAccumulator`, releasing the arrays that held them. */
   override def clear(): Unit = {
     super.clear()
     current = IntAccumulator.emptyIntArray
@@ -170,6 +181,23 @@ final class IntAccumulator
    */
   def apply(i: Int): Int = apply(i.toLong)
 
+  /** Replaces the element at index `idx` with `elem`.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the current array, in which case the write silently succeeds
+   *  without changing any element this accumulator reports. Because the offset into the current
+   *  array is computed as a `Long` and then narrowed to an `Int`, an index far enough out of range
+   *  can also wrap onto an occupied slot and silently overwrite an element this accumulator does
+   *  report. The same narrowing happens on the other branch: `seekSlot` narrows the index it is
+   *  given to an `Int` when locating a slot in `history`, so an out-of-range index can wrap onto
+   *  an occupied history slot as well. Otherwise the write throws.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the `Int` value to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if `idx` is out of range and the computed offset falls
+   *          outside the array being written, rather than into unused current-array capacity or
+   *          onto a slot reached by `Int` wraparound
+   */
   def update(idx: Long, elem: Int): Unit = {
     if (totalSize - idx <= index || hIndex == 0) current((idx - (totalSize - index)).toInt) = elem
     else {
@@ -178,16 +206,45 @@ final class IntAccumulator
     }
   }
 
+  /** Replaces the element at index `idx` with `elem`, using an `Int` index.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the current array, in which case the write silently succeeds
+   *  without changing any element this accumulator reports. Otherwise the write throws. An `Int`
+   *  index is widened to a `Long` without loss, so it can never wrap onto an occupied slot the way
+   *  a sufficiently large `Long` index can.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the `Int` value to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if `idx` is out of range and the computed offset falls
+   *          outside the array being written, rather than into unused current-array capacity
+   */
   def update(idx: Int, elem: Int): Unit = update(idx.toLong, elem)
 
   /** Returns an `Iterator` over the contents of this `IntAccumulator`. The `Iterator` is not specialized. */
   def iterator: Iterator[Int] = stepper.iterator
 
+  /** Applies `f` to every element of this `IntAccumulator`, in order.
+   *
+   *  Elements are read through an [[scala.collection.IntStepper]], so a function specialized for
+   *  `Int` receives them without boxing.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each element
+   */
   override def foreach[U](f: Int => U): Unit = {
     val s = stepper
     while (s.hasStep) f(s.nextStep())
   }
 
+  /** Returns a new `IntAccumulator` containing the results of applying `f` to each element of
+   *  this one, in order.
+   *
+   *  Unlike the inherited `map`, which builds an [[AnyAccumulator]], this overload keeps the
+   *  elements unboxed.
+   *
+   *  @param f the function applied to each element
+   */
   def map(f: Int => Int): IntAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -196,6 +253,14 @@ final class IntAccumulator
     b.result()
   }
 
+  /** Returns a new `IntAccumulator` containing the elements produced by applying `f` to each
+   *  element of this one, concatenated in order.
+   *
+   *  Unlike the inherited `flatMap`, which builds an [[AnyAccumulator]], this overload keeps the
+   *  elements unboxed.
+   *
+   *  @param f the function mapping each element to a collection of `Int`s
+   */
   def flatMap(f: Int => IterableOnce[Int]): IntAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -204,6 +269,14 @@ final class IntAccumulator
     b.result()
   }
 
+  /** Returns a new `IntAccumulator` containing the results of applying `pf` to the elements of
+   *  this one for which it is defined, in order.
+   *
+   *  Unlike the inherited `collect`, which builds an [[AnyAccumulator]], this overload keeps the
+   *  elements unboxed.
+   *
+   *  @param pf the partial function applied to the elements on which it is defined
+   */
   def collect(pf: PartialFunction[Int, Int]): IntAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -224,10 +297,25 @@ final class IntAccumulator
     b.result()
   }
 
+  /** Returns a new `IntAccumulator` containing the elements of this one that satisfy `pred`, in
+   *  order.
+   *
+   *  @param pred the predicate each element is tested against
+   */
   override def filter(pred: Int => Boolean): IntAccumulator = filterAccImpl(pred, not = false)
 
+  /** Returns a new `IntAccumulator` containing the elements of this one that do not satisfy
+   *  `pred`, in order.
+   *
+   *  @param pred the predicate each element is tested against
+   */
   override def filterNot(pred: Int => Boolean): IntAccumulator = filterAccImpl(pred, not = true)
 
+  /** Returns `true` if `p` holds for every element of this `IntAccumulator`, and `true` if this
+   *  `IntAccumulator` is empty. Testing stops at the first element for which `p` is `false`.
+   *
+   *  @param p the predicate each element is tested against
+   */
   override def forall(p: Int => Boolean): Boolean = {
     val s = stepper
     while (s.hasStep)
@@ -235,6 +323,11 @@ final class IntAccumulator
     true
   }
 
+  /** Returns `true` if `p` holds for at least one element of this `IntAccumulator`, `false`
+   *  otherwise. Testing stops at the first element for which `p` is `true`.
+   *
+   *  @param p the predicate each element is tested against
+   */
   override def exists(p: Int => Boolean): Boolean = {
     val s = stepper
     while (s.hasStep)
@@ -242,6 +335,12 @@ final class IntAccumulator
     false
   }
 
+  /** Returns the number of elements of this `IntAccumulator` that satisfy `p`.
+   *
+   *  @param p the predicate each element is tested against
+   *  @return the number of matching elements, as an `Int`, which overflows silently if more than
+   *          `Int.MaxValue` elements match; use [[countLong]] for large accumulators
+   */
   override def count(p: Int => Boolean): Int = {
     var r = 0
     val s = stepper
@@ -250,6 +349,11 @@ final class IntAccumulator
     r
   }
 
+  /** Returns the number of elements of this `IntAccumulator` that satisfy `p`, as a `Long`, so
+   *  that accumulators holding more than `Int.MaxValue` elements are counted correctly.
+   *
+   *  @param p the predicate each element is tested against
+   */
   def countLong(p: Int => Boolean): Long = {
     var r = 0L
     val s = stepper
@@ -314,10 +418,22 @@ final class IntAccumulator
     factory.fromSpecific(iterator)
   }
 
+  /** Returns an `IntAccumulator` holding the elements of `coll`; used by operations that
+   *  preserve this collection's type to build their result.
+   *
+   *  @param coll the collection whose elements are accumulated
+   *  @return `coll` itself if it already is an `IntAccumulator`, otherwise a new `IntAccumulator`
+   *          with all of its elements appended in order
+   */
   override protected def fromSpecific(coll: IterableOnce[Int]): IntAccumulator = IntAccumulator.fromSpecific(coll)
+  /** Returns a new, empty `IntAccumulator`, which acts as both the builder and its result. */
   override protected def newSpecificBuilder: IntAccumulator = IntAccumulator.newBuilder
+  /** Returns the [[AnyAccumulator]] companion object, the factory used to build the results of
+   *  inherited operations, such as `map`, that can produce elements of any type.
+   */
   override def iterableFactory: SeqFactory[AnyAccumulator] = AnyAccumulator
 
+  /** Returns a new, empty `IntAccumulator`. */
   override def empty: IntAccumulator = IntAccumulator.empty
 
   private def writeReplace(): AnyRef = new IntAccumulator.SerializationProxy(this)
@@ -327,6 +443,11 @@ object IntAccumulator extends collection.SpecificIterableFactory[Int, IntAccumul
   private val emptyIntArray = new Array[Int](0)
   private val emptyIntArrayArray = new Array[Array[Int]](0)
 
+  /** Returns the [[IntAccumulator]] companion object as a factory for `java.lang.Integer`
+   *  elements, so that collections of boxed `Integer`s can be built into an `IntAccumulator`.
+   *
+   *  @param ia the `IntAccumulator` companion object being converted (never used)
+   */
   implicit def toJavaIntegerAccumulator(ia: IntAccumulator.type): collection.SpecificIterableFactory[jl.Integer, IntAccumulator] = IntAccumulator.asInstanceOf[collection.SpecificIterableFactory[jl.Integer, IntAccumulator]]
 
   import java.util.{function => jf}
@@ -350,6 +471,13 @@ object IntAccumulator extends collection.SpecificIterableFactory[Int, IntAccumul
     r
   }
 
+  /** Returns an `IntAccumulator` holding the elements of `it`.
+   *
+   *  @param it the collection whose elements are accumulated; it may be a one-shot source, such
+   *         as an `Iterator`, in which case it is consumed
+   *  @return `it` itself if it already is an `IntAccumulator`, otherwise a new `IntAccumulator`
+   *          with all of its elements appended in order
+   */
   override def fromSpecific(it: IterableOnce[Int]): IntAccumulator = it match {
     case acc: IntAccumulator => acc
     case as: collection.immutable.ArraySeq.ofInt => fromArray(as.unsafeArray)
@@ -357,10 +485,19 @@ object IntAccumulator extends collection.SpecificIterableFactory[Int, IntAccumul
     case _ => (new IntAccumulator).addAll(it)
   }
 
+  /** Returns a new, empty `IntAccumulator`. */
   override def empty: IntAccumulator = new IntAccumulator
 
+  /** Returns a builder for `IntAccumulator`s, which is itself a new, empty `IntAccumulator`. */
   override def newBuilder: IntAccumulator = new IntAccumulator
 
+  /** A serialization proxy that writes an `IntAccumulator` as its size followed by its elements,
+   *  and reads it back into a freshly built accumulator.
+   *
+   *  @tparam A an unused type parameter; the proxy always serializes `Int` elements
+   *  @param acc the accumulator whose elements are written; it is `@transient`, so it is only
+   *         available while serializing, not after deserialization
+   */
   class SerializationProxy[A](@transient private val acc: IntAccumulator) extends Serializable {
     @transient private var result: IntAccumulator = compiletime.uninitialized
 

--- a/library/src/scala/jdk/LongAccumulator.scala
+++ b/library/src/scala/jdk/LongAccumulator.scala
@@ -34,8 +34,18 @@ final class LongAccumulator
 
   private[jdk] def cumulative(i: Int) = { val x = history(i); x(x.length-1) }
 
+  /** Returns `"LongAccumulator"`, the prefix used by `toString`. */
   override protected def className: String = "LongAccumulator"
 
+  /** Returns a [[scala.collection.Stepper]] over the elements of this `LongAccumulator` that
+   *  supports efficient splitting, so that it can be traversed in parallel.
+   *
+   *  @tparam S the specific stepper type, determined by `shape`
+   *  @param shape the implicit shape selecting the stepper specialized for `Long`; only
+   *         `LongShape` and `ReferenceShape` are supported
+   *  @return a stepper of shape `S`; for `LongShape` it steps over the elements without boxing,
+   *          for `ReferenceShape` it boxes them as `java.lang.Long`
+   */
   def efficientStepper[S <: Stepper[?]](implicit shape: StepperShape[Long, S]): S & EfficientSplit = {
     val st = new LongAccumulatorStepper(this)
     val r =
@@ -139,6 +149,7 @@ final class LongAccumulator
     that.clear()
   }
 
+  /** Removes all accumulated elements from this `LongAccumulator`, releasing the arrays that held them. */
   override def clear(): Unit = {
     super.clear()
     current = LongAccumulator.emptyLongArray
@@ -165,6 +176,23 @@ final class LongAccumulator
    */
   def apply(i: Int): Long = apply(i.toLong)
 
+  /** Replaces the element at index `idx` with `elem`.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the current array, in which case the write silently succeeds
+   *  without changing any element this accumulator reports. Because the offset into the current
+   *  array is computed as a `Long` and then narrowed to an `Int`, an index far enough out of range
+   *  can also wrap onto an occupied slot and silently overwrite an element this accumulator does
+   *  report. The same narrowing happens on the other branch: `seekSlot` narrows the index it is
+   *  given to an `Int` when locating a slot in `history`, so an out-of-range index can wrap onto an
+   *  occupied history slot as well. Otherwise the write throws.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the `Long` value to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if `idx` is out of range and the computed offset falls
+   *          outside the array being written, rather than into unused current-array capacity or
+   *          onto an occupied slot reached by `Int` narrowing
+   */
   def update(idx: Long, elem: Long): Unit = {
     if (totalSize - idx <= index || hIndex == 0) current((idx - (totalSize - index)).toInt) = elem
     else {
@@ -173,16 +201,45 @@ final class LongAccumulator
     }
   }
 
+  /** Replaces the element at index `idx` with `elem`, using an `Int` index.
+   *
+   *  `idx` is not validated, and an out-of-range index has more than one possible outcome. It can
+   *  land in unused capacity of the current array, in which case the write silently succeeds
+   *  without changing any element this accumulator reports. Otherwise the write throws. An `Int`
+   *  index is widened to a `Long` without loss, so it can never wrap onto an occupied slot the
+   *  way a sufficiently large `Long` index can.
+   *
+   *  @param idx the zero-based index of the element to replace
+   *  @param elem the `Long` value to store at index `idx`
+   *  @throws ArrayIndexOutOfBoundsException if `idx` is out of range and the computed offset falls
+   *          outside the array being written, rather than into unused current-array capacity
+   */
   def update(idx: Int, elem: Long): Unit = update(idx.toLong, elem)
 
   /** Returns an `Iterator` over the contents of this `LongAccumulator`. The `Iterator` is not specialized. */
   def iterator: Iterator[Long] = stepper.iterator
 
+  /** Applies `f` to every element of this `LongAccumulator`, in order.
+   *
+   *  Elements are read through an [[scala.collection.LongStepper]], so a function specialized for
+   *  `Long` receives them without boxing.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each element
+   */
   override def foreach[U](f: Long => U): Unit = {
     val s = stepper
     while (s.hasStep) f(s.nextStep())
   }
 
+  /** Returns a new `LongAccumulator` containing the results of applying `f` to each element of
+   *  this one, in order.
+   *
+   *  Unlike the inherited `map`, which builds an [[AnyAccumulator]], this overload keeps the
+   *  elements unboxed.
+   *
+   *  @param f the function applied to each element
+   */
   def map(f: Long => Long): LongAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -191,6 +248,14 @@ final class LongAccumulator
     b.result()
   }
 
+  /** Returns a new `LongAccumulator` containing the elements produced by applying `f` to each
+   *  element of this one, concatenated in order.
+   *
+   *  Unlike the inherited `flatMap`, which builds an [[AnyAccumulator]], this overload keeps the
+   *  elements unboxed.
+   *
+   *  @param f the function mapping each element to a collection of `Long`s
+   */
   def flatMap(f: Long => IterableOnce[Long]): LongAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -199,6 +264,14 @@ final class LongAccumulator
     b.result()
   }
 
+  /** Returns a new `LongAccumulator` containing the results of applying `pf` to the elements of
+   *  this one for which it is defined, in order.
+   *
+   *  Unlike the inherited `collect`, which builds an [[AnyAccumulator]], this overload keeps the
+   *  elements unboxed.
+   *
+   *  @param pf the partial function applied to the elements on which it is defined
+   */
   def collect(pf: PartialFunction[Long, Long]): LongAccumulator = {
     val b = newSpecificBuilder
     val s = stepper
@@ -219,10 +292,25 @@ final class LongAccumulator
     b.result()
   }
 
+  /** Returns a new `LongAccumulator` containing the elements of this one that satisfy `pred`, in
+   *  order.
+   *
+   *  @param pred the predicate each element is tested against
+   */
   override def filter(pred: Long => Boolean): LongAccumulator = filterAccImpl(pred, not = false)
 
+  /** Returns a new `LongAccumulator` containing the elements of this one that do not satisfy
+   *  `pred`, in order.
+   *
+   *  @param pred the predicate each element is tested against
+   */
   override def filterNot(pred: Long => Boolean): LongAccumulator = filterAccImpl(pred, not = true)
 
+  /** Returns `true` if `p` holds for every element of this `LongAccumulator`, and `true` if this
+   *  `LongAccumulator` is empty. Testing stops at the first element for which `p` is `false`.
+   *
+   *  @param p the predicate each element is tested against
+   */
   override def forall(p: Long => Boolean): Boolean = {
     val s = stepper
     while (s.hasStep)
@@ -230,6 +318,11 @@ final class LongAccumulator
     true
   }
 
+  /** Returns `true` if `p` holds for at least one element of this `LongAccumulator`, `false`
+   *  otherwise. Testing stops at the first element for which `p` is `true`.
+   *
+   *  @param p the predicate each element is tested against
+   */
   override def exists(p: Long => Boolean): Boolean = {
     val s = stepper
     while (s.hasStep)
@@ -237,6 +330,12 @@ final class LongAccumulator
     false
   }
 
+  /** Returns the number of elements of this `LongAccumulator` that satisfy `p`.
+   *
+   *  @param p the predicate each element is tested against
+   *  @return the number of matching elements, as an `Int`, which overflows silently if more than
+   *          `Int.MaxValue` elements match; use [[countLong]] for large accumulators
+   */
   override def count(p: Long => Boolean): Int = {
     var r = 0
     val s = stepper
@@ -245,6 +344,11 @@ final class LongAccumulator
     r
   }
 
+  /** Returns the number of elements of this `LongAccumulator` that satisfy `p`, as a `Long`, so
+   *  that accumulators holding more than `Int.MaxValue` elements are counted correctly.
+   *
+   *  @param p the predicate each element is tested against
+   */
   def countLong(p: Long => Boolean): Long = {
     var r = 0L
     val s = stepper
@@ -309,10 +413,22 @@ final class LongAccumulator
     factory.fromSpecific(iterator)
   }
 
+  /** Returns a `LongAccumulator` holding the elements of `coll`; used by operations that
+   *  preserve this collection's type to build their result.
+   *
+   *  @param coll the collection whose elements are accumulated
+   *  @return `coll` itself if it already is a `LongAccumulator`, otherwise a new `LongAccumulator`
+   *          with all of its elements appended in order
+   */
   override protected def fromSpecific(coll: IterableOnce[Long]): LongAccumulator = LongAccumulator.fromSpecific(coll)
+  /** Returns a new, empty `LongAccumulator`, which acts as both the builder and its result. */
   override protected def newSpecificBuilder: LongAccumulator = LongAccumulator.newBuilder
+  /** Returns the [[AnyAccumulator]] companion object, the factory used to build the results of
+   *  inherited operations, such as `map`, that can produce elements of any type.
+   */
   override def iterableFactory: SeqFactory[AnyAccumulator] = AnyAccumulator
 
+  /** Returns a new, empty `LongAccumulator`. */
   override def empty: LongAccumulator = LongAccumulator.empty
 
   private def writeReplace(): AnyRef = new LongAccumulator.SerializationProxy(this)
@@ -322,6 +438,11 @@ object LongAccumulator extends collection.SpecificIterableFactory[Long, LongAccu
   private val emptyLongArray = new Array[Long](0)
   private val emptyLongArrayArray = new Array[Array[Long]](0)
 
+  /** Returns the [[LongAccumulator]] companion object as a factory for `java.lang.Long`
+   *  elements, so that collections of boxed `Long`s can be built into a `LongAccumulator`.
+   *
+   *  @param ia the `LongAccumulator` companion object being converted (never used)
+   */
   implicit def toJavaLongAccumulator(ia: LongAccumulator.type): collection.SpecificIterableFactory[jl.Long, LongAccumulator] = LongAccumulator.asInstanceOf[collection.SpecificIterableFactory[jl.Long, LongAccumulator]]
 
   import java.util.{function => jf}
@@ -345,6 +466,13 @@ object LongAccumulator extends collection.SpecificIterableFactory[Long, LongAccu
     r
   }
 
+  /** Returns a `LongAccumulator` holding the elements of `it`.
+   *
+   *  @param it the collection whose elements are accumulated; it may be a one-shot source, such
+   *         as an `Iterator`, in which case it is consumed
+   *  @return `it` itself if it already is a `LongAccumulator`, otherwise a new `LongAccumulator`
+   *          with all of its elements appended in order
+   */
   override def fromSpecific(it: IterableOnce[Long]): LongAccumulator = it match {
     case acc: LongAccumulator => acc
     case as: collection.immutable.ArraySeq.ofLong => fromArray(as.unsafeArray)
@@ -352,10 +480,19 @@ object LongAccumulator extends collection.SpecificIterableFactory[Long, LongAccu
     case _ => (new LongAccumulator).addAll(it)
   }
 
+  /** Returns a new, empty `LongAccumulator`. */
   override def empty: LongAccumulator = new LongAccumulator
 
+  /** Returns a builder for `LongAccumulator`s, which is itself a new, empty `LongAccumulator`. */
   override def newBuilder: LongAccumulator = new LongAccumulator
 
+  /** A serialization proxy that writes a `LongAccumulator` as its size followed by its elements,
+   *  and reads it back into a freshly built accumulator.
+   *
+   *  @tparam A an unused type parameter; the proxy always serializes `Long` elements
+   *  @param acc the accumulator whose elements are written; it is `@transient`, so it is only
+   *         available while serializing, not after deserialization
+   */
   class SerializationProxy[A](@transient private val acc: LongAccumulator) extends Serializable {
     @transient private var result: LongAccumulator = compiletime.uninitialized
 

--- a/library/src/scala/jdk/OptionShape.scala
+++ b/library/src/scala/jdk/OptionShape.scala
@@ -41,6 +41,7 @@ sealed abstract class OptionShape[A, O] {
 }
 
 object OptionShape {
+  /** An `OptionShape` converting options of `Double` to `OptionalDouble`. */
   implicit val doubleOptionShape: OptionShape[Double, OptionalDouble] = new OptionShape[Double, OptionalDouble] {
     def fromJava(o: Optional[Double]): OptionalDouble =
       if (o.isPresent) OptionalDouble.of(o.get) else OptionalDouble.empty
@@ -50,8 +51,10 @@ object OptionShape {
       case _ => OptionalDouble.empty
     }
   }
+  /** An `OptionShape` converting options of boxed `java.lang.Double` to `OptionalDouble`, unboxing the value if present. */
   implicit val jDoubleOptionShape: OptionShape[jl.Double, OptionalDouble] = doubleOptionShape.asInstanceOf[OptionShape[jl.Double, OptionalDouble]]
 
+  /** An `OptionShape` converting options of `Int` to `OptionalInt`. */
   implicit val intOptionShape: OptionShape[Int, OptionalInt] = new OptionShape[Int, OptionalInt] {
     def fromJava(o: Optional[Int]): OptionalInt =
       if (o.isPresent) OptionalInt.of(o.get) else OptionalInt.empty
@@ -61,8 +64,10 @@ object OptionShape {
       case _ => OptionalInt.empty
     }
   }
+  /** An `OptionShape` converting options of boxed `java.lang.Integer` to `OptionalInt`, unboxing the value if present. */
   implicit val jIntegerOptionShape: OptionShape[jl.Integer, OptionalInt] = intOptionShape.asInstanceOf[OptionShape[jl.Integer, OptionalInt]]
 
+  /** An `OptionShape` converting options of `Long` to `OptionalLong`. */
   implicit val longOptionShape: OptionShape[Long, OptionalLong] = new OptionShape[Long, OptionalLong] {
     def fromJava(o: Optional[Long]): OptionalLong =
       if (o.isPresent) OptionalLong.of(o.get) else OptionalLong.empty
@@ -72,5 +77,6 @@ object OptionShape {
       case _ => OptionalLong.empty
     }
   }
+  /** An `OptionShape` converting options of boxed `java.lang.Long` to `OptionalLong`, unboxing the value if present. */
   implicit val jLongOptionShape: OptionShape[jl.Long, OptionalLong] = longOptionShape.asInstanceOf[OptionShape[jl.Long, OptionalLong]]
 }

--- a/library/src/scala/quoted/Expr.scala
+++ b/library/src/scala/quoted/Expr.scala
@@ -134,15 +134,13 @@ object Expr {
   def ofList[T](xs: Seq[Expr[T]])(using Type[T])(using Quotes): Expr[List[T]] =
     if xs.isEmpty then Expr(Nil) else '{ List(${Varargs(xs)}*) }
 
-  /** Creates an expression that will construct a copy of this tuple
+  /** Creates an expression that will construct a tuple holding the values of the given expressions.
    *
-   *  Transforms a sequence of expression
-   *    `Seq(e1, e2, ...)` where `ei: Expr[Any]`
-   *  to an expression equivalent to
-   *    `'{ ($e1, $e2, ...) }` typed as an `Expr[Tuple]`
+   *  Non-empty sequences of up to 22 elements are built with the corresponding `TupleN`
+   *  constructor, longer ones with `Tuple.fromIArray`.
    *
-   *  @param seq the sequence of element expressions to combine into a tuple expression
-   *  @return an expression representing a tuple constructed from the given element expressions
+   *  @param seq the element expressions to combine into a tuple expression
+   *  @return an expression equivalent to `'{ ($e1, $e2, ...) }` typed as an `Expr[Tuple]`, or `'{ Tuple() }` if `seq` is empty
    */
   def ofTupleFromSeq(seq: Seq[Expr[Any]])(using Quotes): Expr[Tuple] = {
     seq.size match {

--- a/library/src/scala/quoted/ExprMap.scala
+++ b/library/src/scala/quoted/ExprMap.scala
@@ -3,6 +3,7 @@ package scala.quoted
 import language.experimental.captureChecking
 import scala.annotation.unused
 
+/** A transformation on quoted expressions that maps an expression to an expression of the same type. */
 trait ExprMap:
 
   /** Maps an expression `e` with a type `T`.
@@ -21,12 +22,28 @@ trait ExprMap:
    *
    *  @tparam T the type of the expression whose children are transformed
    *  @param e the expression whose direct sub-expressions will be transformed via `transform`
-   *  @return an expression of type `T` with each direct sub-expression replaced by the result of applying `transform` to it
+   *  @return an expression of type `T` in which the direct sub-expressions of `e` are
+   *          replaced by the result of applying `transform` to them. Not every direct child is
+   *          transformed: the left-hand side of an `Assign`, the type arguments of a `TypeApply`,
+   *          the `call` of an `Inlined` tree and the expression of a `Return` are left as they
+   *          are.
+   *  @note If `e` is itself a bare `Closure` term, which the reflection API's `Closure.apply`
+   *        can build directly rather than in the `Block`-wrapped form the compiler normally
+   *        produces, it is returned completely unmodified and none of its structure, including
+   *        its body, is visited.
    */
   def transformChildren[T](e: Expr[T])(using Type[T])(using Quotes): Expr[T] = {
     import quotes.reflect.*
     final class MapChildren() {
 
+      /** Transforms a statement, delegating to `transformTerm` for terms and to
+       *  `transformDefinition` for definitions.
+       *
+       *  @param tree the statement to transform
+       *  @param owner the symbol that owns `tree`
+       *  @return the transformed statement; an `Import` or `Export` is returned unchanged, as is
+       *          a `Definition` that is a `TypeDef`
+       */
       def transformStatement(tree: Statement)(owner: Symbol): Statement = {
         tree match {
           case tree: Term =>
@@ -38,6 +55,14 @@ trait ExprMap:
         }
       }
 
+      /** Transforms the right-hand side of a `ValDef` or `DefDef`, or the body of a `ClassDef`.
+       *
+       *  @param tree the definition to transform
+       *  @param owner the symbol that owns `tree`, used when transforming the body of a
+       *         `ClassDef` (the definition's own symbol owns the right-hand side of a
+       *         `ValDef` or `DefDef`)
+       *  @return the transformed definition; a `TypeDef` is returned unchanged
+       */
       def transformDefinition(tree: Definition)(owner: Symbol): Definition = {
         tree match {
           case tree: ValDef =>
@@ -55,6 +80,24 @@ trait ExprMap:
         }
       }
 
+      /** Transforms the sub-trees of a term, rebuilding `tree` from the transformed children.
+       *  Some children are left as they are rather than transformed: the left-hand side of an
+       *  `Assign`, the type arguments of a `TypeApply`, the `call` of an `Inlined` tree and, as
+       *  described below, the expression of a `Return` and the `meth` of a `Closure`.
+       *
+       *  @param tree the term whose children are transformed
+       *  @param tpe the expected type of `tree`, propagated to the children that share it,
+       *         such as the branches of an `If` or the result expression of a `Block`
+       *  @param owner the symbol that owns `tree`
+       *  @return a copy of `tree` with its children transformed. `tree` itself is returned when
+       *          it has no children to transform, as for an `Ident`, a `Literal`, a `This` or a
+       *          `Super`, and also when transforming its children produces no change. A `Return`
+       *          is likewise returned unchanged, but only as a workaround for the owner symbol
+       *          being wrong at that point (see the `FIXME` in the body), so its `expr` is left
+       *          untransformed even though it is a real child. A `Closure` is also returned
+       *          unchanged, so its `meth` is left untransformed even though it too is a real
+       *          child.
+       */
       def transformTermChildren(tree: Term, tpe: TypeRepr)(owner: Symbol): Term = tree match {
         case Ident(name) =>
           tree
@@ -113,6 +156,19 @@ trait ExprMap:
           Inlined.copy(tree)(call, transformDefinitions(bindings)(owner), transformTerm(expansion, tpe)(owner))
       }
 
+      /** Transforms a term by applying `transform` to it when it is an expression, and by
+       *  transforming its children otherwise, except for two cases: a `Closure` is returned
+       *  unchanged, and an `Inlined` tree only has its children transformed, bypassing
+       *  `transform` even when the `Inlined` tree is itself an expression.
+       *
+       *  @param tree the term to transform
+       *  @param tpe the expected type of `tree`. It is used as the `Type` argument of `transform`
+       *         when `tree` is an expression, is passed on to `transformTermChildren` for an
+       *         `Inlined` tree and in the remaining case, and is unused for a `Closure`.
+       *  @param owner the symbol that owns `tree`
+       *  @return the transformed term; a `Closure` is returned unchanged and an `Inlined` tree
+       *          has only its children transformed
+       */
       def transformTerm(tree: Term, tpe: TypeRepr)(owner: Symbol): Term =
         tree match
           case _: Closure =>
@@ -131,20 +187,61 @@ trait ExprMap:
           case _ =>
             transformTermChildren(tree, tpe)(owner)
 
+      /** Returns `tree` unchanged, since type trees are not transformed.
+       *
+       *  @param tree the type tree
+       *  @param owner the symbol that owns `tree` (never used)
+       */
       def transformTypeTree(tree: TypeTree)(@unused owner: Symbol): TypeTree = tree
 
+      /** Transforms the guard and the right-hand side of a case, leaving its pattern unchanged.
+       *
+       *  @param tree the case to transform
+       *  @param tpe the expected type of the right-hand side of `tree`
+       *  @param owner the symbol that owns `tree`
+       *  @return a copy of `tree` with its guard transformed as a `Boolean` and its right-hand
+       *          side transformed at type `tpe`
+       */
       def transformCaseDef(tree: CaseDef, tpe: TypeRepr)(owner: Symbol): CaseDef =
         CaseDef.copy(tree)(tree.pattern, tree.guard.map(x => transformTerm(x, TypeRepr.of[Boolean])(owner)), transformTerm(tree.rhs, tpe)(owner))
 
+      /** Returns `tree` unchanged, since `transformTypeTree` transforms neither the pattern nor
+       *  the right-hand side of a type case.
+       *
+       *  @param tree the type case
+       *  @param owner the symbol that owns `tree`, passed on to `transformTypeTree`, which
+       *         ignores it, so its value has no effect
+       */
       def transformTypeCaseDef(tree: TypeCaseDef)(owner: Symbol): TypeCaseDef =
         TypeCaseDef.copy(tree)(transformTypeTree(tree.pattern)(owner), transformTypeTree(tree.rhs)(owner))
 
+      /** Transforms each statement of `trees` with `transformStatement`.
+       *
+       *  @param trees the statements to transform
+       *  @param owner the symbol that owns the statements
+       *  @return the transformed statements, or `trees` itself if no statement changed
+       */
       def transformStats(trees: List[Statement])(owner: Symbol): List[Statement] =
         trees.mapConserve(x => transformStatement(x)(owner))
 
+      /** Transforms each definition of `trees` with `transformDefinition`.
+       *
+       *  @param trees the definitions to transform
+       *  @param owner the symbol that owns the definitions
+       *  @return the transformed definitions, or `trees` itself if no definition changed
+       */
       def transformDefinitions(trees: List[Definition])(owner: Symbol): List[Definition] =
         trees.mapConserve(x => transformDefinition(x)(owner))
 
+      /** Transforms each term of `trees`, using the type at the same position in `tpes` as its
+       *  expected type.
+       *
+       *  @param trees the terms to transform
+       *  @param tpes the expected types, in the same order as `trees` and at least as many
+       *  @param owner the symbol that owns the terms
+       *  @return the transformed terms, or `trees` itself if no term changed
+       *  @throws MatchError if `tpes` is shorter than `trees`
+       */
       def transformTerms(trees: List[Term], tpes: List[TypeRepr])(owner: Symbol): List[Term] =
         var tpes2 = tpes // TODO use proper zipConserve
         trees.mapConserve{ x =>
@@ -153,15 +250,41 @@ trait ExprMap:
           transformTerm(x, tpe)(owner)
         }
 
+      /** Transforms each term of `trees` with `tpe` as the expected type of every term.
+       *
+       *  @param trees the terms to transform
+       *  @param tpe the expected type shared by all the terms
+       *  @param owner the symbol that owns the terms
+       *  @return the transformed terms, or `trees` itself if no term changed
+       */
       def transformTerms(trees: List[Term], tpe: TypeRepr)(owner: Symbol): List[Term] =
         trees.mapConserve(x => transformTerm(x, tpe)(owner))
 
+      /** Returns `trees` unchanged, since `transformTypeTree` does not transform type trees.
+       *
+       *  @param trees the type trees
+       *  @param owner the symbol that owns the type trees, passed on to `transformTypeTree`,
+       *         which ignores it, so its value has no effect
+       */
       def transformTypeTrees(trees: List[TypeTree])(owner: Symbol): List[TypeTree] =
         trees.mapConserve(x => transformTypeTree(x)(owner))
 
+      /** Transforms each case of `trees` with `tpe` as the expected type of every right-hand side.
+       *
+       *  @param trees the cases to transform
+       *  @param tpe the expected type of the right-hand side of each case
+       *  @param owner the symbol that owns the cases
+       *  @return the transformed cases, or `trees` itself if no case changed
+       */
       def transformCaseDefs(trees: List[CaseDef], tpe: TypeRepr)(owner: Symbol): List[CaseDef] =
         trees.mapConserve(x => transformCaseDef(x, tpe)(owner))
 
+      /** Returns `trees` unchanged, since `transformTypeCaseDef` never changes a type case.
+       *
+       *  @param trees the type cases
+       *  @param owner the symbol that owns the type cases, passed through `transformTypeCaseDef`
+       *         to `transformTypeTree`, which ignores it, so its value has no effect
+       */
       def transformTypeCaseDefs(trees: List[TypeCaseDef])(owner: Symbol): List[TypeCaseDef] =
         trees.mapConserve(x => transformTypeCaseDef(x)(owner))
 

--- a/library/src/scala/quoted/Quotes.scala
+++ b/library/src/scala/quoted/Quotes.scala
@@ -294,8 +294,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     }
 
 
-    /** Returns the `Term` representation this expression. */
     extension (expr: Expr[Any])
+      /** Returns the `Term` tree representing this expression.
+       *
+       *  The term can be inspected and transformed with the `quotes.reflect` API
+       *  and converted back with `Term.asExpr` or `Term.asExprOf`.
+       */
       def asTerm: Term
 
     ///////////////
@@ -334,8 +338,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         def asExpr: Expr[Any]
       end extension
 
-      /** Converts this tree to an `quoted.Expr[T]` if the tree is a valid expression or throws. */
       extension (self: Tree)
+        /** Converts this tree to an `quoted.Expr[T]` if the tree is a valid expression of type `T` or throws.
+         *
+         *  @tparam T the expected type of the expression
+         *  @return this tree as an `Expr[T]`
+         */
         def asExprOf[T](using Type[T]): Expr[T]
 
       extension [ThisTree <: Tree](self: ThisTree)
@@ -560,7 +568,22 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
       // TODO add selfOpt: Option[ValDef]?
       // ^ if a use-case shows up, we add this via an overloaded method
       def apply(cls: Symbol, parents: List[Tree /* Term | TypeTree */], body: List[Statement]): ClassDef
+      /** Copies a class definition tree.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the class
+       *  @param constr the primary constructor definition
+       *  @param parents the parent classes or traits: `TypeTree`s if they take no term parameters, `Term`s otherwise
+       *  @param selfOpt the self-type `ValDef` if one is declared, or `None`
+       *  @param body the list of statements within the class body
+       *  @return a copy of `original` with the given name, constructor, parents, self-type and body
+       */
       def copy(original: Tree)(name: String, constr: DefDef, parents: List[Tree /* Term | TypeTree */], selfOpt: Option[ValDef], body: List[Statement]): ClassDef
+      /** Matches a class definition and extracts its components.
+       *
+       *  @param cdef the class definition tree to match against
+       *  @return a tuple of the class name, primary constructor, parents, optional self-type and body statements
+       */
       def unapply(cdef: ClassDef): (String, DefDef, List[Tree /* Term | TypeTree */], Option[ValDef], List[Statement])
 
 
@@ -679,7 +702,21 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  @return a new `DefDef` tree for the given method symbol
        */
       def apply(symbol: Symbol, rhsFn: List[List[Tree]] => Option[Term]): DefDef
+      /** Copies a method definition tree.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the method
+       *  @param paramss the type and term parameter clauses
+       *  @param tpt the return type tree
+       *  @param rhs `Some` containing the method body, or `None` if the method has no implementation
+       *  @return a copy of `original` with the given name, parameter clauses, return type and right-hand side
+       */
       def copy(original: Tree)(name: String, paramss: List[ParamClause], tpt: TypeTree, rhs: Option[Term]): DefDef
+      /** Matches a method definition and extracts its components.
+       *
+       *  @param ddef the method definition tree to match against
+       *  @return a tuple of the method name, parameter clauses, return type tree and optional body
+       */
       def unapply(ddef: DefDef): (String, List[ParamClause], TypeTree, Option[Term])
     }
 
@@ -764,7 +801,20 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  @return a new `ValDef` tree for the given symbol
        */
       def apply(symbol: Symbol, rhs: Option[Term]): ValDef
+      /** Copies a value definition tree.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the value
+       *  @param tpt the type tree of the value
+       *  @param rhs `Some` containing the right-hand side term, or `None` if the value has no right-hand side
+       *  @return a copy of `original` with the given name, type tree and right-hand side
+       */
       def copy(original: Tree)(name: String, tpt: TypeTree, rhs: Option[Term]): ValDef
+      /** Matches a value definition and extracts its components.
+       *
+       *  @param vdef the value definition tree to match against
+       *  @return a tuple of the value name, its type tree and its optional right-hand side
+       */
       def unapply(vdef: ValDef): (String, TypeTree, Option[Term])
 
       /** Creates a block `{ val <name> = <rhs: Term>; <body(x): Term> }`
@@ -869,8 +919,25 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeDef`. */
     trait TypeDefModule { this: TypeDef.type =>
+      /** Creates a type definition `type T ...` with the right-hand side defined in the symbol.
+       *
+       *  @param symbol the type symbol (created using `Symbol.newTypeAlias` or `Symbol.newBoundedType`)
+       *  @return a new `TypeDef` tree for the given symbol
+       */
       def apply(symbol: Symbol): TypeDef
+      /** Copies a type definition tree.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the type
+       *  @param rhs the right-hand side: a `TypeTree` for a type alias, or a `TypeBoundsTree` for an abstract type
+       *  @return a copy of `original` with the given name and right-hand side
+       */
       def copy(original: Tree)(name: String, rhs: Tree): TypeDef
+      /** Matches a type definition and extracts its name and right-hand side.
+       *
+       *  @param tdef the type definition tree to match against
+       *  @return a tuple of the type name and its right-hand side tree
+       */
       def unapply(tdef: TypeDef): (String, Tree)
     }
 
@@ -1108,8 +1175,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Ident`. */
     trait IdentModule { this: Ident.type =>
+      /** Creates a term reference tree from a term reference type.
+       *
+       *  @param tmref the term reference type to create a reference for
+       *  @return a term referring to `tmref`; depending on the prefix of `tmref` it may not be an `Ident`
+       */
       def apply(tmref: TermRef): Term
 
+      /** Copies an `Ident` with the given name.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the referenced definition
+       *  @return a copy of `original` with the given `name`
+       */
       def copy(original: Tree)(name: String): Ident
 
       /** Matches a term identifier and returns its name.
@@ -1204,6 +1282,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def overloaded(qualifier: Term, name: String, targs: List[TypeRepr], args: List[Term], returnType: TypeRepr): Term
 
+      /** Copies a `Select` with the given qualifier and name.
+       *
+       *  @param original the original tree being copied
+       *  @param qualifier the term on which the member is selected
+       *  @param name the name of the selected member
+       *  @return a copy of `original` representing `qualifier.name`
+       */
       def copy(original: Tree)(qualifier: Term, name: String): Select
 
       /** Matches `<qualifier: Term>.<name: String>`.
@@ -1248,6 +1333,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(constant: Constant): Literal
 
+      /** Copies a `Literal` with the given constant.
+       *
+       *  @param original the original tree being copied
+       *  @param constant the constant value for the literal
+       *  @return a copy of `original` wrapping `constant`
+       */
       def copy(original: Tree)(constant: Constant): Literal
 
       /** Matches a literal constant.
@@ -1288,6 +1379,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(cls: Symbol): This
 
+      /** Copies a `This` with the given qualifier.
+       *
+       *  @param original the original tree being copied
+       *  @param qual `Some` containing the name of the qualifying class for `qual.this`, or `None` for an unqualified `this`
+       *  @return a copy of `original` with the given qualifier
+       */
       def copy(original: Tree)(qual: Option[String]): This
 
       /** Matches `this` or `qual.this` and returns the name of `qual`.
@@ -1333,6 +1430,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(tpt: TypeTree): New
 
+      /** Copies a `New` with the given type tree.
+       *
+       *  @param original the original tree being copied
+       *  @param tpt the type tree of the class to instantiate
+       *  @return a copy of `original` representing `new tpt`
+       */
       def copy(original: Tree)(tpt: TypeTree): New
 
       /** Matches `new <tpt: TypeTree>`.
@@ -1374,6 +1477,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(name: String, arg: Term): NamedArg
 
+      /** Copies a `NamedArg` with the given name and argument.
+       *
+       *  @param original the original tree being copied
+       *  @param name the argument name
+       *  @param arg the argument value
+       *  @return a copy of `original` representing `name = arg`
+       */
       def copy(original: Tree)(name: String, arg: Term): NamedArg
 
       /** Matches a named argument `<name: String> = <value: Term>`.
@@ -1419,6 +1529,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(fun: Term, args: List[Term]): Apply
 
+      /** Copies an `Apply` with the given function and arguments.
+       *
+       *  @param original the original tree being copied
+       *  @param fun the function being applied
+       *  @param args the term arguments
+       *  @return a copy of `original` representing `fun(args)`
+       */
       def copy(original: Tree)(fun: Term, args: List[Term]): Apply
 
       /** Matches a function application `<fun: Term>(<args: List[Term]>)`.
@@ -1484,6 +1601,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(fun: Term, args: List[TypeTree]): TypeApply
 
+      /** Copies a `TypeApply` with the given function and type arguments.
+       *
+       *  @param original the original tree being copied
+       *  @param fun the function being applied
+       *  @param args the type argument trees
+       *  @return a copy of `original` representing `fun[args]`
+       */
       def copy(original: Tree)(fun: Term, args: List[TypeTree]): TypeApply
 
       /** Matches a function type application `<fun: Term>[<args: List[TypeTree]>]`.
@@ -1563,6 +1687,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(qual: Term, mix: Option[String]): Super
 
+      /** Copies a `Super` with the given qualifier and mixin name.
+       *
+       *  @param original the original tree being copied
+       *  @param qual the qualifier term
+       *  @param mix the optional mixin class name for `super[mix]`
+       *  @return a copy of `original` representing `qual.super[mix]`
+       */
       def copy(original: Tree)(qual: Term, mix: Option[String]): Super
 
       /** Matches a `<qualifier: Term>.super[<id: Option[Id]>`.
@@ -1579,8 +1710,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Super`. */
     trait SuperMethods:
       extension (self: Super)
+        /** The qualifier part of `qual.super[mix]`. */
         def qualifier: Term
+        /** The mixin name of `super[mix]`, or `None` if there is no mixin qualifier. */
         def id: Option[String]
+        /** Position of the mixin name `mix` in `qual.super[mix]`. */
         def idPos: Position
       end extension
     end SuperMethods
@@ -1609,6 +1743,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(expr: Term, tpt: TypeTree): Typed
 
+      /** Copies a `Typed` with the given expression and type tree.
+       *
+       *  @param original the original tree being copied
+       *  @param expr the expression being ascribed
+       *  @param tpt the type tree for the ascription
+       *  @return a copy of `original` representing `expr: tpt`
+       */
       def copy(original: Tree)(expr: Term, tpt: TypeTree): Typed
 
       /** Matches `<expr: Term>: <tpt: TypeTree>`.
@@ -1625,7 +1766,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Typed`. */
     trait TypedMethods:
       extension (self: Typed)
+        /** The expression part of `expr: tpt`. */
         def expr: Term
+        /** The type tree part of `expr: tpt`. */
         def tpt: TypeTree
       end extension
     end TypedMethods
@@ -1650,6 +1793,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(lhs: Term, rhs: Term): Assign
 
+      /** Copies an `Assign` with the given left-hand and right-hand sides.
+       *
+       *  @param original the original tree being copied
+       *  @param lhs the left-hand side of the assignment
+       *  @param rhs the right-hand side of the assignment
+       *  @return a copy of `original` representing `lhs = rhs`
+       */
       def copy(original: Tree)(lhs: Term, rhs: Term): Assign
 
       /** Matches an assignment `<lhs: Term> = <rhs: Term>`.
@@ -1666,7 +1816,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Assign`. */
     trait AssignMethods:
       extension (self: Assign)
+        /** The left-hand side of `lhs = rhs`. */
         def lhs: Term
+        /** The right-hand side of `lhs = rhs`. */
         def rhs: Term
       end extension
     end AssignMethods
@@ -1691,6 +1843,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(stats: List[Statement], expr: Term): Block
 
+      /** Copies a `Block` with the given statements and result expression.
+       *
+       *  @param original the original tree being copied
+       *  @param stats the list of statements
+       *  @param expr the result expression of the block
+       *  @return a copy of `original` with statements `stats` and result expression `expr`
+       */
       def copy(original: Tree)(stats: List[Statement], expr: Term): Block
 
       /** Matches a block `{ <statements: List[Statement]>; <expr: Term> }`.
@@ -1707,7 +1866,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Block`. */
     trait BlockMethods:
       extension (self: Block)
+        /** The statements of this block, not including the result expression. */
         def statements: List[Statement]
+        /** The result expression of this block. */
         def expr: Term
       end extension
     end BlockMethods
@@ -1731,10 +1892,29 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Methods of the module object `val Closure`. */
     trait ClosureModule { this: Closure.type =>
 
+      /** Creates a closure of the method `meth`.
+       *
+       *  @param meth a reference to the method of the closure; expected to refer to an anonymous
+       *              function, which is only checked under `-Xcheck-macros`
+       *  @param tpe `Some` containing the SAM type of the closure, or `None` if the closure has a function type
+       *  @return a `Closure` tree for `meth`
+       */
       def apply(meth: Term, tpe: Option[TypeRepr]): Closure
 
+      /** Copies a `Closure` with the given method reference and type.
+       *
+       *  @param original the original tree being copied
+       *  @param meth a reference to the method of the closure
+       *  @param tpe `Some` containing the SAM type of the closure, or `None` if the closure has a function type
+       *  @return a copy of `original` with the given `meth` and `tpe`
+       */
       def copy(original: Tree)(meth: Tree, tpe: Option[TypeRepr]): Closure
 
+      /** Matches a closure and extracts the method reference and closure type.
+       *
+       *  @param x the `Closure` to match against
+       *  @return a tuple of the method reference and the optional SAM type of the closure
+       */
       def unapply(x: Closure): (Term, Option[TypeRepr])
     }
 
@@ -1744,7 +1924,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Closure`. */
     trait ClosureMethods:
       extension (self: Closure)
+        /** The reference to the method of this closure. */
         def meth: Term
+        /** The SAM type of this closure, or `None` if the closure has a function type. */
         def tpeOpt: Option[TypeRepr]
       end extension
     end ClosureMethods
@@ -1834,6 +2016,14 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(cond: Term, thenp: Term, elsep: Term): If
 
+      /** Copies an `If` with the given condition and branches.
+       *
+       *  @param original the original tree being copied
+       *  @param cond the condition expression
+       *  @param thenp the then branch expression
+       *  @param elsep the else branch expression
+       *  @return a copy of `original` representing `if (cond) thenp else elsep`
+       */
       def copy(original: Tree)(cond: Term, thenp: Term, elsep: Term): If
 
       /** Matches an if/then/else `if (<cond: Term>) <thenp: Term> else <elsep: Term>`.
@@ -1850,9 +2040,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `If`. */
     trait IfMethods:
       extension (self: If)
+        /** The condition of this `if`, the `cond` in `if (cond) thenp else elsep`. */
         def cond: Term
+        /** The then branch of this `if`, the `thenp` in `if (cond) thenp else elsep`. */
         def thenp: Term
+        /** The else branch of this `if`, the `elsep` in `if (cond) thenp else elsep`. */
         def elsep: Term
+        /** Is this an `inline if`? */
         def isInline: Boolean
       end extension
     end IfMethods
@@ -1877,6 +2071,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(selector: Term, cases: List[CaseDef]): Match
 
+      /** Copies a `Match` with the given scrutinee and cases.
+       *
+       *  @param original the original tree being copied
+       *  @param selector the scrutinee expression being matched
+       *  @param cases the list of case definitions
+       *  @return a copy of `original` representing `selector match { cases }`
+       */
       def copy(original: Tree)(selector: Term, cases: List[CaseDef]): Match
 
       /** Matches a pattern match `<scrutinee: Term> match { <cases: List[CaseDef]> }`.
@@ -1893,8 +2094,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Match`. */
     trait MatchMethods:
       extension (self: Match)
+        /** The expression being pattern matched, the `x` in `x match { ... }`. */
         def scrutinee: Term
+        /** The cases of this match expression. */
         def cases: List[CaseDef]
+        /** Is this an `inline match`? */
         def isInline: Boolean
       end extension
     end MatchMethods
@@ -1918,6 +2122,12 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(cases: List[CaseDef]): SummonFrom
 
+      /** Copies a `SummonFrom` with the given cases.
+       *
+       *  @param original the original tree being copied
+       *  @param cases the list of match cases for the given match
+       *  @return a copy of `original` containing the given `cases`
+       */
       def copy(original: Tree)(cases: List[CaseDef]): SummonFrom
 
       /** Matches a pattern match `given match { <cases: List[CaseDef]> }`.
@@ -1934,6 +2144,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `SummonFrom`. */
     trait SummonFromMethods:
       extension (self: SummonFrom)
+        /** The cases of this `summonFrom` expression. */
         def cases: List[CaseDef]
       end extension
     end SummonFromMethods
@@ -1959,6 +2170,14 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try
 
+      /** Copies a `Try` with the given body, cases and finalizer.
+       *
+       *  @param original the original tree being copied
+       *  @param expr the body expression of the try block
+       *  @param cases the list of catch case definitions
+       *  @param finalizer the optional finally block expression
+       *  @return a copy of `original` representing `try expr catch { cases } finally finalizer`
+       */
       def copy(original: Tree)(expr: Term, cases: List[CaseDef], finalizer: Option[Term]): Try
 
       /** Matches a try/catch `try <body: Term> catch { <cases: List[CaseDef]> } finally <finalizer: Option[Term]>`.
@@ -1975,8 +2194,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Try`. */
     trait TryMethods:
       extension (self: Try)
+        /** The body of the try block, the `x` in `try x catch { ... }`. */
         def body: Term
+        /** The catch cases of this try expression. */
         def cases: List[CaseDef]
+        /** The expression of the `finally` clause, or `None` if there is no `finally` clause. */
         def finalizer: Option[Term]
       end extension
     end TryMethods
@@ -2001,6 +2223,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(expr: Term, from: Symbol): Return
 
+      /** Copies a `Return` with the given expression and method symbol.
+       *
+       *  @param original the original tree being copied
+       *  @param expr the expression being returned
+       *  @param from the symbol of the enclosing method
+       *  @return a copy of `original` representing `return expr` from method `from`
+       */
       def copy(original: Tree)(expr: Term, from: Symbol): Return
 
       /** Matches `return <expr: Term>` and extracts the expression and symbol of the method.
@@ -2017,7 +2246,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Return`. */
     trait ReturnMethods:
       extension (self: Return)
+        /** The expression returned by this `return`. */
         def expr: Term
+        /** The symbol of the method this `return` returns from. */
         def from: Symbol
       end extension
     end ReturnMethods
@@ -2086,7 +2317,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Repeated`. */
     trait RepeatedMethods:
       extension (self: Repeated)
+        /** The element terms of this sequence of varargs. */
         def elems: List[Term]
+        /** The element type tree of this sequence of varargs. */
         def elemtpt: TypeTree
       end extension
     end RepeatedMethods
@@ -2102,8 +2335,31 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Inlined`. */
     trait InlinedModule { this: Inlined.type =>
+      /** Creates an `Inlined` tree representing inlined code.
+       *
+       *  The full inlined code is equivalent to `{ bindings; expansion }`.
+       *
+       *  @param call the call that was inlined, or `None` if no call is recorded
+       *  @param bindings bindings for proxies used in the inlined code
+       *  @param expansion the inlined code, minus the bindings
+       *  @return a new `Inlined` tree
+       */
       def apply(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined
+      /** Copies an `Inlined` tree.
+       *
+       *  @param original the original tree being copied; must be an `Inlined`
+       *  @param call the call that was inlined, or `None` if no call is recorded
+       *  @param bindings bindings for proxies used in the inlined code
+       *  @param expansion the inlined code, minus the bindings
+       *  @return a copy of `original` with the given call, bindings and expansion
+       *  @throws IllegalArgumentException if `original` is not an `Inlined`
+       */
       def copy(original: Tree)(call: Option[Tree /* Term | TypeTree */], bindings: List[Definition], expansion: Term): Inlined
+      /** Matches an `Inlined` tree and extracts the call, bindings and expansion.
+       *
+       *  @param x the `Inlined` to match against
+       *  @return a tuple of the optional inlined call, the proxy bindings and the inlined body
+       */
       def unapply(x: Inlined): (Option[Tree /* Term | TypeTree */], List[Definition], Term)
     }
 
@@ -2113,8 +2369,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Inlined`. */
     trait InlinedMethods:
       extension (self: Inlined)
+        /** The call that was inlined, or `None` if no call is recorded. */
         def call: Option[Tree /* Term | TypeTree */]
+        /** Bindings for proxies used in the inlined code. */
         def bindings: List[Definition]
+        /** The inlined code, minus the bindings. The full inlined code is equivalent to `{ bindings; body }`. */
         def body: Term
       end extension
     end InlinedMethods
@@ -2130,8 +2389,28 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val SelectOuter`. */
     trait SelectOuterModule { this: SelectOuter.type =>
+      /** Creates a `SelectOuter` tree selecting `name` on `qualifier` through the given number of nested scopes.
+       *
+       *  @param qualifier the prefix term the selection is made on
+       *  @param name the name of the selected definition
+       *  @param levels the number of outer-path hops from the qualifier to the intended owner
+       *  @return a new `SelectOuter` tree
+       */
       def apply(qualifier: Term, name: String, levels: Int): SelectOuter
+      /** Copies a `SelectOuter` tree.
+       *
+       *  @param original the original tree being copied
+       *  @param qualifier the prefix term the selection is made on
+       *  @param name the name of the selected definition
+       *  @param levels the number of outer-path hops from the qualifier to the intended owner
+       *  @return a copy of `original` with the given `qualifier`, `name` and `levels`
+       */
       def copy(original: Tree)(qualifier: Term, name: String, levels: Int): SelectOuter
+      /** Matches a `SelectOuter` tree and extracts its qualifier, name, and number of levels.
+       *
+       *  @param x the `SelectOuter` to match against
+       *  @return a tuple of the prefix term, the selected name, and the number of nested scopes traversed
+       */
       def unapply(x: SelectOuter): (Term, String, Int)
     }
 
@@ -2141,8 +2420,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `SelectOuter`. */
     trait SelectOuterMethods:
       extension (self: SelectOuter)
+        /** The prefix term this selection is made on. */
         def qualifier: Term
+        /** The name of the selected definition. */
         def name: String
+        /** The number of nested scopes of inlined trees traversed to resolve this selection. */
         def level: Int
       end extension
     end SelectOuterMethods
@@ -2167,6 +2449,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(cond: Term, body: Term): While
 
+      /** Copies a while loop `while (<cond>) <body>`.
+       *
+       *  @param original the original tree being copied
+       *  @param cond the condition expression
+       *  @param body the loop body expression
+       *  @return a copy of `original` with the given `cond` and `body`
+       */
       def copy(original: Tree)(cond: Term, body: Term): While
 
       /** Extractor for while loops. Matches `while (<cond>) <body>` and returns (<cond>, <body>).
@@ -2183,7 +2472,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `While`. */
     trait WhileMethods:
       extension (self: While)
+        /** The condition of this while loop, i.e. the `cond` of `while (cond) body`. */
         def cond: Term
+        /** The body of this while loop, i.e. the `body` of `while (cond) body`. */
         def body: Term
       end extension
     end WhileMethods
@@ -2208,6 +2499,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(expr: Tree, tpt: TypeTree): TypedOrTest
 
+      /** Copies a `TypedOrTest` tree.
+       *
+       *  @param original the original tree being copied
+       *  @param expr the tree being ascribed
+       *  @param tpt the type tree for the ascription
+       *  @return a copy of `original` with the given `expr` and `tpt`
+       */
       def copy(original: Tree)(expr: Tree, tpt: TypeTree): TypedOrTest
 
       /** Matches `<expr: Tree>: <tpt: TypeTree>`.
@@ -2224,7 +2522,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypedOrTest`. */
     trait TypedOrTestMethods:
       extension (self: TypedOrTest)
+        /** The term or pattern being ascribed or tested, i.e. the `x` of `x: T`. */
         def tree: Tree
+        /** The type tree of the ascription or type test, i.e. the `T` of `x: T`. */
         def tpt: TypeTree
       end extension
     end TypedOrTestMethods
@@ -2277,6 +2577,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Inferred`. */
     trait InferredModule { this: Inferred.type =>
+      /** Creates a type tree of the given type, with no explicit source representation.
+       *
+       *  @param tpe the type the created type tree represents
+       *  @return a new `Inferred` type tree of type `tpe`
+       */
       def apply(tpe: TypeRepr): Inferred
       /** Matches a TypeTree containing an inferred type.
        *
@@ -2297,8 +2602,24 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeIdent`. */
     trait TypeIdentModule { this: TypeIdent.type =>
+      /** Creates a type tree reference to the given type symbol.
+       *
+       *  @param sym the type symbol to reference; must be a type symbol
+       *  @return a type tree referring to `sym`; depending on the prefix of `sym` it may not be a `TypeIdent`
+       */
       def apply(sym: Symbol): TypeTree
+      /** Copies a `TypeIdent` tree.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the referenced type definition
+       *  @return a copy of `original` with the given `name`
+       */
       def copy(original: Tree)(name: String): TypeIdent
+      /** Matches a `TypeIdent` and extracts its name.
+       *
+       *  @param x the `TypeIdent` to match against
+       *  @return `Some` containing the name of the referenced type definition (the match always succeeds)
+       */
       def unapply(x: TypeIdent): Some[String]
     }
 
@@ -2308,6 +2629,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeIdent`. */
     trait TypeIdentMethods:
       extension (self: TypeIdent)
+        /** The name of the type definition referenced by this type identifier. */
         def name: String
       end extension
     end TypeIdentMethods
@@ -2323,8 +2645,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeSelect`. */
     trait TypeSelectModule { this: TypeSelect.type =>
+      /** Creates a type selection `qualifier.name`, where `qualifier` is a term.
+       *
+       *  @param qualifier the term prefix the type is selected on
+       *  @param name the name of the selected type
+       *  @return a new `TypeSelect` tree
+       */
       def apply(qualifier: Term, name: String): TypeSelect
+      /** Copies a type selection `qualifier.name`.
+       *
+       *  @param original the original tree being copied
+       *  @param qualifier the term prefix the type is selected on
+       *  @param name the name of the selected type
+       *  @return a copy of `original` with the given `qualifier` and `name`
+       */
       def copy(original: Tree)(qualifier: Term, name: String): TypeSelect
+      /** Matches a type selection `qualifier.name` and extracts the qualifier and name.
+       *
+       *  @param x the `TypeSelect` to match against
+       *  @return a tuple of the term prefix and the selected type name
+       */
       def unapply(x: TypeSelect): (Term, String)
     }
 
@@ -2334,7 +2674,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeSelect`. */
     trait TypeSelectMethods:
       extension (self: TypeSelect)
+        /** The term prefix of this type selection, i.e. the `qualifier` of `qualifier.name`. */
         def qualifier: Term
+        /** The name of the selected type, i.e. the `name` of `qualifier.name`. */
         def name: String
       end extension
     end TypeSelectMethods
@@ -2350,8 +2692,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeProjection`. */
     trait TypeProjectionModule { this: TypeProjection.type =>
+      /** Creates a type projection `qualifier#name`, where `qualifier` is a type.
+       *
+       *  @param qualifier the type prefix the type is projected on
+       *  @param name the name of the projected type
+       *  @return a new `TypeProjection` tree
+       */
       def apply(qualifier: TypeTree, name: String): TypeProjection
+      /** Copies a type projection `qualifier#name`.
+       *
+       *  @param original the original tree being copied
+       *  @param qualifier the type prefix the type is projected on
+       *  @param name the name of the projected type
+       *  @return a copy of `original` with the given `qualifier` and `name`
+       */
       def copy(original: Tree)(qualifier: TypeTree, name: String): TypeProjection
+      /** Matches a type projection `qualifier#name` and extracts the qualifier and name.
+       *
+       *  @param x the `TypeProjection` to match against
+       *  @return a tuple of the type prefix and the projected type name
+       */
       def unapply(x: TypeProjection): (TypeTree, String)
     }
 
@@ -2361,7 +2721,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeProjection`. */
     trait TypeProjectionMethods:
       extension (self: TypeProjection)
+        /** The type prefix of this projection, i.e. the `qualifier` of `qualifier#name`. */
         def qualifier: TypeTree
+        /** The name of the projected type, i.e. the `name` of `qualifier#name`. */
         def name: String
       end extension
     end TypeProjectionMethods
@@ -2377,8 +2739,24 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Singleton`. */
     trait SingletonModule { this: Singleton.type =>
+      /** Creates a singleton type tree `ref.type`.
+       *
+       *  @param ref the term the singleton type refers to
+       *  @return a new `Singleton` type tree
+       */
       def apply(ref: Term): Singleton
+      /** Copies a singleton type tree `ref.type`.
+       *
+       *  @param original the original tree being copied
+       *  @param ref the term the singleton type refers to
+       *  @return a copy of `original` with the given `ref`
+       */
       def copy(original: Tree)(ref: Term): Singleton
+      /** Matches a singleton type tree `ref.type` and extracts its reference.
+       *
+       *  @param x the `Singleton` to match against
+       *  @return `Some` containing the term the singleton type refers to (the match always succeeds)
+       */
       def unapply(x: Singleton): Some[Term]
     }
 
@@ -2388,6 +2766,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Singleton`. */
     trait SingletonMethods:
       extension (self: Singleton)
+        /** The term this singleton type refers to, i.e. the `ref` of `ref.type`. */
         def ref: Term
       end extension
     end SingletonMethods
@@ -2410,7 +2789,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  @return
        */
       def apply(tpt: TypeTree, refinements: List[Definition], refineCls: Symbol): Refined
+      /** Copies a refinement type tree.
+       *
+       *  @param original the original tree being copied
+       *  @param tpt the parent type being refined
+       *  @param refinements the definitions representing the refinements
+       *  @return a copy of `original` with the given `tpt` and `refinements`
+       */
       def copy(original: Tree)(tpt: TypeTree, refinements: List[Definition]): Refined
+      /** Matches a refinement type tree `tpt { refinements }` and extracts the parent and refinements.
+       *
+       *  @param x the `Refined` to match against
+       *  @return a tuple of the parent type tree and the refinement definitions
+       */
       def unapply(x: Refined): (TypeTree, List[Definition])
     }
 
@@ -2420,7 +2811,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Refined`. */
     trait RefinedMethods:
       extension (self: Refined)
+        /** The parent type being refined, i.e. the `tpt` of `tpt { refinements }`. */
         def tpt: TypeTree
+        /** The definitions representing the refinements, i.e. the `refinements` of `tpt { refinements }`. */
         def refinements: List[Definition]
       end extension
     end RefinedMethods
@@ -2436,8 +2829,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Applied`. */
     trait AppliedModule { this: Applied.type =>
+      /** Creates an applied type tree `tpt[args]`.
+       *
+       *  @param tpt the type constructor tree being applied
+       *  @param args the type argument trees; each is a `TypeTree` or a `TypeBoundsTree`
+       *  @return a new `Applied` type tree
+       */
       def apply(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied
+      /** Copies an applied type tree `tpt[args]`.
+       *
+       *  @param original the original tree being copied
+       *  @param tpt the type constructor tree being applied
+       *  @param args the type argument trees; each is a `TypeTree` or a `TypeBoundsTree`
+       *  @return a copy of `original` with the given `tpt` and `args`
+       */
       def copy(original: Tree)(tpt: TypeTree, args: List[Tree /*TypeTree | TypeBoundsTree*/]): Applied
+      /** Matches an applied type tree `tpt[args]` and extracts the constructor and arguments.
+       *
+       *  @param x the `Applied` to match against
+       *  @return a tuple of the type constructor tree and the type argument trees
+       */
       def unapply(x: Applied): (TypeTree, List[Tree /*TypeTree | TypeBoundsTree*/])
     }
 
@@ -2447,7 +2858,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Applied`. */
     trait AppliedMethods:
       extension (self: Applied)
+        /** The type constructor tree of this applied type, i.e. the `tpt` of `tpt[args]`. */
         def tpt: TypeTree
+        /** The type argument trees of this applied type; each is a `TypeTree` or a `TypeBoundsTree`. */
         def args: List[Tree /*TypeTree | TypeBoundsTree*/]
       end extension
     end AppliedMethods
@@ -2463,8 +2876,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Annotated`. */
     trait AnnotatedModule { this: Annotated.type =>
+      /** Creates an annotated type tree `arg @annotation`.
+       *
+       *  @param arg the type tree being annotated
+       *  @param annotation the constructor call term for the annotation
+       *  @return a new `Annotated` type tree
+       */
       def apply(arg: TypeTree, annotation: Term): Annotated
+      /** Copies an annotated type tree `arg @annotation`.
+       *
+       *  @param original the original tree being copied
+       *  @param arg the type tree being annotated
+       *  @param annotation the constructor call term for the annotation
+       *  @return a copy of `original` with the given `arg` and `annotation`
+       */
       def copy(original: Tree)(arg: TypeTree, annotation: Term): Annotated
+      /** Matches an annotated type tree `arg @annotation` and extracts the type and annotation.
+       *
+       *  @param x the `Annotated` to match against
+       *  @return a tuple of the annotated type tree and the annotation's constructor call term
+       */
       def unapply(x: Annotated): (TypeTree, Term)
     }
 
@@ -2474,7 +2905,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Annotated`. */
     trait AnnotatedMethods:
       extension (self: Annotated)
+        /** The type tree being annotated, i.e. the `arg` of `arg @annotation`. */
         def arg: TypeTree
+        /** The annotation of this annotated type, as a constructor call term. */
         def annotation: Term
       end extension
     end AnnotatedMethods
@@ -2490,8 +2923,28 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val MatchTypeTree`. */
     trait MatchTypeTreeModule { this: MatchTypeTree.type =>
+      /** Creates a match type tree `selector match { cases }`.
+       *
+       *  @param bound the upper bound of the match type, or `None` if it has none
+       *  @param selector the type tree being matched on
+       *  @param cases the type case clauses of the match type
+       *  @return a new `MatchTypeTree`
+       */
       def apply(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree
+      /** Copies a match type tree `selector match { cases }`.
+       *
+       *  @param original the original tree being copied
+       *  @param bound the upper bound of the match type, or `None` if it has none
+       *  @param selector the type tree being matched on
+       *  @param cases the type case clauses of the match type
+       *  @return a copy of `original` with the given `bound`, `selector` and `cases`
+       */
       def copy(original: Tree)(bound: Option[TypeTree], selector: TypeTree, cases: List[TypeCaseDef]): MatchTypeTree
+      /** Matches a match type tree `selector match { cases }` and extracts the bound, selector and cases.
+       *
+       *  @param x the `MatchTypeTree` to match against
+       *  @return a tuple of the optional upper bound, the type tree being matched on, and the type case clauses
+       */
       def unapply(x: MatchTypeTree): (Option[TypeTree], TypeTree, List[TypeCaseDef])
     }
 
@@ -2501,8 +2954,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `MatchTypeTree`. */
     trait MatchTypeTreeMethods:
       extension (self: MatchTypeTree)
+        /** The upper bound of this match type, or `None` if it has none. */
         def bound: Option[TypeTree]
+        /** The type tree being matched on, i.e. the `selector` of `selector match { cases }`. */
         def selector: TypeTree
+        /** The type case clauses of this match type, i.e. the `cases` of `selector match { cases }`. */
         def cases: List[TypeCaseDef]
       end extension
     end MatchTypeTreeMethods
@@ -2518,8 +2974,24 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val ByName`. */
     trait ByNameModule { this: ByName.type =>
+      /** Creates a by-name type tree `=> result`.
+       *
+       *  @param result the type tree of the underlying result type
+       *  @return a new `ByName` type tree
+       */
       def apply(result: TypeTree): ByName
+      /** Copies a by-name type tree `=> result`.
+       *
+       *  @param original the original tree being copied
+       *  @param result the type tree of the underlying result type
+       *  @return a copy of `original` with the given `result`
+       */
       def copy(original: Tree)(result: TypeTree): ByName
+      /** Matches a by-name type tree `=> result` and extracts its result type tree.
+       *
+       *  @param x the `ByName` to match against
+       *  @return `Some` containing the underlying result type tree (the match always succeeds)
+       */
       def unapply(x: ByName): Some[TypeTree]
     }
 
@@ -2529,6 +3001,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `ByName`. */
     trait ByNameMethods:
       extension (self: ByName)
+        /** The underlying result type tree of this by-name type, i.e. the `T` of `=> T`. */
         def result: TypeTree
       end extension
     end ByNameMethods
@@ -2544,8 +3017,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val LambdaTypeTree`. */
     trait LambdaTypeTreeModule { this: LambdaTypeTree.type =>
+      /** Creates a type lambda tree `[tparams] =>> body`.
+       *
+       *  @param tparams the type parameter definitions of the lambda
+       *  @param body the body of the lambda; a `TypeTree` or a `TypeBoundsTree`
+       *  @return a new `LambdaTypeTree`
+       */
       def apply(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree
+      /** Copies a type lambda tree `[tparams] =>> body`.
+       *
+       *  @param original the original tree being copied
+       *  @param tparams the type parameter definitions of the lambda
+       *  @param body the body of the lambda; a `TypeTree` or a `TypeBoundsTree`
+       *  @return a copy of `original` with the given `tparams` and `body`
+       */
       def copy(original: Tree)(tparams: List[TypeDef], body: Tree /*TypeTree | TypeBoundsTree*/): LambdaTypeTree
+      /** Matches a type lambda tree `[tparams] =>> body` and extracts the parameters and body.
+       *
+       *  @param tree the `LambdaTypeTree` to match against
+       *  @return a tuple of the type parameter definitions and the lambda body
+       */
       def unapply(tree: LambdaTypeTree): (List[TypeDef], Tree /*TypeTree | TypeBoundsTree*/)
     }
 
@@ -2555,7 +3046,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `LambdaTypeTree`. */
     trait LambdaTypeTreeMethods:
       extension (self: LambdaTypeTree)
+        /** The type parameter definitions of this type lambda, i.e. the `tparams` of `[tparams] =>> body`. */
         def tparams: List[TypeDef]
+        /** The body of this type lambda; a `TypeTree` or a `TypeBoundsTree`. */
         def body: Tree /*TypeTree | TypeBoundsTree*/
       end extension
     end LambdaTypeTreeMethods
@@ -2571,7 +3064,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeBind`. */
     trait TypeBindModule { this: TypeBind.type =>
+      /** Copies a type binding, such as the binding of `t` in the type pattern of `case _: List[t] =>`.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the bound type variable
+       *  @param tpt the tree the type variable is bound to; a `TypeTree` or a `TypeBoundsTree`
+       *  @return a copy of `original` with the given `name` and `tpt`
+       */
       def copy(original: Tree)(name: String, tpt: Tree /*TypeTree | TypeBoundsTree*/): TypeBind
+      /** Matches a type binding and extracts the name and the bound tree.
+       *
+       *  @param x the `TypeBind` to match against
+       *  @return a tuple of the bound type variable's name and the tree it is bound to
+       */
       def unapply(x: TypeBind): (String, Tree /*TypeTree | TypeBoundsTree*/)
     }
 
@@ -2581,7 +3086,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeBind`. */
     trait TypeBindMethods:
       extension (self: TypeBind)
+        /** The name of the type variable bound by this binding. */
         def name: String
+        /** The tree this type variable is bound to; a `TypeTree` or a `TypeBoundsTree`. */
         def body: Tree /*TypeTree | TypeBoundsTree*/
       end extension
     end TypeBindMethods
@@ -2597,8 +3104,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeBlock`. */
     trait TypeBlockModule { this: TypeBlock.type =>
+      /** Creates a type block `{ aliases; tpt }`, e.g. `{ type U = Int; List[U] }`.
+       *
+       *  @param aliases the type alias definitions of the block
+       *  @param tpt the resulting type tree of the block
+       *  @return a new `TypeBlock` tree
+       */
       def apply(aliases: List[TypeDef], tpt: TypeTree): TypeBlock
+      /** Copies a type block `{ aliases; tpt }`.
+       *
+       *  @param original the original tree being copied
+       *  @param aliases the type alias definitions of the block
+       *  @param tpt the resulting type tree of the block
+       *  @return a copy of `original` with the given `aliases` and `tpt`
+       */
       def copy(original: Tree)(aliases: List[TypeDef], tpt: TypeTree): TypeBlock
+      /** Matches a type block `{ aliases; tpt }` and extracts the aliases and result.
+       *
+       *  @param x the `TypeBlock` to match against
+       *  @return a tuple of the type alias definitions and the resulting type tree
+       */
       def unapply(x: TypeBlock): (List[TypeDef], TypeTree)
     }
 
@@ -2608,7 +3133,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeBlock`. */
     trait TypeBlockMethods:
       extension (self: TypeBlock)
+        /** The type alias definitions of this type block, i.e. the `aliases` of `{ aliases; tpt }`. */
         def aliases: List[TypeDef]
+        /** The resulting type tree of this type block, i.e. the `tpt` of `{ aliases; tpt }`. */
         def tpt: TypeTree
       end extension
     end TypeBlockMethods
@@ -2626,8 +3153,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeBoundsTree`. */
     trait TypeBoundsTreeModule { this: TypeBoundsTree.type =>
+      /** Creates a type-bounds tree `>: <low: TypeTree> <: <hi: TypeTree>`.
+       *
+       *  @param low the lower bound type tree
+       *  @param hi the upper bound type tree
+       *  @return a new `TypeBoundsTree` with the given bounds
+       */
       def apply(low: TypeTree, hi: TypeTree): TypeBoundsTree
+      /** Copies a type-bounds tree `>: <low: TypeTree> <: <hi: TypeTree>`.
+       *
+       *  @param original the original tree being copied
+       *  @param low the lower bound type tree
+       *  @param hi the upper bound type tree
+       *  @return a copy of `original` with the given `low` and `hi` bounds
+       */
       def copy(original: Tree)(low: TypeTree, hi: TypeTree): TypeBoundsTree
+      /** Matches a type-bounds tree `>: <low: TypeTree> <: <hi: TypeTree>` and extracts its bounds.
+       *
+       *  @param x the `TypeBoundsTree` to match against
+       *  @return a tuple of the lower and upper bound type trees
+       */
       def unapply(x: TypeBoundsTree): (TypeTree, TypeTree)
     }
 
@@ -2637,8 +3182,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeBoundsTree`. */
     trait TypeBoundsTreeMethods:
       extension (self: TypeBoundsTree)
+        /** The type of this tree, as a `TypeBounds`. */
         def tpe: TypeBounds
+        /** The lower bound type tree, i.e. the `low` of `>: low <: hi`. */
         def low: TypeTree
+        /** The upper bound type tree, i.e. the `hi` of `>: low <: hi`. */
         def hi: TypeTree
       end extension
     end TypeBoundsTreeMethods
@@ -2657,6 +3205,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val WildcardTypeTree`. */
     trait WildcardTypeTreeModule { this: WildcardTypeTree.type =>
+      /** Creates a wildcard type tree `_` with the given type.
+       *
+       *  @param tpe the type of the wildcard; typically a `TypeBounds`
+       *  @return a new `WildcardTypeTree` of type `tpe`
+       */
       def apply(tpe: TypeRepr): WildcardTypeTree
       /** Matches a TypeBoundsTree containing wildcard type bounds.
        *
@@ -2672,6 +3225,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `WildcardTypeTree`. */
     trait WildcardTypeTreeMethods:
       extension (self: WildcardTypeTree)
+        /** The type of this wildcard; typically a `TypeBounds`. */
         def tpe: TypeRepr
       end extension
     end WildcardTypeTreeMethods
@@ -2689,8 +3243,28 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val CaseDef`. */
     trait CaseDefModule { this: CaseDef.type =>
+      /** Creates a pattern match branch `case <pattern: Tree> if <guard: Option[Term]> => <rhs: Term>`.
+       *
+       *  @param pattern the pattern of the case
+       *  @param guard the optional guard condition; `None` if the case has no guard
+       *  @param rhs the body of the case
+       *  @return a new `CaseDef` tree
+       */
       def apply(pattern: Tree, guard: Option[Term], rhs: Term): CaseDef
+      /** Copies a pattern match branch `case <pattern: Tree> if <guard: Option[Term]> => <rhs: Term>`.
+       *
+       *  @param original the original tree being copied
+       *  @param pattern the pattern of the case
+       *  @param guard the optional guard condition; `None` if the case has no guard
+       *  @param rhs the body of the case
+       *  @return a copy of `original` with the given `pattern`, `guard`, and `rhs`
+       */
       def copy(original: Tree)(pattern: Tree, guard: Option[Term], rhs: Term): CaseDef
+      /** Matches a pattern match branch `case <pattern> if <guard> => <rhs>` and extracts its parts.
+       *
+       *  @param x the `CaseDef` to match against
+       *  @return a tuple of the pattern, the optional guard, and the body
+       */
       def unapply(x: CaseDef): (Tree, Option[Term], Term)
     }
 
@@ -2700,8 +3274,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `CaseDef`. */
     trait CaseDefMethods:
       extension (self: CaseDef)
+        /** The pattern of this case, i.e. the `pattern` of `case pattern if guard => rhs`. */
         def pattern: Tree
+        /** The guard condition of this case, i.e. the `guard` of `case pattern if guard => rhs`; `None` if the case has no guard. */
         def guard: Option[Term]
+        /** The body of this case, i.e. the `rhs` of `case pattern if guard => rhs`. */
         def rhs: Term
       end extension
     end CaseDefMethods
@@ -2717,8 +3294,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeCaseDef`. */
     trait TypeCaseDefModule { this: TypeCaseDef.type =>
+      /** Creates a type pattern match branch `case <pattern: TypeTree> => <rhs: TypeTree>`, as in a match type.
+       *
+       *  @param pattern the type pattern of the case
+       *  @param rhs the result type of the case
+       *  @return a new `TypeCaseDef` tree
+       */
       def apply(pattern: TypeTree, rhs: TypeTree): TypeCaseDef
+      /** Copies a type pattern match branch `case <pattern: TypeTree> => <rhs: TypeTree>`.
+       *
+       *  @param original the original tree being copied
+       *  @param pattern the type pattern of the case
+       *  @param rhs the result type of the case
+       *  @return a copy of `original` with the given `pattern` and `rhs`
+       */
       def copy(original: Tree)(pattern: TypeTree, rhs: TypeTree): TypeCaseDef
+      /** Matches a type pattern match branch `case <pattern> => <rhs>` and extracts its parts.
+       *
+       *  @param tree the `TypeCaseDef` to match against
+       *  @return a tuple of the type pattern and the result type
+       */
       def unapply(tree: TypeCaseDef): (TypeTree, TypeTree)
     }
 
@@ -2728,7 +3323,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeCaseDef`. */
     trait TypeCaseDefMethods:
       extension (self: TypeCaseDef)
+        /** The type pattern of this case, i.e. the `pattern` of `case pattern => rhs`. */
         def pattern: TypeTree
+        /** The result type of this case, i.e. the `rhs` of `case pattern => rhs`. */
         def rhs: TypeTree
       end extension
     end TypeCaseDefMethods
@@ -2746,8 +3343,26 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Bind`. */
     trait BindModule { this: Bind.type =>
+      /** Creates a pattern binding `<sym.name> @ <pattern: Tree>`.
+       *
+       *  @param sym the symbol of the bound variable; must be a bind symbol, as created with `Symbol.newBind`
+       *  @param pattern the pattern the variable is bound to
+       *  @return a new `Bind` tree
+       */
       def apply(sym: Symbol, pattern: Tree): Bind
+      /** Copies a pattern binding `<name> @ <pattern: Tree>`.
+       *
+       *  @param original the original tree being copied
+       *  @param name the name of the bound variable
+       *  @param pattern the pattern the variable is bound to
+       *  @return a copy of `original` with the given `name` and `pattern`
+       */
       def copy(original: Tree)(name: String, pattern: Tree): Bind
+      /** Matches a pattern binding `<name> @ <pattern>` and extracts the name and the pattern.
+       *
+       *  @param pattern the `Bind` to match against
+       *  @return a tuple of the bound variable's name and the pattern it is bound to
+       */
       def unapply(pattern: Bind): (String, Tree)
     }
 
@@ -2757,7 +3372,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Bind`. */
     trait BindMethods:
       extension (self: Bind)
+        /** The name of the bound variable, i.e. the `name` of `name @ pattern`. */
         def name: String
+        /** The pattern the variable is bound to, i.e. the `pattern` of `name @ pattern`. */
         def pattern: Tree
       end extension
     end BindMethods
@@ -2830,8 +3447,24 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Alternatives`. */
     trait AlternativesModule { this: Alternatives.type =>
+      /** Creates a pattern alternative `<pattern1> | ... | <patternN>`.
+       *
+       *  @param patterns the alternative patterns
+       *  @return a new `Alternatives` tree
+       */
       def apply(patterns: List[Tree]): Alternatives
+      /** Copies a pattern alternative `<pattern1> | ... | <patternN>`.
+       *
+       *  @param original the original tree being copied
+       *  @param patterns the alternative patterns
+       *  @return a copy of `original` with the given `patterns`
+       */
       def copy(original: Tree)(patterns: List[Tree]): Alternatives
+      /** Matches a pattern alternative `pattern1 | ... | patternN` and extracts its patterns.
+       *
+       *  @param x the `Alternatives` to match against
+       *  @return `Some` containing the alternative patterns (the match always succeeds)
+       */
       def unapply(x: Alternatives): Some[List[Tree]]
     }
 
@@ -2841,6 +3474,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Alternatives`. */
     trait AlternativesMethods:
       extension (self: Alternatives)
+        /** The alternative patterns, i.e. `pattern1`, ..., `patternN` of `pattern1 | ... | patternN`. */
         def patterns: List[Tree]
       end extension
     end AlternativesMethods
@@ -2897,7 +3531,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TermParamClause`. */
     trait TermParamClauseModule { this: TermParamClause.type =>
+      /** Creates a term parameter clause `(<params: List[ValDef]>)`.
+       *
+       *  @param params the parameter definitions of the clause; expected to be either all implicit
+       *                or all non-implicit, which is only checked under `-Xcheck-macros`
+       *  @return a new `TermParamClause` with the given parameters
+       */
       def apply(params: List[ValDef]): TermParamClause
+      /** Matches a term parameter clause and extracts its parameters.
+       *
+       *  @param x the `TermParamClause` to match against
+       *  @return `Some` containing the parameter definitions (the match always succeeds)
+       */
       def unapply(x: TermParamClause): Some[List[ValDef]]
     }
 
@@ -2935,7 +3580,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeParamClause`. */
     trait TypeParamClauseModule { this: TypeParamClause.type =>
+      /** Creates a type parameter clause `[<params: List[TypeDef]>]`.
+       *
+       *  @param params the type parameter definitions of the clause; must be non-empty
+       *  @return a new `TypeParamClause` with the given parameters
+       *  @throws IllegalArgumentException if `params` is empty
+       */
       def apply(params: List[TypeDef]): TypeParamClause
+      /** Matches a type parameter clause and extracts its parameters.
+       *
+       *  @param x the `TypeParamClause` to match against
+       *  @return `Some` containing the type parameter definitions (the match always succeeds)
+       */
       def unapply(x: TypeParamClause): Some[List[TypeDef]]
     }
 
@@ -2978,7 +3634,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val SimpleSelector`. */
     trait SimpleSelectorModule { this: SimpleSelector.type =>
+      /** Creates a simple selector `<name>`, as `.bar` in `import foo.bar`.
+       *
+       *  @param name the name of the imported member
+       *  @return a new `SimpleSelector` for the given name
+       */
       @experimental def apply(name: String): SimpleSelector
+      /** Matches a simple selector and extracts its name.
+       *
+       *  @param x the `SimpleSelector` to match against
+       *  @return `Some` containing the name of the imported member (the match always succeeds)
+       */
       def unapply(x: SimpleSelector): Some[String]
     }
 
@@ -2988,7 +3654,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `SimpleSelector`. */
     trait SimpleSelectorMethods:
       extension (self: SimpleSelector)
+        /** The name of the imported member, e.g. `bar` in `import foo.bar`. */
         def name: String
+        /** The position of the name within this selector. */
         def namePos: Position
       end extension
     end SimpleSelectorMethods
@@ -3004,7 +3672,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val RenameSelector`. */
     trait RenameSelectorModule { this: RenameSelector.type =>
+      /** Creates a rename selector `<fromName> => <toName>`, as `.{bar => baz}` in `import foo.{bar => baz}`.
+       *
+       *  @param fromName the name of the member being renamed
+       *  @param toName the name the member is renamed to
+       *  @return a new `RenameSelector` renaming `fromName` to `toName`
+       */
       @experimental def apply(fromName: String, toName: String): RenameSelector
+      /** Matches a rename selector `fromName => toName` and extracts the two names.
+       *
+       *  @param x the `RenameSelector` to match against
+       *  @return a tuple of the original name and the new name
+       */
       def unapply(x: RenameSelector): (String, String)
     }
 
@@ -3014,9 +3693,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `RenameSelector`. */
     trait RenameSelectorMethods:
       extension (self: RenameSelector)
+        /** The name of the renamed member, e.g. `bar` in `import foo.{bar => baz}`. */
         def fromName: String
+        /** The position of the original name `fromName` within this selector. */
         def fromPos: Position
+        /** The name the member is renamed to, e.g. `baz` in `import foo.{bar => baz}`. */
         def toName: String
+        /** The position of the new name `toName` within this selector. */
         def toPos: Position
       end extension
     end RenameSelectorMethods
@@ -3032,7 +3715,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val OmitSelector`. */
     trait OmitSelectorModule { this: OmitSelector.type =>
+      /** Creates an omit selector `<name> => _`, as `.{bar => _}` in `import foo.{bar => _}`.
+       *
+       *  @param name the name of the member being omitted
+       *  @return a new `OmitSelector` for the given name
+       */
       @experimental def apply(name: String): OmitSelector
+      /** Matches an omit selector `name => _` and extracts the omitted name.
+       *
+       *  @param x the `OmitSelector` to match against
+       *  @return `Some` containing the name of the omitted member (the match always succeeds)
+       */
       def unapply(x: OmitSelector): Some[String]
     }
 
@@ -3042,7 +3735,10 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `OmitSelector`. */
     trait OmitSelectorMethods:
       extension (self: OmitSelector)
+        /** The name of the omitted member, e.g. `bar` in `import foo.{bar => _}`.
+         */
         def name: String
+        /** The position of the omitted member's name within this selector. */
         def namePos: Position
     end OmitSelectorMethods
 
@@ -3057,7 +3753,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val GivenSelector`. */
     trait GivenSelectorModule { this: GivenSelector.type =>
+      /** Creates a given selector, as `.given` in `import foo.given` or `.{given T}` in `import foo.{given T}`.
+       *
+       *  @param bound the type bound `T` of the selector, or `None` for an unbounded `given`
+       *  @return a new `GivenSelector` with the given bound
+       */
       @experimental def apply(bound: Option[TypeTree]): GivenSelector
+      /** Matches a given selector and extracts its optional type bound.
+       *
+       *  @param x the `GivenSelector` to match against
+       *  @return `Some` containing the optional type bound (the match always succeeds)
+       */
       def unapply(x: GivenSelector): Some[Option[TypeTree]]
     }
 
@@ -3067,6 +3773,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `GivenSelector`. */
     trait GivenSelectorMethods:
       extension (self: GivenSelector)
+        /** The type bound of this given selector, i.e. `T` in `import foo.{given T}`; `None` for an unbounded `given`. */
         def bound: Option[TypeTree]
     end GivenSelectorMethods
 
@@ -3170,9 +3877,15 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
          */
         def simplified: TypeRepr
 
+        /** The class symbol of this type: the least class or trait of which this type
+         *  is a subtype or parameterized instance, or `None` if none exists.
+         */
         def classSymbol: Option[Symbol]
+        /** The type symbol associated with this type; `Symbol.noSymbol` if none exists. */
         def typeSymbol: Symbol
+        /** The term symbol associated with this type; `Symbol.noSymbol` if none exists. */
         def termSymbol: Symbol
+        /** Is this type a (possibly aliased) singleton type? */
         def isSingleton: Boolean
 
        /** The type of `member` as seen from prefix `self`.
@@ -3288,7 +4001,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Type`. */
     trait ConstantTypeModule { this: ConstantType.type =>
+      /** Creates the singleton type of the given constant, e.g. the literal type `1` for `IntConstant(1)`.
+       *
+       *  @param x the constant value
+       *  @return the `ConstantType` of `x`
+       */
       def apply(x : Constant): ConstantType
+      /** Matches a constant type and extracts its constant.
+       *
+       *  @param x the `ConstantType` to match against
+       *  @return `Some` containing the constant value (the match always succeeds)
+       */
       def unapply(x: ConstantType): Some[Constant]
     }
 
@@ -3298,6 +4021,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `ConstantType`. */
     trait ConstantTypeMethods:
       extension (self: ConstantType)
+        /** The constant value of this constant type, e.g. `IntConstant(1)` for the literal type `1`. */
         def constant: Constant
       end extension
     end ConstantTypeMethods
@@ -3314,7 +4038,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `NamedType`. */
     trait NamedTypeMethods:
       extension (self: NamedType)
+        /** The type of the qualifier of this reference, e.g. the type of `p` in a reference `p.X`. */
         def qualifier: TypeRepr
+        /** The name of the referenced term or type, e.g. `X` in a reference `p.X`. */
         def name: String
       end extension
     end NamedTypeMethods
@@ -3330,7 +4056,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TermRef`. */
     trait TermRefModule { this: TermRef.type =>
+      /** Creates a reference to the term member `name` of the type `qual`, i.e. the type of `qual.name`.
+       *
+       *  @param qual the type of the qualifier
+       *  @param name the name of the referenced term member
+       *  @return a new `TermRef` selecting `name` from `qual`
+       */
       def apply(qual: TypeRepr, name: String): TermRef
+      /** Matches a term reference and extracts the qualifier type and the name.
+       *
+       *  @param x the `TermRef` to match against
+       *  @return a tuple of the qualifier type and the referenced term's name
+       */
       def unapply(x: TermRef): (TypeRepr, String)
     }
 
@@ -3345,6 +4082,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeRef`. */
     trait TypeRefModule { this: TypeRef.type =>
+      /** Matches a type reference and extracts the qualifier type and the name.
+       *
+       *  @param x the `TypeRef` to match against
+       *  @return a tuple of the qualifier type and the referenced type's name
+       */
       def unapply(x: TypeRef): (TypeRepr, String)
     }
 
@@ -3354,7 +4096,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeRef`. */
     trait TypeRefMethods:
       extension (self: TypeRef)
+        /** Is this a reference to an opaque type alias? */
         def isOpaqueAlias: Boolean
+        /** The supertype of this reference, with opaque type aliases treated as
+         *  transparent aliases: for a reference to an opaque type alias, the aliased
+         *  type as seen from the reference's prefix; for a reference to a type alias,
+         *  the aliased type; otherwise the upper bound of the referenced type.
+         */
         def translucentSuperType: TypeRepr
       end extension
     end TypeRefMethods
@@ -3370,7 +4118,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val SuperType`. */
     trait SuperTypeModule { this: SuperType.type =>
+      /** Creates the type of a `super` reference, as in `C.super.x`.
+       *
+       *  @param thistpe the type of `this` at the point of the reference
+       *  @param supertpe the type of the value referenced by `super`
+       *  @return a new `SuperType` with the given `this` type and super type
+       */
       def apply(thistpe: TypeRepr, supertpe: TypeRepr): SuperType
+      /** Matches a super type and extracts the `this` type and the super type.
+       *
+       *  @param x the `SuperType` to match against
+       *  @return a tuple of the type of `this` and the type of the value referenced by `super`
+       */
       def unapply(x: SuperType): (TypeRepr, TypeRepr)
     }
 
@@ -3380,7 +4139,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `SuperType`. */
     trait SuperTypeMethods { this: SuperTypeMethods =>
       extension (self: SuperType)
+        /** The type of `this` at this `super` reference. */
         def thistpe: TypeRepr
+        /** The type of the value referenced by `super`. */
         def supertpe: TypeRepr
       end extension
     }
@@ -3396,7 +4157,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val Refinement`. */
     trait RefinementModule { this: Refinement.type =>
+      /** Creates a refinement of `parent` with a single refined member, e.g. `T { def x: Int }` or `T { type U <: S }`.
+       *
+       *  @param parent the type being refined
+       *  @param name the name of the refined member; taken as a type name if `info` is a `TypeBounds`, as a term name otherwise
+       *  @param info the type of the refined member
+       *  @return a new `Refinement` of `parent` refining `name` to `info`
+       */
       def apply(parent: TypeRepr, name: String, info: TypeRepr): Refinement
+      /** Matches a refinement type and extracts the parent, the refined member's name, and its type.
+       *
+       *  @param x the `Refinement` to match against
+       *  @return a tuple of the refined parent type, the refined member's name, and the member's type
+       */
       def unapply(x: Refinement): (TypeRepr, String, TypeRepr)
     }
 
@@ -3406,8 +4179,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `Refinement`. */
     trait RefinementMethods:
       extension (self: Refinement)
+        /** The type being refined, i.e. `T` in `T { type U }`. */
         def parent: TypeRepr
+        /** The name of the refined member, e.g. `U` in `T { type U }`. */
         def name: String
+        /** The type of the refined member; a `TypeBounds` for a refined type member. */
         def info: TypeRepr
       end extension
     end RefinementMethods
@@ -3430,6 +4206,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        *  @return the `AppliedType` `tycon[args]`
        */
       def apply(tycon: TypeRepr, args: List[TypeRepr]): AppliedType
+      /** Matches an applied type `T[T_1,..,T_n]` and extracts the type constructor and its type arguments.
+       *
+       *  @param x the `AppliedType` to match against
+       *  @return a tuple of the type constructor and the list of type arguments
+       */
       def unapply(x: AppliedType): (TypeRepr, List[TypeRepr])
     }
 
@@ -3439,7 +4220,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `AppliedType`. */
     trait AppliedTypeMethods:
       extension (self: AppliedType)
+        /** The type constructor, i.e. `T` in `T[T_1,..,T_n]`. */
         def tycon: TypeRepr
+        /** The type arguments, i.e. `T_1,..,T_n` in `T[T_1,..,T_n]`. */
         def args: List[TypeRepr]
       end extension
     end AppliedTypeMethods
@@ -3455,7 +4238,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val AnnotatedType`. */
     trait AnnotatedTypeModule { this: AnnotatedType.type =>
+      /** Creates an annotated type `T @foo`.
+       *
+       *  @param underlying the type being annotated, i.e. `T`
+       *  @param annot the annotation as a term, i.e. an application of an annotation class constructor
+       *  @return a new `AnnotatedType` of `underlying` annotated with `annot`
+       */
       def apply(underlying: TypeRepr, annot: Term): AnnotatedType
+      /** Matches an annotated type `T @foo` and extracts the underlying type and the annotation.
+       *
+       *  @param x the `AnnotatedType` to match against
+       *  @return a tuple of the underlying type and the annotation term
+       */
       def unapply(x: AnnotatedType): (TypeRepr, Term)
     }
 
@@ -3465,7 +4259,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `AnnotatedType`. */
     trait AnnotatedTypeMethods:
       extension (self: AnnotatedType)
+        /** The type being annotated, i.e. `T` in `T @foo`. */
         def underlying: TypeRepr
+        /** The annotation as a term, i.e. an application of an annotation class constructor. */
         def annotation: Term
       end extension
     end AnnotatedTypeMethods
@@ -3483,7 +4279,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `AndOrType`. */
     trait AndOrTypeMethods:
       extension (self: AndOrType)
+        /** The left operand, i.e. `T` in `T & U` or `T | U`. */
         def left: TypeRepr
+        /** The right operand, i.e. `U` in `T & U` or `T | U`. */
         def right: TypeRepr
       end extension
     end AndOrTypeMethods
@@ -3499,7 +4297,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val AndType`. */
     trait AndTypeModule { this: AndType.type =>
+      /** Creates an intersection type `T & U`.
+       *
+       *  @param lhs the left operand `T`
+       *  @param rhs the right operand `U`
+       *  @return the `AndType` `lhs & rhs`
+       */
       def apply(lhs: TypeRepr, rhs: TypeRepr): AndType
+      /** Matches an intersection type `T & U` and extracts its operands.
+       *
+       *  @param x the `AndType` to match against
+       *  @return a tuple of the left and right operands
+       */
       def unapply(x: AndType): (TypeRepr, TypeRepr)
     }
 
@@ -3514,7 +4323,18 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val OrType`. */
     trait OrTypeModule { this: OrType.type =>
+      /** Creates a union type `T | U`.
+       *
+       *  @param lhs the left operand `T`
+       *  @param rhs the right operand `U`
+       *  @return the `OrType` `lhs | rhs`
+       */
       def apply(lhs: TypeRepr, rhs: TypeRepr): OrType
+      /** Matches a union type `T | U` and extracts its operands.
+       *
+       *  @param x the `OrType` to match against
+       *  @return a tuple of the left and right operands
+       */
       def unapply(x: OrType): (TypeRepr, TypeRepr)
     }
 
@@ -3529,7 +4349,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val MatchType`. */
     trait MatchTypeModule { this: MatchType.type =>
+      /** Creates a match type `S match { case P1 => R1; ... }`.
+       *
+       *  @param bound the upper bound of the match type; any reduction of the match type conforms to it
+       *  @param scrutinee the type being matched, i.e. `S`
+       *  @param cases the cases of the match type, each a `MatchCase`
+       *  @return a new `MatchType`
+       */
       def apply(bound: TypeRepr, scrutinee: TypeRepr, cases: List[TypeRepr]): MatchType
+      /** Matches a match type and extracts its bound, scrutinee, and cases.
+       *
+       *  @param x the `MatchType` to match against
+       *  @return a tuple of the upper bound, the scrutinee type, and the list of cases
+       */
       def unapply(x: MatchType): (TypeRepr, TypeRepr, List[TypeRepr])
     }
 
@@ -3539,8 +4371,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `MatchType`. */
     trait MatchTypeMethods:
       extension (self: MatchType)
+        /** The upper bound of this match type; any reduction of this match type conforms to it. */
         def bound: TypeRepr
+        /** The type being matched, i.e. `S` in `S match { case P => R }`. */
         def scrutinee: TypeRepr
+        /** The cases of this match type, each a `MatchCase` (possibly nested in a `TypeLambda` when the case has type bindings). */
         def cases: List[TypeRepr]
       end extension
     end MatchTypeMethods
@@ -3570,7 +4405,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val ByNameType`. */
     trait ByNameTypeModule { this: ByNameType.type =>
+      /** Creates a by-name type `=> T`.
+       *
+       *  @param underlying the result type `T`
+       *  @return the by-name type of `underlying`
+       */
       def apply(underlying: TypeRepr): TypeRepr
+      /** Matches a by-name type `=> T` and extracts the underlying type.
+       *
+       *  @param x the `ByNameType` to match against
+       *  @return a `Some` containing the underlying result type `T`
+       */
       def unapply(x: ByNameType): Some[TypeRepr]
     }
 
@@ -3580,6 +4425,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `ByNameType`. */
     trait ByNameTypeMethods:
       extension (self: ByNameType)
+        /** The result type, i.e. `T` in `=> T`. */
         def underlying: TypeRepr
       end extension
     end ByNameTypeMethods
@@ -3595,6 +4441,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val ParamRef`. */
     trait ParamRefModule { this: ParamRef.type =>
+      /** Matches a parameter reference and extracts its binder and parameter index.
+       *
+       *  @param x the `ParamRef` to match against
+       *  @return a tuple of the binding lambda type and the zero-based index of the parameter in its parameter list
+       */
       def unapply(x: ParamRef): (TypeRepr, Int)
     }
 
@@ -3604,7 +4455,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `ParamRef`. */
     trait ParamRefMethods:
       extension (self: ParamRef)
+        /** The lambda type binding this parameter, such as a `MethodType`, `PolyType`, or `TypeLambda`. */
         def binder: TypeRepr
+        /** The zero-based index of the referenced parameter in the parameter list of the binder. */
         def paramNum: Int
       end extension
     end ParamRefMethods
@@ -3620,6 +4473,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val ThisType`. */
     trait ThisTypeModule { this: ThisType.type =>
+      /** Matches a `this` type and extracts the reference to the class of the `this`.
+       *
+       *  @param x the `ThisType` to match against
+       *  @return a `Some` containing the type reference to the class, i.e. `C` for the type of `C.this`
+       */
       def unapply(x: ThisType): Some[TypeRepr]
     }
 
@@ -3629,6 +4487,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `ThisType`. */
     trait ThisTypeMethods:
       extension (self: ThisType)
+        /** The type reference to the class of this `this` type, i.e. `C` for the type of `C.this`. */
         def tref: TypeRepr
       end extension
     end ThisTypeMethods
@@ -3644,6 +4503,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val RecursiveThis`. */
     trait RecursiveThisModule { this: RecursiveThis.type =>
+      /** Matches a recursive `this` and extracts the recursive type it refers to.
+       *
+       *  @param x the `RecursiveThis` to match against
+       *  @return a `Some` containing the `RecursiveType` that binds this recursive `this`
+       */
       def unapply(x: RecursiveThis): Some[RecursiveType]
     }
 
@@ -3653,6 +4517,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `RecursiveThis`. */
     trait RecursiveThisMethods:
       extension (self: RecursiveThis)
+        /** The `RecursiveType` that binds this recursive `this` reference. */
         def binder: RecursiveType
       end extension
     end RecursiveThisMethods
@@ -3682,6 +4547,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
        */
       def apply(parentExp: RecursiveType => TypeRepr): RecursiveType
 
+      /** Matches a recursive type and extracts its underlying type.
+       *
+       *  @param x the `RecursiveType` to match against
+       *  @return a `Some` containing the underlying type
+       */
       def unapply(x: RecursiveType): Some[TypeRepr]
     }
 
@@ -3691,7 +4561,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `RecursiveType`. */
     trait RecursiveTypeMethods:
       extension (self: RecursiveType)
+        /** The underlying type of this recursive type, in which `recThis` refers back to the recursive type itself. */
         def underlying: TypeRepr
+        /** The recursive `this` reference that refers to this recursive type from within its underlying type. */
         def recThis: RecursiveThis
       end extension
     end RecursiveTypeMethods
@@ -3708,8 +4580,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `LambdaType`. */
     trait LambdaTypeMethods:
       extension (self: LambdaType)
+        /** The names of the parameters of this lambda type. */
         def paramNames: List[String]
+        /** The types of the parameters of this lambda type: the declared types of term parameters, or the bounds of type parameters. */
         def paramTypes: List[TypeRepr]
+        /** The result type of this lambda type. */
         def resType: TypeRepr
       end extension
     end LambdaTypeMethods
@@ -3740,8 +4615,28 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val MethodType`. */
     trait MethodTypeModule { this: MethodType.type =>
+      /** Creates a method type `(x1: X1, ..., xn: Xn)R` with a plain parameter clause.
+       *
+       *  @param paramNames the names of the parameters
+       *  @param paramInfosExp a function that returns the parameter types, given the method type under construction; use `param` on it to reference earlier parameters
+       *  @param resultTypeExp a function that returns the result type, given the method type under construction
+       *  @return a new `MethodType`
+       */
       def apply(paramNames: List[String])(paramInfosExp: MethodType => List[TypeRepr], resultTypeExp: MethodType => TypeRepr): MethodType
+      /** Creates a method type with a parameter clause of the given kind: plain, implicit, or contextual.
+       *
+       *  @param kind the kind of the parameter clause
+       *  @param paramNames the names of the parameters
+       *  @param paramInfosExp a function that returns the parameter types, given the method type under construction; use `param` on it to reference earlier parameters
+       *  @param resultTypeExp a function that returns the result type, given the method type under construction
+       *  @return a new `MethodType`
+       */
       def apply(kind: MethodTypeKind)(paramNames: List[String])(paramInfosExp: MethodType => List[TypeRepr], resultTypeExp: MethodType => TypeRepr): MethodType
+      /** Matches a method type and extracts the parameter names, parameter types, and result type.
+       *
+       *  @param x the `MethodType` to match against
+       *  @return a tuple of the parameter names, the parameter types, and the result type
+       */
       def unapply(x: MethodType): (List[String], List[TypeRepr], TypeRepr)
     }
 
@@ -3766,6 +4661,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         /** Whether the clause has any erased parameters. */
         @experimental
         def hasErasedParams: Boolean
+        /** Reference to the i-th parameter.
+         *
+         *  @param idx the zero-based index of the parameter
+         *  @return a `TypeRepr` referencing the parameter at position `idx`
+         */
         def param(idx: Int): TypeRepr
       end extension
     end MethodTypeMethods
@@ -3781,7 +4681,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val PolyType`. */
     trait PolyTypeModule { this: PolyType.type =>
+      /** Creates a polymorphic method type `[T_1 >: L_1 <: U_1, ...]R`.
+       *
+       *  @param paramNames the names of the type parameters
+       *  @param paramBoundsExp a function that returns the type parameter bounds, given the polymorphic type under construction; use `param` on it to reference earlier parameters
+       *  @param resultTypeExp a function that returns the result type, given the polymorphic type under construction
+       *  @return a new `PolyType`
+       */
       def apply(paramNames: List[String])(paramBoundsExp: PolyType => List[TypeBounds], resultTypeExp: PolyType => TypeRepr): PolyType
+      /** Matches a polymorphic method type and extracts the type parameter names, their bounds, and the result type.
+       *
+       *  @param x the `PolyType` to match against
+       *  @return a tuple of the type parameter names, the type parameter bounds, and the result type
+       */
       def unapply(x: PolyType): (List[String], List[TypeBounds], TypeRepr)
     }
 
@@ -3791,7 +4703,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `PolyType`. */
     trait PolyTypeMethods:
       extension (self: PolyType)
+        /** Reference to the i-th parameter.
+         *
+         *  @param idx the zero-based index of the parameter
+         *  @return a `TypeRepr` referencing the parameter at position `idx`
+         */
         def param(idx: Int): TypeRepr
+        /** The bounds of the type parameters of this polymorphic type. */
         def paramBounds: List[TypeBounds]
       end extension
     end PolyTypeMethods
@@ -3807,7 +4725,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeLambda`. */
     trait TypeLambdaModule { this: TypeLambda.type =>
+      /** Creates a type lambda `[T_1 >: L_1 <: U_1, ...] =>> R`.
+       *
+       *  @param paramNames the names of the type parameters
+       *  @param boundsFn a function that returns the type parameter bounds, given the type lambda under construction; use `param` on it to reference earlier parameters
+       *  @param bodyFn a function that returns the body of the lambda, given the type lambda under construction
+       *  @return a new `TypeLambda`
+       */
       def apply(paramNames: List[String], boundsFn: TypeLambda => List[TypeBounds], bodyFn: TypeLambda => TypeRepr): TypeLambda
+      /** Matches a type lambda and extracts the type parameter names, their bounds, and the body.
+       *
+       *  @param x the `TypeLambda` to match against
+       *  @return a tuple of the type parameter names, the type parameter bounds, and the body of the lambda
+       */
       def unapply(x: TypeLambda): (List[String], List[TypeBounds], TypeRepr)
     }
 
@@ -3850,8 +4780,19 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Methods of the module object `val MatchCase`. */
     trait MatchCaseModule { this: MatchCase.type =>
       /* Create match type case `case <pattern> => <rhs>` */
+      /** Creates a match type case `case P => R`.
+       *
+       *  @param pattern the pattern type `P`
+       *  @param rhs the result type `R`
+       *  @return a new `MatchCase`
+       */
       def apply(pattern: TypeRepr, rhs: TypeRepr): MatchCase
       /* Matches a match type case `case <pattern> => <rhs>` */
+      /** Matches a match type case `case P => R` and extracts its pattern and result types.
+       *
+       *  @param x the `MatchCase` to match against
+       *  @return a tuple of the pattern type and the result type
+       */
       def unapply(x: MatchCase): (TypeRepr, TypeRepr)
     }
 
@@ -3882,10 +4823,32 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val TypeBounds`. */
     trait TypeBoundsModule { this: TypeBounds.type =>
+      /** Creates type bounds `>: low <: hi`.
+       *
+       *  @param low the lower bound
+       *  @param hi the upper bound
+       *  @return a `TypeBounds` with lower bound `low` and upper bound `hi`
+       */
       def apply(low: TypeRepr, hi: TypeRepr): TypeBounds
+      /** Matches type bounds and extracts the lower and upper bounds.
+       *
+       *  @param x the `TypeBounds` to match against
+       *  @return a tuple of the lower bound and the upper bound
+       */
       def unapply(x: TypeBounds): (TypeRepr, TypeRepr)
+      /** Returns unconstrained type bounds `>: Nothing <: Any`. */
       def empty: TypeBounds
+      /** Creates type bounds with only an upper bound, i.e. `>: Nothing <: hi`.
+       *
+       *  @param hi the upper bound
+       *  @return a `TypeBounds` with lower bound `Nothing` and upper bound `hi`
+       */
       def upper(hi: TypeRepr): TypeBounds
+      /** Creates type bounds with only a lower bound, i.e. `>: lo <: Any`.
+       *
+       *  @param lo the lower bound
+       *  @return a `TypeBounds` with lower bound `lo` and upper bound `Any`
+       */
       def lower(lo: TypeRepr): TypeBounds
     }
 
@@ -3895,7 +4858,9 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `TypeBounds`. */
     trait TypeBoundsMethods:
       extension (self: TypeBounds)
+        /** The lower bound of this type bounds. */
         def low: TypeRepr
+        /** The upper bound of this type bounds. */
         def hi: TypeRepr
       end extension
     end TypeBoundsMethods
@@ -3913,6 +4878,11 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val NoPrefix`. */
     trait NoPrefixModule { this: NoPrefix.type =>
+      /** Matches the `NoPrefix` of a type selection without a prefix.
+       *
+       *  @param x the `NoPrefix` to match against; never used
+       *  @return always `true`
+       */
       def unapply(x: NoPrefix): true
     }
 
@@ -3929,7 +4899,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
 
     /** Methods of the module object `val FlexibleType`. */
     trait FlexibleTypeModule { this: FlexibleType.type =>
+      /** Creates a flexible type from the given type `T`, with upper bound `T` and lower bound `T | Null`.
+       *
+       *  @param tp the underlying type `T`; if `tp` is already a `FlexibleType`, it is returned unchanged
+       *  @return the flexible type of `tp`
+       */
       def apply(tp: TypeRepr): FlexibleType
+      /** Matches a flexible type and extracts its underlying type.
+       *
+       *  @param x the `FlexibleType` to match against
+       *  @return a `Some` containing the underlying type, i.e. the upper bound
+       */
       def unapply(x: FlexibleType): Option[TypeRepr]
     }
 
@@ -3939,8 +4919,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `FlexibleType`. */
     trait FlexibleTypeMethods:
       extension (self: FlexibleType)
+        /** The underlying type of this flexible type; the same as `hi`. */
         def underlying: TypeRepr
+        /** The lower bound of this flexible type, i.e. `T | Null` for the flexible type of `T`. */
         def lo: TypeRepr
+        /** The upper bound of this flexible type, the underlying type `T`. Nothing forces it to be
+         *  non-nullable: `FlexibleType.apply` uses whatever value type it is given.
+         */
         def hi: TypeRepr
       end extension
     end FlexibleTypeMethods
@@ -4312,6 +5297,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `ImplicitSearchSuccess`. */
     trait ImplicitSearchSuccessMethods:
       extension (self: ImplicitSearchSuccess)
+        /** The term that refers to or constructs the found given instance. */
         def tree: Term
       end extension
     end ImplicitSearchSuccessMethods
@@ -4327,6 +5313,7 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     /** Extension methods of `ImplicitSearchFailure`. */
     trait ImplicitSearchFailureMethods:
       extension (self: ImplicitSearchFailure)
+        /** A message explaining why the search failed, suitable for inclusion in error messages. */
         def explanation: String
       end extension
     end ImplicitSearchFailureMethods
@@ -5815,10 +6802,41 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
     trait TreeAccumulator[X]:
 
       // Ties the knot of the traversal: call `foldOver(x, tree))` to dive in the `tree` node.
+      /** Combines the accumulated value with `tree`.
+       *
+       *  Implementations decide how `tree` contributes to the accumulated value,
+       *  and call `foldOverTree(x, tree)(owner)` to accumulate over the subtrees of `tree`.
+       *
+       *  @param x the value accumulated so far
+       *  @param tree the tree to fold over
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the value accumulated after visiting `tree`
+       */
       def foldTree(x: X, tree: Tree)(owner: Symbol): X
 
+      /** Folds `foldTree` over the given trees from left to right, threading the accumulated value.
+       *
+       *  @param x the initial accumulated value
+       *  @param trees the trees to fold over
+       *  @param owner the symbol of the definition enclosing the trees
+       *  @return the value accumulated after visiting all trees
+       */
       def foldTrees(x: X, trees: Iterable[Tree])(owner: Symbol): X = trees.foldLeft(x)((acc, y) => foldTree(acc, y)(owner))
 
+      /** Folds `foldTree` over the subtrees of `tree`, from left to right.
+       *
+       *  Not every `Tree` component is visited: the `call` of an `Inlined`, which records the
+       *  call that was inlined rather than part of the expansion, is skipped.
+       *
+       *  For a definition tree, the subtrees are folded with the symbol of the definition
+       *  itself as their owner.
+       *
+       *  @param x the value accumulated so far
+       *  @param tree the tree whose subtrees are folded over
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the value accumulated after visiting the subtrees of `tree`
+       *  @throws MatchError if `tree` is of an unknown kind
+       */
       def foldOverTree(x: X, tree: Tree)(owner: Symbol): X = {
         tree match {
           case Ident(_) =>
@@ -5927,10 +6945,27 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     trait TreeTraverser extends TreeAccumulator[Unit]:
 
+      /** Traverses `tree`. By default traverses its children; override to inspect the tree,
+       *  calling `traverseTreeChildren(tree)(owner)` to continue the traversal into the children.
+       *
+       *  @param tree the tree to traverse
+       *  @param owner the symbol of the definition enclosing `tree`
+       */
       def traverseTree(tree: Tree)(owner: Symbol): Unit = traverseTreeChildren(tree)(owner)
 
+      /** Traverses `tree` by delegating to `traverseTree`.
+       *
+       *  @param x the accumulated `Unit` value; never used
+       *  @param tree the tree to traverse
+       *  @param owner the symbol of the definition enclosing `tree`
+       */
       def foldTree(@unused x: Unit, tree: Tree)(owner: Symbol): Unit = traverseTree(tree)(owner)
 
+      /** Traverses the direct children of `tree`.
+       *
+       *  @param tree the tree whose children are traversed
+       *  @param owner the symbol of the definition enclosing `tree`
+       */
       protected def traverseTreeChildren(tree: Tree)(owner: Symbol): Unit = foldOverTree((), tree)(owner)
 
     end TreeTraverser
@@ -5955,6 +6990,17 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
      */
     trait TreeMap:
 
+      /** Transforms `tree` by dispatching on its kind to the more specific `transformX` methods
+       *  and rebuilding the tree from its transformed subtrees.
+       *
+       *  Some components are deliberately left as they are rather than transformed: an `Export`
+       *  is returned unchanged, as are the `pattern` of a `Bind` and the `call` of an `Inlined`.
+       *
+       *  @param tree the tree to transform
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the transformed tree
+       *  @throws MatchError if `tree` is of an unknown kind
+       */
       def transformTree(tree: Tree)(owner: Symbol): Tree = {
         tree match {
           case tree: PackageClause =>
@@ -5986,6 +7032,16 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         }
       }
 
+      /** Transforms the statement `tree` by transforming its subtrees.
+       *
+       *  For a definition (`ValDef`, `DefDef`, `TypeDef`, or `ClassDef`), the subtrees are
+       *  transformed with the symbol of the definition itself as their owner.
+       *
+       *  @param tree the statement to transform
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the transformed statement
+       *  @throws MatchError if `tree` is of an unknown kind
+       */
       def transformStatement(tree: Statement)(owner: Symbol): Statement = {
         tree match {
           case tree: Term =>
@@ -6023,6 +7079,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         }
       }
 
+      /** Transforms the term `tree` by transforming its subterms and type trees.
+       *
+       *  @param tree the term to transform
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the transformed term
+       *  @throws MatchError if `tree` is of an unknown kind
+       */
       def transformTerm(tree: Term)(owner: Symbol): Term = {
         tree match {
           case Ident(name) =>
@@ -6072,6 +7135,13 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
         }
       }
 
+      /** Transforms the type tree `tree` by transforming its subtrees.
+       *
+       *  @param tree the type tree to transform
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the transformed type tree
+       *  @throws MatchError if `tree` is of an unknown kind
+       */
       def transformTypeTree(tree: TypeTree)(owner: Symbol): TypeTree = tree match {
         case Inferred() => tree
         case tree: TypeIdent => tree
@@ -6101,32 +7171,90 @@ trait Quotes { self: runtime.QuoteUnpickler & runtime.QuoteMatching =>
           throw MatchError(tree.show(using Printer.TreeStructure))
       }
 
+      /** Transforms the case clause `tree` by transforming its pattern, guard, and body.
+       *
+       *  @param tree the case clause to transform
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the transformed case clause
+       */
       def transformCaseDef(tree: CaseDef)(owner: Symbol): CaseDef = {
         CaseDef.copy(tree)(transformTree(tree.pattern)(owner), tree.guard.map(x => transformTerm(x)(owner)), transformTerm(tree.rhs)(owner))
       }
 
+      /** Transforms the type case clause `tree` of a match type by transforming its pattern and result type trees.
+       *
+       *  @param tree the type case clause to transform
+       *  @param owner the symbol of the definition enclosing `tree`
+       *  @return the transformed type case clause
+       */
       def transformTypeCaseDef(tree: TypeCaseDef)(owner: Symbol): TypeCaseDef = {
         TypeCaseDef.copy(tree)(transformTypeTree(tree.pattern)(owner), transformTypeTree(tree.rhs)(owner))
       }
 
+      /** Transforms each statement with `transformStatement`.
+       *
+       *  @param trees the statements to transform
+       *  @param owner the symbol of the definition enclosing the statements
+       *  @return the transformed statements; the original list if no statement changed
+       */
       def transformStats(trees: List[Statement])(owner: Symbol): List[Statement] =
         trees mapConserve (x => transformStatement(x)(owner))
 
+      /** Transforms each tree with `transformTree`.
+       *
+       *  @param trees the trees to transform
+       *  @param owner the symbol of the definition enclosing the trees
+       *  @return the transformed trees; the original list if no tree changed
+       */
       def transformTrees(trees: List[Tree])(owner: Symbol): List[Tree] =
         trees mapConserve (x => transformTree(x)(owner))
 
+      /** Transforms each term with `transformTerm`.
+       *
+       *  @param trees the terms to transform
+       *  @param owner the symbol of the definition enclosing the terms
+       *  @return the transformed terms; the original list if no term changed
+       */
       def transformTerms(trees: List[Term])(owner: Symbol): List[Term] =
         trees mapConserve (x => transformTerm(x)(owner))
 
+      /** Transforms each type tree with `transformTypeTree`.
+       *
+       *  @param trees the type trees to transform
+       *  @param owner the symbol of the definition enclosing the type trees
+       *  @return the transformed type trees; the original list if no type tree changed
+       */
       def transformTypeTrees(trees: List[TypeTree])(owner: Symbol): List[TypeTree] =
         trees mapConserve (x => transformTypeTree(x)(owner))
 
+      /** Transforms each case clause with `transformCaseDef`.
+       *
+       *  @param trees the case clauses to transform
+       *  @param owner the symbol of the definition enclosing the case clauses
+       *  @return the transformed case clauses; the original list if no case clause changed
+       */
       def transformCaseDefs(trees: List[CaseDef])(owner: Symbol): List[CaseDef] =
         trees mapConserve (x => transformCaseDef(x)(owner))
 
+      /** Transforms each type case clause with `transformTypeCaseDef`.
+       *
+       *  @param trees the type case clauses to transform
+       *  @param owner the symbol of the definition enclosing the type case clauses
+       *  @return the transformed type case clauses; the original list if no type case clause changed
+       */
       def transformTypeCaseDefs(trees: List[TypeCaseDef])(owner: Symbol): List[TypeCaseDef] =
         trees mapConserve (x => transformTypeCaseDef(x)(owner))
 
+      /** Transforms each tree with `transformTree`, keeping the static element type of the list.
+       *
+       *  The transformation must map each tree to a tree of the same type `Tr`; the result is
+       *  cast, not checked.
+       *
+       *  @tparam Tr the type of the trees
+       *  @param trees the trees to transform
+       *  @param owner the symbol of the definition enclosing the trees
+       *  @return the transformed trees; the original list if no tree changed
+       */
       def transformSubTrees[Tr <: Tree](trees: List[Tr])(owner: Symbol): List[Tr] =
         transformTrees(trees)(owner).asInstanceOf[List[Tr]]
 

--- a/library/src/scala/quoted/runtime/QuoteMatching.scala
+++ b/library/src/scala/quoted/runtime/QuoteMatching.scala
@@ -7,8 +7,10 @@ import scala.quoted.{Expr, Type}
 /** Part of the `Quotes` interface that needs to be implemented by the compiler but is not visible to users. */
 trait QuoteMatching:
 
+  /** Module implementing the matching of quoted expression patterns: the compiler translates a pattern `case '{ ... } =>` into a call to `ExprMatch.unapply` */
   val ExprMatch: ExprMatchModule
 
+  /** Methods of the module object `val ExprMatch` */
   trait ExprMatchModule { self: ExprMatch.type =>
     /** Pattern matches an the scrutineeExpr against the patternExpr and returns a tuple
      *  with the matched holes if successful.
@@ -34,8 +36,10 @@ trait QuoteMatching:
     def unapply[TypeBindings, Tup <: Tuple](scrutinee: Expr[Any])(using pattern: Expr[Any]): Option[Tup]
   }
 
+  /** Module implementing the matching of quoted type patterns: the compiler translates a pattern `case '[ ... ] =>` into a call to `TypeMatch.unapply` */
   val TypeMatch: TypeMatchModule
 
+  /** Methods of the module object `val TypeMatch` */
   trait TypeMatchModule { self: TypeMatch.type =>
     /** Pattern matches an the scrutineeType against the patternType and returns a tuple
      *  with the matched holes if successful.

--- a/library/src/scala/quoted/runtime/StopMacroExpansion.scala
+++ b/library/src/scala/quoted/runtime/StopMacroExpansion.scala
@@ -8,4 +8,8 @@ class StopMacroExpansion extends Throwable:
   // Do not fill the stacktrace for performance.
   // We know that the stacktrace will be ignored
   // and only the reported error message will be used.
+  /** Returns `this` without filling in the stack trace, since the trace is ignored: the compiler
+   *  reports the error that was already emitted, or, if the macro threw this without reporting
+   *  one, a diagnostic saying the expansion aborted without an error.
+   */
   override def fillInStackTrace(): Throwable = this


### PR DESCRIPTION
This PR fills in a main doc comment plus @param, @tparam, and @return tags for scala.jdk, scala.quoted and scala.quoted.runtime APIs that are completely missing any Scaladoc documentation. Most of it is quoted/Quotes.scala, which alone accounts for 285 newly documented declarations across the reflection API; the rest covers the scala.jdk accumulators and converters, Expr, ExprMap, FromExpr and Type. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.
