### PR TITLE
runtime (8): Add Scaladoc comments for undocumented entities

### DIFF
--- a/library/src/scala/runtime/ArrayCharSequence.scala
+++ b/library/src/scala/runtime/ArrayCharSequence.scala
@@ -17,6 +17,18 @@ import scala.language.`2.13`
 
 // Still need this one since the implicit class ArrayCharSequence only converts
 // a single argument.
+/** A `CharSequence` view of a slice of an `Array[Char]`.
+ *
+ *  The sequence consists of the characters of `xs` from index `start` until
+ *  `end`. Characters are read from the array on demand, so later writes to
+ *  the array are visible through this sequence. The bounds are not validated
+ *  on construction: `end <= start` yields an empty sequence, and out-of-range
+ *  bounds only surface when characters are accessed.
+ *
+ *  @param xs the underlying character array
+ *  @param start the index in `xs` of the first character of the sequence
+ *  @param end the index in `xs` one past the last character of the sequence
+ */
 final class ArrayCharSequence(val xs: Array[Char], start: Int, end: Int) extends CharSequence {
   // yikes
   // java.lang.VerifyError: (class: scala/runtime/ArrayCharSequence, method: <init> signature: ([C)V)
@@ -24,12 +36,36 @@ final class ArrayCharSequence(val xs: Array[Char], start: Int, end: Int) extends
   //
   // def this(xs: Array[Char]) = this(xs, 0, xs.length)
 
+  /** Returns the number of characters in this sequence: `end - start`, or `0` if `end <= start`. */
   def length: Int = math.max(0, end - start)
+  /** Returns the character at the given index of this sequence, that is, the
+   *  character at index `start + index` of the underlying array.
+   *
+   *  @param index the index of the character to return, from `0` to `length - 1`
+   *  @throws ArrayIndexOutOfBoundsException if `index` is negative or not less
+   *          than `length`, or if the slice this sequence was constructed with
+   *          falls outside the array, since those bounds are not validated (the
+   *          exception message reports the bounds of the underlying array, not
+   *          of this sequence)
+   */
   def charAt(index: Int): Char = {
     if (0 <= index && index < length)
       xs(start + index)
     else throw new ArrayIndexOutOfBoundsException(s"$index is out of bounds (min 0, max ${xs.length - 1})")
   }
+  /** Returns a new `ArrayCharSequence` over the characters of this sequence
+   *  from index `start0` until `end0`.
+   *
+   *  The result is a view over the same underlying array; no characters are
+   *  copied.
+   *
+   *  @param start0 the index in this sequence of the first character of the subsequence
+   *  @param end0 the index in this sequence one past the last character of the subsequence
+   *  @return the subsequence view; empty if `end0 <= start0` (no exception is
+   *          thrown for an inverted range, unlike the `CharSequence` contract)
+   *  @throws ArrayIndexOutOfBoundsException if `start0` is negative or `end0`
+   *          is greater than `length`
+   */
   def subSequence(start0: Int, end0: Int): CharSequence = {
     if (start0 < 0) throw new ArrayIndexOutOfBoundsException(s"$start0 is out of bounds (min 0, max ${length -1})")
     else if (end0 > length) throw new ArrayIndexOutOfBoundsException(s"$end0 is out of bounds (min 0, max ${xs.length -1})")
@@ -40,6 +76,15 @@ final class ArrayCharSequence(val xs: Array[Char], start: Int, end: Int) extends
       new ArrayCharSequence(xs, start1, start1 + newlen)
     }
   }
+  /** Returns the characters of this sequence as a `String`.
+   *
+   *  The bounds are clamped to the underlying array before copying: a
+   *  negative `start` is treated as `0` and the end is capped at the array's
+   *  length, so a sequence constructed with out-of-range bounds yields
+   *  characters rather than throwing. The count is taken from the declared
+   *  bounds, so a negative `start` shifts the window: `start = -2, end = 5`
+   *  copies seven characters from index `0`, not the five in range.
+   */
   override def toString() = {
     val start = math.max(this.start, 0)
     val end = math.min(xs.length, start + length)

--- a/library/src/scala/runtime/EnumValue.scala
+++ b/library/src/scala/runtime/EnumValue.scala
@@ -3,9 +3,27 @@ package scala.runtime
 import language.experimental.captureChecking
 
 transparent trait EnumValue extends Product, Serializable:
+  /** Returns `true` if `that` is the same object as this one, by reference.
+   *
+   *  Each simple enum case is a singleton, so it can only compare equal to
+   *  itself.
+   *
+   *  @param that the value to compare with this enum value
+   */
   override def canEqual(that: Any) = this eq that.asInstanceOf[AnyRef]
+  /** Returns `0`: a simple enum case has no case fields. */
   override def productArity: Int = 0
+  /** Always throws: a simple enum case has no elements.
+   *
+   *  @param n the index of the requested element; no index is valid
+   *  @throws IndexOutOfBoundsException always, with `n` as its message
+   */
   override def productElement(n: Int): Any =
     throw IndexOutOfBoundsException(n.toString)
+  /** Always throws: a simple enum case has no elements.
+   *
+   *  @param n the index of the requested element name; no index is valid
+   *  @throws IndexOutOfBoundsException always, with `n` as its message
+   */
   override def productElementName(n: Int): String =
     throw IndexOutOfBoundsException(n.toString)

--- a/library/src/scala/runtime/FunctionXXL.scala
+++ b/library/src/scala/runtime/FunctionXXL.scala
@@ -12,5 +12,6 @@ trait FunctionXXL {
    */
   def apply(xs: IArray[Object]): Object
 
+  /** Returns the string `"<functionXXL>"`, mirroring the `"<functionN>"` rendering of the `Function0` to `Function22` traits. */
   override def toString() = "<functionXXL>"
 }

--- a/library/src/scala/runtime/LambdaDeserialize.scala
+++ b/library/src/scala/runtime/LambdaDeserialize.scala
@@ -21,6 +21,14 @@ import scala.collection.immutable
 
 import scala.language.`2.13`
 
+/** The per-class state behind the synthetic `$deserializeLambda$` method of
+ *  a class hosting lambdas: the class's lookup, a map from implementation
+ *  method name-and-descriptor keys to their method handles, and a cache of
+ *  deserialization factories keyed the same way.
+ *
+ *  Created by `LambdaDeserialize.bootstrap`, which the JVM invokes via
+ *  `invokedynamic`.
+ */
 final class LambdaDeserialize private (lookup: MethodHandles.Lookup, targetMethods: Array[MethodHandle]) {
   private val targetMethodMap: util.HashMap[String, MethodHandle] = new util.HashMap[String, MethodHandle](targetMethods.length)
 
@@ -32,10 +40,34 @@ final class LambdaDeserialize private (lookup: MethodHandles.Lookup, targetMetho
 
   private val cache = new util.HashMap[String, MethodHandle]
 
+  /** Returns an instance of the functional interface described by
+   *  `serialized`, delegating to [[LambdaDeserializer.deserializeLambda]]
+   *  with this instance's lookup, factory cache, and target method map.
+   *
+   *  @param serialized the serialized form of the lambda to deserialize
+   *  @throws IllegalArgumentException if the implementation method named by
+   *          `serialized` is not among this instance's target methods
+   */
   def deserializeLambda(serialized: SerializedLambda): AnyRef = LambdaDeserializer.deserializeLambda(lookup, cache, targetMethodMap, serialized)
 }
 
 object LambdaDeserialize {
+  /** Bootstrap method that the JVM invokes, via the `invokedynamic`
+   *  instruction in the synthetic `$deserializeLambda$` method of a class
+   *  hosting lambdas, to link that method's call site.
+   *
+   *  @param lookup the lookup of the class hosting the lambdas
+   *  @param invokedName never used
+   *  @param invokedType the type the call site's target is adapted to,
+   *                     taking a `SerializedLambda` and returning the
+   *                     deserialized object
+   *  @param targetMethods handles for the lambda implementation methods of
+   *                       the class, from which deserialization requests
+   *                       are resolved by name and descriptor
+   *  @return a `ConstantCallSite` whose target is `deserializeLambda` bound
+   *          to a `LambdaDeserialize` built over `lookup` and
+   *          `targetMethods`
+   */
   @varargs @throws[Throwable]
   def bootstrap(lookup: MethodHandles.Lookup, @unused invokedName: String, invokedType: MethodType, targetMethods: MethodHandle*): CallSite = {
     val targetMethodsArray = targetMethods.asInstanceOf[immutable.ArraySeq[?]].unsafeArray.asInstanceOf[Array[MethodHandle]]
@@ -43,5 +75,12 @@ object LambdaDeserialize {
     new ConstantCallSite(exact)
   }
 
+  /** Returns the key under which an implementation method is stored in the
+   *  target method map and factory cache: `name` concatenated with
+   *  `descriptor`.
+   *
+   *  @param name the name of the implementation method
+   *  @param descriptor the JVM method descriptor of its signature
+   */
   def nameAndDescriptorKey(name: String, descriptor: String): String = name + descriptor
 }

--- a/library/src/scala/runtime/LambdaDeserializer.scala
+++ b/library/src/scala/runtime/LambdaDeserializer.scala
@@ -51,6 +51,21 @@ object LambdaDeserializer {
     else result
   }
 
+  /** Deserializes a lambda like [[deserializeLambda]], but returns `null`
+   *  instead of throwing when the implementation method named by
+   *  `serialized` has no entry in `targetMethodMap`.
+   *
+   *  @param lookup      The factory for method handles. Must have access to the implementation method, the
+   *                    functional interface class, and `java.io.Serializable`.
+   *  @param cache       A cache used to avoid spinning up a class for each deserialization of a given lambda. May be `null`
+   *  @param targetMethodMap a mapping from lambda implementation method name and signature keys (as produced by
+   *                    `LambdaDeserialize.nameAndDescriptorKey`) to their `MethodHandle`s, used to look up the
+   *                    implementation method during deserialization. Must not be `null`
+   *  @param serialized  The lambda to deserialize. Note that this is typically created by the `readResolve`
+   *                    member of the anonymous class created by `LambdaMetaFactory`.
+   *  @return            an instance of the functional interface, or `null` if the implementation
+   *                    method is not found in `targetMethodMap`
+   */
   def deserializeLambdaOrNull(lookup: MethodHandles.Lookup, cache: java.util.Map[String, MethodHandle],
                               targetMethodMap: java.util.Map[String, MethodHandle], serialized: SerializedLambda): AnyRef | Null = {
     assert(targetMethodMap != null)

--- a/library/src/scala/runtime/LazyRef.scala
+++ b/library/src/scala/runtime/LazyRef.scala
@@ -19,155 +19,398 @@ import scala.language.`2.13`
 @SerialVersionUID(1L)
 class LazyRef[T] extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: T = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or `null` if no value has
+   *  been stored yet: check `initialized` before reading.
+   */
   def value: T = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: T): T = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyRef of: "` followed by the value if initialized, `"LazyRef thunk"` otherwise. */
   override def toString() = s"LazyRef ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Boolean` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyBoolean extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Boolean = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or `false` if no value has
+   *  been stored yet: check `initialized` before reading.
+   */
   def value: Boolean = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Boolean): Boolean = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyBoolean of: "` followed by the value if initialized, `"LazyBoolean thunk"` otherwise. */
   override def toString() = s"LazyBoolean ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Byte` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyByte extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Byte = compiletime.uninitialized
 
+  /** Returns the value stored by `initialize`, or `0` if no value has been
+   *  stored yet: check `initialized` before reading.
+   */
   def value: Byte = _value
 
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Byte): Byte = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyByte of: "` followed by the value if initialized, `"LazyByte thunk"` otherwise. */
   override def toString() = s"LazyByte ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Char` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyChar extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Char = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or the null character if no
+   *  value has been stored yet: check `initialized` before reading.
+   */
   def value: Char = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Char): Char = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyChar of: "` followed by the value if initialized, `"LazyChar thunk"` otherwise. */
   override def toString() = s"LazyChar ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Short` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyShort extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Short = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or `0` if no value has been
+   *  stored yet: check `initialized` before reading.
+   */
   def value: Short = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Short): Short = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyShort of: "` followed by the value if initialized, `"LazyShort thunk"` otherwise. */
   override def toString() = s"LazyShort ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Int` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyInt extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Int = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or `0` if no value has been
+   *  stored yet: check `initialized` before reading.
+   */
   def value: Int = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Int): Int = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyInt of: "` followed by the value if initialized, `"LazyInt thunk"` otherwise. */
   override def toString() = s"LazyInt ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Long` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyLong extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Long = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or `0` if no value has been
+   *  stored yet: check `initialized` before reading.
+   */
   def value: Long = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Long): Long = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyLong of: "` followed by the value if initialized, `"LazyLong thunk"` otherwise. */
   override def toString() = s"LazyLong ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Float` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyFloat extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Float = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or `0.0` if no value has
+   *  been stored yet: check `initialized` before reading.
+   */
   def value: Float = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Float): Float = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyFloat of: "` followed by the value if initialized, `"LazyFloat thunk"` otherwise. */
   override def toString() = s"LazyFloat ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Double` defined in a method.
+ *
+ *  Like [[LazyRef]], but specialized to avoid boxing: stores the value and
+ *  an initialized flag, set once by `initialize` under the
+ *  compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyDouble extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once a value has been stored by `initialize`.
+   *
+   *  The flag is volatile: after a read of `true`, a subsequent read of
+   *  `value` sees the value stored before the flag was set.
+   */
   def initialized = _initialized
 
   private var _value: Double = compiletime.uninitialized
+  /** Returns the value stored by `initialize`, or `0.0` if no value has
+   *  been stored yet: check `initialized` before reading.
+   */
   def value: Double = _value
+  /** Stores `value` and then sets the initialized flag, in that order, so
+   *  that a reader that observes `initialized` as `true` also observes the
+   *  stored value.
+   *
+   *  Performs no locking and does not check the flag: racing or repeated
+   *  calls each overwrite the stored value. The compiler-generated caller
+   *  ensures a single initialization by synchronizing on this holder.
+   *
+   *  @param value the computed value of the lazy val
+   *  @return `value`
+   */
   def initialize(value: Double): Double = {
     _value = value
     _initialized = true
     value
   }
 
+  /** Returns `"LazyDouble of: "` followed by the value if initialized, `"LazyDouble thunk"` otherwise. */
   override def toString() = s"LazyDouble ${if (_initialized) s"of: ${_value}" else "thunk"}"
 }
 
+/** A holder for a lazy val of type `Unit` defined in a method.
+ *
+ *  Like [[LazyRef]], but with no value to store: records only whether the
+ *  right-hand side has been evaluated, via a flag set once by `initialize`
+ *  under the compiler-generated caller's synchronization.
+ */
 @SerialVersionUID(1L)
 class LazyUnit extends Serializable {
   @volatile private var _initialized: Boolean = compiletime.uninitialized
+  /** Returns `true` once `initialize` has been called, that is, once the
+   *  right-hand side of the lazy val has been evaluated for its side
+   *  effects. The flag is volatile.
+   */
   def initialized = _initialized
 
+  /** Sets the initialized flag, recording that the right-hand side of the
+   *  lazy val has been evaluated. Performs no locking; the
+   *  compiler-generated caller synchronizes on this holder.
+   */
   def initialize(): Unit = _initialized = true
 
+  /** Returns `"LazyUnit"` if initialized, `"LazyUnit thunk"` otherwise. */
   override def toString() = s"LazyUnit${if (_initialized) "" else " thunk"}"
 }

--- a/library/src/scala/runtime/LazyVals.scala
+++ b/library/src/scala/runtime/LazyVals.scala
@@ -48,6 +48,14 @@ object LazyVals {
   /* ------------- Start of public API ------------- */
 
   // This trait extends Serializable to fix #16806 that caused a race condition
+  /** A state stored in the field of a lazy val other than an ordinary computed value:
+   *  [[Evaluating]] or a [[Waiting]] latch while the val is not yet bound, and
+   *  [[NullValue]], which is the permanent sentinel for a lazy val that evaluated to
+   *  `null`.
+   *
+   *  Extends `Serializable` so that an object can be serialized while one of
+   *  its lazy vals holds a control state (issue #16806).
+   */
   sealed trait LazyValControlState extends Serializable
 
   /**
@@ -84,8 +92,18 @@ object LazyVals {
    */
   object NullValue extends LazyValControlState
 
+  /** The number of bits each lazy val occupies in the bitmap field of its
+   *  enclosing class, encoding one of four states.
+   */
   final val BITS_PER_LAZY_VAL = 2L
 
+  /** Returns the state of the lazy val with ordinal `ord`, extracted from
+   *  the bitmap value `cur`.
+   *
+   *  @param cur the current value of the bitmap field
+   *  @param ord the ordinal of the lazy val within its bitmap
+   *  @return the 2-bit state, `0` to `3`
+   */
   def STATE(cur: Long, ord: Int): Long = {
     val r = (cur >> (ord * BITS_PER_LAZY_VAL)) & LAZY_VAL_MASK
     if (debug)
@@ -93,6 +111,19 @@ object LazyVals {
     r
   }
 
+  /** Attempts to atomically set the state of the lazy val with ordinal `ord`
+   *  to `v`, expecting the bitmap field at `offset` in `t` to still hold `e`.
+   *
+   *  The proposed bitmap value is `e` with the 2-bit slot of `ord` replaced
+   *  by `v`; the swap fails if the field no longer holds `e`.
+   *
+   *  @param t the object containing the bitmap field
+   *  @param offset the memory offset of the bitmap field in `t`
+   *  @param e the expected current value of the bitmap field
+   *  @param v the new state for the lazy val
+   *  @param ord the ordinal of the lazy val within its bitmap
+   *  @return `true` if the swap succeeded, `false` if the field changed
+   */
   def CAS(t: Object, offset: Long, e: Long, v: Int, ord: Int): Boolean = {
     if (debug)
       println(s"CAS($t, $offset, $e, $v, $ord)")
@@ -101,12 +132,36 @@ object LazyVals {
     unsafe.compareAndSwapLong(t, offset, e, n): @nowarn("cat=deprecation")
   }
 
+  /** Attempts to atomically replace the contents of the object field at
+   *  `offset` in `t` with `n`, expecting the field to still hold `exp`.
+   *
+   *  Used for lazy vals kept in a single object field that holds either the
+   *  computed value or a [[LazyValControlState]].
+   *
+   *  @param t the object containing the field
+   *  @param offset the memory offset of the field in `t`
+   *  @param exp the expected current value, compared by reference
+   *  @param n the value to store
+   *  @return `true` if the swap succeeded, `false` if the field changed
+   */
   def objCAS(t: Object, offset: Long, exp: Object, n: Object): Boolean = {
     if (debug)
       println(s"objCAS($t, $exp, $n)")
     unsafe.compareAndSwapObject(t, offset, exp, n): @nowarn("cat=deprecation")
   }
 
+  /** Sets the state of the lazy val with ordinal `ord` to `v`, retrying the
+   *  compare-and-swap until it succeeds.
+   *
+   *  If the state before the update was `2` (evaluating with waiting
+   *  threads), notifies all threads blocked in [[wait4Notification]] on the
+   *  val's monitor.
+   *
+   *  @param t the object containing the bitmap field
+   *  @param offset the memory offset of the bitmap field in `t`
+   *  @param v the new state for the lazy val
+   *  @param ord the ordinal of the lazy val within its bitmap
+   */
   def setFlag(t: Object, offset: Long, v: Int, ord: Int): Unit = {
     if (debug)
       println(s"setFlag($t, $offset, $v, $ord)")
@@ -127,6 +182,20 @@ object LazyVals {
     }
   }
 
+  /** Blocks until the lazy val with ordinal `ord` leaves the evaluating
+   *  states, that is, until the evaluating thread completes it via
+   *  [[setFlag]].
+   *
+   *  Moves state `1` (evaluating, no waiting threads) to `2` (evaluating
+   *  with waiting threads), then waits on the val's monitor while the state
+   *  remains `2`; returns once the state is neither `1` nor `2`.
+   *
+   *  @param t the object containing the bitmap field
+   *  @param offset the memory offset of the bitmap field in `t`
+   *  @param cur the bitmap value the caller last read; used only for debug
+   *             logging, the current value is re-read on each retry
+   *  @param ord the ordinal of the lazy val within its bitmap
+   */
   def wait4Notification(t: Object, offset: Long, cur: Long, ord: Int): Unit = {
     if (debug)
       println(s"wait4Notification($t, $offset, $cur, $ord)")
@@ -146,6 +215,13 @@ object LazyVals {
     }
   }
 
+  /** Returns the current value of the bitmap field at `off` in `t`, read
+   *  with volatile semantics.
+   *
+   *  @param t the object containing the bitmap field
+   *  @param off the memory offset of the bitmap field in `t`
+   *  @return the bitmap value holding the states of the lazy vals
+   */
   def get(t: Object, off: Long): Long = {
     if (debug)
       println(s"get($t, $off)")
@@ -153,6 +229,15 @@ object LazyVals {
   }
 
   // kept for backward compatibility
+  /** Returns the memory offset of the field named `name` declared in class
+   *  `clz`.
+   *
+   *  @param clz the class declaring the field
+   *  @param name the name of the field
+   *  @return the offset, suitable for the `offset` arguments of the other
+   *          members of this object
+   *  @throws NoSuchFieldException if `clz` declares no field named `name`
+   */
   def getOffset(clz: Class[?], name: String): Long = {
     @nowarn
     val r = unsafe.objectFieldOffset(clz.getDeclaredField(name))
@@ -161,6 +246,13 @@ object LazyVals {
     r
   }
 
+  /** Returns the memory offset of the given static field within the static
+   *  storage of its declaring class.
+   *
+   *  @param field the static field
+   *  @return the offset, suitable for the `offset` arguments of the other
+   *          members of this object
+   */
   def getStaticFieldOffset(field: java.lang.reflect.Field): Long = {
     @nowarn
     val r = unsafe.staticFieldOffset(field)
@@ -169,6 +261,12 @@ object LazyVals {
     r
   }
 
+  /** Returns the memory offset of the given instance field within instances
+   *  of its declaring class, suitable for the `offset` arguments of the
+   *  other members of this object.
+   *
+   *  @param field the instance field
+   */
   def getOffsetStatic(field: java.lang.reflect.Field) =
     @nowarn
     val r = unsafe.objectFieldOffset(field)
@@ -178,11 +276,17 @@ object LazyVals {
 
 
   object Names {
+    /** The name of the [[STATE]] method, for use by code generators. */
     final val state = "STATE"
+    /** The name of the [[CAS]] method, for use by code generators. */
     final val cas = "CAS"
+    /** The name of the [[setFlag]] method, for use by code generators. */
     final val setFlag = "setFlag"
+    /** The name of the [[wait4Notification]] method, for use by code generators. */
     final val wait4Notification = "wait4Notification"
+    /** The name of the [[get]] method, for use by code generators. */
     final val get = "get"
+    /** The name of the [[getOffset]] method, for use by code generators. */
     final val getOffset = "getOffset"
   }
 }

--- a/library/src/scala/runtime/ModuleSerializationProxy.scala
+++ b/library/src/scala/runtime/ModuleSerializationProxy.scala
@@ -38,6 +38,19 @@ private[runtime] object ModuleSerializationProxy {
   }
 }
 
+/** A serialization proxy written in place of a Scala `object` instance.
+ *
+ *  The compiler adds to every serializable static object a `writeReplace`
+ *  method that serializes an instance of this class instead of the object
+ *  itself. On deserialization, `readResolve` replaces the proxy with the
+ *  object's unique instance, obtained reflectively from the `MODULE$` field
+ *  of `moduleClass`, so deserialization yields the singleton rather than a
+ *  fresh copy. The lookup is cached per class where `java.lang.ClassValue` is
+ *  available, and repeated on each deserialization where it is not.
+ *
+ *  @param moduleClass the class of the object whose instance the proxy
+ *                     resolves to
+ */
 @SerialVersionUID(1L)
 final class ModuleSerializationProxy(moduleClass: Class[?]) extends Serializable {
   private def readResolve = ModuleSerializationProxy.instances.get(moduleClass)

--- a/library/src/scala/runtime/NonLocalReturnControl.scala
+++ b/library/src/scala/runtime/NonLocalReturnControl.scala
@@ -17,6 +17,25 @@ import scala.util.control.ControlThrowable
 
 // remove Unit specialization when binary compatibility permits
 // @annotation.nowarn("cat=lint-unit-specialization") TODO: Add warning back when specialization is implemented
+/** The control-flow throwable the compiler uses to implement a non-local
+ *  return, that is, a `return` inside a closure that exits the enclosing
+ *  method.
+ *
+ *  The compiler compiles such a `return` to throwing an instance of this
+ *  class, and wraps the body of the returned-from method in a handler that
+ *  catches it: the handler compares `key` with its own marker object by
+ *  reference and completes the method with `value` on a match, rethrowing
+ *  otherwise, so a throw always unwinds to the invocation it belongs to. As a
+ *  [[scala.util.control.ControlThrowable]] it carries no stack trace and is
+ *  not matched by `NonFatal`.
+ *
+ *  @param key the marker object identifying the method invocation to return
+ *             from; compared by reference by each enclosing handler
+ *  @param value the value returned by the method invocation identified by `key`
+ */
 class NonLocalReturnControl[@specialized(Byte, Short, Int, Long, Char, Float, Double, Boolean, Unit) T](val key: AnyRef, val value: T) extends ControlThrowable {
+  /** Returns `this` without recording a stack trace, keeping the throw cheap;
+   *  the exception exists purely for control flow.
+   */
   final override def fillInStackTrace(): Throwable = this
 }

--- a/library/src/scala/runtime/RichBoolean.scala
+++ b/library/src/scala/runtime/RichBoolean.scala
@@ -15,7 +15,16 @@ package runtime
 
 import scala.language.`2.13`
 
+/** A wrapper providing the comparison methods `<`, `<=`, `>`, `>=`, and
+ *  `compare` on `Boolean` values, using the ordering in which `false` is
+ *  less than `true`.
+ *
+ *  @param self the wrapped `Boolean` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichBoolean(val self: Boolean) extends AnyVal with OrderedProxy[Boolean] {
+  /** The `Ordering` evidence for `Boolean`, [[scala.math.Ordering.Boolean]],
+   *  which orders `false` before `true`.
+   */
   protected def ord: scala.math.Ordering.Boolean.type = scala.math.Ordering.Boolean
 }

--- a/library/src/scala/runtime/RichByte.scala
+++ b/library/src/scala/runtime/RichByte.scala
@@ -15,24 +15,51 @@ package runtime
 
 import scala.language.`2.13`
 
+/** A wrapper providing the additional methods available on `Byte` values,
+ *  such as `max`, `min`, and `abs`.
+ *
+ *  @param self the wrapped `Byte` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichByte(val self: Byte) extends AnyVal with ScalaWholeNumberProxy[Byte] {
+  /** The `Numeric` evidence for `Byte`, [[scala.math.Numeric.ByteIsIntegral]]. */
   protected def num: scala.math.Numeric.ByteIsIntegral.type = scala.math.Numeric.ByteIsIntegral
+  /** The `Ordering` evidence for `Byte`, [[scala.math.Ordering.Byte]]. */
   protected def ord: scala.math.Ordering.Byte.type = scala.math.Ordering.Byte
 
+  /** Returns the wrapped `Byte` converted to a `Double`; the conversion is exact. */
   override def doubleValue = self.toDouble
+  /** Returns the wrapped `Byte` converted to a `Float`; the conversion is exact. */
   override def floatValue  = self.toFloat
+  /** Returns the wrapped `Byte` converted to a `Long`; the conversion is exact. */
   override def longValue   = self.toLong
+  /** Returns the wrapped `Byte` converted to an `Int`; the conversion is exact. */
   override def intValue    = self.toInt
+  /** Returns the wrapped `Byte` itself. */
   override def byteValue   = self
+  /** Returns the wrapped `Byte` converted to a `Short`; the conversion is exact. */
   override def shortValue  = self.toShort
 
+  /** Always `true`, since the wrapped value is already a `Byte`. */
   override def isValidByte   = true
 
   // These method are all overridden and redefined to call out to scala.math to avoid 3 allocations:
   // the primitive boxing, the value class boxing and instantiation of the Numeric num.
   // We'd like to redefine signum and sign too but forwards binary compatibility doesn't allow us to.
+  /** Returns the absolute value of the wrapped `Byte`.
+   *
+   *  @note `Byte.MinValue` has no positive counterpart of type `Byte`, so
+   *        `(-128: Byte).abs` overflows and returns `Byte.MinValue` itself.
+   */
   override def abs: Byte             = math.abs(self).toByte
+  /** Returns the larger of the wrapped `Byte` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def max(that: Byte): Byte = math.max(self, that).toByte
+  /** Returns the smaller of the wrapped `Byte` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def min(that: Byte): Byte = math.min(self, that).toByte
 }

--- a/library/src/scala/runtime/RichChar.scala
+++ b/library/src/scala/runtime/RichChar.scala
@@ -15,54 +15,176 @@ package runtime
 
 import scala.language.`2.13`
 
+/** A wrapper providing the additional methods available on `Char` values:
+ *  comparisons, `to`/`until` range construction, and character classification
+ *  and conversion methods that delegate to `java.lang.Character`.
+ *
+ *  @param self the wrapped `Char` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichChar(val self: Char) extends AnyVal with IntegralProxy[Char] {
+  /** The `Integral` evidence for `Char`, [[scala.math.Numeric.CharIsIntegral]],
+   *  which does arithmetic on the character's integer value.
+   */
   protected def num: scala.math.Numeric.CharIsIntegral.type = scala.math.Numeric.CharIsIntegral
+  /** The `Ordering` evidence for `Char`, [[scala.math.Ordering.Char]], which
+   *  orders characters by their integer value.
+   */
   protected def ord: scala.math.Ordering.Char.type = scala.math.Ordering.Char
 
+  /** Returns this character's integer value (its UTF-16 code unit) as a `Double`. */
   override def doubleValue = self.toDouble
+  /** Returns this character's integer value (its UTF-16 code unit) as a `Float`. */
   override def floatValue  = self.toFloat
+  /** Returns this character's integer value (its UTF-16 code unit) as a `Long`. */
   override def longValue   = self.toLong
+  /** Returns this character's integer value (its UTF-16 code unit) as an `Int`. */
   override def intValue    = self.toInt
+  /** Returns the low 8 bits of this character's integer value as a `Byte`. */
   override def byteValue   = self.toByte
+  /** Returns this character's 16-bit integer value reinterpreted as a signed `Short`. */
   override def shortValue  = self.toShort
 
+  /** Always `true`, since the wrapped value is already a `Char`. */
   override def isValidChar   = true
 
   // These method are all overridden and redefined to call out to scala.math to avoid 3 allocations:
   // the primitive boxing, the value class boxing and instantiation of the Numeric num.
   // We'd like to redefine signum and sign too but forwards binary compatibility doesn't allow us to.
+  /** Returns this character unchanged: a `Char` is unsigned, so it is its own
+   *  absolute value.
+   */
   override def abs: Char             = self
+  /** Returns the larger of this character and `that`, comparing their integer
+   *  values.
+   *
+   *  @param that the character to compare with
+   */
   override def max(that: Char): Char = math.max(self.toInt, that.toInt).toChar
+  /** Returns the smaller of this character and `that`, comparing their integer
+   *  values.
+   *
+   *  @param that the character to compare with
+   */
   override def min(that: Char): Char = math.min(self.toInt, that.toInt).toChar
 
+  /** Returns the numeric value of this character as a digit in radix 36
+   *  (`Character.MAX_RADIX`), or -1 if it is not a valid digit in that radix.
+   *
+   *  Digits `'0'` to `'9'` map to 0 through 9, and letters `'a'` to `'z'` (in
+   *  either case) map to 10 through 35, so `'a'.asDigit` is 10. Digits and
+   *  letters from other Unicode ranges are converted as well.
+   */
   def asDigit: Int                      = Character.digit(self, Character.MAX_RADIX)
 
+  /** Returns `true` if this character is an ISO control character: in the
+   *  range U+0000 through U+001F or U+007F through U+009F.
+   */
   def isControl: Boolean                = Character.isISOControl(self)
+  /** Returns `true` if this character is a digit according to the Unicode
+   *  standard (general category Nd), such as `'7'` or a digit from another
+   *  script's decimal digit range.
+   */
   def isDigit: Boolean                  = Character.isDigit(self)
+  /** Returns `true` if this character is a Unicode letter (general category
+   *  Lu, Ll, Lt, Lm, or Lo).
+   */
   def isLetter: Boolean                 = Character.isLetter(self)
+  /** Returns `true` if this character is a Unicode letter or digit. */
   def isLetterOrDigit: Boolean          = Character.isLetterOrDigit(self)
+  /** Returns `true` if this character is white space according to Java: a
+   *  Unicode space character that is not a non-breaking space, or one of the
+   *  whitespace control characters such as tab, line feed, and carriage
+   *  return (see `java.lang.Character.isWhitespace`).
+   */
   def isWhitespace: Boolean             = Character.isWhitespace(self)
+  /** Returns `true` if this character is a Unicode space character (general
+   *  category Zs, Zl, or Zp). Unlike `isWhitespace`, this includes
+   *  non-breaking spaces but excludes controls such as tab and line feed.
+   */
   def isSpaceChar: Boolean              = Character.isSpaceChar(self)
+  /** Returns `true` if this character is a UTF-16 high-surrogate code unit
+   *  (U+D800 through U+DBFF), the first half of a surrogate pair.
+   */
   def isHighSurrogate: Boolean          = Character.isHighSurrogate(self)
+  /** Returns `true` if this character is a UTF-16 low-surrogate code unit
+   *  (U+DC00 through U+DFFF), the second half of a surrogate pair.
+   */
   def isLowSurrogate: Boolean           = Character.isLowSurrogate(self)
+  /** Returns `true` if this character is a surrogate code unit, either high
+   *  or low.
+   */
   def isSurrogate: Boolean              = isHighSurrogate || isLowSurrogate
+  /** Returns `true` if this character is permissible as the first character
+   *  of a Unicode identifier.
+   */
   def isUnicodeIdentifierStart: Boolean = Character.isUnicodeIdentifierStart(self)
+  /** Returns `true` if this character is permissible after the first
+   *  character of a Unicode identifier.
+   */
   def isUnicodeIdentifierPart: Boolean  = Character.isUnicodeIdentifierPart(self)
+  /** Returns `true` if this character is ignorable in a Java or Unicode
+   *  identifier: a non-whitespace ISO control character or a formatting
+   *  character (general category Cf).
+   */
   def isIdentifierIgnorable: Boolean    = Character.isIdentifierIgnorable(self)
+  /** Returns `true` if this character is mirrored according to the Unicode
+   *  specification, that is, its glyph is mirrored horizontally when
+   *  displayed in right-to-left text, as `'('` is.
+   */
   def isMirrored: Boolean               = Character.isMirrored(self)
 
+  /** Returns `true` if this character is a lowercase character. */
   def isLower: Boolean                  = Character.isLowerCase(self)
+  /** Returns `true` if this character is an uppercase character. */
   def isUpper: Boolean                  = Character.isUpperCase(self)
+  /** Returns `true` if this character is a titlecase letter (general
+   *  category Lt), such as `'ǅ'`.
+   */
   def isTitleCase: Boolean              = Character.isTitleCase(self)
 
+  /** Returns the lowercase form of this character if it has one, or the
+   *  character itself otherwise.
+   *
+   *  The mapping uses Unicode case information but is locale-insensitive and
+   *  can only map one character to one character; for locale-sensitive text,
+   *  use the `toLowerCase` method of `String` instead.
+   */
   def toLower: Char                     = Character.toLowerCase(self)
+  /** Returns the uppercase form of this character if it has one, or the
+   *  character itself otherwise.
+   *
+   *  The mapping uses Unicode case information but is locale-insensitive and
+   *  can only map one character to one character; for locale-sensitive text,
+   *  use the `toUpperCase` method of `String` instead.
+   */
   def toUpper: Char                     = Character.toUpperCase(self)
+  /** Returns the titlecase form of this character if it has one; otherwise
+   *  its uppercase form if it has one; otherwise the character itself.
+   */
   def toTitleCase: Char                 = Character.toTitleCase(self)
 
+  /** Returns an `Int` code for this character's Unicode general category,
+   *  equal to one of the category constants of `java.lang.Character` such as
+   *  `Character.UPPERCASE_LETTER`.
+   */
   def getType: Int                      = Character.getType(self)
+  /** Returns the `Int` value this character represents, such as 5 for `'5'`;
+   *  letters map to 10 through 35 regardless of case, so both `'A'` and
+   *  `'a'` yield 10. Returns -1 if the character has no numeric value, or -2
+   *  if its numeric value is negative or not an integer (as for fraction
+   *  characters).
+   */
   def getNumericValue: Int              = Character.getNumericValue(self)
+  /** Returns the Unicode directionality of this character as a `Byte`, equal
+   *  to one of the `DIRECTIONALITY_` constants of `java.lang.Character`;
+   *  `Character.DIRECTIONALITY_UNDEFINED` if the directionality is
+   *  undefined.
+   */
   def getDirectionality: Byte           = Character.getDirectionality(self)
+  /** Returns the character obtained by swapping the two bytes of this
+   *  character's 16-bit value.
+   */
   def reverseBytes: Char                = Character.reverseBytes(self)
 
   // Java 5 Character methods not added:

--- a/library/src/scala/runtime/RichDouble.scala
+++ b/library/src/scala/runtime/RichDouble.scala
@@ -15,47 +15,136 @@ package runtime
 
 import scala.language.`2.13`
 
+/** A wrapper providing the additional methods available on `Double` values,
+ *  such as `isNaN`, `round`, `ceil`, and `floor`.
+ *
+ *  @param self the wrapped `Double` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichDouble(val self: Double) extends AnyVal with FractionalProxy[Double] {
+  /** The `Fractional` evidence for `Double`, [[scala.math.Numeric.DoubleIsFractional]]. */
   protected def num: Fractional[Double] = scala.math.Numeric.DoubleIsFractional
+  /** The `Ordering` evidence for `Double`:
+   *  [[scala.math.Ordering.Double.TotalOrdering]], a total ordering in which
+   *  `NaN` is greater than every other value and -0.0 is less than 0.0.
+   *  The comparison operators `<`, `<=`, `>`, and `>=` inherited from
+   *  [[scala.math.Ordered]] use this ordering.
+   */
   protected def ord: Ordering[Double]   = scala.math.Ordering.Double.TotalOrdering
 
+  /** Returns the wrapped `Double` itself. */
   override def doubleValue = self
+  /** Returns the wrapped `Double` converted to the nearest `Float`; the
+   *  conversion may round, since a `Float` has only 24 bits of precision,
+   *  and magnitudes beyond the `Float` range convert to the infinities.
+   */
   override def floatValue  = self.toFloat
+  /** Returns the wrapped `Double` truncated toward zero to a `Long`; `NaN`
+   *  converts to 0, and values outside the `Long` range to `Long.MinValue`
+   *  or `Long.MaxValue`.
+   */
   override def longValue   = self.toLong
+  /** Returns the wrapped `Double` truncated toward zero to an `Int`; `NaN`
+   *  converts to 0, and values outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`.
+   */
   override def intValue    = self.toInt
+  /** Returns the wrapped `Double` truncated to an `Int` as by `intValue` and
+   *  then narrowed to its low 8 bits as a `Byte`.
+   */
   override def byteValue   = self.toByte
+  /** Returns the wrapped `Double` truncated to an `Int` as by `intValue` and
+   *  then narrowed to its low 16 bits as a `Short`.
+   */
   override def shortValue  = self.toShort
 
+  /** Returns `true` if the wrapped `Double` is a whole number: finite with
+   *  no fractional part. `NaN` and the infinities are not whole.
+   */
   override def isWhole = {
     val l = self.toLong
     l.toDouble == self || l == Long.MaxValue && self < Double.PositiveInfinity || l == Long.MinValue && self > Double.NegativeInfinity
   }
+  /** Returns `true` if the wrapped `Double` exactly represents an integer in
+   *  the `Byte` range, -128 to 127.
+   */
   override def isValidByte  = self.toByte.toDouble == self
+  /** Returns `true` if the wrapped `Double` exactly represents an integer in
+   *  the `Short` range, -32768 to 32767.
+   */
   override def isValidShort = self.toShort.toDouble == self
+  /** Returns `true` if the wrapped `Double` exactly represents an integer in
+   *  the `Char` range, 0 to 65535.
+   */
   override def isValidChar  = self.toChar.toDouble == self
+  /** Returns `true` if the wrapped `Double` represents an integer in the
+   *  `Int` range, `Int.MinValue` to `Int.MaxValue`; every such integer is
+   *  exactly representable as a `Double`.
+   */
   override def isValidInt   = self.toInt.toDouble == self
   // override def isValidLong = { val l = self.toLong; l.toDouble == self && l != Long.MaxValue }
   // override def isValidFloat = self.toFloat.toDouble == self
   // override def isValidDouble = !java.lang.Double.isNaN(self)
 
+  /** Returns `true` if the wrapped `Double` is `NaN` (not a number).
+   *
+   *  `NaN` is not equal to itself, so `== Double.NaN` is always `false`; use
+   *  this method to test for `NaN`.
+   */
   def isNaN: Boolean         = java.lang.Double.isNaN(self)
+  /** Returns `true` if the wrapped `Double` is `Double.PositiveInfinity` or
+   *  `Double.NegativeInfinity`.
+   */
   def isInfinity: Boolean    = java.lang.Double.isInfinite(self)
+  /** Returns `true` if the wrapped `Double` is neither infinite nor `NaN`. */
   def isFinite: Boolean      = java.lang.Double.isFinite(self)
+  /** Returns `true` if the wrapped `Double` is `Double.PositiveInfinity`. */
   def isPosInfinity: Boolean = Double.PositiveInfinity == self
+  /** Returns `true` if the wrapped `Double` is `Double.NegativeInfinity`. */
   def isNegInfinity: Boolean = Double.NegativeInfinity == self
 
   // These method are all overridden and redefined to call out to scala.math to avoid 3 allocations:
   // the primitive boxing, the value class boxing and instantiation of the Numeric num.
   // We'd like to redefine sign too but forwards binary compatibility doesn't allow us to.
+  /** Returns the absolute value of the wrapped `Double`: `-0.0.abs` is
+   *  `0.0`, both infinities map to `Double.PositiveInfinity`, and `NaN` maps
+   *  to `NaN`.
+   */
   override def abs: Double               = math.abs(self)
+  /** Returns the larger of the wrapped `Double` and `that`. If either value
+   *  is `NaN`, the result is `NaN`; 0.0 is larger than -0.0.
+   *
+   *  @param that the value to compare with
+   */
   override def max(that: Double): Double = math.max(self, that)
+  /** Returns the smaller of the wrapped `Double` and `that`. If either value
+   *  is `NaN`, the result is `NaN`; -0.0 is smaller than 0.0.
+   *
+   *  @param that the value to compare with
+   */
   override def min(that: Double): Double = math.min(self, that)
+  /** Returns the sign of the wrapped `Double` as an `Int`: -1 if it is
+   *  negative, 1 if it is positive, and 0 if it is zero; `-0.0` and `NaN`
+   *  also yield 0.
+   */
   @deprecated("signum does not handle -0.0 or Double.NaN; use `sign` method instead", since = "2.13.0")
   override def signum: Int               = math.signum(self).toInt
 
+  /** Returns the wrapped `Double` rounded to the nearest `Long`, with ties
+   *  rounded upward: `0.5.round` is 1 and `(-0.5).round` is 0. `NaN` rounds
+   *  to 0, and values beyond the `Long` range to `Long.MinValue` or
+   *  `Long.MaxValue`.
+   */
   def round: Long   = math.round(self)
+  /** Returns the smallest `Double` that is greater than or equal to the
+   *  wrapped value and equals a mathematical integer; `NaN`, the infinities,
+   *  and values already equal to an integer return themselves.
+   */
   def ceil: Double  = math.ceil(self)
+  /** Returns the largest `Double` that is less than or equal to the wrapped
+   *  value and equals a mathematical integer; `NaN`, the infinities, and
+   *  values already equal to an integer return themselves.
+   */
   def floor: Double = math.floor(self)
 
   /** Converts an angle measured in degrees to an approximately equivalent

--- a/library/src/scala/runtime/RichFloat.scala
+++ b/library/src/scala/runtime/RichFloat.scala
@@ -15,47 +15,134 @@ package runtime
 
 import scala.language.`2.13`
 
+/** A wrapper providing the additional methods available on `Float` values,
+ *  such as `isNaN`, `round`, `ceil`, and `floor`.
+ *
+ *  @param self the wrapped `Float` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichFloat(val self: Float) extends AnyVal with FractionalProxy[Float] {
+  /** The `Fractional` evidence for `Float`, [[scala.math.Numeric.FloatIsFractional]]. */
   protected def num: Fractional[Float] = scala.math.Numeric.FloatIsFractional
+  /** The `Ordering` evidence for `Float`:
+   *  [[scala.math.Ordering.Float.TotalOrdering]], a total ordering in which
+   *  `NaN` is greater than every other value and -0.0f is less than 0.0f.
+   *  The comparison operators `<`, `<=`, `>`, and `>=` inherited from
+   *  [[scala.math.Ordered]] use this ordering.
+   */
   protected def ord: Ordering[Float]   = scala.math.Ordering.Float.TotalOrdering
 
+  /** Returns the wrapped `Float` converted to a `Double`; the conversion is exact. */
   override def doubleValue = self.toDouble
+  /** Returns the wrapped `Float` itself. */
   override def floatValue  = self
+  /** Returns the wrapped `Float` truncated toward zero to a `Long`; `NaN`
+   *  converts to 0, and values outside the `Long` range to `Long.MinValue`
+   *  or `Long.MaxValue`.
+   */
   override def longValue   = self.toLong
+  /** Returns the wrapped `Float` truncated toward zero to an `Int`; `NaN`
+   *  converts to 0, and values outside the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`.
+   */
   override def intValue    = self.toInt
+  /** Returns the wrapped `Float` truncated to an `Int` as by `intValue` and
+   *  then narrowed to its low 8 bits as a `Byte`.
+   */
   override def byteValue   = self.toByte
+  /** Returns the wrapped `Float` truncated to an `Int` as by `intValue` and
+   *  then narrowed to its low 16 bits as a `Short`.
+   */
   override def shortValue  = self.toShort
 
+  /** Returns `true` if the wrapped `Float` is a whole number: finite with no
+   *  fractional part. `NaN` and the infinities are not whole.
+   */
   override def isWhole = {
     val l = self.toLong
     l.toFloat == self || l == Long.MaxValue && self < Float.PositiveInfinity || l == Long.MinValue && self > Float.NegativeInfinity
   }
+  /** Returns `true` if the wrapped `Float` exactly represents an integer in
+   *  the `Byte` range, -128 to 127.
+   */
   override def isValidByte  = self.toByte.toFloat == self
+  /** Returns `true` if the wrapped `Float` exactly represents an integer in
+   *  the `Short` range, -32768 to 32767.
+   */
   override def isValidShort = self.toShort.toFloat == self
+  /** Returns `true` if the wrapped `Float` exactly represents an integer in
+   *  the `Char` range, 0 to 65535.
+   */
   override def isValidChar  = self.toChar.toFloat == self
+  /** Returns `true` if the wrapped `Float` exactly represents an integer in
+   *  the `Int` range. Since a `Float` has only 24 bits of precision, no
+   *  `Float` equals `Int.MaxValue`, and large in-range integers are only
+   *  valid if they are exactly representable.
+   */
   override def isValidInt   = { val i = self.toInt; i.toFloat == self && i != Int.MaxValue }
   // override def isValidLong = { val l = self.toLong; l.toFloat == self && l != Long.MaxValue }
   // override def isValidFloat = !java.lang.Float.isNaN(self)
   // override def isValidDouble = !java.lang.Float.isNaN(self)
 
+  /** Returns `true` if the wrapped `Float` is `NaN` (not a number).
+   *
+   *  `NaN` is not equal to itself, so `== Float.NaN` is always `false`; use
+   *  this method to test for `NaN`.
+   */
   def isNaN: Boolean         = java.lang.Float.isNaN(self)
+  /** Returns `true` if the wrapped `Float` is `Float.PositiveInfinity` or
+   *  `Float.NegativeInfinity`.
+   */
   def isInfinity: Boolean    = java.lang.Float.isInfinite(self)
+  /** Returns `true` if the wrapped `Float` is neither infinite nor `NaN`. */
   def isFinite: Boolean      = java.lang.Float.isFinite(self)
+  /** Returns `true` if the wrapped `Float` is `Float.PositiveInfinity`. */
   def isPosInfinity: Boolean = Float.PositiveInfinity == self
+  /** Returns `true` if the wrapped `Float` is `Float.NegativeInfinity`. */
   def isNegInfinity: Boolean = Float.NegativeInfinity == self
 
   // These method are all overridden and redefined to call out to scala.math to avoid 3 allocations:
   // the primitive boxing, the value class boxing and instantiation of the Numeric num.
   // We'd like to redefine sign too but forwards binary compatibility doesn't allow us to.
+  /** Returns the absolute value of the wrapped `Float`: `-0.0f.abs` is
+   *  `0.0f`, both infinities map to `Float.PositiveInfinity`, and `NaN` maps
+   *  to `NaN`.
+   */
   override def abs: Float              = math.abs(self)
+  /** Returns the larger of the wrapped `Float` and `that`. If either value
+   *  is `NaN`, the result is `NaN`; 0.0f is larger than -0.0f.
+   *
+   *  @param that the value to compare with
+   */
   override def max(that: Float): Float = math.max(self, that)
+  /** Returns the smaller of the wrapped `Float` and `that`. If either value
+   *  is `NaN`, the result is `NaN`; -0.0f is smaller than 0.0f.
+   *
+   *  @param that the value to compare with
+   */
   override def min(that: Float): Float = math.min(self, that)
+  /** Returns the sign of the wrapped `Float` as an `Int`: -1 if it is
+   *  negative, 1 if it is positive, and 0 if it is zero; `-0.0f` and `NaN`
+   *  also yield 0.
+   */
   @deprecated("signum does not handle -0.0f or Float.NaN; use `sign` method instead", since = "2.13.0")
   override def signum: Int             = math.signum(self).toInt
 
+  /** Returns the wrapped `Float` rounded to the nearest `Int`, with ties
+   *  rounded upward: `0.5f.round` is 1 and `(-0.5f).round` is 0. `NaN`
+   *  rounds to 0, and values beyond the `Int` range to `Int.MinValue` or
+   *  `Int.MaxValue`.
+   */
   def round: Int   = math.round(self)
+  /** Returns the smallest `Float` that is greater than or equal to the
+   *  wrapped value and equals a mathematical integer; `NaN`, the infinities,
+   *  and values already equal to an integer return themselves.
+   */
   def ceil: Float  = math.ceil(self.toDouble).toFloat
+  /** Returns the largest `Float` that is less than or equal to the wrapped
+   *  value and equals a mathematical integer; `NaN`, the infinities, and
+   *  values already equal to an integer return themselves.
+   */
   def floor: Float = math.floor(self.toDouble).toFloat
 
   /** Converts an angle measured in degrees to an approximately equivalent

--- a/library/src/scala/runtime/RichInt.scala
+++ b/library/src/scala/runtime/RichInt.scala
@@ -18,40 +18,85 @@ import scala.collection.immutable.Range
 
 // Note that this does not implement IntegralProxy[Int] so that it can return
 // the Int-specific Range class from until/to.
+/** A wrapper providing the additional methods available on `Int` values, such
+ *  as `max`, `abs`, `toHexString`, and the `to` and `until` range
+ *  constructors.
+ *
+ *  @param self the wrapped `Int` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichInt(val self: Int) extends AnyVal with ScalaNumberProxy[Int] with RangedProxy[Int] {
+  /** The `Numeric` evidence for `Int`, [[scala.math.Numeric.IntIsIntegral]]. */
   protected def num: scala.math.Numeric.IntIsIntegral.type = scala.math.Numeric.IntIsIntegral
+  /** The `Ordering` evidence for `Int`, [[scala.math.Ordering.Int]]. */
   protected def ord: scala.math.Ordering.Int.type = scala.math.Ordering.Int
 
+  /** Returns the wrapped `Int` converted to a `Double`; the conversion is exact. */
   override def doubleValue = self.toDouble
+  /** Returns the wrapped `Int` converted to a `Float`; magnitudes above 2^24^
+   *  may be rounded, since a `Float` has only 24 bits of precision.
+   */
   override def floatValue  = self.toFloat
+  /** Returns the wrapped `Int` converted to a `Long`; the conversion is exact. */
   override def longValue   = self.toLong
+  /** Returns the wrapped `Int` itself. */
   override def intValue    = self
+  /** Returns the low 8 bits of the wrapped `Int` as a `Byte`. */
   override def byteValue   = self.toByte
+  /** Returns the low 16 bits of the wrapped `Int` as a `Short`. */
   override def shortValue  = self.toShort
 
-  /** Returns `**true**` if this number has no decimal component.
-   *  Always `**true**` for `RichInt`.
+  /** Returns `true` if this number has no decimal component.
+   *  Always `true` for `RichInt`.
    */
   @deprecated("isWhole on an integer type is always true", "2.12.15")
   def isWhole = true
 
+  /** Always `true`, since the wrapped value is already an `Int`. */
   override def isValidInt   = true
+  /** Always `true`, since every `Int` value fits in a `Long`. */
   def isValidLong  = true
 
   // These method are all overridden and redefined to call out to scala.math to avoid 3 allocations:
   // the primitive boxing, the value class boxing and instantiation of the Numeric num.
   // We'd like to redefine signum and sign too but forwards binary compatibility doesn't allow us to.
+  /** Returns the absolute value of the wrapped `Int`.
+   *
+   *  @note `Int.MinValue` has no positive counterpart of type `Int`, so
+   *        `Int.MinValue.abs` overflows and returns `Int.MinValue` itself.
+   */
   override def abs: Int            = math.abs(self)
+  /** Returns the larger of the wrapped `Int` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def max(that: Int): Int = math.max(self, that)
+  /** Returns the smaller of the wrapped `Int` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def min(that: Int): Int = math.min(self, that)
 
   /** There is no reason to round an `Int`, but this method is provided to avoid accidental loss of precision from a detour through `Float`. */
   @deprecated("this is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")
   def round: Int = self
 
+  /** Returns the wrapped `Int`'s 32-bit two's-complement value as an unsigned
+   *  base-2 string with no sign and no leading zeros: `255.toBinaryString` is
+   *  `"11111111"`, and `(-1).toBinaryString` is a string of thirty-two `'1'`
+   *  characters.
+   */
   def toBinaryString: String = java.lang.Integer.toBinaryString(self)
+  /** Returns the wrapped `Int`'s 32-bit two's-complement value as an unsigned
+   *  base-16 string with no sign, no leading zeros, and lowercase digits
+   *  `a` to `f`: `255.toHexString` is `"ff"`, and `(-1).toHexString` is
+   *  `"ffffffff"`.
+   */
   def toHexString: String    = java.lang.Integer.toHexString(self)
+  /** Returns the wrapped `Int`'s 32-bit two's-complement value as an unsigned
+   *  base-8 string with no sign and no leading zeros: `8.toOctalString` is
+   *  `"10"`.
+   */
   def toOctalString: String  = java.lang.Integer.toOctalString(self)
 
   type ResultWithoutStep = Range

--- a/library/src/scala/runtime/RichLong.scala
+++ b/library/src/scala/runtime/RichLong.scala
@@ -15,21 +15,51 @@ package runtime
 
 import scala.language.`2.13`
 
+/** A wrapper providing the additional methods available on `Long` values,
+ *  such as `max`, `abs`, `toHexString`, and the `to` and `until` range
+ *  constructors.
+ *
+ *  @param self the wrapped `Long` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
+  /** The `Integral` evidence for `Long`, [[scala.math.Numeric.LongIsIntegral]]. */
   protected def num: scala.math.Numeric.LongIsIntegral.type = scala.math.Numeric.LongIsIntegral
+  /** The `Ordering` evidence for `Long`, [[scala.math.Ordering.Long]]. */
   protected def ord: scala.math.Ordering.Long.type = scala.math.Ordering.Long
 
+  /** Returns the wrapped `Long` converted to a `Double`; magnitudes above
+   *  2^53^ may be rounded, since a `Double` has only 53 bits of precision.
+   */
   override def doubleValue = self.toDouble
+  /** Returns the wrapped `Long` converted to a `Float`; magnitudes above
+   *  2^24^ may be rounded, since a `Float` has only 24 bits of precision.
+   */
   override def floatValue  = self.toFloat
+  /** Returns the wrapped `Long` itself. */
   override def longValue   = self
+  /** Returns the low 32 bits of the wrapped `Long` as an `Int`. */
   override def intValue    = self.toInt
+  /** Returns the low 8 bits of the wrapped `Long` as a `Byte`. */
   override def byteValue   = self.toByte
+  /** Returns the low 16 bits of the wrapped `Long` as a `Short`. */
   override def shortValue  = self.toShort
 
+  /** Returns `true` if the wrapped `Long` fits in a `Byte`, that is, lies
+   *  between -128 and 127 inclusive.
+   */
   override def isValidByte  = self.toByte.toLong == self
+  /** Returns `true` if the wrapped `Long` fits in a `Short`, that is, lies
+   *  between -32768 and 32767 inclusive.
+   */
   override def isValidShort = self.toShort.toLong == self
+  /** Returns `true` if the wrapped `Long` fits in a `Char`, that is, lies
+   *  between 0 and 65535 inclusive.
+   */
   override def isValidChar  = self.toChar.toLong == self
+  /** Returns `true` if the wrapped `Long` fits in an `Int`, that is, lies
+   *  between `Int.MinValue` and `Int.MaxValue` inclusive.
+   */
   override def isValidInt   = self.toInt.toLong == self
            def isValidLong  = true
   // override def isValidFloat = self.toFloat.toLong == self && self != Long.MaxValue
@@ -38,15 +68,42 @@ final class RichLong(val self: Long) extends AnyVal with IntegralProxy[Long] {
   // These method are all overridden and redefined to call out to scala.math to avoid 3 allocations:
   // the primitive boxing, the value class boxing and instantiation of the Numeric num.
   // We'd like to redefine signum and sign too but forwards binary compatibility doesn't allow us to.
+  /** Returns the absolute value of the wrapped `Long`.
+   *
+   *  @note `Long.MinValue` has no positive counterpart of type `Long`, so
+   *        `Long.MinValue.abs` overflows and returns `Long.MinValue` itself.
+   */
   override def abs: Long             = math.abs(self)
+  /** Returns the larger of the wrapped `Long` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def max(that: Long): Long = math.max(self, that)
+  /** Returns the smaller of the wrapped `Long` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def min(that: Long): Long = math.min(self, that)
 
   /** There is no reason to round a `Long`, but this method is provided to avoid accidental conversion to `Int` through `Float`. */
   @deprecated("this is an integer type; there is no reason to round it.  Perhaps you meant to call this on a floating-point value?", "2.11.0")
   def round: Long = self
 
+  /** Returns the wrapped `Long`'s 64-bit two's-complement value as an
+   *  unsigned base-2 string with no sign and no leading zeros:
+   *  `255L.toBinaryString` is `"11111111"`, and `(-1L).toBinaryString` is a
+   *  string of sixty-four `'1'` characters.
+   */
   def toBinaryString: String = java.lang.Long.toBinaryString(self)
+  /** Returns the wrapped `Long`'s 64-bit two's-complement value as an
+   *  unsigned base-16 string with no sign, no leading zeros, and lowercase
+   *  digits `a` to `f`: `255L.toHexString` is `"ff"`, and `(-1L).toHexString`
+   *  is a string of sixteen `'f'` characters.
+   */
   def toHexString: String    = java.lang.Long.toHexString(self)
+  /** Returns the wrapped `Long`'s 64-bit two's-complement value as an
+   *  unsigned base-8 string with no sign and no leading zeros:
+   *  `8L.toOctalString` is `"10"`.
+   */
   def toOctalString: String  = java.lang.Long.toOctalString(self)
 }

--- a/library/src/scala/runtime/RichShort.scala
+++ b/library/src/scala/runtime/RichShort.scala
@@ -15,24 +15,52 @@ package runtime
 
 import scala.language.`2.13`
 
+/** A wrapper providing the additional methods available on `Short` values,
+ *  such as `max`, `min`, and `abs`.
+ *
+ *  @param self the wrapped `Short` value
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 final class RichShort(val self: Short) extends AnyVal with ScalaWholeNumberProxy[Short] {
+  /** The `Numeric` evidence for `Short`, [[scala.math.Numeric.ShortIsIntegral]]. */
   protected def num: scala.math.Numeric.ShortIsIntegral.type = scala.math.Numeric.ShortIsIntegral
+  /** The `Ordering` evidence for `Short`, [[scala.math.Ordering.Short]]. */
   protected def ord: scala.math.Ordering.Short.type = scala.math.Ordering.Short
 
+  /** Returns the wrapped `Short` converted to a `Double`; the conversion is exact. */
   override def doubleValue = self.toDouble
+  /** Returns the wrapped `Short` converted to a `Float`; the conversion is exact. */
   override def floatValue  = self.toFloat
+  /** Returns the wrapped `Short` converted to a `Long`; the conversion is exact. */
   override def longValue   = self.toLong
+  /** Returns the wrapped `Short` converted to an `Int`; the conversion is exact. */
   override def intValue    = self.toInt
+  /** Returns the low 8 bits of the wrapped `Short` as a `Byte`. */
   override def byteValue   = self.toByte
+  /** Returns the wrapped `Short` itself. */
   override def shortValue  = self
 
+  /** Always `true`, since the wrapped value is already a `Short`. */
   override def isValidShort  = true
 
   // These method are all overridden and redefined to call out to scala.math to avoid 3 allocations:
   // the primitive boxing, the value class boxing and instantiation of the Numeric num.
   // We'd like to redefine signum and sign too but forwards binary compatibility doesn't allow us to.
+  /** Returns the absolute value of the wrapped `Short`.
+   *
+   *  @note `Short.MinValue` has no positive counterpart of type `Short`, so
+   *        `(-32768: Short).abs` overflows and returns `Short.MinValue`
+   *        itself.
+   */
   override def abs: Short              = math.abs(self.toInt).toShort
+  /** Returns the larger of the wrapped `Short` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def max(that: Short): Short = math.max(self.toInt, that.toInt).toShort
+  /** Returns the smaller of the wrapped `Short` and `that`.
+   *
+   *  @param that the value to compare with
+   */
   override def min(that: Short): Short = math.min(self.toInt, that.toInt).toShort
 }

--- a/library/src/scala/runtime/Scala3RunTime.scala
+++ b/library/src/scala/runtime/Scala3RunTime.scala
@@ -6,9 +6,20 @@ object Scala3RunTime:
 
   // Called by inline def assert's. Extracted to minimize the bytecode size at call site.
 
+  /** Throws an `AssertionError` whose message is `"assertion failed: "`
+   *  followed by `message`.
+   *
+   *  @param message the explanation of the failed assertion, appended to the
+   *                 fixed prefix
+   *  @throws java.lang.AssertionError always
+   */
   def assertFailed(message: Any): Nothing =
     throw new java.lang.AssertionError("assertion failed: " + message)
 
+  /** Throws an `AssertionError` with the fixed message `"assertion failed"`.
+   *
+   *  @throws java.lang.AssertionError always
+   */
   def assertFailed(): Nothing =
     throw new java.lang.AssertionError("assertion failed")
 

--- a/library/src/scala/runtime/ScalaNumberProxy.scala
+++ b/library/src/scala/runtime/ScalaNumberProxy.scala
@@ -23,76 +23,197 @@ import immutable.NumericRange
  */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 trait ScalaNumberProxy[T] extends Any with ScalaNumericAnyConversions with Proxy.Typed[T] with OrderedProxy[T] {
+  /** The `Numeric` evidence for `T`, used to implement the arithmetic and
+   *  comparison operations of this proxy.
+   */
   protected implicit def num: Numeric[T]
 
+  /** Returns the wrapped value converted to a `Double` by the `Numeric` evidence. */
   def doubleValue = num.toDouble(self)
+  /** Returns the wrapped value converted to a `Float` by the `Numeric` evidence. */
   def floatValue  = num.toFloat(self)
+  /** Returns the wrapped value converted to a `Long` by the `Numeric` evidence. */
   def longValue   = num.toLong(self)
+  /** Returns the wrapped value converted to an `Int` by the `Numeric` evidence. */
   def intValue    = num.toInt(self)
+  /** Returns the wrapped value converted to an `Int` and then narrowed to its low 8 bits as a `Byte`. */
   def byteValue   = intValue.toByte
+  /** Returns the wrapped value converted to an `Int` and then narrowed to its low 16 bits as a `Short`. */
   def shortValue  = intValue.toShort
 
-  /** Returns `**this**` if `**this** < that` or `that` otherwise.
+  /** Returns `this` if `this < that` or `that` otherwise.
    *
    *  @param that the value to compare against for finding the minimum
    *  @return the smaller of `this` and `that`
    */
   def min(that: T): T = num.min(self, that)
-  /** Returns `**this**` if `**this** > that` or `that` otherwise.
+  /** Returns `this` if `this > that` or `that` otherwise.
    *
    *  @param that the value to compare against for finding the maximum
    *  @return the larger of `this` and `that`
    */
   def max(that: T): T = num.max(self, that)
-  /** Returns the absolute value of `**this**`. */
+  /** Returns the absolute value of `this`. */
   def abs             = num.abs(self)
-  /** Returns the sign of `**this**`.
+  /** Returns the sign of `this`.
    *  zero if the argument is zero, -zero if the argument is -zero,
    *  one if the argument is greater than zero, -one if the argument is less than zero,
    *  and NaN if the argument is NaN where applicable.
    */
   def sign: T         = num.sign(self)
-  /** Returns the signum of `**this**`. */
+  /** Returns the signum of `this`. */
   @deprecated("use `sign` method instead", since = "2.13.0") def signum: Int = num.signum(self)
 }
 
+/** Base trait for the `Rich*` wrappers of the whole-number primitive types,
+ *  such as [[RichByte]], [[RichShort]], and [[RichLong]].
+ *
+ *  @tparam T the wrapped primitive type
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 trait ScalaWholeNumberProxy[T] extends Any with ScalaNumberProxy[T] {
+  /** Always `true`, since a whole number has no fractional part. */
   @deprecated("isWhole on an integer type is always true", "2.12.15")
   def isWhole = true
 }
 
+/** Base trait for the `Rich*` wrappers whose type has `Integral` evidence, such
+ *  as [[RichChar]] and [[RichLong]], implementing the `until` and `to` range
+ *  constructors with [[scala.collection.immutable.NumericRange]].
+ *
+ *  @tparam T the wrapped primitive type
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 trait IntegralProxy[T] extends Any with ScalaWholeNumberProxy[T] with RangedProxy[T] {
+  /** The `Integral` evidence for `T`, also used as the source of the default
+   *  range step, `num.one`.
+   */
   protected implicit def num: Integral[T]
   type ResultWithoutStep = NumericRange[T]
 
+  /** Returns a range from the wrapped value up to but not including `end`, in
+   *  steps of `num.one`.
+   *
+   *  @param end the exclusive end point of the range
+   *  @return an exclusive [[scala.collection.immutable.NumericRange]] from this
+   *          value until `end` with step 1
+   */
   def until(end: T): NumericRange.Exclusive[T]          = NumericRange(self, end, num.one)
+  /** Returns a range from the wrapped value up to but not including `end`,
+   *  advancing by `step`.
+   *
+   *  @param end the exclusive end point of the range
+   *  @param step the increment between consecutive elements; may be negative
+   *  @return an exclusive [[scala.collection.immutable.NumericRange]] from this
+   *          value until `end` with the given step
+   *  @throws IllegalArgumentException if `step` is zero, or if the range has more
+   *          than `Int.MaxValue` elements; both are raised when the range's length
+   *          is first computed, not when it is constructed
+   */
   def until(end: T, step: T): NumericRange.Exclusive[T] = NumericRange(self, end, step)
+  /** Returns a range from the wrapped value up to and including `end`, in
+   *  steps of `num.one`.
+   *
+   *  @param end the inclusive end point of the range
+   *  @return an inclusive [[scala.collection.immutable.NumericRange]] from this
+   *          value to `end` with step 1
+   */
   def to(end: T): NumericRange.Inclusive[T]             = NumericRange.inclusive(self, end, num.one)
+  /** Returns a range from the wrapped value up to and including `end`,
+   *  advancing by `step`.
+   *
+   *  @param end the inclusive end point of the range
+   *  @param step the increment between consecutive elements; may be negative
+   *  @return an inclusive [[scala.collection.immutable.NumericRange]] from this
+   *          value to `end` with the given step
+   *  @throws IllegalArgumentException if `step` is zero, or if the range has more
+   *          than `Int.MaxValue` elements; both are raised when the range's length
+   *          is first computed, not when it is constructed
+   */
   def to(end: T, step: T): NumericRange.Inclusive[T]    = NumericRange.inclusive(self, end, step)
 }
 
+/** Base trait for the `Rich*` wrappers of the fractional primitive types,
+ *  [[RichFloat]] and [[RichDouble]].
+ *
+ *  @tparam T the wrapped primitive type
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 trait FractionalProxy[T] extends Any with ScalaNumberProxy[T] {
+  /** The `Fractional` evidence for `T`, used to implement the arithmetic and
+   *  comparison operations of this proxy.
+   */
   protected implicit def num: Fractional[T]
 
+  /** Returns `false`. [[RichFloat]] and [[RichDouble]] override this to test
+   *  whether the wrapped value has a fractional part.
+   */
   def isWhole = false
 }
 
+/** Base trait for the `Rich*` wrappers that implements [[scala.math.Ordered]]
+ *  in terms of an [[scala.math.Ordering]], giving the wrapped value the
+ *  comparison operators `<`, `<=`, `>`, and `>=`.
+ *
+ *  @tparam T the wrapped primitive type
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 trait OrderedProxy[T] extends Any with Ordered[T] with Proxy.Typed[T] {
+  /** The `Ordering` evidence for `T`, used to implement `compare`. */
   protected def ord: Ordering[T]
 
+  /** Returns the result of comparing the wrapped value with `y` using `ord`:
+   *  negative if this value is smaller than `y`, positive if it is larger,
+   *  and 0 if the two are equal.
+   *
+   *  @param y the value to compare the wrapped value with
+   */
   def compare(y: T) = ord.compare(self, y)
 }
 
+/** Base trait for the `Rich*` wrappers that provide the `until` and `to` range
+ *  constructors. [[RichInt]] implements them with the `Int`-specific
+ *  [[scala.collection.immutable.Range]]; the [[IntegralProxy]] wrappers use
+ *  [[scala.collection.immutable.NumericRange]].
+ *
+ *  @tparam T the wrapped primitive type
+ */
 @deprecated("use the extension methods available on primitive types instead", since = "3.10.0")
 trait RangedProxy[T] extends Any with Proxy.Typed[T] {
   type ResultWithoutStep
 
+  /** Returns a range from the wrapped value up to but not including `end`,
+   *  with step 1.
+   *
+   *  @param end the exclusive end point of the range
+   *  @return a range from this value until `end`, excluding `end`
+   */
   def until(end: T): ResultWithoutStep
+  /** Returns a range from the wrapped value up to but not including `end`,
+   *  advancing by `step`.
+   *
+   *  @param end the exclusive end point of the range
+   *  @param step the increment between consecutive elements; may be negative
+   *          but must not be zero
+   *  @return a range from this value until `end`, excluding `end`, with the
+   *          given step
+   */
   def until(end: T, step: T): immutable.IndexedSeq[T]
+  /** Returns a range from the wrapped value up to and including `end`, with
+   *  step 1.
+   *
+   *  @param end the inclusive end point of the range
+   *  @return a range from this value to `end`, including `end`
+   */
   def to(end: T): ResultWithoutStep
+  /** Returns a range from the wrapped value up to and including `end`,
+   *  advancing by `step`.
+   *
+   *  @param end the inclusive end point of the range
+   *  @param step the increment between consecutive elements; may be negative
+   *          but must not be zero
+   *  @return a range from this value to `end`, including `end`, with the
+   *          given step
+   */
   def to(end: T, step: T): immutable.IndexedSeq[T]
 }

--- a/library/src/scala/runtime/ScalaRunTime.scala
+++ b/library/src/scala/runtime/ScalaRunTime.scala
@@ -29,6 +29,14 @@ import java.lang.reflect.{Method => JMethod}
  *  outside the API and subject to change or removal without notice.
  */
 object ScalaRunTime {
+  /** Tests whether `x` is an array with at least `atLevel` dimensions.
+   *
+   *  @param x the value to test; `null` yields `false`
+   *  @param atLevel the number of array dimensions required; a value below 1 never
+   *                 holds, since the check descends one component type per level and
+   *                 fails once it reaches a non-array; the default, 1, accepts any array
+   *  @return `true` if `x` is a non-null array of at least `atLevel` dimensions, `false` otherwise
+   */
   def isArray(x: Any, atLevel: Int = 1): Boolean =
     x != null && isArrayClass(x.getClass, atLevel)
 
@@ -36,6 +44,14 @@ object ScalaRunTime {
     clazz.isArray && (atLevel == 1 || isArrayClass(clazz.getComponentType, atLevel - 1))
 
   // A helper method to make my life in the pattern matcher a lot easier.
+  /** Drops the first `num` elements of a collection-like value, preserving its representation type.
+   *
+   *  @tparam Repr the representation type of the collection
+   *  @param coll the collection-like value to drop from
+   *  @param num the number of leading elements to drop
+   *  @param iterable evidence for viewing `coll` as an iterable whose collection type conforms to `Repr`
+   *  @return `coll` without its first `num` elements
+   */
   def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterable[Repr] { type C <: Repr }): Repr =
     iterable(coll) drop num
 
@@ -120,6 +136,14 @@ object ScalaRunTime {
 
   // TODO: bytecode Object.clone() will in fact work here and avoids
   // the type switch. See Array_clone comment in BCodeBodyBuilder.
+  /** Clones a generic array, dispatching on its element type.
+   *
+   *  A non-array argument fails with a `MatchError`.
+   *
+   *  @param xs the array to clone
+   *  @return a shallow copy of `xs`, with the same element type and length
+   *  @throws NullPointerException if `xs` is `null`
+   */
   def array_clone(xs: AnyRef): AnyRef = (xs: @unchecked) match {
     case x: Array[AnyRef]  => x.clone()
     case x: Array[Int]     => x.clone()
@@ -168,6 +192,13 @@ object ScalaRunTime {
     }
   }
 
+  /** Copies the elements of a sequence into a new `Array[AnyRef]`, boxing primitive values.
+   *
+   *  Returns the shared empty object array when `xs` is empty.
+   *
+   *  @tparam T the element type of the sequence
+   *  @param xs the sequence to copy
+   */
   def toArray[T](xs: scala.collection.Seq[T]) = {
     if (xs.isEmpty) Array.emptyObjectArray
     else {
@@ -184,10 +215,23 @@ object ScalaRunTime {
 
   // Java bug: https://bugs.java.com/view_bug.do?bug_id=4071957
   // More background at ticket #2318.
+  /** Makes the given method callable reflectively, calling `setAccessible(true)` on it if needed.
+   *
+   *  Delegates to [[scala.reflect.ensureAccessible]]; a `SecurityException` thrown in the
+   *  attempt is caught and discarded.
+   *
+   *  @param m the method to make accessible
+   *  @return `m` itself
+   */
   def ensureAccessible(m: JMethod): JMethod = scala.reflect.ensureAccessible(m)
 
   // This is called by the synthetic case class `toString` method.
   // It originally had a `CaseClass` parameter type which was changed to `Product`.
+  /** Returns the default case-class string representation of `x`: its product prefix
+   *  followed by its elements, comma-separated in parentheses, e.g. `Foo(1,two)`.
+   *
+   *  @param x the product to render
+   */
   def _toString(x: Product): String =
     x.productIterator.mkString(x.productPrefix + "(", ",", ")")
 
@@ -195,6 +239,11 @@ object ScalaRunTime {
   // In newer versions, the synthetic case class `hashCode` has either the calculation inlined or calls
   // `MurmurHash3.productHash`.
   // There used to be an `_equals` method as well which was removed in 5e7e81ab2a.
+  /** Returns a hash code for a case class, mixing the hash of its `productPrefix` with
+   *  those of its elements via [[scala.util.hashing.MurmurHash3.caseClassHash]].
+   *
+   *  @param x the product to hash
+   */
   def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.caseClassHash(x)
 
   /** A helper for case classes.
@@ -229,6 +278,23 @@ object ScalaRunTime {
    *  @return        a string representation of arg.
    */
   def stringOf(arg: Any): String = stringOf(arg, scala.Int.MaxValue)
+  /** Returns a string representation of `arg`, rendering at most `maxElements` elements
+   *  of any collection or array encountered.
+   *
+   *  `null` is rendered as `"null"`; arrays as `Array(...)`; Scala collections with their
+   *  class name followed by their elements, map entries as `key -> value`; tuples in
+   *  parentheses; the empty string and strings with leading or trailing whitespace in
+   *  double quotes. Elements are rendered recursively by the same rules. Values better
+   *  served by their own `toString` (ranges, sorted collections, views, string builders,
+   *  XML nodes, and iterables that are not strict Scala collections) are rendered with it.
+   *  Truncation to `maxElements` is silent: no ellipsis marks the omitted elements. If
+   *  rendering fails with an `UnsupportedOperationException` or `AssertionError`, falls
+   *  back to `String.valueOf(arg)`.
+   *
+   *  @param arg the value to stringify
+   *  @param maxElements the maximum number of elements rendered per collection or array;
+   *                     a value below 1 renders none of them
+   */
   def stringOf(arg: Any, maxElements: Int): String = {
     def packageOf(x: AnyRef) = x.getClass.getPackage match {
       case null   => ""
@@ -340,15 +406,77 @@ object ScalaRunTime {
   // which led to a ticket in Scala 3 (scala/scala3#24204). The argument may be null:
   //   - When calling a Scala `@varargs` method from Java
   //   - When using an array as sequence argument in Scala 3: `foo((null: Array[X])*)`
+  /** Wraps an array in an immutable [[scala.collection.immutable.ArraySeq]] without copying it,
+   *  selecting the `ArraySeq` subclass matching the array's element type at runtime.
+   *
+   *  Used when the element type is not statically known; the compiler otherwise emits a
+   *  call to one of the type-specific `wrapXArray` methods below.
+   *
+   *  @tparam T the element type of the array
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq` backed by `xs`, or `null` if `xs` is `null`
+   */
   def genericWrapArray[T](xs: Array[T]): ArraySeq[T]              = mapNull(xs, ArraySeq.unsafeWrapArray(xs))
+  /** Wraps an array of references in an immutable [[scala.collection.immutable.ArraySeq]]
+   *  without copying it.
+   *
+   *  @tparam T the reference element type of the array
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofRef` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapRefArray[T <: AnyRef | Null](xs: Array[T]): ArraySeq[T] = mapNull(xs, new ArraySeq.ofRef[T](xs))
+  /** Wraps an `Array[Int]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofInt` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapIntArray(xs: Array[Int]): ArraySeq[Int]                 = mapNull(xs, new ArraySeq.ofInt(xs))
+  /** Wraps an `Array[Double]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofDouble` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double]        = mapNull(xs, new ArraySeq.ofDouble(xs))
+  /** Wraps an `Array[Long]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofLong` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapLongArray(xs: Array[Long]): ArraySeq[Long]              = mapNull(xs, new ArraySeq.ofLong(xs))
+  /** Wraps an `Array[Float]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofFloat` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapFloatArray(xs: Array[Float]): ArraySeq[Float]           = mapNull(xs, new ArraySeq.ofFloat(xs))
+  /** Wraps an `Array[Char]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofChar` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapCharArray(xs: Array[Char]): ArraySeq[Char]              = mapNull(xs, new ArraySeq.ofChar(xs))
+  /** Wraps an `Array[Byte]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofByte` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte]              = mapNull(xs, new ArraySeq.ofByte(xs))
+  /** Wraps an `Array[Short]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofShort` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapShortArray(xs: Array[Short]): ArraySeq[Short]           = mapNull(xs, new ArraySeq.ofShort(xs))
+  /** Wraps an `Array[Boolean]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofBoolean` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean]     = mapNull(xs, new ArraySeq.ofBoolean(xs))
+  /** Wraps an `Array[Unit]` in an immutable [[scala.collection.immutable.ArraySeq]] without copying it.
+   *
+   *  @param xs the array to wrap
+   *  @return an `ArraySeq.ofUnit` backed by `xs`, or `null` if `xs` is `null`
+   */
   def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit]              = mapNull(xs, new ArraySeq.ofUnit(xs))
 }

--- a/library/src/scala/runtime/StructuralCallSite.scala
+++ b/library/src/scala/runtime/StructuralCallSite.scala
@@ -18,11 +18,25 @@ import java.lang.invoke._
 import java.lang.ref.SoftReference
 import java.lang.reflect.Method
 
+/** The state of one structural (reflective) call site: the parameter types
+ *  of the call and a softly referenced [[MethodCache]] mapping receiver
+ *  classes to resolved methods.
+ *
+ *  Created by `StructuralCallSite.bootstrap`, which the JVM invokes via
+ *  `invokedynamic` for each structural call site the compiler emits.
+ */
 final class StructuralCallSite private (callType: MethodType) {
   private var cache: SoftReference[MethodCache] =  new SoftReference(new EmptyMethodCache)
 
+  /** The parameter classes of the called method, extracted from the call
+   *  site's `MethodType`.
+   */
   val parameterTypes: Array[Class[?]] = callType.parameterArray
 
+  /** Returns the current method cache, installing and returning a fresh
+   *  [[EmptyMethodCache]] if the previous cache's soft reference was
+   *  cleared by the garbage collector.
+   */
   def get: MethodCache = {
     var cache = this.cache.get
     if (cache == null) {
@@ -32,8 +46,28 @@ final class StructuralCallSite private (callType: MethodType) {
     cache
   }
 
+  /** Returns the method this call site resolved for receiver class
+   *  `receiver`, or `null` if none is cached, in which case the caller
+   *  should look up the method and `add` it. Once the cache has turned
+   *  mega-morphic, resolves the method reflectively instead of consulting
+   *  per-receiver entries; see [[MethodCache.find]].
+   *
+   *  @param receiver the runtime `Class` of the receiver object
+   *  @throws NoSuchMethodException from the reflective lookup a mega-morphic cache
+   *          performs, in place of returning `null`
+   */
   def find(receiver: Class[?]): Method | Null = get.find(receiver)
 
+  /** Records that `m` is the method to call for receiver class `receiver`,
+   *  replacing this call site's cache with the extended one, and returns `m`.
+   *
+   *  Once the cache has turned mega-morphic it records nothing per receiver and
+   *  returns itself, so the call site's cache is then left as it was.
+   *
+   *  @param receiver the runtime `Class` of the receiver object
+   *  @param m the method resolved for `receiver`
+   *  @return `m`
+   */
   def add(receiver: Class[?], m: Method): Method = {
     cache = new SoftReference(get.add(receiver, m))
     m
@@ -41,6 +75,17 @@ final class StructuralCallSite private (callType: MethodType) {
 }
 
 object StructuralCallSite {
+  /** Bootstrap method that the JVM invokes, via the `invokedynamic`
+   *  instruction the compiler emits for a structural call, to link the call
+   *  site.
+   *
+   *  @param lookup never used
+   *  @param invokedName never used
+   *  @param invokedType never used
+   *  @param reflectiveCallType the `MethodType` of the structural call
+   *  @return a `ConstantCallSite` whose target constantly returns the one
+   *          `StructuralCallSite` created here for `reflectiveCallType`
+   */
   def bootstrap(@unused lookup: MethodHandles.Lookup, @unused invokedName: String, @unused invokedType: MethodType, reflectiveCallType: MethodType): CallSite = {
     val structuralCallSite = new StructuralCallSite(reflectiveCallType)
     new ConstantCallSite(MethodHandles.constant(classOf[StructuralCallSite], structuralCallSite))

--- a/library/src/scala/runtime/Tuple2Zipped.scala
+++ b/library/src/scala/runtime/Tuple2Zipped.scala
@@ -27,11 +27,22 @@ import scala.language.implicitConversions
  */
 @deprecated("Use scala.collection.LazyZip2.", "2.13.0")
 trait ZippedIterable2[+El1, +El2] extends Any {
+  /** Returns an iterator that produces the element pairs of this zipped iterable. */
   def iterator: Iterator[(El1, El2)]
+  /** Returns `true` if this zipped iterable produces no element pairs. */
   def isEmpty: Boolean
 }
 @deprecated("Use scala.collection.LazyZip2.", "2.13.0")
 object ZippedIterable2 {
+  /** Converts a [[ZippedIterable2]] to an `Iterable` of pairs.
+   *
+   *  The result is a wrapper whose `iterator` and `isEmpty` delegate to `zz`;
+   *  no elements are copied.
+   *
+   *  @tparam El1 the first element type of each pair
+   *  @tparam El2 the second element type of each pair
+   *  @param zz the zipped iterable to convert
+   */
   implicit def zippedIterable2ToIterable[El1, El2](zz: ZippedIterable2[El1, El2]): Iterable[(El1, El2)] = {
     new scala.collection.AbstractIterable[(El1, El2)] {
       def iterator: Iterator[(El1, El2)] = zz.iterator
@@ -40,11 +51,37 @@ object ZippedIterable2 {
   }
 }
 
+/** A decorator over a pair of collections that supports traversing both in
+ *  lockstep.
+ *
+ *  Every operation iterates the two collections side by side and stops as soon
+ *  as either one is exhausted, so excess elements of the longer collection are
+ *  never visited. Instances are created by the deprecated `zipped` method on
+ *  pairs (see [[Tuple2Zipped.Ops]]).
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam It1 the type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam It2 the type of the second collection
+ *  @param colls the pair of collections to traverse
+ */
 @deprecated("Use scala.collection.LazyZip2.", "2.13.0")
 final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](private val colls: (It1, It2)) extends AnyVal with ZippedIterable2[El1, El2] {
   private def coll1 = colls._1
   private def coll2 = colls._2
 
+  /** Returns a collection of the results of applying `f` to corresponding
+   *  elements of the two collections.
+   *
+   *  Iteration stops as soon as the shorter collection is exhausted; excess
+   *  elements of the longer collection are not passed to `f`.
+   *
+   *  @tparam B the type of the values returned by `f`
+   *  @tparam To the type of the resulting collection
+   *  @param f the function applied to each pair of corresponding elements
+   *  @param bf the builder factory that creates the result collection from the
+   *            first collection
+   */
   def map[B, To](f: (El1, El2) => B)(implicit bf: BuildFrom[It1, B, To]): To = {
     val b = bf.newBuilder(coll1)
     b.sizeHint(coll1, delta = 0)
@@ -58,6 +95,18 @@ final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](p
     b.result()
   }
 
+  /** Returns a collection built by applying `f` to corresponding elements of
+   *  the two collections and concatenating the results.
+   *
+   *  Iteration stops as soon as the shorter collection is exhausted; excess
+   *  elements of the longer collection are not passed to `f`.
+   *
+   *  @tparam B the element type of the collections returned by `f`
+   *  @tparam To the type of the resulting collection
+   *  @param f the function applied to each pair of corresponding elements
+   *  @param bf the builder factory that creates the result collection from the
+   *            first collection
+   */
   def flatMap[B, To](f: (El1, El2) => IterableOnce[B])(implicit bf: BuildFrom[It1, B, To]): To = {
     val b = bf.newBuilder(coll1)
     val elems1 = coll1.iterator
@@ -70,6 +119,21 @@ final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](p
     b.result()
   }
 
+  /** Returns the pairs of corresponding elements for which `f` holds, as a
+   *  pair of collections.
+   *
+   *  Iteration stops as soon as the shorter collection is exhausted. When `f`
+   *  is true for a pair, its first element is added to the first result and
+   *  its second element to the second, so the two results have equal length.
+   *
+   *  @tparam To1 the type of the first result collection
+   *  @tparam To2 the type of the second result collection
+   *  @param f the predicate applied to each pair of corresponding elements
+   *  @param bf1 the builder factory that creates the first result collection
+   *             from the first collection
+   *  @param bf2 the builder factory that creates the second result collection
+   *             from the second collection
+   */
   def filter[To1, To2](f: (El1, El2) => Boolean)(implicit bf1: BuildFrom[It1, El1, To1], bf2: BuildFrom[It2, El2, To2]): (To1, To2) = {
     val b1 = bf1.newBuilder(coll1)
     val b2 = bf2.newBuilder(coll2)
@@ -88,6 +152,15 @@ final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](p
     (b1.result(), b2.result())
   }
 
+  /** Returns `true` if `p` holds for at least one pair of corresponding
+   *  elements of the two collections.
+   *
+   *  Iteration stops at the first pair satisfying `p`, or when the shorter
+   *  collection is exhausted; excess elements of the longer collection are
+   *  never tested.
+   *
+   *  @param p the predicate applied to each pair of corresponding elements
+   */
   def exists(p: (El1, El2) => Boolean): Boolean = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -100,11 +173,31 @@ final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](p
     false
   }
 
+  /** Returns `true` if `p` holds for every pair of corresponding elements of
+   *  the two collections.
+   *
+   *  Only as many pairs as the shorter collection provides are tested, so the
+   *  result is `true` when either collection is empty. Iteration stops at the
+   *  first pair failing `p`.
+   *
+   *  @param p the predicate applied to each pair of corresponding elements
+   */
   def forall(p: (El1, El2) => Boolean): Boolean =
     !exists((x, y) => !p(x, y))
 
+  /** Returns an iterator over the pairs of corresponding elements, truncated at the length of the shorter collection. */
   def iterator: Iterator[(El1, El2)] = coll1.iterator.zip(coll2.iterator)
+  /** Returns `true` if either of the two collections is empty. */
   override def isEmpty: Boolean = coll1.isEmpty || coll2.isEmpty
+  /** Applies `f` to each pair of corresponding elements of the two
+   *  collections, for its side effects.
+   *
+   *  Iteration stops as soon as the shorter collection is exhausted; the
+   *  results of `f` are discarded.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each pair of corresponding elements
+   */
   def foreach[U](f: (El1, El2) => U): Unit = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -114,12 +207,38 @@ final class Tuple2Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]](p
     }
   }
 
+  /** Returns a string of the form `(coll1, coll2).zipped`, where `coll1` and `coll2` are the string representations of the two collections. */
   override def toString() = s"($coll1, $coll2).zipped"
 }
 
 @deprecated("Use scala.collection.LazyZip2.", since = "2.13.0")
 object Tuple2Zipped {
+  /** A value class adding the deprecated `zipped` and `invert` operations to
+   *  pairs. Pairs are enriched with it through the implicit conversion
+   *  `Predef.tuple2ToZippedOps`.
+   *
+   *  @tparam T1 the type of the pair's first component
+   *  @tparam T2 the type of the pair's second component
+   *  @param x the wrapped pair
+   */
   final class Ops[T1, T2](private val x: (T1, T2)) extends AnyVal {
+    /** Returns a collection of pairs built from corresponding elements of the
+     *  two collections in this pair, turning a pair of collections into a
+     *  collection of pairs.
+     *
+     *  Both collections are iterated in lockstep, stopping as soon as either
+     *  is exhausted; excess elements of the longer collection are dropped.
+     *
+     *  @tparam El1 the element type of the first collection
+     *  @tparam It1 the type constructor of the first collection
+     *  @tparam El2 the element type of the second collection
+     *  @tparam It2 the type constructor of the second collection
+     *  @tparam That the type of the resulting collection of pairs
+     *  @param w1 evidence that the pair's first component is a collection of `El1`
+     *  @param w2 evidence that the pair's second component is a collection of `El2`
+     *  @param bf the builder factory that creates the result collection from
+     *            the first collection
+     */
     @deprecated("Use xs.lazyZip(yz).map((_, _))", since = "2.13.0")
     def invert[El1, It1[a] <: Iterable[a], El2, It2[a] <: Iterable[a], That]
       (implicit w1: T1 <:< It1[El1],
@@ -135,6 +254,14 @@ object Tuple2Zipped {
         buf.result()
       }
 
+    /** Returns a [[Tuple2Zipped]] decorator that traverses the two collections
+     *  of this pair in lockstep.
+     *
+     *  @tparam El1 the element type of the first collection
+     *  @tparam It1 the type of the first collection
+     *  @tparam El2 the element type of the second collection
+     *  @tparam It2 the type of the second collection
+     */
     @deprecated("Use xs.lazyZip(ys)", since = "2.13.0")
     def zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2]]
       (implicit w1: T1 => IterableOps[El1, Iterable, It1] & It1,

--- a/library/src/scala/runtime/Tuple3Zipped.scala
+++ b/library/src/scala/runtime/Tuple3Zipped.scala
@@ -25,11 +25,23 @@ import scala.language.implicitConversions
  */
 @deprecated("Use scala.collection.LazyZip3.", "2.13.0")
 trait ZippedIterable3[+El1, +El2, +El3] extends Any {
+  /** Returns an iterator that produces the element triples of this zipped iterable. */
   def iterator: Iterator[(El1, El2, El3)]
+  /** Returns `true` if this zipped iterable produces no element triples. */
   def isEmpty: Boolean
 }
 @deprecated("Use scala.collection.LazyZip3.", "2.13.0")
 object ZippedIterable3 {
+  /** Converts a [[ZippedIterable3]] to an `Iterable` of triples.
+   *
+   *  The result is a wrapper whose `iterator` and `isEmpty` delegate to `zz`;
+   *  no elements are copied.
+   *
+   *  @tparam El1 the first element type of each triple
+   *  @tparam El2 the second element type of each triple
+   *  @tparam El3 the third element type of each triple
+   *  @param zz the zipped iterable to convert
+   */
   implicit def zippedIterable3ToIterable[El1, El2, El3](zz: ZippedIterable3[El1, El2, El3]): Iterable[(El1, El2, El3)] = {
     new scala.collection.AbstractIterable[(El1, El2, El3)] {
       def iterator: Iterator[(El1, El2, El3)] = zz.iterator
@@ -38,6 +50,22 @@ object ZippedIterable3 {
   }
 }
 
+/** A decorator over a triple of collections that supports traversing all
+ *  three in lockstep.
+ *
+ *  Every operation iterates the three collections side by side and stops as
+ *  soon as any one of them is exhausted, so excess elements of the longer
+ *  collections are never visited. Instances are created by the deprecated
+ *  `zipped` method on triples (see [[Tuple3Zipped.Ops]]).
+ *
+ *  @tparam El1 the element type of the first collection
+ *  @tparam It1 the type of the first collection
+ *  @tparam El2 the element type of the second collection
+ *  @tparam It2 the type of the second collection
+ *  @tparam El3 the element type of the third collection
+ *  @tparam It3 the type of the third collection
+ *  @param colls the triple of collections to traverse
+ */
 @deprecated("Use scala.collection.LazyZip3.", "2.13.0")
 final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], El3, It3 <: Iterable[El3]](private val colls: (It1, It2, It3))
         extends AnyVal with ZippedIterable3[El1, El2, El3] {
@@ -46,6 +74,18 @@ final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], E
   private def coll2 = colls._2
   private def coll3 = colls._3
 
+  /** Returns a collection of the results of applying `f` to corresponding
+   *  elements of the three collections.
+   *
+   *  Iteration stops as soon as the shortest collection is exhausted; excess
+   *  elements of the longer collections are not passed to `f`.
+   *
+   *  @tparam B the type of the values returned by `f`
+   *  @tparam To the type of the resulting collection
+   *  @param f the function applied to each triple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from the
+   *            first collection
+   */
   def map[B, To](f: (El1, El2, El3) => B)(implicit bf: BuildFrom[It1, B, To]): To = {
     val b = bf.newBuilder(coll1)
     val elems1 = coll1.iterator
@@ -58,6 +98,18 @@ final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], E
     b.result()
   }
 
+  /** Returns a collection built by applying `f` to corresponding elements of
+   *  the three collections and concatenating the results.
+   *
+   *  Iteration stops as soon as the shortest collection is exhausted; excess
+   *  elements of the longer collections are not passed to `f`.
+   *
+   *  @tparam B the element type of the collections returned by `f`
+   *  @tparam To the type of the resulting collection
+   *  @param f the function applied to each triple of corresponding elements
+   *  @param bf the builder factory that creates the result collection from the
+   *            first collection
+   */
   def flatMap[B, To](f: (El1, El2, El3) => IterableOnce[B])(implicit bf: BuildFrom[It1, B, To]): To = {
     val b = bf.newBuilder(coll1)
     val elems1 = coll1.iterator
@@ -70,6 +122,18 @@ final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], E
     b.result()
   }
 
+  /** Returns the triples of corresponding elements for which `f` holds, as a
+   *  triple of collections.
+   *
+   *  Iteration stops as soon as the shortest collection is exhausted. When `f`
+   *  is true for a triple, its elements are added to the corresponding result
+   *  collections, so the three results have equal length.
+   *
+   *  @tparam To1 the type of the first result collection
+   *  @tparam To2 the type of the second result collection
+   *  @tparam To3 the type of the third result collection
+   *  @param f the predicate applied to each triple of corresponding elements
+   */
   def filter[To1, To2, To3](f: (El1, El2, El3) => Boolean)(
                implicit bf1: BuildFrom[It1, El1, To1],
                         bf2: BuildFrom[It2, El2, To2],
@@ -95,6 +159,15 @@ final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], E
     (b1.result(), b2.result(), b3.result())
   }
 
+  /** Returns `true` if `p` holds for at least one triple of corresponding
+   *  elements of the three collections.
+   *
+   *  Iteration stops at the first triple satisfying `p`, or when the shortest
+   *  collection is exhausted; excess elements of the longer collections are
+   *  never tested.
+   *
+   *  @param p the predicate applied to each triple of corresponding elements
+   */
   def exists(p: (El1, El2, El3) => Boolean): Boolean = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -108,11 +181,31 @@ final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], E
     false
   }
 
+  /** Returns `true` if `p` holds for every triple of corresponding elements
+   *  of the three collections.
+   *
+   *  Only as many triples as the shortest collection provides are tested, so
+   *  the result is `true` when any of the collections is empty. Iteration
+   *  stops at the first triple failing `p`.
+   *
+   *  @param p the predicate applied to each triple of corresponding elements
+   */
   def forall(p: (El1, El2, El3) => Boolean): Boolean =
     !exists((x, y, z) => !p(x, y, z))
 
+  /** Returns an iterator over the triples of corresponding elements, truncated at the length of the shortest collection. */
   def iterator: Iterator[(El1, El2, El3)] = coll1.iterator.zip(coll2.iterator).zip(coll3.iterator).map { case ((a, b), c) => (a, b, c)}
+  /** Returns `true` if any of the three collections is empty. */
   override def isEmpty: Boolean = coll1.isEmpty || coll2.isEmpty || coll3.isEmpty
+  /** Applies `f` to each triple of corresponding elements of the three
+   *  collections, for its side effects.
+   *
+   *  Iteration stops as soon as the shortest collection is exhausted; the
+   *  results of `f` are discarded.
+   *
+   *  @tparam U the result type of `f`, which is discarded
+   *  @param f the function applied to each triple of corresponding elements
+   */
   def foreach[U](f: (El1, El2, El3) => U): Unit = {
     val elems1 = coll1.iterator
     val elems2 = coll2.iterator
@@ -123,12 +216,43 @@ final class Tuple3Zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], E
     }
   }
 
+  /** Returns a string of the form `(coll1, coll2, coll3).zipped`, where `coll1`, `coll2` and `coll3` are the string representations of the three collections. */
   override def toString() = s"($coll1, $coll2, $coll3).zipped"
 }
 
 @deprecated("Use scala.collection.LazyZip3.", since = "2.13.0")
 object Tuple3Zipped {
+  /** A value class adding the deprecated `zipped` and `invert` operations to
+   *  triples. Triples are enriched with it through the implicit conversion
+   *  `Predef.tuple3ToZippedOps`.
+   *
+   *  @tparam T1 the type of the triple's first component
+   *  @tparam T2 the type of the triple's second component
+   *  @tparam T3 the type of the triple's third component
+   *  @param x the wrapped triple
+   */
   final class Ops[T1, T2, T3](private val x: (T1, T2, T3)) extends AnyVal {
+    /** Returns a collection of triples built from corresponding elements of
+     *  the three collections in this triple, turning a triple of collections
+     *  into a collection of triples.
+     *
+     *  The collections are iterated in lockstep, stopping as soon as any of
+     *  them is exhausted; excess elements of the longer collections are
+     *  dropped.
+     *
+     *  @tparam El1 the element type of the first collection
+     *  @tparam It1 the type constructor of the first collection
+     *  @tparam El2 the element type of the second collection
+     *  @tparam It2 the type constructor of the second collection
+     *  @tparam El3 the element type of the third collection
+     *  @tparam It3 the type constructor of the third collection
+     *  @tparam That the type of the resulting collection of triples
+     *  @param w1 evidence that the triple's first component is a collection of `El1`
+     *  @param w2 evidence that the triple's second component is a collection of `El2`
+     *  @param w3 evidence that the triple's third component is a collection of `El3`
+     *  @param bf the builder factory that creates the result collection from
+     *            the first collection
+     */
     @deprecated("Use xs.lazyZip(yz).lazyZip(zs).map((_, _, _))", since = "2.13.0")
     def invert[El1, It1[a] <: Iterable[a], El2, It2[a] <: Iterable[a], El3, It3[a] <: Iterable[a], That]
       (implicit w1: T1 <:< It1[El1],
@@ -146,6 +270,16 @@ object Tuple3Zipped {
         buf.result()
       }
 
+    /** Returns a [[Tuple3Zipped]] decorator that traverses the three
+     *  collections of this triple in lockstep.
+     *
+     *  @tparam El1 the element type of the first collection
+     *  @tparam It1 the type of the first collection
+     *  @tparam El2 the element type of the second collection
+     *  @tparam It2 the type of the second collection
+     *  @tparam El3 the element type of the third collection
+     *  @tparam It3 the type of the third collection
+     */
     @deprecated("Use xs.lazyZip(ys).lazyZip(zs)", since = "2.13.0")
     def zipped[El1, It1 <: Iterable[El1], El2, It2 <: Iterable[El2], El3, It3 <: Iterable[El3]]
       (implicit w1: T1 => IterableOps[El1, Iterable, It1] & It1,

--- a/library/src/scala/runtime/TupleMirror.scala
+++ b/library/src/scala/runtime/TupleMirror.scala
@@ -12,6 +12,16 @@ final class TupleMirror(arity: Int) extends scala.deriving.Mirror.Product with S
 
   override type MirroredMonoType <: Tuple
 
+  /** Creates a tuple of this mirror's arity from the elements of `product`.
+   *
+   *  Delegates to [[scala.runtime.Tuples.fromProduct]], so if `product` already is a
+   *  tuple in the representation matching its arity, it is returned as is rather
+   *  than copied.
+   *
+   *  @param product the product supplying the elements of the resulting tuple
+   *  @throws IllegalArgumentException if `product.productArity` differs from the
+   *          arity this mirror was constructed with
+   */
   final def fromProduct(product: Product): MirroredMonoType =
     if product.productArity != arity then
       throw IllegalArgumentException(s"expected Product with $arity elements, got ${product.productArity}")

--- a/library/src/scala/runtime/TupleXXL.scala
+++ b/library/src/scala/runtime/TupleXXL.scala
@@ -2,28 +2,60 @@ package scala.runtime
 
 import language.experimental.captureChecking
 
+/** The runtime representation of tuples with more than 22 elements.
+ *
+ *  Unlike `Tuple1` to `Tuple22`, which store their elements in individual
+ *  fields, a `TupleXXL` stores all elements in a single immutable array.
+ *  Instances are created by the factory methods on the companion object
+ *  (the constructor is private and requires more than 22 elements) and arise
+ *  from the operations in [[scala.runtime.Tuples]] and from compiler-generated
+ *  code; user code manipulates them through the [[scala.Tuple]] API.
+ */
 final class TupleXXL private (es: IArray[Object]) extends Product {
   assert(es.length > 22)
 
+  /** Returns the element of this tuple at index `n`.
+   *
+   *  @param n the 0-based index of the element
+   *  @return the element at index `n`
+   *  @throws IndexOutOfBoundsException if `n` is negative or not less than `productArity`
+   */
   def productElement(n: Int): Any = es(n)
+  /** Returns the number of elements of this tuple; always greater than 22. */
   def productArity: Int = es.length
+  /** Returns the string `"Tuple"`, regardless of arity, unlike the `TupleN` classes whose prefix includes the arity. */
   override def productPrefix: String = "Tuple"
 
   // NOTE: For historical reasons, we cannot change this method
   // to `def toString(): String`. See #24461 for more informations.
+  /** Returns the elements of this tuple, comma-separated and enclosed in parentheses, in the same format as the `TupleN` classes. */
   override def toString: String =
     elems.asInstanceOf[Array[Object]].mkString("(", ",", ")")
 
   // NOTE: For historical reasons, we cannot change this method
   // to `def hashCode(): Int`. See #24461 for more informations.
+  /** Returns a hash code computed from the elements of this tuple, using the standard product hash of [[scala.runtime.ScalaRunTime]], so tuples that are `equals` have equal hash codes. */
   override def hashCode: Int =
     scala.runtime.ScalaRunTime._hashCode(this)
 
+  /** Returns whether `that` can be compared for equality against this tuple.
+   *
+   *  @param that the value to test
+   */
   override def canEqual(that: Any): Boolean = that match {
     case that: TupleXXL => that.productArity == this.productArity
     case _ => false
   }
 
+  /** Returns whether `that` is a `TupleXXL` with the same elements as this tuple.
+   *
+   *  Two `TupleXXL`s are equal if they have the same arity and their elements
+   *  are pairwise equal according to `==`. Two tuples sharing the same backing
+   *  array compare equal without inspecting the elements. A value that is not
+   *  a `TupleXXL` is never equal to this tuple.
+   *
+   *  @param that the value to compare against
+   */
   override def equals(that: Any): Boolean = that match {
     case that: TupleXXL =>
       es.asInstanceOf[AnyRef].eq(that.elems.asInstanceOf[AnyRef]) || {
@@ -37,18 +69,46 @@ final class TupleXXL private (es: IArray[Object]) extends Product {
     case _ => false
   }
 
+  /** Returns the immutable array backing this tuple; the array itself is returned, not a copy. */
   def elems: IArray[Object] = es
 
+  /** Returns a new `TupleXXL` containing all elements of this tuple except the 1st.
+   *
+   *  This tuple must have at least 24 elements (asserted), so that the tail
+   *  still has more than 22. The compiler emits calls to this method when
+   *  optimizing `tail` on tuples statically known to be that large; the general
+   *  case goes through [[scala.runtime.Tuples.tail]] instead.
+   */
   def tailXXL: TupleXXL = {
     assert(es.length > 23)
     new TupleXXL(es.asInstanceOf[Array[Object]].tail.asInstanceOf[IArray[Object]]) // TODO use IArray.tail
   }
 
+  /** Returns a fresh array containing the elements of this tuple; the backing array is cloned, so mutating the result does not affect this tuple. */
   def toArray: Array[Object] = es.asInstanceOf[Array[Object]].clone // TODO use IArray.toArray
 }
 object TupleXXL {
+  /** Creates a `TupleXXL` containing the values produced by `elems`, in order.
+   *
+   *  The iterator is fully consumed into a fresh array.
+   *
+   *  @param elems the iterator supplying the elements; must produce more than 22 values (asserted)
+   */
   def fromIterator(elems: Iterator[Any]): TupleXXL = new TupleXXL(elems.map(_.asInstanceOf[Object]).toArray.asInstanceOf[IArray[Object]]) // TODO use Iterator.toIArray
+  /** Creates a `TupleXXL` backed directly by `elems`; the array is not copied.
+   *
+   *  @param elems the immutable array to use as the tuple's backing storage; must have more than 22 elements (asserted)
+   */
   def fromIArray(elems: IArray[Object]): TupleXXL = new TupleXXL(elems)
+  /** Creates a `TupleXXL` with the given elements.
+   *
+   *  @param elems the elements of the tuple; more than 22 must be supplied (asserted)
+   */
   def apply(elems: Any*): TupleXXL = new TupleXXL(IArray(elems.asInstanceOf[Seq[AnyRef]]*))
+  /** Extracts the elements of a `TupleXXL`, enabling `case TupleXXL(xs*)` patterns.
+   *
+   *  @param x the tuple to extract
+   *  @return `Some` containing the elements of `x` in order; never `None`
+   */
   def unapplySeq(x: TupleXXL): Option[Seq[Any]] = Some(x.elems.asInstanceOf[Array[Object]].toSeq) // TODO use IArray.toSeq
 }

--- a/library/src/scala/runtime/TupledFunctions.scala
+++ b/library/src/scala/runtime/TupledFunctions.scala
@@ -8,36 +8,134 @@ import scala.annotation.experimental
 @experimental
 object TupledFunctions {
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 0
+   *  can be tupled as `G`, the unary function type taking `EmptyTuple` as its
+   *  argument.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 0; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 0
+   *  @tparam G the tupled form of `F`, mapping `EmptyTuple` to `F`'s result
+   */
   def tupledFunction0[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => ((args: EmptyTuple) => f.asInstanceOf[() => Any].apply()).asInstanceOf[G],
     untupledImpl = (g: G) => (() => g.asInstanceOf[EmptyTuple => Any].apply(EmptyTuple)).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 1
+   *  can be tupled as `G`, the unary function type taking the single argument
+   *  of `F` wrapped in a `Tuple1`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 1; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 1
+   *  @tparam G the tupled form of `F`, mapping a `Tuple1` of `F`'s argument to its result
+   */
   def tupledFunction1[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => ((args: Tuple1[Any]) => f.asInstanceOf[Any => Any].apply(args._1)).asInstanceOf[G],
     untupledImpl = (g: G) => ((x1: Any) => g.asInstanceOf[Tuple1[?] => Any].apply(Tuple1(x1))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 2
+   *  can be tupled as `G`, the unary function type taking the 2 arguments of
+   *  `F` as a single `Tuple2`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 2; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 2
+   *  @tparam G the tupled form of `F`, mapping a `Tuple2` of `F`'s arguments to its result
+   */
   def tupledFunction2[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function2[?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) => Function.untupled(g.asInstanceOf[Tuple2[?, ?] => Any]).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 3
+   *  can be tupled as `G`, the unary function type taking the 3 arguments of
+   *  `F` as a single `Tuple3`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 3; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 3
+   *  @tparam G the tupled form of `F`, mapping a `Tuple3` of `F`'s arguments to its result
+   */
   def tupledFunction3[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function3[?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) => Function.untupled(g.asInstanceOf[Tuple3[?, ?, ?] => Any]).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 4
+   *  can be tupled as `G`, the unary function type taking the 4 arguments of
+   *  `F` as a single `Tuple4`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 4; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 4
+   *  @tparam G the tupled form of `F`, mapping a `Tuple4` of `F`'s arguments to its result
+   */
   def tupledFunction4[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function4[?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) => Function.untupled(g.asInstanceOf[Tuple4[?, ?, ?, ?] => Any]).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 5
+   *  can be tupled as `G`, the unary function type taking the 5 arguments of
+   *  `F` as a single `Tuple5`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 5; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 5
+   *  @tparam G the tupled form of `F`, mapping a `Tuple5` of `F`'s arguments to its result
+   */
   def tupledFunction5[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function5[?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) => Function.untupled(g.asInstanceOf[Tuple5[?, ?, ?, ?, ?] => Any]).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 6
+   *  can be tupled as `G`, the unary function type taking the 6 arguments of
+   *  `F` as a single `Tuple6`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 6; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 6
+   *  @tparam G the tupled form of `F`, mapping a `Tuple6` of `F`'s arguments to its result
+   */
   def tupledFunction6[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function6[?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -45,6 +143,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple6[?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 7
+   *  can be tupled as `G`, the unary function type taking the 7 arguments of
+   *  `F` as a single `Tuple7`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 7; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 7
+   *  @tparam G the tupled form of `F`, mapping a `Tuple7` of `F`'s arguments to its result
+   */
   def tupledFunction7[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function7[?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -52,6 +164,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple7[?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 8
+   *  can be tupled as `G`, the unary function type taking the 8 arguments of
+   *  `F` as a single `Tuple8`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 8; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 8
+   *  @tparam G the tupled form of `F`, mapping a `Tuple8` of `F`'s arguments to its result
+   */
   def tupledFunction8[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function8[?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -59,6 +185,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple8[?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 9
+   *  can be tupled as `G`, the unary function type taking the 9 arguments of
+   *  `F` as a single `Tuple9`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 9; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 9
+   *  @tparam G the tupled form of `F`, mapping a `Tuple9` of `F`'s arguments to its result
+   */
   def tupledFunction9[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function9[?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -66,6 +206,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple9[?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 10
+   *  can be tupled as `G`, the unary function type taking the 10 arguments of
+   *  `F` as a single `Tuple10`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 10; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 10
+   *  @tparam G the tupled form of `F`, mapping a `Tuple10` of `F`'s arguments to its result
+   */
   def tupledFunction10[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function10[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -73,6 +227,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple10[?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 11
+   *  can be tupled as `G`, the unary function type taking the 11 arguments of
+   *  `F` as a single `Tuple11`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 11; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 11
+   *  @tparam G the tupled form of `F`, mapping a `Tuple11` of `F`'s arguments to its result
+   */
   def tupledFunction11[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function11[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -80,6 +248,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple11[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 12
+   *  can be tupled as `G`, the unary function type taking the 12 arguments of
+   *  `F` as a single `Tuple12`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 12; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 12
+   *  @tparam G the tupled form of `F`, mapping a `Tuple12` of `F`'s arguments to its result
+   */
   def tupledFunction12[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function12[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -87,6 +269,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple12[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 13
+   *  can be tupled as `G`, the unary function type taking the 13 arguments of
+   *  `F` as a single `Tuple13`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 13; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 13
+   *  @tparam G the tupled form of `F`, mapping a `Tuple13` of `F`'s arguments to its result
+   */
   def tupledFunction13[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function13[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -94,6 +290,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple13[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 14
+   *  can be tupled as `G`, the unary function type taking the 14 arguments of
+   *  `F` as a single `Tuple14`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 14; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 14
+   *  @tparam G the tupled form of `F`, mapping a `Tuple14` of `F`'s arguments to its result
+   */
   def tupledFunction14[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function14[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -101,6 +311,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple14[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 15
+   *  can be tupled as `G`, the unary function type taking the 15 arguments of
+   *  `F` as a single `Tuple15`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 15; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 15
+   *  @tparam G the tupled form of `F`, mapping a `Tuple15` of `F`'s arguments to its result
+   */
   def tupledFunction15[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function15[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -108,6 +332,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple15[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 16
+   *  can be tupled as `G`, the unary function type taking the 16 arguments of
+   *  `F` as a single `Tuple16`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 16; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 16
+   *  @tparam G the tupled form of `F`, mapping a `Tuple16` of `F`'s arguments to its result
+   */
   def tupledFunction16[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function16[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -115,6 +353,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple16[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 17
+   *  can be tupled as `G`, the unary function type taking the 17 arguments of
+   *  `F` as a single `Tuple17`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 17; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 17
+   *  @tparam G the tupled form of `F`, mapping a `Tuple17` of `F`'s arguments to its result
+   */
   def tupledFunction17[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function17[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -122,6 +374,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple17[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 18
+   *  can be tupled as `G`, the unary function type taking the 18 arguments of
+   *  `F` as a single `Tuple18`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 18; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 18
+   *  @tparam G the tupled form of `F`, mapping a `Tuple18` of `F`'s arguments to its result
+   */
   def tupledFunction18[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function18[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -129,6 +395,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple18[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 19
+   *  can be tupled as `G`, the unary function type taking the 19 arguments of
+   *  `F` as a single `Tuple19`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 19; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 19
+   *  @tparam G the tupled form of `F`, mapping a `Tuple19` of `F`'s arguments to its result
+   */
   def tupledFunction19[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function19[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -136,6 +416,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple19[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 20
+   *  can be tupled as `G`, the unary function type taking the 20 arguments of
+   *  `F` as a single `Tuple20`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 20; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 20
+   *  @tparam G the tupled form of `F`, mapping a `Tuple20` of `F`'s arguments to its result
+   */
   def tupledFunction20[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function20[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -143,6 +437,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple20[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 21
+   *  can be tupled as `G`, the unary function type taking the 21 arguments of
+   *  `F` as a single `Tuple21`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 21; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 21
+   *  @tparam G the tupled form of `F`, mapping a `Tuple21` of `F`'s arguments to its result
+   */
   def tupledFunction21[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function21[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -150,6 +458,20 @@ object TupledFunctions {
         g.asInstanceOf[Tuple21[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity 22
+   *  can be tupled as `G`, the unary function type taking the 22 arguments of
+   *  `F` as a single `Tuple22`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity 22; it is not meant to
+   *  be called directly. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity 22
+   *  @tparam G the tupled form of `F`, mapping a `Tuple22` of `F`'s arguments to its result
+   */
   def tupledFunction22[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => f.asInstanceOf[Function22[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?]].tupled.asInstanceOf[G],
     untupledImpl = (g: G) =>
@@ -157,6 +479,26 @@ object TupledFunctions {
         g.asInstanceOf[Tuple22[?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?] => Any].apply((x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22))).asInstanceOf[F]
   )
 
+  /** Returns a `TupledFunction` witnessing that a function type `F` of arity
+   *  greater than 22 can be tupled as `G`, the unary function type taking the
+   *  arguments of `F` as a single `TupleXXL`.
+   *
+   *  The compiler synthesizes calls to this method to materialize a given
+   *  `TupledFunction[F, G]` for function types of arity greater than 22; it is
+   *  not meant to be called directly. Unlike the fixed-arity variants, both
+   *  conversions work on array-based runtime representations: `tupled` turns a
+   *  [[FunctionXXL]] into a function that applies it to the `TupleXXL`
+   *  argument's backing array of elements, and `untupled` builds a new
+   *  `FunctionXXL` whose `apply` wraps its argument array in a `TupleXXL`
+   *  (sharing the array, not copying it) and passes that tuple to the
+   *  converted function. `F` and `G` are unconstrained here: the conversions
+   *  are implemented with unchecked casts, so type arguments of any other
+   *  shape lead to `ClassCastException`s when the conversions or the converted
+   *  functions are applied.
+   *
+   *  @tparam F the function type of arity greater than 22, represented at runtime by [[FunctionXXL]]
+   *  @tparam G the tupled form of `F`, mapping a `TupleXXL` of `F`'s arguments to its result
+   */
   def tupledFunctionXXL[F, G]: TupledFunction[F, G] = TupledFunction[F, G](
     tupledImpl = (f: F) => ((args: TupleXXL) => f.asInstanceOf[FunctionXXL].apply(args.elems)).asInstanceOf[G],
     untupledImpl = (g: G) => new FunctionXXL {

--- a/library/src/scala/runtime/Tuples.scala
+++ b/library/src/scala/runtime/Tuples.scala
@@ -4,20 +4,49 @@ import language.experimental.captureChecking
 
 object Tuples {
 
+  /** The largest arity for which tuples have a dedicated `TupleN` class (22); larger tuples are represented by a [[TupleXXL]] backed by an array. */
   inline val MaxSpecialized = 22
 
+  /** Returns the elements of `self` in an `Array[Object]`; implements [[scala.Tuple.toArray]].
+   *
+   *  For `EmptyTuple` the shared empty array is returned; otherwise the array
+   *  is freshly allocated (a [[TupleXXL]]'s backing array is cloned), so
+   *  mutating it does not affect the tuple.
+   *
+   *  @param self the tuple whose elements are extracted
+   *  @return an array containing the elements of `self`, in order
+   */
   def toArray(self: Tuple): Array[Object] = (self: Any) match {
     case EmptyTuple => Array.emptyObjectArray
     case self: TupleXXL => self.toArray
     case self: Product => productToArray(self)
   }
 
+  /** Returns the elements of `self` in an `IArray[Object]`; implements [[scala.Tuple.toIArray]].
+   *
+   *  For a [[TupleXXL]] this is the tuple's backing array itself, not a copy;
+   *  for `EmptyTuple` it is the shared empty array; for `Tuple1` to `Tuple22`
+   *  a fresh array is filled from the product elements.
+   *
+   *  @param self the tuple whose elements are extracted
+   *  @return an immutable array containing the elements of `self`, in order
+   */
   def toIArray(self: Tuple): IArray[Object] = (self: Any) match {
     case EmptyTuple => Array.emptyObjectArray.asInstanceOf[IArray[Object]]
     case self: TupleXXL => self.elems
     case self: Product => productToArray(self).asInstanceOf[IArray[Object]]
   }
 
+  /** Copies the elements of `self` into a fresh `Array[Object]`.
+   *
+   *  Accepts any `Product`, not just tuples. [[toArray]] uses it for `Tuple1`
+   *  to `Tuple22`, and the compiler calls it directly when optimizing
+   *  `Tuple.toArray` on tuples statically known to have between 1 and 22 elements; the
+   *  empty tuple is handled separately, with `Array.emptyObjectArray`.
+   *
+   *  @param self the product whose elements are copied
+   *  @return a fresh array containing `self.productElement(0)` to `self.productElement(self.productArity - 1)`
+   */
   def productToArray(self: Product): Array[Object] = {
     val arr = new Array[Object](self.productArity)
     var i = 0
@@ -28,6 +57,16 @@ object Tuples {
     arr
   }
 
+  /** Returns a tuple containing the elements of `xs`, in order; backs [[scala.Tuple.fromArray]].
+   *
+   *  Arrays of length 0 to 22 yield `EmptyTuple` or the corresponding `TupleN`;
+   *  longer arrays yield a [[TupleXXL]] wrapping a clone of `xs`. In either
+   *  case, mutating `xs` afterwards does not affect the result. The elements
+   *  must already be boxed; [[scala.Tuple.fromArray]] takes care of that.
+   *
+   *  @param xs the array supplying the elements of the tuple
+   *  @return a tuple of arity `xs.length` with the elements of `xs`
+   */
   def fromArray(xs: Array[Object]): Tuple = xs.length match {
     case 0  => EmptyTuple
     case 1  => Tuple1(xs(0))
@@ -55,10 +94,29 @@ object Tuples {
     case _ => TupleXXL.fromIArray(xs.clone().asInstanceOf[IArray[Object]]).asInstanceOf[Tuple]
   }
 
+  /** Returns a tuple containing the elements of `xs`, in order; backs [[scala.Tuple.fromIArray]].
+   *
+   *  Arrays of length 0 to 22 yield `EmptyTuple` or the corresponding `TupleN`,
+   *  as in [[fromArray]]; longer arrays yield a [[TupleXXL]] backed directly by
+   *  `xs`, without copying.
+   *
+   *  @param xs the immutable array supplying the elements of the tuple
+   *  @return a tuple of arity `xs.length` with the elements of `xs`
+   */
   def fromIArray(xs: IArray[Object]): Tuple =
     if (xs.length <= 22) fromArray(xs.asInstanceOf[Array[Object]])
     else TupleXXL.fromIArray(xs).asInstanceOf[Tuple]
 
+  /** Returns a tuple containing the elements of `xs`, in order; backs [[scala.Tuple.fromProduct]] and [[TupleMirror.fromProduct]].
+   *
+   *  If `xs` already is a tuple in the runtime representation matching its
+   *  arity (a `TupleN` for arities 1 to 22, a [[TupleXXL]] beyond), it is
+   *  returned as is; otherwise its elements are copied into a new tuple of
+   *  arity `xs.productArity`. Every product of arity 0 yields `EmptyTuple`.
+   *
+   *  @param xs the product supplying the elements of the tuple
+   *  @return a tuple of arity `xs.productArity` with the elements of `xs`
+   */
   def fromProduct(xs: Product): Tuple = (xs.productArity match {
     case 0  => EmptyTuple
     case 1 =>
@@ -248,11 +306,32 @@ object Tuples {
     TupleXXL.fromIArray(arr.asInstanceOf[IArray[Object]])
   }
 
+  /** Returns a new tuple with `x` prepended to the elements of `self`; implements [[scala.Tuple.*:]].
+   *
+   *  The result has arity `self.size + 1`: a `Tuple22` or [[TupleXXL]] receiver
+   *  yields a `TupleXXL`, smaller receivers yield the next larger `TupleN`.
+   *
+   *  @param x the element to prepend
+   *  @param self the tuple supplying the remaining elements
+   *  @return a tuple with `x` as its 1st element, followed by the elements of `self`
+   */
   def cons(x: Any, self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlCons(x, xxl).asInstanceOf[Tuple]
     case _ => specialCaseCons(x, self)
   }
 
+  /** Returns the concatenation of `self` and `that`; implements [[scala.Tuple.++]].
+   *
+   *  If either tuple is empty, the other tuple is returned unchanged (the same
+   *  instance, not a copy); otherwise the elements of both are copied into a
+   *  fresh tuple of arity `self.size + that.size`.
+   *
+   *  @tparam This the type of the first tuple
+   *  @tparam That the type of the second tuple
+   *  @param self the tuple supplying the leading elements
+   *  @param that the tuple supplying the trailing elements
+   *  @return a tuple with the elements of `self` followed by the elements of `that`
+   */
   def concat[This <: Tuple, That <: Tuple](self: This, that: That): Tuple = {
     val selfSize: Int = self.size
     // If one of the tuples is empty, we can leave early
@@ -280,6 +359,11 @@ object Tuples {
     fromIArray(arr.asInstanceOf[IArray[Object]])
   }
 
+  /** Returns the number of elements of `self`: 0 for `EmptyTuple`, otherwise its `productArity`; implements [[scala.Tuple.size]].
+   *
+   *  @param self the tuple whose arity is computed
+   *  @return the arity of `self`
+   */
   def size(self: Tuple): Int = (self: Any) match {
     case EmptyTuple => 0
     case self: Product => self.productArity
@@ -352,6 +436,14 @@ object Tuples {
     }
   }
 
+  /** Returns a tuple containing all elements of `self` except the 1st; implements [[scala.Tuple.tail]].
+   *
+   *  `self` must be non-empty.
+   *
+   *  @param self the tuple whose tail is taken
+   *  @return a tuple of arity `self.size - 1` with all elements of `self` except the 1st
+   *  @throws MatchError if `self` is `EmptyTuple`
+   */
   def tail(self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlTail(xxl)
     case _ => specialCaseTail(self)
@@ -427,6 +519,15 @@ object Tuples {
     }
   }
 
+  /** Returns a new tuple with `x` appended to the elements of `self`; implements [[scala.Tuple.:*]].
+   *
+   *  The result has arity `self.size + 1`: a `Tuple22` or [[TupleXXL]] receiver
+   *  yields a `TupleXXL`, smaller receivers yield the next larger `TupleN`.
+   *
+   *  @param x the element to append
+   *  @param self the tuple supplying the leading elements
+   *  @return a tuple with the elements of `self` followed by `x` as its last element
+   */
   def append(x: Any, self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlAppend(x, xxl).asInstanceOf[Tuple]
     case _ => specialCaseAppend(x, self)
@@ -505,6 +606,14 @@ object Tuples {
     }
   }
 
+  /** Returns a tuple with the elements of `self` in reverse order; implements [[scala.Tuple.reverse]].
+   *
+   *  `EmptyTuple` and `Tuple1` receivers are returned unchanged (the same
+   *  instance); all other arities yield a new tuple of the same arity.
+   *
+   *  @param self the tuple to reverse
+   *  @return a tuple whose i-th element is the i-th element of `self` counted from the end
+   */
   def reverse(self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlReverse(xxl)
     case _ => specialCaseReverse(self)
@@ -560,15 +669,36 @@ object Tuples {
     }
   }
 
+  /** Returns a tuple containing all elements of `self` except the last; implements [[scala.Tuple.init]].
+   *
+   *  `self` must be non-empty.
+   *
+   *  @param self the tuple whose initial part is taken
+   *  @return a tuple of arity `self.size - 1` with all elements of `self` except the last
+   *  @throws MatchError if `self` is `EmptyTuple`
+   */
   def init(self: Tuple): Tuple = (self: Any) match {
     case xxl: TupleXXL => xxlInit(xxl)
     case _ => specialCaseInit(self)
   }
 
+  /** Returns the last element of `self`; implements [[scala.Tuple.last]].
+   *
+   *  @param self the tuple whose last element is retrieved
+   *  @return the element of `self` at index `self.size - 1`
+   *  @throws IndexOutOfBoundsException if `self` is `EmptyTuple` (the element at index -1 is requested)
+   */
   def last(self: Tuple): Any = (self: Any) match {
     case self: Product => self.productElement(self.productArity - 1)
   }
 
+  /** Returns the element of `self` at index `n`, via `productElement`; implements [[scala.Tuple.apply]] and [[scala.Tuple.head]].
+   *
+   *  @param self the tuple whose element is retrieved
+   *  @param n the 0-based index of the element
+   *  @return the element at index `n`
+   *  @throws IndexOutOfBoundsException if `n` is negative or not less than `self.size`
+   */
   def apply(self: Tuple, n: Int): Any =
     self.productElement(n)
 
@@ -583,6 +713,16 @@ object Tuples {
     arr.asInstanceOf[IArray[Object]]
   }
 
+  /** Returns a tuple of pairs formed from corresponding elements of `t1` and `t2`; implements [[scala.Tuple.zip]].
+   *
+   *  The result's arity is the smaller of the two arities; extra elements of
+   *  the longer tuple are discarded. If either tuple is empty, the result is
+   *  `EmptyTuple`.
+   *
+   *  @param t1 the tuple supplying the 1st element of each pair
+   *  @param t2 the tuple supplying the 2nd element of each pair
+   *  @return a tuple whose i-th element is the `Tuple2` of the i-th elements of `t1` and `t2`
+   */
   def zip(t1: Tuple, t2: Tuple): Tuple = {
     val t1Size: Int = t1.size
     val t2Size: Int = t2.size
@@ -597,11 +737,30 @@ object Tuples {
     )
   }
 
+  /** Returns a tuple of the same arity as `self` whose elements are the results of applying `f` to the elements of `self`; implements [[scala.Tuple.map]].
+   *
+   *  An `EmptyTuple` receiver is returned unchanged, without calling `f`.
+   *
+   *  @tparam F the type constructor mapping each element type to its result type
+   *  @param self the tuple whose elements are transformed
+   *  @param f the polymorphic function applied to each element
+   *  @return a tuple whose i-th element is `f` applied to the i-th element of `self`
+   */
   def map[F[_]](self: Tuple, f: [t] -> t -> F[t]): Tuple = self match {
     case EmptyTuple => self
     case _ => fromIArray(self.productIterator.map(f(_).asInstanceOf[Object]).toArray.asInstanceOf[IArray[Object]]) // TODO use toIArray
   }
 
+  /** Returns a tuple containing the first `n` elements of `self`; implements [[scala.Tuple.take]].
+   *
+   *  If `n` is greater than `self.size`, all elements are taken; if `n` is 0
+   *  or `self` is empty, the result is `EmptyTuple`.
+   *
+   *  @param self the tuple whose leading elements are taken
+   *  @param n the number of elements to take
+   *  @return a tuple with the first `min(n, self.size)` elements of `self`
+   *  @throws IndexOutOfBoundsException if `n` is negative
+   */
   def take(self: Tuple, n: Int): Tuple = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
     val selfSize: Int = self.size
@@ -623,6 +782,16 @@ object Tuples {
     }
   }
 
+  /** Returns a tuple containing all elements of `self` except the first `n`; implements [[scala.Tuple.drop]].
+   *
+   *  If `n` is greater than or equal to `self.size`, the result is `EmptyTuple`;
+   *  if `n` is 0, the result is a tuple with all elements of `self`.
+   *
+   *  @param self the tuple whose leading elements are dropped
+   *  @param n the number of elements to drop
+   *  @return a tuple with the last `self.size - min(n, self.size)` elements of `self`
+   *  @throws IndexOutOfBoundsException if `n` is negative
+   */
   def drop(self: Tuple, n: Int): Tuple = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
     val size = self.size
@@ -645,6 +814,16 @@ object Tuples {
     }
   }
 
+  /** Splits `self` into two tuples at index `n`; implements [[scala.Tuple.splitAt]].
+   *
+   *  `n` is clamped to `self.size`, so for larger `n` the second tuple is
+   *  `EmptyTuple` and the first contains all elements.
+   *
+   *  @param self the tuple to split
+   *  @param n the number of elements in the first part
+   *  @return a pair of the tuple of the first `min(n, self.size)` elements of `self` and the tuple of the remaining elements
+   *  @throws IndexOutOfBoundsException if `n` is negative
+   */
   def splitAt(self: Tuple, n: Int): (Tuple, Tuple) = {
     if (n < 0) throw new IndexOutOfBoundsException(n.toString)
     val size = self.size
@@ -668,12 +847,43 @@ object Tuples {
     )
   }
 
+  /** Returns an iterator over `head` followed by the elements of `tail`.
+   *
+   *  The compiler emits calls to this method when optimizing `*:` on tuples of
+   *  statically known arity, so the elements of `head *: tail` can be consumed
+   *  without materializing an intermediate tuple.
+   *
+   *  @param head the value produced first
+   *  @param tail the tuple whose elements are produced after `head`
+   *  @return an iterator producing `head`, then the elements of `tail` in order
+   */
   def consIterator(head: Any, tail: Tuple): Iterator[Any] =
     Iterator.single(head) ++ tail.productIterator
 
+  /** Returns an iterator over the elements of `tup1` followed by the elements of `tup2`.
+   *
+   *  The compiler emits calls to this method when optimizing `++` on tuples of
+   *  statically known arity, so the elements of `tup1 ++ tup2` can be consumed
+   *  without materializing an intermediate tuple.
+   *
+   *  @param tup1 the tuple whose elements are produced first
+   *  @param tup2 the tuple whose elements are produced after those of `tup1`
+   *  @return an iterator producing the elements of `tup1`, then those of `tup2`, in order
+   */
   def concatIterator(tup1: Tuple, tup2: Tuple): Iterator[Any] =
     tup1.productIterator ++ tup2.productIterator
 
+  /** Returns whether `x` is a tuple at runtime; the compiler rewrites the type test `x.isInstanceOf[Tuple]` to a call of this method.
+   *
+   *  A value passes the test if it is `EmptyTuple`, an instance of the
+   *  `TupleN` class matching its arity, or a [[TupleXXL]]. Other products are
+   *  rejected: for example, a case class of arity 2 that is not a `Tuple2` is
+   *  not a tuple, and a product of arity 0 is a tuple only if it equals
+   *  `EmptyTuple`.
+   *
+   *  @param x the value to test
+   *  @return `true` if `x` is a tuple, `false` otherwise
+   */
   def isInstanceOfTuple(x: Any): Boolean =
     x match
       case x: Product =>
@@ -705,8 +915,22 @@ object Tuples {
       case _ =>
         false
 
+  /** Returns whether `x` is the empty tuple; the compiler rewrites the type test `x.isInstanceOf[EmptyTuple]` to a call of this method.
+   *
+   *  @param x the value to test
+   *  @return `true` if `x` equals the `EmptyTuple` singleton, `false` otherwise
+   */
   def isInstanceOfEmptyTuple(x: Any): Boolean = x == EmptyTuple
 
+  /** Returns whether `x` is a tuple with at least one element; the compiler rewrites the type tests `x.isInstanceOf[NonEmptyTuple]` and `x.isInstanceOf[_ *: _]` to calls of this method.
+   *
+   *  A value passes the test if it is an instance of the `TupleN` class
+   *  matching its arity, or a [[TupleXXL]]. `EmptyTuple` and products that are
+   *  not tuple classes are rejected.
+   *
+   *  @param x the value to test
+   *  @return `true` if `x` is a non-empty tuple, `false` otherwise
+   */
   def isInstanceOfNonEmptyTuple(x: Any): Boolean =
     x match
       case x: Product =>

--- a/library/src/scala/runtime/VarArgsBuilder.scala
+++ b/library/src/scala/runtime/VarArgsBuilder.scala
@@ -3,14 +3,74 @@ package scala.runtime
 import scala.collection.immutable.ArraySeq
 import scala.reflect.ClassTag
 
+/** A builder used by compiler-generated code to construct the sequences produced
+ *  by sequence literals that contain spread operators.
+ *
+ *  The compiler (in `PostTyper`) translates a sequence literal such as
+ *  `[1, xs*, 2, ys*]` into
+ *  {{{
+ *  scala.runtime.VarArgsBuilder.ofInt(2 + xs.length + ys.length)
+ *    .add(1)
+ *    .addSeq(xs)
+ *    .add(2)
+ *    .addSeq(ys)
+ *    .result()
+ *  }}}
+ *  choosing the companion-object factory that matches the element type. Each
+ *  factory receives the total number of elements up front, and the generated
+ *  code adds exactly that many elements before calling `result()` once.
+ *
+ *  @tparam T the type of the elements of the sequence being built
+ */
 sealed abstract class VarArgsBuilder[T]:
+  /** Adds a single element to the sequence being built.
+   *
+   *  The compiler emits one call to this method per non-spread element of the
+   *  sequence literal.
+   *
+   *  @param elem the element to add
+   *  @return this builder
+   */
   def add(elem: T): this.type
+  /** Adds every element of a sequence, in order, to the sequence being built.
+   *
+   *  The compiler emits a call to this method for each spread element `xs*`
+   *  whose `xs` is a `Seq`.
+   *
+   *  @param elems the sequence of elements to add
+   *  @return this builder
+   */
   def addSeq(elems: Seq[T]): this.type
+  /** Adds every element of an array, in order, to the sequence being built.
+   *
+   *  The compiler emits a call to this method for each spread element `xs*`
+   *  whose `xs` is an array.
+   *
+   *  @param elems the array of elements to add
+   *  @return this builder
+   */
   def addArray(elems: Array[T]): this.type
+  /** Returns a sequence over the builder's whole array, in order.
+   *
+   *  The array is the fixed length the factory was given and no count of added elements is
+   *  kept, so calling this before exactly that many have been added exposes the array's
+   *  default values.
+   */
   def result(): Seq[T]
 
 object VarArgsBuilder:
 
+  /** Returns a builder for elements of a type not statically known to be a
+   *  primitive or a reference type, such as an unbounded type parameter.
+   *
+   *  The builder stores each element, cast to `AnyRef`, in an `Array[AnyRef]`
+   *  of length `n`; `result()` wraps that array in an `ArraySeq.ofRef` cast to
+   *  `ArraySeq[T]`, without copying.
+   *
+   *  @tparam T the element type
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def generic[T](n: Int): VarArgsBuilder[T] = new VarArgsBuilder[T]:
     private val xs = new Array[AnyRef](n)
     def result() = ArraySeq.ofRef(xs).asInstanceOf[ArraySeq[T]]
@@ -30,6 +90,16 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for elements of a reference type.
+   *
+   *  The builder stores elements in an `Array[AnyRef]` of length `n`;
+   *  `result()` wraps that array in an `ArraySeq.ofRef` cast to `ArraySeq[T]`,
+   *  without copying.
+   *
+   *  @tparam T the element type, a reference type
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofRef[T <: AnyRef](n: Int): VarArgsBuilder[T] = new VarArgsBuilder[T]:
     private val xs = new Array[AnyRef](n)
     def result() = ArraySeq.ofRef(xs).asInstanceOf[ArraySeq[T]]
@@ -49,6 +119,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Byte` elements.
+   *
+   *  The builder stores elements in an `Array[Byte]` of length `n`; `result()`
+   *  wraps that array in an `ArraySeq.ofByte`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofByte(n: Int): VarArgsBuilder[Byte] = new VarArgsBuilder[Byte]:
     private val xs = new Array[Byte](n)
     def result() = ArraySeq.ofByte(xs)
@@ -68,6 +146,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Short` elements.
+   *
+   *  The builder stores elements in an `Array[Short]` of length `n`; `result()`
+   *  wraps that array in an `ArraySeq.ofShort`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofShort(n: Int): VarArgsBuilder[Short] = new VarArgsBuilder[Short]:
     private val xs = new Array[Short](n)
     def result() = ArraySeq.ofShort(xs)
@@ -87,6 +173,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Char` elements.
+   *
+   *  The builder stores elements in an `Array[Char]` of length `n`; `result()`
+   *  wraps that array in an `ArraySeq.ofChar`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofChar(n: Int): VarArgsBuilder[Char] = new VarArgsBuilder[Char]:
     private val xs = new Array[Char](n)
     def result() = ArraySeq.ofChar(xs)
@@ -106,6 +200,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Int` elements.
+   *
+   *  The builder stores elements in an `Array[Int]` of length `n`; `result()`
+   *  wraps that array in an `ArraySeq.ofInt`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofInt(n: Int): VarArgsBuilder[Int] = new VarArgsBuilder[Int]:
     private val xs = new Array[Int](n)
     def result() = ArraySeq.ofInt(xs)
@@ -125,6 +227,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Long` elements.
+   *
+   *  The builder stores elements in an `Array[Long]` of length `n`; `result()`
+   *  wraps that array in an `ArraySeq.ofLong`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofLong(n: Int): VarArgsBuilder[Long] = new VarArgsBuilder[Long]:
     private val xs = new Array[Long](n)
     def result() = ArraySeq.ofLong(xs)
@@ -144,6 +254,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Float` elements.
+   *
+   *  The builder stores elements in an `Array[Float]` of length `n`; `result()`
+   *  wraps that array in an `ArraySeq.ofFloat`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofFloat(n: Int): VarArgsBuilder[Float] = new VarArgsBuilder[Float]:
     private val xs = new Array[Float](n)
     def result() = ArraySeq.ofFloat(xs)
@@ -163,6 +281,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Double` elements.
+   *
+   *  The builder stores elements in an `Array[Double]` of length `n`;
+   *  `result()` wraps that array in an `ArraySeq.ofDouble`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofDouble(n: Int): VarArgsBuilder[Double] = new VarArgsBuilder[Double]:
     private val xs = new Array[Double](n)
     def result() = ArraySeq.ofDouble(xs)
@@ -182,6 +308,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Boolean` elements.
+   *
+   *  The builder stores elements in an `Array[Boolean]` of length `n`;
+   *  `result()` wraps that array in an `ArraySeq.ofBoolean`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofBoolean(n: Int): VarArgsBuilder[Boolean] = new VarArgsBuilder[Boolean]:
     private val xs = new Array[Boolean](n)
     def result() = ArraySeq.ofBoolean(xs)
@@ -201,6 +335,14 @@ object VarArgsBuilder:
         i += 1
       this
 
+  /** Returns a builder for `Unit` elements.
+   *
+   *  The builder stores elements in an `Array[Unit]` of length `n`; `result()`
+   *  wraps that array in an `ArraySeq.ofUnit`, without copying.
+   *
+   *  @param n the length of the array to allocate; exactly this many elements are expected
+   *           to be added, which is not enforced
+   */
   def ofUnit(n: Int): VarArgsBuilder[Unit] = new VarArgsBuilder[Unit]:
     private val xs = new Array[Unit](n)
     def result() = ArraySeq.ofUnit(xs)

--- a/library/src/scala/runtime/coverage/Invoker.scala
+++ b/library/src/scala/runtime/coverage/Invoker.scala
@@ -50,6 +50,15 @@ object Invoker {
         writer.write('\n')
         writer.flush()
 
+  /** Returns the coverage measurement file for the current thread in `dataDir`.
+   *
+   *  The file name is `scoverage.measurements.` followed by a UUID chosen once
+   *  per runtime, a dot, and the current thread's id, so every thread of every
+   *  run appends to its own file. This method only names the file; it does not
+   *  create it.
+   *
+   *  @param dataDir the directory holding the coverage measurement files
+   */
   @nowarn("cat=deprecation")
   def measurementFile(dataDir: String): File = new File(
     dataDir,

--- a/library/src/scala/runtime/java8/JFunction0$mcB$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcB$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Byte`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Byte]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcB$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Byte`. */
   def apply$mcB$sp(): Byte
+  /** Applies this function by delegating to `apply$mcB$sp`, boxing the
+   *  `Byte` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToByte(apply$mcB$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction0$mcC$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcC$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Char`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Char]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcC$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Char`. */
   def apply$mcC$sp(): Char
+  /** Applies this function by delegating to `apply$mcC$sp`, boxing the
+   *  `Char` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToCharacter(apply$mcC$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction0$mcD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcD$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Double]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcD$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Double`. */
   def apply$mcD$sp(): Double
+  /** Applies this function by delegating to `apply$mcD$sp`, boxing the
+   *  `Double` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcD$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction0$mcF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcF$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Float]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcF$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Float`. */
   def apply$mcF$sp(): Float
+  /** Applies this function by delegating to `apply$mcF$sp`, boxing the
+   *  `Float` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcF$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction0$mcI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcI$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Int]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcI$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Int`. */
   def apply$mcI$sp(): Int
+  /** Applies this function by delegating to `apply$mcI$sp`, boxing the
+   *  `Int` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcI$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction0$mcJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcJ$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Long]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcJ$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Long`. */
   def apply$mcJ$sp(): Long
+  /** Applies this function by delegating to `apply$mcJ$sp`, boxing the
+   *  `Long` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJ$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction0$mcS$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcS$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Short`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Short]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcS$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Short`. */
   def apply$mcS$sp(): Short
+  /** Applies this function by delegating to `apply$mcS$sp`, boxing the
+   *  `Short` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToShort(apply$mcS$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction0$mcV$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcV$sp.scala
@@ -14,8 +14,17 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning
+ *  `Unit`, allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement `Function0[Unit]` without
+ *  boxing.
+ */
 @FunctionalInterface trait JFunction0$mcV$sp extends Function0[Any] with Serializable {
+  /** Applies this function for its side effects. */
   def apply$mcV$sp(): Unit
+  /** Applies this function by delegating to `apply$mcV$sp`, then returns the
+   *  boxed unit value, `BoxedUnit.UNIT`.
+   */
   override def apply(): Any = {
     apply$mcV$sp()
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction0$mcZ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction0$mcZ$sp.scala
@@ -14,7 +14,16 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function0]] returning an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement `Function0[Boolean]`
+ *  without boxing.
+ */
 @FunctionalInterface trait JFunction0$mcZ$sp extends Function0[Any] with Serializable {
+  /** Applies this function, returning the result as an unboxed `Boolean`. */
   def apply$mcZ$sp(): Boolean
+  /** Applies this function by delegating to `apply$mcZ$sp`, boxing the
+   *  `Boolean` result.
+   */
   override def apply(): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZ$sp())
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDD$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Double` to an unboxed `Double`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Double, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcDD$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDD$sp(v1: Double): Double
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcDD$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcDF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDF$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Float` to an unboxed `Double`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Float, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcDF$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Float`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDF$sp(v1: Float): Double
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcDF$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Float`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDI$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Int` to an unboxed `Double`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Int, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcDI$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDI$sp(v1: Int): Double
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcDI$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcDJ$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Long` to an unboxed `Double`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Long, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcDJ$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDJ$sp(v1: Long): Double
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcDJ$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcFD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFD$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Double` to an unboxed `Float`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Double, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcFD$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFD$sp(v1: Double): Float
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcFD$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcFF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFF$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Float` to an unboxed `Float`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Float, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcFF$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Float`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFF$sp(v1: Float): Float
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcFF$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Float`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcFI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFI$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Int` to an unboxed `Float`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Int, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcFI$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFI$sp(v1: Int): Float
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcFI$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcFJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcFJ$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Long` to an unboxed `Float`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Long, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcFJ$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFJ$sp(v1: Long): Float
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcFJ$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcID$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Double` to an unboxed `Int`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Double, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcID$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcID$sp(v1: Double): Int
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcID$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcID$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcIF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcIF$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Float` to an unboxed `Int`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Float, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcIF$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Float`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIF$sp(v1: Float): Int
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcIF$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Float`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcII$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Int` to an unboxed `Int`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Int, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcII$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcII$sp(v1: Int): Int
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcII$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcII$sp(scala.runtime.BoxesRunTime.unboxToInt(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcIJ$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Long` to an unboxed `Int`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Long, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcIJ$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIJ$sp(v1: Long): Int
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcIJ$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJD$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Double` to an unboxed `Long`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Double, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcJD$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJD$sp(v1: Double): Long
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcJD$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcJF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJF$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Float` to an unboxed `Long`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Float, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcJF$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Float`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJF$sp(v1: Float): Long
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcJF$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Float`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJI$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Int` to an unboxed `Long`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Int, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcJI$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJI$sp(v1: Int): Long
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcJI$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcJJ$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Long` to an unboxed `Long`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Long, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcJJ$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJJ$sp(v1: Long): Long
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcJJ$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcVD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVD$sp.scala
@@ -14,8 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Double` to `Unit`, allowing a Java lambda or
+ *  method reference (and the compiler's `invokedynamic` lambda encoding) to
+ *  implement `Function1[Double, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcVD$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument for its side effects.
+   *
+   *  @param v1 the argument, as an unboxed `Double`
+   */
   def apply$mcVD$sp(v1: Double): Unit
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcVD$sp`, unboxing the argument.
+   *
+   *  @param t the argument, unboxed to a `Double`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(t: Any): Any = {
     apply$mcVD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction1$mcVF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVF$sp.scala
@@ -14,8 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Float` to `Unit`, allowing a Java lambda or
+ *  method reference (and the compiler's `invokedynamic` lambda encoding) to
+ *  implement `Function1[Float, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcVF$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument for its side effects.
+   *
+   *  @param v1 the argument, as an unboxed `Float`
+   */
   def apply$mcVF$sp(v1: Float): Unit
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcVF$sp`, unboxing the argument.
+   *
+   *  @param t the argument, unboxed to a `Float`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(t: Any): Any = {
     apply$mcVF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction1$mcVI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVI$sp.scala
@@ -14,8 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Int` to `Unit`, allowing a Java lambda or
+ *  method reference (and the compiler's `invokedynamic` lambda encoding) to
+ *  implement `Function1[Int, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcVI$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument for its side effects.
+   *
+   *  @param v1 the argument, as an unboxed `Int`
+   */
   def apply$mcVI$sp(v1: Int): Unit
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcVI$sp`, unboxing the argument.
+   *
+   *  @param t the argument, unboxed to an `Int`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(t: Any): Any = {
     apply$mcVI$sp(scala.runtime.BoxesRunTime.unboxToInt(t))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction1$mcVJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcVJ$sp.scala
@@ -14,8 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Long` to `Unit`, allowing a Java lambda or
+ *  method reference (and the compiler's `invokedynamic` lambda encoding) to
+ *  implement `Function1[Long, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcVJ$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument for its side effects.
+   *
+   *  @param v1 the argument, as an unboxed `Long`
+   */
   def apply$mcVJ$sp(v1: Long): Unit
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcVJ$sp`, unboxing the argument.
+   *
+   *  @param t the argument, unboxed to a `Long`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(t: Any): Any = {
     apply$mcVJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction1$mcZD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZD$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Double` to an unboxed `Boolean`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Double, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcZD$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZD$sp(v1: Double): Boolean
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcZD$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZD$sp(scala.runtime.BoxesRunTime.unboxToDouble(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcZF$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZF$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Float` to an unboxed `Boolean`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Float, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcZF$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Float`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZF$sp(v1: Float): Boolean
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcZF$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Float`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZF$sp(scala.runtime.BoxesRunTime.unboxToFloat(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcZI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZI$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Int` to an unboxed `Boolean`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Int, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcZI$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZI$sp(v1: Int): Boolean
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcZI$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZI$sp(scala.runtime.BoxesRunTime.unboxToInt(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction1$mcZJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction1$mcZJ$sp.scala
@@ -14,7 +14,23 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function1]] for a
+ *  function from an unboxed `Long` to an unboxed `Boolean`, allowing a Java
+ *  lambda or method reference (and the compiler's `invokedynamic` lambda
+ *  encoding) to implement `Function1[Long, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction1$mcZJ$sp extends Function1[Any, Any] with Serializable {
+  /** Applies this function to the given argument.
+   *
+   *  @param v1 the argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZJ$sp(v1: Long): Boolean
+  /** Applies this function to the given argument by delegating to
+   *  `apply$mcZJ$sp`, unboxing the argument and boxing the result.
+   *
+   *  @param t the argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(t: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZJ$sp(scala.runtime.BoxesRunTime.unboxToLong(t)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDDD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Double` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Double, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDDD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDDD$sp(v1: Double, v2: Double): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDDD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDDI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Int` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Int, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDDI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDDI$sp(v1: Double, v2: Int): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDDI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDDJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Long` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Long, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDDJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDDJ$sp(v1: Double, v2: Long): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDDJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDID$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Double` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Double, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDID$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDID$sp(v1: Int, v2: Double): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDID$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDII$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Int` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Int, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDII$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDII$sp(v1: Int, v2: Int): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDII$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDIJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Long` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Long, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDIJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDIJ$sp(v1: Int, v2: Long): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDIJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDJD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Double` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Double, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDJD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDJD$sp(v1: Long, v2: Double): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDJD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDJI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Int` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Int, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDJI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDJI$sp(v1: Long, v2: Int): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDJI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcDJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcDJJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Long` to an
+ *  unboxed `Double`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Long, Double]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcDJJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Double`
+   */
   def apply$mcDJJ$sp(v1: Long, v2: Long): Double
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcDJJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Double`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToDouble(apply$mcDJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFDD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Double` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Double, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFDD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFDD$sp(v1: Double, v2: Double): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFDD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFDI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Int` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Int, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFDI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFDI$sp(v1: Double, v2: Int): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFDI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFDJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Long` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Long, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFDJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFDJ$sp(v1: Double, v2: Long): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFDJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFID$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Double` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Double, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFID$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFID$sp(v1: Int, v2: Double): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFID$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFII$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Int` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Int, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFII$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFII$sp(v1: Int, v2: Int): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFII$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFIJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Long` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Long, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFIJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFIJ$sp(v1: Int, v2: Long): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFIJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFJD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Double` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Double, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFJD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFJD$sp(v1: Long, v2: Double): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFJD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFJI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Int` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Int, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFJI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFJI$sp(v1: Long, v2: Int): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFJI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcFJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcFJJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Long` to an
+ *  unboxed `Float`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Long, Float]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcFJJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Float`
+   */
   def apply$mcFJJ$sp(v1: Long, v2: Long): Float
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcFJJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Float`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToFloat(apply$mcFJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIDD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Double` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Double, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIDD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIDD$sp(v1: Double, v2: Double): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIDD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIDI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Int` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Int, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIDI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIDI$sp(v1: Double, v2: Int): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIDI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIDJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Long` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Long, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIDJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIDJ$sp(v1: Double, v2: Long): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIDJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIID$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Double` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Double, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIID$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIID$sp(v1: Int, v2: Double): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIID$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIII$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Int` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Int, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIII$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIII$sp(v1: Int, v2: Int): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIII$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIIJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Long` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Long, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIIJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIIJ$sp(v1: Int, v2: Long): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIIJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIJD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Double` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Double, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIJD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIJD$sp(v1: Long, v2: Double): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIJD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIJI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Int` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Int, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIJI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIJI$sp(v1: Long, v2: Int): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIJI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcIJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcIJJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Long` to an
+ *  unboxed `Int`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Long, Int]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcIJJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Int`
+   */
   def apply$mcIJJ$sp(v1: Long, v2: Long): Int
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcIJJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Int`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToInteger(apply$mcIJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJDD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Double` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Double, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJDD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJDD$sp(v1: Double, v2: Double): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJDD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJDI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Int` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Int, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJDI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJDI$sp(v1: Double, v2: Int): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJDI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJDJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Long` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Long, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJDJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJDJ$sp(v1: Double, v2: Long): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJDJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJID$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Double` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Double, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJID$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJID$sp(v1: Int, v2: Double): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJID$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJII$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Int` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Int, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJII$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJII$sp(v1: Int, v2: Int): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJII$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJIJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Long` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Long, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJIJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJIJ$sp(v1: Int, v2: Long): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJIJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJJD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Double` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Double, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJJD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJJD$sp(v1: Long, v2: Double): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJJD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJJI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Int` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Int, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJJI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJJI$sp(v1: Long, v2: Int): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJJI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcJJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcJJJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Long` to an
+ *  unboxed `Long`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Long, Long]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcJJJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Long`
+   */
   def apply$mcJJJ$sp(v1: Long, v2: Long): Long
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcJJJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Long`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToLong(apply$mcJJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcVDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVDD$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Double` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Double, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVDD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   */
   def apply$mcVDD$sp(v1: Double, v2: Double): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVDD$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVDI$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Int` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Int, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVDI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   */
   def apply$mcVDI$sp(v1: Double, v2: Int): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVDI$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVDJ$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Long` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Long, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVDJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   */
   def apply$mcVDJ$sp(v1: Double, v2: Long): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVDJ$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVID$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Double` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Double, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVID$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   */
   def apply$mcVID$sp(v1: Int, v2: Double): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVID$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVII$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Int` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Int, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVII$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   */
   def apply$mcVII$sp(v1: Int, v2: Int): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVII$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVIJ$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Long` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Long, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVIJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   */
   def apply$mcVIJ$sp(v1: Int, v2: Long): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVIJ$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVJD$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Double` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Double, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVJD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   */
   def apply$mcVJD$sp(v1: Long, v2: Double): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVJD$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVJI$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Int` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Int, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVJI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   */
   def apply$mcVJI$sp(v1: Long, v2: Int): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVJI$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcVJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcVJJ$sp.scala
@@ -14,8 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Long` to `Unit`,
+ *  allowing a Java lambda or method reference (and the compiler's
+ *  `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Long, Unit]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcVJJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments for its side effects.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   */
   def apply$mcVJJ$sp(v1: Long, v2: Long): Unit
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcVJJ$sp`, unboxing the arguments.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the boxed unit value, `BoxedUnit.UNIT`
+   */
   override def apply(v1: Any, v2: Any): Any = {
     apply$mcVJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2))
     scala.runtime.BoxedUnit.UNIT

--- a/library/src/scala/runtime/java8/JFunction2$mcZDD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZDD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Double` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Double, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZDD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZDD$sp(v1: Double, v2: Double): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZDD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZDD$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZDI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZDI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Int` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Int, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZDI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZDI$sp(v1: Double, v2: Int): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZDI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZDI$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZDJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZDJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Double` and an unboxed `Long` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Double, Long, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZDJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Double`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZDJ$sp(v1: Double, v2: Long): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZDJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Double`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZDJ$sp(scala.runtime.BoxesRunTime.unboxToDouble(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZID$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZID$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Double` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Double, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZID$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZID$sp(v1: Int, v2: Double): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZID$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZID$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZII$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZII$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Int` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Int, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZII$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZII$sp(v1: Int, v2: Int): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZII$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZII$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZIJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZIJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Int` and an unboxed `Long` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Int, Long, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZIJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Int`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZIJ$sp(v1: Int, v2: Long): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZIJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to an `Int`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZIJ$sp(scala.runtime.BoxesRunTime.unboxToInt(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZJD$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZJD$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Double` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Double, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZJD$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Double`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZJD$sp(v1: Long, v2: Double): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZJD$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Double`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZJD$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToDouble(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZJI$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZJI$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Int` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Int, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZJI$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Int`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZJI$sp(v1: Long, v2: Int): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZJI$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to an `Int`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZJI$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToInt(v2)))
 }

--- a/library/src/scala/runtime/java8/JFunction2$mcZJJ$sp.scala
+++ b/library/src/scala/runtime/java8/JFunction2$mcZJJ$sp.scala
@@ -14,7 +14,26 @@ package scala.runtime.java8
 
 import scala.language.`2.13`
 
+/** A `@FunctionalInterface` specialization of [[scala.Function2]] for a
+ *  function from an unboxed `Long` and an unboxed `Long` to an
+ *  unboxed `Boolean`, allowing a Java lambda or method reference (and the
+ *  compiler's `invokedynamic` lambda encoding) to implement
+ *  `Function2[Long, Long, Boolean]` without boxing.
+ */
 @FunctionalInterface trait JFunction2$mcZJJ$sp extends Function2[Any, Any, Any] with Serializable {
+  /** Applies this function to the given arguments.
+   *
+   *  @param v1 the 1st argument, as an unboxed `Long`
+   *  @param v2 the 2nd argument, as an unboxed `Long`
+   *  @return the result of applying this function, as an unboxed `Boolean`
+   */
   def apply$mcZJJ$sp(v1: Long, v2: Long): Boolean
+  /** Applies this function to the given arguments by delegating to
+   *  `apply$mcZJJ$sp`, unboxing the arguments and boxing the result.
+   *
+   *  @param v1 the 1st argument, unboxed to a `Long`
+   *  @param v2 the 2nd argument, unboxed to a `Long`
+   *  @return the result of applying this function, as a boxed `Boolean`
+   */
   override def apply(v1: Any, v2: Any): Any = scala.runtime.BoxesRunTime.boxToBoolean(apply$mcZJJ$sp(scala.runtime.BoxesRunTime.unboxToLong(v1), scala.runtime.BoxesRunTime.unboxToLong(v2)))
 }


### PR DESCRIPTION
This PR fills in a main doc comment plus @param, @tparam, and @return tags for `scala.runtime`, `scala.runtime.java8` and `scala.runtime.coverage` APIs that are completely missing any Scaladoc documentation. Most of the files are the 87 of `scala.runtime.java8` that back Java function interop; the rest is the value-class runtime support, the array and tuple helpers, and the rich wrapper classes. I'm submitting it as a draft PR so that I can get the CI to run on it, to see if it breaks anything, and to start getting feedback. We automated the generation of these changes and have not reviewed all of them yet. We will review them all before making the PR non-draft. Please let me know whether you think this is going in the right direction in general, and anything specific that you notice that could be improved.